### PR TITLE
[v0.86][tools] Restore five-command regression and skill smoke coverage

### DIFF
--- a/adl/tools/demo_five_command_editing.sh
+++ b/adl/tools/demo_five_command_editing.sh
@@ -164,7 +164,7 @@ fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
   shift 2
-  if [[ " $* " == *"--json closingIssuesReferences"* && " $* " == *"-q .closingIssuesReferences[]?.number"* ]]; then
+  if [[ " $* " == *" --json closingIssuesReferences "* ]]; then
     echo "42"
     exit 0
   fi

--- a/adl/tools/test_demo_five_command_editing.sh
+++ b/adl/tools/test_demo_five_command_editing.sh
@@ -78,15 +78,22 @@ PY
   exit 1
 }
 
-grep -Fq "PR created:" "$(python3 - <<PY
+GH_LOG_PATH="$(python3 - <<PY
 import json
 from pathlib import Path
 manifest = json.loads(Path("$MANIFEST_PATH").read_text())
-print(manifest["step_logs"]["pr_finish"])
+print(manifest["gh_log"])
 PY
-)" || {
-  echo "assertion failed: pr finish log missing PR creation marker" >&2
+)"
+
+grep -Fq "pr list" "$GH_LOG_PATH" || {
+  echo "assertion failed: gh log missing pr list call" >&2
   exit 1
 }
+
+if grep -Fq "pr create" "$GH_LOG_PATH"; then
+  echo "assertion failed: demo should not open a PR when --no-open is set" >&2
+  exit 1
+fi
 
 echo "five-command editing demo: ok"

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -15,6 +15,7 @@ run_check() {
 run_check adl/tools/test_pr_init.sh
 run_check adl/tools/test_pr_create.sh
 run_check adl/tools/test_pr_start_template_validation.sh
+run_check adl/tools/test_install_adl_pr_cycle_skill.sh
 run_check adl/tools/test_pr_run.sh
 run_check adl/tools/test_pr_finish_default_stage_root.sh
 run_check adl/tools/test_pr_finish_relative_card_paths.sh

--- a/adl/tools/test_install_adl_pr_cycle_skill.sh
+++ b/adl/tools/test_install_adl_pr_cycle_skill.sh
@@ -14,5 +14,9 @@ source_path="${repo_root}/docs/tooling/adl_pr_cycle_skill.md"
 
 [[ -f "${installed}" ]]
 cmp -s "${source_path}" "${installed}"
+grep -Fq 'preflight -> init -> create -> start -> codex -> run_if_required -> finish -> report' "${installed}"
+grep -Fq '.worktrees/adl-wp-<issue_num>' "${installed}"
+grep -Fq 'bash ./adl/tools/pr.sh init <issue_num> --slug <slug> [--version <version>]' "${installed}"
+grep -Fq 'bash adl/tools/test_five_command_regression_suite.sh' "${installed}"
 
 echo "PASS test_install_adl_pr_cycle_skill"

--- a/adl/tools/test_pr_start_template_validation.sh
+++ b/adl/tools/test_pr_start_template_validation.sh
@@ -57,7 +57,7 @@ assert_contains() {
   cd "$repo"
   "$BASH_BIN" adl/tools/pr.sh start 910 --slug validation-pass --no-fetch-issue >/dev/null
   perl -0pi -e 's/Status: IN_PROGRESS/Status: MAYBE/' ".worktrees/adl-wp-910/adl/templates/cards/output_card_template.md"
-  rm -f ".worktrees/adl-wp-910/.adl/v0.3/tasks/issue-0910__validation-pass/sor.md"
+  rm -f ".worktrees/adl-wp-910/.adl/v0.86/tasks/issue-0910__validation-pass/sor.md"
 
   set +e
   bad="$("$BASH_BIN" adl/tools/pr.sh start 910 --slug validation-pass --no-fetch-issue 2>&1)"

--- a/docs/tooling/editor/five_command_regression_suite.md
+++ b/docs/tooling/editor/five_command_regression_suite.md
@@ -18,6 +18,7 @@ The suite protects the shipped five-command surface and its truthful editor clai
 
 It also verifies:
 
+- the installed `adl_pr_cycle` skill still matches the tracked contract and preserves the real five-command state machine
 - the browser/editor adapter remains bounded to `pr start`
 - the editor docs do not overclaim direct browser execution for the other commands
 - the bounded five-command demo still emits the expected lifecycle artifacts
@@ -27,6 +28,7 @@ It also verifies:
 - `adl/tools/test_pr_init.sh`
 - `adl/tools/test_pr_create.sh`
 - `adl/tools/test_pr_start_template_validation.sh`
+- `adl/tools/test_install_adl_pr_cycle_skill.sh`
 - `adl/tools/test_pr_run.sh`
 - `adl/tools/test_pr_finish_default_stage_root.sh`
 - `adl/tools/test_pr_finish_relative_card_paths.sh`


### PR DESCRIPTION
## Summary
- restore the broken `pr start` template-validation regression by targeting the real v0.86 seeded card path
- fold `adl_pr_cycle` smoke coverage into the canonical five-command regression suite
- update the local demo/mock assertions so the suite reflects the current `pr finish` contract instead of stale transcript strings

## Validation
- `bash adl/tools/test_five_command_regression_suite.sh`

## Note on #1121
- `#1121` did not need a separate code branch after review
- its intended smoke-test coverage is now provided here by strengthening `adl/tools/test_install_adl_pr_cycle_skill.sh` and wiring it into `adl/tools/test_five_command_regression_suite.sh`
- treat `#1121` as subsumed by `#1122` unless you want a separate authoring-only traceability closeout
