### PR TITLE
[v0.7][P2] Remove absolute runner paths from nightly coverage issue body

### DIFF
--- a/.github/workflows/nightly-coverage-ratchet.yaml
+++ b/.github/workflows/nightly-coverage-ratchet.yaml
@@ -89,7 +89,13 @@ jobs:
             [.data[].files[]
               | select(.filename | contains("/swarm/src/"))
               | {
-                  f:(.filename | gsub("^/home/runner/work/[^/]+/[^/]+/"; "")),
+                  f:(
+                    .filename
+                    | gsub("\\\\"; "/")
+                    | sub("^/home/runner/work/[^/]+/[^/]+/"; "")
+                    | sub("^/__w/[^/]+/[^/]+/"; "")
+                    | sub("^[A-Za-z]:/a/[^/]+/[^/]+/"; "")
+                  ),
                   covered:(.summary.lines.covered // 0),
                   count:(.summary.lines.count // 0)
                 }


### PR DESCRIPTION
Closes #572\n\n## Summary\n- normalize nightly coverage report file paths to repo-relative form\n- remove /home/runner absolute path leakage from issue body\n- keep report semantics and coverage logic unchanged\n\n## Validation\n- jq transformation sanity check with representative runner path fixture