### PR TITLE
[v0.86][tools] Remove overlapping pr create bootstrap behavior and consolidate kickoff into pr init/start

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ADL is in active development. The repository contains both implemented runtime s
 v0.85 focused on bringing the authoring model, demos, and runtime behavior into a coherent and reliable whole.
 
 Key features:
-- clarified five-command authoring lifecycle (`pr init`, `pr create`, `pr start`, `pr run`, `pr finish`)
+- clarified authoring lifecycle (`pr init`, `pr start`, `pr run`, `pr finish`)
 - bounded editor-command adapter aligned to the control plane
 - end-to-end demo and regression proof surfaces for authoring workflows
 - worktree hygiene and queue-mechanics cleanup

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -23,23 +23,6 @@ struct InitArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum CreateMode {
-    Reconcile {
-        issue: u32,
-        stp_path: PathBuf,
-    },
-    Create {
-        title: String,
-        slug: Option<String>,
-        body: Option<String>,
-        body_file: Option<PathBuf>,
-        labels: String,
-        version: Option<String>,
-        no_start: bool,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 struct StartArgs {
     issue: u32,
     prefix: String,
@@ -83,6 +66,7 @@ struct FinishArgs {
     idempotent: bool,
 }
 
+#[cfg(test)]
 #[derive(Debug, Deserialize)]
 struct IssuePromptFrontMatter {
     title: String,
@@ -90,6 +74,7 @@ struct IssuePromptFrontMatter {
     issue_number: u32,
 }
 
+#[cfg(test)]
 #[derive(Debug)]
 struct IssuePromptDoc {
     front_matter: IssuePromptFrontMatter,
@@ -111,7 +96,7 @@ struct OpenPullRequest {
 
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
-        bail!("pr requires a subcommand: init | create | start | ready | preflight | finish");
+        bail!("pr requires a subcommand: init | start | ready | preflight | finish");
     };
 
     match subcommand {
@@ -661,145 +646,11 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn recover_root_bundle_after_start_failure(
-    repo_root: &Path,
-    issue_ref: &IssueRef,
-    title: &str,
-    source_path: &Path,
-) -> Result<(PathBuf, PathBuf, PathBuf)> {
-    let stp_path = issue_ref.task_bundle_stp_path(repo_root);
-    if !stp_path.is_file() {
-        if let Some(parent) = stp_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::copy(source_path, &stp_path).with_context(|| {
-            format!(
-                "failed to seed task-bundle stp from '{}' to '{}'",
-                source_path.display(),
-                stp_path.display()
-            )
-        })?;
-    }
-    let branch = issue_ref.branch_name("codex");
-    let (bundle_input, bundle_output) =
-        ensure_bootstrap_cards(repo_root, issue_ref, title, &branch, source_path)?;
-    Ok((stp_path, bundle_input, bundle_output))
-}
-
 fn real_pr_create(args: &[String]) -> Result<()> {
-    let mode = parse_create_args(args)?;
-    let repo_root = repo_root()?;
-    let repo = default_repo(&repo_root)?;
-
-    match mode {
-        CreateMode::Reconcile { issue, stp_path } => {
-            let doc = load_issue_prompt(&stp_path)?;
-            if doc.front_matter.issue_number != issue {
-                bail!(
-                    "create: STP issue_number ({}) does not match requested issue ({issue})",
-                    doc.front_matter.issue_number
-                );
-            }
-            reconcile_issue(issue, &repo, &doc)?;
-            println!("ISSUE_NUM={issue}");
-            println!("STP_PATH={}", path_relative_to_repo(&repo_root, &stp_path));
-            println!("MODE=reconcile");
-            Ok(())
-        }
-        CreateMode::Create {
-            title,
-            slug,
-            body,
-            body_file,
-            labels,
-            version,
-            no_start,
-        } => {
-            let slug = sanitize_slug(slug.unwrap_or_else(|| title.clone()));
-            if slug.is_empty() {
-                bail!("new: slug is empty after sanitization");
-            }
-
-            let issue_body = resolve_issue_body(body, body_file.as_deref())?;
-            if issue_body.contains("/Users/") || issue_body.contains("/home/") {
-                bail!("new: issue body contains disallowed absolute host path");
-            }
-
-            let version = version
-                .or_else(|| version_from_labels_csv(&labels))
-                .or_else(|| version_from_title(&title))
-                .unwrap_or_else(|| DEFAULT_VERSION.to_string());
-            let labels_csv = normalize_labels_csv(&labels, &version);
-
-            let issue_url = gh_issue_create(&title, &issue_body, &labels_csv)?;
-            let issue_num = parse_issue_number_from_url(&issue_url)?;
-
-            println!("ISSUE_URL={issue_url}");
-            println!("ISSUE_NUM={issue_num}");
-            println!("STATE=ISSUE_CREATED");
-
-            let issue_ref = IssueRef::new(issue_num, version.clone(), slug.clone())?;
-            let source_path = ensure_source_issue_prompt(
-                &repo_root,
-                &repo,
-                &issue_ref,
-                &title,
-                Some(&labels_csv),
-                &version,
-            )?;
-            println!(
-                "SOURCE_PATH={}",
-                path_relative_to_repo(&repo_root, &source_path)
-            );
-
-            if no_start {
-                println!("START_STATE=SKIPPED");
-                return Ok(());
-            }
-
-            let status = Command::new("bash")
-                .arg("./adl/tools/pr.sh")
-                .arg("start")
-                .arg(issue_num.to_string())
-                .arg("--slug")
-                .arg(slug.clone())
-                .arg("--title")
-                .arg(title.clone())
-                .arg("--version")
-                .arg(version.clone())
-                .current_dir(&repo_root)
-                .status()
-                .with_context(|| "failed to delegate create->start handoff to pr.sh")?;
-            if !status.success() {
-                println!("START_STATE=FAILED");
-                let (stp_path, bundle_input, bundle_output) =
-                    recover_root_bundle_after_start_failure(
-                        &repo_root,
-                        &issue_ref,
-                        &title,
-                        &source_path,
-                    )?;
-                println!("RECOVERY_STATE=ISSUE_AND_BUNDLE_READY");
-                println!("STP_PATH={}", path_relative_to_repo(&repo_root, &stp_path));
-                println!(
-                    "SIP_PATH={}",
-                    path_relative_to_repo(&repo_root, &bundle_input)
-                );
-                println!(
-                    "SOR_PATH={}",
-                    path_relative_to_repo(&repo_root, &bundle_output)
-                );
-                bail!(
-                    "create: issue created and root bundle recovered, but start failed; issue #{} exists and can be resumed from {}",
-                    issue_num,
-                    path_relative_to_repo(&repo_root, &stp_path)
-                );
-            }
-            println!("START_STATE=STARTED");
-            println!("BRANCH=codex/{}-{}", issue_num, slug);
-            Ok(())
-        }
-    }
+    let _ = args;
+    bail!(
+        "create: `adl pr create` is retired. Create or reconcile the GitHub issue outside ADL, then run `adl pr init <issue>` followed by `adl pr start <issue>`."
+    )
 }
 
 fn parse_init_args(args: &[String]) -> Result<InitArgs> {
@@ -838,83 +689,6 @@ fn parse_init_args(args: &[String]) -> Result<InitArgs> {
         i += 1;
     }
     Ok(parsed)
-}
-
-fn parse_create_args(args: &[String]) -> Result<CreateMode> {
-    if let Some(first) = args.first() {
-        if let Ok(issue) = first.parse::<u32>() {
-            let mut stp_path: Option<PathBuf> = None;
-            let mut i = 1;
-            while i < args.len() {
-                match args[i].as_str() {
-                    "--stp" => {
-                        stp_path = Some(PathBuf::from(require_value(args, i, "create", "--stp")?));
-                        i += 1;
-                    }
-                    other => bail!("create: unknown arg: {other}"),
-                }
-                i += 1;
-            }
-            let stp_path =
-                stp_path.ok_or_else(|| anyhow!("create: --stp is required for reconcile mode"))?;
-            return Ok(CreateMode::Reconcile { issue, stp_path });
-        }
-    }
-
-    let mut title: Option<String> = None;
-    let mut slug: Option<String> = None;
-    let mut body: Option<String> = None;
-    let mut body_file: Option<PathBuf> = None;
-    let mut labels = DEFAULT_NEW_LABELS.to_string();
-    let mut version: Option<String> = None;
-    let mut no_start = false;
-    let mut i = 0;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--title" => {
-                title = Some(require_value(args, i, "new", "--title")?);
-                i += 1;
-            }
-            "--slug" => {
-                slug = Some(require_value(args, i, "new", "--slug")?);
-                i += 1;
-            }
-            "--body" => {
-                body = Some(require_value(args, i, "new", "--body")?);
-                i += 1;
-            }
-            "--body-file" => {
-                body_file = Some(PathBuf::from(require_value(args, i, "new", "--body-file")?));
-                i += 1;
-            }
-            "--labels" => {
-                labels = require_value(args, i, "new", "--labels")?;
-                i += 1;
-            }
-            "--version" => {
-                version = Some(require_value(args, i, "new", "--version")?);
-                i += 1;
-            }
-            "--no-start" => no_start = true,
-            other => bail!("new: unknown arg: {other}"),
-        }
-        i += 1;
-    }
-
-    let title = title.ok_or_else(|| anyhow!("new: --title is required"))?;
-    if body.is_some() && body_file.is_some() {
-        bail!("new: pass only one of --body or --body-file");
-    }
-
-    Ok(CreateMode::Create {
-        title,
-        slug,
-        body,
-        body_file,
-        labels,
-        version,
-        no_start,
-    })
 }
 
 fn parse_start_args(args: &[String]) -> Result<StartArgs> {
@@ -2224,6 +1998,7 @@ fn infer_required_outcome_type(labels_csv: &str, title: &str) -> &'static str {
     "code"
 }
 
+#[cfg(test)]
 fn version_from_labels_csv(labels_csv: &str) -> Option<String> {
     labels_csv
         .split(',')
@@ -2245,6 +2020,7 @@ fn validate_issue_prompt_exists(path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn load_issue_prompt(path: &Path) -> Result<IssuePromptDoc> {
     let text = fs::read_to_string(path)
         .with_context(|| format!("failed to read issue prompt '{}'", path.display()))?;
@@ -2269,87 +2045,7 @@ fn load_issue_prompt(path: &Path) -> Result<IssuePromptDoc> {
     })
 }
 
-fn reconcile_issue(issue: u32, repo: &str, doc: &IssuePromptDoc) -> Result<()> {
-    let desired_labels = doc.front_matter.labels.clone();
-    let current_labels = run_capture_allow_failure(
-        "gh",
-        &[
-            "issue",
-            "view",
-            &issue.to_string(),
-            "-R",
-            repo,
-            "--json",
-            "labels",
-            "-q",
-            ".labels[].name",
-        ],
-    )?
-    .unwrap_or_default()
-    .lines()
-    .map(str::trim)
-    .filter(|line| !line.is_empty())
-    .map(str::to_string)
-    .collect::<Vec<_>>();
-
-    let body_file = std::env::temp_dir().join(format!("adl-pr-create-body-{issue}.md"));
-    fs::write(&body_file, &doc.body)?;
-    run_status(
-        "gh",
-        &[
-            "issue",
-            "edit",
-            &issue.to_string(),
-            "-R",
-            repo,
-            "--title",
-            &doc.front_matter.title,
-            "--body-file",
-            body_file
-                .to_str()
-                .ok_or_else(|| anyhow!("body file path must be utf-8"))?,
-        ],
-    )?;
-
-    for desired in desired_labels
-        .iter()
-        .filter(|label| !current_labels.contains(label))
-    {
-        run_status(
-            "gh",
-            &[
-                "issue",
-                "edit",
-                &issue.to_string(),
-                "-R",
-                repo,
-                "--add-label",
-                desired,
-            ],
-        )?;
-    }
-
-    for current in current_labels
-        .iter()
-        .filter(|label| !desired_labels.contains(label))
-    {
-        run_status(
-            "gh",
-            &[
-                "issue",
-                "edit",
-                &issue.to_string(),
-                "-R",
-                repo,
-                "--remove-label",
-                current,
-            ],
-        )?;
-    }
-    let _ = fs::remove_file(&body_file);
-    Ok(())
-}
-
+#[cfg(test)]
 fn resolve_issue_body(body: Option<String>, body_file: Option<&Path>) -> Result<String> {
     if let Some(path) = body_file {
         if path == Path::new("-") {
@@ -2372,33 +2068,7 @@ fn normalize_labels_csv(labels: &str, version: &str) -> String {
     normalized.join(",")
 }
 
-fn gh_issue_create(title: &str, body: &str, labels_csv: &str) -> Result<String> {
-    let mut cmd = Command::new("gh");
-    cmd.arg("issue")
-        .arg("create")
-        .arg("--title")
-        .arg(title)
-        .arg("--body")
-        .arg(body);
-    for label in labels_csv
-        .split(',')
-        .map(str::trim)
-        .filter(|label| !label.is_empty())
-    {
-        cmd.arg("--label").arg(label);
-    }
-    let output = cmd
-        .output()
-        .with_context(|| "failed to run gh issue create")?;
-    if !output.status.success() {
-        bail!(
-            "gh issue create failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
+#[cfg(test)]
 fn parse_issue_number_from_url(url: &str) -> Result<u32> {
     let issue = url
         .trim()
@@ -2913,48 +2583,23 @@ verification_summary:
     #[test]
     fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
         let err = real_pr(&[]).expect_err("missing subcommand");
-        assert!(err.to_string().contains(
-            "pr requires a subcommand: init | create | start | ready | preflight | finish"
-        ));
+        assert!(err
+            .to_string()
+            .contains("pr requires a subcommand: init | start | ready | preflight | finish"));
 
         let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
         assert!(err.to_string().contains("unknown pr subcommand: bogus"));
     }
 
     #[test]
-    fn parse_create_args_supports_reconcile_mode() {
-        match parse_create_args(&[
-            "1151".to_string(),
-            "--stp".to_string(),
-            ".adl/v0.86/tasks/example/stp.md".to_string(),
-        ])
-        .expect("parse")
-        {
-            CreateMode::Reconcile { issue, stp_path } => {
-                assert_eq!(issue, 1151);
-                assert_eq!(stp_path, PathBuf::from(".adl/v0.86/tasks/example/stp.md"));
-            }
-            other => panic!("unexpected mode: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_create_args_requires_title_and_rejects_conflicting_body_flags() {
-        let err = parse_create_args(&["--no-start".to_string()]).expect_err("missing title");
-        assert!(err.to_string().contains("--title is required"));
-
-        let err = parse_create_args(&[
+    fn real_pr_create_is_retired() {
+        let err = real_pr(&[
+            "create".to_string(),
             "--title".to_string(),
             "Example".to_string(),
-            "--body".to_string(),
-            "inline".to_string(),
-            "--body-file".to_string(),
-            "body.md".to_string(),
         ])
-        .expect_err("conflicting body flags");
-        assert!(err
-            .to_string()
-            .contains("only one of --body or --body-file"));
+        .expect_err("create should be retired");
+        assert!(err.to_string().contains("`adl pr create` is retired"));
     }
 
     #[test]
@@ -3024,14 +2669,6 @@ verification_summary:
 
         let err = parse_start_args(&["1152".to_string(), "--bogus".to_string()]).expect_err("err");
         assert!(err.to_string().contains("start: unknown arg"));
-    }
-
-    #[test]
-    fn parse_create_args_reconcile_requires_stp() {
-        let err = parse_create_args(&["1151".to_string()]).expect_err("missing stp");
-        assert!(err
-            .to_string()
-            .contains("create: --stp is required for reconcile mode"));
     }
 
     #[test]
@@ -3116,180 +2753,6 @@ verification_summary:
         );
         assert!(sip_path.is_file());
         assert!(sor_path.is_file());
-    }
-
-    #[test]
-    fn real_pr_create_no_start_creates_issue_and_source_prompt() {
-        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
-        let repo = unique_temp_dir("adl-pr-real-create");
-        init_git_repo(&repo);
-        let bin_dir = repo.join("bin");
-        fs::create_dir_all(&bin_dir).expect("bin dir");
-        let gh_log = repo.join("gh.log");
-        let gh_path = bin_dir.join("gh");
-        write_executable(
-            &gh_path,
-            &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2\" = 'issue create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/issues/1158\\n'\n  exit 0\nfi\nexit 1\n",
-                gh_log.display()
-            ),
-        );
-
-        let old_path = env::var("PATH").unwrap_or_default();
-        let prev_dir = env::current_dir().expect("cwd");
-        unsafe {
-            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
-        }
-        env::set_current_dir(&repo).expect("chdir");
-
-        let result = real_pr(&[
-            "create".to_string(),
-            "--title".to_string(),
-            "[v0.86][tools] Create test".to_string(),
-            "--slug".to_string(),
-            "v0-86-tools-create-test".to_string(),
-            "--body".to_string(),
-            "## Goal\n- test\n\n## Acceptance Criteria\n- works".to_string(),
-            "--labels".to_string(),
-            "track:roadmap,type:task,area:tools,version:v0.86".to_string(),
-            "--no-start".to_string(),
-        ]);
-
-        env::set_current_dir(prev_dir).expect("restore cwd");
-        unsafe {
-            env::set_var("PATH", old_path);
-        }
-        result.expect("real_pr create");
-
-        let issue_ref = IssueRef::new(
-            1158,
-            "v0.86".to_string(),
-            "v0-86-tools-create-test".to_string(),
-        )
-        .expect("issue ref");
-        let source_path = issue_ref.issue_prompt_path(&repo);
-        assert!(source_path.is_file());
-        let source = fs::read_to_string(&source_path).expect("read source");
-        assert!(source.contains("issue_number: 1158"));
-        assert!(source.contains("title: \"[v0.86][tools] Create test\""));
-        let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
-        assert!(gh_calls.contains("issue create"));
-    }
-
-    #[test]
-    fn real_pr_create_with_start_failure_reports_partial_state() {
-        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
-        let repo = unique_temp_dir("adl-pr-real-create-start-fails");
-        init_git_repo(&repo);
-        copy_bootstrap_support_files(&repo);
-        let bin_dir = repo.join("bin");
-        fs::create_dir_all(&bin_dir).expect("bin dir");
-        let gh_log = repo.join("gh.log");
-        let gh_path = bin_dir.join("gh");
-        write_executable(
-            &gh_path,
-            &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2\" = 'issue create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/issues/1158\\n'\n  exit 0\nfi\nexit 1\n",
-                gh_log.display()
-            ),
-        );
-        let tools_dir = repo.join("adl/tools");
-        fs::create_dir_all(&tools_dir).expect("tools dir");
-        write_executable(
-            &tools_dir.join("pr.sh"),
-            "#!/usr/bin/env bash\nset -euo pipefail\nexit 1\n",
-        );
-
-        let old_path = env::var("PATH").unwrap_or_default();
-        let prev_dir = env::current_dir().expect("cwd");
-        unsafe {
-            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
-        }
-        env::set_current_dir(&repo).expect("chdir");
-        let err = real_pr(&[
-            "create".to_string(),
-            "--title".to_string(),
-            "[v0.86][tools] Create start failure".to_string(),
-            "--slug".to_string(),
-            "v0-86-tools-create-start-failure".to_string(),
-            "--body".to_string(),
-            "## Goal\n- test\n\n## Acceptance Criteria\n- works".to_string(),
-            "--labels".to_string(),
-            "track:roadmap,type:task,area:tools,version:v0.86".to_string(),
-        ])
-        .expect_err("create should fail when start delegate fails");
-        env::set_current_dir(prev_dir).expect("restore cwd");
-        unsafe {
-            env::set_var("PATH", old_path);
-        }
-        assert!(err.to_string().contains(
-            "create: issue created and root bundle recovered, but start failed; issue #1158 exists"
-        ));
-        let issue_ref = IssueRef::new(
-            1158,
-            "v0.86".to_string(),
-            "v0-86-tools-create-start-failure".to_string(),
-        )
-        .expect("issue ref");
-        assert!(issue_ref.task_bundle_stp_path(&repo).is_file());
-        assert!(issue_ref.task_bundle_input_path(&repo).is_file());
-        assert!(issue_ref.task_bundle_output_path(&repo).is_file());
-    }
-
-    #[test]
-    fn real_pr_create_reconcile_updates_issue_via_gh() {
-        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
-        let repo = unique_temp_dir("adl-pr-reconcile");
-        init_git_repo(&repo);
-        let bin_dir = repo.join("bin");
-        fs::create_dir_all(&bin_dir).expect("bin dir");
-        let gh_log = repo.join("gh.log");
-        let gh_path = bin_dir.join("gh");
-        write_executable(
-            &gh_path,
-            &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2 $5 $6\" = 'issue view --json labels -q' ]; then\n  printf 'track:roadmap\\nversion:v0.86\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'issue edit' ]; then\n  exit 0\nfi\nexit 1\n",
-                gh_log.display()
-            ),
-        );
-
-        let stp_dir = repo.join(".adl/v0.86/tasks/issue-1151__example");
-        fs::create_dir_all(&stp_dir).expect("stp dir");
-        let stp_path = stp_dir.join("stp.md");
-        fs::write(
-            &stp_path,
-            "---\ntitle: \"[v0.86][tools] Reconcile test\"\nlabels:\n  - \"track:roadmap\"\n  - \"type:task\"\n  - \"area:tools\"\n  - \"version:v0.86\"\nissue_number: 1151\n---\n\n# Body\n\nReconcile me.\n",
-        )
-        .expect("write stp");
-
-        let old_path = env::var("PATH").unwrap_or_default();
-        let prev_dir = env::current_dir().expect("cwd");
-        unsafe {
-            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
-        }
-        env::set_current_dir(&repo).expect("chdir");
-
-        let result = real_pr(&[
-            "create".to_string(),
-            "1151".to_string(),
-            "--stp".to_string(),
-            stp_path.display().to_string(),
-        ]);
-
-        env::set_current_dir(prev_dir).expect("restore cwd");
-        unsafe {
-            env::set_var("PATH", old_path);
-        }
-        result.expect("reconcile");
-
-        let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
-        assert!(gh_calls.contains("issue edit 1151 -R danielbaustin/agent-design-language --title [v0.86][tools] Reconcile test --body-file"));
-        assert!(gh_calls.contains(
-            "issue edit 1151 -R danielbaustin/agent-design-language --add-label type:task"
-        ));
-        assert!(gh_calls.contains(
-            "issue edit 1151 -R danielbaustin/agent-design-language --add-label area:tools"
-        ));
     }
 
     #[test]
@@ -3595,25 +3058,6 @@ verification_summary:
         assert!(err
             .to_string()
             .contains("ready: could not infer slug; pass --slug or run start first"));
-    }
-
-    #[test]
-    fn parse_create_args_supports_new_issue_mode() {
-        match parse_create_args(&[
-            "--title".to_string(),
-            "Example".to_string(),
-            "--no-start".to_string(),
-        ])
-        .expect("parse")
-        {
-            CreateMode::Create {
-                title, no_start, ..
-            } => {
-                assert_eq!(title, "Example");
-                assert!(no_start);
-            }
-            other => panic!("unexpected mode: {other:?}"),
-        }
     }
 
     #[test]

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -4,8 +4,6 @@ pub fn usage() -> &'static str {
   adl resume <run_id> [--steer <steering.json>]
   adl demo <name> [--print-plan] [--trace] [--run] [--out <dir>] [--quiet] [--open] [--no-open]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]
-  adl pr create <issue> --stp <path>
-  adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>] [--no-start]
   adl pr start <issue> [--prefix <prefix>] [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
   adl pr ready <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
   adl pr preflight <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]

--- a/adl/tools/BURST_PLAYBOOK.md
+++ b/adl/tools/BURST_PLAYBOOK.md
@@ -5,8 +5,8 @@ Use this playbook for sequential burst execution.
 ## Sequence
 
 1. Generate a prioritized plan (max 8 issues).
-2. Create child issues with `bash ./adl/tools/pr.sh create --no-start`.
-3. Execute child issues one by one using `adl_pr_cycle` (`init -> create -> start -> codex -> run_if_required -> finish -> report`).
+2. Create child issues outside `pr.sh` and confirm their issue numbers.
+3. Execute child issues one by one using `adl_pr_cycle` (`issue_ready -> init -> start -> codex -> run_if_required -> finish -> report`).
 4. Merge only green PRs.
 5. Write a final summary under `.adl/reports/burst/<timestamp_utc_z>/final_summary.md`.
    Use `adl/tools/BURST_FINAL_SUMMARY_TEMPLATE.md`.

--- a/adl/tools/demo_five_command_editing.sh
+++ b/adl/tools/demo_five_command_editing.sh
@@ -29,11 +29,10 @@ GH_BODY="$REPORT_ROOT/gh_body.md"
 MANIFEST="$REPORT_ROOT/five_command_editing_demo_manifest.json"
 CONTRACT_JSON="$REPORT_ROOT/editor_adapter_contract.json"
 INIT_LOG="$REPORT_ROOT/01-pr-init.txt"
-CREATE_LOG="$REPORT_ROOT/02-pr-create.txt"
-ADAPTER_LOG="$REPORT_ROOT/03-editor-adapter.txt"
-START_LOG="$REPORT_ROOT/04-pr-start.txt"
-RUN_LOG="$REPORT_ROOT/05-pr-run.txt"
-FINISH_LOG="$REPORT_ROOT/06-pr-finish.txt"
+ADAPTER_LOG="$REPORT_ROOT/02-editor-adapter.txt"
+START_LOG="$REPORT_ROOT/03-pr-start.txt"
+RUN_LOG="$REPORT_ROOT/04-pr-run.txt"
+FINISH_LOG="$REPORT_ROOT/05-pr-finish.txt"
 MOCK_OLLAMA="$ROOT_DIR/adl/tools/mock_ollama_v0_4.sh"
 
 mkdir -p "$MOCKBIN" "$REPORT_ROOT"
@@ -86,7 +85,7 @@ pr_start:
 # Issue Card
 
 ## Summary
-Demonstrate the bounded five-command editing lifecycle truthfully.
+Demonstrate the bounded authoring lifecycle truthfully.
 ## Goal
 Show one honest end-to-end lifecycle over the real command surface.
 ## Required Outcome
@@ -195,11 +194,6 @@ export GH_BODY_FILE_CAPTURE="$GH_BODY"
   "$BASH_BIN" adl/tools/pr.sh init "$ISSUE_NUM" --slug "$SLUG" --no-fetch-issue --version v0.85
 ) | tee "$INIT_LOG"
 
-(
-  cd "$REPO"
-  "$BASH_BIN" adl/tools/pr.sh create "$ISSUE_NUM" --stp "$STP_PATH"
-) | tee "$CREATE_LOG"
-
 {
   echo "# editor adapter dry run"
   "$BASH_BIN" adl/tools/editor_action.sh contract --format json >"$CONTRACT_JSON"
@@ -262,11 +256,11 @@ Execution:
 - End Time: 2026-03-24T00:00:01Z
 
 ## Summary
-Bounded demo record for the five-command editing lifecycle.
+Bounded demo record for the authoring lifecycle.
 ## Artifacts produced
 - docs/tooling/editor/five_command_demo_note.md
 ## Actions taken
-- exercised init/create/start/run/finish in one bounded local demo
+- exercised init/start/run/finish in one bounded local demo
 ## Main Repo Integration (REQUIRED)
 - Tracked paths prepared for main-repo integration:
   - \`docs/tooling/editor/five_command_demo_note.md\`
@@ -281,7 +275,7 @@ Bounded demo record for the five-command editing lifecycle.
 ## Validation
 - Validation commands and their purpose:
   - \`bash adl/tools/demo_five_command_editing.sh\`
-    - proves the bounded five-command lifecycle is runnable through the supported command surface and documented adapter path.
+    - proves the bounded authoring lifecycle is runnable through the supported command surface and documented adapter path.
 - Results:
   - all listed commands passed
 ## Verification Summary
@@ -290,7 +284,7 @@ verification_summary:
   validation:
     status: PASS
     checks_run:
-      - "five-command editing demo"
+      - "authoring lifecycle demo"
   determinism:
     status: PASS
     replay_verified: true
@@ -308,7 +302,7 @@ verification_summary:
       approved: not_applicable
 \`\`\`
 ## Determinism Evidence
-- Determinism tests executed: bounded five-command editing demo
+- Determinism tests executed: bounded authoring lifecycle demo
 - Replay verification (same inputs -> same artifacts/order): yes
 - Ordering guarantees (sorting / tie-break rules used): fixed lifecycle order
 - Artifact stability notes: manifest and per-step transcripts are emitted deterministically
@@ -357,7 +351,6 @@ manifest = {
     "editor_adapter_contract_json": str(Path("$CONTRACT_JSON")),
     "step_logs": {
         "pr_init": str(Path("$INIT_LOG")),
-        "pr_create": str(Path("$CREATE_LOG")),
         "editor_adapter": str(Path("$ADAPTER_LOG")),
         "pr_start": str(Path("$START_LOG")),
         "pr_run": str(Path("$RUN_LOG")),

--- a/adl/tools/editor_action.sh
+++ b/adl/tools/editor_action.sh
@@ -37,7 +37,6 @@ supported_actions:
     status: supported
 unsupported_browser_direct_actions:
   - pr init
-  - pr create
   - pr run
   - pr finish
 notes:
@@ -62,7 +61,6 @@ emit_contract_json() {
   ],
   "unsupported_browser_direct_actions": [
     "pr init",
-    "pr create",
     "pr run",
     "pr finish"
   ],

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1986,43 +1986,8 @@ cmd_init() {
 }
 
 cmd_create() {
-  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
-    usage_create
-    return 0
-  fi
-
-  if rust_pr_delegate_available; then
-    delegate_pr_command_to_rust create "$@"
-    return 0
-  fi
-
-  if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
-    local issue="$1"
-    shift || true
-    issue="$(normalize_issue_or_die "$issue")"
-
-    local stp_path=""
-    while [[ $# -gt 0 ]]; do
-      case "$1" in
-        --stp) stp_path="$2"; shift 2 ;;
-        -h|--help) usage_create; return 0 ;;
-        *) die_with_usage "create: unknown arg: $1" usage_create ;;
-      esac
-    done
-
-    [[ -n "$stp_path" ]] || die "create: --stp is required for reconcile mode"
-    [[ -f "$stp_path" ]] || die "create: STP not found: $stp_path"
-    require_cmd gh
-    local repo
-    repo="$(default_repo)"
-    reconcile_issue_from_stp "$issue" "$stp_path" "$repo"
-    echo "ISSUE_NUM=$issue"
-    echo "STP_PATH=$(path_relative_to_repo "$stp_path")"
-    echo "MODE=reconcile"
-    return 0
-  fi
-
-  create_issue "$@"
+  usage_create >&2
+  return 1
 }
 
 cmd_start() {
@@ -2807,8 +2772,6 @@ pr.sh — reduce git/PR thrash while preserving human review
 Commands:
   help
   init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v>]
-  create  <issue> --stp <path>
-  create  --title "<title>" [--slug <slug>] [--body "<text>" | --body-file <path>] [--labels <csv>] [--version <v>] [--no-start]
   run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
   start   <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>]
   card    <issue> [input|output] ... [--version <v0.2>] [-f <input_card.md>]
@@ -2820,13 +2783,6 @@ Commands:
   status
 
 Flags:
-  (create)  <issue> --stp <path>              Reconcile an existing GitHub issue from a canonical STP.
-  (create)  --title "<title>"                 Required issue title for gh issue create.
-  (create)  --body "<text>"                   Optional issue body text.
-  (create)  --body-file <path|->              Optional issue body file path ('-' reads stdin).
-  (create)  --labels <csv>                    Comma-separated labels (default: track:roadmap,type:task,area:tools).
-  (create)  --version <v0.86>                 Default/fallback version label for issue/card flow.
-  (create)  --no-start                        Only create issue; do not invoke start.
   (init)    --version <v0.85>                 Override detected version (otherwise inferred from issue labels version:vX.Y)
   (init)    --no-fetch-issue                  Do not fetch issue title/labels; requires --slug.
   (run)     --runs-root <dir>                 Override canonical run artifact root (default: <repo>/.adl/runs or ADL_RUNS_ROOT).
@@ -2844,6 +2800,7 @@ Flags:
   (start)   --allow-open-pr-wave               Override the open milestone PR wave guard.
 
 Notes:
+- Issue creation/reconciliation is no longer part of `pr.sh`; create the GitHub issue first, then run `pr init` and `pr start`.
 - PRs are created as DRAFT by default to preserve human review.
 - Uses "Closes #N" by default so GitHub auto-closes issues when merged.
 - run is a bounded v0.85 wrapper over the Rust adl runtime; browser/editor direct invocation remains follow-on work.
@@ -2856,8 +2813,6 @@ Notes:
 Examples:
   adl/tools/pr.sh help
   adl/tools/pr.sh init 17 --slug b6-default-system --no-fetch-issue --version v0.85
-  adl/tools/pr.sh create 17 --stp .adl/issues/v0.85/bodies/issue-17-b6-default-system.md
-  adl/tools/pr.sh create --title "adl: fix timeout handling" --slug timeout-fix
   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
   adl/tools/pr.sh start 17 --slug b6-default-system
   adl/tools/pr.sh preflight 17 --slug b6-default-system --version v0.85
@@ -2880,20 +2835,17 @@ Usage:
 
 Notes:
 - `pr new` is retired.
-- Use `adl/tools/pr.sh create --title ...` instead.
+- Create the GitHub issue first, then use `adl/tools/pr.sh init <issue>` and `adl/tools/pr.sh start <issue>`.
 EOF
 }
 
 usage_create() {
   cat <<'EOF'
-Usage:
-  adl/tools/pr.sh create <issue> --stp <path>
-  adl/tools/pr.sh create --title "<title>" [--slug <slug>] [--body "<text>" | --body-file <path>] [--labels <csv>] [--version <v>] [--no-start]
-
 Notes:
-- Reconcile mode updates an existing GitHub issue from a canonical STP.
-- Create mode is the canonical issue-creation path.
-- `pr new` is retired and should not be used.
+- `pr create` is retired.
+- Create or reconcile the GitHub issue outside `pr.sh`, then run:
+  1. `adl/tools/pr.sh init <issue> [...]`
+  2. `adl/tools/pr.sh start <issue> [...]`
 EOF
 }
 
@@ -2904,8 +2856,8 @@ Usage:
 
 Notes:
 - Initializes the canonical local task-bundle authoring surface for an existing issue-backed task.
-- For v0.85, the minimum initialized artifact set is the task-bundle directory plus a validated stp.md copied from the canonical local issue prompt.
-- Does not create sip.md or sor.md; those remain the responsibility of pr start.
+- Emits and validates the root STP/SIP/SOR bundle before returning success.
+- Fails if the full root task bundle cannot be created cleanly.
 EOF
 }
 

--- a/adl/tools/test_demo_five_command_editing.sh
+++ b/adl/tools/test_demo_five_command_editing.sh
@@ -25,7 +25,7 @@ manifest = json.loads(Path("$MANIFEST_PATH").read_text())
 assert manifest["schema_version"] == "five_command_editing_demo.v1"
 assert manifest["demo_entry"] == "bash adl/tools/demo_five_command_editing.sh"
 
-for key in ("pr_init", "pr_create", "editor_adapter", "pr_start", "pr_run", "pr_finish"):
+for key in ("pr_init", "editor_adapter", "pr_start", "pr_run", "pr_finish"):
     path = Path(manifest["step_logs"][key])
     assert path.exists(), f"missing step log: {path}"
 
@@ -42,17 +42,6 @@ print(manifest["step_logs"]["pr_init"])
 PY
 )" || {
   echo "assertion failed: pr init log missing STP path" >&2
-  exit 1
-}
-
-grep -Fq "MODE=reconcile" "$(python3 - <<PY
-import json
-from pathlib import Path
-manifest = json.loads(Path("$MANIFEST_PATH").read_text())
-print(manifest["step_logs"]["pr_create"])
-PY
-)" || {
-  echo "assertion failed: pr create log missing reconcile marker" >&2
   exit 1
 }
 
@@ -96,4 +85,4 @@ if grep -Fq "pr create" "$GH_LOG_PATH"; then
   exit 1
 fi
 
-echo "five-command editing demo: ok"
+echo "editing demo: ok"

--- a/adl/tools/test_five_command_editor_truth.sh
+++ b/adl/tools/test_five_command_editor_truth.sh
@@ -18,17 +18,16 @@ assert_contains() {
 }
 
 assert_contains "  init" "$HELP_OUT" "help lists pr init"
-assert_contains "  create" "$HELP_OUT" "help lists pr create"
 assert_contains "  start" "$HELP_OUT" "help lists pr start"
 assert_contains "  run" "$HELP_OUT" "help lists pr run"
 assert_contains "  finish" "$HELP_OUT" "help lists pr finish"
+if grep -Fq "  create" <<<"$HELP_OUT"; then
+  echo "assertion failed: help must not list pr create" >&2
+  exit 1
+fi
 
 grep -Fq '| `pr init` | yes | no | control-plane only |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
   echo "assertion failed: command_adapter.md must keep pr init control-plane only" >&2
-  exit 1
-}
-grep -Fq '| `pr create` | yes | no | control-plane only |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
-  echo "assertion failed: command_adapter.md must keep pr create control-plane only" >&2
   exit 1
 }
 grep -Fq '| `pr start` | yes | yes, via `adl/tools/editor_action.sh start` | supported thin adapter |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
@@ -48,10 +47,6 @@ grep -Fq -- '- `pr init` is not launched from the browser in this slice' "$ROOT_
   echo "assertion failed: editor demo must keep pr init out of browser scope" >&2
   exit 1
 }
-grep -Fq -- '- `pr create` is not launched from the browser in this slice' "$ROOT_DIR/docs/tooling/editor/demo.md" || {
-  echo "assertion failed: editor demo must keep pr create out of browser scope" >&2
-  exit 1
-}
 grep -Fq -- '- `pr run` is not launched from the browser in this slice' "$ROOT_DIR/docs/tooling/editor/demo.md" || {
   echo "assertion failed: editor demo must keep pr run out of browser scope" >&2
   exit 1
@@ -65,4 +60,4 @@ grep -Fq -- '- the broader lifecycle commands still run through the repo-local c
   exit 1
 }
 
-echo "five-command editor truth checks: ok"
+echo "editor truth checks: ok"

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -23,4 +23,4 @@ run_check adl/tools/test_editor_action.sh
 run_check adl/tools/test_demo_five_command_editing.sh
 run_check adl/tools/test_five_command_editor_truth.sh
 
-echo "five-command regression suite: ok"
+echo "authoring regression suite: ok"

--- a/adl/tools/test_install_adl_pr_cycle_skill.sh
+++ b/adl/tools/test_install_adl_pr_cycle_skill.sh
@@ -14,7 +14,7 @@ source_path="${repo_root}/docs/tooling/adl_pr_cycle_skill.md"
 
 [[ -f "${installed}" ]]
 cmp -s "${source_path}" "${installed}"
-grep -Fq 'preflight -> init -> create -> start -> codex -> run_if_required -> finish -> report' "${installed}"
+grep -Fq 'preflight -> issue_ready -> init -> start -> codex -> run_if_required -> finish -> report' "${installed}"
 grep -Fq '.worktrees/adl-wp-<issue_num>' "${installed}"
 grep -Fq 'bash ./adl/tools/pr.sh init <issue_num> --slug <slug> [--version <version>]' "${installed}"
 grep -Fq 'bash adl/tools/test_five_command_regression_suite.sh' "${installed}"

--- a/adl/tools/test_pr_create.sh
+++ b/adl/tools/test_pr_create.sh
@@ -2,163 +2,25 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
-CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
-PROMPT_LINT_SRC="$ROOT_DIR/adl/tools/lint_prompt_spec.sh"
-PROMPT_VALIDATOR_SRC="$ROOT_DIR/adl/tools/validate_structured_prompt.sh"
-INPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/input_card_template.md"
-OUTPUT_TPL_SRC="$ROOT_DIR/adl/templates/cards/output_card_template.md"
-STP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_task_prompt.contract.yaml"
-SIP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_implementation_prompt.contract.yaml"
-SOR_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_output_record.contract.yaml"
 BASH_BIN="$(command -v bash)"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
-origin="$tmpdir/origin.git"
 repo="$tmpdir/repo"
-bindir="$tmpdir/bin"
-gh_log="$tmpdir/gh.log"
-gh_body="$tmpdir/gh_body.md"
-mkdir -p "$repo/adl/tools" "$repo/adl/templates/cards" "$repo/adl/schemas" "$repo/.adl/issues/v0.85/bodies" "$bindir"
-cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
-cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
-cp "$PROMPT_LINT_SRC" "$repo/adl/tools/lint_prompt_spec.sh"
-cp "$PROMPT_VALIDATOR_SRC" "$repo/adl/tools/validate_structured_prompt.sh"
-cp "$INPUT_TPL_SRC" "$repo/adl/templates/cards/input_card_template.md"
-cp "$OUTPUT_TPL_SRC" "$repo/adl/templates/cards/output_card_template.md"
-cp "$STP_CONTRACT_SRC" "$repo/adl/schemas/structured_task_prompt.contract.yaml"
-cp "$SIP_CONTRACT_SRC" "$repo/adl/schemas/structured_implementation_prompt.contract.yaml"
-cp "$SOR_CONTRACT_SRC" "$repo/adl/schemas/structured_output_record.contract.yaml"
-chmod +x "$repo/adl/tools/pr.sh" "$repo/adl/tools/lint_prompt_spec.sh" "$repo/adl/tools/validate_structured_prompt.sh"
-
-cat >"$repo/.adl/issues/v0.85/bodies/issue-42-test-reconcile.md" <<'EOF'
----
-issue_card_schema: adl.issue.v1
-wp: "authoring"
-slug: "test-reconcile"
-title: "[v0.85][authoring] Reconciled issue title"
-labels:
-  - "track:roadmap"
-  - "version:v0.85"
-  - "area:tools"
-issue_number: 42
-status: "draft"
-action: "edit"
-depends_on: []
-milestone_sprint: "Sprint Test"
-required_outcome_type:
-  - "code"
-repo_inputs:
-  - "adl/tools/pr.sh"
-canonical_files: []
-demo_required: false
-demo_names: []
-issue_graph_notes: []
-pr_start:
-  enabled: true
-  slug: "test-reconcile"
----
-
-# Issue Card
-
-## Summary
-Reconcile the issue body from the canonical STP.
-## Goal
-x
-## Required Outcome
-x
-## Deliverables
-x
-## Acceptance Criteria
-x
-## Repo Inputs
-x
-## Dependencies
-x
-## Demo Expectations
-x
-## Non-goals
-x
-## Issue-Graph Notes
-x
-## Notes
-x
-## Tooling Notes
-x
-EOF
-
-cp "$repo/.adl/issues/v0.85/bodies/issue-42-test-reconcile.md" \
-  "$repo/.adl/issues/v0.85/bodies/issue-43-test-reconcile-no-label-delta.md"
-python3 - "$repo/.adl/issues/v0.85/bodies/issue-43-test-reconcile-no-label-delta.md" <<'PY'
-from pathlib import Path
-import sys
-
-path = Path(sys.argv[1])
-text = path.read_text()
-text = text.replace("slug: \"test-reconcile\"", "slug: \"test-reconcile-no-label-delta\"")
-text = text.replace("issue_number: 42", "issue_number: 43")
-path.write_text(text)
-PY
-
-cat >"$bindir/gh" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-LOG_FILE="${GH_LOG_FILE:?}"
-BODY_FILE_CAPTURE="${GH_BODY_FILE_CAPTURE:?}"
-printf '%s\n' "$*" >>"$LOG_FILE"
-
-if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
-  echo "https://github.com/example/repo/issues/1042"
-  exit 0
-fi
-
-if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
-  issue="${3:-}"
-  shift 3
-  if [[ "$issue" == "42" && "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
-    printf '%s\n' "track:roadmap" "old:remove-me"
-    exit 0
-  fi
-  if [[ "$issue" == "43" && "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
-    printf '%s\n' "track:roadmap" "version:v0.85" "area:tools"
-    exit 0
-  fi
-fi
-
-if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
-  shift 2
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --body-file)
-        cp "$2" "$BODY_FILE_CAPTURE"
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
-  exit 0
-fi
-
-exit 1
-EOF
-chmod +x "$bindir/gh"
+mkdir -p "$repo/adl/tools"
+cp "$ROOT_DIR/adl/tools/pr.sh" "$repo/adl/tools/pr.sh"
+cp "$ROOT_DIR/adl/tools/card_paths.sh" "$repo/adl/tools/card_paths.sh"
+chmod +x "$repo/adl/tools/pr.sh"
 
 (
   cd "$repo"
   git init -q
   git config user.name "Test User"
   git config user.email "test@example.com"
-  git add -A
+  touch README.md
+  git add README.md
   git commit -q -m "init"
-  git branch -M main
-  git init --bare -q "$origin"
-  git remote add origin "$origin"
-  git push -q -u origin main
-  git fetch -q origin main
 )
 
 assert_contains() {
@@ -171,115 +33,21 @@ assert_contains() {
   }
 }
 
-(
-  cd "$repo"
-  export PATH="$bindir:$PATH"
-  export GH_LOG_FILE="$gh_log"
-  export GH_BODY_FILE_CAPTURE="$gh_body"
+set +e
+out="$(
+  cd "$repo" &&
+  "$BASH_BIN" adl/tools/pr.sh create --title "retired path" 2>&1
+)"
+status=$?
+set -e
 
-  out_create="$("$BASH_BIN" adl/tools/pr.sh create \
-    --title "[v0.85][authoring] Transitional create path" \
-    --slug transitional-create-path \
-    --version v0.85 \
-    --body "test body" \
-    --no-start)"
-
-  assert_contains "ISSUE_NUM=1042" "$out_create" "create path issue number"
-  assert_contains "STATE=ISSUE_CREATED" "$out_create" "create state"
-  assert_contains "START_STATE=SKIPPED" "$out_create" "create no-start state"
-  grep -Fq "issue create" "$gh_log" || {
-    echo "assertion failed: expected create path to call gh issue create" >&2
-    exit 1
-  }
-  [[ -f ".adl/issues/v0.85/bodies/issue-1042-transitional-create-path.md" ]] || {
-    echo "assertion failed: expected create path to generate canonical source issue prompt" >&2
-    exit 1
-  }
-
-  : >"$gh_log"
-  out_reconcile="$("$BASH_BIN" adl/tools/pr.sh create 42 --stp .adl/issues/v0.85/bodies/issue-42-test-reconcile.md)"
-  assert_contains "ISSUE_NUM=42" "$out_reconcile" "reconcile issue number"
-  assert_contains "MODE=reconcile" "$out_reconcile" "reconcile mode marker"
-  grep -Fq -- 'issue edit 42' "$gh_log" || {
-    echo "assertion failed: expected reconcile path to call gh issue edit" >&2
-    exit 1
-  }
-  grep -Fq -- '--add-label version:v0.85' "$gh_log" || {
-    echo "assertion failed: expected reconcile path to add missing STP label" >&2
-    exit 1
-  }
-  grep -Fq -- '--add-label area:tools' "$gh_log" || {
-    echo "assertion failed: expected reconcile path to add missing STP label" >&2
-    exit 1
-  }
-  grep -Fq -- '--remove-label old:remove-me' "$gh_log" || {
-    echo "assertion failed: expected reconcile path to remove stale label" >&2
-    exit 1
-  }
-  grep -Fq "## Summary" "$gh_body" || {
-    echo "assertion failed: expected reconcile body file to contain STP markdown body" >&2
-    exit 1
-  }
-
-  : >"$gh_log"
-  out_reconcile_same_labels="$("$BASH_BIN" adl/tools/pr.sh create 43 --stp .adl/issues/v0.85/bodies/issue-43-test-reconcile-no-label-delta.md)"
-  assert_contains "ISSUE_NUM=43" "$out_reconcile_same_labels" "reconcile same-label issue number"
-  assert_contains "MODE=reconcile" "$out_reconcile_same_labels" "reconcile same-label mode marker"
-  grep -Fq -- 'issue edit 43' "$gh_log" || {
-    echo "assertion failed: expected same-label reconcile path to call gh issue edit" >&2
-    exit 1
-  }
-  if grep -Fq -- '--add-label' "$gh_log"; then
-    echo "assertion failed: expected no add-label operations when labels already match" >&2
-    exit 1
-  fi
-  if grep -Fq -- '--remove-label' "$gh_log"; then
-    echo "assertion failed: expected no remove-label operations when labels already match" >&2
-    exit 1
-  fi
-
-  real_git="$(command -v git)"
-  cat >"$bindir/git" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-if [[ "\${1:-}" == "branch" ]]; then
-  echo "fatal: simulated branch creation failure" >&2
+[[ "$status" -ne 0 ]] || {
+  echo "assertion failed: expected pr.sh create to be retired" >&2
   exit 1
-fi
-exec "$real_git" "\$@"
-EOF
-  chmod +x "$bindir/git"
+}
 
-  set +e
-  out_partial="$(PATH="$bindir:$PATH" "$BASH_BIN" adl/tools/pr.sh create \
-    --title "[v0.85][authoring] Recover create path" \
-    --slug recover-create-path \
-    --version v0.85 \
-    --body "test body" 2>&1)"
-  status=$?
-  set -e
-  [[ "$status" -ne 0 ]] || {
-    echo "assertion failed: expected create to fail when start fails" >&2
-    exit 1
-  }
-  assert_contains "STATE=ISSUE_CREATED" "$out_partial" "partial create issue created"
-  assert_contains "START_STATE=FAILED" "$out_partial" "partial create start failed"
-  assert_contains "RECOVERY_STATE=ISSUE_AND_BUNDLE_READY" "$out_partial" "partial create recovery state"
-  assert_contains "STP_PATH=.adl/v0.85/tasks/issue-1042__recover-create-path/stp.md" "$out_partial" "partial create stp path"
-  assert_contains "SIP_PATH=.adl/v0.85/tasks/issue-1042__recover-create-path/sip.md" "$out_partial" "partial create sip path"
-  assert_contains "SOR_PATH=.adl/v0.85/tasks/issue-1042__recover-create-path/sor.md" "$out_partial" "partial create sor path"
-  [[ -f ".adl/v0.85/tasks/issue-1042__recover-create-path/stp.md" ]] || {
-    echo "assertion failed: expected recovered stp after create/start failure" >&2
-    exit 1
-  }
-  [[ -f ".adl/v0.85/tasks/issue-1042__recover-create-path/sip.md" ]] || {
-    echo "assertion failed: expected recovered sip after create/start failure" >&2
-    exit 1
-  }
-  [[ -f ".adl/v0.85/tasks/issue-1042__recover-create-path/sor.md" ]] || {
-    echo "assertion failed: expected recovered sor after create/start failure" >&2
-    exit 1
-  }
-)
+assert_contains '`pr create` is retired.' "$out" "retired notice"
+assert_contains 'adl/tools/pr.sh init <issue>' "$out" "init guidance"
+assert_contains 'adl/tools/pr.sh start <issue>' "$out" "start guidance"
 
-echo "pr.sh create create+reconcile flows: ok"
+echo "pr.sh create retirement: ok"

--- a/adl/tools/test_pr_finish_relative_card_paths.sh
+++ b/adl/tools/test_pr_finish_relative_card_paths.sh
@@ -308,19 +308,6 @@ EOF_SOR
   }
   assert_contains "finish: --body looks like issue-template/prompt text" "$bad"
 
-  cat >"$tmpdir/issue_body_bad.md" <<'EOF_BAD'
-## Goal
-contains /Users/example leak
-EOF_BAD
-  set +e
-  bad="$($BASH_BIN adl/tools/pr.sh create --title "bad issue" --body-file "$tmpdir/issue_body_bad.md" --no-start 2>&1)"
-  status=$?
-  set -e
-  [[ "$status" -ne 0 ]] || {
-    echo "assertion failed: expected pr.sh create absolute-path guard to fail" >&2
-    exit 1
-  }
-  assert_contains "issue body contains disallowed absolute host path" "$bad"
 )
 
-echo "pr.sh finish/new path hygiene: ok"
+echo "pr.sh finish path hygiene: ok"

--- a/adl/tools/test_pr_issue_version_inference.sh
+++ b/adl/tools/test_pr_issue_version_inference.sh
@@ -38,10 +38,6 @@ cat >"$bindir/gh" <<'EOF'
 set -euo pipefail
 LOG_FILE="${GH_LOG_FILE:?}"
 printf '%s\n' "$*" >>"$LOG_FILE"
-if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
-  echo "https://github.com/example/repo/issues/975"
-  exit 0
-fi
 if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
   issue="${3:-}"
   shift 3
@@ -96,36 +92,27 @@ assert_contains() {
   export PATH="$bindir:$PATH"
   export GH_LOG_FILE="$gh_log"
 
-  out="$("$BASH_BIN" adl/tools/pr.sh create \
-    --title "[v0.85][process] Infer current milestone card version from issue title when labels are missing" \
-    --slug v085-process-infer-card-version-from-issue-title \
-    --labels "track:roadmap,version:v0.85,type:bug,area:tools" \
-    --body "test body")"
-
-  assert_contains "ISSUE_NUM=975" "$out" "create prints issue number"
-  [[ -f ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" ]] || {
-    echo "assertion failed: expected canonical input card under the worktree-local .adl/v0.85/tasks" >&2
+  out_init="$("$BASH_BIN" adl/tools/pr.sh init 975 --slug v085-process-infer-card-version-from-issue-title)"
+  assert_contains "STATE    ISSUE_AND_BUNDLE_READY" "$out_init" "init ready state"
+  [[ -f ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" ]] || {
+    echo "assertion failed: expected canonical input card under the root .adl/v0.85/tasks" >&2
     exit 1
   }
-  [[ -f ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sor.md" ]] || {
-    echo "assertion failed: expected canonical output card under the worktree-local .adl/v0.85/tasks" >&2
+  [[ -f ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sor.md" ]] || {
+    echo "assertion failed: expected canonical output card under the root .adl/v0.85/tasks" >&2
     exit 1
   }
-  grep -Fq "Version: v0.85" ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
+  grep -Fq "Version: v0.85" ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
     echo "assertion failed: expected input card version v0.85" >&2
     exit 1
   }
   grep -Fq "Title: [v0.85][process] Infer current milestone card version from issue title when labels are missing" \
-    ".worktrees/adl-wp-975/.adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
+    ".adl/v0.85/tasks/issue-0975__v085-process-infer-card-version-from-issue-title/sip.md" || {
     echo "assertion failed: expected preserved issue title in input card" >&2
     exit 1
   }
-  grep -Fq -- "--label version:v0.85" "$gh_log" || {
-    echo "assertion failed: expected issue create to use version:v0.85" >&2
-    exit 1
-  }
-  if grep -Fq -- "--label version:v0.3" "$gh_log"; then
-    echo "assertion failed: unexpected version:v0.3 label in issue create" >&2
+  if grep -Fq "v0.3" "$gh_log"; then
+    echo "assertion failed: unexpected v0.3 inference in gh issue view path" >&2
     exit 1
   fi
 
@@ -144,22 +131,6 @@ assert_contains() {
     exit 1
   }
 
-  : >"$gh_log"
-  out_title_only="$("$BASH_BIN" adl/tools/pr.sh create \
-    --title "[v0.85][process] Title-only version inference remains stable" \
-    --slug v085-process-title-only-version-inference-remains-stable \
-    --labels "track:roadmap,type:bug,area:tools" \
-    --body "test body" \
-    --no-start)"
-  assert_contains "ISSUE_NUM=975" "$out_title_only" "create no-start prints issue number"
-  grep -Fq -- "--label version:v0.85" "$gh_log" || {
-    echo "assertion failed: expected title-only create to infer version:v0.85" >&2
-    exit 1
-  }
-  if grep -Fq -- "--label version:v0.3" "$gh_log"; then
-    echo "assertion failed: unexpected version:v0.3 label in title-only issue create" >&2
-    exit 1
-  fi
 )
 
-echo "pr.sh create/start title+version inference: ok"
+echo "pr.sh init/start title+version inference: ok"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -2,7 +2,7 @@
 
 This is the default contributor path for ADL development:
 
-`preflight -> init -> create -> start -> codex -> run_if_required -> finish -> report`
+`preflight -> issue_ready -> init -> start -> codex -> run_if_required -> finish -> report`
 
 Tracked mirror of the local skill contract:
 
@@ -14,10 +14,9 @@ Install or resync the local skill with:
 bash adl/tools/install_adl_pr_cycle_skill.sh
 ```
 
-The five-command control-plane surface is:
+The active control-plane surface is:
 
 - `pr init`
-- `pr create`
 - `pr start`
 - `pr run`
 - `pr finish`
@@ -25,7 +24,7 @@ The five-command control-plane surface is:
 The browser/editor adapter remains narrower:
 
 - browser-direct adapter support exists only for `adl/tools/editor_action.sh start`
-- direct browser/editor execution of `pr init`, `pr create`, `pr run`, and `pr finish` is not part of the v0.85 adapter surface
+- direct browser/editor execution of `pr init`, `pr run`, and `pr finish` is not part of the v0.85 adapter surface
 
 ## 1) Initialize Canonical STP
 
@@ -40,13 +39,16 @@ Canonical local task bundle:
 Minimum v0.85 init contract:
 - canonical task-bundle directory
 - validated `stp.md`
-- no implied SIP/SOR creation yet
+- validated root `sip.md`
+- validated root `sor.md`
 
-## 2) Reconcile GitHub Issue From Canonical STP
+## 2) Confirm GitHub Issue Exists
 
 ```bash
-bash ./adl/tools/pr.sh create <issue_num> --stp .adl/v0.85/tasks/<task-id>__<slug>/stp.md
+gh issue view <issue_num>
 ```
+
+`pr.sh` no longer creates or reconciles GitHub issues. The issue must already exist before kickoff continues.
 
 ## 3) Start Issue Branch + Local Cards
 
@@ -96,7 +98,7 @@ Typical local preflight:
 ./adl/tools/batched_checks.sh
 ```
 
-Canonical regression proof surface for the implemented five-command story:
+Canonical regression proof surface for the implemented editing story:
 
 ```bash
 bash adl/tools/test_five_command_regression_suite.sh

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -17,9 +17,8 @@ Use this page when you need to orient quickly in the ADL repo.
 
 ## Workflow Context
 
-Default workflow uses `adl_pr_cycle` with the real five-command control plane:
+Default workflow uses `adl_pr_cycle` with the real authoring control plane:
 - `pr init`
-- `pr create`
 - `pr start`
 - `pr run`
 - `pr finish`

--- a/docs/tooling/adl_pr_cycle_skill.md
+++ b/docs/tooling/adl_pr_cycle_skill.md
@@ -1,6 +1,6 @@
 ---
 name: adl_pr_cycle
-description: Deterministic Codex.app workflow for the real ADL five-command control plane: pr init, pr create, pr start, pr run, and pr finish, with bounded editor-adapter truth and required reporting.
+description: Deterministic Codex.app workflow for the real ADL authoring control plane: pr init, pr start, pr run, and pr finish, with bounded editor-adapter truth and required reporting.
 ---
 
 # adl_pr_cycle
@@ -34,7 +34,7 @@ Inputs:
 
 Hard guardrails:
 1) Deterministic state machine only:
-   preflight -> init -> create -> start -> codex -> run_if_required -> finish -> report
+   preflight -> issue_ready -> init -> start -> codex -> run_if_required -> finish -> report
 2) Never work on main.
 3) Use the repo-local execution clone when available:
    .worktrees/adl-wp-<issue_num>
@@ -48,7 +48,7 @@ Hard guardrails:
 7) Always produce a report file even on failure.
 8) Browser/editor direct support remains bounded to:
    adl/tools/editor_action.sh start
-   Do not imply direct browser/editor invocation of pr init, pr create, pr run, or pr finish.
+   Do not imply direct browser/editor invocation of pr init, pr run, or pr finish.
 
 Procedure:
 1) Preflight
@@ -68,10 +68,9 @@ Procedure:
    - Run:
      bash ./adl/tools/pr.sh init <issue_num> --slug <slug> [--version <version>]
    - Confirm canonical STP exists at <stp_path>.
-3) Create
-   - Run:
-     bash ./adl/tools/pr.sh create <issue_num> --stp <stp_path>
-   - Confirm GitHub issue/body reconciliation used the canonical STP rather than a parallel source.
+3) Issue-ready check
+   - Confirm the GitHub issue already exists and matches the intended issue_num.
+   - Do not invoke `pr create`; issue creation/reconciliation is outside the ADL command surface.
 4) Start
    - Run:
      bash ./adl/tools/pr.sh start <issue_num> --slug <slug> [--version <version>]
@@ -107,7 +106,7 @@ Procedure:
      - Exactly one next action command
 
 Truth boundaries:
-- The five-command control-plane exists in repo truth.
+- The active authoring control-plane exists in repo truth.
 - The browser/editor adapter remains narrower than the full control plane.
 - Use docs/tooling/editor/command_adapter.md and docs/tooling/editor/five_command_demo.md as the canonical proof surfaces for that boundary.
 - Use bash adl/tools/test_five_command_regression_suite.sh as the canonical regression proof surface for the full implemented lifecycle.

--- a/docs/tooling/editor/README.md
+++ b/docs/tooling/editor/README.md
@@ -48,8 +48,8 @@ The editor is intentionally simple:
 ## What It Does Not Do Yet
 
 - it does not write files directly
-- it does not replace `pr create`, `pr start`, `pr run`, or `pr finish`
-- it does not imply direct browser invocation for the full five-command lifecycle
+- it does not replace `pr start`, `pr run`, or `pr finish`
+- it does not imply direct browser invocation for the full authoring lifecycle
 - it does not yet provide the full SOR decision loop or acceptance workflow
 - it does not try to replace human review judgment with browser-only automation
 - it does not yet execute the control plane directly from browser JS

--- a/docs/tooling/editor/command_adapter.md
+++ b/docs/tooling/editor/command_adapter.md
@@ -24,7 +24,6 @@ The browser/editor may:
 The browser/editor may not claim direct browser invocation of:
 
 - `pr init`
-- `pr create`
 - `pr run`
 - `pr finish`
 
@@ -47,7 +46,6 @@ That means:
 | Lifecycle command | Exists in repo | Browser-direct adapter support in v0.85 | Truthful near-term status |
 | --- | --- | --- | --- |
 | `pr init` | yes | no | control-plane only |
-| `pr create` | yes | no | control-plane only |
 | `pr start` | yes | yes, via `adl/tools/editor_action.sh start` | supported thin adapter |
 | `pr run` | yes | no | control-plane only |
 | `pr finish` | yes | no | control-plane only |

--- a/docs/tooling/editor/demo.md
+++ b/docs/tooling/editor/demo.md
@@ -66,7 +66,6 @@ It does not claim a finished browser-only workflow platform.
 ## Still Manual / Out Of Scope
 
 - `pr init` is not launched from the browser in this slice
-- `pr create` is not launched from the browser in this slice
 - `pr run` is not launched from the browser in this slice
 - `pr finish` is not launched from the browser in this slice
 - final review judgment is still human-made

--- a/docs/tooling/editor/five_command_demo.md
+++ b/docs/tooling/editor/five_command_demo.md
@@ -1,6 +1,6 @@
 # Five-Command Editing Demo
 
-This is the bounded, truthful proof surface for the full v0.85 five-command editing lifecycle.
+This is the bounded, truthful proof surface for the current v0.85 authoring lifecycle.
 
 Run:
 
@@ -11,11 +11,10 @@ Run:
 The demo exercises, in order:
 
 1. `pr init`
-2. `pr create`
-3. the validated editor adapter dry-run for `pr start`
-4. `pr start`
-5. `pr run`
-6. `pr finish`
+2. the validated editor adapter dry-run for `pr start`
+3. `pr start`
+4. `pr run`
+5. `pr finish`
 
 The adapter surface is truthful to the current editor contract:
 
@@ -43,7 +42,7 @@ The manifest records:
 
 - The demo uses mocked GitHub and mocked model-provider surfaces to keep the proof local and deterministic.
 - The editor/browser adapter remains thin and only prepares the `pr start` action.
-- The demo does not claim direct browser execution for `pr init`, `pr create`, `pr run`, or `pr finish`.
+- The demo does not claim direct browser execution for `pr init`, `pr run`, or `pr finish`.
 - The finish step intentionally uses `--no-checks` so the demo proves lifecycle sequencing and artifact linkage rather than full CI/validation throughput.
 
 ## Why This Counts
@@ -52,4 +51,4 @@ This is not a hidden parallel workflow. It uses the real `adl/tools/pr.sh` comma
 
 - `docs/tooling/editor/command_adapter.md`
 
-So it is a bounded but honest end-to-end proof of the current v0.85 editing story.
+So it is a bounded but honest end-to-end proof of the current v0.85 authoring story.

--- a/docs/tooling/editor/five_command_regression_suite.md
+++ b/docs/tooling/editor/five_command_regression_suite.md
@@ -8,20 +8,19 @@ Run:
 
 ## What It Covers
 
-The suite protects the shipped five-command surface and its truthful editor claims:
+The suite protects the shipped authoring surface and its truthful editor claims:
 
 1. `pr init`
-2. `pr create`
-3. `pr start`
-4. `pr run`
-5. `pr finish`
+2. `pr start`
+3. `pr run`
+4. `pr finish`
 
 It also verifies:
 
-- the installed `adl_pr_cycle` skill still matches the tracked contract and preserves the real five-command state machine
+- the installed `adl_pr_cycle` skill still matches the tracked contract and preserves the real authoring state machine
 - the browser/editor adapter remains bounded to `pr start`
 - the editor docs do not overclaim direct browser execution for the other commands
-- the bounded five-command demo still emits the expected lifecycle artifacts
+- the bounded demo still emits the expected lifecycle artifacts
 
 ## Suite Components
 

--- a/docs/tooling/structured-prompt-contracts.md
+++ b/docs/tooling/structured-prompt-contracts.md
@@ -152,7 +152,7 @@ This first contract layer does not attempt to solve all editing-control-plane va
 
 Deferred work includes:
 
-- full lifecycle enforcement across `pr init`, `pr create`, `pr run`, and `pr finish`
+- full lifecycle enforcement across `pr init`, `pr start`, `pr run`, and `pr finish`
 - migration of all historical artifacts
 - freezing high-value prose beyond section presence and selected stable scalars
 - full schema coverage for every future authoring/editor surface


### PR DESCRIPTION
Closes #1186

## Summary
Retired the overlapping `pr create` kickoff surface, made `pr init`/`pr start` the only live authoring bootstrap commands, and updated the command/docs/regression proof surfaces so repo truth matches the intended lifecycle.

## Artifacts
- updated command/control-plane surfaces in `adl/tools/pr.sh`, `adl/src/cli/pr_cmd.rs`, and `adl/src/cli/usage.rs`
- updated workflow/editor proof docs under `docs/`
- updated regression/demo coverage under `adl/tools/`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_create.sh`
    - verifies the retired `pr create` command fails clearly and points callers to `pr init` + `pr start`
  - `bash adl/tools/test_pr_issue_version_inference.sh`
    - verifies version inference still works through the surviving `init`/`start` lifecycle without falling back to `v0.3`
  - `bash adl/tools/test_pr_finish_relative_card_paths.sh`
    - verifies `pr finish` path hygiene still holds after removing `pr create`-era issue-body checks
  - `bash adl/tools/test_five_command_editor_truth.sh`
    - verifies help/docs/editor contract no longer advertise `pr create` as a live command
  - `bash adl/tools/test_demo_five_command_editing.sh`
    - verifies the bounded editor demo still works with the authoring lifecycle after `pr create` retirement
  - `bash adl/tools/test_five_command_regression_suite.sh`
    - verifies the end-to-end authoring regression proof surface remains green after the lifecycle change
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`
    - verifies the Rust-owned PR command surfaces still pass focused `pr_cmd` coverage
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verifies Rust formatting remains canonical
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verifies the Rust command/control-plane code is warning-free
- Results:
  - all listed commands passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1186__v0-86-tools-remove-overlapping-pr-create-bootstrap-behavior-and-consolidate-kickoff-into-pr-init-start/sip.md
- Output card: .adl/v0.86/tasks/issue-1186__v0-86-tools-remove-overlapping-pr-create-bootstrap-behavior-and-consolidate-kickoff-into-pr-init-start/sor.md
- Idempotency-Key: v0-86-tools-remove-overlapping-pr-create-bootstrap-behavior-and-consolidate-kickoff-into-pr-init-start-readme-md-adl-src-cli-pr-cmd-rs-adl-src-cli-usage-rs-adl-tools-burst-playbook-md-adl-tools-demo-five-command-editing-sh-adl-tools-editor-action-sh-adl-tools-pr-sh-adl-tools-test-demo-five-command-editing-sh-adl-tools-test-five-command-editor-truth-sh-adl-tools-test-five-command-regression-suite-sh-adl-tools-test-install-adl-pr-cycle-skill-sh-adl-tools-test-pr-create-sh-adl-tools-test-pr-finish-relative-card-paths-sh-adl-tools-test-pr-issue-version-inference-sh-docs-default-workflow-md-docs-onboarding-md-docs-tooling-adl-pr-cycle-skill-md-docs-tooling-editor-readme-md-docs-tooling-editor-command-adapter-md-docs-tooling-editor-demo-md-docs-tooling-editor-five-command-demo-md-docs-tooling-editor-five-command-regression-suite-md-docs-tooling-structured-prompt-contracts-md-adl-v0-86-tasks-issue-1186-v0-86-tools-remove-overlapping-pr-create-bootstrap-behavior-and-consolidate-kickoff-into-pr-init-start-sip-md-adl-v0-86-tasks-issue-1186-v0-86-tools-remove-overlapping-pr-create-bootstrap-behavior-and-consolidate-kickoff-into-pr-init-start-sor-md