### PR TITLE
tools: fix pr.sh EXIT trap under set -u

### DIFF
--- a/swarm/tools/pr.sh
+++ b/swarm/tools/pr.sh
@@ -596,7 +596,7 @@ cmd_finish() {
 
   local pr_body_file
   pr_body_file="$(render_pr_body_file "$issue" "$close_line" "$input_path" "$output_path" "$extra_body" "$no_checks")"
-  trap 'rm -f "$pr_body_file"' EXIT
+  trap 'rm -f "${pr_body_file:-}"' EXIT
 
   local commit_msg="$title"
   if [[ -n "$close_line" ]]; then


### PR DESCRIPTION
Fixes an EXIT trap failure after `pr.sh finish` completes.

Root cause: trap referenced a local variable that is out-of-scope when the trap runs under `set -u`.
Fix: use `${pr_body_file:-}` in the trap.
