### PR TITLE
[v0.85][docs] Reconcile and repair project README surfaces (Closes #982)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,47 @@
 # Agent Design Language (ADL)
 
-Agent Design Language (ADL) is a deterministic, contract-driven orchestration language for AI systems. It lets you define agents, tasks, providers, delegation metadata, and workflows as structured data — not brittle glue code. ADL elevates orchestration from “prompt wiring” to a reviewable, testable, and reproducible engineering discipline.
+Agent Design Language (ADL) is a deterministic, contract-driven orchestration language for AI systems. It is designed for teams that want AI workflows to be reviewable, testable, reproducible, and auditable, with clear execution semantics and transparent runtime behavior.
 
-ADL is built for teams that care about determinism and auditability. Documents are schema-validated, compiled into a deterministic ExecutionPlan, and executed under explicit concurrency, failure, retry, and signing semantics. Every run emits stable artifacts under `.adl/runs/<run_id>/` to support replay, debugging, and post-mortem analysis.
+ADL lets you define the core pieces of an AI system as structured artifacts:
+- providers
+- tools
+- agents
+- tasks
+- workflows
+- runs
+
+Those artifacts are schema-validated, compiled into a deterministic execution plan, and executed with explicit semantics for concurrency, failure handling, retries, signing, and artifact emission. Every run leaves behind stable review surfaces under `.adl/` so execution can be inspected, replayed, and reviewed with confidence.
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.8-orange)
+![Milestone](https://img.shields.io/badge/milestone-v0.85-orange)
 
+## Why ADL
 
-## Try It Now (Happy Path)
+ADL focuses on making agent systems reliable, inspectable, and suitable for real engineering workflows.
+
+ADL is built for readers and builders who care about:
+- deterministic orchestration with clear runtime behavior
+- explicit workflow contracts and structured execution surfaces
+- stable proof surfaces that support review and debugging
+- bounded, inspectable agent behavior
+- local and enterprise-ready control over execution behavior
+
+If you want AI systems that can survive code review, operations review, and postmortem analysis, ADL is aimed at you.
+
+## What ADL Provides
+
+ADL currently provides:
+- a Rust runtime and CLI for deterministic workflow execution
+- structured workflow, task, and provider definitions
+- deterministic planning and execution semantics
+- bounded concurrency, retries, and failure policies
+- signing and verification surfaces for safer execution
+- remote-execution wiring without giving up local scheduler control
+- bounded scientific / Gödel-style execution loops with reviewable artifacts
+- demo and proof surfaces that are meant to be runnable, inspectable, and falsifiable
+
+## Quick Start
 
 From repo root:
 
@@ -17,193 +49,94 @@ From repo root:
 cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-3-fork-join-seq-run.adl.yaml --print-plan
 ```
 
-This prints a deterministic v0.3 fork/join plan with clean output and no provider runtime setup.
+This prints a deterministic fork/join execution plan with no provider runtime setup.
 
-If you want a second quick check:
+A second quick check:
 
 ```bash
 cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-3-on-error-retry.adl.yaml --print-plan
 ```
 
-## Demos (Story-Driven, User-Facing)
+## Current Status
 
-ADL includes both low-level matrix demos and story-driven demo packs for first-time users.
-
-Canonical demo entrypoint:
-- `demos/README.md`
-
-Story packs (released in v0.7):
-- `S-01` Determinism You Can Trust
-- `S-02` From Failure to Clarity
-- `S-03` Portable Learning (Exportable Intelligence)
-- `S-04` Enterprise Trust Boundary (Signed Remote Requests)
-- `S-05` ADL is the Product Name (Compatibility Window)
-
-Canonical demo commands and artifact paths:
-- [v0.7 Demo Matrix (Story-driven section)](docs/milestones/v0.7/DEMOS_v0.7.md#story-driven-demo-packs-user-facing)
-- [v0.8 Demo Matrix (active milestone)](docs/milestones/v0.8/DEMOS_V0.8.md)
-
-Badge semantics:
-- `adl-ci`: main branch CI workflow status
-- `coverage`: Codecov line-coverage signal for `main` (informational; CI still passes if Codecov upload is unavailable)
-- `milestone`: current documentation milestone marker
-
-## Status
-
-- Latest released milestone: **v0.7.0** (tag: `v0.7.0`)
-- Active development milestone: **v0.8**
+- Recent stable milestone: **v0.8**
+- Current closure milestone: **v0.85**
+- Next active milestone: **v0.86**
 - Project changelog: `CHANGELOG.md`
 
-v0.8 status note:
-- The v0.8 milestone currently contains bounded implemented runtime, CLI, schema-artifact, and demo surfaces alongside design/spec/planning docs.
-- Not all v0.8 planning artifacts are runtime-implemented yet; see `docs/milestones/v0.8/RECOVERY_AUDIT_V0.8.md`.
+ADL is in active development. The repository contains both implemented runtime surfaces and milestone/spec/planning documents. The milestone docs should be read as bounded engineering records: they distinguish what has shipped, what is demoable, and what is still planned.
 
-## v0.8 Bounded Godel Runtime
+## Recent Milestones
 
-v0.8 adds a bounded Godel scientific loop to the runtime and demo surfaces. In the current implementation, the loop follows seven explicit stages:
+### v0.85 - Authoring Truth and Demo Proof Surfaces
 
-1. `failure`
-2. `hypothesis`
-3. `mutation`
-4. `experiment`
-5. `evaluation`
-6. `record`
-7. `indexing`
+v0.85 focused on bringing the authoring model, demos, and runtime behavior into a coherent and reliable whole.
 
-This is a deterministic, artifact-driven loop rather than an open-ended self-modifying agent. The runtime persists canonical `mutation`, `evaluation_plan`, `experiment_record`, and `canonical_evidence_view` artifacts so the loop can be inspected, replayed, and reviewed without hidden state.
+Key features:
+- clarified five-command authoring lifecycle (`pr init`, `pr create`, `pr start`, `pr run`, `pr finish`)
+- bounded editor-command adapter aligned to the control plane
+- end-to-end demo and regression proof surfaces for authoring workflows
+- worktree hygiene and queue-mechanics cleanup
+- Rust maintainability improvements (module refactors, test restructuring, guardrails)
 
-What is implemented now:
-- bounded runtime support for the Godel stage loop in the v0.8 demos
-- bounded `adl godel run`, `adl godel inspect`, and `adl godel evaluate` CLI review surfaces
-- canonical artifact emission and validation for the loop's core review surfaces
-- ObsMem integration for indexing and retrieval-backed review flows
-- reviewer-facing runbooks under `demos/` for the bounded Gödel CLI flow and bounded AEE recovery flow
+### v0.8 - Bounded Godel Runtime and Artifact-Centered Review
 
-What is intentionally not claimed in v0.8:
-- autonomous policy learning
-- unconstrained self-modification
-- a fully finished Adaptive Execution Engine
+v0.8 extended ADL into bounded reflective execution with structured artifacts and strong inspection surfaces.
 
-For the deeper milestone docs, start with:
-- `docs/milestones/v0.8/GODEL_SCIENTIFIC_METHOD.md`
-- `docs/milestones/v0.8/GODEL_LOOP_INTEGRATION_V0.8.md`
+Key features:
+- bounded Godel-style scientific loop integrated into runtime
+- canonical artifact emission for mutation, evaluation, and experiment records
+- CLI surfaces for running and inspecting reasoning workflows
+- ObsMem-backed indexing and retrieval-assisted review flows
+- runnable demo and evaluation surfaces for hypothesis-driven execution
+
+### v0.7 - Deterministic Runtime Foundation
+
+v0.7 established the deterministic execution model that underpins the ADL runtime.
+
+Key features:
+- ExecutionPlan-driven runtime
+- deterministic fork/join and concurrency semantics
+- bounded parallelism and explicit retry/failure policies
+- replay-oriented traces and graph export tooling
+- signing and verification surfaces for execution integrity
+
+## Demos and Proof Surfaces
+
+ADL includes both user-facing demos and milestone-specific proof surfaces.
+
+Start here:
+- `demos/README.md`
+
+Important supporting demo/readiness docs:
+- `docs/tooling/editor/README.md`
+- `docs/tooling/editor/five_command_demo.md`
+- `docs/tooling/editor/five_command_regression_suite.md`
+
+For milestone-specific context:
+- `docs/milestones/v0.7/DEMOS_v0.7.md`
 - `docs/milestones/v0.8/DEMOS_V0.8.md`
-
-## v0.7 Naming Migration (Compatibility Window)
-
-- Canonical Rust crate/package/lib identity is `adl`.
-- Canonical CLI/runtime naming is `adl` and `adl-remote`.
-- Legacy compatibility shim commands introduced in v0.7 remain available during the compatibility window with deprecation warnings.
-- Canonical env vars use `ADL_*`; legacy compatibility env vars remain supported during the compatibility window with deprecation warnings.
-
-## Features by Release
-
-### v0.7.0 (Current Release)
-
-* ExecutionPlan-driven runtime execution
-* Deterministic sequential + concurrent fork/join semantics
-* Canonical concurrent ready-step ordering (lexicographic by `step_id`)
-* Deterministic join barrier semantics
-* Bounded parallelism enforcement in runtime
-* Step-level failure policy (`on_error: fail|continue`)
-* Deterministic retries (`retry.max_attempts`, no backoff)
-* Deterministic replay demos + trace diff / graph export tooling
-* Streaming trace events (observational)
-* Human-readable trace timestamps + run/step progress banners
-* Pattern compiler (`linear`, `fork_join`) with deterministic canonical IDs
-* Provider profile registry (predefined profiles)
-* Signing and verification CLI (`keygen`, `sign`, `verify`) with unsigned-run rejection on `--run`
-* Remote execution MVP (`/v1/health`, `/v1/execute`) with local scheduler ownership
-* HITL pause/resume (step-boundary-only) with deterministic, versioned, atomic pause state
-
-### v0.5
-
-* Full primitives support (agents, tasks, providers, workflows)
-* Deterministic plan-only mode
-* Signing canonicalization groundwork
-
-### v0.4
-
-* Deterministic, no-network demo harness (`adl/tools/demo_v0_4.sh`)
-* Bounded executor prototype demos
-* Stable artifact emission
-
-### v0.3
-
-* Fork/join planning semantics
-* Concurrency planning model
-* Plan printing + deterministic ID normalization
+- `docs/milestones/v0.85/DEMO_MATRIX_v0.85.md`
 
 ## Repository Layout
 
-- `demos/`: canonical user-facing demo index, runbooks, and demo docs
 - `adl/`: Rust reference runtime and CLI
 - `adl/examples/`: runnable workflow fixtures used by the runtime and tests
 - `adl-spec/`: language-level specification docs
-- `docs/`: contributor workflow and roadmap docs
-- `docs/adr/`: architecture decision records (major technical decisions)
-- `docs/OBSMEM.md`: user-facing ObsMem boundary and usage guide (v0.75 reference)
-- `.adl/`: cards, reports, and run/report artifacts
-
-## Historical v0.3 Plan-Only Commands
-
-From repo root:
-
-```bash
-cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-3-concurrency-fork-join.adl.yaml --print-plan
-cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-3-on-error-retry.adl.yaml --print-plan
-cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-3-remote-http-provider.adl.yaml --print-plan
-```
-
-To execute (`--run`) local-provider examples, run from `adl/` with a local Ollama available.
-
-## Legacy v0.4 Demos
-
-These demos are deterministic, non-interactive, and run without network by pinning the local mock provider binary.
-
-Fork/Join demo (3 branches + deterministic join barrier):
-
-```bash
-ADL_OLLAMA_BIN=adl/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-4-demo-fork-join.adl.yaml --run --trace --out .adl/reports/demo-v0.4/fork-join
-```
-
-Bounded parallelism stress (8 branch steps with bounded executor):
-
-```bash
-ADL_OLLAMA_BIN=adl/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-4-demo-bounded-parallelism.adl.yaml --run --trace --out .adl/reports/demo-v0.4/bounded-parallelism
-```
-
-Current engine concurrency is intentionally fixed at `MAX_PARALLEL=4` in v0.4; this demo proves bounded execution at that shipped limit.
-
-Deterministic replay (run twice with same command, then compare `replay/join.txt` hash):
-
-```bash
-ADL_OLLAMA_BIN=adl/tools/mock_ollama_v0_4.sh cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-4-demo-deterministic-replay.adl.yaml --run --trace --out .adl/reports/demo-v0.4/deterministic-replay
-```
-
-Run all three demos in sequence:
-
-```bash
-adl/tools/demo_v0_4.sh
-```
-
-## Why v0.7 Matters
-
-v0.7.0 proves:
-- Concurrent execution in the real runtime
-- Deterministic replay behavior
-- Bounded parallelism
-- Stable artifacts under concurrency
-- Signed workflow execution defaults for safer `--run` operation
-- Pattern-driven workflow authoring with deterministic expansion
-- Remote execution MVP wiring without giving up local deterministic scheduling
+- `demos/`: canonical user-facing demo index, runbooks, and proof surfaces
+- `docs/`: contributor workflow, roadmap, tooling, and milestone docs
+- `docs/adr/`: architecture decision records
+- `.adl/`: cards, reports, run artifacts, and related authoring surfaces
 
 ## Default Workflow
 
-Default contributor workflow uses `adl_pr_cycle` (`init -> create -> start -> codex -> run_if_required -> finish -> report`).
-- Guide: `docs/default_workflow.md`
-- Active milestone docs: `docs/milestones/v0.8/`
-- Tools: `adl/tools/README.md`
+The default contributor workflow is documented as a bounded authoring cycle.
+
+Start here:
+- `docs/default_workflow.md`
+- `docs/tooling/adl_pr_cycle_skill.md`
+- `adl/tools/README.md`
+
 
 ## License
 
@@ -212,4 +145,4 @@ Apache-2.0
 ## Security
 
 - Security policy: `SECURITY.md`
-- Threat model (v0.7): `docs/security/THREAT_MODEL_v0.7.md`
+- Threat model: `docs/security/THREAT_MODEL_v0.7.md`

--- a/adl-spec/README.md
+++ b/adl-spec/README.md
@@ -1,74 +1,123 @@
-# ADL Specification
 
-Language-level specification materials for Agent Design Language (ADL).
-This directory is the spec entrypoint: normative text, schema artifacts, and examples.
-Runtime implementation details belong under `adl/` and milestone docs.
+# ADL Specification (`adl-spec/`)
 
-Contributor workflow is governed by the repo-wide `../CONTRIBUTING.md`.
+This directory is the specification entrypoint for **Agent Design Language (ADL)**. It contains the language-level materials that define ADL as a design and authoring system: normative specification text, schema artifacts, and specification examples.
 
-## Project Status
+The specification is intentionally separate from the Rust runtime in `../adl/`. The goal of this directory is to make the language understandable on its own terms: its semantics, invariants, contracts, and design intent.
 
-- ADL 1.0 remains a **draft** language specification.
-- The specification may still change in incompatible ways.
-- The repository remains intentionally spec-first and author-driven.
+## Why the Specification Matters
 
-Contributions are welcome, but clarity and conceptual coherence take priority over rapid expansion.
+The specification is where ADL’s language model becomes explicit.
+
+It provides:
+- normative language for the core ADL concepts and their semantics
+- schema artifacts that support validation and tooling
+- examples that illustrate the structure of ADL documents
+- a stable reference point for design discussions and future runtime work
+- a way to separate language intent from implementation details
+
+## Current Status
+
+- Specification status: **ADL 1.0 draft**
+- Current closure milestone in the main repo: **v0.85**
+- Next active milestone: **v0.86**
+- Current role of this directory: language and schema reference for the evolving ADL design
+
+The specification is still evolving. Clarity, coherence, and explicit contracts take priority over premature stability.
+
+## Recent Milestone Context
+
+### v0.85 — Authoring Alignment and Documentation Truth
+
+v0.85 focused on making the surrounding authoring model, demos, and documentation surfaces line up cleanly with implemented reality.
+
+Highlights relevant to the spec:
+- stronger repo-wide documentation alignment
+- clearer authoring lifecycle language around structured workflow definition
+- improved proof surfaces and review surfaces for what is actually shipped
+- better separation between reader-facing docs and internal control surfaces
+- more consistent documentation entrypoints across the repository
+
+### v0.8 — Bounded Gödel Runtime and Artifact-Centered Review
+
+v0.8 expanded the broader ADL system into bounded reflective execution with explicit artifact surfaces.
+
+Highlights relevant to the spec:
+- stronger articulation of bounded reasoning loops and reviewable artifacts
+- growing pressure to keep language concepts distinct from runtime implementation details
+- clearer relationship between authored workflow structure and execution/review surfaces
+- improved examples and milestone materials that help ground language design
+- stronger connection between specification intent and runtime proof surfaces
+
+### v0.7 — Deterministic Runtime Foundation
+
+v0.7 established the deterministic runtime base that informs the language’s design constraints.
+
+Highlights relevant to the spec:
+- deterministic execution-plan model
+- explicit concurrency and fork/join semantics
+- bounded retry and failure policy surfaces
+- signing and verification concepts for safer execution
+- replay-oriented traces and review artifacts that reinforce explicit contracts
 
 ## Spec Structure
 
-- Normative spec docs: `spec/`
-- Schema artifacts: `schemas/`
-- Spec examples: `examples/`
-
-## Contributing to the Spec
-
-Use the root [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for branching, review, and PR workflow.
-For Codex-specific execution mechanics, use [`../docs/codex_playbook.md`](../docs/codex_playbook.md).
-
-For substantial changes such as new concepts, abstractions, or major restructuring, open an issue first.
-Small clarifications, typo fixes, examples, and explanatory notes that do not change normative meaning are welcome without extra process.
+- `spec/` — normative specification documents
+- `schemas/` — schema artifacts used by validation/tooling surfaces
+- `examples/` — specification examples illustrating ADL document structure
 
 ## Specification vs Runtime
 
-This directory is for **language semantics**, invariants, and design intent.
+This directory is for **language semantics, invariants, and design intent**.
 
-- Runtime implementation details belong under `../adl/`
-- Versioned architecture and release behavior belong under `../docs/milestones/`
-- Cross-cutting architecture decisions belong under `../docs/adr/`
+Use these boundaries consistently:
+- runtime implementation details belong under `../adl/`
+- versioned milestone and release behavior belong under `../docs/milestones/`
+- cross-cutting architectural decisions belong under `../docs/adr/`
 
-Please avoid adding runtime-specific assumptions to specification text.
+Please avoid adding runtime-specific assumptions to specification text unless they are explicitly part of the language contract.
 
 ## Normative Language
 
-Specification text uses **MUST**, **SHOULD**, and **MAY** as defined in RFC 2119.
+Specification text uses **MUST**, **SHOULD**, and **MAY** in the RFC 2119 sense.
 
-When editing spec documents:
-
-- Be precise about normative requirements
-- Avoid introducing ambiguity
-- Distinguish clearly between normative and non-normative sections
+When editing specification documents:
+- be precise about normative requirements
+- avoid introducing ambiguity
+- distinguish clearly between normative and non-normative statements
+- prefer explicit contracts over inferred behavior
 
 ## Design Philosophy
 
-Spec changes should reinforce these principles:
+Specification work should reinforce these principles:
+- design-time intent over incidental implementation detail
+- explicit contracts instead of implicit assumptions
+- determinism where possible, transparency everywhere
+- failure as a first-class, observable outcome
 
-- **Design-time intent over runtime behavior**
-- **Explicit contracts instead of implicit assumptions**
-- **Determinism where possible, transparency everywhere**
-- **Failure as a first-class, observable outcome**
+## Contributing to the Spec
 
-## Spec Change Notes
+Use the root contributor workflow and repository process for branching, review, and PR handling:
+- `../CONTRIBUTING.md`
+- `../docs/codex_playbook.md`
 
-Spec-specific change history is tracked alongside the main repo history.
-The current unreleased spec milestone remains the initial ADL 1.0 specification structure.
+For substantial changes such as new concepts, abstractions, or major restructuring, open an issue first.
 
-## See Also / Canonical Docs
+Small clarifications, typo fixes, examples, and explanatory notes that do not change normative meaning are welcome without extra process.
 
-- Root project entrypoint: `../README.md`
-- Runtime/CLI usage: `../adl/README.md`
-- Contributor workflow: `../CONTRIBUTING.md`
-- Codex operating procedure: `../docs/codex_playbook.md`
-- Design principles: `../docs/design_goals.md`
-- Milestone docs (current): `../docs/milestones/v0.8/`
-- ADRs: `../docs/adr/`
-- Spec sub-index: `spec/README.md`
+## Documentation Map
+
+For broader project context:
+- root project overview: `../README.md`
+- runtime and CLI guide: `../adl/README.md`
+- documentation index: `../docs/README.md`
+- contributor workflow: `../CONTRIBUTING.md`
+- codex operating procedure: `../docs/codex_playbook.md`
+- design goals: `../docs/design_goals.md`
+- milestone docs: `../docs/milestones/`
+- architecture decisions: `../docs/adr/`
+- spec sub-index: `spec/README.md`
+
+## Notes
+
+This README is meant to orient readers to the role of the specification within the larger ADL repository. It is not itself the normative language specification; it is the entrypoint to that material.

--- a/adl/README.md
+++ b/adl/README.md
@@ -1,152 +1,112 @@
 # ADL Runtime (`adl/`)
 
-ADL runtime is the reference Rust runtime for **Agent Design Language (ADL)**. It compiles schema-validated ADL documents into a deterministic ExecutionPlan and executes them with explicit concurrency, failure, retry, signing, and (minimal) remote execution semantics.
+The ADL runtime is the reference Rust runtime and CLI for **Agent Design Language (ADL)**. It takes schema-validated ADL documents, resolves them into a deterministic execution plan, and executes them with explicit semantics for concurrency, retries, failures, signing, tracing, and bounded remote execution.
 
-ADL runtime prioritizes determinism and inspectability. Every run emits stable artifacts under `.adl/runs/<run_id>/` to support replay, debugging, and post-mortem analysis.
+The runtime is built for readers and builders who want AI workflow execution to be predictable, inspectable, and reviewable. It emphasizes clear execution behavior, stable artifacts, and reproducible runs over hidden orchestration logic.
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
 ![MSRV](https://img.shields.io/badge/MSRV-1.74%2B-blue)
 
-Badge note:
-- Status badges above reflect `main` branch workflow health.
-- Coverage is generated via `cargo llvm-cov` in CI and uploaded to Codecov.
-- CI enforces a coverage gate; the Codecov upload is informational.
+## Why the Runtime Matters
 
-## Status
+The runtime is where ADL’s design promises become operational reality.
 
-Latest tagged runtime release: **v0.7.0**
+It provides:
+- deterministic plan materialization and execution
+- bounded concurrency and explicit retry/failure policy
+- stable run artifacts and replay-friendly state
+- signing and verification surfaces for safer execution
+- CLI review surfaces for plan inspection and runtime debugging
+- a foundation for bounded reflective and scientific execution loops
 
-Current main-branch crate version: **0.8.0**
+## Current Status
 
-This README reflects the current `main`-branch runtime surfaces for the active **v0.8** milestone. Treat it as unreleased development documentation layered on top of the latest tagged `v0.7.0` release.
+- Recent stable runtime milestone: **v0.8**
+- Current closure milestone in the main repo: **v0.85**
+- Next active milestone: **v0.86**
+- Current crate version on `main`: **0.8.0**
 
-## v0.7 Naming Migration (Compatibility Window)
+This README describes the runtime as it exists on the current `main` branch and points to the relevant milestone and demo surfaces in the parent repository.
 
-- Canonical binaries are `adl` and `adl-remote`.
-- Legacy compatibility shim binaries were introduced during v0.7 and remain available on `main` during the compatibility window with deprecation warnings.
-- Canonical env vars use `ADL_*`; legacy compatibility env vars remain supported during the compatibility window with deprecation warnings.
+## Recent Runtime Milestones
 
-## Features by Release
+### v0.85 — Authoring Alignment and Runtime Proof Surfaces
 
-### v0.8 (Current Main Branch, Unreleased)
+v0.85 focused on making the surrounding authoring model, demos, and proof surfaces line up cleanly with the runtime and tooling.
 
-The current `main` branch carries the `0.8.0` crate version and includes bounded v0.8 runtime/demo surfaces on top of the shipped v0.7 base.
+Highlights:
+- five-command authoring lifecycle clarified and aligned with runtime-adjacent tooling
+- bounded end-to-end demo and regression proof surfaces for authoring workflows
+- improved queue/worktree hygiene and execution truth surfaces
+- Rust maintainability pass across large modules and oversized test surfaces
+- stronger documentation and review surfaces around what is actually shipped and runnable
 
-### v0.7.0 (Latest Tagged Release)
+### v0.8 — Bounded Gödel Runtime and Artifact-Centered Review
 
-* ExecutionPlan-driven runtime execution
-* Deterministic sequential + concurrent fork/join semantics
-* Canonical concurrent ready-step ordering (lexicographic by `step_id`)
-* Deterministic join barrier semantics
-* Bounded parallelism enforcement via `run.defaults.max_concurrency` (default: 4; must be `>= 1`)
-* Step-level failure controls (`on_error: fail|continue`, deterministic `retry.max_attempts`, no backoff)
-* Streaming trace events (observational) with human-readable timestamps + progress banners
-* Pattern compiler (`linear`, `fork_join`) with deterministic canonical IDs
-* Provider profile registry (predefined profiles) with placeholder endpoint guardrails
-* Signing and verification CLI (`keygen`, `sign`, `verify`) with unsigned-run rejection by default for `--run`
-* Remote execution MVP (`/v1/health`, `/v1/execute`) where scheduler ownership remains local
-* HITL pause/resume (step-boundary-only) with deterministic, versioned, atomic pause state
-* CI-aligned quality gate (`fmt`, `clippy -D warnings`, `test`, coverage gate)
+v0.8 extended the runtime into bounded reflective execution with explicit artifact surfaces.
 
-### v0.5
+Highlights:
+- bounded Gödel-style scientific loop integrated into runtime/demo surfaces
+- canonical artifact emission for mutation, evaluation, experiment, and evidence records
+- CLI surfaces for running and inspecting bounded reasoning workflows
+- ObsMem-backed indexing and retrieval-assisted review flows
+- runnable demos and review packets for bounded adaptive execution
 
-* Full primitives support (agents, tasks, providers, workflows)
-* Deterministic plan-only mode
-* Signing canonicalization groundwork
+### v0.7 — Deterministic Runtime Foundation
 
-### v0.4
+v0.7 established the deterministic runtime core that ADL builds on.
 
-* Deterministic, no-network demo harness (`adl/tools/demo_v0_4.sh`)
-* Stable artifact emission
+Highlights:
+- ExecutionPlan-driven runtime
+- deterministic fork/join and concurrency semantics
+- bounded parallelism and explicit retry/failure policy
+- replay-oriented trace and graph export tooling
+- signing and verification surfaces for execution integrity
 
-### v0.3
+## Quick Start
 
-* Fork/join planning semantics
-* Concurrency planning model
-* Plan printing + deterministic ID normalization
-
-## Documentation Map
-
-- Root repo README: `../README.md`
-- Canonical demo index: `../demos/README.md`
-- v0.8 milestone docs: `../docs/milestones/v0.8/`
-- v0.7 milestone docs: `../docs/milestones/v0.7/`
-- ADRs: `../docs/adr/`
-- Runnable demos:
-  - `../docs/milestones/v0.7/DEMOS_v0.7.md` (latest tagged release)
-  - `../docs/milestones/v0.8/DEMOS_V0.8.md` (active milestone review packet)
-- Crate-local fixture inventory: `examples/README.md`
-
-## How Swarm Processes ADL (Compiler-like Pipeline)
-
-Swarm processes ADL documents in a conservative, compiler-like pipeline:
-
-1. **Parse** an ADL YAML document into a typed in-memory model.
-2. **Validate** the document against a JSON Schema with crisp, path-specific errors.
-3. **Resolve** references deterministically (run → workflow → steps → task → agent → provider).
-4. **Materialize** deterministic artifacts (execution plan, assembled prompts).
-5. **Execute** deterministic workflows (sequential and bounded concurrent execution), with optional tracing.
-
-Provider execution, tracing, contracts, and repair policies are being added incrementally.
-
----
-
-## Fork/Join Mental Model
-
-- **Fork**: declare branch steps under `workflow.kind: concurrent`.
-- **Execution**: ready fork steps execute with bounded parallelism and deterministic lexicographic step-id ordering.
-- **Join**: consume branch outputs via `@state:<save_as_key>` and run only when required inputs are available.
-
----
-
-## 5‑Minute Demo
-
-From the `adl` directory:
+From the `adl/` directory:
 
 ```bash
-# Happy path: v0.7 primitive schema baseline
 cargo run -q --bin adl -- examples/v0-5-primitives-minimal.adl.yaml --print-plan
-
-# Optional: verify pattern compiler canonical IDs
-cargo run -q --bin adl -- examples/v0-5-pattern-fork-join.adl.yaml --print-plan
-
-# Optional: verify remote execution wiring (requires local adl-remote server)
-cargo run -q --bin adl -- examples/v0-5-remote-execution-mvp.adl.yaml --print-plan
 ```
 
-Expected output includes deterministic step ordering and resolved provider bindings.
-Using `-q` keeps demo output focused on the ADL plan rather than Cargo build noise.
+This prints a deterministic plan for a small workflow fixture without requiring provider runtime setup.
 
-For real `--run` execution, configure provider runtime dependencies (for example local Ollama and any required auth env vars).
+A second quick check:
 
-For additional runnable examples, start with `../demos/README.md`.
-Use `examples/README.md` when you specifically want the full crate-local fixture inventory.
+```bash
+cargo run -q --bin adl -- examples/v0-5-pattern-fork-join.adl.yaml --print-plan
+```
 
----
+For a retry-oriented fixture:
 
-## CLI
+```bash
+cargo run -q --bin adl -- examples/v0-3-on-error-retry.adl.yaml --print-plan
+```
+
+## Common CLI Surfaces
 
 ```bash
 cargo run -q --bin adl -- <path-to-adl.yaml> [OPTIONS]
 ```
 
-**Options**
-
+Common options:
 - `--run` — execute the workflow
 - `--print-plan` — print the resolved execution plan only
 - `--print-prompts` — print assembled prompts without execution
 - `--trace` — emit deterministic trace events to stdout
 - `--help` — usage and flag summary
 
-Exit codes are consistent:
+Exit behavior is explicit:
 - `2` — invalid CLI usage
 - non-zero — schema, validation, or runtime error
 
-## Signing Quickstart (v0.7)
+## Signing Quickstart
 
-For v0.7 workflows, signature enforcement is enabled by default for `--run`.
+For workflows that require signing:
 
 ```bash
 # 1) generate local dev keys
@@ -160,7 +120,7 @@ cargo run -q --bin adl -- sign examples/v0-5-pattern-linear.adl.yaml \
 # 3) verify signature
 cargo run -q --bin adl -- verify /tmp/signed.adl.yaml --key ./.keys/ed25519-public.b64
 
-# 4) run signed workflow (no override needed)
+# 4) run signed workflow
 cargo run -q --bin adl -- /tmp/signed.adl.yaml --run
 ```
 
@@ -170,245 +130,89 @@ Dev-only bypass:
 cargo run -q --bin adl -- examples/v0-5-pattern-linear.adl.yaml --run --allow-unsigned
 ```
 
----
+## Run Artifacts
 
-## Run State Artifacts
-
-When running with `--run`, `adl` writes deterministic run state files under:
+When running with `--run`, `adl` writes deterministic run state under:
 
 ```bash
 .adl/runs/<run_id>/
 ```
 
-Files:
-- `run.json`:
-  - `run_id`
-  - `workflow_id`
-  - `version`
-  - `status` (`success` or `failure`)
-  - `start_time_ms`, `end_time_ms`, `duration_ms`
-- `steps.json` (stable step order):
-  - `step_id`
-  - `agent_id`
-  - `provider_id`
-  - `status` (`success`, `failure`, `not_run`)
-  - `output_artifact_path` (when applicable)
+Typical run-state files include:
+- `run.json`
+- `steps.json`
 
-This is additive and does not replace existing stdout summaries.
+These surfaces are intended to make runs inspectable, replay-friendly, and easier to debug.
 
----
+## Remote Execution Surfaces
 
-## Remote Provider (HTTP MVP)
+The runtime supports a minimal remote provider via `type: "http"` and also supports a minimal remote execution protocol for step placement.
 
-`adl` supports a minimal remote provider via `type: "http"` for deterministic,
-blocking prompt completion over HTTP.
+Remote execution boundary:
+- scheduler ownership remains local in `adl`
+- the remote server executes one fully resolved step at a time
+- the remote endpoint is a bounded execution surface, not a remote planner/compiler
 
-Expected request/response contract:
-- Request: `POST <endpoint>` with JSON body `{"prompt":"..."}`
-- Response: JSON object containing string field `output`
-
-Example (see `examples/v0-3-remote-http-provider.adl.yaml`):
-
-```yaml
-providers:
-  remote_http:
-    type: "http"
-    config:
-      endpoint: "http://127.0.0.1:8787/complete"
-      timeout_secs: 10
-      auth:
-        type: bearer
-        env: ADL_REMOTE_BEARER_TOKEN
-```
-
-Run it with:
-
-```bash
-cargo run -q --bin adl -- examples/v0-3-remote-http-provider.adl.yaml --print-plan
-cargo run -q --bin adl -- examples/v0-3-remote-http-provider.adl.yaml --run
-```
-
-Failure behavior is explicit:
-- Missing endpoint -> config error
-- Missing auth env var -> config error naming the env var
-- Non-200 response -> runtime error with status + body snippet
-- Timeout -> runtime error with timeout guidance
-
-## Remote Execution MVP (v0.7 Placement)
-
-In addition to HTTP providers, v0.7 includes a minimal remote execution protocol for
-step placement:
-
+Key endpoints in the MVP protocol:
 - `GET /v1/health`
-- `POST /v1/execute` (single fully-resolved step payload)
+- `POST /v1/execute`
 
-Design boundary:
-- Scheduler ownership stays local in `adl`.
-- Remote server executes exactly one resolved step and returns `{ok,result,error}`.
-- Remote server does not compile/plan/schedule workflows.
+This transport boundary is intended for trusted infrastructure and bounded deployment scenarios, not as a hardened public service.
 
-Limits:
-- Request payloads over 5 MiB are rejected (`413`).
-- No authn/authz in the current MVP (deferred).
+## Documentation Map
 
-### Security Model / Threat Model (v0.7)
+For readers who want the broader context around the runtime:
+- root repo README: `../README.md`
+- canonical demo index: `../demos/README.md`
+- v0.85 milestone docs: `../docs/milestones/v0.85/`
+- v0.8 milestone docs: `../docs/milestones/v0.8/`
+- v0.7 milestone docs: `../docs/milestones/v0.7/`
+- architecture decisions: `../docs/adr/`
+- crate-local fixture inventory: `examples/README.md`
 
-This remote execution path is an MVP transport boundary, not a hardened public
-service. Treat it as trusted-network infrastructure only.
-
-Threat-model assumptions:
-- `adl-remote` runs on localhost or a tightly controlled private network.
-- The caller and remote endpoint are operated by the same trusted team.
-- Network peers are trusted or isolated by external controls.
-
-Current protections:
-- Request-size guard: payloads larger than 5 MiB are rejected (`413`).
-- Placement boundary: scheduler/planner remain local; remote executes exactly
-  one fully resolved step from `POST /v1/execute`.
-- Timeout/error handling: transport timeout/unreachable/bad-status/invalid-json
-  failures are surfaced with explicit stable error categories.
-
-Known gaps / risks (v0.7):
-- No request signing for remote payloads.
-- No built-in authentication/authorization.
-- Unsafe to expose directly on a public interface.
-
-Operational guidance:
-- Bind to loopback for local development:
-  - `cargo run -q --bin adl-remote -- 127.0.0.1:8787`
-- If cross-host is required, prefer private networking plus an authenticated
-  tunnel (for example SSH tunnel or VPN), and restrict ingress with firewall
-  rules to trusted sources only.
-- Log and monitor remote-server lifecycle/events and non-2xx responses so
-  misconfiguration or abuse is visible quickly.
-
-Forward-looking hardening work (v0.7):
-- Remote execution security envelope: https://github.com/danielbaustin/agent-design-language/issues/370
-- Signing trust policy tightening: https://github.com/danielbaustin/agent-design-language/issues/371
-
----
-
-## Schema Validation
-
-- ADL documents are validated **before** parsing.
-- Unknown top-level fields are rejected.
-- Required fields (e.g. `run`) are enforced.
-- Errors include the failing path and reason.
-
-The committed schema artifact lives at:
-
-```
-schemas/adl.schema.json
-```
-
-Note: this JSON file is **DRAFT / not authoritative** and may lag the runtime.
-The runtime’s authoritative schema is generated from the Rust structs in `src/adl.rs`.
-
-Schema tests live in:
-
-```
-tests/schema_tests.rs
-```
-
-Example validation documents live under:
-
-```
-examples/
-```
-
-Legacy examples (e.g. `adl-0.1.yaml`) remain for regression testing, but the runtime behavior described here reflects v0.7.
-
-The schema/runtime behavior described here is aligned with current **v0.7** support.
-
----
+Important demo/readiness references:
+- `../docs/milestones/v0.8/DEMOS_V0.8.md`
+- `../docs/milestones/v0.85/DEMO_MATRIX_v0.85.md`
+- `../docs/tooling/editor/README.md`
 
 ## Project Layout
 
-```
+```text
 src/
-  main.rs        # CLI + wiring
-  adl.rs         # ADL data model + loader
-  schema.rs      # JSON Schema validation
-  resolve.rs     # Deterministic resolution + plan materialization
-  prompt.rs      # Prompt assembly + hashing
-  provider.rs    # Provider abstraction (Ollama)
-  execute.rs     # Sequential execution engine
-  trace.rs       # Deterministic trace events
+  main.rs
+  adl.rs
+  schema.rs
+  resolve.rs
+  prompt.rs
+  provider.rs
+  execute.rs
+  trace.rs
 tests/
 examples/
 ```
 
----
-
+Broadly:
+- `src/` contains the reference runtime and CLI
+- `tests/` contains runtime, schema, and CLI validation surfaces
+- `examples/` contains runnable fixtures used by demos, tests, and inspection workflows
 
 ## Development
 
-Run the full quality gate locally:
+Run the local quality gate from `adl/`:
 
 ```bash
-cargo fmt
+cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
-All of the above must pass for changes to be accepted.
-
----
-
-## Code Coverage
-
-`adl` enforces a **high bar for test coverage**, especially for core compiler-like behavior (parsing, validation, resolution, and execution).
-
-As of v0.7:
-
-- **Overall line coverage:** enforced by CI gate (see coverage badge above)
-- **All critical paths covered:**
-  - Schema validation (strict + loose modes)
-  - ADL parsing and semantic validation
-  - Deterministic resolution
-  - Prompt assembly and hashing
-  - CLI behavior and error handling
-  - Provider execution (mocked and real)
-- Lower coverage areas (e.g. some execution branches) are intentional and documented, not accidental gaps.
-
-Coverage percentage may fluctuate as new features are added; the CI gate ensures regressions are caught.
-
-### Running coverage locally
-
-We use a simple, deterministic coverage script (checked into the repo) rather than relying on CI-specific tooling:
+Coverage is commonly checked with:
 
 ```bash
-./coverage.sh
+cargo llvm-cov --workspace --all-features --summary-only
 ```
 
-This generates:
-
-- `lcov.info`
-- An HTML report showing per-file and per-directory coverage
-
-Coverage artifacts (the `coverage/` directory and `lcov.info`) are intentionally not checked into git.
-
-The report makes it easy to identify:
-- Untested branches
-- Intentionally deferred logic
-- Areas that would benefit from additional tests
-
-### Coverage philosophy
-
-- **Line coverage > function coverage** for v0.7  
-  (many small helper functions are intentionally exercised indirectly)
-- No “coverage theater”:
-  - No dummy tests
-  - No blanket `#[allow(dead_code)]` without justification
-- Coverage is used as a **design signal**, not a vanity metric
-
-Contributors are expected to keep overall line coverage **≥ 85%**, and ideally improve it with each change.
-
-Badge note:
-- `coverage` is the live Codecov percentage for the `adl` upload.
-- `adl-coverage-gate` reflects whether the CI workflow coverage gate passes. It is a status badge, not a live percentage badge.
-
----
+The runtime uses coverage as a design signal for core compiler-like behavior: parsing, validation, resolution, execution, and CLI behavior should remain well exercised.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,40 @@
 # Documentation Index
 
-This directory is the canonical documentation entrypoint for milestone planning,
-architecture decisions, and contributor/reference docs.
+This directory is the main documentation entrypoint for ADL milestone records, contributor workflow docs, tooling guides, and architecture references.
+
 Use this index to find the right source of truth quickly.
 
-## Core Docs
+## Start Here
 
-- v0.8 milestone docs (active): `milestones/v0.8/`
-- ADRs: `adr/`
-- Codex operating procedure: `codex_playbook.md`
-- Design principles: `design_goals.md`
-- Default workflow guide: `default_workflow.md`
+- Current closure milestone: `milestones/v0.85/`
+- Next active milestone: `milestones/v0.86/`
+- Root project overview: `../README.md`
+- Runtime and CLI guide: `../adl/README.md`
+- Language/spec entrypoint: `../adl-spec/README.md`
+- Default contributor workflow: `default_workflow.md`
 
-## Milestones
+## Milestone Documentation
 
-- Current development milestone: `milestones/v0.8/`
-- Previous milestones: `milestones/v0.75/`, `milestones/v0.7/`, `milestones/v0.6/`
+- Current closure milestone: `milestones/v0.85/`
+- Current planning milestone: `milestones/v0.86/`
+- Recent stable milestone: `milestones/v0.8/`
+- Earlier milestones: `milestones/v0.75/`, `milestones/v0.7/`, `milestones/v0.6/`
 - Historical milestones: `milestones/v0.5/`, `milestones/v0.4/`, `milestones/v0.3/`, `milestones/v0.2/`
 
-## See Also / Canonical Docs
+## Core Contributor and Reference Docs
 
-- Root project entrypoint: `../README.md`
-- Runtime/CLI usage: `../adl/README.md`
-- ADL spec entrypoint: `../adl-spec/README.md`
+- Architecture decisions: `adr/`
+- Default workflow guide: `default_workflow.md`
+- Design goals: `design_goals.md`
+- Codex operating procedure: `codex_playbook.md`
+- Tooling index: `tooling/README.md`
+
+## Demo and Tooling Surfaces
+
+- Canonical demo index: `../demos/README.md`
+- v0.85 demo matrix: `milestones/v0.85/DEMO_MATRIX_v0.85.md`
+- Editor/tooling demo surfaces: `tooling/editor/README.md`
+
+## Notes
+
+Milestone docs should be read as bounded engineering records. They distinguish what has shipped, what is currently being closed out, what is demoable, and what is planned for later milestones.

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -1,37 +1,77 @@
-# Tooling Docs
+# Tooling Documentation
 
-This directory documents ADL tooling contracts used by structured prompt automation and reviewer flows.
+This directory is the main entrypoint for ADL tooling guides, prompt-spec references, reviewer surfaces, editor-related proof surfaces, and maintainability utilities.
 
-Prompt Spec is the bridge between:
-- structured task prompts (`issue prompts`)
-- structured implementation prompts (`input cards`)
-- structured output records (`output cards`)
+The goal of this directory is to make ADL’s tooling surfaces understandable and navigable without forcing the reader to learn the entire internal workflow system first.
 
-Tracked public workflow history should live in task-centric record bundles under `docs/records/`, while `.adl/` remains the temporary draft workspace.
+## Start Here
 
-## References
-- [Prompt Spec](prompt-spec.md): machine-readable input-card block defining deterministic prompt generation surfaces and reviewer alignment.
-- [Structured Prompt Contracts](structured-prompt-contracts.md): machine-checkable contracts for Structured Task Prompts, Structured Implementation Prompts, and Structured Output Records.
-- [Worktree Governance](worktree_governance.md): canonical policy for managed ADL worktrees, stale registrations, orphan dirs, and Codex-ephemeral worktree handling.
-- [Rust Module Watch List](rust_module_watch_list.md): canonical watch list and maintainability guardrail for large Rust implementation modules.
-- [Task Bundle Editor](editor/README.md): first bounded editor surface for tracked STP/SIP task-bundle authoring.
-- [Prompt Spec Protocol Bindings](prompt-spec.md#protocol-bindings): linkage to `card_review_checklist.v1` and `card_review_output.v1` reviewer contracts.
-- [Prompt/Reviewer Surface Mapping](prompt-review-surface-mapping.md): field-by-field contract map between Prompt Spec, checklist rules, and deterministic review output fields.
-- [Issue Prompt Templates](issue-prompts/README.md): tracked templates and authoring guidance for structured issue prompts used to shape GitHub issues before `pr start`.
-- [Public Task Records](../records/README.md): tracked task-centric record homes for canonical STP/SIP/SOR bundles.
-- `adl/tools/sync_task_bundle_prompts.sh`: refresh the canonical local `.adl/<scope>/tasks/<task-id>__<slug>/` bundle layout from current compatibility paths.
-- [Reviewer Output Provenance](reviewer-provenance.md): bounded provenance verification for deterministic review-output artifacts.
-- [Reviewer Surface](reviewer-surface.md): first bounded repo-local review/helper surface with deterministic fixture coverage.
-- Prompt Spec execution tooling:
-  - `adl/tools/lint_prompt_spec.sh` (Prompt Spec lint/validation)
-  - `adl/tools/card_prompt.sh` (deterministic prompt generation from cards)
-  - `adl/tools/report_large_rust_modules.sh` (non-blocking Rust implementation-module size report)
-  - `adl/tools/validate_structured_prompt.sh` (structured prompt contract validation)
-  - `adl/tools/verify_review_output_provenance.rb` (deterministic provenance verification for review-output artifacts)
-  - `adl/tools/review_card_surface.rb` (bounded deterministic review helper)
-- [Card Reviewer GPT Instructions](card-reviewer-gpt.md): canonical reviewer behavior and deterministic YAML output contract (`card_reviewer_gpt.v1.1`).
-- [Deterministic Review Output Format](card-review-output-format.md): canonical review artifact schema including finding evidence-state semantics.
-- Reviewer regression fixture (stable):
-  - `docs/tooling/examples/reviewer-regression/issue-661/input_661.md`
-  - `docs/tooling/examples/reviewer-regression/issue-661/output_661.md`
-  - `docs/tooling/examples/reviewer-regression/issue-661/expected_review_output_661.yaml`
+- Prompt-spec and structured prompt surfaces: `prompt-spec.md`
+- Structured prompt contracts: `structured-prompt-contracts.md`
+- Default contributor workflow: `../default_workflow.md`
+- Editor and authoring proof surfaces: `editor/README.md`
+- Root project overview: `../README.md`
+
+## Core Tooling Areas
+
+### Prompt and Card Surfaces
+
+These docs describe the structured prompt surfaces used to shape issues, input cards, output cards, and deterministic reviewer flows.
+
+- [Prompt Spec](prompt-spec.md)
+- [Structured Prompt Contracts](structured-prompt-contracts.md)
+- [Prompt/Reviewer Surface Mapping](prompt-review-surface-mapping.md)
+- [Prompt Spec Protocol Bindings](prompt-spec.md#protocol-bindings)
+- [Issue Prompt Templates](issue-prompts/README.md)
+
+### Reviewer and Validation Surfaces
+
+These docs describe bounded reviewer behavior, deterministic output formats, and provenance/review validation surfaces.
+
+- [Reviewer Surface](reviewer-surface.md)
+- [Reviewer Output Provenance](reviewer-provenance.md)
+- [Card Reviewer GPT Instructions](card-reviewer-gpt.md)
+- [Deterministic Review Output Format](card-review-output-format.md)
+
+Stable reviewer regression fixture:
+- `docs/tooling/examples/reviewer-regression/issue-661/input_661.md`
+- `docs/tooling/examples/reviewer-regression/issue-661/output_661.md`
+- `docs/tooling/examples/reviewer-regression/issue-661/expected_review_output_661.yaml`
+
+### Editor and Authoring Surfaces
+
+These docs describe the bounded editor and authoring surfaces used in the v0.85 authoring/control-plane work.
+
+- [Task Bundle Editor](editor/README.md)
+- `editor/five_command_demo.md`
+- `editor/five_command_regression_suite.md`
+
+### Worktree and Maintainability Surfaces
+
+These docs describe worktree governance, large-module tracking, and related maintenance guidance.
+
+- [Worktree Governance](worktree_governance.md)
+- [Rust Module Watch List](rust_module_watch_list.md)
+- [Public Task Records](../records/README.md)
+
+## Tooling Scripts and Utilities
+
+Important repo-local tooling surfaces include:
+
+- `adl/tools/lint_prompt_spec.sh` — Prompt Spec lint and validation
+- `adl/tools/card_prompt.sh` — deterministic prompt generation from cards
+- `adl/tools/validate_structured_prompt.sh` — structured prompt contract validation
+- `adl/tools/verify_review_output_provenance.rb` — provenance verification for review-output artifacts
+- `adl/tools/review_card_surface.rb` — bounded deterministic review helper
+- `adl/tools/report_large_rust_modules.sh` — non-blocking Rust implementation-module size report
+- `adl/tools/sync_task_bundle_prompts.sh` — refresh canonical local task-bundle prompt layout from compatibility paths
+
+## Current Status
+
+- Current closure milestone: **v0.85**
+- Next active milestone: **v0.86**
+- Role of this directory: tooling/reference entrypoint for prompt, reviewer, editor, and maintenance surfaces
+
+## Notes
+
+Tooling docs should be read as bounded engineering references. They describe the surfaces that support ADL authoring, review, and maintenance without claiming that every internal helper is equally important to every reader.


### PR DESCRIPTION
## Summary
- reconcile and modernize the main README entrypoints
- align root, runtime, spec, docs, and tooling README surfaces with current repo truth
- keep the pass bounded to README/index documentation surfaces only

## Validation
- manual review of touched README surfaces for consistency and path correctness
- branch contains only the intended README/index file set