### PR TITLE
[v0.86][tools] Fix pr.sh false bootstrap-lock behavior in batched init/start/cards flows

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -257,6 +257,11 @@ git_common_dir() {
   git rev-parse --git-common-dir 2>/dev/null || die "Not in a git repo"
 }
 
+issue_bootstrap_lock_name() {
+  local issue="$1"
+  printf 'pr-bootstrap-issue-%s\n' "$issue"
+}
+
 acquire_repo_lock() {
   local name="$1"
   local lock_dir
@@ -1721,7 +1726,7 @@ cmd_cards() {
   done
 
   local lock_dir=""
-  lock_dir="$(acquire_repo_lock "pr-bootstrap")"
+  lock_dir="$(acquire_repo_lock "$(issue_bootstrap_lock_name "$issue")")"
   trap "release_repo_lock '$lock_dir'" RETURN EXIT
 
   local repo
@@ -1786,12 +1791,12 @@ cmd_init() {
   fi
 
   require_cmd git
-  local lock_dir=""
-  lock_dir="$(acquire_repo_lock "pr-bootstrap")"
-  trap "release_repo_lock '$lock_dir'" RETURN EXIT
   local issue="${1:-}"; shift || true
   [[ -n "$issue" ]] || die_with_usage "init: missing <issue> number" usage_init
   issue="$(normalize_issue_or_die "$issue")"
+  local lock_dir=""
+  lock_dir="$(acquire_repo_lock "$(issue_bootstrap_lock_name "$issue")")"
+  trap "release_repo_lock '$lock_dir'" RETURN EXIT
 
   local slug=""
   local no_fetch_issue="0"

--- a/adl/tools/test_pr_init.sh
+++ b/adl/tools/test_pr_init.sh
@@ -174,6 +174,130 @@ assert_contains() {
     echo "assertion failed: expected generated source prompt title" >&2
     exit 1
   }
+
+  cat >"$repo/.adl/issues/v0.85/bodies/issue-44-batch-a.md" <<'EOF'
+---
+issue_card_schema: adl.issue.v1
+wp: "authoring"
+slug: "batch-a"
+title: "[v0.85][authoring] Batch A"
+labels:
+  - "track:roadmap"
+  - "version:v0.85"
+issue_number: 44
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Sprint Test"
+required_outcome_type:
+  - "docs"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes: []
+pr_start:
+  enabled: true
+  slug: "batch-a"
+---
+
+# Batch A
+
+## Summary
+x
+## Goal
+x
+## Required Outcome
+x
+## Deliverables
+x
+## Acceptance Criteria
+x
+## Repo Inputs
+x
+## Dependencies
+x
+## Demo Expectations
+x
+## Non-goals
+x
+## Issue-Graph Notes
+x
+## Notes
+x
+## Tooling Notes
+x
+EOF
+
+  cat >"$repo/.adl/issues/v0.85/bodies/issue-45-batch-b.md" <<'EOF'
+---
+issue_card_schema: adl.issue.v1
+wp: "authoring"
+slug: "batch-b"
+title: "[v0.85][authoring] Batch B"
+labels:
+  - "track:roadmap"
+  - "version:v0.85"
+issue_number: 45
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Sprint Test"
+required_outcome_type:
+  - "docs"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes: []
+pr_start:
+  enabled: true
+  slug: "batch-b"
+---
+
+# Batch B
+
+## Summary
+x
+## Goal
+x
+## Required Outcome
+x
+## Deliverables
+x
+## Acceptance Criteria
+x
+## Repo Inputs
+x
+## Dependencies
+x
+## Demo Expectations
+x
+## Non-goals
+x
+## Issue-Graph Notes
+x
+## Notes
+x
+## Tooling Notes
+x
+EOF
+
+  "$BASH_BIN" adl/tools/pr.sh init 44 --slug batch-a --no-fetch-issue --version v0.85 >"$tmpdir/init44.out" &
+  pid1=$!
+  "$BASH_BIN" adl/tools/pr.sh init 45 --slug batch-b --no-fetch-issue --version v0.85 >"$tmpdir/init45.out" &
+  pid2=$!
+  wait "$pid1"
+  wait "$pid2"
+
+  [[ -f "$repo/.adl/v0.85/tasks/issue-0044__batch-a/stp.md" ]] || {
+    echo "assertion failed: expected concurrent init for issue 44 to succeed" >&2
+    exit 1
+  }
+  [[ -f "$repo/.adl/v0.85/tasks/issue-0045__batch-b/stp.md" ]] || {
+    echo "assertion failed: expected concurrent init for issue 45 to succeed" >&2
+    exit 1
+  }
 )
 
 echo "pr.sh init minimal task-bundle initialization: ok"

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -201,6 +201,22 @@ EOF
   stale_lock_out="$("$BASH_BIN" adl/tools/pr.sh start 993 --slug stale-lock-recovery --no-fetch-issue)"
   stale_wt="$(cd "$repo/.worktrees/adl-wp-993" && pwd -P)"
   assert_contains "WORKTREE $stale_wt" "$stale_lock_out" "stale lock recovery still starts"
+
+  "$BASH_BIN" adl/tools/pr.sh cards 991 --no-fetch-issue --version v0.86 >"$tmpdir/cards991.out" &
+  cards_pid1=$!
+  "$BASH_BIN" adl/tools/pr.sh cards 992 --no-fetch-issue --version v0.86 >"$tmpdir/cards992.out" &
+  cards_pid2=$!
+  wait "$cards_pid1"
+  wait "$cards_pid2"
+
+  [[ -f "$repo/.adl/cards/991/input_991.md" ]] || {
+    echo "assertion failed: expected cards for issue 991 to exist after concurrent cards" >&2
+    exit 1
+  }
+  [[ -f "$repo/.adl/cards/992/input_992.md" ]] || {
+    echo "assertion failed: expected cards for issue 992 to exist after concurrent cards" >&2
+    exit 1
+  }
 )
 
 echo "pr.sh start worktree-safe/idempotent flows: ok"


### PR DESCRIPTION
Closes #1142

## Summary
Scoped bootstrap locking by issue for `pr init` and `pr cards` so independent issue setup no longer contends on one global `pr-bootstrap` lock. Added regressions proving concurrent `init` and concurrent `cards` runs across different issues succeed while the existing `start` lock behavior remains intact.

## Artifacts
- Tracked code change: `adl/tools/pr.sh`
- Regression coverage: `adl/tools/test_pr_init.sh`
- Regression coverage: `adl/tools/test_pr_start_worktree_safe.sh`
- Generated runtime artifacts: not applicable for this tooling issue

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_init.sh` to verify canonical STP initialization still works and concurrent `init` on different issues no longer contends on one bootstrap lock
  - `bash adl/tools/test_pr_start_worktree_safe.sh` to verify the existing start path still works and concurrent `cards` generation for different issues succeeds
- Results:
  - `bash adl/tools/test_pr_init.sh` passed
  - `bash adl/tools/test_pr_start_worktree_safe.sh` passed

## Local Artifacts
- Input card:  .adl/cards/1142/input_1142.md
- Output card: .adl/cards/1142/output_1142.md
- Idempotency-Key: db90a6fcd9e28daf8cb99a8fcacbc71999cf19b37fd41235c2f130c8c12ab5d1
