### PR TITLE
docs: add burst execution operator playbook using adl_pr_cycle

### DIFF
--- a/swarm/tools/BURST_PLAYBOOK.md
+++ b/swarm/tools/BURST_PLAYBOOK.md
@@ -1,0 +1,22 @@
+# Burst Execution Playbook (`adl_pr_cycle`)
+
+Use this playbook for sequential burst execution.
+
+## Sequence
+
+1. Generate a prioritized plan (max 8 issues).
+2. Create child issues with `./swarm/tools/pr.sh new --no-start`.
+3. Execute child issues one by one using `adl_pr_cycle` (`start -> codex -> finish -> report`).
+4. Merge only green PRs.
+5. Write a final summary under `.adl/reports/burst/<timestamp>/final_summary.md`.
+
+## Stop Conditions
+
+- Stop on first hard failure in `finish`.
+- Stop on policy violations.
+- Stop when a human decision is required (scope, risk, or conflict resolution).
+
+## Retry Policy
+
+- Retry transient failures up to 2 times.
+- Do not retry policy failures.

--- a/swarm/tools/README.md
+++ b/swarm/tools/README.md
@@ -9,6 +9,7 @@ Utility scripts for ADL workflow automation and PR hygiene.
 - `codex_pr.sh`: Wrapper that composes `pr.sh start`, Codex execution, and `pr.sh finish`.
 - `codexw.sh`: Codex runner wrapper used by `codex_pr.sh`.
 - `card_paths.sh`: Canonical card path helpers.
+- `BURST_PLAYBOOK.md`: Sequential burst operator guide using `adl_pr_cycle`.
 
 ## Codex.app Skills
 This section documents Codex.app skills used with ADL; skills live in Codex.app but are specified here for versioning.


### PR DESCRIPTION
Closes #174

Local artifacts (not committed):
- Input card:  .adl/cards/174/input_174.md
- Output card: .adl/cards/174/output_174.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
