### PR TITLE
[v0.85][docs] Normalize lingering v0.85planning path references

### DIFF
--- a/.adl/docs/v0.85planning/retired/DESIGN_v0.85.md
+++ b/.adl/docs/v0.85planning/retired/DESIGN_v0.85.md
@@ -132,7 +132,7 @@ New or strengthened behavior should obey the following principles:
   - Mitigation: explicitly prioritize Card Reviewer GPT stabilization and Prompt Spec / authoring improvements as milestone work.
 - Risk: trust language becomes rhetorical rather than implemented.
   - Mitigation: tie dependable execution and verifiable inference to concrete artifacts, replay surfaces, and validation workflows.
-- Risk: milestone documents continue to diverge across `.adl/docs/v085planning` and `docs/milestones/v0.85`, creating planning drift.
+- Risk: milestone documents continue to diverge across `.adl/docs/v0.85planning` and `docs/milestones/v0.85`, creating planning drift.
   - Mitigation: treat this design doc as the alignment anchor for scope, validation, AEE, trust, and affect-model language until a cleanup pass consolidates file locations.
 
 ## Alternatives Considered

--- a/docs/milestones/v0.85/WBS_v0.85.md
+++ b/docs/milestones/v0.85/WBS_v0.85.md
@@ -16,7 +16,7 @@ Use it to answer:
 - which issue owns that work
 - what order the remaining work should happen in
 
-Do not treat the mid-flight review document as the execution plan. [MIDFLIGHT_REVIEW_ISSUES.md](/Users/daniel/git/agent-design-language/.adl/docs/v085planning/MIDFLIGHT_REVIEW_ISSUES.md) is now a diagnostic and closure tracker. Execution should flow through this WBS.
+Do not treat the mid-flight review document as the execution plan. [MIDFLIGHT_REVIEW_ISSUES.md](/Users/daniel/git/agent-design-language/.adl/docs/v0.85planning/MIDFLIGHT_REVIEW_ISSUES.md) is now a diagnostic and closure tracker. Execution should flow through this WBS.
 
 ## Current Milestone State
 


### PR DESCRIPTION
## Summary
- normalize two lingering `v085planning` path references to `v0.85planning`
- fix one retired planning doc reference under `.adl/docs/`
- fix one canonical `v0.85` WBS link that still pointed at the old planning path

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`