### PR TITLE
[v0.86][runtime] Sprint 3A: Make WP-09 evaluation drive explicit control semantics

### DIFF
--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -464,7 +464,18 @@ pub(crate) struct EvaluationSignalsArtifact {
     pub(crate) failure_signal: String,
     pub(crate) termination_reason: String,
     pub(crate) behavior_effect: String,
+    pub(crate) next_control_action: String,
     pub(crate) deterministic_evaluation_rule: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EvaluationControlState {
+    pub(crate) progress_signal: String,
+    pub(crate) contradiction_signal: String,
+    pub(crate) failure_signal: String,
+    pub(crate) termination_reason: String,
+    pub(crate) behavior_effect: String,
+    pub(crate) next_control_action: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1743,19 +1754,17 @@ pub(crate) fn build_bounded_execution_artifact(
     }
 }
 
-pub(crate) fn build_evaluation_signals_artifact(
+pub(crate) fn build_evaluation_control_state(
     run_summary: &RunSummaryArtifact,
-    fast_slow_path: &FastSlowPathArtifact,
-    agency_selection: &AgencySelectionArtifact,
     bounded_execution: &BoundedExecutionArtifact,
-    scores: Option<&ScoresArtifact>,
-) -> EvaluationSignalsArtifact {
+) -> EvaluationControlState {
     let (
         progress_signal,
         contradiction_signal,
         failure_signal,
         termination_reason,
         behavior_effect,
+        next_control_action,
     ) = if run_summary.status == "failure" {
         (
             "stalled_progress",
@@ -1767,6 +1776,11 @@ pub(crate) fn build_evaluation_signals_artifact(
                 "no_progress"
             },
             "emit bounded failure/termination signals for later reframing or policy handling",
+            if bounded_execution.iteration_count > 1 {
+                "handoff_to_reframing"
+            } else {
+                "terminate_with_failure"
+            },
         )
     } else {
         (
@@ -1775,9 +1789,27 @@ pub(crate) fn build_evaluation_signals_artifact(
             "none",
             "success",
             "allow bounded execution to terminate cleanly after evaluation confirms progress",
+            "complete_run",
         )
     };
 
+    EvaluationControlState {
+        progress_signal: progress_signal.to_string(),
+        contradiction_signal: contradiction_signal.to_string(),
+        failure_signal: failure_signal.to_string(),
+        termination_reason: termination_reason.to_string(),
+        behavior_effect: behavior_effect.to_string(),
+        next_control_action: next_control_action.to_string(),
+    }
+}
+
+pub(crate) fn build_evaluation_signals_artifact(
+    run_summary: &RunSummaryArtifact,
+    fast_slow_path: &FastSlowPathArtifact,
+    agency_selection: &AgencySelectionArtifact,
+    state: &EvaluationControlState,
+    scores: Option<&ScoresArtifact>,
+) -> EvaluationSignalsArtifact {
     EvaluationSignalsArtifact {
         evaluation_signals_version: EVALUATION_SIGNALS_VERSION,
         run_id: run_summary.run_id.clone(),
@@ -1789,13 +1821,14 @@ pub(crate) fn build_evaluation_signals_artifact(
         },
         selected_candidate_id: agency_selection.selected_candidate_id.clone(),
         selected_path: fast_slow_path.selected_path.clone(),
-        progress_signal: progress_signal.to_string(),
-        contradiction_signal: contradiction_signal.to_string(),
-        failure_signal: failure_signal.to_string(),
-        termination_reason: termination_reason.to_string(),
-        behavior_effect: behavior_effect.to_string(),
+        progress_signal: state.progress_signal.clone(),
+        contradiction_signal: state.contradiction_signal.clone(),
+        failure_signal: state.failure_signal.clone(),
+        termination_reason: state.termination_reason.clone(),
+        behavior_effect: state.behavior_effect.clone(),
+        next_control_action: state.next_control_action.clone(),
         deterministic_evaluation_rule:
-            "derive bounded evaluation and termination signals from run status plus bounded execution shape without hidden continuation state"
+            "derive bounded evaluation, termination, and next control action from runtime execution evidence without hidden continuation state"
                 .to_string(),
     }
 }
@@ -2194,11 +2227,12 @@ pub(crate) fn write_run_state_artifacts(
         &agency_selection,
         Some(&scores_for_suggestions),
     );
+    let evaluation_control_state = build_evaluation_control_state(&run_summary, &bounded_execution);
     let evaluation_signals = build_evaluation_signals_artifact(
         &run_summary,
         &fast_slow_path,
         &agency_selection,
-        &bounded_execution,
+        &evaluation_control_state,
         Some(&scores_for_suggestions),
     );
     let cognitive_arbitration_json = serde_json::to_vec_pretty(&cognitive_arbitration)

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -1171,18 +1171,20 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
         &success_agency,
         Some(&success_scores),
     );
+    let success_eval_state =
+        run_artifacts::build_evaluation_control_state(&summary, &success_execution);
     let success_left = run_artifacts::build_evaluation_signals_artifact(
         &summary,
         &success_path,
         &success_agency,
-        &success_execution,
+        &success_eval_state,
         Some(&success_scores),
     );
     let success_right = run_artifacts::build_evaluation_signals_artifact(
         &summary,
         &success_path,
         &success_agency,
-        &success_execution,
+        &success_eval_state,
         Some(&success_scores),
     );
     assert_eq!(
@@ -1191,6 +1193,7 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
     );
     assert_eq!(success_left.termination_reason, "success");
     assert_eq!(success_left.failure_signal, "none");
+    assert_eq!(success_left.next_control_action, "complete_run");
 
     summary.status = "failure".to_string();
     summary.counts.failed_steps = 1;
@@ -1247,16 +1250,19 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
         &failure_agency,
         Some(&failure_scores),
     );
+    let failure_eval_state =
+        run_artifacts::build_evaluation_control_state(&summary, &failure_execution);
     let failure_eval = run_artifacts::build_evaluation_signals_artifact(
         &summary,
         &failure_path,
         &failure_agency,
-        &failure_execution,
+        &failure_eval_state,
         Some(&failure_scores),
     );
     assert_eq!(failure_eval.evaluation_signals_version, 1);
     assert_eq!(failure_eval.termination_reason, "bounded_failure");
     assert_eq!(failure_eval.contradiction_signal, "present");
+    assert_eq!(failure_eval.next_control_action, "handoff_to_reframing");
     assert_ne!(
         success_left.termination_reason,
         failure_eval.termination_reason


### PR DESCRIPTION
Closes #1164

## Summary
- Added `EvaluationControlState` so evaluation signals, termination reason, behavior effect, and next control action come from runtime evaluation state instead of post-hoc run-summary narration.
- Added explicit `next_control_action` to the emitted evaluation artifact.
- Refactored evaluation artifact emission to serialize from runtime control state driven by bounded execution evidence.

## Artifacts
- Runtime proof surface:
  - `.adl/runs/<run_id>/learning/evaluation_signals.v1.json`
- Supporting implementation surfaces changed:
  - `adl/src/cli/run_artifacts.rs`
  - `adl/src/cli/tests/artifact_builders.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml artifact_builders`
    - verified deterministic success and bounded-failure evaluation output from runtime control state
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verified formatting on changed Rust sources
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verified the changed runtime surfaces are lint-clean
- Results:
  - PASS: all targeted local validation completed successfully

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1164__v0-86-runtime-sprint-3a-make-wp-09-evaluation-drive-explicit-control-semantics/sip.md
- Output card: .adl/v0.86/tasks/issue-1164__v0-86-runtime-sprint-3a-make-wp-09-evaluation-drive-explicit-control-semantics/sor.md
- Idempotency-Key: v0-86-runtime-sprint-3a-make-wp-09-evaluation-drive-explicit-control-semantics-adl-v0-86-tasks-issue-1164-v0-86-runtime-sprint-3a-make-wp-09-evaluation-drive-explicit-control-semantics-sip-md-adl-v0-86-tasks-issue-1164-v0-86-runtime-sprint-3a-make-wp-09-evaluation-drive-explicit-control-semantics-sor-md