### PR TITLE
test: stabilize provider failure assertion under llvm-cov

### DIFF
--- a/swarm/tests/provider_tests.rs
+++ b/swarm/tests/provider_tests.rs
@@ -246,14 +246,18 @@ config:
     let err = p.complete("test prompt").unwrap_err();
     let msg = format!("{err:#}");
 
+    let mentions_launch_failure = msg.contains("ollama run failed");
+    let mentions_stdin_failure = msg.contains("failed writing prompt to ollama stdin");
     assert!(
-        msg.contains("ollama run failed"),
-        "expected failure to mention ollama run failed, got: {msg}"
+        mentions_launch_failure || mentions_stdin_failure,
+        "expected failure to mention launch or stdin write failure, got: {msg}"
     );
-    assert!(
-        msg.contains("something went wrong"),
-        "expected stderr to be included, got: {msg}"
-    );
+    if mentions_launch_failure {
+        assert!(
+            msg.contains("something went wrong"),
+            "expected stderr to be included on launch failure, got: {msg}"
+        );
+    }
 
     let _ = fs::remove_dir_all(dir);
 }


### PR DESCRIPTION
## What happened
PR #437 failed `swarm-coverage` while `swarm-ci` passed.

Failing assertion expected only one error path (`ollama run failed`), but llvm-cov surfaced an alternate valid deterministic path (`failed writing prompt to ollama stdin`).

Failing run:
- https://github.com/danielbaustin/agent-design-language/actions/runs/22296511554/job/64494168405

## Fix
- Update `provider_complete_surfaces_stderr_on_failure` in `swarm/tests/provider_tests.rs` to accept both valid failure modes:
  - launch failure with stderr (`ollama run failed` + stderr text)
  - stdin write failure (`failed writing prompt to ollama stdin`)
- Keep stderr assertion only for the launch-failure branch.

## Scope
- Tests only
- No runtime behavior changes
- No dependency or CI policy changes

## Validation
- `cd swarm && cargo fmt --all -- --check`
- `cd swarm && cargo clippy --all-targets -- -D warnings`
- `cd swarm && cargo test`
