### PR TITLE
tools: codex CLI overhaul (codexw uses --cd + positional prompt) + pr.sh finish sanity checks

### DIFF
--- a/swarm/tools/codexw.sh
+++ b/swarm/tools/codexw.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Re-exec under bash when invoked via sh or another non-bash shell.
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
 set -euo pipefail
 
 # codexw.sh — run Codex CLI as a disciplined ADL worker.
@@ -140,8 +144,8 @@ run_legacy_mode() {
   note "Running Codex (non-interactive)..."
   codex exec \
     --full-auto \
-    -C "$ROOT" \
-    --prompt "$PROMPT"$'\n'"$FENCE"
+    --cd "$ROOT" \
+    "$PROMPT"$'\n'"$FENCE"
 
   note "Applying patch (codex apply)..."
   codex apply
@@ -314,13 +318,13 @@ run_conveyor_mode() {
   if [[ "$MODE" == "full-auto" ]]; then
     codex exec \
       --full-auto \
-      -C "$(pwd)" \
-      --prompt "$prompt" 2>&1 | tee -a "$LOG_PATH"
+      --cd "$(pwd)" \
+      "$prompt" 2>&1 | tee -a "$LOG_PATH"
   else
     codex exec \
       --approval-mode "$MODE" \
-      -C "$(pwd)" \
-      --prompt "$prompt" 2>&1 | tee -a "$LOG_PATH"
+      --cd "$(pwd)" \
+      "$prompt" 2>&1 | tee -a "$LOG_PATH"
   fi
   codex_rc=${PIPESTATUS[0]}
 

--- a/swarm/tools/pr.sh
+++ b/swarm/tools/pr.sh
@@ -158,6 +158,16 @@ run_swarm_checks() {
   )
 }
 
+run_tooling_sanity_checks() {
+  local root
+  root="$(repo_root)"
+  note "Running tooling sanity checks (codex_pr/codexw)…"
+  bash -n "$root/swarm/tools/codex_pr.sh"
+  bash -n "$root/swarm/tools/codexw.sh"
+  bash "$root/swarm/tools/codex_pr.sh" --help >/dev/null
+  bash "$root/swarm/tools/codexw.sh" --help >/dev/null
+}
+
 gh_repo_flag() {
   local r="$1"
   if [[ -n "$r" ]]; then
@@ -904,6 +914,7 @@ cmd_finish() {
   fi
 
   if [[ "$no_checks" != "1" ]]; then
+    run_tooling_sanity_checks
     run_swarm_checks
   else
     note "Skipping checks (--no-checks)"


### PR DESCRIPTION
Closes #148

Local artifacts (not committed):
- Input card:  .adl/cards/148/input_148.md
- Output card: .adl/cards/148/output_148.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
