### PR TITLE
[v0.86][tools] Make pr ready fast and avoid cargo startup contention

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -149,13 +149,62 @@ require_cmd() {
 
 rust_pr_delegate_available() {
   [[ "${ADL_PR_RUST_DISABLE:-0}" == "1" ]] && return 1
-  command -v cargo >/dev/null 2>&1 || return 1
   [[ -f "$(repo_root)/adl/Cargo.toml" ]] || return 1
+  if [[ -n "${ADL_PR_RUST_BIN:-}" ]]; then
+    [[ -x "${ADL_PR_RUST_BIN}" ]] || return 1
+    return 0
+  fi
+  local cached_bin
+  cached_bin="$(rust_pr_delegate_cached_bin || true)"
+  if [[ -n "$cached_bin" && -x "$cached_bin" ]]; then
+    return 0
+  fi
+  command -v cargo >/dev/null 2>&1 || return 1
+  return 0
+}
+
+rust_pr_delegate_cached_bin() {
+  local root candidate
+  root="$(repo_root)"
+  candidate="$root/adl/target/debug/adl"
+  [[ -x "$candidate" ]] || return 1
+  rust_pr_delegate_bin_is_fresh "$root" "$candidate" || return 1
+  printf '%s\n' "$candidate"
+}
+
+rust_pr_delegate_bin_is_fresh() {
+  local root="$1" candidate="$2"
+  [[ -x "$candidate" ]] || return 1
+  [[ "$candidate" -nt "$root/adl/Cargo.toml" ]] || return 1
+  if [[ -f "$root/adl/Cargo.lock" && "$root/adl/Cargo.lock" -nt "$candidate" ]]; then
+    return 1
+  fi
+  if [[ -f "$root/adl/build.rs" && "$root/adl/build.rs" -nt "$candidate" ]]; then
+    return 1
+  fi
+  if [[ -d "$root/adl/src" ]]; then
+    if find "$root/adl/src" -type f -newer "$candidate" -print -quit | grep -q .; then
+      return 1
+    fi
+  fi
+  return 0
 }
 
 delegate_pr_command_to_rust() {
   local subcommand="$1"; shift || true
-  cargo run --quiet --manifest-path "$(repo_root)/adl/Cargo.toml" --bin adl -- pr "$subcommand" "$@"
+  local root manifest cached_bin
+  root="$(repo_root)"
+  manifest="$root/adl/Cargo.toml"
+  if [[ -n "${ADL_PR_RUST_BIN:-}" ]]; then
+    "${ADL_PR_RUST_BIN}" pr "$subcommand" "$@"
+    return 0
+  fi
+  cached_bin="$(rust_pr_delegate_cached_bin || true)"
+  if [[ -n "$cached_bin" ]]; then
+    "$cached_bin" pr "$subcommand" "$@"
+    return 0
+  fi
+  cargo run --quiet --manifest-path "$manifest" --bin adl -- pr "$subcommand" "$@"
 }
 
 normalize_issue_or_die() {

--- a/adl/tools/test_pr_ready_prefers_built_binary.sh
+++ b/adl/tools/test_pr_ready_prefers_built_binary.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mockbin="$tmpdir/mockbin"
+mkdir -p "$repo/adl/tools" "$repo/adl/target/debug" "$mockbin"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+touch "$repo/adl/Cargo.toml"
+sleep 1
+
+cat >"$repo/adl/target/debug/adl" <<'EOF_ADL'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TMP_ADL_ARGS"
+EOF_ADL
+chmod +x "$repo/adl/target/debug/adl"
+
+cat >"$mockbin/cargo" <<'EOF_CARGO'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "cargo should not be called when built adl binary is fresh" >&2
+exit 99
+EOF_CARGO
+chmod +x "$mockbin/cargo"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "init"
+)
+
+TMP_ADL_ARGS="$tmpdir/adl_args.txt"
+export TMP_ADL_ARGS
+export PATH="$mockbin:$PATH"
+
+(
+  cd "$repo"
+  "$BASH_BIN" adl/tools/pr.sh ready 1152 --slug rust-start --no-fetch-issue --version v0.86 >/dev/null
+)
+
+args="$(cat "$TMP_ADL_ARGS")"
+[[ "$args" == *"pr ready 1152 --slug rust-start --no-fetch-issue --version v0.86"* ]] || {
+  echo "assertion failed: expected built adl binary delegation for ready" >&2
+  echo "$args" >&2
+  exit 1
+}
+
+echo "pr.sh ready built-binary delegation: ok"


### PR DESCRIPTION
Closes #1219

## Summary
Reduced avoidable `pr.sh ready` / `adl pr ready` startup cost by making the shell wrapper prefer a fresh built `adl` binary for Rust delegation instead of always invoking `cargo run`. Added shell regression coverage proving `ready` uses the built binary path when available while preserving the existing Rust delegation fallback path.

## Artifacts
- `adl/tools/pr.sh`
- `adl/tools/test_pr_ready_prefers_built_binary.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_pr_ready_prefers_built_binary.sh`
    Verified `ready` prefers a fresh built `adl` binary and does not call Cargo in that path.
  - `bash adl/tools/test_pr_finish_delegates_to_rust.sh`
    Verified the standard Rust delegation fallback path remains intact for the five-command control plane.
- Results:
  - both shell regression checks passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1219__v0-86-tools-make-pr-ready-fast-and-avoid-cargo-startup-contention/sip.md
- Output card: .adl/v0.86/tasks/issue-1219__v0-86-tools-make-pr-ready-fast-and-avoid-cargo-startup-contention/sor.md
- Idempotency-Key: v0-86-tools-make-pr-ready-fast-and-avoid-cargo-startup-contention-adl-v0-86-tasks-issue-1219-v0-86-tools-make-pr-ready-fast-and-avoid-cargo-startup-contention-sip-md-adl-v0-86-tasks-issue-1219-v0-86-tools-make-pr-ready-fast-and-avoid-cargo-startup-contention-sor-md