### PR TITLE
remove-or-integrate-hash-prompt

### DIFF
--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -201,7 +201,7 @@ pub fn execute_sequential(
 
             // Assemble a single text blob suitable for basic model consumption.
             let prompt_text = prompt::trace_prompt_assembly(&p, &inputs);
-            let prompt_hash = prompt::hash_string(&prompt_text);
+            let prompt_hash = prompt::hash_prompt(&prompt_text);
             tr.prompt_assembled(&step_id, &prompt_hash);
 
             // Build provider from doc.providers[provider_id]

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -235,7 +235,7 @@ fn real_main() -> Result<()> {
                     .collect();
 
                 let prompt_text = prompt::trace_prompt_assembly(&p, &inputs);
-                let hash = prompt::hash_string(&prompt_text);
+                let hash = prompt::hash_prompt(&prompt_text);
                 tr.prompt_assembled(step_id, &hash);
             }
 

--- a/swarm/src/prompt.rs
+++ b/swarm/src/prompt.rs
@@ -5,10 +5,10 @@ use std::hash::{Hash, Hasher};
 use crate::adl::PromptSpec;
 use crate::resolve::AdlResolved;
 
-/// Hash an arbitrary string (used for tracing rendered prompt text).
-pub fn hash_string(s: &str) -> String {
+/// Hash rendered prompt text for trace events.
+pub fn hash_prompt(prompt_text: &str) -> String {
     let mut h = DefaultHasher::new();
-    s.hash(&mut h);
+    prompt_text.hash(&mut h);
     format!("{:016x}", h.finish())
 }
 
@@ -90,16 +90,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn hash_string_is_deterministic() {
-        let a = hash_string("hello world");
-        let b = hash_string("hello world");
+    fn hash_prompt_is_deterministic() {
+        let a = hash_prompt("hello world");
+        let b = hash_prompt("hello world");
         assert_eq!(a, b);
     }
 
     #[test]
-    fn hash_string_changes_with_input() {
-        let a = hash_string("hello world");
-        let b = hash_string("hello world!");
+    fn hash_prompt_changes_with_input() {
+        let a = hash_prompt("hello world");
+        let b = hash_prompt("hello world!");
         assert_ne!(a, b);
     }
 


### PR DESCRIPTION
Closes #98

Local artifacts (not committed):
- Input card:  .adl/cards/issue-0098__input__v0.3.md
- Output card: .adl/cards/issue-0098__output__v0.3.md

## ADL Workflow
- Implemented from the paired ADL input/output card flow.
- Scope kept minimal and issue-specific.

## Validation
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
