### PR TITLE
[v0.86][tools] Make pr finish sync completed output cards to root task bundles and review mirrors

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -411,6 +411,7 @@ fn real_pr_preflight(args: &[String]) -> Result<()> {
 fn real_pr_finish(args: &[String]) -> Result<()> {
     let parsed = parse_finish_args(args)?;
     let repo_root = repo_root()?;
+    let primary_root = primary_checkout_root()?;
     let repo = default_repo(&repo_root)?;
 
     ensure_not_on_main_branch(&repo_root)?;
@@ -461,6 +462,7 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     validate_authored_prompt_surface("finish", &stp_path, PromptSurfaceKind::Stp)?;
     validate_authored_prompt_surface("finish", &input_path, PromptSurfaceKind::Sip)?;
     validate_completed_sor(&repo_root, &output_path)?;
+    sync_completed_output_review_surfaces(&repo_root, &primary_root, &issue_ref, &output_path)?;
 
     let ahead = commits_ahead_of_origin_main(&repo_root)?;
     let has_uncommitted = has_uncommitted_changes(&repo_root)?;
@@ -594,6 +596,39 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     println!("{pr_url}");
+    Ok(())
+}
+
+fn sync_completed_output_review_surfaces(
+    repo_root: &Path,
+    primary_root: &Path,
+    issue_ref: &IssueRef,
+    completed_output_path: &Path,
+) -> Result<()> {
+    let normalized_output_path = if completed_output_path.is_absolute() {
+        completed_output_path.to_path_buf()
+    } else {
+        repo_root.join(completed_output_path)
+    };
+    let canonical_root_output = issue_ref.task_bundle_output_path(primary_root);
+    let copied_to_root = normalized_output_path != canonical_root_output;
+    if copied_to_root {
+        if let Some(parent) = canonical_root_output.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&normalized_output_path, &canonical_root_output).with_context(|| {
+            format!(
+                "finish: failed to sync completed output card '{}' to canonical root task bundle '{}'",
+                normalized_output_path.display(),
+                canonical_root_output.display()
+            )
+        })?;
+        validate_completed_sor(repo_root, &canonical_root_output)?;
+    }
+
+    let cards_root = resolve_cards_root(primary_root, None);
+    let review_output = card_output_path(&cards_root, issue_ref.issue_number());
+    ensure_symlink(&review_output, &canonical_root_output)?;
     Ok(())
 }
 
@@ -3559,6 +3594,196 @@ verification_summary:
         let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
         assert!(gh_calls.contains("pr create"));
         assert!(gh_calls.contains("pr view -R danielbaustin/agent-design-language https://github.com/danielbaustin/agent-design-language/pull/1159 --json closingIssuesReferences --jq .closingIssuesReferences[]?.number"));
+    }
+
+    #[test]
+    fn real_pr_finish_syncs_completed_output_to_root_bundle_and_review_mirror() {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let temp = unique_temp_dir("adl-pr-finish-sync-output");
+        let origin = temp.join("origin.git");
+        let repo = temp.join("repo");
+        let worktree = temp.join("worktree");
+        fs::create_dir_all(&repo).expect("repo dir");
+        copy_bootstrap_support_files(&repo);
+        init_git_repo(&repo);
+        assert!(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo)
+            .status()
+            .expect("git config")
+            .success());
+        assert!(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo)
+            .status()
+            .expect("git config")
+            .success());
+        fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+        fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+        assert!(Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(&repo)
+            .status()
+            .expect("git add")
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(&repo)
+            .status()
+            .expect("git commit")
+            .success());
+        assert!(Command::new("git")
+            .args(["branch", "-M", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git branch")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "init",
+                "--bare",
+                "-q",
+                path_str(&origin).expect("origin path"),
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git init bare")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "remote",
+                "set-url",
+                "origin",
+                path_str(&origin).expect("origin path"),
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git remote set-url")
+            .success());
+        assert!(Command::new("git")
+            .args(["push", "-q", "-u", "origin", "main"])
+            .current_dir(&repo)
+            .status()
+            .expect("git push")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "codex/1153-rust-finish-sync",
+                path_str(&worktree).expect("worktree"),
+                "origin/main",
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("git worktree add")
+            .success());
+
+        let issue_ref =
+            IssueRef::new(1153, "v0.86".to_string(), "rust-finish-sync".to_string()).expect("ref");
+        let root_bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+        let wt_bundle_dir = issue_ref.task_bundle_dir_path(&worktree);
+        fs::create_dir_all(&root_bundle_dir).expect("root bundle dir");
+        fs::create_dir_all(&wt_bundle_dir).expect("wt bundle dir");
+
+        write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish sync");
+        let wt_issue_prompt = issue_ref.issue_prompt_path(&worktree);
+        fs::create_dir_all(wt_issue_prompt.parent().expect("wt prompt parent"))
+            .expect("wt prompt dir");
+        fs::copy(issue_ref.issue_prompt_path(&repo), &wt_issue_prompt).expect("copy issue prompt");
+
+        let root_stp = issue_ref.task_bundle_stp_path(&repo);
+        let wt_stp = issue_ref.task_bundle_stp_path(&worktree);
+        fs::copy(issue_ref.issue_prompt_path(&repo), &root_stp).expect("seed root stp");
+        fs::copy(&wt_issue_prompt, &wt_stp).expect("seed wt stp");
+
+        let root_input = issue_ref.task_bundle_input_path(&repo);
+        let wt_input = issue_ref.task_bundle_input_path(&worktree);
+        write_authored_sip(
+            &root_input,
+            &issue_ref,
+            "[v0.86][tools] Rust finish sync",
+            "codex/1153-rust-finish-sync",
+            &issue_ref.issue_prompt_path(&repo),
+            &repo,
+        );
+        write_authored_sip(
+            &wt_input,
+            &issue_ref,
+            "[v0.86][tools] Rust finish sync",
+            "codex/1153-rust-finish-sync",
+            &wt_issue_prompt,
+            &worktree,
+        );
+
+        let root_output = issue_ref.task_bundle_output_path(&repo);
+        write_output_card(
+            &repo,
+            &root_output,
+            &issue_ref,
+            "[v0.86][tools] Rust finish sync",
+            "codex/1153-rust-finish-sync",
+        )
+        .expect("root output");
+        let wt_output = issue_ref.task_bundle_output_path(&worktree);
+        write_completed_sor_fixture(&wt_output, "codex/1153-rust-finish-sync");
+
+        let cards_root = resolve_cards_root(&repo, None);
+        let compat_output = card_output_path(&cards_root, 1153);
+        ensure_symlink(&compat_output, &root_output).expect("compat symlink");
+
+        fs::write(
+            worktree.join("adl/src/lib.rs"),
+            "pub fn placeholder() {}\npub fn changed() {}\n",
+        )
+        .expect("write change");
+
+        let bin_dir = temp.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        let gh_log = temp.join("gh.log");
+        let gh_path = bin_dir.join("gh");
+        write_executable(
+            &gh_path,
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1159\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1153\\n'\n  else\n    printf 'Closes #1153\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+                gh_log.display()
+            ),
+        );
+
+        let old_path = env::var("PATH").unwrap_or_default();
+        let prev_dir = env::current_dir().expect("cwd");
+        unsafe {
+            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        }
+        env::set_current_dir(&worktree).expect("chdir");
+
+        let result = real_pr(&[
+            "finish".to_string(),
+            "1153".to_string(),
+            "--title".to_string(),
+            "[v0.86][tools] Rust finish sync".to_string(),
+            "--paths".to_string(),
+            "adl".to_string(),
+            "--input".to_string(),
+            path_relative_to_repo(&worktree, &wt_input),
+            "--output".to_string(),
+            path_relative_to_repo(&worktree, &wt_output),
+            "--no-checks".to_string(),
+            "--no-open".to_string(),
+        ]);
+
+        env::set_current_dir(prev_dir).expect("restore cwd");
+        unsafe {
+            env::set_var("PATH", old_path);
+        }
+        result.expect("real_pr finish");
+
+        let root_text = fs::read_to_string(&root_output).expect("root output text");
+        let compat_text = fs::read_to_string(&compat_output).expect("compat output text");
+        assert!(root_text.contains("Status: DONE"));
+        assert!(root_text.contains("codex/1153-rust-finish-sync"));
+        assert_eq!(root_text, compat_text);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1243

## Summary
Made `pr finish` sync the completed SOR into the canonical root task bundle and the `.adl/cards/<issue>/output_<issue>.md` review mirror automatically, so the finished execution record no longer remains stranded in a worktree-local bundle.

The fix also normalizes relative output paths before comparing them with the canonical root path, preventing the finish path from copying an output card onto itself when the caller passes a repo-relative SOR path.

## Artifacts
- `adl/src/cli/pr_cmd.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_syncs_completed_output_to_root_bundle_and_review_mirror -- --nocapture` — proved a worktree-local completed SOR is synced into the root task bundle and review mirror during `finish`
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture` — reverified the draft-PR finish path after the sync helper changed
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_updates_existing_pr_and_marks_ready -- --nocapture` — reverified the existing-PR edit/ready finish path after the sync helper changed
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture` — reverified the wider PR control-plane suite after the helper and test-fixture fixes
  - `bash adl/tools/test_pr_finish_delegates_to_rust.sh` — reverified shell-to-Rust finish delegation parity
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` — verified formatting
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` — verified lint cleanliness
- Results:
  - all targeted and broad finish-path tests passed
  - shell delegation parity passed
  - formatting and clippy passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1243__v0-86-tools-make-pr-finish-sync-completed-output-cards-to-root-task-bundles-and-review-mirrors/sip.md
- Output card: .adl/v0.86/tasks/issue-1243__v0-86-tools-make-pr-finish-sync-completed-output-cards-to-root-task-bundles-and-review-mirrors/sor.md
- Idempotency-Key: v0-86-tools-make-pr-finish-sync-completed-output-cards-to-root-task-bundles-and-review-mirrors-adl-v0-86-tasks-issue-1243-v0-86-tools-make-pr-finish-sync-completed-output-cards-to-root-task-bundles-and-review-mirrors-sip-md-adl-v0-86-tasks-issue-1243-v0-86-tools-make-pr-finish-sync-completed-output-cards-to-root-task-bundles-and-review-mirrors-sor-md