### PR TITLE
ci: add tooling sanity parity checks for shell wrappers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,18 @@ jobs:
           workspaces: |
             swarm -> target
 
+      - name: tooling sanity (bash -n)
+        run: bash -n swarm/tools/*.sh
+        working-directory: .
+
+      - name: tooling sanity (codex_pr help)
+        run: sh swarm/tools/codex_pr.sh --help
+        working-directory: .
+
+      - name: tooling sanity (codexw help)
+        run: sh swarm/tools/codexw.sh --help
+        working-directory: .
+
       - name: fmt
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
Closes #185

Local artifacts (not committed):
- Input card:  .adl/cards/185/input_185.md
- Output card: .adl/cards/185/output_185.md

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
