### PR TITLE
Daily Automated Test Coverage - 2026-03-03 05:57 Total Coverage: 90.08%

### DIFF
--- a/swarm/tests/cli_smoke.rs
+++ b/swarm/tests/cli_smoke.rs
@@ -336,6 +336,31 @@ fn swarm_shim_help_prints_deprecation_once() {
 }
 
 #[test]
+fn swarm_shim_reports_missing_sibling_adl_binary() {
+    let temp = unique_test_temp_dir("swarm-shim-missing-adl");
+    let copied_swarm = temp.join("swarm");
+    fs::copy(env!("CARGO_BIN_EXE_swarm"), &copied_swarm).expect("copy swarm shim");
+
+    let out = Command::new(&copied_swarm)
+        .arg("--help")
+        .output()
+        .expect("run copied swarm shim");
+    assert!(
+        !out.status.success(),
+        "expected failure without sibling adl binary"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("DEPRECATION: 'swarm' CLI is deprecated; use 'adl' instead."),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("failed to launch 'adl' shim target"),
+        "stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn help_prints_examples() {
     let out = run_swarm(&["--help"]);
     assert!(
@@ -1013,5 +1038,30 @@ fn adl_remote_and_swarm_remote_reject_invalid_bind_deterministically() {
     assert!(
         swarm_stderr.contains("failed to bind remote server"),
         "stderr:\n{swarm_stderr}"
+    );
+}
+
+#[test]
+fn swarm_remote_renamed_binary_skips_legacy_deprecation() {
+    let Ok(swarm_remote) = std::env::var("CARGO_BIN_EXE_swarm_remote") else {
+        return;
+    };
+    let temp = unique_test_temp_dir("swarm-remote-renamed");
+    let renamed = temp.join("adl_remote");
+    fs::copy(swarm_remote, &renamed).expect("copy swarm-remote");
+
+    let out = Command::new(&renamed)
+        .arg("127.0.0.1:not-a-port")
+        .output()
+        .expect("run renamed swarm-remote");
+    assert!(!out.status.success(), "expected bind failure");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("DEPRECATION: 'swarm-remote' is deprecated"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("failed to bind remote server"),
+        "stderr:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Daily Coverage Ratchet

- Baseline total line coverage: **90.05%**
- New total line coverage: **90.08%**
- Delta: **+0.03%**
- Current per-file floor: **82%** (from default yesterday floor 80% + 2%)

### Files Still Below Floor (82%)
- `src/bin/swarm_remote.rs`: 66.67%
- `src/bin/adl_remote.rs`: 81.48%
- `src/bin/swarm.rs`: 81.82%

### Changed Files
- `swarm/tests/cli_smoke.rs`

### Top Remaining Uncovered Targets
- `src/bin/swarm_remote.rs` main invocation branches around legacy-name detection and startup flow
- `src/bin/adl_remote.rs` main path coverage around CLI argument parsing/start path
- `src/bin/swarm.rs` residual uncovered branches (notably platform-conditional `adl_binary_name` and unreachable `current_exe` error path on this platform)

### Notes
- Added two deterministic high-signal integration tests (no production behavior changes):
  - `swarm_shim_reports_missing_sibling_adl_binary`
  - `swarm_remote_renamed_binary_skips_legacy_deprecation`
- Required checks run and passing:
  - `cargo llvm-cov --summary-only`
  - `cargo fmt --all`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo test`

Related blocker tracking issue: #554
