### PR TITLE
[v0.86][WP-10] Implement frame adequacy and reframing

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -143,6 +143,11 @@ impl RunArtifactPaths {
         self.learning_dir().join("evaluation_signals.v1.json")
     }
 
+    /// Reframing artifact path for v0.86 bounded frame adequacy and reframing.
+    pub fn reframing_json(&self) -> PathBuf {
+        self.learning_dir().join("reframing.v1.json")
+    }
+
     /// Affect state artifact path for bounded affect-guided adaptation.
     pub fn affect_state_json(&self) -> PathBuf {
         self.learning_dir().join("affect_state.v1.json")

--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -18,6 +18,7 @@ pub(crate) const FAST_SLOW_PATH_VERSION: u32 = 1;
 pub(crate) const AGENCY_SELECTION_VERSION: u32 = 1;
 pub(crate) const BOUNDED_EXECUTION_VERSION: u32 = 1;
 pub(crate) const EVALUATION_SIGNALS_VERSION: u32 = 1;
+pub(crate) const REFRAMING_VERSION: u32 = 1;
 pub(crate) const REASONING_GRAPH_VERSION: u32 = 1;
 pub(crate) const CLUSTER_GROUNDWORK_VERSION: u32 = 1;
 
@@ -468,6 +469,26 @@ pub(crate) struct EvaluationSignalsArtifact {
 }
 
 pub(crate) type EvaluationControlState = execute::EvaluationControlState;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReframingArtifact {
+    pub(crate) reframing_version: u32,
+    pub(crate) run_id: String,
+    pub(crate) generated_from: AeeDecisionGeneratedFrom,
+    pub(crate) selected_candidate_id: String,
+    pub(crate) selected_path: String,
+    pub(crate) frame_adequacy_score: u32,
+    pub(crate) reframing_trigger: String,
+    pub(crate) reframing_reason: String,
+    pub(crate) prior_frame: String,
+    pub(crate) new_frame: String,
+    pub(crate) reexecution_choice: String,
+    pub(crate) post_reframe_state: String,
+    pub(crate) deterministic_reframing_rule: String,
+}
+
+pub(crate) type ReframingControlState = execute::ReframingControlState;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1990,6 +2011,37 @@ pub(crate) fn build_evaluation_signals_artifact(
     }
 }
 
+pub(crate) fn build_reframing_artifact(
+    run_summary: &RunSummaryArtifact,
+    fast_slow_path: &FastSlowPathArtifact,
+    agency_selection: &AgencySelectionArtifact,
+    state: &ReframingControlState,
+    scores: Option<&ScoresArtifact>,
+) -> ReframingArtifact {
+    ReframingArtifact {
+        reframing_version: REFRAMING_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+            suggestions_version: agency_selection.generated_from.suggestions_version,
+            scores_version: scores.map(|value| value.scores_version),
+        },
+        selected_candidate_id: agency_selection.selected_candidate_id.clone(),
+        selected_path: fast_slow_path.selected_path.clone(),
+        frame_adequacy_score: state.frame_adequacy_score,
+        reframing_trigger: state.reframing_trigger.clone(),
+        reframing_reason: state.reframing_reason.clone(),
+        prior_frame: state.prior_frame.clone(),
+        new_frame: state.new_frame.clone(),
+        reexecution_choice: state.reexecution_choice.clone(),
+        post_reframe_state: state.post_reframe_state.clone(),
+        deterministic_reframing_rule:
+            "derive bounded frame adequacy, reframing trigger, and re-execution choice from execute-owned evaluation and bounded execution state without hidden retry loops"
+                .to_string(),
+    }
+}
+
 pub(crate) fn build_aee_decision_artifact(
     run_summary: &RunSummaryArtifact,
     suggestions: &SuggestionsArtifact,
@@ -2397,6 +2449,13 @@ pub(crate) fn write_run_state_artifacts(
         &runtime_control.evaluation,
         Some(&scores_for_suggestions),
     );
+    let reframing = build_reframing_artifact(
+        &run_summary,
+        &fast_slow_path,
+        &agency_selection,
+        &runtime_control.reframing,
+        Some(&scores_for_suggestions),
+    );
     let cognitive_arbitration_json = serde_json::to_vec_pretty(&cognitive_arbitration)
         .context("serialize cognitive_arbitration.v1.json")?;
     let fast_slow_path_json =
@@ -2407,6 +2466,8 @@ pub(crate) fn write_run_state_artifacts(
         .context("serialize bounded_execution.v1.json")?;
     let evaluation_signals_json = serde_json::to_vec_pretty(&evaluation_signals)
         .context("serialize evaluation_signals.v1.json")?;
+    let reframing_json =
+        serde_json::to_vec_pretty(&reframing).context("serialize reframing.v1.json")?;
     let aee_decision = build_aee_decision_artifact(
         &run_summary,
         &suggestions,
@@ -2442,6 +2503,7 @@ pub(crate) fn write_run_state_artifacts(
         &run_paths.evaluation_signals_json(),
         &evaluation_signals_json,
     )?;
+    artifacts::atomic_write(&run_paths.reframing_json(), &reframing_json)?;
     artifacts::atomic_write(&run_paths.cognitive_signals_json(), &cognitive_signals_json)?;
     artifacts::atomic_write(
         &run_paths.cognitive_arbitration_json(),
@@ -2454,6 +2516,7 @@ pub(crate) fn write_run_state_artifacts(
         &run_paths.evaluation_signals_json(),
         &evaluation_signals_json,
     )?;
+    artifacts::atomic_write(&run_paths.reframing_json(), &reframing_json)?;
     artifacts::atomic_write(&run_paths.affect_state_json(), &affect_state_json)?;
     artifacts::atomic_write(&run_paths.aee_decision_json(), &aee_decision_json)?;
     artifacts::atomic_write(&run_paths.reasoning_graph_json(), &reasoning_graph_json)?;

--- a/adl/src/cli/tests/artifact_builders.rs
+++ b/adl/src/cli/tests/artifact_builders.rs
@@ -1572,6 +1572,274 @@ fn build_evaluation_signals_artifact_is_deterministic_and_emits_termination_reas
 }
 
 #[test]
+fn build_reframing_artifact_is_deterministic_and_distinguishes_triggered_paths() {
+    let success_summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "reframing-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "success".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 0,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            evaluation_signals_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let success_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "reframing-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 1.0,
+            failure_count: 0,
+            retry_count: 0,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let success_suggestions = build_suggestions_artifact(&success_summary, Some(&success_scores));
+    let success_signals = run_artifacts::build_cognitive_signals_artifact(
+        &success_summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_affect = run_artifacts::build_affect_state_artifact(
+        &success_summary,
+        &success_suggestions,
+        Some(&success_scores),
+    );
+    let success_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &success_summary,
+        &success_suggestions,
+        &success_signals,
+        &success_affect,
+        Some(&success_scores),
+    );
+    let success_path_state = run_artifacts::build_fast_slow_path_state(&success_arbitration);
+    let success_path = run_artifacts::build_fast_slow_path_artifact(
+        &success_summary,
+        &success_arbitration,
+        &success_path_state,
+        Some(&success_scores),
+    );
+    let success_agency_state = run_artifacts::build_agency_selection_state(
+        &success_signals,
+        &success_arbitration,
+        &success_path_state,
+        &success_path,
+    );
+    let success_agency = run_artifacts::build_agency_selection_artifact(
+        &success_summary,
+        &success_arbitration,
+        &success_agency_state,
+        Some(&success_scores),
+    );
+
+    let success_reframing = execute::ReframingControlState {
+        frame_adequacy_score: 88,
+        reframing_trigger: "not_triggered".to_string(),
+        reframing_reason: "current_frame_adequate_for_bounded_progress".to_string(),
+        prior_frame: "direct_execution_under_current_frame".to_string(),
+        new_frame: "retain_current_frame".to_string(),
+        reexecution_choice: "no_reframe_required".to_string(),
+        post_reframe_state: "complete_run".to_string(),
+    };
+    let success_left = run_artifacts::build_reframing_artifact(
+        &success_summary,
+        &success_path,
+        &success_agency,
+        &success_reframing,
+        Some(&success_scores),
+    );
+    let success_right = run_artifacts::build_reframing_artifact(
+        &success_summary,
+        &success_path,
+        &success_agency,
+        &success_reframing,
+        Some(&success_scores),
+    );
+    assert_eq!(
+        serde_json::to_value(&success_left).expect("success reframing value"),
+        serde_json::to_value(&success_right).expect("success reframing value")
+    );
+    assert_eq!(success_left.reframing_trigger, "not_triggered");
+    assert_eq!(success_left.frame_adequacy_score, 88);
+
+    let failure_summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "reframing-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.86".to_string(),
+        swarm_version: "test".to_string(),
+        status: "failure".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 1,
+            failed_steps: 1,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            evaluation_signals_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let failure_scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "reframing-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.0,
+            failure_count: 1,
+            retry_count: 1,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let failure_suggestions = build_suggestions_artifact(&failure_summary, Some(&failure_scores));
+    let failure_signals = run_artifacts::build_cognitive_signals_artifact(
+        &failure_summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_affect = run_artifacts::build_affect_state_artifact(
+        &failure_summary,
+        &failure_suggestions,
+        Some(&failure_scores),
+    );
+    let failure_arbitration = run_artifacts::build_cognitive_arbitration_artifact(
+        &failure_summary,
+        &failure_suggestions,
+        &failure_signals,
+        &failure_affect,
+        Some(&failure_scores),
+    );
+    let failure_path_state = run_artifacts::build_fast_slow_path_state(&failure_arbitration);
+    let failure_path = run_artifacts::build_fast_slow_path_artifact(
+        &failure_summary,
+        &failure_arbitration,
+        &failure_path_state,
+        Some(&failure_scores),
+    );
+    let failure_agency_state = run_artifacts::build_agency_selection_state(
+        &failure_signals,
+        &failure_arbitration,
+        &failure_path_state,
+        &failure_path,
+    );
+    let failure_agency = run_artifacts::build_agency_selection_artifact(
+        &failure_summary,
+        &failure_arbitration,
+        &failure_agency_state,
+        Some(&failure_scores),
+    );
+    let failure_reframing = execute::ReframingControlState {
+        frame_adequacy_score: 28,
+        reframing_trigger: "triggered".to_string(),
+        reframing_reason: "contradiction_detected_after_bounded_execution".to_string(),
+        prior_frame: "review_and_refine_under_current_frame".to_string(),
+        new_frame: "diagnose_and_restructure_before_retry".to_string(),
+        reexecution_choice: "bounded_reframe_and_retry".to_string(),
+        post_reframe_state: "ready_for_reframed_execution".to_string(),
+    };
+    let failure_artifact = run_artifacts::build_reframing_artifact(
+        &failure_summary,
+        &failure_path,
+        &failure_agency,
+        &failure_reframing,
+        Some(&failure_scores),
+    );
+    assert_eq!(failure_artifact.reframing_trigger, "triggered");
+    assert_eq!(
+        failure_artifact.reexecution_choice,
+        "bounded_reframe_and_retry"
+    );
+    assert_ne!(
+        success_left.frame_adequacy_score,
+        failure_artifact.frame_adequacy_score
+    );
+}
+
+#[test]
 fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
     let summary = RunSummaryArtifact {
         run_summary_version: 1,

--- a/adl/src/cli/tests/run_state.rs
+++ b/adl/src/cli/tests/run_state.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::run_artifacts;
 use crate::cli::run_artifacts::{
     AgencySelectionArtifact, BoundedExecutionArtifact, CognitiveArbitrationArtifact,
     CognitiveSignalsArtifact, EvaluationSignalsArtifact, FastSlowPathArtifact,
@@ -123,6 +124,53 @@ fn runtime_control_for(status: &str, tr: &trace::Trace) -> execute::RuntimeContr
     execute::derive_runtime_control_state(status, &[], tr)
 }
 
+#[test]
+fn derive_runtime_control_state_triggers_reframing_on_failure() {
+    let tr = trace::Trace::new(
+        "runtime-reframing-failure".to_string(),
+        "wf".to_string(),
+        "0.86".to_string(),
+    );
+    let records = vec![execute::StepExecutionRecord {
+        step_id: "s1".to_string(),
+        provider_id: "p1".to_string(),
+        status: "failure".to_string(),
+        attempts: 2,
+        output_bytes: 0,
+    }];
+    let runtime_control = execute::derive_runtime_control_state("failure", &records, &tr);
+    assert_eq!(
+        runtime_control.evaluation.next_control_action,
+        "handoff_to_reframing"
+    );
+    assert_eq!(runtime_control.reframing.reframing_trigger, "triggered");
+    assert_eq!(
+        runtime_control.reframing.reexecution_choice,
+        "bounded_reframe_and_retry"
+    );
+    assert!(
+        runtime_control.reframing.frame_adequacy_score < 50,
+        "failure should lower the frame adequacy score"
+    );
+}
+
+#[test]
+fn derive_runtime_control_state_retains_current_frame_on_success() {
+    let tr = trace::Trace::new(
+        "runtime-reframing-success".to_string(),
+        "wf".to_string(),
+        "0.86".to_string(),
+    );
+    let runtime_control = runtime_control_for("success", &tr);
+    assert_eq!(
+        runtime_control.evaluation.next_control_action,
+        "complete_run"
+    );
+    assert_eq!(runtime_control.reframing.reframing_trigger, "not_triggered");
+    assert_eq!(runtime_control.reframing.new_frame, "retain_current_frame");
+    assert_eq!(runtime_control.reframing.post_reframe_state, "complete_run");
+}
+
 fn custom_runtime_control() -> execute::RuntimeControlState {
     execute::RuntimeControlState {
         signals: execute::CognitiveSignalsState {
@@ -206,6 +254,15 @@ fn custom_runtime_control() -> execute::RuntimeControlState {
             termination_reason: "contradiction_detected".to_string(),
             behavior_effect: "surface contradiction for bounded follow-up".to_string(),
             next_control_action: "handoff_to_reframing".to_string(),
+        },
+        reframing: execute::ReframingControlState {
+            frame_adequacy_score: 24,
+            reframing_trigger: "triggered".to_string(),
+            reframing_reason: "contradiction_detected_after_bounded_execution".to_string(),
+            prior_frame: "review_and_refine_under_current_frame".to_string(),
+            new_frame: "diagnose_and_restructure_before_retry".to_string(),
+            reexecution_choice: "bounded_reframe_and_retry".to_string(),
+            post_reframe_state: "ready_for_reframed_execution".to_string(),
         },
     }
 }
@@ -369,6 +426,15 @@ fn write_run_state_artifacts_projects_execute_owned_runtime_control_state() {
         evaluation.behavior_effect,
         "surface contradiction for bounded follow-up"
     );
+
+    let reframing: run_artifacts::ReframingArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("learning/reframing.v1.json"))
+            .expect("read reframing artifact"),
+    )
+    .expect("parse reframing artifact");
+    assert_eq!(reframing.frame_adequacy_score, 24);
+    assert_eq!(reframing.reframing_trigger, "triggered");
+    assert_eq!(reframing.reexecution_choice, "bounded_reframe_and_retry");
 
     let _ = std::fs::remove_dir_all(run_dir);
     let _ = std::fs::remove_dir_all(out_dir);

--- a/adl/src/execute/state.rs
+++ b/adl/src/execute/state.rs
@@ -160,6 +160,7 @@ pub struct RuntimeControlState {
     pub agency: AgencySelectionState,
     pub bounded_execution: BoundedExecutionState,
     pub evaluation: EvaluationControlState,
+    pub reframing: ReframingControlState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -253,6 +254,18 @@ pub struct EvaluationControlState {
     pub termination_reason: String,
     pub behavior_effect: String,
     pub next_control_action: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReframingControlState {
+    pub frame_adequacy_score: u32,
+    pub reframing_trigger: String,
+    pub reframing_reason: String,
+    pub prior_frame: String,
+    pub new_frame: String,
+    pub reexecution_choice: String,
+    pub post_reframe_state: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -398,6 +411,8 @@ pub fn derive_runtime_control_state(
     let agency = derive_agency_selection_state(&signals, &arbitration, &fast_slow);
     let bounded_execution = derive_bounded_execution_state(overall_status, &agency);
     let evaluation = derive_evaluation_control_state(overall_status, &bounded_execution);
+    let reframing =
+        derive_reframing_control_state(&fast_slow, &agency, &bounded_execution, &evaluation);
 
     RuntimeControlState {
         signals,
@@ -406,6 +421,7 @@ pub fn derive_runtime_control_state(
         agency,
         bounded_execution,
         evaluation,
+        reframing,
     }
 }
 
@@ -926,6 +942,88 @@ fn derive_evaluation_control_state(
         termination_reason: termination_reason.to_string(),
         behavior_effect: behavior_effect.to_string(),
         next_control_action: next_control_action.to_string(),
+    }
+}
+
+fn derive_reframing_control_state(
+    fast_slow: &FastSlowPathState,
+    agency: &AgencySelectionState,
+    bounded_execution: &BoundedExecutionState,
+    evaluation: &EvaluationControlState,
+) -> ReframingControlState {
+    let prior_frame = match fast_slow.selected_path.as_str() {
+        "fast_path" => "direct_execution_under_current_frame",
+        _ => "review_and_refine_under_current_frame",
+    };
+
+    let (
+        frame_adequacy_score,
+        reframing_trigger,
+        reframing_reason,
+        new_frame,
+        reexecution_choice,
+        post_reframe_state,
+    ) = match evaluation.next_control_action.as_str() {
+        "handoff_to_reframing" => {
+            let reason = if evaluation.contradiction_signal == "present" {
+                "contradiction_detected_after_bounded_execution"
+            } else if evaluation.failure_signal != "none" {
+                "bounded_failure_after_execution"
+            } else {
+                "frame_inadequate_for_bounded_progress"
+            };
+            let score = if bounded_execution.iterations.len() > 1 {
+                28
+            } else {
+                40
+            };
+            (
+                score,
+                "triggered",
+                reason,
+                "diagnose_and_restructure_before_retry",
+                if agency.selected_candidate_kind == "review_and_refine" {
+                    "bounded_reframe_and_retry"
+                } else {
+                    "bounded_reframe_then_review"
+                },
+                "ready_for_reframed_execution",
+            )
+        }
+        "terminate_with_failure" => (
+            36,
+            "not_triggered",
+            "failure_detected_but_retry_budget_not_justified",
+            "retain_current_frame",
+            "terminate_without_reframe",
+            "terminate_with_failure",
+        ),
+        "await_resume" => (
+            58,
+            "not_triggered",
+            "pause_boundary_preserves_current_frame_until_resume",
+            "retain_current_frame",
+            "await_resume",
+            "await_resume",
+        ),
+        _ => (
+            88,
+            "not_triggered",
+            "current_frame_adequate_for_bounded_progress",
+            "retain_current_frame",
+            "no_reframe_required",
+            "complete_run",
+        ),
+    };
+
+    ReframingControlState {
+        frame_adequacy_score,
+        reframing_trigger: reframing_trigger.to_string(),
+        reframing_reason: reframing_reason.to_string(),
+        prior_frame: prior_frame.to_string(),
+        new_frame: new_frame.to_string(),
+        reexecution_choice: reexecution_choice.to_string(),
+        post_reframe_state: post_reframe_state.to_string(),
     }
 }
 

--- a/docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md
+++ b/docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md
@@ -206,6 +206,7 @@ For the implemented `v0.86` runtime surface:
 
 - `bounded_execution.v1.json` records the bounded execution handoff and iteration shape
 - `evaluation_signals.v1.json` records evaluation signals and the explicit `termination_reason`
+- `reframing.v1.json` records `frame_adequacy_score`, `reframing_trigger`, `reframing_reason`, and the bounded re-execution or termination choice
 - termination is emitted as a bounded control output, not inferred from prose or hidden state
 
 ## Frame Adequacy and Reframing Notes
@@ -232,8 +233,9 @@ At minimum, the loop must emit artifacts showing:
 - instinct inputs
 - affect signals
 - route_selected
-- bounded frame-adequacy signal or note when used
+- bounded frame-adequacy signal
 - reframing trigger (if any)
+- reframing reason and bounded re-execution or termination choice
 - termination_reason
 
 Artifacts must be:


### PR DESCRIPTION
Closes #1137

## Summary
Implemented execute-owned bounded frame adequacy assessment and reframing for WP-10.

The runtime control state now carries an explicit reframing stage after evaluation, and artifact emission now writes a canonical `reframing.v1.json` proof surface containing `frame_adequacy_score`, `reframing_trigger`, `reframing_reason`, `prior_frame`, `new_frame`, `reexecution_choice`, and `post_reframe_state`.

The implementation keeps the behavior bounded:
- success retains the current frame and completes the run
- bounded failure after reviewed execution triggers reframing and emits a bounded reframe-and-retry choice
- direct failure without enough retry value terminates without reframing

## Artifacts
- `adl/src/execute/state.rs`
- `adl/src/cli/run_artifacts.rs`
- `adl/src/artifacts.rs`
- `adl/src/cli/tests/run_state.rs`
- `adl/src/cli/tests/artifact_builders.rs`
- `docs/milestones/v0.86/features/COGNITIVE_LOOP_MODEL.md`
- canonical proof artifact path: `.adl/runs/<run_id>/learning/reframing.v1.json`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml run_state -- --nocapture`
    verifies execute-owned runtime control derivation and run artifact projection, including reframing-trigger behavior
  - `cargo test --manifest-path adl/Cargo.toml artifact_builders -- --nocapture`
    verifies deterministic reframing artifact construction and triggered vs retained-frame differentiation
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    verifies formatting consistency on all touched Rust surfaces
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    verifies the implementation is lint-clean under repo policy
- Results:
  - all listed validation commands passed locally
  - no additional schema or runtime failures remained after the targeted fixes

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1137__v0-86-wp-10-implement-frame-adequacy-and-reframing/sip.md
- Output card: .adl/v0.86/tasks/issue-1137__v0-86-wp-10-implement-frame-adequacy-and-reframing/sor.md
- Idempotency-Key: v0-86-wp-10-implement-frame-adequacy-and-reframing-adl-src-artifacts-rs-adl-src-cli-run-artifacts-rs-adl-src-cli-tests-artifact-builders-rs-adl-src-cli-tests-run-state-rs-adl-src-execute-state-rs-docs-milestones-v0-86-features-cognitive-loop-model-md-adl-v0-86-tasks-issue-1137-v0-86-wp-10-implement-frame-adequacy-and-reframing-sip-md-adl-v0-86-tasks-issue-1137-v0-86-wp-10-implement-frame-adequacy-and-reframing-sor-md