### PR TITLE
[v0.85][tools] Enforce PR auto-close linkage in pr.sh finish

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -887,6 +887,21 @@ render_pr_body_file() {
   echo "$tmp"
 }
 
+pr_has_closing_linkage() {
+  local repo="$1" pr_ref="$2" issue="$3"
+  local linked
+  linked="$(gh pr view $(gh_repo_flag "$repo") "$pr_ref" --json closingIssuesReferences -q '.closingIssuesReferences[]?.number' 2>/dev/null || true)"
+  grep -Fxq "$issue" <<<"$linked"
+}
+
+ensure_pr_closing_linkage() {
+  local repo="$1" pr_ref="$2" issue="$3" no_close="$4"
+  [[ "$no_close" == "1" ]] && return 0
+  if ! pr_has_closing_linkage "$repo" "$pr_ref" "$issue"; then
+    die "finish: PR is missing GitHub closing linkage for issue #${issue}; ensure the PR body contains 'Closes #${issue}' and that the PR body update was applied"
+  fi
+}
+
 extract_plan_value() {
   local label="$1" plan_output="$2"
   awk -v prefix="$label" '
@@ -2049,6 +2064,7 @@ cmd_finish() {
     if ! gh pr edit $(gh_repo_flag "$repo") "$pr_url" --title "$title" --body-file "$pr_body_file" >/dev/null; then
       die "finish: failed to update existing PR"
     fi
+    ensure_pr_closing_linkage "$repo" "$pr_url" "$issue" "$no_close"
     note "PR updated:"
     echo "$pr_url"
   else
@@ -2056,6 +2072,7 @@ cmd_finish() {
     if ! pr_url="$(gh pr create $(gh_repo_flag "$repo") --base main --head "$branch" --title "$title" --body-file "$pr_body_file" --draft)"; then
       die "finish: failed to create PR"
     fi
+    ensure_pr_closing_linkage "$repo" "$pr_url" "$issue" "$no_close"
     note "PR created:"
     echo "$pr_url"
   fi

--- a/adl/tools/test_pr_finish_relative_card_paths.sh
+++ b/adl/tools/test_pr_finish_relative_card_paths.sh
@@ -43,7 +43,11 @@ if [[ "$1" == "repo" && "$2" == "view" ]]; then
 fi
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
   if [[ " $* " == *" -q "* ]]; then
-    echo ""
+    if [[ "${GH_MOCK_EXISTING_PR:-absent}" == "present" ]]; then
+      echo "https://example.test/pr/1"
+    else
+      echo ""
+    fi
   else
     echo "[]"
   fi
@@ -61,6 +65,24 @@ if [[ "$1" == "pr" && "$2" == "edit" ]]; then
   done
   cp "$body_file" "$TMP_PR_BODY"
   exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json closingIssuesReferences "* ]]; then
+    if [[ " $* " == *" -q "* ]]; then
+      if [[ "${GH_MOCK_CLOSING_LINKAGE:-present}" == "present" ]]; then
+        echo '958'
+      else
+        echo ''
+      fi
+    else
+      if [[ "${GH_MOCK_CLOSING_LINKAGE:-present}" == "present" ]]; then
+        echo '{"closingIssuesReferences":[{"number":958}]}'
+      else
+        echo '{"closingIssuesReferences":[]}'
+      fi
+    fi
+    exit 0
+  fi
 fi
 if [[ "$1" == "pr" && "$2" == "create" ]]; then
   body_file=""
@@ -111,6 +133,8 @@ assert_contains() {
 TMP_PR_BODY="$tmpdir/pr_body.md"
 export TMP_PR_BODY
 export PATH="$mockbin:$PATH"
+export GH_MOCK_CLOSING_LINKAGE="present"
+export GH_MOCK_EXISTING_PR="absent"
 
 (
   cd "$repo"
@@ -221,11 +245,37 @@ EOF_SOR
   body="$(cat "$TMP_PR_BODY")"
   assert_contains ".adl/cards/958/input_958.md" "$body"
   assert_contains ".adl/cards/958/output_958.md" "$body"
+  assert_contains "Closes #958" "$body"
   if grep -Eq '/Users/|/private/|/tmp/' <<<"$body"; then
     echo "assertion failed: PR body leaked absolute host path" >&2
     echo "$body" >&2
     exit 1
   fi
+
+  echo "relative body test again" >> "$worktree/adl/tools/README.md"
+  export GH_MOCK_CLOSING_LINKAGE="missing"
+  set +e
+  bad_finish="$(
+    cd "$worktree" &&
+    "$BASH_BIN" adl/tools/pr.sh finish 958 --title "[v0.85][authoring] Prevent Absolute Host Path Leakage in Issues, Cards, and PR Bodies" --paths "adl/tools/README.md" -f "$repo/.adl/cards/958/input_958.md" --output-card "$repo/.adl/cards/958/output_958.md" --no-checks --no-open 2>&1
+  )"
+  status=$?
+  set -e
+  [[ "$status" -ne 0 ]] || {
+    echo "assertion failed: expected finish to fail without GitHub closing linkage" >&2
+    exit 1
+  }
+  assert_contains "finish: PR is missing GitHub closing linkage for issue #958" "$bad_finish"
+
+  echo "relative body test update path" >> "$worktree/adl/tools/README.md"
+  export GH_MOCK_EXISTING_PR="present"
+  export GH_MOCK_CLOSING_LINKAGE="present"
+  (
+    cd "$worktree"
+    "$BASH_BIN" adl/tools/pr.sh finish 958 --title "[v0.85][authoring] Prevent Absolute Host Path Leakage in Issues, Cards, and PR Bodies" --paths "adl/tools/README.md" -f "$repo/.adl/cards/958/input_958.md" --output-card "$repo/.adl/cards/958/output_958.md" --no-checks --no-open >/dev/null
+  )
+  body="$(cat "$TMP_PR_BODY")"
+  assert_contains "Closes #958" "$body"
 
   cat >"$tmpdir/issue_body_bad.md" <<'EOF_BAD'
 ## Goal


### PR DESCRIPTION
Closes #1055

## Summary
- enforce GitHub issue-closing linkage after `pr.sh finish` creates or updates a PR
- stop relying on title-only `Closes #N` text as a sufficient close mechanism
- extend the existing finish regression harness to cover create, failure, and update linkage paths

## Validation
- `bash adl/tools/test_pr_finish_relative_card_paths.sh`
- `bash -n adl/tools/pr.sh`
