### PR TITLE
[v0.86][tools] Fix pr.sh false pr-bootstrap lock failure after delegated start exits

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -269,6 +269,12 @@ git_common_dir() {
   git rev-parse --git-common-dir 2>/dev/null || die "Not in a git repo"
 }
 
+repo_lock_root() {
+  local root
+  root="$(primary_checkout_root)"
+  echo "$root/.adl/locks"
+}
+
 issue_bootstrap_lock_name() {
   local issue="$1"
   printf 'pr-bootstrap-issue-%s\n' "$issue"
@@ -277,7 +283,8 @@ issue_bootstrap_lock_name() {
 acquire_repo_lock_into() {
   local name="$1" outvar="$2"
   local lock_dir
-  lock_dir="$(git_common_dir)/${name}.lock"
+  lock_dir="$(repo_lock_root)/${name}.lock"
+  mkdir -p "$(dirname "$lock_dir")"
   local attempt max_attempts pid_file owner_pid stale_marker
   max_attempts=50
   for ((attempt=1; attempt<=max_attempts; attempt++)); do

--- a/adl/tools/test_pr_locking.sh
+++ b/adl/tools/test_pr_locking.sh
@@ -54,6 +54,10 @@ chmod +x "$repo/adl/tools/pr.sh" "$repo/adl/tools/lint_prompt_spec.sh" "$repo/ad
     echo "$start_out" >&2
     exit 1
   }
+  [[ -d "$repo/.adl/locks" ]] || {
+    echo "assertion failed: expected shared lock root to exist under .adl/locks" >&2
+    exit 1
+  }
 
   cards_out="$("$BASH_BIN" adl/tools/pr.sh cards 981 --no-fetch-issue --version v0.86)"
   [[ "$cards_out" == *"STATE=ISSUE_AND_CARDS_READY"* ]] || {

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -203,25 +203,25 @@ EOF
 
   git switch -q main
   rm -f untracked.txt
-  mkdir -p "$(git rev-parse --git-common-dir)/pr-bootstrap.lock"
+  mkdir -p "$repo/.adl/locks/pr-bootstrap.lock"
   sleep 30 &
   live_lock_pid=$!
-  echo "$live_lock_pid" > "$(git rev-parse --git-common-dir)/pr-bootstrap.lock/pid"
+  echo "$live_lock_pid" > "$repo/.adl/locks/pr-bootstrap.lock/pid"
   set +e
   bad3="$("$BASH_BIN" adl/tools/pr.sh start 996 --slug bootstrap-lock --no-fetch-issue 2>&1)"
   status=$?
   set -e
   kill "$live_lock_pid" 2>/dev/null || true
   wait "$live_lock_pid" 2>/dev/null || true
-  rm -rf "$(git rev-parse --git-common-dir)/pr-bootstrap.lock"
+  rm -rf "$repo/.adl/locks/pr-bootstrap.lock"
   [[ "$status" -ne 0 ]] || {
     echo "assertion failed: expected bootstrap lock contention to fail" >&2
     exit 1
   }
   assert_contains "another pr.sh bootstrap operation appears to be running" "$bad3" "bootstrap lock message"
 
-  mkdir -p "$(git rev-parse --git-common-dir)/pr-bootstrap.lock"
-  echo "999999" > "$(git rev-parse --git-common-dir)/pr-bootstrap.lock/pid"
+  mkdir -p "$repo/.adl/locks/pr-bootstrap.lock"
+  echo "999999" > "$repo/.adl/locks/pr-bootstrap.lock/pid"
   stale_lock_out="$("$BASH_BIN" adl/tools/pr.sh start 993 --slug stale-lock-recovery --no-fetch-issue)"
   stale_wt="$(cd "$repo/.worktrees/adl-wp-993" && pwd -P)"
   assert_contains "WORKTREE $stale_wt" "$stale_lock_out" "stale lock recovery still starts"


### PR DESCRIPTION
Closes #1181

## Summary
Moved the shared `pr.sh` bootstrap lock out of `.git` and into a shared repo-local `.adl/locks` directory so shell `init` / `start` / `cards` no longer fail on blocked git-metadata writes or report false contention.

Added explicit lock-regression coverage and updated the existing start-worktree test to exercise live and stale lock handling through the new shared lock root.

## Artifacts
- Branch-local implementation surfaces:
  - `adl/tools/pr.sh`
  - `adl/tools/test_pr_locking.sh`
  - `adl/tools/test_pr_start_worktree_safe.sh`
- Generated runtime artifacts: not applicable for this tooling issue.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_locking.sh`
    - verified the lock helper is not invoked via command substitution and that shell `start` plus `cards` bootstrap complete successfully.
  - `bash adl/tools/test_pr_start_worktree_safe.sh`
    - verified the broader start/idempotence suite still passes with the lock changes.
- Results:
  - `adl/tools/test_pr_locking.sh`: PASS
  - `adl/tools/test_pr_start_worktree_safe.sh`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1181__v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits/sip.md
- Output card: .adl/v0.86/tasks/issue-1181__v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits/sor.md
- Idempotency-Key: v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits-adl-v0-86-tasks-issue-1181-v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits-sip-md-adl-v0-86-tasks-issue-1181-v0-86-tools-fix-pr-sh-false-pr-bootstrap-lock-failure-after-delegated-start-exits-sor-md