### PR TITLE
[v0.86][docs] Finish tracked source-of-truth cleanup after v0.86 promotion

### DIFF
--- a/docs/milestones/v0.86/DECISIONS_v0.86.md
+++ b/docs/milestones/v0.86/DECISIONS_v0.86.md
@@ -20,7 +20,7 @@ This log is authoritative for what v0.86 *is* and what it explicitly *is not*.
 | D-01 | v0.86 is scoped as the **first bounded cognitive system** (not a thin control layer) | accepted | The milestone must prove integrated cognition, not partial routing or gating | Ship only a control layer and defer cognition | Forces inclusion of signals, execution, evaluation, reframing, and memory participation | #882 |
 | D-02 | **Demos are the primary proof surface**, not tests or docs | accepted | Cognitive systems must be demonstrated end-to-end, not inferred from components | Rely on unit tests or doc alignment | Elevates demo program to first-class deliverable | DEMO_MATRIX_v0.86.md |
 | D-03 | The **canonical bounded cognitive path demo (D1)** is the primary milestone proof | accepted | One undeniable integrated proof prevents fragmented validation | Multiple equal demos with no anchor | Anchors release and review around a single system-level execution | DEMO_MATRIX_v0.86.md |
-| D-04 | **Signals, bounded execution, evaluation, reframing, and memory participation are IN scope** (minimal bounded form) | accepted | These are required for real cognition and cannot be deferred without invalidating the milestone | Defer these to later milestones | Expands milestone to full loop while keeping implementations minimal and bounded | .adl/docs/v0.86planning (milestone-defining planning docs) |
+| D-04 | **Signals, bounded execution, evaluation, reframing, and memory participation are IN scope** (minimal bounded form) | accepted | These are required for real cognition and cannot be deferred without invalidating the milestone | Defer these to later milestones | Expands milestone to full loop while keeping implementations minimal and bounded | docs/milestones/v0.86/features/ |
 | D-05 | **Agency must be implemented as candidate selection**, not rhetorical output | accepted | Agency must be observable and inspectable in artifacts | Implicit decision-making in text output | Forces real decision structures in runtime | AGENCY_AND_AGENTS.md |
 | D-06 | **Freedom Gate is required in minimal form** (allow / defer / refuse) | accepted | Establishes early decision boundary and moral control surface | Omit gate until later milestones | Introduces real constraint layer into cognition | FREEDOM_GATE.md |
 | D-07 | **Artifacts are the system of record** for behavior | accepted | Behavior must be inspectable and reviewable independent of output text | Logging-only or implicit reasoning | Enables deterministic inspection and review surfaces | DESIGN_v0.86.md |
@@ -29,20 +29,15 @@ This log is authoritative for what v0.86 *is* and what it explicitly *is not*.
 | D-10 | **Local-first execution is required for demos** | accepted | Ensures reproducibility and independence from external providers | Cloud-only demos | Guarantees demos are runnable by reviewers | LOCAL_AGENT_DEMOS.md |
 | D-11 | **Release is blocked unless the full cognitive loop is proven** | accepted | Prevents shipping partial cognition disguised as progress | Release based on CI or partial feature completion | Enforces GO/NO-GO discipline tied to real behavior | RELEASE_PLAN_v0.86.md |
 | D-12 | **There must be exactly one canonical bounded cognitive path** | accepted | Multiple competing paths would fragment behavior and invalidate proof | Allow parallel or experimental paths in milestone | Forces architectural clarity and reviewability | DESIGN_v0.86.md |
-| D-13 | **Bounded implementations are required for all cognitive components** | accepted | Scope must remain executable in a short window while still proving the full loop | Fully general or unbounded implementations | Keeps milestone realistic while preserving correctness of architecture | .adl/docs/v0.86planning (milestone-defining planning docs) |
+| D-13 | **Bounded implementations are required for all cognitive components** | accepted | Scope must remain executable in a short window while still proving the full loop | Fully general or unbounded implementations | Keeps milestone realistic while preserving correctness of architecture | docs/milestones/v0.86/features/ |
 
 ---
 
 ## Source of Truth Model
 
-v0.86 is defined by two coordinated documentation sets:
+v0.86 is defined by the coordinated tracked documentation under `docs/milestones/v0.86/`, including the promoted feature-defining docs under `docs/milestones/v0.86/features/`.
 
-- Tracked milestone docs under `docs/milestones/v0.86/`
-- Milestone-defining planning docs under `.adl/docs/v0.86planning/`
-
-Together, these form the implementation contract for the milestone.
-
-If these two sources diverge, that divergence is a defect and must be resolved before release.
+If tracked milestone docs and promoted feature docs diverge, that divergence is a defect and must be resolved before release.
 
 ---
 

--- a/docs/milestones/v0.86/DEMO_MATRIX_v0.86.md
+++ b/docs/milestones/v0.86/DEMO_MATRIX_v0.86.md
@@ -64,7 +64,7 @@ Additional environment / fixture requirements:
 - WBS / milestone mapping: `docs/milestones/v0.86/WBS_v0.86.md`
 - Sprint / execution plan: `docs/milestones/v0.86/SPRINT_v0.86.md`
 - Release / checklist context: `docs/milestones/v0.86/RELEASE_PLAN_v0.86.md`, `docs/milestones/v0.86/MILESTONE_CHECKLIST_v0.86.md`
-- Other proof-surface docs: `.adl/docs/v0.86planning/LOCAL_AGENT_DEMOS.md`
+- Other proof-surface docs: `docs/milestones/v0.86/features/LOCAL_AGENT_DEMOS.md`
 
 ## Demo Coverage Summary
 

--- a/docs/milestones/v0.86/FEATURE_DOCS_v0.86.md
+++ b/docs/milestones/v0.86/FEATURE_DOCS_v0.86.md
@@ -21,6 +21,6 @@ The goal is to preserve rich planning content while giving the milestone a git-b
 
 ## Notes
 
-- These tracked copies are promoted from `.adl/docs/v0.86planning/`.
+- These tracked copies were promoted from the `v0.86planning` feature-doc set and now serve as the tracked feature-definition surface for the milestone.
 - Promotion preserves substantive content rather than replacing it with thin summaries.
 - Follow-on source-of-truth cleanup and ownership normalization are handled separately.

--- a/docs/milestones/v0.86/MILESTONE_CHECKLIST_v0.86.md
+++ b/docs/milestones/v0.86/MILESTONE_CHECKLIST_v0.86.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Milestone: v0.86
 - Version: 0.86
-- Target release date: Target: end of 2-day execution window
+- Target release date: end of 2-day execution window
 - Owner: Daniel Austin
 
 ## Purpose

--- a/docs/milestones/v0.86/README.md
+++ b/docs/milestones/v0.86/README.md
@@ -7,7 +7,7 @@
 - Owner: `Daniel Austin / Agent Logic`
 
 ## Purpose
-This directory is the canonical tracked documentation set for **v0.86**.
+This directory is the canonical tracked documentation set for **v0.86**, including the promoted feature-defining docs under `docs/milestones/v0.86/features/`.
 
 v0.86 is the milestone where ADL establishes its **first working bounded cognitive system**. The milestone is not about landing every later cognitive concept at once. It is about making the full bounded cognitive loop real, bounded, inspectable, and demonstrable.
 
@@ -77,15 +77,16 @@ Canonical milestone documents:
 - Release plan: `RELEASE_PLAN_v0.86.md`
 - Release notes: `RELEASE_NOTES_v0.86.md`
 
-Supporting / milestone-defining planning docs:
-- `.adl/docs/v0.86planning/AGENCY_AND_AGENTS.md`
-- `.adl/docs/v0.86planning/COGNITIVE_ARBITRATION.md`
-- `.adl/docs/v0.86planning/COGNITIVE_LOOP_MODEL.md`
-- `.adl/docs/v0.86planning/COGNITIVE_STACK.md`
-- `.adl/docs/v0.86planning/FAST_SLOW_THINKING_MODEL.md`
-- `.adl/docs/v0.86planning/FREEDOM_GATE.md`
-- `.adl/docs/v0.86planning/LOCAL_AGENT_DEMOS.md`
-- `.adl/docs/v0.86planning/CONCEPT_PLANNING_FOR_v0.86.md`
+Promoted feature-defining docs:
+- `docs/milestones/v0.86/FEATURE_DOCS_v0.86.md`
+- `docs/milestones/v0.86/features/AGENCY_AND_AGENTS.md`
+- `docs/milestones/v0.86/features/COGNITIVE_ARBITRATION.md`
+- `docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md`
+- `docs/milestones/v0.86/features/COGNITIVE_STACK.md`
+- `docs/milestones/v0.86/features/FAST_SLOW_THINKING_MODEL.md`
+- `docs/milestones/v0.86/features/FREEDOM_GATE.md`
+- `docs/milestones/v0.86/features/LOCAL_AGENT_DEMOS.md`
+- `docs/milestones/v0.86/features/CONCEPT_PLANNING_FOR_v0.86.md`
 
 Context / supplementary planning notes:
 - `.adl/docs/v0.86planning/INTELLECTUAL_INFLUENCES.md`

--- a/docs/milestones/v0.86/RELEASE_PLAN_v0.86.md
+++ b/docs/milestones/v0.86/RELEASE_PLAN_v0.86.md
@@ -21,7 +21,7 @@ All of the following must be TRUE before proceeding:
 - [ ] Demo program runs locally and proves the canonical bounded cognitive path
 - [ ] Demo matrix matches actual runnable demos (`DEMO_MATRIX_v0.86.md`)
 - [ ] DESIGN, WBS, and implementation are aligned (no conceptual drift)
-- [ ] All v0.86 milestone-defining planning docs are implemented in at least one execution path and aligned with the tracked docs
+- [ ] All promoted v0.86 feature-defining docs are implemented in at least one execution path and aligned with the tracked docs
 
 ### Explicit GO / NO-GO Questions
 

--- a/docs/milestones/v0.86/WBS_v0.86.md
+++ b/docs/milestones/v0.86/WBS_v0.86.md
@@ -30,7 +30,7 @@ v0.86 delivers the first **working bounded cognitive system** for ADL, centered 
 - local demos that prove the integrated system is real
 - documentation and proof surfaces strong enough to support implementation and review
 
-This milestone is not satisfied by concept alignment alone. The milestone-defining planning docs under .adl/docs/v0.86planning/ must be implemented in at least one coherent execution path and aligned with the tracked milestone docs.
+This milestone is not satisfied by concept alignment alone. The promoted feature-defining docs under `docs/milestones/v0.86/features/` must be implemented in at least one coherent execution path and aligned with the tracked milestone docs.
 
 ## Work Packages
 
@@ -81,7 +81,7 @@ The intended order is:
 
 If implementation and docs disagree, treat the disagreement as a defect to fix immediately.
 
-The tracked milestone docs in docs/milestones/v0.86/ together with the milestone-defining planning docs under .adl/docs/v0.86planning/ form the implementation contract for v0.86. Any divergence between them is a defect and must be resolved before release.
+The tracked milestone docs in `docs/milestones/v0.86/`, together with the promoted feature-defining docs under `docs/milestones/v0.86/features/`, form the implementation contract for v0.86. Any divergence between them is a defect and must be resolved before release.
 
 ## Acceptance Mapping
 - WP-01 → All planning docs aligned with the corrected v0.86 planning set
@@ -109,7 +109,7 @@ The tracked milestone docs in docs/milestones/v0.86/ together with the milestone
 - WP-23 → Next milestone plan is ready before closure
 
 ## Exit Criteria
-- All v0.86 milestone-defining planning docs are implemented in at least one execution path and aligned with the tracked milestone docs.
+- All promoted v0.86 feature-defining docs are implemented in at least one execution path and aligned with the tracked milestone docs.
 - End-to-end local demo proves the bounded cognitive system, not partial components.
 - Artifacts are complete, inspectable, and consistent across all major stages.
 - Signals, arbitration, fast/slow routing, agency, bounded execution, evaluation, reframing, memory participation, and Freedom Gate behavior are observable.

--- a/docs/milestones/v0.86/features/README.md
+++ b/docs/milestones/v0.86/features/README.md
@@ -8,7 +8,7 @@ Purpose:
 - support follow-on source-of-truth cleanup after promotion
 
 Source:
-- promoted from `.adl/docs/v0.86planning/` for `#1081`
+- promoted into tracked milestone docs by `#1081`
 
 Promoted docs:
 - `AGENCY_AND_AGENTS.md`


### PR DESCRIPTION
## Summary
- finish the tracked v0.86 source-of-truth cleanup after #1087 and #1086
- replace remaining tracked references to  with the promoted tracked  surface where appropriate
- clean the v0.86 checklist wording artifact

## Notes
- local  copies remain as local planning history
- follow-up issue: #1090

Closes #1090