### PR TITLE
[v0.85][WP-20] Documentation consistency pass

### DIFF
--- a/docs/milestones/v0.85/COGNITIVE_LOOP_MODEL_v0.85.md
+++ b/docs/milestones/v0.85/COGNITIVE_LOOP_MODEL_v0.85.md
@@ -127,10 +127,10 @@ Memory feeds back into bounded affect and future arbitration/execution choices.
 
 ## Relationship To Other v0.85 Docs
 
-- [AFFECT_MODEL_v0.85.md](/tmp/adl-wp-929/docs/milestones/v0.85/AFFECT_MODEL_v0.85.md) defines the bounded affect subsystem in more detail.
-- [AFFECTIVE_REASONING_MODEL.md](/tmp/adl-wp-929/docs/milestones/v0.85/AFFECTIVE_REASONING_MODEL.md) defines the signal model attached to reasoning/evaluation surfaces.
-- [DESIGN_v0.85.md](/tmp/adl-wp-929/docs/milestones/v0.85/DESIGN_v0.85.md) describes how this loop fits the milestone architecture.
-- [VISION_v0.85.md](/tmp/adl-wp-929/docs/milestones/v0.85/VISION_v0.85.md) describes the architectural role of the cognitive substrate at milestone level.
+- [AFFECT_MODEL_v0.85.md](AFFECT_MODEL_v0.85.md) defines the bounded affect subsystem in more detail.
+- [AFFECTIVE_REASONING_MODEL.md](AFFECTIVE_REASONING_MODEL.md) defines the signal model attached to reasoning/evaluation surfaces.
+- [DESIGN_v0.85.md](DESIGN_v0.85.md) describes how this loop fits the milestone architecture.
+- [VISION_v0.85.md](VISION_v0.85.md) describes the architectural role of the cognitive substrate at milestone level.
 
 ## Scope Note
 

--- a/docs/milestones/v0.85/DESIGN_v0.85.md
+++ b/docs/milestones/v0.85/DESIGN_v0.85.md
@@ -115,7 +115,7 @@ The design principle across all tracks is that ADL should move toward a system w
 - bounded in adaptation and failure modes
 - documented with less ambiguity at the milestone-planning level
 
-The authoritative loop model for tracked v0.85 docs is intentionally separated into [COGNITIVE_LOOP_MODEL_v0.85.md](/tmp/adl-wp-929/docs/milestones/v0.85/COGNITIVE_LOOP_MODEL_v0.85.md) so milestone design docs do not need to compete over loop authority.
+The authoritative loop model for tracked v0.85 docs is intentionally separated into [COGNITIVE_LOOP_MODEL_v0.85.md](COGNITIVE_LOOP_MODEL_v0.85.md) so milestone design docs do not need to compete over loop authority.
 
 The `swarm` -> `adl` repository cutover is intentionally sequenced at the end of the milestone rather than treated as parallel background churn. The repo still carries many path-sensitive `swarm/...` assumptions, so executing the cutover late reduces merge-conflict pressure while substantive runtime, trust, and authoring work is still landing.
 

--- a/docs/milestones/v0.85/VISION_v0.85.md
+++ b/docs/milestones/v0.85/VISION_v0.85.md
@@ -50,7 +50,7 @@ ADL is aiming at something more rigorous:
 
 In that sense, v0.85 is the milestone where ADL’s **cognitive substrate becomes more explicit**.
 
-Within the tracked v0.85 milestone docs, the authoritative loop definition now lives in [COGNITIVE_LOOP_MODEL_v0.85.md](/tmp/adl-wp-929/docs/milestones/v0.85/COGNITIVE_LOOP_MODEL_v0.85.md).
+Within the tracked v0.85 milestone docs, the authoritative loop definition now lives in [COGNITIVE_LOOP_MODEL_v0.85.md](COGNITIVE_LOOP_MODEL_v0.85.md).
 
 It does not claim sentience, autonomy, or unrestricted self-modification. Instead, it assembles the practical primitives needed for:
 


### PR DESCRIPTION
Closes #880\n\n## Summary\n- normalize stale worktree-specific links in canonical v0.85 milestone docs\n- complete the local planning-directory consistency sweep for the v0.85 reconciliation pass\n- record the WP-20 change log under .adl/docs/v0.85/ for local auditability\n\n## Validation\n- manual duplicate-filename scan across .adl/docs/v0.xxplanning\n- manual stale-path scan for v085planning, v09planning, and /tmp/adl-wp refs\n- local review of the touched v0.85 milestone docs