### PR TITLE
[v0.7][WP-14] Suggestions schema v1 + deterministic suggestions.json

### DIFF
--- a/docs/milestones/v0.7/ARTIFACT_MODEL_v1.md
+++ b/docs/milestones/v0.7/ARTIFACT_MODEL_v1.md
@@ -21,7 +21,7 @@ For each run id:
   logs/                       # reserved deterministic log subtree
   learning/
     scores.json               # scoring hooks v1 artifact
-    suggestions.json          # reserved for WP #484
+    suggestions.json          # suggestions schema v1 artifact
     overlays/                 # reserved for WP #485
   meta/
     ARTIFACT_MODEL.json       # {"artifact_model_version": 1}

--- a/docs/milestones/v0.7/DESIGN_v0.7.md
+++ b/docs/milestones/v0.7/DESIGN_v0.7.md
@@ -167,6 +167,7 @@ Artifact layout/versioning is specified in:
 - `docs/milestones/v0.7/ARTIFACT_MODEL_v1.md`
 - `docs/milestones/v0.7/RUN_SUMMARY_v1.md`
 - `docs/milestones/v0.7/SCORES_v1.md`
+- `docs/milestones/v0.7/SUGGESTIONS_v1.md`
 
 ---
 

--- a/docs/milestones/v0.7/SUGGESTIONS_v1.md
+++ b/docs/milestones/v0.7/SUGGESTIONS_v1.md
@@ -1,0 +1,56 @@
+# Suggestions v1 (v0.7)
+
+Suggestions v1 defines deterministic advisory output at:
+
+`<repo>/.adl/runs/<run_id>/learning/suggestions.json`
+
+## Schema
+
+```json
+{
+  "suggestions_version": 1,
+  "run_id": "example-run",
+  "generated_from": {
+    "artifact_model_version": 1,
+    "run_summary_version": 1,
+    "scores_version": 1
+  },
+  "suggestions": [
+    {
+      "id": "sug-001",
+      "category": "retry",
+      "severity": "improvement",
+      "rationale": "One or more steps failed; consider safer retry policy for transient paths.",
+      "evidence": {
+        "failure_count": 1,
+        "retry_count": 0,
+        "delegation_denied_count": 0,
+        "security_denied_count": 0,
+        "success_ratio": 0.5,
+        "scheduler_max_parallel_observed": 1
+      },
+      "proposed_change": {
+        "intent": "increase_step_retry_budget",
+        "target": "failed-step-set"
+      }
+    }
+  ]
+}
+```
+
+## Determinism + Safety Rules
+
+- No timestamps, randomness, host paths, or secrets.
+- Stable rule ordering yields stable suggestion IDs (`sug-001`, `sug-002`, ...).
+- `proposed_change` uses abstract mutation intent, not direct config keys.
+- Suggestions are advisory only and do not change runtime behavior.
+
+## Data Source Rules
+
+- Primary source: `scores.json` + `run_summary.json`.
+- Fallback: if `scores.json` is not available, suggestions are derived from `run_summary.json` only with the same deterministic rules.
+
+## Guardrail Compatibility
+
+- Suggestions are compatible with learning guardrails and future overlay mapping.
+- No suggestion may imply bypassing envelope, signing/trust policy, or sandbox controls.

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -622,6 +622,7 @@ const RUN_STATE_SCHEMA_VERSION: &str = "run_state.v1";
 const PAUSE_STATE_SCHEMA_VERSION: &str = "pause_state.v1";
 const RUN_SUMMARY_VERSION: u32 = 1;
 const SCORES_VERSION: u32 = 1;
+const SUGGESTIONS_VERSION: u32 = 1;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -724,7 +725,7 @@ struct RunSummaryLinks {
     trace_json: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ScoresArtifact {
     scores_version: u32,
@@ -734,14 +735,14 @@ struct ScoresArtifact {
     metrics: ScoresMetrics,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ScoresGeneratedFrom {
     artifact_model_version: u32,
     run_summary_version: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ScoresSummary {
     success_ratio: f64,
@@ -751,10 +752,57 @@ struct ScoresSummary {
     security_denied_count: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ScoresMetrics {
     scheduler_max_parallel_observed: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SuggestionsArtifact {
+    suggestions_version: u32,
+    run_id: String,
+    generated_from: SuggestionsGeneratedFrom,
+    suggestions: Vec<SuggestionItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SuggestionsGeneratedFrom {
+    artifact_model_version: u32,
+    run_summary_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    scores_version: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SuggestionItem {
+    id: String,
+    category: String,
+    severity: String,
+    rationale: String,
+    evidence: SuggestionEvidence,
+    proposed_change: SuggestedChangeIntent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SuggestionEvidence {
+    failure_count: usize,
+    retry_count: usize,
+    delegation_denied_count: usize,
+    security_denied_count: usize,
+    success_ratio: f64,
+    scheduler_max_parallel_observed: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SuggestedChangeIntent {
+    intent: String,
+    target: String,
 }
 fn stable_fingerprint_hex(bytes: &[u8]) -> String {
     // FNV-1a 64-bit (deterministic, dependency-free fingerprint for persisted metadata).
@@ -1005,6 +1053,161 @@ fn build_scores_artifact(run_summary: &RunSummaryArtifact, tr: &trace::Trace) ->
     }
 }
 
+fn read_scores_if_present(run_paths: &artifacts::RunArtifactPaths) -> Option<ScoresArtifact> {
+    let path = run_paths.scores_json();
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str::<ScoresArtifact>(&raw).ok()
+}
+
+fn build_suggestions_artifact(
+    run_summary: &RunSummaryArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> SuggestionsArtifact {
+    let fallback_summary;
+    let fallback_metrics;
+    let (score_summary, score_metrics, score_version) = if let Some(scores) = scores {
+        (
+            &scores.summary,
+            &scores.metrics,
+            Some(scores.scores_version),
+        )
+    } else {
+        let failed_steps = run_summary.counts.failed_steps;
+        let success_steps = run_summary
+            .counts
+            .completed_steps
+            .saturating_sub(failed_steps);
+        let success_ratio = if run_summary.counts.total_steps == 0 {
+            1.0
+        } else {
+            let permille = (success_steps * 1000) / run_summary.counts.total_steps;
+            (permille as f64) / 1000.0
+        };
+        let security_denied_count: usize =
+            run_summary.policy.security_denials_by_code.values().sum();
+        let delegation_denied_count: usize = run_summary
+            .policy
+            .security_denials_by_code
+            .iter()
+            .filter_map(|(code, count)| {
+                if code.starts_with("DELEGATION_") {
+                    Some(*count)
+                } else {
+                    None
+                }
+            })
+            .sum();
+        fallback_summary = ScoresSummary {
+            success_ratio,
+            failure_count: failed_steps,
+            retry_count: 0,
+            delegation_denied_count,
+            security_denied_count,
+        };
+        fallback_metrics = ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        };
+        (&fallback_summary, &fallback_metrics, None)
+    };
+
+    let base_evidence = SuggestionEvidence {
+        failure_count: score_summary.failure_count,
+        retry_count: score_summary.retry_count,
+        delegation_denied_count: score_summary.delegation_denied_count,
+        security_denied_count: score_summary.security_denied_count,
+        success_ratio: score_summary.success_ratio,
+        scheduler_max_parallel_observed: score_metrics.scheduler_max_parallel_observed,
+    };
+
+    let mut suggestions = Vec::new();
+
+    if score_summary.failure_count > 0 {
+        suggestions.push(SuggestionItem {
+            id: String::new(),
+            category: "retry".to_string(),
+            severity: "improvement".to_string(),
+            rationale: "One or more steps failed; consider safer retry policy for transient paths."
+                .to_string(),
+            evidence: base_evidence.clone(),
+            proposed_change: SuggestedChangeIntent {
+                intent: "increase_step_retry_budget".to_string(),
+                target: "failed-step-set".to_string(),
+            },
+        });
+    }
+    if score_summary.delegation_denied_count > 0 {
+        suggestions.push(SuggestionItem {
+            id: String::new(),
+            category: "delegation".to_string(),
+            severity: "warning".to_string(),
+            rationale: "Delegation-denied signals detected; review delegation policy scope."
+                .to_string(),
+            evidence: base_evidence.clone(),
+            proposed_change: SuggestedChangeIntent {
+                intent: "review_delegation_policy_scope".to_string(),
+                target: "delegation-boundary".to_string(),
+            },
+        });
+    }
+    if score_summary.security_denied_count > 0 {
+        suggestions.push(SuggestionItem {
+            id: String::new(),
+            category: "security".to_string(),
+            severity: "warning".to_string(),
+            rationale: "Security denials observed; align expected capabilities with trust policy."
+                .to_string(),
+            evidence: base_evidence.clone(),
+            proposed_change: SuggestedChangeIntent {
+                intent: "review_security_policy_expectations".to_string(),
+                target: "security-envelope".to_string(),
+            },
+        });
+    }
+    if score_summary.success_ratio < 1.0 {
+        suggestions.push(SuggestionItem {
+            id: String::new(),
+            category: "general".to_string(),
+            severity: "improvement".to_string(),
+            rationale: "Success ratio is below 1.0; review failing steps and dependency shape."
+                .to_string(),
+            evidence: base_evidence.clone(),
+            proposed_change: SuggestedChangeIntent {
+                intent: "review_failure_hotspots".to_string(),
+                target: "workflow-step-dependencies".to_string(),
+            },
+        });
+    }
+    if run_summary.counts.total_steps > 1 && score_metrics.scheduler_max_parallel_observed <= 1 {
+        suggestions.push(SuggestionItem {
+            id: String::new(),
+            category: "scheduler".to_string(),
+            severity: "info".to_string(),
+            rationale: "Observed parallelism is low; evaluate opportunities for safe concurrency."
+                .to_string(),
+            evidence: base_evidence,
+            proposed_change: SuggestedChangeIntent {
+                intent: "evaluate_parallelizable_dependencies".to_string(),
+                target: "workflow-structure".to_string(),
+            },
+        });
+    }
+
+    for (idx, suggestion) in suggestions.iter_mut().enumerate() {
+        suggestion.id = format!("sug-{:03}", idx + 1);
+    }
+
+    SuggestionsArtifact {
+        suggestions_version: SUGGESTIONS_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: SuggestionsGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+            scores_version: score_version,
+        },
+        suggestions,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn write_run_state_artifacts(
     resolved: &resolve::AdlResolved,
@@ -1102,11 +1305,16 @@ fn write_run_state_artifacts(
         serde_json::to_vec_pretty(&run_summary).context("serialize run_summary.json")?;
     let scores = build_scores_artifact(&run_summary, tr);
     let scores_json = serde_json::to_vec_pretty(&scores).context("serialize scores.json")?;
+    let scores_for_suggestions = read_scores_if_present(&run_paths).unwrap_or(scores.clone());
+    let suggestions = build_suggestions_artifact(&run_summary, Some(&scores_for_suggestions));
+    let suggestions_json =
+        serde_json::to_vec_pretty(&suggestions).context("serialize suggestions.json")?;
 
     artifacts::atomic_write(&run_paths.run_json(), &run_json)?;
     artifacts::atomic_write(&run_paths.steps_json(), &steps_json)?;
     artifacts::atomic_write(&run_paths.run_summary_json(), &run_summary_json)?;
     artifacts::atomic_write(&run_paths.scores_json(), &scores_json)?;
+    artifacts::atomic_write(&run_paths.suggestions_json(), &suggestions_json)?;
     if let Some(pause_payload) = pause {
         let pause_artifact = PauseStateArtifact {
             schema_version: PAUSE_STATE_SCHEMA_VERSION.to_string(),

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -2297,6 +2297,7 @@ run:
     let steps_json_path = run_dir.join("steps.json");
     let run_summary_path = run_dir.join("run_summary.json");
     let scores_path = run_dir.join("learning").join("scores.json");
+    let suggestions_path = run_dir.join("learning").join("suggestions.json");
     assert!(
         run_json_path.is_file(),
         "missing {}",
@@ -2313,6 +2314,11 @@ run:
         run_summary_path.display()
     );
     assert!(scores_path.is_file(), "missing {}", scores_path.display());
+    assert!(
+        suggestions_path.is_file(),
+        "missing {}",
+        suggestions_path.display()
+    );
 
     let run_json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&run_json_path).unwrap()).unwrap();
@@ -2390,6 +2396,25 @@ run:
         scores_json["metrics"]["scheduler_max_parallel_observed"].is_number(),
         "scores metrics should include deterministic scheduler observation"
     );
+    let suggestions_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&suggestions_path).unwrap()).unwrap();
+    assert_eq!(suggestions_json["suggestions_version"], 1);
+    assert_eq!(suggestions_json["run_id"], run_id);
+    assert_eq!(
+        suggestions_json["generated_from"]["artifact_model_version"],
+        1
+    );
+    assert_eq!(suggestions_json["generated_from"]["run_summary_version"], 1);
+    assert_eq!(suggestions_json["generated_from"]["scores_version"], 1);
+    let suggestions = suggestions_json["suggestions"]
+        .as_array()
+        .expect("suggestions should be an array");
+    for (idx, item) in suggestions.iter().enumerate() {
+        assert_eq!(item["id"], format!("sug-{:03}", idx + 1));
+        let proposed_change = &item["proposed_change"];
+        assert!(proposed_change["intent"].is_string());
+        assert!(proposed_change["target"].is_string());
+    }
 
     let _ = fs::remove_dir_all(&run_dir);
 }
@@ -2447,15 +2472,28 @@ run:
 
     let first = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
     assert!(first.status.success(), "first run should succeed");
-    let first_bytes = fs::read(run_dir.join("learning").join("scores.json")).unwrap();
+    let first_scores = fs::read(run_dir.join("learning").join("scores.json")).unwrap();
+    let first_suggestions = fs::read(run_dir.join("learning").join("suggestions.json")).unwrap();
 
     let second = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
     assert!(second.status.success(), "second run should succeed");
-    let second_bytes = fs::read(run_dir.join("learning").join("scores.json")).unwrap();
+    let second_scores = fs::read(run_dir.join("learning").join("scores.json")).unwrap();
+    let second_suggestions = fs::read(run_dir.join("learning").join("suggestions.json")).unwrap();
 
     assert_eq!(
-        first_bytes, second_bytes,
+        first_scores, second_scores,
         "scores.json should be byte-stable across repeated identical runs"
+    );
+    assert_eq!(
+        first_suggestions, second_suggestions,
+        "suggestions.json should be byte-stable across repeated identical runs"
+    );
+    let suggestions_text = String::from_utf8(second_suggestions).unwrap();
+    assert!(
+        !suggestions_text.contains("/Users/")
+            && !suggestions_text.contains("\\\\")
+            && !suggestions_text.contains("gho_"),
+        "suggestions output must not leak absolute host paths or secrets: {suggestions_text}"
     );
 
     let _ = fs::remove_dir_all(&run_dir);


### PR DESCRIPTION
Closes #484

Depends on #483; merge #483 first.

## Summary
- Adds deterministic suggestions schema/emission at .adl/runs/[run_id]/learning/suggestions.json
- Derives from scores + run_summary (with run_summary-only fallback if scores missing)
- Keeps suggestions advisory-only with abstract mutation intents, guardrail-compatible

## Files
- swarm/src/main.rs
- swarm/tests/execute_tests.rs
- docs/milestones/v0.7/SUGGESTIONS_v1.md
- docs/milestones/v0.7/ARTIFACT_MODEL_v1.md
- docs/milestones/v0.7/DESIGN_v0.7.md

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test
