### PR TITLE
docs(v0.5): track milestone docs and apply sanity fixes

### DIFF
--- a/docs/milestones/v0.5/DECISIONS_v0.5.md
+++ b/docs/milestones/v0.5/DECISIONS_v0.5.md
@@ -1,0 +1,31 @@
+# ADL v0.5 Decisions Log
+
+## Metadata
+- Milestone: `v0.5`
+- Version: `0.5`
+- Date: `2026-02-18`
+- Owner: `Daniel Austin`
+
+## Purpose
+Capture architectural, language, runtime, and process decisions that define v0.5. This milestone focuses on maturing ADL as a language (explicit primitive schemas + composition rules) while evolving the runtime scheduler in a deterministic and configurable way.
+
+## Decision Log
+| ID | Decision | Status | Rationale | Alternatives | Impact | Link |
+|----|----------|--------|-----------|-------------|--------|------|
+| D-01 | Treat ADL as a first-class language with explicit schemas for all 6 primitives (Agents, Runs, Providers, Tasks, Tools, Workflows). | accepted | Prevent runtime-driven drift and implicit structure; enable validation, tooling, and composition. | Continue implicit struct-based modeling only. | Enables schema validation, better docs, stronger demos. | #330 |
+| D-02 | Separate “primitive definition” from “composition rules.” | accepted | Clarifies language core vs orchestration semantics; reduces coupling. | Embed composition rules inside workflow-only schema. | Cleaner mental model and easier extension. | #330 |
+| D-03 | Runtime concurrency must remain deterministic even when configurable. | accepted | Determinism is foundational to trace + replay guarantees. | Allow nondeterministic scheduling for performance. | Preserves replay invariants and CI stability. | v0.4 precedent |
+| D-04 | Configurable concurrency limit (schema → runtime) will land in v0.5 but default remains conservative. | accepted | Adds flexibility without breaking v0.4 behavior. | Keep hardcoded MAX_PARALLEL indefinitely. | Expands runtime usability while preserving stability. | v0.5 WP-03 |
+| D-05 | v0.5 includes a formal Demo Matrix exercising each primitive alone and in composition. | accepted | Demos are now first-class deliverables, not afterthoughts. | Ad hoc example growth. | Improves clarity, onboarding, and release credibility. | v0.5 docs |
+| D-06 | Milestones follow fixed ceremony structure: Init → Work Units → Demo Pass → Doc Pass → Review → Closing Ceremony. | accepted | Prevents drift and partial completion. | Flexible / informal sprint structure. | Predictable release quality and cadence. | Process decision |
+| D-07 | Observable memory + Bayesian indexing is deferred to v0.6 (or separate module if scope expands). | deferred | Avoid mixing language/runtime stabilization with experimental memory system. | Ship memory system inside v0.5. | Keeps v0.5 focused and finishable. | Future epic |
+
+## Open Questions
+- Should concurrency configuration live at the Run level, Workflow level, or both? (Owner: Daniel) (Issue: TBD)
+- Should composition rules be validated statically (compile phase) or partially at runtime? (Owner: Daniel) (Issue: TBD)
+- Do we introduce a formal "adl validate" command in v0.5? (Owner: Daniel) (Issue: TBD)
+
+## Exit Criteria
+- All language-level and scheduler-level decisions for v0.5 are explicitly recorded.
+- Deferred items clearly moved to future milestone.
+- No structural ambiguity remains about primitive schemas or composition model.

--- a/docs/milestones/v0.5/DESIGN_v0.5.md
+++ b/docs/milestones/v0.5/DESIGN_v0.5.md
@@ -1,0 +1,218 @@
+# ADL v0.5 Design — Deterministic Multi-Agent Patterns + Configurable Scheduler
+
+## Metadata
+- Milestone: `v0.5`
+- Version: `0.5`
+- Date: `2026-02-18`
+- Owner: Daniel Austin
+- Related issues: #308 (epic), #309 (Burst 1), TBD pattern issues
+
+## Purpose
+Define how ADL evolves from deterministic workflow execution (v0.4) into a deterministic multi-agent orchestration platform with configurable runtime scheduling and a clean boundary for an external Observable Memory (ObsMem) module.
+
+This document locks architectural intent before implementation proceeds.
+
+---
+
+## Problem Statement
+
+v0.4 shipped:
+- ExecutionPlan-driven runtime
+- Bounded fork execution
+- Deterministic join barrier
+- Deterministic replayable demos
+
+However:
+
+1. Multi-agent patterns (debate, planner-executor, referee, hierarchical) are not first-class language constructs.
+2. Scheduler behavior is fixed (MAX_PARALLEL=4).
+3. Observable memory is conceptual but not productized or modularized.
+4. The six ADL primitives are not yet explicitly schema-bound with composition guarantees.
+
+v0.5 must:
+- Expand the ADL language
+- Strengthen runtime configurability
+- Establish ADL as a deterministic alternative to AutoGen-style systems
+
+---
+
+## Goals
+
+- Introduce explicit schemas for all six primitives:
+  - Agents
+  - Runs
+  - Providers
+  - Tasks
+  - Tools
+  - Workflows
+- Define compositional model across primitives.
+- Introduce first-class deterministic multi-agent patterns.
+- Expose configurable concurrency controls in runtime.
+- Preserve determinism guarantees.
+- Keep ObsMem modular and separable as its own crate.
+
+---
+
+## Non-Goals
+
+- Distributed execution across clusters.
+- Full checkpoint/recovery engine.
+- Persistent long-term memory store in core runtime.
+- Non-deterministic scheduling policies.
+- External orchestration platform (K8s integration, etc.).
+
+---
+
+## Scope
+
+### In scope
+
+- Pattern schema (v0.1)
+- Pattern → ExecutionPlan compiler
+- Deterministic multi-agent turn ordering
+- Configurable `max_parallel`
+- Scheduler policy surface (minimal: fifo | fair)
+- Stable deterministic trace markers for patterns
+- ObsMem crate scaffold (separate project)
+- Demo pass covering each primitive alone and in composition
+
+### Out of scope
+
+- Distributed multi-node scheduler
+- Advanced dynamic scaling
+- Full RAG system embedded in runtime
+
+---
+
+## Requirements
+
+### Functional
+
+- All six primitives have explicit schema definitions.
+- Workflows can embed patterns.
+- Pattern compilation produces deterministic ExecutionPlan graphs.
+- Runtime supports configurable concurrency limits.
+- Multi-agent execution preserves stable ordering and replayability.
+- Demos exist for:
+  - linear
+  - multi-step
+  - hierarchical
+  - remote
+  - fork/join
+  - multi-agent debate
+
+### Non-functional
+
+- Deterministic behavior and reproducible outputs.
+- Clear failure semantics and observability.
+- Stable trace schema with pattern markers.
+- CI green with expanded test surface.
+- Nightly coverage automation targets as high as reasonable coverage (non-blocking but reported).
+
+---
+
+## Proposed Design
+
+### Overview
+
+v0.5 introduces a three-layer architecture:
+
+1. Language Layer  
+   Explicit schemas for primitives and patterns.
+
+2. Compilation Layer  
+   Pattern compiler → ExecutionPlan DAG.
+
+3. Runtime Layer  
+   Configurable bounded scheduler executing deterministic DAGs.
+
+ObsMem exists as a separate crate and integrates through Tools or Providers.
+
+---
+
+### Interfaces / Data Contracts
+
+- `AgentSchema`
+- `TaskSchema`
+- `ToolSchema`
+- `ProviderSchema`
+- `RunSchema`
+- `WorkflowSchema`
+- `PatternSchema`
+- `SchedulerConfig { max_parallel, policy }`
+
+PatternSchema compiles into deterministic ExecutionPlan nodes with stable IDs.
+
+---
+
+### Execution Semantics
+
+1. Pattern expands to structured DAG.
+2. Stable node IDs derived from canonicalized pattern + seed.
+3. Scheduler respects:
+   - max_parallel
+   - deterministic tie-breaking
+4. Join barriers preserve stable artifact ordering.
+5. Trace logs:
+   - PatternStart
+   - PatternTurn
+   - PatternJoin
+   - SchedulerDecision
+
+Replay remains provider-free and validates ordering invariants.
+
+---
+
+## Risks and Mitigations
+
+- Risk: Pattern explosion increases complexity.
+  - Mitigation: Start with minimal set (debate, planner_executor).
+
+- Risk: Configurable scheduler breaks determinism.
+  - Mitigation: Deterministic tie-breaking and invariant tests.
+
+- Risk: ObsMem coupling contaminates runtime.
+  - Mitigation: Separate crate; integrate via Tool interface only.
+
+---
+
+## Alternatives Considered
+
+- Option: Hardcode patterns in runtime.
+  - Tradeoff: Faster to implement, but not extensible.
+
+- Option: Fully dynamic non-deterministic scheduler.
+  - Tradeoff: Performance flexibility but breaks replay guarantees.
+
+---
+
+## Validation Plan
+
+- Unit tests for:
+  - Pattern compilation
+  - Scheduler determinism
+  - Configurable concurrency
+- Integration tests:
+  - Debate demo
+  - Hierarchical planner demo
+  - Remote multi-agent demo
+- Success metrics:
+  - Stable replay across 100 runs
+  - CI green
+  - Demo pass automated
+- Rollback:
+  - Disable configurable scheduler
+  - Revert to v0.4 fixed concurrency
+
+---
+
+## Exit Criteria
+
+- All six primitives have schemas and validation tests.
+- Pattern compiler produces deterministic DAGs.
+- Configurable scheduler works and remains deterministic.
+- ObsMem crate scaffolded separately.
+- Demo pass complete.
+- Documentation pass complete.
+- Review pass complete.
+- Milestone checklist gates satisfied.

--- a/docs/milestones/v0.5/MILESTONE_CHECKLIST_v0.5.md
+++ b/docs/milestones/v0.5/MILESTONE_CHECKLIST_v0.5.md
@@ -1,0 +1,112 @@
+# ADL v0.5 Milestone Checklist
+
+## Metadata
+- Milestone: `v0.5`
+- Version: `0.5.0`
+- Target release date: `TBD`
+- Owner: `Daniel Austin`
+
+## Purpose
+Ship/no-ship gate for v0.5. Check items only when evidence exists (links, PRs, CI runs, demo logs).
+
+---
+
+## Planning
+- [x] Milestone goal defined (`docs/milestones/v0.5/DESIGN_v0.5.md`)
+- [x] Scope + non-goals documented (`docs/milestones/v0.5/DESIGN_v0.5.md`)
+- [x] WBS created and mapped to work packages (`docs/milestones/v0.5/WBS_v0.5.md`)
+- [x] Decision log initialized (`docs/milestones/v0.5/DECISIONS_v0.5.md`)
+- [x] Sprint plan created (`docs/milestones/v0.5/SPRINT_v0.5.md`)
+- [ ] v0.5 epic(s) created and linked in WBS / docs (see GitHub issues)
+
+## Execution Discipline
+- [ ] Each issue has input/output cards under `.adl/cards/<issue>/`
+- [ ] Each burst writes artifacts under `.adl/reports/burst/<timestamp>/`
+- [ ] Draft PR opened for each issue before merge
+- [ ] Transient failures retried and documented
+- [ ] "Green-only merge" policy followed
+- [ ] Work unit boundaries respected (no drift beyond WBS scope freeze)
+
+## Quality Gates
+- [ ] `cargo fmt` passes (release candidate)
+- [ ] `cargo clippy --all-targets -- -D warnings` passes (release candidate)
+- [ ] `cargo test` passes (release candidate)
+- [ ] CI is green on the merge target (`swarm-ci`, `swarm-coverage`)
+- [ ] Coverage signal is not red (or exception documented)
+- [ ] No unresolved high-priority blockers (link: `.adl/reports/triage/` or issue list snapshot)
+
+## Feature Gates (v0.5)
+### Language surface
+- [ ] Explicit schemas exist for all 6 primitives:
+  - [ ] Agents
+  - [ ] Runs
+  - [ ] Providers
+  - [ ] Tasks
+  - [ ] Tools
+  - [ ] Workflows
+- [ ] Composition rules defined and enforced (validation + deterministic ordering)
+- [ ] Examples exist for each primitive alone and composed
+
+### Patterns + compilation
+- [ ] Pattern schema v0.1 exists and is validated
+- [ ] Pattern → ExecutionPlan compilation implemented
+- [ ] Deterministic multi-agent turn ordering guaranteed and tested
+
+### Scheduler configurability
+- [ ] Configurable concurrency limit (schema → runtime) implemented
+- [ ] Determinism preserved across limits (tests for 1, 2, N)
+- [ ] Trace includes scheduler/config context
+
+### Distributed + trust model (original v0.3 goals)
+- [ ] Remote execution MVP implemented (reference server + client)
+- [ ] Mixed placement workflow example exists (local + remote)
+- [ ] Workflow signing implemented:
+  - [ ] `adl sign` works
+  - [ ] `adl verify` works
+  - [ ] `adl run` enforces signing (dev override documented)
+- [ ] Trace export + replay continues to work with new features
+
+## Demo Generation Pass
+- [ ] Demo matrix complete (primitive-alone + composition)
+- [ ] Structural demos exist and run end-to-end:
+  - [ ] Linear
+  - [ ] Multi-step chain
+  - [ ] Fork/join
+  - [ ] Hierarchical
+  - [ ] Pattern-based debate
+  - [ ] Planner-executor
+  - [ ] Mixed local/remote placement
+  - [ ] Signed workflow execution
+  - [ ] Deterministic replay
+- [ ] All demos are one-command runnable and documented
+- [ ] Demos provide readable timestamps + user-visible progress output
+
+## Documentation Pass
+- [ ] Root README updated for v0.5 (what ADL is, why it matters, quickstart)
+- [ ] `swarm/README.md` updated and consistent with root README
+- [ ] Spec docs updated (`adl-spec/` docs where applicable)
+- [ ] All demo commands in docs are copy/paste verified
+
+## Review Pass
+- [ ] Nightly coverage automation run and report attached (target: 100%)
+- [ ] Nightly docs consistency automation run and report attached
+- [ ] Regression scan performed (no drift from v0.4 demos)
+- [ ] External “new user” walkthrough performed from README
+
+## Release Packaging
+- [ ] Release notes finalized (`docs/milestones/v0.5/RELEASE_NOTES_v0.5.md`)
+- [ ] Tag verified: `v0.5.0`
+- [ ] GitHub Release drafted and published (body based on release notes)
+- [ ] Links validated in release body
+- [ ] Release announcement draft prepared (`docs/milestones/v0.5/RELEASE_NOTES_v0.5.md`)
+
+## Post-Release
+- [ ] Milestone/epic issues closed with release links
+- [ ] Deferred items moved to next milestone backlog
+- [ ] Follow-up bugs/tech debt captured as issues
+- [ ] Roadmap/status docs updated
+- [ ] Retrospective summary recorded (in release plan or separate doc)
+
+## Exit Criteria
+- All required gates are checked, or each exception has an owner + due date.
+- Milestone can be audited end-to-end via the links captured above.

--- a/docs/milestones/v0.5/RELEASE_NOTES_v0.5.md
+++ b/docs/milestones/v0.5/RELEASE_NOTES_v0.5.md
@@ -1,0 +1,57 @@
+# Release Notes Template
+
+## Metadata
+- Product: `{{product_name}}`
+- Version: `{{version}}`
+- Release date: `{{release_date}}`
+- Tag: `{{tag_name}}`
+
+## How To Use
+- Keep statements implementation-accurate and test-validated.
+- Prefer concise bullets over marketing language.
+- Explicitly separate shipped behavior from "What's Next."
+
+# `{{product_name}}` `{{version}}` Release Notes
+
+## Summary
+{{summary_paragraph}}
+
+## Highlights
+- {{highlight_1}}
+- {{highlight_2}}
+- {{highlight_3}}
+
+## What's New In Detail
+
+### {{area_1}}
+- {{detail_1a}}
+- {{detail_1b}}
+
+### {{area_2}}
+- {{detail_2a}}
+- {{detail_2b}}
+
+### {{area_3}}
+- {{detail_3a}}
+- {{detail_3b}}
+
+## Upgrade Notes
+- {{upgrade_note_1}}
+- {{upgrade_note_2}}
+
+## Known Limitations
+- {{limitation_1}}
+- {{limitation_2}}
+
+## Validation Notes
+- {{validation_note_1}}
+- {{validation_note_2}}
+
+## What's Next
+- {{next_1}}
+- {{next_2}}
+
+## Exit Criteria
+- Notes reflect only shipped behavior.
+- Known limitations and future work are explicitly separated.
+- Final text is ready to paste into GitHub Release UI without further editing.

--- a/docs/milestones/v0.5/RELEASE_PLAN_v0.5.md
+++ b/docs/milestones/v0.5/RELEASE_PLAN_v0.5.md
@@ -1,0 +1,83 @@
+# ADL v0.5 Release Plan
+
+## Metadata
+- Milestone: `v0.5`
+- Version: `0.5.0`
+- Release date: `TBD`
+- Release manager: `Daniel Austin`
+
+---
+
+## Purpose
+Operational checklist for shipping ADL v0.5. This document tracks mechanical release steps only. Narrative belongs in release notes.
+
+---
+
+## 1) Release Readiness
+- [ ] Milestone checklist complete (`docs/milestones/v0.5/MILESTONE_CHECKLIST_v0.5.md`)
+- [ ] Release notes finalized (`docs/milestones/v0.5/RELEASE_NOTES_v0.5.md`)
+- [ ] Go/no-go decision recorded (`docs/milestones/v0.5/DECISIONS_v0.5.md`)
+- [ ] All v0.5 WBS work packages marked done (`docs/milestones/v0.5/WBS_v0.5.md`)
+- [ ] Demo matrix fully runnable and validated
+
+---
+
+## 2) Branch And Tag Preparation
+- [ ] Target branch confirmed (`main`)
+- [ ] Working tree clean (`git status`)
+- [ ] Version references validated in:
+  - Root README
+  - swarm/README.md
+  - docs/milestones/v0.5/*
+- [ ] Cargo metadata validated (if applicable)
+- [ ] Tag created: `v0.5.0`
+- [ ] Tag pushed and verified (`git push origin v0.5.0`)
+
+Tag command:
+
+```
+git tag -a v0.5.0 -m "ADL v0.5.0"
+git push origin v0.5.0
+```
+
+---
+
+## 3) GitHub Release Steps
+- [ ] GitHub Release draft created from `v0.5.0`
+- [ ] Release body populated from `RELEASE_NOTES_v0.5.md`
+- [ ] Links to key PRs and issues included
+- [ ] Release visibility confirmed (final, not prerelease unless intended)
+- [ ] Release published
+
+CLI option (if GitHub API stable):
+
+```
+gh release create v0.5.0 \
+  --title "ADL v0.5.0" \
+  --notes-file docs/milestones/v0.5/RELEASE_NOTES_v0.5.md
+```
+
+---
+
+## 4) Verification
+- [ ] Post-release CI status checked
+- [ ] Release links tested (README, docs, demo commands)
+- [ ] All demo scripts verified against tagged release
+- [ ] No critical regressions discovered
+- [ ] Coverage signal acceptable (not red)
+
+---
+
+## 5) Communication
+- [ ] Release announcement prepared (`docs/milestones/v0.5/RELEASE_NOTES_v0.5.md`)
+- [ ] Public announcement published
+- [ ] Roadmap/status updated
+- [ ] Deferred items moved to next milestone
+
+---
+
+## Exit Criteria
+- `v0.5.0` tag exists and is published.
+- GitHub Release exists and is public.
+- All checklist items satisfied or documented with owner + follow-up issue.
+- Release artifacts and demos verified against tagged commit.

--- a/docs/milestones/v0.5/SPRINT_v0.5.md
+++ b/docs/milestones/v0.5/SPRINT_v0.5.md
@@ -1,0 +1,124 @@
+# ADL v0.5 Sprint Plan
+
+## Metadata
+- Sprint: `v0.5-S1`
+- Milestone: `v0.5`
+- Start date: `2026-02-19`
+- End date: `TBD`
+- Owner: `Daniel Austin`
+
+---
+
+## Sprint Goal
+Establish the structural foundation for v0.5 by locking the language surface (6 primitives), defining composition rules, and scaffolding configurable scheduler controls—without introducing runtime instability.
+
+This sprint is architecture-first and discipline-first.
+
+---
+
+## Planned Scope (Unit 0 + Early Work Units)
+
+### Unit 0 — Milestone Initialization (#330)
+- Populate and freeze all v0.5 milestone docs
+- Define work units clearly in WBS
+- Define demo matrix
+- Freeze v0.5 scope
+
+### WP-01 — Explicit Primitive Schemas
+- Define explicit schemas for:
+  - Agents
+  - Runs
+  - Providers
+  - Tasks
+  - Tools
+  - Workflows
+- Validate schema consistency and naming
+- Add validation tests (schema load + negative cases)
+
+### WP-02 — Composition Rules + Validation
+- Define how primitives reference each other
+- Enforce composition constraints in validator
+- Add deterministic ordering guarantees for composed graphs
+
+### WP-03 — Configurable Scheduler Controls (#309)
+- Add concurrency limit configuration surface
+- Wire config → runtime executor
+- Add integration tests for parallelism levels (1, 2, N)
+- Preserve deterministic replay behavior
+
+---
+
+## Work Plan
+
+| Order | Work Unit | Issue | Status |
+|-------|----------|-------|--------|
+| 1 | Unit 0 — Milestone Init | #330 | In Progress |
+| 2 | WP-01 — Explicit primitive schemas | (TBD) | Planned |
+| 3 | WP-02 — Composition rules + validation | (TBD) | Planned |
+| 4 | WP-03 — Configurable scheduler controls | #309 | Planned |
+| 5 | Demo generation pass | (TBD) | Planned |
+| 6 | Documentation pass | (TBD) | Planned |
+| 7 | Review pass | (TBD) | Planned |
+| 8 | Closing ceremony (tag + release docs) | (TBD) | Planned |
+
+---
+
+## Demo Matrix (v0.5 Target)
+
+### Primitive-Alone Demos
+- Agent-only demo
+- Task-only demo
+- Tool-only demo
+- Provider-only demo
+- Workflow-only demo
+
+### Composition Demos
+- Linear workflow
+- Multi-step workflow
+- Hierarchical workflow
+- Parallel fork/join workflow
+- Local + remote mixed placement workflow
+- Deterministic replay workflow
+
+All demos must be:
+- One-command runnable
+- No-network reproducible (mock provider available)
+- Documented in README
+
+---
+
+## Discipline Rules
+- All implementation behind issue cards (`input` / `output`)
+- Draft PR required before merge
+- CI must be green before merge
+- Each work unit must reference a WBS item
+- No silent scope expansion
+
+---
+
+## Risks
+
+### Tooling Stability
+- `pr.sh start` behavior inconsistent
+- Mitigation: tracked separately; avoid coupling runtime work to tooling fixes
+
+### Schema Drift
+- Risk: primitives evolve inconsistently
+- Mitigation: freeze definitions before runtime wiring
+
+### Determinism Regression
+- Risk: configurable concurrency breaks replay guarantees
+- Mitigation: deterministic ordering remains default; tests required for all parallel levels
+
+---
+
+## Exit Criteria
+- Unit 0 complete and milestone structure frozen
+- Primitive schemas explicitly defined and validated
+- Composition rules documented and enforced
+- Scheduler configurability scaffolded with tests
+- Demo matrix implemented and runnable
+- Documentation pass complete
+- Review pass complete
+- CI green
+- Ready for `v0.5.0` tag

--- a/docs/milestones/v0.5/WBS_v0.5.md
+++ b/docs/milestones/v0.5/WBS_v0.5.md
@@ -1,0 +1,143 @@
+## Metadata
+- Milestone: `v0.5`
+- Version: `0.5`
+- Date: `2026-02-18`
+- Owner: Daniel Austin
+
+## Scope Freeze (Unit 0 Output)
+
+v0.5 scope is frozen to the following categories:
+
+1. Language Surface Completion
+   - Explicit schemas for all 6 primitives:
+     Agents, Runs, Providers, Tasks, Tools, Workflows
+   - Deterministic composition semantics
+
+2. Pattern + Compilation Layer
+   - PatternSchema → ExecutionPlan compiler
+   - Deterministic multi-agent pattern expansion
+
+3. Runtime Controls
+   - Configurable scheduler limits
+   - Stable deterministic execution guarantees
+
+4. Distributed + Security Completion (original v0.3 goals)
+   - Remote execution MVP
+   - Workflow signing + enforcement
+   - Structured trace + replay guarantees
+
+Anything not listed above is explicitly deferred to v0.6+.
+
+---
+
+## WBS Summary
+
+v0.5 completes the ADL language surface, introduces deterministic multi-agent pattern compilation, exposes configurable scheduler controls, and formalizes distributed + signing capabilities originally planned for v0.3.
+
+The milestone follows a disciplined execution structure:
+
+0) Milestone Init  
+1) Work Unit 1 — Tooling Stabilization  
+2) Work Unit 2 — Primitive Schema Completion  
+3) Work Unit 3 — Composition + Pattern Compiler  
+4) Work Unit 4 — Scheduler Configurability  
+5) Work Unit 5 — Remote Execution MVP  
+6) Work Unit 6 — Signing + Enforcement  
+7) Demo Generation Pass  
+8) Documentation Pass  
+9) Review Pass  
+10) Closing Ceremony  
+
+---
+
+## Work Packages
+
+| ID | Work Package | Description | Deliverable | Dependencies | Issue |
+|----|--------------|-------------|-------------|--------------|-------|
+| WP-00 | Milestone Init | Finalize milestone docs, freeze scope | DESIGN + WBS + DECISIONS + SPRINT + CHECKLIST finalized | None | #330 |
+| WP-01 | Tooling Stabilization | Fix pr.sh start bug, stabilize nightly automations | pr.sh fix + CI stable | WP-00 | Backlog (pr.sh stabilization) |
+| WP-02 | Primitive Schema Completion | Explicit schemas for Agents, Runs, Providers, Tasks, Tools, Workflows | Schema definitions + validation tests | WP-00 | TBD (to be created in burst planning) |
+| WP-03 | Composition Layer | Implement include/call + hierarchical workflow composition | Deterministic multi-file workflow demo | WP-02 | TBD (to be created in burst planning) |
+| WP-04 | Pattern Compiler v0.1 | PatternSchema → ExecutionPlan compiler (debate, planner_executor) | Deterministic pattern demo | WP-03 | TBD (to be created in burst planning) |
+| WP-05 | Scheduler Configurability | Expose max_parallel + minimal policy surface | Configurable concurrency demo | WP-04 | #309 |
+| WP-06 | Remote Execution MVP | Define remote protocol + reference server + placement rules | Mixed local/remote demo | WP-03 | TBD (to be created in burst planning) |
+| WP-07 | Signing + Enforcement | Implement sign/verify + enforcement in run | Signed workflow demo + rejection test | WP-02 | TBD (to be created in burst planning) |
+| WP-08 | Demo Generation Pass | Systematic demo sweep covering all primitives and patterns | Demo matrix complete | WP-04, WP-05, WP-06, WP-07 | TBD (to be created in burst planning) |
+| WP-09 | Documentation Pass | README + spec + milestone docs updated | Docs aligned with shipped behavior | WP-08 | TBD (to be created in burst planning) |
+| WP-10 | Review Pass | Coverage audit + doc audit + regression audit | CI green + nightly automation stable | WP-09 | TBD (to be created in burst planning) |
+| WP-11 | Closing Ceremony | Release notes + tag + retrospective | v0.5.0 tagged and published | WP-10 | TBD (to be created in burst planning) |
+
+---
+
+## Sequencing
+
+### Phase 1 — Structural Foundation (Language Lock-In)
+- WP-00
+- WP-01
+- WP-02
+
+### Phase 2 — Pattern + Compiler Layer
+- WP-03
+- WP-04
+- WP-05
+
+### Phase 3 — Distributed + Trust Model
+- WP-06
+- WP-07
+
+### Phase 4 — Demo + Documentation Hardening
+- WP-08
+- WP-09
+- WP-10
+
+### Phase 5 — Release + Retrospective
+- WP-11
+
+---
+
+## Demo Matrix (v0.5)
+
+Each primitive must have:
+
+- Solo demo
+- Composed demo
+
+Structural demos must include:
+
+- Linear workflow
+- Multi-step chain
+- Fork/join
+- Hierarchical workflow
+- Pattern-based debate
+- Planner-executor
+- Mixed local/remote placement
+- Signed workflow execution
+- Deterministic replay
+
+---
+
+## Acceptance Mapping
+
+- Primitive schemas complete → WP-02
+- Deterministic composition model → WP-03
+- Pattern compilation deterministic → WP-04
+- Configurable scheduler working → WP-05
+- Remote execution functional → WP-06
+- Signing enforced → WP-07
+- All demos runnable locally → WP-08
+- Docs fully aligned → WP-09
+- CI and nightly automation stable → WP-10
+- Tag + release published → WP-11
+
+---
+
+## Exit Criteria
+
+- Every in-scope requirement maps to at least one WBS item.
+- Every WBS item has an issue reference.
+- Demo matrix fully satisfied.
+- Signing + remote execution verified.
+- Deterministic replay preserved.
+- v0.5 milestone checklist fully satisfied.
+- Release `v0.5.0` tagged and published.
+- All demos execute with readable timestamps and user-visible progress output.


### PR DESCRIPTION
## Summary
Track and sanity-fix v0.5 milestone docs under `docs/milestones/v0.5/`.

### Included fixes
- Removed template boilerplate from `DESIGN_v0.5.md`
- Updated coverage target wording to "as high as reasonable"
- Normalized date in `DECISIONS_v0.5.md`
- Updated release-announcement references to `RELEASE_NOTES_v0.5.md` in:
  - `MILESTONE_CHECKLIST_v0.5.md`
  - `RELEASE_PLAN_v0.5.md`

### Intentionally left as-is
- `RELEASE_NOTES_v0.5.md` placeholders (to be filled later)
- ObsMem scope reconciliation (deferred decision)
- Some `TBD` issue references in WBS

Closes #330
