### PR TITLE
ci: fix Codecov token-gating workflow expression (Closes #286)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     defaults:
       run:
         working-directory: swarm
@@ -92,17 +94,17 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CODECOV_TOKEN != ''
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: swarm/lcov.info
           flags: swarm
           fail_ci_if_error: true
           verbose: true
 
       - name: Skip Codecov upload (missing token)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CODECOV_TOKEN == ''
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.CODECOV_TOKEN == ''
         run: |
           echo "::warning::Skipping Codecov upload because CODECOV_TOKEN is not configured for this repository."
           echo "::warning::Coverage artifact was still generated at swarm/lcov.info."


### PR DESCRIPTION
## Summary
- set `CODECOV_TOKEN` at job `env` from `secrets.CODECOV_TOKEN`
- switch step `if` conditions to `env.CODECOV_TOKEN` checks
- pass `env.CODECOV_TOKEN` into Codecov action

## Why
The prior change used `secrets.*` directly in step `if:` expressions, which can cause workflow evaluation failures before jobs run.

## Files
- `.github/workflows/ci.yaml`
