### PR TITLE
[v0.86][tools] Fix Rust-owned pr start failing on fresh branch/worktree creation

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -182,6 +182,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     eprintln!("• Target branch: {branch}");
     eprintln!("• Target worktree: {}", worktree_path.display());
 
+    ensure_git_metadata_writable()?;
     fetch_origin_main_with_fallback()?;
     ensure_local_branch_exists(&branch)?;
     ensure_worktree_for_branch(&worktree_path, &branch)?;
@@ -1635,6 +1636,29 @@ fn fetch_origin_main_with_fallback() -> Result<()> {
         return Ok(());
     }
     bail!("start: fetch origin main failed and origin/main is unavailable locally");
+}
+
+fn ensure_git_metadata_writable() -> Result<()> {
+    let git_dir = run_capture("git", &["rev-parse", "--git-common-dir"])?;
+    let git_dir = git_dir.trim();
+    let probe_dir = Path::new(git_dir).join(format!(
+        "adl-git-write-probe-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    match fs::create_dir(&probe_dir) {
+        Ok(()) => {
+            let _ = fs::remove_dir(&probe_dir);
+            Ok(())
+        }
+        Err(err) => bail!(
+            "start: git metadata directory '{}' is not writable, so branch/worktree creation cannot proceed. Remediation: restore write access to git metadata before rerunning. ({err})",
+            git_dir
+        ),
+    }
 }
 
 fn ensure_local_branch_exists(branch: &str) -> Result<()> {
@@ -4643,6 +4667,52 @@ verification_summary:
         assert!(bad_title
             .to_string()
             .contains("start: --title produced empty slug after sanitization"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_git_metadata_writable_rejects_unwritable_git_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let repo = unique_temp_dir("adl-pr-git-metadata-write");
+        init_git_repo(&repo);
+        let prev_dir = env::current_dir().expect("cwd");
+        env::set_current_dir(&repo).expect("chdir");
+
+        let git_dir = repo.join(".git");
+        let refs_dir = git_dir.join("refs");
+        let heads_dir = refs_dir.join("heads");
+        let git_mode = fs::metadata(&git_dir)
+            .expect("git metadata")
+            .permissions()
+            .mode();
+        let refs_mode = fs::metadata(&refs_dir)
+            .expect("refs metadata")
+            .permissions()
+            .mode();
+        let heads_mode = fs::metadata(&heads_dir)
+            .expect("heads metadata")
+            .permissions()
+            .mode();
+
+        fs::set_permissions(&git_dir, fs::Permissions::from_mode(0o555)).expect("chmod git");
+        fs::set_permissions(&refs_dir, fs::Permissions::from_mode(0o555)).expect("chmod refs");
+        fs::set_permissions(&heads_dir, fs::Permissions::from_mode(0o555)).expect("chmod heads");
+
+        let err = ensure_git_metadata_writable().expect_err("unwritable git dir should fail");
+
+        fs::set_permissions(&heads_dir, fs::Permissions::from_mode(heads_mode))
+            .expect("restore heads");
+        fs::set_permissions(&refs_dir, fs::Permissions::from_mode(refs_mode))
+            .expect("restore refs");
+        fs::set_permissions(&git_dir, fs::Permissions::from_mode(git_mode)).expect("restore git");
+        env::set_current_dir(prev_dir).expect("restore cwd");
+
+        assert!(err.to_string().contains("git metadata directory"));
+        assert!(err
+            .to_string()
+            .contains("restore write access to git metadata before rerunning"));
     }
 
     #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -269,6 +269,18 @@ git_common_dir() {
   git rev-parse --git-common-dir 2>/dev/null || die "Not in a git repo"
 }
 
+ensure_git_metadata_writable_or_die() {
+  local context="$1"
+  local git_dir probe_dir
+  git_dir="$(git_common_dir)"
+  probe_dir="${git_dir}/adl-git-write-probe.$$.$RANDOM"
+  if mkdir "$probe_dir" 2>/dev/null; then
+    rmdir "$probe_dir" 2>/dev/null || true
+    return 0
+  fi
+  die "${context}: git metadata directory '$git_dir' is not writable, so branch/worktree creation cannot proceed. Remediation: restore write access to git metadata before rerunning."
+}
+
 repo_lock_root() {
   local root
   root="$(primary_checkout_root)"
@@ -2094,6 +2106,7 @@ cmd_start() {
 
   note "Target branch: $branch"
   note "Target worktree: $worktree_path"
+  ensure_git_metadata_writable_or_die "start"
 
   note "Fetching origin/main…"
   local fetch_out="" fetch_status=0

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -274,6 +274,19 @@ EOF
 
   allowed_start="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh start 990 --slug blocked-wave --version v0.86 --no-fetch-issue --allow-open-pr-wave)"
   assert_contains "STATE  FULLY_STARTED" "$allowed_start" "override bypasses start guard"
+
+  chmod 555 "$repo/.git" "$repo/.git/refs" "$repo/.git/refs/heads"
+  set +e
+  metadata_blocked="$("$BASH_BIN" adl/tools/pr.sh start 988 --slug metadata-blocked --no-fetch-issue 2>&1)"
+  status=$?
+  set -e
+  chmod 755 "$repo/.git" "$repo/.git/refs" "$repo/.git/refs/heads"
+  [[ "$status" -ne 0 ]] || {
+    echo "assertion failed: expected start to fail when git metadata is unwritable" >&2
+    exit 1
+  }
+  assert_contains "git metadata directory" "$metadata_blocked" "metadata preflight message"
+  assert_contains "restore write access to git metadata before rerunning" "$metadata_blocked" "metadata remediation"
 )
 
 echo "pr.sh start worktree-safe/idempotent flows: ok"


### PR DESCRIPTION
Closes #1180

## Summary
Added an explicit git-metadata writability preflight to both the shell and Rust-owned `pr start` paths so fresh issue bootstrap fails immediately and clearly when `.git` cannot be written.

Added regression coverage proving `start` now reports the real root cause before fetch / ref-lock failures when git metadata is unwritable.

## Artifacts
- Branch-local implementation surfaces:
  - `adl/tools/pr.sh`
  - `adl/src/cli/pr_cmd.rs`
  - `adl/tools/test_pr_start_worktree_safe.sh`
- Generated runtime artifacts: not applicable for this tooling issue.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_start_worktree_safe.sh`
    - verified normal start flows still pass and that unwritable git metadata now fails immediately with a precise start-path diagnosis.
  - `cargo test --manifest-path adl/Cargo.toml ensure_git_metadata_writable_rejects_unwritable_git_dir -- --nocapture`
    - verified the Rust-owned start path rejects an unwritable `.git` directory before attempting branch/worktree creation.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verified the touched Rust source remains properly formatted.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verified the touched shell/Rust changes compile cleanly with no clippy warnings.
- Results:
  - `adl/tools/test_pr_start_worktree_safe.sh`: PASS
  - `ensure_git_metadata_writable_rejects_unwritable_git_dir`: PASS
  - `cargo fmt --check`: PASS
  - `cargo clippy --all-targets -- -D warnings`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1180__v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation/sip.md
- Output card: .adl/v0.86/tasks/issue-1180__v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation/sor.md
- Idempotency-Key: v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation-adl-v0-86-tasks-issue-1180-v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation-sip-md-adl-v0-86-tasks-issue-1180-v0-86-tools-fix-rust-owned-pr-start-failing-on-fresh-branch-worktree-creation-sor-md