### PR TITLE
swarm: trace UX — human-readable timestamps and per-step durations

### DIFF
--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -166,6 +166,9 @@ fn real_main() -> Result<()> {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
+                if resolved.doc.version.trim() == "0.2" {
+                    tr.run_finished(false);
+                }
                 if do_trace {
                     trace::print_trace(&tr);
                 }
@@ -186,6 +189,9 @@ fn real_main() -> Result<()> {
         }
 
         if do_trace {
+            if resolved.doc.version.trim() == "0.2" {
+                tr.run_finished(true);
+            }
             trace::print_trace(&tr);
         }
 
@@ -225,6 +231,10 @@ fn real_main() -> Result<()> {
             }
 
             tr.step_finished(step_id, true);
+        }
+
+        if resolved.doc.version.trim() == "0.2" {
+            tr.run_finished(true);
         }
 
         trace::print_trace(&tr);

--- a/swarm/tests/trace_tests.rs
+++ b/swarm/tests/trace_tests.rs
@@ -162,3 +162,66 @@ run:
         stdout
     );
 }
+
+#[test]
+fn cli_trace_v0_2_includes_human_timestamps_and_durations() {
+    let exe = env!("CARGO_BIN_EXE_swarm");
+
+    let yaml = r#"version: "0.2"
+providers: {}
+tools: {}
+agents: {}
+tasks:
+  t1:
+    prompt:
+      user: "Hello {{name}}"
+run:
+  name: "trace-v0-2"
+  workflow:
+    kind: sequential
+    steps:
+      - id: "s1"
+        task: "t1"
+        inputs:
+          name: "world"
+"#;
+
+    let mut path = std::env::temp_dir();
+    let unique = format!(
+        "adl-trace-v0-2-{}-{}.yaml",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    path.push(unique);
+
+    std::fs::write(&path, yaml).expect("failed to write temp adl yaml");
+
+    let out = Command::new(exe)
+        .arg(path.to_string_lossy().as_ref())
+        .arg("--trace")
+        .output()
+        .expect("failed to run swarm binary");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        out.status.success(),
+        "expected success, got {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("version=0.2")
+            && stdout.contains("ts=")
+            && stdout.contains("elapsed_ms=")
+            && stdout.contains("elapsed=")
+            && stdout.contains("RunFinished"),
+        "expected v0.2 trace enhancements, stdout was:\n{}",
+        stdout
+    );
+}


### PR DESCRIPTION
Closes #70

Local artifacts (not committed):
- Input card:  .adl/cards/issue-0070__input__v0.2.md
- Output card: .adl/cards/issue-0070__output__v0.2.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
