### PR TITLE
[v0.8][WP-01B] Reconcile v0.8 canonical doc inconsistencies

### DIFF
--- a/docs/milestones/v0.8/ADAPTIVE_EXECUTION_ENGINE.md
+++ b/docs/milestones/v0.8/ADAPTIVE_EXECUTION_ENGINE.md
@@ -1,8 +1,11 @@
 # Adaptive Execution Engine (AEE)
 
+**Status:** Incubation / planning
+**Milestone:** v0.8+ (deferred; likely v0.9)
+
 ## Overview
 
-The **Adaptive Execution Engine (AEE)** is the runtime subsystem in ADL responsible for persistent, policy‑gated task execution. Its purpose is to allow agents to **continue working toward a goal despite failures**, using bounded strategies, deterministic replay, and explicit artifacts.
+The **Adaptive Execution Engine (AEE)** is a planned runtime subsystem in ADL for persistent, policy‑gated task execution. Its purpose is to allow agents to **continue working toward a goal despite failures**, using bounded strategies, deterministic replay, and explicit artifacts.
 
 This capability provides the “sticktoitiveness” behavior commonly observed in advanced coding agents: when a task fails, the system attempts alternative strategies rather than terminating immediately.
 
@@ -13,7 +16,7 @@ Unlike most agent frameworks, the Adaptive Execution Engine is:
 - **Policy‑bounded** (no silent capability escalation)
 - **Artifact‑driven** (all adaptation decisions are captured as trace artifacts)
 
-Conceptually, the AEE serves as a deterministic control system that manages attempts, retries, and strategy changes. ADL agents run workflows and complete tasks using the AEE, which serves as a 'control plane' of sorts for ADL agents and their activities.
+Conceptually, the AEE serves as a deterministic control system that manages attempts, retries, and strategy changes. This document defines the planning contract and does not imply that AEE ships in the v0.8 GA scope.
 
 ---
 

--- a/docs/milestones/v0.8/ARCHITECTURE_V0.8.md
+++ b/docs/milestones/v0.8/ARCHITECTURE_V0.8.md
@@ -10,7 +10,7 @@ This document defines how the following pillars fit together:
 
 - Deterministic Workflow Runtime
 - Replay / Auto‑Retry / Checkpointing
-- ObsMem (Observational Memory + Bayesian Retrieval)
+- ObsMem integration boundary (v0.75 foundation)
 - Gödel Self‑Improvement Model
 - Authoring Surfaces (Plain English → ADL)
 
@@ -152,14 +152,15 @@ Trace bundles are:
 
 ---
 
-## 2.6 ObsMem — Observational Memory
+## 2.6 ObsMem Integration Boundary (v0.75 Foundation)
 
-ObsMem ingests trace bundles and builds:
+ObsMem is treated as an existing dependency from v0.75 and remains outside the v0.8 runtime expansion surface.
+
+ObsMem capabilities available to v0.8:
 
 - Structured index
-- Optional embedding index
-- Derived feature store
-- Bayesian ranking layer
+- Deterministic retrieval over indexed evidence
+- Derived feature summaries
 
 ObsMem retrieval must:
 
@@ -167,14 +168,14 @@ ObsMem retrieval must:
 - Always explain score components
 - Be deterministic given index state + query
 
-ObsMem provides:
+ObsMem integration provides:
 
-- Smart RAG over runs
+- Evidence retrieval over prior runs
 - Failure similarity search
 - Provider/policy analytics
 - Stability metrics
 
-See `OBSMEM_BAYES.md` for full model.
+See `incubation/OBSMEM_BAYES.md` for background model details.
 
 ---
 
@@ -217,6 +218,7 @@ Must ship:
 - Failure taxonomy
 - Auto‑retry policy
 - Trace bundle export v2
+- ObsMem indexing + retrieval v1
 
 v0.75 delivers infrastructure only.
 
@@ -226,8 +228,6 @@ v0.75 delivers infrastructure only.
 
 Must ship:
 
-- ObsMem indexing + retrieval v1
-- Smart RAG over runs
 - Gödel mutation + evaluation harness
 - Authoring Surfaces v1
 - 2–3 flagship end‑to‑end demos
@@ -247,12 +247,12 @@ v0.8 is complete when we can demonstrate:
 - Simulated failure
 - Auto‑retry
 - Replay explains failure
-- ObsMem retrieves similar cases
+- Retrieval surfaces consume v0.75 ObsMem evidence deterministically
 
 ### Demo 2 — Operational Intelligence
 
 - Query: "Best provider under budget"
-- ObsMem returns ranked, cited results
+- Retrieval results are deterministic, cited, and replay-auditable
 - Deterministic ranking
 
 ### Demo 3 — Gödel Improvement Loop
@@ -328,8 +328,8 @@ Implementation order recommendation:
 
 1. Lock execution contract
 2. Lock trace bundle schema
-3. Implement minimal structured ObsMem index
-4. Add Bayesian ranking layer
+3. Consume v0.75 ObsMem retrieval/indexing surfaces
+4. Add v0.8 retrieval integration reports
 5. Build replay‑backed Gödel evaluation harness
 6. Expose authoring loop
 

--- a/docs/milestones/v0.8/EPIC_AUTHORING_SURFACES_v1.md
+++ b/docs/milestones/v0.8/EPIC_AUTHORING_SURFACES_v1.md
@@ -322,7 +322,7 @@ Mitigation: PWA v1 is generate/export only; optional Local Run Bridge provides a
 
 ---
 
-# 11. Canonical Location Note
+# 11. Canonical Location
 
-This document is canonical at:
+This EPIC document is canonical at:
 - `docs/milestones/v0.8/EPIC_AUTHORING_SURFACES_v1.md`

--- a/docs/milestones/v0.8/EPIC_MAPPING_v0.8.md
+++ b/docs/milestones/v0.8/EPIC_MAPPING_v0.8.md
@@ -18,8 +18,8 @@ It answers:
 |-------------------|---------------|----------------------|
 | Deterministic Workflow Runtime | Stable execution contract, hashing, idempotence | EPIC-A (Runtime Core) |
 | Durable Execution Substrate | Activation log, replay, auto-retry | EPIC-A (Replay + Substrate) |
-| Trace Bundles | Stable export contract for indexing | EPIC-A + ObsMem B1 |
-| ObsMem | Indexing + retrieval + Bayesian ranking | EPIC-B (ObsMem v1) |
+| Trace Bundles | Stable export contract for indexing | EPIC-A + EPIC-B |
+| ObsMem | Indexing + retrieval contract (foundation) | EPIC-B (ObsMem v1, v0.75) |
 | Gödel Layer | Proposal → evaluation → overlay | EPIC-C (Godel v1) |
 | Authoring Surfaces | NL → ADL + refinement loop | #517 (Authoring Surfaces v1) |
 
@@ -48,14 +48,14 @@ ObsMem and Gödel depend on this EPIC.
 
 ---
 
-# 3. EPIC-B — ObsMem v1 (Operational Memory)
+# 3. EPIC-B — ObsMem v1 (Operational Memory Foundation)
 
 Implements:
 
 - Architecture §2.6 ObsMem
-- Bayesian model defined in `OBSMEM_BAYES.md`
+- Bayesian model background in `incubation/OBSMEM_BAYES.md`
 
-Sub-issues (created via `create_obsmem_issues_v0.8.sh`):
+Sub-issues (foundation track):
 
 - B1 — Trace Export Bundle v2
 - B2 — Index + Retrieval API v1
@@ -68,7 +68,7 @@ Dependencies:
 
 Milestone target:
 
-> v0.8 (Product Cohesion)
+> v0.75 (Foundation complete before v0.8 product integration)
 
 ---
 
@@ -107,7 +107,7 @@ Implements:
 - Architecture §2.1 Authoring Surfaces
 - Architecture §2.2 Compiler + Static Analysis
 
-Child issues (created via `create_authoring_issues_v0..8.sh`):
+Child issues (authoring track):
 
 - AUTH-1 — NL→ADL Compiler v1
 - AUTH-2 — Interactive Refinement Loop
@@ -152,11 +152,11 @@ Important nuance:
 Complete:
 
 - EPIC-A (fully)
+- EPIC-B (ObsMem v1 foundation)
 - Trace Bundle schema freeze
 
 Do NOT start:
 
-- Bayesian ranking
 - Gödel proposal evaluation
 
 ---
@@ -165,7 +165,6 @@ Do NOT start:
 
 Complete:
 
-- EPIC-B
 - EPIC-C
 - EPIC-D
 - Demo matrix acceptance

--- a/docs/milestones/v0.8/GODEL_SCIENTIFIC_METHOD.md
+++ b/docs/milestones/v0.8/GODEL_SCIENTIFIC_METHOD.md
@@ -35,6 +35,16 @@ Where:
 - **ObsMem** stores indexed knowledge derived from traces.
 - **Gödel** reasons over that evidence and proposes improvements.
 
+## Canonical Schema/Spec Artifacts (Design Stage)
+
+The following machine-readable schema/spec artifacts are canonical for v0.8 design work:
+
+- `docs/milestones/v0.8/agent_profile.v1.json`
+- `docs/milestones/v0.8/mutation.v1.json`
+
+These are design-stage schema artifacts now and are candidates for later promotion into a runtime schema directory.
+Any historical planning copies are non-canonical; source of truth is `docs/milestones/v0.8/`.
+
 ---
 
 # Core Concept: Experiment Records

--- a/docs/milestones/v0.8/README.md
+++ b/docs/milestones/v0.8/README.md
@@ -1,17 +1,14 @@
 # v0.8 Docs Index
 
-This directory is a milestone navigation surface.
-
-Canonical v0.8 milestone planning docs live in this directory (`docs/milestones/v0.8/`).
+This directory is the canonical source of truth for v0.8 milestone docs.
 
 ## Canonical Planning References
 
 - v0.8 architecture: `ARCHITECTURE_V0.8.md`
 - v0.8 epic mapping: `EPIC_MAPPING_v0.8.md`
-- v0.8 cluster planning: `CLUSTER_EXECUTION.md`
-- v0.8 checkpoint/recovery planning: `CHECKPOINT_RECOVERY.md`
-- v0.75 ObsMem plan: `../v0.75/OBSMEM_BAYES.md`
-- v0.85 cluster plan: `../v0.85/CLUSTER_EXECUTION.md`
+- v0.8 vision: `VISION_0.80.md`
+- v0.75 ObsMem contract/background: `../v0.75/OBSMEM_INTEGRATION_CONTRACT_0.75.md`
+- v0.85 cluster planning: `../v0.85/CLUSTER_EXECUTION.md`
 
 ## Canonical Design-Stage Schema/Spec Artifacts
 
@@ -21,7 +18,6 @@ For the Gödel/evolution design track, the canonical machine-readable schema/spe
 - `docs/milestones/v0.8/mutation.v1.json`
 
 These are design-stage schema artifacts now and candidates for later promotion into runtime schemas.
-Legacy `.adl/docs/v07planning/` copies may remain for historical context, but source-of-truth is the `docs/milestones/v0.8/` copies.
 
 Scope slicing reference:
 - v0.75: EPIC-A + EPIC-B (deterministic substrate + ObsMem)

--- a/docs/milestones/v0.8/VISION_0.80.md
+++ b/docs/milestones/v0.8/VISION_0.80.md
@@ -190,4 +190,4 @@ v0.8 proves that thesis.
 
 ---
 
-**Next file to draft:** `.adl/docs/v085planning/VISION_v0.85.md`
+**Related planning:** see `../v0.85/CLUSTER_EXECUTION.md` for deferred cluster/distributed execution scope.


### PR DESCRIPTION
Closes #660\n\n## Summary\n- Reconciles source-of-truth and milestone slicing language across canonical v0.8 docs\n- Removes stale planned-move notes and .adl planning-path references from canonical docs\n- Aligns v0.75/v0.8/v0.85 boundaries and clarifies AEE timing as deferred planning\n- Fixes ambiguous internal references and minor operability wording\n\n## Validation\n- cd swarm && cargo fmt --all\n- cd swarm && cargo clippy --workspace --all-targets -- -D warnings\n- cd swarm && cargo test --workspace