### PR TITLE
[v0.8][godel] Canonical Evidence View v1 schema

### DIFF
--- a/docs/milestones/v0.8/CANONICAL_EVIDENCE_VIEW_V1.md
+++ b/docs/milestones/v0.8/CANONICAL_EVIDENCE_VIEW_V1.md
@@ -1,0 +1,183 @@
+# Canonical Evidence View v1
+
+Status: Canonical design-stage schema/spec for issue #610 (`Canonical Evidence View`)
+
+## Purpose
+
+`Canonical Evidence View v1` is the deterministic evidence normalization artifact used by the Gödel workflow.
+
+It defines a stable, reviewable representation of evidence for a run/experiment so downstream artifacts can compare outcomes without relying on volatile runtime fields.
+
+## Design Invariants
+
+- Deterministic ordering for all comparison-relevant lists.
+- Replay-compatible evidence linkage via repo-relative artifact references.
+- No secrets, tokens, raw prompts, tool arguments, or absolute host paths.
+- Canonicalization metadata is explicit so consumers can reproduce normalization decisions.
+
+## Canonical Artifact Location
+
+Recommended path pattern:
+
+- `artifacts/evidence/<evidence_view_id>/canonical_evidence_view.v1.json`
+
+All references inside the artifact are repository-relative.
+
+## Top-Level Shape
+
+`Canonical Evidence View v1` is a JSON object with:
+
+- `schema_name = "canonical_evidence_view"`
+- `schema_version = 1`
+
+Required top-level fields:
+
+- `schema_name`
+- `schema_version`
+- `evidence_view_id`
+- `run_context`
+- `canonicalization_profile`
+- `failure_codes`
+- `verification_results`
+- `artifact_hashes`
+- `trace_bundle_ref`
+- `activation_log_ref`
+- `comparison_axes`
+- `privacy`
+
+Optional top-level fields:
+
+- `derived_metrics`
+- `notes`
+
+## Field Semantics
+
+### `evidence_view_id` (required)
+
+Stable evidence-view identifier.
+
+### `run_context` (required)
+
+Required fields:
+
+- `run_id`
+- `workflow_id`
+- `subject`
+
+Optional:
+
+- `variant_label` (for baseline/variant comparisons)
+
+### `canonicalization_profile` (required)
+
+Required fields:
+
+- `profile_name`
+- `profile_version`
+- `volatile_fields_excluded` (ordered list)
+
+Defines exactly what was excluded/normalized.
+
+### `failure_codes` (required)
+
+Ordered list of stable failure codes observed in canonical evidence.
+
+### `verification_results` (required)
+
+Ordered list of verification check results.
+
+Each item required fields:
+
+- `check_id`
+- `status` (`pass|fail|not_applicable`)
+- `evidence_ref` (repo-relative)
+
+### `artifact_hashes` (required)
+
+Ordered list of `{ path, sha256 }` objects for canonical evidence integrity.
+
+### `trace_bundle_ref` (required)
+
+Repo-relative reference to trace bundle used as an evidence source.
+
+### `activation_log_ref` (required)
+
+Repo-relative reference to activation log artifact used as an evidence source.
+
+### `comparison_axes` (required)
+
+Required fields:
+
+- `primary_metric`
+- `direction` (`increase_is_better|decrease_is_better|target_match`)
+
+Optional:
+
+- `secondary_metrics` (ordered list)
+
+### `privacy` (required)
+
+Required fields:
+
+- `secrets_present` (must be false)
+- `raw_prompt_or_tool_args_present` (must be false)
+- `absolute_host_paths_present` (must be false)
+
+Optional:
+
+- `redaction_notes` (ordered list)
+
+### `derived_metrics` (optional)
+
+Ordered list of normalized metric summaries for downstream ranking.
+
+### `notes` (optional)
+
+Ordered list of bounded human-readable notes.
+
+## Deterministic Ordering Rules
+
+- `failure_codes`: lexicographic ascending.
+- `verification_results`: ordered by `check_id` ascending.
+- `artifact_hashes`: ordered by `path` ascending.
+- `comparison_axes.secondary_metrics`: ordered by metric id/name ascending.
+- `canonicalization_profile.volatile_fields_excluded`: lexicographic ascending.
+
+## Relationships to Neighbor Artifacts
+
+### Relation to `ExperimentRecord` (#609)
+
+`ExperimentRecord.evidence` references this artifact as the canonical evidence source (`canonical_evidence_ref`).
+
+`ExperimentRecord` holds hypothesis/mutation/decision context; `Canonical Evidence View` holds normalized evidence surfaces used for comparison.
+
+### Relation to `Mutation` (#611)
+
+Mutation artifacts define what changed. `Canonical Evidence View` records what evidence was observed after mutation execution, using deterministic normalization.
+
+### Relation to `EvaluationPlan` (#612)
+
+`verification_results` and `comparison_axes` are expected to align with EvaluationPlan check identifiers and metric semantics.
+
+## Security / Privacy Rules
+
+Forbidden in this artifact:
+
+- secrets or credentials
+- raw prompts
+- tool argument payloads
+- absolute host paths
+
+References must be repository-relative.
+
+## Versioning Rules
+
+- `schema_name` is immutable for this artifact family.
+- `schema_version = 1` is the initial stable version.
+- Breaking changes require a schema version increment.
+- Additive future fields must remain optional.
+
+## Canonical Machine-Readable Artifacts
+
+- Schema: `docs/milestones/v0.8/canonical_evidence_view.v1.schema.json`
+- Example: `docs/milestones/v0.8/canonical_evidence_view.v1.example.json`

--- a/docs/milestones/v0.8/README.md
+++ b/docs/milestones/v0.8/README.md
@@ -59,6 +59,9 @@ Use this index as the primary navigation surface for v0.8 scope, sequencing, and
 - [EXPERIMENT_RECORD_V1.md](EXPERIMENT_RECORD_V1.md)
 - [experiment_record.v1.schema.json](experiment_record.v1.schema.json)
 - [experiment_record.v1.example.json](experiment_record.v1.example.json)
+- [CANONICAL_EVIDENCE_VIEW_V1.md](CANONICAL_EVIDENCE_VIEW_V1.md)
+- [canonical_evidence_view.v1.schema.json](canonical_evidence_view.v1.schema.json)
+- [canonical_evidence_view.v1.example.json](canonical_evidence_view.v1.example.json)
 
 ## Scope Slicing Reference
 

--- a/docs/milestones/v0.8/canonical_evidence_view.v1.example.json
+++ b/docs/milestones/v0.8/canonical_evidence_view.v1.example.json
@@ -1,0 +1,82 @@
+{
+  "schema_name": "canonical_evidence_view",
+  "schema_version": 1,
+  "evidence_view_id": "cev-20260308-mut-a",
+  "run_context": {
+    "run_id": "run-mut-a-001",
+    "workflow_id": "workflow-coverage-experiment",
+    "subject": "swarm/src/coverage.rs",
+    "variant_label": "mutation-a"
+  },
+  "canonicalization_profile": {
+    "profile_name": "godel-evidence-default",
+    "profile_version": 1,
+    "volatile_fields_excluded": [
+      "elapsed_ms",
+      "host_paths",
+      "timestamps"
+    ]
+  },
+  "failure_codes": [
+    "none"
+  ],
+  "verification_results": [
+    {
+      "check_id": "clippy_all_targets",
+      "status": "pass",
+      "evidence_ref": "artifacts/evidence/cev-20260308-mut-a/verifications/clippy.json"
+    },
+    {
+      "check_id": "fmt",
+      "status": "pass",
+      "evidence_ref": "artifacts/evidence/cev-20260308-mut-a/verifications/fmt.json"
+    },
+    {
+      "check_id": "test_workspace",
+      "status": "pass",
+      "evidence_ref": "artifacts/evidence/cev-20260308-mut-a/verifications/test.json"
+    }
+  ],
+  "artifact_hashes": [
+    {
+      "path": "artifacts/evidence/cev-20260308-mut-a/metrics.json",
+      "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    {
+      "path": "artifacts/evidence/cev-20260308-mut-a/verifications/test.json",
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "trace_bundle_ref": "artifacts/traces/run-mut-a-001/trace_bundle_v2.json",
+  "activation_log_ref": "artifacts/runs/run-mut-a-001/logs/activation_log.json",
+  "comparison_axes": {
+    "primary_metric": "coverage_percent",
+    "direction": "increase_is_better",
+    "secondary_metrics": [
+      {
+        "metric": "test_failures",
+        "direction": "decrease_is_better"
+      }
+    ]
+  },
+  "privacy": {
+    "secrets_present": false,
+    "raw_prompt_or_tool_args_present": false,
+    "absolute_host_paths_present": false,
+    "redaction_notes": [
+      "prompt bodies omitted",
+      "tool argument payloads omitted"
+    ]
+  },
+  "derived_metrics": [
+    {
+      "metric": "coverage_percent",
+      "value": 80.5,
+      "unit": "percent"
+    }
+  ],
+  "notes": [
+    "verification_results sorted by check_id",
+    "artifact_hashes sorted by path"
+  ]
+}

--- a/docs/milestones/v0.8/canonical_evidence_view.v1.schema.json
+++ b/docs/milestones/v0.8/canonical_evidence_view.v1.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://adl.dev/schemas/canonical_evidence_view.v1.schema.json",
+  "title": "CanonicalEvidenceView v1",
+  "description": "Canonical deterministic evidence view for Gödel experiment evaluation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_name",
+    "schema_version",
+    "evidence_view_id",
+    "run_context",
+    "canonicalization_profile",
+    "failure_codes",
+    "verification_results",
+    "artifact_hashes",
+    "trace_bundle_ref",
+    "activation_log_ref",
+    "comparison_axes",
+    "privacy"
+  ],
+  "properties": {
+    "schema_name": { "type": "string", "const": "canonical_evidence_view" },
+    "schema_version": { "type": "integer", "const": 1 },
+    "evidence_view_id": { "type": "string", "minLength": 1 },
+    "run_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_id", "workflow_id", "subject"],
+      "properties": {
+        "run_id": { "type": "string", "minLength": 1 },
+        "workflow_id": { "type": "string", "minLength": 1 },
+        "subject": { "type": "string", "minLength": 1 },
+        "variant_label": { "type": "string", "minLength": 1 }
+      }
+    },
+    "canonicalization_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile_name", "profile_version", "volatile_fields_excluded"],
+      "properties": {
+        "profile_name": { "type": "string", "minLength": 1 },
+        "profile_version": { "type": "integer", "minimum": 1 },
+        "volatile_fields_excluded": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "failure_codes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "verification_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["check_id", "status", "evidence_ref"],
+        "properties": {
+          "check_id": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["pass", "fail", "not_applicable"] },
+          "evidence_ref": { "$ref": "#/$defs/repo_relative_ref" }
+        }
+      },
+      "uniqueItems": true
+    },
+    "artifact_hashes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "sha256"],
+        "properties": {
+          "path": { "$ref": "#/$defs/repo_relative_ref" },
+          "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+        }
+      },
+      "uniqueItems": true
+    },
+    "trace_bundle_ref": { "$ref": "#/$defs/repo_relative_ref" },
+    "activation_log_ref": { "$ref": "#/$defs/repo_relative_ref" },
+    "comparison_axes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary_metric", "direction"],
+      "properties": {
+        "primary_metric": { "type": "string", "minLength": 1 },
+        "direction": {
+          "type": "string",
+          "enum": ["increase_is_better", "decrease_is_better", "target_match"]
+        },
+        "secondary_metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["metric", "direction"],
+            "properties": {
+              "metric": { "type": "string", "minLength": 1 },
+              "direction": {
+                "type": "string",
+                "enum": ["increase_is_better", "decrease_is_better", "target_match"]
+              }
+            }
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "secrets_present",
+        "raw_prompt_or_tool_args_present",
+        "absolute_host_paths_present"
+      ],
+      "properties": {
+        "secrets_present": { "type": "boolean", "const": false },
+        "raw_prompt_or_tool_args_present": { "type": "boolean", "const": false },
+        "absolute_host_paths_present": { "type": "boolean", "const": false },
+        "redaction_notes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "derived_metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["metric", "value"],
+        "properties": {
+          "metric": { "type": "string", "minLength": 1 },
+          "value": { "type": "number" },
+          "unit": { "type": "string", "minLength": 1 }
+        }
+      },
+      "uniqueItems": true
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "repo_relative_ref": {
+      "type": "string",
+      "minLength": 1,
+      "allOf": [
+        { "not": { "pattern": "^/" } },
+        { "not": { "pattern": "^[A-Za-z]:[/\\\\]" } },
+        { "not": { "pattern": "\\.\\." } }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Define canonical Evidence View v1 spec for Gödel experiment evidence normalization
- Add machine-readable schema + deterministic example artifact
- Link evidence-view artifacts from v0.8 canonical docs index

## Files
- docs/milestones/v0.8/CANONICAL_EVIDENCE_VIEW_V1.md
- docs/milestones/v0.8/canonical_evidence_view.v1.schema.json
- docs/milestones/v0.8/canonical_evidence_view.v1.example.json
- docs/milestones/v0.8/README.md

## Validation
- `jq . docs/milestones/v0.8/canonical_evidence_view.v1.schema.json`
- `jq . docs/milestones/v0.8/canonical_evidence_view.v1.example.json`
- host-path leakage scan on changed files
- README link check (`40` links, `0` broken)

Closes #610
