### PR TITLE
[v0.7][docs] Verify and fix documented demo commands

### DIFF
--- a/docs/milestones/v0.7/DEMOS_v0.7.md
+++ b/docs/milestones/v0.7/DEMOS_v0.7.md
@@ -60,6 +60,10 @@ export ADL_REMOTE_REQUEST_SIGNING_PRIVATE_KEY_B64="$(tr -d '\n' < "$tmpdir/.keys
 export ADL_REMOTE_REQUEST_SIGNING_KEY_ID="demo-key-1"
 ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl-remote -- 127.0.0.1:8787 >/tmp/adl-remote-s04.log 2>&1 &
 remote_pid=$!
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  rg -n "Listening on 127.0.0.1:8787" /tmp/adl-remote-s04.log >/dev/null 2>&1 && break
+  sleep 0.2
+done
 ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/v0-7-enterprise-signed-remote.adl.yaml --run --trace --allow-unsigned --out "$tmpdir/out"
 kill "$remote_pid"
 unset ADL_REMOTE_REQUEST_SIGNING_PRIVATE_KEY_B64
@@ -138,10 +142,10 @@ cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/failur
 - Commands:
 ```bash
 ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/v0-6-hitl-pause-resume.adl.yaml --run --trace --allow-unsigned --out .tmp/v07-d06-pause
-ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- resume v0-6-hitl-pause-demo --out .tmp/v07-d06-resume
+ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- resume v0-6-hitl-pause-demo
 ```
 - Expected output: first command pauses at deterministic boundary; resume command completes.
-- Artifact paths: `.adl/runs/v0-6-hitl-pause-demo/pause_state.json`, `.tmp/v07-d06-resume/`.
+- Artifact paths: `.adl/runs/v0-6-hitl-pause-demo/pause_state.json`, `.adl/runs/v0-6-hitl-pause-demo/run_summary.json`, `out/` (resume outputs).
 
 ## D-07 Streaming Is Observational
 - Purpose: Show streaming trace output does not change final artifacts.

--- a/swarm/tools/demo_v0_4.sh
+++ b/swarm/tools/demo_v0_4.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MOCK_BIN="$ROOT/swarm/tools/mock_ollama_v0_4.sh"
 OUT_ROOT="$ROOT/.adl/reports/demo-v0.4"
 
-export SWARM_OLLAMA_BIN="$MOCK_BIN"
+export ADL_OLLAMA_BIN="$MOCK_BIN"
 
 run_demo() {
   local name="$1"
@@ -16,7 +16,7 @@ run_demo() {
   mkdir -p "$out_dir"
 
   echo "==> Running $name"
-  cargo run -q --manifest-path "$ROOT/swarm/Cargo.toml" -- "$yaml" --run --trace --out "$out_dir"
+  cargo run -q --manifest-path "$ROOT/swarm/Cargo.toml" --bin adl -- "$yaml" --run --trace --out "$out_dir"
 }
 
 run_demo "fork-join-swarm" "$ROOT/swarm/examples/v0-4-demo-fork-join-swarm.adl.yaml"


### PR DESCRIPTION
Closes #562

## What changed
- Executed all documented demo commands in the v0.7 demo matrix and README demo sections.
- Fixed S-04 signed-remote startup race in docs by adding a deterministic readiness wait after starting `adl-remote`.
- Fixed D-06 resume command docs to use canonical CLI form: `adl resume <run_id>`.
- Fixed `swarm/tools/demo_v0_4.sh` for multi-binary Cargo by adding `--bin adl` and using canonical `ADL_OLLAMA_BIN`.

## Validation
- Ran S-01..S-05 and D-01..D-12 from `docs/milestones/v0.7/DEMOS_v0.7.md`.
- Ran root README demo commands (quickstart, v0.3 historical, v0.4 legacy).
- Ran `swarm/README.md` demo commands.
- Ran quality gates:
  - `cd swarm && cargo fmt --all`
  - `cd swarm && cargo clippy --all-targets -- -D warnings`
  - `cd swarm && cargo test --workspace`
