### PR TITLE
chore: ignore local demo/build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 swarm/issues.csv
 swarm/.local/
 .adl/cards/
+
+# Local demo/build artifacts (do not commit)
+out/
+target/
+issue-*.sh


### PR DESCRIPTION
Ignore out/, target/, and issue-*.sh to prevent git thrash.