### PR TITLE
[v0.86][runtime] Sprint 3A: Make WP-07 agency emit real candidate generation and selection

### DIFF
--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -401,6 +401,17 @@ pub(crate) struct FastSlowPathArtifact {
     pub(crate) deterministic_handoff_rule: String,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct AgencySelectionState {
+    pub(crate) candidate_generation_basis: String,
+    pub(crate) selection_mode: String,
+    pub(crate) candidate_set: Vec<AgencyCandidateRecord>,
+    pub(crate) selected_candidate_id: String,
+    pub(crate) selected_candidate_kind: String,
+    pub(crate) selected_candidate_action: String,
+    pub(crate) selected_candidate_reason: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AgencySelectionArtifact {
@@ -1581,17 +1592,21 @@ pub(crate) fn build_fast_slow_path_artifact(
     }
 }
 
-pub(crate) fn build_agency_selection_artifact(
-    run_summary: &RunSummaryArtifact,
+pub(crate) fn build_agency_selection_state(
     signals: &CognitiveSignalsArtifact,
     arbitration: &CognitiveArbitrationArtifact,
     fast_slow_path: &FastSlowPathArtifact,
-    scores: Option<&ScoresArtifact>,
-) -> AgencySelectionArtifact {
-    let (selection_mode, candidate_set, selected_candidate_id, selected_candidate_reason) =
-        match fast_slow_path.selected_path.as_str() {
-            "fast_path" => {
-                let candidate_set = vec![
+) -> AgencySelectionState {
+    let (
+        selection_mode,
+        candidate_set,
+        selected_candidate_id,
+        selected_candidate_kind,
+        selected_candidate_action,
+        selected_candidate_reason,
+    ) = match fast_slow_path.selected_path.as_str() {
+        "fast_path" => {
+            let candidate_set = vec![
                     AgencyCandidateRecord {
                         candidate_id: "cand-fast-execute".to_string(),
                         candidate_kind: "direct_execution".to_string(),
@@ -1612,15 +1627,17 @@ pub(crate) fn build_agency_selection_artifact(
                         rationale: "keep a fallback candidate available without changing the primary fast-path commitment".to_string(),
                     },
                 ];
-                (
+            (
                     "fast_candidate_commitment",
                     candidate_set,
                     "cand-fast-execute".to_string(),
+                    "direct_execution".to_string(),
+                    "execute selected candidate directly under bounded once semantics".to_string(),
                     "fast path prioritizes direct bounded execution when arbitration confidence is high and failure pressure is absent".to_string(),
                 )
-            }
-            _ => {
-                let candidate_set = vec![
+        }
+        _ => {
+            let candidate_set = vec![
                     AgencyCandidateRecord {
                         candidate_id: "cand-slow-review".to_string(),
                         candidate_kind: "review_and_refine".to_string(),
@@ -1649,15 +1666,39 @@ pub(crate) fn build_agency_selection_artifact(
                         rationale: "preserve a bounded non-execution option when policy or review pressure remains elevated".to_string(),
                     },
                 ];
-                (
+            (
                     "slow_candidate_comparison",
                     candidate_set,
                     "cand-slow-review".to_string(),
+                    "review_and_refine".to_string(),
+                    "review, refine, or veto the current candidate before execution".to_string(),
                     "slow path makes review/refinement the selected candidate when arbitration requires bounded caution".to_string(),
                 )
-            }
-        };
+        }
+    };
 
+    AgencySelectionState {
+        candidate_generation_basis: format!(
+            "path={} route={} candidate_selection_bias={}",
+            fast_slow_path.selected_path,
+            arbitration.route_selected,
+            signals.instinct.candidate_selection_bias
+        ),
+        selection_mode: selection_mode.to_string(),
+        candidate_set,
+        selected_candidate_id,
+        selected_candidate_kind,
+        selected_candidate_action,
+        selected_candidate_reason,
+    }
+}
+
+pub(crate) fn build_agency_selection_artifact(
+    run_summary: &RunSummaryArtifact,
+    arbitration: &CognitiveArbitrationArtifact,
+    state: &AgencySelectionState,
+    scores: Option<&ScoresArtifact>,
+) -> AgencySelectionArtifact {
     AgencySelectionArtifact {
         agency_selection_version: AGENCY_SELECTION_VERSION,
         run_id: run_summary.run_id.clone(),
@@ -1667,16 +1708,13 @@ pub(crate) fn build_agency_selection_artifact(
             suggestions_version: arbitration.generated_from.suggestions_version,
             scores_version: scores.map(|value| value.scores_version),
         },
-        candidate_generation_basis: format!(
-            "path={} route={} candidate_selection_bias={}",
-            fast_slow_path.selected_path, arbitration.route_selected, signals.instinct.candidate_selection_bias
-        ),
-        selection_mode: selection_mode.to_string(),
-        candidate_set,
-        selected_candidate_id,
-        selected_candidate_reason,
+        candidate_generation_basis: state.candidate_generation_basis.clone(),
+        selection_mode: state.selection_mode.clone(),
+        candidate_set: state.candidate_set.clone(),
+        selected_candidate_id: state.selected_candidate_id.clone(),
+        selected_candidate_reason: state.selected_candidate_reason.clone(),
         deterministic_selection_rule:
-            "derive the bounded candidate set and selected candidate from the fast/slow handoff, arbitration route, and instinct bias without hidden initiative state"
+            "derive the bounded candidate set and selected candidate before execution from the fast/slow handoff, arbitration route, and instinct bias without hidden initiative state"
                 .to_string(),
     }
 }
@@ -1685,22 +1723,23 @@ pub(crate) fn build_bounded_execution_artifact(
     run_summary: &RunSummaryArtifact,
     fast_slow_path: &FastSlowPathArtifact,
     agency_selection: &AgencySelectionArtifact,
+    agency_state: &AgencySelectionState,
     scores: Option<&ScoresArtifact>,
 ) -> BoundedExecutionArtifact {
     let (execution_status, continuation_state, provisional_termination_state, iterations) =
-        match fast_slow_path.selected_path.as_str() {
-            "fast_path" => (
+        match agency_state.selected_candidate_kind.as_str() {
+            "direct_execution" => (
                 "completed",
                 "stop_after_one",
                 "ready_for_evaluation",
                 vec![BoundedExecutionIteration {
                     iteration_index: 1,
                     stage: "execute".to_string(),
-                    action: "execute selected candidate directly".to_string(),
+                    action: agency_state.selected_candidate_action.clone(),
                     outcome: "bounded_direct_execution_complete".to_string(),
                 }],
             ),
-            _ => (
+            "review_and_refine" => (
                 "completed",
                 "bounded_review_complete",
                 "ready_for_evaluation",
@@ -1708,7 +1747,7 @@ pub(crate) fn build_bounded_execution_artifact(
                     BoundedExecutionIteration {
                         iteration_index: 1,
                         stage: "review".to_string(),
-                        action: "review and refine the selected candidate".to_string(),
+                        action: agency_state.selected_candidate_action.clone(),
                         outcome: "bounded_review_pass_complete".to_string(),
                     },
                     BoundedExecutionIteration {
@@ -1718,6 +1757,17 @@ pub(crate) fn build_bounded_execution_artifact(
                         outcome: "bounded_reviewed_execution_complete".to_string(),
                     },
                 ],
+            ),
+            _ => (
+                "completed",
+                "deferred",
+                "ready_for_evaluation",
+                vec![BoundedExecutionIteration {
+                    iteration_index: 1,
+                    stage: "defer".to_string(),
+                    action: agency_state.selected_candidate_action.clone(),
+                    outcome: "bounded_deferral_recorded".to_string(),
+                }],
             ),
         };
 
@@ -1738,7 +1788,7 @@ pub(crate) fn build_bounded_execution_artifact(
         iteration_count: iterations.len() as u32,
         iterations,
         deterministic_execution_rule:
-            "derive bounded iteration shape directly from selected path and selected candidate without hidden retry state"
+            "derive bounded iteration shape directly from the runtime-selected candidate and selected path without hidden retry state"
                 .to_string(),
     }
 }
@@ -2181,17 +2231,19 @@ pub(crate) fn write_run_state_artifacts(
         &cognitive_arbitration,
         Some(&scores_for_suggestions),
     );
+    let agency_selection_state =
+        build_agency_selection_state(&cognitive_signals, &cognitive_arbitration, &fast_slow_path);
     let agency_selection = build_agency_selection_artifact(
         &run_summary,
-        &cognitive_signals,
         &cognitive_arbitration,
-        &fast_slow_path,
+        &agency_selection_state,
         Some(&scores_for_suggestions),
     );
     let bounded_execution = build_bounded_execution_artifact(
         &run_summary,
         &fast_slow_path,
         &agency_selection,
+        &agency_selection_state,
         Some(&scores_for_suggestions),
     );
     let evaluation_signals = build_evaluation_signals_artifact(

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -806,18 +806,21 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
         &success_arbitration,
         Some(&success_scores),
     );
-    let fast_left = run_artifacts::build_agency_selection_artifact(
-        &summary,
+    let success_agency_state = run_artifacts::build_agency_selection_state(
         &success_signals,
         &success_arbitration,
         &success_path,
+    );
+    let fast_left = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &success_arbitration,
+        &success_agency_state,
         Some(&success_scores),
     );
     let fast_right = run_artifacts::build_agency_selection_artifact(
         &summary,
-        &success_signals,
         &success_arbitration,
-        &success_path,
+        &success_agency_state,
         Some(&success_scores),
     );
     assert_eq!(
@@ -827,6 +830,14 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
     assert_eq!(fast_left.agency_selection_version, 1);
     assert_eq!(fast_left.candidate_set.len(), 2);
     assert_eq!(fast_left.selected_candidate_id, "cand-fast-execute");
+    assert_eq!(
+        success_agency_state.selected_candidate_id,
+        "cand-fast-execute"
+    );
+    assert_eq!(
+        success_agency_state.selected_candidate_kind,
+        "direct_execution"
+    );
 
     summary.status = "failure".to_string();
     summary.counts.failed_steps = 1;
@@ -870,15 +881,23 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
         &failure_arbitration,
         Some(&failure_scores),
     );
-    let slow = run_artifacts::build_agency_selection_artifact(
-        &summary,
+    let failure_agency_state = run_artifacts::build_agency_selection_state(
         &failure_signals,
         &failure_arbitration,
         &failure_path,
+    );
+    let slow = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &failure_arbitration,
+        &failure_agency_state,
         Some(&failure_scores),
     );
     assert_eq!(slow.selected_candidate_id, "cand-slow-review");
     assert!(slow.candidate_set.len() >= 3);
+    assert_eq!(
+        failure_agency_state.selected_candidate_kind,
+        "review_and_refine"
+    );
     assert_ne!(fast_left.selection_mode, slow.selection_mode);
     assert_ne!(
         fast_left.selected_candidate_reason,
@@ -977,23 +996,29 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
         &success_arbitration,
         Some(&success_scores),
     );
-    let success_agency = run_artifacts::build_agency_selection_artifact(
-        &summary,
+    let success_agency_state = run_artifacts::build_agency_selection_state(
         &success_signals,
         &success_arbitration,
         &success_path,
+    );
+    let success_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &success_arbitration,
+        &success_agency_state,
         Some(&success_scores),
     );
     let fast_left = run_artifacts::build_bounded_execution_artifact(
         &summary,
         &success_path,
         &success_agency,
+        &success_agency_state,
         Some(&success_scores),
     );
     let fast_right = run_artifacts::build_bounded_execution_artifact(
         &summary,
         &success_path,
         &success_agency,
+        &success_agency_state,
         Some(&success_scores),
     );
     assert_eq!(
@@ -1048,17 +1073,22 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
         &failure_arbitration,
         Some(&failure_scores),
     );
-    let failure_agency = run_artifacts::build_agency_selection_artifact(
-        &summary,
+    let failure_agency_state = run_artifacts::build_agency_selection_state(
         &failure_signals,
         &failure_arbitration,
         &failure_path,
+    );
+    let failure_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &failure_arbitration,
+        &failure_agency_state,
         Some(&failure_scores),
     );
     let slow = run_artifacts::build_bounded_execution_artifact(
         &summary,
         &failure_path,
         &failure_agency,
+        &failure_agency_state,
         Some(&failure_scores),
     );
     assert_eq!(slow.bounded_execution_version, 1);
@@ -1158,17 +1188,22 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
         &success_arbitration,
         Some(&success_scores),
     );
-    let success_agency = run_artifacts::build_agency_selection_artifact(
-        &summary,
+    let success_agency_state = run_artifacts::build_agency_selection_state(
         &success_signals,
         &success_arbitration,
         &success_path,
+    );
+    let success_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &success_arbitration,
+        &success_agency_state,
         Some(&success_scores),
     );
     let success_execution = run_artifacts::build_bounded_execution_artifact(
         &summary,
         &success_path,
         &success_agency,
+        &success_agency_state,
         Some(&success_scores),
     );
     let success_left = run_artifacts::build_evaluation_signals_artifact(
@@ -1234,17 +1269,22 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
         &failure_arbitration,
         Some(&failure_scores),
     );
-    let failure_agency = run_artifacts::build_agency_selection_artifact(
-        &summary,
+    let failure_agency_state = run_artifacts::build_agency_selection_state(
         &failure_signals,
         &failure_arbitration,
         &failure_path,
+    );
+    let failure_agency = run_artifacts::build_agency_selection_artifact(
+        &summary,
+        &failure_arbitration,
+        &failure_agency_state,
         Some(&failure_scores),
     );
     let failure_execution = run_artifacts::build_bounded_execution_artifact(
         &summary,
         &failure_path,
         &failure_agency,
+        &failure_agency_state,
         Some(&failure_scores),
     );
     let failure_eval = run_artifacts::build_evaluation_signals_artifact(


### PR DESCRIPTION
Closes #1162

## Summary
- Added `AgencySelectionState` so candidate generation and selected-candidate choice exist as runtime state before execution serialization.
- Made bounded execution consume the selected runtime candidate state instead of narrating execution from the finished artifact alone.
- Preserved the existing candidate artifact schema while making the emitted candidate set reflect actual runtime generation logic.

## Artifacts
- Runtime proof surface:
  - `.adl/runs/<run_id>/learning/agency_selection.v1.json`
  - `.adl/runs/<run_id>/learning/bounded_execution.v1.json`
- Supporting implementation surfaces changed:
  - `adl/src/cli/run_artifacts.rs`
  - `adl/src/cli/tests/artifact_builders.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml artifact_builders`
    - verified deterministic candidate generation/selection and selected-candidate execution consumption
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verified formatting on changed Rust sources
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verified the changed runtime surfaces are lint-clean
- Results:
  - PASS: all targeted local validation completed successfully

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1162__v0-86-runtime-sprint-3a-make-wp-07-agency-emit-real-candidate-generation-and-selection/sip.md
- Output card: .adl/v0.86/tasks/issue-1162__v0-86-runtime-sprint-3a-make-wp-07-agency-emit-real-candidate-generation-and-selection/sor.md
- Idempotency-Key: v0-86-runtime-sprint-3a-make-wp-07-agency-emit-real-candidate-generation-and-selection-adl-v0-86-tasks-issue-1162-v0-86-runtime-sprint-3a-make-wp-07-agency-emit-real-candidate-generation-and-selection-sip-md-adl-v0-86-tasks-issue-1162-v0-86-runtime-sprint-3a-make-wp-07-agency-emit-real-candidate-generation-and-selection-sor-md