### PR TITLE
docs: add v0.4 milestone planning docs (Closes #294)

### DIFF
--- a/docs/milestones/v0.4/DECISIONS_v0.4.md
+++ b/docs/milestones/v0.4/DECISIONS_v0.4.md
@@ -1,0 +1,70 @@
+# Decisions Template
+
+## Metadata
+- Milestone: `{{milestone}}`
+- Version: `{{version}}`
+- Date: `{{date}}`
+- Owner: `{{owner}}`
+
+## Purpose
+Capture significant decisions (architecture, scope, process) at the time they are made.
+
+## How To Use
+- Add one row per decision.
+- Prefer links to issues/PRs over long prose.
+- Keep status current: `accepted`, `rejected`, `deferred`, `superseded`.
+
+## Decision Log
+| ID | Decision | Status | Rationale | Alternatives | Impact | Link |
+|---|---|---|---|---|---|---|
+| D-01 | {{decision_1}} | {{status_1}} | {{rationale_1}} | {{alternatives_1}} | {{impact_1}} | {{link_1}} |
+| D-02 | {{decision_2}} | {{status_2}} | {{rationale_2}} | {{alternatives_2}} | {{impact_2}} | {{link_2}} |
+
+## Open Questions
+- {{open_question_1}} (Owner: {{owner_oq1}}) (Issue: {{issue_oq1}})
+- {{open_question_2}} (Owner: {{owner_oq2}}) (Issue: {{issue_oq2}})
+
+## Exit Criteria
+- All milestone-critical decisions are logged with a rationale.
+- Deferred/rejected/superseded options are explicitly recorded.
+- Open questions have owners and tracking links.
+
+# Decisions – ADL v0.4
+
+## Metadata
+- Milestone: `v0.4`
+- Version: `0.4`
+- Date: {{date}}
+- Owner: Daniel Austin
+- Related issues: #290, #291
+
+## Purpose
+Capture significant v0.4 decisions (architecture, scope, process) as they are made, with links to evidence (issues/PRs).
+
+## How to use
+- Keep entries short; link to issues/PRs for details.
+- Update status as decisions evolve: `accepted`, `deferred`, `superseded`.
+- Add an “Open Question” instead of a half-decided decision.
+
+## Decision Log
+
+| ID | Decision | Status | Rationale | Alternatives | Impact | Link |
+|---|---|---|---|---|---|---|
+| D-01 | Implement **bounded** runtime concurrency for fork branches using a small executor/threadpool. | accepted | We need real runtime concurrency in v0.4, but must keep complexity low and behavior testable. A bounded executor avoids runaway parallelism and makes failure handling simpler. | Unbounded threads; fully async runtime; distributed executor. | Enables real parallel fork execution with controlled resource use. | #291 |
+| D-02 | Preserve a **sequential mode** for deterministic replay/debugging and CI simplification. | accepted | Concurrency increases debug surface area. A sequential mode provides a stable fallback and helps compare traces/artifacts for determinism tests. | Remove sequential mode; always parallel. | Improves debuggability and reduces risk while shipping concurrency. | #291 |
+| D-03 | Join semantics are **wait-for-all** with deterministic merge ordering by **branch ID**. | accepted | Prevents nondeterministic artifact ordering and makes join behavior auditable. | “First-success” joins; merge by completion order. | Deterministic outputs and stable traces across runs. | #291 |
+| D-04 | Default failure policy: **fail-fast** on first unrecoverable branch failure; allow optional “complete-all then aggregate errors” later. | accepted | Matches current workflow expectations and keeps orchestration simple for the first runtime-concurrency increment. | Always aggregate; always continue. | Predictable failure behavior, simpler semantics for v0.4. | #291 |
+| D-05 | Retry semantics remain **deterministic**: no jitter/backoff in v0.4; retries are per-node and must not change artifact ordering guarantees. | accepted | Determinism is core; jitter/backoff can change timing and interleavings in ways that complicate trace comparison. | Exponential backoff with jitter; global retry coordination. | Stable artifacts and trace reasoning; easier tests. | #291 |
+| D-06 | Concurrency-safe state: branch state is isolated; only explicit outputs flow through join (no shared mutable state). | accepted | Avoids hidden data races and makes reasoning about branch correctness straightforward. | Shared mutable state with locks; global state store. | Reduces concurrency bugs; enforces explicit dataflow. | #291 |
+| D-07 | **Observable memory + Bayesian indexing** is explicitly deferred to **v0.5**. | accepted | v0.4 must focus on execution engine credibility; memory/indexing needs separate storage/retrieval semantics and evaluation. | Attempt MVP in v0.4; bolt-on indexing. | Keeps v0.4 scope tight; sets clear roadmap. | (planned) |
+
+## Open Questions
+
+- What is the minimal API boundary between `ExecutionPlan` construction and the executor (types, module layout)? (Owner: Daniel) (Issue: #291)
+- Should “aggregate errors” mode be a workflow-level flag in v0.4 or deferred to v0.5? (Owner: Daniel) (Issue: #291)
+- What is the minimum determinism test suite we require (N repeated runs; artifact diff rules)? (Owner: Daniel) (Issue: #291)
+
+## Exit Criteria
+- All v0.4 milestone-critical decisions are logged with rationale.
+- Any deferred/superseded decisions are explicitly marked.
+- Open questions have owners and tracking links.

--- a/docs/milestones/v0.4/DESIGN_v0.4.md
+++ b/docs/milestones/v0.4/DESIGN_v0.4.md
@@ -1,0 +1,247 @@
+# Design Template
+
+## Metadata
+- Milestone: `{{milestone}}`
+- Version: `{{version}}`
+- Date: `{{date}}`
+- Owner: `{{owner}}`
+- Related issues: {{issues}}
+
+## Purpose
+Define what we are building, why, and how we validate it — concisely, with links to issues/PRs.
+
+## Problem Statement
+{{problem_statement}}
+
+## Goals
+- {{goal_1}}
+- {{goal_2}}
+
+## Non-Goals
+- {{non_goal_1}}
+- {{non_goal_2}}
+
+## Scope
+### In scope
+- {{in_scope_1}}
+- {{in_scope_2}}
+
+### Out of scope
+- {{out_of_scope_1}}
+- {{out_of_scope_2}}
+
+## Requirements
+### Functional
+- {{functional_requirement_1}}
+- {{functional_requirement_2}}
+
+### Non-functional
+- Deterministic behavior and reproducible outputs.
+- Clear failure semantics and observability.
+- {{non_functional_requirement_1}}
+
+## Proposed Design
+### Overview
+{{architecture_summary}}
+
+### Interfaces / Data contracts
+- {{interface_or_contract_1}}
+- {{interface_or_contract_2}}
+
+### Execution semantics
+{{execution_semantics}}
+
+## Risks and Mitigations
+- Risk: {{risk_1}}
+  - Mitigation: {{mitigation_1}}
+- Risk: {{risk_2}}
+  - Mitigation: {{mitigation_2}}
+
+## Alternatives Considered
+- Option: {{alternative_1}}
+  - Tradeoff: {{tradeoff_1}}
+- Option: {{alternative_2}}
+  - Tradeoff: {{tradeoff_2}}
+
+## Validation Plan
+- Checks/tests: {{validation_checks}}
+- Success metrics: {{success_metrics}}
+- Rollback/fallback: {{rollback_plan}}
+
+## Exit Criteria
+- Goals/non-goals and scope boundaries are explicit.
+- Validation plan is actionable and referenced by the milestone checklist.
+- Major open questions are resolved or tracked in the decision log.
+
+# ADL v0.4 Design – Runtime Concurrency + Orchestration
+
+## Metadata
+- Milestone: `v0.4`
+- Version: `0.4`
+- Date: `{{date}}`
+- Owner: Daniel Austin
+- Related issues: #290, #291
+
+## Purpose
+v0.4 moves ADL from “design + sequential execution” to a minimal but real runtime concurrency engine. The goal is to execute fork/join graphs deterministically while preserving the traceability, artifacts, and review discipline established in v0.3.
+
+---
+
+## Problem Statement
+In v0.3, fork/join was design-only and execution remained sequential. ADL needs:
+
+- A real execution scaffold for fork/join graphs.
+- Deterministic concurrency semantics.
+- Clear failure handling and retry policy boundaries.
+- Observability strong enough to support future memory/indexing features (scheduled for v0.5).
+
+Without this, ADL cannot credibly position itself as an orchestration language for multi-agent workflows.
+
+---
+
+## Goals
+- Implement a deterministic runtime fork/join execution scaffold.
+- Preserve sequential fallback for debugging and reproducibility.
+- Ensure full trace artifacts for concurrent steps.
+- Keep runtime simple, testable, and extensible.
+
+## Non-Goals
+- High-performance distributed scheduler.
+- Persistent state store.
+- Observable memory + Bayesian indexing (moved to v0.5).
+- Cross-process or cluster-level execution.
+
+---
+
+## Scope
+
+### In scope
+- Fork node execution model (parallel branches).
+- Join node semantics (wait-for-all).
+- Execution graph validation prior to run.
+- Deterministic scheduling strategy.
+- Structured trace + artifact output per branch.
+
+### Out of scope
+- Remote cluster execution.
+- Dynamic graph mutation during execution.
+- Persistent run recovery.
+
+---
+
+## Requirements
+
+### Functional
+- Execute fork blocks concurrently using a bounded executor.
+- Join blocks must wait for all upstream branches.
+- Fail-fast behavior configurable at workflow level.
+- Retry policy applied per node (existing policy integrated).
+
+### Non-functional
+- Deterministic ordering of emitted artifacts.
+- Reproducible execution traces.
+- Clear and debuggable failure semantics.
+- No unsafe shared mutable state.
+
+---
+
+## Proposed Design
+
+### Overview
+We introduce a lightweight execution engine layer:
+
+- GraphBuilder → validates DAG and constructs execution plan.
+- Executor → runs nodes (sequential or concurrent mode).
+- JoinBarrier → waits for branch completion.
+- TraceRecorder → records step lifecycle events.
+
+Concurrency model:
+- Use a bounded thread pool.
+- Each fork branch executes independently.
+- Join waits for all branch futures.
+- Results merged deterministically (sorted by branch id).
+
+Sequential mode remains available for:
+- Debugging
+- Deterministic replay
+- CI tests
+
+---
+
+### Interfaces / Data Contracts
+
+- `ExecutionPlan` – validated DAG with explicit dependencies.
+- `ExecutionContext` – immutable runtime inputs + scoped branch state.
+- `ExecutionResult` – node result + metadata + trace link.
+- `JoinResult` – ordered merge of branch results.
+
+Branch state must be isolated; only explicit outputs may flow across joins.
+
+---
+
+### Execution Semantics
+
+1. Validate DAG.
+2. Topologically sort nodes.
+3. When encountering a fork:
+   - Spawn tasks for each branch.
+   - Record branch IDs.
+4. Join barrier waits for all branch completions.
+5. Merge outputs deterministically.
+6. Continue downstream execution.
+
+Failure policy:
+- Default: fail-fast on first unrecoverable error.
+- Optional: complete-all then aggregate errors.
+
+Retry policy:
+- Apply existing retry logic per node.
+- Retries must not violate determinism of final artifacts.
+
+---
+
+## Risks and Mitigations
+
+- Risk: Non-deterministic artifact ordering.
+  - Mitigation: Explicit branch ID ordering during join merge.
+
+- Risk: Hidden shared state bugs.
+  - Mitigation: Enforce immutable context and scoped branch state.
+
+- Risk: Debug complexity.
+  - Mitigation: Preserve sequential execution mode.
+
+---
+
+## Alternatives Considered
+
+- Async runtime (e.g., async/await everywhere)
+  - Tradeoff: Higher complexity, less transparent execution model.
+
+- Fully distributed executor
+  - Tradeoff: Premature optimization and infrastructure complexity.
+
+---
+
+## Validation Plan
+
+- Unit tests for fork/join behavior.
+- Determinism test: multiple runs produce identical artifacts.
+- Failure tests: branch failure scenarios.
+- CI must remain green under concurrent execution mode.
+
+Success metrics:
+- Concurrent demo workflow executes correctly.
+- No regression in sequential mode.
+
+Rollback:
+- Feature flag to disable concurrency and revert to sequential mode.
+
+---
+
+## Exit Criteria
+
+- Fork/join executes concurrently with deterministic artifacts.
+- CI is green.
+- Sequential mode still passes all tests.
+- Design doc reflects shipped behavior.

--- a/docs/milestones/v0.4/MILESTONE_CHECKLIST_v0.4.md
+++ b/docs/milestones/v0.4/MILESTONE_CHECKLIST_v0.4.md
@@ -1,0 +1,50 @@
+# Milestone Checklist Template
+
+## Metadata
+- Milestone: `{{milestone}}`
+- Version: `{{version}}`
+- Target release date: `{{target_release_date}}`
+- Owner: `{{owner}}`
+
+## Purpose
+Ship/no-ship gate for the milestone. Check items only when evidence exists.
+
+## Planning
+- [ ] Milestone goal defined (`{{goal_doc_link}}`)
+- [ ] Scope + non-goals documented (`{{scope_doc_link}}`)
+- [ ] WBS created and mapped to issues (`{{wbs_link}}`)
+- [ ] Decision log initialized (`{{decisions_link}}`)
+- [ ] Sprint plan created (`{{sprint_plan_link}}`)
+
+## Execution Discipline
+- [ ] Each issue has input/output cards under `.adl/cards/<issue>/`
+- [ ] Each burst writes artifacts under `.adl/reports/burst/<timestamp>/`
+- [ ] Draft PR opened for each issue before merge
+- [ ] Transient failures retried and documented
+- [ ] "Green-only merge" policy followed
+
+## Quality Gates
+- [ ] `cargo fmt` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo test` passes
+- [ ] CI is green on the merge target
+- [ ] Coverage signal is not red (or exception documented) (`{{coverage_link_or_note}}`)
+- [ ] No unresolved high-priority blockers (`{{blocker_report_link}}`)
+
+## Release Packaging
+- [ ] Release notes finalized (`{{release_notes_link}}`)
+- [ ] Tag verified: `{{tag_name}}`
+- [ ] GitHub Release drafted (`{{release_draft_link}}`)
+- [ ] Links validated in release body
+- [ ] Release published
+
+## Post-Release
+- [ ] Milestone/epic issues closed with release links
+- [ ] Deferred items moved to next milestone backlog
+- [ ] Follow-up bugs/tech debt captured as issues
+- [ ] Roadmap/status docs updated (`{{roadmap_update_link}}`)
+- [ ] Retrospective summary recorded (`{{retro_link}}`)
+
+## Exit Criteria
+- All required gates are checked, or each exception has an owner + due date.
+- Milestone can be audited end-to-end via the links captured above.

--- a/docs/milestones/v0.4/RELEASE_NOTES_v0.4.md
+++ b/docs/milestones/v0.4/RELEASE_NOTES_v0.4.md
@@ -1,0 +1,57 @@
+# Release Notes Template
+
+## Metadata
+- Product: `{{product_name}}`
+- Version: `{{version}}`
+- Release date: `{{release_date}}`
+- Tag: `{{tag_name}}`
+
+## How To Use
+- Keep statements implementation-accurate and test-validated.
+- Prefer concise bullets over marketing language.
+- Explicitly separate shipped behavior from "What's Next."
+
+# `{{product_name}}` `{{version}}` Release Notes
+
+## Summary
+{{summary_paragraph}}
+
+## Highlights
+- {{highlight_1}}
+- {{highlight_2}}
+- {{highlight_3}}
+
+## What's New In Detail
+
+### {{area_1}}
+- {{detail_1a}}
+- {{detail_1b}}
+
+### {{area_2}}
+- {{detail_2a}}
+- {{detail_2b}}
+
+### {{area_3}}
+- {{detail_3a}}
+- {{detail_3b}}
+
+## Upgrade Notes
+- {{upgrade_note_1}}
+- {{upgrade_note_2}}
+
+## Known Limitations
+- {{limitation_1}}
+- {{limitation_2}}
+
+## Validation Notes
+- {{validation_note_1}}
+- {{validation_note_2}}
+
+## What's Next
+- {{next_1}}
+- {{next_2}}
+
+## Exit Criteria
+- Notes reflect only shipped behavior.
+- Known limitations and future work are explicitly separated.
+- Final text is ready to paste into GitHub Release UI without further editing.

--- a/docs/milestones/v0.4/RELEASE_PLAN_v0.4.md
+++ b/docs/milestones/v0.4/RELEASE_PLAN_v0.4.md
@@ -1,0 +1,46 @@
+# Release Process Template
+
+## Metadata
+- Milestone: `{{milestone}}`
+- Version: `{{version}}`
+- Release date: `{{release_date}}`
+- Release manager: `{{release_manager}}`
+
+## How To Use
+- Execute sections in order and capture links for each completed step.
+- Keep this doc focused on shipping mechanics; use release notes for narrative.
+- Mark blockers immediately; do not publish until gates pass.
+
+## 1) Release Readiness
+- [ ] Milestone checklist complete (`{{milestone_checklist_link}}`)
+- [ ] Release notes approved (`{{release_notes_link}}`)
+- [ ] Go/no-go decision recorded (`{{decision_link}}`)
+
+## 2) Branch And Tag Preparation
+- [ ] Target branch confirmed (`{{target_branch}}`)
+- [ ] Working tree clean
+- [ ] Version string(s) validated (`{{version_validation_link}}`)
+- [ ] Tag created: `{{tag_name}}`
+- [ ] Tag pushed and verified
+
+## 3) GitHub Release Steps
+- [ ] GitHub Release draft created from `{{tag_name}}` (`{{release_draft_link}}`)
+- [ ] Release body populated from approved notes
+- [ ] Links to key PRs/issues included
+- [ ] Release visibility confirmed (draft/prerelease/final)
+- [ ] Release published
+
+## 4) Verification
+- [ ] Post-release CI status checked (`{{ci_run_link}}`)
+- [ ] Release links tested (docs, artifacts, notes)
+- [ ] Immediate regressions triaged and tracked (`{{triage_link}}`)
+
+## 5) Communication
+- [ ] Community announcement published (`{{announcement_link}}`)
+- [ ] Internal update posted (`{{internal_update_link}}`)
+- [ ] Roadmap/status updated (`{{roadmap_update_link}}`)
+
+## Exit Criteria
+- Tag and GitHub Release are published and accessible.
+- Verification completed with no unknown critical failures.
+- Communication links captured.

--- a/docs/milestones/v0.4/SPRINT_v0.4.md
+++ b/docs/milestones/v0.4/SPRINT_v0.4.md
@@ -1,0 +1,130 @@
+# Sprint Template
+
+## Metadata
+- Sprint: `{{sprint_id}}`
+- Milestone: `{{milestone}}`
+- Start date: `{{start_date}}`
+- End date: `{{end_date}}`
+- Owner: `{{owner}}`
+
+## How To Use
+- Keep scope small enough to finish with green CI and merged PRs.
+- List work items in planned execution order.
+- Track blockers here (not scattered chat notes).
+
+## Sprint Goal
+{{sprint_goal}}
+
+## Planned Scope
+- {{scope_item_1}}
+- {{scope_item_2}}
+- {{scope_item_3}}
+
+## Work Plan
+| Order | Item | Issue | Owner | Status |
+|---|---|---|---|---|
+| 1 | {{work_item_1}} | {{issue_1}} | {{owner_1}} | {{status_1}} |
+| 2 | {{work_item_2}} | {{issue_2}} | {{owner_2}} | {{status_2}} |
+| 3 | {{work_item_3}} | {{issue_3}} | {{owner_3}} | {{status_3}} |
+
+## Cadence Expectations
+- Use issue cards (`input`/`output`) for each item.
+- Keep changes scoped per issue; use draft PRs until checks pass.
+- Run required quality gates (fmt/clippy/test) for code changes.
+
+## Risks / Dependencies
+- Dependency: {{dependency_1}}
+  - Risk: {{risk_1}}
+  - Mitigation: {{mitigation_1}}
+
+## Demo / Review Plan
+- Demo artifact: {{demo_artifact}}
+- Review date: {{review_date}}
+- Sign-off owners: {{signoff_owners}}
+
+## Exit Criteria
+- All planned scope items completed or explicitly deferred with rationale.
+- Linked issues/PRs updated and traceable.
+- CI is green for merged work.
+- Sprint summary captured in milestone docs.
+
+# ADL v0.4 – Sprint 1 (Runtime Concurrency Scaffold)
+
+## Metadata
+- Sprint: `v0.4-S1`
+- Milestone: `v0.4`
+- Start date: {{start_date}}
+- End date: {{end_date}}
+- Owner: Daniel Austin
+
+---
+
+## Sprint Goal
+Ship a minimal, deterministic fork/join runtime scaffold that executes branches concurrently while preserving traceability and CI stability.
+
+This sprint focuses on correctness and determinism — not performance optimization.
+
+---
+
+## Planned Scope
+- Implement bounded executor for fork branches.
+- Implement deterministic join (wait-for-all + ordered merge).
+- Preserve sequential execution mode for fallback/debug.
+- Add deterministic concurrency tests.
+- Keep CI fully green.
+
+---
+
+## Work Plan
+
+| Order | Item | Issue | Owner | Status |
+|---|---|---|---|---|
+| 1 | Define `ExecutionPlan` + DAG validation scaffold | #291 | Daniel | planned |
+| 2 | Implement bounded executor for fork branches | #291 | Daniel | planned |
+| 3 | Implement deterministic join barrier (ordered merge by branch ID) | #291 | Daniel | planned |
+| 4 | Preserve and test sequential execution mode | #291 | Daniel | planned |
+| 5 | Add determinism test (multi-run artifact equality) | #291 | Daniel | planned |
+| 6 | CI validation + artifact review | #291 | Daniel | planned |
+
+---
+
+## Cadence Expectations
+- Each logical unit of work may be split into sub-issues if needed.
+- All changes go through draft PR first.
+- Required quality gates:
+  - `cargo fmt`
+  - `cargo clippy --all-targets -- -D warnings`
+  - `cargo test`
+- No merge unless CI is fully green.
+
+---
+
+## Risks / Dependencies
+
+- Dependency: Existing v0.3 sequential execution engine.
+  - Risk: Refactor introduces regression in sequential mode.
+  - Mitigation: Maintain explicit sequential path and regression tests.
+
+- Dependency: Deterministic artifact ordering.
+  - Risk: Concurrency introduces nondeterministic ordering.
+  - Mitigation: Explicit branch ID ordering at join stage.
+
+---
+
+## Demo / Review Plan
+- Demo artifact: Minimal fork/join workflow demonstrating parallel branches.
+- Validation: Run workflow multiple times and compare artifacts.
+- Review focus:
+  - Determinism guarantees
+  - Failure semantics
+  - Code clarity over cleverness
+
+---
+
+## Exit Criteria
+- Fork branches execute concurrently under bounded executor.
+- Join waits for all branches and merges deterministically.
+- Sequential mode still passes all existing tests.
+- Determinism test passes across multiple runs.
+- CI is green.
+- No untracked regressions in existing demos.

--- a/docs/milestones/v0.4/WBS_v0.4.md
+++ b/docs/milestones/v0.4/WBS_v0.4.md
@@ -1,0 +1,98 @@
+# Work Breakdown Structure (WBS) Template
+
+## Metadata
+- Milestone: `{{milestone}}`
+- Version: `{{version}}`
+- Date: `{{date}}`
+- Owner: `{{owner}}`
+
+## How To Use
+- Break work into independently-mergeable issues.
+- Keep each item measurable and testable.
+- Include deliverables + dependencies + issue links.
+
+## WBS Summary
+{{wbs_summary}}
+
+## Work Packages
+| ID | Work Package | Description | Deliverable | Dependencies | Issue |
+|---|---|---|---|---|---|
+| WP-01 | {{package_1}} | {{description_1}} | {{deliverable_1}} | {{deps_1}} | {{issue_1}} |
+| WP-02 | {{package_2}} | {{description_2}} | {{deliverable_2}} | {{deps_2}} | {{issue_2}} |
+| WP-03 | {{package_3}} | {{description_3}} | {{deliverable_3}} | {{deps_3}} | {{issue_3}} |
+
+## Sequencing
+- Phase 1: {{phase_1}}
+- Phase 2: {{phase_2}}
+- Phase 3: {{phase_3}}
+
+## Acceptance Mapping
+- {{package_1}} -> {{acceptance_criteria_1}}
+- {{package_2}} -> {{acceptance_criteria_2}}
+- {{package_3}} -> {{acceptance_criteria_3}}
+
+## Exit Criteria
+- Every in-scope requirement maps to at least one WBS item.
+- Every WBS item has an owner, issue reference, and concrete deliverable.
+- Dependency order is explicit enough to execute deterministically.
+
+# ADL v0.4 – Work Breakdown Structure
+
+## Metadata
+- Milestone: `v0.4`
+- Version: `0.4`
+- Date: {{date}}
+- Owner: Daniel Austin
+
+---
+
+## WBS Summary
+v0.4 delivers a deterministic fork/join runtime execution scaffold with bounded concurrency, join semantics, and full traceability. Work is divided into independently mergeable packages aligned to issue #291 (and sub-issues as needed).
+
+Primary objective: ship a minimal but real concurrency engine without regressing sequential execution or CI stability.
+
+---
+
+## Work Packages
+
+| ID | Work Package | Description | Deliverable | Dependencies | Issue |
+|---|---|---|---|---|---|
+| WP-01 | Execution Plan & DAG Validation | Define `ExecutionPlan` type and validate fork/join DAG structure before execution. | Validated execution plan + unit tests for invalid graphs. | Existing sequential executor | #291 |
+| WP-02 | Bounded Fork Executor | Implement bounded executor (threadpool) for branch execution. | Executor module + concurrency tests. | WP-01 | #291 |
+| WP-03 | Deterministic Join Barrier | Implement wait-for-all join with ordered merge by branch ID. | JoinBarrier implementation + deterministic merge tests. | WP-02 | #291 |
+| WP-04 | Sequential Mode Preservation | Ensure existing sequential execution path remains intact and testable. | Passing regression suite under sequential mode. | WP-01 | #291 |
+| WP-05 | Failure & Retry Integration | Integrate existing retry logic with concurrent execution and enforce fail-fast semantics. | Branch failure tests + deterministic retry validation. | WP-02, WP-03 | #291 |
+| WP-06 | Determinism Test Harness | Multi-run execution test to verify identical artifacts across runs. | Determinism test suite + artifact comparison checks. | WP-02, WP-03 | #291 |
+| WP-07 | Demo Workflow Update | Update v0.4 demo to showcase fork/join concurrency. | Working demo workflow + README example. | WP-03 | #291 |
+
+---
+
+## Sequencing
+
+- Phase 1: Core planning and validation (WP-01)
+- Phase 2: Concurrency primitives (WP-02, WP-03)
+- Phase 3: Safety & determinism guarantees (WP-04, WP-05, WP-06)
+- Phase 4: Demo integration and polish (WP-07)
+
+Execution order must follow dependency chain; no join implementation before executor exists.
+
+---
+
+## Acceptance Mapping
+
+- Fork execution requirement -> WP-02
+- Deterministic join requirement -> WP-03
+- Sequential fallback requirement -> WP-04
+- Failure semantics requirement -> WP-05
+- Determinism guarantee requirement -> WP-06
+- Demo validation requirement -> WP-07
+
+---
+
+## Exit Criteria
+
+- Every functional requirement in DESIGN_v0.4.md maps to at least one WBS item.
+- All WBS items have corresponding PR(s) and passing CI.
+- Concurrency execution works with deterministic artifacts.
+- Sequential execution mode passes full regression suite.
+- Demo workflow reflects actual shipped runtime behavior.


### PR DESCRIPTION
Adds v0.4 milestone planning docs under docs/milestones/v0.4 for in-repo planning baseline before WP execution.