### PR TITLE
spec: clarify version-gating semantics and failure modes

### DIFF
--- a/adl-spec/ADL_v0.2_Schema_Extensions.md
+++ b/adl-spec/ADL_v0.2_Schema_Extensions.md
@@ -33,10 +33,29 @@ reference runtime implements these features.
 `version` remains required at the top level.
 
 - v0.2 documents **MUST** declare `version: "0.2"`.
+- Runtimes **MUST** reject documents with unsupported versions (e.g., `0.3`).
 - `run.id` is the stable run identifier (preferred); `run.name` MAY be used as a human-friendly label.
 - Runtimes **MUST** reject newer versions they do not support.
 - Runtimes **MAY** provide a “best-effort” validation mode, but **strict mode** is required
   by default for user-facing runs.
+
+#### Version gating policy (runtime)
+
+Some features may be present in the schema but gated in the runtime until a future version.
+When a gated feature is used, the runtime **MUST** fail fast with a deterministic error.
+
+Required error content:
+
+- feature name (e.g., `concurrency`)
+- required minimum version (e.g., `requires v0.3`)
+- document version (e.g., `document version is 0.2`)
+- location hint when feasible (e.g., `run.workflow.kind=concurrent`)
+
+Example (concurrency gate):
+
+```
+feature 'concurrency' requires v0.3; document version is 0.2 (run.workflow.kind=concurrent)
+```
 
 ### 3.2 Workflow and steps
 
@@ -176,6 +195,7 @@ To preserve ADL’s deterministic core, v0.2 enforces the following constraints:
 
 - v0.1 runtimes **MUST** reject v0.2 docs with a clear version error.
 - v0.2 runtimes **MUST** reject v0.3+ docs unless explicitly supported.
+- Concurrency / parallel execution remains gated to v0.3 and must emit the standard gate error.
 
 ---
 

--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -143,10 +143,11 @@ pub fn execute_sequential(
         resolved.doc.run.workflow.kind,
         crate::adl::WorkflowKind::Sequential
     ) {
+        let doc_version = resolved.doc.version.trim();
         tr.run_failed("concurrent workflows are not supported in v0.1");
         return Err(anyhow!(
-            "v0.1 does not support concurrent workflows. Use a single workflow with sequential steps, \
-or upgrade once concurrency lands (planned v0.3)."
+            "feature 'concurrency' requires v0.3; document version is {doc_version} \
+(run.workflow.kind=concurrent)"
         ));
     }
 

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -301,24 +301,82 @@ run:
         String::from_utf8_lossy(&out.stderr)
     );
 
-    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("concurrent"),
-        "stderr should mention concurrent workflows; stderr was:\n{stderr}"
+        stderr.contains("concurrency"),
+        "stderr should mention concurrency; stderr was:\n{stderr}"
     );
     assert!(
-        stderr.contains("does not support")
-            || stderr.contains("not supported")
-            || stderr.contains("not implemented"),
-        "stderr should explain concurrency is unsupported in v0.1; stderr was:\n{stderr}"
+        stderr.contains("requires v0.3"),
+        "stderr should mention required version; stderr was:\n{stderr}"
     );
     assert!(
-        stderr.contains("sequential") || stderr.contains("single workflow"),
-        "stderr should suggest sequential/single workflow; stderr was:\n{stderr}"
+        stderr.contains("document version is 0.1"),
+        "stderr should include document version; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn run_rejects_concurrent_workflows_in_v0_2() {
+    let base = tmp_dir("exec-reject-concurrent-v0-2");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let yaml = r#"
+version: "0.2"
+
+providers:
+  local:
+    type: "ollama"
+    config:
+      model: "phi4-mini"
+
+agents:
+  a1:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t1:
+    prompt:
+      user: "Summarize: {{text}}"
+
+run:
+  name: "reject-concurrent-v0-2"
+  workflow:
+    kind: "concurrent"
+    steps:
+      - id: "s1"
+        agent: "a1"
+        task: "t1"
+        inputs:
+          text: "hello"
+"#;
+
+    let tmp_yaml = base.join("concurrent-v0-2.yaml");
+    fs::write(&tmp_yaml, yaml.as_bytes()).unwrap();
+
+    let out = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
+    assert!(
+        !out.status.success(),
+        "expected failure for concurrent workflow, got success.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("concurrency"),
+        "stderr should mention concurrency; stderr was:\n{stderr}"
     );
     assert!(
-        stderr.contains("upgrade") || stderr.contains("v0.3"),
-        "stderr should mention upgrading for concurrency; stderr was:\n{stderr}"
+        stderr.contains("requires v0.3"),
+        "stderr should mention required version; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("document version is 0.2"),
+        "stderr should include document version; stderr was:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
Closes #14

Local artifacts (not committed):
- Input card:  .adl/cards/issue-0014__input__v0.2.md
- Output card: .adl/cards/issue-0014__output__v0.2.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
