### PR TITLE
docs: update output card template source lines to adl paths

### DIFF
--- a/.adl/issues/v0.85/bodies/issue-1000-v085-update-output-card-template-source-lines-to-adl-paths.md
+++ b/.adl/issues/v0.85/bodies/issue-1000-v085-update-output-card-template-source-lines-to-adl-paths.md
@@ -1,0 +1,79 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "WP-20"
+slug: "v085-update-output-card-template-source-lines-to-adl-paths"
+title: "[v0.85][docs] Update output card template source lines to adl paths"
+labels:
+  - "track:roadmap"
+  - "version:v0.85"
+  - "type:docs"
+  - "area:tools"
+issue_number: 1000
+status: "draft"
+action: "edit"
+supersedes: []
+duplicates: []
+depends_on: []
+milestone_sprint: "Sprint 4"
+required_outcome_type:
+  - "docs"
+repo_inputs:
+  - "swarm/templates/cards/output_card_template.md"
+canonical_files:
+  - "swarm/templates/cards/output_card_template.md"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Corrects stale template metadata so future generated output cards reference the canonical adl paths."
+  - "Does not rewrite historical generated cards in this pass."
+pr_start:
+  enabled: true
+  slug: "v085-update-output-card-template-source-lines-to-adl-paths"
+---
+
+# Update output card template source lines to adl paths
+
+## Summary
+
+Move the output-card template metadata from legacy `swarm/...` references to the
+canonical `adl/...` paths so newly generated cards stop inheriting stale source
+and consumer references.
+
+## Goal
+
+Ensure future output cards point at the canonical template and generator paths
+without rewriting historical generated cards.
+
+## Required Outcome
+
+This issue is docs-only:
+
+- update the generator template metadata for future output cards
+- keep `main` clean by carrying the accidental edit on a tracked issue branch
+- do not rewrite historical generated cards in this pass
+
+## Deliverables
+
+- corrected output card template metadata
+- issue branch / worktree / cards set up cleanly for the change
+
+## Acceptance Criteria
+
+- newly generated output cards will reference the canonical `adl` template path
+- newly generated output cards will reference `adl/tools/pr.sh`
+- no historical generated cards are bulk rewritten in this pass
+
+## Out Of Scope
+
+- rewriting historical task-bundle cards
+- changing unrelated templates
+- changing card semantics beyond the source/consumer metadata lines
+
+## Validation
+
+- inspect the output card template header
+- confirm no other active templates carry the same stale source/consumer metadata
+
+## Demo Expectations
+
+- no demo required


### PR DESCRIPTION
Closes #1000

Local artifacts (not committed):
- Input card:  .adl/cards/1000/input_1000.md
- Output card: .adl/cards/1000/output_1000.md

Scope:
- update the output card generator template to reference canonical `adl` paths
- include the checked-in issue body file for issue tracking
- do not rewrite historical generated cards in this pass

Validation:
- `rg -n 'Canonical Template Source: .*swarm/templates/cards/output_card_template|Consumed by: .*swarm/tools/pr\\.sh' swarm/templates .adl/templates .adl/v0.85/tasks/issue-1000__v0-85-docs-update-output-card-template-source-lines-to-adl-paths`
- `bash swarm/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.85/tasks/issue-1000__v0-85-docs-update-output-card-template-source-lines-to-adl-paths/sor.md`
