### PR TITLE
[v0.85][authoring] Tighten input-card context-field validation for active and future work

### DIFF
--- a/adl/templates/cards/input_card_template.md
+++ b/adl/templates/cards/input_card_template.md
@@ -9,9 +9,9 @@ Branch:
 Context:
 - Issue:
 - PR:
-- Source Issue Prompt:
-- Docs:
-- Other:
+- Source Issue Prompt: <required repo-relative reference or URL>
+- Docs: <required freeform value or 'none'>
+- Other: <optional note or 'none'>
 
 ## Agent Execution Rules
 - Do not run `pr start`; the branch and worktree already exist.

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -595,6 +595,47 @@ render_template() {
   cat "$tpl"
 }
 
+join_by() {
+  local delimiter="$1"
+  shift || true
+  local first=1 item
+  for item in "$@"; do
+    if [[ "$first" -eq 1 ]]; then
+      printf '%s' "$item"
+      first=0
+    else
+      printf '%s%s' "$delimiter" "$item"
+    fi
+  done
+}
+
+docs_context_value_for_issue_prompt() {
+  local source_path="$1"
+  [[ -f "$source_path" ]] || {
+    printf 'none'
+    return 0
+  }
+
+  local fm tmp item
+  local -a docs=()
+  fm="$(mktemp -t prsh_docs_context_fm_XXXXXX)"
+  extract_front_matter_to_file "$source_path" "$fm"
+  while IFS= read -r item; do
+    item="$(strip_yaml_scalar_quotes "$item")"
+    [[ -n "$item" ]] || continue
+    if [[ "$item" == *.md || "$item" == docs/* || "$item" == .adl/docs/* ]]; then
+      docs+=("$item")
+    fi
+  done < <(stp_array_items "$fm" "repo_inputs")
+  rm -f "$fm"
+
+  if [[ "${#docs[@]}" -eq 0 ]]; then
+    printf 'none'
+  else
+    join_by '; ' "${docs[@]}"
+  fi
+}
+
 validate_card_header_count() {
   # Args: file_path header_line
   local path="$1" header="$2"
@@ -608,7 +649,7 @@ seed_input_card() {
   local task_id run_id
   task_id="issue-$(card_issue_pad "$issue")"
   run_id="$task_id"
-  local tpl tmp repo issue_url
+  local tpl tmp repo issue_url source_path docs_value source_slug
   tpl="$(resolve_input_template)"
   [[ -f "$tpl" ]] || die "missing input card template: $tpl"
 
@@ -628,8 +669,19 @@ seed_input_card() {
   repo="$(default_repo)"
   if [[ -n "$repo" ]]; then
     issue_url="https://github.com/${repo}/issues/${issue}"
-    replace_first_line_re "$tmp" "^- Issue:[[:space:]]*$" "- Issue: $issue_url"
+    replace_first_line_re "$tmp" "^- Issue:.*$" "- Issue: $issue_url"
   fi
+
+  source_slug="$(sanitize_slug "$title")"
+  source_path="$(issue_prompt_path_for_issue "$issue" "$ver" "$source_slug")"
+  if [[ -f "$source_path" ]]; then
+    replace_first_line_re "$tmp" "^- Source Issue Prompt:.*$" "- Source Issue Prompt: $(path_relative_to_repo "$source_path")"
+  elif [[ -n "$issue_url" ]]; then
+    replace_first_line_re "$tmp" "^- Source Issue Prompt:.*$" "- Source Issue Prompt: $issue_url"
+  fi
+  docs_value="$(docs_context_value_for_issue_prompt "$source_path")"
+  replace_first_line_re "$tmp" "^- Docs:.*$" "- Docs: $docs_value"
+  replace_first_line_re "$tmp" "^- Other:.*$" "- Other: none"
 
   if [[ -n "$output_path_actual" ]]; then
     output_path_actual="$(path_relative_to_repo "$output_path_actual")"

--- a/adl/tools/test_pr_cards_context_defaults.sh
+++ b/adl/tools/test_pr_cards_context_defaults.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+INPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/input_card_template.md"
+OUTPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/output_card_template.md"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mkdir -p "$repo/adl/tools" "$repo/adl/templates/cards" "$repo/.adl/issues/v0.85/bodies"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+cp "$INPUT_TPL_SRC" "$repo/adl/templates/cards/input_card_template.md"
+cp "$OUTPUT_TPL_SRC" "$repo/adl/templates/cards/output_card_template.md"
+chmod +x "$repo/adl/tools/pr.sh"
+
+cat >"$repo/.adl/issues/v0.85/bodies/issue-49-v085-context-defaults.md" <<'EOF'
+---
+issue_card_schema: adl.issue.v1
+wp: "authoring"
+slug: "v085-context-defaults"
+title: "[v0.85][authoring] Context defaults"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:bug"
+  - "version:v0.85"
+issue_number: 49
+status: "draft"
+action: "edit"
+supersedes: []
+duplicates: []
+depends_on: []
+milestone_sprint: "Test"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "docs/tooling/prompt-spec.md"
+  - "adl/tools/pr.sh"
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Test fixture"
+pr_start:
+  enabled: true
+  slug: "v085-context-defaults"
+---
+
+# Issue Card
+
+## Summary
+x
+## Goal
+x
+## Required Outcome
+x
+## Deliverables
+x
+## Acceptance Criteria
+x
+## Repo Inputs
+x
+## Dependencies
+x
+## Demo Expectations
+x
+## Non-goals
+x
+## Issue-Graph Notes
+x
+## Notes
+x
+## Tooling Notes
+x
+EOF
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  git add -A
+  git commit -q -m "init"
+)
+
+no_gh_bin="$tmpdir/no-gh-bin"
+mkdir -p "$no_gh_bin"
+for cmd in awk basename cat cp cut dirname git grep head ln mkdir mktemp mv pwd readlink rm sed touch tr python3; do
+  cmd_path="$(command -v "$cmd")"
+  ln -s "$cmd_path" "$no_gh_bin/$cmd"
+done
+
+assert_has() {
+  local pattern="$1" file="$2"
+  grep -Fq -- "$pattern" "$file" || {
+    echo "assertion failed: expected '$pattern' in $file" >&2
+    exit 1
+  }
+}
+
+(
+  cd "$repo"
+  PATH="$no_gh_bin" "$BASH_BIN" adl/tools/pr.sh card 49 --no-fetch-issue --slug v085-context-defaults --version v0.85 >/dev/null
+  card=".adl/v0.85/tasks/issue-0049__v085-context-defaults/sip.md"
+  assert_has "- Source Issue Prompt: .adl/issues/v0.85/bodies/issue-49-v085-context-defaults.md" "$card"
+  assert_has "- Docs: docs/tooling/prompt-spec.md" "$card"
+  assert_has "- Other: none" "$card"
+)
+
+echo "pr.sh cards context defaults: ok"

--- a/adl/tools/test_structured_prompt_validation.sh
+++ b/adl/tools/test_structured_prompt_validation.sh
@@ -77,9 +77,9 @@ Branch: codex/898-valid-sip
 Context:
 - Issue: https://github.com/danielbaustin/agent-design-language/issues/898
 - PR:
-- Source Issue Prompt:
-- Docs:
-- Other:
+- Source Issue Prompt: .adl/issues/v0.85/bodies/issue-0898-v085-valid-sip.md
+- Docs: docs/tooling/prompt-spec.md
+- Other: none
 
 ## Prompt Spec
 ```yaml
@@ -213,6 +213,107 @@ EOF
 "$VALIDATOR" --type stp --input "$tmpdir/stp_valid.md"
 "$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_valid.md"
 "$VALIDATOR" --type sor --phase bootstrap --input "$tmpdir/sor_valid.md"
+
+cat >"$tmpdir/sip_blank_context_invalid.md" <<'EOF'
+# ADL Input Card
+
+Task ID: issue-0898
+Run ID: issue-0898
+Version: v0.85
+Title: invalid-blank-context
+Branch: codex/898-invalid-blank-context
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/898
+- PR:
+- Source Issue Prompt:
+- Docs:
+- Other:
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/cards/898/output_898.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+x
+## Required Outcome
+x
+## Acceptance Criteria
+x
+## Inputs
+x
+## Target Files / Surfaces
+x
+## Validation Plan
+x
+## Demo / Proof Requirements
+x
+## Constraints / Policies
+x
+## System Invariants (must remain true)
+x
+## Reviewer Checklist (machine-readable hints)
+x
+## Non-goals / Out of scope
+x
+## Notes / Risks
+x
+## Instructions to the Agent
+x
+EOF
+
+if "$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_blank_context_invalid.md" >/dev/null 2>&1; then
+  echo "expected blank-context SIP to fail validation" >&2
+  exit 1
+fi
 
 cat >"$tmpdir/stp_absolute_path_invalid.md" <<'EOF'
 ---

--- a/adl/tools/validate_structured_prompt.sh
+++ b/adl/tools/validate_structured_prompt.sh
@@ -64,6 +64,7 @@ valid_github_issue_url() { [[ "$1" =~ ^https://github\.com/[^/]+/[^/]+/issues/[0
 valid_github_pr_url() { [[ "$1" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; }
 valid_reference() { [[ "$1" =~ ^https?://.+$ || "$1" =~ ^[A-Za-z0-9._/-]+$ ]]; }
 valid_iso8601_datetime() { [[ "$1" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; }
+valid_freeform_placeholder() { [[ "$1" == "none" || "$1" == "not_applicable" || "$1" == "n/a" ]]; }
 
 contains_absolute_host_path() {
   local file="$1"
@@ -288,7 +289,9 @@ validate_sip() {
   v="$(trim "$(md_field "$file" "Branch")")"; require_nonblank "Branch" "$v"; valid_branch "$v" || die "Branch must be a codex/ branch"
   v="$(trim "$(md_block_field "$file" "Context" "Issue")")"; require_nonblank "Context.Issue" "$v"; valid_github_issue_url "$v" || die "Context.Issue must be a GitHub issue URL"
   v="$(trim "$(md_block_field "$file" "Context" "PR")")"; [[ -z "$v" || $(valid_github_pr_url "$v"; echo $?) -eq 0 ]] || die "Context.PR must be a GitHub PR URL"
-  v="$(trim "$(md_block_field "$file" "Context" "Source Issue Prompt")")"; [[ -z "$v" || $(valid_reference "$v"; echo $?) -eq 0 ]] || die "Context.Source Issue Prompt must be a repo-relative reference or URL"
+  v="$(trim "$(md_block_field "$file" "Context" "Source Issue Prompt")")"; require_nonblank "Context.Source Issue Prompt" "$v"; valid_reference "$v" || die "Context.Source Issue Prompt must be a repo-relative reference or URL"
+  v="$(trim "$(md_block_field "$file" "Context" "Docs")")"; require_nonblank "Context.Docs" "$v"
+  v="$(trim "$(md_block_field "$file" "Context" "Other")")"; require_nonblank "Context.Other" "$v"
   v="$(trim "$(md_block_field "$file" "Execution" "Source issue-prompt slug")")"; [[ -z "$v" || $(valid_slug "$v"; echo $?) -eq 0 ]] || die "Execution.Source issue-prompt slug must be a normalized slug"
   v="$(trim "$(md_block_field "$file" "Execution" "Required outcome type")")"; [[ -z "$v" || "$v" =~ ^(code|docs|tests|demo|combination)$ ]] || die "Execution.Required outcome type must be one of: code, docs, tests, demo, combination"
   v="$(trim "$(md_block_field "$file" "Execution" "Demo required")")"; [[ -z "$v" || "$v" == "true" || "$v" == "false" ]] || die "Execution.Demo required must be true or false"


### PR DESCRIPTION
## Summary
- require non-blank `Source Issue Prompt`, `Docs`, and `Other` values in SIP validation while keeping `PR` phase-aware
- update card generation so new input cards seed truthful non-blank context values by default
- add focused regressions and normalize the active `#1049` card while revalidating `#1042`

## Review
- input card: `.adl/cards/1049/input_1049.md`
- output card: `.adl/cards/1049/output_1049.md`
