### PR TITLE
[v0.4][WP-02] Bounded fork executor primitive (Closes #297)

### DIFF
--- a/swarm/src/bounded_executor.rs
+++ b/swarm/src/bounded_executor.rs
@@ -1,0 +1,124 @@
+use anyhow::{anyhow, Result};
+use std::collections::VecDeque;
+use std::sync::{mpsc, Arc, Mutex};
+
+struct Job<T> {
+    index: usize,
+    run: Box<dyn FnOnce() -> T + Send + 'static>,
+}
+
+pub fn run_bounded<T: Send + 'static>(
+    max_parallel: usize,
+    jobs: Vec<Box<dyn FnOnce() -> T + Send + 'static>>,
+) -> Result<Vec<T>> {
+    if max_parallel == 0 {
+        return Err(anyhow!("max_parallel must be >= 1"));
+    }
+    if jobs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let worker_count = max_parallel.min(jobs.len());
+    let queue: VecDeque<Job<T>> = jobs
+        .into_iter()
+        .enumerate()
+        .map(|(index, run)| Job { index, run })
+        .collect();
+
+    let queue = Arc::new(Mutex::new(queue));
+    let (tx, rx) = mpsc::channel::<(usize, T)>();
+
+    let mut handles = Vec::with_capacity(worker_count);
+    for _ in 0..worker_count {
+        let queue = Arc::clone(&queue);
+        let tx = tx.clone();
+        handles.push(std::thread::spawn(move || loop {
+            let job = {
+                let mut q = queue.lock().expect("bounded executor queue lock poisoned");
+                q.pop_front()
+            };
+            let Some(job) = job else {
+                break;
+            };
+            let out = (job.run)();
+            if tx.send((job.index, out)).is_err() {
+                break;
+            }
+        }));
+    }
+    drop(tx);
+
+    let mut out: Vec<(usize, T)> = Vec::new();
+    for item in rx {
+        out.push(item);
+    }
+
+    for h in handles {
+        let _ = h.join();
+    }
+
+    out.sort_by_key(|(idx, _)| *idx);
+    Ok(out.into_iter().map(|(_, v)| v).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn run_bounded_rejects_zero_parallelism() {
+        let err = run_bounded::<usize>(0, vec![]).unwrap_err();
+        assert!(err.to_string().contains("max_parallel"), "{err:#}");
+    }
+
+    #[test]
+    fn run_bounded_preserves_job_output_order() {
+        let jobs: Vec<Box<dyn FnOnce() -> usize + Send + 'static>> = vec![
+            Box::new(|| 10usize),
+            Box::new(|| 20usize),
+            Box::new(|| 30usize),
+        ];
+        let out = run_bounded(2, jobs).expect("run_bounded should succeed");
+        assert_eq!(out, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn run_bounded_respects_parallelism_limit() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let observed_max = Arc::new(AtomicUsize::new(0));
+
+        let mut jobs: Vec<Box<dyn FnOnce() -> usize + Send + 'static>> = Vec::new();
+        for i in 0..8usize {
+            let active = Arc::clone(&active);
+            let observed_max = Arc::clone(&observed_max);
+            jobs.push(Box::new(move || {
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                loop {
+                    let prev = observed_max.load(Ordering::SeqCst);
+                    if now <= prev {
+                        break;
+                    }
+                    if observed_max
+                        .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
+                        .is_ok()
+                    {
+                        break;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(30));
+                active.fetch_sub(1, Ordering::SeqCst);
+                i
+            }));
+        }
+
+        let out = run_bounded(3, jobs).expect("run_bounded should succeed");
+        assert_eq!(out.len(), 8);
+        assert!(
+            observed_max.load(Ordering::SeqCst) <= 3,
+            "observed max parallel workers exceeded bound"
+        );
+    }
+}

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod adl;
+pub mod bounded_executor;
 pub mod demo;
 pub mod execute;
 pub mod execution_plan;


### PR DESCRIPTION
## WP-02 Scope
- add bounded executor module (`run_bounded`) for controlled parallel task execution
- deterministic output ordering (job index order)
- tests for zero-bound rejection, output ordering, and parallelism bound enforcement

## Notes
- no runtime behavior switch yet; this introduces the bounded executor primitive for WP-03 wiring
- sequential mode remains unchanged

## Validation
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
