### PR TITLE
[ci] Fix Codecov upload skip condition for coverage badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     defaults:
       run:
         working-directory: swarm
@@ -94,18 +92,12 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.CODECOV_TOKEN != ''
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: swarm/lcov.info
           flags: swarm
           # Keep CI signal stable during transient Codecov outages; upload is informational.
           fail_ci_if_error: false
           verbose: true
-
-      - name: Skip Codecov upload (missing token)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.CODECOV_TOKEN == ''
-        run: |
-          echo "::warning::Skipping Codecov upload because CODECOV_TOKEN is not configured for this repository."
-          echo "::warning::Coverage artifact was still generated at swarm/lcov.info."


### PR DESCRIPTION
Closes #417\n\nFix Codecov upload gating in .github/workflows/ci.yaml by removing env-string token checks and using secrets token directly.