### PR TITLE
docs: align v0.5 release/status messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Agent Design Language (ADL) is a declarative, contract-driven way to define AI w
 
 ADL is built for teams that want repeatability. Documents are parsed and validated, then resolved into a deterministic plan before execution. That plan-first model makes behavior inspectable, testable, and easier to review than runtime-only orchestration.
 
-The current runtime (v0.4 milestone) focuses on predictable execution semantics: deterministic sequential execution, bounded concurrent fork execution, deterministic join barriers, explicit failure policies (`on_error: fail|continue`), and deterministic retry via `retry.max_attempts`.
+The current runtime (v0.5 milestone) focuses on predictable execution semantics: deterministic sequential execution, bounded concurrent fork execution, deterministic join barriers, explicit failure policies (`on_error: fail|continue`), and deterministic retry via `retry.max_attempts`.
 
 ADL also supports a remote HTTP provider MVP for controlled integration with external inference endpoints. Every run can emit stable artifacts under `.adl/runs/<run_id>/` (`run.json`, `steps.json`), which helps with reproducibility, debugging, and auditability.
 
@@ -26,7 +26,7 @@ cargo run -q --manifest-path swarm/Cargo.toml -- swarm/examples/v0-3-on-error-re
 
 [![swarm-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.4-green)
+![Milestone](https://img.shields.io/badge/milestone-v0.5-green)
 
 Badge semantics:
 - `swarm-ci`: main branch CI workflow status
@@ -35,9 +35,9 @@ Badge semantics:
 
 ## Status
 
-Current release: **v0.4.0**
+Current release: **v0.5.0**
 
-v0.4 ships:
+v0.5 ships:
 - ExecutionPlan-driven runtime execution
 - Bounded fork concurrency
 - Canonical concurrent ready-step ordering (lexicographic by `step_id`)
@@ -45,8 +45,11 @@ v0.4 ships:
 - Deterministic replay demos
 - Human-readable trace timestamps
 - Run/Step progress banners
+- Pattern compiler (`linear`, `fork_join`) with deterministic canonical IDs
+- Signing and verification CLI (`keygen`, `sign`, `verify`) with unsigned-run rejection on `--run`
+- Remote execution MVP (`/v1/health`, `/v1/execute`) with local scheduler ownership
 
-## Current Status (v0.4 Milestone)
+## Current Status (v0.5 Milestone)
 
 Implemented in the `swarm/` runtime:
 - Deterministic sequential execution
@@ -56,8 +59,11 @@ Implemented in the `swarm/` runtime:
 - Step-level failure policy: `on_error: fail|continue`
 - Deterministic retries: `retry.max_attempts` (no backoff)
 - Remote HTTP provider (MVP)
+- Remote execution MVP
+- Pattern compiler support via `run.pattern_ref`
+- Signing enforcement for `--run` with `keygen/sign/verify` support
 - Run state artifacts under `.adl/runs/<run_id>/` (`run.json`, `steps.json`)
-- No-network v0.4 demo harness (`swarm/tools/demo_v0_4.sh`)
+- Legacy no-network v0.4 demo harness (`swarm/tools/demo_v0_4.sh`)
 
 Explicitly deferred:
 - Configurable runtime parallelism controls
@@ -83,7 +89,7 @@ cargo run -q --manifest-path swarm/Cargo.toml -- swarm/examples/v0-3-remote-http
 
 To execute (`--run`) local-provider examples, run from `swarm/` with a local Ollama available.
 
-## v0.4 Demos
+## Legacy v0.4 Demos
 
 These demos are deterministic, non-interactive, and run without network by pinning the local mock provider binary.
 
@@ -113,19 +119,22 @@ Run all three demos in sequence:
 swarm/tools/demo_v0_4.sh
 ```
 
-## Why v0.4 Matters
+## Why v0.5 Matters
 
-v0.4 proves:
+v0.5 proves:
 - Concurrent execution in the real runtime
 - Deterministic replay behavior
 - Bounded parallelism
 - Stable artifacts under concurrency
+- Signed workflow execution defaults for safer `--run` operation
+- Pattern-driven workflow authoring with deterministic expansion
+- Remote execution MVP wiring without giving up local deterministic scheduling
 
 ## Default Workflow
 
 Default contributor workflow uses `adl_pr_cycle` (`start -> codex -> finish -> report`).
 - Guide: `docs/default_workflow.md`
-- Milestone docs: `docs/milestones/v0.4/`
+- Milestone docs: `docs/milestones/v0.5/`
 - Tools: `swarm/tools/README.md`
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Docs Spine (v0.4)
+# Docs Spine (v0.5)
 
 Start here for contributor-oriented docs and planning context.
 
@@ -10,11 +10,11 @@ Start here for contributor-oriented docs and planning context.
 2. `swarm/tools/README.md`
 - Operational workflow tools (`pr.sh`, burst helpers, report helpers).
 
-3. `docs/milestones/v0.4/RELEASE_NOTES_v0.4.md`
-- Official v0.4 capability and release summary.
+3. `docs/milestones/v0.5/RELEASE_NOTES_v0.5.md`
+- Official v0.5 capability and release summary.
 
-4. `docs/milestones/v0.4/DESIGN_v0.4.md`
-- Canonical architecture and execution semantics for v0.4.
+4. `docs/milestones/v0.5/DESIGN_v0.5.md`
+- Canonical architecture and execution semantics for v0.5.
 
 5. `swarm/tools/BURST_PLAYBOOK.md`
 - Sequential burst execution pattern and operating guardrails.
@@ -30,7 +30,7 @@ Start here for contributor-oriented docs and planning context.
 - Workflow default: `adl_pr_cycle` (`start -> codex -> finish -> report`)
 - Runtime and CLI work: `swarm/`
 - Language and schema docs: `adl-spec/`
-- v0.4 milestone docs: `docs/milestones/v0.4/`
+- v0.5 milestone docs: `docs/milestones/v0.5/`
 - Burst reporting outputs: `.adl/reports/`
 - Demo command index: `docs/demos.md`
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -16,7 +16,7 @@ cargo run --manifest-path swarm/Cargo.toml -- swarm/examples/v0-3-concurrency-fo
 What to expect:
 - Command succeeds.
 - Plan output includes: `fork.plan`, `fork.branch.alpha`, `fork.branch.beta`, `fork.join`.
-- This is a design/plan demo. Runtime concurrency is intentionally not implemented.
+- This is a historical v0.3 plan-shape demo. The current runtime does implement concurrent execution in v0.5.
 
 ## 2) v0.3 Remote Provider MVP Demo
 


### PR DESCRIPTION
## Summary
- align top-level docs release and milestone messaging to v0.5.0
- refresh docs spine references from v0.4 milestone docs to v0.5 milestone docs
- clarify v0.3 demo wording as historical so it does not conflict with current runtime behavior

## Validation
- cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-5-primitives-minimal.adl.yaml --print-plan
- markdown local-target scan across README/docs/swarm/templates/milestones

Closes #399