### PR TITLE
[v0.6][P1] Minimal deterministic HITL pause-state persistence

### DIFF
--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -226,6 +226,20 @@ fn emit_step_output(step_id: &str, model_output: &str, stream_chunks: &[String],
     println!();
 }
 
+fn stable_fingerprint_hex(bytes: &[u8]) -> String {
+    // FNV-1a 64-bit (deterministic, dependency-free fingerprint for persisted metadata).
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn model_output_fingerprint(output: &str) -> String {
+    stable_fingerprint_hex(output.as_bytes())
+}
+
 /// Execute the resolved run.
 ///
 /// Behavior:
@@ -585,7 +599,8 @@ pub fn execute_sequential_with_resume(
                 if let Some(save_as) = step.save_as.as_ref() {
                     saved_state.insert(save_as.clone(), out.model_output.clone());
                 }
-                completed_outputs.insert(step_id.clone(), out.model_output.clone());
+                completed_outputs
+                    .insert(step_id.clone(), model_output_fingerprint(&out.model_output));
                 completed_step_ids.insert(step_id.clone());
                 outs.push(out);
 
@@ -1290,7 +1305,10 @@ fn execute_concurrent_deterministic(
                     if let Some(save_as) = step.save_as.as_ref() {
                         saved_state.insert(save_as.clone(), success.out.model_output.clone());
                     }
-                    completed_outputs.insert(step_id.clone(), success.out.model_output.clone());
+                    completed_outputs.insert(
+                        step_id.clone(),
+                        model_output_fingerprint(&success.out.model_output),
+                    );
                     outs.push(success.out);
                     completed.insert(step_id.clone());
                     if let Some(reason) = pause_reason_for_step(step) {

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -615,7 +615,7 @@ struct RunStateArtifact {
     start_time_ms: u128,
     end_time_ms: u128,
     duration_ms: u128,
-    execution_plan_json: String,
+    execution_plan_hash: String,
     pause: Option<execute::PauseState>,
 }
 
@@ -627,7 +627,7 @@ struct PauseStateArtifact {
     workflow_id: String,
     version: String,
     status: String,
-    execution_plan_json: String,
+    execution_plan_hash: String,
     pause: execute::PauseState,
 }
 
@@ -665,6 +665,21 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
         )
     })?;
     Ok(())
+}
+
+fn stable_fingerprint_hex(bytes: &[u8]) -> String {
+    // FNV-1a 64-bit (deterministic, dependency-free fingerprint for persisted metadata).
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn execution_plan_hash<T: Serialize>(plan: &T) -> Result<String> {
+    let plan_json = serde_json::to_vec(plan).context("serialize execution plan for hashing")?;
+    Ok(stable_fingerprint_hex(&plan_json))
 }
 
 fn write_run_state_artifacts(
@@ -736,8 +751,7 @@ fn write_run_state_artifacts(
         start_time_ms: start_ms,
         end_time_ms: end_ms,
         duration_ms: end_ms.saturating_sub(start_ms),
-        execution_plan_json: serde_json::to_string(&resolved.execution_plan)
-            .context("serialize execution plan")?,
+        execution_plan_hash: execution_plan_hash(&resolved.execution_plan)?,
         pause: pause.cloned(),
     };
 
@@ -753,8 +767,7 @@ fn write_run_state_artifacts(
             workflow_id: resolved.workflow_id.clone(),
             version: resolved.doc.version.clone(),
             status: "paused".to_string(),
-            execution_plan_json: serde_json::to_string(&resolved.execution_plan)
-                .context("serialize execution plan for pause state")?,
+            execution_plan_hash: execution_plan_hash(&resolved.execution_plan)?,
             pause: pause_payload.clone(),
         };
         let pause_json =
@@ -810,9 +823,8 @@ fn load_resume_state(path: &Path, resolved: &resolve::AdlResolved) -> Result<exe
             resolved.doc.version
         ));
     }
-    let plan_json =
-        serde_json::to_string(&resolved.execution_plan).context("serialize current plan")?;
-    if artifact.execution_plan_json != plan_json {
+    let plan_hash = execution_plan_hash(&resolved.execution_plan)?;
+    if artifact.execution_plan_hash != plan_hash {
         return Err(anyhow::anyhow!(
             "resume execution plan mismatch; resume requires identical plan and ordering"
         ));


### PR DESCRIPTION
## Summary
- Add deterministic, versioned pause-state persistence for HITL paused runs
- Use atomic artifact writes (temp + rename) for run artifacts
- Add strict schema-version validation on resume-state load
- Add tests for pause-state roundtrip and schema mismatch rejection

## Scope
Closes #453

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test