### PR TITLE
[v0.86][tools] Fix pr.sh false pr-bootstrap lock failure after delegated start exits

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -274,16 +274,19 @@ issue_bootstrap_lock_name() {
   printf 'pr-bootstrap-issue-%s\n' "$issue"
 }
 
-acquire_repo_lock() {
-  local name="$1"
+acquire_repo_lock_into() {
+  local name="$1" outvar="$2"
   local lock_dir
   lock_dir="$(git_common_dir)/${name}.lock"
   local attempt max_attempts pid_file owner_pid stale_marker
   max_attempts=50
   for ((attempt=1; attempt<=max_attempts; attempt++)); do
     if mkdir "$lock_dir" 2>/dev/null; then
-      printf '%s\n' "$$" >"$lock_dir/pid"
-      printf '%s\n' "$lock_dir"
+      if ! printf '%s\n' "$$" >"$lock_dir/pid"; then
+        rm -rf "$lock_dir"
+        die "${name}: acquired bootstrap lock but failed to record owner pid at $lock_dir/pid"
+      fi
+      printf -v "$outvar" '%s' "$lock_dir"
       return 0
     fi
     pid_file="$lock_dir/pid"
@@ -303,6 +306,13 @@ acquire_repo_lock() {
     sleep 0.1
   done
   die "${name}: another pr.sh bootstrap operation appears to be running (lock: $lock_dir). Remediation: rerun the command serially after the current bootstrap completes."
+}
+
+acquire_repo_lock() {
+  local name="$1"
+  local lock_dir=""
+  acquire_repo_lock_into "$name" lock_dir
+  printf '%s\n' "$lock_dir"
 }
 
 release_repo_lock() {
@@ -1793,7 +1803,7 @@ cmd_cards() {
   done
 
   local lock_dir=""
-  lock_dir="$(acquire_repo_lock "$(issue_bootstrap_lock_name "$issue")")"
+  acquire_repo_lock_into "$(issue_bootstrap_lock_name "$issue")" lock_dir
   trap "release_repo_lock '$lock_dir'" RETURN EXIT
 
   local repo
@@ -1867,7 +1877,7 @@ cmd_init() {
   [[ -n "$issue" ]] || die_with_usage "init: missing <issue> number" usage_init
   issue="$(normalize_issue_or_die "$issue")"
   local lock_dir=""
-  lock_dir="$(acquire_repo_lock "$(issue_bootstrap_lock_name "$issue")")"
+  acquire_repo_lock_into "$(issue_bootstrap_lock_name "$issue")" lock_dir
   trap "release_repo_lock '$lock_dir'" RETURN EXIT
 
   local slug=""
@@ -2005,7 +2015,7 @@ cmd_start() {
 
   require_cmd git
   local lock_dir=""
-  lock_dir="$(acquire_repo_lock "pr-bootstrap")"
+  acquire_repo_lock_into "pr-bootstrap" lock_dir
   trap "release_repo_lock '$lock_dir'" RETURN EXIT
   local issue="${1:-}"; shift || true
   [[ -n "$issue" ]] || die_with_usage "start: missing <issue> number" usage_start

--- a/adl/tools/test_pr_locking.sh
+++ b/adl/tools/test_pr_locking.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+PROMPT_LINT_SRC="$ROOT_DIR/adl/tools/lint_prompt_spec.sh"
+PROMPT_VALIDATOR_SRC="$ROOT_DIR/adl/tools/validate_structured_prompt.sh"
+INPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/input_card_template.md"
+OUTPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/output_card_template.md"
+STP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_task_prompt.contract.yaml"
+SIP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_implementation_prompt.contract.yaml"
+SOR_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_output_record.contract.yaml"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+if rg -n '\$\(acquire_repo_lock ' "$PR_SH_SRC" >/dev/null 2>&1; then
+  echo "assertion failed: acquire_repo_lock should not be invoked via command substitution" >&2
+  exit 1
+fi
+
+origin="$tmpdir/origin.git"
+repo="$tmpdir/repo"
+mkdir -p "$repo/adl/tools" "$repo/adl/templates/cards" "$repo/adl/schemas"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+cp "$PROMPT_LINT_SRC" "$repo/adl/tools/lint_prompt_spec.sh"
+cp "$PROMPT_VALIDATOR_SRC" "$repo/adl/tools/validate_structured_prompt.sh"
+cp "$INPUT_TPL_SRC" "$repo/adl/templates/cards/input_card_template.md"
+cp "$OUTPUT_TPL_SRC" "$repo/adl/templates/cards/output_card_template.md"
+cp "$STP_CONTRACT_SRC" "$repo/adl/schemas/structured_task_prompt.contract.yaml"
+cp "$SIP_CONTRACT_SRC" "$repo/adl/schemas/structured_implementation_prompt.contract.yaml"
+cp "$SOR_CONTRACT_SRC" "$repo/adl/schemas/structured_output_record.contract.yaml"
+chmod +x "$repo/adl/tools/pr.sh" "$repo/adl/tools/lint_prompt_spec.sh" "$repo/adl/tools/validate_structured_prompt.sh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  git add -A
+  git commit -q -m "init"
+  git branch -M main
+  git init --bare -q "$origin"
+  git remote add origin "$origin"
+  git push -q -u origin main
+  git fetch -q origin main
+
+  start_out="$("$BASH_BIN" adl/tools/pr.sh start 980 --slug lock-smoke --no-fetch-issue)"
+  [[ "$start_out" == *"STATE  FULLY_STARTED"* ]] || {
+    echo "assertion failed: expected legacy start to complete" >&2
+    echo "$start_out" >&2
+    exit 1
+  }
+
+  cards_out="$("$BASH_BIN" adl/tools/pr.sh cards 981 --no-fetch-issue --version v0.86)"
+  [[ "$cards_out" == *"STATE=ISSUE_AND_CARDS_READY"* ]] || {
+    echo "assertion failed: expected cards command to complete" >&2
+    echo "$cards_out" >&2
+    exit 1
+  }
+)
+
+echo "pr.sh lock acquisition and bootstrap smoke: ok"

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -185,10 +185,15 @@ EOF
   git switch -q main
   rm -f untracked.txt
   mkdir -p "$(git rev-parse --git-common-dir)/pr-bootstrap.lock"
+  sleep 30 &
+  live_lock_pid=$!
+  echo "$live_lock_pid" > "$(git rev-parse --git-common-dir)/pr-bootstrap.lock/pid"
   set +e
   bad3="$("$BASH_BIN" adl/tools/pr.sh start 996 --slug bootstrap-lock --no-fetch-issue 2>&1)"
   status=$?
   set -e
+  kill "$live_lock_pid" 2>/dev/null || true
+  wait "$live_lock_pid" 2>/dev/null || true
   rm -rf "$(git rev-parse --git-common-dir)/pr-bootstrap.lock"
   [[ "$status" -ne 0 ]] || {
     echo "assertion failed: expected bootstrap lock contention to fail" >&2


### PR DESCRIPTION
Closes #1181

## Summary
Fixed the shared `pr.sh` bootstrap lock path so legacy `start` / `cards` commands no longer report false contention because lock acquisition happened in a subshell.

Added explicit lock-regression coverage and tightened the existing start-worktree test to model a real live lock owner.

## Artifacts
- Branch-local implementation surfaces:
  - `adl/tools/pr.sh`
  - `adl/tools/test_pr_locking.sh`
  - `adl/tools/test_pr_start_worktree_safe.sh`
- Generated runtime artifacts: not applicable for this tooling issue.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_locking.sh`
    - verified the lock helper is not invoked via command substitution and that shell `start` plus `cards` bootstrap complete successfully.
  - `bash adl/tools/test_pr_start_worktree_safe.sh`
    - verified the broader start/idempotence suite still passes with the lock changes.
- Results:
  - `adl/tools/test_pr_locking.sh`: PASS
  - `adl/tools/test_pr_start_worktree_safe.sh`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1181__v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits/sip.md
- Output card: .adl/v0.86/tasks/issue-1181__v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits/sor.md
- Idempotency-Key: v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits-adl-tools-pr-sh-adl-tools-test-pr-locking-sh-adl-tools-test-pr-start-worktree-safe-sh-adl-v0-86-tasks-issue-1181-v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits-sip-md-adl-v0-86-tasks-issue-1181-v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits-sor-md