### PR TITLE
[v0.7][P0] Align nightly coverage ratchet policy with release gate

### DIFF
--- a/.github/workflows/nightly-coverage-ratchet.yaml
+++ b/.github/workflows/nightly-coverage-ratchet.yaml
@@ -50,6 +50,10 @@ jobs:
         id: report
         env:
           FILE_THRESHOLD: "80"
+          # Keep nightly per-file ratchet focused on canonical runtime surfaces.
+          # Compatibility shim bins are covered by integration tests and the
+          # workspace 90% gate, but are excluded from per-file floor enforcement.
+          EXCLUDE_FROM_FILE_FLOOR_REGEX: "/swarm/src/bin/swarm.rs$|/swarm/src/bin/swarm_remote.rs$"
         run: |
           set -euo pipefail
 
@@ -108,7 +112,10 @@ jobs:
           fi
 
           : > "$below_path"
-          echo "$per_file_rows" | awk -F '\t' -v threshold="$FILE_THRESHOLD" '
+          echo "$per_file_rows" | awk -F '\t' -v threshold="$FILE_THRESHOLD" -v exclude_re="$EXCLUDE_FROM_FILE_FLOOR_REGEX" '
+            ($1 ~ exclude_re) {
+              next
+            }
             ($4 + 0) < threshold {
               printf "%s\t%d/%d\t%.2f%%\n", $1, $2, $3, $4
             }
@@ -135,6 +142,7 @@ jobs:
             echo
             echo "## Notes"
             echo "- This GitHub Actions workflow is a scheduled watchdog/reporter."
+            echo "- Per-file floor excludes legacy compatibility shim bins (`swarm.rs`, `swarm_remote.rs`); workspace 90% gate remains enforced in CI."
             echo "- Code-changing ratchet work (test authoring + PRs) is still handled by Codex automation."
           } > "$report_path"
 


### PR DESCRIPTION
Closes #571\n\n## Summary\n- document and enforce intentional nightly policy split\n- exclude legacy compatibility shim bins from nightly per-file floor\n- keep workspace coverage gate unchanged\n\n## Validation\n- awk filtering sanity check for exclusion behavior\n- workflow logic reviewed against #554 mismatch