### PR TITLE
cards-single-canonical-path-only

### DIFF
--- a/swarm/tools/card_paths.sh
+++ b/swarm/tools/card_paths.sh
@@ -48,44 +48,86 @@ card_legacy_output_path() {
   echo ".adl/cards/issue-${pad}__output__${ver}.md"
 }
 
+card_first_legacy_path() {
+  local kind="$1" issue="$2" ver="${3:-v0.2}"
+  local preferred pattern
+  local -a matches=()
+  local pad
+  pad="$(card_issue_pad "$issue")" || return 1
+
+  case "$kind" in
+    input)
+      preferred="$(card_legacy_input_path "$issue" "$ver")"
+      pattern=".adl/cards/issue-${pad}__input__v*.md"
+      ;;
+    output)
+      preferred="$(card_legacy_output_path "$issue" "$ver")"
+      pattern=".adl/cards/issue-${pad}__output__v*.md"
+      ;;
+    *)
+      echo "invalid card kind: $kind" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ -e "$preferred" || -L "$preferred" ]]; then
+    echo "$preferred"
+    return 0
+  fi
+
+  shopt -s nullglob
+  matches=($pattern)
+  shopt -u nullglob
+  if [[ ${#matches[@]} -gt 0 ]]; then
+    echo "${matches[0]}"
+    return 0
+  fi
+
+  return 1
+}
+
+next_backup_path() {
+  local original="$1"
+  local backup="${original}.bak"
+  local i=0
+  while [[ -e "$backup" || -L "$backup" ]]; do
+    i=$((i + 1))
+    backup="${original}.bak.${i}"
+  done
+  echo "$backup"
+}
+
+ensure_canonical_card_from_legacy() {
+  local canonical="$1" legacy="$2"
+
+  mkdir -p "$(dirname "$canonical")"
+
+  if [[ ! -e "$canonical" && ! -L "$canonical" && -f "$legacy" ]]; then
+    cp -f "$legacy" "$canonical"
+    echo "warning: seeded canonical card from legacy content: $canonical" >&2
+  fi
+
+  sync_legacy_card_link "$canonical" "$legacy"
+}
+
 resolve_input_card_path() {
   local issue="$1" ver="${2:-v0.2}"
-  local p_new p_old p_any
+  local p_new p_legacy
   p_new="$(card_input_path "$issue")" || return 1
-  p_old="$(card_legacy_input_path "$issue" "$ver")"
-  if [[ -f "$p_new" ]]; then
-    echo "$p_new"
-    return 0
-  fi
-  if [[ -f "$p_old" ]]; then
-    echo "$p_old"
-    return 0
-  fi
-  p_any="$(ls -1 .adl/cards/issue-$(card_issue_pad "$issue")__input__v*.md 2>/dev/null | head -n1 || true)"
-  if [[ -n "$p_any" ]]; then
-    echo "$p_any"
-    return 0
+  p_legacy="$(card_first_legacy_path input "$issue" "$ver" || true)"
+  if [[ -n "$p_legacy" ]]; then
+    ensure_canonical_card_from_legacy "$p_new" "$p_legacy"
   fi
   echo "$p_new"
 }
 
 resolve_output_card_path() {
   local issue="$1" ver="${2:-v0.2}"
-  local p_new p_old p_any
+  local p_new p_legacy
   p_new="$(card_output_path "$issue")" || return 1
-  p_old="$(card_legacy_output_path "$issue" "$ver")"
-  if [[ -f "$p_new" ]]; then
-    echo "$p_new"
-    return 0
-  fi
-  if [[ -f "$p_old" ]]; then
-    echo "$p_old"
-    return 0
-  fi
-  p_any="$(ls -1 .adl/cards/issue-$(card_issue_pad "$issue")__output__v*.md 2>/dev/null | head -n1 || true)"
-  if [[ -n "$p_any" ]]; then
-    echo "$p_any"
-    return 0
+  p_legacy="$(card_first_legacy_path output "$issue" "$ver" || true)"
+  if [[ -n "$p_legacy" ]]; then
+    ensure_canonical_card_from_legacy "$p_new" "$p_legacy"
   fi
   echo "$p_new"
 }
@@ -109,23 +151,13 @@ sync_legacy_card_link() {
     fi
     rm -f "$legacy"
   elif [[ -e "$legacy" ]]; then
-    local backup="${legacy}.bak"
-    local i=0
-    while [[ -e "$backup" ]]; do
-      i=$((i + 1))
-      backup="${legacy}.bak.${i}"
-    done
+    local backup
+    backup="$(next_backup_path "$legacy")"
     mv "$legacy" "$backup"
     echo "warning: moved existing legacy file to backup: $backup" >&2
   fi
 
   if ln -s "$target" "$legacy" 2>/dev/null; then
-    return 0
-  fi
-
-  # Best effort fallback for environments where symlink creation is unavailable.
-  if cp -f "$canonical" "$legacy" 2>/dev/null; then
-    echo "warning: symlink unavailable; copied legacy card: $legacy" >&2
     return 0
   fi
 

--- a/swarm/tools/codexw.sh
+++ b/swarm/tools/codexw.sh
@@ -250,7 +250,7 @@ run_legacy_mode() {
 }
 
 run_conveyor_mode() {
-  local issue input_card canonical_input canonical_output
+  local issue input_card canonical_input canonical_output card_version
   local output_pre_exists=0 output_pre_sha="" output_post_sha=""
   local codex_rc=0
   log_note() {
@@ -265,18 +265,20 @@ run_conveyor_mode() {
 
   if [[ -n "$ISSUE" ]]; then
     issue="$(card_issue_normalize "$ISSUE")"
-    input_card="$(card_input_path "$issue")"
+    card_version="v0.3"
   else
     [[ -n "$INPUT_CARD_ARG" ]] || die "Missing --issue or input card path"
     issue="$(issue_from_input_path "$INPUT_CARD_ARG")"
-    canonical_input="$(card_input_path "$issue")"
-    if [[ -f "$canonical_input" ]]; then
-      input_card="$canonical_input"
-    else
-      input_card="$INPUT_CARD_ARG"
+    if [[ -f "$INPUT_CARD_ARG" ]]; then
+      card_version="$(awk -F':' '/^Version:/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' "$INPUT_CARD_ARG" || true)"
     fi
   fi
 
+  if [[ -z "${card_version:-}" ]]; then
+    card_version="v0.3"
+  fi
+
+  input_card="$(resolve_input_card_path "$issue" "$card_version")"
   canonical_input="$(card_input_path "$issue")"
   canonical_output="$(card_output_path "$issue")"
 

--- a/swarm/tools/test_card_paths.sh
+++ b/swarm/tools/test_card_paths.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CARD_PATHS_LIB="$ROOT_DIR/swarm/tools/card_paths.sh"
+# shellcheck disable=SC1090
+source "$CARD_PATHS_LIB"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+cd "$tmpdir"
+
+assert_file() {
+  [[ -f "$1" ]] || { echo "assertion failed: expected file $1" >&2; exit 1; }
+}
+
+assert_symlink() {
+  [[ -L "$1" ]] || { echo "assertion failed: expected symlink $1" >&2; exit 1; }
+}
+
+assert_eq() {
+  [[ "$1" == "$2" ]] || { echo "assertion failed: expected '$1' == '$2'" >&2; exit 1; }
+}
+
+mkdir -p .adl/cards/143
+echo "canonical" > .adl/cards/143/input_143.md
+echo "legacy-a" > .adl/cards/issue-0143__input__v0.3.md
+sync_legacy_card_link ".adl/cards/143/input_143.md" ".adl/cards/issue-0143__input__v0.3.md"
+assert_file ".adl/cards/issue-0143__input__v0.3.md.bak"
+assert_symlink ".adl/cards/issue-0143__input__v0.3.md"
+assert_eq "$(readlink .adl/cards/issue-0143__input__v0.3.md)" "143/input_143.md"
+
+rm -f .adl/cards/issue-0143__input__v0.3.md
+echo "legacy-b" > .adl/cards/issue-0143__input__v0.3.md
+touch .adl/cards/issue-0143__input__v0.3.md.bak
+sync_legacy_card_link ".adl/cards/143/input_143.md" ".adl/cards/issue-0143__input__v0.3.md"
+assert_file ".adl/cards/issue-0143__input__v0.3.md.bak.1"
+assert_symlink ".adl/cards/issue-0143__input__v0.3.md"
+
+rm -rf .adl/cards
+mkdir -p .adl/cards
+echo "legacy-only" > .adl/cards/issue-0143__input__v0.3.md
+resolved_input="$(resolve_input_card_path 143 v0.3)"
+assert_eq "$resolved_input" ".adl/cards/143/input_143.md"
+assert_file "$resolved_input"
+assert_file ".adl/cards/issue-0143__input__v0.3.md.bak"
+assert_symlink ".adl/cards/issue-0143__input__v0.3.md"
+assert_eq "$(cat "$resolved_input")" "legacy-only"
+
+echo "ok"


### PR DESCRIPTION
Closes #143

Local artifacts (not committed):
- Input card:  .adl/cards/143/input_143.md
- Output card: .adl/cards/143/output_143.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
