### PR TITLE
[v0.7][P0] Fix version mismatch (Cargo.toml + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Badge semantics:
 
 ## Status
 
-Current release: **v0.6.0**
+Current release: **v0.7.0**
 
 ## v0.7 Naming Migration (Compatibility Window)
 

--- a/swarm/Cargo.lock
+++ b/swarm/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ADL (Agent Design Language) reference runtime and CLI"


### PR DESCRIPTION
Closes #564\n\n## Summary\n- set swarm package version to 0.7.0\n- updated root README current release to v0.7.0\n- refreshed lockfile after required build/test\n\n## Validation\n- cd swarm && cargo build --workspace\n- cd swarm && cargo test --workspace