### PR TITLE
tools: new card layout .adl/cards/<issue>/{input,output}_<issue>.md (legacy supported)

### DIFF
--- a/swarm/CODEX_PLAYBOOK.md
+++ b/swarm/CODEX_PLAYBOOK.md
@@ -27,8 +27,8 @@ swarm/tools/pr.sh start <issue>
 swarm/tools/pr.sh cards <issue>
 # do the work + tests
 swarm/tools/pr.sh finish <issue> --title "swarm: <short description>" \
-  -f .adl/cards/issue-####__input__v0.2.md \
-  --output-card .adl/cards/issue-####__output__v0.2.md
+  -f .adl/cards/####/input_####.md \
+  --output-card .adl/cards/####/output_####.md
 ```
 
 Recovery (common pitfalls):

--- a/swarm/CONTRIBUTING.md
+++ b/swarm/CONTRIBUTING.md
@@ -74,8 +74,8 @@ swarm/tools/pr.sh start <issue>
 swarm/tools/pr.sh cards <issue>
 # do the work + tests
 swarm/tools/pr.sh finish <issue> --title "swarm: <short description>" \
-  -f .adl/cards/issue-####__input__v0.2.md \
-  --output-card .adl/cards/issue-####__output__v0.2.md
+  -f .adl/cards/####/input_####.md \
+  --output-card .adl/cards/####/output_####.md
 ```
 
 ## Recovery (common pitfalls)

--- a/swarm/tools/card_paths.sh
+++ b/swarm/tools/card_paths.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+card_issue_pad() {
+  printf '%04d' "$1"
+}
+
+card_dir_path() {
+  local issue="$1"
+  local pad
+  pad="$(card_issue_pad "$issue")"
+  echo ".adl/cards/${pad}"
+}
+
+card_input_path() {
+  local issue="$1"
+  local pad
+  pad="$(card_issue_pad "$issue")"
+  echo ".adl/cards/${pad}/input_${pad}.md"
+}
+
+card_output_path() {
+  local issue="$1"
+  local pad
+  pad="$(card_issue_pad "$issue")"
+  echo ".adl/cards/${pad}/output_${pad}.md"
+}
+
+card_legacy_input_path() {
+  local issue="$1" ver="${2:-v0.2}"
+  local pad
+  pad="$(card_issue_pad "$issue")"
+  echo ".adl/cards/issue-${pad}__input__${ver}.md"
+}
+
+card_legacy_output_path() {
+  local issue="$1" ver="${2:-v0.2}"
+  local pad
+  pad="$(card_issue_pad "$issue")"
+  echo ".adl/cards/issue-${pad}__output__${ver}.md"
+}
+
+resolve_input_card_path() {
+  local issue="$1" ver="${2:-v0.2}"
+  local p_new p_old p_any
+  p_new="$(card_input_path "$issue")"
+  p_old="$(card_legacy_input_path "$issue" "$ver")"
+  if [[ -f "$p_new" ]]; then
+    echo "$p_new"
+    return 0
+  fi
+  if [[ -f "$p_old" ]]; then
+    echo "$p_old"
+    return 0
+  fi
+  p_any="$(ls -1 .adl/cards/issue-$(card_issue_pad "$issue")__input__v*.md 2>/dev/null | head -n1 || true)"
+  if [[ -n "$p_any" ]]; then
+    echo "$p_any"
+    return 0
+  fi
+  echo "$p_new"
+}
+
+resolve_output_card_path() {
+  local issue="$1" ver="${2:-v0.2}"
+  local p_new p_old p_any
+  p_new="$(card_output_path "$issue")"
+  p_old="$(card_legacy_output_path "$issue" "$ver")"
+  if [[ -f "$p_new" ]]; then
+    echo "$p_new"
+    return 0
+  fi
+  if [[ -f "$p_old" ]]; then
+    echo "$p_old"
+    return 0
+  fi
+  p_any="$(ls -1 .adl/cards/issue-$(card_issue_pad "$issue")__output__v*.md 2>/dev/null | head -n1 || true)"
+  if [[ -n "$p_any" ]]; then
+    echo "$p_any"
+    return 0
+  fi
+  echo "$p_new"
+}


### PR DESCRIPTION
Closes #123

Local artifacts (not committed):
- Input card:  .adl/cards/issue-0123__input__v0.3.md
- Output card: .adl/cards/issue-0123__output__v0.3.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
