### PR TITLE
[v0.85][tooling] Normalize reviewer protocol IDs across Prompt Spec and card review docs

### DIFF
--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -5,3 +5,4 @@ This directory documents ADL tooling contracts used by card automation and revie
 ## References
 - [Prompt Spec](prompt-spec.md): machine-readable input-card block defining deterministic prompt generation surfaces and reviewer alignment.
 - [Prompt Spec Protocol Bindings](prompt-spec.md#protocol-bindings): linkage to `card_review_checklist.v1` and `card_review_output.v1` reviewer contracts.
+- [Card Reviewer GPT Instructions](card-reviewer-gpt.md): canonical reviewer behavior and deterministic YAML output contract (`card_reviewer_gpt.v1.1`).

--- a/docs/tooling/card-review-output-format.md
+++ b/docs/tooling/card-review-output-format.md
@@ -53,7 +53,7 @@ Top-level key order MUST be:
 
 - type: map
 - required fields:
-  - `reviewer`: string (`human` | versioned reviewer id, e.g. `card_reviewer_gpt.v1`)
+  - `reviewer`: string (`human` | versioned reviewer id, e.g. `card_reviewer_gpt.v1.1`)
   - `review_time_utc`: string (ISO-8601 UTC)
   - `checklist_version`: string (for #650 checklist, use `card_review_checklist.v1`)
 

--- a/docs/tooling/examples/card-review-output-example.yaml
+++ b/docs/tooling/examples/card-review-output-example.yaml
@@ -1,6 +1,6 @@
 review_format_version: card_review_output.v1
 review_metadata:
-  reviewer: card_reviewer_gpt.v1
+  reviewer: card_reviewer_gpt.v1.1
   review_time_utc: 2026-03-06T18:05:00Z
   checklist_version: card_review_checklist.v1
 review_target:

--- a/docs/tooling/prompt-spec.md
+++ b/docs/tooling/prompt-spec.md
@@ -14,6 +14,11 @@ Prompt Spec reduces heuristic parsing and gives a stable contract for automation
 - `constraints`: Safety and determinism constraints the generator must preserve.
 - `review_surfaces`: Reviewer protocols expected to consume outputs.
 
+### `review_surfaces` Protocol ID Rules
+- Use dotted version IDs (for example `card_review_output.v1`), not underscore variants.
+- IDs are case-sensitive and must match referenced specs exactly.
+- Unknown or misspelled IDs should be treated as contract failures by automation/review tooling.
+
 ## Agent Interpretation
 Agents should interpret Prompt Spec as an execution contract:
 - Preserve section order from `inputs.sections`.
@@ -37,5 +42,6 @@ Input Card -> Prompt Generation -> Agent Execution -> Output Card -> Structured 
 Prompt Spec should declare reviewer-facing protocol surfaces using stable IDs:
 - `card_review_checklist.v1`: required checklist semantics used to evaluate card completeness and policy alignment.
 - `card_review_output.v1`: deterministic review artifact envelope used for machine-readable findings output.
+- `card_reviewer_gpt.v1.1`: reviewer behavior contract for deterministic card evaluation and YAML-only output.
 
 When these IDs are present in `review_surfaces`, prompt generators and reviewers can coordinate on stable contracts without markdown heuristic coupling.

--- a/swarm/templates/cards/input_card_template.md
+++ b/swarm/templates/cards/input_card_template.md
@@ -50,7 +50,7 @@ constraints:
 review_surfaces:
   - card_review_checklist.v1
   - card_review_output.v1
-  - card_reviewer_gpt_v1
+  - card_reviewer_gpt.v1.1
 ```
 
 Execution:


### PR DESCRIPTION
## Summary
- normalize reviewer protocol IDs to `card_reviewer_gpt.v1.1` across template/docs/example
- add explicit protocol ID contract rules to Prompt Spec
- add reviewer spec reference in tooling README

## Files changed
- docs/tooling/README.md
- docs/tooling/prompt-spec.md
- docs/tooling/card-review-output-format.md
- docs/tooling/examples/card-review-output-example.yaml
- swarm/templates/cards/input_card_template.md

Closes #755
