### PR TITLE
[v0.6][WP-H2] Coverage audit: >=80% per swarm/src file

### DIFF
--- a/swarm/src/adl.rs
+++ b/swarm/src/adl.rs
@@ -1055,3 +1055,353 @@ pub struct PatternBranchSpec {
 pub struct PatternJoinSpec {
     pub step: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn runspec_resolve_workflow_shapes() {
+        let doc = AdlDoc {
+            version: "0.5".to_string(),
+            providers: HashMap::new(),
+            tools: HashMap::new(),
+            agents: HashMap::new(),
+            tasks: HashMap::new(),
+            workflows: HashMap::new(),
+            patterns: vec![],
+            signature: None,
+            run: RunSpec {
+                id: None,
+                name: None,
+                created_at: None,
+                defaults: RunDefaults::default(),
+                workflow_ref: None,
+                workflow: None,
+                pattern_ref: None,
+                inputs: HashMap::new(),
+                placement: None,
+                remote: None,
+            },
+        };
+
+        let err = doc
+            .run
+            .resolve_workflow(&doc)
+            .expect_err("missing workflow shape should fail");
+        assert!(err
+            .to_string()
+            .contains("must define either workflow_ref or inline workflow"));
+    }
+
+    #[test]
+    fn resolve_workflow_ref_unknown_and_inline_success() {
+        let mut doc = AdlDoc {
+            version: "0.5".to_string(),
+            providers: HashMap::new(),
+            tools: HashMap::new(),
+            agents: HashMap::new(),
+            tasks: HashMap::new(),
+            workflows: HashMap::new(),
+            patterns: vec![],
+            signature: None,
+            run: RunSpec {
+                id: None,
+                name: None,
+                created_at: None,
+                defaults: RunDefaults::default(),
+                workflow_ref: Some("missing".to_string()),
+                workflow: None,
+                pattern_ref: None,
+                inputs: HashMap::new(),
+                placement: None,
+                remote: None,
+            },
+        };
+        let err = doc
+            .run
+            .resolve_workflow(&doc)
+            .expect_err("unknown workflow ref");
+        assert!(err.to_string().contains("references unknown workflow"));
+
+        doc.run.workflow_ref = None;
+        doc.run.workflow = Some(WorkflowSpec {
+            id: Some("wf".to_string()),
+            kind: WorkflowKind::Sequential,
+            max_concurrency: None,
+            steps: vec![],
+        });
+        let resolved = doc.run.resolve_workflow(&doc).expect("inline workflow");
+        assert_eq!(resolved.id.as_deref(), Some("wf"));
+    }
+
+    #[test]
+    fn delegation_canonicalized_and_empty_detection() {
+        let d = DelegationSpec {
+            role: Some("review".to_string()),
+            requires_verification: Some(false),
+            escalation_target: None,
+            tags: vec!["z".to_string(), "a".to_string(), "z".to_string()],
+        };
+        let canonical = d.canonicalized();
+        assert_eq!(canonical.tags, vec!["a".to_string(), "z".to_string()]);
+        assert_eq!(canonical.requires_verification, None);
+
+        let empty = DelegationSpec {
+            role: None,
+            requires_verification: Some(false),
+            escalation_target: None,
+            tags: vec![],
+        };
+        assert!(empty.is_effectively_empty());
+        assert!(!DelegationSpec {
+            role: None,
+            requires_verification: Some(true),
+            escalation_target: None,
+            tags: vec![],
+        }
+        .is_effectively_empty());
+    }
+
+    #[test]
+    fn run_placement_mode_resolves_legacy_values() {
+        assert_eq!(
+            RunPlacementSpec::Mode(PlacementMode::Remote).mode(),
+            Some(PlacementMode::Remote)
+        );
+        let legacy_remote = RunPlacementSpec::Legacy(RunPlacementLegacySpec {
+            provider: None,
+            target: Some("REMOTE".to_string()),
+        });
+        assert_eq!(legacy_remote.mode(), Some(PlacementMode::Remote));
+        let legacy_unknown = RunPlacementSpec::Legacy(RunPlacementLegacySpec {
+            provider: None,
+            target: Some("somewhere".to_string()),
+        });
+        assert_eq!(legacy_unknown.mode(), None);
+    }
+
+    #[test]
+    fn pattern_validate_exercises_linear_and_fork_join_errors() {
+        let linear = PatternSpec {
+            id: "p".to_string(),
+            kind: PatternKind::Linear,
+            steps: vec![],
+            fork: None,
+            join: None,
+        };
+        assert!(linear.validate().is_err());
+
+        let fork_missing = PatternSpec {
+            id: "p".to_string(),
+            kind: PatternKind::ForkJoin,
+            steps: vec![],
+            fork: None,
+            join: Some(PatternJoinSpec {
+                step: "J".to_string(),
+            }),
+        };
+        assert!(fork_missing.validate().is_err());
+
+        let duplicate_branch = PatternSpec {
+            id: "p".to_string(),
+            kind: PatternKind::ForkJoin,
+            steps: vec![],
+            fork: Some(PatternForkSpec {
+                branches: vec![
+                    PatternBranchSpec {
+                        id: "b".to_string(),
+                        steps: vec!["A".to_string()],
+                    },
+                    PatternBranchSpec {
+                        id: "b".to_string(),
+                        steps: vec!["B".to_string()],
+                    },
+                ],
+            }),
+            join: Some(PatternJoinSpec {
+                step: "J".to_string(),
+            }),
+        };
+        let err = duplicate_branch
+            .validate()
+            .expect_err("duplicate branch id");
+        assert!(err.to_string().contains("duplicate branch id"));
+    }
+
+    #[test]
+    fn load_from_file_include_merge_and_cycle_errors() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let base = std::env::temp_dir().join(format!("adl-load-test-{now}-{}", std::process::id()));
+        std::fs::create_dir_all(&base).expect("create base");
+
+        let fragment = base.join("fragment.yaml");
+        let root = base.join("root.yaml");
+        std::fs::write(
+            &fragment,
+            r#"
+providers:
+  p:
+    type: "ollama"
+agents:
+  a:
+    provider: "p"
+    model: "m"
+tasks:
+  t:
+    prompt:
+      user: "u"
+"#,
+        )
+        .expect("write fragment");
+        std::fs::write(
+            &root,
+            r#"
+version: "0.1"
+include: ["fragment.yaml"]
+run:
+  workflow:
+    steps:
+      - agent: "a"
+        task: "t"
+"#,
+        )
+        .expect("write root");
+
+        let doc = AdlDoc::load_from_file(root.to_str().expect("utf8")).expect("load merged doc");
+        assert!(doc.providers.contains_key("p"));
+        assert!(doc.tasks.contains_key("t"));
+
+        let a = base.join("a.yaml");
+        let b = base.join("b.yaml");
+        std::fs::write(
+            &a,
+            r#"
+version: "0.1"
+include: ["b.yaml"]
+run:
+  workflow:
+    steps: []
+"#,
+        )
+        .expect("write a");
+        std::fs::write(
+            &b,
+            r#"
+include: ["a.yaml"]
+"#,
+        )
+        .expect("write b");
+
+        let err = AdlDoc::load_from_file(a.to_str().expect("utf8")).expect_err("cycle error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("include cycle detected"),
+            "unexpected cycle error: {msg}"
+        );
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn deserialize_temperature_number_formats() {
+        let yaml = r#"
+id: "a1"
+provider: "p"
+model: "m"
+temperature: 0.7
+"#;
+        let agent: AgentSpec = serde_yaml::from_str(yaml).expect("parse agent");
+        assert_eq!(agent.temperature.as_deref(), Some("0.7"));
+    }
+
+    #[test]
+    fn validate_provider_http_requires_endpoint() {
+        let provider = ProviderSpec {
+            id: None,
+            profile: None,
+            kind: "http".to_string(),
+            base_url: None,
+            default_model: None,
+            config: HashMap::new(),
+        };
+        let err =
+            validate_provider("p1", &provider).expect_err("http provider must require endpoint");
+        assert!(err
+            .to_string()
+            .contains("requires base_url or config.endpoint"));
+    }
+
+    #[test]
+    fn validate_provider_profile_rejects_empty_value() {
+        let provider = ProviderSpec {
+            id: None,
+            profile: Some("   ".to_string()),
+            kind: "".to_string(),
+            base_url: None,
+            default_model: None,
+            config: HashMap::new(),
+        };
+        let err = validate_provider("p1", &provider).expect_err("empty profile should fail");
+        assert!(err.to_string().contains("profile must not be empty"));
+    }
+
+    #[test]
+    fn validate_tool_rejects_unsupported_kind() {
+        let tool = ToolSpec {
+            id: None,
+            kind: "nope".to_string(),
+            config: HashMap::new(),
+        };
+        let err = validate_tool("t1", &tool).expect_err("unsupported tool kind");
+        assert!(err.to_string().contains("unsupported kind"));
+    }
+
+    #[test]
+    fn validate_rejects_explicit_id_mismatch_with_key() {
+        let doc = AdlDoc {
+            version: "0.5".to_string(),
+            providers: HashMap::from([(
+                "p1".to_string(),
+                ProviderSpec {
+                    id: Some("wrong".to_string()),
+                    profile: None,
+                    kind: "ollama".to_string(),
+                    base_url: None,
+                    default_model: None,
+                    config: HashMap::new(),
+                },
+            )]),
+            tools: HashMap::new(),
+            agents: HashMap::new(),
+            tasks: HashMap::new(),
+            workflows: HashMap::new(),
+            patterns: vec![],
+            signature: None,
+            run: RunSpec {
+                id: None,
+                name: None,
+                created_at: None,
+                defaults: RunDefaults::default(),
+                workflow_ref: None,
+                workflow: Some(WorkflowSpec {
+                    id: None,
+                    kind: WorkflowKind::Sequential,
+                    max_concurrency: None,
+                    steps: vec![],
+                }),
+                pattern_ref: None,
+                inputs: HashMap::new(),
+                placement: None,
+                remote: None,
+            },
+        };
+        let err = doc.validate().expect_err("id mismatch should fail");
+        assert!(err
+            .to_string()
+            .contains("providers.p1.id must match key 'p1'"));
+    }
+}

--- a/swarm/src/bin/swarm_remote.rs
+++ b/swarm/src/bin/swarm_remote.rs
@@ -1,11 +1,41 @@
 use anyhow::Result;
 
+fn bind_arg_from_args(args: &[String]) -> String {
+    args.get(1)
+        .cloned()
+        .unwrap_or_else(|| "127.0.0.1:8787".to_string())
+}
+
+fn run_with_bind(bind: &str) -> Result<()> {
+    eprintln!("swarm-remote listening on http://{bind}");
+    swarm::remote_exec::run_server(bind)
+}
+
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    let bind = args
-        .get(1)
-        .cloned()
-        .unwrap_or_else(|| "127.0.0.1:8787".to_string());
-    eprintln!("swarm-remote listening on http://{bind}");
-    swarm::remote_exec::run_server(&bind)
+    let bind = bind_arg_from_args(&args);
+    run_with_bind(&bind)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bind_arg_from_args, run_with_bind};
+
+    #[test]
+    fn bind_arg_defaults_when_not_provided() {
+        let args = vec!["swarm_remote".to_string()];
+        assert_eq!(bind_arg_from_args(&args), "127.0.0.1:8787".to_string());
+    }
+
+    #[test]
+    fn bind_arg_uses_first_cli_argument() {
+        let args = vec!["swarm_remote".to_string(), "0.0.0.0:9000".to_string()];
+        assert_eq!(bind_arg_from_args(&args), "0.0.0.0:9000".to_string());
+    }
+
+    #[test]
+    fn run_with_bind_returns_error_for_invalid_address() {
+        let err = run_with_bind("127.0.0.1:not-a-port").expect_err("invalid bind");
+        assert!(err.to_string().contains("failed to bind remote server"));
+    }
 }

--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -1467,3 +1467,272 @@ fn missing_prompt_inputs(
     out.sort();
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adl::{AdlDoc, PromptSpec, RunDefaults, RunSpec, WorkflowKind, WorkflowSpec};
+    use crate::resolve::AdlResolved;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn minimal_resolved() -> AdlResolved {
+        AdlResolved {
+            run_id: "run".to_string(),
+            workflow_id: "wf".to_string(),
+            doc: AdlDoc {
+                version: "0.3".to_string(),
+                providers: HashMap::new(),
+                tools: HashMap::new(),
+                agents: HashMap::new(),
+                tasks: HashMap::new(),
+                workflows: HashMap::new(),
+                patterns: vec![],
+                signature: None,
+                run: RunSpec {
+                    id: None,
+                    name: Some("run".to_string()),
+                    created_at: None,
+                    defaults: RunDefaults::default(),
+                    workflow_ref: None,
+                    workflow: Some(WorkflowSpec {
+                        id: None,
+                        kind: WorkflowKind::Concurrent,
+                        max_concurrency: None,
+                        steps: vec![],
+                    }),
+                    pattern_ref: None,
+                    inputs: HashMap::new(),
+                    placement: None,
+                    remote: None,
+                },
+            },
+            steps: vec![],
+            execution_plan: crate::execution_plan::ExecutionPlan {
+                workflow_kind: WorkflowKind::Concurrent,
+                nodes: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn resolve_state_inputs_resolves_and_validates_state_bindings() {
+        let mut inputs = HashMap::new();
+        inputs.insert("a".to_string(), "@state:key1".to_string());
+        inputs.insert("b".to_string(), "literal".to_string());
+        let mut state = HashMap::new();
+        state.insert("key1".to_string(), "value1".to_string());
+
+        let merged = resolve_state_inputs("s1", &inputs, &state).expect("resolve");
+        assert_eq!(merged.get("a").map(String::as_str), Some("value1"));
+        assert_eq!(merged.get("b").map(String::as_str), Some("literal"));
+
+        inputs.insert("a".to_string(), "@state:".to_string());
+        let empty_err = resolve_state_inputs("s1", &inputs, &state).expect_err("empty key fails");
+        assert!(empty_err
+            .to_string()
+            .contains("uses @state: with an empty key"));
+
+        inputs.insert("a".to_string(), "@state:missing".to_string());
+        let missing_err =
+            resolve_state_inputs("s1", &inputs, &state).expect_err("missing key fails");
+        assert!(missing_err
+            .to_string()
+            .contains("references missing saved state"));
+    }
+
+    #[test]
+    fn missing_prompt_inputs_dedupes_and_sorts_missing_keys() {
+        let prompt = PromptSpec {
+            system: Some("{{ b }}".to_string()),
+            user: Some("{{a}} and {{b}} and {{ a }}".to_string()),
+            context: Some("{{c}}".to_string()),
+            ..Default::default()
+        };
+        let mut inputs = HashMap::new();
+        inputs.insert("c".to_string(), "ok".to_string());
+        let missing = missing_prompt_inputs(&prompt, &inputs);
+        assert_eq!(missing, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn validate_write_to_rejects_invalid_paths() {
+        let empty_err = validate_write_to("s1", "   ").expect_err("empty should fail");
+        assert!(empty_err.to_string().contains("empty write_to"));
+
+        let abs_err = validate_write_to("s1", "/tmp/out.txt").expect_err("absolute should fail");
+        assert!(abs_err.to_string().contains("must be a relative path"));
+
+        let traversal_err =
+            validate_write_to("s1", "../escape.txt").expect_err("traversal should fail");
+        assert!(traversal_err.to_string().contains("without '..'"));
+    }
+
+    #[test]
+    fn write_output_creates_parent_directories() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let out_dir =
+            std::env::temp_dir().join(format!("swarm-write-output-{now}-{}", std::process::id()));
+        let path =
+            write_output("s1", &out_dir, "nested/result.txt", "hello").expect("write output");
+        let written = std::fs::read_to_string(&path).expect("read output");
+        assert_eq!(written, "hello");
+        let _ = std::fs::remove_dir_all(out_dir);
+    }
+
+    #[test]
+    fn effective_max_concurrency_precedence_and_validation() {
+        let mut resolved = minimal_resolved();
+        assert_eq!(effective_max_concurrency(&resolved).expect("default"), 4);
+
+        resolved.doc.run.defaults.max_concurrency = Some(3);
+        assert_eq!(
+            effective_max_concurrency(&resolved).expect("run default"),
+            3
+        );
+
+        resolved
+            .doc
+            .run
+            .workflow
+            .as_mut()
+            .expect("workflow")
+            .max_concurrency = Some(2);
+        assert_eq!(
+            effective_max_concurrency(&resolved).expect("workflow override"),
+            2
+        );
+
+        resolved
+            .doc
+            .run
+            .workflow
+            .as_mut()
+            .expect("workflow")
+            .max_concurrency = Some(0);
+        let err = effective_max_concurrency(&resolved).expect_err("zero should fail");
+        assert!(err.to_string().contains("must be >= 1"));
+    }
+
+    #[test]
+    fn effective_max_concurrency_supports_workflow_ref_overrides() {
+        let mut resolved = minimal_resolved();
+        resolved.doc.run.workflow = None;
+        resolved.doc.run.workflow_ref = Some("wf_ref".to_string());
+        resolved.doc.workflows.insert(
+            "wf_ref".to_string(),
+            WorkflowSpec {
+                id: Some("wf_ref".to_string()),
+                kind: WorkflowKind::Concurrent,
+                max_concurrency: Some(5),
+                steps: vec![],
+            },
+        );
+        assert_eq!(
+            effective_max_concurrency(&resolved).expect("workflow ref override"),
+            5
+        );
+    }
+
+    #[test]
+    fn pause_reason_for_step_detects_pause_guard_and_optional_reason() {
+        let mut step = crate::resolve::ResolvedStep {
+            id: "s1".to_string(),
+            agent: None,
+            provider: None,
+            placement: None,
+            task: None,
+            call: None,
+            with: HashMap::new(),
+            as_ns: None,
+            delegation: None,
+            prompt: None,
+            inputs: HashMap::new(),
+            guards: vec![],
+            save_as: None,
+            write_to: None,
+            on_error: None,
+            retry: None,
+        };
+        assert_eq!(pause_reason_for_step(&step), None);
+
+        step.guards.push(crate::adl::GuardSpec {
+            kind: "pause".to_string(),
+            config: HashMap::new(),
+        });
+        assert_eq!(pause_reason_for_step(&step), Some(None));
+
+        step.guards[0].config.insert(
+            "reason".to_string(),
+            serde_json::Value::String("needs review".to_string()),
+        );
+        assert_eq!(
+            pause_reason_for_step(&step),
+            Some(Some("needs review".to_string()))
+        );
+    }
+
+    #[test]
+    fn effective_step_placement_prefers_step_then_run_then_local_default() {
+        let mut doc = minimal_resolved().doc;
+        let step = crate::resolve::ResolvedStep {
+            id: "s1".to_string(),
+            agent: None,
+            provider: None,
+            placement: None,
+            task: None,
+            call: None,
+            with: HashMap::new(),
+            as_ns: None,
+            delegation: None,
+            prompt: None,
+            inputs: HashMap::new(),
+            guards: vec![],
+            save_as: None,
+            write_to: None,
+            on_error: None,
+            retry: None,
+        };
+        assert_eq!(
+            effective_step_placement(&step, &doc),
+            crate::adl::PlacementMode::Local
+        );
+
+        doc.run.placement = Some(crate::adl::RunPlacementSpec::Mode(
+            crate::adl::PlacementMode::Remote,
+        ));
+        assert_eq!(
+            effective_step_placement(&step, &doc),
+            crate::adl::PlacementMode::Remote
+        );
+
+        let mut step_override = step.clone();
+        step_override.placement = Some(crate::adl::PlacementMode::Local);
+        assert_eq!(
+            effective_step_placement(&step_override, &doc),
+            crate::adl::PlacementMode::Local
+        );
+    }
+
+    #[test]
+    fn resolve_call_binding_requires_state_prefix_and_known_key() {
+        let mut state = HashMap::new();
+        state.insert("inputs.topic".to_string(), "ADL".to_string());
+
+        let resolved =
+            resolve_call_binding("@state:inputs.topic", &state).expect("state binding should work");
+        assert_eq!(resolved, "ADL");
+        let templated = resolve_call_binding("{{ state.inputs.topic }}", &state)
+            .expect("templated state binding should work");
+        assert_eq!(templated, "ADL");
+
+        let missing = resolve_call_binding("@state:inputs.missing", &state)
+            .expect_err("missing state key should fail");
+        assert!(missing.to_string().contains("missing state key"));
+
+        let passthrough = resolve_call_binding("literal", &state).expect("literal passthrough");
+        assert_eq!(passthrough, "literal");
+    }
+}

--- a/swarm/src/instrumentation.rs
+++ b/swarm/src/instrumentation.rs
@@ -415,8 +415,9 @@ fn escape_dot(v: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adl::WorkflowKind;
+    use crate::adl::{DelegationSpec, WorkflowKind};
     use crate::execution_plan::ExecutionNode;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
@@ -525,5 +526,245 @@ mod tests {
         let d2 = diff_traces(&left, &right);
         assert_eq!(d1, d2);
         assert_eq!(d1.changed_indices, vec![1]);
+    }
+
+    #[test]
+    fn export_graph_sorts_nodes_and_dedupes_edges() {
+        let plan = ExecutionPlan {
+            workflow_kind: WorkflowKind::Concurrent,
+            nodes: vec![
+                ExecutionNode {
+                    step_id: "b".to_string(),
+                    depends_on: vec!["a".to_string(), "a".to_string()],
+                    save_as: None,
+                    delegation: None,
+                },
+                ExecutionNode {
+                    step_id: "a".to_string(),
+                    depends_on: vec![],
+                    save_as: None,
+                    delegation: None,
+                },
+            ],
+        };
+        let graph = export_graph(&plan);
+        assert_eq!(graph.nodes[0].id, "a");
+        assert_eq!(graph.nodes[1].id, "b");
+        assert_eq!(
+            graph.edges,
+            vec![GraphEdge {
+                from: "a".to_string(),
+                to: "b".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn diff_plans_detects_all_surface_changes() {
+        let left = ExecutionPlan {
+            workflow_kind: WorkflowKind::Sequential,
+            nodes: vec![
+                ExecutionNode {
+                    step_id: "a".to_string(),
+                    depends_on: vec![],
+                    save_as: Some("a_out".to_string()),
+                    delegation: None,
+                },
+                ExecutionNode {
+                    step_id: "b".to_string(),
+                    depends_on: vec!["a".to_string()],
+                    save_as: None,
+                    delegation: None,
+                },
+            ],
+        };
+        let right = ExecutionPlan {
+            workflow_kind: WorkflowKind::Sequential,
+            nodes: vec![
+                ExecutionNode {
+                    step_id: "a".to_string(),
+                    depends_on: vec!["x".to_string()],
+                    save_as: None,
+                    delegation: None,
+                },
+                ExecutionNode {
+                    step_id: "c".to_string(),
+                    depends_on: vec!["a".to_string()],
+                    save_as: None,
+                    delegation: None,
+                },
+            ],
+        };
+        let diff = diff_plans(&left, &right);
+        assert_eq!(diff.added_nodes, vec!["c".to_string()]);
+        assert_eq!(diff.removed_nodes, vec!["b".to_string()]);
+        assert_eq!(diff.changed_dependencies, vec!["a".to_string()]);
+        assert_eq!(diff.changed_save_as, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn diff_traces_reports_tail_items_as_side_specific() {
+        let left = vec![
+            TraceEventNormalized::RunFinished { success: true },
+            TraceEventNormalized::StepFinished {
+                step_id: "s1".to_string(),
+                success: true,
+            },
+        ];
+        let right = vec![TraceEventNormalized::RunFinished { success: true }];
+        let diff = diff_traces(&left, &right);
+        assert!(diff.changed_indices.is_empty());
+        assert_eq!(
+            diff.left_only,
+            vec!["StepFinished step=s1 success=true".to_string()]
+        );
+        assert!(diff.right_only.is_empty());
+    }
+
+    #[test]
+    fn normalize_step_started_omits_effectively_empty_delegation() {
+        let events = vec![TraceEvent::StepStarted {
+            ts_ms: 1,
+            elapsed_ms: 1,
+            step_id: "s1".to_string(),
+            agent_id: "a".to_string(),
+            provider_id: "p".to_string(),
+            task_id: "t".to_string(),
+            delegation: Some(DelegationSpec {
+                role: None,
+                requires_verification: Some(false),
+                escalation_target: None,
+                tags: vec![],
+            }),
+        }];
+        let normalized = normalize_trace_events(&events);
+        let TraceEventNormalized::StepStarted {
+            delegation_json, ..
+        } = &normalized[0]
+        else {
+            panic!("expected StepStarted");
+        };
+        assert!(delegation_json.is_none());
+    }
+
+    #[test]
+    fn normalize_step_started_canonicalizes_delegation_payload() {
+        let events = vec![TraceEvent::StepStarted {
+            ts_ms: 1,
+            elapsed_ms: 1,
+            step_id: "s1".to_string(),
+            agent_id: "a".to_string(),
+            provider_id: "p".to_string(),
+            task_id: "t".to_string(),
+            delegation: Some(DelegationSpec {
+                role: Some("review".to_string()),
+                requires_verification: Some(true),
+                escalation_target: Some("human".to_string()),
+                tags: vec!["z".to_string(), "a".to_string(), "z".to_string()],
+            }),
+        }];
+        let normalized = normalize_trace_events(&events);
+        let TraceEventNormalized::StepStarted {
+            delegation_json, ..
+        } = &normalized[0]
+        else {
+            panic!("expected StepStarted");
+        };
+        let payload = delegation_json.as_ref().expect("delegation json");
+        assert!(payload.contains("\"requires_verification\":true"));
+        assert!(
+            payload.contains("\"tags\":[\"a\",\"z\"]"),
+            "delegation should be sorted+deduped: {payload}"
+        );
+    }
+
+    #[test]
+    fn write_and_load_trace_artifact_round_trip() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "swarm-trace-artifact-{now}-{}.json",
+            std::process::id()
+        ));
+        let events = vec![
+            TraceEvent::RunFinished {
+                ts_ms: 10,
+                elapsed_ms: 10,
+                success: true,
+            },
+            TraceEvent::StepOutputChunk {
+                ts_ms: 11,
+                elapsed_ms: 11,
+                step_id: "s1".to_string(),
+                chunk_bytes: 4,
+            },
+        ];
+        write_trace_artifact(&path, &events).expect("write artifact");
+        let loaded = load_trace_artifact(&path).expect("load artifact");
+        assert_eq!(loaded, normalize_trace_events(&events));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn load_trace_artifact_invalid_json_returns_context_error() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "swarm-trace-invalid-{now}-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, "{").expect("write invalid json");
+        let err = load_trace_artifact(&path).expect_err("invalid json should fail");
+        assert!(
+            err.to_string().contains("failed parsing trace artifact"),
+            "unexpected error: {err:#}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn format_normalized_event_covers_variants() {
+        let messages = [
+            format_normalized_event(&TraceEventNormalized::RunFailed {
+                message: "boom".to_string(),
+            }),
+            format_normalized_event(&TraceEventNormalized::RunFinished { success: true }),
+            format_normalized_event(&TraceEventNormalized::StepStarted {
+                step_id: "s1".to_string(),
+                agent_id: "a".to_string(),
+                provider_id: "p".to_string(),
+                task_id: "t".to_string(),
+                delegation_json: Some("{\"role\":\"r\"}".to_string()),
+            }),
+            format_normalized_event(&TraceEventNormalized::PromptAssembled {
+                step_id: "s1".to_string(),
+                prompt_hash: "abc".to_string(),
+            }),
+            format_normalized_event(&TraceEventNormalized::StepOutputChunk {
+                step_id: "s1".to_string(),
+                chunk_bytes: 3,
+            }),
+            format_normalized_event(&TraceEventNormalized::StepFinished {
+                step_id: "s1".to_string(),
+                success: false,
+            }),
+            format_normalized_event(&TraceEventNormalized::CallEntered {
+                caller_step_id: "caller".to_string(),
+                callee_workflow_id: "wf".to_string(),
+                namespace: "ns".to_string(),
+            }),
+            format_normalized_event(&TraceEventNormalized::CallExited {
+                caller_step_id: "caller".to_string(),
+                status: "success".to_string(),
+                namespace: "ns".to_string(),
+            }),
+        ];
+        assert!(messages.iter().any(|m| m.contains("RunFailed")));
+        assert!(messages.iter().any(|m| m.contains("delegation=")));
+        assert!(messages.iter().any(|m| m.contains("CallExited")));
     }
 }

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -1008,6 +1008,7 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
@@ -1104,5 +1105,182 @@ mod tests {
             let _guard = EnvGuard::set("CI", "true");
             assert!(is_ci_environment());
         }
+    }
+
+    #[test]
+    fn usage_mentions_v0_4_and_legacy_examples() {
+        let text = usage();
+        assert!(text.contains("Usage:"));
+        assert!(text.contains("Examples:"));
+        assert!(text.contains("examples/v0-4-demo-fork-join-swarm.adl.yaml"));
+        assert!(text.contains("examples/adl-0.1.yaml"));
+        assert!(text.contains("--allow-unsigned"));
+    }
+
+    #[test]
+    fn select_open_artifact_returns_none_without_html() {
+        let artifacts = vec![PathBuf::from("out/one.txt"), PathBuf::from("out/two.md")];
+        assert!(select_open_artifact(&artifacts).is_none());
+    }
+
+    #[test]
+    fn run_artifacts_root_points_to_repo_adl_runs() {
+        let root = run_artifacts_root().expect("run artifacts root");
+        let s = root.to_string_lossy();
+        assert!(s.ends_with(".adl/runs"), "unexpected path: {s}");
+    }
+
+    #[test]
+    fn enforce_signature_policy_skips_when_not_running_or_not_v0_5() {
+        let mk_doc = |version: &str| adl::AdlDoc {
+            version: version.to_string(),
+            providers: HashMap::new(),
+            tools: HashMap::new(),
+            agents: HashMap::new(),
+            tasks: HashMap::new(),
+            workflows: HashMap::new(),
+            patterns: vec![],
+            signature: None,
+            run: adl::RunSpec {
+                id: None,
+                name: None,
+                created_at: None,
+                defaults: adl::RunDefaults::default(),
+                workflow_ref: None,
+                workflow: Some(adl::WorkflowSpec {
+                    id: None,
+                    kind: adl::WorkflowKind::Sequential,
+                    max_concurrency: None,
+                    steps: vec![],
+                }),
+                pattern_ref: None,
+                inputs: HashMap::new(),
+                placement: None,
+                remote: None,
+            },
+        };
+
+        enforce_signature_policy(&mk_doc("0.5"), false, false).expect("do_run=false should skip");
+        enforce_signature_policy(&mk_doc("0.4"), true, false).expect("v0.4 should skip");
+        enforce_signature_policy(&mk_doc("0.5"), true, true).expect("allow_unsigned should skip");
+    }
+
+    fn minimal_resolved_for_artifacts(run_id: String) -> resolve::AdlResolved {
+        resolve::AdlResolved {
+            run_id,
+            workflow_id: "wf".to_string(),
+            steps: vec![resolve::ResolvedStep {
+                id: "s1".to_string(),
+                agent: Some("a1".to_string()),
+                provider: Some("p1".to_string()),
+                placement: None,
+                task: Some("t1".to_string()),
+                call: None,
+                with: HashMap::new(),
+                as_ns: None,
+                delegation: None,
+                prompt: Some(adl::PromptSpec {
+                    user: Some("u".to_string()),
+                    ..Default::default()
+                }),
+                inputs: HashMap::new(),
+                guards: vec![],
+                save_as: Some("s1_out".to_string()),
+                write_to: Some("out/s1.txt".to_string()),
+                on_error: None,
+                retry: None,
+            }],
+            execution_plan: swarm::execution_plan::ExecutionPlan {
+                workflow_kind: adl::WorkflowKind::Sequential,
+                nodes: vec![swarm::execution_plan::ExecutionNode {
+                    step_id: "s1".to_string(),
+                    depends_on: vec![],
+                    save_as: Some("s1_out".to_string()),
+                    delegation: None,
+                }],
+            },
+            doc: adl::AdlDoc {
+                version: "0.5".to_string(),
+                providers: HashMap::new(),
+                tools: HashMap::new(),
+                agents: HashMap::new(),
+                tasks: HashMap::new(),
+                workflows: HashMap::new(),
+                patterns: vec![],
+                signature: None,
+                run: adl::RunSpec {
+                    id: None,
+                    name: Some("run".to_string()),
+                    created_at: None,
+                    defaults: adl::RunDefaults::default(),
+                    workflow_ref: None,
+                    workflow: Some(adl::WorkflowSpec {
+                        id: Some("wf".to_string()),
+                        kind: adl::WorkflowKind::Sequential,
+                        max_concurrency: None,
+                        steps: vec![],
+                    }),
+                    pattern_ref: None,
+                    inputs: HashMap::new(),
+                    placement: None,
+                    remote: None,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn write_run_state_and_load_resume_round_trip() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let run_id = format!("run-{now}-{}", std::process::id());
+        let resolved = minimal_resolved_for_artifacts(run_id.clone());
+        let out_dir = std::env::temp_dir().join(format!("swarm-main-out-{now}"));
+
+        let mut tr = trace::Trace::new(run_id.clone(), "wf".to_string(), "0.5".to_string());
+        tr.step_started("s1", "a1", "p1", "t1", None);
+        tr.step_finished("s1", true);
+
+        let pause = execute::PauseState {
+            paused_step_id: "s1".to_string(),
+            reason: Some("review".to_string()),
+            completed_step_ids: vec!["s1".to_string()],
+            remaining_step_ids: vec![],
+            saved_state: HashMap::from([(String::from("k"), String::from("v"))]),
+            completed_outputs: HashMap::from([(String::from("s1_out"), String::from("done"))]),
+        };
+
+        let run_dir =
+            write_run_state_artifacts(&resolved, &tr, &out_dir, 100, 150, "paused", Some(&pause))
+                .expect("write run artifacts");
+
+        let resume =
+            load_resume_state(&run_dir.join("run.json"), &resolved).expect("load resume state");
+        assert!(resume.completed_step_ids.contains("s1"));
+        assert_eq!(resume.saved_state.get("k").map(String::as_str), Some("v"));
+        let _ = std::fs::remove_dir_all(run_dir);
+        let _ = std::fs::remove_dir_all(out_dir);
+    }
+
+    #[test]
+    fn load_resume_state_rejects_non_paused_status() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let run_id = format!("run-nonpaused-{now}-{}", std::process::id());
+        let resolved = minimal_resolved_for_artifacts(run_id.clone());
+        let out_dir = std::env::temp_dir().join(format!("swarm-main-nonpaused-{now}"));
+
+        let tr = trace::Trace::new(run_id, "wf".to_string(), "0.5".to_string());
+        let run_dir = write_run_state_artifacts(&resolved, &tr, &out_dir, 0, 1, "success", None)
+            .expect("write non-paused artifacts");
+        let err = load_resume_state(&run_dir.join("run.json"), &resolved)
+            .expect_err("non-paused run.json should fail for resume");
+        assert!(err.to_string().contains("status='paused'"));
+        let _ = std::fs::remove_dir_all(run_dir);
+        let _ = std::fs::remove_dir_all(out_dir);
     }
 }

--- a/swarm/src/remote_exec.rs
+++ b/swarm/src/remote_exec.rs
@@ -307,4 +307,134 @@ mod tests {
             "expected 413 response for oversized payload, got:\n{resp}"
         );
     }
+
+    fn base_request() -> ExecuteRequest {
+        ExecuteRequest {
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            run_id: "run".to_string(),
+            workflow_id: "wf".to_string(),
+            step_id: "step-1".to_string(),
+            step: ExecuteStepPayload {
+                kind: "task".to_string(),
+                provider: "local".to_string(),
+                prompt: "hello".to_string(),
+                tools: vec![],
+                provider_spec: adl::ProviderSpec {
+                    id: None,
+                    profile: None,
+                    kind: "http".to_string(),
+                    base_url: None,
+                    default_model: None,
+                    config: {
+                        let mut cfg = HashMap::new();
+                        cfg.insert(
+                            "endpoint".to_string(),
+                            serde_json::Value::String("http://127.0.0.1:9".to_string()),
+                        );
+                        cfg
+                    },
+                },
+                model_override: None,
+            },
+            inputs: ExecuteInputsPayload::default(),
+            timeout_ms: 50,
+        }
+    }
+
+    #[test]
+    fn execute_response_ok_sets_success_fields() {
+        let req = base_request();
+        let response = ExecuteResponse::ok(&req, "done".to_string());
+        assert!(response.ok);
+        assert_eq!(response.result.as_deref(), Some("done"));
+        assert!(response.error.is_none());
+        assert_eq!(response.step_id, req.step_id);
+    }
+
+    #[test]
+    fn execute_response_err_sets_error_fields() {
+        let req = base_request();
+        let response = ExecuteResponse::err(&req, "REMOTE_SCHEMA_VIOLATION", "bad");
+        assert!(!response.ok);
+        assert!(response.result.is_none());
+        let err = response.error.expect("error payload");
+        assert_eq!(err.code, "REMOTE_SCHEMA_VIOLATION");
+        assert_eq!(err.message, "bad");
+    }
+
+    #[test]
+    fn execute_request_rejects_protocol_mismatch() {
+        let mut req = base_request();
+        req.protocol_version = "999".to_string();
+        let response = execute_request(&req);
+        assert!(!response.ok);
+        let err = response.error.expect("error");
+        assert_eq!(err.code, "REMOTE_SCHEMA_VIOLATION");
+        assert!(err.message.contains("unsupported protocol_version"));
+    }
+
+    #[test]
+    fn execute_request_rejects_invalid_provider_spec() {
+        let mut req = base_request();
+        req.step.provider_spec.kind = "unsupported".to_string();
+        req.step.provider_spec.config.clear();
+        let response = execute_request(&req);
+        assert!(!response.ok);
+        let err = response.error.expect("error");
+        assert_eq!(err.code, "REMOTE_SCHEMA_VIOLATION");
+        assert!(err.message.contains("invalid provider config"));
+    }
+
+    #[test]
+    fn execute_request_maps_provider_runtime_error() {
+        let req = base_request();
+        let response = execute_request(&req);
+        assert!(!response.ok);
+        let err = response.error.expect("error");
+        assert_eq!(err.code, "REMOTE_EXECUTION_ERROR");
+    }
+
+    #[test]
+    fn execute_remote_maps_transport_and_status_errors() {
+        let req = base_request();
+        let transport_err =
+            execute_remote("http://127.0.0.1:9", 25, &req).expect_err("transport must fail");
+        assert!(
+            transport_err.to_string().starts_with("REMOTE_UNREACHABLE:")
+                || transport_err.to_string().starts_with("REMOTE_TIMEOUT:"),
+            "unexpected transport error: {transport_err:#}"
+        );
+
+        let Some(port) = reserve_local_port() else {
+            return;
+        };
+        let bind_addr = format!("127.0.0.1:{port}");
+        let server = tiny_http::Server::http(&bind_addr).expect("bind");
+        let handle = thread::spawn(move || {
+            if let Some(request) = server.incoming_requests().next() {
+                let _ = request.respond(tiny_http::Response::empty(503));
+            }
+        });
+
+        let status_err =
+            execute_remote(&format!("http://{bind_addr}"), 500, &req).expect_err("503 must fail");
+        assert!(
+            status_err
+                .to_string()
+                .contains("REMOTE_BAD_STATUS: 503 Service Unavailable"),
+            "unexpected status error: {status_err:#}"
+        );
+        let _ = handle.join();
+    }
+
+    #[test]
+    fn json_response_sets_content_type_header() {
+        let resp = json_response(200, b"{}".to_vec());
+        let content_type = resp
+            .headers()
+            .iter()
+            .find(|h| h.field.equiv("Content-Type"))
+            .map(|h| h.value.as_str().to_string());
+        assert_eq!(content_type.as_deref(), Some("application/json"));
+    }
 }


### PR DESCRIPTION
## Summary
- completes WP-H2 coverage audit for #409
- adds focused tests in `adl.rs`, `execute.rs`, `instrumentation.rs`, `remote_exec.rs`, `main.rs`, and `bin/swarm_remote.rs`
- keeps runtime semantics unchanged (test-focused hardening)
- verifies per-file line coverage >=80% across `swarm/src/*.rs` using `cargo llvm-cov` (aggregated across all report data units)

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo llvm-cov --workspace --all-targets --lcov --output-path .tmp/lcov.info`
- `cargo llvm-cov report --json --summary-only --output-path .tmp/coverage-summary.json`

## Coverage highlights (post-buffer)
- `swarm/src/main.rs`: 80.81%
- `swarm/src/adl.rs`: 82.04%
- `swarm/src/execute.rs`: 83.15%

Closes #409
