### PR TITLE
docs: use task-identifying prompt titles

### DIFF
--- a/docs/tooling/issue-prompts/issue-prompt-stub-template.md
+++ b/docs/tooling/issue-prompts/issue-prompt-stub-template.md
@@ -27,7 +27,7 @@ pr_start:
   slug: "replace-me"
 ---
 
-# Issue Prompt Stub
+# Replace Me
 
 ## Summary
 
@@ -76,3 +76,5 @@ State the concrete purpose of this issue in one or two sentences.
 ## Notes
 
 - Keep any additional scope or sequencing notes here.
+- The H1 should identify the specific task, not just the artifact class.
+- Use a temporary task-identifying title even in the stub state; avoid generic headings like "Issue Prompt Stub."

--- a/docs/tooling/issue-prompts/issue-prompt-template.md
+++ b/docs/tooling/issue-prompts/issue-prompt-template.md
@@ -30,7 +30,7 @@ pr_start:
   slug: "replace-me"
 ---
 
-# Issue Prompt
+# Replace Me
 
 ## Summary
 
@@ -99,6 +99,8 @@ State what must be real by the end of this issue.
 ## Tooling Notes
 
 - `title`, `labels`, `milestone_sprint`, `required_outcome_type`, `repo_inputs`, `canonical_files`, and demo metadata are machine-readable in the front matter.
+- The H1 should identify the specific task, usually by reusing the human-readable `title` value or a cleaner version of it.
+- Do not use a generic heading like "Issue Prompt" or "Structured Task Prompt" as the permanent visible title.
 - `pr_start.slug` is the value tooling should pass to:
   - `swarm/tools/pr.sh start <issue> --slug <slug>`
 - `repo_inputs` should stay lightweight coordination metadata; the long-form sections below remain the canonical issue content.


### PR DESCRIPTION
Closes #920

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/cards/920/input_920.md
- Output card: /Users/daniel/git/agent-design-language/.adl/cards/920/output_920.md
- Idempotency-Key: 29c39ef8f4a97beb6f37eb1439bceb40d684d43c482ab0cdbbc8851696991fba

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
