### PR TITLE
[v0.86][runtime] Sprint 2A: Make WP-05 arbitration a real runtime control stage

### DIFF
--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -344,6 +344,20 @@ pub(crate) struct CognitiveAffectSignalRecord {
     pub(crate) deterministic_update_rule: String,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct CognitiveSignalsState {
+    pub(crate) dominant_instinct: String,
+    pub(crate) completion_pressure: String,
+    pub(crate) integrity_bias: String,
+    pub(crate) curiosity_bias: String,
+    pub(crate) candidate_selection_bias: String,
+    pub(crate) urgency_level: String,
+    pub(crate) salience_level: String,
+    pub(crate) persistence_pressure: String,
+    pub(crate) confidence_shift: String,
+    pub(crate) downstream_influence: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AffectStateRecord {
@@ -381,6 +395,17 @@ pub(crate) struct CognitiveArbitrationArtifact {
     pub(crate) cost_latency_assumption: String,
     pub(crate) route_reason: String,
     pub(crate) deterministic_selection_rule: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CognitiveArbitrationState {
+    pub(crate) route_selected: String,
+    pub(crate) reasoning_mode: String,
+    pub(crate) confidence: String,
+    pub(crate) risk_class: String,
+    pub(crate) applied_constraints: Vec<String>,
+    pub(crate) cost_latency_assumption: String,
+    pub(crate) route_reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1280,11 +1305,11 @@ pub(crate) fn build_affect_state_artifact(
     }
 }
 
-pub(crate) fn build_cognitive_signals_artifact(
+pub(crate) fn build_cognitive_signals_state(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
-    scores: Option<&ScoresArtifact>,
-) -> CognitiveSignalsArtifact {
+    _scores: Option<&ScoresArtifact>,
+) -> CognitiveSignalsState {
     let selected = suggestions
         .suggestions
         .first()
@@ -1369,6 +1394,27 @@ pub(crate) fn build_cognitive_signals_artifact(
         selected.evidence.retry_count
     );
 
+    CognitiveSignalsState {
+        dominant_instinct: dominant_instinct.to_string(),
+        completion_pressure: completion_pressure.to_string(),
+        integrity_bias: integrity_bias.to_string(),
+        curiosity_bias: curiosity_bias.to_string(),
+        candidate_selection_bias: candidate_selection_bias.to_string(),
+        urgency_level: completion_pressure.to_string(),
+        salience_level: salience_level.to_string(),
+        persistence_pressure: persistence_pressure.to_string(),
+        confidence_shift: confidence_shift.to_string(),
+        downstream_influence,
+    }
+}
+
+pub(crate) fn build_cognitive_signals_artifact(
+    run_summary: &RunSummaryArtifact,
+    suggestions: &SuggestionsArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> CognitiveSignalsArtifact {
+    let state = build_cognitive_signals_state(run_summary, suggestions, scores);
+
     CognitiveSignalsArtifact {
         cognitive_signals_version: COGNITIVE_SIGNALS_VERSION,
         run_id: run_summary.run_id.clone(),
@@ -1380,22 +1426,22 @@ pub(crate) fn build_cognitive_signals_artifact(
         },
         instinct: CognitiveInstinctRecord {
             instinct_profile_id: "instinct-001".to_string(),
-            dominant_instinct: dominant_instinct.to_string(),
-            completion_pressure: completion_pressure.to_string(),
-            integrity_bias: integrity_bias.to_string(),
-            curiosity_bias: curiosity_bias.to_string(),
-            candidate_selection_bias: candidate_selection_bias.to_string(),
+            dominant_instinct: state.dominant_instinct,
+            completion_pressure: state.completion_pressure,
+            integrity_bias: state.integrity_bias,
+            curiosity_bias: state.curiosity_bias,
+            candidate_selection_bias: state.candidate_selection_bias,
             deterministic_update_rule:
                 "derive bounded instinct profile from stable failure, retry, security, and success evidence ordering"
                     .to_string(),
         },
         affect: CognitiveAffectSignalRecord {
             affect_state_id: "signal-affect-001".to_string(),
-            urgency_level: completion_pressure.to_string(),
-            salience_level: salience_level.to_string(),
-            persistence_pressure: persistence_pressure.to_string(),
-            confidence_shift: confidence_shift.to_string(),
-            downstream_influence,
+            urgency_level: state.urgency_level,
+            salience_level: state.salience_level,
+            persistence_pressure: state.persistence_pressure,
+            confidence_shift: state.confidence_shift,
+            downstream_influence: state.downstream_influence,
             deterministic_update_rule:
                 "derive bounded affect signals from the first stable suggestion plus bounded run summary evidence"
                     .to_string(),
@@ -1403,12 +1449,12 @@ pub(crate) fn build_cognitive_signals_artifact(
     }
 }
 
-pub(crate) fn build_cognitive_arbitration_artifact(
-    run_summary: &RunSummaryArtifact,
+pub(crate) fn build_cognitive_arbitration_state(
+    _run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
+    signals: &CognitiveSignalsArtifact,
     affect_state: &AffectStateArtifact,
-    scores: Option<&ScoresArtifact>,
-) -> CognitiveArbitrationArtifact {
+) -> CognitiveArbitrationState {
     let selected = suggestions
         .suggestions
         .first()
@@ -1433,14 +1479,20 @@ pub(crate) fn build_cognitive_arbitration_artifact(
             },
         });
 
-    let (route_selected, reasoning_mode) =
-        if selected.evidence.security_denied_count > 0 || selected.evidence.failure_count > 0 {
-            ("slow", "review_heavy")
-        } else if affect_state.affect.recovery_bias >= 2 || selected.evidence.retry_count > 0 {
-            ("hybrid", "bounded_recovery")
-        } else {
-            ("fast", "direct_execution")
-        };
+    let (route_selected, reasoning_mode) = if selected.evidence.security_denied_count > 0
+        || selected.evidence.failure_count > 0
+        || signals.instinct.integrity_bias == "reinforced"
+    {
+        ("slow", "review_heavy")
+    } else if affect_state.affect.recovery_bias >= 2
+        || selected.evidence.retry_count > 0
+        || signals.affect.confidence_shift == "reduced"
+        || signals.affect.persistence_pressure == "sustained"
+    {
+        ("hybrid", "bounded_recovery")
+    } else {
+        ("fast", "direct_execution")
+    };
     let risk_class = if selected.evidence.security_denied_count > 0 {
         "high"
     } else if selected.evidence.failure_count > 0 || affect_state.affect.recovery_bias >= 2 {
@@ -1475,14 +1527,36 @@ pub(crate) fn build_cognitive_arbitration_artifact(
         _ => "spend bounded additional cognition when failure or policy risk is present",
     };
     let route_reason = format!(
-        "route={} affect_mode={} failure_count={} retry_count={} security_denied_count={} selected_intent={}",
+        "route={} dominant_instinct={} confidence_shift={} affect_mode={} failure_count={} retry_count={} security_denied_count={} selected_intent={}",
         route_selected,
+        signals.instinct.dominant_instinct,
+        signals.affect.confidence_shift,
         affect_state.affect.affect_mode,
         selected.evidence.failure_count,
         selected.evidence.retry_count,
         selected.evidence.security_denied_count,
         selected.proposed_change.intent
     );
+
+    CognitiveArbitrationState {
+        route_selected: route_selected.to_string(),
+        reasoning_mode: reasoning_mode.to_string(),
+        confidence: confidence.to_string(),
+        risk_class: risk_class.to_string(),
+        applied_constraints,
+        cost_latency_assumption: cost_latency_assumption.to_string(),
+        route_reason,
+    }
+}
+
+pub(crate) fn build_cognitive_arbitration_artifact(
+    run_summary: &RunSummaryArtifact,
+    suggestions: &SuggestionsArtifact,
+    signals: &CognitiveSignalsArtifact,
+    affect_state: &AffectStateArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> CognitiveArbitrationArtifact {
+    let state = build_cognitive_arbitration_state(run_summary, suggestions, signals, affect_state);
 
     CognitiveArbitrationArtifact {
         cognitive_arbitration_version: COGNITIVE_ARBITRATION_VERSION,
@@ -1493,15 +1567,15 @@ pub(crate) fn build_cognitive_arbitration_artifact(
             suggestions_version: suggestions.suggestions_version,
             scores_version: scores.map(|value| value.scores_version),
         },
-        route_selected: route_selected.to_string(),
-        reasoning_mode: reasoning_mode.to_string(),
-        confidence: confidence.to_string(),
-        risk_class: risk_class.to_string(),
-        applied_constraints,
-        cost_latency_assumption: cost_latency_assumption.to_string(),
-        route_reason,
+        route_selected: state.route_selected,
+        reasoning_mode: state.reasoning_mode,
+        confidence: state.confidence,
+        risk_class: state.risk_class,
+        applied_constraints: state.applied_constraints,
+        cost_latency_assumption: state.cost_latency_assumption,
+        route_reason: state.route_reason,
         deterministic_selection_rule:
-            "derive route from stable failure/security/retry evidence ordering plus bounded affect recovery bias"
+            "derive route from runtime signal state, bounded affect recovery bias, and stable failure/security/retry evidence ordering"
                 .to_string(),
     }
 }
@@ -2173,6 +2247,7 @@ pub(crate) fn write_run_state_artifacts(
     let cognitive_arbitration = build_cognitive_arbitration_artifact(
         &run_summary,
         &suggestions,
+        &cognitive_signals,
         &affect_state,
         Some(&scores_for_suggestions),
     );

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -468,6 +468,88 @@ fn build_cognitive_signals_artifact_is_deterministic_and_bounded() {
 }
 
 #[test]
+fn build_cognitive_signals_state_is_deterministic_and_runtime_usable() {
+    let summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "cognitive-signals-state-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "failure".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 1,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            evaluation_signals_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "cognitive-signals-state-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.0,
+            failure_count: 1,
+            retry_count: 1,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let suggestions = build_suggestions_artifact(&summary, Some(&scores));
+
+    let left = run_artifacts::build_cognitive_signals_state(&summary, &suggestions, Some(&scores));
+    let right = run_artifacts::build_cognitive_signals_state(&summary, &suggestions, Some(&scores));
+
+    assert_eq!(left.dominant_instinct, right.dominant_instinct);
+    assert_eq!(left.confidence_shift, right.confidence_shift);
+    assert_eq!(left.persistence_pressure, right.persistence_pressure);
+    assert_eq!(left.dominant_instinct, "completion");
+    assert_eq!(left.confidence_shift, "reduced");
+    assert_eq!(left.persistence_pressure, "retry_biased");
+}
+
+#[test]
 fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() {
     let summary = RunSummaryArtifact {
         run_summary_version: 1,
@@ -537,18 +619,22 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
         },
     };
     let suggestions = build_suggestions_artifact(&summary, Some(&scores));
+    let signals =
+        run_artifacts::build_cognitive_signals_artifact(&summary, &suggestions, Some(&scores));
     let affect_state =
         run_artifacts::build_affect_state_artifact(&summary, &suggestions, Some(&scores));
 
     let left = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &suggestions,
+        &signals,
         &affect_state,
         Some(&scores),
     );
     let right = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &suggestions,
+        &signals,
         &affect_state,
         Some(&scores),
     );
@@ -567,6 +653,104 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
     assert!(left
         .route_reason
         .contains("selected_intent=increase_step_retry_budget"));
+    assert!(left.route_reason.contains("dominant_instinct=completion"));
+}
+
+#[test]
+fn build_cognitive_arbitration_artifact_consumes_signal_state() {
+    let summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "cognitive-arbitration-signals-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "success".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 0,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            evaluation_signals_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "cognitive-arbitration-signals-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 1.0,
+            failure_count: 0,
+            retry_count: 0,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let suggestions = build_suggestions_artifact(&summary, Some(&scores));
+    let affect_state =
+        run_artifacts::build_affect_state_artifact(&summary, &suggestions, Some(&scores));
+    let baseline_signals =
+        run_artifacts::build_cognitive_signals_artifact(&summary, &suggestions, Some(&scores));
+    let mut reduced_confidence = baseline_signals.clone();
+    reduced_confidence.affect.confidence_shift = "reduced".to_string();
+    reduced_confidence.affect.persistence_pressure = "sustained".to_string();
+
+    let fast = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &suggestions,
+        &baseline_signals,
+        &affect_state,
+        Some(&scores),
+    );
+    let hybrid = run_artifacts::build_cognitive_arbitration_artifact(
+        &summary,
+        &suggestions,
+        &reduced_confidence,
+        &affect_state,
+        Some(&scores),
+    );
+
+    assert_eq!(fast.route_selected, "fast");
+    assert_eq!(hybrid.route_selected, "hybrid");
 }
 
 #[test]
@@ -644,9 +828,15 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
         &success_suggestions,
         Some(&success_scores),
     );
+    let success_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
     let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &success_suggestions,
+        &success_signals,
         &success_affect,
         Some(&success_scores),
     );
@@ -694,9 +884,15 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
         &failure_suggestions,
         Some(&failure_scores),
     );
+    let failure_signals = run_artifacts::build_cognitive_signals_artifact(
+        &summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
     let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &failure_suggestions,
+        &failure_signals,
         &failure_affect,
         Some(&failure_scores),
     );
@@ -798,6 +994,7 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
     let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &success_suggestions,
+        &success_signals,
         &success_affect,
         Some(&success_scores),
     );
@@ -862,6 +1059,7 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
     let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &failure_suggestions,
+        &failure_signals,
         &failure_affect,
         Some(&failure_scores),
     );
@@ -969,6 +1167,7 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
     let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &success_suggestions,
+        &success_signals,
         &success_affect,
         Some(&success_scores),
     );
@@ -1040,6 +1239,7 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
     let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &failure_suggestions,
+        &failure_signals,
         &failure_affect,
         Some(&failure_scores),
     );
@@ -1150,6 +1350,7 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
     let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &success_suggestions,
+        &success_signals,
         &success_affect,
         Some(&success_scores),
     );
@@ -1226,6 +1427,7 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
     let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
         &summary,
         &failure_suggestions,
+        &failure_signals,
         &failure_affect,
         Some(&failure_scores),
     );


### PR DESCRIPTION
Closes #1166

## Summary
- Added `CognitiveArbitrationState` so route selection exists as runtime control state before serialization.
- Refactored arbitration artifact emission to serialize from runtime arbitration state.
- Preserved existing reviewer-visible arbitration outputs while making them depend explicitly on upstream signal state.

## Artifacts
- Runtime proof surface:
  - `.adl/runs/<run_id>/learning/cognitive_arbitration.v1.json`
- Supporting implementation surfaces changed:
  - `adl/src/cli/run_artifacts.rs`
  - `adl/src/cli/tests/artifact_builders.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml artifact_builders`
    - verified deterministic arbitration-state emission and signal-state consumption
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verified formatting on changed Rust sources
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verified the changed runtime surfaces are lint-clean
- Results:
  - PASS: all targeted local validation completed successfully

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1166__v0-86-runtime-sprint-2a-make-wp-05-arbitration-a-real-runtime-control-stage/sip.md
- Output card: .adl/v0.86/tasks/issue-1166__v0-86-runtime-sprint-2a-make-wp-05-arbitration-a-real-runtime-control-stage/sor.md
- Idempotency-Key: v0-86-runtime-sprint-2a-make-wp-05-arbitration-a-real-runtime-control-stage-adl-v0-86-tasks-issue-1166-v0-86-runtime-sprint-2a-make-wp-05-arbitration-a-real-runtime-control-stage-sip-md-adl-v0-86-tasks-issue-1166-v0-86-runtime-sprint-2a-make-wp-05-arbitration-a-real-runtime-control-stage-sor-md