### PR TITLE
swarm: persist deterministic run state artifacts

### DIFF
--- a/swarm/README.md
+++ b/swarm/README.md
@@ -100,6 +100,32 @@ Exit codes are consistent:
 
 ---
 
+## Run State Artifacts
+
+When running with `--run`, `swarm` writes deterministic run state files under:
+
+```bash
+.adl/runs/<run_id>/
+```
+
+Files:
+- `run.json`:
+  - `run_id`
+  - `workflow_id`
+  - `version`
+  - `status` (`success` or `failure`)
+  - `start_time_ms`, `end_time_ms`, `duration_ms`
+- `steps.json` (stable step order):
+  - `step_id`
+  - `agent_id`
+  - `provider_id`
+  - `status` (`success`, `failure`, `not_run`)
+  - `output_artifact_path` (when applicable)
+
+This is additive and does not replace existing stdout summaries.
+
+---
+
 ## Remote Provider (HTTP MVP)
 
 `swarm` supports a minimal remote provider via `type: "http"` for deterministic,

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use swarm::{adl, demo, execute, plan, prompt, resolve, trace};
 
@@ -164,6 +166,7 @@ fn real_main() -> Result<()> {
 
     if do_run {
         let print_outputs = !quiet;
+        let run_started_ms = now_ms();
         let mut tr = trace::Trace::new(
             resolved.run_id.clone(),
             resolved.workflow_id.clone(),
@@ -175,6 +178,15 @@ fn real_main() -> Result<()> {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
+                let run_finished_ms = now_ms();
+                let _run_dir = write_run_state_artifacts(
+                    &resolved,
+                    &tr,
+                    &out_dir,
+                    run_started_ms,
+                    run_finished_ms,
+                    false,
+                )?;
                 if resolved.doc.version.trim() == "0.2" {
                     tr.run_finished(false);
                 }
@@ -186,6 +198,15 @@ fn real_main() -> Result<()> {
         };
         let outputs = result.outputs;
         let artifacts = result.artifacts;
+        let run_finished_ms = now_ms();
+        let _run_dir = write_run_state_artifacts(
+            &resolved,
+            &tr,
+            &out_dir,
+            run_started_ms,
+            run_finished_ms,
+            true,
+        )?;
 
         // Explicitly consume StepOutput so clippy -D warnings stays green
         println!("RUN SUMMARY: {} step(s)", outputs.len());
@@ -250,6 +271,129 @@ fn real_main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+fn run_artifacts_root() -> Result<PathBuf> {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest
+        .parent()
+        .context("failed to derive repo root from CARGO_MANIFEST_DIR")?;
+    Ok(repo_root.join(".adl").join("runs"))
+}
+
+#[derive(Debug, Serialize)]
+struct RunStateArtifact {
+    run_id: String,
+    workflow_id: String,
+    version: String,
+    status: String,
+    start_time_ms: u128,
+    end_time_ms: u128,
+    duration_ms: u128,
+}
+
+#[derive(Debug, Serialize)]
+struct StepStateArtifact {
+    step_id: String,
+    agent_id: String,
+    provider_id: String,
+    status: String,
+    output_artifact_path: Option<String>,
+}
+
+fn write_run_state_artifacts(
+    resolved: &resolve::AdlResolved,
+    tr: &trace::Trace,
+    out_dir: &Path,
+    start_ms: u128,
+    end_ms: u128,
+    success: bool,
+) -> Result<PathBuf> {
+    let runs_root = run_artifacts_root()?;
+    let run_dir = runs_root.join(&resolved.run_id);
+    std::fs::create_dir_all(&run_dir)
+        .with_context(|| format!("failed to create run artifact dir '{}'", run_dir.display()))?;
+
+    let mut status_by_step: HashMap<String, String> = HashMap::new();
+    for ev in &tr.events {
+        if let trace::TraceEvent::StepFinished {
+            step_id, success, ..
+        } = ev
+        {
+            let status = if *success { "success" } else { "failure" };
+            status_by_step.insert(step_id.clone(), status.to_string());
+        }
+    }
+
+    let mut steps = Vec::with_capacity(resolved.steps.len());
+    for step in &resolved.steps {
+        let status = status_by_step
+            .get(&step.id)
+            .cloned()
+            .unwrap_or_else(|| "not_run".to_string());
+        let output_artifact_path = match (status.as_str(), step.write_to.as_deref()) {
+            ("success", Some(write_to)) => Some(out_dir.join(write_to).display().to_string()),
+            _ => None,
+        };
+
+        let agent_id = step
+            .agent
+            .as_deref()
+            .unwrap_or("<unresolved-agent>")
+            .to_string();
+        let provider_id = step
+            .provider
+            .as_deref()
+            .unwrap_or("<unresolved-provider>")
+            .to_string();
+
+        steps.push(StepStateArtifact {
+            step_id: step.id.clone(),
+            agent_id,
+            provider_id,
+            status,
+            output_artifact_path,
+        });
+    }
+
+    let run_artifact = RunStateArtifact {
+        run_id: resolved.run_id.clone(),
+        workflow_id: resolved.workflow_id.clone(),
+        version: resolved.doc.version.clone(),
+        status: if success {
+            "success".to_string()
+        } else {
+            "failure".to_string()
+        },
+        start_time_ms: start_ms,
+        end_time_ms: end_ms,
+        duration_ms: end_ms.saturating_sub(start_ms),
+    };
+
+    let run_json = serde_json::to_vec_pretty(&run_artifact).context("serialize run.json")?;
+    let steps_json = serde_json::to_vec_pretty(&steps).context("serialize steps.json")?;
+
+    std::fs::write(run_dir.join("run.json"), run_json).with_context(|| {
+        format!(
+            "failed to write run artifact '{}'",
+            run_dir.join("run.json").display()
+        )
+    })?;
+    std::fs::write(run_dir.join("steps.json"), steps_json).with_context(|| {
+        format!(
+            "failed to write run artifact '{}'",
+            run_dir.join("steps.json").display()
+        )
+    })?;
+
+    Ok(run_dir)
 }
 
 fn real_demo(args: &[String]) -> Result<()> {

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -707,6 +707,99 @@ run:
 }
 
 #[test]
+fn run_writes_run_state_artifacts() {
+    let base = tmp_dir("exec-run-state-artifacts");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let run_id = "run-state-artifacts-test";
+    let run_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join(".adl")
+        .join("runs")
+        .join(run_id);
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let yaml = format!(
+        r#"
+version: "0.2"
+
+providers:
+  local:
+    type: "ollama"
+    config:
+      model: "phi4-mini"
+
+agents:
+  a1:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t1:
+    prompt:
+      user: "Summarize: {{text}}"
+
+run:
+  name: "{run_id}"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "a1"
+        task: "t1"
+        inputs:
+          text: "hello"
+"#
+    );
+
+    let tmp_yaml = base.join("run-state.yaml");
+    fs::write(&tmp_yaml, yaml.as_bytes()).unwrap();
+
+    let out = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
+    assert!(
+        out.status.success(),
+        "expected success, got {:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let run_json_path = run_dir.join("run.json");
+    let steps_json_path = run_dir.join("steps.json");
+    assert!(
+        run_json_path.is_file(),
+        "missing {}",
+        run_json_path.display()
+    );
+    assert!(
+        steps_json_path.is_file(),
+        "missing {}",
+        steps_json_path.display()
+    );
+
+    let run_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&run_json_path).unwrap()).unwrap();
+    assert_eq!(run_json["run_id"], run_id);
+    assert_eq!(run_json["workflow_id"], "workflow");
+    assert_eq!(run_json["status"], "success");
+
+    let steps_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&steps_json_path).unwrap()).unwrap();
+    let steps = steps_json
+        .as_array()
+        .expect("steps.json should be an array");
+    assert_eq!(steps.len(), 1);
+    assert_eq!(steps[0]["step_id"], "s1");
+    assert_eq!(steps[0]["status"], "success");
+    assert_eq!(steps[0]["provider_id"], "local");
+
+    let _ = fs::remove_dir_all(&run_dir);
+}
+
+#[test]
 fn run_rejects_write_to_traversal() {
     let base = tmp_dir("exec-write-traversal");
     let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);


### PR DESCRIPTION
Closes #255

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/255/input_255.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/255/output_255.md
- Idempotency-Key: 87a0c0a4f4cb2b20c1deb8acfe45787346d3d0ae3d225ad64b30bdd8391d8ee5

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
