### PR TITLE
docs: fix invalid v0.2 release-notes command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: docs command check
+        run: bash tools/check_release_notes_commands.sh
+
       - name: test
         run: cargo test
 

--- a/swarm/RELEASE_NOTES_v0.2.md
+++ b/swarm/RELEASE_NOTES_v0.2.md
@@ -23,13 +23,13 @@ Run from the `swarm/` directory.
 Inspect the coordinator plan (no provider call required):
 
 ```bash
-cargo run --example coordinator -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan
 ```
 
 Run the coordinator workflow (requires local Ollama provider setup):
 
 ```bash
-cargo run --example coordinator -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace
 ```
 
 If local provider setup is not ready yet, use the plan command above as the recommended quickstart and track demo UX polish in the following issues:

--- a/swarm/tools/check_release_notes_commands.sh
+++ b/swarm/tools/check_release_notes_commands.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR/swarm"
+
+release_notes="RELEASE_NOTES_v0.2.md"
+invalid_cmd="cargo run --example coordinator -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan"
+quickstart_cmd="cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan"
+
+if grep -Fq "$invalid_cmd" "$release_notes"; then
+  echo "invalid command present in $release_notes: $invalid_cmd" >&2
+  exit 1
+fi
+
+if ! grep -Fq "$quickstart_cmd" "$release_notes"; then
+  echo "missing quickstart command in $release_notes: $quickstart_cmd" >&2
+  exit 1
+fi
+
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan >/dev/null
+
+echo "release-notes command check: ok"


### PR DESCRIPTION
Closes #86

Local artifacts (not committed):
- Input card:  .adl/cards/86/input_86.md
- Output card: .adl/cards/86/output_86.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
