### PR TITLE
[v0.85][tools] Fix pr.sh start version fallback and local task-bundle spillover

### DIFF
--- a/adl/tools/card_paths.sh
+++ b/adl/tools/card_paths.sh
@@ -2,16 +2,35 @@
 set -euo pipefail
 
 card_primary_checkout_root() {
-  local common top
+  local common top current_top current_base current_parent
+  current_top="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+  current_base="$(basename "$current_top")"
+  current_parent="$(basename "$(dirname "$current_top")")"
+
+  # Repo-local execution clones/worktrees under .worktrees/adl-wp-* should keep
+  # their local ADL artifact state inside that execution surface, not spill back
+  # into the shared primary checkout.
+  if [[ "$current_parent" == ".worktrees" && "$current_base" == adl-wp-* ]]; then
+    printf '%s\n' "$current_top"
+    return 0
+  fi
+
   common="$(git rev-parse --git-common-dir 2>/dev/null || true)"
   if [[ -z "$common" ]]; then
-    pwd -P
+    printf '%s\n' "$current_top"
     return 0
   fi
 
   if [[ "$common" != /* ]]; then
-    top="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+    top="$current_top"
     common="$(cd "$top/$common" && pwd -P)"
+  fi
+
+  # For any non-primary git worktree, keep local ADL artifact state inside the
+  # active worktree rather than redirecting it back into the shared checkout.
+  if [[ "$current_top" != "$(cd "$common/.." && pwd -P)" ]]; then
+    printf '%s\n' "$current_top"
+    return 0
   fi
 
   cd "$common/.." && pwd -P

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -538,11 +538,12 @@ resolve_structured_prompt_validator() {
 
 issue_version() {
   local issue="$1"
-  local v
-  v="$(gh issue view "$issue" --json labels -q '.labels[].name' 2>/dev/null | sed -n 's/^version://p' | head -n1 || true)"
+  local v repo
+  repo="$(default_repo)"
+  v="$(gh issue view "$issue" $(gh_repo_flag "$repo") --json labels -q '.labels[].name' 2>/dev/null | sed -n 's/^version://p' | head -n1 || true)"
   if [[ -z "$v" ]]; then
     local title
-    title="$(gh issue view "$issue" --json title -q .title 2>/dev/null || true)"
+    title="$(gh issue view "$issue" $(gh_repo_flag "$repo") --json title -q .title 2>/dev/null || true)"
     if [[ "$title" =~ \[(v[0-9]+\.[0-9]+)\] ]]; then
       v="${BASH_REMATCH[1]}"
     fi
@@ -1722,23 +1723,32 @@ cmd_start() {
     require_cmd gh
     ver="$(issue_version "$issue")"
   fi
-  in_path="$(input_card_path "$issue" "$ver" "$slug")"
-  out_path="$(output_card_path "$issue" "$ver" "$slug")"
-  ensure_adl_dirs
-  if ! ensure_nonempty_file "$in_path"; then
-    note "Creating input card: $in_path"
-    seed_input_card "$in_path" "$issue" "$title" "$branch" "$ver" "$out_path"
-  else
-    note "Input card exists: $in_path"
-  fi
-  if ! ensure_nonempty_file "$out_path"; then
-    note "Creating output card: $out_path"
-    seed_output_card "$out_path" "$issue" "$title" "$branch" "$ver"
-  else
-    note "Output card exists: $out_path"
-  fi
-  sync_legacy_links_for_issue "$issue" "$ver" "$slug"
-  validate_bootstrap_cards "$issue" "$branch" "$in_path" "$out_path"
+  local start_paths_file
+  start_paths_file="$(mktemp -t prsh_start_paths_XXXXXX)"
+  (
+    cd "$worktree_path"
+    in_path="$(input_card_path "$issue" "$ver" "$slug")"
+    out_path="$(output_card_path "$issue" "$ver" "$slug")"
+    ensure_adl_dirs
+    if ! ensure_nonempty_file "$in_path"; then
+      note "Creating input card: $in_path"
+      seed_input_card "$in_path" "$issue" "$title" "$branch" "$ver" "$out_path"
+    else
+      note "Input card exists: $in_path"
+    fi
+    if ! ensure_nonempty_file "$out_path"; then
+      note "Creating output card: $out_path"
+      seed_output_card "$out_path" "$issue" "$title" "$branch" "$ver"
+    else
+      note "Output card exists: $out_path"
+    fi
+    sync_legacy_links_for_issue "$issue" "$ver" "$slug"
+    validate_bootstrap_cards "$issue" "$branch" "$in_path" "$out_path"
+    printf '%s\n%s\n' "$in_path" "$out_path" >"$start_paths_file"
+  )
+  in_path="$(sed -n '1p' "$start_paths_file")"
+  out_path="$(sed -n '2p' "$start_paths_file")"
+  rm -f "$start_paths_file"
   echo "• Agent:"
   echo "  READ   $in_path"
   echo "  WRITE  $out_path"

--- a/adl/tools/test_card_paths.sh
+++ b/adl/tools/test_card_paths.sh
@@ -63,4 +63,18 @@ canonical_output="$(resolve_output_card_path 145 v0.85 demo-title)"
 assert_eq "$(canon_path "$(dirname "$canonical_input")")/$(basename "$canonical_input")" "$(canon_path "$repo/.adl/v0.85/tasks/issue-0145__demo-title")/sip.md"
 assert_eq "$(canon_path "$(dirname "$canonical_output")")/$(basename "$canonical_output")" "$(canon_path "$repo/.adl/v0.85/tasks/issue-0145__demo-title")/sor.md"
 
+git branch -q worktree-test
+mkdir -p "$repo/.worktrees"
+git worktree add -q "$repo/.worktrees/adl-wp-200" worktree-test
+(
+  cd "$repo/.worktrees/adl-wp-200"
+  unset ADL_CARDS_ROOT
+  # shellcheck disable=SC1091
+  source "$repo/adl/tools/card_paths.sh"
+  local_cards_root="$(cards_root_resolve)"
+  local_bundle_path="$(task_bundle_dir_path 200 v0.85 local-scope)"
+  assert_eq "$(canon_path "$local_cards_root")" "$(canon_path "$repo/.worktrees/adl-wp-200/.adl/cards")"
+  assert_eq "$(canon_path "$(dirname "$local_bundle_path")")/$(basename "$local_bundle_path")" "$(canon_path "$repo/.worktrees/adl-wp-200/.adl/v0.85/tasks")/issue-0200__local-scope"
+)
+
 echo "ok"

--- a/adl/tools/test_pr_issue_version_inference.sh
+++ b/adl/tools/test_pr_issue_version_inference.sh
@@ -60,6 +60,12 @@ exit 1
 EOF
 chmod +x "$bindir/gh"
 
+canon_path() {
+  local p="$1"
+  mkdir -p "$p"
+  (cd "$p" && pwd -P)
+}
+
 (
   cd "$repo"
   git init -q
@@ -96,20 +102,20 @@ assert_contains() {
     --body "test body")"
 
   assert_contains "ISSUE_NUM=975" "$out" "new prints issue number"
-  [[ -f ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" ]] || {
-    echo "assertion failed: expected canonical input card under .adl/v0.85/tasks" >&2
+  [[ -f ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" ]] || {
+    echo "assertion failed: expected canonical input card under the worktree-local .adl/v0.85/tasks" >&2
     exit 1
   }
-  [[ -f ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sor.md" ]] || {
-    echo "assertion failed: expected canonical output card under .adl/v0.85/tasks" >&2
+  [[ -f ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sor.md" ]] || {
+    echo "assertion failed: expected canonical output card under the worktree-local .adl/v0.85/tasks" >&2
     exit 1
   }
-  grep -Fq "Version: v0.85" ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
+  grep -Fq "Version: v0.85" ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
     echo "assertion failed: expected input card version v0.85" >&2
     exit 1
   }
   grep -Fq "Title: [v0.85][process] Infer current milestone card version from issue title when labels are missing" \
-    ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
+    ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
     echo "assertion failed: expected preserved issue title in input card" >&2
     exit 1
   }
@@ -121,6 +127,21 @@ assert_contains() {
     echo "assertion failed: unexpected version:v0.3 label in issue create" >&2
     exit 1
   fi
+
+  out_start="$("$BASH_BIN" adl/tools/pr.sh start 975 --slug v085-process-infer-card-version-from-issue-title)"
+  assert_contains "WORKTREE $(canon_path "$repo/.worktrees/adl-wp-975")" "$out_start" "start prints worktree path"
+  [[ -f "$repo/.worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" ]] || {
+    echo "assertion failed: expected start to create input card inside worktree-local v0.85 task bundle" >&2
+    exit 1
+  }
+  [[ -f "$repo/.worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sor.md" ]] || {
+    echo "assertion failed: expected start to create output card inside worktree-local v0.85 task bundle" >&2
+    exit 1
+  }
+  [[ ! -e "$repo/.adl/v0.3/tasks/issue-0975__v085-process-infer-card-version-from-issue-title" ]] || {
+    echo "assertion failed: unexpected v0.3 fallback task bundle after start" >&2
+    exit 1
+  }
 )
 
 echo "pr.sh new/start title+version inference: ok"

--- a/adl/tools/test_pr_start_template_validation.sh
+++ b/adl/tools/test_pr_start_template_validation.sh
@@ -56,11 +56,11 @@ assert_contains() {
 (
   cd "$repo"
   "$BASH_BIN" adl/tools/pr.sh start 910 --slug validation-pass --no-fetch-issue >/dev/null
-
-  perl -0pi -e 's/Status: IN_PROGRESS/Status: MAYBE/' adl/templates/cards/output_card_template.md
+  perl -0pi -e 's/Status: IN_PROGRESS/Status: MAYBE/' ".worktrees/adl-wp-910/adl/templates/cards/output_card_template.md"
+  rm -f ".worktrees/adl-wp-910/.adl/v0.3/tasks/issue-0910__validation-pass/sor.md"
 
   set +e
-  bad="$("$BASH_BIN" adl/tools/pr.sh start 911 --slug validation-fail --no-fetch-issue 2>&1)"
+  bad="$("$BASH_BIN" adl/tools/pr.sh start 910 --slug validation-pass --no-fetch-issue 2>&1)"
   status=$?
   set -e
 

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -76,19 +76,19 @@ assert_contains() {
     echo "assertion failed: expected branch in worktree" >&2
     exit 1
   }
-  [[ -f "$repo/.adl/v0.3/tasks/issue-0999__test-smoke/sip.md" ]] || {
-    echo "assertion failed: expected canonical input card" >&2
+  [[ -f "$wt_path/.adl/v0.3/tasks/issue-0999__test-smoke/sip.md" ]] || {
+    echo "assertion failed: expected canonical input card inside the worktree-local task bundle" >&2
     exit 1
   }
-  [[ -f "$repo/.adl/v0.3/tasks/issue-0999__test-smoke/sor.md" ]] || {
-    echo "assertion failed: expected canonical output card" >&2
+  [[ -f "$wt_path/.adl/v0.3/tasks/issue-0999__test-smoke/sor.md" ]] || {
+    echo "assertion failed: expected canonical output card inside the worktree-local task bundle" >&2
     exit 1
   }
-  [[ -L "$repo/.adl/cards/999/input_999.md" ]] || {
+  [[ -L "$wt_path/.adl/cards/999/input_999.md" ]] || {
     echo "assertion failed: expected input compatibility link" >&2
     exit 1
   }
-  [[ -L "$repo/.adl/cards/999/output_999.md" ]] || {
+  [[ -L "$wt_path/.adl/cards/999/output_999.md" ]] || {
     echo "assertion failed: expected output compatibility link" >&2
     exit 1
   }


### PR DESCRIPTION
Closes #1061

## Summary
- fix `pr.sh start` issue-version lookup to use the resolved repository context
- keep start-created cards and task bundles inside the active execution worktree instead of the shared checkout
- update the start/card-path regressions to prove the corrected routing behavior

## Validation
- `bash adl/tools/test_card_paths.sh`
- `bash adl/tools/test_pr_issue_version_inference.sh`
- `bash adl/tools/test_pr_start_worktree_safe.sh`
- `bash adl/tools/test_pr_start_template_validation.sh`
- `bash -n adl/tools/pr.sh`
