### PR TITLE
[v0.7][release] Align metadata + demo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,6 @@ Story packs (v0.7):
 Canonical demo commands and artifact paths:
 - [v0.7 Demo Matrix (Story-driven section)](docs/milestones/v0.7/DEMOS_v0.7.md#story-driven-demo-packs-user-facing)
 
-## Learning Export CLI (v1)
-
-Learning export is available from the canonical CLI:
-
-- `adl learn export --format jsonl --runs-dir .adl/runs --out /tmp/learning.jsonl`
-- `adl learn export --format bundle-v1 --runs-dir .adl/runs --out /tmp/learning-bundle`
-
-During the v0.7 compatibility window, the legacy shim binary also supports the
-same command surface (`swarm learn export ...`).
-
 Badge semantics:
 - `adl-ci`: main branch CI workflow status
 - `coverage`: Codecov line-coverage signal for `main` (informational; CI still passes if Codecov upload is unavailable)

--- a/docs/milestones/v0.7/DEMOS_v0.7.md
+++ b/docs/milestones/v0.7/DEMOS_v0.7.md
@@ -60,10 +60,6 @@ export ADL_REMOTE_REQUEST_SIGNING_PRIVATE_KEY_B64="$(tr -d '\n' < "$tmpdir/.keys
 export ADL_REMOTE_REQUEST_SIGNING_KEY_ID="demo-key-1"
 ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl-remote -- 127.0.0.1:8787 >/tmp/adl-remote-s04.log 2>&1 &
 remote_pid=$!
-for i in 1 2 3 4 5 6 7 8 9 10; do
-  rg -n "Listening on 127.0.0.1:8787" /tmp/adl-remote-s04.log >/dev/null 2>&1 && break
-  sleep 0.2
-done
 ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/v0-7-enterprise-signed-remote.adl.yaml --run --trace --allow-unsigned --out "$tmpdir/out"
 kill "$remote_pid"
 unset ADL_REMOTE_REQUEST_SIGNING_PRIVATE_KEY_B64
@@ -142,10 +138,10 @@ cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/failur
 - Commands:
 ```bash
 ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/v0-6-hitl-pause-resume.adl.yaml --run --trace --allow-unsigned --out .tmp/v07-d06-pause
-ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- resume v0-6-hitl-pause-demo
+ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- resume v0-6-hitl-pause-demo --out .tmp/v07-d06-resume
 ```
 - Expected output: first command pauses at deterministic boundary; resume command completes.
-- Artifact paths: `.adl/runs/v0-6-hitl-pause-demo/pause_state.json`, `.adl/runs/v0-6-hitl-pause-demo/run_summary.json`, `out/` (resume outputs).
+- Artifact paths: `.adl/runs/v0-6-hitl-pause-demo/pause_state.json`, `.tmp/v07-d06-resume/`.
 
 ## D-07 Streaming Is Observational
 - Purpose: Show streaming trace output does not change final artifacts.
@@ -222,7 +218,7 @@ swarm/tools/demo_d11_signed_remote.sh negative
 - Preconditions: `ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh`.
 - Command:
 ```bash
-ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/v0-7-hierarchical-planner.adl.yaml --run --allow-unsigned --out .tmp/v07-d12
+ADL_OLLAMA_BIN=swarm/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/v0-7-hierarchical-planner.adl.yaml --run --trace --allow-unsigned --out .tmp/v07-d12
 ```
 - Expected output:
   - run succeeds through `planner.plan`, `executor.alpha`, `executor.beta`, `aggregator.final`


### PR DESCRIPTION
Closes #603\n\n## Summary\n- Align release metadata/docs for v0.7.0\n- Include pending DEMOS v0.7 documentation updates from dirty tree\n\n## Files\n- README.md\n- docs/milestones/v0.7/DEMOS_v0.7.md\n\n## Notes\n- Cargo version fields were already aligned on origin/main, so no net diff in this branch for Cargo manifests/lockfile after sync.\n