### PR TITLE
tools: enforce canonical .adl/cards layout and disable legacy links

### DIFF
--- a/swarm/tools/card_paths.sh
+++ b/swarm/tools/card_paths.sh
@@ -106,8 +106,6 @@ ensure_canonical_card_from_legacy() {
     cp -f "$legacy" "$canonical"
     echo "warning: seeded canonical card from legacy content: $canonical" >&2
   fi
-
-  sync_legacy_card_link "$canonical" "$legacy"
 }
 
 resolve_input_card_path() {

--- a/swarm/tools/pr.sh
+++ b/swarm/tools/pr.sh
@@ -318,18 +318,9 @@ resolve_output_card_path_abs() {
 }
 
 sync_legacy_links_for_issue() {
-  local issue="$1" ver="$2"
-  local canonical_input canonical_output
-  local legacy_input legacy_output
-  canonical_input="$(card_input_path "$issue")"
-  canonical_output="$(card_output_path "$issue")"
-  legacy_input="$(card_legacy_input_path "$issue" "$ver")"
-  legacy_output="$(card_legacy_output_path "$issue" "$ver")"
-  (
-    cd "$(repo_root)"
-    sync_legacy_card_link "$canonical_input" "$legacy_input"
-    sync_legacy_card_link "$canonical_output" "$legacy_output"
-  )
+  # Legacy compatibility links are intentionally disabled to keep cards
+  # canonicalized under .adl/cards/<issue>/ only.
+  :
 }
 
 render_template() {


### PR DESCRIPTION
Closes #183

Local artifacts (not committed):
- Input card:  .adl/cards/183/input_183.md
- Output card: .adl/cards/183/output_183.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
