### PR TITLE
[v0.7][hardening] Remove duplicate remote bin target wiring

### DIFF
--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/bin/swarm_remote.rs"
 
 [[bin]]
 name = "adl-remote"
-path = "src/bin/swarm_remote.rs"
+path = "src/bin/adl_remote.rs"
 
 [dependencies]
 # CLI


### PR DESCRIPTION
## Summary
- fix duplicate Cargo bin target mapping for remote CLI
- wire `adl-remote` to its canonical entrypoint (`src/bin/adl_remote.rs`)
- preserve legacy `swarm-remote` shim behavior

## Why
- removes repeated build-target warning
- avoids duplicate compile/test execution of the same source file
- keeps hardening sweep small and surgical

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test

Closes #492
