### PR TITLE
[v0.85][authoring] Provide task-bundle workspace shell for editor

### DIFF
--- a/docs/records/v0.85/tasks/task-v085-wp05-demo/README.md
+++ b/docs/records/v0.85/tasks/task-v085-wp05-demo/README.md
@@ -6,5 +6,6 @@ It demonstrates the intended public-record layout:
 
 - `stp.md`
 - `sip.md`
+- `sor.md`
 
-These files are intentionally lightweight. They show the shape that the first editor surface is meant to support before richer editors and workflow automation arrive.
+These files are intentionally lightweight. They show the linked three-card task-bundle shape that the first editor workspace shell is meant to support before richer editors and workflow automation arrive.

--- a/docs/records/v0.85/tasks/task-v085-wp05-demo/sor.md
+++ b/docs/records/v0.85/tasks/task-v085-wp05-demo/sor.md
@@ -1,0 +1,32 @@
+---
+artifact_type: "Structured Output Record"
+title: "[v0.85][WP-05] First authoring/editor surfaces"
+task_id: "task-v085-wp05-demo"
+run_id: "task-v085-wp05-demo"
+version: "v0.85"
+branch: "codex/870-v085-wp05-first-editor-surfaces"
+status: "IN_PROGRESS"
+---
+
+# Structured Output Record
+
+## Summary
+
+Bounded execution/review card linked to the same public task bundle as the STP and SIP examples.
+
+## Workspace Role
+
+- visible in the task-bundle workspace shell
+- demonstrates the canonical `sor.md` bundle shape
+- keeps the execution/review artifact linked even before the richer review surface lands
+
+## Current Boundaries
+
+- this example is intentionally lightweight
+- richer validation, provenance, and review controls are deferred to later editor/review issues
+
+## Follow-ups
+
+- add full review surface behavior
+- add validation/provenance display
+- add accept / reject / iterate workflow

--- a/docs/tooling/editor/README.md
+++ b/docs/tooling/editor/README.md
@@ -11,12 +11,14 @@ The editor is intentionally simple:
 - no build step
 - no framework dependency
 - works as a tracked static artifact
-- supports the two highest-friction authoring surfaces in the current workflow:
+- supports a linked task-bundle workspace with:
   - `Structured Task Prompt` (STP)
   - `Structured Implementation Prompt` (SIP)
+  - visible `Structured Output Record` (SOR) shell
 
 ## What This First Slice Does
 
+- presents one task bundle as a linked three-card workspace
 - guides a human through the core metadata and section fields
 - previews the rendered markdown artifact live
 - shows schema-aware checks for required fields and section presence
@@ -27,9 +29,10 @@ The editor is intentionally simple:
 
 - it does not write files directly
 - it does not replace `pr create`, `pr start`, `pr run`, or `pr finish`
-- it does not yet edit `Structured Output Records` (SORs)
-- it does not yet call the Ruby validator directly from the browser
+- it does not yet provide the full SOR review flow
+- it does not yet invoke the control plane directly
+- it does not yet call the structured-prompt validator directly from the browser
 
 ## Why This Is Still Useful
 
-This first slice reduces structural editing fragility without pretending the full editor architecture already exists. It gives users a safer tracked surface than raw markdown-only editing while preserving the public task-bundle model and the current deterministic workflow boundaries.
+This first slice reduces structural editing fragility without pretending the full editor architecture already exists. It gives users a safer tracked surface than raw markdown-only editing while preserving the public task-bundle model and making the three-card bundle visible as one workspace.

--- a/docs/tooling/editor/demo.md
+++ b/docs/tooling/editor/demo.md
@@ -1,26 +1,32 @@
 # Editor Workflow Demo
 
-This bounded demo is the proof surface for the first WP-05 editor slice.
+This bounded demo is the proof surface for the first WP-05 task-bundle workspace slice.
 
 ## Steps
 
 1. Open `docs/tooling/editor/index.html` in a browser.
-2. Leave the default `Structured Task Prompt` selection in place.
-3. Edit the task ID, title, and required sections.
-4. Observe the validation panel:
+2. Confirm the workspace shows three linked cards:
+   - `Structured Task Prompt`
+   - `Structured Implementation Prompt`
+   - `Structured Output Record`
+3. Leave the default `Structured Task Prompt` card selected.
+4. Edit the task ID, title, and required sections.
+5. Observe the validation panel:
    - required fields show warnings when blank
    - valid task IDs and branch values show passing checks
-5. Review the rendered artifact preview.
-6. Switch to `Structured Implementation Prompt`.
-7. Confirm the bundle target changes to:
+6. Review the rendered artifact preview.
+7. Switch to `Structured Implementation Prompt` and confirm the active bundle target changes to:
    - `docs/records/v0.85/tasks/<task-id>/sip.md`
-8. Compare the preview output with the tracked example bundle:
+8. Switch to `Structured Output Record` and confirm the SOR card remains visibly linked in the same bundle workspace.
+9. Compare the preview output with the tracked example bundle:
    - `docs/records/v0.85/tasks/task-v085-wp05-demo/stp.md`
    - `docs/records/v0.85/tasks/task-v085-wp05-demo/sip.md`
+   - `docs/records/v0.85/tasks/task-v085-wp05-demo/sor.md`
 
 ## Demo Claims
 
 - the editor is a real tracked repo surface, not a design sketch
-- the editor supports both STP and SIP flows
+- the editor presents a linked task-bundle workspace rather than isolated artifact editing only
+- the editor supports STP and SIP authoring while keeping SOR visibly linked in the same workspace
 - the editor keeps the public task-bundle destination visible
 - the editor reduces structural editing fragility by guiding required fields and rendering the final markdown artifact live

--- a/docs/tooling/editor/index.html
+++ b/docs/tooling/editor/index.html
@@ -12,17 +12,14 @@
       <p class="eyebrow">WP-05 Editor Slice</p>
       <h1>ADL Task Bundle Editor</h1>
       <p class="lede">
-        A bounded first editor surface for Structured Task Prompts and Structured Implementation Prompts.
+        A bounded task-bundle workspace shell for Structured Task Prompts, Structured Implementation Prompts,
+        and the first visible Structured Output Record card.
         This editor keeps the public task-bundle model visible while reducing fragile raw markdown editing.
       </p>
     </header>
 
     <section class="panel controls">
       <div class="control-grid">
-        <label>
-          Artifact Type
-          <select id="artifact-type"></select>
-        </label>
         <label>
           Task ID
           <input id="task-id" type="text" placeholder="task-v085-wp05">
@@ -36,14 +33,23 @@
           <input id="branch" type="text" placeholder="codex/870-v085-wp05-first-editor-surfaces">
         </label>
       </div>
-      <div class="bundle-path" id="bundle-path"></div>
+      <div class="bundle-path" id="bundle-root"></div>
+      <div class="bundle-path bundle-path-secondary" id="bundle-active-path"></div>
+    </section>
+
+    <section class="panel bundle-shell">
+      <div class="section-header">
+        <h2>Task Bundle Workspace</h2>
+        <p>Three linked cards, one bounded bundle.</p>
+      </div>
+      <div id="bundle-cards" class="bundle-cards"></div>
     </section>
 
     <section class="workspace">
       <section class="panel form-panel">
         <div class="section-header">
-          <h2>Structured Fields</h2>
-          <p>Fill the required sections. The preview updates as you type.</p>
+          <h2 id="editor-panel-title">Structured Fields</h2>
+          <p id="editor-panel-copy">Fill the required sections. The preview updates as you type.</p>
         </div>
         <form id="artifact-form" class="artifact-form"></form>
       </section>
@@ -65,7 +71,9 @@
     <section class="panel notes">
       <h2>First Slice Boundaries</h2>
       <ul>
-        <li>This editor supports STP and SIP first because they are the current highest-friction authoring surfaces.</li>
+        <li>This issue establishes a task-bundle-native workspace shell with visible STP, SIP, and SOR cards.</li>
+        <li>STP and SIP remain the editable first-slice authoring surfaces in this issue.</li>
+        <li>SOR is visible as a linked bundle card now, with richer review behavior deferred to the next review-surface issue.</li>
         <li>The canonical public record remains a tracked task bundle under <code>docs/records/&lt;scope&gt;/tasks/&lt;task-id&gt;/</code>.</li>
         <li>Drafts may still begin in <code>.adl/</code>, but the public record should be promoted into a tracked task bundle before authoritative transitions.</li>
       </ul>

--- a/docs/tooling/editor/style.css
+++ b/docs/tooling/editor/style.css
@@ -118,6 +118,72 @@ textarea {
   font-size: 0.9rem;
 }
 
+.bundle-path-secondary {
+  margin-top: 10px;
+  background: #f9f2e8;
+}
+
+.bundle-shell {
+  padding: 20px;
+  margin-bottom: 24px;
+}
+
+.bundle-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.bundle-card {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 16px;
+  background: #fff;
+  display: grid;
+  gap: 10px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.bundle-card.active {
+  border-color: rgba(15, 106, 90, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(15, 106, 90, 0.2);
+  background: var(--accent-soft);
+}
+
+.bundle-card-label {
+  font-weight: 700;
+}
+
+.bundle-card-meta,
+.bundle-card-copy {
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.bundle-card-status {
+  display: inline-block;
+  width: fit-content;
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: #efe5d6;
+  color: var(--ink);
+}
+
+.bundle-card-status.editable {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.bundle-card-status.shell {
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
 .workspace {
   display: grid;
   grid-template-columns: minmax(320px, 1fr) minmax(360px, 1fr);
@@ -146,6 +212,15 @@ textarea {
 .artifact-form {
   display: grid;
   gap: 18px;
+}
+
+.shell-note {
+  padding: 14px 16px;
+  border: 1px solid rgba(140, 63, 31, 0.25);
+  border-radius: 14px;
+  background: var(--warning-soft);
+  color: var(--warning);
+  line-height: 1.5;
 }
 
 .field-group {

--- a/docs/tooling/editor/task_bundle_editor.js
+++ b/docs/tooling/editor/task_bundle_editor.js
@@ -2,6 +2,8 @@ const ARTIFACTS = {
   stp: {
     label: "Structured Task Prompt",
     extension: "stp.md",
+    cardState: "editable",
+    cardCopy: "Design surface for the task definition and public bundle intent.",
     metadata: [
       { key: "task_id", label: "Task ID", required: true },
       { key: "issue_number", label: "GitHub Issue Number", required: false },
@@ -33,6 +35,8 @@ const ARTIFACTS = {
   sip: {
     label: "Structured Implementation Prompt",
     extension: "sip.md",
+    cardState: "editable",
+    cardCopy: "Implementation surface for concrete files, commands, and proof paths.",
     metadata: [
       { key: "task_id", label: "Task ID", required: true },
       { key: "run_id", label: "Run ID", required: true },
@@ -65,37 +69,77 @@ const ARTIFACTS = {
       non_goals: "- Full productization",
       notes: "- Keep the slice bounded and honest."
     }
+  },
+  sor: {
+    label: "Structured Output Record",
+    extension: "sor.md",
+    cardState: "shell",
+    cardCopy: "Execution/review card is visibly linked now; richer review flow lands in the next slice.",
+    editable: false
   }
 };
 
-const typeSelect = document.getElementById("artifact-type");
 const form = document.getElementById("artifact-form");
 const preview = document.getElementById("artifact-preview");
 const validationList = document.getElementById("validation-list");
-const bundlePath = document.getElementById("bundle-path");
+const bundleRoot = document.getElementById("bundle-root");
+const bundleActivePath = document.getElementById("bundle-active-path");
+const bundleCards = document.getElementById("bundle-cards");
 const taskIdInput = document.getElementById("task-id");
 const titleInput = document.getElementById("title");
 const branchInput = document.getElementById("branch");
 const copyButton = document.getElementById("copy-preview");
+const editorPanelTitle = document.getElementById("editor-panel-title");
+const editorPanelCopy = document.getElementById("editor-panel-copy");
 
-Object.entries(ARTIFACTS).forEach(([value, artifact]) => {
-  const option = document.createElement("option");
-  option.value = value;
-  option.textContent = artifact.label;
-  typeSelect.append(option);
-});
+let currentArtifact = "stp";
+
+function buildCards() {
+  bundleCards.innerHTML = "";
+  Object.entries(ARTIFACTS).forEach(([value, artifact]) => {
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = `bundle-card ${value === currentArtifact ? "active" : ""}`;
+    card.dataset.artifact = value;
+    card.innerHTML = `
+      <span class="bundle-card-status ${artifact.cardState}">${artifact.cardState}</span>
+      <span class="bundle-card-label">${artifact.label}</span>
+      <span class="bundle-card-meta">${artifact.extension}</span>
+      <span class="bundle-card-copy">${artifact.cardCopy}</span>
+    `;
+    card.addEventListener("click", () => {
+      currentArtifact = value;
+      buildForm();
+    });
+    bundleCards.append(card);
+  });
+}
 
 function buildForm() {
-  const artifact = ARTIFACTS[typeSelect.value];
+  const artifact = ARTIFACTS[currentArtifact];
   form.innerHTML = "";
+  editorPanelTitle.textContent = artifact.label;
 
-  artifact.metadata.forEach((field) => {
-    form.append(createField(field.key, field.label, field.defaultValue || "", false, field.required));
-  });
+  if (artifact.editable === false) {
+    editorPanelCopy.textContent = "This card is visible in the workspace shell now; the richer review surface is intentionally deferred.";
+    const note = document.createElement("div");
+    note.className = "shell-note";
+    note.innerHTML = `
+      <strong>SOR shell only in WP-05.</strong><br>
+      This workspace proves that STP, SIP, and SOR stay linked as one task bundle.
+      Full SOR review, validation/provenance display, and decision flow land in the next review-surface slice.
+    `;
+    form.append(note);
+  } else {
+    editorPanelCopy.textContent = "Fill the required sections. The preview updates as you type.";
+    artifact.metadata.forEach((field) => {
+      form.append(createField(field.key, field.label, field.defaultValue || "", false, field.required));
+    });
 
-  artifact.sections.forEach(([key, label]) => {
-    form.append(createField(key, label, artifact.placeholders[key] || "", true, true));
-  });
+    artifact.sections.forEach(([key, label]) => {
+      form.append(createField(key, label, artifact.placeholders[key] || "", true, true));
+    });
+  }
 
   updateAll();
 }
@@ -123,19 +167,24 @@ function createField(key, label, initialValue, isTextarea, required) {
 }
 
 function gather() {
-  const artifact = ARTIFACTS[typeSelect.value];
+  const artifact = ARTIFACTS[currentArtifact];
   const metadata = {};
-  artifact.metadata.forEach((field) => {
+  (artifact.metadata || []).forEach((field) => {
     metadata[field.key] = valueFor(field.key);
   });
   const sections = {};
-  artifact.sections.forEach(([key]) => {
+  (artifact.sections || []).forEach(([key]) => {
     sections[key] = valueFor(key);
   });
 
   metadata.task_id = taskIdInput.value.trim() || metadata.task_id;
-  if (typeSelect.value === "sip") {
+  if (currentArtifact === "sip" || currentArtifact === "sor") {
     metadata.branch = branchInput.value.trim() || metadata.branch;
+  }
+  if (currentArtifact === "sor") {
+    metadata.run_id = taskIdInput.value.trim() || metadata.run_id || "task-id";
+    metadata.version = "v0.85";
+    metadata.status = "IN_PROGRESS";
   }
 
   return { artifact, metadata, sections };
@@ -147,9 +196,10 @@ function valueFor(id) {
 }
 
 function updateBundlePath() {
-  const artifact = ARTIFACTS[typeSelect.value];
+  const artifact = ARTIFACTS[currentArtifact];
   const taskId = taskIdInput.value.trim() || "task-id";
-  bundlePath.textContent = `Tracked bundle target: docs/records/v0.85/tasks/${taskId}/${artifact.extension}`;
+  bundleRoot.textContent = `Tracked bundle root: docs/records/v0.85/tasks/${taskId}/`;
+  bundleActivePath.textContent = `Active card target: docs/records/v0.85/tasks/${taskId}/${artifact.extension}`;
 }
 
 function validate({ artifact, metadata, sections }) {
@@ -167,25 +217,31 @@ function validate({ artifact, metadata, sections }) {
     results.push({ ok: false, text: "Title is required." });
   }
 
-  if (typeSelect.value === "sip" && !/^codex\/[a-z0-9][a-z0-9-]*$/.test(branchInput.value.trim())) {
+  if ((currentArtifact === "sip" || currentArtifact === "sor") && !/^codex\/[a-z0-9][a-z0-9-]*$/.test(branchInput.value.trim())) {
     results.push({ ok: false, text: "Branch should use the codex/<slug> format for SIP work." });
-  } else if (typeSelect.value === "sip") {
-    results.push({ ok: true, text: "Branch format is valid for the implementation prompt." });
+  } else if (currentArtifact === "sip" || currentArtifact === "sor") {
+    results.push({ ok: true, text: "Branch format is valid for the bundle execution surfaces." });
   }
 
-  artifact.metadata.forEach((field) => {
+  (artifact.metadata || []).forEach((field) => {
     if (field.required && !metadata[field.key]) {
       results.push({ ok: false, text: `${field.label} is required.` });
     }
   });
 
-  artifact.sections.forEach(([key, label]) => {
+  (artifact.sections || []).forEach(([key, label]) => {
     if (sections[key]) {
       results.push({ ok: true, text: `${label} is present.` });
     } else {
       results.push({ ok: false, text: `${label} is required.` });
     }
   });
+
+  results.push({ ok: true, text: "Task bundle keeps STP, SIP, and SOR visible together in one workspace." });
+
+  if (currentArtifact === "sor") {
+    results.push({ ok: true, text: "SOR is visibly linked in the workspace shell; richer review behavior is intentionally deferred." });
+  }
 
   return results;
 }
@@ -205,9 +261,17 @@ function renderYaml(metadata) {
 function renderMarkdown({ artifact, metadata, sections }) {
   const lines = [renderYaml({ artifact_type: artifact.label, title: titleInput.value.trim(), ...metadata }), "", `# ${artifact.label}`, ""];
   lines.push("## Summary", "", titleInput.value.trim() || "Replace me.", "");
-  artifact.sections.forEach(([key, label]) => {
-    lines.push(`## ${label}`, "", sections[key] || "", "");
-  });
+
+  if (artifact.editable === false) {
+    lines.push("## Workspace Role", "", "Visible execution/review card for the linked task bundle shell.", "");
+    lines.push("## Current Boundaries", "", "- Visible in the bundle workspace\n- Full review flow deferred to the dedicated SOR/review issue", "");
+    lines.push("## Follow-ups", "", "- Add provenance display\n- Add accept / reject / iterate flow", "");
+  } else {
+    artifact.sections.forEach(([key, label]) => {
+      lines.push(`## ${label}`, "", sections[key] || "", "");
+    });
+  }
+
   return lines.join("\n").trimEnd();
 }
 
@@ -240,9 +304,9 @@ copyButton.addEventListener("click", async () => {
 taskIdInput.addEventListener("input", updateAll);
 titleInput.addEventListener("input", updateAll);
 branchInput.addEventListener("input", updateAll);
-typeSelect.addEventListener("change", buildForm);
 
 taskIdInput.value = "task-v085-wp05";
 titleInput.value = "[v0.85][WP-05] First authoring/editor surfaces";
 branchInput.value = "codex/870-v085-wp05-first-editor-surfaces";
+buildCards();
 buildForm();


### PR DESCRIPTION
Closes #935

Local artifacts (not committed):
- Input card:  .adl/cards/935/input_935.md
- Output card: .adl/cards/935/output_935.md
- Idempotency-Key: 0ca52b676090111aedb4b7282497a4ea3075a0bc52be89047ee956dd1335a332

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
