### PR TITLE
[v0.4] Runtime fork/join deterministic integration coverage (#302)

### DIFF
--- a/.adl/cards/302/input_302.md
+++ b/.adl/cards/302/input_302.md
@@ -1,0 +1,68 @@
+# ADL Input Card
+
+Task ID: issue-0302
+Run ID: issue-0302
+Version: v0.4
+Title: v0-4-burst-2-runtime-fork-join
+Branch: codex/302-v0-4-burst-2-runtime-fork-join
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/302
+- PR: https://github.com/danielbaustin/agent-design-language/pull/303
+- Docs: /Users/daniel/git/agent-design-language/docs/milestones/v0.4/WBS_v0.4.md
+- Other: /Users/daniel/git/agent-design-language/.adl/cards/302/output_302.md
+
+Execution:
+- Agent: Codex (GPT-5)
+- Provider: local CLI + GitHub CLI
+- Tools allowed: git, gh, cargo, repo-local scripts
+- Sandbox / approvals: workspace-write; halt on policy/scope violations or human decision required
+
+## Goal
+Implement Burst 2 runtime fork/join execution wiring validation for v0.4 with deterministic behavior guarantees, using bounded fork execution and deterministic join semantics, with integration tests that validate real behavior.
+
+## Acceptance Criteria
+- Runtime path is wired to execute fork/join flows under deterministic semantics.
+- Fork stage uses bounded executor behavior (no unbounded parallel fan-out).
+- Join barrier behavior is deterministic and stable.
+- Artifacts and trace ordering remain deterministic.
+- Integration tests cover:
+  - deterministic concurrent/fork execution outputs
+  - bounded parallelism respected
+- v0.3 behavior remains intact.
+- Quality gates pass:
+  - `cargo fmt`
+  - `cargo clippy --all-targets -- -D warnings`
+  - `cargo test`
+- Draft PR opened first; merge only when CI is green.
+
+## Inputs
+- GitHub issue #302 requirements
+- Existing runtime/execution plan implementation
+- Existing integration test harness in `swarm/tests/execute_tests.rs`
+
+## Constraints / Policies
+- Determinism requirements:
+  - Stable ordering for execution-observable outputs
+  - Join barrier must not introduce nondeterministic behavior
+- Security / privacy requirements:
+  - No external secret handling changes
+  - No expansion of provider auth surface
+- Resource limits (time/CPU/memory/network):
+  - Keep tests deterministic and CI-friendly
+  - Avoid heavy or flaky timing-sensitive constructs
+
+## Non-goals / Out of scope
+- No schema version changes.
+- No v0.4 thread-pool redesign beyond bounded behavior already scoped.
+- No unrelated README/docs refactors.
+- No merge automation in this burst.
+
+## Notes / Risks
+- Timing-based bounded-parallel assertions can be CI-sensitive; bounds must allow runner variability while still proving behavior.
+- Lock-file based shell synchronization can hang under contention; prefer deterministic lightweight mock behavior.
+
+## Instructions to the Agent
+- Read this file.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -223,6 +223,19 @@ echo "MOCK_CONTINUE_OK"
 exit 0
 "#
         }
+        MockOllamaBehavior::SleepTrackConcurrency => {
+            r#"#!/bin/sh
+set -eu
+if [ "${1:-}" != "run" ]; then
+  echo "mock ollama: expected 'run'" 1>&2
+  exit 2
+fi
+cat >/dev/null
+sleep 1
+echo "MOCK_SLEEP_OK"
+exit 0
+"#
+        }
     };
 
     fs::write(&bin, script.as_bytes()).unwrap();
@@ -247,6 +260,7 @@ enum MockOllamaBehavior {
     EchoPrompt,
     FailOnce,
     FailOnToken,
+    SleepTrackConcurrency,
 }
 
 fn run_swarm(args: &[&str]) -> std::process::Output {
@@ -1247,6 +1261,120 @@ run:
     assert!(
         !stdout.contains("StepStarted step=fork.join"),
         "join step should not start after branch failure; stdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn run_v0_3_concurrent_execution_is_deterministic_across_runs() {
+    let base = tmp_dir("exec-concurrent-v0-3-deterministic");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let out1 = run_swarm(&["examples/v0-3-concurrency-fork-join.adl.yaml", "--run"]);
+    assert!(
+        out1.status.success(),
+        "first run failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out1.stdout),
+        String::from_utf8_lossy(&out1.stderr)
+    );
+
+    let out2 = run_swarm(&["examples/v0-3-concurrency-fork-join.adl.yaml", "--run"]);
+    assert!(
+        out2.status.success(),
+        "second run failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out2.stdout),
+        String::from_utf8_lossy(&out2.stderr)
+    );
+
+    let s1 = String::from_utf8_lossy(&out1.stdout);
+    let s2 = String::from_utf8_lossy(&out2.stdout);
+    assert_eq!(s1, s2, "concurrent run output should be deterministic");
+}
+
+#[test]
+fn run_v0_3_concurrent_workflow_respects_bounded_parallelism() {
+    use std::time::Instant;
+
+    let base = tmp_dir("exec-concurrent-v0-3-bounded");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::SleepTrackConcurrency);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let yaml = r#"
+version: "0.3"
+
+providers:
+  local:
+    type: "ollama"
+    config:
+      model: "phi4-mini"
+
+agents:
+  a:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t:
+    prompt:
+      user: "work {{n}}"
+
+run:
+  name: "bounded-parallelism"
+  workflow:
+    kind: "concurrent"
+    steps:
+      - id: "s1"
+        agent: "a"
+        task: "t"
+        inputs: { n: "1" }
+      - id: "s2"
+        agent: "a"
+        task: "t"
+        inputs: { n: "2" }
+      - id: "s3"
+        agent: "a"
+        task: "t"
+        inputs: { n: "3" }
+      - id: "s4"
+        agent: "a"
+        task: "t"
+        inputs: { n: "4" }
+      - id: "s5"
+        agent: "a"
+        task: "t"
+        inputs: { n: "5" }
+      - id: "s6"
+        agent: "a"
+        task: "t"
+        inputs: { n: "6" }
+      - id: "s7"
+        agent: "a"
+        task: "t"
+        inputs: { n: "7" }
+      - id: "s8"
+        agent: "a"
+        task: "t"
+        inputs: { n: "8" }
+"#;
+
+    let tmp_yaml = base.join("bounded-parallelism.yaml");
+    fs::write(&tmp_yaml, yaml).unwrap();
+
+    let started = Instant::now();
+    let out = run_swarm(&[tmp_yaml.to_str().unwrap(), "--run"]);
+    let elapsed = started.elapsed().as_secs_f64();
+    assert!(
+        out.status.success(),
+        "expected success for bounded parallelism run.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        (1.6..=4.5).contains(&elapsed),
+        "expected bounded parallel runtime window (>=1.6s and <=4.5s), got {elapsed:.3}s"
     );
 }
 


### PR DESCRIPTION
## Summary\n- add deterministic integration coverage for runtime fork/join behavior\n- add bounded parallelism integration coverage with deterministic runtime window assertions\n- keep scope tight to issue #302 requirements\n\n## Validation\n- cd swarm && cargo fmt\n- cd swarm && cargo clippy --all-targets -- -D warnings\n- cd swarm && cargo test\n\nCloses #302