### PR TITLE
[v0.86][tools] Add thin-shell pr.sh delegation and end-to-end parity tests for Rust control plane

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -101,7 +101,6 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
 
     match subcommand {
         "init" => real_pr_init(&args[1..]),
-        "create" => real_pr_create(&args[1..]),
         "start" => real_pr_start(&args[1..]),
         "ready" => real_pr_ready(&args[1..]),
         "preflight" => real_pr_preflight(&args[1..]),
@@ -644,13 +643,6 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     println!("  STATE    ISSUE_AND_BUNDLE_READY");
     eprintln!("• Done.");
     Ok(())
-}
-
-fn real_pr_create(args: &[String]) -> Result<()> {
-    let _ = args;
-    bail!(
-        "create: `adl pr create` is retired. Create or reconcile the GitHub issue outside ADL, then run `adl pr init <issue>` followed by `adl pr start <issue>`."
-    )
 }
 
 fn parse_init_args(args: &[String]) -> Result<InitArgs> {
@@ -2609,17 +2601,6 @@ verification_summary:
 
         let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
         assert!(err.to_string().contains("unknown pr subcommand: bogus"));
-    }
-
-    #[test]
-    fn real_pr_create_is_retired() {
-        let err = real_pr(&[
-            "create".to_string(),
-            "--title".to_string(),
-            "Example".to_string(),
-        ])
-        .expect_err("create should be retired");
-        assert!(err.to_string().contains("`adl pr create` is retired"));
     }
 
     #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -2952,7 +2952,6 @@ main() {
   case "$cmd" in
     help) usage ;;
     init) cmd_init "$@" ;;
-    create) cmd_create "$@" ;;
     new) cmd_new "$@" ;;
     run) cmd_run "$@" ;;
     start) cmd_start "$@" ;;

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -14,6 +14,7 @@ run_check() {
 
 run_check adl/tools/test_pr_init.sh
 run_check adl/tools/test_pr_create.sh
+run_check adl/tools/test_pr_finish_delegates_to_rust.sh
 run_check adl/tools/test_pr_start_template_validation.sh
 run_check adl/tools/test_install_adl_pr_cycle_skill.sh
 run_check adl/tools/test_pr_run.sh

--- a/adl/tools/test_pr_create.sh
+++ b/adl/tools/test_pr_create.sh
@@ -42,12 +42,10 @@ status=$?
 set -e
 
 [[ "$status" -ne 0 ]] || {
-  echo "assertion failed: expected pr.sh create to be retired" >&2
+  echo "assertion failed: expected pr.sh create to be unavailable" >&2
   exit 1
 }
 
-assert_contains '`pr create` is retired.' "$out" "retired notice"
-assert_contains 'adl/tools/pr.sh init <issue>' "$out" "init guidance"
-assert_contains 'adl/tools/pr.sh start <issue>' "$out" "start guidance"
+assert_contains 'Unknown command: create' "$out" "unknown command"
 
-echo "pr.sh create retirement: ok"
+echo "pr.sh create removal: ok"

--- a/adl/tools/test_pr_finish_delegates_to_rust.sh
+++ b/adl/tools/test_pr_finish_delegates_to_rust.sh
@@ -20,7 +20,7 @@ touch "$repo/adl/Cargo.toml"
 cat >"$mockbin/cargo" <<'EOF_CARGO'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" > "$TMP_CARGO_ARGS"
+printf '%s\n' "$*" >> "$TMP_CARGO_ARGS"
 EOF_CARGO
 chmod +x "$mockbin/cargo"
 
@@ -38,16 +38,63 @@ TMP_CARGO_ARGS="$tmpdir/cargo_args.txt"
 export TMP_CARGO_ARGS
 export PATH="$mockbin:$PATH"
 
-(
-  cd "$repo"
-  "$BASH_BIN" adl/tools/pr.sh finish 1153 --title "Example" --no-checks --no-open >/dev/null
-)
+run_and_capture() {
+  (
+    cd "$repo"
+    "$BASH_BIN" adl/tools/pr.sh "$@" >/dev/null
+  )
+}
+
+: >"$TMP_CARGO_ARGS"
+run_and_capture init 1151 --slug example --no-fetch-issue --version v0.86
+run_and_capture start 1152 --slug rust-start --no-fetch-issue --version v0.86 --allow-open-pr-wave
+run_and_capture ready 1152 --slug rust-start --no-fetch-issue --version v0.86
+run_and_capture preflight 1152 --slug rust-start --no-fetch-issue --version v0.86
+run_and_capture finish 1153 --title "Example" --no-checks --no-open
 
 args="$(cat "$TMP_CARGO_ARGS")"
+[[ "$args" == *"--bin adl -- pr init 1151 --slug example --no-fetch-issue --version v0.86"* ]] || {
+  echo "assertion failed: expected rust delegation for init" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"--bin adl -- pr start 1152 --slug rust-start --no-fetch-issue --version v0.86 --allow-open-pr-wave"* ]] || {
+  echo "assertion failed: expected rust delegation for start" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"--bin adl -- pr ready 1152 --slug rust-start --no-fetch-issue --version v0.86"* ]] || {
+  echo "assertion failed: expected rust delegation for ready" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"--bin adl -- pr preflight 1152 --slug rust-start --no-fetch-issue --version v0.86"* ]] || {
+  echo "assertion failed: expected rust delegation for preflight" >&2
+  echo "$args" >&2
+  exit 1
+}
 [[ "$args" == *"--bin adl -- pr finish 1153 --title Example --no-checks --no-open"* ]] || {
   echo "assertion failed: expected rust delegation for finish" >&2
   echo "$args" >&2
   exit 1
 }
 
-echo "pr.sh finish Rust delegation: ok"
+set +e
+create_out="$(
+  cd "$repo" &&
+  "$BASH_BIN" adl/tools/pr.sh create --title "retired path" 2>&1
+)"
+create_status=$?
+set -e
+
+[[ "$create_status" -ne 0 ]] || {
+  echo "assertion failed: create should not be exposed by pr.sh" >&2
+  exit 1
+}
+[[ "$create_out" == *"Unknown command: create"* ]] || {
+  echo "assertion failed: create should fail as an unknown command" >&2
+  echo "$create_out" >&2
+  exit 1
+}
+
+echo "pr.sh Rust delegation parity: ok"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -133,7 +133,7 @@ Write a per-issue report under:
 - Missing canonical STP:
   - Re-run `pr.sh init <issue_num> --slug <slug> --version v0.85`.
 - Stale GitHub issue body:
-  - Re-run `pr.sh create <issue_num> --stp .adl/v0.85/tasks/<task-id>__<slug>/stp.md`.
+  - Reconcile the GitHub issue outside `pr.sh`, then re-run `pr.sh init <issue_num>` if the local root bundle must be reseeded.
 - Missing card files:
   - Re-run `pr.sh start <issue_num> --slug <slug>` to seed canonical card paths.
 - Browser/editor overclaims:


### PR DESCRIPTION
Closes #1154

## Summary
Finished the thin-shell control-plane cleanup by removing `create` from the exposed `pr.sh` and Rust `adl pr` command surfaces, updating the active workflow docs accordingly, and adding a wrapper parity test that proves the supported shell commands delegate to Rust consistently.

## Artifacts
- Code:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/tools/pr.sh`
  - `adl/tools/test_pr_create.sh`
  - `adl/tools/test_pr_finish_delegates_to_rust.sh`
  - `adl/tools/test_five_command_regression_suite.sh`
  - `docs/default_workflow.md`
- Generated runtime artifacts: not_applicable for this tooling task

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_create.sh`
    Verified the removed command surface stays absent.
  - `bash adl/tools/test_pr_finish_delegates_to_rust.sh`
    Verified wrapper parity across the supported delegated commands.
  - `bash adl/tools/test_five_command_editor_truth.sh`
    Verified the public help/docs truth boundary.
  - `bash adl/tools/test_five_command_regression_suite.sh`
    Verified the broader authoring lifecycle regression suite.
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`
    Verified the Rust `pr` command suite.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified lint cleanliness.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatter cleanliness.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1154__v0-86-tools-add-thin-shell-pr-sh-delegation-and-end-to-end-parity-tests-for-rust-control-plane/sip.md
- Output card: .adl/v0.86/tasks/issue-1154__v0-86-tools-add-thin-shell-pr-sh-delegation-and-end-to-end-parity-tests-for-rust-control-plane/sor.md
- Idempotency-Key: v0-86-tools-add-thin-shell-pr-sh-delegation-and-end-to-end-parity-tests-for-rust-control-plane-adl-src-cli-pr-cmd-rs-adl-tools-pr-sh-adl-tools-test-five-command-regression-suite-sh-adl-tools-test-pr-create-sh-adl-tools-test-pr-finish-delegates-to-rust-sh-docs-default-workflow-md-adl-v0-86-tasks-issue-1154-v0-86-tools-add-thin-shell-pr-sh-delegation-and-end-to-end-parity-tests-for-rust-control-plane-sip-md-adl-v0-86-tasks-issue-1154-v0-86-tools-add-thin-shell-pr-sh-delegation-and-end-to-end-parity-tests-for-rust-control-plane-sor-md