### PR TITLE
[v0.6][WP-D] Deterministic provider profiles

### DIFF
--- a/swarm/src/provider.rs
+++ b/swarm/src/provider.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::error::Error as StdError;
 use std::fmt;
@@ -120,6 +120,140 @@ pub fn is_retryable_error(err: &anyhow::Error) -> bool {
         }
     }
     true
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProviderProfilePreset {
+    kind: &'static str,
+    default_model: Option<&'static str>,
+    endpoint: Option<&'static str>,
+}
+
+fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProfilePreset> {
+    let mut m = BTreeMap::new();
+    // Ollama / local presets
+    m.insert(
+        "ollama:phi4-mini",
+        ProviderProfilePreset {
+            kind: "ollama",
+            default_model: Some("phi4-mini"),
+            endpoint: None,
+        },
+    );
+    m.insert(
+        "ollama:qwen2.5-7b",
+        ProviderProfilePreset {
+            kind: "ollama",
+            default_model: Some("qwen2.5:7b"),
+            endpoint: None,
+        },
+    );
+    m.insert(
+        "ollama:llama3.1-8b",
+        ProviderProfilePreset {
+            kind: "ollama",
+            default_model: Some("llama3.1:8b"),
+            endpoint: None,
+        },
+    );
+    m.insert(
+        "ollama:mistral-7b",
+        ProviderProfilePreset {
+            kind: "ollama",
+            default_model: Some("mistral:7b"),
+            endpoint: None,
+        },
+    );
+    // Mock/testing preset
+    m.insert(
+        "mock:echo-v1",
+        ProviderProfilePreset {
+            kind: "mock",
+            default_model: Some("echo-v1"),
+            endpoint: None,
+        },
+    );
+    // HTTP presets (explicit fixed endpoint placeholders; no secrets)
+    for (name, model) in [
+        ("http:gpt-4o-mini", "gpt-4o-mini"),
+        ("http:gpt-4.1-mini", "gpt-4.1-mini"),
+        ("http:claude-3-5-haiku", "claude-3-5-haiku-latest"),
+        ("http:claude-3-7-sonnet", "claude-3-7-sonnet-latest"),
+        ("http:gemini-2.0-flash", "gemini-2.0-flash"),
+        ("http:deepseek-chat", "deepseek-chat"),
+        ("http:llama-3.3-70b", "llama-3.3-70b-instruct"),
+    ] {
+        m.insert(
+            name,
+            ProviderProfilePreset {
+                kind: "http",
+                default_model: Some(model),
+                endpoint: Some("https://api.example.invalid/v1/complete"),
+            },
+        );
+    }
+    m
+}
+
+pub fn provider_profile_names() -> Vec<String> {
+    provider_profile_registry()
+        .keys()
+        .map(|name| (*name).to_string())
+        .collect()
+}
+
+pub fn expand_provider_profiles(doc: &adl::AdlDoc) -> Result<adl::AdlDoc> {
+    let registry = provider_profile_registry();
+    let available = provider_profile_names().join(", ");
+    let mut expanded = doc.clone();
+    let mut provider_ids: Vec<String> = expanded.providers.keys().cloned().collect();
+    provider_ids.sort();
+
+    for provider_id in provider_ids {
+        let Some(spec) = expanded.providers.get(&provider_id).cloned() else {
+            continue;
+        };
+        let Some(profile_name_raw) = spec.profile.as_deref() else {
+            continue;
+        };
+
+        if !spec.kind.trim().is_empty()
+            || spec.base_url.is_some()
+            || spec.default_model.is_some()
+            || !spec.config.is_empty()
+        {
+            return Err(anyhow!(
+                "providers.{provider_id} uses profile and explicit provider fields together (remove type/base_url/default_model/config when profile is set)"
+            ));
+        }
+
+        let profile_name = profile_name_raw.trim();
+        let Some(preset) = registry.get(profile_name) else {
+            return Err(anyhow!(
+                "providers.{provider_id}.profile '{}' is unknown (available: {})",
+                profile_name,
+                available
+            ));
+        };
+
+        let mut config = HashMap::new();
+        if let Some(endpoint) = preset.endpoint {
+            config.insert("endpoint".to_string(), Value::String(endpoint.to_string()));
+        }
+
+        expanded.providers.insert(
+            provider_id,
+            adl::ProviderSpec {
+                id: spec.id.clone(),
+                profile: Some(profile_name.to_string()),
+                kind: preset.kind.to_string(),
+                base_url: None,
+                default_model: preset.default_model.map(|m| m.to_string()),
+                config,
+            },
+        );
+    }
+    Ok(expanded)
 }
 
 /// Factory: build a provider implementation from ADL ProviderSpec.

--- a/swarm/src/resolve.rs
+++ b/swarm/src/resolve.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::adl;
 use crate::execution_plan;
 use crate::plan;
+use crate::provider;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AdlVersion {
@@ -173,6 +174,8 @@ fn resolve_provider_for_pattern(doc: &adl::AdlDoc) -> Result<(Option<String>, St
 
 /// Resolve the run section into a deterministic, convenient form.
 pub fn resolve_run(doc: &adl::AdlDoc) -> Result<AdlResolved> {
+    let doc = provider::expand_provider_profiles(doc)
+        .with_context(|| "failed to expand provider profiles")?;
     let _version = parse_version(&doc.version)?;
 
     let run_id = doc.run.name.clone().unwrap_or_else(|| "run".to_string());
@@ -183,7 +186,7 @@ pub fn resolve_run(doc: &adl::AdlDoc) -> Result<AdlResolved> {
         let compiled = registry
             .compile(pattern_ref)
             .with_context(|| format!("failed to compile pattern '{}'", pattern_ref))?;
-        let (agent, provider) = resolve_provider_for_pattern(doc)?;
+        let (agent, provider) = resolve_provider_for_pattern(&doc)?;
 
         let mut save_as_by_step: HashMap<&str, Option<String>> = HashMap::new();
         for node in &compiled.execution_plan.nodes {
@@ -229,7 +232,7 @@ pub fn resolve_run(doc: &adl::AdlDoc) -> Result<AdlResolved> {
         });
     }
 
-    let workflow = doc.run.resolve_workflow(doc)?;
+    let workflow = doc.run.resolve_workflow(&doc)?;
     let workflow_id = doc
         .run
         .workflow_ref
@@ -247,7 +250,7 @@ pub fn resolve_run(doc: &adl::AdlDoc) -> Result<AdlResolved> {
                 .unwrap_or_else(|| format!("step-{idx}"))
         });
 
-        let provider = resolve_provider_for_step(s, doc);
+        let provider = resolve_provider_for_step(s, &doc);
 
         steps.push(ResolvedStep {
             id,
@@ -280,7 +283,7 @@ pub fn resolve_run(doc: &adl::AdlDoc) -> Result<AdlResolved> {
         workflow_id,
         steps,
         execution_plan,
-        doc: doc.clone(),
+        doc,
     })
 }
 
@@ -322,6 +325,7 @@ mod tests {
             "local".to_string(),
             adl::ProviderSpec {
                 id: None,
+                profile: None,
                 kind: "ollama".to_string(),
                 base_url: None,
                 default_model: None,
@@ -438,6 +442,7 @@ mod tests {
             "other".to_string(),
             adl::ProviderSpec {
                 id: None,
+                profile: None,
                 kind: "ollama".to_string(),
                 base_url: None,
                 default_model: None,
@@ -699,6 +704,7 @@ mod wp02_followup_tests {
             "other".to_string(),
             crate::adl::ProviderSpec {
                 id: None,
+                profile: None,
                 kind: "ollama".to_string(),
                 base_url: None,
                 default_model: None,

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -2551,6 +2551,7 @@ fn run_executes_compiled_pattern_fork_join_happy_path() {
         "local".to_string(),
         swarm::adl::ProviderSpec {
             id: None,
+            profile: None,
             kind: "ollama".to_string(),
             base_url: None,
             default_model: None,


### PR DESCRIPTION
## Summary
- add optional provider profile schema field
- add deterministic in-code provider profile registry (12 profiles)
- expand profile-based providers to explicit specs during resolve
- reject profile/explicit-field conflicts and unknown profiles with sorted available list
- add unit/integration coverage for registry determinism and expansion behavior

## Scope discipline
- no scheduler changes
- no concurrency semantics changes
- no network-dependent tests added

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test

Closes #404