### PR TITLE
[v0.86][tools] Fix Rust-owned pr start failing on fresh branch/worktree creation

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1999,8 +1999,10 @@ cmd_start() {
   fi
 
   if rust_pr_delegate_available; then
-    delegate_pr_command_to_rust start "$@"
-    return 0
+    if delegate_pr_command_to_rust start "$@"; then
+      return 0
+    fi
+    note "Warning: Rust-owned start failed; falling back to shell implementation."
   fi
 
   require_cmd git

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -155,6 +155,25 @@ EOF
     exit 1
   }
 
+  fakecargo="$tmpdir/fakecargo"
+  mkdir -p "$fakecargo"
+  cat >"$fakecargo/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$fakecargo/cargo"
+  mkdir -p "$repo/adl"
+  : >"$repo/adl/Cargo.toml"
+  out_rust_fallback="$(PATH="$fakecargo:$PATH" "$BASH_BIN" adl/tools/pr.sh start 989 --slug rust-delegate-fallback --no-fetch-issue)"
+  rust_fallback_wt="$(cd "$repo/.worktrees/adl-wp-989" && pwd -P)"
+  assert_contains "Warning: Rust-owned start failed; falling back to shell implementation." "$out_rust_fallback" "rust fallback warning"
+  assert_contains "WORKTREE $rust_fallback_wt" "$out_rust_fallback" "rust fallback still creates worktree"
+  [[ -d "$rust_fallback_wt" ]] || {
+    echo "assertion failed: expected rust-fallback worktree" >&2
+    exit 1
+  }
+  rm -f "$repo/adl/Cargo.toml"
+
   git branch codex/998-collision origin/main
   git worktree add -q "$tmpdir/other-path" codex/998-collision
   set +e


### PR DESCRIPTION
Closes #1180

## Summary
Added a shell fallback in `adl/tools/pr.sh start` so ADL issue bootstrap still completes when the Rust-owned `start` delegate fails.

Added regression coverage proving `start` creates the worktree and task-bundle surfaces after a forced delegate failure.

## Artifacts
- Branch-local implementation surfaces:
  - `adl/tools/pr.sh`
  - `adl/tools/test_pr_start_worktree_safe.sh`
- Generated runtime artifacts: not applicable for this tooling issue.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_start_worktree_safe.sh`
    - verified normal start flows still pass and that a forced Rust delegate failure falls back to the shell implementation.
- Results:
  - `adl/tools/test_pr_start_worktree_safe.sh`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1180__v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation/sip.md
- Output card: .adl/v0.86/tasks/issue-1180__v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation/sor.md
- Idempotency-Key: v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation-adl-tools-pr-sh-adl-tools-test-pr-start-worktree-safe-sh-adl-v0-86-tasks-issue-1180-v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation-sip-md-adl-v0-86-tasks-issue-1180-v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation-sor-md