### PR TITLE
[v0.85][authoring] Rename tracked issue-card templates to issue prompts

### DIFF
--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -6,6 +6,7 @@ This directory documents ADL tooling contracts used by card automation and revie
 - [Prompt Spec](prompt-spec.md): machine-readable input-card block defining deterministic prompt generation surfaces and reviewer alignment.
 - [Prompt Spec Protocol Bindings](prompt-spec.md#protocol-bindings): linkage to `card_review_checklist.v1` and `card_review_output.v1` reviewer contracts.
 - [Prompt/Reviewer Surface Mapping](prompt-review-surface-mapping.md): field-by-field contract map between Prompt Spec, checklist rules, and deterministic review output fields.
+- [Issue Prompt Templates](issue-prompts/README.md): tracked templates and authoring guidance for structured issue prompts used to shape GitHub issues before `pr start`.
 - Prompt Spec execution tooling:
   - `swarm/tools/lint_prompt_spec.sh` (Prompt Spec lint/validation)
   - `swarm/tools/card_prompt.sh` (deterministic prompt generation from cards)

--- a/docs/tooling/issue-prompts/README.md
+++ b/docs/tooling/issue-prompts/README.md
@@ -1,0 +1,51 @@
+# Issue Prompt Templates
+
+This directory is the tracked home for reusable issue-prompt templates and authoring guidance.
+
+The intended model is:
+
+- issue prompts: structured design prompts used to create or edit GitHub issues
+- input cards: structured implementation prompts used after `pr start`
+- output cards: structured implementation records produced after execution
+
+## Why These Templates Live Here
+
+The repo ignores `.adl/`, which is a good place for generated or work-in-progress bodies, reconciliation manifests, and local authoring experiments.
+
+But the reusable templates themselves should be tracked so they can:
+
+- evolve under review
+- support future editors and validation tooling
+- serve as canonical references for issue-prompt generation
+
+So the split is:
+
+- tracked templates and guidance: `docs/tooling/issue-prompts/`
+- local or generated issue prompts and manifests: `.adl/`
+
+## Template Set
+
+- `issue-prompt-template.md`
+  - full structured issue-prompt template
+- `issue-prompt-stub-template.md`
+  - transitional issue-prompt stub template for reconciliation passes
+
+## Authoring Guidance
+
+- Keep one canonical prompt file per target issue/WP.
+- Pull existing GitHub issue content into issue prompts selectively, not mechanically.
+- State the required outcome explicitly so an agent can tell whether code, tests, docs, or a demo must ship.
+- Prefer exact repo paths in `Repo Inputs` when a prompt depends on specific files or modules.
+- Include demo expectations when the WP requires runnable proof surfaces.
+- Use `Issue-Graph Notes` to record duplicate, supersede, split, merge, or renumber intent explicitly.
+
+## Transitional Stub Guidance
+
+Use the stub template when the tracker must be reorganized now but the final issue prompt is not ready yet.
+
+A stub should:
+
+- keep the title, labels, sprint, and slug correct
+- state the WP purpose and required outcome briefly
+- name key dependencies and known repo inputs
+- explicitly say that the full structured issue prompt is still pending

--- a/docs/tooling/issue-prompts/issue-prompt-stub-template.md
+++ b/docs/tooling/issue-prompts/issue-prompt-stub-template.md
@@ -1,0 +1,78 @@
+---
+issue_prompt_schema: adl.issue.v1
+wp: "WP-XX"
+slug: "replace-me"
+title: "[v0.85][WP-XX] Replace Me"
+labels:
+  - "track:roadmap"
+  - "version:v0.85"
+  - "type:task"
+  - "area:runtime"
+issue_number:
+status: "draft"
+action: "create"
+supersedes: []
+duplicates: []
+depends_on: []
+milestone_sprint: "Sprint X"
+required_outcome_type:
+  - "docs"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes: []
+pr_start:
+  enabled: true
+  slug: "replace-me"
+---
+
+# Issue Prompt Stub
+
+## Summary
+
+One short paragraph describing the work package and why it exists in the milestone.
+
+## Goal
+
+State the concrete purpose of this issue in one or two sentences.
+
+## Required Outcome
+
+- State whether this WP is expected to land code, tests, docs, demos, or a combination.
+- Keep this brief but explicit.
+
+## Deliverables
+
+- List the minimum expected outputs known right now.
+
+## Acceptance Criteria
+
+- Keep this to the minimum canonical criteria needed to keep the issue graph honest.
+- Do not over-specify if the final body is still pending.
+
+## Repo Inputs
+
+- List the key docs/issues/files already known to shape this WP.
+
+## Dependencies
+
+- List upstream WPs or issues if known.
+
+## Demo Expectations
+
+- Name the required demo if already known.
+- Otherwise state `Full demo expectations pending under issue-prompt reconciliation.`
+
+## Non-goals
+
+- Say what this issue is not meant to do yet.
+
+## Issue-Graph Notes
+
+- State whether this issue is being kept, retitled, merged, split, superseded, or created.
+- Explicitly say when a full structured issue prompt is still pending.
+
+## Notes
+
+- Keep any additional scope or sequencing notes here.

--- a/docs/tooling/issue-prompts/issue-prompt-template.md
+++ b/docs/tooling/issue-prompts/issue-prompt-template.md
@@ -1,0 +1,104 @@
+---
+issue_prompt_schema: adl.issue.v1
+wp: "WP-XX"
+slug: "replace-me"
+title: "[v0.85][WP-XX] Replace Me"
+labels:
+  - "track:roadmap"
+  - "version:v0.85"
+  - "type:task"
+  - "area:runtime"
+issue_number:
+status: "draft"
+action: "create"
+supersedes: []
+duplicates: []
+depends_on: []
+milestone_sprint: "Sprint X"
+required_outcome_type:
+  - "code"
+  - "docs"
+  - "tests"
+  - "demo"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes: []
+pr_start:
+  enabled: true
+  slug: "replace-me"
+---
+
+# Issue Prompt
+
+## Summary
+
+One short paragraph describing the work package, why it matters in the milestone, and what visible capability or proof surface it is expected to produce.
+
+## Goal
+
+State the concrete outcome this issue is meant to produce.
+
+## Required Outcome
+
+State what must be real by the end of this issue.
+
+- If code is required, say so explicitly.
+- If a demo is required, say so explicitly.
+- If docs-only completion is allowed, say so explicitly.
+- Prefer "must result in" language over vague improvement language.
+
+## Deliverables
+
+- Name the real outputs expected from the issue.
+- Prefer concrete artifacts, code paths, tests, demos, or docs.
+
+## Acceptance Criteria
+
+- Make the criteria testable and bounded.
+- Prefer "what must exist" over "what should feel improved".
+- If demos are required, name them.
+- If code is required, say so explicitly.
+
+## Repo Inputs
+
+- List the exact milestone docs, source files, schemas, prompts, or modules that define the starting point for this issue.
+- Prefer concrete repo paths over generic references.
+- Include the canonical issue(s) or issue prompt(s) that this work absorbs, depends on, or supersedes.
+
+## Inputs
+
+- Canonical milestone docs
+- Existing issues that this work absorbs or supersedes
+- Code/docs/schemas already in the repo that shape the work
+
+## Dependencies
+
+- List upstream WPs or issues
+
+## Demo Expectations
+
+- State the required demo or proof surface if this issue must produce one.
+- If no demo is required, say why.
+- If the demo belongs to a later WP, name that dependency explicitly.
+
+## Non-goals
+
+- Say what this issue is not meant to do
+
+## Issue-Graph Notes
+
+- Record duplicate, supersede, split, merge, or renumbering expectations here.
+- Keep tracker cleanup intent explicit if this issue is part of a milestone reorganization.
+
+## Notes
+
+- Add migration, design, scope, or sequencing notes here if needed.
+
+## Tooling Notes
+
+- `title`, `labels`, `milestone_sprint`, `required_outcome_type`, `repo_inputs`, `canonical_files`, and demo metadata are machine-readable in the front matter.
+- `pr_start.slug` is the value tooling should pass to:
+  - `swarm/tools/pr.sh start <issue> --slug <slug>`
+- `repo_inputs` should stay lightweight coordination metadata; the long-form sections below remain the canonical issue content.

--- a/swarm/templates/cards/input_card_template.md
+++ b/swarm/templates/cards/input_card_template.md
@@ -9,7 +9,7 @@ Branch:
 Context:
 - Issue:
 - PR:
-- Source Issue Card:
+- Source Issue Prompt:
 - Docs:
 - Other:
 
@@ -56,7 +56,7 @@ constraints:
   disallow_secrets: true
   disallow_absolute_host_paths: true
 automation_hints:
-  source_issue_card_required: true
+  source_issue_prompt_required: true
   target_files_surfaces_recommended: true
   validation_plan_required: true
   required_outcome_type_supported: true
@@ -76,7 +76,7 @@ Execution:
 - Provider:
 - Tools allowed:
 - Sandbox / approvals:
-- Source issue-card slug:
+- Source issue-prompt slug:
 - Required outcome type:
 - Demo required:
 
@@ -144,7 +144,7 @@ ci_validation_required: true
 - Generation requirements:
   - Deterministic output for identical input card content
   - No secrets, tokens, or absolute host paths in generated prompt text
-  - Preserve traceability back to the source issue card
+  - Preserve traceability back to the source issue prompt
   - Preserve explicit required-outcome and demo/proof requirements
 
 ## Non-goals / Out of scope
@@ -153,6 +153,6 @@ ci_validation_required: true
 
 ## Instructions to the Agent
 - Read this file.
-- Read the linked source issue card before starting work.
+- Read the linked source issue prompt before starting work.
 - Do the work described above.
 - Write results to the paired output card file.


### PR DESCRIPTION
Closes #891

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/891/input_891.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/891/output_891.md
- Idempotency-Key: 8d2c4ebd3446de9dba29e3bd86782376e213dda20f2ba4157fc640bf8a6970cb

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
