### PR TITLE
reject-unknown-yaml-fields-key-specs

### DIFF
--- a/swarm/src/adl.rs
+++ b/swarm/src/adl.rs
@@ -131,6 +131,7 @@ pub struct ProviderSpec {
 
 /// Tool spec (eventually maps to MCP tools, local tools, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct ToolSpec {
     /// Tool type (e.g. "mcp", "http", "local").
     #[serde(rename = "type")]
@@ -197,6 +198,7 @@ where
 
 /// Task spec.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct TaskSpec {
     #[serde(default)]
     pub description: Option<String>,
@@ -207,6 +209,7 @@ pub struct TaskSpec {
 
 /// Prompt specification: structured fields that will be assembled into a final prompt.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct PromptSpec {
     #[serde(default)]
     pub system: Option<String>,
@@ -228,6 +231,7 @@ pub struct PromptSpec {
 
 /// Run spec: what to execute.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct RunSpec {
     #[serde(default)]
     pub name: Option<String>,
@@ -243,6 +247,7 @@ pub struct RunSpec {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct RunDefaults {
     /// Default system string applied if prompt has no system.
     #[serde(default)]
@@ -250,6 +255,7 @@ pub struct RunDefaults {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct WorkflowSpec {
     #[serde(default)]
     pub kind: WorkflowKind,
@@ -336,6 +342,7 @@ impl StepSpec {
 
 /// Guard directive (content normalization / output constraints, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct GuardSpec {
     #[serde(rename = "type")]
     pub kind: String,

--- a/swarm/src/schema.rs
+++ b/swarm/src/schema.rs
@@ -89,7 +89,13 @@ pub fn validate_adl_yaml(yaml_text: &str) -> Result<()> {
                     msgs.push("... (more schema errors omitted)".to_string());
                     break;
                 }
-                msgs.push(e.to_string());
+                let instance_path = e.instance_path.to_string();
+                let path = if instance_path.is_empty() {
+                    "/".to_string()
+                } else {
+                    instance_path
+                };
+                msgs.push(format!("at {path}: {e}"));
             }
 
             Err(anyhow!(


### PR DESCRIPTION
Closes #92

Local artifacts (not committed):
- Input card:  .adl/cards/0092/input_0092.md
- Output card: .adl/cards/0092/output_0092.md

## ADL Workflow
- Implemented from the paired ADL input/output card flow.
- Scope kept minimal and issue-specific.

## Validation
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
