### PR TITLE
[v0.6][WP-H] Demo matrix + deterministic integration demos

### DIFF
--- a/docs/milestones/v0.6/DEMOS_v0.6.md
+++ b/docs/milestones/v0.6/DEMOS_v0.6.md
@@ -1,0 +1,36 @@
+# v0.6 Demo Matrix
+
+This is the canonical v0.6 integration demo matrix for milestone validation.
+
+Execution assumptions:
+- Run from repo root.
+- No network dependencies.
+- Use local mock provider for run-mode demos: `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh`.
+- Determinism checks are based on running each demo twice.
+
+| Demo | Features Covered | Commands | Expected Artifacts | Determinism Notes |
+|---|---|---|---|---|
+| D1 Deterministic Concurrent Workflow | #406 | `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-3-concurrency-fork-join.adl.yaml --run --out <out_dir>` | `<out_dir>/fork/alpha.txt`, `<out_dir>/fork/beta.txt`, `<out_dir>/fork/join.txt` | Compare file contents across two runs. Ignore absolute output directory path differences. |
+| D2 Pattern Expansion Plan | #401 | `cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-5-pattern-fork-join.adl.yaml --print-plan` | Plan text on stdout | Compare stdout byte-for-byte across two runs. |
+| D3 HITL Pause/Resume | #402 | `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-6-hitl-pause-resume.adl.yaml --run --trace --out <paused_out>` then `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-6-hitl-pause-resume.adl.yaml --run --resume .adl/runs/v0-6-hitl-pause-demo/run.json --out <resume_out>` and baseline `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-6-hitl-no-pause.adl.yaml --run --out <plain_out>` | `<resume_out>/s3.txt`, `<plain_out>/s3.txt`, `.adl/runs/v0-6-hitl-pause-demo/run.json` | Resume output must match non-paused output; repeat whole cycle twice. |
+| D4 Streaming Output Observational | #403 | `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-6-hitl-no-pause.adl.yaml --run --trace --out <stream_out>` and `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-6-hitl-no-pause.adl.yaml --run --quiet --out <quiet_out>` | `<stream_out>/s1.txt`, `<stream_out>/s2.txt`, `<stream_out>/s3.txt`, `<quiet_out>/s3.txt` | Trace includes `StepOutputChunk`. For trace comparisons, normalize timestamps and compare semantic event lines only. Artifacts must match with/without streaming output. |
+| D5 Provider Profiles + Delegation Metadata | #404, #405 | `SWARM_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-6-provider-profile-delegation.adl.yaml --allow-unsigned --run --trace --out <out_dir>` | `<out_dir>/b.txt` | Normalize timestamps and compare semantic trace lines across runs. Verify step `a` omits false-only delegation and step `b` emits canonicalized delegation JSON (deduped/sorted tags). |
+| D6 Instrumentation (Graph/Replay/Diff) | #407 | `cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- instrument graph swarm/examples/v0-5-pattern-fork-join.adl.yaml --format json` ; `cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- instrument graph swarm/examples/v0-5-pattern-fork-join.adl.yaml --format dot` ; `cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- instrument replay swarm/examples/v0-6-trace-sample-a.json` ; `cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- instrument diff-plan swarm/examples/v0-5-pattern-linear.adl.yaml swarm/examples/v0-5-pattern-fork-join.adl.yaml` ; `cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- instrument diff-trace swarm/examples/v0-6-trace-sample-a.json swarm/examples/v0-6-trace-sample-b.json` | stdout artifacts for each command | Compare each command output byte-for-byte across two runs. |
+
+## Twice-Run Determinism Evidence
+
+Evidence directory used for this WP run:
+- `/Users/daniel/git/adl-wp-408/.tmp/wp408-20260221-234841`
+
+Results:
+- D1: `D1_ALPHA=STABLE`, `D1_BETA=STABLE`, `D1_JOIN=STABLE`
+- D2: `D2=STABLE`
+- D3: `D3_RESUME=STABLE`, `D3_EQ_PLAIN=YES`
+- D4: `D4_TRACE_SEMANTIC=STABLE`, `D4_ARTIFACT_STREAM_EQ_QUIET=YES`, `D4_CHUNK_EVENTS=YES`
+- D5: `D5_TRACE_SEMANTIC=STABLE`, `D5_FALSE_ONLY_OMITTED=YES`, `D5_CANONICAL_DELEGATION=YES`
+- D6: `D6_GRAPH_JSON=STABLE`, `D6_GRAPH_DOT=STABLE`, `D6_REPLAY=STABLE`, `D6_DIFF_PLAN=STABLE`, `D6_DIFF_TRACE=STABLE`
+
+## Notes
+
+- Raw trace output contains timestamps and elapsed milliseconds, so semantic comparisons remove those prefixes.
+- Some raw artifacts include output-directory paths in logs; deterministic checks use content-level comparisons for files and normalized event lines for traces.

--- a/swarm/examples/README.md
+++ b/swarm/examples/README.md
@@ -139,3 +139,6 @@ cargo run -q --manifest-path swarm/Cargo.toml --bin swarm -- swarm/examples/v0-5
 
 For a full v0.5 reproducibility checklist, see:
 - `../docs/milestones/v0.5/DEMO_MATRIX_v0.5.md`
+
+For v0.6 integration demos and determinism checks, see:
+- `../docs/milestones/v0.6/DEMOS_v0.6.md`

--- a/swarm/examples/v0-6-hitl-no-pause.adl.yaml
+++ b/swarm/examples/v0-6-hitl-no-pause.adl.yaml
@@ -1,0 +1,39 @@
+version: "0.3"
+
+providers:
+  local:
+    type: "ollama"
+
+agents:
+  worker:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t:
+    prompt:
+      user: "step {{n}}"
+
+run:
+  name: "v0-6-hitl-no-pause-demo"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "worker"
+        task: "t"
+        inputs: { n: "1" }
+        save_as: "s1"
+        write_to: "s1.txt"
+      - id: "s2"
+        agent: "worker"
+        task: "t"
+        inputs: { n: "2" }
+        save_as: "s2"
+        write_to: "s2.txt"
+      - id: "s3"
+        agent: "worker"
+        task: "t"
+        inputs: { n: "3" }
+        save_as: "s3"
+        write_to: "s3.txt"

--- a/swarm/examples/v0-6-hitl-pause-resume.adl.yaml
+++ b/swarm/examples/v0-6-hitl-pause-resume.adl.yaml
@@ -1,0 +1,42 @@
+version: "0.3"
+
+providers:
+  local:
+    type: "ollama"
+
+agents:
+  worker:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t:
+    prompt:
+      user: "step {{n}}"
+
+run:
+  name: "v0-6-hitl-pause-demo"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "worker"
+        task: "t"
+        inputs: { n: "1" }
+        save_as: "s1"
+        write_to: "s1.txt"
+      - id: "s2"
+        agent: "worker"
+        task: "t"
+        inputs: { n: "2" }
+        save_as: "s2"
+        write_to: "s2.txt"
+        guards:
+          - type: pause
+            config: { reason: "await_review" }
+      - id: "s3"
+        agent: "worker"
+        task: "t"
+        inputs: { n: "3" }
+        save_as: "s3"
+        write_to: "s3.txt"

--- a/swarm/examples/v0-6-provider-profile-delegation.adl.yaml
+++ b/swarm/examples/v0-6-provider-profile-delegation.adl.yaml
@@ -1,0 +1,42 @@
+version: "0.5"
+
+providers:
+  local:
+    profile: "ollama:phi4-mini"
+
+agents:
+  reviewer:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t1:
+    prompt:
+      user: "first {{topic}}"
+  t2:
+    prompt:
+      user: "second {{a}}"
+
+run:
+  name: "v0-6-profile-delegation"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "a"
+        agent: "reviewer"
+        task: "t1"
+        inputs: { topic: "profiles" }
+        save_as: "a"
+        delegation:
+          requires_verification: false
+      - id: "b"
+        agent: "reviewer"
+        task: "t2"
+        inputs: { a: "@state:a" }
+        save_as: "b"
+        write_to: "b.txt"
+        delegation:
+          role: "reviewer"
+          requires_verification: true
+          escalation_target: "human"
+          tags: ["safety", "compliance", "safety"]

--- a/swarm/examples/v0-6-trace-sample-a.json
+++ b/swarm/examples/v0-6-trace-sample-a.json
@@ -1,0 +1,20 @@
+[
+  {
+    "kind": "StepStarted",
+    "step_id": "s1",
+    "agent_id": "agent-a",
+    "provider_id": "provider-a",
+    "task_id": "task-a",
+    "delegation_json": null
+  },
+  {
+    "kind": "StepOutputChunk",
+    "step_id": "s1",
+    "chunk_bytes": 12
+  },
+  {
+    "kind": "StepFinished",
+    "step_id": "s1",
+    "success": true
+  }
+]

--- a/swarm/examples/v0-6-trace-sample-b.json
+++ b/swarm/examples/v0-6-trace-sample-b.json
@@ -1,0 +1,20 @@
+[
+  {
+    "kind": "StepStarted",
+    "step_id": "s1",
+    "agent_id": "agent-a",
+    "provider_id": "provider-a",
+    "task_id": "task-a",
+    "delegation_json": null
+  },
+  {
+    "kind": "StepOutputChunk",
+    "step_id": "s1",
+    "chunk_bytes": 13
+  },
+  {
+    "kind": "StepFinished",
+    "step_id": "s1",
+    "success": true
+  }
+]


### PR DESCRIPTION
## Summary
Implements WP-H by adding a canonical v0.6 demo matrix and deterministic integration demo fixtures.

### Added
- `docs/milestones/v0.6/DEMOS_v0.6.md`
- `swarm/examples/v0-6-hitl-pause-resume.adl.yaml`
- `swarm/examples/v0-6-hitl-no-pause.adl.yaml`
- `swarm/examples/v0-6-provider-profile-delegation.adl.yaml`
- `swarm/examples/v0-6-trace-sample-a.json`
- `swarm/examples/v0-6-trace-sample-b.json`
- `swarm/examples/README.md` link to v0.6 demos

### Coverage
Matrix covers feature areas from:
- #401 pattern registry
- #402 HITL pause/resume
- #403 streaming output (observational)
- #404 provider profiles
- #405 delegation metadata
- #406 deterministic concurrent execution
- #407 instrumentation graph/replay/diff

### Determinism
Each demo was run twice and recorded with deterministic checks (content comparisons, semantic trace normalization where timestamps are present).

### Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Closes #408
