### PR TITLE
swarm: v0.2 coordinator example demonstrates real file-based state handoff

### DIFF
--- a/swarm/examples/v0-2-coordinator-agents-sdk.adl.yaml
+++ b/swarm/examples/v0-2-coordinator-agents-sdk.adl.yaml
@@ -27,26 +27,19 @@ tasks:
   brief:
     prompt:
       user: |
+        BRIEF_STATE:
         Define a simple HTML game concept and constraints:
         - single HTML file
         - no external assets
-
-        Topic:
-        {{topic}}
+        Topic: {{topic}}
   design:
     prompt:
       user: |
-        Outline the gameplay and controls for the game.
-
-        Game concept:
-        {{brief}}
+        DESIGN_FROM_FILE={{brief}}
   implementation:
     prompt:
       user: |
-        Produce the full HTML file implementing the game.
-
-        Game design:
-        {{design}}
+        IMPLEMENTATION_FROM_FILE={{design}}
 
 run:
   name: "v0-2-coordinator-agents-sdk"
@@ -59,16 +52,18 @@ run:
         inputs:
           topic: "Simple HTML game demo."
         save_as: "brief"
+        write_to: "state/brief.txt"
       - id: "design"
         agent: "designer"
         task: "design"
         inputs:
-          brief: "{{brief}}"
+          brief: "@file:out/state/brief.txt"
         save_as: "design"
+        write_to: "state/design.txt"
       - id: "implementation"
         agent: "implementer"
         task: "implementation"
         inputs:
-          design: "{{design}}"
+          design: "@file:out/state/design.txt"
         save_as: "html"
         write_to: "index.html"

--- a/swarm/examples/v0-2-coordinator-agents-sdk.md
+++ b/swarm/examples/v0-2-coordinator-agents-sdk.md
@@ -5,7 +5,7 @@ but expressed declaratively in ADL:
 
 - A coordinator agent defines the brief and performs final review.
 - Specialist agents (researcher, analyst, writer) produce intermediate artifacts.
-- Artifacts are passed explicitly via named inputs and `save_as` fields.
+- Artifacts are passed explicitly via files (`write_to` + `@file:`) and named `save_as` fields.
 
 ## Mapping to the SDK demo
 
@@ -24,11 +24,12 @@ but expressed declaratively in ADL:
 From `swarm/`:
 
 ```bash
-cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --out examples/out --run
 ```
 
-## Note on artifact wiring
+## Artifact wiring
 
-The current runtime keeps handoffs explicit by listing inputs directly.
-`save_as` names the intended artifact for future wiring while preserving
-fully deterministic inputs today.
+This example uses real, deterministic file-based handoff:
+- `coordinator-brief` writes `examples/out/state/brief.txt`
+- `design` reads `@file:out/state/brief.txt` and writes `examples/out/state/design.txt`
+- `implementation` reads `@file:out/state/design.txt`


### PR DESCRIPTION
Closes #85

Local artifacts (not committed):
- Input card:  .adl/cards/85/input_85.md
- Output card: .adl/cards/85/output_85.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
