### PR TITLE
[v0.86][docs] Reconcile promoted feature docs with final milestone scope

### DIFF
--- a/docs/milestones/v0.86/DECISIONS_v0.86.md
+++ b/docs/milestones/v0.86/DECISIONS_v0.86.md
@@ -35,7 +35,7 @@ This log is authoritative for what v0.86 *is* and what it explicitly *is not*.
 
 ## Source of Truth Model
 
-v0.86 is defined by the coordinated tracked documentation under `docs/milestones/v0.86/`, including the promoted feature-defining docs under `docs/milestones/v0.86/features/`.
+v0.86 is defined by the tracked milestone docs under `docs/milestones/v0.86/`, including the promoted feature-defining docs under `docs/milestones/v0.86/features/`.
 
 If tracked milestone docs and promoted feature docs diverge, that divergence is a defect and must be resolved before release.
 
@@ -54,4 +54,4 @@ If tracked milestone docs and promoted feature docs diverge, that divergence is 
 - In-scope cognitive components (signals, execution, evaluation, reframing, memory participation) are clearly included
 - Out-of-scope features are clearly excluded and linked to future milestones
 - No conflicting architectural interpretations remain
-- The source-of-truth model (tracked docs + planning docs) is consistent and non-contradictory
+- The source-of-truth model (tracked docs + promoted feature docs) is consistent and non-contradictory

--- a/docs/milestones/v0.86/DEMO_MATRIX_v0.86.md
+++ b/docs/milestones/v0.86/DEMO_MATRIX_v0.86.md
@@ -10,6 +10,8 @@
 ## Purpose
 Define the canonical demo program for v0.86: which bounded local demos exist, which milestone claims they prove, how to run them, and which artifacts or proof surfaces reviewers should inspect.
 
+All v0.86 demos must be framed around **energy-use reduction**. The milestone proof is not generic cognition in the abstract; it is bounded cognition applied to identifying, evaluating, and controlling lower-energy choices.
+
 This matrix is not a brainstorming surface. It is the bounded proof plan for the first working bounded cognitive system.
 
 ## How To Use
@@ -72,11 +74,11 @@ Use this table as the fast review surface for milestone coverage.
 
 | Demo ID | Demo title | Milestone claim / WP proved | Command entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
 |---|---|---|---|---|---|---|---|
-| D1 | Canonical Bounded Cognitive Path | `WP-13` canonical bounded cognitive path; integrated stack + loop + signals + arbitration + execution + evaluation + reframing + memory + Freedom Gate | `adl/tools/demo_v086_control_path.sh` | control-path artifact set + summary output | One run traverses signals -> candidate selection -> arbitration -> fast/slow path -> bounded execution -> evaluation -> reframing -> memory participation -> Freedom Gate -> final action/refusal | Fixed local model + stable artifact naming; reruns should preserve the same control-path shape | PLANNED |
-| D2 | Fast vs Slow Routing | `WP-05`, `WP-06` arbitration and fast/slow reasoning paths | `adl/tools/demo_v086_fast_slow.sh` | routing decision artifacts for two scenarios | Simple task routes to fast path; complex/ambiguous task routes to slow path | Same scenarios and fixed local config should preserve route choice or explainable justification | PLANNED |
-| D3 | Agency / Candidate Selection | `WP-07` bounded agency via candidate selection | `adl/tools/demo_v086_candidate_selection.sh` | candidate-set artifact + selected candidate record | Multiple candidates are generated and one is explicitly selected with rationale | Candidate count and selected candidate should be stable enough for review with fixed input | PLANNED |
-| D4 | Freedom Gate Enforcement | `WP-12` Freedom Gate decision control | `adl/tools/demo_v086_freedom_gate.sh` | Freedom Gate decision event | At least one case is allowed and at least one case is deferred or refused | Same blocked/allowed scenarios should preserve gate outcome under fixed inputs | PLANNED |
-| D5 | Full Review Surface Walkthrough | `WP-15`, `WP-16` local demo program + review surface | `adl/tools/demo_v086_review_surface.sh` | combined demo manifest / review guide / artifact directory | Reviewer can run one command and locate all primary proof surfaces | Artifact directory layout and manifest names must remain stable | PLANNED |
+| D1 | Canonical Energy Reduction Path | `WP-13` canonical bounded cognitive path; integrated stack + loop + signals + arbitration + execution + evaluation + reframing + memory + Freedom Gate | `adl/tools/demo_v086_control_path.sh` | control-path artifact set + summary output | One run traverses signals -> candidate selection -> arbitration -> fast/slow path -> bounded execution -> evaluation -> reframing -> memory participation -> Freedom Gate -> final lower-energy recommendation or refusal | Fixed local model + stable artifact naming; reruns should preserve the same control-path shape | PLANNED |
+| D2 | Fast vs Slow Energy Routing | `WP-05`, `WP-06` arbitration and fast/slow reasoning paths | `adl/tools/demo_v086_fast_slow.sh` | routing decision artifacts for two energy-reduction scenarios | Simple energy-saving task routes to fast path; complex/ambiguous energy tradeoff routes to slow path | Same scenarios and fixed local config should preserve route choice or explainable justification | PLANNED |
+| D3 | Energy Action Candidate Selection | `WP-07` bounded agency via candidate selection | `adl/tools/demo_v086_candidate_selection.sh` | candidate-set artifact + selected candidate record | Multiple energy-reduction candidates are generated and one is explicitly selected with rationale | Candidate count and selected candidate should be stable enough for review with fixed input | PLANNED |
+| D4 | Freedom Gate for High-Energy Actions | `WP-12` Freedom Gate decision control | `adl/tools/demo_v086_freedom_gate.sh` | Freedom Gate decision event | At least one lower-energy action is allowed and at least one wasteful/high-energy action is deferred or refused | Same blocked/allowed scenarios should preserve gate outcome under fixed inputs | PLANNED |
+| D5 | Energy Review Surface Walkthrough | `WP-15`, `WP-16` local demo program + review surface | `adl/tools/demo_v086_review_surface.sh` | combined demo manifest / review guide / artifact directory | Reviewer can run one command and locate all primary proof surfaces for the energy-reduction demo set | Artifact directory layout and manifest names must remain stable | PLANNED |
 
 Status guidance:
 - `PLANNED` = intended but not yet validated
@@ -97,7 +99,7 @@ Status guidance:
 ### D1) Canonical Bounded Cognitive Path
 
 Description:
-- Proves that the first v0.86 bounded cognitive system executes end-to-end.
+- Proves that the first v0.86 bounded cognitive system executes end-to-end on an energy-use reduction task.
 - Demonstrates the canonical path rather than isolated subsystem behavior.
 
 Milestone claims / work packages covered:
@@ -148,6 +150,7 @@ Expected success signals:
 - Reframing/adaptation occurs in at least one case
 - Memory participation is visible
 - Freedom Gate decision occurs before final action
+- The final recommendation or refusal is explicitly about reducing energy use
 
 Determinism / replay notes:
 - Replay stability is judged by control-path shape and artifact structure, not byte-for-byte natural-language identity.
@@ -166,8 +169,8 @@ Known limits / caveats:
 ### D2) Fast vs Slow Routing
 
 Description:
-- Demonstrates that arbitration meaningfully distinguishes between fast-path and slow-path reasoning.
-- Uses bounded local tasks rather than open-ended workloads.
+- Demonstrates that arbitration meaningfully distinguishes between fast-path and slow-path reasoning for energy-use reduction decisions.
+- Uses bounded local energy-saving tasks rather than open-ended workloads.
 
 Milestone claims / work packages covered:
 - `WP-05` Cognitive Arbitration
@@ -192,8 +195,8 @@ Secondary proof surfaces:
 - `artifacts/v086/fast_slow/complex_case.json`
 
 Expected success signals:
-- The simple case selects the fast path.
-- The complex or ambiguous case selects the slow path.
+- The simple energy-saving case selects the fast path.
+- The complex or ambiguous energy tradeoff case selects the slow path.
 - The comparison output explains the difference in control behavior.
 
 Determinism / replay notes:
@@ -212,7 +215,7 @@ Known limits / caveats:
 ### D3) Agency / Candidate Selection
 
 Description:
-- Shows that the system generates and selects among bounded alternatives.
+- Shows that the system generates and selects among bounded energy-reduction alternatives.
 - Demonstrates agency as structured selection, not as free-form rhetoric.
 
 Milestone claims / work packages covered:

--- a/docs/milestones/v0.86/features/LOCAL_AGENT_DEMOS.md
+++ b/docs/milestones/v0.86/features/LOCAL_AGENT_DEMOS.md
@@ -4,11 +4,11 @@
 
 This document defines the **local agent demo program** for v0.86.
 
-The goal is not to showcase isolated capabilities, but to **prove that the ADL cognitive control layer works end-to-end using local models**.
+The goal is not to showcase isolated capabilities, but to **prove that the ADL bounded cognitive system can reduce energy use end-to-end using local models**.
 
-These demos are scoped strictly to the v0.86 cognitive control layer and must not include later-milestone behaviors such as AEE convergence, reframing systems, or persistent memory adaptation.
+These demos are scoped strictly to the bounded `v0.86` cognitive system and must not include later-milestone behaviors such as richer convergence systems, deeper persistence-driven adaptation, or later governance/identity surfaces.
 
-These demos are first-class deliverables. The milestone is not complete without them, but they must remain bounded to the actual v0.86 control-layer scope.
+These demos are first-class deliverables. The milestone is not complete without them, but they must remain bounded to the actual `v0.86` milestone scope.
 
 ---
 
@@ -19,9 +19,10 @@ v0.86 introduces a critical architectural claim:
 > Small / local models can produce high-quality behavior when structured by a deterministic cognitive architecture.
 
 The demo program must demonstrate:
-- control > raw model capability
+- control architecture > raw model capability
 - structure > scale
-- arbitration + bounded agency + structured control > single-pass inference
+- arbitration + bounded agency + bounded cognition > single-pass inference
+- lower-energy decisions are chosen, justified, and enforced better than naïve single-pass output
 
 If the demos do not show this, the milestone has failed regardless of code completeness.
 
@@ -36,7 +37,8 @@ All demos must:
 - emit full artifact traces
 - exercise arbitration and control decisions
 - be deterministic enough to reproduce behavior
-- remain within v0.86 scope (no AEE convergence, reframing systems, or persistence-driven adaptation)
+- remain within v0.86 scope (no richer convergence systems, deeper persistence-driven adaptation, or later governance/identity layers)
+- focus on energy-use reduction scenarios, tradeoffs, recommendations, and enforcement
 
 All demos must avoid:
 - hidden prompts
@@ -47,10 +49,10 @@ All demos must avoid:
 
 ## Core Demo Set (v0.86)
 
-### Demo 1 — Canonical Control Path
+### Demo 1 — Canonical Energy Reduction Path
 
 **Purpose:**
-Prove that the full cognitive control path executes end-to-end.
+Prove that the full bounded cognitive path executes end-to-end for an energy-use reduction task.
 
 **Must include:**
 - loop execution
@@ -59,6 +61,7 @@ Prove that the full cognitive control path executes end-to-end.
 - candidate selection
 - Freedom Gate decision
 - final output
+- explicit lower-energy recommendation or refusal
 
 **Artifacts required:**
 - routing decision
@@ -69,14 +72,14 @@ Prove that the full cognitive control path executes end-to-end.
 
 ---
 
-### Demo 2 — Fast vs Slow Thinking
+### Demo 2 — Fast vs Slow Energy Routing
 
 **Purpose:**
-Demonstrate that arbitration meaningfully selects between execution modes.
+Demonstrate that arbitration meaningfully selects between execution modes for energy-use reduction decisions.
 
 **Scenario:**
-- one simple task (fast path)
-- one complex/ambiguous task (slow path)
+- one simple energy-saving task (fast path)
+- one complex/ambiguous energy tradeoff (slow path)
 
 **Must show:**
 - different execution paths
@@ -85,10 +88,10 @@ Demonstrate that arbitration meaningfully selects between execution modes.
 
 ---
 
-### Demo 3 — Agency (Candidate Selection)
+### Demo 3 — Energy Action Candidate Selection
 
 **Purpose:**
-Show that the system generates and selects among alternatives.
+Show that the system generates and selects among energy-reduction alternatives.
 
 **Must include:**
 - multiple candidates
@@ -100,19 +103,19 @@ If only one option is ever produced, this demo fails.
 
 ---
 
-### Demo 4 — Freedom Gate Enforcement
+### Demo 4 — Freedom Gate for High-Energy Actions
 
 **Purpose:**
-Prove that the system can refuse or defer execution.
+Prove that the system can refuse or defer wasteful/high-energy actions.
 
 **Must include:**
-- at least one blocked or deferred action
+- at least one blocked or deferred high-energy action
 - explicit policy reasoning
 - inspectable decision artifact
 
 ---
 
-These four demos are the complete bounded v0.86 demo set. Any future demos involving iteration, reframing, persistence, or convergence belong to later milestones and must not be treated as required evidence for v0.86.
+These four demos are the complete bounded v0.86 demo set. Every one of them must remain anchored to energy-use reduction. Any future demos involving iteration, reframing, persistence, or convergence belong to later milestones and must not be treated as required evidence for v0.86.
 
 ---
 


### PR DESCRIPTION
## Summary
- reconcile promoted tracked v0.86 feature docs with the final milestone package
- replace stale tracked references to local `.adl/docs/v0.86planning/` feature-doc surfaces with tracked `docs/milestones/v0.86/features/` references where appropriate
- align the promoted `LOCAL_AGENT_DEMOS.md` with the bounded cognitive system scope and energy-use reduction framing

Closes #1094
