### PR TITLE
[v0.86][tools] Make output card title use the issue slug instead of generic heading

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -313,6 +313,7 @@ fn real_pr_ready(args: &[String]) -> Result<()> {
     validate_ready_cards(
         &repo_root,
         parsed.issue,
+        issue_ref.slug(),
         wt_branch.trim(),
         &root_bundle_input,
         &root_bundle_output,
@@ -320,6 +321,7 @@ fn real_pr_ready(args: &[String]) -> Result<()> {
     validate_ready_cards(
         &worktree_path,
         parsed.issue,
+        issue_ref.slug(),
         wt_branch.trim(),
         &wt_bundle_input,
         &wt_bundle_output,
@@ -1526,7 +1528,9 @@ fn ensure_bootstrap_cards(
             &bundle_output,
         )?;
     }
-    if !bundle_output.is_file() {
+    if !bundle_output.is_file()
+        || !output_card_title_matches_slug(&bundle_output, issue_ref.slug())?
+    {
         write_output_card(root, &bundle_output, issue_ref, title, branch)?;
     }
 
@@ -1539,6 +1543,7 @@ fn ensure_bootstrap_cards(
     validate_bootstrap_cards(
         root,
         issue_ref.issue_number(),
+        issue_ref.slug(),
         branch,
         &bundle_input,
         &bundle_output,
@@ -1649,6 +1654,7 @@ fn write_output_card(
 ) -> Result<()> {
     let mut text =
         fs::read_to_string(repo_root.join("adl/templates/cards/output_card_template.md"))?;
+    replace_markdown_h1(&mut text, issue_ref.slug());
     replace_field_line(
         &mut text,
         "Task ID",
@@ -1675,6 +1681,35 @@ fn write_output_card(
     );
     fs::write(path, text)?;
     Ok(())
+}
+
+fn replace_markdown_h1(text: &mut String, value: &str) {
+    let mut replaced = false;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if !replaced && line.starts_with("# ") {
+            out.push(format!("# {value}"));
+            replaced = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    *text = out.join("\n");
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+}
+
+fn output_card_title_matches_slug(path: &Path, slug: &str) -> Result<bool> {
+    let expected = format!("# {slug}");
+    let text = fs::read_to_string(path)?;
+    let header = text
+        .lines()
+        .find(|line| line.starts_with("# "))
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    Ok(header == expected)
 }
 
 fn replace_field_line(text: &mut String, label: &str, value: &str) {
@@ -1744,6 +1779,7 @@ fn validate_bootstrap_stp(repo_root: &Path, path: &Path) -> Result<()> {
 fn validate_bootstrap_cards(
     repo_root: &Path,
     issue: u32,
+    slug: &str,
     branch: &str,
     input_path: &Path,
     output_path: &Path,
@@ -1792,12 +1828,16 @@ fn validate_bootstrap_cards(
     if field_line_value(output_path, "Branch")? != branch {
         bail!("start: output card branch mismatch");
     }
+    if !output_card_title_matches_slug(output_path, slug)? {
+        bail!("start: output card title mismatch");
+    }
     Ok(())
 }
 
 fn validate_ready_cards(
     _repo_root: &Path,
     issue: u32,
+    slug: &str,
     actual_branch: &str,
     input_path: &Path,
     output_path: &Path,
@@ -1820,6 +1860,9 @@ fn validate_ready_cards(
     }
     if !branch_matches_started_state(&field_line_value(output_path, "Branch")?, actual_branch) {
         bail!("ready: output card branch mismatch");
+    }
+    if !output_card_title_matches_slug(output_path, slug)? {
+        bail!("ready: output card title mismatch");
     }
     validate_authored_prompt_surface("ready", input_path, PromptSurfaceKind::Sip)?;
     Ok(())
@@ -2213,7 +2256,7 @@ mod tests {
 
     fn write_completed_sor_fixture(path: &Path, branch: &str) {
         let body = format!(
-            r#"# ADL Output Card
+            r#"# rust-finish-test
 
 Canonical Template Source: `adl/templates/cards/output_card_template.md`
 Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
@@ -3417,7 +3460,7 @@ verification_summary:
         fs::write(&input, "# input\n").expect("write input");
         fs::write(
             &output,
-            "# ADL Output Card\n\n## Summary\nsummary text\n\n## Artifacts produced\n- adl/src/cli/pr_cmd.rs\n\n## Validation\n- cargo test\n",
+            "# rust-finish-test\n\n## Summary\nsummary text\n\n## Artifacts produced\n- adl/src/cli/pr_cmd.rs\n\n## Validation\n- cargo test\n",
         )
         .expect("write output");
 
@@ -4256,7 +4299,7 @@ verification_summary:
         );
         fs::write(
             &output,
-            r#"# ADL Output Card
+            r#"# output-card-guard
 
 Task ID: issue-1156
 Run ID: issue-1156

--- a/adl/templates/cards/output_card_template.md
+++ b/adl/templates/cards/output_card_template.md
@@ -1,4 +1,4 @@
-# ADL Output Card
+# <issue-slug>
 
 Canonical Template Source: `adl/templates/cards/output_card_template.md`
 Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.

--- a/adl/tools/codexw.sh
+++ b/adl/tools/codexw.sh
@@ -234,7 +234,7 @@ run_legacy_mode() {
     fi
 
     {
-      echo "# ADL Output Card"
+      echo "# $(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')"
       echo
       echo "Task ID: ${task_id}"
       echo "Run ID: ${run_id}"

--- a/adl/tools/demo_five_command_editing.sh
+++ b/adl/tools/demo_five_command_editing.sh
@@ -239,7 +239,7 @@ EOF
 git -C "$WORKTREE" add docs/tooling/editor/five_command_demo_note.md
 
 cat >"$OUTPUT_CARD" <<EOF
-# ADL Output Card
+# five-command-editing-demo-issue
 
 Task ID: issue-0042
 Run ID: issue-0042

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1048,6 +1048,16 @@ validate_card_header_count() {
   [[ "$count" == "1" ]]
 }
 
+replace_first_markdown_h1() {
+  local file="$1" title="$2"
+  replace_first_line_re "$file" '^# .*$' "# $title"
+}
+
+output_card_title_matches_slug() {
+  local path="$1" slug="$2"
+  validate_card_header_count "$path" "# $slug"
+}
+
 seed_input_card() {
   local path="$1" issue="$2" title="$3" branch="$4" ver="$5" output_path_actual="${6:-}"
   local task_id run_id
@@ -1100,9 +1110,10 @@ seed_input_card() {
 
 seed_output_card() {
   local path="$1" issue="$2" title="$3" branch="$4" ver="$5"
-  local task_id run_id
+  local task_id run_id issue_slug
   task_id="issue-$(card_issue_pad "$issue")"
   run_id="$task_id"
+  issue_slug="$(sanitize_slug "$title")"
   local out_tpl tmp
   out_tpl="$(resolve_output_template)"
   [[ -f "$out_tpl" ]] || die "missing output card template: $out_tpl"
@@ -1117,18 +1128,19 @@ seed_output_card() {
   set_field_line "$tmp" "Version" "$ver"
   set_field_line "$tmp" "Title" "$title"
   set_field_line "$tmp" "Branch" "$branch"
+  replace_first_markdown_h1 "$tmp" "$issue_slug"
 
   # Default Status if template left it blank.
   replace_first_line_re "$tmp" "^Status:[[:space:]]*$" "Status: NOT_STARTED | IN_PROGRESS | DONE | FAILED"
   replace_first_line_re "$tmp" "^- Integration state:.*$" "- Integration state: worktree_only"
   replace_first_line_re "$tmp" "^- Verification scope:.*$" "- Verification scope: worktree"
-  validate_card_header_count "$tmp" "# ADL Output Card" || die "generated output card must contain exactly one '# ADL Output Card' header"
+  validate_card_header_count "$tmp" "# $issue_slug" || die "generated output card must contain exactly one '# $issue_slug' header"
   ensure_nonempty_file "$tmp" || die "generated output card is empty: $tmp"
   mv "$tmp" "$path"
 }
 
 validate_bootstrap_cards() {
-  local issue="$1" branch="$2" in_path="$3" out_path="$4"
+  local issue="$1" slug="$2" branch="$3" in_path="$4" out_path="$5"
   local validator expected task_id run_id in_branch out_branch
   validator="$(resolve_structured_prompt_validator)"
 
@@ -1152,6 +1164,7 @@ validate_bootstrap_cards() {
   out_branch="$(field_line_value "$out_path" "Branch")"
   [[ "$in_branch" == "$branch" ]] || die "start: input card branch mismatch (expected $branch, found ${in_branch:-<empty>})"
   [[ "$out_branch" == "$branch" ]] || die "start: output card branch mismatch (expected $branch, found ${out_branch:-<empty>})"
+  output_card_title_matches_slug "$out_path" "$slug" || die "start: output card title mismatch (expected '# $slug')"
 }
 
 validate_bootstrap_stp() {
@@ -1190,7 +1203,7 @@ seed_bootstrap_surfaces() {
   else
     note "Input card exists: $in_path" >&2
   fi
-  if ! ensure_nonempty_file "$out_path"; then
+  if ! ensure_nonempty_file "$out_path" || ! output_card_title_matches_slug "$out_path" "$slug"; then
     note "Creating output card: $out_path" >&2
     seed_output_card "$out_path" "$issue" "$title" "$branch" "$version"
   else
@@ -1198,7 +1211,7 @@ seed_bootstrap_surfaces() {
   fi
   sync_legacy_links_for_issue "$issue" "$version" "$slug"
   validate_bootstrap_stp "$stp_path"
-  validate_bootstrap_cards "$issue" "$branch" "$in_path" "$out_path"
+  validate_bootstrap_cards "$issue" "$slug" "$branch" "$in_path" "$out_path"
   printf '%s\n%s\n%s\n' "$stp_path" "$in_path" "$out_path"
 }
 

--- a/adl/tools/test_pr_finish_default_stage_root.sh
+++ b/adl/tools/test_pr_finish_default_stage_root.sh
@@ -140,7 +140,7 @@ export TMP_PR_BODY
   mkdir -p .adl/cards/1021
 
   cat > .adl/cards/1021/output_1021.md <<'EOF_SOR'
-# ADL Output Card
+# finish-default-root
 
 Task ID: issue-1021
 Run ID: issue-1021

--- a/adl/tools/test_pr_finish_relative_card_paths.sh
+++ b/adl/tools/test_pr_finish_relative_card_paths.sh
@@ -155,7 +155,7 @@ export GH_MOCK_EXISTING_PR="absent"
   mkdir -p .adl/cards/958
 
   cat > .adl/cards/958/output_958.md <<'EOF_SOR'
-# ADL Output Card
+# relative-card-paths
 
 Task ID: issue-0958
 Run ID: issue-0958

--- a/adl/tools/test_structured_prompt_validation.sh
+++ b/adl/tools/test_structured_prompt_validation.sh
@@ -162,7 +162,7 @@ x
 EOF
 
 cat >"$tmpdir/sor_valid.md" <<'EOF'
-# ADL Output Card
+# valid-sor
 
 Task ID: issue-0898
 Run ID: issue-0898
@@ -382,7 +382,7 @@ if [[ "$rc" -eq 0 ]]; then
 fi
 
 cat >"$tmpdir/sor_completed_invalid_status.md" <<'EOF'
-# ADL Output Card
+# dependable-execution-fixture
 
 Task ID: issue-0898
 Run ID: issue-0898
@@ -437,7 +437,7 @@ x
 EOF
 
 cat >"$tmpdir/sor_invalid.md" <<'EOF'
-# ADL Output Card
+# dependable-execution-fixture
 
 Task ID: issue-0898
 Run ID: issue-0898
@@ -495,7 +495,7 @@ if [[ "$rc" -eq 0 ]]; then
 fi
 
 cat >"$tmpdir/sor_offset_timestamp_invalid.md" <<'EOF'
-# ADL Output Card
+# dependable-execution-fixture
 
 Task ID: issue-0898
 Run ID: issue-0898
@@ -566,7 +566,7 @@ if [[ "$rc" -eq 0 ]]; then
 fi
 
 cat >"$tmpdir/sor_completed_worktree_only_valid.md" <<'EOF'
-# ADL Output Card
+# dependable-execution-fixture
 
 Task ID: issue-0898
 Run ID: issue-0898
@@ -617,7 +617,7 @@ EOF
 "$VALIDATOR" --type sor --phase completed --input "$tmpdir/sor_completed_worktree_only_valid.md" >/dev/null
 
 cat >"$tmpdir/sor_absolute_path_invalid.md" <<'EOF'
-# ADL Output Card
+# dependable-execution-fixture
 
 Task ID: issue-0898
 Run ID: issue-0898

--- a/adl/tools/test_sync_task_bundle_prompts.sh
+++ b/adl/tools/test_sync_task_bundle_prompts.sh
@@ -31,7 +31,7 @@ Task ID: issue-0918
 EOF
 
 cat > "$TMP/.adl/cards/918/output_918.md" <<'EOF'
-# ADL Output Card
+# v085-output-card-template-tightening
 Task ID: issue-0918
 EOF
 

--- a/docs/tooling/examples/reviewer-regression/issue-661/output_661.md
+++ b/docs/tooling/examples/reviewer-regression/issue-661/output_661.md
@@ -1,4 +1,4 @@
-# ADL Output Card
+# canonical-v08-milestone-index-and-navigation
 
 Task ID: issue-0661
 Run ID: issue-0661

--- a/docs/tooling/examples/workflow-state/bad_output_record.md
+++ b/docs/tooling/examples/workflow-state/bad_output_record.md
@@ -1,4 +1,4 @@
-# ADL Output Card
+# dependable-execution-fixture
 
 Task ID: issue-0999
 Run ID: issue-0999

--- a/docs/tooling/examples/workflow-state/good_output_record.md
+++ b/docs/tooling/examples/workflow-state/good_output_record.md
@@ -1,4 +1,4 @@
-# ADL Output Card
+# dependable-execution-fixture
 
 Task ID: issue-0999
 Run ID: issue-0999


### PR DESCRIPTION
Closes #1235

## Summary
Changed output-card generation so the top-level markdown title is the issue slug, updated readiness/bootstrap checks to enforce that rule, and normalized the active Sprint 5 output cards plus supporting fixtures to the new heading format.

## Artifacts
- Code:
  - `adl/templates/cards/output_card_template.md`
  - `adl/tools/pr.sh`
  - `adl/src/cli/pr_cmd.rs`
  - `adl/tools/codexw.sh`
  - `adl/tools/demo_five_command_editing.sh`
  - `adl/tools/test_structured_prompt_validation.sh`
  - `adl/tools/test_sync_task_bundle_prompts.sh`
  - `adl/tools/test_pr_finish_default_stage_root.sh`
  - `adl/tools/test_pr_finish_relative_card_paths.sh`
- Documentation / examples:
  - `docs/tooling/examples/workflow-state/good_output_record.md`
  - `docs/tooling/examples/workflow-state/bad_output_record.md`
  - `docs/tooling/examples/reviewer-regression/issue-661/output_661.md`
- Generated runtime artifacts: not_applicable for this tooling task

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`
    - exercised the Rust five-command lifecycle and output-card generation/validation paths.
  - `bash adl/tools/test_structured_prompt_validation.sh`
    - exercised SOR contract validation with slug-based headings.
  - `bash adl/tools/test_sync_task_bundle_prompts.sh`
    - exercised prompt-sync behavior for generated task bundles.
  - `bash adl/tools/test_pr_finish_default_stage_root.sh`
    - exercised default repo-root staging with a completed output record.
  - `bash adl/tools/test_pr_finish_relative_card_paths.sh`
    - exercised relative output-card path handling in `pr finish`.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - checked Rust formatting.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - checked Rust lints.
- Results:
  - all listed commands passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  /Users/daniel/git/agent-design-language/.adl/v0.86/tasks/issue-1235__v0-86-tools-make-output-card-title-use-the-issue-slug-instead-of-generic-heading/sip.md
- Output card: /Users/daniel/git/agent-design-language/.adl/v0.86/tasks/issue-1235__v0-86-tools-make-output-card-title-use-the-issue-slug-instead-of-generic-heading/sor.md
- Idempotency-Key: v0-86-tools-make-output-card-title-use-the-issue-slug-instead-of-generic-heading-adl-templates-cards-output-card-template-md-adl-tools-pr-sh-adl-src-cli-pr-cmd-rs-adl-tools-codexw-sh-adl-tools-demo-five-command-editing-sh-adl-tools-test-structured-prompt-validation-sh-adl-tools-test-sync-task-bundle-prompts-sh-adl-tools-test-pr-finish-default-stage-root-sh-adl-tools-test-pr-finish-relative-card-paths-sh-docs-tooling-examples-workflow-state-good-output-record-md-docs-tooling-examples-workflow-state-bad-output-record-md-docs-tooling-examples-reviewer-regression-issue-661-output-661-md-users-daniel-git-agent-design-language-adl-v0-86-tasks-issue-1235-v0-86-tools-make-output-card-title-use-the-issue-slug-instead-of-generic-heading-sip-md-users-daniel-git-agent-design-language-adl-v0-86-tasks-issue-1235-v0-86-tools-make-output-card-title-use-the-issue-slug-instead-of-generic-heading-sor-md