### PR TITLE
swarm: add v0.3 remote HTTP provider MVP docs/example/test

### DIFF
--- a/swarm/examples/v0-3-remote-http-provider.adl.yaml
+++ b/swarm/examples/v0-3-remote-http-provider.adl.yaml
@@ -1,0 +1,38 @@
+version: "0.3"
+
+providers:
+  remote_http:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8787/complete"
+      timeout_secs: 10
+      auth:
+        type: bearer
+        env: SWARM_REMOTE_BEARER_TOKEN
+      headers:
+        X-Client: "swarm-v0.3"
+
+agents:
+  writer:
+    provider: "remote_http"
+    model: "unused-for-http-provider"
+
+tasks:
+  summarize:
+    prompt:
+      user: |
+        Summarize the following content in 3 bullets.
+
+        Content:
+        {{content}}
+
+run:
+  name: "v0-3-remote-http-provider"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "remote_summary"
+        agent: "writer"
+        task: "summarize"
+        inputs:
+          content: "ADL v0.3 adds deterministic parse/plan improvements."


### PR DESCRIPTION
Closes #236

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/236/input_236.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/236/output_236.md
- Idempotency-Key: b75cbb394941d834dcc2f9b9ef6ecc37f88f1e25cae2327369e91f956bb3a51c

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
