### PR TITLE
[tools][cleanup] Eliminate duplicate root-level .adl/cards artifacts

### DIFF
--- a/swarm/tools/test_card_paths.sh
+++ b/swarm/tools/test_card_paths.sh
@@ -14,28 +14,9 @@ assert_file() {
   [[ -f "$1" ]] || { echo "assertion failed: expected file $1" >&2; exit 1; }
 }
 
-assert_symlink() {
-  [[ -L "$1" ]] || { echo "assertion failed: expected symlink $1" >&2; exit 1; }
-}
-
 assert_eq() {
   [[ "$1" == "$2" ]] || { echo "assertion failed: expected '$1' == '$2'" >&2; exit 1; }
 }
-
-mkdir -p .adl/cards/143
-echo "canonical" > .adl/cards/143/input_143.md
-echo "legacy-a" > .adl/cards/issue-0143__input__v0.3.md
-sync_legacy_card_link ".adl/cards/143/input_143.md" ".adl/cards/issue-0143__input__v0.3.md"
-assert_file ".adl/cards/issue-0143__input__v0.3.md.bak"
-assert_symlink ".adl/cards/issue-0143__input__v0.3.md"
-assert_eq "$(readlink .adl/cards/issue-0143__input__v0.3.md)" "143/input_143.md"
-
-rm -f .adl/cards/issue-0143__input__v0.3.md
-echo "legacy-b" > .adl/cards/issue-0143__input__v0.3.md
-touch .adl/cards/issue-0143__input__v0.3.md.bak
-sync_legacy_card_link ".adl/cards/143/input_143.md" ".adl/cards/issue-0143__input__v0.3.md"
-assert_file ".adl/cards/issue-0143__input__v0.3.md.bak.1"
-assert_symlink ".adl/cards/issue-0143__input__v0.3.md"
 
 rm -rf .adl/cards
 mkdir -p .adl/cards
@@ -43,8 +24,13 @@ echo "legacy-only" > .adl/cards/issue-0143__input__v0.3.md
 resolved_input="$(resolve_input_card_path 143 v0.3)"
 assert_eq "$resolved_input" ".adl/cards/143/input_143.md"
 assert_file "$resolved_input"
-assert_file ".adl/cards/issue-0143__input__v0.3.md.bak"
-assert_symlink ".adl/cards/issue-0143__input__v0.3.md"
 assert_eq "$(cat "$resolved_input")" "legacy-only"
+assert_file ".adl/cards/_legacy_migrated/issue-0143__input__v0.3.md"
+[[ ! -e ".adl/cards/issue-0143__input__v0.3.md" ]] || { echo "assertion failed: expected migrated legacy root card" >&2; exit 1; }
+
+echo "legacy-only-2" > .adl/cards/issue-0143__input__v0.3.md
+resolved_input_again="$(resolve_input_card_path 143 v0.3)"
+assert_eq "$resolved_input_again" ".adl/cards/143/input_143.md"
+assert_file ".adl/cards/_legacy_migrated/issue-0143__input__v0.3.md.1"
 
 echo "ok"


### PR DESCRIPTION
Closes #180

Local artifacts (not committed):
- Input card:  .adl/cards/180/input_180.md
- Output card: .adl/cards/180/output_180.md
- Idempotency-Key: d0637b8b605b5cd0fcf36834386c81dc52293a648c597f5e4a85630b8886672e

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
