### PR TITLE
[v0.8][authoring] Integrate Prompt Spec block with reviewer surfaces

### DIFF
--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -5,6 +5,7 @@ This directory documents ADL tooling contracts used by card automation and revie
 ## References
 - [Prompt Spec](prompt-spec.md): machine-readable input-card block defining deterministic prompt generation surfaces and reviewer alignment.
 - [Prompt Spec Protocol Bindings](prompt-spec.md#protocol-bindings): linkage to `card_review_checklist.v1` and `card_review_output.v1` reviewer contracts.
+- [Prompt/Reviewer Surface Mapping](prompt-review-surface-mapping.md): field-by-field contract map between Prompt Spec, checklist rules, and deterministic review output fields.
 - Prompt Spec execution tooling:
   - `swarm/tools/lint_prompt_spec.sh` (Prompt Spec lint/validation)
   - `swarm/tools/card_prompt.sh` (deterministic prompt generation from cards)

--- a/docs/tooling/card-review-checklist.md
+++ b/docs/tooling/card-review-checklist.md
@@ -69,6 +69,7 @@ Each rule has:
 - `CRS-STR-002` (`high`): `Status` is a valid terminal or in-progress value and matches narrative state.
 - `CRS-STR-003` (`medium`): `Execution` metadata is present and non-placeholder.
 - `CRS-STR-004` (`high`): `Artifacts produced` contains explicit repo-relative paths.
+- `CRS-STR-005` (`high`): If input card has `## Prompt Spec`, protocol bindings are version-compatible with reviewer/checklist/output surfaces (`card_review_checklist.v1`, `card_review_output.v1`, `card_reviewer_gpt.v1.1`).
 
 ### Acceptance Domain
 
@@ -125,6 +126,23 @@ Each finding must include at least one evidence pointer:
 - artifact path
 
 Narrative-only claims without evidence should be marked as `needs_evidence` and fail the relevant rule.
+
+## Prompt Spec Integration Notes
+
+When `CRS-STR-005` applies, reviewers should verify:
+
+- Prompt Spec `prompt_schema` is recognized (`adl.v1`)
+- Prompt Spec `review_surfaces` contains required protocol IDs in canonical order:
+  1. `card_review_checklist.v1`
+  2. `card_review_output.v1`
+  3. `card_reviewer_gpt.v1.1`
+- review output metadata/version fields are compatible:
+  - `review_metadata.checklist_version`
+  - `review_format_version`
+  - `review_metadata.reviewer`
+
+Canonical cross-surface field map:
+- `docs/tooling/prompt-review-surface-mapping.md`
 
 ## Example Checklist Application (Real ADL Card)
 

--- a/docs/tooling/card-review-output-format.md
+++ b/docs/tooling/card-review-output-format.md
@@ -65,6 +65,11 @@ Top-level key order MUST be:
   - `output_card_path`: string (repo-relative)
   - `input_card_path`: string (repo-relative)
   - `pr`: string or null
+- optional field:
+  - `prompt_spec_bindings`: map or null with fields:
+    - `prompt_schema`: string
+    - `review_surfaces`: ordered list of protocol IDs
+    - `bindings_validated`: boolean
 
 ### `decision`
 
@@ -185,3 +190,11 @@ This example is normative for structure and field ordering.
 
 - Reviewers MAY include additional keys only under a future version (`card_review_output.v2+`).
 - v1 parsers should reject unknown top-level keys to prevent silent schema drift.
+
+## Prompt Spec Alignment
+
+When the reviewed input card contains a Prompt Spec block, reviewers should populate
+`review_target.prompt_spec_bindings` to make the protocol/version alignment explicit.
+
+Canonical mapping reference:
+- `docs/tooling/prompt-review-surface-mapping.md`

--- a/docs/tooling/card-reviewer-gpt.md
+++ b/docs/tooling/card-reviewer-gpt.md
@@ -114,6 +114,7 @@ Do not mark a field as both satisfied and unsatisfied in the same artifact.
 
 The reviewer MUST output YAML conforming to:
 - `docs/tooling/card-review-output-format.md`
+- `docs/tooling/prompt-review-surface-mapping.md` (for Prompt Spec binding fields when Prompt Spec is present)
 
 Decision enum is strictly:
 - `PASS`

--- a/docs/tooling/examples/card-review-output-example.yaml
+++ b/docs/tooling/examples/card-review-output-example.yaml
@@ -8,6 +8,13 @@ review_target:
   output_card_path: .adl/cards/660/output_660.md
   input_card_path: .adl/cards/660/input_660.md
   pr: "#670"
+  prompt_spec_bindings:
+    prompt_schema: adl.v1
+    review_surfaces:
+      - card_review_checklist.v1
+      - card_review_output.v1
+      - card_reviewer_gpt.v1.1
+    bindings_validated: true
 decision: PASS
 summary:
   status_line: "All checklist domains passed; no findings."

--- a/docs/tooling/prompt-review-surface-mapping.md
+++ b/docs/tooling/prompt-review-surface-mapping.md
@@ -1,0 +1,47 @@
+# Prompt/Reviewer Surface Mapping
+
+Status: canonical v0.8 alignment surface for issue #668
+
+## Purpose
+
+Define the shared field contract between:
+
+1. Prompt Spec block in input cards (`adl.v1`)
+2. Card Review Checklist (`card_review_checklist.v1`)
+3. Deterministic review output artifact (`card_review_output.v1`)
+
+This mapping is the anti-drift reference for reviewer tooling behavior.
+
+## Deterministic Contract
+
+For identical input card + output card content:
+
+- checklist rule evaluation order is fixed by checklist spec
+- findings ordering is fixed by review output spec
+- protocol IDs and versions are validated from Prompt Spec
+
+No hidden inference should be required to bind these surfaces.
+
+## Field Mapping
+
+| Prompt Spec surface | Checklist surface | Review output surface | Notes |
+|---|---|---|---|
+| `prompt_schema` (`adl.v1`) | `CRS-STR-005` (Prompt Spec contract compatibility) | `review_target.prompt_spec_bindings.prompt_schema` | Reviewer confirms recognized Prompt Spec schema version. |
+| `review_surfaces` includes `card_review_checklist.v1` | `CRS-STR-005` | `review_metadata.checklist_version` + `review_target.prompt_spec_bindings.review_surfaces` | Checklist version in output must match Prompt Spec declared protocol. |
+| `review_surfaces` includes `card_review_output.v1` | `CRS-STR-005` | `review_format_version` + `review_target.prompt_spec_bindings.review_surfaces` | Review artifact schema version must match Prompt Spec declared protocol. |
+| `review_surfaces` includes `card_reviewer_gpt.v1.1` | `CRS-STR-005` | `review_metadata.reviewer` + `review_target.prompt_spec_bindings.review_surfaces` | Reviewer identity/version should be compatible with Prompt Spec declaration. |
+| `inputs.sections` ordering | `CRS-DET-002` | `determinism_checks.ordering_contract_verified` | Ordering contract for prompt generation must be explicit and stable. |
+| `constraints.disallow_secrets` | `CRS-SEC-001` / `CRS-SEC-002` | `security_privacy_checks.secrets_present` and `security_privacy_checks.raw_prompt_or_tool_args_present` | Reviewer confirms no leakage in output artifacts. |
+| `constraints.disallow_absolute_host_paths` | `CRS-SEC-003` | `security_privacy_checks.absolute_host_paths_present` | Reviewer confirms repo-relative path hygiene. |
+| `constraints.include_system_invariants` | `CRS-DET-001` | `determinism_checks.notes` | Reviewer checks determinism assertions are present when required by card contract. |
+| `constraints.include_reviewer_checklist` | `CRS-VAL-001` and `CRS-ACC-001` | `validation_checks.required_commands_run` and `acceptance_criteria` | Reviewer checks checklist-driven validation claims are evidenced. |
+
+## Canonical Version Set (v0.8)
+
+- Prompt Spec schema: `adl.v1`
+- Checklist schema: `card_review_checklist.v1`
+- Review output schema: `card_review_output.v1`
+- Reviewer protocol id: `card_reviewer_gpt.v1.1`
+
+If any one of these changes, a versioned update to this mapping is required.
+

--- a/docs/tooling/prompt-spec.md
+++ b/docs/tooling/prompt-spec.md
@@ -72,3 +72,11 @@ Prompt Spec should declare reviewer-facing protocol surfaces using stable IDs:
 - `card_reviewer_gpt.v1.1`: reviewer behavior contract for deterministic card evaluation and YAML-only output.
 
 When these IDs are present in `review_surfaces`, prompt generators and reviewers can coordinate on stable contracts without markdown heuristic coupling.
+
+## Shared Contract Mapping
+
+Canonical field mapping between Prompt Spec, checklist rules, and deterministic review-output fields is defined in:
+
+- `docs/tooling/prompt-review-surface-mapping.md`
+
+That mapping is the source of truth for cross-surface alignment and drift prevention.

--- a/swarm/tools/lint_prompt_spec.sh
+++ b/swarm/tools/lint_prompt_spec.sh
@@ -163,4 +163,53 @@ for bool_key in include_system_invariants include_reviewer_checklist disallow_se
   fi
 done
 
+review_surfaces=()
+while IFS= read -r line; do
+  review_surfaces+=("$line")
+done < <(
+  awk '
+    /^review_surfaces:[[:space:]]*$/ { in_review=1; next }
+    in_review && /^[A-Za-z0-9_]+:[[:space:]]*$/ { in_review=0; next }
+    in_review && /^  -[[:space:]]+/ {
+      line=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      print line
+      next
+    }
+    in_review && !/^  / { in_review=0 }
+  ' <<<"$spec"
+)
+
+[[ "${#review_surfaces[@]}" -gt 0 ]] || die "review_surfaces must include at least one protocol id"
+
+has_checklist=0
+has_output=0
+has_reviewer=0
+for surface in "${review_surfaces[@]}"; do
+  case "$surface" in
+    card_review_checklist.v1) has_checklist=1 ;;
+    card_review_output.v1) has_output=1 ;;
+    card_reviewer_gpt.v1.1) has_reviewer=1 ;;
+  esac
+done
+
+[[ "$has_checklist" -eq 1 ]] || die "review_surfaces missing required protocol id: card_review_checklist.v1"
+[[ "$has_output" -eq 1 ]] || die "review_surfaces missing required protocol id: card_review_output.v1"
+[[ "$has_reviewer" -eq 1 ]] || die "review_surfaces missing required protocol id: card_reviewer_gpt.v1.1"
+
+checklist_pos=-1
+output_pos=-1
+reviewer_pos=-1
+for i in "${!review_surfaces[@]}"; do
+  case "${review_surfaces[$i]}" in
+    card_review_checklist.v1) checklist_pos="$i" ;;
+    card_review_output.v1) output_pos="$i" ;;
+    card_reviewer_gpt.v1.1) reviewer_pos="$i" ;;
+  esac
+done
+
+if [[ "$checklist_pos" -gt "$output_pos" || "$output_pos" -gt "$reviewer_pos" ]]; then
+  die "review_surfaces must appear in canonical order: checklist -> output -> reviewer"
+fi
+
 echo "PASS: Prompt Spec is valid for $INPUT"

--- a/swarm/tools/test_prompt_spec_lint.sh
+++ b/swarm/tools/test_prompt_spec_lint.sh
@@ -51,6 +51,7 @@ constraints:
 review_surfaces:
   - card_review_checklist.v1
   - card_review_output.v1
+  - card_reviewer_gpt.v1.1
 ```
 EOF
 
@@ -101,6 +102,53 @@ EOF
   set -e
   if [[ "$rc" -eq 0 ]]; then
     echo "assertion failed: invalid prompt spec unexpectedly passed lint" >&2
+    exit 1
+  fi
+)
+
+cat > "$repo/.adl/cards/761/input_missing_surface_761.md" <<'EOF'
+# ADL Input Card
+
+Task ID: issue-0761
+Run ID: issue-0761
+Version: v0.8
+Title: lint-fail-missing-review-surface
+Branch: codex/761-lint-fail
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+outputs:
+  output_card: .adl/cards/761/output_761.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+```
+EOF
+
+(
+  cd "$repo"
+  set +e
+  ./swarm/tools/lint_prompt_spec.sh --input .adl/cards/761/input_missing_surface_761.md >/dev/null 2>&1
+  rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "assertion failed: missing card_reviewer_gpt.v1.1 unexpectedly passed lint" >&2
     exit 1
   fi
 )


### PR DESCRIPTION
## Summary
- define and document a canonical field mapping across Prompt Spec, checklist, and review-output surfaces
- enforce reviewer protocol bindings in Prompt Spec lint tooling (including canonical order)
- align checklist/output specs and normative example with Prompt Spec bindings

## Validation
- swarm/tools/test_prompt_spec_lint.sh
- swarm/tools/test_card_prompt.sh
- swarm/tools/lint_prompt_spec.sh --input swarm/templates/cards/input_card_template.md
- rg -n '/Users/|/home/|\.adl/docs/v08planning' docs/tooling/*.md docs/tooling/examples/*.yaml

Closes #668