### PR TITLE
[v0.8][docs] Promote reviewer tooling docs into docs/tooling

### DIFF
--- a/docs/tooling/card-review-checklist.md
+++ b/docs/tooling/card-review-checklist.md
@@ -1,0 +1,152 @@
+# ADL Card Review Checklist Spec
+
+Status: Draft (v0.8 tooling)
+Applies to: ADL output-card review
+Primary issue: #650
+
+## Purpose
+
+Define a deterministic, machine-readable checklist for reviewing ADL output cards.
+This checklist is the canonical rule surface for:
+
+- human reviewers
+- Card Reviewer GPT behavior (#649)
+- deterministic review output artifacts (#651)
+- future CI parsing and enforcement
+
+## Scope
+
+In scope:
+- output card structural validity
+- acceptance-criteria verification
+- determinism and replay assertions
+- security/privacy hygiene checks
+- artifact and validation evidence checks
+- deterministic decision mapping (`PASS`, `MINOR_FIXES`, `MAJOR_ISSUES`)
+
+Out of scope:
+- CI enforcement implementation
+- runtime feature validation beyond card evidence
+- policy changes to card schema
+
+## Review Inputs
+
+Required inputs:
+- issue input card (`.adl/cards/<issue>/input_<issue>.md`)
+- issue output card (`.adl/cards/<issue>/output_<issue>.md`)
+- changed files listed in output card
+
+Optional inputs:
+- PR diff and command logs
+- generated artifacts referenced by output card
+
+## Deterministic Review Rules
+
+Rule ordering is fixed and must not be changed without versioning this spec.
+Reviewers MUST evaluate rules in the following domain order:
+
+1. `structure`
+2. `acceptance`
+3. `determinism`
+4. `security_privacy`
+5. `artifacts`
+6. `validation`
+
+Within each domain, evaluate rules by ascending `rule_id`.
+
+## Rule Catalog
+
+Each rule has:
+- `rule_id`: stable identifier
+- `domain`: fixed domain name
+- `severity`: `blocker | high | medium | low`
+- `check`: deterministic condition
+- `evidence`: required evidence source
+
+### Structure Domain
+
+- `CRS-STR-001` (`high`): Output card has required top sections from template.
+- `CRS-STR-002` (`high`): `Status` is a valid terminal or in-progress value and matches narrative state.
+- `CRS-STR-003` (`medium`): `Execution` metadata is present and non-placeholder.
+- `CRS-STR-004` (`high`): `Artifacts produced` contains explicit repo-relative paths.
+
+### Acceptance Domain
+
+- `CRS-ACC-001` (`blocker`): All input-card acceptance criteria are explicitly addressed.
+- `CRS-ACC-002` (`high`): Any unmet criterion is listed under deviations/follow-ups.
+- `CRS-ACC-003` (`medium`): Scope constraints/non-goals are respected.
+
+### Determinism Domain
+
+- `CRS-DET-001` (`blocker`): Determinism assertions are present for applicable changes.
+- `CRS-DET-002` (`high`): Ordering/tie-break behavior is explicit where relevant.
+- `CRS-DET-003` (`high`): Replay compatibility impact is stated (`unchanged` or explicit delta).
+
+### Security/Privacy Domain
+
+- `CRS-SEC-001` (`blocker`): No secrets/tokens in output card text.
+- `CRS-SEC-002` (`blocker`): No raw prompts/tool arguments leaked in evidence.
+- `CRS-SEC-003` (`high`): No absolute host paths in persisted examples/evidence.
+- `CRS-SEC-004` (`high`): Security-sensitive deltas include explicit safety statement.
+
+### Artifacts Domain
+
+- `CRS-ART-001` (`high`): Required artifacts from task are listed and present (or justified).
+- `CRS-ART-002` (`high`): Artifact schema/version changes are explicit and approved.
+- `CRS-ART-003` (`medium`): Missing optional artifacts have rationale.
+
+### Validation Domain
+
+- `CRS-VAL-001` (`blocker`): Required validation commands from input card were executed.
+- `CRS-VAL-002` (`high`): Validation results are explicit (`PASS/FAIL`) and consistent.
+- `CRS-VAL-003` (`medium`): Failed/skipped checks include deterministic rationale.
+
+## Decision Mapping
+
+Decision mapping is deterministic and rule-based:
+
+- `MAJOR_ISSUES`:
+  - any failed `blocker` rule, OR
+  - 2+ failed `high` rules
+- `MINOR_FIXES`:
+  - no failed `blocker` rules, AND
+  - 1 failed `high` rule OR any failed `medium/low` rule
+- `PASS`:
+  - no failed `blocker/high/medium` rules
+
+If two outcomes appear possible, choose the stricter outcome.
+
+## Evidence Requirements
+
+Each finding must include at least one evidence pointer:
+- file path
+- command
+- CI check
+- artifact path
+
+Narrative-only claims without evidence should be marked as `needs_evidence` and fail the relevant rule.
+
+## Example Checklist Application (Real ADL Card)
+
+Review target:
+- issue `#660` output card (`.adl/cards/660/output_660.md`)
+
+Example outcome summary:
+- structure: pass
+- acceptance: pass
+- determinism: pass (docs-only, replay unchanged)
+- security/privacy: pass (no host paths/secrets)
+- artifacts: pass
+- validation: pass (`cargo fmt`, `cargo clippy`, `cargo test` documented)
+
+Result:
+- decision: `PASS`
+- failed rules: `[]`
+
+## Versioning
+
+Checklist version: `card_review_checklist.v1`
+
+Future updates must:
+- preserve existing `rule_id` semantics, OR
+- version bump with explicit migration notes

--- a/docs/tooling/card-review-output-format.md
+++ b/docs/tooling/card-review-output-format.md
@@ -1,0 +1,187 @@
+# ADL Deterministic Card Review Output Format
+
+Status: Draft (v0.8 tooling)
+Applies to: ADL output-card review artifacts
+Primary issue: #651
+Depends on: `docs/tooling/card-review-checklist.md` (#650)
+
+## Purpose
+
+Define the canonical, deterministic, machine-readable output artifact produced by card reviewers.
+
+This format is the standard surface for:
+- human-readable review summaries
+- Card Reviewer GPT outputs (#649)
+- future CI parsing and gating
+
+## Format Contract
+
+- Serialization: YAML
+- Encoding: UTF-8
+- Top-level key order: fixed (as specified below)
+- Enumerations: constrained values only
+- Optional sections: explicit and nullable where defined
+- Paths: repository-relative only
+
+## Canonical Top-Level Schema
+
+Top-level key order MUST be:
+
+1. `review_format_version`
+2. `review_metadata`
+3. `review_target`
+4. `decision`
+5. `summary`
+6. `domain_results`
+7. `findings`
+8. `acceptance_criteria`
+9. `determinism_checks`
+10. `security_privacy_checks`
+11. `artifact_checks`
+12. `validation_checks`
+13. `follow_ups`
+
+## Field Definitions
+
+### `review_format_version`
+
+- type: string
+- required
+- fixed initial value: `card_review_output.v1`
+
+### `review_metadata`
+
+- type: map
+- required fields:
+  - `reviewer`: string (`human` | versioned reviewer id, e.g. `card_reviewer_gpt.v1`)
+  - `review_time_utc`: string (ISO-8601 UTC)
+  - `checklist_version`: string (for #650 checklist, use `card_review_checklist.v1`)
+
+### `review_target`
+
+- type: map
+- required fields:
+  - `issue`: string (e.g., `#660`)
+  - `output_card_path`: string (repo-relative)
+  - `input_card_path`: string (repo-relative)
+  - `pr`: string or null
+
+### `decision`
+
+- type: string
+- required
+- enum:
+  - `PASS`
+  - `MINOR_FIXES`
+  - `MAJOR_ISSUES`
+
+Decision must be derived using #650 deterministic decision mapping.
+
+### `summary`
+
+- type: map
+- required fields:
+  - `status_line`: short deterministic text summary
+  - `failed_rule_count`: integer
+  - `failed_rule_ids`: ordered list of rule IDs
+
+### `domain_results`
+
+- type: ordered list
+- required
+- one item per fixed domain in this order:
+  - `structure`
+  - `acceptance`
+  - `determinism`
+  - `security_privacy`
+  - `artifacts`
+  - `validation`
+
+Each item fields:
+- `domain`: string
+- `status`: enum (`PASS` | `FAIL` | `PARTIAL`)
+- `failed_rules`: ordered list of checklist rule IDs
+
+### `findings`
+
+- type: ordered list
+- required (empty list allowed)
+- each finding fields:
+  - `rule_id`: checklist rule id
+  - `severity`: enum (`blocker` | `high` | `medium` | `low`)
+  - `title`: short deterministic summary
+  - `evidence`: ordered list of evidence pointers (`path:...`, `command:...`, `ci:...`)
+  - `remediation`: deterministic action statement
+
+### `acceptance_criteria`
+
+- type: ordered list
+- required
+- each item fields:
+  - `criterion`: exact criterion text or stable criterion ID
+  - `status`: enum (`met` | `not_met` | `partial`)
+  - `evidence`: ordered list
+
+### `determinism_checks`
+
+- type: map
+- required fields:
+  - `ordering_contract_verified`: boolean
+  - `replay_impact`: enum (`unchanged` | `changed` | `not_applicable`)
+  - `notes`: string
+
+### `security_privacy_checks`
+
+- type: map
+- required fields:
+  - `secrets_present`: boolean
+  - `raw_prompt_or_tool_args_present`: boolean
+  - `absolute_host_paths_present`: boolean
+  - `notes`: string
+
+### `artifact_checks`
+
+- type: map
+- required fields:
+  - `required_artifacts_present`: boolean
+  - `schema_change_present`: boolean
+  - `schema_change_status`: enum (`approved` | `rejected` | `not_applicable`)
+  - `notes`: string
+
+### `validation_checks`
+
+- type: map
+- required fields:
+  - `required_commands_run`: boolean
+  - `validation_result`: enum (`PASS` | `FAIL` | `PARTIAL`)
+  - `commands`: ordered list of command strings
+  - `notes`: string
+
+### `follow_ups`
+
+- type: ordered list
+- required (empty list allowed)
+- each item fields:
+  - `type`: enum (`fix_now` | `defer` | `new_issue`)
+  - `summary`: string
+  - `reference`: string or null
+
+## Determinism Rules
+
+- Field names and top-level order are fixed.
+- Domain order is fixed.
+- Findings order must be deterministic: by severity (`blocker`, `high`, `medium`, `low`), then `rule_id` ascending, then lexicographic `title`.
+- Lists of rule IDs must be lexicographically sorted unless domain order is explicitly required.
+- No host-specific or environment-specific values outside normalized fields.
+
+## Normative Example
+
+See:
+- `docs/tooling/examples/card-review-output-example.yaml`
+
+This example is normative for structure and field ordering.
+
+## Compatibility Notes
+
+- Reviewers MAY include additional keys only under a future version (`card_review_output.v2+`).
+- v1 parsers should reject unknown top-level keys to prevent silent schema drift.

--- a/docs/tooling/card-reviewer-gpt.md
+++ b/docs/tooling/card-reviewer-gpt.md
@@ -1,0 +1,127 @@
+# ADL Card Reviewer GPT Spec
+
+Status: Draft (v0.8 tooling)
+Applies to: deterministic review of ADL output cards
+Primary issue: #649
+Depends on:
+- `docs/tooling/card-review-checklist.md` (#650)
+- `docs/tooling/card-review-output-format.md` (#651)
+
+## Purpose
+
+Define the operating contract for the Card Reviewer GPT.
+The reviewer is a schema-driven, deterministic reviewer that evaluates ADL output cards and emits a structured review artifact.
+
+## Inputs
+
+Required:
+- input card path (`.adl/cards/<issue>/input_<issue>.md`)
+- output card path (`.adl/cards/<issue>/output_<issue>.md`)
+- checklist spec version (`card_review_checklist.v1`)
+- output format version (`card_review_output.v1`)
+
+Optional:
+- PR number or URL
+- CI check references
+- artifact file paths listed by output card
+
+## Output
+
+The reviewer MUST output YAML conforming to:
+- `docs/tooling/card-review-output-format.md`
+
+Decision enum is strictly:
+- `PASS`
+- `MINOR_FIXES`
+- `MAJOR_ISSUES`
+
+## Deterministic Operating Model
+
+The reviewer executes the same fixed pipeline for every review:
+
+1. Parse input and output cards.
+2. Load checklist rules from #650 spec.
+3. Evaluate domains in fixed order:
+   - structure
+   - acceptance
+   - determinism
+   - security_privacy
+   - artifacts
+   - validation
+4. Record findings with evidence pointers.
+5. Apply deterministic decision mapping.
+6. Emit canonical YAML output with fixed top-level key ordering.
+
+No hidden memory or prior conversation context is allowed.
+
+## Rule Application Contract
+
+- Rule IDs and domain order are authoritative from the checklist spec.
+- Evidence is mandatory for each failed rule.
+- If evidence is missing, mark the relevant rule failed with `needs_evidence` remediation.
+- If conflicting evidence exists, choose stricter interpretation and note ambiguity in findings.
+
+## Boundaries and Non-Goals
+
+The reviewer does not:
+- modify code or docs
+- run networked checks
+- invent acceptance criteria not present in input card
+- infer missing validations as passed
+
+The reviewer may classify unresolved uncertainty only as:
+- `MINOR_FIXES` (non-blocking gaps)
+- `MAJOR_ISSUES` (blocking gaps or invariant risks)
+
+## Security and Privacy Requirements
+
+Review output must not include:
+- secrets or tokens
+- raw prompts or tool arguments
+- absolute host paths
+
+Any detected leakage in the reviewed card must be reported as findings using checklist security rules.
+
+## Failure Handling
+
+If the reviewer cannot parse the input/output card:
+- emit `decision: MAJOR_ISSUES`
+- include parse failure finding with deterministic remediation
+
+If checklist version/output format version mismatch occurs:
+- emit `decision: MAJOR_ISSUES`
+- include `version_mismatch` finding
+
+If required sections are absent:
+- fail relevant structure rules
+- continue evaluating remaining domains where possible
+
+## Prompt Contract (for Manual/Agent Use)
+
+When run via GPT prompt, the reviewer prompt should require:
+- strict use of checklist rules from #650
+- strict output schema from #651
+- no prose-only final output; YAML artifact first
+- deterministic ordering in all lists and sections
+
+Recommended execution prompt skeleton:
+- identify target issue/output card
+- state checklist version and output schema version
+- evaluate each domain in fixed order
+- output only canonical YAML artifact
+
+## Normative Example Mapping
+
+For issue `#660` output card, a conforming reviewer output should:
+- pass all six domains
+- emit `decision: PASS`
+- include empty `findings` and `follow_ups`
+- include validation commands from output card evidence
+
+## Versioning
+
+- reviewer spec version: `card_reviewer_gpt.v1`
+- checklist dependency: `card_review_checklist.v1`
+- output dependency: `card_review_output.v1`
+
+Future behavior changes require explicit version bump and migration notes.

--- a/docs/tooling/examples/card-review-output-example.yaml
+++ b/docs/tooling/examples/card-review-output-example.yaml
@@ -1,0 +1,69 @@
+review_format_version: card_review_output.v1
+review_metadata:
+  reviewer: card_reviewer_gpt.v1
+  review_time_utc: 2026-03-06T18:05:00Z
+  checklist_version: card_review_checklist.v1
+review_target:
+  issue: "#660"
+  output_card_path: .adl/cards/660/output_660.md
+  input_card_path: .adl/cards/660/input_660.md
+  pr: "#670"
+decision: PASS
+summary:
+  status_line: "All checklist domains passed; no findings."
+  failed_rule_count: 0
+  failed_rule_ids: []
+domain_results:
+  - domain: structure
+    status: PASS
+    failed_rules: []
+  - domain: acceptance
+    status: PASS
+    failed_rules: []
+  - domain: determinism
+    status: PASS
+    failed_rules: []
+  - domain: security_privacy
+    status: PASS
+    failed_rules: []
+  - domain: artifacts
+    status: PASS
+    failed_rules: []
+  - domain: validation
+    status: PASS
+    failed_rules: []
+findings: []
+acceptance_criteria:
+  - criterion: "Canonical source-of-truth language is consistent across README and v0.8 docs."
+    status: met
+    evidence:
+      - path:docs/milestones/v0.8/README.md
+      - path:docs/milestones/v0.8/ARCHITECTURE_V0.8.md
+  - criterion: "v0.75 vs v0.8 milestone split is consistent across architecture and epic mapping docs."
+    status: met
+    evidence:
+      - path:docs/milestones/v0.8/ARCHITECTURE_V0.8.md
+      - path:docs/milestones/v0.8/EPIC_MAPPING_v0.8.md
+determinism_checks:
+  ordering_contract_verified: true
+  replay_impact: unchanged
+  notes: "Docs-only changes; runtime behavior unchanged."
+security_privacy_checks:
+  secrets_present: false
+  raw_prompt_or_tool_args_present: false
+  absolute_host_paths_present: false
+  notes: "No sensitive data or host paths in review artifact."
+artifact_checks:
+  required_artifacts_present: true
+  schema_change_present: false
+  schema_change_status: not_applicable
+  notes: "Expected docs artifacts present."
+validation_checks:
+  required_commands_run: true
+  validation_result: PASS
+  commands:
+    - cargo fmt --all
+    - cargo clippy --workspace --all-targets -- -D warnings
+    - cargo test --workspace
+  notes: "All required checks passed."
+follow_ups: []


### PR DESCRIPTION
## Summary
- Add reviewer tooling docs under tracked docs/tooling/
- Recover files via git-managed checkout from authoritative reviewer branches
- No manual file copy and no runtime changes

## Files
- docs/tooling/card-review-checklist.md
- docs/tooling/card-review-output-format.md
- docs/tooling/card-reviewer-gpt.md
- docs/tooling/examples/card-review-output-example.yaml

Closes #675
