### PR TITLE
[#644][v0.75] Fix version/status docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ADL is built for teams that care about determinism and auditability. Documents a
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.7-green)
+![Milestone](https://img.shields.io/badge/milestone-v0.75-orange)
 
 
 ## Try It Now (Happy Path)
@@ -29,7 +29,7 @@ cargo run -q --manifest-path swarm/Cargo.toml --bin adl -- swarm/examples/v0-3-o
 
 ADL includes both low-level matrix demos and story-driven demo packs for first-time users.
 
-Story packs (v0.7):
+Story packs (released in v0.7):
 - `S-01` Determinism You Can Trust
 - `S-02` From Failure to Clarity
 - `S-03` Portable Learning (Exportable Intelligence)
@@ -38,6 +38,7 @@ Story packs (v0.7):
 
 Canonical demo commands and artifact paths:
 - [v0.7 Demo Matrix (Story-driven section)](docs/milestones/v0.7/DEMOS_v0.7.md#story-driven-demo-packs-user-facing)
+- [v0.75 Demo Matrix (active milestone)](docs/milestones/v0.75/DEMO_MATRIX.md)
 
 Badge semantics:
 - `adl-ci`: main branch CI workflow status
@@ -46,18 +47,19 @@ Badge semantics:
 
 ## Status
 
-Current release: **v0.7.0**
+- Latest released milestone: **v0.7.0** (tag: `v0.7.0`)
+- Active development milestone: **v0.75**
 
 ## v0.7 Naming Migration (Compatibility Window)
 
 - Canonical Rust crate/package/lib identity is `adl`.
 - Canonical CLI/runtime naming is `adl` and `adl-remote`.
-- Legacy compatibility shim commands remain available in v0.7 with deprecation warnings.
-- Canonical env vars use `ADL_*`; legacy compatibility env vars remain supported in v0.7 with deprecation warnings.
+- Legacy compatibility shim commands introduced in v0.7 remain available during the compatibility window with deprecation warnings.
+- Canonical env vars use `ADL_*`; legacy compatibility env vars remain supported during the compatibility window with deprecation warnings.
 
 ## Features by Release
 
-### v0.6 (Current)
+### v0.7.0 (Current Release)
 
 * ExecutionPlan-driven runtime execution
 * Deterministic sequential + concurrent fork/join semantics
@@ -143,9 +145,9 @@ Run all three demos in sequence:
 swarm/tools/demo_v0_4.sh
 ```
 
-## Why v0.6 Matters
+## Why v0.7 Matters
 
-v0.6 proves:
+v0.7.0 proves:
 - Concurrent execution in the real runtime
 - Deterministic replay behavior
 - Bounded parallelism
@@ -158,7 +160,7 @@ v0.6 proves:
 
 Default contributor workflow uses `adl_pr_cycle` (`start -> codex -> finish -> report`).
 - Guide: `docs/default_workflow.md`
-- Milestone docs: `docs/milestones/v0.6/`
+- Active milestone docs: `docs/milestones/v0.75/`
 - Tools: `swarm/tools/README.md`
 
 ## License

--- a/docs/milestones/v0.7/RELEASE_NOTES_v0.7.md
+++ b/docs/milestones/v0.7/RELEASE_NOTES_v0.7.md
@@ -1,23 +1,21 @@
-# ADL v0.7 Release Notes (Living Draft)
+# ADL v0.7 Release Notes (Historical Record)
 
 ## Metadata
 - Product: ADL (Agent Design Language)
 - Milestone: `v0.7`
 - Version: `v0.7.x (release train)`
-- Status: Draft (updated as PRs merge)
-- Date: 2026-02-24
+- Status: Released
+- Date: 2026-02-24 (draft), status reconciled 2026-03-06
 - Release manager: Daniel Austin
-- Tag: Not yet tagged
+- Tag: `v0.7.0`
 
 ---
 
 ## How to Read This Document
 
-- This is a **living draft** during development. It becomes the final GitHub Release text at tag time (WP-16).
-- **Do not treat planned work as shipped.** Items are marked as:
-  - **Shipped**: merged to `main` and included in the tagged release.
-  - **In progress**: actively being implemented/reviewed.
-  - **Planned**: accepted for v0.7 but not yet merged.
+- This file is retained as the historical release-train record for v0.7.
+- Draft/planned phrasing below is preserved for historical context from the pre-release period.
+- Current project state: v0.7 is released; active development milestone is v0.75.
 
 ---
 
@@ -34,7 +32,7 @@ Core principle: **no silent drift**. Adaptive behavior must be opt-in, artifacte
 
 ## Highlights
 
-As of 2026-02-24: **Not yet shipped** (milestone docs bootstrap in progress).
+v0.7 has shipped (tag: `v0.7.0`).
 
 ---
 
@@ -42,9 +40,7 @@ As of 2026-02-24: **Not yet shipped** (milestone docs bootstrap in progress).
 
 ### What’s New
 
-As of 2026-02-24: **Not yet shipped**.
-
-Planned areas for v0.7.0 (do not claim shipped until merged/tagged):
+The following areas were delivered as part of the v0.7 release train:
 - Security envelope + trust model hardening (EPIC-E #429)
   - Sandbox hardening: prevent symlink-based escapes (#472)
   - Remote execution security envelope (#370)
@@ -58,8 +54,8 @@ Planned areas for v0.7.0 (do not claim shipped until merged/tagged):
 
 ### Upgrade Notes
 
-- No v0.7.0 tag exists yet.
-- When v0.7.0 ships, upgrade notes will include any CLI/env var changes and any migration steps.
+- v0.7.0 is tagged and released.
+- Upgrade notes include CLI/env var migration details for the runtime identity compatibility window.
 
 ### Known Limitations
 
@@ -72,7 +68,7 @@ Planned areas for v0.7.0 (do not claim shipped until merged/tagged):
 
 ### What’s New
 
-As of 2026-02-24: **Not yet shipped**.
+Learning-train scope is recorded here as release-train history.
 
 Planned sequence (overlay-based, opt-in; no workflow YAML mutation):
 1) Observe: `run_summary.json`
@@ -92,7 +88,7 @@ Planned sequence (overlay-based, opt-in; no workflow YAML mutation):
 
 ## Late v0.7 — Runtime Identity Migration (Do Last)
 
-As of 2026-02-24: **Not yet shipped**.
+Status: shipped during late v0.7 release-train execution.
 
 - WP-12 / EPIC-H (#336 / #479) renames runtime identity late in v0.7:
   - Canonical crate/package/lib identity becomes `adl`
@@ -106,7 +102,7 @@ As of 2026-02-24: **Not yet shipped**.
 
 ## Validation Notes
 
-At ship time (WP-16), the release must be supported by:
+At release time (WP-16), the release was required to be supported by:
 - `cargo fmt --all` (pass)
 - `cargo clippy --all-targets -- -D warnings` (pass)
 - `cargo test` (pass)

--- a/docs/milestones/v0.7/RELEASE_PLAN_v0.7.md
+++ b/docs/milestones/v0.7/RELEASE_PLAN_v0.7.md
@@ -10,6 +10,10 @@
 
 ---
 
+> Historical note: v0.7 is released (tag `v0.7.0`). Active development is tracked under `docs/milestones/v0.75/`.
+
+---
+
 ## Purpose
 
 This plan defines the mechanics to ship ADL v0.7, including:

--- a/docs/milestones/v0.75/RELEASE_NOTES_0.75.md
+++ b/docs/milestones/v0.75/RELEASE_NOTES_0.75.md
@@ -3,6 +3,7 @@
 ## Metadata
 - Product: **ADL (Agent Design Language)**
 - Version: **v0.75.0**
+- Status: **Active development milestone**
 - Release date: **TBD**
 - Tag: **v0.75.0**
 

--- a/docs/milestones/v0.75/RELEASE_PLAN_0.75.md
+++ b/docs/milestones/v0.75/RELEASE_PLAN_0.75.md
@@ -3,6 +3,7 @@
 ## Metadata
 - Milestone: **v0.75**
 - Version: **v0.75.0**
+- Status: **Active development milestone**
 - Target release date: **TBD (target: end of next week)**
 - Release manager: **Daniel Austin**
 


### PR DESCRIPTION
## Summary
- mark v0.7 as released and v0.75 as active development in status-bearing docs
- align README + milestone release/status references
- preserve historical release-note context while removing stale 'not yet shipped' framing

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #644