### PR TITLE
[v0.7][WP-13] Scoring hooks v1 + deterministic scores.json

### DIFF
--- a/docs/milestones/v0.7/ARTIFACT_MODEL_v1.md
+++ b/docs/milestones/v0.7/ARTIFACT_MODEL_v1.md
@@ -20,7 +20,7 @@ For each run id:
   outputs/                    # canonical output subtree
   logs/                       # reserved deterministic log subtree
   learning/
-    scores.json               # reserved for WP #483
+    scores.json               # scoring hooks v1 artifact
     suggestions.json          # reserved for WP #484
     overlays/                 # reserved for WP #485
   meta/

--- a/docs/milestones/v0.7/DESIGN_v0.7.md
+++ b/docs/milestones/v0.7/DESIGN_v0.7.md
@@ -166,6 +166,7 @@ Overlay application requires `--learn=apply` and records:
 Artifact layout/versioning is specified in:
 - `docs/milestones/v0.7/ARTIFACT_MODEL_v1.md`
 - `docs/milestones/v0.7/RUN_SUMMARY_v1.md`
+- `docs/milestones/v0.7/SCORES_v1.md`
 
 ---
 

--- a/docs/milestones/v0.7/SCORES_v1.md
+++ b/docs/milestones/v0.7/SCORES_v1.md
@@ -1,0 +1,43 @@
+# Scores v1 (v0.7)
+
+Scores v1 defines deterministic run-level scoring emitted at:
+
+`<repo>/.adl/runs/<run_id>/learning/scores.json`
+
+## Schema
+
+```json
+{
+  "scores_version": 1,
+  "run_id": "example-run",
+  "generated_from": {
+    "artifact_model_version": 1,
+    "run_summary_version": 1
+  },
+  "summary": {
+    "success_ratio": 1.0,
+    "failure_count": 0,
+    "retry_count": 0,
+    "delegation_denied_count": 0,
+    "security_denied_count": 0
+  },
+  "metrics": {
+    "scheduler_max_parallel_observed": 1
+  }
+}
+```
+
+## Determinism Rules
+
+- No timestamps or randomness in the artifact.
+- Values are derived only from `run_summary.json` and in-memory trace events.
+- `success_ratio` is quantized to thousandths.
+- Retry count is computed deterministically from repeated `StepStarted` events per step id.
+- `scheduler_max_parallel_observed` is derived from a deterministic trace scan.
+- JSON is emitted via `serde_json::to_vec_pretty` + `artifacts::atomic_write`.
+
+## Semantics
+
+- Scores are read-only analytics.
+- Scoring does not mutate execution state or affect scheduling/provider behavior.
+- Scores are advisory inputs for later learning surfaces (`suggestions.json`, overlays), not enforcement.

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -621,6 +621,7 @@ fn now_ms() -> u128 {
 const RUN_STATE_SCHEMA_VERSION: &str = "run_state.v1";
 const PAUSE_STATE_SCHEMA_VERSION: &str = "pause_state.v1";
 const RUN_SUMMARY_VERSION: u32 = 1;
+const SCORES_VERSION: u32 = 1;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -721,6 +722,39 @@ struct RunSummaryLinks {
     overlays_dir: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     trace_json: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScoresArtifact {
+    scores_version: u32,
+    run_id: String,
+    generated_from: ScoresGeneratedFrom,
+    summary: ScoresSummary,
+    metrics: ScoresMetrics,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScoresGeneratedFrom {
+    artifact_model_version: u32,
+    run_summary_version: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScoresSummary {
+    success_ratio: f64,
+    failure_count: usize,
+    retry_count: usize,
+    delegation_denied_count: usize,
+    security_denied_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScoresMetrics {
+    scheduler_max_parallel_observed: usize,
 }
 fn stable_fingerprint_hex(bytes: &[u8]) -> String {
     // FNV-1a 64-bit (deterministic, dependency-free fingerprint for persisted metadata).
@@ -894,6 +928,83 @@ fn build_run_summary(
     }
 }
 
+fn compute_retry_count(tr: &trace::Trace) -> usize {
+    let mut started_by_step: BTreeMap<&str, usize> = BTreeMap::new();
+    for event in &tr.events {
+        if let trace::TraceEvent::StepStarted { step_id, .. } = event {
+            *started_by_step.entry(step_id.as_str()).or_insert(0) += 1;
+        }
+    }
+    started_by_step
+        .values()
+        .map(|count| count.saturating_sub(1))
+        .sum()
+}
+
+fn compute_max_parallel_observed(tr: &trace::Trace) -> usize {
+    let mut active: BTreeSet<&str> = BTreeSet::new();
+    let mut max_parallel = 0usize;
+    for event in &tr.events {
+        match event {
+            trace::TraceEvent::StepStarted { step_id, .. } => {
+                active.insert(step_id.as_str());
+                max_parallel = max_parallel.max(active.len());
+            }
+            trace::TraceEvent::StepFinished { step_id, .. } => {
+                active.remove(step_id.as_str());
+            }
+            _ => {}
+        }
+    }
+    max_parallel
+}
+
+fn build_scores_artifact(run_summary: &RunSummaryArtifact, tr: &trace::Trace) -> ScoresArtifact {
+    let success_steps = run_summary
+        .counts
+        .completed_steps
+        .saturating_sub(run_summary.counts.failed_steps);
+    let success_ratio = if run_summary.counts.total_steps == 0 {
+        1.0
+    } else {
+        // Quantize to thousandths for deterministic JSON across runtimes.
+        let permille = (success_steps * 1000) / run_summary.counts.total_steps;
+        (permille as f64) / 1000.0
+    };
+    let security_denied_count: usize = run_summary.policy.security_denials_by_code.values().sum();
+    let delegation_denied_count: usize = run_summary
+        .policy
+        .security_denials_by_code
+        .iter()
+        .filter_map(|(code, count)| {
+            if code.starts_with("DELEGATION_") {
+                Some(*count)
+            } else {
+                None
+            }
+        })
+        .sum();
+
+    ScoresArtifact {
+        scores_version: SCORES_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+        },
+        summary: ScoresSummary {
+            success_ratio,
+            failure_count: run_summary.counts.failed_steps,
+            retry_count: compute_retry_count(tr),
+            delegation_denied_count,
+            security_denied_count,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: compute_max_parallel_observed(tr),
+        },
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn write_run_state_artifacts(
     resolved: &resolve::AdlResolved,
@@ -989,10 +1100,13 @@ fn write_run_state_artifacts(
     );
     let run_summary_json =
         serde_json::to_vec_pretty(&run_summary).context("serialize run_summary.json")?;
+    let scores = build_scores_artifact(&run_summary, tr);
+    let scores_json = serde_json::to_vec_pretty(&scores).context("serialize scores.json")?;
 
     artifacts::atomic_write(&run_paths.run_json(), &run_json)?;
     artifacts::atomic_write(&run_paths.steps_json(), &steps_json)?;
     artifacts::atomic_write(&run_paths.run_summary_json(), &run_summary_json)?;
+    artifacts::atomic_write(&run_paths.scores_json(), &scores_json)?;
     if let Some(pause_payload) = pause {
         let pause_artifact = PauseStateArtifact {
             schema_version: PAUSE_STATE_SCHEMA_VERSION.to_string(),

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -2296,6 +2296,7 @@ run:
     let run_json_path = run_dir.join("run.json");
     let steps_json_path = run_dir.join("steps.json");
     let run_summary_path = run_dir.join("run_summary.json");
+    let scores_path = run_dir.join("learning").join("scores.json");
     assert!(
         run_json_path.is_file(),
         "missing {}",
@@ -2311,6 +2312,7 @@ run:
         "missing {}",
         run_summary_path.display()
     );
+    assert!(scores_path.is_file(), "missing {}", scores_path.display());
 
     let run_json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&run_json_path).unwrap()).unwrap();
@@ -2374,6 +2376,86 @@ run:
     assert!(
         summary_json.get("started_at").is_none(),
         "run summary v1 should avoid wall-clock timestamps by default"
+    );
+    let scores_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&scores_path).unwrap()).unwrap();
+    assert_eq!(scores_json["scores_version"], 1);
+    assert_eq!(scores_json["run_id"], run_id);
+    assert_eq!(scores_json["generated_from"]["artifact_model_version"], 1);
+    assert_eq!(scores_json["generated_from"]["run_summary_version"], 1);
+    assert!(scores_json["summary"]["success_ratio"].is_number());
+    assert!(scores_json["summary"]["failure_count"].is_number());
+    assert!(scores_json["summary"]["retry_count"].is_number());
+    assert!(
+        scores_json["metrics"]["scheduler_max_parallel_observed"].is_number(),
+        "scores metrics should include deterministic scheduler observation"
+    );
+
+    let _ = fs::remove_dir_all(&run_dir);
+}
+
+#[test]
+fn run_scores_artifact_is_byte_stable_across_repeated_identical_runs() {
+    let base = tmp_dir("exec-scores-stability");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let run_id = "scores-stable-test";
+    let run_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join(".adl")
+        .join("runs")
+        .join(run_id);
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let yaml = format!(
+        r#"
+version: "0.2"
+
+providers:
+  local:
+    type: "ollama"
+    config:
+      model: "phi4-mini"
+
+agents:
+  a1:
+    provider: "local"
+    model: "phi4-mini"
+
+tasks:
+  t1:
+    prompt:
+      user: "Summarize: {{text}}"
+
+run:
+  name: "{run_id}"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "a1"
+        task: "t1"
+        inputs:
+          text: "hello"
+"#
+    );
+    let tmp_yaml = base.join("scores-stability.yaml");
+    fs::write(&tmp_yaml, yaml).unwrap();
+
+    let first = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
+    assert!(first.status.success(), "first run should succeed");
+    let first_bytes = fs::read(run_dir.join("learning").join("scores.json")).unwrap();
+
+    let second = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
+    assert!(second.status.success(), "second run should succeed");
+    let second_bytes = fs::read(run_dir.join("learning").join("scores.json")).unwrap();
+
+    assert_eq!(
+        first_bytes, second_bytes,
+        "scores.json should be byte-stable across repeated identical runs"
     );
 
     let _ = fs::remove_dir_all(&run_dir);


### PR DESCRIPTION
Closes #483

## Summary
- Adds deterministic Scoring Hooks v1
- Emits canonical .adl/runs/[run_id]/learning/scores.json via RunArtifactPaths + atomic_write
- Keeps scoring pure/read-only (derived from run_summary + trace), with no execution-semantics changes

## Files
- swarm/src/main.rs
- swarm/tests/execute_tests.rs
- docs/milestones/v0.7/SCORES_v1.md
- docs/milestones/v0.7/ARTIFACT_MODEL_v1.md
- docs/milestones/v0.7/DESIGN_v0.7.md

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test
