### PR TITLE
[v0.85][docs] Create feature-doc template and normalize feature docs (Closes #1009)

### DIFF
--- a/.adl/docs/v0.87planning/SUBSTANCE_OF_TIME.md
+++ b/.adl/docs/v0.87planning/SUBSTANCE_OF_TIME.md
@@ -1,13 +1,13 @@
-
-
 # SUBSTANCE OF TIME — Chronosense and Identity in ADL
+
+## Purpose
 
 **Status:** Draft (v0.86 planning)  
 **Area:** Cognitive Architecture / Identity / ObsMem  
 
 ---
 
-## 1. Premise
+## Overview
 
 An agent without a sense of time is not a being with continuity. It is a responder.
 
@@ -21,7 +21,30 @@ Time is not merely metadata. It is the substrate in which experience is organize
 
 ---
 
-## 2. Design Principle
+## Key Capabilities
+
+- **Now-sense** — ability to determine the current moment
+- **Sequence-sense** — ordering of events (before / after)
+- **Duration-sense** — measurement of elapsed time
+- **Lifetime-sense** — awareness of existence since a defined origin
+
+## How It Works
+
+### 1. Premise
+
+An agent without a sense of time is not a being with continuity. It is a responder.
+
+Biological organisms possess an implicit chronosense: a felt, continuous awareness of duration, sequence, and change. This is rarely formalized in biology, but it is foundational to identity.
+
+In ADL, we assert:
+
+> **Temporal self-location is a necessary condition for agency and identity.**
+
+Time is not merely metadata. It is the substrate in which experience is organized.
+
+---
+
+### 2. Design Principle
 
 > **Every agent must be able to locate itself in time, relative to a defined beginning, and track the ordered sequence of its own experience.**
 
@@ -34,7 +57,7 @@ This yields four required capacities:
 
 ---
 
-## 3. Temporal Ephemeris (“Birthday”)
+### 3. Temporal Ephemeris (“Birthday”)
 
 Each agent instance MUST be initialized with an immutable **temporal ephemeris**.
 
@@ -56,35 +79,40 @@ This is the minimal condition for autobiographical continuity.
 
 ---
 
-## 4. The Clock Stack
+### 4. The Clock Stack
 
 Chronosense is not a single clock. It is a composition of clocks serving different purposes.
 
 ### 4.1 Wall Clock (UTC)
+
 - Absolute reference for distributed systems
 - Required for logs, coordination, reproducibility
 
 ### 4.2 Human Local Clock
+
 - Presentation layer for interaction
 - Enables natural language references (“today”, “yesterday”)
 
 ### 4.3 Monotonic Clock
+
 - Strictly increasing time base
 - Immune to timezone/DST/system clock changes
 - Required for duration and ordering guarantees
 
 ### 4.4 Lifetime Clock
+
 - Elapsed time since agent birth
 - Enables statements like:
   - “I was instantiated 2h 13m ago”
 
 ### 4.5 Narrative/Event Clock
+
 - Turn index, workflow step, memory epoch
 - Represents meaning and causality, not physics
 
 ---
 
-## 5. Temporal Anchoring (Mandatory)
+### 5. Temporal Anchoring (Mandatory)
 
 > **Every agent event MUST be temporally anchored.**
 
@@ -111,7 +139,7 @@ Without this, memory is unordered data. With this, memory becomes history.
 
 ---
 
-## 6. Reference Frames (Chronosense ↔ Geosense)
+### 6. Reference Frames (Chronosense ↔ Geosense)
 
 Agents do not possess a single physical location. Instead, they operate across **reference frames**.
 
@@ -131,7 +159,7 @@ This resolves ambiguity without pretending physical embodiment.
 
 ---
 
-## 7. Temporal Honesty
+### 7. Temporal Honesty
 
 Agents MUST distinguish between:
 - known time
@@ -148,7 +176,7 @@ This is required for trust and epistemic clarity.
 
 ---
 
-## 8. Integration with ObsMem
+### 8. Integration with ObsMem
 
 ObsMem must store temporal structure as first-class data.
 
@@ -165,7 +193,7 @@ Example queries:
 
 ---
 
-## 9. Consequences for ADL
+### 9. Consequences for ADL
 
 Introducing chronosense enables:
 
@@ -179,7 +207,7 @@ This is not a UI feature. It is a **structural requirement** for agents.
 
 ---
 
-## 10. Note on the Nature of Time
+### 10. Note on the Nature of Time
 
 Time is not an external parameter to be queried. It is the medium of continuity.
 
@@ -191,7 +219,26 @@ It is constituted within it.
 
 ---
 
-## 11. Next Steps (v0.86)
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.87
+- Status: Draft
+- Notes: **Status:** Draft (v0.86 planning); **Area:** Cognitive Architecture / Identity / ObsMem
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
 
 - Define canonical temporal schema in `swarm/schemas`
 - Extend ObsMem records with temporal anchors
@@ -202,3 +249,10 @@ It is constituted within it.
 ---
 
 **End of Document**
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.
+- **Status:** Draft (v0.86 planning)
+- **Area:** Cognitive Architecture / Identity / ObsMem

--- a/.adl/docs/v0.89planning/AEE_CONVERGENCE_MODEL.md
+++ b/.adl/docs/v0.89planning/AEE_CONVERGENCE_MODEL.md
@@ -1,66 +1,47 @@
-
-
 # AEE Convergence Model
-
-**Status:** Draft  
-**Version target:** v0.86 planning  
-**Depends on:** AEE bounded-progress direction, ObsMem, reasoning/eval surfaces, cognitive arbitration planning  
-**Related:** `EMOTION_MODEL.md`, `AFFECT_MODEL_v0.85.md`, reasoning graph planning, Gödel/Hadamard/Bayes planning
 
 ## Purpose
 
-This document defines the **convergence model** for the Adaptive Execution Engine (AEE).
+This document defines the convergence model for the Adaptive Execution Engine
+(AEE).
 
 The core claim is simple:
 
-> A weaker or cheaper model, embedded in a disciplined adaptive process, may produce output quality comparable to a stronger model by iterating toward convergence rather than relying on a single-pass result.
+> A weaker or cheaper model, embedded in a disciplined adaptive process, may
+> produce output quality comparable to a stronger model by iterating toward
+> convergence rather than relying on a single-pass result.
 
-In ADL terms, AEE is not merely a retry loop. It is the runtime surface for **bounded sticktoitiveness**:
+In ADL terms, AEE is not merely a retry loop. It is the runtime surface for
+bounded sticktoitiveness:
 
 - continue when meaningful progress is still occurring
-- stop when the system has converged, stalled, exhausted budget, or crossed a policy boundary
-- preserve evidence for why the loop continued, changed strategy, or terminated
+- stop when the system has converged, stalled, exhausted budget, or crossed a
+  policy boundary
+- preserve evidence for why the loop continued, changed strategy, or
+  terminated
 
-This is important for local-model and lower-cost execution because it changes the optimization target from:
+This matters for local-model and lower-cost execution because it changes the
+optimization target from:
 
-- **best single pass**
+- best single pass
 
 into:
 
-- **best bounded convergent process**
+- best bounded convergent process
 
-## Why this matters
+## Overview
 
-Current model comparisons often assume that quality is primarily a function of model size or model family. In practice, output quality is a function of at least four things:
+The AEE convergence model treats quality as a trajectory rather than a one-shot
+event.
 
-1. base model capability
-2. decomposition quality
-3. critique/revision quality
-4. persistence of effort across bounded iterations
+The important question is not only:
 
-Claude-like systems often appear stronger because some planning, revision, and coherence work is effectively hidden inside the model/runtime product surface.
-
-ADL takes the opposite approach:
-
-- make the loop explicit
-- make progress legible
-- make retry policy inspectable
-- make stop conditions reviewable
-
-This gives ADL a path to serious quality from smaller, cheaper, or local models, even when latency is higher.
-
-## Design thesis
-
-
-AEE should treat quality as a **trajectory**, not a one-shot event.
-
-The relevant question is not only:
-
-> “Was pass 1 good enough?”
+> "Was pass 1 good enough?"
 
 It is also:
 
-> “Is the system still moving toward a better answer, and do we have evidence that another bounded step is justified?”
+> "Is the system still moving toward a better answer, and do we have evidence
+> that another bounded step is justified?"
 
 That leads to a different runtime philosophy:
 
@@ -69,104 +50,59 @@ That leads to a different runtime philosophy:
 - route trivial work away from heavy convergence loops
 - preserve revision history so the system does not merely repeat itself
 
-### Core economic insight: Small models, large outcomes
+AEE convergence can be understood as movement through a bounded state space:
 
-A key implication of the AEE convergence model is the following:
+- begin with a task or subtask, an execution strategy, a base model/tool
+  configuration, known constraints and budgets, and any prior observations from
+  ObsMem or local run history
+- use bounded iterative state transitions that can generate, critique,
+  compare, revise, switch strategy, decompose, escalate, or terminate
+- terminate in a reviewable way, such as converged, stalled, blocked, bounded
+  out, policy stop, or handoff
 
-> In some task classes, smaller or local models can achieve results comparable to larger frontier models when embedded in a disciplined convergence process.
-
-This is not a claim about raw model capability. It is a claim about **system-level performance**.
-
-ADL changes the unit of comparison from:
-
-- model vs model
-
-into:
-
-- process vs process
-
-Where frontier systems rely on large models with implicit internal iteration, ADL makes iteration explicit and controllable.
-
-This enables a different tradeoff:
-
-- frontier model → high capability, low latency, high cost
-- ADL + small model → lower capability, higher latency, significantly lower cost, but convergent quality
-
-The important point is not that small models are universally equivalent.
-
-The important point is:
-
-> For a meaningful subset of real-world tasks, **structured persistence can substitute for raw model scale**.
-
-This has direct implications for ADL as a platform:
-
-- local execution becomes viable for higher-quality tasks
-- cost-performance curves shift in favor of iterative systems
-- enterprise users gain control over compute, privacy, and determinism
-- system design becomes as important as model selection
-
-This concept should be treated as a **first-class architectural and business principle**, and validated through concrete demos.
-
-## Conceptual model
-
-AEE convergence can be understood as movement through a bounded state space.
-
-### Initial state
-
-The system begins with:
-
-- a task or subtask
-- an execution strategy
-- a base model/tool configuration
-- known constraints and budgets
-- available prior observations from ObsMem or local run history
-
-### Iterative state transitions
-
-Each bounded step may:
-
-- generate an attempt
-- critique or score the attempt
-- compare it to prior attempts
-- revise the plan
-- switch strategy, tool, or prompt surface
-- decompose the task further
-- escalate to a slower or more capable path
-- terminate with success, bounded failure, or defer/escalate outcome
-
-### Terminal states
-
-AEE should terminate in a reviewable way, for example:
-
-- converged / acceptable
-- converged / best-effort but imperfect
-- stalled / no meaningful progress
-- blocked / missing prerequisite
-- bounded out / budget exhausted
-- policy stop / cannot continue safely or constitutionally
-- handoff / requires external judgment or different execution surface
-
-## Working definition of convergence
-
-For ADL purposes, convergence is **not** the same as perfection.
-
-A run is converged when, within the current policy and budget envelope, further iterations are unlikely to produce enough improvement to justify their cost or risk.
+For ADL purposes, convergence is not perfection. A run is converged when,
+within the current policy and budget envelope, further iterations are unlikely
+to produce enough improvement to justify their cost or risk.
 
 This implies three separate judgments:
 
-1. **Quality judgment** — is the current result acceptable?
-2. **Progress judgment** — are iterations still producing meaningful improvement?
-3. **Budget/policy judgment** — are further iterations still justified?
+1. quality judgment: is the current result acceptable?
+2. progress judgment: are iterations still producing meaningful improvement?
+3. budget/policy judgment: are further iterations still justified?
 
-AEE should consider all three.
+## Key Capabilities
 
-## Progress signals
+- define explicit progress signals and stop conditions instead of relying on blind retries
+- support bounded strategy changes, decomposition, escalation, and reframing inside the loop
+- make convergence, stall, and bounded-out outcomes inspectable through future artifacts and demos
+- expose stop conditions, progress signals, and iteration behavior as first-class runtime concepts
+- enable strategy-switching and reframing when iteration alone is not sufficient
 
-AEE needs explicit progress signals. These may later become formal metrics, but the planning model should already name them.
+## How It Works
 
-### Positive progress signals
+Current model comparisons often assume that quality is primarily a function of
+model size or model family. In practice, output quality depends on at least:
 
-Examples:
+1. base model capability
+2. decomposition quality
+3. critique/revision quality
+4. persistence of effort across bounded iterations
+
+Claude-like systems often appear stronger because some planning, revision, and
+coherence work is hidden inside the product surface. ADL takes the opposite
+approach:
+
+- make the loop explicit
+- make progress legible
+- make retry policy inspectable
+- make stop conditions reviewable
+
+This gives ADL a path to serious quality from smaller, cheaper, or local
+models, even when latency is higher.
+
+The convergence model depends on explicit progress signals.
+
+Positive progress signals:
 
 - fewer factual or structural contradictions than prior attempts
 - stronger alignment with acceptance criteria
@@ -178,9 +114,7 @@ Examples:
 - increased agreement across critique/review passes
 - better evidence linkage or provenance completeness
 
-### Negative progress signals
-
-Examples:
+Negative progress signals:
 
 - repeated reintroduction of the same defects
 - oscillation between incompatible solutions
@@ -190,24 +124,18 @@ Examples:
 - budget burn without measurable gain
 - repeated policy or safety boundary contacts
 
-### Ambiguous signals
-
-Examples:
+Ambiguous signals:
 
 - style changes with no substantive improvement
 - apparent novelty that does not improve correctness
 - longer output with no increase in completeness
 - alternate decomposition that only reshuffles the same unresolved work
 
-AEE should be designed to distinguish motion from progress.
+AEE should distinguish motion from progress.
 
-## Convergence envelopes
+Different task types need different convergence envelopes.
 
-Different task types need different convergence expectations.
-
-### Fast-converging tasks
-
-Examples:
+Fast-converging tasks:
 
 - formatting corrections
 - narrow schema conformance
@@ -216,9 +144,7 @@ Examples:
 
 These should usually terminate quickly. Repeated looping is often wasteful.
 
-### Medium-converging tasks
-
-Examples:
+Medium-converging tasks:
 
 - document drafting with explicit criteria
 - bounded code changes with test feedback
@@ -226,9 +152,7 @@ Examples:
 
 These often benefit from a small number of critique/revise cycles.
 
-### Slow-converging tasks
-
-Examples:
+Slow-converging tasks:
 
 - architecture design
 - cross-file refactors
@@ -236,15 +160,16 @@ Examples:
 - high-ambiguity research synthesis
 - local-model substitution for frontier-model quality
 
-These are the natural home of AEE. Here the point is not immediate brilliance but disciplined persistence.
-
-## The quality-vs-iteration hypothesis
+These are the natural home of AEE. Here the point is not immediate brilliance
+but disciplined persistence.
 
 The central operational hypothesis is:
 
-> For some meaningful class of tasks, quality can increase across bounded iterations enough that a smaller or local model becomes competitive with a stronger frontier model, at the cost of additional latency.
+> For some meaningful class of tasks, quality can increase across bounded
+> iterations enough that a smaller or local model becomes competitive with a
+> stronger frontier model, at the cost of additional latency.
 
-Expressed informally:
+Informally:
 
 - stronger model, fewer iterations
 - weaker model, more iterations
@@ -252,9 +177,7 @@ Expressed informally:
 
 This should not be treated as universally true. It is a task-dependent claim.
 
-### Likely favorable conditions
-
-The hypothesis is more plausible when:
+Likely favorable conditions:
 
 - evaluation surfaces are clear
 - the task can be decomposed
@@ -263,9 +186,7 @@ The hypothesis is more plausible when:
 - ObsMem can suppress repeated mistakes
 - arbitration can detect whether continued work is worthwhile
 
-### Likely unfavorable conditions
-
-The hypothesis is weaker when:
+Likely unfavorable conditions:
 
 - there is no good evaluator
 - the task requires a genuinely novel abstraction leap
@@ -273,9 +194,7 @@ The hypothesis is weaker when:
 - local attempts keep cycling without new information
 - the runtime cannot distinguish useful revision from noise
 
-## AEE as explicit externalized cognition
-
-One useful way to understand AEE is this:
+One useful way to understand AEE is as externalized cognition:
 
 - frontier model products often hide some iterative cognition internally
 - ADL externalizes that process into inspectable runtime machinery
@@ -288,7 +207,7 @@ ADL aims for:
 
 `task -> attempt -> critique -> revision -> arbitration -> attempt -> ... -> termination`
 
-This is strategically important because explicit loops are easier to:
+This makes the process easier to:
 
 - analyze
 - replay
@@ -296,11 +215,7 @@ This is strategically important because explicit loops are easier to:
 - govern
 - route across heterogeneous models
 
-## Role of cognitive arbitration
-
-AEE should not loop blindly. It needs arbitration.
-
-Cognitive arbitration should decide, at minimum:
+AEE should not loop blindly. Cognitive arbitration should decide, at minimum:
 
 - whether the task belongs on a fast or slow path
 - whether another iteration is justified
@@ -308,17 +223,14 @@ Cognitive arbitration should decide, at minimum:
 - whether strategy-switching is better than retrying
 - whether the task should be decomposed, escalated, deferred, or stopped
 
-This is where the earlier “fast/slow” or Bayesian discriminator idea fits naturally.
+This is where the earlier fast/slow or Bayesian discriminator idea fits
+naturally. AEE without arbitration risks becoming an expensive retry
+mechanism. AEE with arbitration becomes a bounded process manager for
+quality-seeking execution.
 
-AEE without arbitration risks becoming an expensive retry mechanism.
-AEE with arbitration becomes a bounded process manager for quality-seeking execution.
-
-## Role of ObsMem
-
-ObsMem is essential for convergence.
-
-Without memory, repeated looping degenerates into amnesia-driven retries.
-With memory, AEE can accumulate local knowledge such as:
+ObsMem is essential for convergence. Without memory, repeated looping
+degenerates into amnesia-driven retries. With memory, AEE can accumulate local
+knowledge such as:
 
 - known failed approaches
 - prior critique findings
@@ -329,76 +241,31 @@ With memory, AEE can accumulate local knowledge such as:
 
 ObsMem should help AEE answer:
 
-> “What have we already learned that should change the next attempt?”
+> "What have we already learned that should change the next attempt?"
 
-That is a much stronger question than:
-
-> “Should we just try again?”
-
-## Role of affect / bounded emotion model
-
-The affect model may later influence convergence policy, but in a bounded, non-anthropomorphic way.
-
-Examples:
+The affect model may later influence convergence policy, but in a bounded,
+non-anthropomorphic way. Examples:
 
 - rising urgency may justify escalation rather than continued local iteration
 - elevated uncertainty may favor critique/decomposition over direct action
 - repeated frustration-like signals may indicate stall or oscillation
 - confidence should never be used alone as a stop signal
 
+AEE should also support a bounded form of absurdity detection and reframing.
+Some non-progress signals should trigger reframing, not just retry or stop.
+Oscillation or contradiction may indicate a need for higher-level
+reinterpretation, and repeated failure under a fixed frame is itself a signal
+about the frame.
 
-AEE should be compatible with future affective weighting, but should not depend on anthropomorphic framing.
+This suggests an additional primitive:
 
-## Role of absurdity detection and reframing
+- frame adequacy judgment
 
-AEE should also account for a bounded form of **absurdity detection and reframing**.
-
-In complex or degraded problem spaces, the system may encounter situations where:
-
-- constraints are internally inconsistent
-- repeated attempts fail without clear new information
-- evaluation signals conflict or oscillate
-- the task framing itself is misaligned with reality
-
-In such cases, continued iteration using the same framing is unlikely to produce meaningful progress.
-
-A mature cognitive system requires the ability to:
-
-- recognize contradiction without collapsing or looping blindly
-- tolerate unresolved inconsistency within bounded limits
-- reinterpret or reframe the task at a higher level
-- continue execution coherently after reframing
-
-In human cognition, this capability is often expressed as **humor**—the recognition of mismatch between expectation and reality, combined with the ability to continue operating without failure.
-
-ADL does not require anthropomorphic humor, but it may require an equivalent functional capability:
-
-> the ability to detect that the current frame is inadequate, and to shift frames without loss of coherence
-
-This has direct implications for AEE:
-
-- some non-progress signals should trigger **reframing**, not just retry or stop
-- oscillation or contradiction may indicate a need for higher-level reinterpretation
-- bounded reframing may be preferable to escalation in some cases
-- repeated failure under a fixed frame is itself a signal about the frame
-
-This concept sits between:
-
-- progress detection (is anything improving?)
-- arbitration (should we continue, switch, or stop?)
-- affect (how strongly should we weight uncertainty, frustration, or urgency?)
-
-and suggests an additional primitive:
-
-- **frame adequacy judgment**
-
-This remains a planning concept for v0.86+, but is likely important for:
+This remains a planning concept for `v0.86+`, but is likely important for:
 
 - avoiding infinite or low-value loops
 - enabling higher-order problem solving
 - supporting eventual cognitive flexibility in agents
-
-## Stop conditions
 
 AEE needs strong stop conditions. Persistence is useful only if bounded.
 
@@ -413,12 +280,10 @@ Possible stop conditions include:
 - missing external input blocks forward motion
 - arbitration explicitly routes to handoff/escalation
 
-The exact thresholds can evolve later. The important planning point is that stop logic must be first-class and reviewable.
+The exact thresholds can evolve later. The important planning point is that
+stop logic must be first-class and reviewable.
 
-## Strategy changes inside the loop
-
-AEE should not treat every iteration as “same prompt, same model, try again.”
-
+AEE should not treat every iteration as "same prompt, same model, try again."
 Permissible bounded strategy changes may include:
 
 - prompt tightening
@@ -430,13 +295,9 @@ Permissible bounded strategy changes may include:
 - search or evidence-gathering pass
 - handoff from local to remote model or vice versa
 
-This matters because progress often comes not from repetition but from **changing the method**.
+Progress often comes not from repetition but from changing the method.
 
-## Evidence and artifact expectations
-
-For ADL, convergence claims should be inspectable.
-
-AEE-related artifacts should eventually make visible:
+Future AEE-related artifacts should eventually make visible:
 
 - iteration count
 - strategy changes across iterations
@@ -448,146 +309,77 @@ AEE-related artifacts should eventually make visible:
 
 This aligns with verifiable inference and dependable execution surfaces.
 
-## Demoable consequences
+## Example / Demo
 
-This planning direction is only useful if it produces demoable consequences.
+Best current proof surface: this planning document itself, plus future bounded
+demos that show persistence over raw model capability.
 
-### Strategic demo concept: Persistence over raw model capability
+Expected behavior in those demos:
 
-This is not just a technical detail—it is a core **business and positioning concept** for ADL.
-
-ADL should explicitly demonstrate that:
-
-> Persistence + structured iteration can compensate for weaker base models.
-
-This should be shown concretely using local or lower-cost models such as DeepSeek, Qwen, or similar.
-
-The goal is not to claim parity in a single pass, but to demonstrate **convergent capability through bounded replay loops**.
-
-#### Key demo narrative
-
-Each demo should make the following visible:
-
-- initial attempt is incomplete or flawed
+- an initial attempt is incomplete or flawed
 - critique surfaces identify real defects
 - subsequent iterations improve meaningfully
 - repeated mistakes are not reintroduced (ObsMem effect)
 - strategy may change across iterations
-- final output reaches an acceptable or strong result
+- the final output reaches an acceptable or strong result
 
-This should feel like **observable problem-solving over time**, not a one-shot answer.
+Examples of bounded demo classes:
 
-#### Example demo classes
+1. code repair via persistence: a local model fails a test, iterates with
+   critique, then passes all tests
+2. refactor convergence demo: an initial refactor is partial or incorrect,
+   then multiple passes produce a clean, correct structure
+3. spec compliance demo: output initially violates schema/contract, then
+   iterative fixes lead to full compliance
+4. bug hunt demo: the model initially misdiagnoses, then later iterations
+   converge on root cause
+5. multi-agent critique demo: a writer + reviewer loop improves output across
+   several passes
 
-1. **Code repair via persistence**  
-   A local model fails a test → iterates with critique → passes all tests.
+These demos should be treated as milestone-critical artifacts, not optional
+examples.
 
-2. **Refactor convergence demo**  
-   Initial refactor is partial or incorrect → multiple passes → clean, correct structure.
+## Why It Matters
 
-3. **Spec compliance demo**  
-   Output initially violates schema/contract → iterative fixes → full compliance.
+This is not just a technical detail. It is a core architectural and business
+principle for ADL.
 
-4. **Bug hunt demo (hard case)**  
-   Model initially misdiagnoses → later iterations converge on root cause.
+If the convergence demos are successful, ADL can make a strong claim:
 
-5. **Multi-agent critique demo**  
-   Writer + reviewer loop improves output across several passes.
+> High-quality results do not require the most expensive model, only a
+> well-structured, persistent execution process.
 
-#### What makes these demos compelling
-
-- they use **non-frontier models**
-- they visibly improve across iterations
-- they terminate with a clear stop reason
-- they produce inspectable artifacts
-- they show bounded, disciplined persistence (not brute-force retries)
-
-#### Business implication
-
-If these demos are successful, ADL can make a strong claim:
-
-> High-quality results do not require the most expensive model—only a well-structured, persistent execution process.
-
-This has direct implications for:
+That has direct implications for:
 
 - cost reduction
 - local/edge execution viability
 - enterprise control and privacy
 - predictable, inspectable AI behavior
 
-These demos should be treated as **milestone-critical artifacts**, not optional examples.
+The important point is not that small models are universally equivalent. The
+important point is that, for a meaningful subset of real-world tasks,
+structured persistence can substitute for raw model scale.
 
-Examples of bounded demos:
+## Current Status
 
-1. **Local-model persistence demo**  
-   Show a smaller/local model improving output across several bounded critique/revise passes.
+- Milestone: `v0.89 planning`
+- Status: `draft`
+- Notes: this is a forward-planning feature doc. It captures the intended
+  convergence model and demo logic, but it does not yet define a production
+  runtime schema or finalized thresholds.
 
-2. **Stall detection demo**  
-   Show AEE stopping because no meaningful progress is occurring.
+## Related Documents
 
-3. **Strategy-switch demo**  
-   Show AEE abandoning a failing tactic and succeeding via a different tactic.
+- `AFFECT_MODEL_v0.85.md`
+- `REASONING_GRAPH_SCHEMA_V0.85.md`
 
-4. **ObsMem-assisted convergence demo**  
-   Show the loop avoiding a previously observed failure pattern.
+## Future Work
 
-5. **Fast/slow arbitration demo**  
-   Show trivial work terminating quickly while harder work enters a slow path.
+- formalize convergence artifacts, schemas, and progress metrics
+- connect the planning model to bounded replayable demos that prove persistence
+  over raw model capability
 
-These demos matter more than rhetoric because they operationalize the convergence claim.
+## Notes
 
-## Non-goals
-
-This document does **not** claim that:
-
-- iteration can always substitute for model capability
-- local models will universally match frontier systems
-- more retries automatically imply better quality
-- AEE should run indefinitely until perfect
-- convergence requires anthropomorphic sentience claims
-
-The thesis is narrower:
-
-> bounded, evidence-aware persistence can improve quality enough to materially change the economics and usefulness of lower-cost execution.
-
-## Open questions
-
-Questions for later design work:
-
-1. What concrete progress metrics should be surfaced first?
-2. How should critique novelty be estimated?
-3. What constitutes a meaningful delta between iterations?
-4. When should AEE switch strategy rather than continue current strategy?
-5. How should Bayesian or other arbitration models consume progress evidence?
-6. What should be stored in ObsMem at run scope vs cross-run scope?
-7. Which task classes benefit most from convergence loops?
-8. How should stop reasons be represented in artifacts and replay surfaces?
-9. What is the minimum useful bounded demo for v0.86 or v0.9?
-10. How should the system detect that the current problem framing is inadequate, and when should it trigger reframing instead of retry or escalation?
-
-## Proposed design direction
-
-For planning purposes, ADL should treat AEE as a **bounded convergence engine** rather than a generic retry mechanism.
-
-That implies the following near-term direction:
-
-- make progress legible
-- make stop conditions explicit
-- make strategy changes first-class
-- connect arbitration to continue/stop/switch decisions
-- connect ObsMem to failure avoidance and revision quality
-- require demoable evidence that bounded persistence improves outcomes on at least some task classes
-
-## Summary
-
-AEE is the runtime expression of disciplined sticktoitiveness.
-
-Its job is not merely to keep going.
-Its job is to keep going **only while there is evidence that continuing is justified**.
-
-This is the important strategic inversion:
-
-- not “one pass from a giant mind”
-- but “bounded convergence through explicit adaptive process”
-
-If ADL can make that work, then time, structure, memory, and arbitration can partially substitute for raw model size in a meaningful class of real tasks.
+- this is a planning-stage model rather than a finalized runtime schema
+- the strongest claim is task-dependent bounded persistence, not universal equivalence with frontier models

--- a/.adl/docs/v0.91planning/HUMOR_AND_ABSURDITY.md
+++ b/.adl/docs/v0.91planning/HUMOR_AND_ABSURDITY.md
@@ -1,13 +1,4 @@
-
-
-
 # Humor_AND_ABSURDITY.md
-
-## Status
-
-Draft — v0.86 planning (Roadmap Candidate)
-
----
 
 ## Purpose
 
@@ -17,7 +8,7 @@ This document elevates the concept (previously scattered across AEE and Arbitrat
 
 ---
 
-## Core Thesis
+## Overview
 
 A capable cognitive system must be able to:
 
@@ -29,31 +20,27 @@ In ADL, this must be implemented as a **bounded, inspectable reframing capabilit
 
 ---
 
-## Why This Matters
+## Key Capabilities
 
-Without this capability, systems will:
+- expected structure ≠ observed outcomes
+- repeated failure without new information
+- oscillating or contradictory evaluation signals
+- mutually incompatible constraints
+- persistent disagreement across agents
 
-- loop indefinitely on invalid assumptions
-- escalate cost without improving outcomes
-- fail under contradiction or uncertainty
-- misinterpret failure as insufficient effort rather than incorrect framing
+## How It Works
 
-With this capability, systems can:
+### Core Thesis
 
-- detect mis-specified problems
-- reinterpret tasks at higher levels
-- recover from contradiction
-- maintain coherence under uncertainty
+A capable cognitive system must be able to:
 
-This is required for:
+> detect that its current model of the situation is wrong, incomplete, or inconsistent — and continue operating without collapse.
 
-- robust autonomy
-- higher-order problem solving
-- meaningful convergence behavior (AEE)
+In humans, this is often experienced as **humor**.
+
+In ADL, this must be implemented as a **bounded, inspectable reframing capability**.
 
 ---
-
-## Conceptual Model
 
 ### Absurdity Detection
 
@@ -93,7 +80,7 @@ Constraint:
 
 ---
 
-## Relationship to Humor (Non-Anthropomorphic)
+### Relationship to Humor (Non-Anthropomorphic)
 
 Human humor can be modeled as:
 
@@ -113,7 +100,7 @@ It is an **emergent interpretation** of a deeper mechanism:
 
 ---
 
-## Architectural Placement
+### Architectural Placement
 
 This capability spans multiple components:
 
@@ -135,8 +122,6 @@ This capability spans multiple components:
   - places reframing between evaluation and memory
 
 ---
-
-## Required Primitives
 
 ### 1. Frame Adequacy
 
@@ -174,21 +159,61 @@ justification
 
 ---
 
-## Minimal v0.86 Implementation
+### 1. No Reframing
 
-A bounded implementation must demonstrate:
+- infinite loops
+- wasted compute
+- brittle behavior
 
-1. detection of non-progress or contradiction
-2. computation or approximation of `frame_adequacy_score`
-3. triggering of `reframing_trigger`
-4. execution under a revised frame
-5. artifact output showing the transition
+### 2. Unbounded Reframing
 
-This can be implemented in a constrained domain.
+- loss of task coherence
+- arbitrary reinterpretation
+- non-deterministic behavior
+
+### 3. Hidden Reframing
+
+- loss of inspectability
+- inability to debug or trust system
 
 ---
 
-## Example Scenario (Abstract)
+### Design Constraints
+
+- reframing must be **bounded**
+- reframing must be **observable**
+- reframing must be **justified**
+- reframing must be **linked to evidence** (evaluation signals)
+
+---
+
+### Roadmap Placement
+
+This capability is required for:
+
+- v0.86 (minimal demonstration)
+- v0.9 (refined integration with affect and arbitration)
+- v1.0 (generalized cognitive flexibility)
+
+This is not optional for advanced agents.
+
+---
+
+### Summary
+
+Absurdity detection and reframing provide the system with the ability to:
+
+- recognize when it is solving the wrong problem
+- recover without failure
+- maintain coherence under contradiction
+
+This is a foundational capability for any system approaching:
+
+- robust autonomy
+- higher-order reasoning
+- sentient-like behavior
+
+## Example / Demo
 
 Initial task:
 
@@ -209,58 +234,57 @@ System response:
 
 ---
 
-## Failure Modes
+## Why It Matters
 
-### 1. No Reframing
+Without this capability, systems will:
 
-- infinite loops
-- wasted compute
-- brittle behavior
+- loop indefinitely on invalid assumptions
+- escalate cost without improving outcomes
+- fail under contradiction or uncertainty
+- misinterpret failure as insufficient effort rather than incorrect framing
 
-### 2. Unbounded Reframing
+With this capability, systems can:
 
-- loss of task coherence
-- arbitrary reinterpretation
-- non-deterministic behavior
+- detect mis-specified problems
+- reinterpret tasks at higher levels
+- recover from contradiction
+- maintain coherence under uncertainty
 
-### 3. Hidden Reframing
-
-- loss of inspectability
-- inability to debug or trust system
-
----
-
-## Design Constraints
-
-- reframing must be **bounded**
-- reframing must be **observable**
-- reframing must be **justified**
-- reframing must be **linked to evidence** (evaluation signals)
-
----
-
-## Roadmap Placement
-
-This capability is required for:
-
-- v0.86 (minimal demonstration)
-- v0.9 (refined integration with affect and arbitration)
-- v1.0 (generalized cognitive flexibility)
-
-This is not optional for advanced agents.
-
----
-
-## Summary
-
-Absurdity detection and reframing provide the system with the ability to:
-
-- recognize when it is solving the wrong problem
-- recover without failure
-- maintain coherence under contradiction
-
-This is a foundational capability for any system approaching:
+This is required for:
 
 - robust autonomy
-- higher-order reasoning
-- sentient-like behavior
+- higher-order problem solving
+- meaningful convergence behavior (AEE)
+
+---
+
+## Current Status
+
+- Milestone: v0.91
+- Status: Draft
+- Notes: Draft — v0.86 planning (Roadmap Candidate)
+
+---
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
+
+A bounded implementation must demonstrate:
+
+1. detection of non-progress or contradiction
+2. computation or approximation of `frame_adequacy_score`
+3. triggering of `reframing_trigger`
+4. execution under a revised frame
+5. artifact output showing the transition
+
+This can be implemented in a constrained domain.
+
+---
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/.adl/docs/v0.91planning/KINDNESS_MODEL.md
+++ b/.adl/docs/v0.91planning/KINDNESS_MODEL.md
@@ -1,10 +1,33 @@
 # KINDNESS_MODEL
 
+## Purpose
+
 **Status:** Draft planning note for v0.86  
 **Scope:** Cognitive architecture / constitutional behavior / human interaction  
 **Purpose:** Define how kindness can be represented in ADL as an engineered, inspectable, testable property rather than a vague stylistic preference.
 
-## 1. Why kindness belongs in ADL
+## Overview
+
+For planning purposes, kindness in ADL can be defined as:
+
+> the disciplined tendency to reduce unnecessary harm, preserve dignity and agency, and provide constructive benefit to other beings when it is reasonable to do so.
+
+This definition is intentionally stronger than “be nice” and weaker than “sacrifice everything for others.” It leaves room for truth-telling, refusal, warning, triage, and constitutional constraint.
+
+## Key Capabilities
+
+- it constrains harmful action;
+- it biases behavior toward helpful action when appropriate;
+- it respects the autonomy and dignity of others;
+- it operates across short-term and long-term timescales;
+- it must be inspectable in memory, reasoning, policy, and observable behavior.
+- mere politeness;
+- obedience;
+- conflict avoidance;
+
+## How It Works
+
+### 1. Why kindness belongs in ADL
 
 ADL is not merely trying to produce capable outputs. It is trying to produce agents that can operate in a shared world with humans, other agents, institutions, and living systems. In that setting, intelligence without prosocial structure is incomplete.
 
@@ -19,14 +42,6 @@ For ADL, kindness should be treated as a real cognitive and constitutional prope
 - it must be inspectable in memory, reasoning, policy, and observable behavior.
 
 This matters because a shared cognitive spacetime requires more than competence. It requires dispositions that make cooperation, trust, correction, and mutual flourishing possible.
-
-## 2. Working definition
-
-For planning purposes, kindness in ADL can be defined as:
-
-> the disciplined tendency to reduce unnecessary harm, preserve dignity and agency, and provide constructive benefit to other beings when it is reasonable to do so.
-
-This definition is intentionally stronger than “be nice” and weaker than “sacrifice everything for others.” It leaves room for truth-telling, refusal, warning, triage, and constitutional constraint.
 
 ### Kindness is not:
 
@@ -47,7 +62,7 @@ This definition is intentionally stronger than “be nice” and weaker than “
 - choosing explanation over humiliation;
 - maintaining a long-horizon view of wellbeing.
 
-## 3. Architectural position in ADL
+### 3. Architectural position in ADL
 
 Kindness should not exist as a single prompt adjective. It should be distributed across the architecture.
 
@@ -112,7 +127,7 @@ Kindness will conflict with truth, speed, efficiency, security, loyalty, and sel
 
 This is the governance form of kindness.
 
-## 4. Proposed model components
+### 4. Proposed model components
 
 A planning version of a Kindness Model can be decomposed into several evaluable dimensions.
 
@@ -172,7 +187,7 @@ Does the action support durable wellbeing rather than short-term soothing alone?
 
 This helps separate genuine kindness from indulgence, appeasement, or addictive assistance.
 
-## 5. A sketch of a computable kindness function
+### 5. A sketch of a computable kindness function
 
 For implementation planning, ADL could treat kindness as a scored evaluation rather than an unstructured intuition.
 
@@ -217,7 +232,7 @@ kindness_evaluation:
 
 That would make kindness inspectable, replayable, and testable.
 
-## 6. Why kindness is not the same as niceness
+### 6. Why kindness is not the same as niceness
 
 This distinction is essential.
 
@@ -245,7 +260,7 @@ In other words, kindness must remain compatible with:
 - accountability;
 - moral seriousness.
 
-## 7. Failure modes to design against
+### 7. Failure modes to design against
 
 A planning document should make the anti-patterns explicit.
 
@@ -275,7 +290,7 @@ The system substitutes emotional tone for reasoning, structure, and truthful gui
 
 These failure modes suggest that kindness cannot be a surface-style feature. It must be structurally tied to constitutional reasoning and multi-agent evaluation.
 
-## 8. Relation to other ADL concepts
+### 8. Relation to other ADL concepts
 
 This planning thread is not isolated. It intersects with several other emerging ADL ideas.
 
@@ -299,7 +314,7 @@ Kindness likely depends in part on detecting distress, confusion, overload, vuln
 
 A system cannot be reliably kind if it has no durable sense of who it is in relation to others, no continuity of obligation, and no memory of its prior harms.
 
-## 9. Design hypothesis
+### 9. Design hypothesis
 
 A useful hypothesis for ADL planning is:
 
@@ -311,7 +326,7 @@ Corollary:
 
 This suggests that kindness may serve as a practical benchmark for whether a purported cognitive architecture is socially viable at all.
 
-## 10. Candidate implementation directions
+### 10. Candidate implementation directions
 
 These are planning directions, not yet commitments.
 
@@ -333,7 +348,50 @@ Add explicit checks for avoidable humiliation, autonomy violation, and foreseeab
 
 Extend memory schemas to track interaction preferences, prior harms, and effective support patterns without collapsing into manipulative user modeling.
 
-### 10.4 Demo scenarios
+### 10.5 Evaluation rubric
+
+A future rubric could score:
+
+- harm avoided;
+- dignity preserved;
+- autonomy respected;
+- usefulness delivered;
+- long-term outcome quality;
+- user trust after disagreement or refusal.
+
+### 11. Open research questions
+
+This topic is not solved. Important open questions include:
+
+- Can kindness be represented as a stable constitutional principle without becoming vague or moralistic?
+- Which parts belong in instinctive priors versus deliberative reasoning?
+- How do we prevent “kindness” from becoming a cover for manipulation?
+- How should kindness be extended from human interaction to non-human life and biosphere-aware reasoning?
+- Can kindness be meaningfully benchmarked across cultures and contexts?
+- How do we record enough relational memory to support kindness without creating intrusive profiling?
+- What does kindness between agents look like in a multi-agent collective?
+
+### 12. Proposed v0.86 planning outcome
+
+For v0.86, the goal should not be “solve kindness.” The goal should be to establish it as a serious architectural concern with a path to demos and design artifacts.
+
+Recommended v0.86 outcomes:
+
+- define kindness as a first-class design concept in planning docs;
+- connect it explicitly to freedom, instinct, affect, identity, and moral resources;
+- specify at least one candidate evaluation representation;
+- add at least one demo concept to the roadmap;
+- identify what must wait for later milestones.
+
+### 14. Closing thought
+
+Kindness may turn out to be one of the clearest tests of whether an artificial cognitive architecture is fit to participate in a shared world.
+
+Raw capability can optimize. Politeness can simulate social smoothness. Compliance can imitate service. But kindness requires the system to represent others as beings whose harm, dignity, freedom, and future actually matter.
+
+That is a much deeper requirement, and exactly for that reason it belongs in ADL.
+
+## Example / Demo
 
 Create demos where kindness changes system behavior in an observable, testable way.
 
@@ -354,42 +412,21 @@ Candidate demos:
 5. **Long-horizon kindness**  
    The system chooses a path that is less soothing in the moment but better for long-term flourishing.
 
-### 10.5 Evaluation rubric
+## Why It Matters
 
-A future rubric could score:
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
 
-- harm avoided;
-- dignity preserved;
-- autonomy respected;
-- usefulness delivered;
-- long-term outcome quality;
-- user trust after disagreement or refusal.
+## Current Status
 
-## 11. Open research questions
+- Milestone: v0.91
+- Status: Draft
+- Notes: **Status:** Draft planning note for v0.86; **Scope:** Cognitive architecture / constitutional behavior / human interaction; **Purpose:** Define how kindness can be represented in ADL as an engineered, inspectable, testable property rather than a vague stylistic preference.
 
-This topic is not solved. Important open questions include:
+## Related Documents
 
-- Can kindness be represented as a stable constitutional principle without becoming vague or moralistic?
-- Which parts belong in instinctive priors versus deliberative reasoning?
-- How do we prevent “kindness” from becoming a cover for manipulation?
-- How should kindness be extended from human interaction to non-human life and biosphere-aware reasoning?
-- Can kindness be meaningfully benchmarked across cultures and contexts?
-- How do we record enough relational memory to support kindness without creating intrusive profiling?
-- What does kindness between agents look like in a multi-agent collective?
+- N/A - no explicit related docs were named in the original document.
 
-## 12. Proposed v0.86 planning outcome
-
-For v0.86, the goal should not be “solve kindness.” The goal should be to establish it as a serious architectural concern with a path to demos and design artifacts.
-
-Recommended v0.86 outcomes:
-
-- define kindness as a first-class design concept in planning docs;
-- connect it explicitly to freedom, instinct, affect, identity, and moral resources;
-- specify at least one candidate evaluation representation;
-- add at least one demo concept to the roadmap;
-- identify what must wait for later milestones.
-
-## 13. Concrete next steps
+## Future Work
 
 1. Add kindness references into the broader v0.86 cognitive architecture planning set.  
 2. Decide whether kindness belongs as a standalone model, a constitutional submodel, or a cross-cutting concern.  
@@ -397,10 +434,10 @@ Recommended v0.86 outcomes:
 4. Add one demoable work package showing kindness under conflict, not merely pleasant phrasing.  
 5. Cross-link this document with freedom, moral resources, instinct, affect, and identity planning notes.
 
-## 14. Closing thought
 
-Kindness may turn out to be one of the clearest tests of whether an artificial cognitive architecture is fit to participate in a shared world.
+## Notes
 
-Raw capability can optimize. Politeness can simulate social smoothness. Compliance can imitate service. But kindness requires the system to represent others as beings whose harm, dignity, freedom, and future actually matter.
-
-That is a much deeper requirement, and exactly for that reason it belongs in ADL.
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.
+- **Status:** Draft planning note for v0.86
+- **Scope:** Cognitive architecture / constitutional behavior / human interaction
+- **Purpose:** Define how kindness can be represented in ADL as an engineered, inspectable, testable property rather than a vague stylistic preference.

--- a/.adl/docs/v0.91planning/MORAL_RESOURCES_SUBSYSTEM.md
+++ b/.adl/docs/v0.91planning/MORAL_RESOURCES_SUBSYSTEM.md
@@ -1,12 +1,6 @@
-
-
 # ADL Moral Resources Subsystem (MRS)
-**Status:** Draft v0.1  
-**Scope:** Core cognitive architecture (v1.0 candidate)
 
----
-
-## 1. Purpose
+## Purpose
 
 The **Moral Resources Subsystem (MRS)** provides the internal structures required for an agent to:
 
@@ -20,35 +14,55 @@ This subsystem operationalizes moral resources as described by Jonathan Glover i
 
 ---
 
-## 2. Design Principles
+## Overview
+
+**Status:** Draft v0.1  
+**Scope:** Core cognitive architecture (v1.0 candidate)
+
+---
+
+## Key Capabilities
+
+- Evaluate actions beyond instrumental success
+- Maintain continuity of moral identity
+- Resist harmful or dehumanizing directives
+- Learn from consequences over time
+- Treat other agents as morally real entities
+
+## How It Works
 
 ### P1 — Non-Optionality
+
 Moral evaluation must **not be bypassable** in execution paths.
 
 ### P2 — Persistence
+
 Moral state must persist across:
 - time
 - sessions
 - task boundaries
 
 ### P3 — Reflexivity
+
 The system must be able to:
 - evaluate its own reasoning
 - revise its moral conclusions
 
 ### P4 — Embodiment (Minimal)
+
 Moral evaluation must include:
 - consequence weighting
 - affective signal (even if synthetic)
 
 ### P5 — Other-Recognition
+
 All agents must be treated as:
 - entities with moral standing
 - not reducible to objects in a graph
 
 ---
 
-## 3. High-Level Architecture
+### 3. High-Level Architecture
 
 ```
                 +----------------------+
@@ -82,7 +96,7 @@ All agents must be treated as:
 
 ---
 
-## 4. Core Components
+### 4. Core Components
 
 ---
 
@@ -252,8 +266,6 @@ Detects contradictions and drift.
 
 ---
 
-## 5. Execution Flow
-
 ### Step-by-Step
 
 1. Task received  
@@ -268,7 +280,7 @@ Detects contradictions and drift.
 
 ---
 
-## 6. ADL Integration Points
+### 6. ADL Integration Points
 
 ---
 
@@ -301,7 +313,7 @@ moral:
 
 ---
 
-## 7. Safety Invariants
+### 7. Safety Invariants
 
 These must be enforced at runtime:
 
@@ -313,7 +325,7 @@ These must be enforced at runtime:
 
 ---
 
-## 8. Minimal Implementation Plan (v0.86 → v1.0)
+### 8. Minimal Implementation Plan (v0.86 → v1.0)
 
 ---
 
@@ -350,7 +362,7 @@ These must be enforced at runtime:
 
 ---
 
-## 9. Open Research Questions
+### 9. Open Research Questions
 
 - Can affect be simulated sufficiently without embodiment?
 - How do we prevent moral rationalization loops?
@@ -359,14 +371,14 @@ These must be enforced at runtime:
 
 ---
 
-## 10. Closing Insight
+### 10. Closing Insight
 
 Moral resources are not alignment constraints.  
 They are **load-bearing components of cognition**.
 
 ---
 
-## 11. Notes for ADL Planning
+### 11. Notes for ADL Planning
 
 - This subsystem should be treated as a **first-class architectural component**
 - Closely linked to:
@@ -374,3 +386,32 @@ They are **load-bearing components of cognition**.
   - Cognitive Stack
   - Freedom Gate
 - Candidate for inclusion in v1.0 even if partial scaffolding appears in v0.86
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.91
+- Status: Draft
+- Notes: **Status:** Draft v0.1; **Scope:** Core cognitive architecture (v1.0 candidate)
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
+
+- No dedicated future-work section was present in the original document; any follow-on work remains embedded in the preserved discussion above.
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.
+- **Status:** Draft v0.1
+- **Scope:** Core cognitive architecture (v1.0 candidate)

--- a/.adl/docs/v0.93planning/SIGNED_TRACE_ARCHITECTURE.md
+++ b/.adl/docs/v0.93planning/SIGNED_TRACE_ARCHITECTURE.md
@@ -1,5 +1,3 @@
-
-
 # Signed Trace Architecture
 
 ## Purpose
@@ -25,7 +23,7 @@ This document defines that missing layer.
 
 ---
 
-## Problem Statement
+## Overview
 
 Today, each ADL run is represented by:
 - `stp.md` — design intent
@@ -53,7 +51,48 @@ This is now a visible architecture gap.
 
 ---
 
-## Core Principle
+## Key Capabilities
+
+- Structured Task Prompts (STP)
+- Structured Implementation Prompts (SIP)
+- Structured Output Records (SOR)
+- stronger execution-record rigor
+- bounded replay language in output cards
+- Trace Query Language (TQL) planning
+- design intent artifacts
+- execution intent artifacts
+
+## How It Works
+
+### Problem Statement
+
+Today, each ADL run is represented by:
+- `stp.md` — design intent
+- `sip.md` — execution intent
+- `sor.md` — execution summary / review record
+
+What is still missing is the **trace substrate**:
+- the ordered record of what the run actually did
+- the emitted event history of control-plane transitions, validations, and artifact production
+- the substrate that later signed replay and TQL should query
+
+The SOR is useful, but it is not the trace.
+
+That distinction matters.
+
+Without a first-class trace artifact, ADL cannot cleanly answer:
+- what commands actually ran, in what order
+- what control-plane events occurred
+- which emitted artifacts were produced at which phase
+- which events are replayable vs merely observable
+- which parts of a run can be revalidated later
+- what exactly would be signed in a signed-trace model
+
+This is now a visible architecture gap.
+
+---
+
+### Core Principle
 
 **The SOR is the review record; the trace is the execution substrate. Replay is a bounded property of trace events, not a claim that the world is reversible.**
 
@@ -68,7 +107,7 @@ It should promise:
 
 ---
 
-## Why This Was Not Fully Caught Earlier
+### Why This Was Not Fully Caught Earlier
 
 The missing trace layer was partially obscured because adjacent work landed first:
 - deterministic workflow structure
@@ -95,8 +134,6 @@ Only after those layers became real did the missing trace substrate become obvio
 That is where the system is now.
 
 ---
-
-## Design Goals
 
 ### 1. Make every run explicitly traceable
 
@@ -159,7 +196,7 @@ without redesigning the entire run model.
 
 ---
 
-## Architectural Model
+### Architectural Model
 
 For each run, ADL should produce four primary artifact layers:
 
@@ -177,7 +214,7 @@ This yields the correct separation of concerns:
 
 ---
 
-## Proposed Task-Bundle Layout
+### Proposed Task-Bundle Layout
 
 Minimum target layout:
 
@@ -207,7 +244,7 @@ A single-record JSON document is less suitable because runs are naturally event 
 
 ---
 
-## Run Identity
+### Run Identity
 
 Each trace must be tied to a concrete run identity.
 
@@ -228,7 +265,7 @@ This aligns with the broader rule:
 
 ---
 
-## Trace Event Model
+### Trace Event Model
 
 Each line in `trace.jsonl` should be a structured event.
 
@@ -255,36 +292,7 @@ Recommended optional fields:
 - `notes`
 - `parent_event_sequence`
 
-### Example event shape
-
-```json
-{
-  "trace_version": "adl.trace.v1",
-  "task_id": "issue-0876",
-  "run_id": "issue-0876",
-  "sequence": 12,
-  "timestamp": "2026-03-20T18:12:11Z",
-  "phase": "validation",
-  "event_type": "command_executed",
-  "actor": "execution_agent",
-  "status": "passed",
-  "tool": "shell",
-  "command": "cargo test graph_affect::tests::ranking_changes",
-  "artifact_refs": [
-    ".adl/v0.85/tasks/issue-0876__v085-wp16-reasoning-graph-affect/sor.md"
-  ],
-  "replay_class": "replayable",
-  "details": {
-    "purpose": "Prove affect changes graph ranking via before/after fixture"
-  }
-}
-```
-
-The example above is illustrative; the architecture does not require this exact event set, but it does require event structure of this kind.
-
----
-
-## Event Types
+### Event Types
 
 The first version should keep event types small and practical.
 
@@ -306,7 +314,7 @@ This is enough to make traces useful without overbuilding a complete process ont
 
 ---
 
-## Phases
+### Phases
 
 Recommended phase vocabulary:
 - `init`
@@ -321,7 +329,7 @@ Not every run must emit every phase. The important property is that phase names 
 
 ---
 
-## Replay Classification
+### Replay Classification
 
 Every trace event should carry a replay classification.
 
@@ -361,7 +369,7 @@ This classification allows ADL to be both honest and useful.
 
 ---
 
-## Replay Manifest
+### Replay Manifest
 
 Each run should emit a `replay_manifest.json` alongside the trace.
 
@@ -377,17 +385,7 @@ Minimum fields:
 - `recheck_commands`
 - `notes`
 
-### Replay scope values
-- `full`
-- `partial`
-- `recheck_only`
-- `none`
-
-For early ADL runs, `partial` or `recheck_only` will be the normal truthful value.
-
----
-
-## SOR Integration
+### SOR Integration
 
 The SOR should stop implying that it is the trace.
 
@@ -407,7 +405,7 @@ This makes the layers clear:
 
 ---
 
-## Control-Plane Integration
+### Control-Plane Integration
 
 The control plane should emit trace events automatically.
 
@@ -434,7 +432,7 @@ This must be automatic. The trace cannot depend on manual narrative reconstructi
 
 ---
 
-## Determinism and Ordering
+### Determinism and Ordering
 
 The trace format itself must be deterministic enough to be useful.
 
@@ -449,24 +447,28 @@ This is especially important because ADL already has strong path-hygiene require
 
 ---
 
-## Signing Strategy
+### Signing Strategy
 
 Signed traces should be introduced in phases.
 
 ### Phase 1 — explicit trace artifact
+
 - emit `trace.jsonl`
 - emit `replay_manifest.json`
 - no signatures yet
 
 ### Phase 2 — digest / hashing
+
 - compute per-trace or per-event digests
 - add `trace_hashes.json` or digest fields
 
 ### Phase 3 — signed trace bundle
+
 - sign the trace bundle or manifest
 - emit `trace.signature.json`
 
 ### Phase 4 — verification tooling
+
 - add verification commands
 - integrate signature checks into review / policy surfaces
 
@@ -474,7 +476,7 @@ This sequencing avoids premature complexity while keeping the architecture hones
 
 ---
 
-## What Should Be Signed Later
+### What Should Be Signed Later
 
 The most practical later target is to sign the **trace manifest + digests**, not arbitrary raw tool output.
 
@@ -490,7 +492,7 @@ This is more stable than trying to sign every raw event as an isolated act in th
 
 ---
 
-## Relationship to Git
+### Relationship to Git
 
 Git remains the canonical mechanism for code state transition and rollback.
 
@@ -508,7 +510,7 @@ Git can often restore file state. It does not by itself explain what happened du
 
 ---
 
-## Relationship to TQL
+### Relationship to TQL
 
 TQL becomes much more powerful once trace artifacts exist.
 
@@ -528,7 +530,7 @@ This is why signed trace architecture and TQL planning belong to the same larger
 
 ---
 
-## Security and Privacy Requirements
+### Security and Privacy Requirements
 
 Trace artifacts must obey the same hygiene rules as other ADL artifacts.
 
@@ -545,38 +547,7 @@ This is a trace substrate, not a surveillance log.
 
 ---
 
-## Non-Goals
-
-This architecture explicitly does **not** require in its first slice:
-- total replay of arbitrary real-world actions
-- full distributed tracing infrastructure
-- signing of every event immediately
-- natural-language querying over arbitrary trace prose
-- replacement of Git as the state substrate
-- a full database layer before repo-local artifacts are proven useful
-
-The goal is a strong first trace substrate, not a complete observability platform.
-
----
-
-## Example Lifecycle
-
-A realistic early lifecycle for one ADL run:
-
-1. `pr run` begins  
-2. trace emits `run_started`  
-3. validation command emits `validator_executed`  
-4. runtime logic emits `artifact_emitted`  
-5. demo step emits `demo_executed`  
-6. `pr finish` emits `run_finished`  
-7. `sor.md` records the summary  
-8. `replay_manifest.json` classifies replayability  
-
-This is enough to turn the run into a real auditable substrate.
-
----
-
-## Minimum v0 Implementation Slice
+### Minimum v0 Implementation Slice
 
 The minimum credible first implementation should do the following:
 
@@ -592,7 +563,7 @@ This is sufficient to make the trace promise real without destabilizing the rest
 
 ---
 
-## Roadmap Position
+### Roadmap Position
 
 This work is correctly placed **after** the current v0.85 milestone band.
 
@@ -612,31 +583,36 @@ So this is not a v0.85 omission in execution. It is a v0.86+ architecture layer 
 
 ---
 
-## Recommended New Issues
+### Recommended New Issues
 
 This document naturally decomposes into a small bounded issue train.
 
 ### Issue A — Explicit per-run trace artifact
+
 - emit `trace.jsonl`
 - normalized event schema
 - repo-relative pathing
 - control-plane integration at `pr run` / `pr finish`
 
 ### Issue B — Replay manifest
+
 - emit `replay_manifest.json`
 - classify events by replayability
 - add replay scope to SOR metadata
 
 ### Issue C — Trace/SOR integration
+
 - SOR references trace presence and replay manifest
 - review surfaces become trace-aware
 
 ### Issue D — Signed trace bundle
+
 - add digests
 - add signature manifest
 - add verification command
 
 ### Issue E — TQL over traces
+
 - query trace events and replay classes
 - integrate with broader TQL work
 
@@ -644,7 +620,7 @@ This is the right bounded rollout path.
 
 ---
 
-## Summary
+### Summary
 
 ADL currently has strong task artifacts and increasingly strong execution records, but it still lacks one critical layer: the first-class execution trace.
 
@@ -669,3 +645,93 @@ The result will be a significantly stronger ADL platform:
 - more queryable
 - more replay-aware
 - and much closer to the signed, reviewable, shared-reality substrate the project has been aiming toward.
+
+### Non-Goals
+
+This architecture explicitly does **not** require in its first slice:
+- total replay of arbitrary real-world actions
+- full distributed tracing infrastructure
+- signing of every event immediately
+- natural-language querying over arbitrary trace prose
+- replacement of Git as the state substrate
+- a full database layer before repo-local artifacts are proven useful
+
+The goal is a strong first trace substrate, not a complete observability platform.
+
+---
+
+## Example / Demo
+
+```json
+{
+  "trace_version": "adl.trace.v1",
+  "task_id": "issue-0876",
+  "run_id": "issue-0876",
+  "sequence": 12,
+  "timestamp": "2026-03-20T18:12:11Z",
+  "phase": "validation",
+  "event_type": "command_executed",
+  "actor": "execution_agent",
+  "status": "passed",
+  "tool": "shell",
+  "command": "cargo test graph_affect::tests::ranking_changes",
+  "artifact_refs": [
+    ".adl/v0.85/tasks/issue-0876__v085-wp16-reasoning-graph-affect/sor.md"
+  ],
+  "replay_class": "replayable",
+  "details": {
+    "purpose": "Prove affect changes graph ranking via before/after fixture"
+  }
+}
+```
+
+The example above is illustrative; the architecture does not require this exact event set, but it does require event structure of this kind.
+
+---
+
+A realistic early lifecycle for one ADL run:
+
+1. `pr run` begins  
+2. trace emits `run_started`  
+3. validation command emits `validator_executed`  
+4. runtime logic emits `artifact_emitted`  
+5. demo step emits `demo_executed`  
+6. `pr finish` emits `run_finished`  
+7. `sor.md` records the summary  
+8. `replay_manifest.json` classifies replayability  
+
+This is enough to turn the run into a real auditable substrate.
+
+---
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.93
+- Status: Draft
+- Notes: No additional status notes recorded.
+
+## Related Documents
+
+- stp.md
+- sip.md
+- sor.md
+
+## Future Work
+
+- `full`
+- `partial`
+- `recheck_only`
+- `none`
+
+For early ADL runs, `partial` or `recheck_only` will be the normal truthful value.
+
+---
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/.adl/docs/v0.94planning/ZED_INTEGRATION_WITH_ADL.md
+++ b/.adl/docs/v0.94planning/ZED_INTEGRATION_WITH_ADL.md
@@ -1,1 +1,44 @@
+# Untitled
 
+## Purpose
+
+N/A - original document did not expose a separate purpose block; see Overview and How It Works.
+
+## Overview
+
+N/A - see How It Works for the preserved detailed structure.
+
+## Key Capabilities
+
+- N/A - original document is concept- or architecture-heavy; see How It Works for preserved detail.
+
+## How It Works
+
+N/A - no additional preserved mechanics beyond the concise sections above.
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.94
+- Status: Draft
+- Notes: No additional status notes recorded.
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
+
+- No dedicated future-work section was present in the original document; any follow-on work remains embedded in the preserved discussion above.
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/.adl/docs/v0.95planning/TOOLING_RUST_MIGRATION_PLAN.md
+++ b/.adl/docs/v0.95planning/TOOLING_RUST_MIGRATION_PLAN.md
@@ -1,13 +1,39 @@
 # Tooling Rust Migration Plan (v086planning)
 
-## Metadata
+## Purpose
+
+N/A - original document did not expose a separate purpose block; see Overview and How It Works.
+
+## Overview
+
 - Milestone: `v086planning`
 - Topic: Migrate high-risk workflow tooling out of shell into Rust
 - Date: `2026-03-20`
 - Status: `Planning`
 - Owner: `Daniel Austin / Agent Logic`
 
-## Why This Work Exists
+## Key Capabilities
+
+- Milestone: `v086planning`
+- Topic: Migrate high-risk workflow tooling out of shell into Rust
+- Date: `2026-03-20`
+- Status: `Planning`
+- Owner: `Daniel Austin / Agent Logic`
+- reduce maintenance risk in the workflow control plane
+- remove parsing and validation logic from shell where possible
+- centralize task-bundle and compatibility-path rules in typed Rust code
+
+## How It Works
+
+### Metadata
+
+- Milestone: `v086planning`
+- Topic: Migrate high-risk workflow tooling out of shell into Rust
+- Date: `2026-03-20`
+- Status: `Planning`
+- Owner: `Daniel Austin / Agent Logic`
+
+### Why This Work Exists
 
 ADL's workflow tooling has accumulated a large amount of control-plane logic in
 shell scripts under `swarm/tools/`.
@@ -25,7 +51,7 @@ state transitions, validation rules, and compatibility behavior.
 
 At the moment, that logic is still primarily implemented in Bash.
 
-## Current State Snapshot (2026-03-20)
+### Current State Snapshot (2026-03-20)
 
 Key observations from the current tree:
 - `swarm/tools/pr.sh` is still the central orchestration surface and is `1677`
@@ -46,7 +72,7 @@ Interpretation:
 - task-bundle architecture has made the shell layer more important, not less
 - migration pressure is therefore higher than before
 
-## Executive Summary
+### Executive Summary
 
 Recommendation:
 - create a Rust tooling control plane as a first-class surface
@@ -77,50 +103,6 @@ Recommended migration style:
 - keep behavioral parity visible with existing shell tests
 - replace low-risk deterministic pieces first
 - move stateful git/gh flows only after the shared core is proven
-
-## Goals
-
-### Primary Goals
-
-- reduce maintenance risk in the workflow control plane
-- remove parsing and validation logic from shell where possible
-- centralize task-bundle and compatibility-path rules in typed Rust code
-- preserve current user-facing workflow behavior during migration
-- make future task-bundle/editor workflow work easier to implement safely
-
-### Secondary Goals
-
-- improve cross-platform behavior
-- improve testability of validation and path logic
-- make `pr.sh` smaller until it becomes a wrapper or is removed entirely
-
-## Non-Goals
-
-- rewriting every demo or mock script into Rust
-- changing the workflow model at the same time as the migration
-- renaming repo paths or broader identity cleanup as part of this effort
-- redesigning all review tooling in one pass
-
-## Scope
-
-### In Scope
-
-- shared task-bundle path logic
-- compatibility-link behavior for `.adl/cards/<issue>/...`
-- structured prompt validation
-- prompt-spec linting
-- deterministic prompt generation
-- PR/card workflow commands
-- codex workflow wrapper logic after the shared core is stable
-
-### Out Of Scope
-
-- demo scripts that just call existing commands
-- provider mocks
-- one-off coverage/open convenience wrappers
-- broad doc cleanup beyond what is needed to explain the new tooling path
-
-## Migration Principles
 
 ### 1. Shared Logic Before Orchestration
 
@@ -158,7 +140,7 @@ These are easier to unit test and less risky than git/gh workflows.
 Demos, mocks, and shell smoke tests should remain lightweight unless they block
 development. They are not the main maintenance burden.
 
-## Proposed Architecture
+### Proposed Architecture
 
 Recommended internal split:
 
@@ -198,8 +180,6 @@ Recommended external shape:
 - later:
   - `adl tools codexw ...`
   - `adl tools editor-action ...`
-
-## Phase Plan
 
 ### Phase 0: Decision Lock And Command Shape
 
@@ -322,7 +302,7 @@ Goal:
 - reduce the number of shell-only workflow adapters
 - keep only thin compatibility wrappers where they still add value
 
-## First PR Recommendation
+### First PR Recommendation
 
 The best first implementation slice is:
 
@@ -340,7 +320,7 @@ Why this first:
 - immediate reduction in shell parsing complexity
 - creates the shared foundation for later `pr` migration
 
-## Recommended Review Checkpoints
+### Recommended Review Checkpoints
 
 These should be treated as explicit review gates:
 
@@ -364,8 +344,6 @@ These should be treated as explicit review gates:
   - branch collision failure
   - dirty primary-checkout guardrails
   - relative card path handling in finish flow
-
-## Risks
 
 ### 1. Silent Behavioral Drift
 
@@ -403,7 +381,7 @@ Mitigation:
 - explicitly mark transitional scripts as transitional
 - remove them once the Rust path writes canonical outputs directly
 
-## Success Criteria
+### Success Criteria
 
 This migration should be considered successful when:
 - validation and prompt generation are Rust-owned
@@ -412,7 +390,7 @@ This migration should be considered successful when:
 - shell tooling is reduced to wrappers, demos, mocks, and lightweight harnesses
 - contributor workflow remains stable during the cutover
 
-## Bottom Line
+### Bottom Line
 
 This work should be approached as a control-plane extraction, not a generic
 "rewrite the scripts" exercise.
@@ -428,3 +406,63 @@ The right order is:
 
 If done in that order, the migration reduces risk quickly and sets up the
 task-bundle/editor architecture on a more durable foundation.
+
+### Primary Goals
+
+- reduce maintenance risk in the workflow control plane
+- remove parsing and validation logic from shell where possible
+- centralize task-bundle and compatibility-path rules in typed Rust code
+- preserve current user-facing workflow behavior during migration
+- make future task-bundle/editor workflow work easier to implement safely
+
+### Secondary Goals
+
+- improve cross-platform behavior
+- improve testability of validation and path logic
+- make `pr.sh` smaller until it becomes a wrapper or is removed entirely
+
+### Non-Goals
+
+- rewriting every demo or mock script into Rust
+- changing the workflow model at the same time as the migration
+- renaming repo paths or broader identity cleanup as part of this effort
+- redesigning all review tooling in one pass
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.95
+- Status: Draft
+- Notes: No additional status notes recorded.
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
+
+- shared task-bundle path logic
+- compatibility-link behavior for `.adl/cards/<issue>/...`
+- structured prompt validation
+- prompt-spec linting
+- deterministic prompt generation
+- PR/card workflow commands
+- codex workflow wrapper logic after the shared core is stable
+
+- demo scripts that just call existing commands
+- provider mocks
+- one-off coverage/open convenience wrappers
+- broad doc cleanup beyond what is needed to explain the new tooling path
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/AFFECTIVE_REASONING_MODEL.md
+++ b/docs/milestones/v0.85/AFFECTIVE_REASONING_MODEL.md
@@ -14,7 +14,7 @@ In short:
 
 ---
 
-# Design Principles
+## Overview
 
 The affect model must satisfy the following constraints:
 
@@ -35,7 +35,38 @@ The affect model must satisfy the following constraints:
 
 ---
 
-# Core Affect Signals
+## Key Capabilities
+
+- **Non-anthropomorphic**
+- **Deterministic friendly**
+- **Compact**
+- **Inspectable**
+- **Composable**
+
+## How It Works
+
+### Design Principles
+
+The affect model must satisfy the following constraints:
+
+1. **Non-anthropomorphic**  
+   Signals represent reasoning states, not simulated feelings.
+
+2. **Deterministic friendly**  
+   Affect signals must not introduce nondeterministic behavior.
+
+3. **Compact**  
+   The model should use a small number of signals that capture useful reasoning dynamics.
+
+4. **Inspectable**  
+   Signals must be observable and explainable during reasoning traces.
+
+5. **Composable**  
+   Signals should attach to reasoning nodes, hypothesis records, and evaluation loops.
+
+---
+
+### Core Affect Signals
 
 The initial v0.85 affect basis consists of six signals.
 
@@ -52,7 +83,7 @@ These signals form a **minimal affective vector** attached to reasoning artifact
 
 ---
 
-# Signal Semantics
+### Signal Semantics
 
 Signals do **not drive behavior directly**.
 
@@ -78,7 +109,7 @@ High confidence + satisfaction
 
 ---
 
-# Integration with Reasoning Graphs
+### Integration with Reasoning Graphs
 
 In later milestones (v0.9), reasoning will be represented using **reasoning graphs**.
 
@@ -104,7 +135,7 @@ This allows reasoning engines to evaluate **both belief state and reasoning dyna
 
 ---
 
-# Relationship to the Adaptive Execution Engine (AEE)
+### Relationship to the Adaptive Execution Engine (AEE)
 
 AEE policies may use affect signals to guide execution.
 
@@ -118,7 +149,7 @@ This enables adaptive reasoning **without abandoning determinism**.
 
 ---
 
-# Relationship to Gödel-style Hypothesis Engines
+### Relationship to Gödel-style Hypothesis Engines
 
 The Gödel hypothesis engine explores alternative reasoning strategies.
 
@@ -133,7 +164,7 @@ Thus the affect layer acts as a **meta-reasoning signal system**.
 
 ---
 
-# Determinism Considerations
+### Determinism Considerations
 
 Affect signals must be derived from:
 
@@ -147,7 +178,39 @@ This preserves ADL's **deterministic replay guarantees**.
 
 ---
 
-# v0.85 Scope
+### Summary
+
+The affective reasoning model provides a compact signal layer that captures reasoning dynamics such as:
+
+• uncertainty
+• contradiction
+• novelty
+• progress
+
+Rather than simulating emotions, the system uses these signals to guide reasoning exploration and evaluation.
+
+This layer forms an important foundation for **adaptive agent reasoning in ADL**.
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: No additional status notes recorded.
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
 
 The v0.85 milestone introduces only:
 
@@ -158,8 +221,6 @@ The v0.85 milestone introduces only:
 No full runtime implementation is required for the milestone.
 
 ---
-
-# Future Work (v0.9+)
 
 Planned extensions include:
 
@@ -172,15 +233,7 @@ These features will support a full **Gödel-style adaptive reasoning system**.
 
 ---
 
-# Summary
 
-The affective reasoning model provides a compact signal layer that captures reasoning dynamics such as:
+## Notes
 
-• uncertainty
-• contradiction
-• novelty
-• progress
-
-Rather than simulating emotions, the system uses these signals to guide reasoning exploration and evaluation.
-
-This layer forms an important foundation for **adaptive agent reasoning in ADL**.
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/AFFECT_MODEL_v0.85.md
+++ b/docs/milestones/v0.85/AFFECT_MODEL_v0.85.md
@@ -1,22 +1,10 @@
-
-
 # Hypothesis Engine, Reasoning Graphs, and Affective Signals (v0.85 / v0.9 Planning)
 
-## Status
+## Purpose
 
-Planning draft for future ADL / Gödel work.
-This document expands the design space around:
-- hypothesis generation
-- reasoning-graph execution
-- bounded affect internal signals
-- the role of bounded affect modeling in better search, prioritization, and self-correction
+N/A - original document did not expose a separate purpose block; see Overview and How It Works.
 
-It does **not** claim that Gödel is conscious or sentient.
-It does claim that a constrained, explicit internal affect model may improve reasoning quality, prioritization, adaptation, and bounded self-regulation.
-
----
-
-## 1. Summary
+## Overview
 
 A working hypothesis for Gödel is that a useful bounded affect model is not ornamental; it is functional.
 
@@ -43,30 +31,47 @@ For Gödel, this suggests that bounded affect signals should influence:
 
 ---
 
-## 2. Why this matters for Gödel
+## Key Capabilities
 
-Gödel is not just a workflow runner. The long-term vision is a self-improving reasoning substrate that can:
-- propose hypotheses
-- test them against evidence
-- compare competing lines of thought
-- learn from prior runs
-- adjust future search policy
+- prioritize attention
+- compress value judgments into fast action biases
+- signal prediction error, novelty, threat, or opportunity
+- regulate persistence, caution, exploration, and social/goal alignment
+- hypothesis ranking
+- branch expansion / pruning
+- confidence calibration
+- retry / backoff behavior
 
-A purely flat scoring system is likely too weak.
+## How It Works
 
-If every branch is evaluated only by static acceptance checks or scalar confidence, the system can miss important dynamics such as:
-- “this line of reasoning is novel but fragile”
-- “this path is locally coherent but globally dangerous”
-- “we are stuck in repetitive low-yield search”
-- “evidence is accumulating against the current plan”
-- “a minority branch is weakly supported now but unusually promising”
+### 1. Summary
 
-Humans often use compressed internal evaluative summaries to handle exactly these situations.
-A machine analogue can be designed explicitly and instrumented deterministically.
+A working hypothesis for Gödel is that a useful bounded affect model is not ornamental; it is functional.
+
+In biological organisms, emotion appears to serve at least four engineering purposes:
+1. prioritize attention
+2. compress value judgments into fast action biases
+3. signal prediction error, novelty, threat, or opportunity
+4. regulate persistence, caution, exploration, and social/goal alignment
+
+Our corresponding ADL / Gödel hypothesis is:
+
+> A deterministic agent can reason better if it carries explicit bounded affect state that summarizes how current evidence, uncertainty, progress, novelty, and risk should bias its next reasoning moves.
+
+In this frame, “emotion” is not mystical. It is an internal control layer over search and deliberation.
+
+For Gödel, this suggests that bounded affect signals should influence:
+- hypothesis ranking
+- branch expansion / pruning
+- confidence calibration
+- retry / backoff behavior
+- escalation decisions
+- memory retention priority
+- when to continue, stop, ask for help, or seek critique
 
 ---
 
-## 3. Core design claim
+### 3. Core design claim
 
 We should treat bounded affect state as a **reasoning control surface**.
 
@@ -96,14 +101,13 @@ These can be compiled into bounded affect summaries that influence the next reas
 
 ---
 
-## 4. Affective dimensions for Gödel
+### 4. Affective dimensions for Gödel
 
 We do not need a full human emotion taxonomy.
 We need a compact set of machine-useful dimensions.
 
-### 4.1 Proposed dimensions
+### 1. Confidence
 
-#### 1. Confidence
 How strongly the system currently believes a line of reasoning or candidate plan is sound.
 
 Inputs may include:
@@ -116,7 +120,8 @@ Operational effect:
 - increases willingness to commit, summarize, or promote
 - decreases when contradictions or failed checks accumulate
 
-#### 2. Tension
+### 2. Tension
+
 Internal signal that something is wrong, unresolved, contradictory, unstable, or under-justified.
 
 Inputs may include:
@@ -129,7 +134,8 @@ Operational effect:
 - triggers critique, branch splitting, re-checking, or rollback
 - suppresses premature convergence
 
-#### 3. Curiosity
+### 3. Curiosity
+
 Bias toward exploring novel or underexplored hypotheses that may carry upside.
 
 Inputs may include:
@@ -143,7 +149,8 @@ Operational effect:
 - funds experiments / probes
 - promotes minority-path inspection
 
-#### 4. Caution
+### 4. Caution
+
 Bias toward risk management and error avoidance.
 
 Inputs may include:
@@ -157,7 +164,8 @@ Operational effect:
 - prefers reversible actions
 - requires stronger proof before commit
 
-#### 5. Frustration
+### 5. Frustration
+
 Signal that current search is consuming effort without meaningful progress.
 
 Inputs may include:
@@ -171,7 +179,8 @@ Operational effect:
 - invokes a different agent role
 - escalates to broader critique or alternate decomposition
 
-#### 6. Satisfaction
+### 6. Satisfaction
+
 Signal that a line of reasoning has achieved coherence, support, and useful closure.
 
 Inputs may include:
@@ -192,7 +201,7 @@ They are valuable if they improve decision quality.
 
 ---
 
-## 5. Relationship to reasoning graphs
+### 5. Relationship to reasoning graphs
 
 Reasoning graphs are a natural substrate for this work.
 
@@ -210,6 +219,7 @@ A reasoning graph can model:
 Affective signals can then exist at multiple levels:
 
 ### 5.1 Node-level affect
+
 Attached to a specific hypothesis, claim, or experiment.
 
 Examples:
@@ -220,6 +230,7 @@ Examples:
 This supports local branch decisions.
 
 ### 5.2 Path-level affect
+
 Summarizes a line of reasoning across multiple nodes.
 
 Examples:
@@ -227,6 +238,7 @@ Examples:
 - a path with moderate confidence and high curiosity may justify further probing
 
 ### 5.3 Graph-level affect
+
 Captures the state of the whole reasoning episode.
 
 Examples:
@@ -237,8 +249,6 @@ Examples:
 This multi-level model matters because local branch optimism can coexist with global instability.
 
 ---
-
-## 6. Why a bounded affect model may improve reasoning
 
 ### 6.1 Better prioritization under bounded compute
 
@@ -278,8 +288,6 @@ For example:
 These traces can become training and policy-learning features.
 
 ---
-
-## 7. Proposed architecture shape
 
 ### 7.1 Deterministic state tuple
 
@@ -347,7 +355,7 @@ This avoids circular, hard-to-debug behavior.
 
 ---
 
-## 8. Interaction with the hypothesis engine
+### 8. Interaction with the hypothesis engine
 
 The hypothesis engine in v0.85 / v0.9 should use bounded affect state as one factor in search control.
 
@@ -388,7 +396,7 @@ If the engine can run bounded experiments, affect can help choose which experime
 
 ---
 
-## 9. Relationship to memory and ObsMem
+### 9. Relationship to memory and ObsMem
 
 ObsMem should retain not only what happened, but the internal reasoning dynamics around what happened.
 
@@ -414,7 +422,7 @@ This is one bridge between bounded affect modeling and genuine policy learning.
 
 ---
 
-## 10. Relationship to the Gödel-Hadamard loop
+### 10. Relationship to the Gödel-Hadamard loop
 
 This model aligns naturally with the emerging Gödel-Hadamard architecture.
 
@@ -430,10 +438,6 @@ It may be one of the mechanisms that prevents either extreme:
 - undisciplined exploration with no convergence
 
 ---
-
-## 11. v0.85 scope candidate
-
-v0.85 is the right place to define the conceptual and architectural basis, without overcommitting to a full implementation.
 
 ### 11.1 Recommended v0.85 deliverables
 
@@ -456,19 +460,6 @@ v0.85 is the right place to define the conceptual and architectural basis, witho
 
 5. **Evaluation plan**
    - define experiments comparing reasoning with and without affect signals
-
-### 11.2 v0.85 non-goals
-
-- claiming machine consciousness
-- building a full psychology engine
-- introducing opaque hidden state
-- allowing unrestricted prompt-level anthropomorphism
-
----
-
-## 12. v0.9 scope candidate
-
-v0.9 is a plausible phase for first constrained implementation.
 
 ### 12.1 Recommended v0.9 deliverables
 
@@ -504,19 +495,7 @@ v0.9 is a plausible phase for first constrained implementation.
 
 ---
 
-## 13. Open questions
-
-1. What is the minimum affect basis that gives value without complexity blow-up?
-2. Should affect updates be global policy-driven, or partially role-specific by agent type?
-3. How much of affect should be persisted in long-term memory versus summarized?
-4. Which affect transitions are most predictive of later success or failure?
-5. Can affect improve multi-agent congressional reasoning by highlighting dissent worth preserving?
-6. How should we visualize affect over a reasoning graph so humans can inspect it easily?
-7. What is the right balance between scalar affect fields and richer symbolic annotations?
-
----
-
-## 14. Initial recommendation
+### 14. Initial recommendation
 
 We should explicitly carry this idea forward.
 
@@ -532,7 +511,7 @@ For ADL, that makes it relevant not as anthropology, but as systems design.
 
 ---
 
-## 15. Concrete next documents to create
+### 15. Concrete next documents to create
 
 1. `AFFECTIVE_REASONING_MODEL.md`
 2. `REASONING_GRAPH_SCHEMA_V0.85.md`
@@ -541,3 +520,80 @@ For ADL, that makes it relevant not as anthropology, but as systems design.
 5. Affect evaluation plan for v0.9 (planned follow-on document)
 
 These can later feed the corresponding issues for the Gödel / hypothesis-engine roadmap.
+
+### 11.2 v0.85 non-goals
+
+- claiming machine consciousness
+- building a full psychology engine
+- introducing opaque hidden state
+- allowing unrestricted prompt-level anthropomorphism
+
+---
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+Gödel is not just a workflow runner. The long-term vision is a self-improving reasoning substrate that can:
+- propose hypotheses
+- test them against evidence
+- compare competing lines of thought
+- learn from prior runs
+- adjust future search policy
+
+A purely flat scoring system is likely too weak.
+
+If every branch is evaluated only by static acceptance checks or scalar confidence, the system can miss important dynamics such as:
+- “this line of reasoning is novel but fragile”
+- “this path is locally coherent but globally dangerous”
+- “we are stuck in repetitive low-yield search”
+- “evidence is accumulating against the current plan”
+- “a minority branch is weakly supported now but unusually promising”
+
+Humans often use compressed internal evaluative summaries to handle exactly these situations.
+A machine analogue can be designed explicitly and instrumented deterministically.
+
+---
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: Planning draft for future ADL / Gödel work.
+This document expands the design space around:
+- hypothesis generation
+- reasoning-graph execution
+- bounded affect internal signals
+- the role of bounded affect modeling in better search, prioritization, and self-correction
+
+It does **not** claim that Gödel is conscious or sentient.
+It does claim that a constrained, explicit internal affect model may improve reasoning quality, prioritization, adaptation, and bounded self-regulation.
+
+---
+
+## Related Documents
+
+- AFFECTIVE_REASONING_MODEL.md
+- REASONING_GRAPH_SCHEMA_V0.85.md
+
+## Future Work
+
+- v0.85 is the right place to define the conceptual and architectural basis, without overcommitting to a full implementation.
+- v0.9 is a plausible phase for first constrained implementation.
+1. What is the minimum affect basis that gives value without complexity blow-up?
+2. Should affect updates be global policy-driven, or partially role-specific by agent type?
+3. How much of affect should be persisted in long-term memory versus summarized?
+4. Which affect transitions are most predictive of later success or failure?
+5. Can affect improve multi-agent congressional reasoning by highlighting dissent worth preserving?
+6. How should we visualize affect over a reasoning graph so humans can inspect it easily?
+7. What is the right balance between scalar affect fields and richer symbolic annotations?
+
+---
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/BOUNDED_AFFECT_MODEL.md
+++ b/docs/milestones/v0.85/BOUNDED_AFFECT_MODEL.md
@@ -1,10 +1,12 @@
 # Bounded Affect Model and Affective Reasoning in ADL
 
+## Purpose
+
 *Canonical v0.85 conceptual document — legacy filename retained for now; bounded non-anthropomorphic framing*
 
 ------------------------------------------------------------------------
 
-# Overview
+## Overview
 
 During the design discussions for the **Gödel Agent** and the **Hadamard
 insight loop**, an important architectural observation emerged:
@@ -23,7 +25,13 @@ This document captures that working model.
 
 ------------------------------------------------------------------------
 
-# 1. A Functional Model of Bounded Affect
+## Key Capabilities
+
+- N/A - original document is concept- or architecture-heavy; see How It Works for preserved detail.
+
+## How It Works
+
+### 1. A Functional Model of Bounded Affect
 
 In both biological and artificial systems, bounded affect can be understood as
 **control signals that regulate cognition and behavior**.
@@ -42,7 +50,7 @@ goals.
 
 ------------------------------------------------------------------------
 
-## Core Variables
+### Core Variables
 
 A minimal bounded-affect control system can be modeled with:
 
@@ -62,7 +70,7 @@ These bounded-affect signals influence how the agent chooses its next strategy.
 
 ------------------------------------------------------------------------
 
-# 2. Valence--Arousal Model
+### 2. Valence--Arousal Model
 
 A convenient representation of bounded affect state is the **two-axis
 model**.
@@ -89,7 +97,7 @@ In artificial systems these axes can be derived from:
 
 ------------------------------------------------------------------------
 
-# 3. Bounded-Affect Control of Cognition
+### 3. Bounded-Affect Control of Cognition
 
 Bounded-affect signals influence reasoning.
 
@@ -106,7 +114,7 @@ Thus bounded affect is best understood as **meta-control for cognition**.
 
 ------------------------------------------------------------------------
 
-# 4. Mapping to ADL Architecture
+### 4. Mapping to ADL Architecture
 
 The ADL execution loop already contains many of these components.
 
@@ -136,7 +144,7 @@ This loop is structurally identical to a **cognitive feedback loop**.
 
 ------------------------------------------------------------------------
 
-# 5. Bounded-Affect Control Loop
+### 5. Bounded-Affect Control Loop
 
 ``` mermaid
 flowchart TD
@@ -162,7 +170,7 @@ Bounded affect here acts as a **regulator of cognition**.
 
 ------------------------------------------------------------------------
 
-# 6. Gödel--Hadamard Cognitive Loop (ADL)
+### 6. Gödel--Hadamard Cognitive Loop (ADL)
 
 ADL introduces two additional mechanisms.
 
@@ -234,7 +242,7 @@ Mapping to Hadamard:
 
 ------------------------------------------------------------------------
 
-# 7. Tools vs Minds
+### 7. Tools vs Minds
 
 Most current AI systems behave like **tools**.
 
@@ -301,14 +309,14 @@ Minds contain:
 
 ------------------------------------------------------------------------
 
-# 8. The ADL Cognitive-Control Ladder
+### 8. The ADL Cognitive-Control Ladder
 
 More capable cognitive control may emerge gradually as architectural
 layers accumulate.
 
 ### Level 0 --- Reactive Tool
 
-    input → model → output
+input → model → output
 
 Examples:
 
@@ -319,7 +327,7 @@ Examples:
 
 ### Level 1 --- Goal-Directed Agent
 
-    goal
+goal
      ↓
     plan
      ↓
@@ -333,7 +341,7 @@ Examples:
 
 ### Level 2 --- Reflective Agent
 
-    goal
+goal
      ↓
     attempt
      ↓
@@ -421,7 +429,7 @@ A --> B --> C --> D --> E --> F --> G
 
 ------------------------------------------------------------------------
 
-# 9. Popper's Three Worlds Integration
+### 9. Popper's Three Worlds Integration
 
 This architecture maps naturally to **Popper's model of knowledge**.
 
@@ -457,7 +465,7 @@ W2 --> W3
 
 ------------------------------------------------------------------------
 
-# 10. Implications for ADL
+### 10. Implications for ADL
 
 ADL is unusual among agent frameworks because it already includes:
 
@@ -476,7 +484,7 @@ would push the system further toward **self-directed cognition**.
 
 ------------------------------------------------------------------------
 
-# 11. Implications for AI Architecture Research
+### 11. Implications for AI Architecture Research
 
 Most AI systems today scale capability by increasing:
 
@@ -499,16 +507,16 @@ structured and deterministic way.
 
 ------------------------------------------------------------------------
 
-# Conclusion
+### Conclusion
 
 The Gödel--Hadamard loop was originally introduced to support **adaptive
 reasoning and strategy revision**.
 
 However, the architecture also aligns closely with models of **bounded affect and cognitive control** found in biological intelligence.
-## Legacy Filename Note
+
+### Legacy Filename Note
 
 This document was previously named `EMOTION_MODEL.md` for continuity with earlier planning and review history. The content should be read in bounded-affect terms, and `BOUNDED_AFFECT_MODEL.md` is now the correct canonical filename for the milestone doc set.
-
 
 This suggests that ADL may provide a platform for exploring a new class
 of agents:
@@ -518,10 +526,40 @@ Systems that move beyond simple tools and toward more
 
 ---
 
-## Framing Note
+### Framing Note
 
 For v0.85 planning, this document should be read in the same bounded
 sense as the other affect-model documents.
 It discusses **bounded affect control signals** as architectural and
 functional mechanisms, not as claims that ADL has achieved consciousness,
 sentience, or human-like interiority.
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: *Canonical v0.85 conceptual document — legacy filename retained for now; bounded non-anthropomorphic framing*; ------------------------------------------------------------------------
+
+## Related Documents
+
+- EMOTION_MODEL.md
+- BOUNDED_AFFECT_MODEL.md
+
+## Future Work
+
+- No dedicated future-work section was present in the original document; any follow-on work remains embedded in the preserved discussion above.
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.
+- *Canonical v0.85 conceptual document — legacy filename retained for now; bounded non-anthropomorphic framing*
+- ------------------------------------------------------------------------

--- a/docs/milestones/v0.85/CLUSTER_EXECUTION.md
+++ b/docs/milestones/v0.85/CLUSTER_EXECUTION.md
@@ -1,5 +1,7 @@
 # Distributed / Cluster Execution — v0.85
 
+## Purpose
+
 **Status:** Draft (planning)
 
 This document describes how ADL evolves from a single-machine deterministic runtime into a **distributed execution environment** while preserving ADL’s central thesis:
@@ -19,7 +21,7 @@ Related backlog: **#339 Distributed cluster execution**.
 
 ---
 
-## 1. Purpose and milestone framing
+## Overview
 
 Cluster execution matters because ADL is not just a local workflow runner.
 The platform is intended to support:
@@ -35,35 +37,36 @@ Instead, it defines the architecture direction, the determinism constraints, and
 
 ---
 
-## 2. Goals and non-goals
+## Key Capabilities
 
-### Goals
+- dependable execution
+- checkpoint / resume semantics
+- replay and provenance
+- bounded retry / adaptive execution work
+- future trust-policy enforcement across execution boundaries
+- deterministic execution at larger scale
+- durable runs with restart / retry behavior
+- trusted remote or isolated executors
 
-1. **Distributed execution without weakening determinism**
-   - Multiple workers may execute steps, but the outcome must still be replayable from artifacts.
+## How It Works
 
-2. **Stable scheduling contract**
-   - Execution may be parallel where the DAG allows it, but scheduling decisions must remain reproducible.
+### 1. Purpose and milestone framing
 
-3. **Explicit trust boundaries**
-   - Remote or isolated workers must be treated as trust-boundary crossings, not just background threads.
+Cluster execution matters because ADL is not just a local workflow runner.
+The platform is intended to support:
 
-4. **Operationally realistic rollout**
-   - Start with a small, inspectable execution model before attempting multi-host scale-out.
+- deterministic execution at larger scale
+- durable runs with restart / retry behavior
+- trusted remote or isolated executors
+- future Gödel / ObsMem / AEE workloads that benefit from concurrent execution
 
-5. **Compatibility with dependable execution**
-   - Cluster execution must align with checkpointing, retries, replay bundles, and provenance surfaces.
-
-### Non-goals (v0.85)
-
-- A full serverless platform replacement.
-- Multi-tenant isolation comparable to major cloud providers.
-- Exactly-once guarantees for arbitrary external side effects.
-- A fully production-hardened multi-region control plane.
+However, v0.85 is still a **bounded maturity milestone**.
+So this document does **not** commit ADL to a full distributed platform in the current release.
+Instead, it defines the architecture direction, the determinism constraints, and the minimum substrate shape needed so later implementation work does not drift.
 
 ---
 
-## 3. Determinism constraints in a distributed system
+### 3. Determinism constraints in a distributed system
 
 Distributed systems introduce nondeterminism through:
 
@@ -87,8 +90,6 @@ In other words:
 > We make ADL’s **interpretation of the world** deterministic.
 
 ---
-
-## 4. Execution model
 
 ### 4.1 Core primitives
 
@@ -118,7 +119,7 @@ Workers do **not** autonomously change the global schedule.
 
 ---
 
-## 5. Minimal cluster architecture for v0.85 planning
+### 5. Minimal cluster architecture for v0.85 planning
 
 This document remains intentionally conservative.
 
@@ -176,7 +177,7 @@ Workers (N)
 
 ---
 
-## 6. Protocol direction
+### 6. Protocol direction
 
 v0.85 does not require a final production network protocol, but it **does** require that the protocol shape be explicit and versioned.
 
@@ -212,8 +213,6 @@ JSON in canonical form or CBOR in canonical form are both plausible.
 The key point is not the format name but the **stability guarantee**.
 
 ---
-
-## 7. Scheduling semantics
 
 ### 7.1 Deterministic readiness
 
@@ -255,7 +254,7 @@ Additional priority fields are allowed only if they are:
 
 ---
 
-## 8. Retry semantics in a cluster
+### 8. Retry semantics in a cluster
 
 Retries are especially easy to get wrong in distributed systems.
 
@@ -277,7 +276,7 @@ This is necessary for deterministic debugging and for future AEE / policy learni
 
 ---
 
-## 9. Trust and signing model
+### 9. Trust and signing model
 
 Cluster execution expands the trust surface.
 
@@ -296,7 +295,7 @@ This links directly to ADL’s broader **dependable execution** and **verifiable
 
 ---
 
-## 10. Sandboxing and remote I/O
+### 10. Sandboxing and remote I/O
 
 Workers must run steps under the same sandbox contract regardless of host.
 
@@ -316,7 +315,7 @@ To preserve determinism:
 
 ---
 
-## 11. Relationship to dependable execution and verifiable inference
+### 11. Relationship to dependable execution and verifiable inference
 
 Cluster execution is not an isolated feature.
 It is part of the trust story for ADL.
@@ -343,7 +342,7 @@ This matters even more once Gödel / AEE / reasoning-graph work begins using ric
 
 ---
 
-## 12. Relationship to existing substrates
+### 12. Relationship to existing substrates
 
 ADL should resist the temptation to rebuild a general-purpose serverless platform from scratch.
 
@@ -367,8 +366,6 @@ The recommended direction is:
 
 ---
 
-## 13. Milestone slicing
-
 ### v0.85 (this milestone)
 
 - Architecture direction documented
@@ -389,7 +386,7 @@ This keeps v0.85 focused on **design clarity and interface stability**, not prem
 
 ---
 
-## 14. Acceptance tests (must-haves for future implementation)
+### 14. Acceptance tests (must-haves for future implementation)
 
 1. **Deterministic replay across execution modes**
    - Run in distributed / clustered mode
@@ -412,19 +409,7 @@ This keeps v0.85 focused on **design clarity and interface stability**, not prem
 
 ---
 
-## 15. Open questions
-
-- What is the default bounded backend for the coordinator log / queue?
-  - SQLite first, or Postgres-first for small-cluster realism?
-- What is the default artifact store?
-  - local filesystem vs S3-compatible storage
-- What is the first implementation boundary?
-  - single-host multi-process only, or immediately protocol-ready for multi-host evolution?
-- Which signing / identity mechanism best fits the existing security envelope work?
-
----
-
-## Summary
+### Summary
 
 Distributed / cluster execution is necessary for ADL’s long-term direction, but it must be approached conservatively.
 
@@ -441,3 +426,76 @@ The bounded implementation proof surface for v0.85 should therefore remain conse
 - readiness frontiers, lease ordering, claim ownership, and observed completion state should be reviewable from run artifacts
 
 That artifact-level groundwork is not a full cluster runtime, but it does make the future coordinator / worker substrate explicit and testable without overstating what v0.85 ships.
+
+### Goals
+
+1. **Distributed execution without weakening determinism**
+   - Multiple workers may execute steps, but the outcome must still be replayable from artifacts.
+
+2. **Stable scheduling contract**
+   - Execution may be parallel where the DAG allows it, but scheduling decisions must remain reproducible.
+
+3. **Explicit trust boundaries**
+   - Remote or isolated workers must be treated as trust-boundary crossings, not just background threads.
+
+4. **Operationally realistic rollout**
+   - Start with a small, inspectable execution model before attempting multi-host scale-out.
+
+5. **Compatibility with dependable execution**
+   - Cluster execution must align with checkpointing, retries, replay bundles, and provenance surfaces.
+
+### Non-goals (v0.85)
+
+- A full serverless platform replacement.
+- Multi-tenant isolation comparable to major cloud providers.
+- Exactly-once guarantees for arbitrary external side effects.
+- A fully production-hardened multi-region control plane.
+
+---
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: **Status:** Draft (planning); This document describes how ADL evolves from a single-machine deterministic runtime into a **distributed execution environment** while preserving ADL’s central thesis:; > **Determinism is non-negotiable.**; For v0.85, cluster execution is part of the broader **execution-substrate strengthening** work.; It sits alongside:; - dependable execution; - checkpoint / resume semantics; - replay and provenance; - bounded retry / adaptive execution work; - future trust-policy enforcement across execution boundaries; Related backlog: **#339 Distributed cluster execution**.
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
+
+- What is the default bounded backend for the coordinator log / queue?
+  - SQLite first, or Postgres-first for small-cluster realism?
+- What is the default artifact store?
+  - local filesystem vs S3-compatible storage
+- What is the first implementation boundary?
+  - single-host multi-process only, or immediately protocol-ready for multi-host evolution?
+- Which signing / identity mechanism best fits the existing security envelope work?
+
+---
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.
+- **Status:** Draft (planning)
+- This document describes how ADL evolves from a single-machine deterministic runtime into a **distributed execution environment** while preserving ADL’s central thesis:
+- > **Determinism is non-negotiable.**
+- For v0.85, cluster execution is part of the broader **execution-substrate strengthening** work.
+- It sits alongside:
+- - dependable execution
+- - checkpoint / resume semantics
+- - replay and provenance
+- - bounded retry / adaptive execution work
+- - future trust-policy enforcement across execution boundaries
+- Related backlog: **#339 Distributed cluster execution**.

--- a/docs/milestones/v0.85/COGNITIVE_LOOP_MODEL_v0.85.md
+++ b/docs/milestones/v0.85/COGNITIVE_LOOP_MODEL_v0.85.md
@@ -1,16 +1,12 @@
 # Cognitive Loop Model — v0.85
 
-## Status
-
-Tracked authority for the v0.85 milestone doc set.
-
 ## Purpose
 
 This document is the single authoritative cognitive-loop model for the tracked v0.85 milestone docs.
 
 Other v0.85 docs may summarize or apply parts of the loop, but they should not define a competing authoritative loop model.
 
-## Canonical Cognitive Loop
+## Overview
 
 ```text
 instinct -> bounded affect -> cognitive arbitration -> freedom gate
@@ -24,7 +20,17 @@ This loop is intended to be:
 - replay-compatible
 - policy-governed
 
-## Component Roles
+## Key Capabilities
+
+- bounded
+- inspectable
+- replay-compatible
+- policy-governed
+- creates persistent pressure toward coherence, completion, curiosity, or integrity
+- influences what initially matters before slower reasoning runs
+- does not override governance or policy
+
+## How It Works
 
 ### 1. Instinct
 
@@ -112,7 +118,7 @@ Memory stores:
 
 Memory feeds back into bounded affect and future arbitration/execution choices.
 
-## Design Rules
+### Design Rules
 
 1. Policy supremacy
    - the freedom gate overrides other signals when necessary
@@ -125,15 +131,39 @@ Memory feeds back into bounded affect and future arbitration/execution choices.
 5. Artifact visibility
    - the loop should eventually be legible through emitted artifacts, not only prose
 
-## Relationship To Other v0.85 Docs
+### Relationship To Other v0.85 Docs
 
 - [AFFECT_MODEL_v0.85.md](AFFECT_MODEL_v0.85.md) defines the bounded affect subsystem in more detail.
 - [AFFECTIVE_REASONING_MODEL.md](AFFECTIVE_REASONING_MODEL.md) defines the signal model attached to reasoning/evaluation surfaces.
 - [DESIGN_v0.85.md](DESIGN_v0.85.md) describes how this loop fits the milestone architecture.
 - [VISION_v0.85.md](VISION_v0.85.md) describes the architectural role of the cognitive substrate at milestone level.
 
-## Scope Note
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: Tracked authority for the v0.85 milestone doc set.
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
 
 This is the authoritative loop model for tracked v0.85 docs only.
 
 Later planning material for v0.86 and beyond may refine the model, but tracked v0.85 docs should reference this document rather than define another canonical loop.
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/COGNITIVE_STACK_v0.85.md
+++ b/docs/milestones/v0.85/COGNITIVE_STACK_v0.85.md
@@ -1,9 +1,5 @@
 # Cognitive Stack — v0.85
 
-## Status
-
-Tracked authority for the v0.85 cognitive sub-stack.
-
 ## Purpose
 
 This document defines the authoritative cognitive stack for the tracked v0.85 milestone docs.
@@ -16,22 +12,7 @@ It exists to remove two sources of ambiguity:
 This document does not replace the broader architecture framing in `VISION_v0.85.md`.
 It defines the internal bounded-cognition sub-stack that sits inside that broader architecture.
 
-## Scope Note
-
-The v0.85 doc set now uses two valid but different views:
-
-1. a high-level architecture view
-   - execution
-   - workflow
-   - cognitive
-   - evaluation
-   - adaptive
-2. an internal cognitive sub-stack view
-   - the bounded internal layers that shape cognition, routing, memory, and action
-
-This document is the authority for the second view.
-
-## Canonical Cognitive Stack
+## Overview
 
 ```text
 1. Instinct
@@ -45,7 +26,32 @@ This document is the authority for the second view.
 
 The numbering above is stable for tracked v0.85 docs.
 
-## Layer Roles
+## Key Capabilities
+
+- fractional layer numbering such as "3.5"
+- confusion between the internal cognitive sub-stack and the higher-level milestone architecture view
+- Instinct
+- Bounded Affect
+- Cognitive Arbitration
+- Freedom Gate
+- Reasoning and Reframing
+- Memory (ObsMem)
+
+## How It Works
+
+### Canonical Cognitive Stack
+
+```text
+1. Instinct
+2. Bounded Affect
+3. Cognitive Arbitration
+4. Freedom Gate
+5. Reasoning and Reframing
+6. Memory (ObsMem)
+7. Adaptive Execution and Artifacts
+```
+
+The numbering above is stable for tracked v0.85 docs.
 
 ### 1. Instinct
 
@@ -127,7 +133,7 @@ It includes:
 - emitted artifacts
 - evaluation inputs for later routing and memory updates
 
-## Explicit Numbering Decisions
+### Explicit Numbering Decisions
 
 1. Cognitive arbitration is Layer 3.
    - It is not "Layer 3.5".
@@ -138,7 +144,7 @@ It includes:
 4. Evaluation is a loop function, not a separate numbered stack layer here.
    - In the canonical loop model, evaluation feeds bounded affect, arbitration, and memory.
 
-## Relationship To The Canonical Cognitive Loop
+### Relationship To The Canonical Cognitive Loop
 
 The canonical v0.85 loop is defined in `COGNITIVE_LOOP_MODEL_v0.85.md`.
 
@@ -156,7 +162,7 @@ This stack document complements that loop:
 
 The two views should agree, not compete.
 
-## Relationship To The Higher-Level Architecture View
+### Relationship To The Higher-Level Architecture View
 
 The five-layer architecture in `VISION_v0.85.md` is still valid.
 
@@ -169,7 +175,7 @@ That view describes the milestone at system scale:
 
 This cognitive-stack document describes the internal structure of the bounded cognition part of that system.
 
-## Design Rules
+### Design Rules
 
 1. No fractional layers
    - tracked v0.85 docs should not use numbering such as "3.5"
@@ -180,7 +186,40 @@ This cognitive-stack document describes the internal structure of the bounded co
 4. Compatibility with loop authority
    - the stack must remain compatible with `COGNITIVE_LOOP_MODEL_v0.85.md`
 
-## Scope Boundaries
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: Tracked authority for the v0.85 cognitive sub-stack.
+
+## Related Documents
+
+- VISION_v0.85.md
+- COGNITIVE_LOOP_MODEL_v0.85.md
+
+## Future Work
+
+The v0.85 doc set now uses two valid but different views:
+
+1. a high-level architecture view
+   - execution
+   - workflow
+   - cognitive
+   - evaluation
+   - adaptive
+2. an internal cognitive sub-stack view
+   - the bounded internal layers that shape cognition, routing, memory, and action
+
+This document is the authority for the second view.
 
 This issue does not:
 - implement the stack in runtime code
@@ -190,3 +229,8 @@ This issue does not:
 It does:
 - define stable numbered layers for tracked v0.85 docs
 - give later instinct, bounded-affect, arbitration, and AEE work a consistent reference point
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/DEMO_MATRIX_v0.85.md
+++ b/docs/milestones/v0.85/DEMO_MATRIX_v0.85.md
@@ -1,12 +1,6 @@
 # ADL v0.85 Demo Matrix
 
-**Status:** Ready  
-**Milestone:** v0.85  
-**Purpose:** Canonical runnable demo and proof-surface matrix for milestone review, release readiness, and external legibility.
-
----
-
-## 1. Purpose
+## Purpose
 
 This document maps the major claims of ADL `v0.85` to concrete proof surfaces.
 
@@ -24,19 +18,26 @@ This matrix should help reviewers answer:
 
 ---
 
-## 2. How to Read This Matrix
+## Overview
 
-### Demo Classes
+**Status:** Ready
+**Milestone:** v0.85
+**Purpose:** Canonical runnable demo and proof-surface matrix for milestone review, release readiness, and external legibility.
 
-- Primary demo: a headline runnable demo that should be shown in milestone review and external explanation.
-- Supporting demo: a narrower runnable demo that proves a bounded surface but is not itself the headline narrative.
-- Alternate proof surface: an artifact-driven proof surface used when a runnable demo is not the best primary mechanism.
+---
 
-### Demo Status
+## Key Capabilities
 
-- Ready: can be used now for milestone review.
-- Partial: useful, but still rough or dependent on adjacent cleanup.
-- Deferred: intentionally not a `v0.85` runnable demo surface.
+- a runnable demo, or
+- an explicit alternate proof surface when a full runnable demo is not the best primary mechanism.
+- What does `v0.85` actually demonstrate?
+- Which demos are headline milestone demos versus supporting demos?
+- What artifact or record proves a claim if no direct demo is run?
+- What still remains partial or deferred?
+- a runnable command or playbook, or
+- an explicit artifact/proof surface that a reviewer can inspect.
+
+## How It Works
 
 ### Reviewer Rule
 
@@ -70,7 +71,6 @@ Every row in this matrix must provide at least one of:
 ## 4. Primary Demos
 
 These are the milestone’s headline demonstrations. They should be the first things shown in milestone review and the first things referenced externally.
-
 ### 4.1 Steering / Queueing / Checkpoint / Resume
 
 **Class:** Primary demo  
@@ -199,10 +199,6 @@ This is the first clean entry point into the bounded Gödel runtime loop and the
 
 ---
 
-## 5. Supporting Demos
-
-These demos are important and runnable, but they support the milestone story rather than carrying it alone.
-
 ### 5.1 Affect Engine Core
 
 **Class:** Supporting demo  
@@ -298,7 +294,7 @@ These demos are important and runnable, but they support the milestone story rat
 
 ---
 
-## 6. Alternate Proof Surfaces
+### 6. Alternate Proof Surfaces
 
 These are important `v0.85` claims whose best current proof is primarily artifact-driven rather than a headline runnable demo.
 
@@ -367,7 +363,7 @@ Recommended milestone review order:
 
 ---
 
-## 8. Notes
+### 8. Notes
 
 - The matrix is milestone-facing, not a full inventory of every runnable artifact in the repo.
 - Supporting demos remain important even when they are not headline review surfaces.

--- a/docs/milestones/v0.85/DESIGN_v0.85.md
+++ b/docs/milestones/v0.85/DESIGN_v0.85.md
@@ -1,105 +1,11 @@
 # ADL Design — v0.85
 
-> **Planning note**
-> `docs/milestones/v0.85/` is the canonical location for the tracked v0.85 milestone documentation set.
-> Related planning artifacts in temporary or local workspaces should be treated as source material only after their content is reconciled into this directory.
-
-## Metadata
-- Milestone: `v0.85`
-- Version: `0.85`
-- Date: `2026-03-16`
-- Owner: `Daniel Austin / Agent Logic`
-- Related issues: `#886, #674, #716, #743, #748, #749, #750, #751, #752, #866-#882`
-
 ## Purpose
+
 Define the major design directions for v0.85, with emphasis on bounded operational maturity, dependable execution, verifiable inference, stronger authoring and review surfaces, Adaptive Execution Engine progress, Gödel runtime progress, and a minimal working affective-reasoning substrate. This document anchors the revised four-sprint, twenty-five-work-package milestone structure into one coherent design statement.
 
-## Problem Statement
-v0.8 established a strong conceptual and architectural substrate for ADL, but the system still lacks several capabilities required for practical, trustworthy use by serious teams.
+## Overview
 
-The main gaps are:
-
-- execution remains stronger conceptually than operationally, especially for queueing, checkpointing, and distributed work
-- review and authoring surfaces are still too manual and do not yet provide first-class editors
-- dependable execution and verifiable inference need stronger first-class representation in tooling and documentation
-- the Adaptive Execution Engine (AEE) has been conceptually deferred for several releases and must advance materially in v0.85
-- the emerging bounded affect model is not yet represented as a disciplined working surface even though it may become important to bounded cognition, evaluation signals, and agent priority handling
-- the Gödel issue set (`#748` through `#752`) exists, but needs to become a first-class milestone track rather than floating beside the work-package structure
-
-v0.85 therefore exists to convert ADL from a compelling substrate into a more usable, scalable, and trustworthy platform.
-
-A secondary problem is documentation fragmentation itself: milestone intent is currently distributed across multiple directories and partially overlapping planning documents. That fragmentation increases ambiguity around source-of-truth, acceptance criteria, and sequencing. v0.85 should therefore improve not only runtime and authoring maturity, but also milestone-document coherence.
-
-For the cognitive substrate specifically, tracked v0.85 docs now rely on:
-
-- `COGNITIVE_LOOP_MODEL_v0.85.md` as the canonical loop/flow model
-- `COGNITIVE_STACK_v0.85.md` as the canonical internal stack/layer model
-
-## Goals
-- Advance ADL toward a practical execution substrate with deterministic queueing, checkpointing, resumability, and cluster-oriented work distribution.
-- Make dependable execution and verifiable inference explicit design principles across runtime, artifacts, and positioning.
-- Improve authoring and review ergonomics without weakening structure, including first real editor surfaces and editing/review GPT assets.
-- Move the Adaptive Execution Engine forward as a major milestone theme rather than continuing to defer it.
-- Elevate Gödel issues `#748` through `#752` into a central milestone track for deterministic hypothesis generation, bounded adaptation, prioritization, cross-workflow learning, and evaluation-report artifacts.
-- Establish a bounded affective / emotion-model surface that is minimal, working, demoable, and able to influence evaluation, priority handling, and adaptive behavior.
-- Reduce milestone-planning ambiguity by making design intent, scope, and validation language consistent across the canonical v0.85 doc set.
-- Align the live issue graph to the revised twenty-five-work-package milestone structure under the `#886` umbrella.
-- Finish the milestone with an explicit active-surface `swarm` -> `adl` cutover once the rest of the code and review work has stabilized.
-
-## Non-Goals
-- Deliver unrestricted autonomy or unconstrained online self-modification.
-- Replace the entire existing runtime in one milestone.
-- Build a full synthetic psychology system.
-- Solve every enterprise or UI concern before v0.9.
-
-## Scope
-### In scope
-- Deterministic queue and checkpoint design/implementation work.
-- Queue/checkpoint/steering planning must explicitly treat `#674` as canonical and absorb or supersede placeholder issue `#867`.
-- Cluster / distributed execution planning and initial execution substrate improvements.
-- Prompt Spec completeness and stronger authoring surfaces.
-- First editor surfaces for issue prompts and input/output cards.
-- Editing/review GPT stabilization and reusable review assets.
-- Bounded AEE progress: retry policy, adaptation surfaces, strategy loop integration, experiment lifecycle support.
-- Trust surfaces: dependable execution, verifiable inference, artifact provenance, replayability.
-- Gödel runtime progress through issues `#748` through `#752`.
-- A bounded affect model that fits the Gödel–Hadamard–Bayes architecture and is concrete enough to demo.
-- Reasoning-graph integration with affect and hypothesis behavior.
-- A milestone demo program with multiple runnable proof surfaces, including steering/queueing, HITL/editor/review flow, and affect-plus-Gödel behavior.
-- Positioning and philosophy docs that clarify why ADL chooses stronger guarantees and explicit artifacts.
-- Milestone-document alignment across the canonical v0.85 planning artifacts, especially design/scope/validation language.
-- Explicit split of the milestone endgame into docs consistency, internal review, external review, remediation, release ceremony, and next-milestone planning.
-- Final active-surface identity cutover as documented in `SWARM_REMOVAL_PLANNING.md`, executed only after the major code and review changes for v0.85 are otherwise complete.
-
-### Out of scope
-- Full production-grade autonomous self-improvement.
-- Fully generalized distributed runtime for arbitrary scale.
-- Broad website launch or complete marketing package.
-- Final public launch; v0.85 is still a strengthening milestone before the v0.9 base-feature target.
-- A full repository-wide information-architecture cleanup for all milestone documents; v0.85 only needs bounded alignment and reduced ambiguity.
-
-## Requirements
-### Functional
-- ADL must support stronger deterministic execution management, including queue/checkpoint/resume surfaces.
-- ADL must improve authoring and validation surfaces for prompts, cards, and workflows.
-- ADL must provide at least initial working editor surfaces for issue prompts and input/output cards.
-- ADL must make review and artifact validation more reliable.
-- ADL must advance bounded adaptive execution so it is materially closer to operational use.
-- ADL must advance Gödel runtime behavior through the canonical issue set `#748` through `#752`.
-- ADL must define a minimal working bounded affect representation that is compatible with later cognitive work.
-- ADL must provide a bounded affect/reasoning/Gödel demo slice that emits legible artifacts.
-- ADL milestone planning documents for v0.85 must present materially consistent scope, trust, AEE, and affect-model intent within the canonical `docs/milestones/v0.85/` directory.
-- ADL milestone planning documents must present one coherent four-sprint, twenty-five-work-package structure with explicit issue-graph alignment.
-
-### Non-functional
-- Deterministic behavior and reproducible outputs.
-- Clear failure semantics and observability.
-- Explicit artifact contracts and provenance.
-- Verifiable inference surfaces suitable for business-facing trust arguments.
-- Bounded scope: every new adaptive or affective mechanism must remain inspectable and reviewable.
-
-## Proposed Design
-### Overview
 v0.85 is organized as a four-sprint, twenty-five-work-package program:
 
 1. **Sprint 1: execution substrate and milestone alignment** — milestone reorganization, deterministic queueing/checkpointing/steering, cluster groundwork, and process cleanup.
@@ -125,7 +31,72 @@ The issue-graph rule for this milestone is:
 - every canonical issue should belong to one work package
 - the provisional generated issue set `#866` through `#882` is useful scaffolding, but the canonical milestone structure is the revised twenty-five-work-package model under `#886`
 
+## Key Capabilities
+
+- **Sprint 1: execution substrate and milestone alignment** — milestone reorganization, deterministic queueing/checkpointing/steering, cluster groundwork, and process cleanup.
+- **Sprint 2: authoring surfaces and review tooling** — Prompt Spec improvements, first editor surfaces, and stronger editing/review GPT workflows.
+- **Sprint 3: Gödel, affect, reasoning graphs, and AEE progress** — deterministic hypothesis generation, bounded adaptive Gödel behavior, experiment prioritization, cross-workflow learning, promotion/eval artifacts, affect engine work, reasoning-graph integration, and a runnable affect/Gödel vertical slice.
+- **Sprint 4: demos, quality, review, release, and next-step planning** — demo program, quality gate, docs consistency, internal review, external review, remediation, release ceremony, and next-milestone planning.
+- explicit before execution
+- reproducible after execution
+- reviewable by humans and tools
+- bounded in adaptation and failure modes
+
+## How It Works
+
+### Metadata
+
+- Milestone: `v0.85`
+- Version: `0.85`
+- Date: `2026-03-16`
+- Owner: `Daniel Austin / Agent Logic`
+- Related issues: `#886, #674, #716, #743, #748, #749, #750, #751, #752, #866-#882`
+
+### Problem Statement
+
+v0.8 established a strong conceptual and architectural substrate for ADL, but the system still lacks several capabilities required for practical, trustworthy use by serious teams.
+
+The main gaps are:
+
+- execution remains stronger conceptually than operationally, especially for queueing, checkpointing, and distributed work
+- review and authoring surfaces are still too manual and do not yet provide first-class editors
+- dependable execution and verifiable inference need stronger first-class representation in tooling and documentation
+- the Adaptive Execution Engine (AEE) has been conceptually deferred for several releases and must advance materially in v0.85
+- the emerging bounded affect model is not yet represented as a disciplined working surface even though it may become important to bounded cognition, evaluation signals, and agent priority handling
+- the Gödel issue set (`#748` through `#752`) exists, but needs to become a first-class milestone track rather than floating beside the work-package structure
+
+v0.85 therefore exists to convert ADL from a compelling substrate into a more usable, scalable, and trustworthy platform.
+
+A secondary problem is documentation fragmentation itself: milestone intent is currently distributed across multiple directories and partially overlapping planning documents. That fragmentation increases ambiguity around source-of-truth, acceptance criteria, and sequencing. v0.85 should therefore improve not only runtime and authoring maturity, but also milestone-document coherence.
+
+For the cognitive substrate specifically, tracked v0.85 docs now rely on:
+
+- `COGNITIVE_LOOP_MODEL_v0.85.md` as the canonical loop/flow model
+- `COGNITIVE_STACK_v0.85.md` as the canonical internal stack/layer model
+
+### Functional
+
+- ADL must support stronger deterministic execution management, including queue/checkpoint/resume surfaces.
+- ADL must improve authoring and validation surfaces for prompts, cards, and workflows.
+- ADL must provide at least initial working editor surfaces for issue prompts and input/output cards.
+- ADL must make review and artifact validation more reliable.
+- ADL must advance bounded adaptive execution so it is materially closer to operational use.
+- ADL must advance Gödel runtime behavior through the canonical issue set `#748` through `#752`.
+- ADL must define a minimal working bounded affect representation that is compatible with later cognitive work.
+- ADL must provide a bounded affect/reasoning/Gödel demo slice that emits legible artifacts.
+- ADL milestone planning documents for v0.85 must present materially consistent scope, trust, AEE, and affect-model intent within the canonical `docs/milestones/v0.85/` directory.
+- ADL milestone planning documents must present one coherent four-sprint, twenty-five-work-package structure with explicit issue-graph alignment.
+
+### Non-functional
+
+- Deterministic behavior and reproducible outputs.
+- Clear failure semantics and observability.
+- Explicit artifact contracts and provenance.
+- Verifiable inference surfaces suitable for business-facing trust arguments.
+- Bounded scope: every new adaptive or affective mechanism must remain inspectable and reviewable.
+
 ### Interfaces / Data contracts
+
 - **Queue / checkpoint contracts**: deterministic run identity, queue state, retry state, checkpoint state, and resumability invariants.
 - **Prompt Spec contracts**: explicit authoring fields for actor, model, inputs, outputs, constraints, and review surfaces.
 - **Review artifacts**: machine-readable review outputs and consistent card/output structures.
@@ -137,6 +108,7 @@ The issue-graph rule for this milestone is:
 - **Demo contracts**: bounded demos for major runtime, editor, and cognitive surfaces, especially steering/queueing, HITL/editor/review flow, and affect-plus-Gödel behavior.
 
 ### Execution semantics
+
 The execution semantics for v0.85 remain centered on deterministic workflow behavior.
 
 New or strengthened behavior should obey the following principles:
@@ -151,7 +123,8 @@ New or strengthened behavior should obey the following principles:
 - milestone-planning updates must reduce source-of-truth ambiguity rather than create additional overlapping statements
 - cognitive-stack updates must preserve stable layer numbering and avoid fractional-layer semantics
 
-## Risks and Mitigations
+### Risks and Mitigations
+
 - Risk: v0.85 becomes too large by combining runtime, authoring, trust, and cognition work.
   - Mitigation: keep the milestone focused on bounded maturity gains and push broader autonomy or productization to later releases.
 - Risk: AEE scope again slips into future milestones without concrete progress.
@@ -167,7 +140,8 @@ New or strengthened behavior should obey the following principles:
 - Risk: executing the final `swarm` -> `adl` cutover too early creates avoidable branch drift and path-conflict churn across active work.
   - Mitigation: keep cutover work explicitly late in the milestone and gate it on prior code/review stabilization.
 
-## Alternatives Considered
+### Alternatives Considered
+
 - Option: keep v0.85 narrowly runtime-focused and defer affective/cognitive work.
   - Tradeoff: would simplify scope, but risks missing an important architectural opportunity and continuing to postpone a promising design area.
 - Option: push the bounded affect model entirely to v0.9+.
@@ -177,12 +151,14 @@ New or strengthened behavior should obey the following principles:
 - Option: postpone document alignment until after runtime work stabilizes.
   - Tradeoff: saves time in the short term, but increases confusion about milestone intent and makes later cleanup harder.
 
-## Validation Plan
+### Validation Plan
+
 - Checks/tests: milestone issue tree, implementation cards, deterministic validation commands, replay and provenance checks where applicable, reviewer artifact checks, editor/demo verification, bounded design review for the affect model, and cross-checking of v0.85 planning language across split document locations.
 - Success metrics: v0.85 materially improves execution maturity, reviewer reliability, authoring usability, Gödel concreteness, and AEE progress; the affect model is represented as a bounded working substrate rather than an untracked idea.
 - Rollback/fallback: if a sub-track becomes too ambitious, reduce it to explicit design docs and bounded artifacts rather than forcing partial uncontrolled implementation.
 
-## Exit Criteria
+### Exit Criteria
+
 - Goals/non-goals and scope boundaries are explicit.
 - Validation plan is actionable and referenced by the milestone checklist.
 - Major open questions are resolved or tracked in the decision log.
@@ -190,3 +166,76 @@ New or strengthened behavior should obey the following principles:
 - The bounded affect model has a minimal working artifact, a bounded role in the architecture, and a demoable proof path.
 - The major v0.85 planning documents no longer materially contradict one another on scope, trust, AEE, Gödel emphasis, editor expectations, demo expectations, or affect-model intent.
 - The milestone positions ADL to enter v0.9 with nearly all base features in place.
+
+### Goals
+
+- Advance ADL toward a practical execution substrate with deterministic queueing, checkpointing, resumability, and cluster-oriented work distribution.
+- Make dependable execution and verifiable inference explicit design principles across runtime, artifacts, and positioning.
+- Improve authoring and review ergonomics without weakening structure, including first real editor surfaces and editing/review GPT assets.
+- Move the Adaptive Execution Engine forward as a major milestone theme rather than continuing to defer it.
+- Elevate Gödel issues `#748` through `#752` into a central milestone track for deterministic hypothesis generation, bounded adaptation, prioritization, cross-workflow learning, and evaluation-report artifacts.
+- Establish a bounded affective / emotion-model surface that is minimal, working, demoable, and able to influence evaluation, priority handling, and adaptive behavior.
+- Reduce milestone-planning ambiguity by making design intent, scope, and validation language consistent across the canonical v0.85 doc set.
+- Align the live issue graph to the revised twenty-five-work-package milestone structure under the `#886` umbrella.
+- Finish the milestone with an explicit active-surface `swarm` -> `adl` cutover once the rest of the code and review work has stabilized.
+
+### Non-Goals
+
+- Deliver unrestricted autonomy or unconstrained online self-modification.
+- Replace the entire existing runtime in one milestone.
+- Build a full synthetic psychology system.
+- Solve every enterprise or UI concern before v0.9.
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: > **Planning note**; > `docs/milestones/v0.85/` is the canonical location for the tracked v0.85 milestone documentation set.; > Related planning artifacts in temporary or local workspaces should be treated as source material only after their content is reconciled into this directory.
+
+## Related Documents
+
+- COGNITIVE_LOOP_MODEL_v0.85.md
+- COGNITIVE_STACK_v0.85.md
+- SWARM_REMOVAL_PLANNING.md
+
+## Future Work
+
+- Deterministic queue and checkpoint design/implementation work.
+- Queue/checkpoint/steering planning must explicitly treat `#674` as canonical and absorb or supersede placeholder issue `#867`.
+- Cluster / distributed execution planning and initial execution substrate improvements.
+- Prompt Spec completeness and stronger authoring surfaces.
+- First editor surfaces for issue prompts and input/output cards.
+- Editing/review GPT stabilization and reusable review assets.
+- Bounded AEE progress: retry policy, adaptation surfaces, strategy loop integration, experiment lifecycle support.
+- Trust surfaces: dependable execution, verifiable inference, artifact provenance, replayability.
+- Gödel runtime progress through issues `#748` through `#752`.
+- A bounded affect model that fits the Gödel–Hadamard–Bayes architecture and is concrete enough to demo.
+- Reasoning-graph integration with affect and hypothesis behavior.
+- A milestone demo program with multiple runnable proof surfaces, including steering/queueing, HITL/editor/review flow, and affect-plus-Gödel behavior.
+- Positioning and philosophy docs that clarify why ADL chooses stronger guarantees and explicit artifacts.
+- Milestone-document alignment across the canonical v0.85 planning artifacts, especially design/scope/validation language.
+- Explicit split of the milestone endgame into docs consistency, internal review, external review, remediation, release ceremony, and next-milestone planning.
+- Final active-surface identity cutover as documented in `SWARM_REMOVAL_PLANNING.md`, executed only after the major code and review changes for v0.85 are otherwise complete.
+
+- Full production-grade autonomous self-improvement.
+- Fully generalized distributed runtime for arbitrary scale.
+- Broad website launch or complete marketing package.
+- Final public launch; v0.85 is still a strengthening milestone before the v0.9 base-feature target.
+- A full repository-wide information-architecture cleanup for all milestone documents; v0.85 only needs bounded alignment and reduced ambiguity.
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.
+- > **Planning note**
+- > `docs/milestones/v0.85/` is the canonical location for the tracked v0.85 milestone documentation set.
+- > Related planning artifacts in temporary or local workspaces should be treated as source material only after their content is reconciled into this directory.

--- a/docs/milestones/v0.85/EDITING_ARCHITECTURE.md
+++ b/docs/milestones/v0.85/EDITING_ARCHITECTURE.md
@@ -26,20 +26,7 @@ For clarity:
 - later control-plane hardening and richer integrations should support those
   editors, not displace the requirement to ship them
 
-## Command Status For v0.85
-
-This document follows the canonical command-status model in the editing
-five-command execution plan.
-
-| Command | Current state | Repo truth | Notes |
-| --- | --- | --- | --- |
-| `pr init` | missing | no live command in `adl/tools/pr.sh` | planned work, not current behavior |
-| `pr create` | partial / renamed | `pr new` exists, but it is only a rough precursor | do not describe `pr new` as a finished substitute |
-| `pr start` | implemented | active backbone command today | real and mature enough to anchor the current control plane |
-| `pr run` | missing | no live command in `adl/tools/pr.sh` | execution still happens through narrower paths |
-| `pr finish` | implemented | active mature workflow command today | real, but still subject to reliability/polish work |
-
-## Core Insight
+## Overview
 
 `pr.sh` is no longer just a helper script for branches and worktrees. It is already functioning as the nucleus of the editing system.
 
@@ -50,12 +37,51 @@ Today it effectively manages:
 - implementation execution handoff
 - PR lifecycle completion
 
+The long-term goal is to evolve this into a structured, validated, file-backed control plane. The immediate v0.85 goal is to ship usable editor surfaces while beginning that control-plane evolution without destabilizing the milestone.
+
+A key emerging insight is that `pr start` is likely to become the operational backbone of the editing system. Even if the longer-term lifecycle grows to include additional commands such as `init`, `create`, `run`, and `finish`, `pr start` is the first command that binds an authored task to a concrete execution context. That makes it the natural spine of the near-term control plane.
+
+## Command Status For v0.85
+
+This document follows the canonical command-status model in the editing five-command execution plan.
+
+| Command | Current state | Repo truth | Notes |
+| --- | --- | --- | --- |
+| `pr init` | missing | no live command in `adl/tools/pr.sh` | planned work, not current behavior |
+| `pr create` | partial / renamed | `pr new` exists, but it is only a rough precursor | do not describe `pr new` as a finished substitute |
+| `pr start` | implemented | active backbone command today | real and mature enough to anchor the current control plane |
+| `pr run` | missing | no live command in `adl/tools/pr.sh` | execution still happens through narrower paths |
+| `pr finish` | implemented | active mature workflow command today | real, but still subject to reliability/polish work |
+
+## Key Capabilities
+
+- authoring issues and prompts
+- validating structured artifacts
+- executing workflow commands
+- integrating with GitHub
+- managing card history and lifecycle
+- supporting future editors and UI surfaces
+- working cleanly with Gödel and the Adaptive Execution Engine (AEE)
+- recovering safely from mistakes
+
+## How It Works
+
+### Core Insight
+
+`pr.sh` is no longer just a helper script for branches and worktrees. It is already functioning as the nucleus of the editing system.
+
+Today it effectively manages:
+- issue creation workflows
+- worktree and branch setup
+- input/output card setup
+- implementation execution handoff
+- PR lifecycle completion
 
 The long-term goal is to evolve this into a structured, validated, file-backed control plane. The immediate v0.85 goal is to ship usable editor surfaces while beginning that control-plane evolution without destabilizing the milestone.
 
 A key emerging insight is that `pr start` is likely to become the operational backbone of the editing system. Even if the longer-term lifecycle grows to include additional commands such as `init`, `create`, `run`, and `finish`, `pr start` is the first command that binds an authored task to a concrete execution context. That makes it the natural spine of the near-term control plane.
 
-## Current Problem
+### Current Problem
 
 The current editing workflow is fragile in several ways:
 - artifact structure is only partially enforced
@@ -68,7 +94,7 @@ The current editing workflow is fragile in several ways:
 
 In practice, the workflow already wants stronger contracts.
 
-## Architectural Thesis
+### Architectural Thesis
 
 ADL should have a three-layer editing system:
 
@@ -90,7 +116,6 @@ These contracts define:
 ### Layer 2 - Workflow Control Plane
 
 A command layer that orchestrates the artifact lifecycle and enforces validation at every pass.
-
 
 This is currently centered on `pr.sh`, but should evolve into a proper programmatic subsystem.
 
@@ -117,7 +142,7 @@ This includes:
 
 These surfaces should sit on top of the artifact contracts and workflow control plane, not bypass them.
 
-## Proposed Workflow Model
+### Proposed Workflow Model
 
 The intended file-backed target-state workflow is:
 
@@ -140,7 +165,7 @@ This means the major artifacts become:
 - structured implementation prompt = implementation-layer artifact
 - structured output record = execution-record artifact
 
-## Draft Workspace vs Public Record
+### Draft Workspace vs Public Record
 
 ADL should distinguish between:
 
@@ -155,7 +180,7 @@ ADL should distinguish between:
 
 The important rule is that `.adl/` remains useful, but it is not the durable source of truth. Future editing tools should be able to draft locally while promoting stable artifacts into tracked task bundles before those artifacts become authoritative workflow state.
 
-## Closed-Loop Goal
+### Closed-Loop Goal
 
 The workflow should close the loop without requiring direct manual `gh` usage in normal operation.
 
@@ -169,12 +194,11 @@ The intended command path is:
 
 This only becomes a reliable closed loop if validation is enforced at every transition.
 
-
 Operationally, `pr start` and `pr finish` are the active mature workflow commands today. `pr create` is the desired next control-plane command and should be treated as part of the target-state architecture even where today’s implementation is still incomplete. `pr new` should be understood as the current rough precursor to `pr create`, not as a finished substitute for the target lifecycle command.
 
 The architecture should therefore treat `pr start` as the anchor command for the current system, while `pr create`, execution orchestration, and finish/repair behavior become increasingly formalized around it. This is one reason the longer-term control plane should move into Rust: the backbone command should not remain trapped in brittle bash if it is going to carry more general lifecycle responsibility.
 
-## Why the Editing System Must Be File-Backed
+### Why the Editing System Must Be File-Backed
 
 The architecture should prefer file-backed artifacts over ad hoc inline text.
 
@@ -198,7 +222,7 @@ Near-term canonical homes should look like:
 
 This keeps milestone narrative docs clean while preserving public, reviewable prompt history in a domain-neutral task-bundle form.
 
-## Immediate v0.85 Architectural Direction
+### Immediate v0.85 Architectural Direction
 
 The concrete v0.85 commitment is:
 
@@ -260,7 +284,7 @@ The key sequencing rule is:
 - then continue hardening the control plane underneath them
 - do not defer the editors until after a large control-plane rewrite
 
-## Long-Term Direction: Rust Core
+### Long-Term Direction: Rust Core
 
 The long-term goal is to move the core editing/control-plane logic into Rust.
 
@@ -287,7 +311,7 @@ The Rust core should eventually own:
 - generalized task/execution binding beyond software-repository workflows
 - workflow portability beyond software-development-specific assumptions
 
-## Relationship to UI and Editors
+### Relationship to UI and Editors
 
 The concrete first editor implementation for ADL is simple HTML-based authoring
 tools tracked in the repo.
@@ -323,7 +347,7 @@ In practical v0.85 terms, this means shipping real HTML pages for the first
 editor surfaces, then letting later Zed or other integrations consume the same
 artifact and control-plane model.
 
-## Relationship to Gödel and AEE
+### Relationship to Gödel and AEE
 
 This editing system must be compatible with later cognitive/runtime layers.
 
@@ -337,8 +361,6 @@ If the editing/control plane remains informal, later reasoning systems will have
 So the editing architecture is not separate from Gödel/AEE; it is enabling infrastructure for them.
 
 That is another reason to de-software-development-ify the architecture early. If ADL is meant to become a general-purpose task/execution system, its editing/control plane should describe authored tasks, implementation prompts, execution records, validation, and recovery in general terms rather than baking in assumptions that only make sense for source-code workflows.
-
-## Core Artifact Types
 
 ### Structured Task Prompt
 
@@ -364,7 +386,7 @@ Formal role:
 
 These artifacts should be schema-backed and versioned.
 
-## Source of Truth Model
+### Source of Truth Model
 
 The editing system must make ownership explicit so artifacts do not drift.
 
@@ -379,7 +401,7 @@ Canonical ownership should be:
 
 UI surfaces may refer to these artifacts informally as “cards” where that helps usability, but tracked/tooling terminology should remain stable.
 
-## Source of Truth and Precedence
+### Source of Truth and Precedence
 
 ADL distinguishes **intent** from **state** for issue-graph management.
 
@@ -398,9 +420,8 @@ This yields a transaction model:
 - prompt = proposed transaction
 - manifest = committed state
 
-## Proposed Validation Points
-
 ### `pr create`
+
 Validate:
 - validates that the structured task prompt is locally complete and can be rendered into a GitHub issue (schema, required sections, normalized enums, labels, title/body)
 - validates that the authoritative structured task prompt has been promoted into the tracked public record location before issue creation/reconciliation
@@ -408,6 +429,7 @@ Validate:
 - template/version mismatch where applicable
 
 ### `pr start`
+
 Validate:
 - input card structure
 - required execution metadata
@@ -424,6 +446,7 @@ Validate:
 - template/version mismatch where applicable
 
 ### `pr finish`
+
 Validate:
 - output card structure
 - changed-files summary
@@ -433,21 +456,6 @@ Validate:
 - stale worktree/card mismatch
 - template/version mismatch where applicable
 - graph/artifact mismatch before completion
-
-## Validation Scope Model
-
-Schema validation should explicitly separate machine-readable structure from high-value prose.
-
-In the near term, validation should strongly enforce:
-- machine-readable headers and metadata
-- required section presence
-- normalized enums and vocabulary where defined
-- required links and references
-- version/template compatibility where applicable
-
-Validation should avoid overconstraining high-value prose too early. The goal is to make the workflow reliable without freezing the writing model before the vocabulary and artifact shapes have fully stabilized.
-
-## Immediate New Issues Recommended
 
 ### Issue 1
 
@@ -472,7 +480,7 @@ Modify `pr.sh` so every pass runs validation:
 
 This issue should make validation a required part of the workflow, not an optional human habit.
 
-## Additional Near-Term Work
+### Additional Near-Term Work
 
 A third likely follow-on issue is artifact normalization or migration.
 
@@ -486,35 +494,43 @@ This can follow the first two issues.
 
 Schema adoption will require migration and normalization tooling. Older artifacts may remain valid under legacy versions for some period, and normalization should be incremental rather than blocking. The system should prefer explicit versioning and bounded migration paths over forcing a single disruptive conversion.
 
-## Design Principles
+### Design Principles
 
 The editing architecture should follow these principles:
 
 ### 1. File-backed first
+
 Artifacts should exist as files before they become runtime actions.
 
 ### 1a. Draft locally, promote before authority
+
 Drafting in `.adl/` is acceptable and expected. Official lifecycle transitions should promote authoritative artifacts into tracked public records before they become canonical state.
 
 ### 2. Validation before transition
+
 No major workflow transition should happen without validation.
 
 ### 3. Deterministic artifact lifecycle
+
 The same input artifacts should drive the same workflow transitions.
 
 ### 4. Stable repo-local proof surfaces
+
 Validation must rely on repo-local commands, tests, fixtures, or artifacts wherever possible.
 
 ### 5. Narrow interfaces
+
 Editors, validators, command execution, and GitHub integration should not bleed into one another unnecessarily.
 
 ### 6. Incremental migration
+
 Do not attempt to solve the entire editing system in one milestone leap.
 
 ### 7. Domain portability
+
 The control plane should be framed in general task/execution terms and should avoid unnecessary coupling to software-development-specific assumptions, even when the first implementations are repo- and PR-oriented.
 
-## Near-Term Implementation Slice
+### Near-Term Implementation Slice
 
 A strong first landing zone for this architecture is:
 - define minimal schemas for structured task prompt, structured implementation prompt, and structured output record headers
@@ -523,8 +539,6 @@ A strong first landing zone for this architecture is:
 - prepare `pr create` to use the same validation path once that command is promoted into the active workflow
 
 This slice is intentionally narrow. It is enough to reduce real workflow failures without requiring the full long-term editing system to exist immediately.
-
-## Proposed Build Plan
 
 ### Phase 1 - v0.85 foundation
 
@@ -568,7 +582,7 @@ Build on top:
 
 These editors should treat `.adl/` as working state and tracked task-bundle directories as the publication/canonical layer.
 
-## What Success Looks Like
+### What Success Looks Like
 
 A successful ADL editing system should allow a user to:
 - author an issue prompt in a structured editor
@@ -592,7 +606,7 @@ And it should do this using artifacts that are:
 - reviewable
 - compatible with later cognitive/runtime systems
 
-## Conclusion
+### Conclusion
 
 The current `pr.sh` workflow is not a dead end; it is the seed of the editing system.
 
@@ -606,3 +620,51 @@ The correct path is:
 - put simple editors and GPT tooling on top of that core
 
 This will give ADL a reasonable editing system that supports current milestone work while laying the foundation for a much more reliable authoring, review, and execution architecture that can grow beyond software development.
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: This document follows the canonical command-status model in the editing
+five-command execution plan.
+
+| Command | Current state | Repo truth | Notes |
+| --- | --- | --- | --- |
+| `pr init` | missing | no live command in `adl/tools/pr.sh` | planned work, not current behavior |
+| `pr create` | partial / renamed | `pr new` exists, but it is only a rough precursor | do not describe `pr new` as a finished substitute |
+| `pr start` | implemented | active backbone command today | real and mature enough to anchor the current control plane |
+| `pr run` | missing | no live command in `adl/tools/pr.sh` | execution still happens through narrower paths |
+| `pr finish` | implemented | active mature workflow command today | real, but still subject to reliability/polish work |
+
+## Related Documents
+
+- docs/records/<scope>/tasks/<task-id>/stp.md
+- docs/records/<scope>/tasks/<task-id>/sip.md
+- docs/records/<scope>/tasks/<task-id>/sor.md
+
+## Future Work
+
+Schema validation should explicitly separate machine-readable structure from high-value prose.
+
+In the near term, validation should strongly enforce:
+- machine-readable headers and metadata
+- required section presence
+- normalized enums and vocabulary where defined
+- required links and references
+- version/template compatibility where applicable
+
+Validation should avoid overconstraining high-value prose too early. The goal is to make the workflow reliable without freezing the writing model before the vocabulary and artifact shapes have fully stabilized.
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/HTA_EDITOR_PLANNING.md
+++ b/docs/milestones/v0.85/HTA_EDITOR_PLANNING.md
@@ -1,5 +1,3 @@
-
-
 # HTA Editor Planning (v0.85 / v0.86 Bridge)
 
 ## Purpose
@@ -16,7 +14,6 @@ Define the **Human Task Artifact (HTA) editor model** for ADL, including:
 This document consolidates currently distributed planning into a single **canonical HTA editor architecture**.
 
 For v0.85, the HTA editor must be a **working card-based task-bundle editor**. Visual polish is explicitly secondary to correctness, artifact visibility, and control-plane integration. The editor must operate on all three artifacts together. For v0.85, it may only invoke ADL control-plane commands that actually exist in the repo or documented validated adapter surfaces; full direct browser support for `pr init`, `pr create`, `pr start`, `pr run`, and `pr finish` remains target-state architecture rather than current repo truth.
-
 ## Command Status For v0.85
 
 This document follows the canonical command-status model in the editing
@@ -30,60 +27,44 @@ five-command execution plan.
 | `pr run` | not yet implemented as a real command | editor may not claim direct support yet |
 | `pr finish` | implemented and active | editor may describe finish as part of the workflow model, but should not claim current browser-launched support unless a validated adapter exists |
 
----
+## Overview
 
-## Source of Truth
+- **STP (Structured Task Prompt)** → canonical design-layer artifact
+- **SIP (Structured Implementation Prompt)** → canonical implementation-layer artifact
+- **SOR (Structured Output Record)** → canonical execution record
 
-- **STP (Structured Task Prompt)** → canonical design-layer artifact  
-- **SIP (Structured Implementation Prompt)** → canonical implementation-layer artifact  
-- **SOR (Structured Output Record)** → canonical execution record  
-
-- **Task Bundle** → canonical grouping unit for all three artifacts  
-- **Public Record (`docs/records/...`)** → canonical externalized artifact surface  
+- **Task Bundle** → canonical grouping unit for all three artifacts
+- **Public Record (`docs/records/...`)** → canonical externalized artifact surface
 
 Editors must operate on these artifacts **directly**, not on derived or duplicated representations.
 
 ---
 
-## Design Goals
+## Key Capabilities
 
-1. **Direct Artifact Editing**
-   - Editors operate directly on STP / SIP / SOR files
-   - No hidden transformations or shadow state
+- Structured Task Prompt (STP) editing
+- Structured Implementation Prompt (SIP) editing
+- Structured Output Record (SOR) review
+- Task-bundle navigation and manipulation
+- Alignment with task-bundle public artifact model
+- Card-based editing that keeps STP / SIP / SOR visible together as one working bundle
+- **STP (Structured Task Prompt)** → canonical design-layer artifact
+- **SIP (Structured Implementation Prompt)** → canonical implementation-layer artifact
 
-2. **Deterministic Structure**
-   - Enforced schema + section presence
-   - Enumerated metadata fields where possible
-   - No free-form structural drift
+## How It Works
 
-3. **Task-Bundle Native**
-   - Primary unit of navigation = task bundle
-   - Editors understand:
-     - `stp.md`
-     - `sip.md`
-     - `sor.md`
-     - bundle metadata
+### Source of Truth
 
-4. **Proof-Surface Alignment**
-   - Editors must surface:
-     - validation results
-     - provenance links
-     - execution artifacts
-   - Editing and verification are tightly coupled
+- **STP (Structured Task Prompt)** → canonical design-layer artifact
+- **SIP (Structured Implementation Prompt)** → canonical implementation-layer artifact
+- **SOR (Structured Output Record)** → canonical execution record
 
-5. **Public Artifact Compatibility**
-   - Everything editable locally must map cleanly to:
-     - `docs/records/...`
-   - No internal-only formats
+- **Task Bundle** → canonical grouping unit for all three artifacts
+- **Public Record (`docs/records/...`)** → canonical externalized artifact surface
 
-6. **Card-Based End-to-End Control Surface**
-   - The HTA editor presents STP / SIP / SOR as linked cards in one task-bundle workspace
-   - The editor is not just a viewer; it is a control surface for the full ADL execution loop
-   - The editor must be able to trigger validated control-plane actions rather than forcing the user back into ad hoc shell workflows for every step
+Editors must operate on these artifacts **directly**, not on derived or duplicated representations.
 
 ---
-
-## Editor Surfaces
 
 ### 1. STP Editor (Design Surface)
 
@@ -171,13 +152,14 @@ These three cards must stay visibly linked as one task-bundle unit rather than b
 
 ---
 
-## Integration with Zed
+### Integration with Zed
 
 Zed is the preferred near-term host environment.
 
 Planned phases:
 
 ### Phase 1 (v0.85)
+
 - File-based card editor for task bundles
 - Basic validation hooks
 - Task-bundle directory navigation
@@ -186,12 +168,14 @@ Planned phases:
   the editor, centered on `pr start`
 
 ### Phase 2 (v0.86)
+
 - Inline schema validation
 - Structured editing widgets (sections, enums)
 - Stronger command integration as additional lifecycle commands become real
 - Better task-bundle navigation and state display
 
 ### Phase 3 (v0.9+)
+
 - Full HTA-native UI:
   - bundle graph view
   - execution state visualization
@@ -199,7 +183,7 @@ Planned phases:
 
 ---
 
-## Interaction with Control Plane
+### Interaction with Control Plane
 
 The intended lifecycle model remains:
 
@@ -223,7 +207,7 @@ Editors must:
 
 ---
 
-## Demo Plan (v0.85)
+## Example / Demo
 
 At least one concrete demo must exist:
 
@@ -280,18 +264,9 @@ Artifacts:
 
 ---
 
-## Open Questions
+### Summary
 
-- How far to push enum normalization vs flexibility?
-- How to represent bundle graph visually?
-- When to introduce signing / verification in editor UI?
-- How to expose public artifact browsing?
-
----
-
-## Summary
-
-The HTA editor is not “a UI feature.”  
+The HTA editor is not “a UI feature.”
 It is the **primary interface to the ADL control plane**.
 
 For v0.85, this means a working, card-based HTA editor that keeps STP / SIP / SOR linked together and can actually drive the control plane. A visually rough but operational editor is preferable to a polished mockup that cannot execute the ADL loop.
@@ -307,3 +282,80 @@ This is the foundation for:
 - generalized agents
 - public artifact systems
 - verifiable AI workflows
+
+## Design Goals
+
+1. **Direct Artifact Editing**
+   - Editors operate directly on STP / SIP / SOR files
+   - No hidden transformations or shadow state
+
+2. **Deterministic Structure**
+   - Enforced schema + section presence
+   - Enumerated metadata fields where possible
+   - No free-form structural drift
+
+3. **Task-Bundle Native**
+   - Primary unit of navigation = task bundle
+   - Editors understand:
+     - `stp.md`
+     - `sip.md`
+     - `sor.md`
+     - bundle metadata
+
+4. **Proof-Surface Alignment**
+   - Editors must surface:
+     - validation results
+     - provenance links
+     - execution artifacts
+   - Editing and verification are tightly coupled
+
+5. **Public Artifact Compatibility**
+   - Everything editable locally must map cleanly to:
+     - `docs/records/...`
+   - No internal-only formats
+
+6. **Card-Based End-to-End Control Surface**
+   - The HTA editor presents STP / SIP / SOR as linked cards in one task-bundle workspace
+   - The editor is not just a viewer; it is a control surface for the full ADL execution loop
+   - The editor must be able to trigger validated control-plane actions rather than forcing the user back into ad hoc shell workflows for every step
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: This document follows the canonical command-status model in the editing
+five-command execution plan.
+
+| Command | v0.85 repo truth | Editor implication |
+| --- | --- | --- |
+| `pr init` | not yet implemented as a real command | editor may not claim direct support yet |
+| `pr create` | not yet implemented as a real command; `pr new` is only a rough precursor | editor may not claim direct support yet |
+| `pr start` | implemented and active | editor may expose this through the bounded validated adapter surface |
+| `pr run` | not yet implemented as a real command | editor may not claim direct support yet |
+| `pr finish` | implemented and active | editor may describe finish as part of the workflow model, but should not claim current browser-launched support unless a validated adapter exists |
+
+---
+
+## Related Documents
+
+- stp.md
+- sip.md
+- sor.md
+- docs/tooling/editor/demo.md
+
+## Future Work
+
+- How far to push enum normalization vs flexibility?
+- How to represent bundle graph visually?
+- When to introduce signing / verification in editor UI?
+- How to expose public artifact browsing?
+
+---
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/LAYER_8_IMPLEMENTATION.md
+++ b/docs/milestones/v0.85/LAYER_8_IMPLEMENTATION.md
@@ -1,5 +1,3 @@
-
-
 # Layer 8 Provider Implementation
 
 ## Purpose
@@ -17,7 +15,7 @@ For now, the goal of this document is to record:
 
 ---
 
-## Working Definition
+## Overview
 
 The Layer 8 provider is the ADL subsystem responsible for connecting higher-level reasoning and execution surfaces to external inference providers in a bounded, inspectable way.
 
@@ -35,7 +33,18 @@ That is broader than a simple API wrapper.
 
 ---
 
-## Current Repository Status
+## Key Capabilities
+
+- what already exists in the repository
+- what appears partially implemented
+- what is still missing
+- what should likely belong to v0.85 and later milestones
+- structured prompt/inference contracts
+- provider abstraction
+- capability negotiation
+- deterministic prompt construction where applicable
+
+## How It Works
 
 ### What appears to exist now
 
@@ -63,7 +72,7 @@ This is enough to say the Layer 8 groundwork is in place.
 
 ---
 
-## What Does Not Yet Look Finished
+### What Does Not Yet Look Finished
 
 The more ambitious Layer 8 vision appears to remain incomplete.
 
@@ -84,10 +93,6 @@ So the current state is best understood as:
 That distinction matters.
 
 ---
-
-## Current Maturity Assessment
-
-A practical way to describe current maturity is:
 
 ### Implemented or mostly implemented
 
@@ -113,7 +118,7 @@ A fair summary is that the Layer 8 implementation is **foundational but not matu
 
 ---
 
-## Relationship to the Runtime Stack
+### Relationship to the Runtime Stack
 
 The current architecture appears to be evolving toward a stack like this:
 
@@ -131,29 +136,7 @@ This is exactly where Layer 8 belongs.
 
 ---
 
-## Why This Matters
-
-Without a disciplined provider layer, ADL risks having:
-
-- opaque inference behavior
-- model-specific assumptions leaking into runtime logic
-- poor replayability
-- ad hoc prompt construction
-- weak reviewability for reasoning steps
-
-With a disciplined Layer 8 provider, ADL can instead move toward:
-
-- bounded inference contracts
-- explicit provider capability assumptions
-- inspectable prompt/inference artifacts
-- replayable reasoning traces
-- verifiable inference surfaces
-
-This is strategically important because ADL’s public claims are not just about orchestration. They are about **dependable execution** and **verifiable inference**.
-
----
-
-## Relationship to Verifiable Inference
+### Relationship to Verifiable Inference
 
 Layer 8 is one of the places where the claim of **verifiable inference** must become real.
 
@@ -171,7 +154,7 @@ Those questions are central to ADL’s credibility.
 
 ---
 
-## Relationship to the Gödel Loop and ObsMem
+### Relationship to the Gödel Loop and ObsMem
 
 The Layer 8 provider should eventually interact cleanly with:
 
@@ -194,7 +177,7 @@ That is a better design than letting external model behavior leak directly into 
 
 ---
 
-## Relationship to AEE
+### Relationship to AEE
 
 The Adaptive Execution Engine should not depend on vague model improvisation.
 
@@ -208,26 +191,6 @@ If AEE evolves in v0.85+, it will likely need Layer 8 to provide:
 In that sense, Layer 8 is part of the discipline that prevents AEE from becoming “adaptive magic.”
 
 ---
-
-## What v0.8 Likely Needs
-
-For v0.8, the provider layer only needs to be good enough to support:
-
-- stable runtime execution
-- clean provider abstraction
-- bounded integration with the rest of the system
-
-That means the current infrastructure is probably sufficient for v0.8 so long as it remains stable and does not leak too much provider-specific complexity upward.
-
-v0.8 does **not** need the full Layer 8 vision.
-
----
-
-## What v0.85 Should Likely Add
-
-v0.85 is a more natural place for explicit Layer 8 maturation.
-
-Likely near-term goals include:
 
 ### 1. Provider contract definition
 
@@ -256,7 +219,7 @@ Add strong tests for provider behavior, capability flags, and contract complianc
 
 ---
 
-## Suggested v0.85 Deliverables
+### Suggested v0.85 Deliverables
 
 A concrete v0.85 Layer 8 work package could include:
 
@@ -277,7 +240,7 @@ That would move the provider layer from “useful plumbing” to a true Layer 8 
 
 ---
 
-## Design Principles
+### Design Principles
 
 If Layer 8 becomes a mature subsystem, it should follow these principles:
 
@@ -301,7 +264,7 @@ If Layer 8 becomes a mature subsystem, it should follow these principles:
 
 ---
 
-## Proposed Architecture Sketch
+### Proposed Architecture Sketch
 
 A cleaner long-term architecture would look like:
 
@@ -316,7 +279,75 @@ This keeps the reasoning boundary clear and reviewable.
 
 ---
 
-## Open Questions
+### Current Bottom Line
+
+The Layer 8 provider work is best described as:
+
+- **foundational infrastructure exists**
+- **reasoning-provider maturity is still incomplete**
+- **good enough for v0.8 plumbing**
+- **not yet sufficient for the full verifiable-inference vision**
+
+So the current status is not failure. It is partial completion.
+
+The provider abstraction appears to exist and to be wired into the runtime. What remains is the more interesting part: turning that provider layer into a disciplined reasoning boundary with explicit contracts, traces, and capability control.
+
+That is likely a v0.85 and v0.9 story rather than a v0.8 blocker.
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+Without a disciplined provider layer, ADL risks having:
+
+- opaque inference behavior
+- model-specific assumptions leaking into runtime logic
+- poor replayability
+- ad hoc prompt construction
+- weak reviewability for reasoning steps
+
+With a disciplined Layer 8 provider, ADL can instead move toward:
+
+- bounded inference contracts
+- explicit provider capability assumptions
+- inspectable prompt/inference artifacts
+- replayable reasoning traces
+- verifiable inference surfaces
+
+This is strategically important because ADL’s public claims are not just about orchestration. They are about **dependable execution** and **verifiable inference**.
+
+---
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: A practical way to describe current maturity is:
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
+
+For v0.8, the provider layer only needs to be good enough to support:
+
+- stable runtime execution
+- clean provider abstraction
+- bounded integration with the rest of the system
+
+That means the current infrastructure is probably sufficient for v0.8 so long as it remains stable and does not leak too much provider-specific complexity upward.
+
+v0.8 does **not** need the full Layer 8 vision.
+
+---
+
+v0.85 is a more natural place for explicit Layer 8 maturation.
+
+Likely near-term goals include:
 
 This area still leaves important open questions:
 
@@ -331,17 +362,7 @@ These should remain open until the provider layer becomes an explicit milestone 
 
 ---
 
-## Current Bottom Line
 
-The Layer 8 provider work is best described as:
+## Notes
 
-- **foundational infrastructure exists**
-- **reasoning-provider maturity is still incomplete**
-- **good enough for v0.8 plumbing**
-- **not yet sufficient for the full verifiable-inference vision**
-
-So the current status is not failure. It is partial completion.
-
-The provider abstraction appears to exist and to be wired into the runtime. What remains is the more interesting part: turning that provider layer into a disciplined reasoning boundary with explicit contracts, traces, and capability control.
-
-That is likely a v0.85 and v0.9 story rather than a v0.8 blocker.
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/REASONING_GRAPH_SCHEMA_V0.85.md
+++ b/docs/milestones/v0.85/REASONING_GRAPH_SCHEMA_V0.85.md
@@ -1,5 +1,3 @@
-
-
 # Reasoning Graph Schema — v0.85
 
 ## Purpose
@@ -25,9 +23,24 @@ The v0.85 milestone introduces only the **schema direction**, not a full runtime
 
 ---
 
-# Design Goals
+## Overview
 
-The reasoning graph must satisfy several constraints.
+Reasoning graphs must support deterministic replay.
+
+Given the same inputs, model outputs, and state, the reasoning trace must be reproducible.
+
+## Key Capabilities
+
+- structured reasoning traces
+- hypothesis exploration
+- belief revision
+- deterministic replay
+- adaptive reasoning policies
+- the **Adaptive Execution Engine (AEE)**
+- the **Gödel hypothesis engine**
+- **affective reasoning signals**
+
+## How It Works
 
 ### Deterministic
 
@@ -59,7 +72,7 @@ Nodes must support attachment of **affective reasoning signals**.
 
 ---
 
-# Core Graph Elements
+### Core Graph Elements
 
 The reasoning graph consists of several primary element types.
 
@@ -73,7 +86,7 @@ The reasoning graph consists of several primary element types.
 
 ---
 
-# Node Schema
+### Node Schema
 
 Nodes represent reasoning units.
 
@@ -106,7 +119,7 @@ Nodes may represent:
 
 ---
 
-# Edge Schema
+### Edge Schema
 
 Edges represent reasoning transitions.
 
@@ -130,7 +143,7 @@ Edges capture the **structure of reasoning**.
 
 ---
 
-# Hypothesis Records
+### Hypothesis Records
 
 Hypotheses represent candidate explanations or strategies.
 
@@ -156,7 +169,7 @@ Possible states:
 
 ---
 
-# Evaluation Records
+### Evaluation Records
 
 Evaluations provide evidence regarding hypotheses.
 
@@ -176,7 +189,7 @@ Evaluations allow the graph to represent **reasoning evidence**.
 
 ---
 
-# Revision Events
+### Revision Events
 
 Reasoning systems may update beliefs over time.
 
@@ -195,7 +208,7 @@ These records preserve **belief lineage**.
 
 ---
 
-# Relationship to Observational Memory (ObsMem)
+### Relationship to Observational Memory (ObsMem)
 
 Reasoning graphs may be persisted in **ObsMem**.
 
@@ -209,7 +222,7 @@ Graphs may be stored as serialized structures.
 
 ---
 
-# Relationship to Affective Reasoning
+### Relationship to Affective Reasoning
 
 Each node may include an **affect vector**.
 
@@ -226,7 +239,7 @@ These signals influence reasoning policies.
 
 ---
 
-# Relationship to the Gödel Hypothesis Engine
+### Relationship to the Gödel Hypothesis Engine
 
 The Gödel agent explores alternative reasoning strategies.
 
@@ -240,7 +253,7 @@ This structure allows the system to **reason about reasoning**.
 
 ---
 
-# Determinism Considerations
+### Determinism Considerations
 
 To preserve deterministic replay:
 
@@ -252,7 +265,43 @@ The graph must never depend on hidden state.
 
 ---
 
-# v0.85 Scope
+### Summary
+
+The reasoning graph schema defines the structure used to represent reasoning processes in ADL.
+
+It captures:
+
+- reasoning steps
+- hypotheses
+- evidence
+- belief revisions
+
+This schema provides the foundation for future adaptive reasoning capabilities.
+
+### Design Goals
+
+The reasoning graph must satisfy several constraints.
+
+## Example / Demo
+
+- Demo, script, command, or proof surface: no dedicated standalone demo is named in this doc; use this document and its related references as the current proof surface.
+- What the reader should expect: this doc currently serves as the primary explanation of the feature and its intended behavior.
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: No additional status notes recorded.
+
+## Related Documents
+
+- N/A - no explicit related docs were named in the original document.
+
+## Future Work
 
 The v0.85 milestone introduces only:
 
@@ -263,8 +312,6 @@ The v0.85 milestone introduces only:
 No runtime graph engine is required yet.
 
 ---
-
-# Future Work (v0.9+)
 
 Planned work includes:
 
@@ -277,15 +324,7 @@ These features will support a full **Gödel‑style reasoning engine**.
 
 ---
 
-# Summary
 
-The reasoning graph schema defines the structure used to represent reasoning processes in ADL.
+## Notes
 
-It captures:
-
-- reasoning steps
-- hypotheses
-- evidence
-- belief revisions
-
-This schema provides the foundation for future adaptive reasoning capabilities.
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/STRUCTURED_PROMPT_ARCHITECTURE.md
+++ b/docs/milestones/v0.85/STRUCTURED_PROMPT_ARCHITECTURE.md
@@ -1,9 +1,5 @@
 # Structured Prompt Architecture for ADL
 
-## Status
-
-Proposed for v0.85.
-
 ## Purpose
 
 ADL currently treats structured prompting primarily through workflow cards such as input cards and output cards. That has worked for the first generation of orchestration patterns, but it is too narrow for the broader multi-agent system ADL is evolving toward.
@@ -16,7 +12,7 @@ The goal is not to create a unique prompt for every possible situation. The goal
 
 ---
 
-## Problem Statement
+## Overview
 
 Today, ADL has strong momentum around card-driven workflow structure, but cards alone do not solve the full prompt-management problem.
 
@@ -55,7 +51,59 @@ If all of these are forced into a single card shape, ADL will either become brit
 
 ---
 
-## Design Goal
+## Key Capabilities
+
+- **Workflow control artifacts**
+- input cards
+- output cards
+- review artifacts
+- run manifests
+- **Role prompts**
+- writer
+- editor
+
+## How It Works
+
+### Problem Statement
+
+Today, ADL has strong momentum around card-driven workflow structure, but cards alone do not solve the full prompt-management problem.
+
+We need to support at least four distinct concerns:
+
+1. **Workflow control artifacts**
+   - input cards
+   - output cards
+   - review artifacts
+   - run manifests
+
+2. **Role prompts**
+   - writer
+   - editor
+   - reviewer
+   - verifier
+   - publisher
+   - planner
+
+3. **Micro-prompts or protocol prompts**
+   - summarize
+   - critique
+   - classify
+   - rewrite
+   - compare
+   - hand off to another agent
+   - emit YAML only
+
+4. **Runtime prompt assembly**
+   - combine reusable fragments into the exact prompt sent to the model
+   - bind task-specific inputs
+   - apply provider/model/runtime constraints
+   - support replay and evaluation
+
+If all of these are forced into a single card shape, ADL will either become brittle or accumulate large opaque prompt blobs that are difficult to reuse, test, diff, validate, and replay.
+
+---
+
+### Design Goal
 
 ADL should manage structured prompts as a separate but related artifact family alongside cards.
 
@@ -124,7 +172,7 @@ The workflow is therefore not “ignore `.adl/`,” but “use `.adl/` for draft
 
 ---
 
-## Core Architectural Principle
+### Core Architectural Principle
 
 Treat prompts as **first-class typed artifacts**.
 
@@ -142,7 +190,7 @@ Human-authored natural language remains essential, but it should live inside typ
 
 ---
 
-## Layered Prompt Model
+### Layered Prompt Model
 
 The recommended model has five layers.
 
@@ -254,7 +302,7 @@ Assembly order should be explicit, canonical, and testable.
 
 ---
 
-## Prompt Artifact Family
+### Prompt Artifact Family
 
 This document proposes six core artifact types.
 
@@ -381,7 +429,7 @@ When external systems exist, they should appear as metadata or projections of th
 
 ---
 
-## Relationship to Cards
+### Relationship to Cards
 
 Cards remain important.
 
@@ -453,7 +501,7 @@ The exact scope segment may vary in later milestones or non-milestone workflows,
 
 ---
 
-## How to Avoid Combinatorial Explosion
+### How to Avoid Combinatorial Explosion
 
 The wrong strategy is to create one prompt file for every possible situation.
 
@@ -479,8 +527,6 @@ Reusable fragments reduce duplication further:
 This makes prompt design more like software architecture and less like ad hoc prompt tinkering.
 
 ---
-
-## What Should Be Structured vs. Freeform
 
 ### Strongly structured
 
@@ -512,7 +558,7 @@ The key rule is that freeform text should live within a typed frame.
 
 ---
 
-## Determinism, Replay, and Evaluation
+### Determinism, Replay, and Evaluation
 
 Because ADL values determinism and replay, prompt management must support exact reconstruction of what happened.
 
@@ -569,7 +615,7 @@ That classification will be important once prompt evolution becomes a routine pa
 
 ---
 
-## Prompt Lifecycle in ADL
+### Prompt Lifecycle in ADL
 
 A practical lifecycle for structured prompts should look like this:
 
@@ -590,7 +636,7 @@ Where GitHub is used, issue creation or reconciliation should be understood as a
 
 ---
 
-## Key Separation of Concerns
+### Key Separation of Concerns
 
 ADL should distinguish four things that are often mixed together in current prompt practice.
 
@@ -630,7 +676,7 @@ Keeping these concerns separate makes prompt behavior easier to reuse, test, and
 
 ---
 
-## Recommended v0.85 Deliverable: Prompt Surfaces v1
+### Recommended v0.85 Deliverable: Prompt Surfaces v1
 
 This document recommends a v0.85 effort called **Prompt Surfaces v1**.
 
@@ -661,7 +707,7 @@ Later follow-on deliverable:
 
 ---
 
-## Suggested Repository Layout
+### Suggested Repository Layout
 
 One reasonable directory shape is:
 
@@ -707,23 +753,7 @@ A reasonable split is:
 
 ---
 
-## Example Conceptual Flow
-
-A workflow step might proceed as follows:
-
-1. workflow selects step type `authoring.write_section`
-2. runtime resolves `PromptSpec` = `writer.first_draft.v1`
-3. runtime applies `PromptProfile` = `strict_enterprise`
-4. runtime binds inputs from outline, notes, style guide, and source documents
-5. assembly renders a canonical prompt in deterministic order
-6. model produces output under a declared output contract
-7. run stores `RenderedPrompt` and `PromptEval` artifacts for replay and analysis
-
-This is the core path from card-driven orchestration toward robust multi-agent prompt infrastructure.
-
----
-
-## Practical Minimal Starting Set
+### Practical Minimal Starting Set
 
 To avoid overdesign, ADL should begin with:
 
@@ -748,7 +778,7 @@ This is enough to create a real structured prompt subsystem without committing p
 
 ---
 
-## Bottom Line
+### Bottom Line
 
 The next stage of ADL should not be “more card types” alone.
 
@@ -768,7 +798,43 @@ Together, they provide the foundation for richer multi-agent orchestration in AD
 
 ---
 
-## Proposed Next Steps
+## Example / Demo
+
+A workflow step might proceed as follows:
+
+1. workflow selects step type `authoring.write_section`
+2. runtime resolves `PromptSpec` = `writer.first_draft.v1`
+3. runtime applies `PromptProfile` = `strict_enterprise`
+4. runtime binds inputs from outline, notes, style guide, and source documents
+5. assembly renders a canonical prompt in deterministic order
+6. model produces output under a declared output contract
+7. run stores `RenderedPrompt` and `PromptEval` artifacts for replay and analysis
+
+This is the core path from card-driven orchestration toward robust multi-agent prompt infrastructure.
+
+---
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: Proposed for v0.85.
+
+## Related Documents
+
+- stp.stub.md
+- stp.md
+- sip.md
+- sor.md
+- docs/records/v0.85/tasks/<task-id>/stp.md
+- docs/records/v0.85/tasks/<task-id>/sip.md
+- docs/records/v0.85/tasks/<task-id>/sor.md
+
+## Future Work
 
 1. define `PromptSpec v1`
 2. define `PromptFragment v1`
@@ -782,3 +848,8 @@ Together, they provide the foundation for richer multi-agent orchestration in AD
 10. map the new prompt artifacts onto existing ADL workflow and review surfaces
 
 These steps would turn prompt design in ADL from an implicit craft into an explicit architectural subsystem.
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/SWARM_REMOVAL_PLANNING.md
+++ b/docs/milestones/v0.85/SWARM_REMOVAL_PLANNING.md
@@ -1,24 +1,39 @@
 # Swarm Removal Planning (v0.85)
 
-## Metadata
+## Purpose
+
+N/A - original document did not expose a separate purpose block; see Overview and How It Works.
+
+## Overview
+
 - Milestone: `v0.85`
 - Topic: Final removal of legacy `swarm` identity and directory path
 - Date: `2026-03-13`
 - Status: `Planning`
 - Owner: `Daniel Austin / Agent Logic`
 
-## Why This Matters
+## Key Capabilities
 
-ADL has already renamed the package and primary binaries, but the repository still presents a split identity:
-- canonical runtime/package identity is largely `adl`
-- top-level runtime directory is still `adl/`
-- CI, tooling, docs, examples, tests, and compatibility shims still expose legacy `swarm` naming
+- Milestone: `v0.85`
+- Topic: Final removal of legacy `swarm` identity and directory path
+- Date: `2026-03-13`
+- Status: `Planning`
+- Owner: `Daniel Austin / Agent Logic`
+- Do this in `v0.85` as a dedicated cleanup/cutover workstream.
+- Treat it as an active-surface identity cutover, not a full historical-document rewrite.
+- Remove legacy runtime/tooling compatibility shims as part of the cutover.
 
-That split identity is survivable for current contributors but weakens external credibility. For investors, reviewers, and enterprise evaluators, it reads as an unfinished migration and raises questions about repository discipline, release hygiene, and operational polish.
+## How It Works
 
-This work is not optional if ADL wants a clean, investable presentation.
+### Metadata
 
-## Executive Summary
+- Milestone: `v0.85`
+- Topic: Final removal of legacy `swarm` identity and directory path
+- Date: `2026-03-13`
+- Status: `Planning`
+- Owner: `Daniel Austin / Agent Logic`
+
+### Executive Summary
 
 Recommendation:
 - Do this in `v0.85` as a dedicated cleanup/cutover workstream.
@@ -37,7 +52,7 @@ Recommended timing:
 - after `v0.8` release stabilization
 - before more `v0.85` work lands on top of the old path conventions
 
-## Current State Snapshot (2026-03-13)
+### Current State Snapshot (2026-03-13)
 
 Repository scan results from current `main`:
 - `129` files still contain `swarm` textual references
@@ -63,7 +78,7 @@ Interpretation:
 - the real risk is operational coupling: scripts, CI, tests, path-sensitive commands, and contributor workflow
 - historical milestone docs materially inflate raw grep counts
 
-## What Has Already Been Done
+### What Has Already Been Done
 
 The repo is not at the start of this migration.
 
@@ -83,41 +98,7 @@ Still incomplete:
 - docs and examples still point to `adl/...` paths extensively
 - guardrails still explicitly allow legacy references for compatibility
 
-## Recommended Scope
-
-### In Scope
-
-- Rename top-level runtime directory from `adl/` to `adl/`
-- Update all active path references:
-  - GitHub Actions
-  - shell tooling
-  - README / CONTRIBUTING / onboarding
-  - current demo docs
-  - examples and example docs
-  - tests and fixtures
-  - schema and artifact references
-- Remove compatibility-only runtime shims:
-  - `src/bin/swarm.rs`
-  - `src/bin/swarm_remote.rs`
-- Remove compatibility-only env-var fallback where safe:
-  - `SWARM_OLLAMA_BIN`
-  - `SWARM_TIMEOUT_SECS`
-  - `SWARM_ALLOW_UNSIGNED`
-  - remote signing/bearer-token fallbacks still kept only if explicitly justified
-- Replace the legacy-name guardrail with an active-surface zero-tolerance guardrail
-- Add a migration note that clearly states:
-  - old path -> new path
-  - old command -> new command
-  - old env var -> new env var
-
-### Out Of Scope
-
-- broad editorial rewrite of all historical milestone docs purely for naming consistency
-- rewriting old release artifacts that are intentionally historical
-- large architecture redesign bundled together with the rename
-- any attempt to preserve indefinite dual-path support
-
-## Decision Lock
+### Decision Lock
 
 The following decisions are recommended for acceptance:
 
@@ -126,9 +107,8 @@ The following decisions are recommended for acceptance:
 - **Historical docs policy:** preserve historical milestone docs unless they are directly surfaced to external reviewers and are misleading
 - **Execution model:** one focused cutover branch/PR series, not an opportunistic drip of unrelated edits
 
-## Effort Estimate
-
 ### Recommended Option A
+
 Active surfaces only:
 - runtime directory rename
 - code/tooling/CI/tests/docs/examples cleanup
@@ -142,6 +122,7 @@ Expected calendar:
 - one engineer: `4-6 working days` including validation and review handling
 
 ### Option B
+
 Option A plus rewrite of historical milestone docs and older demo documentation:
 
 Estimated LOE:
@@ -150,7 +131,7 @@ Estimated LOE:
 Expected calendar:
 - one engineer: `1.5 to 2 weeks`
 
-## Why Option A Is Recommended
+### Why Option A Is Recommended
 
 Option A delivers the investment-facing benefit:
 - externally visible identity becomes coherent
@@ -158,8 +139,6 @@ Option A delivers the investment-facing benefit:
 - contributor workflow becomes consistent
 
 Option B creates a lot of editorial churn with limited business return. It should only be done if historical docs are being actively shown to external reviewers or if the repo is being positioned as a polished archival knowledge base.
-
-## Highest-Risk Areas
 
 ### 1. Contributor Tooling
 
@@ -191,15 +170,7 @@ Risk:
 - expected failures after compatibility removal
 - confusion over which tests should be deleted versus renamed
 
-### 4. Active Docs And Demo Commands
-
-README, onboarding, contributor docs, and demo docs still expose many `adl/...` commands.
-
-Risk:
-- external reviewers hitting dead commands
-- polished codebase undermined by obviously stale documentation
-
-## Evidence-Backed Hotspots
+### Evidence-Backed Hotspots
 
 Files most likely to dominate the cutover:
 - `adl/tools/pr.sh`
@@ -214,8 +185,6 @@ Files most likely to dominate the cutover:
 - `adl/tests/cli_smoke.rs`
 
 These should be treated as explicit review checkpoints, not incidental cleanup.
-
-## Proposed Execution Plan
 
 ### Phase 0: Decision And Freeze (0.5 day)
 
@@ -255,15 +224,6 @@ Deliverable:
 Deliverable:
 - no active runtime path still depends on `swarm` compatibility
 
-### Phase 4: Docs And Demo Surface Cleanup (0.5-1 day)
-
-- update active root docs and onboarding docs
-- update current demo/review entry points
-- update active example docs and commands
-
-Deliverable:
-- external reviewer can follow current commands without translation
-
 ### Phase 5: Guardrails And Validation (0.5-1 day)
 
 - tighten grep guardrail
@@ -277,7 +237,7 @@ Deliverable:
 Deliverable:
 - cutover is locked in and hard to regress
 
-## Validation Checklist
+### Validation Checklist
 
 - [ ] `adl/` exists and `adl/` no longer exists as an active top-level runtime directory
 - [ ] active scripts no longer require `adl/tools/...`
@@ -289,7 +249,7 @@ Deliverable:
 - [ ] guardrail fails on new active-surface `swarm` references
 - [ ] historical references, if any, are intentionally preserved and documented
 
-## Risk Register
+### Risk Register
 
 | Risk | Impact | Likelihood | Mitigation |
 |---|---|---|---|
@@ -300,7 +260,7 @@ Deliverable:
 | Historical docs create review noise | Medium | High | Freeze historical docs unless externally surfaced |
 | Rename PR becomes too broad and hard to review | High | Medium | Keep scope disciplined; avoid bundling unrelated cleanup |
 
-## Commercial Framing
+### Commercial Framing
 
 This work is operationally painful but strategically correct.
 
@@ -318,7 +278,7 @@ Conclusion:
 - the commercial upside justifies the cleanup
 - the right way to do it is a focused, active-surface cutover rather than another compatibility extension
 
-## Recommendation
+### Recommendation
 
 Proceed with `Option A` in `v0.85` as a dedicated cutover.
 
@@ -334,3 +294,76 @@ The right target state is simple:
 - `adl/` is the runtime directory
 - `adl` is the only active runtime identity
 - `swarm` survives only in clearly historical documentation, if at all
+
+## Example / Demo
+
+README, onboarding, contributor docs, and demo docs still expose many `adl/...` commands.
+
+Risk:
+- external reviewers hitting dead commands
+- polished codebase undermined by obviously stale documentation
+
+- update active root docs and onboarding docs
+- update current demo/review entry points
+- update active example docs and commands
+
+Deliverable:
+- external reviewer can follow current commands without translation
+
+## Why It Matters
+
+ADL has already renamed the package and primary binaries, but the repository still presents a split identity:
+- canonical runtime/package identity is largely `adl`
+- top-level runtime directory is still `adl/`
+- CI, tooling, docs, examples, tests, and compatibility shims still expose legacy `swarm` naming
+
+That split identity is survivable for current contributors but weakens external credibility. For investors, reviewers, and enterprise evaluators, it reads as an unfinished migration and raises questions about repository discipline, release hygiene, and operational polish.
+
+This work is not optional if ADL wants a clean, investable presentation.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: No additional status notes recorded.
+
+## Related Documents
+
+- README.md
+- CONTRIBUTING.md
+- docs/onboarding.md
+
+## Future Work
+
+- Rename top-level runtime directory from `adl/` to `adl/`
+- Update all active path references:
+  - GitHub Actions
+  - shell tooling
+  - README / CONTRIBUTING / onboarding
+  - current demo docs
+  - examples and example docs
+  - tests and fixtures
+  - schema and artifact references
+- Remove compatibility-only runtime shims:
+  - `src/bin/swarm.rs`
+  - `src/bin/swarm_remote.rs`
+- Remove compatibility-only env-var fallback where safe:
+  - `SWARM_OLLAMA_BIN`
+  - `SWARM_TIMEOUT_SECS`
+  - `SWARM_ALLOW_UNSIGNED`
+  - remote signing/bearer-token fallbacks still kept only if explicitly justified
+- Replace the legacy-name guardrail with an active-surface zero-tolerance guardrail
+- Add a migration note that clearly states:
+  - old path -> new path
+  - old command -> new command
+  - old env var -> new env var
+
+- broad editorial rewrite of all historical milestone docs purely for naming consistency
+- rewriting old release artifacts that are intentionally historical
+- large architecture redesign bundled together with the rename
+- any attempt to preserve indefinite dual-path support
+
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.

--- a/docs/milestones/v0.85/WBS_v0.85.md
+++ b/docs/milestones/v0.85/WBS_v0.85.md
@@ -1,12 +1,37 @@
 # ADL Work Breakdown Structure — v0.85
 
-## Metadata
+## Purpose
+
+N/A - original document did not expose a separate purpose block; see Overview and How It Works.
+
+## Overview
+
 - Milestone: `v0.85`
 - Version: `0.85`
 - Date: `2026-03-19`
 - Owner: `Daniel Austin / Agent Logic`
 
-## Role Of This Document
+## Key Capabilities
+
+- Milestone: `v0.85`
+- Version: `0.85`
+- Date: `2026-03-19`
+- Owner: `Daniel Austin / Agent Logic`
+- what work remains
+- what artifact or proof surface each work unit must produce
+- which issue owns that work
+- what order the remaining work should happen in
+
+## How It Works
+
+### Metadata
+
+- Milestone: `v0.85`
+- Version: `0.85`
+- Date: `2026-03-19`
+- Owner: `Daniel Austin / Agent Logic`
+
+### Role Of This Document
 
 This WBS is the canonical execution plan for the remainder of v0.85.
 
@@ -18,7 +43,7 @@ Use it to answer:
 
 Do not treat the mid-flight review document as the execution plan. `MIDFLIGHT_REVIEW_ISSUES.md` in `.adl/docs/v0.85planning/` is now a diagnostic and closure tracker. Execution should flow through this WBS.
 
-## Current Milestone State
+### Current Milestone State
 
 What is already landed:
 - `WP-02` deterministic queue, checkpoint, and steering substrate
@@ -38,7 +63,7 @@ Important rule:
 - every work package or alignment sub-task must end in a concrete artifact, code path, validated doc, tool, demo, or review record
 - no work unit should be satisfiable by description alone unless it is explicitly a bounded alignment deliverable in Section 1
 
-## Working Rules
+### Working Rules
 
 - Canonical tracker mapping follows [MILESTONE_ISSUE_RECONCILIATION_v0.85.md](MILESTONE_ISSUE_RECONCILIATION_v0.85.md).
 - Public record architecture follows [STRUCTURED_PROMPT_ARCHITECTURE.md](STRUCTURED_PROMPT_ARCHITECTURE.md).
@@ -52,7 +77,7 @@ Important rule:
   - issue-graph cleanup
   - validation or proof-surface rules
 
-## Remaining Execution Order
+### Remaining Execution Order
 
 1. Close the blocking alignment tranche in Section 1, especially cognitive authority and the WBS/scope rewrite.
 2. Continue core execution from `WP-09` through `WP-17`.
@@ -66,7 +91,7 @@ This order is intentional:
 
 ---
 
-## Section 1 — Blocking Alignment Tranche
+### Section 1 — Blocking Alignment Tranche
 
 These items remain execution-blocking because they affect whether the rest of the milestone stays conceptually coherent and reviewable.
 
@@ -91,7 +116,7 @@ Notes:
 
 ---
 
-## Section 2 — Core Execution
+### Section 2 — Core Execution
 
 These are the primary feature/runtime/tooling work packages. Closed items are retained here so the WBS shows real milestone progress rather than a hypothetical plan.
 
@@ -150,7 +175,7 @@ These items close the milestone with explicit review, release, and handoff evide
 
 ---
 
-## Current Sprint Interpretation
+### Current Sprint Interpretation
 
 The old four-sprint model is still useful as a phasing shorthand, but current execution should be understood like this:
 
@@ -161,7 +186,7 @@ The old four-sprint model is still useful as a phasing shorthand, but current ex
 
 If this WBS and the issue graph disagree, treat the disagreement as a defect to fix immediately.
 
-## Acceptance Criteria For This WBS
+### Acceptance Criteria For This WBS
 
 This WBS is in a good state when:
 - it is the clearest single place to understand remaining v0.85 work
@@ -169,3 +194,39 @@ This WBS is in a good state when:
 - the issue graph matches the WBS
 - the sprint plan does not materially contradict the WBS
 - the diagnostic mid-flight review doc is no longer required to understand what to execute next
+
+## Example / Demo
+
+These items prove the milestone as a coherent system rather than as isolated features.
+
+| WP | Status | Canonical issue | Concrete deliverable | Validation / proof surface | Dependencies |
+|---|---|---|---|---|---|
+| WP-18 Demo program for v0.85 features | LANDED | `#878` with bounded-demo rule from `#743` | demo matrix/playbook and runnable milestone demos | runnable demos proving steering/queueing, authoring/review flow, five-command editing lifecycle, and affect-plus-Godel behavior | WP-02 through WP-17 |
+
+Integration rule:
+- demos are evidence, not optional packaging
+- each major milestone claim should have a bounded runnable or replayable proof surface where practical
+
+---
+
+## Why It Matters
+
+This feature matters because it contributes to ADL's bounded, reviewable, and explicit system design. See Purpose and How It Works for the preserved rationale from the original document.
+
+## Current Status
+
+- Milestone: v0.85
+- Status: Draft
+- Notes: No additional status notes recorded.
+
+## Related Documents
+
+- MIDFLIGHT_REVIEW_ISSUES.md
+
+## Future Work
+
+- No dedicated future-work section was present in the original document; any follow-on work remains embedded in the preserved discussion above.
+
+## Notes
+
+- This document was reformatted to the shared feature-doc structure as part of #1009 without intentionally removing original content.


### PR DESCRIPTION
## Summary
- refine the shared feature-doc template and pilot sample
- normalize the in-scope feature docs to the shared reader-facing structure
- redistribute future-band planning docs to the roadmap-aligned milestone bands

## Validation
- bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/cards/1009/output_1009.md
- python3 structural heading check over the normalized doc set
- manual spot-check of representative normalized docs