### PR TITLE
[v0.86][runtime] Make Sprint 2A/3A runtime state native to the execute engine

### DIFF
--- a/adl/src/cli/run.rs
+++ b/adl/src/cli/run.rs
@@ -231,6 +231,7 @@ pub(crate) fn run_workflow(args: &[String]) -> Result<()> {
                     "failure",
                     None,
                     &steering_history,
+                    &execute::derive_runtime_control_state("failure", &[], &tr),
                     resume_completed_ids.as_ref(),
                     Some(&err),
                 )?;
@@ -270,6 +271,7 @@ pub(crate) fn run_workflow(args: &[String]) -> Result<()> {
             status,
             pause_state.as_ref(),
             &result.steering_history,
+            &result.runtime_control,
             resume_completed_ids.as_ref(),
             None,
         )?;
@@ -499,6 +501,7 @@ pub(crate) fn real_resume(args: &[String]) -> Result<()> {
         },
         result.pause.as_ref(),
         &result.steering_history,
+        &result.runtime_control,
         Some(&resume_completed_ids),
         None,
     )?;

--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -344,19 +344,8 @@ pub(crate) struct CognitiveAffectSignalRecord {
     pub(crate) deterministic_update_rule: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CognitiveSignalsState {
-    pub(crate) dominant_instinct: String,
-    pub(crate) completion_pressure: String,
-    pub(crate) integrity_bias: String,
-    pub(crate) curiosity_bias: String,
-    pub(crate) candidate_selection_bias: String,
-    pub(crate) urgency_level: String,
-    pub(crate) salience_level: String,
-    pub(crate) persistence_pressure: String,
-    pub(crate) confidence_shift: String,
-    pub(crate) downstream_influence: String,
-}
+#[cfg(test)]
+pub(crate) type CognitiveSignalsState = execute::CognitiveSignalsState;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -397,29 +386,11 @@ pub(crate) struct CognitiveArbitrationArtifact {
     pub(crate) deterministic_selection_rule: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CognitiveArbitrationState {
-    pub(crate) route_selected: String,
-    pub(crate) reasoning_mode: String,
-    pub(crate) confidence: String,
-    pub(crate) risk_class: String,
-    pub(crate) applied_constraints: Vec<String>,
-    pub(crate) cost_latency_assumption: String,
-    pub(crate) route_reason: String,
-}
+#[cfg(test)]
+pub(crate) type CognitiveArbitrationState = execute::CognitiveArbitrationState;
 
-#[derive(Debug, Clone)]
-pub(crate) struct FastSlowPathState {
-    pub(crate) selected_path: String,
-    pub(crate) path_family: String,
-    pub(crate) runtime_branch_taken: String,
-    pub(crate) handoff_state: String,
-    pub(crate) candidate_strategy: String,
-    pub(crate) review_depth: String,
-    pub(crate) execution_profile: String,
-    pub(crate) termination_expectation: String,
-    pub(crate) path_difference_summary: String,
-}
+#[cfg(test)]
+pub(crate) type FastSlowPathState = execute::FastSlowPathState;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -440,16 +411,8 @@ pub(crate) struct FastSlowPathArtifact {
     pub(crate) deterministic_handoff_rule: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct AgencySelectionState {
-    pub(crate) candidate_generation_basis: String,
-    pub(crate) selection_mode: String,
-    pub(crate) candidate_set: Vec<AgencyCandidateRecord>,
-    pub(crate) selected_candidate_id: String,
-    pub(crate) selected_candidate_kind: String,
-    pub(crate) selected_candidate_action: String,
-    pub(crate) selected_candidate_reason: String,
-}
+#[cfg(test)]
+pub(crate) type AgencySelectionState = execute::AgencySelectionState;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -465,16 +428,7 @@ pub(crate) struct AgencySelectionArtifact {
     pub(crate) deterministic_selection_rule: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct AgencyCandidateRecord {
-    pub(crate) candidate_id: String,
-    pub(crate) candidate_kind: String,
-    pub(crate) bounded_action: String,
-    pub(crate) review_requirement: String,
-    pub(crate) execution_priority: u32,
-    pub(crate) rationale: String,
-}
+pub(crate) type AgencyCandidateRecord = execute::AgencyCandidateRecord;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -492,22 +446,9 @@ pub(crate) struct BoundedExecutionArtifact {
     pub(crate) deterministic_execution_rule: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct BoundedExecutionState {
-    pub(crate) execution_status: String,
-    pub(crate) continuation_state: String,
-    pub(crate) provisional_termination_state: String,
-    pub(crate) iterations: Vec<BoundedExecutionIteration>,
-}
+pub(crate) type BoundedExecutionState = execute::BoundedExecutionState;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct BoundedExecutionIteration {
-    pub(crate) iteration_index: u32,
-    pub(crate) stage: String,
-    pub(crate) action: String,
-    pub(crate) outcome: String,
-}
+pub(crate) type BoundedExecutionIteration = execute::BoundedExecutionIteration;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -526,15 +467,7 @@ pub(crate) struct EvaluationSignalsArtifact {
     pub(crate) deterministic_evaluation_rule: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct EvaluationControlState {
-    pub(crate) progress_signal: String,
-    pub(crate) contradiction_signal: String,
-    pub(crate) failure_signal: String,
-    pub(crate) termination_reason: String,
-    pub(crate) behavior_effect: String,
-    pub(crate) next_control_action: String,
-}
+pub(crate) type EvaluationControlState = execute::EvaluationControlState;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1349,6 +1282,7 @@ pub(crate) fn build_affect_state_artifact(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_cognitive_signals_state(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -1452,13 +1386,22 @@ pub(crate) fn build_cognitive_signals_state(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_cognitive_signals_artifact(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
     scores: Option<&ScoresArtifact>,
 ) -> CognitiveSignalsArtifact {
     let state = build_cognitive_signals_state(run_summary, suggestions, scores);
+    build_cognitive_signals_artifact_from_state(run_summary, &state, suggestions, scores)
+}
 
+pub(crate) fn build_cognitive_signals_artifact_from_state(
+    run_summary: &RunSummaryArtifact,
+    state: &execute::CognitiveSignalsState,
+    suggestions: &SuggestionsArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> CognitiveSignalsArtifact {
     CognitiveSignalsArtifact {
         cognitive_signals_version: COGNITIVE_SIGNALS_VERSION,
         run_id: run_summary.run_id.clone(),
@@ -1470,22 +1413,22 @@ pub(crate) fn build_cognitive_signals_artifact(
         },
         instinct: CognitiveInstinctRecord {
             instinct_profile_id: "instinct-001".to_string(),
-            dominant_instinct: state.dominant_instinct,
-            completion_pressure: state.completion_pressure,
-            integrity_bias: state.integrity_bias,
-            curiosity_bias: state.curiosity_bias,
-            candidate_selection_bias: state.candidate_selection_bias,
+            dominant_instinct: state.dominant_instinct.clone(),
+            completion_pressure: state.completion_pressure.clone(),
+            integrity_bias: state.integrity_bias.clone(),
+            curiosity_bias: state.curiosity_bias.clone(),
+            candidate_selection_bias: state.candidate_selection_bias.clone(),
             deterministic_update_rule:
                 "derive bounded instinct profile from stable failure, retry, security, and success evidence ordering"
                     .to_string(),
         },
         affect: CognitiveAffectSignalRecord {
             affect_state_id: "signal-affect-001".to_string(),
-            urgency_level: state.urgency_level,
-            salience_level: state.salience_level,
-            persistence_pressure: state.persistence_pressure,
-            confidence_shift: state.confidence_shift,
-            downstream_influence: state.downstream_influence,
+            urgency_level: state.urgency_level.clone(),
+            salience_level: state.salience_level.clone(),
+            persistence_pressure: state.persistence_pressure.clone(),
+            confidence_shift: state.confidence_shift.clone(),
+            downstream_influence: state.downstream_influence.clone(),
             deterministic_update_rule:
                 "derive bounded affect signals from the first stable suggestion plus bounded run summary evidence"
                     .to_string(),
@@ -1493,6 +1436,7 @@ pub(crate) fn build_cognitive_signals_artifact(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_cognitive_arbitration_state(
     _run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -1593,6 +1537,7 @@ pub(crate) fn build_cognitive_arbitration_state(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_cognitive_arbitration_artifact(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -1601,7 +1546,15 @@ pub(crate) fn build_cognitive_arbitration_artifact(
     scores: Option<&ScoresArtifact>,
 ) -> CognitiveArbitrationArtifact {
     let state = build_cognitive_arbitration_state(run_summary, suggestions, signals, affect_state);
+    build_cognitive_arbitration_artifact_from_state(run_summary, suggestions, &state, scores)
+}
 
+pub(crate) fn build_cognitive_arbitration_artifact_from_state(
+    run_summary: &RunSummaryArtifact,
+    suggestions: &SuggestionsArtifact,
+    state: &execute::CognitiveArbitrationState,
+    scores: Option<&ScoresArtifact>,
+) -> CognitiveArbitrationArtifact {
     CognitiveArbitrationArtifact {
         cognitive_arbitration_version: COGNITIVE_ARBITRATION_VERSION,
         run_id: run_summary.run_id.clone(),
@@ -1611,19 +1564,20 @@ pub(crate) fn build_cognitive_arbitration_artifact(
             suggestions_version: suggestions.suggestions_version,
             scores_version: scores.map(|value| value.scores_version),
         },
-        route_selected: state.route_selected,
-        reasoning_mode: state.reasoning_mode,
-        confidence: state.confidence,
-        risk_class: state.risk_class,
-        applied_constraints: state.applied_constraints,
-        cost_latency_assumption: state.cost_latency_assumption,
-        route_reason: state.route_reason,
+        route_selected: state.route_selected.clone(),
+        reasoning_mode: state.reasoning_mode.clone(),
+        confidence: state.confidence.clone(),
+        risk_class: state.risk_class.clone(),
+        applied_constraints: state.applied_constraints.clone(),
+        cost_latency_assumption: state.cost_latency_assumption.clone(),
+        route_reason: state.route_reason.clone(),
         deterministic_selection_rule:
             "derive route from runtime signal state, bounded affect recovery bias, and stable failure/security/retry evidence ordering"
                 .to_string(),
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_fast_slow_path_state(
     arbitration: &CognitiveArbitrationArtifact,
 ) -> FastSlowPathState {
@@ -1693,7 +1647,7 @@ pub(crate) fn build_fast_slow_path_state(
 pub(crate) fn build_fast_slow_path_artifact(
     run_summary: &RunSummaryArtifact,
     arbitration: &CognitiveArbitrationArtifact,
-    state: &FastSlowPathState,
+    state: &execute::FastSlowPathState,
     scores: Option<&ScoresArtifact>,
 ) -> FastSlowPathArtifact {
     FastSlowPathArtifact {
@@ -1721,6 +1675,7 @@ pub(crate) fn build_fast_slow_path_artifact(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_agency_selection_state(
     signals: &CognitiveSignalsArtifact,
     arbitration: &CognitiveArbitrationArtifact,
@@ -1827,7 +1782,7 @@ pub(crate) fn build_agency_selection_state(
 pub(crate) fn build_agency_selection_artifact(
     run_summary: &RunSummaryArtifact,
     arbitration: &CognitiveArbitrationArtifact,
-    state: &AgencySelectionState,
+    state: &execute::AgencySelectionState,
     scores: Option<&ScoresArtifact>,
 ) -> AgencySelectionArtifact {
     AgencySelectionArtifact {
@@ -1850,6 +1805,7 @@ pub(crate) fn build_agency_selection_artifact(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_bounded_execution_state(
     run_summary: &RunSummaryArtifact,
     _fast_slow_path: &FastSlowPathArtifact,
@@ -1954,6 +1910,7 @@ pub(crate) fn build_bounded_execution_artifact(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_evaluation_control_state(
     run_summary: &RunSummaryArtifact,
     bounded_execution: &BoundedExecutionArtifact,
@@ -2268,6 +2225,7 @@ pub(crate) fn write_run_state_artifacts(
     status: &str,
     pause: Option<&execute::PauseState>,
     steering_history: &[execute::SteeringRecord],
+    runtime_control: &execute::RuntimeControlState,
     resume_completed_step_ids: Option<&HashSet<String>>,
     failure: Option<&anyhow::Error>,
 ) -> Result<PathBuf> {
@@ -2395,59 +2353,48 @@ pub(crate) fn write_run_state_artifacts(
     let suggestions = build_suggestions_artifact(&run_summary, Some(&scores_for_suggestions));
     let suggestions_json =
         serde_json::to_vec_pretty(&suggestions).context("serialize suggestions.json")?;
-    let cognitive_signals =
-        build_cognitive_signals_artifact(&run_summary, &suggestions, Some(&scores_for_suggestions));
+    let cognitive_signals = build_cognitive_signals_artifact_from_state(
+        &run_summary,
+        &runtime_control.signals,
+        &suggestions,
+        Some(&scores_for_suggestions),
+    );
     let cognitive_signals_json = serde_json::to_vec_pretty(&cognitive_signals)
         .context("serialize cognitive_signals.v1.json")?;
     let affect_state =
         build_affect_state_artifact(&run_summary, &suggestions, Some(&scores_for_suggestions));
     let affect_state_json =
         serde_json::to_vec_pretty(&affect_state).context("serialize affect_state.v1.json")?;
-    let cognitive_arbitration = build_cognitive_arbitration_artifact(
+    let cognitive_arbitration = build_cognitive_arbitration_artifact_from_state(
         &run_summary,
         &suggestions,
-        &cognitive_signals,
-        &affect_state,
+        &runtime_control.arbitration,
         Some(&scores_for_suggestions),
     );
-    let fast_slow_state = build_fast_slow_path_state(&cognitive_arbitration);
     let fast_slow_path = build_fast_slow_path_artifact(
         &run_summary,
         &cognitive_arbitration,
-        &fast_slow_state,
+        &runtime_control.fast_slow,
         Some(&scores_for_suggestions),
-    );
-    let agency_selection_state = build_agency_selection_state(
-        &cognitive_signals,
-        &cognitive_arbitration,
-        &fast_slow_state,
-        &fast_slow_path,
     );
     let agency_selection = build_agency_selection_artifact(
         &run_summary,
         &cognitive_arbitration,
-        &agency_selection_state,
+        &runtime_control.agency,
         Some(&scores_for_suggestions),
-    );
-    let bounded_execution_state = build_bounded_execution_state(
-        &run_summary,
-        &fast_slow_path,
-        &agency_selection,
-        &agency_selection_state,
     );
     let bounded_execution = build_bounded_execution_artifact(
         &run_summary,
         &fast_slow_path,
         &agency_selection,
-        &bounded_execution_state,
+        &runtime_control.bounded_execution,
         Some(&scores_for_suggestions),
     );
-    let evaluation_control_state = build_evaluation_control_state(&run_summary, &bounded_execution);
     let evaluation_signals = build_evaluation_signals_artifact(
         &run_summary,
         &fast_slow_path,
         &agency_selection,
-        &evaluation_control_state,
+        &runtime_control.evaluation,
         Some(&scores_for_suggestions),
     );
     let cognitive_arbitration_json = serde_json::to_vec_pretty(&cognitive_arbitration)

--- a/adl/src/cli/tests/run_state.rs
+++ b/adl/src/cli/tests/run_state.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::cli::run_artifacts::{
+    AgencySelectionArtifact, BoundedExecutionArtifact, CognitiveArbitrationArtifact,
+    CognitiveSignalsArtifact, EvaluationSignalsArtifact, FastSlowPathArtifact,
+};
 
 #[test]
 fn select_open_artifact_returns_none_without_html() {
@@ -115,6 +119,97 @@ pub(super) fn minimal_resolved_for_artifacts(run_id: String) -> resolve::AdlReso
     }
 }
 
+fn runtime_control_for(status: &str, tr: &trace::Trace) -> execute::RuntimeControlState {
+    execute::derive_runtime_control_state(status, &[], tr)
+}
+
+fn custom_runtime_control() -> execute::RuntimeControlState {
+    execute::RuntimeControlState {
+        signals: execute::CognitiveSignalsState {
+            dominant_instinct: "integrity".to_string(),
+            completion_pressure: "guarded".to_string(),
+            integrity_bias: "high".to_string(),
+            curiosity_bias: "bounded".to_string(),
+            candidate_selection_bias: "prefer lower-risk constrained candidates".to_string(),
+            urgency_level: "moderate".to_string(),
+            salience_level: "high".to_string(),
+            persistence_pressure: "stabilize_then_retry".to_string(),
+            confidence_shift: "reduced".to_string(),
+            downstream_influence: "custom downstream influence".to_string(),
+        },
+        arbitration: execute::CognitiveArbitrationState {
+            route_selected: "slow".to_string(),
+            reasoning_mode: "review_heavy".to_string(),
+            confidence: "guarded".to_string(),
+            risk_class: "high".to_string(),
+            applied_constraints: vec![
+                "security_denial_present".to_string(),
+                "failure_recovery_bias".to_string(),
+            ],
+            cost_latency_assumption:
+                "spend bounded additional cognition when failure or policy risk is present"
+                    .to_string(),
+            route_reason: "custom arbitration reason".to_string(),
+        },
+        fast_slow: execute::FastSlowPathState {
+            selected_path: "slow_path".to_string(),
+            path_family: "slow".to_string(),
+            runtime_branch_taken: "slow_review_refine_branch".to_string(),
+            handoff_state: "review_handoff".to_string(),
+            candidate_strategy: "validate, refine, or veto the current bounded candidate"
+                .to_string(),
+            review_depth: "verification_required".to_string(),
+            execution_profile: "review_and_refine_before_execution".to_string(),
+            termination_expectation: "terminate_after_bounded_review_cycle_or_policy_block"
+                .to_string(),
+            path_difference_summary: "custom path difference summary".to_string(),
+        },
+        agency: execute::AgencySelectionState {
+            candidate_generation_basis: "custom generation basis".to_string(),
+            selection_mode: "slow_candidate_comparison".to_string(),
+            candidate_set: vec![execute::AgencyCandidateRecord {
+                candidate_id: "cand-custom-review".to_string(),
+                candidate_kind: "review_and_refine".to_string(),
+                bounded_action: "review and refine the candidate".to_string(),
+                review_requirement: "verification_required".to_string(),
+                execution_priority: 1,
+                rationale: "custom rationale".to_string(),
+            }],
+            selected_candidate_id: "cand-custom-review".to_string(),
+            selected_candidate_kind: "review_and_refine".to_string(),
+            selected_candidate_action: "review and refine the candidate".to_string(),
+            selected_candidate_reason: "custom selected candidate reason".to_string(),
+        },
+        bounded_execution: execute::BoundedExecutionState {
+            execution_status: "completed".to_string(),
+            continuation_state: "bounded_review_complete".to_string(),
+            provisional_termination_state: "ready_for_evaluation".to_string(),
+            iterations: vec![
+                execute::BoundedExecutionIteration {
+                    iteration_index: 1,
+                    stage: "review".to_string(),
+                    action: "review the candidate".to_string(),
+                    outcome: "bounded_review_pass_complete".to_string(),
+                },
+                execute::BoundedExecutionIteration {
+                    iteration_index: 2,
+                    stage: "execute".to_string(),
+                    action: "execute the reviewed candidate".to_string(),
+                    outcome: "bounded_reviewed_execution_complete".to_string(),
+                },
+            ],
+        },
+        evaluation: execute::EvaluationControlState {
+            progress_signal: "steady_progress".to_string(),
+            contradiction_signal: "present".to_string(),
+            failure_signal: "none".to_string(),
+            termination_reason: "contradiction_detected".to_string(),
+            behavior_effect: "surface contradiction for bounded follow-up".to_string(),
+            next_control_action: "handoff_to_reframing".to_string(),
+        },
+    }
+}
+
 #[test]
 fn write_run_state_and_load_resume_round_trip() {
     let now = SystemTime::now()
@@ -150,6 +245,7 @@ fn write_run_state_and_load_resume_round_trip() {
         "paused",
         Some(&pause),
         &[],
+        &runtime_control_for("paused", &tr),
         None,
         None,
     )
@@ -185,6 +281,100 @@ fn write_run_state_and_load_resume_round_trip() {
 }
 
 #[test]
+fn write_run_state_artifacts_projects_execute_owned_runtime_control_state() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let run_id = format!("runtime-control-{now}-{}", std::process::id());
+    let resolved = minimal_resolved_for_artifacts(run_id.clone());
+    let out_dir = std::env::temp_dir().join(format!("adl-main-runtime-control-{now}"));
+    let runs_root = unique_temp_dir("adl-main-runs-runtime-control");
+    let _runs_guard = EnvGuard::set("ADL_RUNS_ROOT", &runs_root.to_string_lossy());
+
+    let mut tr = trace::Trace::new(run_id.clone(), "wf".to_string(), "0.5".to_string());
+    tr.step_started("s1", "a1", "p1", "t1", None);
+    tr.step_finished("s1", true);
+
+    let runtime_control = custom_runtime_control();
+    let run_dir = write_run_state_artifacts(
+        &resolved,
+        &tr,
+        Path::new("examples/adl-0.1.yaml"),
+        &out_dir,
+        50,
+        75,
+        "success",
+        None,
+        &[],
+        &runtime_control,
+        None,
+        None,
+    )
+    .expect("write projected runtime-control artifacts");
+
+    let signals: CognitiveSignalsArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("learning/cognitive_signals.v1.json"))
+            .expect("read cognitive signals"),
+    )
+    .expect("parse cognitive signals");
+    assert_eq!(signals.instinct.dominant_instinct, "integrity");
+    assert_eq!(
+        signals.affect.downstream_influence,
+        "custom downstream influence"
+    );
+
+    let arbitration: CognitiveArbitrationArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("learning/cognitive_arbitration.v1.json"))
+            .expect("read cognitive arbitration"),
+    )
+    .expect("parse cognitive arbitration");
+    assert_eq!(arbitration.route_selected, "slow");
+    assert_eq!(arbitration.route_reason, "custom arbitration reason");
+
+    let fast_slow: FastSlowPathArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("learning/fast_slow_path.v1.json"))
+            .expect("read fast slow path"),
+    )
+    .expect("parse fast slow path");
+    assert_eq!(fast_slow.runtime_branch_taken, "slow_review_refine_branch");
+    assert_eq!(
+        fast_slow.path_difference_summary,
+        "custom path difference summary"
+    );
+
+    let agency: AgencySelectionArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("learning/agency_selection.v1.json"))
+            .expect("read agency selection"),
+    )
+    .expect("parse agency selection");
+    assert_eq!(agency.selected_candidate_id, "cand-custom-review");
+    assert_eq!(agency.candidate_generation_basis, "custom generation basis");
+
+    let bounded_execution: BoundedExecutionArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("learning/bounded_execution.v1.json"))
+            .expect("read bounded execution"),
+    )
+    .expect("parse bounded execution");
+    assert_eq!(bounded_execution.iteration_count, 2);
+    assert_eq!(bounded_execution.iterations[1].stage, "execute");
+
+    let evaluation: EvaluationSignalsArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("learning/evaluation_signals.v1.json"))
+            .expect("read evaluation signals"),
+    )
+    .expect("parse evaluation signals");
+    assert_eq!(evaluation.termination_reason, "contradiction_detected");
+    assert_eq!(
+        evaluation.behavior_effect,
+        "surface contradiction for bounded follow-up"
+    );
+
+    let _ = std::fs::remove_dir_all(run_dir);
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+#[test]
 fn load_resume_state_rejects_non_paused_status() {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -207,6 +397,7 @@ fn load_resume_state_rejects_non_paused_status() {
         "success",
         None,
         &[],
+        &runtime_control_for("success", &tr),
         None,
         None,
     )
@@ -256,6 +447,7 @@ fn load_resume_state_rejects_unknown_schema_version() {
         "paused",
         Some(&pause),
         &[],
+        &runtime_control_for("paused", &tr),
         None,
         None,
     )
@@ -304,6 +496,7 @@ fn load_resume_state_rejects_missing_pause_payload() {
         "paused",
         None,
         &[],
+        &runtime_control_for("paused", &tr),
         None,
         None,
     )
@@ -347,6 +540,7 @@ fn load_resume_state_rejects_workflow_mismatch() {
         "paused",
         Some(&pause),
         &[],
+        &runtime_control_for("paused", &tr),
         None,
         None,
     )
@@ -394,6 +588,7 @@ fn load_resume_state_rejects_version_mismatch() {
         "paused",
         Some(&pause),
         &[],
+        &runtime_control_for("paused", &tr),
         None,
         None,
     )
@@ -441,6 +636,7 @@ fn load_resume_state_rejects_execution_plan_mismatch() {
         "paused",
         Some(&pause),
         &[],
+        &runtime_control_for("paused", &tr),
         None,
         None,
     )

--- a/adl/src/execute/mod.rs
+++ b/adl/src/execute/mod.rs
@@ -225,6 +225,7 @@ pub fn execute_sequential_with_resume(
                             .filter(|id| !completed_step_ids.contains(id))
                             .collect::<Vec<_>>();
                         return Ok(ExecutionResult {
+                            runtime_control: derive_runtime_control_state("paused", &records, tr),
                             outputs: outs,
                             artifacts,
                             records,
@@ -325,6 +326,7 @@ pub fn execute_sequential_with_resume(
                         .filter(|id| !completed_step_ids.contains(id))
                         .collect::<Vec<_>>();
                     return Ok(ExecutionResult {
+                        runtime_control: derive_runtime_control_state("paused", &records, tr),
                         outputs: outs,
                         artifacts,
                         records,
@@ -370,6 +372,7 @@ pub fn execute_sequential_with_resume(
     }
 
     Ok(ExecutionResult {
+        runtime_control: derive_runtime_control_state("success", &records, tr),
         outputs: outs,
         artifacts,
         records,

--- a/adl/src/execute/runner.rs
+++ b/adl/src/execute/runner.rs
@@ -697,6 +697,7 @@ pub(super) fn execute_concurrent_deterministic(
             let mut remaining_step_ids: Vec<String> = pending.iter().cloned().collect();
             remaining_step_ids.sort();
             return Ok(ExecutionResult {
+                runtime_control: derive_runtime_control_state("paused", &records, tr),
                 outputs: outs,
                 artifacts,
                 records,
@@ -714,6 +715,7 @@ pub(super) fn execute_concurrent_deterministic(
     }
 
     Ok(ExecutionResult {
+        runtime_control: derive_runtime_control_state("success", &records, tr),
         outputs: outs,
         artifacts,
         records,

--- a/adl/src/execute/state.rs
+++ b/adl/src/execute/state.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::DELEGATION_POLICY_DENY_CODE;
 use crate::sandbox;
+use crate::trace;
 
 pub fn materialize_inputs(
     mut inputs: HashMap<String, String>,
@@ -147,6 +148,121 @@ pub struct ExecutionResult {
     pub records: Vec<StepExecutionRecord>,
     pub pause: Option<PauseState>,
     pub steering_history: Vec<SteeringRecord>,
+    pub runtime_control: RuntimeControlState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeControlState {
+    pub signals: CognitiveSignalsState,
+    pub arbitration: CognitiveArbitrationState,
+    pub fast_slow: FastSlowPathState,
+    pub agency: AgencySelectionState,
+    pub bounded_execution: BoundedExecutionState,
+    pub evaluation: EvaluationControlState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CognitiveSignalsState {
+    pub dominant_instinct: String,
+    pub completion_pressure: String,
+    pub integrity_bias: String,
+    pub curiosity_bias: String,
+    pub candidate_selection_bias: String,
+    pub urgency_level: String,
+    pub salience_level: String,
+    pub persistence_pressure: String,
+    pub confidence_shift: String,
+    pub downstream_influence: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CognitiveArbitrationState {
+    pub route_selected: String,
+    pub reasoning_mode: String,
+    pub confidence: String,
+    pub risk_class: String,
+    pub applied_constraints: Vec<String>,
+    pub cost_latency_assumption: String,
+    pub route_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FastSlowPathState {
+    pub selected_path: String,
+    pub path_family: String,
+    pub runtime_branch_taken: String,
+    pub handoff_state: String,
+    pub candidate_strategy: String,
+    pub review_depth: String,
+    pub execution_profile: String,
+    pub termination_expectation: String,
+    pub path_difference_summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgencySelectionState {
+    pub candidate_generation_basis: String,
+    pub selection_mode: String,
+    pub candidate_set: Vec<AgencyCandidateRecord>,
+    pub selected_candidate_id: String,
+    pub selected_candidate_kind: String,
+    pub selected_candidate_action: String,
+    pub selected_candidate_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgencyCandidateRecord {
+    pub candidate_id: String,
+    pub candidate_kind: String,
+    pub bounded_action: String,
+    pub review_requirement: String,
+    pub execution_priority: u32,
+    pub rationale: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BoundedExecutionState {
+    pub execution_status: String,
+    pub continuation_state: String,
+    pub provisional_termination_state: String,
+    pub iterations: Vec<BoundedExecutionIteration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BoundedExecutionIteration {
+    pub iteration_index: u32,
+    pub stage: String,
+    pub action: String,
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvaluationControlState {
+    pub progress_signal: String,
+    pub contradiction_signal: String,
+    pub failure_signal: String,
+    pub termination_reason: String,
+    pub behavior_effect: String,
+    pub next_control_action: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RuntimeSignalEvidence {
+    failure_count: usize,
+    retry_count: usize,
+    delegation_denied_count: usize,
+    security_denied_count: usize,
+    success_ratio_permille: usize,
+    scheduler_max_parallel_observed: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -267,6 +383,549 @@ pub fn steering_record_from_patch(
         payload_fingerprint,
         set_state_keys,
         removed_state_keys,
+    }
+}
+
+pub fn derive_runtime_control_state(
+    overall_status: &str,
+    records: &[StepExecutionRecord],
+    tr: &trace::Trace,
+) -> RuntimeControlState {
+    let evidence = collect_runtime_signal_evidence(overall_status, records, tr);
+    let signals = derive_cognitive_signals_state(overall_status, evidence);
+    let arbitration = derive_cognitive_arbitration_state(overall_status, evidence, &signals);
+    let fast_slow = derive_fast_slow_path_state(&arbitration);
+    let agency = derive_agency_selection_state(&signals, &arbitration, &fast_slow);
+    let bounded_execution = derive_bounded_execution_state(overall_status, &agency);
+    let evaluation = derive_evaluation_control_state(overall_status, &bounded_execution);
+
+    RuntimeControlState {
+        signals,
+        arbitration,
+        fast_slow,
+        agency,
+        bounded_execution,
+        evaluation,
+    }
+}
+
+fn collect_runtime_signal_evidence(
+    overall_status: &str,
+    records: &[StepExecutionRecord],
+    tr: &trace::Trace,
+) -> RuntimeSignalEvidence {
+    let total_steps = records.len();
+    let failure_count = records
+        .iter()
+        .filter(|record| record.status != "success")
+        .count();
+    let success_count = total_steps.saturating_sub(failure_count);
+    let retry_count: usize = records
+        .iter()
+        .map(|record| record.attempts.saturating_sub(1) as usize)
+        .sum();
+    let delegation_denied_count = tr
+        .events
+        .iter()
+        .filter(|event| matches!(event, trace::TraceEvent::DelegationDenied { .. }))
+        .count();
+    let security_denied_count = delegation_denied_count;
+    let success_ratio_permille = if total_steps == 0 {
+        if overall_status == "success" {
+            1000
+        } else {
+            0
+        }
+    } else {
+        (success_count * 1000) / total_steps
+    };
+    let scheduler_max_parallel_observed = compute_max_parallel_observed_from_trace(tr);
+
+    RuntimeSignalEvidence {
+        failure_count,
+        retry_count,
+        delegation_denied_count,
+        security_denied_count,
+        success_ratio_permille,
+        scheduler_max_parallel_observed,
+    }
+}
+
+fn compute_max_parallel_observed_from_trace(tr: &trace::Trace) -> usize {
+    let mut active: HashSet<&str> = HashSet::new();
+    let mut max_parallel = 0usize;
+    for event in &tr.events {
+        match event {
+            trace::TraceEvent::StepStarted { step_id, .. } => {
+                active.insert(step_id.as_str());
+                max_parallel = max_parallel.max(active.len());
+            }
+            trace::TraceEvent::StepFinished { step_id, .. } => {
+                active.remove(step_id.as_str());
+            }
+            _ => {}
+        }
+    }
+    max_parallel.max(1)
+}
+
+fn derive_cognitive_signals_state(
+    overall_status: &str,
+    evidence: RuntimeSignalEvidence,
+) -> CognitiveSignalsState {
+    let completion_pressure = if evidence.failure_count > 0 || overall_status == "failure" {
+        "elevated"
+    } else if evidence.retry_count > 0 || overall_status == "paused" {
+        "guarded"
+    } else {
+        "steady"
+    };
+    let integrity_bias = if evidence.security_denied_count > 0 {
+        "high"
+    } else {
+        "bounded"
+    };
+    let curiosity_bias = if evidence.success_ratio_permille < 1000 && evidence.failure_count == 0 {
+        "active"
+    } else {
+        "low"
+    };
+    let dominant_instinct = if integrity_bias == "high" {
+        "integrity"
+    } else if completion_pressure == "elevated" {
+        "completion"
+    } else if curiosity_bias == "active" {
+        "curiosity"
+    } else {
+        "coherence"
+    };
+    let candidate_selection_bias = match dominant_instinct {
+        "integrity" => "prefer lower-risk constrained candidates",
+        "completion" => "prefer candidates that reduce unfinished work quickly",
+        "curiosity" => "prefer candidates that reduce uncertainty",
+        _ => "prefer candidates that preserve bounded coherence",
+    };
+    let salience_level = if evidence.failure_count > 0 || evidence.delegation_denied_count > 0 {
+        "high"
+    } else if evidence.retry_count > 0 {
+        "moderate"
+    } else {
+        "low"
+    };
+    let persistence_pressure = if evidence.failure_count > 0 {
+        "retry_biased"
+    } else if evidence.retry_count > 0 {
+        "stabilize_then_retry"
+    } else {
+        "bounded_once"
+    };
+    let confidence_shift = if evidence.failure_count > 0 || evidence.delegation_denied_count > 0 {
+        "reduced"
+    } else {
+        "stable"
+    };
+
+    CognitiveSignalsState {
+        dominant_instinct: dominant_instinct.to_string(),
+        completion_pressure: completion_pressure.to_string(),
+        integrity_bias: integrity_bias.to_string(),
+        curiosity_bias: curiosity_bias.to_string(),
+        candidate_selection_bias: candidate_selection_bias.to_string(),
+        urgency_level: completion_pressure.to_string(),
+        salience_level: salience_level.to_string(),
+        persistence_pressure: persistence_pressure.to_string(),
+        confidence_shift: confidence_shift.to_string(),
+        downstream_influence: format!(
+            "dominant_instinct={} failure_count={} retry_count={} delegation_denied_count={} max_parallel={}",
+            dominant_instinct,
+            evidence.failure_count,
+            evidence.retry_count,
+            evidence.delegation_denied_count,
+            evidence.scheduler_max_parallel_observed
+        ),
+    }
+}
+
+fn derive_cognitive_arbitration_state(
+    overall_status: &str,
+    evidence: RuntimeSignalEvidence,
+    signals: &CognitiveSignalsState,
+) -> CognitiveArbitrationState {
+    let (route_selected, reasoning_mode) = if evidence.security_denied_count > 0
+        || evidence.failure_count > 0
+        || signals.dominant_instinct == "integrity"
+    {
+        ("slow", "review_heavy")
+    } else if evidence.retry_count > 0
+        || overall_status == "paused"
+        || signals.confidence_shift == "reduced"
+    {
+        ("hybrid", "bounded_recovery")
+    } else {
+        ("fast", "direct_execution")
+    };
+    let risk_class = if evidence.security_denied_count > 0 {
+        "high"
+    } else if evidence.failure_count > 0 || evidence.retry_count > 0 {
+        "medium"
+    } else {
+        "low"
+    };
+    let confidence = if route_selected == "fast" {
+        "high"
+    } else if route_selected == "hybrid" {
+        "guarded"
+    } else {
+        "review_required"
+    };
+    let mut applied_constraints = Vec::new();
+    if evidence.security_denied_count > 0 {
+        applied_constraints.push("security_denial_present".to_string());
+    }
+    if evidence.failure_count > 0 {
+        applied_constraints.push("failure_recovery_bias".to_string());
+    }
+    if evidence.retry_count > 0 {
+        applied_constraints.push("retry_budget_pressure".to_string());
+    }
+    if overall_status == "paused" {
+        applied_constraints.push("pause_boundary_present".to_string());
+    }
+    if applied_constraints.is_empty() {
+        applied_constraints.push("bounded_default_path".to_string());
+    }
+    let cost_latency_assumption = match route_selected {
+        "fast" => "prefer lower-cost low-latency execution when bounded evidence is stable",
+        "hybrid" => "allow bounded extra review when retry or pause pressure is present",
+        _ => "spend bounded additional cognition when failure or policy risk is present",
+    };
+
+    CognitiveArbitrationState {
+        route_selected: route_selected.to_string(),
+        reasoning_mode: reasoning_mode.to_string(),
+        confidence: confidence.to_string(),
+        risk_class: risk_class.to_string(),
+        applied_constraints,
+        cost_latency_assumption: cost_latency_assumption.to_string(),
+        route_reason: format!(
+            "route={} dominant_instinct={} overall_status={} failure_count={} retry_count={} delegation_denied_count={}",
+            route_selected,
+            signals.dominant_instinct,
+            overall_status,
+            evidence.failure_count,
+            evidence.retry_count,
+            evidence.delegation_denied_count
+        ),
+    }
+}
+
+fn derive_fast_slow_path_state(arbitration: &CognitiveArbitrationState) -> FastSlowPathState {
+    let (
+        selected_path,
+        path_family,
+        runtime_branch_taken,
+        handoff_state,
+        candidate_strategy,
+        review_depth,
+        execution_profile,
+        termination_expectation,
+    ) = match arbitration.route_selected.as_str() {
+        "fast" => (
+            "fast_path",
+            "fast",
+            "fast_direct_execution_branch",
+            "direct_handoff",
+            "accept first bounded candidate",
+            "minimal",
+            "single_pass_direct_execution",
+            "terminate_on_first_bounded_success_or_policy_block",
+        ),
+        "hybrid" => (
+            "slow_path",
+            "slow",
+            "slow_bounded_recovery_branch",
+            "bounded_recovery_handoff",
+            "compare current candidate against one bounded refinement",
+            "bounded_recovery_review",
+            "review_then_execute_once",
+            "terminate_after_bounded_review_cycle_or_policy_block",
+        ),
+        _ => (
+            "slow_path",
+            "slow",
+            "slow_review_refine_branch",
+            "review_handoff",
+            "validate, refine, or veto the current bounded candidate",
+            "verification_required",
+            "review_and_refine_before_execution",
+            "terminate_after_bounded_review_cycle_or_policy_block",
+        ),
+    };
+    let path_difference_summary = match selected_path {
+        "fast_path" => {
+            "fast_path favors direct execution with minimal review and a single bounded candidate handoff"
+        }
+        _ => {
+            "slow_path requires bounded review/refinement before execution and can revise or veto the current candidate"
+        }
+    };
+
+    FastSlowPathState {
+        selected_path: selected_path.to_string(),
+        path_family: path_family.to_string(),
+        runtime_branch_taken: runtime_branch_taken.to_string(),
+        handoff_state: handoff_state.to_string(),
+        candidate_strategy: candidate_strategy.to_string(),
+        review_depth: review_depth.to_string(),
+        execution_profile: execution_profile.to_string(),
+        termination_expectation: termination_expectation.to_string(),
+        path_difference_summary: path_difference_summary.to_string(),
+    }
+}
+
+fn derive_agency_selection_state(
+    signals: &CognitiveSignalsState,
+    arbitration: &CognitiveArbitrationState,
+    fast_slow: &FastSlowPathState,
+) -> AgencySelectionState {
+    let (
+        selection_mode,
+        candidate_set,
+        selected_candidate_id,
+        selected_candidate_kind,
+        selected_candidate_action,
+        selected_candidate_reason,
+    ) = match fast_slow.selected_path.as_str() {
+        "fast_path" => {
+            let candidate_set = vec![
+                AgencyCandidateRecord {
+                    candidate_id: "cand-fast-execute".to_string(),
+                    candidate_kind: "direct_execution".to_string(),
+                    bounded_action:
+                        "execute selected candidate directly under bounded once semantics"
+                            .to_string(),
+                    review_requirement: "minimal".to_string(),
+                    execution_priority: 1,
+                    rationale: format!(
+                        "route={} dominant_instinct={} confidence={}",
+                        arbitration.route_selected, signals.dominant_instinct, arbitration.confidence
+                    ),
+                },
+                AgencyCandidateRecord {
+                    candidate_id: "cand-fast-verify".to_string(),
+                    candidate_kind: "bounded_verification".to_string(),
+                    bounded_action:
+                        "perform one bounded verification pass before execution".to_string(),
+                    review_requirement: "light".to_string(),
+                    execution_priority: 2,
+                    rationale:
+                        "keep a fallback candidate available without changing the primary fast-path commitment"
+                            .to_string(),
+                },
+            ];
+            (
+                "fast_candidate_commitment",
+                candidate_set,
+                "cand-fast-execute".to_string(),
+                "direct_execution".to_string(),
+                "execute selected candidate directly under bounded once semantics".to_string(),
+                "fast path prioritizes direct bounded execution when arbitration confidence is high and failure pressure is absent".to_string(),
+            )
+        }
+        _ => {
+            let candidate_set = vec![
+                AgencyCandidateRecord {
+                    candidate_id: "cand-slow-review".to_string(),
+                    candidate_kind: "review_and_refine".to_string(),
+                    bounded_action:
+                        "review, refine, or veto the current candidate before execution"
+                            .to_string(),
+                    review_requirement: "verification_required".to_string(),
+                    execution_priority: 1,
+                    rationale: format!(
+                        "route={} dominant_instinct={} risk_class={}",
+                        arbitration.route_selected, signals.dominant_instinct, arbitration.risk_class
+                    ),
+                },
+                AgencyCandidateRecord {
+                    candidate_id: "cand-slow-direct".to_string(),
+                    candidate_kind: "direct_execution".to_string(),
+                    bounded_action:
+                        "execute the current candidate without additional refinement".to_string(),
+                    review_requirement: "minimal".to_string(),
+                    execution_priority: 2,
+                    rationale:
+                        "retain the direct-execution alternative as a bounded comparator candidate"
+                            .to_string(),
+                },
+                AgencyCandidateRecord {
+                    candidate_id: "cand-slow-defer".to_string(),
+                    candidate_kind: "bounded_deferral".to_string(),
+                    bounded_action:
+                        "defer execution and surface the candidate set for later gate/review stages"
+                            .to_string(),
+                    review_requirement: "review_required".to_string(),
+                    execution_priority: 3,
+                    rationale:
+                        "preserve a bounded non-execution option when policy or review pressure remains elevated"
+                            .to_string(),
+                },
+            ];
+            (
+                "slow_candidate_comparison",
+                candidate_set,
+                "cand-slow-review".to_string(),
+                "review_and_refine".to_string(),
+                "review, refine, or veto the current candidate before execution".to_string(),
+                "slow path makes review/refinement the selected candidate when arbitration requires bounded caution".to_string(),
+            )
+        }
+    };
+
+    AgencySelectionState {
+        candidate_generation_basis: format!(
+            "path={} runtime_branch={} route={} candidate_selection_bias={}",
+            fast_slow.selected_path,
+            fast_slow.runtime_branch_taken,
+            arbitration.route_selected,
+            signals.candidate_selection_bias
+        ),
+        selection_mode: selection_mode.to_string(),
+        candidate_set,
+        selected_candidate_id,
+        selected_candidate_kind,
+        selected_candidate_action,
+        selected_candidate_reason,
+    }
+}
+
+fn derive_bounded_execution_state(
+    overall_status: &str,
+    agency: &AgencySelectionState,
+) -> BoundedExecutionState {
+    let (execution_status, continuation_state, provisional_termination_state, iterations) =
+        match agency.selected_candidate_kind.as_str() {
+            "direct_execution" => (
+                "completed",
+                "stop_after_one",
+                "ready_for_evaluation",
+                vec![BoundedExecutionIteration {
+                    iteration_index: 1,
+                    stage: "execute".to_string(),
+                    action: agency.selected_candidate_action.clone(),
+                    outcome: "bounded_direct_execution_complete".to_string(),
+                }],
+            ),
+            "review_and_refine" => (
+                "completed",
+                "bounded_review_complete",
+                "ready_for_evaluation",
+                vec![
+                    BoundedExecutionIteration {
+                        iteration_index: 1,
+                        stage: "review".to_string(),
+                        action: agency.selected_candidate_action.clone(),
+                        outcome: "bounded_review_pass_complete".to_string(),
+                    },
+                    BoundedExecutionIteration {
+                        iteration_index: 2,
+                        stage: "execute".to_string(),
+                        action: "execute the reviewed bounded candidate".to_string(),
+                        outcome: "bounded_reviewed_execution_complete".to_string(),
+                    },
+                ],
+            ),
+            _ => (
+                "completed",
+                "deferred",
+                "ready_for_evaluation",
+                vec![BoundedExecutionIteration {
+                    iteration_index: 1,
+                    stage: "defer".to_string(),
+                    action: agency.selected_candidate_action.clone(),
+                    outcome: "bounded_deferral_recorded".to_string(),
+                }],
+            ),
+        };
+
+    let execution_status = if overall_status == "failure" {
+        "completed_with_failure_signal"
+    } else if overall_status == "paused" {
+        "paused_for_review"
+    } else {
+        execution_status
+    };
+    let continuation_state = if overall_status == "failure" && iterations.len() > 1 {
+        "bounded_review_complete_with_failure_signal"
+    } else if overall_status == "paused" {
+        "paused_before_termination"
+    } else {
+        continuation_state
+    };
+
+    BoundedExecutionState {
+        execution_status: execution_status.to_string(),
+        continuation_state: continuation_state.to_string(),
+        provisional_termination_state: provisional_termination_state.to_string(),
+        iterations,
+    }
+}
+
+fn derive_evaluation_control_state(
+    overall_status: &str,
+    bounded_execution: &BoundedExecutionState,
+) -> EvaluationControlState {
+    let (
+        progress_signal,
+        contradiction_signal,
+        failure_signal,
+        termination_reason,
+        behavior_effect,
+        next_control_action,
+    ) = if overall_status == "failure" {
+        (
+            "stalled_progress",
+            "present",
+            "bounded_failure_detected",
+            if bounded_execution.iterations.len() > 1 {
+                "bounded_failure"
+            } else {
+                "no_progress"
+            },
+            "emit bounded failure/termination signals for later reframing or policy handling",
+            if bounded_execution.iterations.len() > 1 {
+                "handoff_to_reframing"
+            } else {
+                "terminate_with_failure"
+            },
+        )
+    } else if overall_status == "paused" {
+        (
+            "guarded_progress",
+            "none",
+            "none",
+            "pause_boundary",
+            "preserve bounded state for resume or explicit review handling",
+            "await_resume",
+        )
+    } else {
+        (
+            "steady_progress",
+            "none",
+            "none",
+            "success",
+            "allow bounded execution to terminate cleanly after evaluation confirms progress",
+            "complete_run",
+        )
+    };
+
+    EvaluationControlState {
+        progress_signal: progress_signal.to_string(),
+        contradiction_signal: contradiction_signal.to_string(),
+        failure_signal: failure_signal.to_string(),
+        termination_reason: termination_reason.to_string(),
+        behavior_effect: behavior_effect.to_string(),
+        next_control_action: next_control_action.to_string(),
     }
 }
 


### PR DESCRIPTION
Closes #1176

## Summary
Moved Sprint 2A/3A runtime-control ownership into the execute engine by adding execute-owned runtime state to `ExecutionResult`, deriving that state from execute-path records and trace evidence, and changing `adl/src/cli/run_artifacts.rs` to serialize projections of execute-owned state instead of acting as the primary place where that state is created.

## Artifacts
- Execute-owned runtime-control state in `adl/src/execute/state.rs`
- Execute-path wiring in `adl/src/execute/mod.rs`, `adl/src/execute/runner.rs`, and `adl/src/cli/run.rs`
- Projection-only runtime-artifact serialization updates in `adl/src/cli/run_artifacts.rs`
- Proof test `write_run_state_artifacts_projects_execute_owned_runtime_control_state` in `adl/src/cli/tests/run_state.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified formatting for the modified Rust implementation and tests.
  - `cargo test --manifest-path adl/Cargo.toml artifact_builders` verified the existing deterministic artifact-builder suite still passes after execute-owned state became primary.
  - `cargo test --manifest-path adl/Cargo.toml run_state` verified run-state persistence plus the new projection proof test.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` verified the implementation is warning-free under the repository lint gate.
- Results:
  - `fmt`: PASS
  - `artifact_builders`: PASS
  - `run_state`: PASS
  - `clippy -D warnings`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1176__v0-86-runtime-make-sprint-2a-3a-runtime-state-native-to-the-execute-engine/sip.md
- Output card: .adl/v0.86/tasks/issue-1176__v0-86-runtime-make-sprint-2a-3a-runtime-state-native-to-the-execute-engine/sor.md
- Idempotency-Key: v0-86-runtime-make-sprint-2a-3a-runtime-state-native-to-the-execute-engine-adl-v0-86-tasks-issue-1176-v0-86-runtime-make-sprint-2a-3a-runtime-state-native-to-the-execute-engine-sip-md-adl-v0-86-tasks-issue-1176-v0-86-runtime-make-sprint-2a-3a-runtime-state-native-to-the-execute-engine-sor-md