### PR TITLE
[v0.8][godel] Demo: failure -> hypothesis -> experiment

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -44,3 +44,16 @@ cargo run --manifest-path swarm/Cargo.toml -- swarm/examples/v0-3-remote-http-pr
 What to expect:
 - On reachable endpoint: step output + run summary.
 - On failure: clear error for timeout, non-200 response, or missing auth env var.
+
+## 3) v0.8 Gödel Failure -> Hypothesis -> Experiment (Docs Demo)
+
+Files:
+- `docs/demos/godel_failure_hypothesis_experiment.md`
+- `docs/demos/artifacts/godel_failure_signal.v1.example.json`
+- `docs/demos/artifacts/godel_hypothesis.v1.example.json`
+- `docs/demos/artifacts/godel_experiment_proposal.v1.example.json`
+
+What to expect:
+- Deterministic, artifact-driven loop documentation only.
+- Explicit stage flow: failure -> hypothesis -> experiment.
+- Bounded experiment proposal aligned to Mutation v1 and EvaluationPlan v1 references.

--- a/docs/demos/artifacts/godel_experiment_proposal.v1.example.json
+++ b/docs/demos/artifacts/godel_experiment_proposal.v1.example.json
@@ -1,0 +1,23 @@
+{
+  "artifact_version": "godel_experiment_proposal.v1",
+  "experiment_id": "exp-0301",
+  "hypothesis_id": "hyp-0201",
+  "mutation": {
+    "mutation_version": "mutation.v1",
+    "mutation_id": "mut-0501",
+    "intent": "set_verification_mode",
+    "scope": "workflow_config",
+    "bounded_change": true
+  },
+  "evaluation_plan_ref": "eval-plan-0007",
+  "expected_outcome": "verification step passes and failure class is not emitted",
+  "stop_criteria": [
+    "single experiment run",
+    "no policy expansion"
+  ],
+  "artifact_refs": [
+    "docs/milestones/v0.8/MUTATION_FORMAT_V1.md",
+    "docs/milestones/v0.8/EVALUATION_PLAN_V1.md",
+    "docs/milestones/v0.8/EXPERIMENT_RECORD_V1.md"
+  ]
+}

--- a/docs/demos/artifacts/godel_failure_signal.v1.example.json
+++ b/docs/demos/artifacts/godel_failure_signal.v1.example.json
@@ -1,0 +1,17 @@
+{
+  "artifact_version": "godel_failure_signal.v1",
+  "run_id": "run-0100",
+  "workflow_id": "godel-demo-v1",
+  "failure_id": "fail-0001",
+  "failure_class": "verification_failed",
+  "failure_code": "REPLAY_INVARIANT_VIOLATION",
+  "step_id": "evaluation",
+  "evidence_refs": [
+    "evidence-0004",
+    "evidence-0009"
+  ],
+  "artifact_refs": [
+    ".adl/runs/run-0100/learning/canonical_evidence_view.json",
+    ".adl/runs/run-0100/run_summary.json"
+  ]
+}

--- a/docs/demos/artifacts/godel_hypothesis.v1.example.json
+++ b/docs/demos/artifacts/godel_hypothesis.v1.example.json
@@ -1,0 +1,16 @@
+{
+  "artifact_version": "godel_hypothesis.v1",
+  "hypothesis_id": "hyp-0201",
+  "failure_id": "fail-0001",
+  "failure_class": "verification_failed",
+  "claim": "Evaluation step fails because verification mode is omitted for this workflow profile.",
+  "confidence": 0.62,
+  "evidence_refs": [
+    "evidence-0004",
+    "evidence-0009"
+  ],
+  "related_run_refs": [
+    "run-0098",
+    "run-0100"
+  ]
+}

--- a/docs/demos/godel_failure_hypothesis_experiment.md
+++ b/docs/demos/godel_failure_hypothesis_experiment.md
@@ -1,0 +1,72 @@
+# v0.8 Demo: Failure -> Hypothesis -> Experiment
+
+## Purpose
+
+This demo illustrates the deterministic Gödel scientific loop as documentation artifacts:
+
+1. observed failure
+2. hypothesis from evidence
+3. bounded experiment proposal
+
+This is a docs/demo surface only. It does not execute runtime mutation.
+
+## Integration Surfaces
+
+The demo aligns with:
+
+- `docs/milestones/v0.8/EXPERIMENT_RECORD_V1.md` (#609)
+- `docs/milestones/v0.8/CANONICAL_EVIDENCE_VIEW_V1.md` (#610)
+- `docs/milestones/v0.8/MUTATION_FORMAT_V1.md` (#611)
+- `docs/milestones/v0.8/EVALUATION_PLAN_V1.md` (#612)
+- `docs/milestones/v0.8/GODEL_EXPERIMENT_WORKFLOW_TEMPLATE_V1.md` (#613)
+- `docs/milestones/v0.8/OBSMEM_INDEXING_SURFACES_V1.md` (#614)
+
+## Deterministic Demo Artifacts
+
+- Failure signal:
+  - `docs/demos/artifacts/godel_failure_signal.v1.example.json`
+- Hypothesis:
+  - `docs/demos/artifacts/godel_hypothesis.v1.example.json`
+- Experiment proposal:
+  - `docs/demos/artifacts/godel_experiment_proposal.v1.example.json`
+
+## Loop Walkthrough
+
+### Stage 1: Failure
+
+The failure artifact records a bounded, deterministic failure summary:
+
+- stable identifiers (`run_id`, `workflow_id`, `failure_id`)
+- structured failure class
+- canonical evidence references
+
+### Stage 2: Hypothesis
+
+The hypothesis artifact explains the failure using evidence IDs and deterministic claims:
+
+- one failure class target
+- one explicit causal claim
+- bounded confidence value
+- deterministic links to evidence and prior run references
+
+### Stage 3: Experiment
+
+The experiment proposal artifact defines a bounded test:
+
+- one mutation descriptor (no unconstrained patch language)
+- one evaluation plan reference
+- expected success criteria and stop criteria
+- deterministic ordering fields and stable IDs
+
+## Replay and Audit Notes
+
+- All artifact references are repo-relative.
+- No raw logs, prompts, tool arguments, or secrets are stored.
+- Artifact shape is deterministic for identical input conditions.
+- Runtime execution is intentionally out of scope for this demo.
+
+## Non-goals
+
+- Autonomous hypothesis generation
+- Runtime mutation execution
+- Policy-learning or scheduler changes


### PR DESCRIPTION
Adds a deterministic, artifact-driven Gödel demo flow for v0.8 docs:\n- docs/demos/godel_failure_hypothesis_experiment.md\n- docs/demos/artifacts/godel_failure_signal.v1.example.json\n- docs/demos/artifacts/godel_hypothesis.v1.example.json\n- docs/demos/artifacts/godel_experiment_proposal.v1.example.json\n- docs/demos.md update\n\nCloses #615