### PR TITLE
[v0.86][WP-09] Implement evaluation signals and termination

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -138,6 +138,11 @@ impl RunArtifactPaths {
         self.learning_dir().join("bounded_execution.v1.json")
     }
 
+    /// Evaluation-signals artifact path for v0.86 bounded evaluation and termination.
+    pub fn evaluation_signals_json(&self) -> PathBuf {
+        self.learning_dir().join("evaluation_signals.v1.json")
+    }
+
     /// Affect state artifact path for bounded affect-guided adaptation.
     pub fn affect_state_json(&self) -> PathBuf {
         self.learning_dir().join("affect_state.v1.json")
@@ -385,6 +390,9 @@ mod tests {
         assert!(paths
             .bounded_execution_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/bounded_execution.v1.json"));
+        assert!(paths
+            .evaluation_signals_json()
+            .ends_with(".adl/runs/artifact-path-accessors/learning/evaluation_signals.v1.json"));
         assert!(paths
             .affect_state_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/affect_state.v1.json"));

--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -17,6 +17,7 @@ pub(crate) const COGNITIVE_ARBITRATION_VERSION: u32 = 1;
 pub(crate) const FAST_SLOW_PATH_VERSION: u32 = 1;
 pub(crate) const AGENCY_SELECTION_VERSION: u32 = 1;
 pub(crate) const BOUNDED_EXECUTION_VERSION: u32 = 1;
+pub(crate) const EVALUATION_SIGNALS_VERSION: u32 = 1;
 pub(crate) const REASONING_GRAPH_VERSION: u32 = 1;
 pub(crate) const CLUSTER_GROUNDWORK_VERSION: u32 = 1;
 
@@ -152,6 +153,8 @@ pub(crate) struct RunSummaryLinks {
     pub(crate) agency_selection_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) bounded_execution_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) evaluation_signals_json: Option<String>,
     pub(crate) cognitive_arbitration_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) affect_state_json: Option<String>,
@@ -450,6 +453,22 @@ pub(crate) struct BoundedExecutionIteration {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct EvaluationSignalsArtifact {
+    pub(crate) evaluation_signals_version: u32,
+    pub(crate) run_id: String,
+    pub(crate) generated_from: AeeDecisionGeneratedFrom,
+    pub(crate) selected_candidate_id: String,
+    pub(crate) selected_path: String,
+    pub(crate) progress_signal: String,
+    pub(crate) contradiction_signal: String,
+    pub(crate) failure_signal: String,
+    pub(crate) termination_reason: String,
+    pub(crate) behavior_effect: String,
+    pub(crate) deterministic_evaluation_rule: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ReasoningGraphArtifact {
     pub(crate) reasoning_graph_version: u32,
     pub(crate) run_id: String,
@@ -633,6 +652,11 @@ pub(crate) fn build_run_summary(
         .strip_prefix(run_paths.run_dir())
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "learning/bounded_execution.v1.json".to_string());
+    let evaluation_signals_rel = run_paths
+        .evaluation_signals_json()
+        .strip_prefix(run_paths.run_dir())
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "learning/evaluation_signals.v1.json".to_string());
     let cognitive_arbitration_rel = run_paths
         .cognitive_arbitration_json()
         .strip_prefix(run_paths.run_dir())
@@ -706,6 +730,7 @@ pub(crate) fn build_run_summary(
             fast_slow_path_json: Some(fast_slow_path_rel),
             agency_selection_json: Some(agency_selection_rel),
             bounded_execution_json: Some(bounded_execution_rel),
+            evaluation_signals_json: Some(evaluation_signals_rel),
             cognitive_arbitration_json: Some(cognitive_arbitration_rel),
             affect_state_json: Some(affect_state_rel),
             reasoning_graph_json: Some(reasoning_graph_rel),
@@ -1718,6 +1743,63 @@ pub(crate) fn build_bounded_execution_artifact(
     }
 }
 
+pub(crate) fn build_evaluation_signals_artifact(
+    run_summary: &RunSummaryArtifact,
+    fast_slow_path: &FastSlowPathArtifact,
+    agency_selection: &AgencySelectionArtifact,
+    bounded_execution: &BoundedExecutionArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> EvaluationSignalsArtifact {
+    let (
+        progress_signal,
+        contradiction_signal,
+        failure_signal,
+        termination_reason,
+        behavior_effect,
+    ) = if run_summary.status == "failure" {
+        (
+            "stalled_progress",
+            "present",
+            "bounded_failure_detected",
+            if bounded_execution.iteration_count > 1 {
+                "bounded_failure"
+            } else {
+                "no_progress"
+            },
+            "emit bounded failure/termination signals for later reframing or policy handling",
+        )
+    } else {
+        (
+            "steady_progress",
+            "none",
+            "none",
+            "success",
+            "allow bounded execution to terminate cleanly after evaluation confirms progress",
+        )
+    };
+
+    EvaluationSignalsArtifact {
+        evaluation_signals_version: EVALUATION_SIGNALS_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+            suggestions_version: agency_selection.generated_from.suggestions_version,
+            scores_version: scores.map(|value| value.scores_version),
+        },
+        selected_candidate_id: agency_selection.selected_candidate_id.clone(),
+        selected_path: fast_slow_path.selected_path.clone(),
+        progress_signal: progress_signal.to_string(),
+        contradiction_signal: contradiction_signal.to_string(),
+        failure_signal: failure_signal.to_string(),
+        termination_reason: termination_reason.to_string(),
+        behavior_effect: behavior_effect.to_string(),
+        deterministic_evaluation_rule:
+            "derive bounded evaluation and termination signals from run status plus bounded execution shape without hidden continuation state"
+                .to_string(),
+    }
+}
+
 pub(crate) fn build_aee_decision_artifact(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -2112,6 +2194,13 @@ pub(crate) fn write_run_state_artifacts(
         &agency_selection,
         Some(&scores_for_suggestions),
     );
+    let evaluation_signals = build_evaluation_signals_artifact(
+        &run_summary,
+        &fast_slow_path,
+        &agency_selection,
+        &bounded_execution,
+        Some(&scores_for_suggestions),
+    );
     let cognitive_arbitration_json = serde_json::to_vec_pretty(&cognitive_arbitration)
         .context("serialize cognitive_arbitration.v1.json")?;
     let fast_slow_path_json =
@@ -2120,6 +2209,8 @@ pub(crate) fn write_run_state_artifacts(
         .context("serialize agency_selection.v1.json")?;
     let bounded_execution_json = serde_json::to_vec_pretty(&bounded_execution)
         .context("serialize bounded_execution.v1.json")?;
+    let evaluation_signals_json = serde_json::to_vec_pretty(&evaluation_signals)
+        .context("serialize evaluation_signals.v1.json")?;
     let aee_decision = build_aee_decision_artifact(
         &run_summary,
         &suggestions,
@@ -2151,6 +2242,10 @@ pub(crate) fn write_run_state_artifacts(
     artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
     artifacts::atomic_write(&run_paths.agency_selection_json(), &agency_selection_json)?;
     artifacts::atomic_write(&run_paths.bounded_execution_json(), &bounded_execution_json)?;
+    artifacts::atomic_write(
+        &run_paths.evaluation_signals_json(),
+        &evaluation_signals_json,
+    )?;
     artifacts::atomic_write(&run_paths.cognitive_signals_json(), &cognitive_signals_json)?;
     artifacts::atomic_write(
         &run_paths.cognitive_arbitration_json(),
@@ -2159,6 +2254,10 @@ pub(crate) fn write_run_state_artifacts(
     artifacts::atomic_write(&run_paths.fast_slow_path_json(), &fast_slow_path_json)?;
     artifacts::atomic_write(&run_paths.agency_selection_json(), &agency_selection_json)?;
     artifacts::atomic_write(&run_paths.bounded_execution_json(), &bounded_execution_json)?;
+    artifacts::atomic_write(
+        &run_paths.evaluation_signals_json(),
+        &evaluation_signals_json,
+    )?;
     artifacts::atomic_write(&run_paths.affect_state_json(), &affect_state_json)?;
     artifacts::atomic_write(&run_paths.aee_decision_json(), &aee_decision_json)?;
     artifacts::atomic_write(&run_paths.reasoning_graph_json(), &reasoning_graph_json)?;

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -141,6 +141,10 @@ fn build_run_summary_sorts_remote_policy_and_tracks_denials() {
         Some("learning/bounded_execution.v1.json")
     );
     assert_eq!(
+        summary.links.evaluation_signals_json.as_deref(),
+        Some("learning/evaluation_signals.v1.json")
+    );
+    assert_eq!(
         summary.links.cognitive_arbitration_json.as_deref(),
         Some("learning/cognitive_arbitration.v1.json")
     );
@@ -198,6 +202,7 @@ fn build_aee_decision_artifact_selects_retry_recovery_for_failures() {
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -295,6 +300,7 @@ fn build_affect_state_artifact_covers_watchful_and_steady_modes() {
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -412,6 +418,7 @@ fn build_cognitive_signals_artifact_is_deterministic_and_bounded() {
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -502,6 +509,7 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -603,6 +611,7 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -748,6 +757,7 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -918,6 +928,7 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -1057,6 +1068,202 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
 }
 
 #[test]
+fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reasons() {
+    let mut summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "evaluation-signals-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "success".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 0,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            evaluation_signals_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let success_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "evaluation-signals-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 1.0,
+            failure_count: 0,
+            retry_count: 0,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let success_suggestions = build_suggestions_artifact(&summary, Some(&success_scores));
+    let success_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &success_suggestions,
+        &success_affect,
+        Some(&success_scores),
+    );
+    let success_path = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &success_arbitration,
+        Some(&success_scores),
+    );
+    let success_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &success_signals,
+        &success_arbitration,
+        &success_path,
+        Some(&success_scores),
+    );
+    let success_execution = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &success_path,
+        &success_agency,
+        Some(&success_scores),
+    );
+    let success_left = run_artifacts::build_evaluation_signals_artifact(
+        &summary,
+        &success_path,
+        &success_agency,
+        &success_execution,
+        Some(&success_scores),
+    );
+    let success_right = run_artifacts::build_evaluation_signals_artifact(
+        &summary,
+        &success_path,
+        &success_agency,
+        &success_execution,
+        Some(&success_scores),
+    );
+    assert_eq!(
+        serde_json::to_value(&success_left).expect("success left value"),
+        serde_json::to_value(&success_right).expect("success right value")
+    );
+    assert_eq!(success_left.termination_reason, "success");
+    assert_eq!(success_left.failure_signal, "none");
+
+    summary.status = "failure".to_string();
+    summary.counts.failed_steps = 1;
+    let failure_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "evaluation-signals-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.0,
+            failure_count: 1,
+            retry_count: 1,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let failure_suggestions = build_suggestions_artifact(&summary, Some(&failure_scores));
+    let failure_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_affect = run_artifacts::build_affect_state_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &failure_suggestions,
+        &failure_affect,
+        Some(&failure_scores),
+    );
+    let failure_path = run_artifacts::build_fast_slow_path_artifact(
+        &summary,
+        &failure_arbitration,
+        Some(&failure_scores),
+    );
+    let failure_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &failure_signals,
+        &failure_arbitration,
+        &failure_path,
+        Some(&failure_scores),
+    );
+    let failure_execution = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &failure_path,
+        &failure_agency,
+        Some(&failure_scores),
+    );
+    let failure_eval = run_artifacts::build_evaluation_signals_artifact(
+        &summary,
+        &failure_path,
+        &failure_agency,
+        &failure_execution,
+        Some(&failure_scores),
+    );
+    assert_eq!(failure_eval.evaluation_signals_version, 1);
+    assert_eq!(failure_eval.termination_reason, "bounded_failure");
+    assert_eq!(failure_eval.contradiction_signal, "present");
+    assert_ne!(
+        success_left.termination_reason,
+        failure_eval.termination_reason
+    );
+}
+
+#[test]
 fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
     let summary = RunSummaryArtifact {
         run_summary_version: 1,
@@ -1098,6 +1305,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -1193,6 +1401,7 @@ fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,
@@ -1345,6 +1554,7 @@ fn build_scores_and_suggestions_artifacts_are_deterministic() {
             fast_slow_path_json: None,
             agency_selection_json: None,
             bounded_execution_json: None,
+            evaluation_signals_json: None,
             cognitive_arbitration_json: None,
             affect_state_json: None,
             reasoning_graph_json: None,

--- a/docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md
+++ b/docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md
@@ -202,6 +202,12 @@ Requirements:
 - must be visible in artifacts
 - must be deterministic or explainable
 
+For the implemented `v0.86` runtime surface:
+
+- `bounded_execution.v1.json` records the bounded execution handoff and iteration shape
+- `evaluation_signals.v1.json` records evaluation signals and the explicit `termination_reason`
+- termination is emitted as a bounded control output, not inferred from prose or hidden state
+
 ## Frame Adequacy and Reframing Notes
 
 `v0.86` may use bounded frame-adequacy indicators and a bounded reframing trigger, but those should be treated as supporting control primitives, not as a separate full subsystem.


### PR DESCRIPTION
## Summary
- add a bounded `evaluation_signals.v1.json` runtime artifact for explicit evaluation signals and termination reasons
- thread the new artifact through canonical run artifact paths and run summary links
- add deterministic tests proving success and failure scenarios emit different bounded termination reasons
- update the tracked loop doc to describe the implemented v0.86 evaluation surface truthfully

## Validation
- `cargo fmt --manifest-path adl/Cargo.toml --all`
- `cargo test --manifest-path adl/Cargo.toml artifact_builders`

## Stack
- stacked on #1146

Closes #1128
