### PR TITLE
Daily Automated Test Coverage - 2026-03-18 03:09 Total Line Coverage: 91.88%

### DIFF
--- a/swarm/src/bounded_executor.rs
+++ b/swarm/src/bounded_executor.rs
@@ -295,4 +295,64 @@ mod tests {
         let wrapped: anyhow::Error = err.into();
         assert_eq!(stable_failure_kind(&wrapped), Some("io_error"));
     }
+
+    #[test]
+    fn run_bounded_caps_worker_count_when_parallelism_exceeds_jobs() {
+        let jobs: Vec<Box<dyn FnOnce() -> usize + Send + 'static>> = vec![
+            Box::new(|| 11usize),
+            Box::new(|| 22usize),
+            Box::new(|| 33usize),
+        ];
+        let out = run_bounded(99, jobs).expect("run_bounded should succeed");
+        assert_eq!(out, vec![11, 22, 33]);
+    }
+
+    #[test]
+    fn run_bounded_single_worker_path_is_deterministic() {
+        let jobs: Vec<Box<dyn FnOnce() -> usize + Send + 'static>> = (0..5usize)
+            .map(|i| Box::new(move || i * 2) as Box<dyn FnOnce() -> usize + Send + 'static>)
+            .collect();
+        let out = run_bounded(1, jobs).expect("single worker should execute all jobs");
+        assert_eq!(out, vec![0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn run_bounded_supports_non_copy_outputs_in_order() {
+        let jobs: Vec<Box<dyn FnOnce() -> String + Send + 'static>> = vec![
+            Box::new(|| "alpha".to_string()),
+            Box::new(|| "beta".to_string()),
+            Box::new(|| "gamma".to_string()),
+        ];
+        let out = run_bounded(2, jobs).expect("string jobs should succeed");
+        assert_eq!(out, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn bounded_executor_error_display_is_stable() {
+        let err = BoundedExecutorError::new(
+            BoundedExecutorErrorKind::InvalidParallelism,
+            "max_parallel must be >= 1",
+        );
+        assert_eq!(format!("{err}"), "max_parallel must be >= 1");
+    }
+
+    #[test]
+    fn stable_failure_kind_maps_wrapped_queue_poisoned_to_panic() {
+        let err = BoundedExecutorError::new(
+            BoundedExecutorErrorKind::QueuePoisoned,
+            "queue lock poisoned",
+        );
+        let wrapped = anyhow::Error::new(err).context("outer wrapper");
+        assert_eq!(stable_failure_kind(&wrapped), Some("panic"));
+    }
+
+    #[test]
+    fn stable_failure_kind_maps_wrapped_output_count_mismatch_to_io_error() {
+        let err = BoundedExecutorError::new(
+            BoundedExecutorErrorKind::OutputCountMismatch,
+            "output count mismatch",
+        );
+        let wrapped = anyhow::Error::new(err).context("outer wrapper");
+        assert_eq!(stable_failure_kind(&wrapped), Some("io_error"));
+    }
 }

--- a/swarm/src/signing.rs
+++ b/swarm/src/signing.rs
@@ -484,6 +484,7 @@ fn decode_verifying_key_b64(raw_b64: &str) -> Result<VerifyingKey> {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn sample_doc() -> adl::AdlDoc {
         let yaml = r#"
@@ -618,5 +619,111 @@ run:
             .expect_err("tamper should fail");
         assert_eq!(err.kind, VerificationErrorKind::SignatureMismatch);
         assert_eq!(err.code, "SIGNATURE_MISMATCH");
+    }
+
+    #[test]
+    fn verification_key_source_parse_and_as_str_are_stable() {
+        assert_eq!(
+            VerificationKeySource::parse(" embedded "),
+            Some(VerificationKeySource::Embedded)
+        );
+        assert_eq!(
+            VerificationKeySource::parse("EXPLICIT_KEY"),
+            Some(VerificationKeySource::ExplicitKey)
+        );
+        assert_eq!(VerificationKeySource::parse("unknown"), None);
+        assert_eq!(VerificationKeySource::Embedded.as_str(), "embedded");
+        assert_eq!(VerificationKeySource::ExplicitKey.as_str(), "explicit_key");
+    }
+
+    #[test]
+    fn verification_profile_canonicalized_normalizes_and_dedupes() {
+        let profile = VerificationProfile {
+            require_signature: true,
+            require_key_id: false,
+            allowed_algs: vec![
+                "  ED25519 ".to_string(),
+                "ed25519".to_string(),
+                "".to_string(),
+            ],
+            allowed_key_sources: vec![
+                VerificationKeySource::ExplicitKey,
+                VerificationKeySource::Embedded,
+                VerificationKeySource::Embedded,
+            ],
+        }
+        .canonicalized();
+        assert_eq!(profile.allowed_algs, vec!["ed25519".to_string()]);
+        assert_eq!(
+            profile.allowed_key_sources,
+            vec![
+                VerificationKeySource::Embedded,
+                VerificationKeySource::ExplicitKey
+            ]
+        );
+    }
+
+    #[test]
+    fn verify_doc_with_profile_currently_requires_signature_even_when_optional() {
+        let doc = sample_doc();
+        let profile = VerificationProfile {
+            require_signature: false,
+            require_key_id: true,
+            allowed_algs: vec!["ed25519".to_string()],
+            allowed_key_sources: vec![VerificationKeySource::Embedded],
+        };
+        let err = verify_doc_with_profile(&doc, None, &profile)
+            .expect_err("current implementation requires an attached signature");
+        assert_eq!(err.kind, VerificationErrorKind::PolicyViolation);
+        assert_eq!(err.code, "SIGN_POLICY_UNSIGNED_REQUIRED");
+    }
+
+    #[test]
+    fn profile_rejects_signed_doc_when_key_source_cannot_be_determined() {
+        let mut doc = sample_doc();
+        doc.signature = Some(adl::SignatureSpec {
+            alg: "ed25519".to_string(),
+            key_id: "dev-local".to_string(),
+            public_key_b64: None,
+            sig_b64: B64.encode([0_u8; 64]),
+            signed_header: default_signed_header(&doc),
+        });
+        let err = verify_doc_with_profile(&doc, None, &VerificationProfile::default())
+            .expect_err("missing key source should fail before signature decode");
+        assert_eq!(err.kind, VerificationErrorKind::PolicyViolation);
+        assert_eq!(err.code, "SIGN_POLICY_MISSING_KEY_SOURCE");
+    }
+
+    #[test]
+    fn malformed_signature_base64_maps_to_stable_code() {
+        let (mut doc, pub_b64) = signed_doc_and_pubkey();
+        let signature = doc.signature.as_mut().expect("signature");
+        signature.public_key_b64 = Some(pub_b64);
+        signature.sig_b64 = "not-base64###".to_string();
+        let err = verify_doc_with_profile(&doc, None, &VerificationProfile::default())
+            .expect_err("invalid base64 signature should fail");
+        assert_eq!(err.kind, VerificationErrorKind::MalformedSignatureMaterial);
+        assert_eq!(err.code, "SIGN_MALFORMED_SIGNATURE");
+    }
+
+    #[test]
+    fn malformed_explicit_public_key_maps_to_stable_code() {
+        let (doc, _pub_b64) = signed_doc_and_pubkey();
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("adl-signing-tests-{unique}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let key_path = dir.join("bad-public.b64");
+        fs::write(&key_path, "not-base64").expect("write key");
+
+        let err = verify_doc_with_profile(&doc, Some(&key_path), &VerificationProfile::default())
+            .expect_err("invalid explicit public key should fail");
+        assert_eq!(err.kind, VerificationErrorKind::MalformedSignatureMaterial);
+        assert_eq!(err.code, "SIGN_MALFORMED_PUBLIC_KEY");
+
+        let _ = fs::remove_file(&key_path);
+        let _ = fs::remove_dir(&dir);
     }
 }


### PR DESCRIPTION
## Daily coverage ratchet (corrected metrics)

The previously published 77% coverage values were incorrect. A fresh clean rerun from an archived snapshot of the exact branch ref shows the real numbers below.

- Baseline total line coverage (`origin/main` @ `137dab649cfc9f41b964369db8701e19902a631f`): **91.82%**
- Final branch-local total line coverage (`codex/coverage-ratchet-20260318`): **91.88%**
- Current refreshed repository-truth total line coverage: **91.82%**
- Delta (branch-local minus baseline): **+0.06%**
- Fixed per-file floor: **80%**

### Files below 80% line coverage
- None

### Changed files
- `swarm/src/signing.rs`
- `swarm/src/bounded_executor.rs`

### Validation
- Fresh archived-snapshot rerun of `origin/main`
- Fresh archived-snapshot rerun of `codex/coverage-ratchet-20260318`
- `cargo llvm-cov clean --workspace`
- `cargo llvm-cov --workspace --summary-only`
- `cargo llvm-cov report --json --output-path coverage-summary.json`

### Correction note
The prior nightly report for this run published incorrect low-77% totals. Repository truth and branch-local truth are both above 91%, so there is no live below-floor blocker from this run.
