### PR TITLE
[v0.86][WP-08] Implement bounded execution (AEE-lite)

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -133,6 +133,11 @@ impl RunArtifactPaths {
         self.learning_dir().join("agency_selection.v1.json")
     }
 
+    /// Bounded execution artifact path for v0.86 AEE-lite execution state.
+    pub fn bounded_execution_json(&self) -> PathBuf {
+        self.learning_dir().join("bounded_execution.v1.json")
+    }
+
     /// Affect state artifact path for bounded affect-guided adaptation.
     pub fn affect_state_json(&self) -> PathBuf {
         self.learning_dir().join("affect_state.v1.json")
@@ -377,6 +382,9 @@ mod tests {
         assert!(paths
             .agency_selection_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/agency_selection.v1.json"));
+        assert!(paths
+            .bounded_execution_json()
+            .ends_with(".adl/runs/artifact-path-accessors/learning/bounded_execution.v1.json"));
         assert!(paths
             .affect_state_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/affect_state.v1.json"));

--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -16,6 +16,7 @@ pub(crate) const COGNITIVE_SIGNALS_VERSION: u32 = 1;
 pub(crate) const COGNITIVE_ARBITRATION_VERSION: u32 = 1;
 pub(crate) const FAST_SLOW_PATH_VERSION: u32 = 1;
 pub(crate) const AGENCY_SELECTION_VERSION: u32 = 1;
+pub(crate) const BOUNDED_EXECUTION_VERSION: u32 = 1;
 pub(crate) const REASONING_GRAPH_VERSION: u32 = 1;
 pub(crate) const CLUSTER_GROUNDWORK_VERSION: u32 = 1;
 
@@ -149,6 +150,8 @@ pub(crate) struct RunSummaryLinks {
     pub(crate) fast_slow_path_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) agency_selection_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) bounded_execution_json: Option<String>,
     pub(crate) cognitive_arbitration_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) affect_state_json: Option<String>,
@@ -422,6 +425,31 @@ pub(crate) struct AgencyCandidateRecord {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct BoundedExecutionArtifact {
+    pub(crate) bounded_execution_version: u32,
+    pub(crate) run_id: String,
+    pub(crate) generated_from: AeeDecisionGeneratedFrom,
+    pub(crate) selected_candidate_id: String,
+    pub(crate) selected_path: String,
+    pub(crate) execution_status: String,
+    pub(crate) continuation_state: String,
+    pub(crate) provisional_termination_state: String,
+    pub(crate) iteration_count: u32,
+    pub(crate) iterations: Vec<BoundedExecutionIteration>,
+    pub(crate) deterministic_execution_rule: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BoundedExecutionIteration {
+    pub(crate) iteration_index: u32,
+    pub(crate) stage: String,
+    pub(crate) action: String,
+    pub(crate) outcome: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ReasoningGraphArtifact {
     pub(crate) reasoning_graph_version: u32,
     pub(crate) run_id: String,
@@ -600,6 +628,11 @@ pub(crate) fn build_run_summary(
         .strip_prefix(run_paths.run_dir())
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "learning/agency_selection.v1.json".to_string());
+    let bounded_execution_rel = run_paths
+        .bounded_execution_json()
+        .strip_prefix(run_paths.run_dir())
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "learning/bounded_execution.v1.json".to_string());
     let cognitive_arbitration_rel = run_paths
         .cognitive_arbitration_json()
         .strip_prefix(run_paths.run_dir())
@@ -672,6 +705,7 @@ pub(crate) fn build_run_summary(
             cognitive_signals_json: Some(cognitive_signals_rel),
             fast_slow_path_json: Some(fast_slow_path_rel),
             agency_selection_json: Some(agency_selection_rel),
+            bounded_execution_json: Some(bounded_execution_rel),
             cognitive_arbitration_json: Some(cognitive_arbitration_rel),
             affect_state_json: Some(affect_state_rel),
             reasoning_graph_json: Some(reasoning_graph_rel),
@@ -1622,6 +1656,68 @@ pub(crate) fn build_agency_selection_artifact(
     }
 }
 
+pub(crate) fn build_bounded_execution_artifact(
+    run_summary: &RunSummaryArtifact,
+    fast_slow_path: &FastSlowPathArtifact,
+    agency_selection: &AgencySelectionArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> BoundedExecutionArtifact {
+    let (execution_status, continuation_state, provisional_termination_state, iterations) =
+        match fast_slow_path.selected_path.as_str() {
+            "fast_path" => (
+                "completed",
+                "stop_after_one",
+                "ready_for_evaluation",
+                vec![BoundedExecutionIteration {
+                    iteration_index: 1,
+                    stage: "execute".to_string(),
+                    action: "execute selected candidate directly".to_string(),
+                    outcome: "bounded_direct_execution_complete".to_string(),
+                }],
+            ),
+            _ => (
+                "completed",
+                "bounded_review_complete",
+                "ready_for_evaluation",
+                vec![
+                    BoundedExecutionIteration {
+                        iteration_index: 1,
+                        stage: "review".to_string(),
+                        action: "review and refine the selected candidate".to_string(),
+                        outcome: "bounded_review_pass_complete".to_string(),
+                    },
+                    BoundedExecutionIteration {
+                        iteration_index: 2,
+                        stage: "execute".to_string(),
+                        action: "execute the reviewed bounded candidate".to_string(),
+                        outcome: "bounded_reviewed_execution_complete".to_string(),
+                    },
+                ],
+            ),
+        };
+
+    BoundedExecutionArtifact {
+        bounded_execution_version: BOUNDED_EXECUTION_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+            suggestions_version: agency_selection.generated_from.suggestions_version,
+            scores_version: scores.map(|value| value.scores_version),
+        },
+        selected_candidate_id: agency_selection.selected_candidate_id.clone(),
+        selected_path: fast_slow_path.selected_path.clone(),
+        execution_status: execution_status.to_string(),
+        continuation_state: continuation_state.to_string(),
+        provisional_termination_state: provisional_termination_state.to_string(),
+        iteration_count: iterations.len() as u32,
+        iterations,
+        deterministic_execution_rule:
+            "derive bounded iteration shape directly from selected path and selected candidate without hidden retry state"
+                .to_string(),
+    }
+}
+
 pub(crate) fn build_aee_decision_artifact(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -2010,12 +2106,20 @@ pub(crate) fn write_run_state_artifacts(
         &fast_slow_path,
         Some(&scores_for_suggestions),
     );
+    let bounded_execution = build_bounded_execution_artifact(
+        &run_summary,
+        &fast_slow_path,
+        &agency_selection,
+        Some(&scores_for_suggestions),
+    );
     let cognitive_arbitration_json = serde_json::to_vec_pretty(&cognitive_arbitration)
         .context("serialize cognitive_arbitration.v1.json")?;
     let fast_slow_path_json =
         serde_json::to_vec_pretty(&fast_slow_path).context("serialize fast_slow_path.v1.json")?;
     let agency_selection_json = serde_json::to_vec_pretty(&agency_selection)
         .context("serialize agency_selection.v1.json")?;
+    let bounded_execution_json = serde_json::to_vec_pretty(&bounded_execution)
+        .context("serialize bounded_execution.v1.json")?;
     let aee_decision = build_aee_decision_artifact(
         &run_summary,
         &suggestions,
@@ -2046,6 +2150,7 @@ pub(crate) fn write_run_state_artifacts(
     )?;
     artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
     artifacts::atomic_write(&run_paths.agency_selection_json(), &agency_selection_json)?;
+    artifacts::atomic_write(&run_paths.bounded_execution_json(), &bounded_execution_json)?;
     artifacts::atomic_write(&run_paths.cognitive_signals_json(), &cognitive_signals_json)?;
     artifacts::atomic_write(
         &run_paths.cognitive_arbitration_json(),
@@ -2053,6 +2158,7 @@ pub(crate) fn write_run_state_artifacts(
     )?;
     artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
     artifacts::atomic_write(&run_paths.agency_selection_json(), &agency_selection_json)?;
+    artifacts::atomic_write(&run_paths.bounded_execution_json(), &bounded_execution_json)?;
     artifacts::atomic_write(&run_paths.affect_state_json(), &affect_state_json)?;
     artifacts::atomic_write(&run_paths.aee_decision_json(), &aee_decision_json)?;
     artifacts::atomic_write(&run_paths.reasoning_graph_json(), &reasoning_graph_json)?;

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -137,6 +137,10 @@ fn build_run_summary_sorts_remote_policy_and_tracks_denials() {
         Some("learning/agency_selection.v1.json")
     );
     assert_eq!(
+        summary.links.bounded_execution_json.as_deref(),
+        Some("learning/bounded_execution.v1.json")
+    );
+    assert_eq!(
         summary.links.cognitive_arbitration_json.as_deref(),
         Some("learning/cognitive_arbitration.v1.json")
     );
@@ -193,6 +197,7 @@ fn build_aee_decision_artifact_selects_retry_recovery_for_failures() {
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -289,6 +294,7 @@ fn build_affect_state_artifact_covers_watchful_and_steady_modes() {
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -405,6 +411,7 @@ fn build_cognitive_signals_artifact_is_deterministic_and_bounded() {
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -494,6 +501,7 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -594,6 +602,7 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -738,6 +747,7 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -867,6 +877,186 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
 }
 
 #[test]
+fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape() {
+    let mut summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "bounded-execution-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "success".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 0,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let success_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "bounded-execution-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 1.0,
+            failure_count: 0,
+            retry_count: 0,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let success_suggestions = build_suggestions_artifact(&summary, Some(&success_scores));
+    let success_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &success_suggestions,
+        &success_affect,
+        Some(&success_scores),
+    );
+    let success_path = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &success_arbitration,
+        Some(&success_scores),
+    );
+    let success_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &success_signals,
+        &success_arbitration,
+        &success_path,
+        Some(&success_scores),
+    );
+    let fast_left = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &success_path,
+        &success_agency,
+        Some(&success_scores),
+    );
+    let fast_right = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &success_path,
+        &success_agency,
+        Some(&success_scores),
+    );
+    assert_eq!(
+        serde_json::to_value(&fast_left).expect("fast left value"),
+        serde_json::to_value(&fast_right).expect("fast right value")
+    );
+    assert_eq!(fast_left.iteration_count, 1);
+    assert_eq!(
+        fast_left.provisional_termination_state,
+        "ready_for_evaluation"
+    );
+
+    summary.status = "failure".to_string();
+    summary.counts.failed_steps = 1;
+    let failure_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "bounded-execution-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.0,
+            failure_count: 1,
+            retry_count: 1,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let failure_suggestions = build_suggestions_artifact(&summary, Some(&failure_scores));
+    let failure_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &failure_suggestions,
+        &failure_affect,
+        Some(&failure_scores),
+    );
+    let failure_path = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &failure_arbitration,
+        Some(&failure_scores),
+    );
+    let failure_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &failure_signals,
+        &failure_arbitration,
+        &failure_path,
+        Some(&failure_scores),
+    );
+    let slow = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &failure_path,
+        &failure_agency,
+        Some(&failure_scores),
+    );
+    assert_eq!(slow.bounded_execution_version, 1);
+    assert_eq!(slow.iteration_count, 2);
+    assert_eq!(slow.iterations[0].stage, "review");
+    assert_ne!(fast_left.iteration_count, slow.iteration_count);
+}
+
+#[test]
 fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
     let summary = RunSummaryArtifact {
         run_summary_version: 1,
@@ -907,6 +1097,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -1001,6 +1192,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -1152,6 +1344,7 @@ fn build_scores_and_suggestions_artifacts_are_deterministic() {
             cognitive_signals_json: None,
             fast_slow_path_json: None,
             agency_selection_json: None,
+            bounded_execution_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,

--- a/docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md
+++ b/docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md
@@ -50,6 +50,15 @@ For `v0.86`, this means:
 - evaluation may trigger bounded reframing
 - termination conditions are explicit and artifact-visible
 
+The implemented runtime execution surface for this milestone is:
+
+- `bounded_execution.v1.json` records visible bounded execution iterations
+- fast-path execution performs one direct bounded execution iteration
+- slow-path execution performs a bounded review iteration followed by one execution iteration
+- execution exits into an explicit provisional termination state for later evaluation
+
+This milestone does not implement open-ended convergence, adaptive retry loops, or unbounded continuation.
+
 ---
 
 ## Component Roles


### PR DESCRIPTION
## Summary
- add a bounded `bounded_execution.v1.json` runtime artifact for visible AEE-lite execution state
- thread the new artifact through canonical run artifact paths and run summary links
- add deterministic tests proving fast-path and slow-path scenarios produce different bounded iteration shapes
- update the tracked loop doc to describe the implemented v0.86 execution surface truthfully

## Validation
- `cargo fmt --manifest-path adl/Cargo.toml --all`
- `cargo test --manifest-path adl/Cargo.toml artifact_builders`

## Stack
- stacked on #1145

Closes #1127
