### PR TITLE
[v0.86][tools] Make create/start emit valid authored surfaces on the first pass

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -95,6 +95,7 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     } else {
         body.clone()
     };
+    validate_issue_body_for_create(&repo_root, &title, &normalized_labels, &slug, &create_body)?;
     let issue_url = gh_issue_create(&repo, &title, &create_body, &normalized_labels)?;
     let issue = parse_issue_number_from_url(&issue_url)?;
     let issue_ref = IssueRef::new(issue, version.clone(), slug.clone())?;
@@ -115,6 +116,8 @@ fn real_pr_create(args: &[String]) -> Result<()> {
         &issue_url,
         &final_body,
     )?;
+    validate_bootstrap_stp(&repo_root, &source_path)?;
+    validate_authored_prompt_surface("create", &source_path, PromptSurfaceKind::IssuePrompt)?;
     if create_body != final_body {
         gh_issue_edit_body(&repo, issue, &final_body)?;
     }
@@ -1510,7 +1513,9 @@ fn ensure_bootstrap_cards(
     if let Some(parent) = bundle_input.parent() {
         fs::create_dir_all(parent)?;
     }
-    if !bundle_input.is_file() {
+    if !bundle_input.is_file()
+        || prompt_surface_is_bootstrap_stub(&bundle_input, PromptSurfaceKind::Sip)?
+    {
         write_input_card(
             root,
             &bundle_input,
@@ -1538,7 +1543,38 @@ fn ensure_bootstrap_cards(
         &bundle_input,
         &bundle_output,
     )?;
+    validate_authored_prompt_surface("start", &bundle_input, PromptSurfaceKind::Sip)?;
     Ok((bundle_input, bundle_output))
+}
+
+fn prompt_surface_is_bootstrap_stub(path: &Path, kind: PromptSurfaceKind) -> Result<bool> {
+    if !path.is_file() {
+        return Ok(false);
+    }
+    let text = fs::read_to_string(path)?;
+    Ok(bootstrap_stub_reason(&text, kind).is_some())
+}
+
+fn validate_issue_body_for_create(
+    repo_root: &Path,
+    title: &str,
+    labels_csv: &str,
+    slug: &str,
+    body: &str,
+) -> Result<()> {
+    let probe_issue = 999_999;
+    let probe_url = format!(
+        "https://github.com/{}/issues/{probe_issue}",
+        default_repo(repo_root)?
+    );
+    let prompt =
+        render_issue_prompt_from_body(probe_issue, slug, title, labels_csv, &probe_url, body);
+    let temp = write_temp_markdown("issue_body_probe", &prompt)?;
+    validate_bootstrap_stp(repo_root, &temp)
+        .with_context(|| "create: issue body cannot satisfy source-prompt validation")?;
+    validate_authored_prompt_surface("create", &temp, PromptSurfaceKind::IssuePrompt)
+        .with_context(|| "create: issue body is still bootstrap stub content")?;
+    Ok(())
 }
 
 fn write_input_card(
@@ -2760,7 +2796,7 @@ verification_summary:
             "--slug".to_string(),
             "v0-86-tools-simplified-init-path".to_string(),
             "--body".to_string(),
-            "## Goal\n- simplify init".to_string(),
+            "## Summary\n\nTighten lifecycle validation for issue creation.\n\n## Goal\n\nMake create reject bodies that cannot become valid source prompts.\n\n## Required Outcome\n\nThis issue ships tooling code and tests.\n\n## Deliverables\n\n- create-path validation\n\n## Acceptance Criteria\n\n- invalid issue bodies are rejected early\n\n## Repo Inputs\n\n- adl/src/cli/pr_cmd.rs\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- lifecycle redesign\n\n## Issue-Graph Notes\n\n- test fixture\n\n## Notes\n\n- authored test body\n\n## Tooling Notes\n\n- should pass source-prompt validation\n".to_string(),
             "--labels".to_string(),
             "track:roadmap,type:task,area:tools".to_string(),
             "--version".to_string(),
@@ -2784,13 +2820,15 @@ verification_summary:
         );
         let prompt = fs::read_to_string(&source).expect("read source prompt");
         assert!(prompt.contains("issue_number: 1202"));
-        assert!(prompt.contains("## Goal\n- simplify init"));
+        assert!(prompt.contains("## Summary"));
+        assert!(prompt.contains("## Tooling Notes"));
         assert!(
             !repo.join(".adl/v0.86/tasks").exists(),
             "create should not bootstrap the local task bundle"
         );
         let issue_body = fs::read_to_string(&issue_body_log).expect("issue body");
-        assert_eq!(issue_body, "## Goal\n- simplify init");
+        assert!(issue_body.contains("## Summary"));
+        assert!(issue_body.contains("## Tooling Notes"));
     }
 
     #[test]
@@ -2847,6 +2885,53 @@ verification_summary:
         assert!(prompt.contains("issue_number: 1203"));
         assert!(prompt.contains("## Goal"));
         assert!(!prompt.contains("## Goal\n-"));
+    }
+
+    #[test]
+    fn real_pr_create_rejects_issue_body_that_cannot_pass_source_prompt_validation() {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let repo = unique_temp_dir("adl-pr-real-create-invalid-body");
+        init_git_repo(&repo);
+        copy_bootstrap_support_files(&repo);
+
+        let bin_dir = repo.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        let gh_path = bin_dir.join("gh");
+        write_executable(
+            &gh_path,
+            "#!/usr/bin/env bash\nset -euo pipefail\nexit 99\n",
+        );
+
+        let old_path = env::var("PATH").unwrap_or_default();
+        let prev_dir = env::current_dir().expect("cwd");
+        unsafe {
+            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        }
+        env::set_current_dir(&repo).expect("chdir");
+
+        let err = real_pr(&[
+            "create".to_string(),
+            "--title".to_string(),
+            "[v0.86][tools] Invalid issue body".to_string(),
+            "--slug".to_string(),
+            "v0-86-tools-invalid-issue-body".to_string(),
+            "--body".to_string(),
+            "## Goal\n\nmissing required sections\n".to_string(),
+            "--labels".to_string(),
+            "track:roadmap,type:task,area:tools".to_string(),
+            "--version".to_string(),
+            "v0.86".to_string(),
+        ])
+        .expect_err("invalid issue body should fail before gh issue create");
+
+        env::set_current_dir(prev_dir).expect("restore cwd");
+        unsafe {
+            env::set_var("PATH", old_path);
+        }
+
+        assert!(err
+            .to_string()
+            .contains("create: issue body cannot satisfy source-prompt validation"));
     }
 
     #[test]
@@ -4888,6 +4973,56 @@ Status: NOT_STARTED
         assert_eq!(
             field_line_value(&bundle_output, "Status").expect("output status"),
             "IN_PROGRESS"
+        );
+        let bundle_input_text = fs::read_to_string(&bundle_input).expect("bundle input");
+        assert_eq!(
+            bootstrap_stub_reason(&bundle_input_text, PromptSurfaceKind::Sip),
+            None
+        );
+    }
+
+    #[test]
+    fn ensure_bootstrap_cards_rewrites_existing_bootstrap_stub_input_card() {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let repo = unique_temp_dir("adl-pr-bootstrap-cards-rewrite");
+        init_git_repo(&repo);
+        copy_bootstrap_support_files(&repo);
+
+        let issue_ref = IssueRef::new(
+            1154,
+            "v0.86".to_string(),
+            "rewrite-bootstrap-sip".to_string(),
+        )
+        .expect("ref");
+        let source_path = issue_ref.issue_prompt_path(&repo);
+        fs::create_dir_all(source_path.parent().expect("source parent")).expect("mkdir");
+        fs::write(
+            &source_path,
+            "---\ntitle: \"[v0.86][tools] Rewrite bootstrap SIP\"\nlabels:\n  - \"track:roadmap\"\nissue_number: 1154\n---\n\n## Summary\nx\n## Goal\nx\n## Required Outcome\nx\n## Deliverables\nx\n## Acceptance Criteria\nx\n## Repo Inputs\nx\n## Dependencies\nx\n## Demo Expectations\nx\n## Non-goals\nx\n## Issue-Graph Notes\nx\n## Notes\nx\n## Tooling Notes\nx\n",
+        )
+        .expect("write source");
+
+        let bundle_input = issue_ref.task_bundle_input_path(&repo);
+        fs::create_dir_all(bundle_input.parent().expect("input parent")).expect("mkdir");
+        fs::write(
+            &bundle_input,
+            "# ADL Input Card\n\n## Goal\n\n\n## Required Outcome\n\n- State whether this issue must ship code, docs, tests, demo artifacts, or a combination.\n\n## Acceptance Criteria\n\n\n",
+        )
+        .expect("write stub input");
+
+        let (repaired_input, _) = ensure_bootstrap_cards(
+            &repo,
+            &issue_ref,
+            "[v0.86][tools] Rewrite bootstrap SIP",
+            "codex/1154-rewrite-bootstrap-sip",
+            &source_path,
+        )
+        .expect("bootstrap cards");
+
+        let repaired_text = fs::read_to_string(repaired_input).expect("read repaired input");
+        assert_eq!(
+            bootstrap_stub_reason(&repaired_text, PromptSurfaceKind::Sip),
+            None
         );
     }
 }

--- a/adl/templates/cards/input_card_template.md
+++ b/adl/templates/cards/input_card_template.md
@@ -87,35 +87,41 @@ Execution:
 
 ## Goal
 
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
 ## Required Outcome
 
-- State whether this issue must ship code, docs, tests, demo artifacts, or a combination.
-- If docs-only completion is acceptable, say so explicitly.
-- If a runnable demo or proof surface is required, say so explicitly.
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
 
 ## Acceptance Criteria
 
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
 ## Inputs
-- 
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
 
 ## Target Files / Surfaces
-- Likely files, modules, docs, commands, schemas, or artifacts to modify or validate
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
 
 ## Validation Plan
-- Required commands:
-- Required tests:
-- Required artifacts / traces:
-- Required reviewer or demo checks:
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
 
 ## Demo / Proof Requirements
-- Required demo(s):
-- Required proof surface(s):
-- If no demo is required, say why:
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
 
 ## Constraints / Policies
-- Determinism requirements:
-- Security / privacy requirements:
-- Resource limits (time/CPU/memory/network):
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
 
 ## System Invariants (must remain true)
 - Deterministic execution for identical inputs.
@@ -154,7 +160,12 @@ ci_validation_required: true
 
 ## Non-goals / Out of scope
 
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
 ## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
 
 ## Instructions to the Agent
 - Read this file.

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -123,6 +123,63 @@ replace_first_line_re() {
   mv "$tmp" "$file"
 }
 
+section_has_authored_content() {
+  local file="$1" header="$2"
+  awk -v header="$header" '
+    BEGIN { in_section = 0; found = 0 }
+    {
+      line = $0
+      trimmed = line
+      sub(/^[[:space:]]+/, "", trimmed)
+      sub(/[[:space:]]+$/, "", trimmed)
+      if (trimmed == header) {
+        in_section = 1
+        next
+      }
+      if (in_section && trimmed ~ /^##[[:space:]]+/) {
+        in_section = 0
+      }
+      if (in_section && trimmed != "" && trimmed != "-" && trimmed != "none") {
+        found = 1
+        exit
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$file"
+}
+
+input_card_is_bootstrap_stub() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  if ! section_has_authored_content "$file" "## Goal"; then
+    return 0
+  fi
+  if ! section_has_authored_content "$file" "## Acceptance Criteria"; then
+    return 0
+  fi
+  local marker
+  while IFS= read -r marker; do
+    [[ -n "$marker" ]] || continue
+    if grep -Fqx -- "$marker" "$file"; then
+      return 0
+    fi
+  done <<'EOF'
+- State whether this issue must ship code, docs, tests, demo artifacts, or a combination.
+- Likely files, modules, docs, commands, schemas, or artifacts to modify or validate
+- Required commands:
+- Required tests:
+- Required artifacts / traces:
+- Required reviewer or demo checks:
+- Required demo(s):
+- Required proof surface(s):
+- If no demo is required, say why:
+- Determinism requirements:
+- Security / privacy requirements:
+- Resource limits (time/CPU/memory/network):
+EOF
+  return 1
+}
+
 field_line_value() {
   local file="$1" key="$2"
   awk -v k="$key" '
@@ -1127,7 +1184,7 @@ seed_bootstrap_surfaces() {
   in_path="$(input_card_path "$issue" "$version" "$slug")"
   out_path="$(output_card_path "$issue" "$version" "$slug")"
   ensure_adl_dirs
-  if ! ensure_nonempty_file "$in_path"; then
+  if ! ensure_nonempty_file "$in_path" || input_card_is_bootstrap_stub "$in_path"; then
     note "Creating input card: $in_path" >&2
     seed_input_card "$in_path" "$issue" "$title" "$branch" "$version" "$out_path"
   else
@@ -2727,9 +2784,11 @@ cmd_ready() {
   [[ -f "$wt_input" ]] || die "ready: missing worktree input card: $wt_input"
   [[ -f "$wt_output" ]] || die "ready: missing worktree output card: $wt_output"
   validate_bootstrap_cards "$issue" "$branch" "$wt_input" "$wt_output"
+  input_card_is_bootstrap_stub "$wt_input" && die "ready: input card is still bootstrap stub content: $wt_input"
   [[ -f "$root_input" ]] || die "ready: missing root input card: $root_input"
   [[ -f "$root_output" ]] || die "ready: missing root output card: $root_output"
   validate_bootstrap_cards "$issue" "$branch" "$root_input" "$root_output"
+  input_card_is_bootstrap_stub "$root_input" && die "ready: input card is still bootstrap stub content: $root_input"
 
   echo "ISSUE=$issue"
   echo "VERSION=$version"

--- a/adl/tools/test_pr_start_template_validation.sh
+++ b/adl/tools/test_pr_start_template_validation.sh
@@ -56,6 +56,8 @@ assert_contains() {
 (
   cd "$repo"
   "$BASH_BIN" adl/tools/pr.sh start 910 --slug validation-pass --no-fetch-issue >/dev/null
+  ready_out="$("$BASH_BIN" adl/tools/pr.sh ready 910 --slug validation-pass --no-fetch-issue)"
+  assert_contains "READY=PASS" "$ready_out"
   perl -0pi -e 's/Status: IN_PROGRESS/Status: MAYBE/' ".worktrees/adl-wp-910/adl/templates/cards/output_card_template.md"
   rm -f ".worktrees/adl-wp-910/.adl/v0.86/tasks/issue-0910__validation-pass/sor.md"
 


### PR DESCRIPTION
Closes #1230

## Summary
Fixed the Sprint 7 bootstrap lifecycle gaps in two places. `pr create` now rejects issue bodies that cannot become valid authored source prompts, and `pr init` / `pr start` now emit SIP cards that are `ready`-clean on first generation. Rerunning `start` also repairs older generated bootstrap-stub SIP cards instead of silently reusing them.

## Artifacts
- updated Rust lifecycle control in `adl/src/cli/pr_cmd.rs`
- updated bootstrap SIP template in `adl/templates/cards/input_card_template.md`
- updated shell parity logic in `adl/tools/pr.sh`
- updated shell regression in `adl/tools/test_pr_start_template_validation.sh`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_ -- --nocapture`
    - verify create-path acceptance and rejection cases
  - `cargo test --manifest-path adl/Cargo.toml ensure_bootstrap_cards_creates_bundle_and_compat_links -- --nocapture`
    - verify bootstrap card generation stays ready-clean
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`
    - run the broader PR control-plane regression suite
  - `bash adl/tools/test_pr_init.sh`
    - verify shell init bootstrap remains valid
  - `bash adl/tools/test_pr_start_template_validation.sh`
    - verify shell start emits a ready-pass issue bundle and still catches later template breakage
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verify Rust formatting
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verify Rust lint cleanliness
- Results:
  - all listed commands passed after the final patch set

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Also closes #1220.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1230__v0-86-tools-make-pr-start-emit-ready-clean-sip-cards-instead-of-bootstrap-templates/sip.md
- Output card: .adl/v0.86/tasks/issue-1230__v0-86-tools-make-pr-start-emit-ready-clean-sip-cards-instead-of-bootstrap-templates/sor.md
- Idempotency-Key: v0-86-tools-make-create-start-emit-valid-authored-surfaces-on-the-first-pass-adl-src-cli-pr-cmd-rs-adl-templates-cards-input-card-template-md-adl-tools-pr-sh-adl-tools-test-pr-start-template-validation-sh-adl-v0-86-tasks-issue-1230-v0-86-tools-make-pr-start-emit-ready-clean-sip-cards-instead-of-bootstrap-templates-sip-md-adl-v0-86-tasks-issue-1230-v0-86-tools-make-pr-start-emit-ready-clean-sip-cards-instead-of-bootstrap-templates-sor-md