### PR TITLE
[v0.8][review] Add CLI command: adl godel evaluate

### DIFF
--- a/swarm/src/cli/godel_cmd.rs
+++ b/swarm/src/cli/godel_cmd.rs
@@ -13,16 +13,27 @@ struct GodelRunCliSummary {
     obsmem_index_path: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct GodelEvaluateCliSummary {
+    failure_code: String,
+    experiment_result: String,
+    score_delta: i32,
+    decision: String,
+    rationale: String,
+    evaluation_plan_example: String,
+}
+
 pub(crate) fn real_godel(args: &[String]) -> Result<()> {
     let Some(cmd) = args.first().map(|s| s.as_str()) else {
         return Err(anyhow::anyhow!(
-            "godel subcommand required (supported: run)"
+            "godel subcommand required (supported: run, evaluate)"
         ));
     };
     match cmd {
         "run" => real_godel_run(&args[1..]),
+        "evaluate" => real_godel_evaluate(&args[1..]),
         other => Err(anyhow::anyhow!(
-            "unknown godel subcommand '{other}' (supported: run)"
+            "unknown godel subcommand '{other}' (supported: run, evaluate)"
         )),
     }
 }
@@ -115,6 +126,75 @@ pub(crate) fn real_godel_run(args: &[String]) -> Result<()> {
             .collect(),
         experiment_record_path: result.experiment_record_rel_path.display().to_string(),
         obsmem_index_path: result.obsmem_index_rel_path.display().to_string(),
+    };
+    println!("{}", serde_json::to_string_pretty(&summary)?);
+    Ok(())
+}
+
+pub(crate) fn real_godel_evaluate(args: &[String]) -> Result<()> {
+    let mut failure_code: Option<String> = None;
+    let mut experiment_result: Option<String> = None;
+    let mut score_delta: Option<i32> = None;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--failure-code" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(anyhow::anyhow!("--failure-code requires a value"));
+                };
+                failure_code = Some(v.clone());
+                i += 1;
+            }
+            "--experiment-result" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(anyhow::anyhow!("--experiment-result requires a value"));
+                };
+                experiment_result = Some(v.clone());
+                i += 1;
+            }
+            "--score-delta" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(anyhow::anyhow!("--score-delta requires an integer"));
+                };
+                score_delta = Some(
+                    v.parse::<i32>()
+                        .map_err(|_| anyhow::anyhow!("--score-delta must be a valid i32"))?,
+                );
+                i += 1;
+            }
+            other => {
+                return Err(anyhow::anyhow!(
+                    "unknown godel evaluate arg '{other}' (supported: --failure-code, --experiment-result, --score-delta)"
+                ));
+            }
+        }
+        i += 1;
+    }
+
+    let failure_code = failure_code
+        .ok_or_else(|| anyhow::anyhow!("godel evaluate requires --failure-code <code>"))?;
+    let experiment_result = experiment_result.ok_or_else(|| {
+        anyhow::anyhow!("godel evaluate requires --experiment-result <ok|blocked>")
+    })?;
+    if !matches!(experiment_result.as_str(), "ok" | "blocked") {
+        return Err(anyhow::anyhow!(
+            "godel evaluate requires --experiment-result <ok|blocked>"
+        ));
+    }
+    let score_delta = score_delta
+        .ok_or_else(|| anyhow::anyhow!("godel evaluate requires --score-delta <int>"))?;
+
+    let outcome =
+        godel::evaluation::evaluate_experiment(&failure_code, &experiment_result, score_delta);
+    let summary = GodelEvaluateCliSummary {
+        failure_code,
+        experiment_result,
+        score_delta,
+        decision: format!("{:?}", outcome.decision).to_lowercase(),
+        rationale: outcome.rationale,
+        evaluation_plan_example: "adl-spec/examples/v0.8/evaluation_plan.v1.example.json"
+            .to_string(),
     };
     println!("{}", serde_json::to_string_pretty(&summary)?);
     Ok(())

--- a/swarm/src/cli/tests.rs
+++ b/swarm/src/cli/tests.rs
@@ -1,6 +1,6 @@
 use super::commands::real_learn_export;
 use super::demo_cmd::{is_ci_environment, real_demo};
-use super::godel_cmd::{real_godel, real_godel_run};
+use super::godel_cmd::{real_godel, real_godel_evaluate, real_godel_run};
 use super::open::{
     detect_platform, open_artifact, open_command_for, select_open_artifact, CommandRunner,
     OpenPlatform, RealCommandRunner,
@@ -188,6 +188,7 @@ fn usage_mentions_v0_4_and_legacy_examples() {
     assert!(text.contains("Usage:"));
     assert!(text.contains("adl resume <run_id>"));
     assert!(text.contains("adl godel run"));
+    assert!(text.contains("adl godel evaluate"));
     assert!(text.contains("Examples:"));
     assert!(text.contains("examples/v0-4-demo-fork-join-swarm.adl.yaml"));
     assert!(text.contains("examples/adl-0.1.yaml"));
@@ -197,7 +198,7 @@ fn usage_mentions_v0_4_and_legacy_examples() {
 #[test]
 fn real_godel_validates_subcommand_and_run_args() {
     let err = real_godel(&[]).expect_err("missing subcommand");
-    assert!(err.to_string().contains("supported: run"));
+    assert!(err.to_string().contains("supported: run, evaluate"));
 
     let err = real_godel(&["unknown".to_string()]).expect_err("unknown subcommand");
     assert!(err.to_string().contains("unknown godel subcommand"));
@@ -219,6 +220,44 @@ fn real_godel_validates_subcommand_and_run_args() {
     ])
     .expect_err("unsafe evidence ref should fail");
     assert!(err.to_string().contains("GODEL_STAGE_LOOP_INVALID_INPUT"));
+}
+
+#[test]
+fn real_godel_evaluate_validates_args_and_returns_summary() {
+    let err = real_godel_evaluate(&[]).expect_err("missing failure-code");
+    assert!(err.to_string().contains("requires --failure-code"));
+
+    let err = real_godel_evaluate(&[
+        "--failure-code".to_string(),
+        "tool_failure".to_string(),
+        "--experiment-result".to_string(),
+        "mystery".to_string(),
+        "--score-delta".to_string(),
+        "1".to_string(),
+    ])
+    .expect_err("invalid experiment result");
+    assert!(err.to_string().contains("<ok|blocked>"));
+
+    let err = real_godel_evaluate(&[
+        "--failure-code".to_string(),
+        "tool_failure".to_string(),
+        "--experiment-result".to_string(),
+        "ok".to_string(),
+        "--score-delta".to_string(),
+        "nope".to_string(),
+    ])
+    .expect_err("invalid score delta");
+    assert!(err.to_string().contains("valid i32"));
+
+    real_godel_evaluate(&[
+        "--failure-code".to_string(),
+        "tool_failure".to_string(),
+        "--experiment-result".to_string(),
+        "blocked".to_string(),
+        "--score-delta".to_string(),
+        "0".to_string(),
+    ])
+    .expect("evaluate summary");
 }
 
 #[test]

--- a/swarm/src/cli/usage.rs
+++ b/swarm/src/cli/usage.rs
@@ -4,6 +4,7 @@ pub fn usage() -> &'static str {
   adl resume <run_id>
   adl demo <name> [--print-plan] [--trace] [--run] [--out <dir>] [--quiet] [--open] [--no-open]
   adl godel run --run-id <id> --workflow-id <id> --failure-code <code> --failure-summary <text> [--evidence-ref <path> ...] [--runs-dir <dir>]
+  adl godel evaluate --failure-code <code> --experiment-result <ok|blocked> --score-delta <int>
   adl keygen --out-dir <dir>
   adl sign <adl.yaml> --key <private_key_path> [--key-id <id>] [--out <signed_file>]
   adl instrument <graph|replay|replay-bundle|diff-plan|diff-trace> ...
@@ -39,6 +40,7 @@ Examples:
   adl demo demo-e-multi-agent-card-pipeline --run --trace --out ./out
   adl demo demo-f-obsmem-retrieval --run --trace --out ./out
   adl godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary \"step failed with deterministic parse error\" --evidence-ref runs/run-745-a/run_status.json
+  adl godel evaluate --failure-code tool_failure --experiment-result ok --score-delta 1
   adl keygen --out-dir ./.keys
   adl sign examples/v0-5-pattern-linear.adl.yaml --key ./.keys/ed25519-private.b64 --out /tmp/signed.adl.yaml
   adl instrument graph examples/v0-5-pattern-fork-join.adl.yaml --format dot

--- a/swarm/tests/cli_smoke.rs
+++ b/swarm/tests/cli_smoke.rs
@@ -613,6 +613,72 @@ fn godel_run_executes_bounded_stage_loop_and_persists_artifacts() {
 }
 
 #[test]
+fn godel_evaluate_validates_required_and_unknown_args() {
+    let missing_failure_code = run_swarm(&["godel", "evaluate"]);
+    assert!(!missing_failure_code.status.success());
+    let stderr_missing = String::from_utf8_lossy(&missing_failure_code.stderr);
+    assert!(
+        stderr_missing.contains("godel evaluate requires --failure-code <code>"),
+        "stderr:\n{stderr_missing}"
+    );
+
+    let unknown = run_swarm(&["godel", "evaluate", "--bogus", "x"]);
+    assert!(!unknown.status.success());
+    let stderr_unknown = String::from_utf8_lossy(&unknown.stderr);
+    assert!(
+        stderr_unknown.contains("unknown godel evaluate arg"),
+        "stderr:\n{stderr_unknown}"
+    );
+}
+
+#[test]
+fn godel_evaluate_produces_deterministic_summary() {
+    let out1 = run_swarm(&[
+        "godel",
+        "evaluate",
+        "--failure-code",
+        "tool_failure",
+        "--experiment-result",
+        "ok",
+        "--score-delta",
+        "1",
+    ]);
+    let out2 = run_swarm(&[
+        "godel",
+        "evaluate",
+        "--failure-code",
+        "tool_failure",
+        "--experiment-result",
+        "ok",
+        "--score-delta",
+        "1",
+    ]);
+    assert!(
+        out1.status.success() && out2.status.success(),
+        "stderr1:\n{}\nstderr2:\n{}",
+        String::from_utf8_lossy(&out1.stderr),
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    assert_eq!(out1.stdout, out2.stdout, "expected deterministic summary");
+
+    let stdout = String::from_utf8_lossy(&out1.stdout);
+    let summary: serde_json::Value =
+        serde_json::from_str(&stdout).expect("parse godel evaluate summary");
+    assert_eq!(summary["failure_code"], "tool_failure");
+    assert_eq!(summary["experiment_result"], "ok");
+    assert_eq!(summary["score_delta"], 1);
+    assert_eq!(summary["decision"], "adopt");
+    assert_eq!(
+        summary["rationale"],
+        "Evaluation for failure_code=tool_failure produced decision=Adopt with score_delta=1."
+    );
+    assert_eq!(
+        summary["evaluation_plan_example"],
+        "adl-spec/examples/v0.8/evaluation_plan.v1.example.json"
+    );
+}
+
+#[test]
 fn instrument_graph_output_is_stable() {
     let path = fixture_path("examples/v0-5-pattern-fork-join.adl.yaml");
     let out1 = run_swarm(&[


### PR DESCRIPTION
Closes #799

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/799/input_799.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/799/output_799.md
- Idempotency-Key: 9371f4f58a85d2f2d959ddf59b3200708dde888c813e08d2d62ad46e0d9c2206

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
