### PR TITLE
v0.2 burndown: #96

### DIFF
--- a/swarm/tests/fixtures/concurrent_v0_2.adl.yaml
+++ b/swarm/tests/fixtures/concurrent_v0_2.adl.yaml
@@ -1,0 +1,28 @@
+version: "0.2"
+
+providers:
+  local:
+    type: "ollama"
+    config:
+      model: "phi4-mini"
+
+agents:
+  a1:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t1:
+    prompt:
+      user: "Summarize: {{text}}"
+
+run:
+  name: "reject-concurrent-v0-2"
+  workflow:
+    kind: "concurrent"
+    steps:
+      - id: "s1"
+        agent: "a1"
+        task: "t1"
+        inputs:
+          text: "hello"


### PR DESCRIPTION
Closes #96

Local artifacts (not committed):
- Input card:  .adl/cards/96/input_96.md
- Output card: .adl/cards/96/output_96.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
