### PR TITLE
v0.2 burndown: #93 deterministic test temp dirs

### DIFF
--- a/swarm/src/demo.rs
+++ b/swarm/src/demo.rs
@@ -493,15 +493,15 @@ fn generate_rps_game_html() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_DIR_SEQ: AtomicU64 = AtomicU64::new(0);
 
     fn tmp_dir(prefix: &str) -> PathBuf {
-        let mut p = std::env::temp_dir();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        p.push(format!("swarm-{prefix}-{nanos}"));
+        let mut p = std::env::temp_dir().join("swarm-test-temp");
+        std::fs::create_dir_all(&p).unwrap();
+        let seq = TEMP_DIR_SEQ.fetch_add(1, Ordering::Relaxed);
+        p.push(format!("swarm-{prefix}-pid{}-n{seq}", std::process::id()));
         std::fs::create_dir_all(&p).unwrap();
         p
     }

--- a/swarm/tests/cli_smoke.rs
+++ b/swarm/tests/cli_smoke.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+mod helpers;
+use helpers::unique_test_temp_dir;
 
 fn fixture_path(rel: &str) -> PathBuf {
     // Robust: works regardless of where tests are run from.
@@ -12,12 +14,7 @@ fn write_temp_adl_yaml() -> PathBuf {
     let yaml_path = fixture_path("tests/fixtures/cli_smoke.adl.yaml");
     let yaml = fs::read_to_string(&yaml_path).expect("read cli_smoke.adl.yaml fixture");
 
-    let mut p = std::env::temp_dir();
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("adl-cli-smoke-{nonce}.yaml"));
+    let p = unique_test_temp_dir("cli-smoke").join("cli_smoke.adl.yaml");
 
     fs::write(&p, yaml).expect("write temp yaml");
     p

--- a/swarm/tests/demo_tests.rs
+++ b/swarm/tests/demo_tests.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+mod helpers;
+use helpers::unique_test_temp_dir;
 
 fn run_swarm(args: &[&str]) -> std::process::Output {
     let exe = env!("CARGO_BIN_EXE_swarm");
@@ -18,14 +20,7 @@ fn run_swarm_with_ci(args: &[&str]) -> std::process::Output {
 }
 
 fn tmp_dir(prefix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("swarm-{prefix}-{nanos}"));
-    fs::create_dir_all(&p).unwrap();
-    p
+    unique_test_temp_dir(prefix)
 }
 
 #[test]

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -5,17 +5,10 @@ use std::process::Command;
 use swarm::execute::materialize_inputs;
 
 mod helpers;
-use helpers::EnvVarGuard;
+use helpers::{unique_test_temp_dir, EnvVarGuard};
 
 fn tmp_dir(prefix: &str) -> std::path::PathBuf {
-    let mut p = std::env::temp_dir();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("swarm-{prefix}-{nanos}"));
-    fs::create_dir_all(&p).unwrap();
-    p
+    unique_test_temp_dir(prefix)
 }
 
 fn write_file(dir: &Path, rel: &str, contents: &[u8]) -> std::path::PathBuf {

--- a/swarm/tests/file_inputs.rs
+++ b/swarm/tests/file_inputs.rs
@@ -1,20 +1,14 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use swarm::execute::materialize_inputs;
 
+mod helpers;
+use helpers::unique_test_temp_dir;
+
 fn tmp_dir() -> std::path::PathBuf {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let p = std::env::temp_dir()
-        .join("swarm-file-input-tests")
-        .join(format!("{nonce}"));
-    fs::create_dir_all(&p).unwrap();
-    p
+    unique_test_temp_dir("file-inputs")
 }
 
 fn write_file(path: &Path, contents: &str) {

--- a/swarm/tests/trace_tests.rs
+++ b/swarm/tests/trace_tests.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+mod helpers;
+use helpers::unique_test_temp_dir;
+
 #[test]
 fn cli_trace_flag_prints_trace_header() {
     // This verifies end-to-end CLI wiring produces trace output.
@@ -22,16 +25,7 @@ run:
       - {}
 "#;
 
-    let mut path = std::env::temp_dir();
-    let unique = format!(
-        "adl-trace-test-{}-{}.yaml",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    path.push(unique);
+    let path = unique_test_temp_dir("trace-flag").join("trace.yaml");
 
     std::fs::write(&path, yaml).expect("failed to write temp adl yaml");
 
@@ -65,16 +59,7 @@ run:
 fn cli_trace_reports_run_failed_on_invalid_yaml() {
     let exe = env!("CARGO_BIN_EXE_swarm");
 
-    let mut path = std::env::temp_dir();
-    let unique = format!(
-        "adl-trace-invalid-{}-{}.yaml",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    path.push(unique);
+    let path = unique_test_temp_dir("trace-invalid-yaml").join("invalid.yaml");
 
     std::fs::write(&path, "version: [").expect("failed to write invalid yaml");
 
@@ -123,16 +108,7 @@ run:
           doc: "@file:does-not-exist.txt"
 "#;
 
-    let mut path = std::env::temp_dir();
-    let unique = format!(
-        "adl-trace-missing-file-{}-{}.yaml",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    path.push(unique);
+    let path = unique_test_temp_dir("trace-missing-file").join("missing-file.yaml");
 
     std::fs::write(&path, yaml).expect("failed to write temp adl yaml");
 
@@ -186,16 +162,7 @@ run:
           name: "world"
 "#;
 
-    let mut path = std::env::temp_dir();
-    let unique = format!(
-        "adl-trace-v0-2-{}-{}.yaml",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    path.push(unique);
+    let path = unique_test_temp_dir("trace-v0-2").join("trace-v0-2.yaml");
 
     std::fs::write(&path, yaml).expect("failed to write temp adl yaml");
 


### PR DESCRIPTION
Closes #93

Local artifacts (not committed):
- Input card:  .adl/cards/93/input_93.md
- Output card: .adl/cards/93/output_93.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
