### PR TITLE
[v0.86][tools] Fix pr.sh finish using output cards as canonical PR-body source

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1027,6 +1027,26 @@ ensure_nonempty_file() {
   return 0
 }
 
+extract_markdown_section() {
+  # Extract the body of a top-level markdown section (## Heading) from a file.
+  local path="$1" heading="$2"
+  awk -v heading="## ${heading}" '
+    $0 == heading { in_section=1; next }
+    in_section && /^## / { exit }
+    in_section { print }
+  ' "$path" | sed '/^[[:space:]]*$/{
+    :a
+    N
+    /^\n*$/d
+    ba
+  }' | sed '${/^[[:space:]]*$/d;}'
+}
+
+extra_pr_body_looks_like_issue_template() {
+  local body="${1:-}"
+  grep -Eqi '(^|[[:space:]])(issue_card_schema:|wp:|pr_start:)([[:space:]]|$)|^## (Goal|Deliverables|Acceptance criteria)$|^---$' <<<"$body"
+}
+
 render_pr_body_file() {
   # Renders a PR body into a temp file and echoes its path.
   # Args: issue close_line input_path output_path extra_body no_checks fingerprint
@@ -1035,9 +1055,16 @@ render_pr_body_file() {
   local tmp
   tmp="$(mktemp -t pr_body_XXXXXX.md)"
 
-  local input_ref output_ref
+  local input_ref output_ref summary_section artifacts_section validation_section
   input_ref="$(issue_card_reference input "$issue")"
   output_ref="$(issue_card_reference output "$issue")"
+  summary_section="$(extract_markdown_section "$output_path" "Summary")"
+  artifacts_section="$(extract_markdown_section "$output_path" "Artifacts produced")"
+  validation_section="$(extract_markdown_section "$output_path" "Validation")"
+
+  if [[ -n "$extra_body" ]] && extra_pr_body_looks_like_issue_template "$extra_body"; then
+    die "finish: --body looks like issue-template/prompt text; use the output card as the PR summary source instead"
+  fi
 
   {
     if [[ -n "$close_line" ]]; then
@@ -1045,23 +1072,40 @@ render_pr_body_file() {
       echo
     fi
 
-    echo "Local artifacts (not committed):"
-    echo "- Input card:  $input_ref"
-    echo "- Output card: $output_ref"
-    echo "- Idempotency-Key: $fingerprint"
-    echo
+    if [[ -n "$summary_section" ]]; then
+      echo "## Summary"
+      echo "$summary_section"
+      echo
+    fi
+
+    if [[ -n "$artifacts_section" ]]; then
+      echo "## Artifacts"
+      echo "$artifacts_section"
+      echo
+    fi
+
+    if [[ -n "$validation_section" ]]; then
+      echo "## Validation"
+      echo "$validation_section"
+      echo
+    elif [[ "$no_checks" != "1" ]]; then
+      echo "## Validation"
+      echo "- cargo fmt"
+      echo "- cargo clippy --all-targets -- -D warnings"
+      echo "- cargo test"
+      echo
+    fi
 
     if [[ -n "$extra_body" ]]; then
+      echo "## Notes"
       echo "$extra_body"
       echo
     fi
 
-    if [[ "$no_checks" != "1" ]]; then
-      echo "Tests:"
-      echo "- cargo fmt"
-      echo "- cargo clippy --all-targets -- -D warnings"
-      echo "- cargo test"
-    fi
+    echo "## Local Artifacts"
+    echo "- Input card:  $input_ref"
+    echo "- Output card: $output_ref"
+    echo "- Idempotency-Key: $fingerprint"
   } >"$tmp"
 
   echo "$tmp"

--- a/adl/tools/test_pr_finish_default_stage_root.sh
+++ b/adl/tools/test_pr_finish_default_stage_root.sh
@@ -53,9 +53,43 @@ if [[ "$1" == "pr" && "$2" == "list" ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "edit" ]]; then
+  body_file=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--body-file" ]]; then
+      body_file="$2"
+      shift 2
+    else
+      shift
+    fi
+  done
+  [[ -n "$body_file" ]] && cp "$body_file" "$TMP_PR_BODY"
   exit 0
 fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json closingIssuesReferences "* ]]; then
+    if [[ " $* " == *" -q "* ]]; then
+      echo '1021'
+    else
+      echo '{"closingIssuesReferences":[{"number":1021}]}'
+    fi
+    exit 0
+  fi
+  if [[ " $* " == *" --json body "* ]]; then
+    cat "$TMP_PR_BODY"
+    exit 0
+  fi
+fi
 if [[ "$1" == "pr" && "$2" == "create" ]]; then
+  body_file=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--body-file" ]]; then
+      body_file="$2"
+      shift 2
+    else
+      shift
+    fi
+  done
+  [[ -n "$body_file" ]] && cp "$body_file" "$TMP_PR_BODY"
   echo "https://example.test/pr/1"
   exit 0
 fi
@@ -92,14 +126,18 @@ assert_contains() {
 }
 
 export PATH="$mockbin:$PATH"
+TMP_PR_BODY="$tmpdir/pr_body.md"
+export TMP_PR_BODY
 
 (
   cd "$repo"
 
   "$BASH_BIN" adl/tools/pr.sh start 1021 --slug finish-default-root --no-fetch-issue >/dev/null
+  "$BASH_BIN" adl/tools/pr.sh cards 1021 --no-fetch-issue >/dev/null
   worktree="$repo/.worktrees/adl-wp-1021"
   git -C "$worktree" config user.name "Test User"
   git -C "$worktree" config user.email "test@example.com"
+  mkdir -p .adl/cards/1021
 
   cat > .adl/cards/1021/output_1021.md <<'EOF_SOR'
 # ADL Output Card
@@ -202,6 +240,13 @@ EOF_SOR
     cd "$worktree"
     "$BASH_BIN" adl/tools/pr.sh finish 1021 --title "[v0.85][authoring] Harden pr finish command behavior" -f "$repo/.adl/cards/1021/input_1021.md" --output-card "$repo/.adl/cards/1021/output_1021.md" --no-checks --no-open >/dev/null
   )
+
+  body="$(cat "$TMP_PR_BODY")"
+  assert_contains "Closes #1021" "$body" "finish keeps closing linkage"
+  assert_contains "## Summary" "$body" "finish renders summary section"
+  assert_contains "Finish default root stages both docs and code paths." "$body" "finish uses output card summary"
+  assert_contains "## Artifacts" "$body" "finish renders artifacts section"
+  assert_contains "docs/tooling/README.md" "$body" "finish lists docs artifact"
 
   changed="$(git -C "$worktree" show --name-only --format=oneline HEAD)"
   assert_contains "adl/tools/README.md" "$changed" "finish stages code path by default"

--- a/adl/tools/test_pr_finish_relative_card_paths.sh
+++ b/adl/tools/test_pr_finish_relative_card_paths.sh
@@ -256,6 +256,11 @@ EOF_SOR
   assert_contains ".adl/cards/958/input_958.md" "$body"
   assert_contains ".adl/cards/958/output_958.md" "$body"
   assert_contains "Closes #958" "$body"
+  assert_contains "## Summary" "$body"
+  assert_contains "Finished relative card path test." "$body"
+  assert_contains "## Artifacts" "$body"
+  assert_contains "adl/tools/README.md" "$body"
+  assert_contains "## Validation" "$body"
   if grep -Eq '/Users/|/private/|/tmp/' <<<"$body"; then
     echo "assertion failed: PR body leaked absolute host path" >&2
     echo "$body" >&2
@@ -288,6 +293,20 @@ EOF_SOR
   )
   body="$(cat "$TMP_PR_BODY")"
   assert_contains "Closes #958" "$body"
+
+  bad_finish_body=$'issue_card_schema: adl.issue.v1\nwp: WP-04\npr_start:\n## Goal\nleaked issue template'
+  set +e
+  bad="$(
+    cd "$worktree" &&
+    "$BASH_BIN" adl/tools/pr.sh finish 958 --title "[v0.85][authoring] Prevent Absolute Host Path Leakage in Issues, Cards, and PR Bodies" --paths "adl/tools/README.md" -f "$repo/.adl/cards/958/input_958.md" --output-card "$repo/.adl/cards/958/output_958.md" --no-checks --no-open --body "$bad_finish_body" 2>&1
+  )"
+  status=$?
+  set -e
+  [[ "$status" -ne 0 ]] || {
+    echo "assertion failed: expected finish to reject issue-template body text" >&2
+    exit 1
+  }
+  assert_contains "finish: --body looks like issue-template/prompt text" "$bad"
 
   cat >"$tmpdir/issue_body_bad.md" <<'EOF_BAD'
 ## Goal


### PR DESCRIPTION
Closes #1133

## Summary
Fix `adl/tools/pr.sh finish` so PR bodies are rendered from the completed output card instead of depending on arbitrary `--body` text, and reject issue-template/prompt-shaped `--body` content before publishing it.

## Artifacts
- `adl/tools/pr.sh`
- `adl/tools/test_pr_finish_default_stage_root.sh`
- `adl/tools/test_pr_finish_relative_card_paths.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_finish_default_stage_root.sh`
    - verifies the default finish path renders summary/artifact sections from the output card and stages code+docs changes together.
  - `bash adl/tools/test_pr_finish_relative_card_paths.sh`
    - verifies relative card references, closing linkage handling, and rejection of issue-template/prompt-shaped PR body text.
- Results:
  - both listed commands passed

## Local Artifacts
- Input card:  .adl/cards/1133/input_1133.md
- Output card: .adl/cards/1133/output_1133.md
- Idempotency-Key: 924a9f9452104d119a7c9afbc96d686f356ac22c3e0fc4c3abf2b776927312ad
