### PR TITLE
[v0.86][tools] Make pr.sh ready trust actual codex worktree branch for started issues

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -7,7 +7,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use ::adl::control_plane::{
-    card_input_path, card_output_path, resolve_cards_root, sanitize_slug, IssueRef,
+    card_input_path, card_output_path, resolve_cards_root, resolve_primary_checkout_root,
+    sanitize_slug, IssueRef,
 };
 
 const DEFAULT_VERSION: &str = "v0.86";
@@ -210,7 +211,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
 
 fn real_pr_ready(args: &[String]) -> Result<()> {
     let parsed = parse_ready_args(args)?;
-    let repo_root = repo_root()?;
+    let repo_root = primary_checkout_root()?;
     let repo = default_repo(&repo_root)?;
 
     let (version, slug) =
@@ -901,8 +902,22 @@ fn require_value(args: &[String], index: usize, cmd: &str, flag: &str) -> Result
 }
 
 fn repo_root() -> Result<PathBuf> {
-    let out = run_capture("git", &["rev-parse", "--show-toplevel"])?;
-    Ok(PathBuf::from(out.trim()))
+    let current_top = PathBuf::from(run_capture("git", &["rev-parse", "--show-toplevel"])?.trim());
+    Ok(current_top)
+}
+
+fn primary_checkout_root() -> Result<PathBuf> {
+    let current_top = repo_root()?;
+    let common_dir = run_capture_allow_failure("git", &["rev-parse", "--git-common-dir"])?;
+    let common_dir = common_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    Ok(resolve_primary_checkout_root(
+        &current_top,
+        common_dir.as_deref(),
+    ))
 }
 
 fn path_str(path: &Path) -> Result<&str> {
@@ -2895,6 +2910,113 @@ verification_summary:
         assert!(card_output_path(&root_cards, 1152)
             .symlink_metadata()
             .is_ok());
+    }
+
+    #[test]
+    fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let temp = unique_temp_dir("adl-pr-ready-worktree-cwd");
+        let origin = temp.join("origin.git");
+        let repo = temp.join("repo");
+        fs::create_dir_all(&repo).expect("repo dir");
+        copy_bootstrap_support_files(&repo);
+        init_git_repo(&repo);
+        assert!(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo)
+            .status()
+            .expect("git config")
+            .success());
+        assert!(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo)
+            .status()
+            .expect("git config")
+            .success());
+        fs::write(repo.join("README.md"), "ready from worktree\n").expect("seed file");
+        assert!(Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(&repo)
+            .status()
+            .expect("git add")
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(&repo)
+            .status()
+            .expect("git commit")
+            .success());
+        assert!(Command::new("git")
+            .args(["branch", "-M", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git branch")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "init",
+                "--bare",
+                "-q",
+                path_str(&origin).expect("origin path"),
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git init bare")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "remote",
+                "set-url",
+                "origin",
+                path_str(&origin).expect("origin path"),
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git remote set-url")
+            .success());
+        assert!(Command::new("git")
+            .args(["push", "-q", "-u", "origin", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git push")
+            .success());
+        assert!(Command::new("git")
+            .args(["fetch", "-q", "origin", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git fetch")
+            .success());
+
+        let prev_dir = env::current_dir().expect("cwd");
+        env::set_current_dir(&repo).expect("chdir");
+        real_pr(&[
+            "start".to_string(),
+            "1198".to_string(),
+            "--slug".to_string(),
+            "ready-worktree-cwd".to_string(),
+            "--title".to_string(),
+            "[v0.86][tools] Ready worktree cwd".to_string(),
+            "--no-fetch-issue".to_string(),
+            "--version".to_string(),
+            "v0.86".to_string(),
+        ])
+        .expect("real_pr start");
+        let issue_ref = IssueRef::new(1198, "v0.86", "ready-worktree-cwd").expect("issue ref");
+        let worktree = issue_ref.default_worktree_path(&repo, None);
+        env::set_current_dir(&worktree).expect("chdir worktree");
+
+        let ready = real_pr(&[
+            "ready".to_string(),
+            "1198".to_string(),
+            "--slug".to_string(),
+            "ready-worktree-cwd".to_string(),
+            "--no-fetch-issue".to_string(),
+            "--version".to_string(),
+            "v0.86".to_string(),
+        ]);
+
+        env::set_current_dir(prev_dir).expect("restore cwd");
+        ready.expect("ready from worktree");
     }
 
     #[test]

--- a/adl/src/control_plane.rs
+++ b/adl/src/control_plane.rs
@@ -130,20 +130,6 @@ pub fn sanitize_slug(raw: impl AsRef<str>) -> String {
 }
 
 pub fn resolve_primary_checkout_root(current_top: &Path, git_common_dir: Option<&Path>) -> PathBuf {
-    let current_base = current_top.file_name().and_then(|name| name.to_str());
-    let current_parent = current_top
-        .parent()
-        .and_then(|parent| parent.file_name())
-        .and_then(|name| name.to_str());
-
-    if current_parent == Some(".worktrees")
-        && current_base
-            .map(|name| name.starts_with("adl-wp-"))
-            .unwrap_or(false)
-    {
-        return current_top.to_path_buf();
-    }
-
     let Some(common_dir) = git_common_dir else {
         return current_top.to_path_buf();
     };
@@ -154,16 +140,31 @@ pub fn resolve_primary_checkout_root(current_top: &Path, git_common_dir: Option<
         current_top.join(common_dir)
     };
 
-    let shared_root = common_abs
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| current_top.to_path_buf());
-
-    if current_top != shared_root {
-        return current_top.to_path_buf();
+    if common_abs.file_name().and_then(|name| name.to_str()) == Some(".git") {
+        return common_abs
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| current_top.to_path_buf());
     }
 
-    shared_root
+    let worktrees_dir = common_abs.parent();
+    let git_dir = worktrees_dir.and_then(Path::parent);
+    if worktrees_dir
+        .and_then(|path| path.file_name())
+        .and_then(|name| name.to_str())
+        == Some("worktrees")
+        && git_dir
+            .and_then(|path| path.file_name())
+            .and_then(|name| name.to_str())
+            == Some(".git")
+    {
+        return git_dir
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| current_top.to_path_buf());
+    }
+
+    current_top.to_path_buf()
 }
 
 pub fn resolve_cards_root(
@@ -271,13 +272,13 @@ mod tests {
     }
 
     #[test]
-    fn primary_checkout_root_uses_current_worktree_for_repo_local_worktrees() {
+    fn primary_checkout_root_resolves_primary_checkout_for_repo_local_worktrees() {
         let current_top = Path::new("/repo/.worktrees/adl-wp-200");
         let common = Path::new("/repo/.git/worktrees/adl-wp-200");
 
         assert_eq!(
             resolve_primary_checkout_root(current_top, Some(common)),
-            PathBuf::from("/repo/.worktrees/adl-wp-200")
+            PathBuf::from("/repo")
         );
     }
 


### PR DESCRIPTION
Closes #1198

## Summary
Moved the remaining `ready` repo-root logic into Rust so a started repo-local worktree resolves canonical source/task surfaces from the primary checkout. Added a real regression that invokes `ready` from inside a started worktree and proved the shell path against `#1137`.

## Artifacts
- Updated Rust control-plane path resolution in `adl/src/control_plane.rs`
- Updated Rust `ready` command root detection in `adl/src/cli/pr_cmd.rs`
- Added `real_pr_ready_succeeds_when_invoked_from_started_worktree`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml primary_checkout_root_resolves_primary_checkout_for_repo_local_worktrees -- --nocapture`
    verifies repo-local worktrees resolve back to the primary checkout root
  - `cargo test --manifest-path adl/Cargo.toml real_pr_ready_succeeds_when_invoked_from_started_worktree -- --nocapture`
    proves `ready` succeeds when invoked from inside a started worktree
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`
    checks the broader Rust PR command surface after the fix
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    verifies lint-clean Rust control-plane changes
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    verifies formatting
  - `bash ./adl/tools/pr.sh ready 1137 --slug v0-86-wp-10-implement-frame-adequacy-and-reframing --version v0.86`
    confirms the real shell path now passes from inside `adl-wp-1198`
- Results:
  - all commands passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1198__v0-86-tools-make-pr-sh-ready-trust-actual-codex-worktree-branch-for-started-issues/sip.md
- Output card: .adl/v0.86/tasks/issue-1198__v0-86-tools-make-pr-sh-ready-trust-actual-codex-worktree-branch-for-started-issues/sor.md
- Idempotency-Key: v0-86-tools-make-pr-sh-ready-trust-actual-codex-worktree-branch-for-started-issues-adl-v0-86-tasks-issue-1198-v0-86-tools-make-pr-sh-ready-trust-actual-codex-worktree-branch-for-started-issues-sip-md-adl-v0-86-tasks-issue-1198-v0-86-tools-make-pr-sh-ready-trust-actual-codex-worktree-branch-for-started-issues-sor-md