### PR TITLE
[v0.8][WP-11] Rust transpiler fixture + workflow scaffold

### DIFF
--- a/demos/rust_output/workflow_runtime.rs
+++ b/demos/rust_output/workflow_runtime.rs
@@ -1,0 +1,42 @@
+// v0.8 bounded Rust transpiler demo output skeleton.
+// This file represents deterministic compiled structure from:
+// examples/workflows/rust_transpiler_demo.yaml
+
+#[derive(Debug, Clone)]
+struct WorkflowState {
+    source_token: String,
+    payload: String,
+    normalized_payload: String,
+    result_token: String,
+}
+
+fn step_prepare_input(source_token: &str) -> String {
+    source_token.to_string()
+}
+
+fn step_normalize_payload(payload: &str) -> String {
+    payload.trim().to_lowercase()
+}
+
+fn step_finalize_output(normalized_payload: &str) -> String {
+    format!("workflow_complete:{normalized_payload}")
+}
+
+fn run_workflow() -> WorkflowState {
+    let source_token = "Hello_ADL  ".to_string();
+    let payload = step_prepare_input(&source_token);
+    let normalized_payload = step_normalize_payload(&payload);
+    let result_token = step_finalize_output(&normalized_payload);
+
+    WorkflowState {
+        source_token,
+        payload,
+        normalized_payload,
+        result_token,
+    }
+}
+
+fn main() {
+    let state = run_workflow();
+    println!("{:?}", state);
+}

--- a/docs/demos/rust-transpiler/README.md
+++ b/docs/demos/rust-transpiler/README.md
@@ -1,0 +1,61 @@
+# Rust Transpiler Demo Scaffold (v0.8)
+
+## Purpose
+
+This is a bounded demonstration artifact for v0.8 showing how a minimal ADL-style
+workflow fixture maps to a deterministic Rust runtime skeleton.
+
+It is not a production compiler or full transpiler.
+
+The goal is confidence and clarity: one fixture, one mapping scaffold, one runtime
+skeleton, and one explicit path to deterministic verification in `#703`.
+
+## Demo Surfaces
+
+1. Workflow fixture (input contract)
+   - `examples/workflows/rust_transpiler_demo.yaml`
+2. Rust transpiler scaffold (mapping demonstration entrypoint)
+   - `tools/transpiler_demo/Cargo.toml`
+   - `tools/transpiler_demo/src/main.rs`
+3. Rust output skeleton (compiled/runtime shape)
+   - `demos/rust_output/workflow_runtime.rs`
+4. This explainer
+   - `docs/demos/rust-transpiler/README.md`
+
+## Fixture to Rust Mapping
+
+The fixture defines a tiny deterministic pipeline with three steps:
+
+- `step_prepare_input`
+- `step_normalize_payload`
+- `step_finalize_output`
+
+The Rust skeleton mirrors this one-to-one:
+
+- one function per workflow step
+- `run_workflow()` executes steps in order
+- data flow is explicit and deterministic:
+  `source_token -> payload -> normalized_payload -> result_token`
+
+## How to Inspect the Mapping
+
+Run:
+
+`cargo run --manifest-path tools/transpiler_demo/Cargo.toml --quiet`
+
+The scaffold prints:
+
+- fixture and Rust artifact paths
+- ordered step-to-function mapping
+- `PASS`/`FAIL` order consistency check
+- artifact layout status
+
+No code generation occurs in this demo.
+
+## Verification Hand-off to #703
+
+Issue `#703` verifies:
+
+1. deterministic correspondence between fixture step order and Rust function order
+2. replay-compatibility expectations for this bounded demo surface
+3. stability of artifact paths and mapping for identical repository state

--- a/examples/workflows/rust_transpiler_demo.yaml
+++ b/examples/workflows/rust_transpiler_demo.yaml
@@ -1,0 +1,33 @@
+version: "v0.8-demo"
+workflow_id: "rust_transpiler_demo"
+name: "Rust Transpiler Demonstration Workflow"
+deterministic: true
+description: "Minimal fixture used to demonstrate deterministic ADL-to-Rust mapping."
+
+inputs:
+  source_token: "Hello_ADL  "
+
+steps:
+  - id: "step_prepare_input"
+    kind: "transform"
+    description: "Read deterministic fixture input into workflow state."
+    input_from: "inputs.source_token"
+    emit:
+      payload: "Hello_ADL  "
+
+  - id: "step_normalize_payload"
+    kind: "transform"
+    description: "Normalize payload in a deterministic way (trim + lowercase)."
+    input_from: "step_prepare_input.payload"
+    emit:
+      normalized_payload: "hello_adl"
+
+  - id: "step_finalize_output"
+    kind: "transform"
+    description: "Produce deterministic terminal token from normalized payload."
+    input_from: "step_normalize_payload.normalized_payload"
+    emit:
+      result_token: "workflow_complete:hello_adl"
+
+outputs:
+  final_token_from: "step_finalize_output.result_token"

--- a/tools/transpiler_demo/Cargo.toml
+++ b/tools/transpiler_demo/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "transpiler_demo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/tools/transpiler_demo/src/main.rs
+++ b/tools/transpiler_demo/src/main.rs
@@ -1,0 +1,89 @@
+use std::fs;
+use std::path::Path;
+
+const FIXTURE_PATH: &str = "examples/workflows/rust_transpiler_demo.yaml";
+const RUST_OUTPUT_PATH: &str = "demos/rust_output/workflow_runtime.rs";
+
+fn extract_fixture_step_ids(yaml_text: &str) -> Vec<String> {
+    yaml_text
+        .lines()
+        .filter_map(|line| {
+            let t = line.trim();
+            if !t.starts_with("- id:") {
+                return None;
+            }
+            let first = t.find('"')?;
+            let second = t[first + 1..].find('"')? + first + 1;
+            Some(t[first + 1..second].to_string())
+        })
+        .collect()
+}
+
+fn extract_rust_step_functions(rust_text: &str) -> Vec<String> {
+    rust_text
+        .lines()
+        .filter_map(|line| {
+            let t = line.trim_start();
+            if !t.starts_with("fn step_") {
+                return None;
+            }
+            let open = t.find('(')?;
+            Some(t[3..open].trim().to_string())
+        })
+        .collect()
+}
+
+fn main() -> Result<(), String> {
+    if !Path::new(FIXTURE_PATH).exists() {
+        return Err(format!("missing fixture: {FIXTURE_PATH}"));
+    }
+    if !Path::new(RUST_OUTPUT_PATH).exists() {
+        return Err(format!("missing rust output skeleton: {RUST_OUTPUT_PATH}"));
+    }
+
+    let fixture_text = fs::read_to_string(FIXTURE_PATH)
+        .map_err(|e| format!("failed to read fixture: {e}"))?;
+    let rust_text = fs::read_to_string(RUST_OUTPUT_PATH)
+        .map_err(|e| format!("failed to read rust output skeleton: {e}"))?;
+
+    let fixture_steps = extract_fixture_step_ids(&fixture_text);
+    let rust_steps = extract_rust_step_functions(&rust_text);
+
+    if fixture_steps.is_empty() {
+        return Err("no workflow steps found in fixture".to_string());
+    }
+    if rust_steps.is_empty() {
+        return Err("no step functions found in rust output skeleton".to_string());
+    }
+
+    println!("v0.8 rust transpiler demo scaffold");
+    println!("fixture: {FIXTURE_PATH}");
+    println!("rust output skeleton: {RUST_OUTPUT_PATH}");
+    println!("deterministic step mapping (fixture -> rust):");
+
+    for (index, step_id) in fixture_steps.iter().enumerate() {
+        let rust_fn = rust_steps
+            .get(index)
+            .map(String::as_str)
+            .unwrap_or("<missing>");
+        let status = if step_id == rust_fn { "PASS" } else { "FAIL" };
+        println!("  {}. {} -> fn {}(...) [{}]", index + 1, step_id, rust_fn, status);
+    }
+
+    let same_order = fixture_steps == rust_steps;
+    println!(
+        "mapping order check: {}",
+        if same_order { "PASS" } else { "FAIL" }
+    );
+    println!("artifact layout check:");
+    println!("  - fixture exists: PASS");
+    println!("  - rust skeleton exists: PASS");
+    println!("note: this scaffold demonstrates deterministic mapping only;");
+    println!("it does not generate Rust code dynamically.");
+
+    if same_order {
+        Ok(())
+    } else {
+        Err("fixture and rust step ordering do not match".to_string())
+    }
+}


### PR DESCRIPTION
## Summary
- add bounded Rust-first transpiler demo scaffold for v0.8
- include canonical workflow fixture, Rust scaffold entrypoint, and deterministic Rust runtime skeleton
- add demo README describing fixture -> scaffold -> runtime mapping and #703 handoff

## Validation
- cargo run --manifest-path tools/transpiler_demo/Cargo.toml --quiet
- required artifact path checks
- path hygiene scan for host paths/stale planning refs

Closes #702