### PR TITLE
[#647][v0.75] Add ObsMem ADR and user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Current release: **v0.7.0**
 - `adl-spec/`: language-level specification docs
 - `docs/`: contributor workflow and roadmap docs
 - `docs/adr/`: architecture decision records (major technical decisions)
+- `docs/OBSMEM.md`: user-facing ObsMem boundary and usage guide (v0.75)
 - `.adl/`: cards, reports, and run/report artifacts
 
 ## Historical v0.3 Plan-Only Commands

--- a/docs/OBSMEM.md
+++ b/docs/OBSMEM.md
@@ -1,0 +1,59 @@
+# ObsMem User Guide (v0.75)
+
+This guide explains the user-facing ObsMem surface in ADL v0.75.
+
+## What ObsMem Is in v0.75
+
+ObsMem in v0.75 is an operational memory boundary built on deterministic ADL
+run artifacts and traces.
+
+Important scope notes:
+- ObsMem is external to the core runtime implementation.
+- ADL integrates through a contract/adapter boundary.
+- Deterministic indexing/retrieval behavior is required for identical inputs.
+
+## Why ObsMem Is External
+
+ADL keeps memory decoupled so core execution/replay remains stable and
+backend-agnostic. Runtime code depends on `swarm::obsmem_contract` and adapter
+surfaces, not a concrete memory service implementation.
+
+## Contract and Versioning Expectations
+
+Contract surface:
+- `ObsMemClient::write_entry(...)`
+- `ObsMemClient::query(...)`
+
+Validation expectations:
+- Requests are validated for required fields and path safety.
+- Relative artifact paths are required.
+- Validation failures are surfaced as explicit contract errors.
+
+Versioning expectations:
+- Contract behavior must remain deterministic for equivalent validated inputs.
+- Future backend evolution must preserve contract semantics and ordering rules.
+
+## Deterministic Indexing and Retrieval
+
+v0.75 indexing/retrieval behavior is deterministic:
+- Indexing derives ordered context from activation-log event order.
+- Query policy normalizes tags/limits/filters deterministically.
+- Retrieval ordering uses deterministic tie-break rules.
+
+For identical normalized request inputs and identical index state, result-set
+membership and ordering should be identical.
+
+## Current User-Facing Usage Surface
+
+v0.75 does not expose a dedicated top-level `adl obsmem ...` CLI.
+
+ObsMem behavior is demonstrated through existing workflows and artifacts:
+- Run with `ADL_OBSMEM_DEMO=1` in the demo matrix.
+- Inspect emitted artifacts under:
+  - `.adl/runs/<run_id>/learning/obs_mem_index_summary.json`
+  - `.adl/runs/<run_id>/learning/obs_mem_query_result.json`
+
+See:
+- `docs/milestones/v0.75/DEMO_MATRIX.md`
+- `docs/milestones/v0.75/OBSMEM_INTEGRATION_CONTRACT_0.75.md`
+- `docs/adr/0007-obsmem-external-boundary.md`

--- a/docs/adr/0007-obsmem-external-boundary.md
+++ b/docs/adr/0007-obsmem-external-boundary.md
@@ -1,0 +1,53 @@
+# ADR 0007: ObsMem External Boundary for v0.75
+
+## Status
+
+Accepted (v0.75).
+
+## Context
+
+ADL v0.75 introduces ObsMem indexing/retrieval surfaces while preserving core
+runtime determinism and replay guarantees. Review feedback highlighted missing
+architectural documentation for why ObsMem is kept outside core runtime logic
+and how versioned contracts should be treated.
+
+Current runtime integration points are:
+- `swarm::obsmem_contract` (`ObsMemClient` trait and request/response types)
+- `swarm::obsmem_adapter` (runtime-facing adapter to contract client)
+- `swarm::obsmem_indexing` and `swarm::obsmem_retrieval_policy` (deterministic
+  indexing/query policy behavior)
+
+## Decision
+
+For v0.75, ObsMem remains an external subsystem behind a stable contract
+boundary and is not embedded as a hard runtime dependency.
+
+The canonical integration model is:
+1. ADL runtime emits deterministic artifacts/traces.
+2. Adapter builds validated contract requests from those artifacts.
+3. An `ObsMemClient` implementation handles write/query behavior.
+4. Retrieval remains optional and must not change replay determinism.
+
+Versioning and contract expectations:
+- Contract payloads are validated before client usage.
+- Validation failures return explicit contract errors.
+- Request/path surfaces are relative-path constrained and privacy-safe.
+- Future backends may evolve independently as long as they honor contract
+  semantics and deterministic ordering guarantees.
+
+## Consequences
+
+Positive:
+- Preserves runtime modularity and reduces coupling risk.
+- Keeps replay-sufficient artifacts independent of memory backend availability.
+- Makes deterministic validation behavior testable at the contract boundary.
+
+Trade-offs:
+- No single built-in memory backend in core runtime for v0.75.
+- Users must treat memory operations as boundary-driven integration surfaces.
+
+## Related References
+
+- `docs/OBSMEM.md`
+- `docs/milestones/v0.75/OBSMEM_INTEGRATION_CONTRACT_0.75.md`
+- `docs/milestones/v0.75/DESIGN_0.75.md`

--- a/docs/milestones/v0.75/DEMO_MATRIX.md
+++ b/docs/milestones/v0.75/DEMO_MATRIX.md
@@ -28,6 +28,7 @@ No network access is required.
 
 - Design contract: `docs/milestones/v0.75/DESIGN_0.75.md`
 - Demo planning context: `docs/milestones/v0.75/DEMO_PLANNING.md`
+- User-facing ObsMem guide: `docs/OBSMEM.md`
 
 ## Demo Matrix
 


### PR DESCRIPTION
## Summary
- add ObsMem ADR under docs/adr documenting external boundary decision
- add user-facing docs/OBSMEM.md for contract/versioning and deterministic usage expectations
- add milestone cross-reference from v0.75 demo docs to user guide

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #647