### PR TITLE
tools: stabilize codex_pr CLI + batch safety (deterministic logs, remove codex apply)

### DIFF
--- a/swarm/tools/codexw.sh
+++ b/swarm/tools/codexw.sh
@@ -147,9 +147,6 @@ run_legacy_mode() {
     --cd "$ROOT" \
     "$PROMPT"$'\n'"$FENCE"
 
-  note "Applying patch (codex apply)..."
-  codex apply
-
   note "Running checks..."
   check_log="$(mktemp)"
   check_results=()
@@ -222,7 +219,6 @@ run_legacy_mode() {
       echo
       echo "## Actions taken"
       echo "- codex exec --full-auto"
-      echo "- codex apply"
       echo
       echo "## Validation"
       echo "- Tests / checks run:"
@@ -328,11 +324,6 @@ run_conveyor_mode() {
   fi
   codex_rc=${PIPESTATUS[0]}
 
-  if [[ $codex_rc -eq 0 ]]; then
-    log_note "Applying patch (codex apply)..."
-    codex apply 2>&1 | tee -a "$LOG_PATH"
-    codex_rc=${PIPESTATUS[0]}
-  fi
   set -e
 
   if [[ $codex_rc -ne 0 ]]; then


### PR DESCRIPTION
Closes #154

Local artifacts (not committed):
- Input card:  .adl/cards/154/input_154.md
- Output card: .adl/cards/154/output_154.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
