### PR TITLE
dedupe-plan-printing

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod adl;
 pub mod demo;
 pub mod execute;
+pub mod plan;
 pub mod prompt;
 pub mod provider;
 pub mod resolve;

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
-use swarm::{adl, demo, execute, prompt, resolve, trace};
+use swarm::{adl, demo, execute, plan, prompt, resolve, trace};
 
 fn usage() -> &'static str {
     "Usage:
@@ -321,14 +321,20 @@ fn real_demo(args: &[String]) -> Result<()> {
     }
 
     if print_plan {
-        println!("Demo: {demo_name}");
-        println!("Run ID: {demo_name}");
-        println!("Workflow: demo-workflow");
         let steps = demo::plan_steps(demo_name);
-        println!("Steps: {}", steps.len());
-        for (idx, step) in steps.iter().enumerate() {
-            println!("  {idx}. {step}");
-        }
+        println!("Demo: {demo_name}");
+        plan::print_plan(
+            plan::PlanHeaders {
+                run: "Run ID:",
+                workflow: "Workflow:",
+                steps: "Steps:",
+            },
+            demo_name,
+            "demo-workflow",
+            steps.len(),
+            steps.iter(),
+            |step| step.to_string(),
+        );
     }
 
     if do_run {

--- a/swarm/src/plan.rs
+++ b/swarm/src/plan.rs
@@ -1,0 +1,25 @@
+pub struct PlanHeaders<'a> {
+    pub run: &'a str,
+    pub workflow: &'a str,
+    pub steps: &'a str,
+}
+
+pub fn print_plan<I, F>(
+    headers: PlanHeaders<'_>,
+    run_id: &str,
+    workflow_id: &str,
+    step_count: usize,
+    steps: I,
+    mut format_step: F,
+) where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> String,
+{
+    println!("{} {}", headers.run, run_id);
+    println!("{} {}", headers.workflow, workflow_id);
+    println!("{} {}", headers.steps, step_count);
+
+    for (idx, step) in steps.into_iter().enumerate() {
+        println!("  {idx}. {}", format_step(step));
+    }
+}

--- a/swarm/src/resolve.rs
+++ b/swarm/src/resolve.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 
 use crate::adl;
+use crate::plan;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AdlVersion {
@@ -148,20 +149,23 @@ pub fn resolve_run(doc: &adl::AdlDoc) -> Result<AdlResolved> {
 
 /// Used by the CLI `--print-plan` path; kept separate from execution for clarity.
 pub fn print_resolved_plan(resolved: &AdlResolved) {
-    println!("Resolved run: {}", resolved.run_id);
-    println!("Workflow:     {}", resolved.workflow_id);
-    println!("Steps:        {}", resolved.steps.len());
-
-    for (idx, step) in resolved.steps.iter().enumerate() {
-        let agent = step.agent.as_deref().unwrap_or("<unresolved-agent>");
-        let provider = step.provider.as_deref().unwrap_or("<unresolved-provider>");
-        let task = step.task.as_deref().unwrap_or("<unresolved-task>");
-
-        println!(
-            "  {idx}. {}  agent={agent} provider={provider} task={task}",
-            step.id
-        );
-    }
+    plan::print_plan(
+        plan::PlanHeaders {
+            run: "Resolved run:",
+            workflow: "Workflow:    ",
+            steps: "Steps:       ",
+        },
+        &resolved.run_id,
+        &resolved.workflow_id,
+        resolved.steps.len(),
+        resolved.steps.iter(),
+        |step| {
+            let agent = step.agent.as_deref().unwrap_or("<unresolved-agent>");
+            let provider = step.provider.as_deref().unwrap_or("<unresolved-provider>");
+            let task = step.task.as_deref().unwrap_or("<unresolved-task>");
+            format!("{}  agent={agent} provider={provider} task={task}", step.id)
+        },
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #97

Local artifacts (not committed):
- Input card:  .adl/cards/issue-0097__input__v0.3.md
- Output card: .adl/cards/issue-0097__output__v0.3.md

## ADL Workflow
- Implemented from the paired ADL input/output card flow.
- Scope kept minimal and issue-specific.

## Validation
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
