### PR TITLE
swarm: v0.2 demo UX — single happy-path command (no flags)

### DIFF
--- a/swarm/RELEASE_CHECKLIST_v0.2.md
+++ b/swarm/RELEASE_CHECKLIST_v0.2.md
@@ -28,7 +28,7 @@
 Recommended demo run:
 ```
 # If supported by current CLI:
-cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace --out ./out --quiet --open
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml
 ```
 
 ## 4) Documentation consistency

--- a/swarm/examples/README.md
+++ b/swarm/examples/README.md
@@ -17,8 +17,7 @@ Expected: two steps execute in order and print outputs for each step.
 Coordinator demo (writes HTML artifact):
 
 ```bash
-cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace --out ./out --quiet --open
-open ./out/index.html
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml
 ```
 
 ## v0.2 failure-mode examples

--- a/swarm/examples/v0-2-coordinator-agents-sdk.md
+++ b/swarm/examples/v0-2-coordinator-agents-sdk.md
@@ -24,8 +24,7 @@ but expressed declaratively in ADL:
 From `swarm/`:
 
 ```bash
-cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace --out ./out --quiet --open
-open ./out/index.html
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml
 ```
 
 ## Note on artifact wiring


### PR DESCRIPTION
Closes #71

Local artifacts (not committed):
- Input card:  .adl/cards/issue-0071__input__v0.2.md
- Output card: .adl/cards/issue-0071__output__v0.2.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
