### PR TITLE
[v0.86][tools] Enforce milestone PR-wave preflight so open corrective PRs cannot be left behind

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -47,6 +47,7 @@ struct StartArgs {
     title_arg: Option<String>,
     no_fetch_issue: bool,
     version: Option<String>,
+    allow_open_pr_wave: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,6 +55,14 @@ struct ReadyArgs {
     issue: u32,
     slug: Option<String>,
     version: Option<String>,
+    no_fetch_issue: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PreflightArgs {
+    issue: u32,
+    version: Option<String>,
+    slug: Option<String>,
     no_fetch_issue: bool,
 }
 
@@ -87,9 +96,22 @@ struct IssuePromptDoc {
     body: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct OpenPullRequest {
+    number: u32,
+    title: String,
+    url: String,
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(rename = "baseRefName")]
+    base_ref_name: String,
+    #[serde(rename = "isDraft")]
+    is_draft: bool,
+}
+
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
-        bail!("pr requires a subcommand: init | create | start | ready | finish");
+        bail!("pr requires a subcommand: init | create | start | ready | preflight | finish");
     };
 
     match subcommand {
@@ -97,6 +119,7 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "create" => real_pr_create(&args[1..]),
         "start" => real_pr_start(&args[1..]),
         "ready" => real_pr_ready(&args[1..]),
+        "preflight" => real_pr_preflight(&args[1..]),
         "finish" => real_pr_finish(&args[1..]),
         other => bail!("unknown pr subcommand: {other}"),
     }
@@ -145,6 +168,14 @@ fn real_pr_start(args: &[String]) -> Result<()> {
 
     let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
     let branch = issue_ref.branch_name(&parsed.prefix);
+    let unresolved = unresolved_milestone_pr_wave(&repo, &version, Some(&branch))?;
+    if !parsed.allow_open_pr_wave && !unresolved.is_empty() {
+        bail!(
+            "start: unresolved open PR wave detected for {}. Resolve or merge these PRs first, or rerun with --allow-open-pr-wave if you are deliberately overriding the guard:\n{}",
+            version,
+            format_open_pr_wave(&unresolved)
+        );
+    }
     let managed_root = std::env::var_os("ADL_WORKTREE_ROOT").map(PathBuf::from);
     let worktree_path = issue_ref.default_worktree_path(&repo_root, managed_root.as_deref());
 
@@ -301,6 +332,55 @@ fn real_pr_ready(args: &[String]) -> Result<()> {
     );
     println!("READY=PASS");
     let _ = repo; // keep parity with init/create remote-based inference
+    Ok(())
+}
+
+fn real_pr_preflight(args: &[String]) -> Result<()> {
+    let parsed = parse_preflight_args(args)?;
+    let repo_root = repo_root()?;
+    let repo = default_repo(&repo_root)?;
+
+    let (version, slug) =
+        if let (Some(version), Some(slug)) = (parsed.version.clone(), parsed.slug.clone()) {
+            (version, slug)
+        } else {
+            let inferred = resolve_issue_scope_and_slug_from_local_state(&repo_root, parsed.issue)?;
+            (
+                parsed
+                    .version
+                    .clone()
+                    .or(inferred.as_ref().map(|x| x.0.clone()))
+                    .unwrap_or_else(|| DEFAULT_VERSION.to_string()),
+                parsed
+                    .slug
+                    .clone()
+                    .or(inferred.map(|x| x.1))
+                    .unwrap_or_else(|| format!("issue-{}", parsed.issue)),
+            )
+        };
+
+    let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug)?;
+    let branch = issue_ref.branch_name("codex");
+    let unresolved = unresolved_milestone_pr_wave(&repo, &version, Some(&branch))?;
+
+    println!("ISSUE={}", parsed.issue);
+    println!("VERSION={version}");
+    println!("BRANCH={branch}");
+    println!("OPEN_PR_COUNT={}", unresolved.len());
+    for pr in &unresolved {
+        println!(
+            "OPEN_PR=#{}|{}|{}|{}",
+            pr.number,
+            pr.head_ref_name,
+            if pr.is_draft { "draft" } else { "ready" },
+            pr.url
+        );
+    }
+    if unresolved.is_empty() {
+        println!("PREFLIGHT=PASS");
+    } else {
+        println!("PREFLIGHT=BLOCK");
+    }
     Ok(())
 }
 
@@ -801,6 +881,7 @@ fn parse_start_args(args: &[String]) -> Result<StartArgs> {
         title_arg: None,
         no_fetch_issue: false,
         version: None,
+        allow_open_pr_wave: false,
     };
     let mut i = 1;
     while i < args.len() {
@@ -822,7 +903,40 @@ fn parse_start_args(args: &[String]) -> Result<StartArgs> {
                 i += 1;
             }
             "--no-fetch-issue" => parsed.no_fetch_issue = true,
+            "--allow-open-pr-wave" => parsed.allow_open_pr_wave = true,
             other => bail!("start: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    Ok(parsed)
+}
+
+fn parse_preflight_args(args: &[String]) -> Result<PreflightArgs> {
+    let issue_raw = args
+        .first()
+        .ok_or_else(|| anyhow!("preflight: missing <issue> number"))?;
+    let issue = issue_raw
+        .parse::<u32>()
+        .with_context(|| format!("invalid issue number: {issue_raw}"))?;
+    let mut parsed = PreflightArgs {
+        issue,
+        version: None,
+        slug: None,
+        no_fetch_issue: false,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--slug" => {
+                parsed.slug = Some(require_value(args, i, "preflight", "--slug")?);
+                i += 1;
+            }
+            "--version" => {
+                parsed.version = Some(require_value(args, i, "preflight", "--version")?);
+                i += 1;
+            }
+            "--no-fetch-issue" => parsed.no_fetch_issue = true,
+            other => bail!("preflight: unknown arg: {other}"),
         }
         i += 1;
     }
@@ -1310,6 +1424,55 @@ fn current_pr_url(repo: &str, branch: &str) -> Result<Option<String>> {
     Ok(out
         .map(|x| x.trim().to_string())
         .filter(|x| !x.is_empty() && x != "null"))
+}
+
+fn unresolved_milestone_pr_wave(
+    repo: &str,
+    version: &str,
+    current_branch: Option<&str>,
+) -> Result<Vec<OpenPullRequest>> {
+    let out = run_capture_allow_failure(
+        "gh",
+        &[
+            "pr",
+            "list",
+            "-R",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,title,url,headRefName,baseRefName,isDraft",
+        ],
+    )?
+    .unwrap_or_else(|| "[]".to_string());
+    let prs: Vec<OpenPullRequest> =
+        serde_json::from_str(&out).with_context(|| "failed to parse gh pr list json")?;
+    let version_tag = format!("[{version}]");
+    Ok(prs
+        .into_iter()
+        .filter(|pr| pr.base_ref_name == "main")
+        .filter(|pr| pr.title.contains(&version_tag))
+        .filter(|pr| {
+            current_branch
+                .map(|branch| pr.head_ref_name != branch)
+                .unwrap_or(true)
+        })
+        .collect())
+}
+
+fn format_open_pr_wave(prs: &[OpenPullRequest]) -> String {
+    prs.iter()
+        .map(|pr| {
+            format!(
+                "- #{} [{}] {} ({})",
+                pr.number,
+                if pr.is_draft { "draft" } else { "ready" },
+                pr.title,
+                pr.url
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn pr_has_closing_linkage(repo: &str, pr_ref: &str, issue: u32) -> Result<bool> {
@@ -2677,9 +2840,9 @@ verification_summary:
     #[test]
     fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
         let err = real_pr(&[]).expect_err("missing subcommand");
-        assert!(err
-            .to_string()
-            .contains("pr requires a subcommand: init | create | start | ready | finish"));
+        assert!(err.to_string().contains(
+            "pr requires a subcommand: init | create | start | ready | preflight | finish"
+        ));
 
         let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
         assert!(err.to_string().contains("unknown pr subcommand: bogus"));
@@ -2742,6 +2905,27 @@ verification_summary:
     }
 
     #[test]
+    fn parse_preflight_args_accepts_flags_and_rejects_unknown_arg() {
+        let parsed = parse_preflight_args(&[
+            "1173".to_string(),
+            "--slug".to_string(),
+            "preflight-test".to_string(),
+            "--version".to_string(),
+            "v0.86".to_string(),
+            "--no-fetch-issue".to_string(),
+        ])
+        .expect("parse preflight");
+        assert_eq!(parsed.issue, 1173);
+        assert_eq!(parsed.slug.as_deref(), Some("preflight-test"));
+        assert_eq!(parsed.version.as_deref(), Some("v0.86"));
+        assert!(parsed.no_fetch_issue);
+
+        let err =
+            parse_preflight_args(&["1173".to_string(), "--bogus".to_string()]).expect_err("err");
+        assert!(err.to_string().contains("preflight: unknown arg"));
+    }
+
+    #[test]
     fn parse_start_args_accepts_prefix_and_rejects_unknown_arg() {
         let parsed = parse_start_args(&[
             "1152".to_string(),
@@ -2754,6 +2938,7 @@ verification_summary:
             "--version".to_string(),
             "v0.86".to_string(),
             "--no-fetch-issue".to_string(),
+            "--allow-open-pr-wave".to_string(),
         ])
         .expect("parse start");
         assert_eq!(parsed.issue, 1152);
@@ -2762,6 +2947,7 @@ verification_summary:
         assert_eq!(parsed.title_arg.as_deref(), Some("Start Test"));
         assert_eq!(parsed.version.as_deref(), Some("v0.86"));
         assert!(parsed.no_fetch_issue);
+        assert!(parsed.allow_open_pr_wave);
 
         let err = parse_start_args(&["1152".to_string(), "--bogus".to_string()]).expect_err("err");
         assert!(err.to_string().contains("start: unknown arg"));
@@ -3152,6 +3338,155 @@ verification_summary:
         assert!(card_output_path(&root_cards, 1152)
             .symlink_metadata()
             .is_ok());
+    }
+
+    #[test]
+    fn real_pr_preflight_reports_open_milestone_prs() {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let repo = unique_temp_dir("adl-pr-preflight");
+        init_git_repo(&repo);
+        let bin_dir = repo.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        let gh_path = bin_dir.join("gh");
+        write_executable(
+            &gh_path,
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  cat <<'JSON'\n[{\"number\":1169,\"title\":\"[v0.86][runtime] Sprint 3A: Make WP-06 fast / slow paths drive real runtime behavior\",\"url\":\"https://example.test/pr/1169\",\"headRefName\":\"codex/1161-v0-86-runtime-sprint-3a-make-wp-06-fast-slow-paths-drive-real-runtime-behavior\",\"baseRefName\":\"main\",\"isDraft\":true}]\nJSON\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let old_path = env::var("PATH").unwrap_or_default();
+        let prev_dir = env::current_dir().expect("cwd");
+        unsafe {
+            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        }
+        env::set_current_dir(&repo).expect("chdir");
+
+        let result = real_pr(&[
+            "preflight".to_string(),
+            "1173".to_string(),
+            "--slug".to_string(),
+            "v0-86-tools-preflight".to_string(),
+            "--version".to_string(),
+            "v0.86".to_string(),
+            "--no-fetch-issue".to_string(),
+        ]);
+
+        env::set_current_dir(prev_dir).expect("restore cwd");
+        unsafe {
+            env::set_var("PATH", old_path);
+        }
+        result.expect("preflight");
+    }
+
+    #[test]
+    fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let temp = unique_temp_dir("adl-pr-start-blocks-wave");
+        let origin = temp.join("origin.git");
+        let repo = temp.join("repo");
+        fs::create_dir_all(&repo).expect("repo dir");
+        copy_bootstrap_support_files(&repo);
+        init_git_repo(&repo);
+        assert!(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo)
+            .status()
+            .expect("git config")
+            .success());
+        assert!(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo)
+            .status()
+            .expect("git config")
+            .success());
+        assert!(Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(&repo)
+            .status()
+            .expect("git add")
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(&repo)
+            .status()
+            .expect("git commit")
+            .success());
+        assert!(Command::new("git")
+            .args(["branch", "-M", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git branch")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "init",
+                "--bare",
+                "-q",
+                path_str(&origin).expect("origin path")
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git init bare")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "remote",
+                "set-url",
+                "origin",
+                path_str(&origin).expect("origin path"),
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git remote set-url")
+            .success());
+        assert!(Command::new("git")
+            .args(["push", "-q", "-u", "origin", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git push")
+            .success());
+        assert!(Command::new("git")
+            .args(["fetch", "-q", "origin", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git fetch")
+            .success());
+
+        let bin_dir = repo.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        let gh_path = bin_dir.join("gh");
+        write_executable(
+            &gh_path,
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  cat <<'JSON'\n[{\"number\":1169,\"title\":\"[v0.86][runtime] Sprint 3A: Make WP-06 fast / slow paths drive real runtime behavior\",\"url\":\"https://example.test/pr/1169\",\"headRefName\":\"codex/1161-v0-86-runtime-sprint-3a-make-wp-06-fast-slow-paths-drive-real-runtime-behavior\",\"baseRefName\":\"main\",\"isDraft\":true}]\nJSON\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let old_path = env::var("PATH").unwrap_or_default();
+        let prev_dir = env::current_dir().expect("cwd");
+        unsafe {
+            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        }
+        env::set_current_dir(&repo).expect("chdir");
+
+        let err = real_pr(&[
+            "start".to_string(),
+            "1173".to_string(),
+            "--slug".to_string(),
+            "v0-86-tools-preflight-guard".to_string(),
+            "--title".to_string(),
+            "[v0.86][tools] Preflight guard".to_string(),
+            "--version".to_string(),
+            "v0.86".to_string(),
+            "--no-fetch-issue".to_string(),
+        ])
+        .expect_err("start should block on open PR wave");
+
+        env::set_current_dir(prev_dir).expect("restore cwd");
+        unsafe {
+            env::set_var("PATH", old_path);
+        }
+        assert!(err
+            .to_string()
+            .contains("start: unresolved open PR wave detected for v0.86"));
+        assert!(err.to_string().contains("#1169 [draft]"));
     }
 
     #[test]

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -6,8 +6,9 @@ pub fn usage() -> &'static str {
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]
   adl pr create <issue> --stp <path>
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>] [--no-start]
-  adl pr start <issue> [--prefix <prefix>] [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]
+  adl pr start <issue> [--prefix <prefix>] [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
   adl pr ready <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
+  adl pr preflight <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
   adl pr finish <issue> --title <title> [--body <text>] [--paths <csv>] [-f|--input <path>] [--output-card <path>] [--no-checks] [--no-close] [--ready] [--merge] [--no-open]
   adl godel run --run-id <id> --workflow-id <id> --failure-code <code> --failure-summary <text> [--evidence-ref <path> ...] [--runs-dir <dir>]
   adl godel inspect --run-id <id> [--runs-dir <dir>]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -18,6 +18,7 @@
 #   adl/tools/pr.sh run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
 #   adl/tools/pr.sh card    <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <input_card.md>] [--version <v0.2>]
 #   adl/tools/pr.sh output  <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <output_card.md>] [--version <v0.2>]
+#   adl/tools/pr.sh preflight <issue> [--slug <slug>] [--no-fetch-issue] [--version <v0.2>]
 #   adl/tools/pr.sh finish  <issue> --title "<title>" [-f <input_card.md>] [--output-card <output_card.md>] [--body "<extra body>"] [--paths "<p1,p2,...>"] [--no-checks] [--no-close] [--ready] [--allow-gitignore] [--no-open]
 #   adl/tools/pr.sh open
 #   adl/tools/pr.sh status
@@ -762,6 +763,61 @@ issue_version() {
     echo "$v"
   else
     echo "$DEFAULT_VERSION"
+  fi
+}
+
+open_milestone_pr_wave_json() {
+  local repo="$1"
+  gh pr list $(gh_repo_flag "$repo") --state open --json number,title,url,headRefName,baseRefName,isDraft 2>/dev/null || echo "[]"
+}
+
+filter_open_milestone_pr_wave() {
+  local version="$1" current_branch="${2:-}"
+  python3 -c '
+import json
+import sys
+
+version = sys.argv[1]
+current_branch = sys.argv[2]
+prs = json.load(sys.stdin)
+tag = f"[{version}]"
+filtered = []
+for pr in prs:
+    if pr.get("baseRefName") != "main":
+        continue
+    if tag not in pr.get("title", ""):
+        continue
+    if current_branch and pr.get("headRefName") == current_branch:
+        continue
+    filtered.append(pr)
+json.dump(filtered, sys.stdout)
+' "$version" "$current_branch"
+}
+
+count_open_milestone_pr_wave() {
+  python3 -c 'import json, sys; print(len(json.load(sys.stdin)))'
+}
+
+render_open_milestone_pr_wave_lines() {
+  python3 -c '
+import json
+import sys
+prs = json.load(sys.stdin)
+for pr in prs:
+    state = "draft" if pr.get("isDraft") else "ready"
+    print("#{} [{}] {} ({})".format(pr["number"], state, pr["title"], pr["url"]))
+'
+}
+
+ensure_no_open_milestone_pr_wave() {
+  local repo="$1" version="$2" current_branch="$3"
+  local filtered count lines
+  filtered="$(open_milestone_pr_wave_json "$repo" | filter_open_milestone_pr_wave "$version" "$current_branch")"
+  count="$(printf '%s' "$filtered" | count_open_milestone_pr_wave)"
+  if [[ "$count" != "0" ]]; then
+    lines="$(printf '%s' "$filtered" | render_open_milestone_pr_wave_lines)"
+    die "start: unresolved open PR wave detected for $version. Resolve or merge these PRs first, or rerun with --allow-open-pr-wave if you are deliberately overriding the guard:
+$lines"
   fi
 }
 
@@ -1961,6 +2017,7 @@ cmd_start() {
   local title=""
   local title_arg=""
   local version=""
+  local allow_open_pr_wave="0"
   local branch_preexisting="0"
 
   while [[ $# -gt 0 ]]; do
@@ -1970,6 +2027,7 @@ cmd_start() {
       --title) title_arg="$2"; shift 2 ;;
       --version) version="$2"; shift 2 ;;
       --no-fetch-issue) no_fetch_issue="1"; shift ;;
+      --allow-open-pr-wave) allow_open_pr_wave="1"; shift ;;
       -h|--help) usage_start; return 0 ;;
       *) die_with_usage "start: unknown arg: $1" usage_start ;;
     esac
@@ -2005,6 +2063,11 @@ cmd_start() {
   branch="$(branch_for_issue "$prefix" "$issue" "$slug")"
   local worktree_path
   worktree_path="$(default_worktree_path_for_issue "$issue")"
+
+  if [[ "$allow_open_pr_wave" != "1" ]]; then
+    require_cmd gh
+    ensure_no_open_milestone_pr_wave "$repo" "$version" "$branch"
+  fi
 
   note "Target branch: $branch"
   note "Target worktree: $worktree_path"
@@ -2603,6 +2666,77 @@ cmd_ready() {
   echo "READY=PASS"
 }
 
+cmd_preflight() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_preflight
+    return 0
+  fi
+
+  if rust_pr_delegate_available; then
+    delegate_pr_command_to_rust preflight "$@"
+    return 0
+  fi
+
+  require_cmd gh
+  local issue="${1:-}"; shift || true
+  [[ -n "$issue" ]] || die_with_usage "preflight: missing <issue> number" usage_preflight
+  issue="$(normalize_issue_or_die "$issue")"
+
+  local slug="" version="" no_fetch_issue="0"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --slug) slug="$2"; shift 2 ;;
+      --version) version="$2"; shift 2 ;;
+      --no-fetch-issue) no_fetch_issue="1"; shift ;;
+      -h|--help) usage_preflight; return 0 ;;
+      *) die_with_usage "preflight: unknown arg: $1" usage_preflight ;;
+    esac
+  done
+
+  local resolved_scope="" resolved_slug="" parsed
+  if [[ -z "$version" || -z "$slug" ]]; then
+    parsed="$(resolve_issue_scope_and_slug_from_local_state "$issue" || true)"
+    if [[ -n "$parsed" ]]; then
+      resolved_scope="$(sed -n '1p' <<<"$parsed")"
+      resolved_slug="$(sed -n '2p' <<<"$parsed")"
+    fi
+  fi
+  [[ -n "$version" ]] || version="$resolved_scope"
+  if [[ -z "$version" && "$no_fetch_issue" != "1" ]]; then
+    version="$(issue_version "$issue")"
+  fi
+  [[ -n "$version" ]] || version="$DEFAULT_VERSION"
+  [[ -n "$slug" ]] || slug="$resolved_slug"
+  [[ -n "$slug" ]] || slug="issue-$issue"
+
+  local branch repo filtered count
+  branch="$(branch_for_issue "codex" "$issue" "$slug")"
+  repo="$(default_repo)"
+  filtered="$(open_milestone_pr_wave_json "$repo" | filter_open_milestone_pr_wave "$version" "$branch")"
+  count="$(printf '%s' "$filtered" | count_open_milestone_pr_wave)"
+
+  echo "ISSUE=$issue"
+  echo "VERSION=$version"
+  echo "BRANCH=$branch"
+  echo "OPEN_PR_COUNT=$count"
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    echo "OPEN_PR=$line"
+  done < <(printf '%s' "$filtered" | python3 -c '
+import json
+import sys
+prs = json.load(sys.stdin)
+for pr in prs:
+    state = "draft" if pr.get("isDraft") else "ready"
+    print("#{}|{}|{}|{}".format(pr["number"], pr["headRefName"], state, pr["url"]))
+')
+  if [[ "$count" == "0" ]]; then
+    echo "PREFLIGHT=PASS"
+  else
+    echo "PREFLIGHT=BLOCK"
+  fi
+}
+
 cmd_open() {
   require_cmd gh
   local repo
@@ -2652,6 +2786,7 @@ Flags:
   (card/start) --slug <slug>                   Use an explicit slug instead of fetching the issue title.
   (start)   --title "<title>"                  Optional; accepted for UX symmetry and used to derive slug when --slug is omitted.
   (start)   --version <v0.85>                  Override detected version when the caller already knows the intended milestone band.
+  (start)   --allow-open-pr-wave               Override the open milestone PR wave guard.
 
 Notes:
 - PRs are created as DRAFT by default to preserve human review.
@@ -2670,6 +2805,7 @@ Examples:
   adl/tools/pr.sh create --title "adl: fix timeout handling" --slug timeout-fix
   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
   adl/tools/pr.sh start 17 --slug b6-default-system
+  adl/tools/pr.sh preflight 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh card  17 --help
   adl/tools/pr.sh card  17 --version v0.2
   adl/tools/pr.sh card  17 input
@@ -2721,12 +2857,13 @@ EOF
 usage_start() {
   cat <<'EOF'
 Usage:
-  adl/tools/pr.sh start <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>]
+  adl/tools/pr.sh start <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
 
 Notes:
 - Creates or reuses issue worktree at .worktrees/adl-wp-<issue> by default.
 - Keeps the primary checkout on main.
 - `--version` overrides inferred issue version when the caller already knows the intended milestone band.
+- Refuses to start a later issue when an open PR wave already exists for the same milestone band unless `--allow-open-pr-wave` is passed.
 EOF
 }
 
@@ -2782,6 +2919,17 @@ Notes:
 EOF
 }
 
+usage_preflight() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh preflight <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
+
+Notes:
+- Reports whether unresolved open PRs already exist for the same milestone/version band.
+- Prints PREFLIGHT=PASS or PREFLIGHT=BLOCK.
+EOF
+}
+
 usage_finish() {
   cat <<'EOF'
 Usage:
@@ -2802,6 +2950,7 @@ main() {
     run) cmd_run "$@" ;;
     start) cmd_start "$@" ;;
     ready) cmd_ready "$@" ;;
+    preflight) cmd_preflight "$@" ;;
     finish) cmd_finish "$@" ;;
     card) cmd_card "$@" ;;
     output) cmd_output "$@" ;;

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -217,6 +217,39 @@ EOF
     echo "assertion failed: expected cards for issue 992 to exist after concurrent cards" >&2
     exit 1
   }
+
+  fakegh="$tmpdir/fakegh"
+  mkdir -p "$fakegh"
+  cat >"$fakegh/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number":1169,"title":"[v0.86][runtime] Sprint 3A: Make WP-06 fast / slow paths drive real runtime behavior","url":"https://example.test/pr/1169","headRefName":"codex/1161-v0-86-runtime-sprint-3a-make-wp-06-fast-slow-paths-drive-real-runtime-behavior","baseRefName":"main","isDraft":true}]
+JSON
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$fakegh/gh"
+
+  preflight_out="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh preflight 990 --slug blocked-wave --version v0.86 --no-fetch-issue)"
+  assert_contains "OPEN_PR_COUNT=1" "$preflight_out" "preflight detects open wave"
+  assert_contains "PREFLIGHT=BLOCK" "$preflight_out" "preflight blocks"
+
+  set +e
+  blocked_start="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh start 990 --slug blocked-wave --version v0.86 --no-fetch-issue 2>&1)"
+  status=$?
+  set -e
+  [[ "$status" -ne 0 ]] || {
+    echo "assertion failed: expected start to block on unresolved open PR wave" >&2
+    exit 1
+  }
+  assert_contains "unresolved open PR wave detected for v0.86" "$blocked_start" "start guard message"
+  assert_contains "#1169 [draft]" "$blocked_start" "start guard lists open pr"
+
+  allowed_start="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh start 990 --slug blocked-wave --version v0.86 --no-fetch-issue --allow-open-pr-wave)"
+  assert_contains "STATE  FULLY_STARTED" "$allowed_start" "override bypasses start guard"
 )
 
 echo "pr.sh start worktree-safe/idempotent flows: ok"


### PR DESCRIPTION
Closes #1173

## Summary
Implemented milestone PR-wave preflight in both the Rust control plane and the `pr.sh` fallback path. `adl pr preflight` / `pr.sh preflight` now report unresolved open `v0.86` PRs targeting `main`, and `start` now blocks by default until that PR wave is cleared unless the operator explicitly passes `--allow-open-pr-wave`.

## Artifacts
- Runtime/tooling surfaces:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/usage.rs`
  - `adl/tools/pr.sh`
  - `adl/tools/test_pr_start_worktree_safe.sh`
- Produced proof surfaces:
  - machine-readable `preflight` command output (`ISSUE=`, `VERSION=`, `BRANCH=`, `OPEN_PR_COUNT=`, `OPEN_PR=`, `PREFLIGHT=`)
  - regression coverage proving block and override behavior in both Rust and shell paths

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd`
    verifies Rust CLI parsing, preflight reporting, and start-time blocking/override behavior
  - `bash adl/tools/test_pr_start_worktree_safe.sh`
    verifies shell fallback preflight output, start blocking, and explicit override success without Rust delegation
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    verifies Rust formatting compliance
- Results:
  - all listed validation commands passed on the issue branch

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1173__v0-86-tools-enforce-milestone-pr-wave-preflight-so-open-corrective-prs-cannot-be-left-behind/sip.md
- Output card: .adl/v0.86/tasks/issue-1173__v0-86-tools-enforce-milestone-pr-wave-preflight-so-open-corrective-prs-cannot-be-left-behind/sor.md
- Idempotency-Key: v0-86-tools-enforce-milestone-pr-wave-preflight-so-open-corrective-prs-cannot-be-left-behind-adl-src-cli-pr-cmd-rs-adl-src-cli-usage-rs-adl-tools-pr-sh-adl-tools-test-pr-start-worktree-safe-sh-adl-v0-86-tasks-issue-1173-v0-86-tools-enforce-milestone-pr-wave-preflight-so-open-corrective-prs-cannot-be-left-behind-sip-md-adl-v0-86-tasks-issue-1173-v0-86-tools-enforce-milestone-pr-wave-preflight-so-open-corrective-prs-cannot-be-left-behind-sor-md