### PR TITLE
tools: resolve cards root to primary checkout (worktree-safe)

### DIFF
--- a/swarm/tools/open_artifact.sh
+++ b/swarm/tools/open_artifact.sh
@@ -68,8 +68,8 @@ main() {
       local issue="${2:-}" which="${3:-output}" p=""
       [[ -n "$issue" ]] || { usage; exit 2; }
       case "$which" in
-        input) p="$ROOT/$(card_input_path "$issue")" ;;
-        output) p="$ROOT/$(card_output_path "$issue")" ;;
+        input) p="$(card_input_path "$issue")" ;;
+        output) p="$(card_output_path "$issue")" ;;
         *) echo "invalid card kind: $which (expected input|output)" >&2; exit 2 ;;
       esac
       [[ -f "$p" || -L "$p" ]] || { echo "card path not found: $p" >&2; exit 1; }

--- a/swarm/tools/pr.sh
+++ b/swarm/tools/pr.sh
@@ -23,7 +23,7 @@
 #   swarm/tools/pr.sh start 14 --slug b6-default-system
 #   swarm/tools/pr.sh card  14 --version v0.2
 #   swarm/tools/pr.sh output 14 --version v0.2
-#   swarm/tools/pr.sh finish 14 --title "swarm: apply run.defaults.system fallback" -f .adl/cards/14/input_14.md --output-card .adl/cards/14/output_14.md
+#   swarm/tools/pr.sh finish 14 --title "swarm: apply run.defaults.system fallback" -f /abs/cards_root/14/input_14.md --output-card /abs/cards_root/14/output_14.md
 #   swarm/tools/pr.sh open
 #
 set -euo pipefail
@@ -275,7 +275,6 @@ current_pr_url() {
 
 # ---------- cards + templates (templates tracked; cards local-only) ----------
 ADL_DIR=".adl"
-ADL_CARDS_DIR="$ADL_DIR/cards"
 
 INPUT_TEMPLATE="swarm/templates/cards/input_card_template.md"
 OUTPUT_TEMPLATE="swarm/templates/cards/output_card_template.md"
@@ -321,35 +320,27 @@ issue_version() {
 }
 
 ensure_adl_dirs() {
-  mkdir -p "$(repo_root)/$ADL_CARDS_DIR"
+  mkdir -p "$(cards_root_resolve)"
 }
 
 input_card_path() {
   local issue="$1"
-  local rel
-  rel="$(card_input_path "$issue")" || die "invalid issue number: $issue"
-  echo "$(repo_root)/$rel"
+  card_input_path "$issue" || die "invalid issue number: $issue"
 }
 
 output_card_path() {
   local issue="$1"
-  local rel
-  rel="$(card_output_path "$issue")" || die "invalid issue number: $issue"
-  echo "$(repo_root)/$rel"
+  card_output_path "$issue" || die "invalid issue number: $issue"
 }
 
 resolve_input_card_path_abs() {
   local issue="$1" ver="$2"
-  local rel
-  rel="$(cd "$(repo_root)" && resolve_input_card_path "$issue" "$ver")" || die "invalid issue number: $issue"
-  echo "$(repo_root)/$rel"
+  resolve_input_card_path "$issue" "$ver" || die "invalid issue number: $issue"
 }
 
 resolve_output_card_path_abs() {
   local issue="$1" ver="$2"
-  local rel
-  rel="$(cd "$(repo_root)" && resolve_output_card_path "$issue" "$ver")" || die "invalid issue number: $issue"
-  echo "$(repo_root)/$rel"
+  resolve_output_card_path "$issue" "$ver" || die "invalid issue number: $issue"
 }
 
 sync_legacy_links_for_issue() {
@@ -1177,8 +1168,8 @@ Flags:
   (new)     --labels <csv>                    Comma-separated labels (default: track:roadmap,version:v0.3,type:bug,area:tools,epic:v0.3-tooling-git).
   (new)     --version <v0.3>                  Default/fallback version label for new issue/card flow.
   (new)     --no-start                        Only create issue; do not invoke start.
-  (card)    -f, --file <input_card.md>         Output path for the generated input card (default: .adl/cards/<issue>/input_<issue>.md)
-  (output)  -f, --file <output_card.md>        Output path for the generated output card (default: .adl/cards/<issue>/output_<issue>.md)
+  (card)    -f, --file <input_card.md>         Output path for the generated input card (default: <cards_root>/<issue>/input_<issue>.md)
+  (output)  -f, --file <output_card.md>        Output path for the generated output card (default: <cards_root>/<issue>/output_<issue>.md)
   (cards)   --version <v0.2>                   Override detected version (otherwise inferred from issue labels version:vX.Y)
   (cards)   --no-fetch-issue                   Do not fetch issue title/labels (uses issue-<n> title)
   (card/output) --version <v0.2>               Override detected version (otherwise inferred from issue labels version:vX.Y)
@@ -1193,7 +1184,8 @@ Notes:
 - Runs Rust checks in swarm/ by default (fmt, clippy -D warnings, test).
 - finish stages swarm/ by default (reduces accidental commits).
 - Templates are stored in swarm/templates/cards/ (legacy fallback: .adl/templates/).
-- Cards are stored locally under .adl/cards/ and are not committed to git.
+- Cards are stored locally under cards_root and are not committed to git.
+  cards_root resolves as: ADL_CARDS_ROOT (if set) else <primary-checkout>/.adl/cards.
 
 Examples:
   swarm/tools/pr.sh new --title "swarm: fix timeout handling" --slug timeout-fix
@@ -1201,7 +1193,7 @@ Examples:
   swarm/tools/pr.sh card  17 --version v0.2
   swarm/tools/pr.sh output 17 --version v0.2
   swarm/tools/pr.sh cards 17 --version v0.2
-  swarm/tools/pr.sh finish 17 --title "swarm: apply run.defaults.system fallback" -f .adl/cards/17/input_17.md --output-card .adl/cards/17/output_17.md
+  swarm/tools/pr.sh finish 17 --title "swarm: apply run.defaults.system fallback" -f /abs/cards_root/17/input_17.md --output-card /abs/cards_root/17/output_17.md
 EOF
 }
 

--- a/swarm/tools/test_card_paths.sh
+++ b/swarm/tools/test_card_paths.sh
@@ -3,12 +3,26 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CARD_PATHS_LIB="$ROOT_DIR/swarm/tools/card_paths.sh"
-# shellcheck disable=SC1090
-source "$CARD_PATHS_LIB"
-
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-cd "$tmpdir"
+repo="$tmpdir/repo"
+
+mkdir -p "$repo/swarm/tools"
+cp "$CARD_PATHS_LIB" "$repo/swarm/tools/card_paths.sh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  touch .gitkeep
+  git add .gitkeep
+  git commit -q -m "init"
+)
+
+cd "$repo"
+# shellcheck disable=SC1091
+source "$repo/swarm/tools/card_paths.sh"
 
 assert_file() {
   [[ -f "$1" ]] || { echo "assertion failed: expected file $1" >&2; exit 1; }
@@ -18,19 +32,30 @@ assert_eq() {
   [[ "$1" == "$2" ]] || { echo "assertion failed: expected '$1' == '$2'" >&2; exit 1; }
 }
 
-rm -rf .adl/cards
-mkdir -p .adl/cards
-echo "legacy-only" > .adl/cards/issue-0143__input__v0.3.md
+canon_path() {
+  local p="$1"
+  mkdir -p "$p"
+  (cd "$p" && pwd -P)
+}
+
+cards_root="$(cards_root_resolve)"
+mkdir -p "$cards_root"
+echo "legacy-only" > "$cards_root/issue-0143__input__v0.3.md"
 resolved_input="$(resolve_input_card_path 143 v0.3)"
-assert_eq "$resolved_input" ".adl/cards/143/input_143.md"
+assert_eq "$resolved_input" "$cards_root/143/input_143.md"
 assert_file "$resolved_input"
 assert_eq "$(cat "$resolved_input")" "legacy-only"
-assert_file ".adl/cards/_legacy_migrated/issue-0143__input__v0.3.md"
-[[ ! -e ".adl/cards/issue-0143__input__v0.3.md" ]] || { echo "assertion failed: expected migrated legacy root card" >&2; exit 1; }
+assert_file "$cards_root/_legacy_migrated/issue-0143__input__v0.3.md"
+[[ ! -e "$cards_root/issue-0143__input__v0.3.md" ]] || { echo "assertion failed: expected migrated legacy root card" >&2; exit 1; }
 
-echo "legacy-only-2" > .adl/cards/issue-0143__input__v0.3.md
+echo "legacy-only-2" > "$cards_root/issue-0143__input__v0.3.md"
 resolved_input_again="$(resolve_input_card_path 143 v0.3)"
-assert_eq "$resolved_input_again" ".adl/cards/143/input_143.md"
-assert_file ".adl/cards/_legacy_migrated/issue-0143__input__v0.3.md.1"
+assert_eq "$resolved_input_again" "$cards_root/143/input_143.md"
+assert_file "$cards_root/_legacy_migrated/issue-0143__input__v0.3.md.1"
+
+ADL_CARDS_ROOT="custom/cards"
+export ADL_CARDS_ROOT
+assert_eq "$(canon_path "$(cards_root_resolve)")" "$(canon_path "$repo/custom/cards")"
+assert_eq "$(canon_path "$(dirname "$(card_input_path 144)")")" "$(canon_path "$repo/custom/cards/144")"
 
 echo "ok"

--- a/swarm/tools/test_pr_cards_primary_root.sh
+++ b/swarm/tools/test_pr_cards_primary_root.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/swarm/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/swarm/tools/card_paths.sh"
+INPUT_TPL_SRC="$ROOT_DIR/swarm/templates/cards/input_card_template.md"
+OUTPUT_TPL_SRC="$ROOT_DIR/swarm/templates/cards/output_card_template.md"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+worktree="$tmpdir/repo-worktree"
+mkdir -p "$repo/swarm/tools" "$repo/swarm/templates/cards"
+cp "$PR_SH_SRC" "$repo/swarm/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/swarm/tools/card_paths.sh"
+cp "$INPUT_TPL_SRC" "$repo/swarm/templates/cards/input_card_template.md"
+cp "$OUTPUT_TPL_SRC" "$repo/swarm/templates/cards/output_card_template.md"
+chmod +x "$repo/swarm/tools/pr.sh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  git add -A
+  git commit -q -m "init"
+  git branch -m main
+  git worktree add -q -b codex/301-linked-worktree "$worktree" main
+)
+
+(
+  cd "$worktree"
+  "$BASH_BIN" swarm/tools/pr.sh card 301 --no-fetch-issue --slug linked-worktree >/dev/null
+  "$BASH_BIN" swarm/tools/pr.sh output 301 --no-fetch-issue --slug linked-worktree >/dev/null
+)
+
+[[ -f "$repo/.adl/cards/301/input_301.md" ]] || { echo "assertion failed: expected primary checkout input card" >&2; exit 1; }
+[[ -f "$repo/.adl/cards/301/output_301.md" ]] || { echo "assertion failed: expected primary checkout output card" >&2; exit 1; }
+[[ ! -f "$worktree/.adl/cards/301/input_301.md" ]] || { echo "assertion failed: unexpected linked worktree input card" >&2; exit 1; }
+[[ ! -f "$worktree/.adl/cards/301/output_301.md" ]] || { echo "assertion failed: unexpected linked worktree output card" >&2; exit 1; }
+
+echo "pr.sh linked worktree cards root resolution: ok"


### PR DESCRIPTION
Closes #250

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/250/input_250.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/250/output_250.md
- Idempotency-Key: a363e9962f694cdbb118d1ece91ef3d9cd0a90f34d02935fdbaf6486df60e3fc

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
