### PR TITLE
docs(v0.5): map WBS work packages to created issues

### DIFF
--- a/docs/milestones/v0.5/WBS_v0.5.md
+++ b/docs/milestones/v0.5/WBS_v0.5.md
@@ -52,20 +52,20 @@ The milestone follows a disciplined execution structure:
 
 ## Work Packages
 
-| ID | Work Package | Description | Deliverable | Dependencies | Issue |
-|----|--------------|-------------|-------------|--------------|-------|
-| WP-00 | Milestone Init | Finalize milestone docs, freeze scope | DESIGN + WBS + DECISIONS + SPRINT + CHECKLIST finalized | None | #330 |
-| WP-01 | Tooling Stabilization | Fix pr.sh start bug, stabilize nightly automations | pr.sh fix + CI stable | WP-00 | Backlog (pr.sh stabilization) |
-| WP-02 | Primitive Schema Completion | Explicit schemas for Agents, Runs, Providers, Tasks, Tools, Workflows | Schema definitions + validation tests | WP-00 | TBD (to be created in burst planning) |
-| WP-03 | Composition Layer | Implement include/call + hierarchical workflow composition | Deterministic multi-file workflow demo | WP-02 | TBD (to be created in burst planning) |
-| WP-04 | Pattern Compiler v0.1 | PatternSchema → ExecutionPlan compiler (debate, planner_executor) | Deterministic pattern demo | WP-03 | TBD (to be created in burst planning) |
-| WP-05 | Scheduler Configurability | Expose max_parallel + minimal policy surface | Configurable concurrency demo | WP-04 | #309 |
-| WP-06 | Remote Execution MVP | Define remote protocol + reference server + placement rules | Mixed local/remote demo | WP-03 | TBD (to be created in burst planning) |
-| WP-07 | Signing + Enforcement | Implement sign/verify + enforcement in run | Signed workflow demo + rejection test | WP-02 | TBD (to be created in burst planning) |
-| WP-08 | Demo Generation Pass | Systematic demo sweep covering all primitives and patterns | Demo matrix complete | WP-04, WP-05, WP-06, WP-07 | TBD (to be created in burst planning) |
-| WP-09 | Documentation Pass | README + spec + milestone docs updated | Docs aligned with shipped behavior | WP-08 | TBD (to be created in burst planning) |
-| WP-10 | Review Pass | Coverage audit + doc audit + regression audit | CI green + nightly automation stable | WP-09 | TBD (to be created in burst planning) |
-| WP-11 | Closing Ceremony | Release notes + tag + retrospective | v0.5.0 tagged and published | WP-10 | TBD (to be created in burst planning) |
+| ID    | Work Package             | Description                                                 | Deliverable                         | Dependencies                     | Issue |
+|-------|--------------------------|-------------------------------------------------------------|-----------------------------------|---------------------------------|-------|
+| WP-00 | Milestone Init           | Finalize milestone docs, freeze scope                        | DESIGN + WBS + DECISIONS + SPRINT + CHECKLIST finalized | None                            | #330  |
+| WP-01 | Tooling Stabilization    | Fix pr.sh start bug, stabilize nightly automations          | pr.sh fix + CI stable              | WP-00                           | #342  |
+| WP-02 | Primitive Schema Completion | Explicit schemas for Agents, Runs, Providers, Tasks, Tools, Workflows | Schema definitions + validation tests | WP-00                           | #343  |
+| WP-03 | Composition Layer        | Implement include/call + hierarchical workflow composition  | Deterministic multi-file workflow demo | WP-02                       | #344  |
+| WP-04 | Pattern Compiler v0.1    | PatternSchema → ExecutionPlan compiler (debate, planner_executor) | Deterministic pattern demo        | WP-03                           | #345  |
+| WP-05 | Scheduler Configurability | Expose max_parallel + minimal policy surface                | Configurable concurrency demo     | WP-04                           | #309  |
+| WP-06 | Remote Execution MVP     | Define remote protocol + reference server + placement rules | Mixed local/remote demo            | WP-03                           | #346  |
+| WP-07 | Signing + Enforcement    | Implement sign/verify + enforcement in run                   | Signed workflow demo + rejection test | WP-02                       | #347  |
+| WP-08 | Demo Generation Pass     | Systematic demo sweep covering all primitives and patterns  | Demo matrix complete               | WP-04, WP-05, WP-06, WP-07      | #348  |
+| WP-09 | Documentation Pass       | README + spec + milestone docs updated                       | Docs aligned with shipped behavior | WP-08                          | #349  |
+| WP-10 | Review Pass              | Coverage audit + doc audit + regression audit                | CI green + nightly automation stable | WP-09                         | #350  |
+| WP-11 | Closing Ceremony         | Release notes + tag + retrospective                          | v0.5.0 tagged and published       | WP-10                           | #351  |
 
 ---
 


### PR DESCRIPTION
## Summary
- update v0.5 WBS work package table to reference the created WP issues
- replace backlog/TBD placeholders with concrete issue links (#342-#351, plus #309)

## Validation
- doc-only change

Refs #352