### PR TITLE
[v0.86][WP-06] Implement fast / slow thinking paths

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -123,6 +123,11 @@ impl RunArtifactPaths {
         self.learning_dir().join("cognitive_arbitration.v1.json")
     }
 
+    /// Fast/slow path artifact path for bounded v0.86 route handoff.
+    pub fn fast_slow_path_json(&self) -> PathBuf {
+        self.learning_dir().join("fast_slow_path.v1.json")
+    }
+
     /// Affect state artifact path for bounded affect-guided adaptation.
     pub fn affect_state_json(&self) -> PathBuf {
         self.learning_dir().join("affect_state.v1.json")
@@ -361,6 +366,9 @@ mod tests {
         assert!(paths
             .cognitive_arbitration_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/cognitive_arbitration.v1.json"));
+        assert!(paths
+            .fast_slow_path_json()
+            .ends_with(".adl/runs/artifact-path-accessors/learning/fast_slow_path.v1.json"));
         assert!(paths
             .affect_state_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/affect_state.v1.json"));

--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -14,6 +14,7 @@ pub(crate) const SUGGESTIONS_VERSION: u32 = 1;
 pub(crate) const AEE_DECISION_VERSION: u32 = 1;
 pub(crate) const COGNITIVE_SIGNALS_VERSION: u32 = 1;
 pub(crate) const COGNITIVE_ARBITRATION_VERSION: u32 = 1;
+pub(crate) const FAST_SLOW_PATH_VERSION: u32 = 1;
 pub(crate) const REASONING_GRAPH_VERSION: u32 = 1;
 pub(crate) const CLUSTER_GROUNDWORK_VERSION: u32 = 1;
 
@@ -143,6 +144,8 @@ pub(crate) struct RunSummaryLinks {
     pub(crate) aee_decision_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) cognitive_signals_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) fast_slow_path_json: Option<String>,
     pub(crate) cognitive_arbitration_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) affect_state_json: Option<String>,
@@ -373,6 +376,24 @@ pub(crate) struct CognitiveArbitrationArtifact {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct FastSlowPathArtifact {
+    pub(crate) fast_slow_path_version: u32,
+    pub(crate) run_id: String,
+    pub(crate) generated_from: AeeDecisionGeneratedFrom,
+    pub(crate) arbitration_route: String,
+    pub(crate) selected_path: String,
+    pub(crate) path_family: String,
+    pub(crate) handoff_state: String,
+    pub(crate) candidate_strategy: String,
+    pub(crate) review_depth: String,
+    pub(crate) execution_profile: String,
+    pub(crate) termination_expectation: String,
+    pub(crate) path_difference_summary: String,
+    pub(crate) deterministic_handoff_rule: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ReasoningGraphArtifact {
     pub(crate) reasoning_graph_version: u32,
     pub(crate) run_id: String,
@@ -541,6 +562,11 @@ pub(crate) fn build_run_summary(
         .strip_prefix(run_paths.run_dir())
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "learning/cognitive_signals.v1.json".to_string());
+    let fast_slow_path_rel = run_paths
+        .fast_slow_path_json()
+        .strip_prefix(run_paths.run_dir())
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "learning/fast_slow_path.v1.json".to_string());
     let cognitive_arbitration_rel = run_paths
         .cognitive_arbitration_json()
         .strip_prefix(run_paths.run_dir())
@@ -611,6 +637,7 @@ pub(crate) fn build_run_summary(
             suggestions_json: Some(suggestions_rel),
             aee_decision_json: Some(aee_decision_rel),
             cognitive_signals_json: Some(cognitive_signals_rel),
+            fast_slow_path_json: Some(fast_slow_path_rel),
             cognitive_arbitration_json: Some(cognitive_arbitration_rel),
             affect_state_json: Some(affect_state_rel),
             reasoning_graph_json: Some(reasoning_graph_rel),
@@ -1386,6 +1413,81 @@ pub(crate) fn build_cognitive_arbitration_artifact(
     }
 }
 
+pub(crate) fn build_fast_slow_path_artifact(
+    run_summary: &RunSummaryArtifact,
+    arbitration: &CognitiveArbitrationArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> FastSlowPathArtifact {
+    let (
+        selected_path,
+        path_family,
+        handoff_state,
+        candidate_strategy,
+        review_depth,
+        execution_profile,
+        termination_expectation,
+    ) = match arbitration.route_selected.as_str() {
+        "fast" => (
+            "fast_path",
+            "fast",
+            "direct_handoff",
+            "accept first bounded candidate",
+            "minimal",
+            "single_pass_direct_execution",
+            "terminate_on_first_bounded_success_or_policy_block",
+        ),
+        "hybrid" => (
+            "slow_path",
+            "slow",
+            "bounded_recovery_handoff",
+            "compare current candidate against one bounded refinement",
+            "bounded_recovery_review",
+            "review_then_execute_once",
+            "terminate_after_bounded_review_cycle_or_policy_block",
+        ),
+        _ => (
+            "slow_path",
+            "slow",
+            "review_handoff",
+            "validate, refine, or veto the current bounded candidate",
+            "verification_required",
+            "review_and_refine_before_execution",
+            "terminate_after_bounded_review_cycle_or_policy_block",
+        ),
+    };
+    let path_difference_summary = match selected_path {
+        "fast_path" => {
+            "fast_path favors direct execution with minimal review and a single bounded candidate handoff"
+        }
+        _ => {
+            "slow_path requires bounded review/refinement before execution and can revise or veto the current candidate"
+        }
+    };
+
+    FastSlowPathArtifact {
+        fast_slow_path_version: FAST_SLOW_PATH_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+            suggestions_version: arbitration.generated_from.suggestions_version,
+            scores_version: scores.map(|value| value.scores_version),
+        },
+        arbitration_route: arbitration.route_selected.clone(),
+        selected_path: selected_path.to_string(),
+        path_family: path_family.to_string(),
+        handoff_state: handoff_state.to_string(),
+        candidate_strategy: candidate_strategy.to_string(),
+        review_depth: review_depth.to_string(),
+        execution_profile: execution_profile.to_string(),
+        termination_expectation: termination_expectation.to_string(),
+        path_difference_summary: path_difference_summary.to_string(),
+        deterministic_handoff_rule:
+            "derive fast/slow path handoff directly from bounded arbitration route selection without hidden execution-mode state"
+                .to_string(),
+    }
+}
+
 pub(crate) fn build_aee_decision_artifact(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -1762,8 +1864,15 @@ pub(crate) fn write_run_state_artifacts(
         &affect_state,
         Some(&scores_for_suggestions),
     );
+    let fast_slow_path = build_fast_slow_path_artifact(
+        &run_summary,
+        &cognitive_arbitration,
+        Some(&scores_for_suggestions),
+    );
     let cognitive_arbitration_json = serde_json::to_vec_pretty(&cognitive_arbitration)
         .context("serialize cognitive_arbitration.v1.json")?;
+    let fast_slow_path_json =
+        serde_json::to_vec_pretty(&fast_slow_path).context("serialize fast_slow_path.v1.json")?;
     let aee_decision = build_aee_decision_artifact(
         &run_summary,
         &suggestions,
@@ -1792,11 +1901,13 @@ pub(crate) fn write_run_state_artifacts(
         &run_paths.cognitive_arbitration_json(),
         &cognitive_arbitration_json,
     )?;
+    artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
     artifacts::atomic_write(&run_paths.cognitive_signals_json(), &cognitive_signals_json)?;
     artifacts::atomic_write(
         &run_paths.cognitive_arbitration_json(),
         &cognitive_arbitration_json,
     )?;
+    artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
     artifacts::atomic_write(&run_paths.affect_state_json(), &affect_state_json)?;
     artifacts::atomic_write(&run_paths.aee_decision_json(), &aee_decision_json)?;
     artifacts::atomic_write(&run_paths.reasoning_graph_json(), &reasoning_graph_json)?;

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -129,6 +129,10 @@ fn build_run_summary_sorts_remote_policy_and_tracks_denials() {
         Some("learning/cognitive_signals.v1.json")
     );
     assert_eq!(
+        summary.links.fast_slow_path_json.as_deref(),
+        Some("learning/fast_slow_path.v1.json")
+    );
+    assert_eq!(
         summary.links.cognitive_arbitration_json.as_deref(),
         Some("learning/cognitive_arbitration.v1.json")
     );
@@ -183,6 +187,7 @@ fn build_aee_decision_artifact_selects_retry_recovery_for_failures() {
             suggestions_json: None,
             aee_decision_json: None,
             cognitive_signals_json: None,
+            fast_slow_path_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -277,6 +282,7 @@ fn build_affect_state_artifact_covers_watchful_and_steady_modes() {
             suggestions_json: None,
             aee_decision_json: None,
             cognitive_signals_json: None,
+            fast_slow_path_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -391,6 +397,7 @@ fn build_cognitive_signals_artifact_is_deterministic_and_bounded() {
             suggestions_json: None,
             aee_decision_json: None,
             cognitive_signals_json: None,
+            fast_slow_path_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -478,6 +485,7 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
             suggestions_json: None,
             aee_decision_json: None,
             cognitive_signals_json: None,
+            fast_slow_path_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -538,6 +546,149 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
 }
 
 #[test]
+fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
+    let mut summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "fast-slow-path-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "success".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 0,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let success_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "fast-slow-path-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 1.0,
+            failure_count: 0,
+            retry_count: 0,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let success_suggestions = build_suggestions_artifact(&summary, Some(&success_scores));
+    let success_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &success_suggestions,
+        &success_affect,
+        Some(&success_scores),
+    );
+    let fast_left = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &success_arbitration,
+        Some(&success_scores),
+    );
+    let fast_right = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &success_arbitration,
+        Some(&success_scores),
+    );
+    assert_eq!(
+        serde_json::to_value(&fast_left).expect("fast left value"),
+        serde_json::to_value(&fast_right).expect("fast right value")
+    );
+    assert_eq!(fast_left.selected_path, "fast_path");
+    assert_eq!(fast_left.review_depth, "minimal");
+    assert_eq!(fast_left.execution_profile, "single_pass_direct_execution");
+
+    summary.status = "failure".to_string();
+    summary.counts.failed_steps = 1;
+    let failure_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "fast-slow-path-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.0,
+            failure_count: 1,
+            retry_count: 1,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let failure_suggestions = build_suggestions_artifact(&summary, Some(&failure_scores));
+    let failure_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &failure_suggestions,
+        &failure_affect,
+        Some(&failure_scores),
+    );
+    let slow = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &failure_arbitration,
+        Some(&failure_scores),
+    );
+    assert_eq!(slow.fast_slow_path_version, 1);
+    assert_eq!(slow.selected_path, "slow_path");
+    assert_eq!(slow.review_depth, "verification_required");
+    assert_eq!(slow.execution_profile, "review_and_refine_before_execution");
+    assert_ne!(
+        fast_left.path_difference_summary,
+        slow.path_difference_summary
+    );
+}
+
+#[test]
 fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
     let summary = RunSummaryArtifact {
         run_summary_version: 1,
@@ -576,6 +727,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             suggestions_json: None,
             aee_decision_json: None,
             cognitive_signals_json: None,
+            fast_slow_path_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -668,6 +820,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             suggestions_json: None,
             aee_decision_json: None,
             cognitive_signals_json: None,
+            fast_slow_path_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -817,6 +970,7 @@ fn build_scores_and_suggestions_artifacts_are_deterministic() {
             suggestions_json: None,
             aee_decision_json: None,
             cognitive_signals_json: None,
+            fast_slow_path_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,

--- a/docs/milestones/v0.86/features/FAST_SLOW_THINKING_MODEL.md
+++ b/docs/milestones/v0.86/features/FAST_SLOW_THINKING_MODEL.md
@@ -258,6 +258,20 @@ In ADL:
 
 Therefore, the system must explicitly model:
 
+## Implemented v0.86 Bounded Surface
+
+For `v0.86`, the implemented runtime surface is intentionally narrower than the broader conceptual routing model in this document.
+
+The tracked runtime contract is:
+
+- `cognitive_arbitration.v1.json` records the bounded arbitration route
+- `fast_slow_path.v1.json` records the explicit arbitration-to-path handoff
+- `fast_path` means direct bounded execution with minimal review
+- `slow_path` means bounded review/refinement before execution
+- path selection is deterministic for identical bounded inputs
+
+This milestone does not implement adaptive Bayesian learning, threshold updates, or Gödel-driven routing improvement.
+
 - cost of failure
 - reversibility of actions
 - safety constraints


### PR DESCRIPTION
## Summary
- add a bounded `fast_slow_path.v1.json` runtime artifact for explicit arbitration-to-path handoff
- thread the new artifact through canonical run artifact paths and run summary links
- add deterministic tests proving fast and slow paths produce different bounded execution profiles
- update the tracked fast/slow feature doc to describe the implemented v0.86 surface truthfully

## Validation
- `cargo fmt --manifest-path adl/Cargo.toml --all`
- `cargo test --manifest-path adl/Cargo.toml artifact_builders`

Closes #1125
