### PR TITLE
[v0.85][authoring] Harden pr start command behavior

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -192,16 +192,11 @@ primary_checkout_root() {
 
 default_worktree_path_for_issue() {
   local issue="$1"
-  local primary parent managed_root
+  local primary managed_root
   primary="$(primary_checkout_root)"
-  parent="$(cd "$primary/.." && pwd -P)"
   managed_root="${ADL_WORKTREE_ROOT:-}"
   if [[ -z "$managed_root" ]]; then
-    if [[ "$primary" == "$HOME/git/"* || "$primary" == "$HOME/git" ]]; then
-      managed_root="$HOME/git"
-    else
-      managed_root="$parent"
-    fi
+    managed_root="$primary/.worktrees"
   fi
   echo "$managed_root/adl-wp-${issue}"
 }
@@ -1167,6 +1162,7 @@ cmd_start() {
       note "Reusing existing worktree path: $worktree_path"
     else
       note "Creating worktree: $worktree_path"
+      mkdir -p "$(dirname "$worktree_path")"
       run_git_or_die "start: git worktree add '$worktree_path' '$branch'" git worktree add "$worktree_path" "$branch"
     fi
   fi
@@ -1649,7 +1645,7 @@ Usage:
   adl/tools/pr.sh start <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue]
 
 Notes:
-- Creates or reuses issue worktree at ../adl-wp-<issue>.
+- Creates or reuses issue worktree at .worktrees/adl-wp-<issue> by default.
 - Keeps the primary checkout on main.
 EOF
 }

--- a/adl/tools/test_pr_start_template_validation.sh
+++ b/adl/tools/test_pr_start_template_validation.sh
@@ -57,7 +57,7 @@ assert_contains() {
   cd "$repo"
   "$BASH_BIN" adl/tools/pr.sh start 910 --slug validation-pass --no-fetch-issue >/dev/null
 
-  perl -0pi -e 's/Status: NOT_STARTED/Status: MAYBE/' adl/templates/cards/output_card_template.md
+  perl -0pi -e 's/Status: IN_PROGRESS/Status: MAYBE/' adl/templates/cards/output_card_template.md
 
   set +e
   bad="$("$BASH_BIN" adl/tools/pr.sh start 911 --slug validation-fail --no-fetch-issue 2>&1)"

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -66,7 +66,7 @@ assert_contains() {
     exit 1
   }
 
-  wt_path="$tmpdir/adl-wp-999"
+  wt_path="$repo/.worktrees/adl-wp-999"
   [[ -d "$wt_path" ]] || {
     echo "assertion failed: expected worktree to exist at $wt_path" >&2
     exit 1


### PR DESCRIPTION
Closes #1019

Local artifacts (not committed):
- Input card: .adl/cards/1019/input_1019.md
- Output card: .adl/cards/1019/output_1019.md

Summary:
- restore failing template-validation regression
- move default managed worktrees to repo-local .worktrees
- preserve idempotent and offline/no-fetch pr start behavior