### PR TITLE
[v0.8][obsmem] Resolve ObsMem + Bayes follow-through versus current implementation

### DIFF
--- a/docs/milestones/v0.8/ARCHITECTURE_V0.8.md
+++ b/docs/milestones/v0.8/ARCHITECTURE_V0.8.md
@@ -39,7 +39,7 @@ Replay + Activation Log
         ↓
 Structured Trace Bundles
         ↓
-ObsMem (Bayesian Retrieval)
+ObsMem (Deterministic Retrieval)
         ↓
 Gödel Evaluation + Mutation
         ↓

--- a/docs/milestones/v0.8/GODEL_AGENT_NOTES.md
+++ b/docs/milestones/v0.8/GODEL_AGENT_NOTES.md
@@ -10,16 +10,16 @@ Replay and determinism remain essential properties of the architecture. Experime
 
 - Gödel-style self-improvement loops
 - Hadamard-style hypothesis generation and creative insight
-- Bayesian evaluation of evidence and experiment outcomes
+- evidence-guided evaluation of experiment outcomes, with Bayesian-style updating deferred beyond the current v0.8 runtime
 
-Together these form what can be thought of as the **Gödel–Hadamard–Bayes cognition loop**. Failures generate hypotheses, hypotheses generate bounded mutations and experiments, experiments produce evidence, and evidence updates the system's understanding of which strategies are effective.
+Together these form what can be thought of as the **Gödel–Hadamard–Bayes cognition loop**. In current repo truth, failures generate hypotheses, hypotheses generate bounded mutations and experiments, experiments produce evidence, and deterministic evaluation/indexing surfaces preserve that evidence. A fuller Bayesian update layer remains future-facing rather than implemented.
 
 ObsMem is the memory substrate that makes this loop possible. It stores the scientific artifacts of the agent's reasoning process: failures, hypotheses, experiments, evaluations, and outcomes. With proper indexing, the system can retrieve prior reasoning and reuse it when encountering similar failures.
 
 This transforms the architecture from a simple agent execution framework into something closer to a scientific discovery engine. The agent is not merely executing workflows; it is accumulating knowledge about which ideas work, which do not, and why.
 
 
-The long-term vision is that the Gödel–Hadamard–Bayes loop, backed by deterministic replay and ObsMem indexing, will allow ADL agents to improve their strategies over time while remaining transparent, inspectable, and scientifically grounded.
+The long-term vision is that the Gödel–Hadamard–Bayes loop, backed by deterministic replay and ObsMem indexing, will allow ADL agents to improve their strategies over time while remaining transparent, inspectable, and scientifically grounded. The current runtime should be read as providing the replay/indexing substrate, not a completed Bayes subsystem.
 
 ---
 

--- a/docs/milestones/v0.8/GODEL_LOOP_DIAGRAM.md
+++ b/docs/milestones/v0.8/GODEL_LOOP_DIAGRAM.md
@@ -69,10 +69,10 @@ Future hypothesis search / experiment selection
 
 ## Conceptual framing
 
-This loop is the visual expression of the Gödel–Hadamard–Bayes cognition model emerging in ADL:
+This loop is the visual expression of the Gödel–Hadamard–Bayes conceptual framing emerging in ADL:
 
 - **Gödel** → self-referential system improvement through explicit mutation and experiment records
 - **Hadamard** → hypothesis generation and conceptual search
-- **Bayes** → evidence-based evaluation of experiment outcomes
+- **Bayes** → future-facing evidence-update discipline; v0.8 currently implements deterministic evaluation artifacts rather than a Bayesian runtime layer
 
 In ADL v0.8, these ideas are represented through deterministic artifacts and bounded workflows rather than unconstrained autonomous self-modification.

--- a/docs/milestones/v0.8/OBSMEM_BAYES.md
+++ b/docs/milestones/v0.8/OBSMEM_BAYES.md
@@ -4,6 +4,12 @@
 
 This note explains how **Observational Memory (ObsMem)** can support **Bayesian-style reasoning** inside ADL without requiring a full probabilistic programming system.
 
+For v0.8, this document is conceptual and intentionally narrower than the phrase
+“ObsMem + Bayes” may suggest. The current runtime implements deterministic
+ObsMem indexing, retrieval filtering, and explicit score-based ranking. It does
+not implement a general Bayesian update subsystem or hidden confidence
+adjustment in runtime paths.
+
 The goal is not to turn ADL into a mathematically heavy inference engine. The goal is to give ADL a disciplined way to:
 
 - remember prior observations
@@ -30,7 +36,7 @@ At a high level:
 In ADL terms:
 
 - ObsMem provides the memory substrate
-- Bayes provides the update discipline
+- Bayes is a future framing for how evidence updates might later be made more disciplined
 
 This means ADL can move from:
 
@@ -46,7 +52,7 @@ Toward:
 
 Without a disciplined update rule, memory retrieval can become little more than pattern matching theater.
 
-With a Bayesian framing, ObsMem becomes more useful because it can support:
+With a Bayesian framing, ObsMem could eventually support:
 
 - confidence ranking of retrieved prior cases
 - bounded comparison of competing hypotheses
@@ -57,6 +63,23 @@ With a Bayesian framing, ObsMem becomes more useful because it can support:
 This supports the broader ADL theme of **verifiable inference**.
 
 ---
+
+## Current v0.8 Boundary
+
+Current repository truth for v0.8 is:
+
+- ObsMem indexing exists for run summaries and experiment records.
+- ObsMem retrieval exists as deterministic contract queries plus explicit
+  score-based ordering.
+- Retrieval policy filters by workflow, failure code, and tags, then sorts by
+  explicit record score and stable lexical tie-breaks.
+- No runtime path currently computes posterior confidence, prior probability, or
+  Bayesian evidence updates from retrieved cases.
+
+So the bounded v0.8 story is:
+
+- deterministic memory surfaces are implemented now
+- Bayesian-style update remains deferred
 
 ## Minimal ADL Interpretation of Bayes
 
@@ -110,7 +133,9 @@ The Gödel loop already has the right conceptual stages:
 - record
 - indexing
 
-ObsMem + Bayes fits naturally into that loop.
+ObsMem fits naturally into that loop today. Bayesian-style update is a possible
+future refinement to the evaluation/selection portions of the loop, but it is
+not a concrete v0.8 runtime subsystem.
 
 ### Failure
 
@@ -126,7 +151,13 @@ Prior related cases are retrieved from memory.
 
 ### Bayesian-style Update
 
-Retrieved cases alter the relative confidence of each hypothesis.
+Retrieved cases may later alter the relative confidence of each hypothesis.
+
+In current v0.8 code, the implemented behavior stops earlier:
+
+- retrieve prior cases deterministically
+- sort them by explicit score
+- leave any confidence interpretation to future bounded follow-through
 
 ### Mutation / Experiment
 
@@ -146,7 +177,7 @@ This makes the loop cumulative rather than stateless.
 
 ## What ObsMem Should Remember
 
-For Bayesian-style usefulness, ObsMem should not only remember raw artifacts. It should preserve enough structure to support evidence updates.
+For Bayesian-style usefulness, ObsMem should not only remember raw artifacts. It should preserve enough structure to support evidence updates later.
 
 Useful fields include:
 
@@ -196,7 +227,7 @@ ObsMem retrieval finds four prior similar cases:
 - three succeeded after normalizing transition names
 - one failed because the real problem was a missing state, not a naming mismatch
 
-A bounded Bayesian-style update might do something like this:
+A bounded Bayesian-style update might later do something like this:
 
 - raise confidence in the “normalize transition names” hypothesis
 - keep a secondary hypothesis alive for “missing state definition”
@@ -217,7 +248,8 @@ This also matters for the Adaptive Execution Engine.
 
 AEE should not become a vague “adaptive magic” layer. It should have disciplined reasons for changing strategy.
 
-ObsMem + Bayes provides one possible basis for that discipline:
+ObsMem retrieval plus explicit score ordering provides the current v0.8 basis
+for that discipline, while a fuller Bayes-style update remains future-facing:
 
 - retrieved prior cases inform confidence
 - confidence informs retry/adapt/escalate decisions
@@ -256,7 +288,8 @@ Near-term ADL use should remain modest.
 
 - record and retrieve prior cases through ObsMem
 - preserve enough structure for future confidence updates
-- keep confidence usage bounded and reviewable
+- keep retrieval deterministic and reviewable
+- defer Bayesian-style confidence updates rather than implying they already exist
 
 ### v0.85
 
@@ -330,7 +363,8 @@ These questions should remain open for now.
 ## Bottom Line
 
 ObsMem gives ADL memory.
-Bayesian-style updating gives that memory discipline.
+Bayesian-style updating remains a possible future discipline rather than a
+current runtime guarantee.
 
 Together they suggest a future in which ADL can:
 

--- a/swarm/src/obsmem_retrieval_policy.rs
+++ b/swarm/src/obsmem_retrieval_policy.rs
@@ -5,7 +5,11 @@ use crate::obsmem_contract::{
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RetrievalOrder {
-    /// Canonical default: descending score, then deterministic lexical tie-breaks.
+    /// Canonical default: descending explicit score, then deterministic lexical tie-breaks.
+    ///
+    /// v0.8 note: this is deterministic ranking over scores already present on
+    /// retrieved records. It does not perform hidden Bayesian updates or infer
+    /// new confidence values from memory hits.
     ScoreDescIdAsc,
     /// Simple deterministic lexical ordering for explicit policy/testing.
     IdAsc,
@@ -106,6 +110,9 @@ impl RetrievalRequest {
 ///
 /// For identical inputs and index state, this function must produce identical
 /// result ordering and truncation.
+///
+/// v0.8 boundary: the policy layer filters and sorts explicit retrieval
+/// results, but it does not synthesize posterior confidence or mutate scores.
 pub fn apply_policy_to_results(
     policy: &RetrievalPolicyV1,
     request: &RetrievalRequest,
@@ -266,6 +273,38 @@ mod tests {
         assert_eq!(left.hits.len(), 2);
         assert_eq!(left.hits[0].id, "a");
         assert_eq!(left.hits[1].id, "b");
+    }
+
+    #[test]
+    fn apply_policy_uses_explicit_scores_without_hidden_confidence_updates() {
+        let policy = RetrievalPolicyV1 {
+            default_limit: 3,
+            required_tags: vec![],
+            required_failure_code: None,
+            order: RetrievalOrder::ScoreDescIdAsc,
+        };
+
+        let request = RetrievalRequest {
+            workflow_id: Some("wf-a".to_string()),
+            failure_code: None,
+            tags: vec![],
+            limit_override: None,
+        };
+
+        let input = MemoryQueryResult {
+            hits: vec![
+                hit("b", "0.25", &[]),
+                hit("a", "0.25", &[]),
+                hit("c", "0.90", &[]),
+            ],
+        };
+
+        let output = apply_policy_to_results(&policy, &request, input).expect("apply policy");
+        let ids: Vec<&str> = output.hits.iter().map(|h| h.id.as_str()).collect();
+        let scores: Vec<&str> = output.hits.iter().map(|h| h.score.as_str()).collect();
+
+        assert_eq!(ids, vec!["c", "a", "b"]);
+        assert_eq!(scores, vec!["0.90", "0.25", "0.25"]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #798

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/798/input_798.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/798/output_798.md
- Idempotency-Key: 34b68b42bb2638ab77354697c4e280e12f28f52b342cabcf41ac662b0f1fe6e0

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
