### PR TITLE
[v0.86][security] Fix optional-signature verification semantics for unsigned-allowed profiles

### DIFF
--- a/adl/src/signing.rs
+++ b/adl/src/signing.rs
@@ -271,12 +271,9 @@ pub fn verify_doc_with_profile(
     };
     enforce_verification_profile(&metadata, &profile)?;
 
-    let sig = doc.signature.as_ref().ok_or_else(|| {
-        VerificationError::policy(
-            "SIGN_POLICY_UNSIGNED_REQUIRED",
-            "workflow is unsigned and verification profile requires signature",
-        )
-    })?;
+    let Some(sig) = doc.signature.as_ref() else {
+        return Ok(());
+    };
 
     let public = if let Some(path) = public_key_path {
         load_verifying_key(path).map_err(|err| {
@@ -726,7 +723,7 @@ run:
     }
 
     #[test]
-    fn verify_doc_with_profile_currently_requires_signature_even_when_optional() {
+    fn verify_doc_with_profile_allows_unsigned_when_signature_is_optional() {
         let doc = sample_doc();
         let profile = VerificationProfile {
             require_signature: false,
@@ -734,10 +731,8 @@ run:
             allowed_algs: vec!["ed25519".to_string()],
             allowed_key_sources: vec![VerificationKeySource::Embedded],
         };
-        let err = verify_doc_with_profile(&doc, None, &profile)
-            .expect_err("current implementation requires an attached signature");
-        assert_eq!(err.kind, VerificationErrorKind::PolicyViolation);
-        assert_eq!(err.code, "SIGN_POLICY_UNSIGNED_REQUIRED");
+        verify_doc_with_profile(&doc, None, &profile)
+            .expect("unsigned document should be allowed when signature is optional");
     }
 
     #[test]

--- a/adl/tests/signing_tests.rs
+++ b/adl/tests/signing_tests.rs
@@ -341,7 +341,7 @@ fn enforce_profile_rejects_disallowed_key_source() {
 }
 
 #[test]
-fn verify_doc_with_profile_rejects_unsigned_when_profile_allows_unsigned_without_sig_material() {
+fn verify_doc_with_profile_allows_unsigned_when_profile_allows_unsigned_without_sig_material() {
     let base = tmp_dir("verify-unsigned-no-sig");
     let unsigned = write_unsigned_fixture(&base);
     let raw = fs::read_to_string(&unsigned).expect("read unsigned doc");
@@ -350,9 +350,8 @@ fn verify_doc_with_profile_rejects_unsigned_when_profile_allows_unsigned_without
         require_signature: false,
         ..VerificationProfile::default()
     };
-    let err = verify_doc_with_profile(&doc, None, &profile).expect_err("unsigned must fail here");
-    assert_eq!(err.kind, VerificationErrorKind::PolicyViolation);
-    assert_eq!(err.code, "SIGN_POLICY_UNSIGNED_REQUIRED");
+    verify_doc_with_profile(&doc, None, &profile)
+        .expect("unsigned document should be allowed when signature is optional");
 }
 
 #[test]


### PR DESCRIPTION
Closes #1262

## Summary
Fixed the optional-signature verification contract so unsigned documents now succeed when the verification profile sets `require_signature: false`, while required-signature profiles still fail unsigned documents. Updated both the library-level and integration-level signing tests so they assert the intended behavior instead of encoding the old bug.

## Artifacts
- Updated signing verification logic in `adl/src/signing.rs`
- Updated signing regression coverage in `adl/tests/signing_tests.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml signing::tests::verify_doc_with_profile_allows_unsigned_when_signature_is_optional -- --nocapture`
    Verified the library-level optional-signature contract directly at the narrow seam that was wrong before the fix.
  - `cargo test --manifest-path adl/Cargo.toml --test signing_tests -- --nocapture`
    Verified the full signing integration test surface, including the updated unsigned-allowed path and existing required-signature behavior.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified formatting stayed clean.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the change compiles cleanly under the repository lint bar.
- Results:
  - all listed commands passed
  - optional-signature verification now succeeds when the profile allows unsigned documents
  - required-signature enforcement remained covered by the existing test surface

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1262__v0-86-security-fix-optional-signature-verification-semantics-for-unsigned-allowed-profiles/sip.md
- Output card: .adl/v0.86/tasks/issue-1262__v0-86-security-fix-optional-signature-verification-semantics-for-unsigned-allowed-profiles/sor.md
- Idempotency-Key: v0-86-security-fix-optional-signature-verification-semantics-for-unsigned-allowed-profiles-adl-src-signing-rs-adl-tests-signing-tests-rs-adl-v0-86-tasks-issue-1262-v0-86-security-fix-optional-signature-verification-semantics-for-unsigned-allowed-profiles-sip-md-adl-v0-86-tasks-issue-1262-v0-86-security-fix-optional-signature-verification-semantics-for-unsigned-allowed-profiles-sor-md