### PR TITLE
[v0.6][docs] Milestone docs kickoff consistency cleanup

### DIFF
--- a/docs/milestones/v0.6/DECISIONS_v0.6.md
+++ b/docs/milestones/v0.6/DECISIONS_v0.6.md
@@ -1,0 +1,81 @@
+# Decisions — v0.6
+
+## Metadata
+- Milestone: v0.6
+- Version: v0.6
+- Status: Active
+- Owner: ADL core (Daniel + Codex-assisted implementation)
+- Related WPs: #401–#411
+
+---
+
+## Purpose
+
+Capture architectural and scope decisions for v0.6 so that:
+
+- v0.6/v0.7 boundaries are explicit.
+- Determinism invariants remain non-negotiable.
+- Deferred work is clearly tracked.
+- Implementation decisions are traceable to rationale.
+
+This document supplements ADRs but is milestone-scoped.
+
+---
+
+# Decision Log
+
+| ID | Decision | Status | Rationale | Alternatives Considered | Impact | Link |
+|----|----------|--------|-----------|--------------------------|--------|------|
+
+| D-01 | Determinism remains a hard invariant in v0.6 | Accepted | ADL’s core identity is deterministic execution planning + ordering guarantees. v0.6 extends runtime surface but must not compromise determinism. | Allow adaptive runtime behavior in v0.6 | Preserves trust model and replay guarantees | ADR-0001 + WP-F (#406) |
+
+| D-02 | Delegation metadata is log-only in v0.6 | Accepted | We introduce structured delegation metadata but defer enforcement to avoid destabilizing runtime semantics. | Implement full policy engine in v0.6 | Keeps v0.6 low-risk and sets stage for v0.7 EPIC-B | WP-E (#405) |
+
+| D-03 | No distributed execution in v0.6 | Accepted | Distributed orchestration increases complexity and risk; determinism must be preserved first. | Introduce multi-node execution in v0.6 | Keeps runtime single-node deterministic | Backlog #339 |
+
+| D-04 | No checkpoint/recovery engine in v0.6 | Accepted | Checkpointing interacts deeply with scheduler and state semantics; defer to avoid destabilization. | Add resumable workflows in v0.6 | Maintains scheduler simplicity | Backlog #340 |
+
+| D-05 | Streaming must not alter artifact determinism | Accepted | Streaming is an observability feature, not a semantic one. Artifacts must remain byte-stable. | Allow streaming to influence step completion ordering | Maintains replay guarantees | WP-C (#403) |
+
+| D-06 | Pause/Resume is explicit and trace-visible | Accepted | Human control must be visible, auditable, and deterministic. | Implicit pause via runtime hooks | Maintains transparency + auditability | WP-B (#402) |
+
+| D-07 | Coverage >80% per file becomes milestone gate | Accepted | Establish quality ratchet without requiring perfection. | Global coverage % only | Raises engineering discipline | WP-H2 (#409) |
+
+| D-08 | Provider profiles are documentation-level in v0.6 | Accepted | Avoid runtime heuristics and auto-selection; profiles are configuration contracts. | Dynamic provider auto-selection | Keeps runtime predictable | WP-D (#404) |
+
+| D-09 | Graph export + replay diff are tooling-layer concerns | Accepted | Instrumentation belongs outside core scheduling logic. | Embed visualization logic in scheduler | Maintains clean separation of concerns | WP-G (#407) |
+
+| D-10 | Remote execution security hardening remains bounded in v0.6 | Accepted | v0.5 established threat model; v0.6 clarifies envelope but does not claim production-grade auth. | Full authn/authz implementation | Prevents false security claims | #370, #386 |
+
+| D-11 | v0.6 is a “stabilize + formalize” release, not a learning release | Accepted | Learning/adaptation introduces non-determinism and policy enforcement complexity. | Introduce adaptive behavior in v0.6 | Preserves conceptual clarity | v0.7 EPIC-A (#412) |
+
+| D-12 | ObsMem remains a separate project | Accepted | Memory integration must remain loosely coupled. ADL provides interfaces only. | Integrate RAG directly into runtime | Maintains modularity | v0.7 EPIC-C (#414) |
+
+---
+
+# Open Questions
+
+- Should streaming trace events include fine-grained token-level output, or remain step-bounded?  
+  Owner: Daniel  
+  Tracking: WP-C (#403)
+
+- What minimal schema shape is required for delegation policy enforcement in v0.7?  
+  Owner: Daniel  
+  Tracking: EPIC-B (#413)
+
+- What graph export format becomes canonical (Mermaid vs DOT vs JSON)?  
+  Owner: Daniel  
+  Tracking: WP-G (#407)
+
+- Should coverage exclusions be centralized in a documented file (e.g., COVERAGE_EXCLUSIONS.md)?  
+  Owner: Daniel  
+  Tracking: WP-H2 (#409)
+
+---
+
+# Exit Criteria
+
+- All milestone-critical architectural decisions recorded.
+- Deferred features clearly linked to backlog or v0.7 epics.
+- No placeholder template content remains.
+- Decisions align with DESIGN_v0.6.md.

--- a/docs/milestones/v0.6/DESIGN_v0.6.md
+++ b/docs/milestones/v0.6/DESIGN_v0.6.md
@@ -1,0 +1,315 @@
+# ADL v0.6 Design
+
+## Metadata
+- Milestone: v0.6
+- Version: v0.6
+- Status: Planning
+- Owner: ADL core (Daniel + Codex-assisted implementation)
+- Related issues:
+  - #401–#411 (v0.6 umbrella WPs)
+  - #409 (Coverage audit >80% per file)
+  - #370, #371, #386 (remote security + signing follow-ups)
+
+---
+
+## Purpose
+
+v0.6 moves ADL from a “deterministic execution engine with primitives” to a
+structured, instrumented, policy-aware runtime foundation.
+
+The goal is not to dramatically expand surface area, but to:
+- Formalize patterns as first-class registry artifacts.
+- Introduce minimal human-in-the-loop (HITL) control points.
+- Enable streaming output and richer instrumentation.
+- Harden determinism and scheduler semantics.
+- Establish measurable quality gates (coverage audit).
+- Produce a clean, demo-ready release.
+
+v0.6 is an architectural consolidation and capability extension release.
+It is not a distributed systems release and not a memory-integrated release.
+
+---
+
+## Problem Statement
+
+ADL v0.5 ships:
+- Deterministic execution planning.
+- Bounded concurrency.
+- Signing + canonicalization.
+- Remote execution MVP with documented trust limits.
+
+However, several gaps remain:
+
+1. Patterns exist but are not yet treated as a coherent registry surface.
+2. Delegation metadata exists conceptually but is not logged/structured at runtime.
+3. Output is buffered; streaming semantics are not clearly defined.
+4. Instrumentation is usable but not yet exportable for replay/diff workflows.
+5. Human pause/resume semantics are not formally defined.
+6. Quality bar is not enforced via a measurable coverage ratchet.
+
+v0.6 addresses these without destabilizing the deterministic core.
+
+---
+
+## Goals
+
+### 1. Pattern Registry + Compiler Expansion (WP-A, #401)
+- Formalize a pattern registry abstraction.
+- Ensure fork/join and linear patterns are byte-stable.
+- Document registry structure and constraints.
+- Keep patterns deterministic and declarative.
+
+### 2. Minimal HITL Pause/Resume (WP-B, #402)
+- Introduce an explicit pause state in execution lifecycle.
+- Pause must be:
+  - Deterministic.
+  - Explicit in trace.
+  - Resume-capable without hidden state.
+- No background magic or autonomous mutation.
+
+### 3. Streaming Output Semantics (WP-C, #403)
+- Define streaming boundaries:
+  - stdout (step output)
+  - stderr (progress)
+  - trace events
+- Preserve deterministic step ordering.
+- Streaming must not change final artifact determinism.
+
+### 4. Provider Profiles (WP-D, #404)
+- Define documented profiles for a curated set of models.
+- Profiles are configuration/documentation-level constructs.
+- No runtime auto-selection heuristics in v0.6.
+
+### 5. Delegation Metadata (Log-Only) (WP-E, #405)
+- Introduce structured delegation metadata in schema.
+- Record metadata in trace.
+- Do not enforce policy in v0.6 (policy engine deferred to v0.7).
+
+### 6. Determinism + Scheduler Hardening (WP-F, #406)
+- Clarify concurrency override semantics.
+- Preserve lexicographic batching guarantees.
+- Ensure max-concurrency invariants remain test-backed.
+
+### 7. Instrumentation + Replay Diff + Graph Export (WP-G, #407)
+- Export trace in structured format.
+- Enable replay comparison/diff workflows.
+- Provide graph export (DOT or Mermaid) for workflow visualization.
+
+### 8. Demo Matrix + Integration Demos (WP-H, #408)
+- Define canonical demos covering:
+  - Concurrency
+  - Signing
+  - Remote execution
+  - Pattern usage
+  - Delegation metadata logging
+- Ensure demos are deterministic and CI-verifiable.
+
+### 9. Coverage Audit (>80% per file) (WP-H2, #409)
+- Perform per-file coverage analysis.
+- Raise coverage floor to >80% where practical.
+- Identify intentional exclusions explicitly.
+
+### 10. Docs + Review Pass (WP-I, #410)
+- Align README, docs, milestone planning.
+- Ensure threat-model and determinism invariants are explicit.
+
+### 11. Release Ceremony (WP-J, #411)
+- Tag.
+- Release notes.
+- Clean milestone checklist.
+
+---
+
+## Non-Goals
+
+- No distributed cluster execution (#339).
+- No checkpoint/recovery engine (#340).
+- No advanced adaptive scheduler (#338).
+- No ObsMem integration (#337).
+- No runtime policy enforcement for delegation (v0.7).
+- No public-facing hardened remote server (security envelope tracked in #370/#371).
+
+---
+
+## Scope
+
+### In Scope
+- Deterministic runtime enhancements.
+- Streaming + instrumentation improvements.
+- Registry formalization.
+- Logging-only delegation metadata.
+- Demo standardization.
+- Coverage ratchet.
+
+### Out of Scope
+- Learning systems.
+- Autonomous policy engines.
+- Hidden adaptive behavior.
+- Cross-node orchestration.
+
+---
+
+## Requirements
+
+### Functional
+- Pattern registry must compile deterministically.
+- Pause/resume must preserve execution state integrity.
+- Streaming must not reorder step completion artifacts.
+- Delegation metadata must appear in trace.
+- Graph export must reflect compiled execution plan.
+
+### Non-Functional
+- Deterministic behavior and reproducible outputs.
+- Clear failure semantics and observability.
+- >80% per-file test coverage target (WP-H2).
+- No regression in existing CLI smoke tests.
+
+---
+
+## Proposed Design
+
+### Architectural Overview
+
+v0.6 maintains the same core runtime pipeline:
+
+Schema → Resolve → Compile → Execute → Trace → Artifacts
+
+Enhancements occur at:
+- Compile phase (pattern registry formalization).
+- Execute phase (pause/streaming semantics).
+- Trace layer (delegation metadata + streaming events).
+- Tooling layer (graph export + replay diff).
+
+Core invariants remain:
+- Deterministic plan construction.
+- Deterministic step ordering.
+- Bounded concurrency guarantees.
+
+---
+
+### Pattern Registry (WP-A)
+
+- Patterns are declared and referenced symbolically.
+- Registry maps pattern IDs → compile transforms.
+- Compile output must remain byte-stable.
+- No dynamic mutation of patterns at runtime.
+
+Risk: registry abstraction drift.
+Mitigation: keep registry thin and declarative.
+
+---
+
+### HITL Pause/Resume (WP-B)
+
+Execution state machine extended with:
+
+- Running
+- Paused
+- Completed
+- Failed
+
+Pause:
+- Emitted in trace.
+- Explicit barrier before next step.
+- Resume must re-enter scheduler cleanly.
+
+No background worker resumption or implicit timeouts.
+
+---
+
+### Streaming Semantics (WP-C)
+
+Streaming applies to:
+- Step output (stdout).
+- Progress (stderr).
+- Trace events.
+
+Rules:
+- Streaming may occur during execution.
+- Final artifacts remain deterministic.
+- Ordering guarantees apply to step lifecycle events.
+
+---
+
+### Delegation Metadata (WP-E)
+
+Schema extension:
+- Optional delegation block per step.
+
+Runtime:
+- Metadata logged into trace.
+- No enforcement logic in v0.6.
+- Enables v0.7 policy engine.
+
+---
+
+### Scheduler Hardening (WP-F)
+
+- Clarify max_concurrency overrides.
+- Preserve lexicographic batching.
+- Ensure bounded executor remains test-backed.
+
+---
+
+### Instrumentation + Graph Export (WP-G)
+
+- Structured trace output.
+- Replay diff tool compares trace artifacts.
+- Graph export format (Mermaid or DOT) generated from compiled plan.
+
+---
+
+## Risks and Mitigations
+
+Risk: Streaming breaks determinism.
+Mitigation: enforce ordering at lifecycle boundary.
+
+Risk: Pause introduces inconsistent state.
+Mitigation: explicit state transitions + test coverage.
+
+Risk: Scope creep into v0.7 territory.
+Mitigation: delegation remains log-only.
+
+Risk: Coverage work stalls progress.
+Mitigation: timebox audit and document exclusions.
+
+Risk: Registry abstraction overcomplicates compiler.
+Mitigation: keep compile transforms simple and pure.
+
+---
+
+## Alternatives Considered
+
+### Alternative: Full delegation enforcement in v0.6
+Tradeoff: increases risk and destabilizes runtime. Deferred to v0.7.
+
+### Alternative: Adaptive scheduler in v0.6
+Tradeoff: conflicts with determinism guarantees. Deferred.
+
+### Alternative: Integrated memory (ObsMem) in v0.6
+Tradeoff: coupling risk; violates separation principle. Deferred.
+
+---
+
+## Validation Plan
+
+- All new behaviors covered by tests.
+- Determinism tests pass across multiple runs.
+- Streaming tests confirm ordering guarantees.
+- Coverage report confirms >80% per file where practical.
+- Demo matrix runs clean in CI.
+
+Rollback:
+- Feature flags or revert branch.
+- Determinism invariants must remain intact.
+
+---
+
+## Exit Criteria
+
+- All WPs #401–#411 complete.
+- Coverage audit complete (#409).
+- Docs pass complete (#410).
+- Release notes drafted and reviewed.
+- Determinism invariants explicitly documented.
+- No template placeholders remain in milestone docs.

--- a/docs/milestones/v0.6/MILESTONE_CHECKLIST_v0.6.md
+++ b/docs/milestones/v0.6/MILESTONE_CHECKLIST_v0.6.md
@@ -1,0 +1,133 @@
+# Milestone Checklist — v0.6
+
+## Metadata
+- Milestone: v0.6
+- Version: v0.6
+- Target release: TBD (set at RC freeze when WP-I enters final review)
+- Owner: ADL core (Daniel + Codex-assisted implementation)
+
+---
+
+## Purpose
+
+This checklist is the ship / no-ship gate for ADL v0.6.
+
+v0.6 is a **stabilize + formalize** release.  
+It must:
+
+- Preserve determinism invariants.
+- Introduce structured runtime surface (streaming, HITL, delegation metadata).
+- Harden scheduler and policy surfaces.
+- Establish coverage ratchet discipline.
+- Ship clean documentation aligned with WPs #401–#411.
+
+Items are checked only when objective evidence exists (PRs, CI runs, artifacts).
+
+---
+
+# Planning Integrity
+
+- [x] DESIGN_v0.6.md finalized and aligned with WPs #401–#411
+- [x] WBS_v0.6.md maps work to umbrella WPs (#401–#411)
+- [x] SPRINT_v0.6.md defines phased execution order
+- [x] DECISIONS_v0.6.md records architectural boundaries
+- [ ] RELEASE_PLAN_v0.6.md finalized (entry/exit criteria + ceremony)
+- [ ] RELEASE_NOTES_v0.6.md drafted (non-template, no placeholders)
+
+---
+
+# Scope Discipline
+
+- [ ] No runtime behavior violates determinism guarantees (see ADR-0001)
+- [ ] Delegation remains metadata + trace only (no policy enforcement in v0.6)
+- [ ] No distributed execution introduced (#339 deferred)
+- [ ] No checkpoint/recovery engine introduced (#340 deferred)
+- [ ] ObsMem remains separate project (#337 deferred)
+- [ ] Advanced adaptive scheduler policies deferred to v0.7 (#338)
+
+---
+
+# WP Completion Gates
+
+## Core Runtime
+
+- [ ] WP-A (#401) Pattern registry + compiler expansion complete
+- [ ] WP-B (#402) HITL pause/resume minimal surface complete
+- [ ] WP-C (#403) Streaming output implemented without altering artifact determinism
+- [ ] WP-D (#404) Provider profiles documented and validated
+- [ ] WP-E (#405) Delegation metadata schema + trace logging implemented
+- [ ] WP-F (#406) Determinism + scheduler policy hardening complete
+
+## Tooling & Observability
+
+- [ ] WP-G (#407) Instrumentation + replay diff + graph export available
+- [ ] WP-H (#408) Demo matrix updated and validated
+- [ ] WP-H2 (#409) Coverage audit complete (>80% per file or documented exception)
+
+## Finalization
+
+- [ ] WP-I (#410) Docs + review pass complete
+- [ ] WP-J (#411) Release ceremony executed
+
+---
+
+# Quality Gates (Hard Blockers)
+
+- [ ] `cargo fmt --all` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo test` passes
+- [ ] CI green on `main`
+- [ ] No unresolved high-priority runtime bugs labeled `version:v0.6`
+- [ ] Coverage gate satisfied per WP-H2 (#409)
+
+Coverage Gate Definition:
+- Target: >80% per file.
+- Exceptions must:
+  - Be documented.
+  - Have explicit issue link.
+  - Have an owner.
+
+---
+
+# Documentation Integrity
+
+- [ ] All v0.6 milestone docs contain no template placeholders e.g. curly braces
+- [ ] DESIGN/WBS/SPRINT/DECISIONS reflect actual shipped behavior
+- [ ] README updated if public surface changes
+- [ ] SECURITY.md updated if threat model changes
+- [ ] Demos reflect v0.6 capabilities accurately
+
+---
+
+# Release Packaging
+
+- [ ] Version bumped appropriately
+- [ ] Tag created (v0.6.0)
+- [ ] Release notes finalized and reviewed
+- [ ] GitHub release drafted and verified
+- [ ] Artifacts reproducible from clean checkout
+
+---
+
+# Post-Release Discipline
+
+- [ ] All v0.6 issues closed or explicitly deferred
+- [ ] Deferred items moved to v0.7 label
+- [ ] v0.7 epics (#412–#415) updated if scope changed
+- [ ] Retrospective summary written in docs/milestones/v0.6/
+- [ ] Roadmap updated
+
+---
+
+# Exit Criteria
+
+v0.6 can ship only if:
+
+1. All core WPs (#401–#411) are complete or explicitly deferred with rationale.
+2. Determinism invariants remain intact and validated.
+3. Coverage gate (#409) is satisfied.
+4. CI is green and reproducible.
+5. Documentation accurately describes shipped behavior.
+
+No partial ship. No “we’ll fix it in patch.”  
+v0.6 is a foundation release.

--- a/docs/milestones/v0.6/RELEASE_NOTES_v0.6.md
+++ b/docs/milestones/v0.6/RELEASE_NOTES_v0.6.md
@@ -1,0 +1,157 @@
+# ADL v0.6.0 Release Notes (Draft)
+
+## Metadata
+- Product: ADL (Agent Design Language)
+- Version: v0.6.0
+- Status: Draft (will be finalized as part of WP-J)
+- Related WPs: #401–#411
+- Quality gate: #409 (coverage audit >80% per file)
+
+---
+
+## Summary
+
+ADL v0.6 is a **stabilize + formalize** release focused on determinism, explicit runtime semantics, and better observability.
+It expands the pattern surface, introduces minimal human-in-the-loop control, adds streaming output, and improves trace tooling — without turning ADL into a learning system.
+
+These notes are intentionally scoped to the v0.6 umbrella WPs. Update the “Shipped” bullets during WP-J to reflect the exact merged PRs and behavior.
+
+---
+
+## Highlights
+
+- Determinism invariants strengthened and more explicitly tested. (WP-F, #406)
+- Pattern registry/compiler surface formalized to support consistent multi-agent patterns. (WP-A, #401)
+- Minimal HITL pause/resume semantics added (explicit + trace-visible). (WP-B, #402)
+- Streaming output defined as an observability feature that does not alter artifact determinism. (WP-C, #403)
+- Better tooling for trace export, replay diff, and workflow graph visualization. (WP-G, #407)
+- Coverage ratchet introduced (>80% per file or documented exception). (WP-H2, #409)
+
+---
+
+## What’s New (By Work Package)
+
+### WP-A — Pattern registry + compiler expansion (#401)
+Planned for v0.6:
+- A formal pattern registry boundary (pattern IDs → compile transforms).
+- Improved documentation for the pattern surface.
+- Regression tests for compile/pattern stability where applicable.
+
+Notes:
+- Patterns remain declarative and deterministic (no runtime mutation).
+
+### WP-B — HITL pause/resume (minimal) (#402)
+Planned for v0.6:
+- Explicit pause state in the execution lifecycle.
+- Resume entrypoint with trace-visible transitions.
+- Tests validating that pause/resume does not introduce hidden state.
+
+Notes:
+- HITL is opt-in and must be auditable through trace artifacts.
+
+### WP-C — Streaming output (trace + runtime) (#403)
+Planned for v0.6:
+- Clear streaming semantics for step output and trace events.
+- Ordering guarantees preserved at step lifecycle boundaries.
+- Tests confirming streaming does not affect final artifact bytes.
+
+Notes:
+- Streaming is treated as observability, not semantics.
+
+### WP-D — Provider profiles: top models (#404)
+Planned for v0.6:
+- Documented provider profiles (configuration-level), with clear constraints and intended usage.
+- No runtime auto-selection heuristics in v0.6.
+
+Notes:
+- The exact profile list is expected to evolve; keep claims conservative.
+
+### WP-E — Delegation metadata (schema + trace logging only) (#405)
+Planned for v0.6:
+- Schema support for structured delegation metadata per step.
+- Trace logging of delegation metadata.
+- Validation and regression tests around the schema surface.
+
+Notes:
+- v0.6 does not enforce delegation policy at runtime (policy engine is v0.7 scope).
+
+### WP-F — Determinism + scheduler policy hardening (#406)
+Planned for v0.6:
+- Clarified max-concurrency override semantics.
+- Hardened lexicographic batching / ordering guarantees where applicable.
+- Expanded determinism regression tests.
+
+Notes:
+- Any scheduling policy work that introduces adaptive behavior is deferred.
+
+### WP-G — Instrumentation + replay diff + graph export (#407)
+Planned for v0.6:
+- Structured trace export suitable for downstream tooling.
+- Replay diff capability for comparing runs.
+- Graph export (format finalized during WP-G execution).
+
+Notes:
+- Tooling concerns remain separated from core scheduling logic.
+
+### WP-H — Demo matrix + integration demos (#408)
+Planned for v0.6:
+- A demo matrix defining canonical scenarios for v0.6.
+- Deterministic demos that run cleanly under CI.
+
+### WP-H2 — Test coverage audit (>80% per file) (#409)
+Planned for v0.6:
+- Per-file coverage audit.
+- Target: >80% per file or documented exception with an owner and linked issue.
+
+### WP-I — Docs + review pass (#410)
+Planned for v0.6:
+- Documentation updated to match v0.6 behavior.
+- Threat-model and determinism invariants clarified and easy to find.
+
+### WP-J — Release ceremony (#411)
+Planned for v0.6:
+- Final checklist completion, tag creation, and GitHub release publication.
+
+---
+
+## Upgrade Notes
+
+- v0.6 is expected to be backward-compatible at the workflow level, but may refine trace fields and tooling outputs.
+- If a schema or CLI flag changes, document it here during WP-J with exact migration guidance.
+
+---
+
+## Known Limitations / Explicit Non-Goals
+
+- No distributed cluster execution (deferred; backlog #339).
+- No checkpoint/recovery engine (deferred; backlog #340).
+- No adaptive scheduler policies in v0.6 (deferred; backlog #338).
+- No ObsMem integration in core runtime (remains separate; backlog #337).
+- Delegation policy enforcement is deferred to v0.7 (EPIC-B, #413).
+- v0.6 does not claim production-grade remote authn/authz; security envelope work remains tracked separately (#370, #371, #386).
+
+---
+
+## Validation Notes
+
+- CI must be green at tag time: fmt, clippy (deny warnings), and tests.
+- Coverage gate is enforced via WP-H2 (#409).
+- Determinism must be verified across repeated runs for canonical demos.
+
+---
+
+## What’s Next
+
+v0.7 epics are already defined and intentionally out of scope for v0.6:
+- EPIC-A: Dynamic learning (trace/feedback → adaptation) (#412)
+- EPIC-B: Delegation runtime + policy engine (#413)
+- EPIC-C: ObsMem integration + learning surfaces (#414)
+- EPIC-D: Cleanup + deferred hard systems work (#415)
+
+---
+
+## Exit Criteria
+
+- Notes reflect shipped behavior only (convert all "Planned for v0.6" bullets to "Shipped in v0.6" during WP-J).
+- Known limitations and future work remain explicitly separated.
+- Text is ready to paste into the GitHub Release UI for tag v0.6.0.

--- a/docs/milestones/v0.6/RELEASE_PLAN_v0.6.md
+++ b/docs/milestones/v0.6/RELEASE_PLAN_v0.6.md
@@ -1,0 +1,159 @@
+# Release Plan — v0.6
+
+## Metadata
+- Milestone: v0.6
+- Version: v0.6.0
+- Owner: ADL core (Daniel + Codex-assisted implementation)
+- Governing WPs: #401–#411
+- Coverage Gate: WP-H2 (#409)
+
+---
+
+# Release Identity
+
+v0.6 is a **stabilize + formalize** release.
+
+It does not introduce adaptive learning or distributed systems.
+It strengthens the runtime foundation by:
+
+- Expanding the pattern compiler surface (WP-A)
+- Introducing minimal HITL pause/resume (WP-B)
+- Adding streaming output without breaking determinism (WP-C)
+- Formalizing provider profiles (WP-D)
+- Logging structured delegation metadata (WP-E)
+- Hardening scheduler and determinism invariants (WP-F)
+- Improving instrumentation and replay tooling (WP-G)
+- Validating demos and integration matrix (WP-H)
+- Establishing a coverage ratchet discipline (WP-H2)
+- Completing docs + review pass (WP-I)
+
+v0.6 must ship clean, reproducible, and architecturally coherent.
+
+---
+
+# Entry Criteria (Release Candidate Gate)
+
+Before release branch/tag creation:
+
+## 1. WP Completion
+
+- All WPs #401–#411 marked complete or explicitly deferred.
+- Any deferral includes:
+  - Rationale
+  - Linked issue
+  - Owner
+
+## 2. Determinism Validation
+
+- Concurrency tests pass consistently across multiple runs.
+- Replay/diff tooling (WP-G) confirms byte-stable plan output.
+- No streaming feature alters execution ordering or artifact bytes.
+- Delegation remains metadata-only (no policy enforcement).
+
+## 3. Coverage Gate (WP-H2 #409)
+
+- >80% coverage per file, OR
+- Documented exception with:
+  - Explicit issue
+  - Owner
+  - Justification
+
+Coverage status must be recorded in the milestone checklist.
+
+## 4. CI Clean
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- CI green on `main`
+
+No red pipelines allowed at tag time.
+
+---
+
+# Release Procedure
+
+## Phase 1 — Final Freeze
+
+1. Merge final WP PR.
+2. Run full test suite locally.
+3. Verify no open `version:v0.6` runtime blockers.
+4. Re-run coverage audit.
+5. Confirm milestone checklist fully satisfied.
+
+Freeze window begins after checklist confirmation.
+
+---
+
+## Phase 2 — Version + Tag
+
+1. Confirm version number (v0.6.0).
+2. Ensure working tree clean from fresh checkout.
+3. Tag:
+
+   ```
+   git tag -a v0.6.0 -m "ADL v0.6.0"
+   git push origin v0.6.0
+   ```
+
+4. Verify tag points to intended commit.
+
+---
+
+## Phase 3 — Release Publication
+
+1. Finalize `RELEASE_NOTES_v0.6.md`
+   - No template placeholders
+   - Clear summary of:
+     - New runtime surface
+     - Determinism guarantees
+     - Coverage ratchet
+     - Explicit non-goals (no distributed, no checkpointing, no learning)
+
+2. Create GitHub release:
+   - Title: `ADL v0.6.0`
+   - Body from release notes
+   - Verify links
+
+3. Confirm release appears in:
+   - GitHub releases
+   - Repo tags
+
+---
+
+# Post-Release Actions
+
+1. Close WP-J (#411) and milestone docs bootstrap issue (#416).
+2. Close WP-J (#411).
+3. Move any remaining `version:v0.6` items to `version:v0.7` with explanation.
+4. Update roadmap documentation.
+5. Begin Sprint 1 execution on v0.7 EPIC-A (#412).
+
+---
+
+# Rollback Plan
+
+If a critical issue is discovered after tag but before announcement:
+
+- Create hotfix branch from tag.
+- Patch deterministically.
+- Tag `v0.6.1`.
+- Document delta clearly.
+
+No force-push or tag rewrite allowed.
+
+---
+
+# Exit Criteria
+
+v0.6 is considered successfully released when:
+
+- Tag v0.6.0 exists and is immutable.
+- GitHub release published.
+- All WPs #401–#411 closed or deferred.
+- Coverage gate satisfied.
+- Determinism invariants verified.
+- Documentation reflects actual shipped behavior.
+
+v0.6 is a foundation release.  
+Stability and clarity outweigh feature count.

--- a/docs/milestones/v0.6/SPRINT_v0.6.md
+++ b/docs/milestones/v0.6/SPRINT_v0.6.md
@@ -1,0 +1,174 @@
+# Sprint Plan — v0.6
+
+## Metadata
+- Milestone: v0.6
+- Version: v0.6
+- Owner: ADL core (Daniel + Codex-assisted implementation)
+- Duration model: 3 execution sprints + release sprint
+- Governing WPs: #401–#411
+- Quality gate: #409 (coverage audit >80% per file)
+
+---
+
+# Sprint 1 — Deterministic Foundations
+
+## Goal
+Lock down determinism invariants and formalize the pattern registry
+before adding new runtime surfaces.
+
+This sprint establishes architectural safety so later work does not
+destabilize ordering guarantees.
+
+## Scope
+- WP-A: Pattern registry + compiler expansion (#401)
+- WP-F: Determinism + scheduler hardening (#406)
+- Initial design clarifications for scheduler policy surface (historical context only; not a v0.6 gate)
+
+## Planned Work (Execution Order)
+
+| Order | Item | Issue | Owner | Status |
+|-------|------|-------|-------|--------|
+| 1 | Formalize registry abstraction boundary | #401 | Daniel + Codex | Planned |
+| 2 | Ensure byte-stable compile transforms | #401 | Codex | Planned |
+| 3 | Add regression tests for compile stability | #401 | Codex | Planned |
+| 4 | Clarify max_concurrency override semantics | #406 | Daniel | Planned |
+| 5 | Harden lexicographic batching guarantees | #406 | Codex | Planned |
+| 6 | Add determinism regression tests | #406 | Codex | Planned |
+
+## Definition of Done
+- Pattern compilation is byte-stable.
+- Scheduler invariants explicitly tested.
+- No regression in existing deterministic tests.
+- CI fully green.
+
+---
+
+# Sprint 2 — Runtime Surface Extensions
+
+## Goal
+Add minimal, explicitly defined runtime extensions without compromising
+the deterministic execution model.
+
+## Scope
+- WP-B: HITL pause/resume (#402)
+- WP-C: Streaming output semantics (#403)
+- WP-E: Delegation metadata (log-only) (#405)
+- Early alignment with signing trust policy (#371, read-only coordination)
+
+## Planned Work (Execution Order)
+
+| Order | Item | Issue | Owner | Status |
+|-------|------|-------|-------|--------|
+| 1 | Extend execution state machine (Paused state) | #402 | Codex | Planned |
+| 2 | Implement resume entrypoint + tests | #402 | Codex | Planned |
+| 3 | Define streaming lifecycle boundaries | #403 | Daniel | Planned |
+| 4 | Implement streaming trace events | #403 | Codex | Planned |
+| 5 | Extend schema with delegation metadata block | #405 | Codex | Planned |
+| 6 | Log delegation metadata in trace (no enforcement) | #405 | Codex | Planned |
+| 7 | Add regression + integration tests | #402/#403/#405 | Codex | Planned |
+
+## Definition of Done
+- Pause/resume visible in trace and test-covered.
+- Streaming does not alter final artifact determinism.
+- Delegation metadata appears in trace.
+- Determinism tests still pass across repeated runs.
+
+---
+
+# Sprint 3 — Tooling, Profiles, and Validation
+
+## Goal
+Make v0.6 demonstrable, observable, and measurable.
+
+## Scope
+- WP-D: Provider profiles (#404)
+- WP-G: Instrumentation + replay diff + graph export (#407)
+- WP-H: Demo matrix (#408)
+- WP-H2: Coverage audit (#409)
+
+## Planned Work (Execution Order)
+
+| Order | Item | Issue | Owner | Status |
+|-------|------|-------|-------|--------|
+| 1 | Define provider profile documentation surface | #404 | Daniel | Planned |
+| 2 | Implement structured trace export format | #407 | Codex | Planned |
+| 3 | Implement replay diff utility | #407 | Codex | Planned |
+| 4 | Implement graph export (Mermaid or DOT) | #407 | Codex | Planned |
+| 5 | Define demo matrix coverage | #408 | Daniel | Planned |
+| 6 | Implement demo scenarios | #408 | Codex | Planned |
+| 7 | Run per-file coverage audit | #409 | Codex | Planned |
+| 8 | Raise coverage to >80% where practical | #409 | Codex | Planned |
+| 9 | Document justified coverage exclusions | #409 | Daniel | Planned |
+
+## Definition of Done
+- Replay + graph export produce usable artifacts.
+- Demo matrix runs deterministically in CI.
+- Coverage >80% per file (or documented exception).
+- No regression in runtime invariants.
+
+---
+
+# Sprint 4 — Documentation and Release
+
+## Goal
+Ship a coherent, documented, stable release.
+
+## Scope
+- WP-I: Docs + review pass (#410)
+- WP-J: Release ceremony (#411)
+- Alignment with remote security envelope (#370)
+- Alignment with signing trust policy (#371)
+
+## Planned Work (Execution Order)
+
+| Order | Item | Issue | Owner | Status |
+|-------|------|-------|-------|--------|
+| 1 | Align README + milestone docs | #410 | Daniel | Planned |
+| 2 | Final regression review | #410 | Daniel | Planned |
+| 3 | Validate coverage + demo artifacts | #409/#408 | Daniel | Planned |
+| 4 | Tag release | #411 | Daniel | Planned |
+| 5 | Publish release notes | #411 | Daniel | Planned |
+
+## Definition of Done
+- All WPs #401–#411 closed.
+- CI green on main.
+- Coverage audit complete.
+- Release notes accurate and published.
+- v0.6.0 tag created.
+
+---
+
+# Cadence Expectations
+
+- Use issue cards (`input` / `output`) for each WP or subtask.
+- No multi-WP PRs.
+- Determinism invariants are reviewed before merge.
+- CI must be green before merge to main.
+- Avoid parallel edits in the same file across WPs.
+
+---
+
+# Risks and Mitigation
+
+Risk: Streaming conflicts with determinism.
+Mitigation: Enforce lifecycle boundary ordering tests.
+
+Risk: Pause/resume introduces hidden state.
+Mitigation: Explicit state transitions + trace assertions.
+
+Risk: Coverage audit consumes disproportionate time.
+Mitigation: Timebox + document exclusions instead of perfection.
+
+Risk: Scope creep into v0.7 (learning/adaptive runtime).
+Mitigation: Delegation remains log-only; no adaptive scheduler.
+
+---
+
+# Exit Criteria (Milestone-Level)
+
+- All sprint definitions of done satisfied.
+- Deterministic behavior preserved across multiple runs.
+- Replay + graph export produce consistent artifacts.
+- Coverage audit complete.
+- Documentation reflects shipped runtime.
+- No template placeholders remain in milestone docs.

--- a/docs/milestones/v0.6/WBS_v0.6.md
+++ b/docs/milestones/v0.6/WBS_v0.6.md
@@ -1,0 +1,244 @@
+# Work Breakdown Structure (WBS) — v0.6
+
+## Metadata
+- Milestone: v0.6
+- Version: v0.6
+- Owner: ADL core (Daniel + Codex-assisted implementation)
+- Governing issues: #401–#411
+- Quality gate: #409 (coverage audit >80% per file)
+
+---
+
+## WBS Summary
+
+v0.6 is organized around eleven umbrella Work Packages (WPs), each mapped
+directly to an open GitHub issue (#401–#411).
+
+The milestone structure emphasizes:
+
+1. Determinism preservation.
+2. Explicit runtime semantics.
+3. Instrumentation + observability.
+4. Controlled expansion (no v0.7 scope creep).
+5. Measurable quality ratchet (coverage audit).
+
+Each WP below is decomposed into concrete, mergeable deliverables.
+
+---
+
+## Work Packages
+
+| ID | Work Package | Description | Deliverables | Dependencies | Issue |
+|----|-------------|------------|-------------|--------------|-------|
+| WP-A | Pattern registry + compiler expansion | Formalize registry abstraction and stabilize compile transforms | Registry abstraction, compile transforms updated, byte-stability tests, docs update | None (foundation) | #401 |
+| WP-B | HITL pause/resume (minimal) | Add explicit pause state + resume semantics | State machine extension, trace events, resume tests | WP-F (scheduler invariants) | #402 |
+| WP-C | Streaming output (trace + runtime) | Define and implement streaming semantics without breaking determinism | Streaming lifecycle events, stdout/stderr policy docs, tests | WP-F | #403 |
+| WP-D | Provider profiles (curated set) | Curated documented provider configurations | Profile definitions, config examples, docs section | None | #404 |
+| WP-E | Delegation metadata (log-only) | Schema extension + trace logging (no enforcement) | Schema update, trace logging, validation tests | WP-A (compile stability) | #405 |
+| WP-F | Determinism + scheduler hardening | Clarify concurrency + ordering invariants | Tests proving invariants, docs clarification | None | #406 |
+| WP-G | Instrumentation + replay diff + graph export | Improve trace tooling and visualization | Structured trace export, replay diff utility, graph export (Mermaid/DOT), demo | WP-A | #407 |
+| WP-H | Demo matrix + integration demos | Standardized demo coverage for v0.6 features | Demo matrix doc, CI-verifiable demos | WP-A–WP-G | #408 |
+| WP-H2 | Coverage audit (>80% per file) | Per-file coverage ratchet + exclusions documented | Coverage report, exclusions documented, follow-up issues | WP-A–WP-G implemented | #409 |
+| WP-I | Docs + review pass | Consolidate documentation for release | README updates, milestone doc alignment, threat-model references | WP-H2 | #410 |
+| WP-J | Release ceremony | Final validation + tag + release notes | Tag, release notes, checklist signoff | WP-I | #411 |
+
+---
+
+## Detailed Breakdown
+
+### WP-A — Pattern Registry (#401)
+
+Subtasks:
+- Define registry abstraction boundary.
+- Map pattern IDs → compile transforms.
+- Ensure byte-stable compilation.
+- Add regression tests for pattern stability.
+- Update DESIGN and docs.
+
+Deliverable:
+- Deterministic registry-based compile pipeline.
+
+---
+
+### WP-B — HITL Pause/Resume (#402)
+
+Subtasks:
+- Extend execution state machine.
+- Add explicit pause trace event.
+- Implement resume entrypoint.
+- Add tests for state integrity.
+- Document pause semantics.
+
+Deliverable:
+- Deterministic pause/resume feature with full trace visibility.
+
+---
+
+### WP-C — Streaming Output (#403)
+
+Subtasks:
+- Define lifecycle streaming boundaries.
+- Implement trace event emission during execution.
+- Preserve deterministic completion ordering.
+- Add streaming-specific tests.
+- Update docs.
+
+Deliverable:
+- Streaming that does not alter artifact determinism.
+
+---
+
+### WP-D — Provider Profiles (#404)
+
+Subtasks:
+- Identify curated provider list.
+- Define profile schema conventions.
+- Add example configurations.
+- Document tradeoffs and constraints.
+
+Deliverable:
+- Clear provider configuration surface (documentation-level).
+
+---
+
+### WP-E — Delegation Metadata (#405)
+
+Subtasks:
+- Extend schema with delegation block.
+- Validate schema changes.
+- Log delegation metadata in trace.
+- Add regression tests.
+- Document log-only scope.
+
+Deliverable:
+- Delegation metadata recorded in trace (no enforcement).
+
+---
+
+### WP-F — Determinism + Scheduler Hardening (#406)
+
+Subtasks:
+- Clarify max_concurrency override semantics.
+- Harden lexicographic batching guarantees.
+- Add regression tests.
+- Update DESIGN invariants section.
+
+Deliverable:
+- Deterministic scheduler guarantees explicitly enforced.
+
+---
+
+### WP-G — Instrumentation + Replay + Graph Export (#407)
+
+Subtasks:
+- Define structured trace export format.
+- Implement replay diff comparison tool.
+- Implement graph export (Mermaid or DOT).
+- Add CLI integration.
+- Provide demo artifact example.
+
+Deliverable:
+- Trace → diff → visualization workflow.
+
+---
+
+### WP-H — Demo Matrix (#408)
+
+Subtasks:
+- Define demo matrix coverage.
+- Implement demo scenarios covering new features.
+- Ensure deterministic CI execution.
+- Document demo usage.
+
+Deliverable:
+- CI-validated demos covering v0.6 scope.
+
+---
+
+### WP-H2 — Coverage Audit (#409)
+
+Subtasks:
+- Run per-file coverage analysis.
+- Identify files <80%.
+- Add targeted tests.
+- Document justified exclusions.
+- Commit coverage report artifact.
+
+Deliverable:
+- >80% coverage per file (where practical) + documented exceptions.
+
+Gate:
+- WP-I cannot complete until coverage audit is complete.
+
+---
+
+### WP-I — Docs + Review Pass (#410)
+
+Subtasks:
+- Align README with v0.6 scope.
+- Link milestone docs.
+- Validate threat-model alignment (#370, #371).
+- Final regression review.
+
+Deliverable:
+- Documentation consistent with runtime behavior.
+
+---
+
+### WP-J — Release Ceremony (#411)
+
+Subtasks:
+- Final checklist verification.
+- Tag release.
+- Publish release notes.
+- Confirm CI stability.
+
+Deliverable:
+- v0.6.0 tagged + published.
+
+---
+
+## Sequencing
+
+### Phase 1 — Foundations
+WP-A, WP-F
+
+### Phase 2 — Runtime Extensions
+WP-B, WP-C, WP-E
+
+### Phase 3 — Tooling + Profiles
+WP-D, WP-G
+
+### Phase 4 — Validation
+WP-H, WP-H2
+
+### Phase 5 — Ship
+WP-I, WP-J
+
+This order minimizes merge conflicts and preserves determinism invariants first.
+
+---
+
+## Acceptance Mapping
+
+- Determinism invariants → WP-F
+- Pattern formalization → WP-A
+- Streaming semantics → WP-C
+- HITL support → WP-B
+- Delegation logging → WP-E
+- Instrumentation improvements → WP-G
+- Demonstrable capability → WP-H
+- Quality ratchet → WP-H2
+- Documentation coherence → WP-I
+- Release readiness → WP-J
+
+---
+
+## Exit Criteria
+
+- Every WP (#401–#411) closed.
+- Coverage audit complete (#409).
+- Determinism invariants preserved across test suite.
+- Demo matrix passes in CI.
+- Documentation reflects shipped behavior.
+- No placeholder content remains in milestone docs.


### PR DESCRIPTION
## Summary
Applies a focused pre-kickoff consistency pass for v0.6 milestone docs.

### Changes
- Normalizes release-note pre-release wording from "Shipped / expected" to "Planned for v0.6"
- Clarifies sprint reference to #369 as historical context (not a v0.6 execution gate)
- Normalizes WP-D provider wording to "curated set"
- Clarifies release closeout mapping for #411 and #416
- Clarifies target-release wording in milestone checklist

## Validation
- rg -n "{{" docs/milestones/v0.6 || true
- rg -n "Shipped / expected|Planned for v0.6|top 12|historical context only; not a v0.6 gate|Close WP-J \(#411\) and milestone docs bootstrap issue \(#416\)|Target release: TBD \(set at RC freeze" docs/milestones/v0.6/*.md

Closes #416
