### PR TITLE
[v0.85][authoring] Enforce Execution-Record Standard in ADL Output Card Template

### DIFF
--- a/docs/tooling/examples/workflow-state/bad_output_record.md
+++ b/docs/tooling/examples/workflow-state/bad_output_record.md
@@ -35,7 +35,7 @@ Invalid fixture output record for dependable-execution completed-phase validatio
 - Result:
 
 ## Validation
-- Tests / checks run:
+- Validation commands and their purpose:
 - Results:
 
 ## Verification Summary
@@ -64,6 +64,7 @@ verification_summary:
 
 ## Determinism Evidence
 - Determinism tests executed:
+- Fixtures or scripts used:
 - Replay verification (same inputs -> same artifacts/order):
 - Ordering guarantees (sorting / tie-break rules used):
 - Artifact stability notes:

--- a/docs/tooling/examples/workflow-state/good_output_record.md
+++ b/docs/tooling/examples/workflow-state/good_output_record.md
@@ -36,8 +36,9 @@ Fixture output record for dependable-execution completed-phase validation.
 - Result: PASS
 
 ## Validation
-- Tests / checks run:
+- Validation commands and their purpose:
   - `bash swarm/tools/validate_structured_prompt.sh --type sor --phase completed --input docs/tooling/examples/workflow-state/good_output_record.md`
+    - verifies the completed-phase fixture remains structurally valid and machine-auditable.
 - Results:
   - pass
 
@@ -67,14 +68,15 @@ verification_summary:
 
 ## Determinism Evidence
 - Determinism tests executed: completed-phase validator
-- Replay verification (same inputs -> same artifacts/order): not applicable
+- Fixtures or scripts used: `docs/tooling/examples/workflow-state/good_output_record.md` as the deterministic fixture input
+- Replay verification (same inputs -> same artifacts/order): rerunning the validator against the same checked-in fixture yields the same validation result
 - Ordering guarantees (sorting / tie-break rules used): fixed section and field ordering
 - Artifact stability notes: fixture is checked in for deterministic reruns
 
 ## Security / Privacy Checks
-- Secret leakage scan performed: yes
-- Prompt / tool argument redaction verified: yes
-- Absolute path leakage check: pass
+- Secret leakage scan performed: yes, by manual inspection of the checked-in fixture
+- Prompt / tool argument redaction verified: yes, by manual inspection of the checked-in fixture
+- Absolute path leakage check: pass, verified by checking that recorded commands and references stay repository-relative
 - Sandbox / policy invariants preserved: yes
 
 ## Replay Artifacts
@@ -84,7 +86,7 @@ verification_summary:
 - Replay result:
 
 ## Artifact Verification
-- Required artifacts present: yes
+- Required artifacts present: yes; the primary proof artifact is `docs/tooling/examples/workflow-state/good_output_record.md`
 - Artifact schema/version checks: completed-phase validator pass
 - Hash/byte-stability checks: not run
 - Missing/optional artifacts and rationale: replay artifacts are not required for this fixture

--- a/docs/tooling/structured-prompt-contracts.md
+++ b/docs/tooling/structured-prompt-contracts.md
@@ -91,8 +91,21 @@ These fields should not be conflated.
 In particular:
 
 - `Integration state: pr_open` does not imply verification happened in a worktree
+- `Integration state: pr_open` should still truthfully report any worktree-only paths remaining
 - `Integration method used: direct write in main repo` should normally pair with `Verification scope: main_repo`
 - deviations are allowed, but should be explained in the record rather than left ambiguous
+
+## Execution-Record Quality Expectations
+
+Structured Output Records are machine-auditable execution records, not narrative summaries.
+
+In practice that means:
+
+- every listed validation command should also say what it verified
+- deterministic scripts or fixtures should be identified as determinism evidence, not merely listed
+- rerunnable deterministic scripts and fixtures count as replay evidence when they reproduce the same result
+- security and privacy checks should state what was checked and how it was checked
+- section headers should not be left empty; if something does not apply, the record should say why
 
 ## Absolute-Path Policy
 

--- a/swarm/templates/cards/output_card_template.md
+++ b/swarm/templates/cards/output_card_template.md
@@ -3,6 +3,12 @@
 Canonical Template Source: `swarm/templates/cards/output_card_template.md`
 Consumed by: `swarm/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
 
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
 Task ID:
 Run ID:
 Version:
@@ -43,18 +49,22 @@ Rules:
 - If artifacts exist only in the worktree, the task is NOT complete.
 - `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
 - `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
 - If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
 - Completed output records must not leave `Status` as `NOT_STARTED`.
 - By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
-- Tests / checks run:
+- Validation commands and their purpose:
 - Results:
 
 Validation command/path rules:
 - Prefer repository-relative paths in recorded commands and artifact references.
 - Do not record absolute host paths in output records unless they are explicitly required and justified.
 - `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
 
 ## Verification Summary
 ```yaml
@@ -82,15 +92,25 @@ verification_summary:
 
 ## Determinism Evidence
 - Determinism tests executed:
+- Fixtures or scripts used:
 - Replay verification (same inputs -> same artifacts/order):
 - Ordering guarantees (sorting / tie-break rules used):
 - Artifact stability notes:
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
 
 ## Security / Privacy Checks
 - Secret leakage scan performed:
 - Prompt / tool argument redaction verified:
 - Absolute path leakage check:
 - Sandbox / policy invariants preserved:
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
 
 ## Replay Artifacts
 - Trace bundle path(s):
@@ -107,3 +127,7 @@ verification_summary:
 ## Decisions / Deviations
 
 ## Follow-ups / Deferred work
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.


### PR DESCRIPTION
Closes #918

Local artifacts (not committed):
- Input card:  /Users/daniel/git/agent-design-language/.adl/v0.85/tasks/issue-0918__v085-output-card-template-tightening/sip.md
- Output card: /Users/daniel/git/agent-design-language/.adl/v0.85/tasks/issue-0918__v085-output-card-template-tightening/sor.md
- Idempotency-Key: eb08d4fa3abb4a4261b808cb13a629733d0246f4e7455893f7e1e72aa8bd13fa

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
