### PR TITLE
[v0.8][godel] ExperimentRecord: add improvement_delta and experiment_seed

### DIFF
--- a/docs/milestones/v0.8/EXPERIMENT_RECORD_V1.md
+++ b/docs/milestones/v0.8/EXPERIMENT_RECORD_V1.md
@@ -32,6 +32,7 @@ Required top-level fields:
 - `schema_name`
 - `schema_version`
 - `experiment_id`
+- `experiment_seed`
 - `comparison_key`
 - `runs`
 - `hypothesis`
@@ -39,6 +40,7 @@ Required top-level fields:
 - `evaluation_plan`
 - `evidence`
 - `outcome`
+- `improvement_delta`
 - `decision`
 - `replay`
 - `obsmem_index`
@@ -63,6 +65,11 @@ Optional top-level fields:
 - Type: string
 - Pattern: `^[a-z0-9][a-z0-9._-]{2,127}$`
 - Why: stable join key across evidence/mutation/evaluation/ObsMem.
+
+### `experiment_seed` (required)
+- Type: string
+- Pattern: `^[a-z0-9][a-z0-9._:-]{2,127}$`
+- Why: deterministic reproduction anchor for the experiment. This seed identifies the controlled experiment setup and must be stable for identical replay conditions.
 
 ### `comparison_key` (required)
 - Type: object
@@ -135,6 +142,16 @@ Optional top-level fields:
   - `secondary_metrics` (ordered list of same shape)
 - Why: deterministic experiment comparison for automation and review.
 
+### `improvement_delta` (required)
+- Type: object
+- Required fields:
+  - `metric` (string)
+  - `baseline` (number)
+  - `experiment` (number)
+  - `delta` (number; `experiment - baseline`)
+  - `direction` (`increase_is_better|decrease_is_better|target_match`)
+- Why: explicit, index-friendly improvement summary used by downstream ranking/selection and ObsMem query surfaces.
+
 ### `decision` (required)
 - Type: object
 - Required fields:
@@ -181,6 +198,7 @@ Optional top-level fields:
 - `mutation.scope` sorted lexicographically ascending.
 - `obsmem_index.tags` sorted lexicographically ascending and de-duplicated.
 - `replay.artifact_manifest` sorted by `path` ascending.
+- `improvement_delta` uses fixed keys and deterministic numeric values derived from canonical evaluation results.
 
 ## Security and Privacy Rules
 
@@ -203,3 +221,8 @@ All artifact references must be repository-relative.
 
 - Schema: `docs/milestones/v0.8/experiment_record.v1.schema.json`
 - Example: `docs/milestones/v0.8/experiment_record.v1.example.json`
+
+## Integration Notes
+
+- `improvement_delta` is the canonical ranking signal consumed by indexing/query surfaces (see #614).
+- `experiment_seed` is the canonical reproduction signal for deterministic rerun/replay comparisons.

--- a/docs/milestones/v0.8/experiment_record.v1.example.json
+++ b/docs/milestones/v0.8/experiment_record.v1.example.json
@@ -2,6 +2,7 @@
   "schema_name": "experiment_record",
   "schema_version": 1,
   "experiment_id": "exp-20260308-coverage-floor",
+  "experiment_seed": "seed-20260308-coverage-floor-a",
   "comparison_key": {
     "subject": "swarm/src/coverage.rs",
     "baseline_label": "main",
@@ -91,6 +92,13 @@
         "delta": 0
       }
     ]
+  },
+  "improvement_delta": {
+    "metric": "coverage_percent",
+    "baseline": 78.1,
+    "experiment": 80.5,
+    "delta": 2.4,
+    "direction": "increase_is_better"
   },
   "decision": {
     "result": "adopt",

--- a/docs/milestones/v0.8/experiment_record.v1.schema.json
+++ b/docs/milestones/v0.8/experiment_record.v1.schema.json
@@ -9,6 +9,7 @@
     "schema_name",
     "schema_version",
     "experiment_id",
+    "experiment_seed",
     "comparison_key",
     "runs",
     "hypothesis",
@@ -16,6 +17,7 @@
     "evaluation_plan",
     "evidence",
     "outcome",
+    "improvement_delta",
     "decision",
     "replay",
     "obsmem_index"
@@ -32,6 +34,10 @@
     "experiment_id": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"
+    },
+    "experiment_seed": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._:-]{2,127}$"
     },
     "comparison_key": {
       "type": "object",
@@ -176,6 +182,40 @@
             }
           },
           "uniqueItems": true
+        }
+      }
+    },
+    "improvement_delta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "metric",
+        "baseline",
+        "experiment",
+        "delta",
+        "direction"
+      ],
+      "properties": {
+        "metric": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseline": {
+          "type": "number"
+        },
+        "experiment": {
+          "type": "number"
+        },
+        "delta": {
+          "type": "number"
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "increase_is_better",
+            "decrease_is_better",
+            "target_match"
+          ]
         }
       }
     },


### PR DESCRIPTION
Schema/docs-only enhancement for ExperimentRecord v1:\n- add required experiment_seed for deterministic reproduction anchoring\n- add required structured improvement_delta for explicit experiment comparison/ranking compatibility\n- update schema, example, and canonical doc in lockstep\n\nCloses #683