### PR TITLE
[v0.86][tools] Retire pr new and remove obsolete create compatibility

### DIFF
--- a/adl/tools/BURST_PLAYBOOK.md
+++ b/adl/tools/BURST_PLAYBOOK.md
@@ -5,7 +5,7 @@ Use this playbook for sequential burst execution.
 ## Sequence
 
 1. Generate a prioritized plan (max 8 issues).
-2. Create child issues with `./adl/tools/pr.sh new --no-start`.
+2. Create child issues with `./adl/tools/pr.sh create --no-start`.
 3. Execute child issues one by one using `adl_pr_cycle` (`init -> create -> start -> codex -> run_if_required -> finish -> report`).
 4. Merge only green PRs.
 5. Write a final summary under `.adl/reports/burst/<timestamp>/final_summary.md`.

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -41,8 +41,8 @@ CARD_PATHS_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/card_paths.sh"
 # shellcheck disable=SC1090
 source "$CARD_PATHS_LIB"
 
-DEFAULT_VERSION="v0.3"
-DEFAULT_NEW_LABELS="track:roadmap,version:v0.3,type:bug,area:tools,epic:v0.3-tooling-git"
+DEFAULT_VERSION="v0.86"
+DEFAULT_NEW_LABELS="track:roadmap,type:task,area:tools"
 
 
 #
@@ -1623,9 +1623,7 @@ cmd_create() {
     return 0
   fi
 
-  # v0.85 transition strategy: allow the new lifecycle name to drive the current
-  # issue-creation precursor flow while keeping `pr new` as a compatibility alias.
-  cmd_new "$@"
+  create_issue "$@"
 }
 
 cmd_start() {
@@ -1795,12 +1793,7 @@ cmd_start() {
   note "Done."
 }
 
-cmd_new() {
-  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
-    usage_new
-    return 0
-  fi
-
+create_issue() {
   require_cmd gh
 
   local title=""
@@ -1917,6 +1910,14 @@ cmd_new() {
 
   cmd_start "$issue_num" --slug "$slug" --title "$title" --version "$version"
   echo "BRANCH=codex/${issue_num}-${slug}"
+}
+
+cmd_new() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_new
+    return 0
+  fi
+  die "new: retired; use 'adl/tools/pr.sh create --title ...' instead"
 }
 
 cmd_finish() {
@@ -2186,8 +2187,8 @@ pr.sh — reduce git/PR thrash while preserving human review
 Commands:
   help
   init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v>]
-  create  [<issue> --stp <path>] | [legacy new-issue args]
-  new     --title "<title>" [--slug <slug>] [--body "<text>" | --body-file <path>] [--labels <csv>] [--version <v>] [--no-start]
+  create  <issue> --stp <path>
+  create  --title "<title>" [--slug <slug>] [--body "<text>" | --body-file <path>] [--labels <csv>] [--version <v>] [--no-start]
   run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
   start   <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>]
   card    <issue> [input|output] ... [--version <v0.2>] [-f <input_card.md>]
@@ -2198,14 +2199,13 @@ Commands:
   status
 
 Flags:
-  (new)     --title "<title>"                 Required issue title for gh issue create.
-  (new)     --body "<text>"                   Optional issue body text.
-  (new)     --body-file <path|->              Optional issue body file path ('-' reads stdin).
-  (new)     --labels <csv>                    Comma-separated labels (default: track:roadmap,version:v0.3,type:bug,area:tools,epic:v0.3-tooling-git).
-  (new)     --version <v0.3>                  Default/fallback version label for new issue/card flow.
-  (new)     --no-start                        Only create issue; do not invoke start.
   (create)  <issue> --stp <path>              Reconcile an existing GitHub issue from a canonical STP.
-  (create)  [legacy new-issue args]           Create path reuses the current precursor semantics during v0.85.
+  (create)  --title "<title>"                 Required issue title for gh issue create.
+  (create)  --body "<text>"                   Optional issue body text.
+  (create)  --body-file <path|->              Optional issue body file path ('-' reads stdin).
+  (create)  --labels <csv>                    Comma-separated labels (default: track:roadmap,type:task,area:tools).
+  (create)  --version <v0.86>                 Default/fallback version label for issue/card flow.
+  (create)  --no-start                        Only create issue; do not invoke start.
   (init)    --version <v0.85>                 Override detected version (otherwise inferred from issue labels version:vX.Y)
   (init)    --no-fetch-issue                  Do not fetch issue title/labels; requires --slug.
   (run)     --runs-root <dir>                 Override canonical run artifact root (default: <repo>/.adl/runs or ADL_RUNS_ROOT).
@@ -2235,7 +2235,7 @@ Examples:
   adl/tools/pr.sh help
   adl/tools/pr.sh init 17 --slug b6-default-system --no-fetch-issue --version v0.85
   adl/tools/pr.sh create 17 --stp .adl/issues/v0.85/bodies/issue-17-b6-default-system.md
-  adl/tools/pr.sh new --title "adl: fix timeout handling" --slug timeout-fix
+  adl/tools/pr.sh create --title "adl: fix timeout handling" --slug timeout-fix
   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
   adl/tools/pr.sh start 17 --slug b6-default-system
   adl/tools/pr.sh card  17 --help
@@ -2253,10 +2253,11 @@ EOF
 usage_new() {
   cat <<'EOF'
 Usage:
-  adl/tools/pr.sh new --title "<title>" [--slug <slug>] [--body "<text>" | --body-file <path>] [--labels <csv>] [--version <v>] [--no-start]
+  adl/tools/pr.sh new ...
 
 Notes:
-- Compatibility alias during v0.85 for the create path now exposed as `pr create`.
+- `pr new` is retired.
+- Use `adl/tools/pr.sh create --title ...` instead.
 EOF
 }
 
@@ -2268,8 +2269,8 @@ Usage:
 
 Notes:
 - Reconcile mode updates an existing GitHub issue from a canonical STP.
-- Create mode reuses the current `pr new` precursor behavior during v0.85.
-- `pr new` remains a compatibility alias while `pr create` becomes the canonical lifecycle name.
+- Create mode is the canonical issue-creation path.
+- `pr new` is retired and should not be used.
 EOF
 }
 

--- a/adl/tools/test_pr_finish_relative_card_paths.sh
+++ b/adl/tools/test_pr_finish_relative_card_paths.sh
@@ -139,17 +139,19 @@ export GH_MOCK_EXISTING_PR="absent"
 (
   cd "$repo"
 
-  "$BASH_BIN" adl/tools/pr.sh start 958 --slug relative-card-paths --no-fetch-issue >/dev/null
+  "$BASH_BIN" adl/tools/pr.sh start 958 --slug relative-card-paths --no-fetch-issue --version v0.85 >/dev/null
+  "$BASH_BIN" adl/tools/pr.sh cards 958 --version v0.85 --no-fetch-issue >/dev/null
   worktree="$repo/.worktrees/adl-wp-958"
   git -C "$worktree" config user.name "Test User"
   git -C "$worktree" config user.email "test@example.com"
+  mkdir -p .adl/cards/958
 
   cat > .adl/cards/958/output_958.md <<'EOF_SOR'
 # ADL Output Card
 
 Task ID: issue-0958
 Run ID: issue-0958
-Version: v0.3
+Version: v0.85
 Title: relative-card-paths
 Branch: codex/958-relative-card-paths
 Status: DONE
@@ -282,14 +284,14 @@ EOF_SOR
 contains /Users/example leak
 EOF_BAD
   set +e
-  bad="$($BASH_BIN adl/tools/pr.sh new --title "bad issue" --body-file "$tmpdir/issue_body_bad.md" --no-start 2>&1)"
+  bad="$($BASH_BIN adl/tools/pr.sh create --title "bad issue" --body-file "$tmpdir/issue_body_bad.md" --no-start 2>&1)"
   status=$?
   set -e
   [[ "$status" -ne 0 ]] || {
-    echo "assertion failed: expected pr.sh new absolute-path guard to fail" >&2
+    echo "assertion failed: expected pr.sh create absolute-path guard to fail" >&2
     exit 1
   }
-  assert_contains "new: issue body contains disallowed absolute host path" "$bad"
+  assert_contains "issue body contains disallowed absolute host path" "$bad"
 )
 
 echo "pr.sh finish/new path hygiene: ok"

--- a/adl/tools/test_pr_help_and_card_open.sh
+++ b/adl/tools/test_pr_help_and_card_open.sh
@@ -43,16 +43,20 @@ assert_contains() {
 
   help_out="$("$BASH_BIN" adl/tools/pr.sh help)"
   assert_contains "Commands:" "$help_out" "help alias"
+  if grep -Fq "  new     " <<<"$help_out"; then
+    echo "assertion failed: help should not advertise retired pr new command" >&2
+    exit 1
+  fi
 
   card_help_out="$("$BASH_BIN" adl/tools/pr.sh card --help)"
   assert_contains "Usage:" "$card_help_out" "card --help"
 
   in_path="$("$BASH_BIN" adl/tools/pr.sh card 271 input --no-fetch-issue --slug demo-title)"
-  [[ "$in_path" == *"/.adl/v0.3/tasks/issue-0271__demo-title/sip.md" ]] || {
+  [[ "$in_path" == *"/.adl/v0.86/tasks/issue-0271__demo-title/sip.md" ]] || {
     echo "assertion failed: unexpected input card path: $in_path" >&2
     exit 1
   }
-  [[ -f ".adl/v0.3/tasks/issue-0271__demo-title/sip.md" ]] || {
+  [[ -f ".adl/v0.86/tasks/issue-0271__demo-title/sip.md" ]] || {
     echo "assertion failed: expected input card file to exist" >&2
     exit 1
   }
@@ -62,11 +66,11 @@ assert_contains() {
   }
 
   out_path="$("$BASH_BIN" adl/tools/pr.sh card 271 output --no-fetch-issue --slug demo-title)"
-  [[ "$out_path" == *"/.adl/v0.3/tasks/issue-0271__demo-title/sor.md" ]] || {
+  [[ "$out_path" == *"/.adl/v0.86/tasks/issue-0271__demo-title/sor.md" ]] || {
     echo "assertion failed: unexpected output card path via card command: $out_path" >&2
     exit 1
   }
-  [[ -f ".adl/v0.3/tasks/issue-0271__demo-title/sor.md" ]] || {
+  [[ -f ".adl/v0.86/tasks/issue-0271__demo-title/sor.md" ]] || {
     echo "assertion failed: expected output card file to exist" >&2
     exit 1
   }
@@ -76,13 +80,13 @@ assert_contains() {
   }
 
   out_path2="$("$BASH_BIN" adl/tools/pr.sh output 271 output --no-fetch-issue --slug demo-title)"
-  [[ "$out_path2" == *"/.adl/v0.3/tasks/issue-0271__demo-title/sor.md" ]] || {
+  [[ "$out_path2" == *"/.adl/v0.86/tasks/issue-0271__demo-title/sor.md" ]] || {
     echo "assertion failed: unexpected output card path via output command: $out_path2" >&2
     exit 1
   }
 
   in_path2="$("$BASH_BIN" adl/tools/pr.sh output 271 input --no-fetch-issue --slug demo-title)"
-  [[ "$in_path2" == *"/.adl/v0.3/tasks/issue-0271__demo-title/sip.md" ]] || {
+  [[ "$in_path2" == *"/.adl/v0.86/tasks/issue-0271__demo-title/sip.md" ]] || {
     echo "assertion failed: unexpected input card path via output command: $in_path2" >&2
     exit 1
   }


### PR DESCRIPTION
Closes #1074

## Summary
- make `pr create` the canonical issue-creation path
- retire `pr new` from the active CLI/help surface
- remove the stale `v0.3` default issue-create labels and default version
- update focused tooling docs/tests for the new flow

## Validation
- bash adl/tools/test_pr_create.sh
- bash adl/tools/test_pr_issue_version_inference.sh
- bash adl/tools/test_pr_help_and_card_open.sh
- bash adl/tools/test_pr_finish_relative_card_paths.sh