### PR TITLE
[v0.85][process] Infer current milestone card version from issue title when labels are missing

### DIFF
--- a/swarm/tools/pr.sh
+++ b/swarm/tools/pr.sh
@@ -472,6 +472,13 @@ issue_version() {
   local issue="$1"
   local v
   v="$(gh issue view "$issue" --json labels -q '.labels[].name' 2>/dev/null | sed -n 's/^version://p' | head -n1 || true)"
+  if [[ -z "$v" ]]; then
+    local title
+    title="$(gh issue view "$issue" --json title -q .title 2>/dev/null || true)"
+    if [[ "$title" =~ \[(v[0-9]+\.[0-9]+)\] ]]; then
+      v="${BASH_REMATCH[1]}"
+    fi
+  fi
   if [[ -n "$v" ]]; then
     echo "$v"
   else
@@ -1101,13 +1108,15 @@ cmd_start() {
     [[ -n "$slug" ]] || die "start: --title produced empty slug after sanitization"
     title="$title_arg"
   fi
+  if [[ -z "$title" && "$no_fetch_issue" != "1" ]]; then
+    require_cmd gh
+    note "Fetching issue title via gh…"
+    title="$(gh issue view "$issue" $(gh_repo_flag "$repo") --json title -q .title 2>/dev/null || true)"
+  fi
   if [[ -z "$slug" ]]; then
     if [[ "$no_fetch_issue" == "1" ]]; then
       die "start: --slug is required when --no-fetch-issue is set"
     fi
-    require_cmd gh
-    note "Fetching issue title via gh…"
-    title="$(gh issue view "$issue" $(gh_repo_flag "$repo") --json title -q .title 2>/dev/null || true)"
     [[ -n "$title" ]] || die "Could not fetch issue #$issue title. Pass --slug or check gh auth/repo."
     slug="$(sanitize_slug "$title")"
   fi
@@ -1261,10 +1270,27 @@ cmd_new() {
     die "new: issue body contains disallowed absolute host path"
   fi
 
-  local labels_csv
+  local labels_csv normalized_labels label
   labels_csv="$labels"
-  if [[ "$labels_csv" != *"version:"* ]]; then
-    labels_csv="${labels_csv},version:${version}"
+  normalized_labels=""
+  IFS=',' read -r -a label_arr <<< "$labels_csv"
+  for label in "${label_arr[@]}"; do
+    label="$(trim_ws "$label")"
+    [[ -n "$label" ]] || continue
+    [[ "$label" == version:* ]] && continue
+    if [[ -z "$normalized_labels" ]]; then
+      normalized_labels="$label"
+    else
+      normalized_labels="${normalized_labels},${label}"
+    fi
+  done
+  labels_csv="$normalized_labels"
+  if [[ -n "$version" ]]; then
+    if [[ -n "$labels_csv" ]]; then
+      labels_csv="${labels_csv},version:${version}"
+    else
+      labels_csv="version:${version}"
+    fi
   fi
 
   local -a gh_args

--- a/swarm/tools/test_pr_issue_version_inference.sh
+++ b/swarm/tools/test_pr_issue_version_inference.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/swarm/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/swarm/tools/card_paths.sh"
+PROMPT_LINT_SRC="$ROOT_DIR/swarm/tools/lint_prompt_spec.sh"
+PROMPT_VALIDATOR_SRC="$ROOT_DIR/swarm/tools/validate_structured_prompt.sh"
+INPUT_TPL_SRC="$ROOT_DIR/swarm/templates/cards/input_card_template.md"
+OUTPUT_TPL_SRC="$ROOT_DIR/swarm/templates/cards/output_card_template.md"
+STP_CONTRACT_SRC="$ROOT_DIR/swarm/schemas/structured_task_prompt.contract.yaml"
+SIP_CONTRACT_SRC="$ROOT_DIR/swarm/schemas/structured_implementation_prompt.contract.yaml"
+SOR_CONTRACT_SRC="$ROOT_DIR/swarm/schemas/structured_output_record.contract.yaml"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+origin="$tmpdir/origin.git"
+repo="$tmpdir/repo"
+bindir="$tmpdir/bin"
+gh_log="$tmpdir/gh.log"
+mkdir -p "$repo/swarm/tools" "$repo/swarm/templates/cards" "$repo/swarm/schemas" "$bindir"
+cp "$PR_SH_SRC" "$repo/swarm/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/swarm/tools/card_paths.sh"
+cp "$PROMPT_LINT_SRC" "$repo/swarm/tools/lint_prompt_spec.sh"
+cp "$PROMPT_VALIDATOR_SRC" "$repo/swarm/tools/validate_structured_prompt.sh"
+cp "$INPUT_TPL_SRC" "$repo/swarm/templates/cards/input_card_template.md"
+cp "$OUTPUT_TPL_SRC" "$repo/swarm/templates/cards/output_card_template.md"
+cp "$STP_CONTRACT_SRC" "$repo/swarm/schemas/structured_task_prompt.contract.yaml"
+cp "$SIP_CONTRACT_SRC" "$repo/swarm/schemas/structured_implementation_prompt.contract.yaml"
+cp "$SOR_CONTRACT_SRC" "$repo/swarm/schemas/structured_output_record.contract.yaml"
+chmod +x "$repo/swarm/tools/pr.sh"
+chmod +x "$repo/swarm/tools/lint_prompt_spec.sh" "$repo/swarm/tools/validate_structured_prompt.sh"
+
+cat >"$bindir/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${GH_LOG_FILE:?}"
+printf '%s\n' "$*" >>"$LOG_FILE"
+if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+  echo "https://github.com/example/repo/issues/975"
+  exit 0
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+  issue="${3:-}"
+  shift 3
+  if [[ "$issue" != "975" ]]; then
+    exit 1
+  fi
+  if [[ "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
+    exit 0
+  fi
+  if [[ "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
+    echo "[v0.85][process] Infer current milestone card version from issue title when labels are missing"
+    exit 0
+  fi
+fi
+exit 1
+EOF
+chmod +x "$bindir/gh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  git add -A
+  git commit -q -m "init"
+  git branch -M main
+  git init --bare -q "$origin"
+  git remote add origin "$origin"
+  git push -q -u origin main
+  git fetch -q origin main
+)
+
+assert_contains() {
+  local pattern="$1" text="$2" label="$3"
+  grep -Fq "$pattern" <<<"$text" || {
+    echo "assertion failed ($label): expected to find '$pattern'" >&2
+    echo "actual output:" >&2
+    echo "$text" >&2
+    exit 1
+  }
+}
+
+(
+  cd "$repo"
+  export PATH="$bindir:$PATH"
+  export GH_LOG_FILE="$gh_log"
+
+  out="$("$BASH_BIN" swarm/tools/pr.sh new \
+    --title "[v0.85][process] Infer current milestone card version from issue title when labels are missing" \
+    --slug v085-process-infer-card-version-from-issue-title \
+    --version v0.85 \
+    --body "test body")"
+
+  assert_contains "ISSUE_NUM=975" "$out" "new prints issue number"
+  [[ -f ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" ]] || {
+    echo "assertion failed: expected canonical input card under .adl/v0.85/tasks" >&2
+    exit 1
+  }
+  [[ -f ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sor.md" ]] || {
+    echo "assertion failed: expected canonical output card under .adl/v0.85/tasks" >&2
+    exit 1
+  }
+  grep -Fq "Version: v0.85" ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
+    echo "assertion failed: expected input card version v0.85" >&2
+    exit 1
+  }
+  grep -Fq "Title: [v0.85][process] Infer current milestone card version from issue title when labels are missing" \
+    ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
+    echo "assertion failed: expected preserved issue title in input card" >&2
+    exit 1
+  }
+  grep -Fq -- "--label version:v0.85" "$gh_log" || {
+    echo "assertion failed: expected issue create to use version:v0.85" >&2
+    exit 1
+  }
+  if grep -Fq -- "--label version:v0.3" "$gh_log"; then
+    echo "assertion failed: unexpected version:v0.3 label in issue create" >&2
+    exit 1
+  fi
+)
+
+echo "pr.sh new/start title+version inference: ok"


### PR DESCRIPTION
Closes #975

Local artifacts (not committed):
- Input card:  .adl/cards/975/input_975.md
- Output card: .adl/cards/975/output_975.md
- Idempotency-Key: 156b2a702df90d17b8985470b2f108e3bc193da633b4fcc7377273326c7a20d0

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
