### PR TITLE
prsh-offline-card-generation-no-fetch

### DIFF
--- a/swarm/tools/pr.sh
+++ b/swarm/tools/pr.sh
@@ -461,8 +461,6 @@ open_in_browser() {
 }
 
 cmd_card() {
-  require_cmd gh
-
   local issue="${1:-}"; shift || true
   [[ -n "$issue" ]] || die "card: missing <issue> number"
   issue="$(normalize_issue_or_die "$issue")"
@@ -488,6 +486,7 @@ cmd_card() {
 
   local title=""
   if [[ "$no_fetch_issue" != "1" ]]; then
+    require_cmd gh
     note "Fetching issue title via gh…"
     title="$(gh issue view "$issue" $(gh_repo_flag "$repo") --json title -q .title 2>/dev/null || true)"
   fi
@@ -505,7 +504,12 @@ cmd_card() {
   fi
 
   if [[ -z "$version" ]]; then
-    version="$(issue_version "$issue")"
+    if [[ "$no_fetch_issue" == "1" ]]; then
+      version="$DEFAULT_VERSION"
+    else
+      require_cmd gh
+      version="$(issue_version "$issue")"
+    fi
   fi
   if [[ -z "$out_path" ]]; then
     out_path="$(input_card_path "$issue")"
@@ -526,8 +530,6 @@ cmd_card() {
 }
 
 cmd_output() {
-  require_cmd gh
-
   local issue="${1:-}"; shift || true
   [[ -n "$issue" ]] || die "output: missing <issue> number"
   issue="$(normalize_issue_or_die "$issue")"
@@ -553,6 +555,7 @@ cmd_output() {
 
   local title=""
   if [[ "$no_fetch_issue" != "1" ]]; then
+    require_cmd gh
     note "Fetching issue title via gh…"
     title="$(gh issue view "$issue" $(gh_repo_flag "$repo") --json title -q .title 2>/dev/null || true)"
   fi
@@ -570,7 +573,12 @@ cmd_output() {
   fi
 
   if [[ -z "$version" ]]; then
-    version="$(issue_version "$issue")"
+    if [[ "$no_fetch_issue" == "1" ]]; then
+      version="$DEFAULT_VERSION"
+    else
+      require_cmd gh
+      version="$(issue_version "$issue")"
+    fi
   fi
   if [[ -z "$out_path" ]]; then
     out_path="$(output_card_path "$issue")"
@@ -591,8 +599,6 @@ cmd_output() {
 }
 
 cmd_cards() {
-  require_cmd gh
-
   local issue="${1:-}"; shift || true
   [[ -n "$issue" ]] || die "cards: missing <issue> number"
   issue="$(normalize_issue_or_die "$issue")"
@@ -613,6 +619,7 @@ cmd_cards() {
 
   local title=""
   if [[ "$no_fetch_issue" != "1" ]]; then
+    require_cmd gh
     note "Fetching issue title via gh…"
     title="$(gh issue view "$issue" $(gh_repo_flag "$repo") --json title -q .title 2>/dev/null || true)"
   fi
@@ -622,7 +629,12 @@ cmd_cards() {
   fi
 
   if [[ -z "$version" ]]; then
-    version="$(issue_version "$issue")"
+    if [[ "$no_fetch_issue" == "1" ]]; then
+      version="$DEFAULT_VERSION"
+    else
+      require_cmd gh
+      version="$(issue_version "$issue")"
+    fi
   fi
   [[ -n "$version" ]] || version="v0.2"
 

--- a/swarm/tools/test_pr_no_fetch_offline.sh
+++ b/swarm/tools/test_pr_no_fetch_offline.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/swarm/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/swarm/tools/card_paths.sh"
+INPUT_TPL_SRC="$ROOT_DIR/swarm/templates/cards/input_card_template.md"
+OUTPUT_TPL_SRC="$ROOT_DIR/swarm/templates/cards/output_card_template.md"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mkdir -p "$repo/swarm/tools" "$repo/swarm/templates/cards"
+cp "$PR_SH_SRC" "$repo/swarm/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/swarm/tools/card_paths.sh"
+cp "$INPUT_TPL_SRC" "$repo/swarm/templates/cards/input_card_template.md"
+cp "$OUTPUT_TPL_SRC" "$repo/swarm/templates/cards/output_card_template.md"
+chmod +x "$repo/swarm/tools/pr.sh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  git add -A
+  git commit -q -m "init"
+)
+
+no_gh_bin="$tmpdir/no-gh-bin"
+mkdir -p "$no_gh_bin"
+for cmd in awk cat cp cut dirname git grep head ln mkdir mktemp mv pwd readlink rm sed touch tr; do
+  cmd_path="$(command -v "$cmd")"
+  ln -s "$cmd_path" "$no_gh_bin/$cmd"
+done
+
+assert_file() {
+  [[ -f "$1" ]] || { echo "assertion failed: expected file $1" >&2; exit 1; }
+}
+
+assert_has() {
+  local pattern="$1" file="$2"
+  grep -Fq "$pattern" "$file" || {
+    echo "assertion failed: expected '$pattern' in $file" >&2
+    exit 1
+  }
+}
+
+(
+  cd "$repo"
+  PATH="$no_gh_bin" "$BASH_BIN" swarm/tools/pr.sh card 87 --no-fetch-issue --slug offline-title >/dev/null
+  PATH="$no_gh_bin" "$BASH_BIN" swarm/tools/pr.sh output 87 --no-fetch-issue --slug offline-title >/dev/null
+  PATH="$no_gh_bin" "$BASH_BIN" swarm/tools/pr.sh cards 88 --no-fetch-issue >/dev/null
+
+  assert_file ".adl/cards/87/input_87.md"
+  assert_file ".adl/cards/87/output_87.md"
+  assert_file ".adl/cards/88/input_88.md"
+  assert_file ".adl/cards/88/output_88.md"
+
+  assert_has "Title: offline-title" ".adl/cards/87/input_87.md"
+  assert_has "Title: offline-title" ".adl/cards/87/output_87.md"
+  assert_has "Title: issue-88" ".adl/cards/88/input_88.md"
+  assert_has "Title: issue-88" ".adl/cards/88/output_88.md"
+)
+
+echo "offline no-fetch pr.sh card generation: ok"


### PR DESCRIPTION
Closes #87

Local artifacts (not committed):
- Input card:  .adl/cards/87/input_87.md
- Output card: .adl/cards/87/output_87.md

## ADL Workflow
- Implemented from the paired ADL input/output card flow.
- Scope kept minimal and issue-specific.

## Validation
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
