### PR TITLE
[v0.6][docs] Restore missing WP-I WBS subtask

### DIFF
--- a/docs/milestones/v0.6/WBS_v0.6.md
+++ b/docs/milestones/v0.6/WBS_v0.6.md
@@ -176,6 +176,7 @@ Gate:
 
 Subtasks:
 - Align README with v0.6 scope.
+- Eliminate duplicated README content in root and swarm directories; establish canonical docs locations.
 - Link milestone docs.
 - Validate threat-model alignment (#370, #371).
 - Final regression review.


### PR DESCRIPTION
Restores the missing WP-I subtask line in v0.6 WBS:\n\n- Eliminate duplicated README content in root and swarm directories; establish canonical docs locations.\n\nCloses #421