### PR TITLE
[v0.3] Demo A: remote planner guiding local execution (say MCP)

### DIFF
--- a/swarm/examples/README.md
+++ b/swarm/examples/README.md
@@ -20,6 +20,23 @@ Coordinator demo (writes HTML artifact):
 cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml
 ```
 
+## v0.3 flagship demo
+
+Run the deterministic artifact demo (single command):
+
+```bash
+cargo run -- demo demo-a-say-mcp --run --trace --open
+```
+
+Artifacts are written to:
+
+```bash
+out/demo-a-say-mcp/
+```
+
+Reference ADL doc for the demo scenario:
+- `v0-3-demo-a-say-mcp.adl.yaml`
+
 ## v0.2 failure-mode examples
 
 - `v0-2-failure-unknown-field.adl.yaml`

--- a/swarm/examples/v0-3-demo-a-say-mcp.adl.yaml
+++ b/swarm/examples/v0-3-demo-a-say-mcp.adl.yaml
@@ -1,0 +1,66 @@
+version: "0.3"
+
+providers:
+  local_ollama:
+    type: "ollama"
+    base_url: "http://localhost:11434"
+    default_model: "gemma3:latest"
+
+agents:
+  coordinator:
+    provider: "local_ollama"
+    model: "gemma3:latest"
+    prompt:
+      system: "You coordinate deterministic artifact generation for a local engineering workflow."
+
+tasks:
+  brief:
+    prompt:
+      user: |
+        Write a short design.md for an MCP server wrapping macOS say safely.
+  scaffold:
+    prompt:
+      user: |
+        Produce Rust module and tests for a demo MCP say tool with input validation.
+  coverage:
+    prompt:
+      user: |
+        Produce a short coverage report showing pragmatic ~80% line coverage.
+  game:
+    prompt:
+      user: |
+        Produce a single-file Rock Paper Scissors HTML game.
+
+run:
+  name: "demo-a-say-mcp"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "brief"
+        agent: "coordinator"
+        task: "brief"
+        inputs:
+          objective: "MCP say server design"
+        save_as: "design_doc"
+        write_to: "design.md"
+      - id: "scaffold"
+        agent: "coordinator"
+        task: "scaffold"
+        inputs:
+          language: "rust"
+        save_as: "server_code"
+        write_to: "src/lib.rs"
+      - id: "coverage"
+        agent: "coordinator"
+        task: "coverage"
+        inputs:
+          target: "80%"
+        save_as: "coverage_report"
+        write_to: "coverage.txt"
+      - id: "game"
+        agent: "coordinator"
+        task: "game"
+        inputs:
+          title: "Rock Paper Scissors"
+        save_as: "game_html"
+        write_to: "index.html"

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod adl;
+pub mod demo;
 pub mod execute;
 pub mod prompt;
 pub mod provider;

--- a/swarm/tests/demo_tests.rs
+++ b/swarm/tests/demo_tests.rs
@@ -1,0 +1,79 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn run_swarm(args: &[&str]) -> std::process::Output {
+    let exe = env!("CARGO_BIN_EXE_swarm");
+    Command::new(exe).args(args).output().unwrap()
+}
+
+fn tmp_dir(prefix: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("swarm-{prefix}-{nanos}"));
+    fs::create_dir_all(&p).unwrap();
+    p
+}
+
+#[test]
+fn demo_print_plan_works() {
+    let out = run_swarm(&["demo", "demo-a-say-mcp", "--print-plan"]);
+    assert!(
+        out.status.success(),
+        "expected success, stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Demo: demo-a-say-mcp"), "stdout:\n{stdout}");
+    assert!(stdout.contains("Steps: 4"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn demo_run_writes_required_artifacts() {
+    let out_root = tmp_dir("demo-run");
+    let out = run_swarm(&[
+        "demo",
+        "demo-a-say-mcp",
+        "--run",
+        "--trace",
+        "--out",
+        out_root.to_string_lossy().as_ref(),
+    ]);
+    assert!(
+        out.status.success(),
+        "expected success, stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let run_out = out_root.join("demo-a-say-mcp");
+    assert!(run_out.join("design.md").is_file());
+    assert!(run_out.join("src/lib.rs").is_file());
+    assert!(run_out.join("src/main.rs").is_file());
+    assert!(run_out.join("tests/say_server_tests.rs").is_file());
+    assert!(run_out.join("coverage.txt").is_file());
+    assert!(run_out.join("index.html").is_file());
+    assert!(run_out.join("trace.jsonl").is_file());
+
+    let trace = fs::read_to_string(run_out.join("trace.jsonl")).unwrap();
+    assert!(
+        trace.contains("TRACE run_id=demo-a-say-mcp"),
+        "trace:\n{trace}"
+    );
+    assert!(trace.contains("RunFinished"), "trace:\n{trace}");
+}
+
+#[test]
+fn demo_unknown_name_exits_with_code_2() {
+    let out = run_swarm(&["demo", "nope", "--run"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit 2, got {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
Closes #102

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/issue-0102__input__v0.3.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/issue-0102__output__v0.3.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
