### PR TITLE
[tools] pr.sh: canonical per-issue card layout (legacy compatibility)

### DIFF
--- a/swarm/tools/card_paths.sh
+++ b/swarm/tools/card_paths.sh
@@ -1,29 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+card_issue_normalize() {
+  local raw="$1"
+  if [[ ! "$raw" =~ ^[0-9]+$ ]]; then
+    echo "invalid issue number: $raw" >&2
+    return 1
+  fi
+  echo "$((10#$raw))"
+}
+
 card_issue_pad() {
-  printf '%04d' "$1"
+  local issue
+  issue="$(card_issue_normalize "$1")" || return 1
+  printf '%04d' "$issue"
 }
 
 card_dir_path() {
-  local issue="$1"
-  local pad
-  pad="$(card_issue_pad "$issue")"
-  echo ".adl/cards/${pad}"
+  local issue
+  issue="$(card_issue_normalize "$1")" || return 1
+  echo ".adl/cards/${issue}"
 }
 
 card_input_path() {
-  local issue="$1"
-  local pad
-  pad="$(card_issue_pad "$issue")"
-  echo ".adl/cards/${pad}/input_${pad}.md"
+  local issue
+  issue="$(card_issue_normalize "$1")" || return 1
+  echo ".adl/cards/${issue}/input_${issue}.md"
 }
 
 card_output_path() {
-  local issue="$1"
-  local pad
-  pad="$(card_issue_pad "$issue")"
-  echo ".adl/cards/${pad}/output_${pad}.md"
+  local issue
+  issue="$(card_issue_normalize "$1")" || return 1
+  echo ".adl/cards/${issue}/output_${issue}.md"
 }
 
 card_legacy_input_path() {
@@ -43,7 +51,7 @@ card_legacy_output_path() {
 resolve_input_card_path() {
   local issue="$1" ver="${2:-v0.2}"
   local p_new p_old p_any
-  p_new="$(card_input_path "$issue")"
+  p_new="$(card_input_path "$issue")" || return 1
   p_old="$(card_legacy_input_path "$issue" "$ver")"
   if [[ -f "$p_new" ]]; then
     echo "$p_new"
@@ -64,7 +72,7 @@ resolve_input_card_path() {
 resolve_output_card_path() {
   local issue="$1" ver="${2:-v0.2}"
   local p_new p_old p_any
-  p_new="$(card_output_path "$issue")"
+  p_new="$(card_output_path "$issue")" || return 1
   p_old="$(card_legacy_output_path "$issue" "$ver")"
   if [[ -f "$p_new" ]]; then
     echo "$p_new"
@@ -80,4 +88,35 @@ resolve_output_card_path() {
     return 0
   fi
   echo "$p_new"
+}
+
+sync_legacy_card_link() {
+  local canonical="$1" legacy="$2"
+  local legacy_dir
+  legacy_dir="$(dirname "$legacy")"
+  mkdir -p "$legacy_dir"
+
+  if [[ -L "$legacy" ]]; then
+    local current
+    current="$(readlink "$legacy" 2>/dev/null || true)"
+    if [[ "$current" == "$canonical" ]]; then
+      return 0
+    fi
+    rm -f "$legacy"
+  elif [[ -e "$legacy" ]]; then
+    echo "warning: legacy path exists and is not a symlink, leaving as-is: $legacy" >&2
+    return 0
+  fi
+
+  if ln -s "$canonical" "$legacy" 2>/dev/null; then
+    return 0
+  fi
+
+  # Best effort fallback for environments where symlink creation is unavailable.
+  if cp -f "$canonical" "$legacy" 2>/dev/null; then
+    echo "warning: symlink unavailable; copied legacy card: $legacy" >&2
+    return 0
+  fi
+
+  echo "warning: failed to create legacy compatibility at: $legacy" >&2
 }

--- a/swarm/tools/codex_pr.sh
+++ b/swarm/tools/codex_pr.sh
@@ -89,9 +89,9 @@ if [[ "$base" =~ ^issue-([0-9]+)__input__(v[0-9.]+)\.md$ ]]; then
   out_card="${CARD/__input__/__output__}"
 fi
 
-# New layout: .adl/cards/0102/input_0102.md
+# New layout: .adl/cards/102/input_102.md (or zero-padded variants)
 if [[ -z "$issue_padded" ]]; then
-  local_re='(^|/)([0-9]{4})/input_([0-9]{4})\.md$'
+  local_re='(^|/)([0-9]+)/input_([0-9]+)\.md$'
   if [[ "$CARD" =~ $local_re ]]; then
     if [[ "${BASH_REMATCH[2]}" != "${BASH_REMATCH[3]}" ]]; then
       die "Card path mismatch: directory issue ${BASH_REMATCH[2]} != filename issue ${BASH_REMATCH[3]}"
@@ -103,7 +103,7 @@ if [[ -z "$issue_padded" ]]; then
 fi
 
 if [[ -z "$issue_padded" ]]; then
-  die "Could not parse input card path: $CARD (expected .adl/cards/0102/input_0102.md or .adl/cards/issue-0102__input__v0.3.md)"
+  die "Could not parse input card path: $CARD (expected .adl/cards/102/input_102.md or .adl/cards/issue-0102__input__v0.3.md)"
 fi
 if [[ -z "$version" ]]; then
   version="v0.x"


### PR DESCRIPTION
Closes #129

Local artifacts (not committed):
- Input card:  .adl/cards/129/input_129.md
- Output card: .adl/cards/129/output_129.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
