### PR TITLE
[v0.86][WP-07] Implement agency and candidate selection

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -128,6 +128,11 @@ impl RunArtifactPaths {
         self.learning_dir().join("fast_slow_path.v1.json")
     }
 
+    /// Agency-selection artifact path for bounded v0.86 candidate generation and selection.
+    pub fn agency_selection_json(&self) -> PathBuf {
+        self.learning_dir().join("agency_selection.v1.json")
+    }
+
     /// Affect state artifact path for bounded affect-guided adaptation.
     pub fn affect_state_json(&self) -> PathBuf {
         self.learning_dir().join("affect_state.v1.json")
@@ -369,6 +374,9 @@ mod tests {
         assert!(paths
             .fast_slow_path_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/fast_slow_path.v1.json"));
+        assert!(paths
+            .agency_selection_json()
+            .ends_with(".adl/runs/artifact-path-accessors/learning/agency_selection.v1.json"));
         assert!(paths
             .affect_state_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/affect_state.v1.json"));

--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -15,6 +15,7 @@ pub(crate) const AEE_DECISION_VERSION: u32 = 1;
 pub(crate) const COGNITIVE_SIGNALS_VERSION: u32 = 1;
 pub(crate) const COGNITIVE_ARBITRATION_VERSION: u32 = 1;
 pub(crate) const FAST_SLOW_PATH_VERSION: u32 = 1;
+pub(crate) const AGENCY_SELECTION_VERSION: u32 = 1;
 pub(crate) const REASONING_GRAPH_VERSION: u32 = 1;
 pub(crate) const CLUSTER_GROUNDWORK_VERSION: u32 = 1;
 
@@ -146,6 +147,8 @@ pub(crate) struct RunSummaryLinks {
     pub(crate) cognitive_signals_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) fast_slow_path_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) agency_selection_json: Option<String>,
     pub(crate) cognitive_arbitration_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) affect_state_json: Option<String>,
@@ -394,6 +397,31 @@ pub(crate) struct FastSlowPathArtifact {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct AgencySelectionArtifact {
+    pub(crate) agency_selection_version: u32,
+    pub(crate) run_id: String,
+    pub(crate) generated_from: AeeDecisionGeneratedFrom,
+    pub(crate) candidate_generation_basis: String,
+    pub(crate) selection_mode: String,
+    pub(crate) candidate_set: Vec<AgencyCandidateRecord>,
+    pub(crate) selected_candidate_id: String,
+    pub(crate) selected_candidate_reason: String,
+    pub(crate) deterministic_selection_rule: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AgencyCandidateRecord {
+    pub(crate) candidate_id: String,
+    pub(crate) candidate_kind: String,
+    pub(crate) bounded_action: String,
+    pub(crate) review_requirement: String,
+    pub(crate) execution_priority: u32,
+    pub(crate) rationale: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ReasoningGraphArtifact {
     pub(crate) reasoning_graph_version: u32,
     pub(crate) run_id: String,
@@ -567,6 +595,11 @@ pub(crate) fn build_run_summary(
         .strip_prefix(run_paths.run_dir())
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "learning/fast_slow_path.v1.json".to_string());
+    let agency_selection_rel = run_paths
+        .agency_selection_json()
+        .strip_prefix(run_paths.run_dir())
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "learning/agency_selection.v1.json".to_string());
     let cognitive_arbitration_rel = run_paths
         .cognitive_arbitration_json()
         .strip_prefix(run_paths.run_dir())
@@ -638,6 +671,7 @@ pub(crate) fn build_run_summary(
             aee_decision_json: Some(aee_decision_rel),
             cognitive_signals_json: Some(cognitive_signals_rel),
             fast_slow_path_json: Some(fast_slow_path_rel),
+            agency_selection_json: Some(agency_selection_rel),
             cognitive_arbitration_json: Some(cognitive_arbitration_rel),
             affect_state_json: Some(affect_state_rel),
             reasoning_graph_json: Some(reasoning_graph_rel),
@@ -1488,6 +1522,106 @@ pub(crate) fn build_fast_slow_path_artifact(
     }
 }
 
+pub(crate) fn build_agency_selection_artifact(
+    run_summary: &RunSummaryArtifact,
+    signals: &CognitiveSignalsArtifact,
+    arbitration: &CognitiveArbitrationArtifact,
+    fast_slow_path: &FastSlowPathArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> AgencySelectionArtifact {
+    let (selection_mode, candidate_set, selected_candidate_id, selected_candidate_reason) =
+        match fast_slow_path.selected_path.as_str() {
+            "fast_path" => {
+                let candidate_set = vec![
+                    AgencyCandidateRecord {
+                        candidate_id: "cand-fast-execute".to_string(),
+                        candidate_kind: "direct_execution".to_string(),
+                        bounded_action: "execute selected candidate directly under bounded once semantics".to_string(),
+                        review_requirement: "minimal".to_string(),
+                        execution_priority: 1,
+                        rationale: format!(
+                            "route={} dominant_instinct={} confidence={}",
+                            arbitration.route_selected, signals.instinct.dominant_instinct, arbitration.confidence
+                        ),
+                    },
+                    AgencyCandidateRecord {
+                        candidate_id: "cand-fast-verify".to_string(),
+                        candidate_kind: "bounded_verification".to_string(),
+                        bounded_action: "perform one bounded verification pass before execution".to_string(),
+                        review_requirement: "light".to_string(),
+                        execution_priority: 2,
+                        rationale: "keep a fallback candidate available without changing the primary fast-path commitment".to_string(),
+                    },
+                ];
+                (
+                    "fast_candidate_commitment",
+                    candidate_set,
+                    "cand-fast-execute".to_string(),
+                    "fast path prioritizes direct bounded execution when arbitration confidence is high and failure pressure is absent".to_string(),
+                )
+            }
+            _ => {
+                let candidate_set = vec![
+                    AgencyCandidateRecord {
+                        candidate_id: "cand-slow-review".to_string(),
+                        candidate_kind: "review_and_refine".to_string(),
+                        bounded_action: "review, refine, or veto the current candidate before execution".to_string(),
+                        review_requirement: "verification_required".to_string(),
+                        execution_priority: 1,
+                        rationale: format!(
+                            "route={} dominant_instinct={} risk_class={}",
+                            arbitration.route_selected, signals.instinct.dominant_instinct, arbitration.risk_class
+                        ),
+                    },
+                    AgencyCandidateRecord {
+                        candidate_id: "cand-slow-direct".to_string(),
+                        candidate_kind: "direct_execution".to_string(),
+                        bounded_action: "execute the current candidate without additional refinement".to_string(),
+                        review_requirement: "minimal".to_string(),
+                        execution_priority: 2,
+                        rationale: "retain the direct-execution alternative as a bounded comparator candidate".to_string(),
+                    },
+                    AgencyCandidateRecord {
+                        candidate_id: "cand-slow-defer".to_string(),
+                        candidate_kind: "bounded_deferral".to_string(),
+                        bounded_action: "defer execution and surface the candidate set for later gate/review stages".to_string(),
+                        review_requirement: "review_required".to_string(),
+                        execution_priority: 3,
+                        rationale: "preserve a bounded non-execution option when policy or review pressure remains elevated".to_string(),
+                    },
+                ];
+                (
+                    "slow_candidate_comparison",
+                    candidate_set,
+                    "cand-slow-review".to_string(),
+                    "slow path makes review/refinement the selected candidate when arbitration requires bounded caution".to_string(),
+                )
+            }
+        };
+
+    AgencySelectionArtifact {
+        agency_selection_version: AGENCY_SELECTION_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+            suggestions_version: arbitration.generated_from.suggestions_version,
+            scores_version: scores.map(|value| value.scores_version),
+        },
+        candidate_generation_basis: format!(
+            "path={} route={} candidate_selection_bias={}",
+            fast_slow_path.selected_path, arbitration.route_selected, signals.instinct.candidate_selection_bias
+        ),
+        selection_mode: selection_mode.to_string(),
+        candidate_set,
+        selected_candidate_id,
+        selected_candidate_reason,
+        deterministic_selection_rule:
+            "derive the bounded candidate set and selected candidate from the fast/slow handoff, arbitration route, and instinct bias without hidden initiative state"
+                .to_string(),
+    }
+}
+
 pub(crate) fn build_aee_decision_artifact(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -1869,10 +2003,19 @@ pub(crate) fn write_run_state_artifacts(
         &cognitive_arbitration,
         Some(&scores_for_suggestions),
     );
+    let agency_selection = build_agency_selection_artifact(
+        &run_summary,
+        &cognitive_signals,
+        &cognitive_arbitration,
+        &fast_slow_path,
+        Some(&scores_for_suggestions),
+    );
     let cognitive_arbitration_json = serde_json::to_vec_pretty(&cognitive_arbitration)
         .context("serialize cognitive_arbitration.v1.json")?;
     let fast_slow_path_json =
         serde_json::to_vec_pretty(&fast_slow_path).context("serialize fast_slow_path.v1.json")?;
+    let agency_selection_json = serde_json::to_vec_pretty(&agency_selection)
+        .context("serialize agency_selection.v1.json")?;
     let aee_decision = build_aee_decision_artifact(
         &run_summary,
         &suggestions,
@@ -1902,12 +2045,14 @@ pub(crate) fn write_run_state_artifacts(
         &cognitive_arbitration_json,
     )?;
     artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
+    artifacts::atomic_write(&run_paths.agency_selection_json(), &agency_selection_json)?;
     artifacts::atomic_write(&run_paths.cognitive_signals_json(), &cognitive_signals_json)?;
     artifacts::atomic_write(
         &run_paths.cognitive_arbitration_json(),
         &cognitive_arbitration_json,
     )?;
     artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
+    artifacts::atomic_write(&run_paths.agency_selection_json(), &agency_selection_json)?;
     artifacts::atomic_write(&run_paths.affect_state_json(), &affect_state_json)?;
     artifacts::atomic_write(&run_paths.aee_decision_json(), &aee_decision_json)?;
     artifacts::atomic_write(&run_paths.reasoning_graph_json(), &reasoning_graph_json)?;

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -133,6 +133,10 @@ fn build_run_summary_sorts_remote_policy_and_tracks_denials() {
         Some("learning/fast_slow_path.v1.json")
     );
     assert_eq!(
+        summary.links.agency_selection_json.as_deref(),
+        Some("learning/agency_selection.v1.json")
+    );
+    assert_eq!(
         summary.links.cognitive_arbitration_json.as_deref(),
         Some("learning/cognitive_arbitration.v1.json")
     );
@@ -188,6 +192,7 @@ fn build_aee_decision_artifact_selects_retry_recovery_for_failures() {
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -283,6 +288,7 @@ fn build_affect_state_artifact_covers_watchful_and_steady_modes() {
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -398,6 +404,7 @@ fn build_cognitive_signals_artifact_is_deterministic_and_bounded() {
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -486,6 +493,7 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -585,6 +593,7 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -689,6 +698,175 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
 }
 
 #[test]
+fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidates() {
+    let mut summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "agency-selection-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "success".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 0,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let success_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "agency-selection-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 1.0,
+            failure_count: 0,
+            retry_count: 0,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let success_suggestions = build_suggestions_artifact(&summary, Some(&success_scores));
+    let success_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &success_suggestions,
+        &success_affect,
+        Some(&success_scores),
+    );
+    let success_path = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &success_arbitration,
+        Some(&success_scores),
+    );
+    let fast_left = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &success_signals,
+        &success_arbitration,
+        &success_path,
+        Some(&success_scores),
+    );
+    let fast_right = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &success_signals,
+        &success_arbitration,
+        &success_path,
+        Some(&success_scores),
+    );
+    assert_eq!(
+        serde_json::to_value(&fast_left).expect("fast left value"),
+        serde_json::to_value(&fast_right).expect("fast right value")
+    );
+    assert_eq!(fast_left.agency_selection_version, 1);
+    assert_eq!(fast_left.candidate_set.len(), 2);
+    assert_eq!(fast_left.selected_candidate_id, "cand-fast-execute");
+
+    summary.status = "failure".to_string();
+    summary.counts.failed_steps = 1;
+    let failure_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "agency-selection-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.0,
+            failure_count: 1,
+            retry_count: 1,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let failure_suggestions = build_suggestions_artifact(&summary, Some(&failure_scores));
+    let failure_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &failure_suggestions,
+        &failure_affect,
+        Some(&failure_scores),
+    );
+    let failure_path = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &failure_arbitration,
+        Some(&failure_scores),
+    );
+    let slow = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &failure_signals,
+        &failure_arbitration,
+        &failure_path,
+        Some(&failure_scores),
+    );
+    assert_eq!(slow.selected_candidate_id, "cand-slow-review");
+    assert!(slow.candidate_set.len() >= 3);
+    assert_ne!(fast_left.selection_mode, slow.selection_mode);
+    assert_ne!(
+        fast_left.selected_candidate_reason,
+        slow.selected_candidate_reason
+    );
+}
+
+#[test]
 fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
     let summary = RunSummaryArtifact {
         run_summary_version: 1,
@@ -728,6 +906,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -821,6 +1000,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -971,6 +1151,7 @@ fn build_scores_and_suggestions_artifacts_are_deterministic() {
             aee_decision_json: None,
             cognitive_signals_json: None,
             fast_slow_path_json: None,
+            agency_selection_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,

--- a/docs/milestones/v0.86/features/AGENCY_AND_AGENTS.md
+++ b/docs/milestones/v0.86/features/AGENCY_AND_AGENTS.md
@@ -171,6 +171,20 @@ A long chain of calls is not agency.
 
 Agency begins when internal state and internal policy materially participate in action selection.
 
+## Implemented v0.86 Bounded Surface
+
+For `v0.86`, the implemented runtime surface is narrower than the broader long-term agency architecture described here.
+
+The tracked runtime contract is:
+
+- `agency_selection.v1.json` emits a bounded candidate set
+- one candidate is explicitly selected with a deterministic reason
+- fast-path scenarios keep a smaller direct-execution candidate set
+- slow-path scenarios keep a larger review/refinement candidate set
+- the selected candidate is intended for later bounded execution and Freedom Gate stages
+
+This milestone does not implement open-ended initiative, policy continuity across episodes, or identity-bearing agency.
+
 ---
 
 ## What Makes an Agent Different from a Workflow?


### PR DESCRIPTION
## Summary
- add a bounded `agency_selection.v1.json` runtime artifact for candidate generation and explicit candidate selection
- thread the new artifact through canonical run artifact paths and run summary links
- add deterministic tests proving fast-path and slow-path scenarios emit different candidate sets and selected candidates
- update the tracked agency feature doc to describe the implemented v0.86 surface truthfully

## Validation
- `cargo fmt --manifest-path adl/Cargo.toml --all`
- `cargo test --manifest-path adl/Cargo.toml artifact_builders`

## Stack
- stacked on #1144

Closes #1126
