### PR TITLE
[v0.3][concurrency] Accept version: 0.3 + plan-only fork/join (no runtime concurrency yet)

### DIFF
--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -138,16 +138,21 @@ pub fn execute_sequential(
     adl_base_dir: &Path,
     out_dir: &Path,
 ) -> Result<ExecutionResult> {
-    // Gate concurrent early (per our decision).
+    // Gate concurrent execution early.
     if !matches!(
         resolved.doc.run.workflow.kind,
         crate::adl::WorkflowKind::Sequential
     ) {
         let doc_version = resolved.doc.version.trim();
-        tr.run_failed("concurrent workflows are not supported in v0.1");
+        if doc_version == "0.3" {
+            let msg = "concurrent workflow execution is not implemented yet for ADL v0.3 (parse/plan supported)";
+            tr.run_failed(msg);
+            return Err(anyhow!("{msg}"));
+        }
+
+        tr.run_failed("concurrent workflows are not supported in v0.1/v0.2");
         return Err(anyhow!(
-            "feature 'concurrency' requires v0.3; document version is {doc_version} \
-(run.workflow.kind=concurrent)"
+            "feature 'concurrency' requires v0.3; document version is {doc_version} (run.workflow.kind=concurrent)"
         ));
     }
 

--- a/swarm/src/resolve.rs
+++ b/swarm/src/resolve.rs
@@ -8,6 +8,7 @@ use crate::plan;
 enum AdlVersion {
     V0_1,
     V0_2,
+    V0_3,
 }
 
 fn parse_version(version: &str) -> Result<AdlVersion> {
@@ -15,9 +16,10 @@ fn parse_version(version: &str) -> Result<AdlVersion> {
     match v {
         "0.1" => Ok(AdlVersion::V0_1),
         "0.2" => Ok(AdlVersion::V0_2),
+        "0.3" => Ok(AdlVersion::V0_3),
         "" => Err(anyhow!("ADL document is missing required field: version")),
         _ => Err(anyhow!(
-            "unsupported ADL version '{v}' (supported: 0.1, 0.2)"
+            "unsupported ADL version '{v}' (supported: 0.1, 0.2, 0.3)"
         )),
     }
 }
@@ -254,13 +256,21 @@ mod tests {
     #[test]
     fn resolve_run_rejects_unsupported_version() {
         let mut doc = minimal_doc();
-        doc.version = "0.3".to_string();
+        doc.version = "9.9".to_string();
         let err = resolve_run(&doc).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("unsupported ADL version") && msg.contains("0.3"),
+            msg.contains("unsupported ADL version") && msg.contains("9.9"),
             "{msg}"
         );
+    }
+
+    #[test]
+    fn resolve_run_accepts_v0_3() {
+        let mut doc = minimal_doc();
+        doc.version = "0.3".to_string();
+        let resolved = resolve_run(&doc).expect("v0.3 should resolve for parse/plan");
+        assert_eq!(resolved.doc.version, "0.3");
     }
 
     #[test]

--- a/swarm/tests/cli_smoke.rs
+++ b/swarm/tests/cli_smoke.rs
@@ -100,6 +100,26 @@ fn print_plan_preserves_explicit_step_ids_v0_2() {
 }
 
 #[test]
+fn print_plan_v0_3_concurrency_fixture_works() {
+    let path = fixture_path("examples/v0-3-concurrency-fork-join.adl.yaml");
+    let out = run_swarm(&[path.to_str().unwrap(), "--print-plan"]);
+    assert!(
+        out.status.success(),
+        "expected success, stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("fork.plan")
+            && stdout.contains("fork.branch.alpha")
+            && stdout.contains("fork.join"),
+        "expected v0.3 fork/join steps in plan output, stdout:\n{}",
+        stdout
+    );
+}
+
+#[test]
 fn unknown_arg_exits_with_code_2_and_prints_usage() {
     let path = write_temp_adl_yaml();
     let out = run_swarm(&[path.to_str().unwrap(), "--nope"]);

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -464,6 +464,27 @@ fn run_rejects_concurrent_workflows_in_v0_2() {
 }
 
 #[test]
+fn run_rejects_concurrent_workflows_in_v0_3_with_not_implemented_error() {
+    let base = tmp_dir("exec-reject-concurrent-v0-3");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let out = run_swarm(&["examples/v0-3-concurrency-fork-join.adl.yaml", "--run"]);
+    assert!(
+        !out.status.success(),
+        "expected failure for v0.3 concurrent run, got success.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let expected =
+        "Error: concurrent workflow execution is not implemented yet for ADL v0.3 (parse/plan supported)";
+    assert_eq!(stderr.trim(), expected, "stderr mismatch:\n{stderr}");
+}
+
+#[test]
 fn run_reports_error_when_materialized_doc_is_missing() {
     let base = tmp_dir("exec-missing-doc");
     let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);


### PR DESCRIPTION
Closes #248

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.worktrees/burst/248-v0-3-parse-plan-only-fork-join/.adl/cards/248/input_248.md
- Output card: /Users/daniel/git/agent-design-language/.worktrees/burst/248-v0-3-parse-plan-only-fork-join/.adl/cards/248/output_248.md
- Idempotency-Key: 43205c74d26e7539d2a4e6283a941f27a609987480b35702e7b0da297029374b

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
