### PR TITLE
[v0.86][tools] Ensure pr.sh fully seeds init start and cards for fresh v0.86 issues

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1925,7 +1925,7 @@ cmd_start() {
 
   ensure_primary_checkout_on_main
 
-  local ver in_path out_path
+  local ver in_path out_path source_path
   if [[ -n "$version" ]]; then
     ver="$version"
   elif [[ "$no_fetch_issue" == "1" ]]; then
@@ -1934,10 +1934,34 @@ cmd_start() {
     require_cmd gh
     ver="$(issue_version "$issue")"
   fi
+
+  source_path="$(issue_prompt_path_for_issue "$issue" "$ver" "$slug")"
+  if [[ ! -f "$source_path" ]]; then
+    if [[ "$no_fetch_issue" == "1" ]]; then
+      note "Source issue prompt missing; generating offline canonical local issue prompt: $source_path"
+      write_generated_issue_prompt "$source_path" "$issue" "$ver" "$slug" "$title" "version:${ver}" "https://github.com/$(default_repo)/issues/${issue}"
+    fi
+    if [[ ! -f "$source_path" ]]; then
+      note "Source issue prompt missing; generating canonical local issue prompt: $source_path"
+      source_path="$(ensure_source_issue_prompt "$issue" "$ver" "$slug" "$title")"
+    fi
+  fi
+  validate_bootstrap_stp "$source_path"
+
   local start_paths_file
   start_paths_file="$(mktemp -t prsh_start_paths_XXXXXX)"
   (
     cd "$worktree_path"
+    local bundle_dir stp_path
+    bundle_dir="$(task_bundle_dir_path "$issue" "$ver" "$slug")"
+    stp_path="$bundle_dir/stp.md"
+    mkdir -p "$bundle_dir"
+    if ! ensure_nonempty_file "$stp_path"; then
+      note "Creating task-bundle STP: $stp_path"
+      cp "$source_path" "$stp_path"
+    else
+      note "Task-bundle STP exists: $stp_path"
+    fi
     in_path="$(input_card_path "$issue" "$ver" "$slug")"
     out_path="$(output_card_path "$issue" "$ver" "$slug")"
     ensure_adl_dirs
@@ -1954,13 +1978,17 @@ cmd_start() {
       note "Output card exists: $out_path"
     fi
     sync_legacy_links_for_issue "$issue" "$ver" "$slug"
+    validate_bootstrap_stp "$stp_path"
     validate_bootstrap_cards "$issue" "$branch" "$in_path" "$out_path"
-    printf '%s\n%s\n' "$in_path" "$out_path" >"$start_paths_file"
+    printf '%s\n%s\n%s\n' "$stp_path" "$in_path" "$out_path" >"$start_paths_file"
   )
-  in_path="$(sed -n '1p' "$start_paths_file")"
-  out_path="$(sed -n '2p' "$start_paths_file")"
+  local stp_path
+  stp_path="$(sed -n '1p' "$start_paths_file")"
+  in_path="$(sed -n '2p' "$start_paths_file")"
+  out_path="$(sed -n '3p' "$start_paths_file")"
   rm -f "$start_paths_file"
   echo "• Agent:"
+  echo "  STP    $stp_path"
   echo "  READ   $in_path"
   echo "  WRITE  $out_path"
   echo "  WORKTREE $worktree_path"

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -76,6 +76,10 @@ assert_contains() {
     echo "assertion failed: expected branch in worktree" >&2
     exit 1
   }
+  [[ -f "$wt_path/.adl/v0.86/tasks/issue-0999__test-smoke/stp.md" ]] || {
+    echo "assertion failed: expected canonical stp inside the worktree-local task bundle" >&2
+    exit 1
+  }
   [[ -f "$wt_path/.adl/v0.86/tasks/issue-0999__test-smoke/sip.md" ]] || {
     echo "assertion failed: expected canonical input card inside the worktree-local task bundle" >&2
     exit 1


### PR DESCRIPTION
## Summary
Make `pr start` leave fresh v0.86 issues actually authoring-ready by seeding the task-bundle `stp.md` from the canonical source prompt.

## What changed
- `pr start` now ensures a canonical source prompt exists before bundle seeding
- `pr start` seeds `stp.md` into the task bundle if it is missing
- offline `--no-fetch-issue` startup can synthesize a minimal canonical source prompt when needed
- added a regression assertion that started issues contain `stp.md`

## Validation
- `bash adl/tools/test_pr_start_worktree_safe.sh`

Closes #1116