### PR TITLE
[v0.4][WP-01] ExecutionPlan + DAG validation scaffold (Closes #298)

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod adl;
 pub mod demo;
 pub mod execute;
+pub mod execution_plan;
 pub mod plan;
 pub mod prompt;
 pub mod provider;


### PR DESCRIPTION
## WP-01 Scope
- add `ExecutionPlan`/`ExecutionNode` model
- build plan during `resolve_run`
- validate DAG structure before execution:
  - duplicate step IDs rejected
  - duplicate `save_as` keys rejected
  - missing `@state:` producers rejected
  - cycles rejected

## Notes
- no executor behavior changes yet
- sequential mode behavior preserved

## Validation
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
