### PR TITLE
[v0.5][post-review] Add v0.5 ADR stubs and README entrypoint link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Explicitly deferred:
 - `swarm/`: Rust reference runtime and CLI
 - `adl-spec/`: language-level specification docs
 - `docs/`: contributor workflow and roadmap docs
+- `docs/adr/`: architecture decision records (major technical decisions)
 - `.adl/`: cards, reports, and run/report artifacts
 
 ## Historical v0.3 Plan-Only Commands

--- a/docs/adr/0001-determinism.md
+++ b/docs/adr/0001-determinism.md
@@ -1,0 +1,25 @@
+# ADR 0001: Deterministic Execution Semantics
+
+## Status
+Accepted (v0.5)
+
+## Decision
+ADL runtime execution must remain deterministic for identical inputs and
+configuration:
+- ready-step ordering is lexicographic by full step id
+- bounded execution preserves stable output ordering
+- plan generation is deterministic for canonicalized workflow/pattern inputs
+
+## Rationale
+Determinism improves reproducibility, debugging, and trust in CI/regression
+signals. It is foundational for trace comparison and replay-oriented workflows.
+
+## Alternatives Considered
+- Preserve declaration-order execution only
+- Opportunistic scheduler ordering based on runtime readiness timing
+- Max-throughput scheduling without deterministic constraints
+
+## Consequences
+- Runtime and tests enforce deterministic ordering invariants explicitly.
+- Some throughput optimizations are deferred when they would break stability.
+- Documentation and demos must present deterministic behavior as a contract.

--- a/docs/adr/0002-signing-ed25519.md
+++ b/docs/adr/0002-signing-ed25519.md
@@ -1,0 +1,26 @@
+# ADR 0002: Signing Model (Ed25519)
+
+## Status
+Accepted (v0.5)
+
+## Decision
+ADL signing/verification uses Ed25519 with deterministic canonicalization:
+- top-level `signature` is excluded from signed bytes
+- canonical JSON envelope is recursively key-sorted
+- run-time signature enforcement is enabled by default for v0.5 `--run`
+
+## Rationale
+Ed25519 provides compact signatures and straightforward verification behavior.
+Canonicalization ensures stable bytes for repeatable signing and tamper checks.
+
+## Alternatives Considered
+- RSA-based signatures
+- Pluggable multi-algorithm support in v0.5
+- Optional default enforcement for unsigned runs
+
+## Consequences
+- v0.5 scope stays minimal and deterministic.
+- Advanced policy features (key rotation, trust stores, richer policy surface)
+  are deferred to follow-on milestones.
+- Operators can use explicit development override where unsigned runs are
+  intentionally allowed.

--- a/docs/adr/0003-remote-exec-mvp.md
+++ b/docs/adr/0003-remote-exec-mvp.md
@@ -1,0 +1,25 @@
+# ADR 0003: Remote Execution MVP Boundary
+
+## Status
+Accepted (v0.5)
+
+## Decision
+Remote execution MVP is intentionally scoped to a narrow boundary:
+- local scheduler owns planning, dependency resolution, and ordering
+- remote endpoint executes one fully resolved step via `/v1/execute`
+- request payloads are capped at 5 MiB
+
+## Rationale
+This separation allows distributed execution experiments without moving scheduler
+correctness into a network service in v0.5.
+
+## Alternatives Considered
+- Full remote orchestration service in v0.5
+- Remote planner/scheduler ownership
+- Unbounded request payloads
+
+## Consequences
+- Deployment guidance must treat this as trusted-network/localhost MVP.
+- Security envelope items (authn/authz, request signing, richer policy) are
+  deferred to subsequent milestone work.
+- Integration tests focus on deterministic mixed local/remote step behavior.


### PR DESCRIPTION
## Summary
- add ADR stubs for determinism, signing, and remote execution MVP
- add README link to docs/adr/
- documentation-only change

## Files
- docs/adr/0001-determinism.md
- docs/adr/0002-signing-ed25519.md
- docs/adr/0003-remote-exec-mvp.md
- README.md

Closes #384