### PR TITLE
[v0.86][runtime] Sprint 3A: Make WP-08 bounded execution reflect real loop state

### DIFF
--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -478,6 +478,14 @@ pub(crate) struct BoundedExecutionArtifact {
     pub(crate) deterministic_execution_rule: String,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct BoundedExecutionState {
+    pub(crate) execution_status: String,
+    pub(crate) continuation_state: String,
+    pub(crate) provisional_termination_state: String,
+    pub(crate) iterations: Vec<BoundedExecutionIteration>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct BoundedExecutionIteration {
@@ -1804,13 +1812,12 @@ pub(crate) fn build_agency_selection_artifact(
     }
 }
 
-pub(crate) fn build_bounded_execution_artifact(
+pub(crate) fn build_bounded_execution_state(
     run_summary: &RunSummaryArtifact,
-    fast_slow_path: &FastSlowPathArtifact,
-    agency_selection: &AgencySelectionArtifact,
+    _fast_slow_path: &FastSlowPathArtifact,
+    _agency_selection: &AgencySelectionArtifact,
     agency_state: &AgencySelectionState,
-    scores: Option<&ScoresArtifact>,
-) -> BoundedExecutionArtifact {
+) -> BoundedExecutionState {
     let (execution_status, continuation_state, provisional_termination_state, iterations) =
         match agency_state.selected_candidate_kind.as_str() {
             "direct_execution" => (
@@ -1856,6 +1863,37 @@ pub(crate) fn build_bounded_execution_artifact(
             ),
         };
 
+    let execution_status = if run_summary.status == "failure" {
+        "completed_with_failure_signal"
+    } else {
+        execution_status
+    };
+    let continuation_state = if run_summary.status == "failure" && iterations.len() > 1 {
+        "bounded_review_complete_with_failure_signal"
+    } else {
+        continuation_state
+    };
+    let provisional_termination_state = if run_summary.status == "failure" {
+        "ready_for_runtime_evaluation"
+    } else {
+        provisional_termination_state
+    };
+
+    BoundedExecutionState {
+        execution_status: execution_status.to_string(),
+        continuation_state: continuation_state.to_string(),
+        provisional_termination_state: provisional_termination_state.to_string(),
+        iterations,
+    }
+}
+
+pub(crate) fn build_bounded_execution_artifact(
+    run_summary: &RunSummaryArtifact,
+    fast_slow_path: &FastSlowPathArtifact,
+    agency_selection: &AgencySelectionArtifact,
+    state: &BoundedExecutionState,
+    scores: Option<&ScoresArtifact>,
+) -> BoundedExecutionArtifact {
     BoundedExecutionArtifact {
         bounded_execution_version: BOUNDED_EXECUTION_VERSION,
         run_id: run_summary.run_id.clone(),
@@ -1867,13 +1905,13 @@ pub(crate) fn build_bounded_execution_artifact(
         },
         selected_candidate_id: agency_selection.selected_candidate_id.clone(),
         selected_path: fast_slow_path.selected_path.clone(),
-        execution_status: execution_status.to_string(),
-        continuation_state: continuation_state.to_string(),
-        provisional_termination_state: provisional_termination_state.to_string(),
-        iteration_count: iterations.len() as u32,
-        iterations,
+        execution_status: state.execution_status.clone(),
+        continuation_state: state.continuation_state.clone(),
+        provisional_termination_state: state.provisional_termination_state.clone(),
+        iteration_count: state.iterations.len() as u32,
+        iterations: state.iterations.clone(),
         deterministic_execution_rule:
-            "derive bounded iteration shape directly from the runtime-selected candidate and selected path without hidden retry state"
+            "derive bounded iteration shape, continuation state, and provisional termination from runtime loop state without hidden retry state"
                 .to_string(),
     }
 }
@@ -2347,11 +2385,17 @@ pub(crate) fn write_run_state_artifacts(
         &agency_selection_state,
         Some(&scores_for_suggestions),
     );
-    let bounded_execution = build_bounded_execution_artifact(
+    let bounded_execution_state = build_bounded_execution_state(
         &run_summary,
         &fast_slow_path,
         &agency_selection,
         &agency_selection_state,
+    );
+    let bounded_execution = build_bounded_execution_artifact(
+        &run_summary,
+        &fast_slow_path,
+        &agency_selection,
+        &bounded_execution_state,
         Some(&scores_for_suggestions),
     );
     let evaluation_control_state = build_evaluation_control_state(&run_summary, &bounded_execution);

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -1206,18 +1206,24 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
         &success_agency_state,
         Some(&success_scores),
     );
-    let fast_left = run_artifacts::build_bounded_execution_artifact(
+    let success_state = run_artifacts::build_bounded_execution_state(
         &summary,
         &success_path,
         &success_agency,
         &success_agency_state,
+    );
+    let fast_left = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &success_path,
+        &success_agency,
+        &success_state,
         Some(&success_scores),
     );
     let fast_right = run_artifacts::build_bounded_execution_artifact(
         &summary,
         &success_path,
         &success_agency,
-        &success_agency_state,
+        &success_state,
         Some(&success_scores),
     );
     assert_eq!(
@@ -1229,6 +1235,7 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
         fast_left.provisional_termination_state,
         "ready_for_evaluation"
     );
+    assert_eq!(success_state.continuation_state, "stop_after_one");
 
     summary.status = "failure".to_string();
     summary.counts.failed_steps = 1;
@@ -1284,16 +1291,26 @@ fn build_bounded_execution_artifact_is_deterministic_and_shows_iteration_shape()
         &failure_agency_state,
         Some(&failure_scores),
     );
-    let slow = run_artifacts::build_bounded_execution_artifact(
+    let failure_state = run_artifacts::build_bounded_execution_state(
         &summary,
         &failure_path,
         &failure_agency,
         &failure_agency_state,
+    );
+    let slow = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &failure_path,
+        &failure_agency,
+        &failure_state,
         Some(&failure_scores),
     );
     assert_eq!(slow.bounded_execution_version, 1);
     assert_eq!(slow.iteration_count, 2);
     assert_eq!(slow.iterations[0].stage, "review");
+    assert_eq!(
+        slow.provisional_termination_state,
+        "ready_for_runtime_evaluation"
+    );
     assert_ne!(fast_left.iteration_count, slow.iteration_count);
 }
 
@@ -1400,11 +1417,17 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
         &success_agency_state,
         Some(&success_scores),
     );
-    let success_execution = run_artifacts::build_bounded_execution_artifact(
+    let success_execution_state = run_artifacts::build_bounded_execution_state(
         &summary,
         &success_path,
         &success_agency,
         &success_agency_state,
+    );
+    let success_execution = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &success_path,
+        &success_agency,
+        &success_execution_state,
         Some(&success_scores),
     );
     let success_eval_state =
@@ -1485,11 +1508,17 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
         &failure_agency_state,
         Some(&failure_scores),
     );
-    let failure_execution = run_artifacts::build_bounded_execution_artifact(
+    let failure_execution_state = run_artifacts::build_bounded_execution_state(
         &summary,
         &failure_path,
         &failure_agency,
         &failure_agency_state,
+    );
+    let failure_execution = run_artifacts::build_bounded_execution_artifact(
+        &summary,
+        &failure_path,
+        &failure_agency,
+        &failure_execution_state,
         Some(&failure_scores),
     );
     let failure_eval_state =


### PR DESCRIPTION
Closes #1163

## Summary
- Added `BoundedExecutionState` so iteration records, continuation, and provisional termination come from runtime loop state instead of fixed path templates alone.
- Refactored the emitted bounded execution artifact to serialize from the runtime loop state.
- Preserved the reviewer-visible iteration artifact while upgrading it into a real runtime control surface.

## Artifacts
- Runtime proof surface:
  - `.adl/runs/<run_id>/learning/bounded_execution.v1.json`
- Supporting implementation surfaces changed:
  - `adl/src/cli/run_artifacts.rs`
  - `adl/src/cli/tests/artifact_builders.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml artifact_builders`
    - verified deterministic single-iteration and multi-iteration bounded execution output from runtime loop state
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verified formatting on changed Rust sources
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verified the changed runtime surfaces are lint-clean
- Results:
  - PASS: all targeted local validation completed successfully

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1163__v0-86-runtime-sprint-3a-make-wp-08-bounded-execution-reflect-real-loop-state/sip.md
- Output card: .adl/v0.86/tasks/issue-1163__v0-86-runtime-sprint-3a-make-wp-08-bounded-execution-reflect-real-loop-state/sor.md
- Idempotency-Key: v0-86-runtime-sprint-3a-make-wp-08-bounded-execution-reflect-real-loop-state-adl-v0-86-tasks-issue-1163-v0-86-runtime-sprint-3a-make-wp-08-bounded-execution-reflect-real-loop-state-sip-md-adl-v0-86-tasks-issue-1163-v0-86-runtime-sprint-3a-make-wp-08-bounded-execution-reflect-real-loop-state-sor-md