### PR TITLE
[v0.86][runtime] Stop trusting pause artifact adl_path before full resume validation

### DIFF
--- a/adl/src/cli/run.rs
+++ b/adl/src/cli/run.rs
@@ -381,10 +381,20 @@ pub(crate) fn real_resume(args: &[String]) -> Result<()> {
         eprintln!("{}", resume_usage());
         std::process::exit(2);
     };
+    let mut adl_path: Option<PathBuf> = None;
     let mut steer_path: Option<PathBuf> = None;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
+            "--adl" => {
+                let Some(path) = args.get(i + 1) else {
+                    eprintln!("resume --adl requires a path to the ADL document");
+                    eprintln!("{}", resume_usage());
+                    std::process::exit(2);
+                };
+                adl_path = Some(PathBuf::from(path));
+                i += 1;
+            }
             "--steer" => {
                 let Some(path) = args.get(i + 1) else {
                     eprintln!("resume --steer requires a path to steering patch JSON");
@@ -395,11 +405,16 @@ pub(crate) fn real_resume(args: &[String]) -> Result<()> {
                 i += 1;
             }
             other => {
-                if args.len() > 1 && args.get(1).map(|s| s.as_str()) != Some("--steer") {
-                    eprintln!("resume accepts exactly one argument: <run_id>");
+                if args.len() > 1
+                    && args
+                        .iter()
+                        .skip(1)
+                        .all(|arg| arg != "--adl" && arg != "--steer")
+                {
+                    eprintln!("resume requires <run_id> plus --adl <path>");
                 } else {
                     eprintln!(
-                        "resume accepts <run_id> [--steer <steering.json>] (unknown arg: {other})"
+                        "resume accepts <run_id> --adl <path> [--steer <steering.json>] (unknown arg: {other})"
                     );
                 }
                 eprintln!("{}", resume_usage());
@@ -408,7 +423,6 @@ pub(crate) fn real_resume(args: &[String]) -> Result<()> {
         }
         i += 1;
     }
-
     let pause_path = resume_state_path_for_run_id(run_id)?;
     if !pause_path.exists() {
         return Err(anyhow::anyhow!(
@@ -417,13 +431,19 @@ pub(crate) fn real_resume(args: &[String]) -> Result<()> {
             pause_path.display()
         ));
     }
+    let Some(adl_path) = adl_path else {
+        eprintln!(
+            "resume requires --adl <path> so the ADL document comes from a trusted explicit source"
+        );
+        eprintln!("{}", resume_usage());
+        std::process::exit(2);
+    };
     let pause_artifact = load_pause_state_artifact(&pause_path)?;
     validate_pause_artifact_basic(&pause_artifact, run_id)?;
 
-    let adl_path = PathBuf::from(&pause_artifact.adl_path);
     let adl_path_str = adl_path
         .to_str()
-        .context("resume ADL path from pause state must be valid UTF-8")?;
+        .context("resume ADL path must be valid UTF-8")?;
     let adl_base_dir: PathBuf = adl_path.parent().unwrap_or(Path::new(".")).to_path_buf();
     let doc = adl::AdlDoc::load_from_file(adl_path_str).with_context(|| {
         format!(

--- a/adl/src/cli/tests/open_usage.rs
+++ b/adl/src/cli/tests/open_usage.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::resume_usage;
 
 #[test]
 fn select_open_artifact_prefers_first_html() {
@@ -102,8 +103,9 @@ fn is_ci_environment_treats_falsey_values_as_false() {
 #[test]
 fn usage_mentions_v0_4_and_legacy_examples() {
     let text = usage();
+    let resume_text = resume_usage();
     assert!(text.contains("Usage:"));
-    assert!(text.contains("adl resume <run_id>"));
+    assert!(resume_text.contains("adl resume <run_id> --adl <path>"));
     assert!(text.contains("adl godel run"));
     assert!(text.contains("adl godel inspect"));
     assert!(text.contains("adl godel evaluate"));

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -72,10 +72,12 @@ Examples:
 
 pub fn resume_usage() -> &'static str {
     "Usage:
-  adl resume <run_id> [--steer <steering.json>]
+  adl resume <run_id> --adl <path> [--steer <steering.json>]
 
 Semantics:
   - Loads .adl/runs/<run_id>/pause_state.json
+  - Uses the explicit --adl path as the trusted document source for resume
+  - Treats pause_state.json path fields as untrusted observational metadata only
   - Strict validation only: schema_version, status=paused, run_id, execution_plan_hash
   - Optional steering patch applies only at the resume boundary
   - Resumes only at step boundary (no checkpoint engine, no mid-step resume)"

--- a/adl/tests/cli_smoke/basics.rs
+++ b/adl/tests/cli_smoke/basics.rs
@@ -340,7 +340,7 @@ fn verify_requires_path_arg() {
 }
 
 #[test]
-fn resume_requires_exactly_one_run_id() {
+fn resume_requires_run_id_and_explicit_adl_path() {
     let none = run_adl(&["resume"]);
     assert_eq!(
         none.status.code(),
@@ -354,16 +354,16 @@ fn resume_requires_exactly_one_run_id() {
         "stderr:\n{stderr_none}"
     );
 
-    let many = run_adl(&["resume", "a", "b"]);
+    let many = run_adl(&["resume", "a"]);
     assert_eq!(
         many.status.code(),
-        Some(2),
+        Some(1),
         "stderr:\n{}",
         String::from_utf8_lossy(&many.stderr)
     );
     let stderr_many = String::from_utf8_lossy(&many.stderr);
     assert!(
-        stderr_many.contains("resume accepts exactly one argument"),
+        stderr_many.contains("pause state not found"),
         "stderr:\n{stderr_many}"
     );
 }

--- a/adl/tests/cli_smoke/instrument_and_cli.rs
+++ b/adl/tests/cli_smoke/instrument_and_cli.rs
@@ -171,7 +171,13 @@ fn demo_command_accepts_no_open_flag_for_print_plan() {
 
 #[test]
 fn resume_unknown_run_id_fails_with_pause_state_message() {
-    let out = run_adl(&["resume", "does-not-exist-475"]);
+    let fixture = fixture_path("examples/v0-5-pattern-linear.adl.yaml");
+    let out = run_adl(&[
+        "resume",
+        "does-not-exist-475",
+        "--adl",
+        fixture.to_str().unwrap(),
+    ]);
     assert!(!out.status.success(), "resume should fail");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(

--- a/adl/tests/execute_tests/delegation_resume.rs
+++ b/adl/tests/execute_tests/delegation_resume.rs
@@ -1084,7 +1084,15 @@ run:
         serde_json::from_str(&fs::read_to_string(&run_json_path).unwrap()).unwrap();
     assert_eq!(run_json["status"], "paused");
 
-    let resumed = run_swarm_in_dir(&paused_case, &["resume", "hitl-roundtrip-cli"]);
+    let resumed = run_swarm_in_dir(
+        &paused_case,
+        &[
+            "resume",
+            "hitl-roundtrip-cli",
+            "--adl",
+            paused_path.to_str().unwrap(),
+        ],
+    );
     assert!(
         resumed.status.success(),
         "resume CLI should succeed\nstdout:\n{}\nstderr:\n{}",
@@ -1180,7 +1188,15 @@ run:
     let paused = run_swarm_in_dir(&paused_case, &[paused_path.to_str().unwrap(), "--run"]);
     assert!(paused.status.success(), "paused run should succeed");
 
-    let resumed = run_swarm_in_dir(&paused_case, &["resume", "resume-skip-verified"]);
+    let resumed = run_swarm_in_dir(
+        &paused_case,
+        &[
+            "resume",
+            "resume-skip-verified",
+            "--adl",
+            paused_path.to_str().unwrap(),
+        ],
+    );
     assert!(resumed.status.success(), "resume should succeed");
     let resumed_stderr = String::from_utf8_lossy(&resumed.stderr);
     assert!(
@@ -1258,7 +1274,15 @@ run:
     assert!(paused.status.success(), "paused run should succeed");
     fs::remove_file(paused_case.join("out").join("s1.txt")).unwrap();
 
-    let resumed = run_swarm_in_dir(&paused_case, &["resume", "resume-rerun-missing"]);
+    let resumed = run_swarm_in_dir(
+        &paused_case,
+        &[
+            "resume",
+            "resume-rerun-missing",
+            "--adl",
+            paused_path.to_str().unwrap(),
+        ],
+    );
     assert!(resumed.status.success(), "resume should succeed");
     let resumed_stderr = String::from_utf8_lossy(&resumed.stderr);
     assert!(
@@ -1343,6 +1367,8 @@ run:
         &[
             "resume",
             "resume-steer",
+            "--adl",
+            yaml_path.to_str().unwrap(),
             "--steer",
             steer_path.to_str().unwrap(),
         ],
@@ -1734,7 +1760,12 @@ run:
         String::from_utf8_lossy(&paused.stderr)
     );
 
-    let resume = run_swarm(&["resume", "hitl-resume-subcommand"]);
+    let resume = run_swarm(&[
+        "resume",
+        "hitl-resume-subcommand",
+        "--adl",
+        paused_path.to_str().unwrap(),
+    ]);
     assert!(
         resume.status.success(),
         "resume subcommand should succeed.\nstdout:\n{}\nstderr:\n{}",
@@ -1786,7 +1817,12 @@ run:
     pause_json["execution_plan_hash"] = serde_json::Value::String("deadbeef".to_string());
     fs::write(&pause_path, serde_json::to_vec_pretty(&pause_json).unwrap()).unwrap();
 
-    let resumed = run_swarm(&["resume", "hitl-resume-subcommand-bad-hash"]);
+    let resumed = run_swarm(&[
+        "resume",
+        "hitl-resume-subcommand-bad-hash",
+        "--adl",
+        paused_path.to_str().unwrap(),
+    ]);
     assert!(
         !resumed.status.success(),
         "resume subcommand should reject hash mismatch"
@@ -1795,6 +1831,64 @@ run:
     assert!(
         stderr.contains("execution plan hash mismatch"),
         "stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn resume_subcommand_ignores_tampered_pause_artifact_adl_path_when_explicit_path_is_supplied() {
+    let base = tmp_dir("exec-resume-subcommand-tampered-adl-path");
+    let _bin = write_mock_ollama(&base, MockOllamaBehavior::EchoPrompt);
+    let new_path = prepend_path(&base);
+    let _path_guard = EnvVarGuard::set("PATH", new_path);
+
+    let paused_yaml = r#"
+version: "0.3"
+providers: { local: { type: "ollama" } }
+agents: { a: { provider: "local", model: "phi4-mini" } }
+tasks: { t: { prompt: { user: "step {{n}}" } } }
+run:
+  name: "hitl-resume-subcommand-tampered-adl-path"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "s1"
+        agent: "a"
+        task: "t"
+        save_as: "s1"
+        write_to: "s1.txt"
+        inputs: { n: "1" }
+        guards: [ { type: pause } ]
+      - id: "s2"
+        agent: "a"
+        task: "t"
+        save_as: "s2"
+        write_to: "s2.txt"
+        inputs: { n: "2" }
+"#;
+    let paused_path = base.join("paused-resume-subcommand-tampered-adl-path.yaml");
+    fs::write(&paused_path, paused_yaml).unwrap();
+
+    let paused = run_swarm(&[paused_path.to_str().unwrap(), "--run"]);
+    assert!(paused.status.success(), "paused run should succeed");
+
+    let pause_path = pause_state_path("hitl-resume-subcommand-tampered-adl-path");
+    let mut pause_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&pause_path).unwrap()).unwrap();
+    pause_json["adl_path"] =
+        serde_json::Value::String(base.join("tampered-other.yaml").display().to_string());
+    fs::write(&pause_path, serde_json::to_vec_pretty(&pause_json).unwrap()).unwrap();
+
+    let resumed = run_swarm(&[
+        "resume",
+        "hitl-resume-subcommand-tampered-adl-path",
+        "--adl",
+        paused_path.to_str().unwrap(),
+    ]);
+    assert!(
+        resumed.status.success(),
+        "resume should ignore tampered pause_state adl_path when explicit --adl is supplied.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&resumed.stdout),
+        String::from_utf8_lossy(&resumed.stderr)
     );
 }
 


### PR DESCRIPTION
Closes #1264

## Summary
Implemented a resume hardening change so `adl resume` no longer trusts the unverified `adl_path` recorded inside `pause_state.json` when deciding which ADL document to load. Resume now requires an explicit trusted `--adl <path>` argument, treats the path inside the pause artifact as observational metadata only, and adds direct regression coverage proving a tampered pause artifact path does not redirect resume behavior.

## Artifacts
- Updated resume parsing and trusted path resolution in `adl/src/cli/run.rs`.
- Updated resume usage/help text in `adl/src/cli/usage.rs`.
- Added resume CLI guard coverage in `adl/tests/cli_smoke/basics.rs`.
- Updated CLI smoke coverage in `adl/tests/cli_smoke/instrument_and_cli.rs`.
- Updated usage-surface coverage in `adl/src/cli/tests/open_usage.rs`.
- Added resume tamper and success-path regressions in `adl/tests/execute_tests/delegation_resume.rs`.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml resume_requires_run_id_and_explicit_adl_path -- --nocapture` to verify resume now rejects invocation without the explicit trusted ADL path.
  - `cargo test --manifest-path adl/Cargo.toml resume_subcommand_resumes_from_pause_state_successfully -- --nocapture` to verify the normal resume path still works when the caller supplies the trusted ADL path.
  - `cargo test --manifest-path adl/Cargo.toml resume_subcommand_rejects_pause_state_plan_hash_mismatch -- --nocapture` to verify the hardened flow still enforces plan-hash validation on resumed runs.
  - `cargo test --manifest-path adl/Cargo.toml resume_subcommand_ignores_tampered_pause_artifact_adl_path_when_explicit_path_is_supplied -- --nocapture` to verify a corrupted pause artifact path cannot redirect resume when the caller supplies the trusted document path.
  - `cargo test --manifest-path adl/Cargo.toml usage_mentions_v0_4_and_legacy_examples -- --nocapture` to verify the public usage surface documents the new `adl resume <run_id> --adl <path>` contract.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` to verify the CLI and test changes remain formatting-clean.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` to verify the hardened resume flow compiles cleanly under the repo lint baseline.
- Results:
  - All targeted resume and usage tests passed.
  - Formatting passed with no further edits required after the final parser fix.
  - Clippy passed with no warnings.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1264__v0-86-runtime-stop-trusting-pause-artifact-adl-path-before-full-resume-validation/sip.md
- Output card: .adl/v0.86/tasks/issue-1264__v0-86-runtime-stop-trusting-pause-artifact-adl-path-before-full-resume-validation/sor.md
- Idempotency-Key: v0-86-runtime-stop-trusting-pause-artifact-adl-path-before-full-resume-validation-adl-src-cli-run-rs-adl-src-cli-usage-rs-adl-src-cli-tests-open-usage-rs-adl-tests-cli-smoke-basics-rs-adl-tests-cli-smoke-instrument-and-cli-rs-adl-tests-execute-tests-delegation-resume-rs-adl-v0-86-tasks-issue-1264-v0-86-runtime-stop-trusting-pause-artifact-adl-path-before-full-resume-validation-sip-md-adl-v0-86-tasks-issue-1264-v0-86-runtime-stop-trusting-pause-artifact-adl-path-before-full-resume-validation-sor-md