### PR TITLE
docs(v0.4): finalize release-state consistency updates

### DIFF
--- a/docs/milestones/v0.4/DESIGN_v0.4.md
+++ b/docs/milestones/v0.4/DESIGN_v0.4.md
@@ -59,4 +59,4 @@ v0.3 had deterministic fork/join modeling but runtime behavior needed stronger, 
 - Configurable parallelism and advanced scheduling are deferred.
 
 ## Exit
-v0.4 ships real, observable runtime concurrency with deterministic join behavior and reproducible demos, while preserving existing v0.3 stability guarantees.
+v0.4 ships plan-driven runtime concurrency with deterministic fork/join semantics and reproducible artifacts, while preserving existing v0.3 stability guarantees.

--- a/docs/milestones/v0.4/MILESTONE_CHECKLIST_v0.4.md
+++ b/docs/milestones/v0.4/MILESTONE_CHECKLIST_v0.4.md
@@ -37,8 +37,8 @@
 ## Post-Release
 - [x] Demo pass merged and issue closed (#306 / #307)
 - [x] Remaining open milestone umbrella issues closed with release links (`#290`, `#291`)
-- [ ] Deferred items moved to next milestone backlog (v0.5)
-- [ ] Retrospective summary recorded
+- [x] Deferred items moved to next milestone backlog (v0.5)
+- [x] Retrospective summary recorded
 
 ## Exit Criteria
-Milestone implementation and release publication are complete; remaining work is post-release process follow-through.
+Milestone implementation is complete, documented, and release-complete.

--- a/docs/milestones/v0.4/RELEASE_NOTES_v0.4.md
+++ b/docs/milestones/v0.4/RELEASE_NOTES_v0.4.md
@@ -5,6 +5,7 @@
 - Version: `0.4`
 - Release date: `2026-02-18`
 - Tag: `v0.4.0`
+- Release: https://github.com/danielbaustin/agent-design-language/releases/tag/v0.4.0
 
 ## Summary
 ADL v0.4 ships real runtime concurrency behavior with deterministic fork/join semantics, bounded fork execution, strengthened runtime wiring through `ExecutionPlan`, and no-network demos that make the behavior directly reproducible.
@@ -39,6 +40,9 @@ ADL v0.4 ships real runtime concurrency behavior with deterministic fork/join se
 ## Known Limitations
 - Configurable runtime parallelism is not exposed yet.
 - Advanced scheduler policies and richer trace schema are deferred.
+
+## Breaking Changes
+None.
 
 ## Validation Notes
 - Local gates used for shipped PRs: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.

--- a/docs/milestones/v0.4/RELEASE_v0.4.md
+++ b/docs/milestones/v0.4/RELEASE_v0.4.md
@@ -1,6 +1,7 @@
 # ADL v0.4 Release Announcement
 
 ADL v0.4 is now complete.
+Release: https://github.com/danielbaustin/agent-design-language/releases/tag/v0.4.0
 
 This release marks the shift from planned concurrency to shipped, observable runtime concurrency behavior.
 


### PR DESCRIPTION
## Summary
- remove stale "pending tag publish" wording from v0.4 release notes
- add published release URL in release notes and release announcement
- add explicit "Breaking Changes" section with "None."
- mark release/tag steps complete in release plan
- mark umbrella closure/post-release checklist items complete
- strengthen DESIGN v0.4 exit wording to match shipped semantics

## Files
- docs/milestones/v0.4/RELEASE_NOTES_v0.4.md
- docs/milestones/v0.4/RELEASE_PLAN_v0.4.md
- docs/milestones/v0.4/MILESTONE_CHECKLIST_v0.4.md
- docs/milestones/v0.4/DESIGN_v0.4.md
- docs/milestones/v0.4/RELEASE_v0.4.md

## Validation
- docs-only change; no runtime/code changes