### PR TITLE
tools: bash-safety for codex_pr/codexw + finish sanity checks

### DIFF
--- a/swarm/tools/pr.sh
+++ b/swarm/tools/pr.sh
@@ -166,6 +166,8 @@ run_tooling_sanity_checks() {
   bash -n "$root/swarm/tools/codexw.sh"
   bash "$root/swarm/tools/codex_pr.sh" --help >/dev/null
   bash "$root/swarm/tools/codexw.sh" --help >/dev/null
+  sh "$root/swarm/tools/codex_pr.sh" --help >/dev/null
+  sh "$root/swarm/tools/codexw.sh" --help >/dev/null
 }
 
 gh_repo_flag() {


### PR DESCRIPTION
Closes #164

Local artifacts (not committed):
- Input card:  .adl/cards/164/input_164.md
- Output card: .adl/cards/164/output_164.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
