### PR TITLE
[v0.86][runtime] Stop retrying deterministic remote policy and schema failures

### DIFF
--- a/adl/src/execute/runner.rs
+++ b/adl/src/execute/runner.rs
@@ -370,7 +370,11 @@ where
                 }
                 crate::adl::PlacementMode::Remote => {
                     let remote = doc.run.remote.as_ref().ok_or_else(|| {
-                        anyhow!("REMOTE_SCHEMA_VIOLATION: run.remote.endpoint is required when placement=remote")
+                        crate::remote_exec::RemoteExecuteClientError::new(
+                            crate::remote_exec::RemoteExecuteClientErrorKind::SchemaViolation,
+                            "REMOTE_SCHEMA_VIOLATION",
+                            "run.remote.endpoint is required when placement=remote",
+                        )
                     })?;
                     let timeout_ms = remote.timeout_ms.unwrap_or(30_000);
                     let mut req = remote_exec::ExecuteRequest {

--- a/adl/src/execute/tests.rs
+++ b/adl/src/execute/tests.rs
@@ -2,7 +2,10 @@ use super::runner::{
     effective_max_concurrency_with_source, effective_step_placement, resolve_call_binding,
 };
 use super::*;
-use crate::adl::{AdlDoc, PromptSpec, RunDefaults, RunSpec, WorkflowKind, WorkflowSpec};
+use crate::adl::{
+    AdlDoc, PlacementMode, PromptSpec, RunDefaults, RunPlacementSpec, RunSpec, StepRetry,
+    WorkflowKind, WorkflowSpec,
+};
 use crate::resolve::AdlResolved;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -64,6 +67,30 @@ fn step_with_write_to(id: &str, write_to: Option<&str>) -> crate::resolve::Resol
         write_to: write_to.map(str::to_string),
         on_error: None,
         retry: None,
+    }
+}
+
+fn remote_retry_step(max_attempts: u32) -> crate::resolve::ResolvedStep {
+    crate::resolve::ResolvedStep {
+        id: "remote-step".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Remote),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        prompt: Some(PromptSpec {
+            user: Some("hello".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::new(),
+        guards: vec![],
+        save_as: None,
+        write_to: None,
+        on_error: None,
+        retry: Some(StepRetry { max_attempts }),
     }
 }
 
@@ -329,6 +356,44 @@ fn pause_reason_for_step_detects_pause_guard_and_optional_reason() {
     assert_eq!(
         pause_reason_for_step(&step),
         Some(Some("needs review".to_string()))
+    );
+}
+
+#[test]
+fn execute_step_with_retry_does_not_retry_remote_schema_violation() {
+    let mut doc = minimal_resolved().doc;
+    doc.providers.insert(
+        "p1".to_string(),
+        crate::adl::ProviderSpec {
+            id: None,
+            profile: None,
+            kind: "http".to_string(),
+            base_url: None,
+            default_model: None,
+            config: HashMap::new(),
+        },
+    );
+    doc.run.placement = Some(RunPlacementSpec::Mode(PlacementMode::Remote));
+    doc.run.remote = None;
+    let step = remote_retry_step(3);
+
+    let failure = execute_step_with_retry_core(
+        &step,
+        &doc,
+        "run-1",
+        "wf-1",
+        &HashMap::new(),
+        std::path::Path::new("."),
+        false,
+        |_| {},
+    )
+    .expect_err("remote schema violation should fail");
+
+    assert_eq!(failure.attempts, 1);
+    assert!(
+        failure.err.to_string().contains("REMOTE_SCHEMA_VIOLATION"),
+        "unexpected error: {:#}",
+        failure.err
     );
 }
 

--- a/adl/src/provider.rs
+++ b/adl/src/provider.rs
@@ -167,6 +167,9 @@ pub fn is_retryable_error(err: &anyhow::Error) -> bool {
             );
         }
     }
+    if let Some(retryable) = crate::remote_exec::retryability(err) {
+        return retryable;
+    }
     true
 }
 
@@ -796,6 +799,33 @@ mod tests {
         assert!(!is_retryable_error(&panic));
         assert_eq!(stable_failure_kind(&panic), Some("panic"));
         assert!(format!("{panic:#}").contains("provider mock panic: panic"));
+    }
+
+    #[test]
+    fn remote_retry_classification_distinguishes_deterministic_failures() {
+        let schema = anyhow::Error::new(crate::remote_exec::RemoteExecuteClientError::new(
+            crate::remote_exec::RemoteExecuteClientErrorKind::SchemaViolation,
+            "REMOTE_SCHEMA_VIOLATION",
+            "missing result on ok response",
+        ));
+        assert!(!is_retryable_error(&schema));
+
+        let envelope = anyhow::Error::new(crate::remote_exec::SecurityEnvelopeError::MissingKeyId);
+        assert!(!is_retryable_error(&envelope));
+
+        let remote_schema = anyhow::Error::new(crate::remote_exec::RemoteExecuteClientError::new(
+            crate::remote_exec::RemoteExecuteClientErrorKind::RemoteExecution,
+            "REMOTE_SCHEMA_VIOLATION",
+            "invalid provider config",
+        ));
+        assert!(!is_retryable_error(&remote_schema));
+
+        let timeout = anyhow::Error::new(crate::remote_exec::RemoteExecuteClientError::new(
+            crate::remote_exec::RemoteExecuteClientErrorKind::Timeout,
+            "REMOTE_TIMEOUT",
+            "timed out",
+        ));
+        assert!(is_retryable_error(&timeout));
     }
 
     #[test]

--- a/adl/src/remote_exec.rs
+++ b/adl/src/remote_exec.rs
@@ -216,7 +216,7 @@ impl std::fmt::Display for RemoteExecuteClientError {
 impl std::error::Error for RemoteExecuteClientError {}
 
 impl RemoteExecuteClientError {
-    fn new(
+    pub(crate) fn new(
         kind: RemoteExecuteClientErrorKind,
         code: impl Into<String>,
         message: impl Into<String>,
@@ -227,6 +227,35 @@ impl RemoteExecuteClientError {
             message: message.into(),
         }
     }
+}
+
+pub fn retryability(err: &anyhow::Error) -> Option<bool> {
+    for cause in err.chain() {
+        if cause.downcast_ref::<SecurityEnvelopeError>().is_some() {
+            return Some(false);
+        }
+        if let Some(remote) = cause.downcast_ref::<RemoteExecuteClientError>() {
+            return Some(match remote.kind {
+                RemoteExecuteClientErrorKind::Timeout
+                | RemoteExecuteClientErrorKind::Unreachable
+                | RemoteExecuteClientErrorKind::BadStatus
+                | RemoteExecuteClientErrorKind::InvalidJson => true,
+                RemoteExecuteClientErrorKind::SchemaViolation => false,
+                RemoteExecuteClientErrorKind::RemoteExecution => {
+                    !matches!(
+                        remote.code.as_str(),
+                        "REMOTE_SCHEMA_VIOLATION"
+                            | "SIGN_POLICY_UNSIGNED_REQUIRED"
+                            | "SIGN_POLICY_MISSING_KEY_ID"
+                            | "SIGN_POLICY_DISALLOWED_ALGORITHM"
+                            | "SIGN_POLICY_DISALLOWED_KEY_SOURCE"
+                            | "SIGN_POLICY_MISSING_KEY_SOURCE"
+                    ) && !remote.code.starts_with("REMOTE_ENVELOPE_")
+                }
+            });
+        }
+    }
+    None
 }
 
 pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {


### PR DESCRIPTION
Closes #1263

## Summary
Implemented a focused retry-classification fix so deterministic remote policy and schema failures no longer consume retry budget as if they were transient transport errors. The patch keeps timeout and reachability failures retryable, converts the runner-side remote schema precondition into a typed schema error, and adds direct tests for both the classifier and the retry loop behavior.

## Artifacts
- Updated runtime retry classification in `adl/src/provider.rs`.
- Added remote retryability helper logic in `adl/src/remote_exec.rs`.
- Updated remote step schema failure emission in `adl/src/execute/runner.rs`.
- Added focused regression coverage in `adl/src/execute/tests.rs`.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml remote_retry_classification_distinguishes_deterministic_failures -- --nocapture` to verify deterministic remote policy/schema failures are classified as non-retryable while transient remote failures remain retryable.
  - `cargo test --manifest-path adl/Cargo.toml execute_step_with_retry_does_not_retry_remote_schema_violation -- --nocapture` to verify the retry loop stops after the first remote schema violation even when retry budget is configured.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` to verify the runtime patch remains formatting-clean.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` to verify the classification and test changes compile cleanly under the repo lint baseline.
- Results:
  - Both focused retry tests passed.
  - Formatting passed without changes required after the final patch.
  - Clippy passed with no warnings.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1263__v0-86-runtime-stop-retrying-deterministic-remote-policy-and-schema-failures/sip.md
- Output card: .adl/v0.86/tasks/issue-1263__v0-86-runtime-stop-retrying-deterministic-remote-policy-and-schema-failures/sor.md
- Idempotency-Key: v0-86-runtime-stop-retrying-deterministic-remote-policy-and-schema-failures-adl-src-provider-rs-adl-src-remote-exec-rs-adl-src-execute-runner-rs-adl-src-execute-tests-rs-adl-v0-86-tasks-issue-1263-v0-86-runtime-stop-retrying-deterministic-remote-policy-and-schema-failures-sip-md-adl-v0-86-tasks-issue-1263-v0-86-runtime-stop-retrying-deterministic-remote-policy-and-schema-failures-sor-md