### PR TITLE
[v0.86][docs] Re-redistribute feature docs to match actual milestone scope

### DIFF
--- a/docs/milestones/v0.86/FEATURE_DOC_REDISTRIBUTION_v0.86.md
+++ b/docs/milestones/v0.86/FEATURE_DOC_REDISTRIBUTION_v0.86.md
@@ -1,0 +1,75 @@
+# v0.86 Feature Doc Redistribution
+
+## Purpose
+
+Record the corrected `v0.86` feature-doc ownership after the earlier redistribution proved too aggressive.
+
+This document exists so the milestone truth is reviewable in tracked git rather than living only in issue discussion or ignored planning surfaces.
+
+## Corrected v0.86 Ownership
+
+The following promoted docs now define the tracked `v0.86` bounded cognitive system surface:
+
+- `docs/milestones/v0.86/features/AGENCY_AND_AGENTS.md`
+- `docs/milestones/v0.86/features/COGNITIVE_ARBITRATION.md`
+- `docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md`
+- `docs/milestones/v0.86/features/COGNITIVE_STACK.md`
+- `docs/milestones/v0.86/features/CONCEPT_PLANNING_FOR_v0.86.md`
+- `docs/milestones/v0.86/features/FAST_SLOW_THINKING_MODEL.md`
+- `docs/milestones/v0.86/features/FREEDOM_GATE.md`
+- `docs/milestones/v0.86/features/LOCAL_AGENT_DEMOS.md`
+
+These tracked feature docs together define the broader `v0.86` bounded cognitive system, including:
+
+- signals
+- arbitration
+- fast/slow reasoning
+- candidate selection / agency
+- bounded execution
+- evaluation
+- minimal reframing
+- memory participation
+- Freedom Gate
+- the canonical stack / loop
+
+## Redistribution Correction
+
+The corrected `v0.86` milestone is broader than the earlier thin-control-layer interpretation.
+
+What changed:
+- the milestone is no longer treated as only an initial control layer
+- the broader bounded cognitive system described by the `v0.86planning` feature docs is restored to `v0.86` ownership
+- the tracked milestone package now has a promoted tracked home for those feature-defining docs
+
+What this does not do:
+- it does not automatically pull every later milestone concept paper back into `v0.86`
+- it does not delete later milestone docs that still have distinct roadmap value
+- it does not replace later milestone deepening work on richer convergence, identity, governance, reasoning graph, or MVP-convergence surfaces
+
+## Docs Not Reassigned By This Issue
+
+The following docs remain outside the promoted `v0.86` tracked feature set unless separately reallocated:
+
+- `.adl/docs/v0.88planning/SUBSTANCE_OF_TIME.md`
+- `.adl/docs/v0.88planning/PHI_METRICS_FOR_ADL.md`
+- `.adl/docs/v0.88planning/WP_INSTINCT_AND_BOUNDED_AGENCY.md`
+- `.adl/docs/v0.88planning/INSTINCT_MODEL.md`
+- `.adl/docs/v0.89planning/AEE_CONVERGENCE_MODEL.md`
+- `.adl/docs/v0.89planning/SECURITY_AND_THREAT_MODELING.md`
+- `.adl/docs/v0.90planning/HYPOTHESIS_ENGINE_REASONING_GRAPH_V0.9.md`
+- `.adl/docs/v0.90planning/SIGNED_TRACE_ARCHITECTURE.md`
+- `.adl/docs/v0.90planning/TRACE_QUERY_LANGUAGE.md`
+- `.adl/docs/v0.91planning/AFFECT_MODEL_v0.90.md`
+- `.adl/docs/v0.92planning/ADL_IDENTITY_ARCHITECTURE.md`
+- `.adl/docs/v0.92planning/ADL_PROVIDER_CAPABILITIES.md`
+- `.adl/docs/v0.93planning/ADL_AGENT_RIGHTS_AND_DUTIES.md`
+
+This means `v0.86` now owns the first bounded cognitive system as a real milestone without erasing the later roadmap bands.
+
+## Exit Condition
+
+This redistribution pass is complete when:
+
+- the corrected `v0.86` feature-defining docs have a tracked home
+- the tracked milestone package can point to those promoted docs directly
+- there is no ambiguity about which broad bounded-cognitive-system docs belong to `v0.86`


### PR DESCRIPTION
## Summary
- record the corrected v0.86 feature-doc redistribution in a tracked ownership doc
- make the broadened bounded-cognitive-system scope reviewable in git
- preserve later roadmap bands without collapsing every later concept paper back into v0.86

## Notes
- stacked on top of #1081
- intended merge order: #882 -> #1081 -> #1085

Closes #1085