### PR TITLE
[v0.85][docs] Relocate ROAD_TO_v0.95 into roadmaps

### DIFF
--- a/.adl/docs/roadmaps/ROAD_TO_v0.95.md
+++ b/.adl/docs/roadmaps/ROAD_TO_v0.95.md
@@ -58,13 +58,38 @@ After this pass, the planned domain set should be treated as closed for
 `v1.0` feature-complete purposes unless an exceptional later decision says
 otherwise.
 
+## Critical Dependency Ordering
+
+Trace v1 (`v0.87`)
+↓
+Provider / Transport Substrate v1 (`v0.87`)
+↓
+Shared ObsMem (`v0.87`)
+↓
+AEE 1.0 (`v0.89`)
+↓
+Gödel Agent (`v0.89`)
+↓
+Signed Trace (`v0.90`)
+↓
+Identity Integration (`v0.90+`)
+↓
+Capability Routing (`v0.92+`)
+
+**Key Principle:**
+AEE depends on trace and provider correctness.  
+Gödel depends on AEE.  
+Trust depends on trace.  
+Do not invert this order.
+
 ## Framing
 
-The roadmap should be read with three high-level bands:
+The roadmap should be read with these high-level bands:
 
-- `v0.85` through `v0.89`: make the cognition, agency, convergence, and security architecture real, bounded, and demoable
-- `v0.90` through `v0.92`: deepen reasoning, affect, and identity into a coherent cognitive substrate
-- `v0.93` through `v0.95`: governance, convergence, hardening, and final platform integration
+- `v0.85` through `v0.87`: establish the operational, trace, memory, and cognitive-control substrate
+- `v0.88` through `v0.90`: deepen persistence, agency, AEE, reasoning, provenance, and demoability into a coherent cognitive substrate
+- `v0.91` through `v0.93`: deepen affect, identity, governance, and delegated agency into a coherent social/cognitive substrate
+- `v0.94` through `v0.95`: integration, convergence, hardening, and final platform freeze
 - `v0.95`: convergence and freeze; after this point, new major architectural themes require explicit justification and are not added by default
 
 The intent is to preserve milestone discipline.
@@ -135,13 +160,15 @@ This is deliberate:
 
 Use the major versions as architectural umbrellas:
 
-- `v0.86` = cognitive control band
-- `v0.88` = persistence, instinct, and bounded agency band
-- `v0.89` = AEE convergence and security/threat modeling band
+- `v0.86` = bounded cognitive system band
+- `v0.87` = operational + trace + shared-memory substrate band
+- `v0.88` = persistence, instinct, aptitudes, and bounded agency band
+- `v0.89` = AEE 1.0 convergence and security/threat modeling band
 - `v0.90` = reasoning graph, signed trace, and trace query band
 - `v0.91` = affect and moral cognition band
 - `v0.92` = identity, continuity, and capability band
 - `v0.93` = governance and delegation band
+- `v0.94` = integration and dependency-gap closure band
 - `v0.95` = MVP convergence, tooling migration, and optional Zed band
 
 Use sub-milestones as the actual executable planning slices.
@@ -175,12 +202,13 @@ Why this belongs here:
 | Milestone | Demo |
 | --- | --- |
 | `v0.86` | cognitive agent with arbitration + instinct + freedom gate |
+| `v0.87` | traceable / inspectable agent with provider portability, shared memory, and operational skill substrate |
 | `v0.88` | agent shows persistence over time with instinct influence |
 | `v0.89` | agent shows AEE convergence under explicit security/threat constraints |
-| `v0.90` | reasoning graph + signed trace + query |
+| `v0.90` | PR Demo prototype: reasoning graph + signed trace + query |
 | `v0.91` | agent exhibits affect + kindness + bounded humor |
-| `v0.92` | agent maintains identity across runs |
-| `v0.93` | agent follows social contract + delegation |
+| `v0.92` | PR Demo: agent maintains identity across runs |
+| `v0.93` | PR Demo: agent follows social contract + delegation |
 
 ### v0.86 - Cognitive Control Band
 
@@ -211,11 +239,47 @@ Why this belongs here:
   convergence, and reasoning-graph work
 - the proof surface is concrete and demoable
 
-### v0.88 - Persistence, Instinct, and Bounded Agency Band
+### v0.87 - Operational, Trace, and Shared Memory Substrate Band
 
 Theme:
-make persistence-over-time and instinct-shaped agency real, inspectable, and
-demoable.
+make the system coherent across execution, memory, inspection, and demo planning before deeper persistence and convergence work.
+
+Sub-milestones:
+
+- `v0.87.1`:
+  trace v1 substrate
+  canonical trace/event schema, stable event naming/IDs, artifact ↔ trace linkage,
+  and minimal reviewer-facing trace surfaces
+
+- `v0.87.2`:
+  provider / transport substrate v1
+  explicit vendor/transport/model separation, stable `model_ref`, provider model
+  mapping, transport adapters for common providers, and backward-compatible
+  profile expansion
+
+- `v0.87.3`:
+  shared ObsMem foundation
+  shared memory substrate across runs, structured retrieval integration, and
+  early persistence/indexing discipline
+
+- `v0.87.4`:
+  operational skills + demo planning substrate
+  first-class operational skills (`preflight-check`, `card-review`, bootstrap /
+  recovery flows) plus canonical demo catalog/planning and reviewer-facing demo
+  manifest conventions
+
+Why this belongs here:
+
+- later AEE, identity, governance, and provenance work require stable trace and provider/model correctness
+- shared ObsMem must exist before later persistence, identity, and richer agency layers can be real
+- operational skills reduce execution friction for every later milestone
+- demo planning should become a first-class execution surface early rather than a late packaging exercise
+- this milestone gives later cognition and PR Demo surfaces a real substrate instead of ad hoc proof surfaces
+
+### v0.88 - Persistence, Instinct, Aptitudes, and Bounded Agency Band
+
+Theme:
+make persistence-over-time and instinct/aptitude-shaped agency real, inspectable, and demoable.
 
 Sub-milestones:
 
@@ -225,44 +289,51 @@ Sub-milestones:
   surfaces
 
 - `v0.88.2`:
-  instinct signals + runtime surface
-  instinct declaration, instinct runtime surfaces, and simple prioritization
-  hooks influenced by instinct/arbitration
+  instinct + aptitudes runtime surface
+  instinct declaration, aptitude surfaces, and simple prioritization / shaping
+  hooks influenced by instinct, memory, and arbitration
 
 - `v0.88.3`:
   bounded agency demo
-  one clear demo showing persistence, prioritization, constraint, and
-  accountable choice
+  one clear demo showing persistence, prioritization, aptitude/instinct shaping,
+  constraint, and accountable choice
 
 Why this belongs here:
 
-- persistence, instinct, and bounded agency are more coherent together than as
-  separate tiny milestones
-- the Freedom Gate belongs in the earlier cognition-control band, while
-  instinct/runtime shaping and continuity belong here
-- one strong persistence-plus-agency demo is more valuable than many
-  speculative slices
+- persistence, instinct, aptitudes, and bounded agency are more coherent together than as separate tiny milestones
+- the Freedom Gate belongs in the earlier cognition-control band, while continuity, instinct/runtime shaping, and aptitude-bearing behavior belong here
+- one strong persistence-plus-agency demo is more valuable than many speculative slices
 
-### v0.89 - AEE Convergence Band
+### v0.89 - AEE 1.0 Convergence Band
 
 Theme:
-make AEE minimally real and demonstrable under bounded security and threat
-constraints, not fully generalized.
+deliver **AEE 1.0** as a real, core ADL subsystem under bounded security and
+threat constraints.
 
 Sub-milestones:
 
 - `v0.89.1`:
   convergence loop
-  simple convergence signals and stop conditions
+  explicit convergence signals, bounded stop conditions, and inspectable
+  convergence state
 
 - `v0.89.2`:
   retry/adaptation loop
-  visible adaptation behavior within bounded retries
+  visible adaptation behavior within bounded retries using the stabilized trace
+  and shared-memory substrate
 
 - `v0.89.3`:
-  convergence demo
+  AEE 1.0 demo
   one demo proving bounded convergence under explicit security/threat
-  constraints
+  constraints, with AEE complete enough that later milestones consume it rather
+  than continue defining its basic capability
+
+Why this belongs here:
+
+- AEE is a core ADL subsystem, not an optional later add-on
+- the first version is already being established in the bounded cognitive system band and should continue forward rather than stall
+- later milestones may integrate with AEE, govern it, or rely on it, but they should not still be defining what AEE fundamentally is
+- stable trace, shared memory, and persistence signals make `v0.89` the right point to deliver AEE 1.0 rather than a placeholder convergence story
 
 ### v0.90 - Reasoning Graph, Signed Trace, and Trace Query Band
 
@@ -277,9 +348,9 @@ Sub-milestones:
   first-class reasoning-graph artifacts and hypothesis/report structure
 
 - `v0.90.2`:
-  signed trace substrate
-  signed-trace-ready provenance, Freedom Gate event capture, and durable trace
-  structure
+  signed trace completion
+  signing / verification completion for the trace substrate, Freedom Gate event
+  capture, and durable authoritative provenance structure
 
 - `v0.90.3`:
   trace query
@@ -443,6 +514,12 @@ Clarifications:
 - after the additions in this roadmap pass, no additional major architectural
   domains should be admitted silently before `1.0`
 
+Integration and late-admission rule:
+
+- `v0.94` is the last explicit gap-closure band before MVP freeze
+- use `v0.94` only for dependency-gap closure, cross-cutting integration, and already-implied MVP work
+- do not introduce new architectural domains in `v0.94`
+
 Demo policy:
 
 - demos are for users and reviewers to understand behavior, not for replacing
@@ -482,11 +559,12 @@ This split is intentionally conservative.
 The core reasoning is:
 
 - `v0.85` should remain a strengthening milestone rather than a catch-all milestone
-- `v0.86` should establish cognition control cleanly rather than act as a future authoring catch-all
-- cognitive control should land before bounded agency, and bounded agency before stronger AEE work
+- `v0.86` should establish the first bounded cognitive system cleanly rather than act as a future authoring catch-all
+- `v0.87` should land the operational, trace, provider, shared-memory, and demo-planning substrate before deeper persistence and convergence work
+- cognitive control should land before bounded agency, and bounded agency before AEE 1.0 convergence
 - the Freedom Gate belongs with first cognition-control surfaces, not as a late add-on
-- AEE plus bounded security should become concrete before the reasoning/provenance stack deepens
-- reasoning-graph artifacts, signed trace, and query belong together rather than being spread across later bands
+- AEE is core and should become real in `v0.89`, before the reasoning/provenance stack deepens
+- reasoning-graph artifacts, signed trace completion, and query belong together rather than being spread across later bands
 - affect and moral cognition should form one readable milestone band rather than many thin slices
 - identity substrate should come before governance and delegation
 - final convergence should focus on tooling migration, integration, demos, and freeze discipline
@@ -497,14 +575,54 @@ The core reasoning is:
 The intended dependency flow is:
 
 1. `v0.85` operational maturity
-2. `v0.86.1` to `v0.86.3` cognitive control
-3. `v0.88.1` to `v0.88.3` persistence, instinct, and bounded agency
-4. `v0.89.1` to `v0.89.3` AEE convergence and security/threat modeling
-5. `v0.90.1` to `v0.90.3` reasoning graph, signed trace, and trace query
-6. `v0.91.1` to `v0.91.3` affect and moral cognition
-7. `v0.92.1` to `v0.92.3` identity, continuity, and capability substrate
-8. `v0.93.1` to `v0.93.3` governance and delegation
-9. `v0.95.1` to `v0.95.3` MVP convergence, tooling migration, demo closure, and `1.0` definition freeze
+2. `v0.86.1` to `v0.86.3` bounded cognitive system
+3. `v0.87.1` to `v0.87.4` operational, trace, provider, shared-memory, and demo-planning substrate
+4. `v0.88.1` to `v0.88.3` persistence, instinct, aptitudes, and bounded agency
+5. `v0.89.1` to `v0.89.3` AEE 1.0 convergence and security/threat modeling
+6. `v0.90.1` to `v0.90.3` reasoning graph, signed trace completion, and trace query
+7. `v0.91.1` to `v0.91.3` affect and moral cognition
+8. `v0.92.1` to `v0.92.3` identity, continuity, and capability substrate
+9. `v0.93.1` to `v0.93.3` governance and delegation
+10. `v0.94` integration and dependency-gap closure
+11. `v0.95.1` to `v0.95.3` MVP convergence, tooling migration, demo closure, and `1.0` definition freeze
+
+## Demo Planning Track
+
+Demo work should not be deferred to the end.
+
+Each major milestone should have an explicit demo obligation tied to the runtime surfaces that milestone introduces.
+
+- `v0.87`: define the canonical demo catalog for `v0.87` through `v0.95`, including prototype, milestone-proof, investor-facing, and PR Demo classes
+- `v0.88`: first persistence / continuity demo and first bounded agency-over-time demo
+- `v0.89`: first real AEE 1.0 convergence demo
+- `v0.90`: first proto PR Demo plus reasoning/provenance demo
+- `v0.91`: affect + moral cognition vertical slice demo
+- `v0.92`: first real PR Demo with persistent identities across runs
+- `v0.93`: governed PR Demo with delegation / accountability surfaces
+- `v0.95`: polished MVP walkthrough and investor-facing integrated demo set
+
+This keeps demo planning as an enabling substrate rather than a late packaging exercise.
+
+## PR Demo Staging
+
+Earliest viable milestone for a **real** PR Demo: `v0.92`.
+
+Staging plan:
+
+- `v0.87`: define the PR Demo plan, artifact expectations, and role model
+- `v0.90`: deliver a proto PR Demo with inspectable reasoning/provenance
+- `v0.92`: deliver the first real persistent PR Demo
+- `v0.93`: deliver the governed PR Demo
+- `v0.95`: polish the PR Demo into MVP-facing walkthrough form
+
+Why not earlier:
+
+- `v0.88` supplies persistence / chronosense and bounded agency
+- `v0.89` supplies AEE 1.0 adaptive behavior
+- `v0.90` supplies inspectable reasoning/provenance and signed-trace completion
+- `v0.92` supplies persistent identity across runs
+
+Without identity, there is not yet a true PR Demo society surface—only repeated executions.
 
 ## Guardrail
 

--- a/.adl/v0.85/bodies/issue-1245-v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main.md
+++ b/.adl/v0.85/bodies/issue-1245-v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main.md
@@ -1,0 +1,114 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+title: "[v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:docs"
+  - "version:v0.85"
+issue_number: 1245
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "docs"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Bootstrap-generated from GitHub issue metadata because no canonical local issue prompt existed yet."
+pr_start:
+  enabled: true
+  slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+---
+
+---
+issue_card_schema: adl.issue.v1
+wp: "DOCS"
+slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+title: "[v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:docs"
+  - "version:v0.85"
+status: "active"
+action: "edit"
+milestone_sprint: "Planning follow-up"
+required_outcome_type:
+  - "docs"
+repo_inputs:
+  - ".adl/docs/roadmaps/ROAD_TO_v0.95.md"
+canonical_files:
+  - ".adl/docs/roadmaps/ROAD_TO_v0.95.md"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Tracks a user-authored roadmap restructuring diff that was left loose on main."
+pr_start:
+  enabled: true
+  slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+---
+
+# [v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main
+
+## Summary
+
+Move the loose roadmap restructuring edits from the primary checkout into a tracked issue/worktree so the planning change is reviewable and `main` remains clean while roadmap editing continues. Also relocate `ROAD_TO_v0.95.md` out of `v0.85planning` into a cross-milestone roadmap location without losing any of the current edits.
+
+## Goal
+
+Capture the current `ROAD_TO_v0.95.md` changes on their own issue branch, preserve the in-progress content exactly, and move the document to a semantically correct non-`v0.85planning` home.
+
+## Required Outcome
+
+This issue is docs-only.
+
+## Deliverables
+
+- a tracked issue for the loose roadmap edit
+- a started worktree carrying the current `ROAD_TO_v0.95.md` diff
+- a clean primary checkout after the diff is moved
+- a follow-through relocation plan and execution path for moving `ROAD_TO_v0.95.md` out of `.adl/docs/v0.85planning/`
+
+## Acceptance Criteria
+
+- the exact current diff from `ROAD_TO_v0.95.md` is preserved in the issue worktree and moved to `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+- the primary checkout no longer has that loose roadmap modification
+- the issue explicitly tracks relocation of the roadmap to a cross-milestone docs location, preserving all current edits
+- no unrelated files are changed
+
+## Repo Inputs
+
+- `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- no demo required
+
+## Non-goals
+
+- revising the roadmap content beyond preserving the existing edit and tracking the path relocation work
+- editing unrelated docs or roadmap files
+
+## Issue-Graph Notes
+
+- This issue exists only to preserve and track the currently loose roadmap edit.
+- The roadmap is misfiled under `v0.85planning`; this issue now also tracks relocating it to a cross-milestone roadmap location.
+
+## Notes
+
+- Keep the edit content exactly as-is while moving it off `main`.
+- Preserve the current roadmap edits first; do not lose them while fixing the document location.
+
+## Tooling Notes
+
+- Use the normal `pr create -> pr init -> pr start` lifecycle.

--- a/.adl/v0.85/tasks/issue-1245__v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main/sip.md
+++ b/.adl/v0.85/tasks/issue-1245__v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main/sip.md
@@ -1,0 +1,176 @@
+# ADL Input Card
+
+Task ID: issue-1245
+Run ID: issue-1245
+Version: v0.85
+Title: [v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main
+Branch: codex/1245-v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1245
+- PR:
+- Source Issue Prompt: .adl/v0.85/bodies/issue-1245-v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.85/tasks/issue-1245__v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands, preserving the live roadmap edits while tracking the file-relocation work.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+- the linked source issue prompt and paired task cards that now track relocation of this roadmap out of `v0.85planning`
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+- losing or rewriting the current roadmap edits while resolving the document location
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.85/tasks/issue-1245__v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main/sor.md
+++ b/.adl/v0.85/tasks/issue-1245__v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main/sor.md
@@ -1,0 +1,160 @@
+# v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1245
+Run ID: issue-1245
+Version: v0.85
+Title: [v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main
+Branch: codex/1245-v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: OpenAI
+- Start Time: 2026-03-31
+- End Time: 2026-03-31
+
+## Summary
+
+Preserved the in-progress `ROAD_TO_v0.95.md` edits, moved the roadmap from `.adl/docs/v0.85planning/` to the cross-milestone location `.adl/docs/roadmaps/`, and updated the issue/task surfaces to follow the new path.
+
+## Artifacts produced
+- `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+- updated issue body, STP, and SIP pointing at the new roadmap location
+
+## Actions taken
+- created `.adl/docs/roadmaps/` in the issue worktree
+- moved `ROAD_TO_v0.95.md` from `.adl/docs/v0.85planning/` to `.adl/docs/roadmaps/`
+- preserved the existing roadmap edits during the move
+- updated the issue body, STP, and SIP to reference the new canonical path
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; changes are staged on the issue branch for PR review
+- Worktree-only paths remaining: `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: moved the tracked file within the issue branch and prepared it for PR review
+- Verification performed:
+  - `git status --short`
+  - `ls .adl/docs/roadmaps`
+  - `git diff --stat`
+- Result: the new roadmap path exists in the issue worktree, the edited content is preserved, and the old path is removed on the branch
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `git status --short`
+    verified the intended moved file and task-surface edits were the only active branch changes
+  - `ls .adl/docs/roadmaps`
+    verified the new roadmap directory and moved file exist
+  - `git diff --stat`
+    verified the branch carries the roadmap move plus the related issue/task-surface updates
+- Results:
+  - validation passed for the docs move and review-surface alignment
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "git status --short"
+      - "ls .adl/docs/roadmaps"
+      - "git diff --stat"
+  determinism:
+    status: NOT_RUN
+    replay_verified: unknown
+    ordering_guarantees_verified: unknown
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: none; this is a docs move and review-surface alignment task
+- Fixtures or scripts used: not applicable
+- Replay verification (same inputs -> same artifacts/order): not run
+- Ordering guarantees (sorting / tie-break rules used): not applicable
+- Artifact stability notes: the edited roadmap content was preserved byte-for-byte through a file move within the branch
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of the moved doc and task-surface updates only; no secrets introduced
+- Prompt / tool argument redaction verified: yes; no prompts or tool arguments were added to the roadmap doc
+- Absolute path leakage check: passed; only repository-relative paths are recorded in the output card
+- Sandbox / policy invariants preserved: yes
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable
+- Run artifact root: not applicable
+- Replay command used for verification: not applicable
+- Replay result: not applicable
+
+## Artifact Verification
+- Primary proof surface: `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+- Required artifacts present: yes
+- Artifact schema/version checks: not applicable for this docs move
+- Hash/byte-stability checks: not run; preservation was verified by moving the edited file in-branch and reviewing the resulting diff
+- Missing/optional artifacts and rationale: none
+
+## Decisions / Deviations
+
+- Chose `.adl/docs/roadmaps/ROAD_TO_v0.95.md` as the new canonical location because the document spans multiple milestone bands and should not live under `v0.85planning`.
+
+## Follow-ups / Deferred work
+
+- Close `#1245` after PR review/merge once the roadmap move is accepted.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.85/tasks/issue-1245__v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main/stp.md
+++ b/.adl/v0.85/tasks/issue-1245__v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main/stp.md
@@ -1,0 +1,114 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+title: "[v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:docs"
+  - "version:v0.85"
+issue_number: 1245
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "docs"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Bootstrap-generated from GitHub issue metadata because no canonical local issue prompt existed yet."
+pr_start:
+  enabled: true
+  slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+---
+
+---
+issue_card_schema: adl.issue.v1
+wp: "DOCS"
+slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+title: "[v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:docs"
+  - "version:v0.85"
+status: "active"
+action: "edit"
+milestone_sprint: "Planning follow-up"
+required_outcome_type:
+  - "docs"
+repo_inputs:
+  - ".adl/docs/roadmaps/ROAD_TO_v0.95.md"
+canonical_files:
+  - ".adl/docs/roadmaps/ROAD_TO_v0.95.md"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Tracks a user-authored roadmap restructuring diff that was left loose on main."
+pr_start:
+  enabled: true
+  slug: "v0-85-docs-capture-road-to-v0-95-roadmap-restructure-edits-from-main"
+---
+
+# [v0.85][docs] Capture ROAD_TO_v0.95 roadmap restructure edits from main
+
+## Summary
+
+Move the loose roadmap restructuring edits from the primary checkout into a tracked issue/worktree so the planning change is reviewable and `main` remains clean while roadmap editing continues. Also relocate `ROAD_TO_v0.95.md` out of `v0.85planning` into a cross-milestone roadmap location without losing any of the current edits.
+
+## Goal
+
+Capture the current `ROAD_TO_v0.95.md` changes on their own issue branch, preserve the in-progress content exactly, and move the document to a semantically correct non-`v0.85planning` home.
+
+## Required Outcome
+
+This issue is docs-only.
+
+## Deliverables
+
+- a tracked issue for the loose roadmap edit
+- a started worktree carrying the current `ROAD_TO_v0.95.md` diff
+- a clean primary checkout after the diff is moved
+- a follow-through relocation plan and execution path for moving `ROAD_TO_v0.95.md` out of `.adl/docs/v0.85planning/`
+
+## Acceptance Criteria
+
+- the exact current diff from `ROAD_TO_v0.95.md` is preserved in the issue worktree and moved to `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+- the primary checkout no longer has that loose roadmap modification
+- the issue explicitly tracks relocation of the roadmap to a cross-milestone docs location, preserving all current edits
+- no unrelated files are changed
+
+## Repo Inputs
+
+- `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- no demo required
+
+## Non-goals
+
+- revising the roadmap content beyond preserving the existing edit and tracking the path relocation work
+- editing unrelated docs or roadmap files
+
+## Issue-Graph Notes
+
+- This issue exists only to preserve and track the currently loose roadmap edit.
+- The roadmap is misfiled under `v0.85planning`; this issue now also tracks relocating it to a cross-milestone roadmap location.
+
+## Notes
+
+- Keep the edit content exactly as-is while moving it off `main`.
+- Preserve the current roadmap edits first; do not lose them while fixing the document location.
+
+## Tooling Notes
+
+- Use the normal `pr create -> pr init -> pr start` lifecycle.


### PR DESCRIPTION
## Summary
- move `ROAD_TO_v0.95.md` from `.adl/docs/v0.85planning/` to `.adl/docs/roadmaps/`
- preserve the current in-progress roadmap edits during the move
- include the issue body, STP, SIP, and SOR review surfaces for `#1245`

## Validation
- `git status --short`
- `ls .adl/docs/roadmaps`
- `git diff --stat`

Closes #1245