### PR TITLE
[v0.6][P1] Fail-fast guardrails for placeholder provider profile endpoints

### DIFF
--- a/swarm/src/provider.rs
+++ b/swarm/src/provider.rs
@@ -136,6 +136,23 @@ struct ProviderProfilePreset {
     endpoint: Option<&'static str>,
 }
 
+const HTTP_PROFILE_PLACEHOLDER_ENDPOINT: &str = "https://api.example.invalid/v1/complete";
+const INVALID_ENDPOINT_HOST_MARKER: &str = "example.invalid";
+
+fn validate_profile_endpoint(provider_id: &str, profile_name: &str, endpoint: &str) -> Result<()> {
+    let trimmed = endpoint.trim();
+    if trimmed.is_empty()
+        || trimmed == HTTP_PROFILE_PLACEHOLDER_ENDPOINT
+        || trimmed.contains(INVALID_ENDPOINT_HOST_MARKER)
+    {
+        return Err(anyhow!(
+            "providers.{provider_id}.profile '{}' has placeholder or invalid endpoint; configure providers.{provider_id}.config.endpoint with a real endpoint",
+            profile_name
+        ));
+    }
+    Ok(())
+}
+
 fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProfilePreset> {
     let mut m = BTreeMap::new();
     // Ollama / local presets
@@ -195,7 +212,7 @@ fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProfilePreset> 
             ProviderProfilePreset {
                 kind: "http",
                 default_model: Some(model),
-                endpoint: Some("https://api.example.invalid/v1/complete"),
+                endpoint: Some(HTTP_PROFILE_PLACEHOLDER_ENDPOINT),
             },
         );
     }
@@ -245,6 +262,7 @@ pub fn expand_provider_profiles(doc: &adl::AdlDoc) -> Result<adl::AdlDoc> {
 
         let mut config = HashMap::new();
         if let Some(endpoint) = preset.endpoint {
+            validate_profile_endpoint(&provider_id, profile_name, endpoint)?;
             config.insert("endpoint".to_string(), Value::String(endpoint.to_string()));
         }
 

--- a/swarm/tests/provider_tests.rs
+++ b/swarm/tests/provider_tests.rs
@@ -647,13 +647,13 @@ fn expand_provider_profiles_is_byte_stable_across_runs() {
         r#"
 version: "0.5"
 providers:
-  z_http:
-    profile: "http:gpt-4o-mini"
-  a_ollama:
+  a_mock:
+    profile: "mock:echo-v1"
+  z_ollama:
     profile: "ollama:phi4-mini"
 agents:
   a1:
-    provider: "a_ollama"
+    provider: "z_ollama"
     model: "m"
 tasks:
   t1:
@@ -675,17 +675,79 @@ run:
     assert_eq!(json1, json2, "profile expansion must be byte-stable");
 
     assert_eq!(
-        expanded1.providers["a_ollama"].kind, "ollama",
+        expanded1.providers["z_ollama"].kind, "ollama",
         "ollama profile should expand to kind=ollama"
     );
     assert_eq!(
-        expanded1.providers["z_http"].kind, "http",
-        "http profile should expand to kind=http"
+        expanded1.providers["a_mock"].kind, "mock",
+        "mock profile should expand to kind=mock"
     );
+}
+
+#[test]
+fn expand_provider_profiles_rejects_placeholder_http_endpoint_profiles() {
+    let doc = adl_doc_from_yaml(
+        r#"
+version: "0.5"
+providers:
+  p1:
+    profile: "http:gpt-4o-mini"
+agents:
+  a1:
+    provider: "p1"
+    model: "m"
+tasks:
+  t1:
+    prompt:
+      user: "u"
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: "a1"
+        task: "t1"
+"#,
+    );
+    let err = expand_provider_profiles(&doc).expect_err("placeholder endpoint profile must fail");
+    let msg = err.to_string();
     assert!(
-        expanded1.providers["z_http"]
-            .config
-            .contains_key("endpoint"),
-        "http profile should include endpoint in config"
+        msg.contains("providers.p1.profile 'http:gpt-4o-mini'")
+            && msg.contains("placeholder or invalid endpoint")
+            && msg.contains("configure providers.p1.config.endpoint"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn resolve_run_accepts_explicit_valid_http_endpoint() {
+    let doc = adl_doc_from_yaml(
+        r#"
+version: "0.5"
+providers:
+  p1:
+    type: "http"
+    config:
+      endpoint: "https://api.openai.com/v1/complete"
+agents:
+  a1:
+    provider: "p1"
+    model: "gpt-4o-mini"
+tasks:
+  t1:
+    prompt:
+      user: "u"
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: "a1"
+        task: "t1"
+"#,
+    );
+    let resolved = swarm::resolve::resolve_run(&doc).expect("valid endpoint should pass resolve");
+    assert_eq!(
+        resolved.steps.len(),
+        1,
+        "expected exactly one resolved step"
     );
 }


### PR DESCRIPTION
## Summary
- Add deterministic fail-fast validation for profile-derived placeholder/invalid endpoints
- Validate before execution (resolve/config phase), with no network probing
- Add tests for placeholder rejection and valid endpoint acceptance

## Scope
Closes #452

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test