### PR TITLE
[v0.86][tools] Make issue bootstrap emit active-schema STP/SIP surfaces or fail

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -614,10 +614,9 @@ fn real_pr_init(args: &[String]) -> Result<()> {
 
     let stp_path = issue_ref.task_bundle_stp_path(&repo_root);
     let bundle_dir = issue_ref.task_bundle_dir_path(&repo_root);
-    if stp_path.is_file() {
-        eprintln!("• STP already exists: {}", stp_path.display());
-    } else {
-        eprintln!("• Initializing task bundle: {}", bundle_dir.display());
+    let init_branch = issue_ref.branch_name("codex");
+    eprintln!("• Initializing task bundle: {}", bundle_dir.display());
+    if !stp_path.is_file() {
         if let Some(parent) = stp_path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -628,16 +627,24 @@ fn real_pr_init(args: &[String]) -> Result<()> {
                 stp_path.display()
             )
         })?;
+    } else {
+        eprintln!("• STP already exists: {}", stp_path.display());
     }
-
-    if bundle_dir.join("sip.md").exists() || bundle_dir.join("sor.md").exists() {
-        eprintln!("• SIP/SOR already exist; pr init leaves them untouched.");
-    }
+    let (bundle_input, bundle_output) =
+        ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &init_branch, &source_path)?;
 
     println!("• Initialized:");
     println!(
         "  STP      {}",
         path_relative_to_repo(&repo_root, &stp_path)
+    );
+    println!(
+        "  READ     {}",
+        path_relative_to_repo(&repo_root, &bundle_input)
+    );
+    println!(
+        "  WRITE    {}",
+        path_relative_to_repo(&repo_root, &bundle_output)
     );
     println!(
         "  BUNDLE   {}",
@@ -647,8 +654,8 @@ fn real_pr_init(args: &[String]) -> Result<()> {
         "  SOURCE   {}",
         path_relative_to_repo(&repo_root, &source_path)
     );
-    println!("  CONTRACT minimum v0.85 init = task-bundle directory + validated stp.md only");
-    println!("  STATE    ISSUE_AND_STP_READY");
+    println!("  CONTRACT minimum v0.86 init = validated source prompt + root stp/sip/sor bundle");
+    println!("  STATE    ISSUE_AND_BUNDLE_READY");
     eprintln!("• Done.");
     Ok(())
 }
@@ -2966,6 +2973,7 @@ verification_summary:
         let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let repo = unique_temp_dir("adl-pr-real-init");
         init_git_repo(&repo);
+        copy_bootstrap_support_files(&repo);
         let prev_dir = env::current_dir().expect("cwd");
         env::set_current_dir(&repo).expect("chdir");
 
@@ -2992,8 +3000,12 @@ verification_summary:
         .expect("issue ref");
         let stp_path = issue_ref.task_bundle_stp_path(&repo);
         let source_path = issue_ref.issue_prompt_path(&repo);
+        let sip_path = issue_ref.task_bundle_input_path(&repo);
+        let sor_path = issue_ref.task_bundle_output_path(&repo);
         assert!(stp_path.is_file());
         assert!(source_path.is_file());
+        assert!(sip_path.is_file());
+        assert!(sor_path.is_file());
         let stp = fs::read_to_string(&stp_path).expect("read stp");
         assert!(stp.contains("issue_number: 1151"));
         assert!(stp.contains("title: \"[v0.86][tools] Init test\""));
@@ -3004,6 +3016,7 @@ verification_summary:
         let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let repo = unique_temp_dir("adl-pr-real-init-existing");
         init_git_repo(&repo);
+        copy_bootstrap_support_files(&repo);
         let issue_ref = IssueRef::new(
             1151,
             "v0.86".to_string(),
@@ -3011,6 +3024,8 @@ verification_summary:
         )
         .expect("issue ref");
         let stp_path = issue_ref.task_bundle_stp_path(&repo);
+        let sip_path = issue_ref.task_bundle_input_path(&repo);
+        let sor_path = issue_ref.task_bundle_output_path(&repo);
         fs::create_dir_all(stp_path.parent().expect("parent")).expect("bundle dir");
         fs::write(&stp_path, "sentinel\n").expect("write sentinel");
 
@@ -3033,6 +3048,8 @@ verification_summary:
             fs::read_to_string(&stp_path).expect("read stp"),
             "sentinel\n"
         );
+        assert!(sip_path.is_file());
+        assert!(sor_path.is_file());
     }
 
     #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1929,10 +1929,11 @@ cmd_init() {
   fi
   [[ -n "$version" ]] || die "init: version must be non-empty"
 
-  local source_path bundle_dir stp_path
+  local source_path bundle_dir stp_path in_path out_path init_branch
   source_path="$(issue_prompt_path_for_issue "$issue" "$version" "$slug")"
   bundle_dir="$(task_bundle_dir_path "$issue" "$version" "$slug")"
   stp_path="$bundle_dir/stp.md"
+  init_branch="codex/${issue}-${slug}"
 
   if [[ ! -f "$source_path" ]]; then
     note "Source issue prompt missing; generating canonical local issue prompt: $source_path"
@@ -1940,25 +1941,21 @@ cmd_init() {
   fi
   validate_bootstrap_stp "$source_path"
 
-  if ensure_nonempty_file "$stp_path"; then
-    note "STP already exists: $stp_path"
-    validate_bootstrap_stp "$stp_path"
-  else
-    note "Initializing task bundle: $bundle_dir"
-    seed_task_bundle_stp "$source_path" "$stp_path"
-    validate_bootstrap_stp "$stp_path"
-  fi
-
-  if [[ -e "$bundle_dir/sip.md" || -e "$bundle_dir/sor.md" ]]; then
-    note "SIP/SOR already exist; pr init leaves them untouched."
-  fi
+  note "Initializing task bundle: $bundle_dir"
+  {
+    read -r stp_path
+    read -r in_path
+    read -r out_path
+  } < <(seed_bootstrap_surfaces "$issue" "$version" "$slug" "$title" "$init_branch" "$source_path")
 
   echo "• Initialized:"
   echo "  STP      $(path_relative_to_repo "$stp_path")"
+  echo "  READ     $(path_relative_to_repo "$in_path")"
+  echo "  WRITE    $(path_relative_to_repo "$out_path")"
   echo "  BUNDLE   $(path_relative_to_repo "$bundle_dir")"
   echo "  SOURCE   $(path_relative_to_repo "$source_path")"
-  echo "  CONTRACT minimum v0.85 init = task-bundle directory + validated stp.md only"
-  echo "  STATE    ISSUE_AND_STP_READY"
+  echo "  CONTRACT minimum v0.86 init = validated source prompt + root stp/sip/sor bundle"
+  echo "  STATE    ISSUE_AND_BUNDLE_READY"
   note "Done."
 }
 

--- a/adl/tools/test_pr_init.sh
+++ b/adl/tools/test_pr_init.sh
@@ -6,6 +6,8 @@ PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
 CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
 PROMPT_LINT_SRC="$ROOT_DIR/adl/tools/lint_prompt_spec.sh"
 PROMPT_VALIDATOR_SRC="$ROOT_DIR/adl/tools/validate_structured_prompt.sh"
+INPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/input_card_template.md"
+OUTPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/output_card_template.md"
 STP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_task_prompt.contract.yaml"
 SIP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_implementation_prompt.contract.yaml"
 SOR_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_output_record.contract.yaml"
@@ -19,6 +21,7 @@ bindir="$tmpdir/bin"
 gh_log="$tmpdir/gh.log"
 mkdir -p \
   "$repo/adl/tools" \
+  "$repo/adl/templates/cards" \
   "$repo/adl/schemas" \
   "$repo/.adl/issues/v0.85/bodies" \
   "$bindir"
@@ -27,6 +30,8 @@ cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
 cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
 cp "$PROMPT_LINT_SRC" "$repo/adl/tools/lint_prompt_spec.sh"
 cp "$PROMPT_VALIDATOR_SRC" "$repo/adl/tools/validate_structured_prompt.sh"
+cp "$INPUT_TPL_SRC" "$repo/adl/templates/cards/input_card_template.md"
+cp "$OUTPUT_TPL_SRC" "$repo/adl/templates/cards/output_card_template.md"
 cp "$STP_CONTRACT_SRC" "$repo/adl/schemas/structured_task_prompt.contract.yaml"
 cp "$SIP_CONTRACT_SRC" "$repo/adl/schemas/structured_implementation_prompt.contract.yaml"
 cp "$SOR_CONTRACT_SRC" "$repo/adl/schemas/structured_output_record.contract.yaml"
@@ -134,20 +139,30 @@ assert_contains() {
 
   out1="$("$BASH_BIN" adl/tools/pr.sh init 42 --slug test-init --no-fetch-issue --version v0.85)"
   assert_contains "STP      .adl/v0.85/tasks/issue-0042__test-init/stp.md" "$out1" "stp path"
-  assert_contains "CONTRACT minimum v0.85 init = task-bundle directory + validated stp.md only" "$out1" "contract line"
-  assert_contains "STATE    ISSUE_AND_STP_READY" "$out1" "state line"
+  assert_contains "READ     .adl/v0.85/tasks/issue-0042__test-init/sip.md" "$out1" "read path"
+  assert_contains "WRITE    .adl/v0.85/tasks/issue-0042__test-init/sor.md" "$out1" "write path"
+  assert_contains "CONTRACT minimum v0.86 init = validated source prompt + root stp/sip/sor bundle" "$out1" "contract line"
+  assert_contains "STATE    ISSUE_AND_BUNDLE_READY" "$out1" "state line"
 
   stp_path="$repo/.adl/v0.85/tasks/issue-0042__test-init/stp.md"
   [[ -f "$stp_path" ]] || {
     echo "assertion failed: expected stp.md to exist" >&2
     exit 1
   }
-  [[ ! -e "$repo/.adl/v0.85/tasks/issue-0042__test-init/sip.md" ]] || {
-    echo "assertion failed: sip.md should not be created by pr init" >&2
+  [[ -f "$repo/.adl/v0.85/tasks/issue-0042__test-init/sip.md" ]] || {
+    echo "assertion failed: expected sip.md to exist" >&2
     exit 1
   }
-  [[ ! -e "$repo/.adl/v0.85/tasks/issue-0042__test-init/sor.md" ]] || {
-    echo "assertion failed: sor.md should not be created by pr init" >&2
+  [[ -f "$repo/.adl/v0.85/tasks/issue-0042__test-init/sor.md" ]] || {
+    echo "assertion failed: expected sor.md to exist" >&2
+    exit 1
+  }
+  [[ -L "$repo/.adl/cards/42/input_42.md" ]] || {
+    echo "assertion failed: expected canonical input compatibility link" >&2
+    exit 1
+  }
+  [[ -L "$repo/.adl/cards/42/output_42.md" ]] || {
+    echo "assertion failed: expected canonical output compatibility link" >&2
     exit 1
   }
   cmp "$repo/.adl/issues/v0.85/bodies/issue-42-test-init.md" "$stp_path" >/dev/null || {
@@ -156,11 +171,13 @@ assert_contains() {
   }
 
   out2="$("$BASH_BIN" adl/tools/pr.sh init 42 --slug test-init --no-fetch-issue --version v0.85)"
-  assert_contains "STP already exists" "$out2" "idempotent reuse"
+  assert_contains "STATE    ISSUE_AND_BUNDLE_READY" "$out2" "idempotent reuse"
 
   out3="$("$BASH_BIN" adl/tools/pr.sh init 43 --version v0.86)"
   assert_contains "Source issue prompt missing; generating canonical local issue prompt" "$out3" "generated source prompt note"
   assert_contains "STP      .adl/v0.86/tasks/issue-0043__v0-86-wp-03-generated-loop-prompt/stp.md" "$out3" "generated stp path"
+  assert_contains "READ     .adl/v0.86/tasks/issue-0043__v0-86-wp-03-generated-loop-prompt/sip.md" "$out3" "generated sip path"
+  assert_contains "WRITE    .adl/v0.86/tasks/issue-0043__v0-86-wp-03-generated-loop-prompt/sor.md" "$out3" "generated sor path"
   assert_contains "SOURCE   .adl/issues/v0.86/bodies/issue-43-v0-86-wp-03-generated-loop-prompt.md" "$out3" "generated source path"
   [[ -f "$repo/.adl/issues/v0.86/bodies/issue-43-v0-86-wp-03-generated-loop-prompt.md" ]] || {
     echo "assertion failed: expected generated canonical source issue prompt" >&2
@@ -168,6 +185,14 @@ assert_contains() {
   }
   [[ -f "$repo/.adl/v0.86/tasks/issue-0043__v0-86-wp-03-generated-loop-prompt/stp.md" ]] || {
     echo "assertion failed: expected generated task-bundle stp" >&2
+    exit 1
+  }
+  [[ -f "$repo/.adl/v0.86/tasks/issue-0043__v0-86-wp-03-generated-loop-prompt/sip.md" ]] || {
+    echo "assertion failed: expected generated task-bundle sip" >&2
+    exit 1
+  }
+  [[ -f "$repo/.adl/v0.86/tasks/issue-0043__v0-86-wp-03-generated-loop-prompt/sor.md" ]] || {
+    echo "assertion failed: expected generated task-bundle sor" >&2
     exit 1
   }
   grep -Fq 'title: "[v0.86][WP-03] Generated loop prompt"' "$repo/.adl/issues/v0.86/bodies/issue-43-v0-86-wp-03-generated-loop-prompt.md" || {


### PR DESCRIPTION
Closes #1178

## Summary
Changed `pr init` so it now emits and validates the full root task bundle on first bootstrap instead of stopping after the source prompt and `stp.md`.

The shell and Rust control-plane paths now both create `stp.md`, `sip.md`, and `sor.md` immediately, wire the compatibility card links, and validate the generated SIP/SOR surfaces before returning success.

## Artifacts
- Branch-local implementation surfaces:
  - `adl/tools/pr.sh`
  - `adl/src/cli/pr_cmd.rs`
  - `adl/tools/test_pr_init.sh`
- Generated runtime artifacts: not applicable for this tooling issue.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_init.sh`
    - verified shell `pr init` now creates validated root `stp.md`, `sip.md`, and `sor.md` plus compatibility links.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_init -- --nocapture`
    - verified Rust-owned `pr init` now emits the same validated root bundle.
  - `cargo test --manifest-path adl/Cargo.toml ensure_bootstrap_cards -- --nocapture`
    - verified the bootstrap bundle helper still creates SIP/SOR and compatibility links deterministically.
  - `bash adl/tools/test_pr_start_worktree_safe.sh`
    - verified the stronger root init contract did not regress `start` or worktree bootstrap behavior.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verified Rust formatting stayed clean.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verified the changed Rust control-plane code stayed warning-free.
- Results:
  - `bash adl/tools/test_pr_init.sh`: PASS
  - `cargo test --manifest-path adl/Cargo.toml real_pr_init -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml ensure_bootstrap_cards -- --nocapture`: PASS
  - `bash adl/tools/test_pr_start_worktree_safe.sh`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`: PASS
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1178__v0-86-tools-make-issue-bootstrap-emit-active-schema-stp-sip-surfaces-or-fail/sip.md
- Output card: .adl/v0.86/tasks/issue-1178__v0-86-tools-make-issue-bootstrap-emit-active-schema-stp-sip-surfaces-or-fail/sor.md
- Idempotency-Key: v0-86-tools-make-issue-bootstrap-emit-active-schema-stp-sip-surfaces-or-fail-adl-v0-86-tasks-issue-1178-v0-86-tools-make-issue-bootstrap-emit-active-schema-stp-sip-surfaces-or-fail-sip-md-adl-v0-86-tasks-issue-1178-v0-86-tools-make-issue-bootstrap-emit-active-schema-stp-sip-surfaces-or-fail-sor-md