### PR TITLE
[v0.86][tools] Make pr.sh create recover cleanly when issue creation succeeds but start fails

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -653,6 +653,31 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     Ok(())
 }
 
+fn recover_root_bundle_after_start_failure(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    source_path: &Path,
+) -> Result<(PathBuf, PathBuf, PathBuf)> {
+    let stp_path = issue_ref.task_bundle_stp_path(repo_root);
+    if !stp_path.is_file() {
+        if let Some(parent) = stp_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source_path, &stp_path).with_context(|| {
+            format!(
+                "failed to seed task-bundle stp from '{}' to '{}'",
+                source_path.display(),
+                stp_path.display()
+            )
+        })?;
+    }
+    let branch = issue_ref.branch_name("codex");
+    let (bundle_input, bundle_output) =
+        ensure_bootstrap_cards(repo_root, issue_ref, title, &branch, source_path)?;
+    Ok((stp_path, bundle_input, bundle_output))
+}
+
 fn real_pr_create(args: &[String]) -> Result<()> {
     let mode = parse_create_args(args)?;
     let repo_root = repo_root()?;
@@ -739,10 +764,27 @@ fn real_pr_create(args: &[String]) -> Result<()> {
                 .with_context(|| "failed to delegate create->start handoff to pr.sh")?;
             if !status.success() {
                 println!("START_STATE=FAILED");
+                let (stp_path, bundle_input, bundle_output) =
+                    recover_root_bundle_after_start_failure(
+                        &repo_root,
+                        &issue_ref,
+                        &title,
+                        &source_path,
+                    )?;
+                println!("RECOVERY_STATE=ISSUE_AND_BUNDLE_READY");
+                println!("STP_PATH={}", path_relative_to_repo(&repo_root, &stp_path));
+                println!(
+                    "SIP_PATH={}",
+                    path_relative_to_repo(&repo_root, &bundle_input)
+                );
+                println!(
+                    "SOR_PATH={}",
+                    path_relative_to_repo(&repo_root, &bundle_output)
+                );
                 bail!(
-                    "create: issue created but start failed; issue #{} exists and source prompt is at {}",
+                    "create: issue created and root bundle recovered, but start failed; issue #{} exists and can be resumed from {}",
                     issue_num,
-                    path_relative_to_repo(&repo_root, &source_path)
+                    path_relative_to_repo(&repo_root, &stp_path)
                 );
             }
             println!("START_STATE=STARTED");
@@ -3098,6 +3140,7 @@ verification_summary:
         let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let repo = unique_temp_dir("adl-pr-real-create-start-fails");
         init_git_repo(&repo);
+        copy_bootstrap_support_files(&repo);
         let bin_dir = repo.join("bin");
         fs::create_dir_all(&bin_dir).expect("bin dir");
         let gh_log = repo.join("gh.log");
@@ -3138,9 +3181,18 @@ verification_summary:
         unsafe {
             env::set_var("PATH", old_path);
         }
-        assert!(err
-            .to_string()
-            .contains("create: issue created but start failed; issue #1158 exists"));
+        assert!(err.to_string().contains(
+            "create: issue created and root bundle recovered, but start failed; issue #1158 exists"
+        ));
+        let issue_ref = IssueRef::new(
+            1158,
+            "v0.86".to_string(),
+            "v0-86-tools-create-start-failure".to_string(),
+        )
+        .expect("issue ref");
+        assert!(issue_ref.task_bundle_stp_path(&repo).is_file());
+        assert!(issue_ref.task_bundle_input_path(&repo).is_file());
+        assert!(issue_ref.task_bundle_output_path(&repo).is_file());
     }
 
     #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1075,6 +1075,13 @@ seed_bootstrap_surfaces() {
   printf '%s\n%s\n%s\n' "$stp_path" "$in_path" "$out_path"
 }
 
+recover_root_bundle_after_start_failure() {
+  local issue="$1" version="$2" slug="$3" title="$4" source_path="$5"
+  local branch
+  branch="codex/${issue}-${slug}"
+  seed_bootstrap_surfaces "$issue" "$version" "$slug" "$title" "$branch" "$source_path"
+}
+
 resolve_issue_scope_and_slug_from_local_state() {
   local issue="$1"
   local first path_remainder scope dir_name slug
@@ -2321,9 +2328,28 @@ create_issue() {
     return 0
   fi
 
-  if ! cmd_start "$issue_num" --slug "$slug" --title "$title" --version "$version"; then
+  local start_output start_status
+  set +e
+  start_output="$(
+    cmd_start "$issue_num" --slug "$slug" --title "$title" --version "$version" 2>&1
+  )"
+  start_status=$?
+  set -e
+  [[ -n "$start_output" ]] && printf '%s\n' "$start_output"
+
+  if [[ "$start_status" -ne 0 ]]; then
     echo "START_STATE=FAILED"
-    die "create: issue created but start failed; issue #$issue_num exists and source prompt is at $(path_relative_to_repo "$source_path")"
+    local stp_path in_path out_path
+    {
+      read -r stp_path
+      read -r in_path
+      read -r out_path
+    } < <(recover_root_bundle_after_start_failure "$issue_num" "$version" "$slug" "$title" "$source_path")
+    echo "RECOVERY_STATE=ISSUE_AND_BUNDLE_READY"
+    echo "STP_PATH=$(path_relative_to_repo "$stp_path")"
+    echo "SIP_PATH=$(path_relative_to_repo "$in_path")"
+    echo "SOR_PATH=$(path_relative_to_repo "$out_path")"
+    die "create: issue created and root bundle recovered, but start failed; issue #$issue_num exists and can be resumed from $(path_relative_to_repo "$stp_path")"
   fi
   echo "START_STATE=STARTED"
   echo "BRANCH=codex/${issue_num}-${slug}"

--- a/adl/tools/test_pr_create.sh
+++ b/adl/tools/test_pr_create.sh
@@ -237,6 +237,49 @@ assert_contains() {
     echo "assertion failed: expected no remove-label operations when labels already match" >&2
     exit 1
   fi
+
+  real_git="$(command -v git)"
+  cat >"$bindir/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "branch" ]]; then
+  echo "fatal: simulated branch creation failure" >&2
+  exit 1
+fi
+exec "$real_git" "\$@"
+EOF
+  chmod +x "$bindir/git"
+
+  set +e
+  out_partial="$(PATH="$bindir:$PATH" "$BASH_BIN" adl/tools/pr.sh create \
+    --title "[v0.85][authoring] Recover create path" \
+    --slug recover-create-path \
+    --version v0.85 \
+    --body "test body" 2>&1)"
+  status=$?
+  set -e
+  [[ "$status" -ne 0 ]] || {
+    echo "assertion failed: expected create to fail when start fails" >&2
+    exit 1
+  }
+  assert_contains "STATE=ISSUE_CREATED" "$out_partial" "partial create issue created"
+  assert_contains "START_STATE=FAILED" "$out_partial" "partial create start failed"
+  assert_contains "RECOVERY_STATE=ISSUE_AND_BUNDLE_READY" "$out_partial" "partial create recovery state"
+  assert_contains "STP_PATH=.adl/v0.85/tasks/issue-1042__recover-create-path/stp.md" "$out_partial" "partial create stp path"
+  assert_contains "SIP_PATH=.adl/v0.85/tasks/issue-1042__recover-create-path/sip.md" "$out_partial" "partial create sip path"
+  assert_contains "SOR_PATH=.adl/v0.85/tasks/issue-1042__recover-create-path/sor.md" "$out_partial" "partial create sor path"
+  [[ -f ".adl/v0.85/tasks/issue-1042__recover-create-path/stp.md" ]] || {
+    echo "assertion failed: expected recovered stp after create/start failure" >&2
+    exit 1
+  }
+  [[ -f ".adl/v0.85/tasks/issue-1042__recover-create-path/sip.md" ]] || {
+    echo "assertion failed: expected recovered sip after create/start failure" >&2
+    exit 1
+  }
+  [[ -f ".adl/v0.85/tasks/issue-1042__recover-create-path/sor.md" ]] || {
+    echo "assertion failed: expected recovered sor after create/start failure" >&2
+    exit 1
+  }
 )
 
 echo "pr.sh create create+reconcile flows: ok"


### PR DESCRIPTION
Closes #1179

## Summary
Changed `pr create` so that if GitHub issue creation succeeds but the subsequent `start` handoff fails, the command still recovers a validated root `stp.md` / `sip.md` / `sor.md` bundle instead of leaving a half-bootstrapped issue.

The shell and Rust create paths now both report partial-state recovery explicitly with `RECOVERY_STATE=ISSUE_AND_BUNDLE_READY` and the recovered bundle paths.

## Artifacts
- Branch-local implementation surfaces:
  - `adl/tools/pr.sh`
  - `adl/src/cli/pr_cmd.rs`
  - `adl/tools/test_pr_create.sh`
- Generated runtime artifacts: not applicable for this tooling issue.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_create.sh`
    - verified shell create, reconcile, and create->start failure recovery behavior including recovered root bundle paths.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_with_start_failure_reports_partial_state -- --nocapture`
    - verified Rust-owned create reports partial state and recovers the root bundle when start delegation fails.
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    - normalized Rust formatting after the recovery-path changes.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verified the Rust create-recovery implementation is warning-free.
- Results:
  - `bash adl/tools/test_pr_create.sh`: PASS
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_with_start_failure_reports_partial_state -- --nocapture`: PASS
  - `cargo fmt --manifest-path adl/Cargo.toml --all`: PASS
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1179__v0-86-tools-make-pr-sh-create-recover-cleanly-when-issue-creation-succeeds-but-start-fails/sip.md
- Output card: .adl/v0.86/tasks/issue-1179__v0-86-tools-make-pr-sh-create-recover-cleanly-when-issue-creation-succeeds-but-start-fails/sor.md
- Idempotency-Key: v0-86-tools-make-pr-sh-create-recover-cleanly-when-issue-creation-succeeds-but-start-fails-adl-v0-86-tasks-issue-1179-v0-86-tools-make-pr-sh-create-recover-cleanly-when-issue-creation-succeeds-but-start-fails-sip-md-adl-v0-86-tasks-issue-1179-v0-86-tools-make-pr-sh-create-recover-cleanly-when-issue-creation-succeeds-but-start-fails-sor-md