### PR TITLE
[v0.85][docs] Retire Why Rust for ADL from the canonical milestone set

### DIFF
--- a/docs/milestones/v0.85/README.md
+++ b/docs/milestones/v0.85/README.md
@@ -60,9 +60,12 @@ The current tracked v0.85 set includes:
 - `SWARM_REMOVAL_PLANNING.md`
 - `VISION_v0.85.md`
 - `WBS_v0.85.md`
-- `WHY_RUST_FOR_ADL.md`
 
 If v0.85 planning material exists elsewhere in a temporary workspace or local draft area, reconcile it into this directory rather than treating that alternate location as authoritative.
+
+Retired historical docs may remain in this directory for continuity, but they
+are not part of the active canonical milestone set. `WHY_RUST_FOR_ADL.md` is
+currently retained in that historical-only status.
 
 ## Cognitive Authority
 

--- a/docs/milestones/v0.85/WHY_RUST_FOR_ADL.md
+++ b/docs/milestones/v0.85/WHY_RUST_FOR_ADL.md
@@ -1,210 +1,37 @@
 # Why Rust for ADL
 
-## Origin of the Choice
-
-ADL began partly as a practical experiment: learn Rust on a new machine and avoid falling back into the default ecosystem of Python glue code. What started as a small technical preference quickly revealed deeper architectural implications.
-
-The more the system evolved, the clearer it became that Rust was not just a language choice but a **design philosophy aligned with the goals of ADL**.
-
-ADL is intended to support:
-
-- dependable execution
-- deterministic execution
-- verifiable inference
-- replayable agent workflows
-- explicit contracts between agents
-- inspectable artifacts
-- long-lived infrastructure
-
-These properties are difficult to guarantee in systems built primarily around interpreted glue code.
-
-## The Historical Role of Interpreted Languages
-
-Before the rise of AI-assisted development, interpreted languages offered clear advantages:
-
-- fast iteration
-- low ceremony
-- flexible experimentation
-- minimal compile-time friction
-
-In a world where most software was written entirely by humans, those advantages often outweighed the costs.
-
-However, interpreted ecosystems also encouraged architectural patterns that do not scale well for infrastructure systems:
-
-- implicit structure
-- runtime surprises
-- fragile integrations
-- script accumulation instead of system design
-
-Many orchestration systems built around Python have drifted toward this pattern: powerful, but difficult to reason about and difficult to stabilize over time.
-
-## The AI-Assisted Engineering Shift
-
-The arrival of AI-assisted engineering changes the trade-off.
-
-When AI systems can generate boilerplate, navigate type systems, and maintain structural discipline, the historical productivity advantages of interpreted languages shrink considerably.
-
-Meanwhile, the advantages of strongly structured systems become more important:
-
-- compile-time guarantees
-- explicit types and contracts
-- predictable execution behavior
-- easier long-term maintenance
-
-For agent infrastructure—especially systems aiming for dependable execution, verifiable inference, deterministic execution, and replay—these guarantees are extremely valuable.
-
-## Why Rust Aligns With ADL
-
-Rust provides several properties that align directly with ADL’s design goals.
-
-### Dependable Execution
-
-ADL is trying to make execution behavior more dependable before it tries to make agents more powerful. That means more emphasis on:
-
-- compilation before execution
-- explicit workflow contracts
-- replayable artifacts
-- earlier failure detection
-- fewer runtime surprises in the core substrate
-
-Rust is a strong fit for that direction because it helps push errors and ambiguity earlier in the lifecycle, where they can be reviewed and corrected before a workflow runs.
-
-### Determinism
-
-ADL is built around deterministic workflows and replayable execution. Rust encourages explicit control over state, ownership, and side effects, making deterministic behavior easier to reason about.
-
-### Verifiable Inference
-
-ADL does not only want outputs that look plausible. It wants outputs whose reasoning and evidence can be inspected after the fact.
-
-That is the practical meaning of **verifiable inference** in ADL:
-
-- explicit contracts before execution
-- reviewable artifacts after execution
-- replayable runs
-- evidence-linked outputs
-- bounded, inspectable system behavior
-
-Rust does not create verifiable inference by itself, but it supports the kind of execution substrate in which verifiable inference is more credible. The stronger the guarantees around execution and artifact production, the stronger ADL’s trust claims can be.
-
-### Reliability
-
-Memory safety and strict compile-time checks reduce classes of runtime failures that can destabilize long-running agent systems.
-
-### Performance Headroom
-
-Even if early ADL implementations are small, the architecture anticipates much larger workloads. Rust provides performance headroom without requiring architectural redesign later.
-
-### Structural Clarity
-
-Rust naturally encourages modular system design rather than script-driven integration. This aligns with ADL’s emphasis on:
-
-- cards
-- schemas
-- explicit workflows
-- observable artifacts
-
-### Future Runtime Direction
-
-ADL ultimately aims toward a compiled, deterministic execution substrate for agent workflows. Rust provides a credible foundation for that direction.
-
-## Rust vs "Python Glue"
-
-Python remains extremely valuable for experimentation, data analysis, quick scripting, and teaching. It has an enormous ecosystem and an elegant philosophy created by Guido van Rossum. The same is true, in different ways, of other interpreted or highly dynamic traditions such as Node.js and Smalltalk. Their creators and communities contributed enormously to modern software development.
-
-ADL does not reject that history. It benefits from it.
-
-However, ADL is aiming at a different center of gravity.
-
-For exploratory work, loosely connected scripts and runtime conventions can be productive. For infrastructure intended to be deterministic, inspectable, replayable, and saleable to businesses, that model introduces long-term fragility.
-
-Business customers do not only want flexibility. They want confidence. They want systems that are explicit about structure, checked before execution, and less likely to fail in surprising ways at runtime.
-
-That is one of the core reasons ADL is Rust-first.
-
-The preference here is not rooted in contempt for interpreted languages. It is rooted in the belief that, for the core substrate of an agent system, compilation and stronger guarantees are better aligned with the needs of serious production infrastructure than interpretation and late discovery of errors.
-
-## A Design Principle
-
-> In an AI-assisted engineering world, the historical convenience advantage of interpreted languages becomes less compelling for core infrastructure, while the value of stronger guarantees becomes more important.
-
-This does not eliminate the value of interpreted languages. They remain useful for:
-
-- experimentation
-- local tooling
-- data processing
-- temporary integration layers
-
-But for the **core substrate of an agent system intended for business use**, stronger guarantees are preferable:
-
-- dependable execution
-- compilation before execution
-- explicit contracts
-- deterministic behavior
-- verifiable artifacts
-- verifiable inference
-- fewer runtime surprises
-
-This is why the decision is architectural rather than ideological. ADL can still benefit from Python, JavaScript, Smalltalk, and other dynamic environments around the edges. But for the core execution substrate, ADL prefers stronger guarantees because they make dependable execution and verifiable inference more believable.
-
-## Rust and the Gödel–Hadamard–Bayes Loop
-
-This language choice also connects to one of ADL’s deeper architectural ideas: the emerging Gödel–Hadamard–Bayes cognition loop.
-
-That loop depends on several properties:
-
-- explicit hypotheses
-- explicit experiment artifacts
-- deterministic evaluation
-- reproducible execution
-- durable memory surfaces
-
-In other words, it depends on a system that can treat its own work as something structured, inspectable, and revisable.
-
-Rust is a strong fit for this style of system-building.
-
-A Gödel-style loop requires explicit self-reference rather than hidden behavior. A Hadamard-style loop benefits from freedom at the level of ideas, but not from chaos at the level of infrastructure. A Bayes-style loop requires evidence that can be trusted, replayed, and compared.
-
-Those requirements align naturally with a language and runtime philosophy that values:
-
-- explicit structure
-- strong contracts
-- predictable behavior
-- bounded side effects
-
-This does not mean Rust “creates” intelligence or scientific reasoning by itself. But it does provide a much better substrate for implementing these loops without collapsing into script sprawl and hidden state.
-
-In that sense, the choice of Rust is not only about performance or safety. It is also about building an environment in which agent cognition can be made disciplined, observable, scientifically improvable, and credible to organizations that need systems they can trust.
-
-Put more directly: if ADL wants to argue for dependable execution and verifiable inference, it needs a substrate whose failure modes, contracts, and artifact boundaries are explicit enough to support that argument.
-
-## A Small Experiment That Became Something Larger
-
-What began as a simple exercise—"learn some Rust and avoid Python for a while"—grew into something more significant.
-
-The constraints imposed by Rust encouraged a system architecture built around:
-
-- explicit artifacts
-- deterministic workflows
-- reproducible execution
-- compilation and checking before execution
-
-Those same properties turned out to be exactly what an agent orchestration system aimed at business use requires.
-
-This may reflect a particular bias or temperament. Other ecosystems optimize for different virtues, and many of those virtues are real. But ADL is making a deliberate choice.
-
-It is choosing a world in which the system should be checked before it runs, should fail earlier rather than later, and should make inference and execution more verifiable rather than less.
-
-In retrospect, Rust was not merely a convenient choice for ADL.
-
-It was the right foundation for the kind of system ADL is trying to become.
-
-## A Note on Language Debates
-
-ADL's Rust-first stance should not be mistaken for hostility toward interpreted ecosystems. Languages such as Python, JavaScript, and Smalltalk—and the communities around them—have contributed enormously to the progress of modern computing. Many of the ideas that shaped today's AI ecosystem emerged from those environments. ADL benefits from that history and respects it.
-
-The decision to build ADL around Rust is therefore not about declaring one tradition superior to another. It is about choosing the right center of gravity for a specific kind of system. ADL aims to provide deterministic, replayable, inspectable agent infrastructure suitable for serious production environments. For that goal, compilation, explicit contracts, and stronger guarantees before execution are better aligned with the needs of organizations that require reliable systems.
-
-In other words, this is not a language war. It is an architectural choice. Interpreted languages remain excellent tools for exploration, rapid experimentation, and research workflows. Rust simply provides a more appropriate foundation for the core execution substrate that ADL is attempting to build.
-
-That is the central claim of this document: ADL is Rust-first because it is trying to build a system whose execution is more dependable and whose inference is more verifiable, not because it wants to score points in a language debate.
+> Retired canonical milestone doc.
+>
+> This file is retained only as historical rationale material.
+> It is no longer part of the active canonical `v0.85` milestone set and should
+> not be treated as a roadmap-driving or implementation-driving document.
+
+## Status
+
+This document is preserved for historical context only.
+
+Its previous role was to explain why ADL chose Rust as its primary implementation
+language. That rationale may still be useful as background, but it is no longer
+an active milestone planning surface and it does not require additional `v0.85`
+documentation work.
+
+## Current Canonical Guidance
+
+For milestone planning and roadmap control, use the active `v0.85` milestone
+docs instead:
+
+- `README.md`
+- `VISION_v0.85.md`
+- `DESIGN_v0.85.md`
+- `WBS_v0.85.md`
+- `SPRINT_v0.85.md`
+- `MILESTONE_CHECKLIST_v0.85.md`
+- `RELEASE_PLAN_v0.85.md`
+- `RELEASE_NOTES_v0.85.md`
+- `DEMO_MATRIX_v0.85.md`
+
+## Notes
+
+- Keep this file for historical continuity.
+- Do not promote it into future milestone directories.
+- Do not treat it as a remaining roadmap gap.


### PR DESCRIPTION
Closes #979

Local artifacts (not committed):
- Input card:  .adl/cards/979/input_979.md
- Output card: .adl/cards/979/output_979.md
- Idempotency-Key: c30ecfa3b282236a4b992e3bb30c3dbc3828a758791cb4d6c624db29ed123920

Tests:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
