### PR TITLE
[v0.8][P1] Rustdoc coverage improvement pass

### DIFF
--- a/swarm/src/adl.rs
+++ b/swarm/src/adl.rs
@@ -811,7 +811,7 @@ pub struct WorkflowSpec {
     /// Optional workflow-local concurrency cap for concurrent runs.
     ///
     /// Precedence for concurrent workflow runs:
-    /// 1) run.workflow.max_concurrency (or workflows.<id>.max_concurrency via workflow_ref)
+    /// 1) `run.workflow.max_concurrency` (or `workflows.<id>.max_concurrency` via `workflow_ref`)
     /// 2) run.defaults.max_concurrency
     /// 3) runtime default (4)
     #[serde(default)]

--- a/swarm/src/artifacts.rs
+++ b/swarm/src/artifacts.rs
@@ -5,6 +5,9 @@ use serde::Serialize;
 
 pub const ARTIFACT_MODEL_VERSION: u32 = 1;
 
+/// Canonical run artifact path builder.
+///
+/// Produces deterministic, timestamp-free paths under `.adl/runs/<run_id>/`.
 #[derive(Debug, Clone)]
 pub struct RunArtifactPaths {
     run_id: String,
@@ -18,6 +21,7 @@ struct ArtifactModelMarker {
 }
 
 impl RunArtifactPaths {
+    /// Construct deterministic artifact paths for a run id.
     pub fn for_run(run_id: &str) -> Result<Self> {
         let run_id = run_id.trim();
         if run_id.is_empty() {
@@ -29,70 +33,87 @@ impl RunArtifactPaths {
         })
     }
 
+    /// Run identifier associated with this path set.
     pub fn run_id(&self) -> &str {
         &self.run_id
     }
 
+    /// Root directory containing all run artifacts.
     pub fn runs_root(&self) -> &Path {
         &self.runs_root
     }
 
+    /// Run-scoped directory path.
     pub fn run_dir(&self) -> PathBuf {
         self.runs_root.join(&self.run_id)
     }
 
+    /// Canonical `run.json` path.
     pub fn run_json(&self) -> PathBuf {
         self.run_dir().join("run.json")
     }
 
+    /// Canonical `steps.json` path.
     pub fn steps_json(&self) -> PathBuf {
         self.run_dir().join("steps.json")
     }
 
+    /// Canonical pause-state artifact path.
     pub fn pause_state_json(&self) -> PathBuf {
         self.run_dir().join("pause_state.json")
     }
 
+    /// Canonical run-summary artifact path.
     pub fn run_summary_json(&self) -> PathBuf {
         self.run_dir().join("run_summary.json")
     }
 
+    /// Canonical run-status artifact path.
     pub fn run_status_json(&self) -> PathBuf {
         self.run_dir().join("run_status.json")
     }
 
+    /// Output artifact directory.
     pub fn outputs_dir(&self) -> PathBuf {
         self.run_dir().join("outputs")
     }
 
+    /// Logs artifact directory.
     pub fn logs_dir(&self) -> PathBuf {
         self.run_dir().join("logs")
     }
 
+    /// Learning artifact directory.
     pub fn learning_dir(&self) -> PathBuf {
         self.run_dir().join("learning")
     }
 
+    /// Learning scores artifact path.
     pub fn scores_json(&self) -> PathBuf {
         self.learning_dir().join("scores.json")
     }
 
+    /// Learning suggestions artifact path.
     pub fn suggestions_json(&self) -> PathBuf {
         self.learning_dir().join("suggestions.json")
     }
 
+    /// Learning overlays directory.
     pub fn overlays_dir(&self) -> PathBuf {
         self.learning_dir().join("overlays")
     }
 
+    /// Metadata artifact directory.
     pub fn meta_dir(&self) -> PathBuf {
         self.run_dir().join("meta")
     }
 
+    /// Artifact model marker path.
     pub fn artifact_model_marker_json(&self) -> PathBuf {
         self.meta_dir().join("ARTIFACT_MODEL.json")
     }
 
+    /// Ensure canonical directory layout exists for this run.
     pub fn ensure_layout(&self) -> Result<()> {
         let run_dir = self.run_dir();
         std::fs::create_dir_all(&run_dir).with_context(|| {
@@ -109,6 +130,7 @@ impl RunArtifactPaths {
         Ok(())
     }
 
+    /// Write the artifact model marker file atomically.
     pub fn write_model_marker(&self) -> Result<()> {
         let marker = ArtifactModelMarker {
             artifact_model_version: ARTIFACT_MODEL_VERSION,
@@ -119,6 +141,7 @@ impl RunArtifactPaths {
     }
 }
 
+/// Resolve repository run-artifact root (`.adl/runs`).
 pub fn runs_root() -> Result<PathBuf> {
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
     let repo_root = manifest
@@ -127,6 +150,7 @@ pub fn runs_root() -> Result<PathBuf> {
     Ok(repo_root.join(".adl").join("runs"))
 }
 
+/// Atomically write bytes to a file using same-directory temp + rename.
 pub fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
     // Best-effort atomic write strategy:
     // 1) write temp file in the same directory as the target

--- a/swarm/src/delegation_policy.rs
+++ b/swarm/src/delegation_policy.rs
@@ -2,10 +2,14 @@ use crate::adl::{
     DelegationActionKind, DelegationPolicySpec, DelegationRuleEffect, DelegationSpec,
 };
 
+/// Result of evaluating delegation policy for an attempted action.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DelegationDecision {
+    /// Delegated action is permitted immediately.
     Allowed,
+    /// Delegated action is rejected by policy.
     Denied,
+    /// Delegated action is permitted only after explicit approval.
     NeedsApproval,
 }
 
@@ -21,10 +25,19 @@ impl DelegationDecision {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DelegationPolicyOutcome {
+    /// Final policy decision for this attempted action.
     pub decision: DelegationDecision,
+    /// Matched rule id when a concrete policy rule decided the outcome.
     pub rule_id: Option<String>,
 }
 
+/// Evaluate delegation policy for a single action and target.
+///
+/// Evaluation order is deterministic:
+/// 1) if delegation metadata is absent, allow
+/// 2) if no policy exists, allow
+/// 3) first matching rule in declared order decides
+/// 4) otherwise fall back to `default_allow`
 pub fn evaluate(
     policy: Option<&DelegationPolicySpec>,
     delegation: Option<&DelegationSpec>,

--- a/swarm/src/execute.rs
+++ b/swarm/src/execute.rs
@@ -376,7 +376,7 @@ fn emit_resume_note(enabled: bool, step_id: &str, action: &str, reason: &str) {
 /// - ready-step ordering is lexicographic by full step id
 /// - bounded batches preserve deterministic output/record order
 /// - effective max concurrency for concurrent workflow runs is deterministic and applied as:
-///   1) run.workflow.max_concurrency (or workflows.<id>.max_concurrency via workflow_ref)
+///   1) `run.workflow.max_concurrency` (or `workflows.<id>.max_concurrency` via `workflow_ref`)
 ///   2) run.defaults.max_concurrency
 ///   3) DEFAULT_MAX_CONCURRENCY
 pub fn execute_sequential(

--- a/swarm/src/learning_export.rs
+++ b/swarm/src/learning_export.rs
@@ -9,6 +9,7 @@ use crate::artifacts;
 pub const DATASET_VERSION: u32 = 1;
 pub const BUNDLE_VERSION: u32 = 1;
 
+/// Deterministic learning export row (JSONL format).
 #[derive(Debug, Serialize)]
 pub struct DatasetRowV1 {
     pub dataset_version: u32,
@@ -24,6 +25,7 @@ pub struct DatasetRowV1 {
     pub suggestions_summary: SuggestionsSummary,
 }
 
+/// Stable per-step record embedded in dataset exports.
 #[derive(Debug, Serialize)]
 pub struct StepRecord {
     pub step_id: String,
@@ -33,6 +35,7 @@ pub struct StepRecord {
     pub output_pointer_hash: Option<String>,
 }
 
+/// Compact deterministic suggestions summary.
 #[derive(Debug, Default, Serialize)]
 pub struct SuggestionsSummary {
     pub ids: Vec<String>,
@@ -65,6 +68,13 @@ struct BundleFileEntry {
     hash: String,
 }
 
+/// Export selected runs as deterministic JSONL rows.
+///
+/// # Examples
+///
+/// ```text
+/// adl learn export --format jsonl --runs-dir .adl/runs --out /tmp/learning.jsonl
+/// ```
 pub fn export_jsonl(runs_root: &Path, run_ids: &[String], out_file: &Path) -> Result<usize> {
     let mut ids = resolve_export_ids(runs_root, run_ids)?;
 
@@ -82,6 +92,13 @@ pub fn export_jsonl(runs_root: &Path, run_ids: &[String], out_file: &Path) -> Re
     Ok(lines.len())
 }
 
+/// Export selected runs as bundle v1 under `learning_export_v1/`.
+///
+/// # Examples
+///
+/// ```text
+/// adl learn export --format bundle --runs-dir .adl/runs --out /tmp/learning-bundle
+/// ```
 pub fn export_bundle_v1(runs_root: &Path, run_ids: &[String], out_dir: &Path) -> Result<usize> {
     let ids = resolve_export_ids(runs_root, run_ids)?;
     let bundle_root = out_dir.join("learning_export_v1");

--- a/swarm/src/learning_guardrails.rs
+++ b/swarm/src/learning_guardrails.rs
@@ -9,6 +9,7 @@
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[allow(dead_code)] // Wired into overlay-apply path in #485.
+/// Internal mutation-intent envelope used for overlay security validation.
 pub(crate) struct OverlaySecurityMutationAttempt {
     pub require_signed_requests: Option<bool>,
     pub allow_unsigned: Option<bool>,
@@ -23,6 +24,7 @@ pub(crate) struct OverlaySecurityMutationAttempt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)] // Wired into overlay-apply path in #485.
 #[allow(clippy::enum_variant_names)] // Mirrors stable *_IMMUTABLE error-code taxonomy.
+/// Guardrail classification for blocked overlay security mutations.
 pub(crate) enum LearningGuardrailError {
     TrustPolicyImmutable,
     SandboxPolicyImmutable,
@@ -31,6 +33,7 @@ pub(crate) enum LearningGuardrailError {
 
 #[allow(dead_code)] // Wired into overlay-apply path in #485.
 impl LearningGuardrailError {
+    /// Stable machine-readable error code.
     pub(crate) fn code(&self) -> &'static str {
         match self {
             Self::TrustPolicyImmutable => "LEARNING_GUARDRAIL_TRUST_POLICY_IMMUTABLE",
@@ -39,6 +42,7 @@ impl LearningGuardrailError {
         }
     }
 
+    /// Human-readable explanation suitable for operator logs.
     pub(crate) fn message(&self) -> &'static str {
         match self {
             Self::TrustPolicyImmutable => {
@@ -55,6 +59,7 @@ impl LearningGuardrailError {
 }
 
 #[allow(dead_code)] // Wired into overlay-apply path in #485.
+/// Validate that overlay mutation intents do not weaken immutable security surfaces.
 pub(crate) fn validate_overlay_security_guardrails(
     attempt: &OverlaySecurityMutationAttempt,
 ) -> Result<(), LearningGuardrailError> {

--- a/swarm/src/overlay.rs
+++ b/swarm/src/overlay.rs
@@ -11,18 +11,25 @@ use crate::learning_guardrails::{
 
 pub const OVERLAY_VERSION: u32 = 1;
 
+/// Overlay schema v1 used for deterministic learning-time config mutations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OverlaySpecV1 {
+    /// Overlay schema version marker.
     pub overlay_version: u32,
+    /// Logical source run id for audit linkage (optional).
     #[serde(default)]
     pub base_run_id: Option<String>,
+    /// Author/automation identifier.
     pub created_by: String,
+    /// Source artifact versions used to generate this overlay.
     pub created_from: OverlayCreatedFrom,
+    /// Ordered set of overlay changes to apply.
     #[serde(default)]
     pub changes: Vec<OverlayChange>,
 }
 
+/// Version metadata captured when overlay is generated from learning artifacts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OverlayCreatedFrom {
@@ -32,24 +39,34 @@ pub struct OverlayCreatedFrom {
     pub artifact_model_version: Option<u32>,
 }
 
+/// Supported overlay operation kinds.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OverlayOp {
+    /// Set the target field to a new value.
     Set,
 }
 
+/// Single overlay mutation entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OverlayChange {
+    /// Stable change identifier.
     pub id: String,
+    /// Canonical target path.
     pub path: String,
+    /// Mutation operation.
     pub op: OverlayOp,
+    /// New value to apply.
     pub value: JsonValue,
+    /// Human-readable reason.
     pub rationale: String,
+    /// Optional supporting evidence object.
     #[serde(default)]
     pub evidence: Option<JsonValue>,
 }
 
+/// Deterministic audit payload emitted after overlay application.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppliedOverlayAudit {
@@ -59,6 +76,7 @@ pub struct AppliedOverlayAudit {
     pub applied_paths: Vec<String>,
 }
 
+/// Load and validate an overlay file from disk.
 pub fn load_overlay(path: &Path) -> Result<OverlaySpecV1> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read overlay file '{}'", path.display()))?;
@@ -78,6 +96,7 @@ pub fn load_overlay(path: &Path) -> Result<OverlaySpecV1> {
     Ok(overlay)
 }
 
+/// Apply an overlay to an ADL document and return deterministic audit metadata.
 pub fn apply_overlay_to_doc(
     doc: &mut adl::AdlDoc,
     overlay: &OverlaySpecV1,

--- a/swarm/src/sandbox.rs
+++ b/swarm/src/sandbox.rs
@@ -3,6 +3,7 @@ use std::path::{Component, Path, PathBuf};
 /// Best-effort filesystem policy for sandbox path resolution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SandboxPathPolicy {
+    /// When false, traversing any symlinked component is denied.
     pub allow_symlink_traversal: bool,
 }
 
@@ -16,31 +17,48 @@ impl Default for SandboxPathPolicy {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SandboxPathError {
+    /// Path was denied before canonical resolution.
     PathDenied {
+        /// Sanitized requested path (never host-absolute).
         requested_path: String,
+        /// Stable machine-readable denial reason.
         reason: &'static str,
     },
+    /// Requested path does not exist.
     PathNotFound {
+        /// Sanitized requested path.
         requested_path: String,
     },
+    /// Path could not be canonicalized safely/deterministically.
     PathNotCanonical {
+        /// Sanitized requested path.
         requested_path: String,
     },
+    /// Symlink traversal is disallowed by sandbox policy.
     SymlinkDisallowed {
+        /// Sanitized requested path.
         requested_path: String,
+        /// Optional sanitized resolved path.
         resolved_path: Option<String>,
     },
+    /// Canonical path escapes the sandbox root.
     EscapeAttempt {
+        /// Sanitized requested path.
         requested_path: String,
+        /// Optional sanitized resolved path.
         resolved_path: Option<String>,
     },
+    /// IO error occurred while validating path safety.
     IoError {
+        /// Sanitized requested path.
         requested_path: String,
+        /// Stable operation label where the IO error occurred.
         operation: &'static str,
     },
 }
 
 impl SandboxPathError {
+    /// Stable error code used by traces/artifacts and tests.
     pub fn code(&self) -> &'static str {
         match self {
             Self::PathDenied { .. } => "sandbox_path_denied",
@@ -52,6 +70,7 @@ impl SandboxPathError {
         }
     }
 
+    /// Human-readable, safe message without host-absolute paths.
     pub fn message(&self) -> String {
         match self {
             Self::PathDenied { reason, .. } => {
@@ -76,6 +95,7 @@ impl SandboxPathError {
         }
     }
 
+    /// Sanitized requested path when available.
     pub fn requested_path(&self) -> Option<&str> {
         match self {
             Self::PathDenied { requested_path, .. }
@@ -87,6 +107,7 @@ impl SandboxPathError {
         }
     }
 
+    /// Sanitized resolved path for escape/symlink errors.
     pub fn resolved_path(&self) -> Option<&str> {
         match self {
             Self::SymlinkDisallowed { resolved_path, .. }
@@ -255,6 +276,10 @@ pub fn resolve_existing_path_within_root(
     resolve_existing_path_within_root_with_policy(root, candidate, SandboxPathPolicy::default())
 }
 
+/// Resolve an existing file path under a sandbox root with explicit policy.
+///
+/// This enforces canonical ancestry under `root`, and optionally blocks any
+/// traversed symlink component.
 pub fn resolve_existing_path_within_root_with_policy(
     root: &Path,
     candidate: &Path,
@@ -301,6 +326,10 @@ pub fn resolve_relative_path_for_write_within_root(
     resolve_relative_path_for_write_within_root_with_policy(root, rel, SandboxPathPolicy::default())
 }
 
+/// Resolve a relative path for write operations under the sandbox root.
+///
+/// Non-existent targets are accepted only when their nearest existing ancestor
+/// canonicalizes under `root`.
 pub fn resolve_relative_path_for_write_within_root_with_policy(
     root: &Path,
     rel: &Path,


### PR DESCRIPTION
Closes #565\n\n## Summary\n- expand rustdoc coverage for targeted public API modules\n- add/clarify docs for public structs, enums, fields, and functions\n- keep scope docs-only (no behavior changes)\n\n## Validation\n- cargo fmt --all -- --check\n- cargo clippy --all-targets -- -D warnings\n- cargo test --workspace\n- cargo doc --workspace --no-deps