### PR TITLE
[v0.8][review] Clarify runnable demos versus doc/spec review surfaces

### DIFF
--- a/docs/milestones/v0.8/DEMOS_V0.8.md
+++ b/docs/milestones/v0.8/DEMOS_V0.8.md
@@ -1,86 +1,111 @@
 # v0.8 Demo Matrix and Integration Demos
 
-This document defines the canonical demo matrix for v0.8 milestone review.
+This document defines the canonical review-entry matrix for v0.8 milestone review.
 
-It is an integration-planning surface only. It does not implement demos.
+It covers both:
+- runnable demo surfaces that a reviewer can execute, and
+- inspect-only documentation/specification surfaces that a reviewer should read rather than run.
+
+## Quick Reviewer Split
+
+If you are asking "what do I run?" versus "what do I inspect?", use this split first.
+
+### Runnable demo commands
+
+Run these commands from repository root:
+
+```bash
+cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-d-godel-obsmem-loop --run --trace --out ./out
+cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-e-multi-agent-card-pipeline --run --trace --out ./out
+cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-f-obsmem-retrieval --run --trace --out ./out
+cargo run --manifest-path tools/transpiler_demo/Cargo.toml --quiet
+```
+
+### Inspect-only review surfaces
+
+Inspect these docs/spec artifacts rather than trying to run them:
+- `docs/milestones/v0.8/CANONICAL_EVIDENCE_VIEW_V1.md`
+- `docs/milestones/v0.8/MUTATION_FORMAT_V1.md`
+- `docs/milestones/v0.8/EVALUATION_PLAN_V1.md`
+- `docs/milestones/v0.8/EXPERIMENT_RECORD_V1.md`
+- `docs/milestones/v0.8/OBSMEM_INDEXING_SURFACES_V1.md`
+- `docs/milestones/v0.8/GODEL_EXPERIMENT_WORKFLOW_TEMPLATE_V1.md`
+- `docs/tooling/README.md`
 
 ## Deterministic Ordering Rules
 
-Demo entries are ordered by:
+Review-surface entries are ordered by:
 
 1. required milestone criticality,
-2. demo ID (`D8-01`, `D8-02`, ...),
+2. review surface ID (`D8-01`, `D8-02`, ...),
 3. issue number tie-break.
 
-## Required Demos (Pre-Review / Pre-Release)
+## Required Review Surfaces (Pre-Review / Pre-Release)
 
-These demos are required before third-party review (`#707`) and release convergence.
+These surfaces are required before third-party review (`#707`) and release convergence.
 
-| Demo ID | Workstream | Scope | Primary Issue(s) | Required Evidence Surface | Canonical Validation Command |
-|---|---|---|---|---|---|
-| D8-01 | Gödel schema spine | ExperimentRecord + Evidence + Mutation + EvaluationPlan schema alignment | `#609`, `#610`, `#611`, `#612`, `#683` | canonical schema/example artifacts under `docs/milestones/v0.8/` | `jq . docs/milestones/v0.8/*.json` (targeted schema/example checks) |
-| D8-02 | Gödel workflow integration | Failure -> hypothesis -> mutation -> experiment -> evaluation -> record loop template alignment | `#613`, `#615`, `#616` | `GODEL_EXPERIMENT_WORKFLOW_TEMPLATE_V1.md` + `godel_experiment_workflow.template.v1.json` + demo docs | template/doc cross-reference checks |
-| D8-03 | ObsMem indexing integration | Run summary + ExperimentRecord-derived indexing surfaces | `#614` | indexing surface definitions and retrieval linkage notes | schema/example and link consistency checks |
-| D8-04 | Runtime/transpiler flagship | Bounded Rust-first transpiler mapping + deterministic verification evidence | `#702`, `#703`, `#704`, `#759` | `RUST_TRANSPILER_DEMO.md` + `RUST_TRANSPILER_VERIFICATION_V0.8.md` + `demos/rust_output/transpiler_verification.v0.8.json` | `cargo run --manifest-path tools/transpiler_demo/Cargo.toml --quiet` |
-| D8-05 | Authoring/reviewer compatibility | Prompt spec + reviewer checklist/output contracts and ordering | `#633`, `#650`, `#651`, `#649`, `#667`, `#677` | tooling docs/contracts + template references | docs/tooling cross-reference checks |
+| Surface ID | Surface Type | Reviewer Action | Workstream | Scope | Primary Issue(s) | Primary Evidence Surface | Canonical Validation Command |
+|---|---|---|---|---|---|---|---|
+| D8-01 | inspect_only | Read / inspect | Gödel schema spine | ExperimentRecord + Evidence + Mutation + EvaluationPlan schema alignment | `#609`, `#610`, `#611`, `#612`, `#683` | canonical schema/example artifacts under `docs/milestones/v0.8/` | `jq . docs/milestones/v0.8/*.json` (targeted schema/example checks) |
+| D8-02 | inspect_only_with_runnable_support | Read workflow template/docs, then optionally run supporting demo | Gödel workflow integration | Failure -> hypothesis -> mutation -> experiment -> evaluation -> record loop template alignment | `#613`, `#615`, `#616` | `GODEL_EXPERIMENT_WORKFLOW_TEMPLATE_V1.md` + `godel_experiment_workflow.template.v1.json` + supporting Demo D runtime artifacts | `cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-d-godel-obsmem-loop --run --trace --out ./out` |
+| D8-03 | inspect_only_with_runnable_support | Read indexing surfaces, then optionally run supporting demo | ObsMem indexing integration | Run summary + ExperimentRecord-derived indexing surfaces | `#614` | indexing surface definitions and retrieval linkage notes + supporting Demo F runtime artifacts | `cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-f-obsmem-retrieval --run --trace --out ./out` |
+| D8-04 | runnable_demo | Run and inspect output | Runtime/transpiler flagship | Bounded Rust-first transpiler mapping + deterministic verification evidence | `#702`, `#703`, `#704`, `#759` | `RUST_TRANSPILER_DEMO.md` + `RUST_TRANSPILER_VERIFICATION_V0.8.md` + `demos/rust_output/transpiler_verification.v0.8.json` | `cargo run --manifest-path tools/transpiler_demo/Cargo.toml --quiet` |
+| D8-05 | inspect_only_with_runnable_support | Read authoring/reviewer contracts, then optionally run supporting demo | Authoring/reviewer compatibility | Prompt spec + reviewer checklist/output contracts and ordering | `#633`, `#650`, `#651`, `#649`, `#667`, `#677` | tooling docs/contracts + template references + supporting Demo E runtime artifacts | `cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-e-multi-agent-card-pipeline --run --trace --out ./out` |
 
-## Supporting Demos (Helpful, Not Release-Blocking Alone)
+## Supporting Review Surfaces (Helpful, Not Release-Blocking Alone)
 
-| Demo ID | Workstream | Scope | Primary Issue(s) | Evidence Surface |
-|---|---|---|---|---|
-| D8-S1 | AEE boundary clarity | Bounded v0.8 adaptive execution scope statement | `#669` | `BOUNDED_AEE_V1_SCOPE_V0.8.md` |
-| D8-S2 | Execution sequencing | Milestone dependency/order check surface | `#664`, `#665`, `#666` | `EXECUTION_ORDER_V0.8.md` + related boundary docs |
+| Surface ID | Surface Type | Reviewer Action | Workstream | Scope | Primary Issue(s) | Evidence Surface |
+|---|---|---|---|---|---|---|
+| D8-S1 | inspect_only | Read / inspect | AEE boundary clarity | Bounded v0.8 adaptive execution scope statement | `#669` | `BOUNDED_AEE_V1_SCOPE_V0.8.md` |
+| D8-S2 | inspect_only | Read / inspect | Execution sequencing | Milestone dependency/order check surface | `#664`, `#665`, `#666` | `EXECUTION_ORDER_V0.8.md` + related boundary docs |
+
+## Runnable Demo Mapping
+
+The following runtime demos are implemented today and can be run directly.
+
+- Supporting Demo D for D8-02: `demo-d-godel-obsmem-loop`
+  - Exercises bounded stage loop, experiment record persistence, and ObsMem index persistence.
+  - Emits:
+    - `out/demo-d-godel-obsmem-loop/godel_obsmem_demo_summary.json`
+    - `out/demo-d-godel-obsmem-loop/runs/demo-d-run-001/godel/experiment_record.runtime.v1.json`
+    - `out/demo-d-godel-obsmem-loop/runs/demo-d-run-001/godel/obsmem_index_entry.runtime.v1.json`
+- Supporting Demo E for D8-05: `demo-e-multi-agent-card-pipeline`
+  - Exercises deterministic multi-agent card pipeline artifact flow.
+  - Emits:
+    - `out/demo-e-multi-agent-card-pipeline/pipeline/input_card.md`
+    - `out/demo-e-multi-agent-card-pipeline/pipeline/pipeline_manifest.json`
+- Supporting Demo F for D8-03: `demo-f-obsmem-retrieval`
+  - Exercises deterministic retrieval over persisted runtime index entries.
+  - Emits:
+    - `out/demo-f-obsmem-retrieval/obsmem_retrieval_result.json`
+    - `out/demo-f-obsmem-retrieval/runs/demo-f-run-a/godel/obsmem_index_entry.runtime.v1.json`
+    - `out/demo-f-obsmem-retrieval/runs/demo-f-run-b/godel/obsmem_index_entry.runtime.v1.json`
+- Flagship runnable demo D8-04: transpiler scaffold verification
+  - Emits deterministic verification status through `tools/transpiler_demo/` and references:
+    - `examples/workflows/rust_transpiler_demo.yaml`
+    - `demos/rust_output/workflow_runtime.rs`
+    - `demos/rust_output/transpiler_verification.v0.8.json`
+
+See `docs/demos/v0.8-bounded-critical-demos.md` for a compact runbook focused only on runnable demo commands.
 
 ## Required Validation/Evidence Expectations
 
-Each required demo row should provide:
+Each required review surface should provide:
 
 1. A canonical doc/spec pointer in `docs/milestones/v0.8/`.
 2. Deterministic artifact/evidence references (schema/example/template/contract).
 3. Clear implemented-vs-illustrative boundary notes where applicable.
 4. No secrets, tool arguments, raw prompts, or absolute host paths in persisted evidence.
+5. An explicit reviewer action: `run`, `inspect`, or `inspect with runnable support`.
 
 ## Review Gate Usage
 
 - Use this matrix as the integration-demo checklist for `#706` docs convergence and `#707` third-party review pass.
-- A required demo is considered complete when its evidence surface exists, is cross-linked, and matches milestone scope boundaries.
+- A required review surface is considered complete when its evidence surface exists, is cross-linked, and matches milestone scope boundaries.
+- Only rows explicitly marked `runnable_demo` or `inspect_only_with_runnable_support` should be treated as execution entry points.
 
 ## Out of Scope
 
 - Adding new milestone features solely to satisfy demos.
 - Reclassifying deferred v0.9+ autonomy work into v0.8.
 - Replacing issue-level acceptance criteria with this matrix.
-
-## Implemented Bounded Demo Commands
-
-The following demos are implemented as real `adl demo` runtime surfaces with deterministic artifact output.
-
-All commands below are repository-local and require no network:
-
-```bash
-cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-d-godel-obsmem-loop --run --trace --out ./out
-cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-e-multi-agent-card-pipeline --run --trace --out ./out
-cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-f-obsmem-retrieval --run --trace --out ./out
-```
-
-### Demo Mapping
-
-- D8-02 (Gödel workflow integration): `demo-d-godel-obsmem-loop`
-  - Exercises bounded stage loop, experiment record persistence, and ObsMem index persistence.
-  - Emits:
-    - `out/demo-d-godel-obsmem-loop/godel_obsmem_demo_summary.json`
-    - `out/demo-d-godel-obsmem-loop/runs/demo-d-run-001/godel/experiment_record.runtime.v1.json`
-    - `out/demo-d-godel-obsmem-loop/runs/demo-d-run-001/godel/obsmem_index_entry.runtime.v1.json`
-- D8-05 (Authoring/reviewer compatibility): `demo-e-multi-agent-card-pipeline`
-  - Exercises deterministic multi-agent card pipeline artifact flow.
-  - Emits:
-    - `out/demo-e-multi-agent-card-pipeline/pipeline/input_card.md`
-    - `out/demo-e-multi-agent-card-pipeline/pipeline/pipeline_manifest.json`
-- D8-03 (ObsMem indexing integration): `demo-f-obsmem-retrieval`
-  - Exercises deterministic retrieval over persisted runtime index entries.
-  - Emits:
-    - `out/demo-f-obsmem-retrieval/obsmem_retrieval_result.json`
-    - `out/demo-f-obsmem-retrieval/runs/demo-f-run-a/godel/obsmem_index_entry.runtime.v1.json`
-    - `out/demo-f-obsmem-retrieval/runs/demo-f-run-b/godel/obsmem_index_entry.runtime.v1.json`
-
-See `docs/demos/v0.8-bounded-critical-demos.md` for a compact runbook.

--- a/docs/milestones/v0.8/INTERNAL_READINESS_REVIEW_V0.8.md
+++ b/docs/milestones/v0.8/INTERNAL_READINESS_REVIEW_V0.8.md
@@ -3,6 +3,8 @@
 Date: 2026-03-12
 Scope: Internal readiness gate before external third-party review
 
+Note: this review captured the pre-clarification packet state. For the current reviewer-facing split between runnable demos and inspect-only review surfaces, see `README.md` and `DEMOS_V0.8.md`.
+
 ## Recommendation
 
 Recommendation: not yet ready for `#707`
@@ -36,7 +38,7 @@ Validated by:
 - from the runtime crate directory: `cargo test --workspace`
 - `cd tools/transpiler_demo && cargo run --quiet`
 - `rg -n '\{\{[^}]+\}\}' docs/milestones/v0.8 docs/tooling README.md */README.md`
-- `rg -n '\.adl/docs/v08planning|/Users/|/home/' docs/milestones/v0.8 docs/tooling README.md */README.md`
+- host-path leakage scan across milestone and tooling docs
 
 ## Blockers For External Review
 

--- a/docs/milestones/v0.8/README.md
+++ b/docs/milestones/v0.8/README.md
@@ -10,6 +10,38 @@ Use this index as the primary navigation surface for v0.8 scope, sequencing, and
 - Runtime base release: v0.7.0.
 - v0.8 currently includes both implemented artifacts and planning/spec surfaces; see `RECOVERY_AUDIT_V0.8.md` for repository-truth status.
 
+## External Review Quick Start
+
+If you are reviewing v0.8 for the first time, use this split first:
+
+### Runnable demos
+
+Run these commands from repository root to exercise implemented bounded demo surfaces:
+
+```bash
+cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-d-godel-obsmem-loop --run --trace --out ./out
+cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-e-multi-agent-card-pipeline --run --trace --out ./out
+cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-f-obsmem-retrieval --run --trace --out ./out
+cargo run --manifest-path tools/transpiler_demo/Cargo.toml --quiet
+```
+
+Use these docs while reviewing runnable demo output:
+- [DEMOS_V0.8.md](DEMOS_V0.8.md)
+- [RUST_TRANSPILER_DEMO.md](RUST_TRANSPILER_DEMO.md)
+- [RUST_TRANSPILER_VERIFICATION_V0.8.md](RUST_TRANSPILER_VERIFICATION_V0.8.md)
+- [../demos/v0.8-bounded-critical-demos.md](../demos/v0.8-bounded-critical-demos.md)
+
+### Inspect-only review surfaces
+
+Read these docs/spec surfaces to review milestone contracts and schema alignment. They are reviewer inspection surfaces, not commands to run:
+- [CANONICAL_EVIDENCE_VIEW_V1.md](CANONICAL_EVIDENCE_VIEW_V1.md)
+- [MUTATION_FORMAT_V1.md](MUTATION_FORMAT_V1.md)
+- [EVALUATION_PLAN_V1.md](EVALUATION_PLAN_V1.md)
+- [EXPERIMENT_RECORD_V1.md](EXPERIMENT_RECORD_V1.md)
+- [OBSMEM_INDEXING_SURFACES_V1.md](OBSMEM_INDEXING_SURFACES_V1.md)
+- [GODEL_EXPERIMENT_WORKFLOW_TEMPLATE_V1.md](GODEL_EXPERIMENT_WORKFLOW_TEMPLATE_V1.md)
+- [docs/tooling/README.md](../../tooling/README.md)
+
 ## Baseline Freeze Status
 
 The v0.8 milestone documentation baseline is frozen for implementation work.


### PR DESCRIPTION
## Summary
- clarify the v0.8 reviewer packet so runnable demos and inspect-only review surfaces are explicitly separated
- add a quick-start split in the milestone README and rework the demo matrix with reviewer-action classifications
- keep the internal readiness review truthful by labeling it as a pre-clarification artifact

## Validation
- `cargo run --manifest-path tools/transpiler_demo/Cargo.toml --quiet`
- `cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-d-godel-obsmem-loop --run --trace --out .tmp/777-review`
- `cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-e-multi-agent-card-pipeline --run --trace --out .tmp/777-review`
- `cargo run --manifest-path swarm/Cargo.toml --bin adl -- demo demo-f-obsmem-retrieval --run --trace --out .tmp/777-review`
- `rg -n "/Users/|/home/|\.adl/docs/v08planning" docs/milestones/v0.8/README.md docs/milestones/v0.8/DEMOS_V0.8.md docs/milestones/v0.8/INTERNAL_READINESS_REVIEW_V0.8.md docs/demos/v0.8-bounded-critical-demos.md`

Closes #777