### PR TITLE
[v0.85][tools] Fix pr.sh create/start FETCH_HEAD bootstrap failure

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1606,9 +1606,25 @@ cmd_start() {
   note "Target worktree: $worktree_path"
 
   note "Fetching origin/main…"
-  run_git_or_die "start: fetch origin main" git fetch origin main
+  local fetch_out="" fetch_status=0
+  set +e
+  fetch_out="$(git fetch origin main 2>&1)"
+  fetch_status=$?
+  set -e
+  if [[ "$fetch_status" -ne 0 ]]; then
+    if [[ "$fetch_out" == *".git/index.lock"* ]]; then
+      die_index_lock "start: fetch origin main"
+    fi
+    if git rev-parse --verify --quiet origin/main >/dev/null; then
+      note "Warning: start: fetch origin main failed; reusing existing local origin/main"
+      [[ -n "$fetch_out" ]] && note "$fetch_out"
+    else
+      [[ -n "$fetch_out" ]] && echo "$fetch_out" >&2
+      die "start: fetch origin main failed and origin/main is unavailable locally"
+    fi
+  fi
   if ! git rev-parse --verify --quiet origin/main >/dev/null; then
-    die "start: origin/main not found after fetch; verify remote setup and permissions"
+    die "start: origin/main not available; verify remote setup and permissions"
   fi
 
   # Ensure local branch exists (without switching the caller to it).

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -113,6 +113,27 @@ assert_contains() {
     exit 1
   }
 
+  fakebin="$tmpdir/fakebin"
+  mkdir -p "$fakebin"
+  cat >"$fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "fetch" && "\$2" == "origin" && "\$3" == "main" ]]; then
+  echo "error: cannot open '.git/FETCH_HEAD': Operation not permitted" >&2
+  exit 1
+fi
+exec "$(command -v git)" "\$@"
+EOF
+  chmod +x "$fakebin/git"
+  out_fetch_fallback="$(PATH="$fakebin:$PATH" "$BASH_BIN" adl/tools/pr.sh start 994 --slug fetch-fallback --no-fetch-issue)"
+  fetch_wt="$repo/.worktrees/adl-wp-994"
+  fetch_wt="$(cd "$fetch_wt" && pwd -P)"
+  assert_contains "start: fetch origin main failed; reusing existing local origin/main" "$out_fetch_fallback" "fetch fallback warning"
+  assert_contains "WORKTREE $fetch_wt" "$out_fetch_fallback" "fetch fallback still creates worktree"
+  [[ -d "$fetch_wt" ]] || {
+    echo "assertion failed: expected fetch-fallback worktree" >&2
+    exit 1
+  }
+
   git branch codex/998-collision origin/main
   git worktree add -q "$tmpdir/other-path" codex/998-collision
   set +e


### PR DESCRIPTION
Closes #1047

## Summary
- allow \ to reuse an existing local \ when fetch fails
- keep the hard failure when \ is unavailable locally
- add a regression shell test for the FETCH_HEAD permission-failure fallback path

## Testing
- bash adl/tools/test_pr_start_worktree_safe.sh
- bash adl/tools/test_pr_start_template_validation.sh
- bash -n adl/tools/pr.sh adl/tools/test_pr_start_worktree_safe.sh
- adl/tools/pr.sh start 1047 --slug v085-fix-prsh-fetch-head-bootstrap-failure --no-fetch-issue