### PR TITLE
[v0.8][docs] Create v0.8 execution order and dependency map

### DIFF
--- a/docs/milestones/v0.8/EXECUTION_ORDER_V0.8.md
+++ b/docs/milestones/v0.8/EXECUTION_ORDER_V0.8.md
@@ -1,0 +1,96 @@
+# v0.8 Execution Order and Dependency Map
+
+This document defines the canonical implementation sequence for v0.8 work.
+
+It is a planning/control artifact only. It does not change architecture or milestone scope.
+
+## Scope Baseline
+
+This execution map is anchored to the frozen v0.8 milestone docs baseline under:
+
+- `docs/milestones/v0.8/`
+
+## Deterministic Ordering Rules
+
+Use these rules whenever multiple items appear runnable at the same time:
+
+1. Respect explicit dependency edges first.
+2. Prefer lower work package IDs (`WP-02` before `WP-03`, etc.).
+3. If still tied, prefer lower issue number.
+4. If still tied, use lexicographic branch slug.
+
+## Workstreams
+
+- `WS-A` Gödel experiment substrate: `WP-02` to `WP-06`
+- `WS-B` Memory and evidence integration: `WP-07` and `WP-08`
+- `WS-C` Authoring and automation: `WP-09` and `WP-10`
+- `WS-D` Flagship demo implementation: `WP-11` and `WP-12`
+- `WS-E` Release tail and convergence: `WP-13` to `WP-16`
+
+## Canonical Execution Sequence
+
+### Phase 0: Milestone Doc Baseline (Completed)
+
+| Order | Item | Issue | Depends on |
+|---|---|---|---|
+| 0.1 | Promote canonical v0.8 docs | #659 | v0.75 release convergence |
+| 0.2 | Reconcile canonical v0.8 doc inconsistencies | #660 | #659 |
+| 0.3 | Canonical index and navigation pass | #661 | #660 |
+| 0.4 | Freeze canonical docs baseline | #662 | #661 |
+
+### Phase 1: Schema Spine
+
+| Order | Item | Issue | Depends on |
+|---|---|---|---|
+| 1.1 | ExperimentRecord schema v1 (`WP-02`) | #609 | #662 |
+| 1.2 | Canonical Evidence View (`WP-03`) | #610 | #662 |
+| 1.3 | Mutation format v1 (`WP-04`) | #611 | #662 |
+| 1.4 | EvaluationPlan v1 (`WP-05`) | #612 | #609, #610, #611 |
+| 1.5 | Gödel experiment workflow template (`WP-06`) | #613 | #609, #610, #611, #612 |
+
+### Phase 2: Memory + Runtime Contract Hardening
+
+| Order | Item | Issue | Depends on |
+|---|---|---|---|
+| 2.1 | ObsMem indexing for run summaries + experiment records (`WP-07`) | #614 | #609, #610, #613 |
+| 2.2 | ToolResult contract hardening (`WP-08`) | #618 | #610 |
+
+### Phase 3: Authoring + Prompt Automation
+
+| Order | Item | Issue | Depends on |
+|---|---|---|---|
+| 3.1 | Authoring surfaces v1 (`WP-09`) | #517 | #662 |
+| 3.2 | Prompt automation + reviewer-ready flow (`WP-10`) | TBD | #517, #618 |
+
+### Phase 4: Flagship Rust Transpiler Demo
+
+| Order | Item | Issue | Depends on |
+|---|---|---|---|
+| 4.1 | Rust transpiler fixture + scaffold (`WP-11`) | TBD | #613, #517 |
+| 4.2 | Rust transpiler verification + adaptive evidence (`WP-12`) | TBD | #612, #618, WP-10, WP-11 |
+
+### Phase 5: Release Tail
+
+| Order | Item | Issue | Depends on |
+|---|---|---|---|
+| 5.1 | Demo matrix + integration demos (`WP-13`) | TBD | WP-06, WP-07, WP-10, WP-12 |
+| 5.2 | Coverage / quality gate (`WP-14`) | TBD | WP-08 through WP-13 |
+| 5.3 | Docs pass + review convergence (`WP-15`) | TBD | WP-13, WP-14 |
+| 5.4 | 3rd party review pass | TBD | WP-15 docs freeze |
+| 5.5 | Review fixes / explicit deferrals | TBD | 3rd party review findings |
+| 5.6 | Release ceremony (`WP-16`) | TBD | WP-15, review convergence |
+
+## Cross-Workstream Dependency Notes
+
+- `WP-10` is an integration hinge: it depends on both authoring (`WP-09`) and runtime contract hardening (`WP-08`).
+- `WP-12` should not begin until `WP-10` and `WP-11` are stable; this avoids rework in demo evidence wiring.
+- Release-tail items (`WP-13` onward) should not start before Phase 1 and Phase 2 core surfaces are merged.
+
+## Contributor Guidance
+
+When starting a v0.8 implementation issue:
+
+1. Confirm its dependency row in this file is satisfied.
+2. If a dependency issue is `TBD`, create/assign that issue before implementation.
+3. Do not reorder release-tail sequence (`WP-13` -> `WP-14` -> `WP-15` -> review -> `WP-16`).
+

--- a/docs/milestones/v0.8/README.md
+++ b/docs/milestones/v0.8/README.md
@@ -38,6 +38,7 @@ Use this index as the primary navigation surface for v0.8 scope, sequencing, and
 
 - [WBS_V0.8.md](WBS_V0.8.md)
 - [SPRINT_V0.8.md](SPRINT_V0.8.md)
+- [EXECUTION_ORDER_V0.8.md](EXECUTION_ORDER_V0.8.md)
 - [MILESTONE_CHECKLIST_V0.8.md](MILESTONE_CHECKLIST_V0.8.md)
 - [DECISIONS_V0.8.md](DECISIONS_V0.8.md)
 - [RELEASE_PLAN_V0.8.md](RELEASE_PLAN_V0.8.md)
@@ -66,4 +67,3 @@ Use this index as the primary navigation surface for v0.8 scope, sequencing, and
 
 - [v0.75 milestone docs](../v0.75/)
 - [v0.85 milestone docs](../v0.85/)
-


### PR DESCRIPTION
## Summary
- Add canonical v0.8 execution order + dependency map doc
- Group known work into explicit workstreams and phases
- Add deterministic ordering/tie-break rules for contributor execution sequencing
- Link the new execution-order doc from the v0.8 README

## Files
- docs/milestones/v0.8/EXECUTION_ORDER_V0.8.md
- docs/milestones/v0.8/README.md

## Validation
- Link checks on updated planning docs
- No stale `.adl/docs/v08planning` refs in updated surfaces
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #663
