### PR TITLE
docs: standardize burst final summary format

### DIFF
--- a/swarm/tools/BURST_FINAL_SUMMARY_TEMPLATE.md
+++ b/swarm/tools/BURST_FINAL_SUMMARY_TEMPLATE.md
@@ -1,0 +1,32 @@
+# Burst Final Summary Template
+
+Use this structure for `.adl/reports/burst/<timestamp>/final_summary.md`.
+
+## Run Metadata
+
+- Parent issue:
+- Burst timestamp:
+- Operator:
+- Mode: sequential
+
+## Created Issues
+
+- `#<issue>` `<title>`
+
+## Execution Order And Results
+
+1. `#<issue>` - `SUCCESS|FAILED|SKIPPED` - PR: `<url|n/a>` - notes
+
+## Halt Reason
+
+- `none` (all complete) or explicit first-failure/policy/human-decision reason.
+
+## Suggested Tags
+
+- `release-note:*`
+- `area:*`
+- `risk:*`
+
+## Next Action
+
+- Exactly one command.

--- a/swarm/tools/BURST_PLAYBOOK.md
+++ b/swarm/tools/BURST_PLAYBOOK.md
@@ -9,6 +9,7 @@ Use this playbook for sequential burst execution.
 3. Execute child issues one by one using `adl_pr_cycle` (`start -> codex -> finish -> report`).
 4. Merge only green PRs.
 5. Write a final summary under `.adl/reports/burst/<timestamp>/final_summary.md`.
+   Use `swarm/tools/BURST_FINAL_SUMMARY_TEMPLATE.md`.
 
 ## Stop Conditions
 


### PR DESCRIPTION
Closes #175

Local artifacts (not committed):
- Input card:  .adl/cards/175/input_175.md
- Output card: .adl/cards/175/output_175.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
