### PR TITLE
[v0.5][post-review] Rustdoc pass for key public APIs

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1,3 +1,15 @@
+//! ADL `swarm` runtime library.
+//!
+//! This crate provides the language model (`adl`), resolution/planning (`resolve`,
+//! `execution_plan`), deterministic execution (`execute`), and trust/verification
+//! boundaries (`signing`, `remote_exec`) used by the `swarm` CLI.
+//!
+//! v0.5 invariants:
+//! - deterministic execution order for ready steps
+//! - bounded concurrency for concurrent execution plans
+//! - optional signature verification with strict enforcement on `--run`
+//! - remote execution MVP where scheduling remains local
+
 pub mod adl;
 pub mod bounded_executor;
 pub mod demo;


### PR DESCRIPTION
## Summary
- add rustdoc across key public boundaries in lib/execute/adl/remote_exec/signing
- document determinism and security assumptions where relevant
- no runtime logic changes

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo doc --no-deps
- cargo test

Closes #381