### PR TITLE
[v0.7] Resilience surfaces v1

### DIFF
--- a/docs/milestones/v0.7/RESILIENCE_SURFACES_v1.md
+++ b/docs/milestones/v0.7/RESILIENCE_SURFACES_v1.md
@@ -1,0 +1,87 @@
+# Resilience Surfaces v1 (v0.7)
+
+`run_status.json` is the canonical deterministic resilience artifact for v0.7.
+
+Location:
+- `.adl/runs/<run_id>/run_status.json`
+
+## Schema
+
+Required fields:
+- `run_status_version: 1`
+- `run_id`
+- `workflow_id`
+- `overall_status`
+- `completed_steps`
+- `pending_steps`
+- `attempt_counts_by_step`
+
+Optional fields:
+- `failure_kind`
+- `failed_step_id`
+- `started_steps`
+- `effective_max_concurrency`
+- `effective_max_concurrency_source`
+
+## Overall Status Semantics
+
+`overall_status` is one of:
+- `running`
+- `succeeded`
+- `failed`
+- `canceled`
+
+v0.7 note:
+- a paused run is emitted as `overall_status: "running"` because the run is incomplete but resumable
+
+## Failure Taxonomy
+
+`failure_kind` is stable and intentionally coarse. Current values are:
+- `provider_error`
+- `tool_error`
+- `schema_error`
+- `policy_denied`
+- `sandbox_denied`
+- `io_error`
+- `timeout`
+- `panic`
+
+Rules:
+- failure kinds are derived from structured/runtime error sources
+- no raw provider stderr or endpoint strings are persisted in `run_status.json`
+- no substring scraping of arbitrary error text is required for the artifact
+
+## Resume Rules
+
+Resume is deterministic and explicit:
+- the engine reuses a `run_id` only when the user explicitly resumes that run
+- a completed step is skipped only when:
+  - the step is recorded as completed in pause state, and
+  - its expected artifact is present and validates against the stored fingerprint
+- if the expected artifact is missing or invalid, the step is rerun
+- resume emits deterministic notes describing whether each previously completed step was skipped or rerun
+
+Examples:
+- `RESUME step=s1 action=skip reason=completed_artifact_verified`
+- `RESUME step=s1 action=rerun reason=missing_expected_artifact`
+
+## Determinism Guarantees
+
+- no timestamps in `run_status.json`
+- sorted lists/maps only
+- stable scheduler policy source values
+- artifact path is canonical via `RunArtifactPaths`
+- file writes use `artifacts::atomic_write`
+
+## Privacy / Security
+
+`run_status.json` must not include:
+- secrets
+- raw provider output
+- raw tool arguments
+- absolute host paths
+
+Resume does not weaken:
+- sandbox boundaries
+- signature / trust validation
+- scheduler policy semantics

--- a/swarm/src/artifacts.rs
+++ b/swarm/src/artifacts.rs
@@ -57,6 +57,10 @@ impl RunArtifactPaths {
         self.run_dir().join("run_summary.json")
     }
 
+    pub fn run_status_json(&self) -> PathBuf {
+        self.run_dir().join("run_status.json")
+    }
+
     pub fn outputs_dir(&self) -> PathBuf {
         self.run_dir().join("outputs")
     }
@@ -165,6 +169,9 @@ mod tests {
         let paths = RunArtifactPaths::for_run("demo-run-1").expect("paths");
         assert!(paths.run_dir().ends_with(".adl/runs/demo-run-1"));
         assert!(paths.run_json().ends_with(".adl/runs/demo-run-1/run.json"));
+        assert!(paths
+            .run_status_json()
+            .ends_with(".adl/runs/demo-run-1/run_status.json"));
         assert!(paths
             .artifact_model_marker_json()
             .ends_with(".adl/runs/demo-run-1/meta/ARTIFACT_MODEL.json"));

--- a/swarm/src/bounded_executor.rs
+++ b/swarm/src/bounded_executor.rs
@@ -1,6 +1,52 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::collections::VecDeque;
 use std::sync::{mpsc, Arc, Mutex};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoundedExecutorErrorKind {
+    InvalidParallelism,
+    QueuePoisoned,
+    WorkerPanic,
+    OutputCountMismatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedExecutorError {
+    pub kind: BoundedExecutorErrorKind,
+    pub message: String,
+}
+
+impl std::fmt::Display for BoundedExecutorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for BoundedExecutorError {}
+
+impl BoundedExecutorError {
+    fn new(kind: BoundedExecutorErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
+    for cause in err.chain() {
+        if let Some(exec_err) = cause.downcast_ref::<BoundedExecutorError>() {
+            return Some(match exec_err.kind {
+                BoundedExecutorErrorKind::WorkerPanic | BoundedExecutorErrorKind::QueuePoisoned => {
+                    "panic"
+                }
+                BoundedExecutorErrorKind::InvalidParallelism => "schema_error",
+                BoundedExecutorErrorKind::OutputCountMismatch => "io_error",
+            });
+        }
+    }
+    None
+}
 
 struct Job<T> {
     index: usize,
@@ -12,7 +58,11 @@ pub fn run_bounded<T: Send + 'static>(
     jobs: Vec<Box<dyn FnOnce() -> T + Send + 'static>>,
 ) -> Result<Vec<T>> {
     if max_parallel == 0 {
-        return Err(anyhow!("max_parallel must be >= 1"));
+        return Err(BoundedExecutorError::new(
+            BoundedExecutorErrorKind::InvalidParallelism,
+            "max_parallel must be >= 1",
+        )
+        .into());
     }
     if jobs.is_empty() {
         return Ok(Vec::new());
@@ -73,18 +123,26 @@ pub fn run_bounded<T: Send + 'static>(
 
     for h in handles {
         if h.join().is_err() {
-            return Err(anyhow!("bounded executor worker panicked"));
+            return Err(BoundedExecutorError::new(
+                BoundedExecutorErrorKind::WorkerPanic,
+                "bounded executor worker panicked",
+            )
+            .into());
         }
     }
     if let Some(msg) = worker_error {
-        return Err(anyhow!(msg));
+        return Err(BoundedExecutorError::new(BoundedExecutorErrorKind::QueuePoisoned, msg).into());
     }
 
     if out.len() != expected_count {
-        return Err(anyhow!(
-            "bounded executor output count mismatch (expected {expected_count}, got {})",
-            out.len()
-        ));
+        return Err(BoundedExecutorError::new(
+            BoundedExecutorErrorKind::OutputCountMismatch,
+            format!(
+                "bounded executor output count mismatch (expected {expected_count}, got {})",
+                out.len()
+            ),
+        )
+        .into());
     }
 
     out.sort_by_key(|(idx, _)| *idx);

--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -173,6 +173,77 @@ pub struct ResumeState {
     pub completed_outputs: HashMap<String, String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionPolicyErrorKind {
+    Denied,
+    ApprovalRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionPolicyError {
+    pub kind: ExecutionPolicyErrorKind,
+    pub step_id: String,
+    pub action_kind: String,
+    pub target_id: String,
+    pub rule_id: Option<String>,
+}
+
+impl ExecutionPolicyError {
+    pub fn code(&self) -> &'static str {
+        match self.kind {
+            ExecutionPolicyErrorKind::Denied => DELEGATION_POLICY_DENY_CODE,
+            ExecutionPolicyErrorKind::ApprovalRequired => "DELEGATION_POLICY_APPROVAL_REQUIRED",
+        }
+    }
+}
+
+impl std::fmt::Display for ExecutionPolicyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let suffix = self
+            .rule_id
+            .as_ref()
+            .map(|id| format!(" (rule_id={id})"))
+            .unwrap_or_default();
+        match self.kind {
+            ExecutionPolicyErrorKind::Denied => write!(
+                f,
+                "{}: step '{}' action '{}' target '{}' denied{}",
+                self.code(),
+                self.step_id,
+                self.action_kind,
+                self.target_id,
+                suffix
+            ),
+            ExecutionPolicyErrorKind::ApprovalRequired => write!(
+                f,
+                "{}: step '{}' action '{}' target '{}' requires approval{}",
+                self.code(),
+                self.step_id,
+                self.action_kind,
+                self.target_id,
+                suffix
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ExecutionPolicyError {}
+
+pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
+    for cause in err.chain() {
+        if cause.downcast_ref::<ExecutionPolicyError>().is_some() {
+            return Some("policy_denied");
+        }
+    }
+    None
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResumeDisposition {
+    Skip(&'static str),
+    Rerun(&'static str),
+}
+
 fn pause_reason_for_step(step: &crate::resolve::ResolvedStep) -> Option<Option<String>> {
     for guard in &step.guards {
         if guard.kind.trim().eq_ignore_ascii_case("pause") {
@@ -243,6 +314,49 @@ fn stable_fingerprint_hex(bytes: &[u8]) -> String {
 
 fn model_output_fingerprint(output: &str) -> String {
     stable_fingerprint_hex(output.as_bytes())
+}
+
+fn resume_disposition_for_step(
+    step: &crate::resolve::ResolvedStep,
+    out_dir: &Path,
+    completed_outputs: &HashMap<String, String>,
+) -> Result<ResumeDisposition> {
+    let Some(write_to) = step.write_to.as_deref() else {
+        return Ok(ResumeDisposition::Skip("completed_no_artifact_expected"));
+    };
+
+    validate_write_to(&step.id, write_to)?;
+    let artifact_path = out_dir.join(write_to);
+    if !artifact_path.is_file() {
+        return Ok(ResumeDisposition::Rerun("missing_expected_artifact"));
+    }
+
+    let Some(expected_fingerprint) = completed_outputs.get(&step.id) else {
+        return Ok(ResumeDisposition::Rerun("missing_output_fingerprint"));
+    };
+    let actual = std::fs::read_to_string(&artifact_path).with_context(|| {
+        format!(
+            "failed to read expected resume artifact for step '{}' at '{}'",
+            step.id,
+            artifact_path.display()
+        )
+    })?;
+    let actual_fingerprint = model_output_fingerprint(&actual);
+    if &actual_fingerprint != expected_fingerprint {
+        return Ok(ResumeDisposition::Rerun("invalid_expected_artifact"));
+    }
+
+    Ok(ResumeDisposition::Skip("completed_artifact_verified"))
+}
+
+fn emit_resume_note(enabled: bool, step_id: &str, action: &str, reason: &str) {
+    if !enabled {
+        return;
+    }
+    eprintln!(
+        "RESUME step={} action={} reason={}",
+        step_id, action, reason
+    );
 }
 
 /// Execute the resolved run.
@@ -329,6 +443,29 @@ pub fn execute_sequential_with_resume(
         .as_ref()
         .map(|r| r.completed_step_ids.clone())
         .unwrap_or_default();
+
+    if let Some(resume) = resume.as_ref() {
+        let mut validated_completed = HashSet::new();
+        for step in &resolved.steps {
+            if !resume.completed_step_ids.contains(&step.id) {
+                continue;
+            }
+            match resume_disposition_for_step(step, out_dir, &completed_outputs)? {
+                ResumeDisposition::Skip(reason) => {
+                    emit_resume_note(emit_progress, &step.id, "skip", reason);
+                    validated_completed.insert(step.id.clone());
+                }
+                ResumeDisposition::Rerun(reason) => {
+                    emit_resume_note(emit_progress, &step.id, "rerun", reason);
+                    if let Some(save_as) = step.save_as.as_ref() {
+                        saved_state.remove(save_as);
+                    }
+                    completed_outputs.remove(&step.id);
+                }
+            }
+        }
+        completed_step_ids = validated_completed;
+    }
 
     for step in &resolved.steps {
         let step_id = step.id.clone();
@@ -697,14 +834,13 @@ pub fn execute_sequential_with_resume(
                     continue;
                 }
                 tr.run_failed(&err.to_string());
-                return Err(anyhow!(
-                    "step '{}' failed (attempt {}/{}, max_attempts={}): {:#}",
+                return Err(err.context(format!(
+                    "step '{}' failed (attempt {}/{}, max_attempts={})",
                     step_id,
                     attempt.max(1),
                     max_attempts,
-                    max_attempts,
-                    err
-                ));
+                    max_attempts
+                )));
             }
         }
     }
@@ -1149,18 +1285,14 @@ fn enforce_delegation_policy(
                 outcome.decision.as_str(),
                 outcome.rule_id.as_deref(),
             );
-            Err(anyhow!(
-                "{}: step '{}' action '{}' target '{}' requires approval{}",
-                DELEGATION_POLICY_APPROVAL_REQUIRED_CODE,
-                step.id,
-                action.as_str(),
-                target_id,
-                outcome
-                    .rule_id
-                    .as_ref()
-                    .map(|id| format!(" (rule_id={id})"))
-                    .unwrap_or_default()
-            ))
+            Err(ExecutionPolicyError {
+                kind: ExecutionPolicyErrorKind::ApprovalRequired,
+                step_id: step.id.clone(),
+                action_kind: action.as_str().to_string(),
+                target_id: target_id.to_string(),
+                rule_id: outcome.rule_id,
+            }
+            .into())
         }
         DelegationDecision::Denied => {
             tr.delegation_policy_evaluated(
@@ -1176,18 +1308,14 @@ fn enforce_delegation_policy(
                 target_id,
                 outcome.rule_id.as_deref(),
             );
-            Err(anyhow!(
-                "{}: step '{}' action '{}' target '{}' denied{}",
-                DELEGATION_POLICY_DENY_CODE,
-                step.id,
-                action.as_str(),
-                target_id,
-                outcome
-                    .rule_id
-                    .as_ref()
-                    .map(|id| format!(" (rule_id={id})"))
-                    .unwrap_or_default()
-            ))
+            Err(ExecutionPolicyError {
+                kind: ExecutionPolicyErrorKind::Denied,
+                step_id: step.id.clone(),
+                action_kind: action.as_str().to_string(),
+                target_id: target_id.to_string(),
+                rule_id: outcome.rule_id,
+            }
+            .into())
         }
     }
 }
@@ -1402,14 +1530,13 @@ fn execute_step_with_retry(
     }
 
     let err = last_err.unwrap_or_else(|| anyhow!("step '{}' failed", step_id));
-    Err(anyhow!(
-        "step '{}' failed (attempt {}/{}, max_attempts={}): {:#}",
+    Err(err.context(format!(
+        "step '{}' failed (attempt {}/{}, max_attempts={})",
         step_id,
         attempt.max(1),
         max_attempts,
-        max_attempts,
-        err
-    ))
+        max_attempts
+    )))
 }
 
 fn execute_concurrent_deterministic(
@@ -1436,6 +1563,28 @@ fn execute_concurrent_deterministic(
     let mut completed: HashSet<String> = resume
         .map(|r| r.completed_step_ids.clone())
         .unwrap_or_default();
+    if let Some(resume) = resume {
+        let mut validated_completed = HashSet::new();
+        for step in &resolved.steps {
+            if !resume.completed_step_ids.contains(&step.id) {
+                continue;
+            }
+            match resume_disposition_for_step(step, out_dir, &completed_outputs)? {
+                ResumeDisposition::Skip(reason) => {
+                    emit_resume_note(emit_progress, &step.id, "skip", reason);
+                    validated_completed.insert(step.id.clone());
+                }
+                ResumeDisposition::Rerun(reason) => {
+                    emit_resume_note(emit_progress, &step.id, "rerun", reason);
+                    if let Some(save_as) = step.save_as.as_ref() {
+                        saved_state.remove(save_as);
+                    }
+                    completed_outputs.remove(&step.id);
+                }
+            }
+        }
+        completed = validated_completed;
+    }
     let mut pending: HashSet<String> = resolved
         .execution_plan
         .nodes

--- a/swarm/src/main.rs
+++ b/swarm/src/main.rs
@@ -6,8 +6,8 @@ use std::process::Stdio;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use swarm::{
-    adl, artifacts, demo, execute, instrumentation, learning_export, overlay, plan, prompt,
-    resolve, signing, trace,
+    adl, artifacts, bounded_executor, demo, execute, instrumentation, learning_export, overlay,
+    plan, prompt, provider, remote_exec, resolve, sandbox, signing, trace,
 };
 
 fn usage() -> &'static str {
@@ -275,6 +275,7 @@ fn real_main() -> Result<()> {
             Some(path) => Some(load_resume_state(path, &resolved)?),
             None => None,
         };
+        let resume_completed_ids = resume_state.as_ref().map(|r| r.completed_step_ids.clone());
 
         let result = execute::execute_sequential_with_resume(
             &resolved,
@@ -298,6 +299,8 @@ fn real_main() -> Result<()> {
                     run_finished_ms,
                     "failure",
                     None,
+                    resume_completed_ids.as_ref(),
+                    Some(&err),
                 )?;
                 if !quiet {
                     eprintln!(
@@ -334,6 +337,8 @@ fn real_main() -> Result<()> {
             run_finished_ms,
             status,
             pause_state.as_ref(),
+            resume_completed_ids.as_ref(),
+            None,
         )?;
         if !quiet {
             let status_label = if pause_state.is_some() {
@@ -755,6 +760,7 @@ fn now_ms() -> u128 {
 
 const RUN_STATE_SCHEMA_VERSION: &str = "run_state.v1";
 const PAUSE_STATE_SCHEMA_VERSION: &str = "pause_state.v1";
+const RUN_STATUS_VERSION: u32 = 1;
 const RUN_SUMMARY_VERSION: u32 = 1;
 const SCORES_VERSION: u32 = 1;
 const SUGGESTIONS_VERSION: u32 = 1;
@@ -799,6 +805,28 @@ struct StepStateArtifact {
     provider_id: String,
     status: String,
     output_artifact_path: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RunStatusArtifact {
+    run_status_version: u32,
+    run_id: String,
+    workflow_id: String,
+    overall_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    failure_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    failed_step_id: Option<String>,
+    completed_steps: Vec<String>,
+    pending_steps: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    started_steps: Option<Vec<String>>,
+    attempt_counts_by_step: BTreeMap<String, u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    effective_max_concurrency: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    effective_max_concurrency_source: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -954,30 +982,22 @@ fn execution_plan_hash<T: Serialize>(plan: &T) -> Result<String> {
     Ok(stable_fingerprint_hex(&plan_json))
 }
 
-fn extract_error_kind(message: &str) -> Option<String> {
-    // Best-effort extraction from formatted error text until all failure
-    // surfaces provide structured error-kind fields.
-    // Keep this deterministic: choose the first token matching known stable
-    // code prefixes and uppercase underscore format.
-    const PREFIXES: &[&str] = &[
-        "REMOTE_",
-        "SIGNATURE_",
-        "LEARNING_",
-        "SANDBOX_",
-        "PROVIDER_",
-        "HTTP_",
-        "VALIDATION_",
-    ];
-    for token in message
-        .split(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'))
-        .filter(|t| !t.is_empty())
-    {
-        if token.len() >= 3 && token.contains('_') && PREFIXES.iter().any(|p| token.starts_with(p))
-        {
-            return Some(token.to_string());
-        }
-    }
-    None
+fn classify_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
+    execute::stable_failure_kind(err)
+        .or_else(|| provider::stable_failure_kind(err))
+        .or_else(|| remote_exec::stable_failure_kind(err))
+        .or_else(|| bounded_executor::stable_failure_kind(err))
+        .or_else(|| {
+            err.chain().find_map(|cause| {
+                if cause.downcast_ref::<sandbox::SandboxPathError>().is_some() {
+                    Some("sandbox_denied")
+                } else if cause.downcast_ref::<std::io::Error>().is_some() {
+                    Some("io_error")
+                } else {
+                    None
+                }
+            })
+        })
 }
 
 fn build_run_summary(
@@ -986,7 +1006,7 @@ fn build_run_summary(
     pause: Option<&execute::PauseState>,
     steps: &[StepStateArtifact],
     records: usize,
-    error_message: Option<&str>,
+    failure: Option<&anyhow::Error>,
     run_paths: &artifacts::RunArtifactPaths,
 ) -> RunSummaryArtifact {
     let failed_steps = steps.iter().filter(|s| s.status == "failure").count();
@@ -1015,8 +1035,10 @@ fn build_run_summary(
         })
         .count();
     let mut security_denials_by_code = BTreeMap::new();
-    if let Some(code) = error_message.and_then(extract_error_kind) {
-        *security_denials_by_code.entry(code).or_insert(0) += 1;
+    if let Some(code) = failure.and_then(classify_failure_kind) {
+        *security_denials_by_code
+            .entry(code.to_string())
+            .or_insert(0) += 1;
     }
 
     let (
@@ -1059,7 +1081,7 @@ fn build_run_summary(
         adl_version: resolved.doc.version.clone(),
         swarm_version: env!("CARGO_PKG_VERSION").to_string(),
         status: status.to_string(),
-        error_kind: error_message.and_then(extract_error_kind),
+        error_kind: failure.and_then(classify_failure_kind).map(str::to_string),
         counts: RunSummaryCounts {
             total_steps: resolved.steps.len(),
             completed_steps,
@@ -1108,6 +1130,70 @@ fn build_run_summary(
                 .unwrap_or_else(|_| "learning/overlays".to_string()),
             trace_json: None,
         },
+    }
+}
+
+fn build_run_status(
+    resolved: &resolve::AdlResolved,
+    tr: &trace::Trace,
+    overall_status: &str,
+    steps: &[StepStateArtifact],
+    failure: Option<&anyhow::Error>,
+    resume_completed_step_ids: &BTreeSet<String>,
+) -> RunStatusArtifact {
+    let mut completed_steps: BTreeSet<String> = resume_completed_step_ids.clone();
+    let mut pending_steps: BTreeSet<String> = BTreeSet::new();
+    let mut failed_step_id: Option<String> = None;
+
+    for step in steps {
+        match step.status.as_str() {
+            "success" => {
+                completed_steps.insert(step.step_id.clone());
+            }
+            "failure" => {
+                if failed_step_id.is_none() {
+                    failed_step_id = Some(step.step_id.clone());
+                }
+                pending_steps.insert(step.step_id.clone());
+            }
+            _ => {
+                pending_steps.insert(step.step_id.clone());
+            }
+        }
+    }
+
+    let mut attempts_by_step: BTreeMap<String, u32> = resume_completed_step_ids
+        .iter()
+        .map(|step_id| (step_id.clone(), 0))
+        .collect();
+    let mut started_set = BTreeSet::new();
+    for event in &tr.events {
+        if let trace::TraceEvent::StepStarted { step_id, .. } = event {
+            started_set.insert(step_id.clone());
+            *attempts_by_step.entry(step_id.clone()).or_insert(0) += 1;
+        }
+    }
+
+    let scheduler_policy = execute::scheduler_policy_for_run(resolved).ok().flatten();
+
+    RunStatusArtifact {
+        run_status_version: RUN_STATUS_VERSION,
+        run_id: resolved.run_id.clone(),
+        workflow_id: resolved.workflow_id.clone(),
+        overall_status: overall_status.to_string(),
+        failure_kind: failure.and_then(classify_failure_kind).map(str::to_string),
+        failed_step_id,
+        completed_steps: completed_steps.into_iter().collect(),
+        pending_steps: pending_steps.into_iter().collect(),
+        started_steps: if started_set.is_empty() {
+            None
+        } else {
+            Some(started_set.into_iter().collect())
+        },
+        attempt_counts_by_step: attempts_by_step,
+        effective_max_concurrency: scheduler_policy.map(|(value, _)| value),
+        effective_max_concurrency_source: scheduler_policy
+            .map(|(_, source)| source.as_str().to_string()),
     }
 }
 
@@ -1348,16 +1434,21 @@ fn write_run_state_artifacts(
     resolved: &resolve::AdlResolved,
     tr: &trace::Trace,
     adl_path: &Path,
-    out_dir: &Path,
+    _out_dir: &Path,
     start_ms: u128,
     end_ms: u128,
     status: &str,
     pause: Option<&execute::PauseState>,
+    resume_completed_step_ids: Option<&std::collections::HashSet<String>>,
+    failure: Option<&anyhow::Error>,
 ) -> Result<PathBuf> {
     let run_paths = artifacts::RunArtifactPaths::for_run(&resolved.run_id)?;
     run_paths.ensure_layout()?;
     run_paths.write_model_marker()?;
     let run_dir = run_paths.run_dir();
+    let resume_completed: BTreeSet<String> = resume_completed_step_ids
+        .map(|ids| ids.iter().cloned().collect())
+        .unwrap_or_default();
 
     let mut status_by_step: HashMap<String, String> = HashMap::new();
     for ev in &tr.events {
@@ -1375,9 +1466,14 @@ fn write_run_state_artifacts(
         let status = status_by_step
             .get(&step.id)
             .cloned()
+            .or_else(|| {
+                resume_completed
+                    .contains(&step.id)
+                    .then(|| "success".to_string())
+            })
             .unwrap_or_else(|| "not_run".to_string());
         let output_artifact_path = match (status.as_str(), step.write_to.as_deref()) {
-            ("success", Some(write_to)) => Some(out_dir.join(write_to).display().to_string()),
+            ("success", Some(write_to)) => Some(write_to.to_string()),
             _ => None,
         };
 
@@ -1433,11 +1529,27 @@ fn write_run_state_artifacts(
             .iter()
             .filter(|ev| matches!(ev, trace::TraceEvent::StepFinished { .. }))
             .count(),
-        error_message.as_deref(),
+        failure,
         &run_paths,
+    );
+    let overall_status = match status {
+        "success" => "succeeded",
+        "failure" => "failed",
+        "paused" => "running",
+        other => other,
+    };
+    let run_status = build_run_status(
+        resolved,
+        tr,
+        overall_status,
+        &steps,
+        failure,
+        &resume_completed,
     );
     let run_summary_json =
         serde_json::to_vec_pretty(&run_summary).context("serialize run_summary.json")?;
+    let run_status_json =
+        serde_json::to_vec_pretty(&run_status).context("serialize run_status.json")?;
     let scores = build_scores_artifact(&run_summary, tr);
     let scores_json = serde_json::to_vec_pretty(&scores).context("serialize scores.json")?;
     let scores_for_suggestions = read_scores_if_present(&run_paths).unwrap_or(scores.clone());
@@ -1447,6 +1559,7 @@ fn write_run_state_artifacts(
 
     artifacts::atomic_write(&run_paths.run_json(), &run_json)?;
     artifacts::atomic_write(&run_paths.steps_json(), &steps_json)?;
+    artifacts::atomic_write(&run_paths.run_status_json(), &run_status_json)?;
     artifacts::atomic_write(&run_paths.run_summary_json(), &run_summary_json)?;
     artifacts::atomic_write(&run_paths.scores_json(), &scores_json)?;
     artifacts::atomic_write(&run_paths.suggestions_json(), &suggestions_json)?;
@@ -1680,6 +1793,7 @@ fn real_resume(args: &[String]) -> Result<()> {
         saved_state: pause_artifact.pause.saved_state,
         completed_outputs: pause_artifact.pause.completed_outputs,
     };
+    let resume_completed_ids = resume_state.completed_step_ids.clone();
 
     let out_dir = PathBuf::from("out");
     let run_started_ms = now_ms();
@@ -1718,6 +1832,8 @@ fn real_resume(args: &[String]) -> Result<()> {
             "success"
         },
         result.pause.as_ref(),
+        Some(&resume_completed_ids),
+        None,
     )?;
     eprintln!(
         "RUN done (+{}ms) {} artifacts={}",
@@ -2243,6 +2359,8 @@ mod tests {
             150,
             "paused",
             Some(&pause),
+            None,
+            None,
         )
         .expect("write run artifacts");
 
@@ -2295,6 +2413,8 @@ mod tests {
             1,
             "success",
             None,
+            None,
+            None,
         )
         .expect("write non-paused artifacts");
         let err = load_resume_state(&run_dir.join("run.json"), &resolved)
@@ -2339,6 +2459,8 @@ mod tests {
             20,
             "paused",
             Some(&pause),
+            None,
+            None,
         )
         .expect("write run artifacts");
 
@@ -2382,6 +2504,8 @@ mod tests {
             1,
             "paused",
             None,
+            None,
+            None,
         )
         .expect("write paused artifacts");
 
@@ -2420,6 +2544,8 @@ mod tests {
             1,
             "paused",
             Some(&pause),
+            None,
+            None,
         )
         .expect("write paused artifacts");
 
@@ -2462,6 +2588,8 @@ mod tests {
             1,
             "paused",
             Some(&pause),
+            None,
+            None,
         )
         .expect("write paused artifacts");
 
@@ -2504,6 +2632,8 @@ mod tests {
             1,
             "paused",
             Some(&pause),
+            None,
+            None,
         )
         .expect("write paused artifacts");
 

--- a/swarm/src/provider.rs
+++ b/swarm/src/provider.rs
@@ -28,6 +28,8 @@ pub trait Provider: Send + Sync {
 enum ProviderErrorKind {
     UnknownKind,
     InvalidConfig,
+    Timeout,
+    Panic,
     RuntimeRetryable,
     RuntimeNonRetryable,
 }
@@ -74,6 +76,22 @@ Set providers.<id>.type to one of: ollama, http."
             message: message.into(),
         }
     }
+
+    fn timeout(provider: &str, message: impl Into<String>) -> Self {
+        Self {
+            kind: ProviderErrorKind::Timeout,
+            provider: Some(provider.to_string()),
+            message: message.into(),
+        }
+    }
+
+    fn panic(provider: &str, message: impl Into<String>) -> Self {
+        Self {
+            kind: ProviderErrorKind::Panic,
+            provider: Some(provider.to_string()),
+            message: message.into(),
+        }
+    }
 }
 
 impl fmt::Display for ProviderError {
@@ -83,6 +101,18 @@ impl fmt::Display for ProviderError {
             ProviderErrorKind::InvalidConfig => write!(
                 f,
                 "provider {} invalid config: {}",
+                self.provider.as_deref().unwrap_or("<unknown>"),
+                self.message
+            ),
+            ProviderErrorKind::Timeout => write!(
+                f,
+                "provider {} timeout: {}",
+                self.provider.as_deref().unwrap_or("<unknown>"),
+                self.message
+            ),
+            ProviderErrorKind::Panic => write!(
+                f,
+                "provider {} panic: {}",
                 self.provider.as_deref().unwrap_or("<unknown>"),
                 self.message
             ),
@@ -120,13 +150,40 @@ fn runtime_error_non_retryable(provider: &str, message: impl Into<String>) -> an
     ProviderError::runtime_non_retryable(provider, message).into()
 }
 
+fn timeout_error(provider: &str, message: impl Into<String>) -> anyhow::Error {
+    ProviderError::timeout(provider, message).into()
+}
+
+fn panic_error(provider: &str, message: impl Into<String>) -> anyhow::Error {
+    ProviderError::panic(provider, message).into()
+}
+
 pub fn is_retryable_error(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
         if let Some(p) = cause.downcast_ref::<ProviderError>() {
-            return matches!(p.kind, ProviderErrorKind::RuntimeRetryable);
+            return matches!(
+                p.kind,
+                ProviderErrorKind::RuntimeRetryable | ProviderErrorKind::Timeout
+            );
         }
     }
     true
+}
+
+pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
+    for cause in err.chain() {
+        if let Some(p) = cause.downcast_ref::<ProviderError>() {
+            return Some(match p.kind {
+                ProviderErrorKind::Timeout => "timeout",
+                ProviderErrorKind::Panic => "panic",
+                ProviderErrorKind::UnknownKind | ProviderErrorKind::InvalidConfig => "schema_error",
+                ProviderErrorKind::RuntimeRetryable | ProviderErrorKind::RuntimeNonRetryable => {
+                    "provider_error"
+                }
+            });
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -428,7 +485,7 @@ impl OllamaProvider {
                     }
                     std::thread::sleep(Duration::from_millis(10));
                 }
-                return Err(runtime_error(
+                return Err(timeout_error(
                     "ollama",
                     format!("timed out after {timeout_secs}s (set SWARM_TIMEOUT_SECS to override)"),
                 ));
@@ -446,12 +503,12 @@ impl OllamaProvider {
 
         out_handle
             .join()
-            .map_err(|_| runtime_error("ollama", "stdout reader thread panicked"))?
+            .map_err(|_| panic_error("ollama", "stdout reader thread panicked"))?
             .context("failed reading ollama stdout")
             .map_err(|err| runtime_error("ollama", err.to_string()))?;
         let err_buf = err_handle
             .join()
-            .map_err(|_| runtime_error("ollama", "stderr reader thread panicked"))?
+            .map_err(|_| panic_error("ollama", "stderr reader thread panicked"))?
             .context("failed reading ollama stderr")
             .map_err(|err| runtime_error("ollama", err.to_string()))?;
 
@@ -634,7 +691,7 @@ impl Provider for HttpProvider {
                                 .to_string()
                         }
                     };
-                    return Err(runtime_error("http", msg));
+                    return Err(timeout_error("http", msg));
                 }
 
                 return Err(runtime_error(

--- a/swarm/src/remote_exec.rs
+++ b/swarm/src/remote_exec.rs
@@ -142,6 +142,64 @@ pub enum SecurityEnvelopeError {
     SymlinkEscape { path: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteExecuteClientErrorKind {
+    Timeout,
+    Unreachable,
+    BadStatus,
+    InvalidJson,
+    SchemaViolation,
+    RemoteExecution,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteExecuteClientError {
+    pub kind: RemoteExecuteClientErrorKind,
+    pub code: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for RemoteExecuteClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for RemoteExecuteClientError {}
+
+impl RemoteExecuteClientError {
+    fn new(
+        kind: RemoteExecuteClientErrorKind,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
+    for cause in err.chain() {
+        if cause.downcast_ref::<SecurityEnvelopeError>().is_some() {
+            return Some("policy_denied");
+        }
+        if let Some(remote) = cause.downcast_ref::<RemoteExecuteClientError>() {
+            return Some(match remote.kind {
+                RemoteExecuteClientErrorKind::Timeout => "timeout",
+                RemoteExecuteClientErrorKind::SchemaViolation => "schema_error",
+                RemoteExecuteClientErrorKind::Unreachable
+                | RemoteExecuteClientErrorKind::BadStatus
+                | RemoteExecuteClientErrorKind::InvalidJson => "io_error",
+                RemoteExecuteClientErrorKind::RemoteExecution => "provider_error",
+            });
+        }
+    }
+    None
+}
+
 impl SecurityEnvelopeError {
     pub fn code(&self) -> &'static str {
         match self {
@@ -203,6 +261,14 @@ impl SecurityEnvelopeError {
         }
     }
 }
+
+impl std::fmt::Display for SecurityEnvelopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code(), self.message())
+    }
+}
+
+impl std::error::Error for SecurityEnvelopeError {}
 
 fn sort_value(value: &mut Value) {
     match value {
@@ -552,7 +618,7 @@ impl ExecuteResponse {
 /// - returns only the remote model output for successful requests
 pub fn execute_remote(endpoint: &str, timeout_ms: u64, req: &ExecuteRequest) -> Result<String> {
     if let Err(env_err) = validate_security_envelope(req) {
-        return Err(anyhow!("{}: {}", env_err.code(), env_err.message()));
+        return Err(env_err.into());
     }
     let client = Client::builder()
         .timeout(Duration::from_millis(timeout_ms))
@@ -560,32 +626,65 @@ pub fn execute_remote(endpoint: &str, timeout_ms: u64, req: &ExecuteRequest) -> 
         .context("failed to build remote executor client")?;
 
     let url = format!("{}/v1/execute", endpoint.trim_end_matches('/'));
-    let response = client.post(url).json(req).send().map_err(|err| {
-        if err.is_timeout() {
-            anyhow!("REMOTE_TIMEOUT: {err}")
-        } else {
-            anyhow!("REMOTE_UNREACHABLE: {err}")
-        }
-    })?;
+    let response = client
+        .post(url)
+        .json(req)
+        .send()
+        .map_err(|err| -> anyhow::Error {
+            if err.is_timeout() {
+                RemoteExecuteClientError::new(
+                    RemoteExecuteClientErrorKind::Timeout,
+                    "REMOTE_TIMEOUT",
+                    err.to_string(),
+                )
+                .into()
+            } else {
+                RemoteExecuteClientError::new(
+                    RemoteExecuteClientErrorKind::Unreachable,
+                    "REMOTE_UNREACHABLE",
+                    err.to_string(),
+                )
+                .into()
+            }
+        })?;
 
     if response.status() != StatusCode::OK {
-        return Err(anyhow!("REMOTE_BAD_STATUS: {}", response.status()));
+        return Err(RemoteExecuteClientError::new(
+            RemoteExecuteClientErrorKind::BadStatus,
+            "REMOTE_BAD_STATUS",
+            response.status().to_string(),
+        )
+        .into());
     }
 
-    let parsed: ExecuteResponse = response
-        .json()
-        .map_err(|err| anyhow!("REMOTE_INVALID_JSON: {err}"))?;
+    let parsed: ExecuteResponse = response.json().map_err(|err| {
+        RemoteExecuteClientError::new(
+            RemoteExecuteClientErrorKind::InvalidJson,
+            "REMOTE_INVALID_JSON",
+            err.to_string(),
+        )
+    })?;
     if parsed.ok {
-        parsed
-            .result
-            .ok_or_else(|| anyhow!("REMOTE_SCHEMA_VIOLATION: missing result on ok response"))
+        parsed.result.ok_or_else(|| {
+            RemoteExecuteClientError::new(
+                RemoteExecuteClientErrorKind::SchemaViolation,
+                "REMOTE_SCHEMA_VIOLATION",
+                "missing result on ok response",
+            )
+            .into()
+        })
     } else {
         let err = parsed.error.unwrap_or(RemoteError {
             code: "REMOTE_EXECUTION_ERROR".to_string(),
             message: "remote execution failed".to_string(),
             details: HashMap::new(),
         });
-        Err(anyhow!("{}: {}", err.code, err.message))
+        Err(RemoteExecuteClientError::new(
+            RemoteExecuteClientErrorKind::RemoteExecution,
+            err.code,
+            err.message,
+        )
+        .into())
     }
 }
 

--- a/swarm/src/sandbox.rs
+++ b/swarm/src/sandbox.rs
@@ -36,6 +36,14 @@ impl SandboxPathError {
     }
 }
 
+impl std::fmt::Display for SandboxPathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message())
+    }
+}
+
+impl std::error::Error for SandboxPathError {}
+
 fn validate_relative(path: &Path) -> Result<(), SandboxPathError> {
     let raw = path.display().to_string();
     if raw.trim().is_empty() {

--- a/swarm/tests/execute_tests.rs
+++ b/swarm/tests/execute_tests.rs
@@ -405,13 +405,18 @@ fn run_swarm_in_dir(cwd: &Path, args: &[&str]) -> std::process::Output {
         .unwrap()
 }
 
+fn repo_runs_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repo root")
+        .join(".adl")
+        .join("runs")
+}
+
 fn run_artifact_paths(
     run_id: &str,
 ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
-    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("repo root");
-    let run_dir = repo_root.join(".adl").join("runs").join(run_id);
+    let run_dir = repo_runs_dir().join(run_id);
     (
         run_dir.join("run.json"),
         run_dir.join("steps.json"),
@@ -420,14 +425,7 @@ fn run_artifact_paths(
 }
 
 fn pause_state_path(run_id: &str) -> std::path::PathBuf {
-    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("repo root");
-    repo_root
-        .join(".adl")
-        .join("runs")
-        .join(run_id)
-        .join("pause_state.json")
+    repo_runs_dir().join(run_id).join("pause_state.json")
 }
 
 #[test]
@@ -2276,6 +2274,8 @@ run:
       - id: "s1"
         agent: "a1"
         task: "t1"
+        save_as: "s1"
+        write_to: "s1.txt"
         inputs:
           text: "hello"
 "#
@@ -2294,6 +2294,7 @@ run:
     );
 
     let run_json_path = run_dir.join("run.json");
+    let run_status_path = run_dir.join("run_status.json");
     let steps_json_path = run_dir.join("steps.json");
     let run_summary_path = run_dir.join("run_summary.json");
     let scores_path = run_dir.join("learning").join("scores.json");
@@ -2302,6 +2303,11 @@ run:
         run_json_path.is_file(),
         "missing {}",
         run_json_path.display()
+    );
+    assert!(
+        run_status_path.is_file(),
+        "missing {}",
+        run_status_path.display()
     );
     assert!(
         steps_json_path.is_file(),
@@ -2335,6 +2341,26 @@ run:
     assert_eq!(steps[0]["step_id"], "s1");
     assert_eq!(steps[0]["status"], "success");
     assert_eq!(steps[0]["provider_id"], "local");
+    assert_eq!(steps[0]["output_artifact_path"], "s1.txt");
+
+    let run_status_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&run_status_path).unwrap()).unwrap();
+    assert_eq!(run_status_json["run_status_version"], 1);
+    assert_eq!(run_status_json["run_id"], run_id);
+    assert_eq!(run_status_json["workflow_id"], "workflow");
+    assert_eq!(run_status_json["overall_status"], "succeeded");
+    assert_eq!(
+        run_status_json["completed_steps"],
+        serde_json::json!(["s1"])
+    );
+    assert_eq!(run_status_json["pending_steps"], serde_json::json!([]));
+    assert_eq!(run_status_json["started_steps"], serde_json::json!(["s1"]));
+    assert_eq!(run_status_json["attempt_counts_by_step"]["s1"], 1);
+    let run_status_raw = fs::read_to_string(&run_status_path).unwrap();
+    assert!(
+        !run_status_raw.contains(base.to_str().unwrap()),
+        "run_status.json must not leak absolute host paths:\n{run_status_raw}"
+    );
 
     let summary_json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&run_summary_path).unwrap()).unwrap();
@@ -2495,6 +2521,126 @@ run:
             && !suggestions_text.contains("gho_"),
         "suggestions output must not leak absolute host paths or secrets: {suggestions_text}"
     );
+
+    let _ = fs::remove_dir_all(&run_dir);
+}
+
+#[test]
+fn run_status_artifact_is_byte_stable_across_repeated_identical_runs() {
+    let base = tmp_dir("exec-run-status-stability");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::Success);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let run_id = "run-status-stable";
+    let run_dir = repo_runs_dir().join(run_id);
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let yaml = format!(
+        r#"
+version: "0.3"
+providers:
+  local:
+    type: "ollama"
+agents:
+  a1:
+    provider: "local"
+    model: "phi4-mini"
+tasks:
+  t1:
+    prompt:
+      user: "Echo {{text}}"
+run:
+  name: "{run_id}"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "a1"
+        task: "t1"
+        save_as: "s1_out"
+        write_to: "s1.txt"
+        inputs:
+          text: "hello"
+"#
+    );
+    let tmp_yaml = base.join("run-status-stable.yaml");
+    fs::write(&tmp_yaml, yaml).unwrap();
+
+    let out1 = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
+    assert!(out1.status.success(), "first run failed");
+    let first = fs::read(run_dir.join("run_status.json")).unwrap();
+
+    let out2 = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
+    assert!(out2.status.success(), "second run failed");
+    let second = fs::read(run_dir.join("run_status.json")).unwrap();
+
+    assert_eq!(first, second, "run_status.json must be byte-stable");
+
+    let _ = fs::remove_dir_all(run_dir);
+}
+
+#[test]
+fn run_status_failure_kind_maps_timeout_without_raw_provider_error_text() {
+    let listener = match TcpListener::bind("127.0.0.1:0") {
+        Ok(listener) => listener,
+        Err(e) => panic!("failed to bind local test server: {e}"),
+    };
+    let bind_addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf);
+            std::thread::sleep(Duration::from_millis(1200));
+            let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}");
+        }
+    });
+
+    let base = tmp_dir("exec-run-status-timeout");
+    let run_id = "run-status-timeout";
+    let run_dir = repo_runs_dir().join(run_id);
+    let _ = fs::remove_dir_all(&run_dir);
+    let yaml = format!(
+        r#"
+version: "0.5"
+providers:
+  http:
+    type: "http"
+    config:
+      endpoint: "http://{bind_addr}"
+      timeout_secs: 1
+agents:
+  a1:
+    provider: "http"
+    model: "unused-for-http-provider"
+tasks:
+  t1:
+    prompt:
+      user: "timeout"
+run:
+  name: "{run_id}"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "a1"
+        task: "t1"
+"#
+    );
+    let tmp_yaml = base.join("run-status-timeout.yaml");
+    fs::write(&tmp_yaml, yaml).unwrap();
+
+    let out = run_swarm(&[tmp_yaml.to_string_lossy().as_ref(), "--run"]);
+    assert!(!out.status.success(), "timeout run must fail");
+
+    let run_status: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(run_dir.join("run_status.json")).unwrap())
+            .unwrap();
+    assert_eq!(run_status["overall_status"], "failed");
+    assert_eq!(run_status["failure_kind"], "timeout");
+    let raw = serde_json::to_string_pretty(&run_status).unwrap();
+    assert!(!raw.contains("127.0.0.1"));
+    assert!(!raw.contains("providers.<id>.config.timeout_secs"));
 
     let _ = fs::remove_dir_all(&run_dir);
 }
@@ -4267,7 +4413,7 @@ run:
         "--resume",
         run_json_path.to_str().unwrap(),
         "--out",
-        base.join("out-resume").to_str().unwrap(),
+        base.join("out-paused").to_str().unwrap(),
     ]);
     assert!(
         out_resumed.status.success(),
@@ -4289,7 +4435,7 @@ run:
         String::from_utf8_lossy(&out_plain.stderr)
     );
 
-    let resumed_final = fs::read_to_string(base.join("out-resume").join("s3.txt")).unwrap();
+    let resumed_final = fs::read_to_string(base.join("out-paused").join("s3.txt")).unwrap();
     let plain_final = fs::read_to_string(base.join("out-plain").join("s3.txt")).unwrap();
     assert_eq!(resumed_final, plain_final);
 }
@@ -4447,6 +4593,148 @@ fn resume_cli_rejects_missing_pause_state_for_unknown_run_id() {
     assert!(
         stderr.contains("run-id-does-not-exist"),
         "stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn resume_skips_verified_completed_steps_and_preserves_run_status() {
+    let base = tmp_dir("exec-resume-skip-verified");
+    let endpoint = start_fixed_http_provider_server(8, "resume-ok");
+    let paused_case = base.join("paused");
+    fs::create_dir_all(&paused_case).unwrap();
+
+    let paused_yaml = r#"
+version: "0.5"
+providers:
+  http:
+    type: "http"
+    config:
+      endpoint: "__ENDPOINT__"
+agents:
+  a:
+    provider: "http"
+    model: "unused-for-http-provider"
+tasks:
+  t:
+    prompt:
+      user: "step {{n}}"
+run:
+  name: "resume-skip-verified"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "a"
+        task: "t"
+        save_as: "s1"
+        write_to: "s1.txt"
+        inputs: { n: "1" }
+        guards:
+          - type: pause
+            config:
+              reason: "after step 1"
+      - id: "s2"
+        agent: "a"
+        task: "t"
+        save_as: "s2"
+        write_to: "s2.txt"
+        inputs: { n: "2" }
+"#
+    .replace("__ENDPOINT__", &endpoint);
+    let paused_path = paused_case.join("resume-skip.yaml");
+    fs::write(&paused_path, paused_yaml).unwrap();
+
+    let paused = run_swarm_in_dir(&paused_case, &[paused_path.to_str().unwrap(), "--run"]);
+    assert!(paused.status.success(), "paused run should succeed");
+
+    let resumed = run_swarm_in_dir(&paused_case, &["resume", "resume-skip-verified"]);
+    assert!(resumed.status.success(), "resume should succeed");
+    let resumed_stderr = String::from_utf8_lossy(&resumed.stderr);
+    assert!(
+        resumed_stderr.contains("RESUME step=s1 action=skip reason=completed_artifact_verified"),
+        "stderr was:\n{resumed_stderr}"
+    );
+    assert!(
+        !resumed_stderr.contains("STEP start (+0ms) s1"),
+        "resumed run must not rerun verified step s1:\n{resumed_stderr}"
+    );
+
+    let run_status_path = repo_runs_dir()
+        .join("resume-skip-verified")
+        .join("run_status.json");
+    let run_status: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&run_status_path).unwrap()).unwrap();
+    assert_eq!(run_status["overall_status"], "succeeded");
+    assert_eq!(
+        run_status["completed_steps"],
+        serde_json::json!(["s1", "s2"])
+    );
+    assert_eq!(run_status["attempt_counts_by_step"]["s1"], 0);
+    assert_eq!(run_status["attempt_counts_by_step"]["s2"], 1);
+}
+
+#[test]
+fn resume_reruns_completed_step_when_expected_artifact_is_missing() {
+    let base = tmp_dir("exec-resume-rerun-missing");
+    let endpoint = start_fixed_http_provider_server(8, "resume-rerun");
+    let paused_case = base.join("paused");
+    fs::create_dir_all(&paused_case).unwrap();
+
+    let paused_yaml = r#"
+version: "0.5"
+providers:
+  http:
+    type: "http"
+    config:
+      endpoint: "__ENDPOINT__"
+agents:
+  a:
+    provider: "http"
+    model: "unused-for-http-provider"
+tasks:
+  t:
+    prompt:
+      user: "step {{n}}"
+run:
+  name: "resume-rerun-missing"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "a"
+        task: "t"
+        save_as: "s1"
+        write_to: "s1.txt"
+        inputs: { n: "1" }
+        guards:
+          - type: pause
+            config:
+              reason: "after step 1"
+      - id: "s2"
+        agent: "a"
+        task: "t"
+        save_as: "s2"
+        write_to: "s2.txt"
+        inputs: { n: "2" }
+"#
+    .replace("__ENDPOINT__", &endpoint);
+    let paused_path = paused_case.join("resume-rerun.yaml");
+    fs::write(&paused_path, paused_yaml).unwrap();
+
+    let paused = run_swarm_in_dir(&paused_case, &[paused_path.to_str().unwrap(), "--run"]);
+    assert!(paused.status.success(), "paused run should succeed");
+    fs::remove_file(paused_case.join("out").join("s1.txt")).unwrap();
+
+    let resumed = run_swarm_in_dir(&paused_case, &["resume", "resume-rerun-missing"]);
+    assert!(resumed.status.success(), "resume should succeed");
+    let resumed_stderr = String::from_utf8_lossy(&resumed.stderr);
+    assert!(
+        resumed_stderr.contains("RESUME step=s1 action=rerun reason=missing_expected_artifact"),
+        "stderr was:\n{resumed_stderr}"
+    );
+    assert!(
+        resumed_stderr.contains("s1 provider=http"),
+        "missing artifact must force rerun of s1:\n{resumed_stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add deterministic run_status.json via RunArtifactPaths + atomic_write
- harden resume behavior to skip only verified completed artifacts and rerun missing/invalid outputs
- document resilience surfaces v1 and add deterministic taxonomy/resume tests

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test

Closes #491