### PR TITLE
docs: write v0.2 release notes (what shipped / what deferred)

### DIFF
--- a/swarm/README.md
+++ b/swarm/README.md
@@ -14,6 +14,8 @@ agent workflows with deterministic resolution and clear failure modes.
 
 `swarm` is a small, conservative reference runtime for **Agent Design Language (ADL)**.
 
+For the v0.2 summary and demo commands, see `RELEASE_NOTES_v0.2.md`.
+
 It is intentionally *compiler-like* in how it processes ADL documents:
 
 1. **Parse** an ADL YAML document into a typed in-memory model.

--- a/swarm/RELEASE_NOTES_v0.2.md
+++ b/swarm/RELEASE_NOTES_v0.2.md
@@ -1,0 +1,48 @@
+# Release Notes: ADL v0.2
+
+ADL v0.2 expands the reference runtime and examples while preserving the deterministic execution model from v0.1.
+
+## What shipped
+
+- Multi-step v0.2 example suite in `examples/v0-2-multi-step-basic.adl.yaml`, `examples/v0-2-multi-step-file-input.adl.yaml`, and `examples/v0-2-coordinator-agents-sdk.adl.yaml`.
+- Failure-mode examples with deterministic, testable errors in `examples/v0-2-failure-unknown-field.adl.yaml` and `examples/v0-2-failure-unknown-state-ref.adl.yaml`.
+- Stricter validation and clearer failure behavior for invalid schemas and unresolved inputs.
+- Trace UX improvements for v0.2 runs (human-readable timestamp/duration fields in trace output).
+- Provider safety improvements, including bounded subprocess behavior and timeout validation.
+
+## What is deferred to v0.3+
+
+- Concurrency primitives and parallel workflow execution.
+- DAG scheduling and dynamic branching semantics.
+- Streaming/tool execution semantics beyond current v0.2 scope.
+
+## Flagship demo (copy/paste)
+
+Run from the `swarm/` directory.
+
+Inspect the coordinator plan (no provider call required):
+
+```bash
+cargo run --example coordinator -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan
+```
+
+Run the coordinator workflow (requires local Ollama provider setup):
+
+```bash
+cargo run --example coordinator -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace
+```
+
+If local provider setup is not ready yet, use the plan command above as the recommended quickstart and track demo UX polish in the following issues:
+- https://github.com/danielbaustin/agent-design-language/issues/60
+- https://github.com/danielbaustin/agent-design-language/issues/71
+
+## More examples
+
+- Examples index: `examples/README.md`
+- Coordinator walkthrough: `examples/v0-2-coordinator-agents-sdk.md`
+
+## Key docs
+
+- v0.2 schema extensions: `../adl-spec/ADL_v0.2_Schema_Extensions.md`
+- ADL spec index: `../adl-spec/spec/README.md`
+- Provider implementation reference: `src/provider.rs`


### PR DESCRIPTION
Closes #38

Local artifacts (not committed):
- Input card:  .adl/cards/issue-0038__input__v0.2.md
- Output card: .adl/cards/issue-0038__output__v0.2.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
