### PR TITLE
ci: skip Codecov upload when token is missing (Closes #284)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -100,3 +100,9 @@ jobs:
           flags: swarm
           fail_ci_if_error: true
           verbose: true
+
+      - name: Skip Codecov upload (missing token)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CODECOV_TOKEN == ''
+        run: |
+          echo "::warning::Skipping Codecov upload because CODECOV_TOKEN is not configured for this repository."
+          echo "::warning::Coverage artifact was still generated at swarm/lcov.info."


### PR DESCRIPTION
## Summary
- gate Codecov upload on `secrets.CODECOV_TOKEN != ''`
- add explicit warning step when token is missing on `main`
- keep coverage generation + artifact upload unchanged

## Why
`swarm-coverage` was failing on `main` push despite successful coverage generation because Codecov rejected tokenless upload on protected branch.

## Validation
- workflow logic updated in `.github/workflows/ci.yaml`
- `swarm/lcov.info` generation + artifact upload path unchanged
