### PR TITLE
[v0.85][docs] Retire duplicated v0.85 PMO planning docs from .adl/docs

### DIFF
--- a/.adl/docs/v0.85planning/retired/DECISIONS_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/DECISIONS_v0.85.md
@@ -1,0 +1,57 @@
+# ADL Decision Log — v0.85
+
+## Metadata
+- Milestone: `v0.85`
+- Version: `0.85`
+- Date: `2026-03-11`
+- Owner: `Daniel Austin / Agent Logic`
+
+## Purpose
+Capture significant architectural, scope, and process decisions made during the v0.85 milestone so they are reviewable later.
+
+This log intentionally records *why* decisions were made, not only the final outcome.
+
+## How To Use
+- Add one row per decision.
+- Prefer links to issues or PRs instead of long prose.
+- Keep status current: `accepted`, `rejected`, `deferred`, `superseded`.
+
+---
+
+## Decision Log
+
+| ID | Decision | Status | Rationale | Alternatives | Impact | Link |
+|---|---|---|---|---|---|---|
+| D-01 | Treat v0.85 as a **strengthening milestone** rather than expanding scope. | accepted | ADL needs stronger operational maturity before expanding feature scope toward v0.9. | Expand feature scope now. | Keeps milestone disciplined and release‑focused. | `DESIGN_v0.85.md` |
+| D-02 | Make **Adaptive Execution Engine (AEE)** a named theme of the milestone. | accepted | AEE had been repeatedly deferred; surfacing it clarifies the cognitive direction of ADL. | Continue deferring AEE to later milestones. | Establishes AEE as part of the core roadmap. | Issue #559 |
+| D-03 | Introduce a **bounded affect / emotion model** as a reasoning control surface. | accepted | Emotion signals help prioritize reasoning and evaluation without introducing anthropomorphic claims. | Ignore affect entirely or implement unconstrained cognitive features. | Provides a structured foundation for later reasoning systems. | `AFFECT_MODEL_v0.85.md` |
+| D-04 | Use v0.85 to define the **reasoning graph schema direction**. | accepted | Early schema alignment avoids later incompatibility between hypothesis engines and memory structures. | Wait until v0.9 implementation stage. | Creates a clean interface boundary for future reasoning work. | `REASONING_GRAPH_SCHEMA_V0.85.md` |
+| D-05 | Tie **dependable execution** and **verifiable inference** to explicit artifacts rather than positioning language. | accepted | Trust claims must be grounded in observable system behavior. | Treat trust primarily as messaging or documentation. | Strengthens enterprise credibility of ADL. | Issue #729 |
+| D-06 | Temporarily treat the planning workspace as the planning anchor even while docs remain split. | accepted | Avoid blocking work while milestone docs are reorganized. | Pause planning until doc layout cleanup finishes. | Allows milestone planning to progress immediately. | WBS_v0.85.md |
+| D-07 | Allow a **bounded coverage threshold (≈90%)** for milestone release with documented rationale. | accepted | Prevents the release from being blocked by diminishing‑return test work. | Require higher coverage before release. | Keeps schedule realistic while maintaining quality visibility. | Issue #705 |
+| D-08 | Require **internal review and external review** before the release ceremony. | accepted | Ensures milestone planning and architecture receive independent scrutiny. | Internal review only. | Improves trustworthiness and architectural discipline. | WBS_v0.85.md |
+
+---
+
+## Open Questions
+
+- What demonstration artifacts should be required to validate **verifiable inference** before v0.9?  
+  Owner: Daniel Austin  
+  Tracking: Issue #729
+
+- What is the minimum affect‑signal set that improves reasoning without unnecessary complexity?  
+  Owner: Daniel Austin  
+  Tracking: AFFECT_MODEL_v0.85.md
+
+- Should milestone planning documents be consolidated into a single directory after v0.85?  
+  Owner: Daniel Austin  
+  Tracking: follow‑up cleanup
+
+---
+
+## Exit Criteria
+
+- All milestone‑critical architectural decisions are logged with rationale.
+- Deferred or rejected alternatives are recorded where relevant.
+- Open questions have owners and tracking references.
+- The decision log can explain the milestone design during internal or external review.

--- a/.adl/docs/v0.85planning/retired/DESIGN_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/DESIGN_v0.85.md
@@ -1,0 +1,160 @@
+# ADL Design — v0.85
+
+> **Planning note**
+> v0.85 planning artifacts are currently split between:
+> - the temporary planning workspace
+> - `docs/milestones/v0.85/`
+>
+> Until a cleanup pass consolidates them, this document should describe the intended design for the milestone without assuming a single canonical directory layout. Any duplicated or overlapping milestone docs should be aligned to this design.
+
+## Metadata
+- Milestone: `v0.85`
+- Version: `0.85`
+- Date: `2026-03-10`
+- Owner: `Daniel Austin / Agent Logic`
+- Related issues: `#674, #716, #730, #735, #559, #681`
+
+## Purpose
+Define the major design directions for v0.85, with emphasis on bounded operational maturity, dependable execution, verifiable inference, stronger authoring and review surfaces, Adaptive Execution Engine progress, and an initial affective / emotion-model substrate. This document is intended to anchor scattered milestone planning material into one coherent design statement.
+
+## Problem Statement
+v0.8 established a strong conceptual and architectural substrate for ADL, but the system still lacks several capabilities required for practical, trustworthy use by serious teams.
+
+The main gaps are:
+
+- execution remains stronger conceptually than operationally, especially for queueing, checkpointing, and distributed work
+- review and authoring surfaces are still too manual
+- dependable execution and verifiable inference need stronger first-class representation in tooling and documentation
+- the Adaptive Execution Engine (AEE) has been conceptually deferred for several releases and must advance materially in v0.85
+- the emerging emotion / affect model is not yet represented as a disciplined design surface even though it may become important to bounded cognition, evaluation signals, and agent priority handling
+
+v0.85 therefore exists to convert ADL from a compelling substrate into a more usable, scalable, and trustworthy platform.
+
+A secondary problem is documentation fragmentation itself: milestone intent is currently distributed across multiple directories and partially overlapping planning documents. That fragmentation increases ambiguity around source-of-truth, acceptance criteria, and sequencing. v0.85 should therefore improve not only runtime and authoring maturity, but also milestone-document coherence.
+
+## Goals
+- Advance ADL toward a practical execution substrate with deterministic queueing, checkpointing, resumability, and cluster-oriented work distribution.
+- Make dependable execution and verifiable inference explicit design principles across runtime, artifacts, and positioning.
+- Improve authoring and review ergonomics without weakening structure.
+- Move the Adaptive Execution Engine forward as a major milestone theme rather than continuing to defer it.
+- Establish a bounded affective / emotion-model design surface that can later influence evaluation, priority handling, and adaptive behavior.
+- Reduce milestone-planning ambiguity by making design intent, scope, and validation language more consistent across scattered planning documents.
+
+## Non-Goals
+- Deliver unrestricted autonomy or unconstrained online self-modification.
+- Replace the entire existing runtime in one milestone.
+- Build a full synthetic psychology system.
+- Solve every enterprise or UI concern before v0.9.
+
+## Scope
+### In scope
+- Deterministic queue and checkpoint design/implementation work.
+- Cluster / distributed execution planning and initial execution substrate improvements.
+- Prompt Spec completeness and stronger authoring surfaces.
+- Card Reviewer GPT stabilization.
+- Bounded AEE progress: retry policy, adaptation surfaces, strategy loop integration, experiment lifecycle support.
+- Trust surfaces: dependable execution, verifiable inference, artifact provenance, replayability.
+- A bounded emotion / affect model design that fits the Gödel–Hadamard–Bayes architecture.
+- Positioning and philosophy docs that clarify why ADL chooses stronger guarantees and explicit artifacts.
+- Milestone-document alignment across scattered planning artifacts, especially design/scope/validation language for v0.85.
+
+### Out of scope
+- Full production-grade autonomous self-improvement.
+- Fully generalized distributed runtime for arbitrary scale.
+- Broad website launch or complete marketing package.
+- Final public launch; v0.85 is still a strengthening milestone before the v0.9 base-feature target.
+- A full repository-wide information-architecture cleanup for all milestone documents; v0.85 only needs bounded alignment and reduced ambiguity.
+
+## Requirements
+### Functional
+- ADL must support stronger deterministic execution management, including queue/checkpoint/resume surfaces.
+- ADL must improve authoring and validation surfaces for prompts, cards, and workflows.
+- ADL must make review and artifact validation more reliable.
+- ADL must advance bounded adaptive execution so it is materially closer to operational use.
+- ADL must define an initial emotion / affect representation that is compatible with later cognitive work.
+- ADL milestone planning documents for v0.85 must present materially consistent scope, trust, AEE, and affect-model intent even while temporarily split across directories.
+
+### Non-functional
+- Deterministic behavior and reproducible outputs.
+- Clear failure semantics and observability.
+- Explicit artifact contracts and provenance.
+- Verifiable inference surfaces suitable for business-facing trust arguments.
+- Bounded scope: every new adaptive or affective mechanism must remain inspectable and reviewable.
+
+## Proposed Design
+### Overview
+v0.85 is organized around six mutually reinforcing tracks:
+
+1. **Execution substrate** — deterministic queueing, checkpointing, resumability, and cluster execution.
+2. **Authoring surfaces** — Prompt Spec completeness, HTML/card-based authoring, validation and linting.
+3. **Trust and verification** — dependable execution, verifiable inference, replay bundles, and review surfaces.
+4. **Cognitive substrate** — bounded AEE progress, hypothesis/experiment support, and a first affective model.
+5. **Operational maturity** — Card Reviewer GPT stabilization, clearer issue/card workflows, and cleaner milestone documentation.
+6. **Planning coherence** — tighter alignment of design, WBS, decisions, release, and milestone-checklist language across split documentation locations.
+
+The design principle across all tracks is that ADL should move toward a system whose behavior is increasingly:
+
+- explicit before execution
+- reproducible after execution
+- reviewable by humans and tools
+- bounded in adaptation and failure modes
+- documented with less ambiguity at the milestone-planning level
+
+### Interfaces / Data contracts
+- **Queue / checkpoint contracts**: deterministic run identity, queue state, retry state, checkpoint state, and resumability invariants.
+- **Prompt Spec contracts**: explicit authoring fields for actor, model, inputs, outputs, constraints, and review surfaces.
+- **Review artifacts**: machine-readable review outputs and consistent card/output structures.
+- **AEE interfaces**: bounded strategy-loop hooks, retry/adaptation policy surfaces, and experiment lifecycle integration points.
+- **Emotion / affect surfaces**: explicit state or signal representation for priorities, tensions, and evaluation guidance.
+- **Trust surfaces**: replay bundles, provenance markers, validation artifacts, and evidence-linked output structures.
+- **Planning contracts**: consistent terminology and scope boundaries across design, WBS, decisions, checklist, and release artifacts.
+
+### Execution semantics
+The execution semantics for v0.85 remain centered on deterministic workflow behavior.
+
+New or strengthened behavior should obey the following principles:
+
+- queue and checkpoint behavior must not weaken deterministic replay guarantees
+- retry and adaptation must remain bounded, explicit, and policy-driven
+- affective or emotional signals must not become hidden nondeterministic state; they must appear as inspectable inputs to evaluation or prioritization
+- distributed execution must preserve explicit ownership, claims, and resumability semantics
+- authoring improvements must generate more reliable artifacts, not more ambiguous ones
+- milestone-planning updates must reduce source-of-truth ambiguity rather than create additional overlapping statements
+
+## Risks and Mitigations
+- Risk: v0.85 becomes too large by combining runtime, authoring, trust, and cognition work.
+  - Mitigation: keep the milestone focused on bounded maturity gains and push broader autonomy or productization to later releases.
+- Risk: AEE scope again slips into future milestones without concrete progress.
+  - Mitigation: make AEE a named centerpiece of v0.85 and require concrete deliverables, not only planning language.
+- Risk: the emotion model is treated as either too speculative or too vague to matter.
+  - Mitigation: define it as a bounded operational substrate for priorities, tensions, and evaluation signals rather than synthetic psychology.
+- Risk: authoring and reviewer improvements remain secondary and continue to bottleneck throughput.
+  - Mitigation: explicitly prioritize Card Reviewer GPT stabilization and Prompt Spec / authoring improvements as milestone work.
+- Risk: trust language becomes rhetorical rather than implemented.
+  - Mitigation: tie dependable execution and verifiable inference to concrete artifacts, replay surfaces, and validation workflows.
+- Risk: milestone documents continue to diverge across `.adl/docs/v085planning` and `docs/milestones/v0.85`, creating planning drift.
+  - Mitigation: treat this design doc as the alignment anchor for scope, validation, AEE, trust, and affect-model language until a cleanup pass consolidates file locations.
+
+## Alternatives Considered
+- Option: keep v0.85 narrowly runtime-focused and defer affective/cognitive work.
+  - Tradeoff: would simplify scope, but risks missing an important architectural opportunity and continuing to postpone a promising design area.
+- Option: push the emotion model entirely to v0.9+.
+  - Tradeoff: safer in the short term, but loses the chance to shape the cognitive substrate while foundational interfaces are still being designed.
+- Option: prioritize only authoring/UI improvements and defer AEE again.
+  - Tradeoff: would improve usability, but would continue a pattern of postponing one of ADL’s most strategically important runtime themes.
+- Option: postpone document alignment until after runtime work stabilizes.
+  - Tradeoff: saves time in the short term, but increases confusion about milestone intent and makes later cleanup harder.
+
+## Validation Plan
+- Checks/tests: milestone issue tree, implementation cards, deterministic validation commands, replay and provenance checks where applicable, reviewer artifact checks, bounded design doc review for the emotion model, and cross-checking of v0.85 planning language across split document locations.
+- Success metrics: v0.85 materially improves execution maturity, reviewer reliability, authoring usability, and AEE concreteness; the emotion model is represented as a disciplined design surface rather than an untracked idea.
+- Rollback/fallback: if a sub-track becomes too ambitious, reduce it to explicit design docs and bounded artifacts rather than forcing partial uncontrolled implementation.
+
+## Exit Criteria
+- Goals/non-goals and scope boundaries are explicit.
+- Validation plan is actionable and referenced by the milestone checklist.
+- Major open questions are resolved or tracked in the decision log.
+- v0.85 clearly advances AEE, reviewer reliability, and authoring maturity.
+- The emotion / affect model has a disciplined design artifact and an agreed bounded role in the architecture.
+- The major v0.85 planning documents no longer materially contradict one another on scope, trust, AEE, or affect-model intent.
+- The milestone positions ADL to enter v0.9 with nearly all base features in place.

--- a/.adl/docs/v0.85planning/retired/MILESTONE_CHECKLIST_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/MILESTONE_CHECKLIST_v0.85.md
@@ -1,0 +1,87 @@
+# Milestone Checklist — v0.85
+
+## Metadata
+- Milestone: `v0.85`
+- Version: `0.85`
+- Target release date: `TBD`
+- Owner: `Daniel Austin / Agent Logic`
+
+## Purpose
+Ship / no‑ship gate for the v0.85 milestone.
+
+This checklist verifies that planning, implementation discipline, quality gates, and release packaging steps have all been satisfied before the release ceremony.
+
+Evidence should exist for every checked item.
+
+---
+
+## Planning
+
+- [x] Milestone goal defined (`DESIGN_v0.85.md`)
+- [x] Scope + non‑goals documented (`DESIGN_v0.85.md`)
+- [x] WBS created and mapped to milestone work (`WBS_v0.85.md`)
+- [x] Decision log initialized (`DECISIONS_v0.85.md`)
+- [x] Sprint plan created (`SPRINT_v0.85.md`)
+
+---
+
+## Execution Discipline
+
+- [ ] Each issue has input/output cards under `.adl/cards/<issue>/`
+- [ ] Each burst writes artifacts under `.adl/reports/burst/<timestamp>/`
+- [ ] Draft PR opened for each issue before merge
+- [ ] Transient failures retried and documented
+- [ ] "Green‑only merge" policy followed
+
+---
+
+## Quality Gates
+
+- [ ] `cargo fmt` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [ ] `cargo test --workspace` passes
+- [ ] CI is green on the merge target
+- [ ] Coverage signal is not red (or exception documented)
+- [ ] No unresolved high‑priority blockers remain
+
+---
+
+## Review Sequence
+
+The milestone requires both internal and external review before the release ceremony.
+
+- [ ] Milestone docs made internally consistent
+- [ ] Internal review completed
+- [ ] External review completed
+- [ ] Review findings resolved or explicitly deferred
+
+---
+
+## Release Packaging
+
+- [ ] Release notes finalized (`RELEASE_NOTES_v0.85.md`)
+- [ ] Tag verified: `v0.85.0`
+- [ ] GitHub Release drafted
+- [ ] Links validated in release body
+- [ ] Release published
+
+---
+
+## Post‑Release
+
+- [ ] Milestone / epic issues closed with release links
+- [ ] Deferred items moved to next milestone backlog
+- [ ] Follow‑up bugs / tech debt captured as issues
+- [ ] Roadmap / status docs updated
+- [ ] Retrospective summary recorded
+
+---
+
+## Exit Criteria
+
+The milestone is considered successfully shipped when:
+
+- All required gates are checked, **or**
+- Any remaining exceptions have a documented rationale, owner, and follow‑up issue.
+
+The milestone should be auditable end‑to‑end using the documents and artifacts referenced above.

--- a/.adl/docs/v0.85planning/retired/RELEASE_NOTES_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/RELEASE_NOTES_v0.85.md
@@ -1,0 +1,57 @@
+# ADL v0.85 Release Notes
+
+## Metadata
+- Product: `ADL (Agent Design Language)`
+- Version: `0.85`
+- Release date: `TBD`
+- Tag: `v0.85.0`
+
+## Summary
+v0.85 is a **stabilization and maturity milestone** for ADL. The release focuses on strengthening execution discipline, improving authoring and review workflows, clarifying the architectural direction of the Adaptive Execution Engine (AEE), and establishing early cognitive infrastructure for reasoning graphs and affect‑based evaluation signals.
+
+This milestone prepares the platform for the larger v0.9 phase by tightening planning artifacts, improving trust surfaces, and aligning runtime work with the broader Gödel‑inspired reasoning roadmap.
+
+## Highlights
+- Stronger milestone planning structure (design, WBS, decisions, sprint, release plan, checklist).
+- Continued progress toward **dependable execution** and **verifiable inference**.
+- Early architectural foundation for **AEE**, **reasoning graphs**, and **affective evaluation signals**.
+
+## What's New In Detail
+
+### Execution Discipline
+- Improved alignment between milestone planning artifacts and implementation work.
+- Clearer workflow expectations for issue cards, PR structure, and artifact generation.
+- Reinforced "green‑only merge" and CI validation discipline.
+
+### Authoring and Review Workflow
+- Stronger definition of the ADL authoring and review lifecycle.
+- Improved consistency of structured prompt and card workflows.
+- Clearer separation between planning artifacts and runtime artifacts.
+
+### Cognitive Architecture Foundations
+- Initial architectural definition of the **Adaptive Execution Engine (AEE)** direction.
+- Early schema direction for **reasoning graphs**.
+- Introduction of a **bounded affect / emotion model** used as a reasoning control surface.
+
+## Upgrade Notes
+- v0.85 remains part of the **pre‑v0.9 stabilization track**.
+- No major breaking runtime changes are expected for current ADL workflows.
+- Documentation structure may continue to evolve as milestone planning artifacts are consolidated.
+
+## Known Limitations
+- The AEE subsystem is still in early architectural stages.
+- Reasoning graph support is design‑level and not yet a fully implemented runtime feature.
+
+## Validation Notes
+- CI validation and testing must pass before the final release tag is created.
+- Coverage target for this milestone is **≈90%**, with documented rationale if higher thresholds are deferred.
+
+## What's Next
+- Continued runtime stabilization and tooling improvements.
+- Implementation of reasoning graph infrastructure.
+- Expansion of AEE capabilities and hypothesis‑engine integration.
+
+## Exit Criteria
+- Notes reflect only shipped behavior.
+- Known limitations and future work are clearly separated.
+- Document is ready to paste directly into the GitHub Release UI.

--- a/.adl/docs/v0.85planning/retired/RELEASE_PLAN_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/RELEASE_PLAN_v0.85.md
@@ -1,0 +1,103 @@
+# Release Plan — v0.85
+
+## Metadata
+- Milestone: `v0.85`
+- Version: `0.85`
+- Release date: `TBD`
+- Release manager: `Daniel Austin / Agent Logic`
+
+## How To Use
+- Execute sections in order and capture links for each completed step.
+- Keep this document focused on **release mechanics**, not milestone narrative.
+- Use `RELEASE_NOTES_v0.85.md` for descriptive content.
+- If a blocker appears, stop the process and record it explicitly.
+
+---
+
+# 1) Release Readiness
+
+Before beginning the release process the following must be true:
+
+- [ ] Milestone checklist complete (`MILESTONE_CHECKLIST_v0.85.md`)
+- [ ] Internal review completed
+- [ ] External review completed
+- [ ] Review findings resolved or explicitly deferred
+- [ ] Release notes approved (`RELEASE_NOTES_v0.85.md`)
+- [ ] Go / No‑Go decision recorded in decision log (`DECISIONS_v0.85.md`)
+
+These steps correspond to the **Release Tail** defined in the milestone sprint plan.
+
+---
+
+# 2) Branch and Tag Preparation
+
+Prepare the repository state for the release.
+
+- [ ] Target branch confirmed (`main`, unless otherwise specified)
+- [ ] Working tree clean
+- [ ] All intended PRs merged
+- [ ] CI passing
+- [ ] Version strings validated (Cargo manifests / docs if applicable)
+
+Tag creation:
+
+- [ ] Tag created: `v0.85.0`
+- [ ] Tag pushed to GitHub
+- [ ] Tag presence verified
+
+---
+
+# 3) GitHub Release Creation
+
+Create the GitHub release artifact.
+
+- [ ] GitHub Release draft created from tag `v0.85.0`
+- [ ] Release body populated from `RELEASE_NOTES_v0.85.md`
+- [ ] Links to key PRs and issues included
+- [ ] Release visibility confirmed (draft / prerelease / final)
+- [ ] Release published
+
+---
+
+# 4) Post‑Release Verification
+
+Confirm that the release is valid and visible.
+
+- [ ] Post‑release CI run verified
+- [ ] Documentation links tested
+- [ ] Release notes formatting verified
+- [ ] Repository state confirmed stable
+
+If any immediate regression is detected:
+
+- [ ] Regression issue opened
+- [ ] Hotfix decision recorded if needed
+
+---
+
+# 5) Communication
+
+Publish the release externally and internally.
+
+- [ ] GitHub release visible
+- [ ] Roadmap / milestone status updated
+- [ ] Internal project update posted
+
+Optional (depending on project stage):
+
+- [ ] Community announcement
+- [ ] Documentation site update
+
+---
+
+# Exit Criteria
+
+The release process is complete when:
+
+- The release tag exists and is publicly accessible.
+- The GitHub Release is published.
+- CI is green after the release.
+- Release notes and links are verified.
+- No unknown critical regressions remain.
+
+At that point the milestone can be considered **successfully shipped**.

--- a/.adl/docs/v0.85planning/retired/SPRINT_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/SPRINT_v0.85.md
@@ -1,0 +1,142 @@
+# Sprint Plan — v0.85
+
+## Metadata
+- Sprint plan: `v0.85`
+- Milestone: `v0.85`
+- Start date: `2026-03-10`
+- End date: `TBD`
+- Owner: `Daniel Austin / Agent Logic`
+
+## How To Use
+- Keep scope small enough to finish each sprint with green CI and merged PRs.
+- Execute work in dependency order from the WBS.
+- Use issue cards (`input` / `output`) for each item.
+- Treat docs as first-class deliverables; planning docs should converge early.
+- Include an explicit **internal review and external review** step before the release ceremony.
+
+## Sprint Goal
+Deliver v0.85 as the milestone where ADL transitions from an experimental substrate into a **more operationally mature agent engineering platform** by completing:
+
+- dependable execution improvements
+- verifiable inference surfaces
+- stronger authoring and tooling surfaces
+- bounded Adaptive Execution Engine progress
+- early cognitive substrate work (affect model + reasoning graph foundations)
+
+For the authoring track, v0.85 is expected to ship real usable HTML-based
+editor surfaces, not only editor-direction docs.
+
+## Sprint Structure
+v0.85 is organized into **three implementation sprints plus a release tail**.
+
+### Sprint 1 — Planning Alignment + Runtime Foundations
+Goal:
+Finalize milestone planning artifacts and begin the core runtime infrastructure improvements required for dependable execution.
+
+Scope:
+- WP-01 Design pass (planning alignment)
+- WP-02 Runtime reliability improvements
+- WP-03 Deterministic queue / checkpoint surfaces
+- WP-04 Retry / backoff / bounded adaptation surfaces
+
+### Sprint 2 — Authoring + Trust Surfaces
+Goal:
+Strengthen the development workflow and improve the trust and verification infrastructure around ADL artifacts.
+
+Scope:
+- WP-05 Prompt Spec completeness improvements
+- WP-06 Authoring and tooling improvements, including working HTA/task-bundle editor flow
+- WP-07 Artifact validation and verification improvements
+- WP-08 Review and CI surfaces
+
+### Sprint 3 — Cognitive Substrate (Gödel + Affect)
+Goal:
+Advance the cognitive architecture that supports Gödel-style experimentation and adaptive reasoning.
+
+Scope:
+- WP-09 Hypothesis engine foundations
+- WP-10 Reasoning graph schema
+- WP-11 ObsMem integration for reasoning artifacts
+- WP-12 Affective reasoning / evaluation signals
+
+### Release Tail — Demos, Quality Gate, Docs Alignment, Review, Ceremony
+Goal:
+Stabilize the milestone, validate demonstrations, enforce quality gates, converge documentation, execute internal and external reviews, and perform the release ceremony.
+
+Scope:
+- WP-13 Demo matrix + integration demos
+- WP-14 Coverage / quality gate
+- WP-15 Docs alignment + review sequence
+  - Step 1: docs consistent
+  - Step 2: internal review
+  - Step 3: external review
+- Review findings / fixes
+- WP-16 Release ceremony
+
+## Work Plan
+| Order | Item | Issue | Owner | Status |
+|---|---|---|---|---|
+| 1 | WP-01 Design pass (planning alignment) | #674 | Daniel / Codex | Planned |
+| 2 | WP-02 Runtime reliability improvements | TBD | Daniel / Codex | Planned |
+| 3 | WP-03 Deterministic queue / checkpoint surfaces | TBD | Daniel / Codex | Planned |
+| 4 | WP-04 Retry / adaptation surfaces | TBD | Daniel / Codex | Planned |
+| 5 | WP-05 Prompt Spec completeness | #716 | Daniel / Codex | Planned |
+| 6 | WP-06 Authoring / tooling improvements | TBD | Daniel / Codex | Planned |
+| 7 | WP-07 Artifact validation / verification | #729 | Daniel / Codex | Planned |
+| 8 | WP-08 Review and CI surfaces | TBD | Daniel / Codex | Planned |
+| 9 | WP-09 Hypothesis engine foundations | #748 | Daniel / Codex | Planned |
+| 10 | WP-10 Reasoning graph schema | #750 | Daniel / Codex | Planned |
+| 11 | WP-11 ObsMem reasoning integration | #751 | Daniel / Codex | Planned |
+| 12 | WP-12 Affective reasoning model | #752 | Daniel / Codex | Planned |
+| 13 | WP-13 Demo matrix + integration demos | TBD | Daniel / Codex | Planned |
+| 14 | WP-14 Coverage / quality gate | TBD | Daniel / Codex | Planned |
+| 15 | WP-15 Docs alignment + review sequence | TBD | Daniel / Codex | Planned |
+| 16 | Internal review pass | TBD | Daniel / reviewers | Planned |
+| 17 | External review pass | TBD | Daniel / external reviewer | Planned |
+| 18 | WP-16 Release ceremony | TBD | Daniel / Codex | Planned |
+
+## Cadence Expectations
+- Each WP should have its own issue, branch, worktree, and input/output cards.
+- Code changes must pass `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` unless the WP is documentation-only.
+- Documentation should converge before formal review begins.
+- Once review begins, milestone docs should remain stable except for explicit review findings.
+- Demos should be runnable with deterministic, CI-friendly commands when possible.
+
+## Risks / Dependencies
+- Dependency: ongoing runtime refactors
+  - Risk: implementation surfaces move faster than milestone docs
+  - Mitigation: treat `DESIGN_v0.85.md` and `WBS_v0.85.md` as alignment anchors
+
+- Dependency: cognitive subsystem design still evolving
+  - Risk: Gödel / reasoning graph design churn
+  - Mitigation: keep early implementations bounded and schema-focused
+
+- Dependency: CI and coverage work still in progress
+  - Risk: quality gate delays release
+  - Mitigation: allow bounded exceptions with documented rationale
+
+## Demo / Review Plan
+- Demo artifacts:
+  - reasoning graph example
+  - hypothesis evaluation loop example
+- HTA/editor/review workflow example
+
+- Review sequence:
+  1. Internal planning and design convergence
+  2. Documentation alignment
+  3. Internal review
+  4. External review
+  5. Fix findings / explicit deferrals
+  6. Release ceremony
+
+- Sign-off owners:
+  - Daniel Austin
+  - External reviewer (for external review step)
+
+## Exit Criteria
+- All planned scope items are completed or explicitly deferred with rationale.
+- Linked issues/PRs are updated and traceable.
+- CI is green for merged work.
+- Major v0.85 planning docs are internally consistent.
+- Internal and external reviews are completed before release ceremony.
+- Sprint outcomes are captured in milestone documentation.

--- a/.adl/docs/v0.85planning/retired/VISION_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/VISION_v0.85.md
@@ -1,0 +1,222 @@
+# ADL Vision — v0.85
+
+## Overview
+
+Version 0.85 is the milestone where ADL evolves from a powerful experimental substrate into a **usable, scalable, and trustworthy agent engineering platform**.
+
+v0.8 established the core foundations:
+
+- deterministic workflow execution
+- Gödel-style scientific improvement loop
+- ExperimentRecord / Evidence / Evaluation surfaces
+- reproducible artifacts and traceability
+
+v0.85 focuses on **operational maturity**.
+
+The goal is to make ADL practical for real teams building serious systems while strengthening the architectural pillars of:
+
+- dependable execution
+- verifiable inference
+- structured authoring
+- bounded adaptive learning
+
+v0.85 also advances the **Adaptive Execution Engine (AEE)** and introduces more robust tooling and execution capabilities.
+
+---
+
+# Core Goals
+
+v0.85 advances ADL in five major areas:
+
+1. Execution substrate
+2. Authoring surfaces
+3. Trust and verification
+4. Cognitive substrate
+5. Operational maturity
+
+---
+
+# 1. Execution Substrate
+
+v0.85 expands ADL's runtime capabilities so workflows can scale beyond single-machine experimentation.
+
+Key objectives:
+
+- deterministic execution queue
+- checkpointing and resumable runs
+- cluster / distributed execution
+- work leasing and task claims
+- retry and backoff policies
+- bounded adaptive execution surfaces
+
+These capabilities transform ADL from a workflow specification system into a **distributed execution substrate for agentic systems**.
+
+The runtime must guarantee:
+
+- reproducibility
+- deterministic ordering
+- bounded mutation
+- auditable artifacts
+
+---
+
+# 2. Authoring Surfaces
+
+ADL must become easier to use without sacrificing rigor.
+
+v0.85 introduces improved authoring tools:
+
+- structured prompt improvements
+- Prompt Spec completeness and validation
+- HTML authoring interface
+- working HTA/task-bundle editor surfaces for STP, SIP, and SOR
+- workflow visualization
+- linting and validation for ADL artifacts
+
+The goal is to move from raw file editing toward **guided authoring surfaces**.
+
+For v0.85, those surfaces should be real usable HTML-based editors in the repo,
+not just design direction.
+
+These tools should help users construct valid systems quickly while maintaining strict structure.
+
+---
+
+# 3. Trust and Verification
+
+A central design principle of ADL is **verifiable inference**.
+
+Agent systems must not merely produce answers. They must produce **evidence-backed, inspectable results**.
+
+v0.85 strengthens this pillar with:
+
+- artifact provenance tracking
+- reproducible run bundles
+- evidence surfaces
+- deterministic replay
+- review artifacts
+
+This work supports the broader principle of **dependable execution**.
+
+Systems built with ADL must behave in ways that are:
+
+- inspectable
+- reproducible
+- auditable
+
+This is essential for enterprise adoption.
+
+---
+
+# 4. Cognitive Substrate
+
+v0.85 continues development of ADL's Gödel-style improvement architecture.
+
+The focus remains on **bounded scientific reasoning**, not unrestricted self-modification.
+
+Key capabilities:
+
+- hypothesis registry
+- experiment ranking and evaluation
+- improved ObsMem retrieval for experiments
+- bounded mutation mechanisms
+
+v0.85 also introduces early work on an **affective / emotion model**.
+
+This is not intended as synthetic psychology, but as a mechanism for representing:
+
+- internal priorities
+- tension between goals
+- evaluation signals
+
+These signals can guide experimentation and adaptive behavior in the Gödel–Hadamard–Bayes loop.
+
+---
+
+# 5. Operational Maturity
+
+To support real-world use, v0.85 must improve operational tooling.
+
+Important targets include:
+
+- Card Reviewer GPT stabilization
+- improved review workflows
+- better CI validation surfaces
+- clearer milestone documentation
+
+The **Card Reviewer GPT** becomes an important part of the development workflow, helping enforce:
+
+- deterministic artifacts
+- schema correctness
+- consistent card structure
+
+This reduces review overhead and improves engineering velocity.
+
+---
+
+# The Adaptive Execution Engine (AEE)
+
+The Adaptive Execution Engine becomes a central focus of v0.85.
+
+Previous releases defined the architecture but deferred deeper implementation.
+
+v0.85 advances AEE with:
+
+- clearer strategy loop integration
+- policy surfaces for retry and adaptation
+- bounded mutation hooks
+- improved experiment lifecycle support
+
+The AEE is responsible for ensuring that learning and adaptation remain:
+
+- bounded
+- reproducible
+- observable
+
+This keeps the system aligned with ADL's core design philosophy.
+
+---
+
+# Milestone Context
+
+v0.8 represents a major architectural milestone.
+
+From v0.9 onward the project will likely shift toward smaller incremental releases:
+
+- v0.91
+- v0.92
+- v0.93
+
+The goal is to have nearly all foundational capabilities in place by **v0.9**.
+
+v0.85 therefore focuses on strengthening the platform before that stage.
+
+---
+
+# Long-Term Direction
+
+ADL is being designed as an infrastructure layer for trustworthy agent systems.
+
+Its long-term goals include:
+
+- dependable execution
+- verifiable inference
+- structured agent workflows
+- bounded adaptive learning
+
+These principles aim to move agent engineering beyond ad-hoc orchestration toward a more rigorous and reliable discipline.
+
+---
+
+# Summary
+
+v0.85 is the milestone where ADL becomes:
+
+- more scalable
+- easier to author
+- more trustworthy
+- more operationally mature
+
+It strengthens the execution substrate, advances the Adaptive Execution Engine, improves authoring surfaces, and stabilizes the development workflow.
+
+These improvements prepare the system for the next phase of development leading toward **v0.9 and eventually 1.0**.

--- a/.adl/docs/v0.85planning/retired/WBS_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/WBS_v0.85.md
@@ -1,0 +1,58 @@
+
+# ADL Work Breakdown Structure — v0.85
+
+## Metadata
+- Milestone: `v0.85`
+- Version: `0.85`
+- Date: `2026-03-11`
+- Owner: `Daniel Austin / Agent Logic`
+
+## Summary
+v0.85 is a strengthening milestone focused on bounded operational maturity, stronger trust surfaces, clearer authoring/review workflows, and concrete progress on the Adaptive Execution Engine (AEE) and affective reasoning substrate.
+
+This WBS is retained as planning source material, but the canonical tracked v0.85
+WBS now lives under `docs/milestones/v0.85/WBS_v0.85.md`.
+
+If this file disagrees with the canonical WBS, the canonical WBS wins.
+
+## Work Packages
+
+| WP | Package | Description | Deliverable(s) | Dependencies | Related issue(s) |
+|---|---|---|---|---|---|
+| WP-01 | Design pass (milestone docs + planning) | Align milestone design, scope, planning language, and cross-document intent for v0.85. | Updated design/WBS/decision/checklist/release-plan docs with materially consistent scope and validation language. | None | #716 |
+| WP-02 | Deterministic queueing + checkpoint substrate | Strengthen queue/checkpoint/resume semantics so workflows can be paused, resumed, and reasoned about without weakening determinism. | Runtime changes, validation commands, and design notes for deterministic execution state transitions. | WP-01 | #674 |
+| WP-03 | Cluster / distributed execution groundwork | Advance cluster execution planning and initial substrate behavior while preserving explicit ownership, claims, and replay semantics. | Cluster execution doc updates and bounded implementation/prototype work. | WP-01, WP-02 | #730 |
+| WP-04 | Prompt Spec completeness | Improve structured prompt contracts and authoring completeness so prompts/cards can be reviewed and generated more reliably. | Prompt Spec design/doc updates, validation/linting expectations, and linked issue/card work. | WP-01 | #735 |
+| WP-05 | First authoring/editor surfaces | Ship real HTA/task-bundle editor surfaces rather than only editor direction. | Working HTML-based editor artifacts for linked STP/SIP/SOR task bundles, validation/preview flow, and compatible public-record paths. | WP-01, WP-04 | #870 provisional remap issue |
+| WP-06 | Card Reviewer GPT stabilization | Improve review reliability, YAML/output consistency, and repeatability in card review workflows. | Reviewer prompt/process updates, validation expectations, and output quality improvements. | WP-01, WP-04 | #559 |
+| WP-07 | Dependable execution surfaces | Turn dependable execution from positioning language into explicit runtime/artifact/trust surfaces. | Design and implementation work that ties dependable execution to observable workflow behavior and release validation. | WP-02, WP-03 | #681 |
+| WP-08 | Verifiable inference surfaces | Strengthen evidence-linked outputs, provenance, and replay/report structures so ADL can make serious trust claims. | Reviewable artifacts and documentation for provenance, replay, and inference verification. | WP-02, WP-06, WP-07 | #681 |
+| WP-09 | Adaptive Execution Engine (AEE) bounded progress | Advance AEE from deferred concept to concrete milestone work with bounded policy hooks and strategy-loop progress. | AEE design updates, issue/card work, and explicit bounded-scope deliverables. | WP-02, WP-07 | #716 |
+| WP-10 | Emotion / affect model design | Define a bounded affective reasoning surface that can later influence evaluation, prioritization, and adaptive behavior. | Affective reasoning doc set, emotion/affect design notes, and alignment with Gödel–Hadamard–Bayes work. | WP-01, WP-09 | #716 |
+| WP-11 | Reasoning graph schema direction | Define the schema direction for reasoning graphs, hypothesis records, tension records, and revision-friendly belief lineage. | Reasoning graph schema doc and linked planning material for later v0.9 work. | WP-10 | #716 |
+| WP-12 | Hypothesis engine planning linkage | Connect affective reasoning and reasoning graphs to the planned Gödel hypothesis engine direction. | Planning docs that clarify the v0.85 conceptual role and the v0.9 implementation path. | WP-10, WP-11 | #716 |
+| WP-13 | Demo matrix + integration demos | Validate that major v0.85 themes can be demonstrated coherently rather than only described independently. | Demo checklist, integration scenarios, and supporting artifacts. | WP-02 through WP-12 | #716 |
+| WP-14 | Coverage / quality gate | Reach an acceptable quality gate for the milestone with documented exceptions if needed. | Coverage status, test notes, ratchet/exclusion decisions, and release-quality evidence. | WP-02 through WP-13 | #674 |
+| WP-15 | Docs + review pass (3-step alignment) | Reduce contradictions across milestone docs and complete a bounded review sequence: (1) docs consistent, (2) internal review, (3) external review. | Cleaned milestone docs, internal review notes/findings, external review notes/findings, and aligned release-facing planning artifacts. | WP-01 through WP-14 | #716 |
+| WP-16 | Release ceremony (final validation + tag + notes + cleanup) | Execute the bounded release process for v0.85. | Final validation evidence, release notes, release plan completion, tag, and follow-up cleanup notes. | WP-13, WP-14, WP-15 | #716 |
+
+## Phasing
+- Phase 1: Planning alignment and design clarity (WP-01, WP-10, WP-11, WP-12)
+- Phase 2: Runtime / trust / authoring execution (WP-02 through WP-09)
+- Phase 3: Demonstration, quality gate, doc alignment, and release (WP-13 through WP-16)
+
+## Acceptance Criteria by Work Package
+- WP-01 (Design pass) -> The core v0.85 planning docs no longer materially contradict one another on scope, trust, AEE, or affect-model intent.
+- WP-02 -> Deterministic queue/checkpoint/resume behavior is documented and validated with explicit commands or test evidence.
+- WP-03 -> Cluster/distributed execution direction is explicit and bounded; no hidden weakening of replay or ownership semantics.
+- WP-04 -> Prompt Spec expectations are explicit enough to support consistent authoring and review.
+- WP-05 -> Real editor surfaces exist in-repo, materially improve authoring flow, and support linked STP/SIP/SOR task-bundle work.
+- WP-06 -> Reviewer outputs are materially more reliable and structurally consistent.
+- WP-07 -> Dependable execution claims are tied to concrete runtime/artifact behavior.
+- WP-08 -> Verifiable inference claims are tied to provenance, replay, and evidence-linked artifacts.
+- WP-09 -> AEE shows concrete bounded progress rather than remaining a deferred concept.
+- WP-10 -> The affective reasoning / emotion model is captured as a disciplined design surface, not as vague aspiration.
+- WP-11 -> Reasoning graph schema direction is explicit enough to guide later implementation.
+- WP-12 -> Hypothesis engine linkage is clear across the v0.85 conceptual layer and v0.9 implementation planning.
+- WP-13 (Demos) -> At least one coherent integration/demo path exists across major milestone themes.
+- WP-14 (Quality gate) -> Coverage and validation evidence are acceptable for release, or documented exceptions are explicitly justified.


### PR DESCRIPTION
## Summary
- retire the duplicated `v0.85` PMO planning docs under `.adl/docs/v0.85planning/` by recording their retired copies under `.adl/docs/v0.85planning/retired/`
- preserve the canonical milestone PMO set under `docs/milestones/v0.85/`
- leave the already-aligned planning docs untouched

Closes #987
Parent tracking: #880

## Included retired docs
- `DECISIONS_v0.85.md`
- `DESIGN_v0.85.md`
- `MILESTONE_CHECKLIST_v0.85.md`
- `RELEASE_NOTES_v0.85.md`
- `RELEASE_PLAN_v0.85.md`
- `SPRINT_v0.85.md`
- `VISION_v0.85.md`
- `WBS_v0.85.md`

## Intentionally untouched
- `HUMAN-IN-THE-LOOP-DESIGN-NOTES.MD`
- `REASONING_GRAPH_SCHEMA_V0.85.md`
- `SWARM_REMOVAL_PLANNING.md`

## Validation
- verified the retired set exists and is non-writable in the live `.adl` workspace
- verified the aligned files remained present and untouched
- `cargo fmt --check`: pass
- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: environment-blocked in this worktree during sandbox path setup for runtime test outputs (`out` / `.adl/runs`), not by the retirement doc content itself
