### PR TITLE
swarm: improve v0.1 concurrency rejection guidance

### DIFF
--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -137,8 +137,8 @@ pub fn execute_sequential(
         crate::adl::WorkflowKind::Sequential
     ) {
         return Err(anyhow!(
-            "workflow kind {:?} is not implemented in v0.1 (only 'sequential')",
-            resolved.doc.run.workflow.kind
+            "v0.1 does not support concurrent workflows. Use a single workflow with sequential steps, \
+or upgrade once concurrency lands (planned v0.3)."
         ));
     }
 

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -307,10 +307,18 @@ run:
         "stderr should mention concurrent workflows; stderr was:\n{stderr}"
     );
     assert!(
-        stderr.contains("not supported")
-            || stderr.contains("unsupported")
+        stderr.contains("does not support")
+            || stderr.contains("not supported")
             || stderr.contains("not implemented"),
-        "stderr should explain concurrent workflows are not supported/implemented in v0.1; stderr was:\n{stderr}"
+        "stderr should explain concurrency is unsupported in v0.1; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("sequential") || stderr.contains("single workflow"),
+        "stderr should suggest sequential/single workflow; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("upgrade") || stderr.contains("v0.3"),
+        "stderr should mention upgrading for concurrency; stderr was:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
Closes #2

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test