### PR TITLE
[v0.86][runtime] Validate run IDs as safe artifact path segments

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -5,6 +5,29 @@ use serde::Serialize;
 
 pub const ARTIFACT_MODEL_VERSION: u32 = 1;
 
+pub fn validate_run_id_path_segment(run_id: &str) -> Result<String> {
+    let trimmed = run_id.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("run_id must not be empty for artifact paths"));
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(anyhow!(
+            "run_id must be a safe path segment, not '.' or '..'"
+        ));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(anyhow!(
+            "run_id must be a safe path segment and must not contain path separators"
+        ));
+    }
+    if trimmed.contains(':') {
+        return Err(anyhow!(
+            "run_id must be a safe path segment and must not contain drive-like ':' prefixes"
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
 /// Canonical run artifact path builder.
 ///
 /// Produces deterministic, timestamp-free paths under `.adl/runs/<run_id>/`.
@@ -28,12 +51,9 @@ impl RunArtifactPaths {
 
     /// Construct deterministic artifact paths for a run id under an explicit runs root.
     pub fn for_run_in_root(run_id: &str, runs_root: impl Into<PathBuf>) -> Result<Self> {
-        let run_id = run_id.trim();
-        if run_id.is_empty() {
-            return Err(anyhow!("run_id must not be empty for artifact paths"));
-        }
+        let run_id = validate_run_id_path_segment(run_id)?;
         Ok(Self {
-            run_id: run_id.to_string(),
+            run_id,
             runs_root: runs_root.into(),
         })
     }
@@ -377,6 +397,17 @@ mod tests {
             err.to_string().contains("run_id must not be empty"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn for_run_rejects_traversal_separator_and_drive_like_run_ids() {
+        for bad in ["..", "a/b", "a\\b", "/tmp/run", "C:\\run"] {
+            let err = RunArtifactPaths::for_run(bad).expect_err("unsafe run_id should fail");
+            assert!(
+                err.to_string().contains("safe path segment"),
+                "unexpected error for '{bad}': {err}"
+            );
+        }
     }
 
     #[test]

--- a/adl/src/learning_export.rs
+++ b/adl/src/learning_export.rs
@@ -239,8 +239,9 @@ pub fn export_trace_bundle_v2(
 
     let mut file_entries = Vec::new();
     for run_id in &ids {
-        let src_run_dir = runs_root.join(run_id);
-        let out_run_dir = runs_root_out.join(run_id);
+        let safe_run_id = artifacts::validate_run_id_path_segment(run_id)?;
+        let src_run_dir = runs_root.join(&safe_run_id);
+        let out_run_dir = runs_root_out.join(&safe_run_id);
         std::fs::create_dir_all(&out_run_dir)
             .with_context(|| format!("create bundle run dir '{}'", out_run_dir.display()))?;
 
@@ -256,7 +257,7 @@ pub fn export_trace_bundle_v2(
                 &bundle_root,
                 &src_run_dir.join(rel),
                 &out_run_dir.join(rel),
-                &format!("runs/{run_id}/{rel}"),
+                &format!("runs/{safe_run_id}/{rel}"),
                 &mut file_entries,
             )?;
         }
@@ -268,7 +269,7 @@ pub fn export_trace_bundle_v2(
                     &bundle_root,
                     &src,
                     &out_run_dir.join(rel),
-                    &format!("runs/{run_id}/{rel}"),
+                    &format!("runs/{safe_run_id}/{rel}"),
                     &mut file_entries,
                 )?;
             }
@@ -278,7 +279,7 @@ pub fn export_trace_bundle_v2(
         let status: JsonValue = read_json(&src_run_dir.join("run_status.json"))?;
         let metadata = TraceBundleRunMetadataV2 {
             trace_bundle_run_version: TRACE_BUNDLE_VERSION,
-            run_id: run_id.to_string(),
+            run_id: safe_run_id.clone(),
             workflow_id: summary
                 .get("workflow_id")
                 .and_then(|v| v.as_str())
@@ -307,7 +308,7 @@ pub fn export_trace_bundle_v2(
         write_trace_bundle_json(
             &bundle_root,
             &out_run_dir.join("metadata.json"),
-            &format!("runs/{run_id}/metadata.json"),
+            &format!("runs/{safe_run_id}/metadata.json"),
             &metadata,
             &mut file_entries,
         )?;
@@ -587,7 +588,8 @@ fn discover_run_ids(runs_root: &Path) -> Result<Vec<String>> {
 }
 
 fn load_dataset_row(runs_root: &Path, run_id: &str) -> Result<DatasetRowV1> {
-    let run_dir = runs_root.join(run_id);
+    let safe_run_id = artifacts::validate_run_id_path_segment(run_id)?;
+    let run_dir = runs_root.join(&safe_run_id);
     let run_summary_path = run_dir.join("run_summary.json");
     let steps_path = run_dir.join("steps.json");
     let scores_path = run_dir.join("learning").join("scores.json");
@@ -683,7 +685,7 @@ fn load_dataset_row(runs_root: &Path, run_id: &str) -> Result<DatasetRowV1> {
 
     Ok(DatasetRowV1 {
         dataset_version: DATASET_VERSION,
-        run_id: run_id.to_string(),
+        run_id: safe_run_id,
         workflow_id,
         adl_version,
         swarm_version,
@@ -1078,6 +1080,16 @@ mod tests {
         )
         .expect("resolve ids");
         assert_eq!(ids, vec!["r1".to_string(), "r2".to_string()]);
+    }
+
+    #[test]
+    fn export_jsonl_rejects_unsafe_explicit_run_id_path_segment() {
+        let root = std::env::temp_dir().join(format!("learn-unsafe-{}", std::process::id()));
+        let out = root.join("out.jsonl");
+        std::fs::create_dir_all(&root).unwrap();
+        let err = export_jsonl(&root, &["../escape".to_string()], &out)
+            .expect_err("unsafe explicit run_id must fail");
+        assert!(err.to_string().contains("safe path segment"));
     }
 
     #[test]

--- a/adl/src/obsmem_adapter.rs
+++ b/adl/src/obsmem_adapter.rs
@@ -78,18 +78,15 @@ pub fn build_write_request_from_run_artifacts(
     runs_root: &Path,
     run_id: &str,
 ) -> Result<MemoryWriteRequest, ObsMemContractError> {
-    if run_id.trim().is_empty() {
-        return Err(ObsMemContractError::new(
-            ObsMemContractErrorCode::InvalidRequest,
-            "run_id must be non-empty",
-        ));
-    }
+    let safe_run_id = crate::artifacts::validate_run_id_path_segment(run_id).map_err(|err| {
+        ObsMemContractError::new(ObsMemContractErrorCode::InvalidRequest, err.to_string())
+    })?;
 
-    let run_dir = runs_root.join(run_id);
+    let run_dir = runs_root.join(&safe_run_id);
     let run_summary_path = run_dir.join("run_summary.json");
     let run_status_path = run_dir.join("run_status.json");
     let activation_log_path = run_dir.join("logs").join("activation_log.json");
-    let indexed = index_run_from_artifacts(runs_root, run_id)?;
+    let indexed = index_run_from_artifacts(runs_root, &safe_run_id)?;
 
     let workflow_id = indexed.workflow_id;
     let failure_code = indexed.failure_code;
@@ -99,25 +96,25 @@ pub fn build_write_request_from_run_artifacts(
     let mut citations = Vec::new();
     citations.push(citation_for_path(
         &run_summary_path,
-        format!("runs/{run_id}/run_summary.json"),
+        format!("runs/{safe_run_id}/run_summary.json"),
     )?);
     citations.push(citation_for_path(
         &run_status_path,
-        format!("runs/{run_id}/run_status.json"),
+        format!("runs/{safe_run_id}/run_status.json"),
     )?);
     citations.push(citation_for_path(
         &activation_log_path,
-        format!("runs/{run_id}/logs/activation_log.json"),
+        format!("runs/{safe_run_id}/logs/activation_log.json"),
     )?);
 
     // Contract requires a relative trace-bundle pointer; WP-08 uses a stable
     // contract anchor and WP-09 will wire full bundle indexing flow.
     let mut req = MemoryWriteRequest {
         contract_version: OBSMEM_CONTRACT_VERSION,
-        run_id: run_id.to_string(),
+        run_id: safe_run_id.clone(),
         workflow_id: workflow_id.to_string(),
         trace_bundle_rel_path: "trace_bundle_v2/manifest.json".to_string(),
-        activation_log_rel_path: format!("runs/{run_id}/logs/activation_log.json"),
+        activation_log_rel_path: format!("runs/{safe_run_id}/logs/activation_log.json"),
         failure_code,
         summary,
         tags,
@@ -269,6 +266,14 @@ mod tests {
             a.activation_log_rel_path,
             "runs/r1/logs/activation_log.json".to_string()
         );
+    }
+
+    #[test]
+    fn build_write_request_from_artifacts_rejects_unsafe_run_id_path_segments() {
+        let tmp = unique_temp_dir("unsafe-run-id");
+        let err = build_write_request_from_run_artifacts(&tmp, "../escape")
+            .expect_err("unsafe run_id must fail");
+        assert!(err.message.contains("safe path segment"));
     }
 
     #[test]

--- a/adl/src/obsmem_indexing.rs
+++ b/adl/src/obsmem_indexing.rs
@@ -91,14 +91,11 @@ pub fn index_run_from_artifacts(
     runs_root: &Path,
     run_id: &str,
 ) -> Result<IndexedMemoryEntry, ObsMemContractError> {
-    if run_id.trim().is_empty() {
-        return Err(ObsMemContractError::new(
-            ObsMemContractErrorCode::InvalidRequest,
-            "run_id must be non-empty",
-        ));
-    }
+    let safe_run_id = crate::artifacts::validate_run_id_path_segment(run_id).map_err(|err| {
+        ObsMemContractError::new(ObsMemContractErrorCode::InvalidRequest, err.to_string())
+    })?;
 
-    let run_dir = runs_root.join(run_id);
+    let run_dir = runs_root.join(&safe_run_id);
     let run_summary_path = run_dir.join("run_summary.json");
     let run_status_path = run_dir.join("run_status.json");
     let activation_log_path = run_dir.join("logs").join("activation_log.json");
@@ -145,7 +142,7 @@ pub fn index_run_from_artifacts(
     }
 
     let mut tags = vec![
-        format!("run:{run_id}"),
+        format!("run:{safe_run_id}"),
         format!("workflow:{workflow_id}"),
         format!("status:{status}"),
         format!("step_context_count:{}", steps.len()),
@@ -161,7 +158,7 @@ pub fn index_run_from_artifacts(
     );
 
     let mut entry = IndexedMemoryEntry {
-        run_id: run_id.to_string(),
+        run_id: safe_run_id,
         workflow_id,
         status,
         failure_code,
@@ -369,11 +366,19 @@ mod tests {
     fn index_run_from_artifacts_rejects_empty_and_missing_run_inputs() {
         let tmp = unique_temp_dir("missing-inputs");
         let err = index_run_from_artifacts(&tmp, "").expect_err("empty run_id must fail");
-        assert!(err.message.contains("run_id must be non-empty"));
+        assert!(err.message.contains("run_id must not be empty"));
 
         let err =
             index_run_from_artifacts(&tmp, "missing-run").expect_err("missing files must fail");
         assert!(err.message.contains("failed reading"));
+    }
+
+    #[test]
+    fn index_run_from_artifacts_rejects_unsafe_run_id_path_segments() {
+        let tmp = unique_temp_dir("unsafe-run-id");
+        let err = index_run_from_artifacts(&tmp, "../escape")
+            .expect_err("unsafe run_id must fail before filesystem access");
+        assert!(err.message.contains("safe path segment"));
     }
 
     #[test]

--- a/adl/src/resolve.rs
+++ b/adl/src/resolve.rs
@@ -180,7 +180,9 @@ pub fn resolve_run(doc: &adl::AdlDoc) -> Result<AdlResolved> {
         .with_context(|| "failed to expand provider profiles")?;
     let _version = parse_version(&doc.version)?;
 
-    let run_id = doc.run.name.clone().unwrap_or_else(|| "run".to_string());
+    let run_id =
+        crate::artifacts::validate_run_id_path_segment(doc.run.name.as_deref().unwrap_or("run"))
+            .with_context(|| "run.name must resolve to a safe artifact path segment")?;
 
     if let Some(pattern_ref) = doc.run.pattern_ref.as_ref() {
         let registry = execution_plan::PatternRegistry::new(&doc.patterns)
@@ -439,6 +441,14 @@ mod tests {
         doc.version = "0.3".to_string();
         let resolved = resolve_run(&doc).expect("v0.3 should resolve for parse/plan");
         assert_eq!(resolved.doc.version, "0.3");
+    }
+
+    #[test]
+    fn resolve_run_rejects_unsafe_run_name_for_artifact_paths() {
+        let mut doc = minimal_doc();
+        doc.run.name = Some("../escape".to_string());
+        let err = resolve_run(&doc).expect_err("unsafe run name must fail");
+        assert!(err.to_string().contains("safe artifact path segment"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1265

## Summary
Implemented a shared run-id path-segment validator and moved the main runtime filesystem consumers onto it so traversal, separator, and drive-like run IDs are rejected before they can shape artifact paths. The fix validates run names early in `resolve_run`, keeps the canonical artifact path builder as the primary boundary, and extends the same contract to learning export and ObsMem indexing/write-request flows.

## Artifacts
- Updated shared run-id path validation in `adl/src/artifacts.rs`.
- Hardened run resolution in `adl/src/resolve.rs`.
- Hardened learning export path handling in `adl/src/learning_export.rs`.
- Hardened ObsMem indexing path handling in `adl/src/obsmem_indexing.rs`.
- Hardened ObsMem adapter write-request path handling in `adl/src/obsmem_adapter.rs`.
- Added focused path-safety regressions in the same modules' in-tree test suites.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml resolve_run_rejects_unsafe_run_name_for_artifact_paths -- --nocapture` to verify `resolve_run` rejects unsafe `run.name` values before runtime execution continues.
  - `cargo test --manifest-path adl/Cargo.toml index_run_from_artifacts_rejects_unsafe_run_id_path_segments -- --nocapture` to verify ObsMem indexing rejects traversal-style run IDs before filesystem access.
  - `cargo test --manifest-path adl/Cargo.toml build_write_request_from_artifacts_rejects_unsafe_run_id_path_segments -- --nocapture` to verify ObsMem adapter write-request construction uses the same safe boundary.
  - `cargo test --manifest-path adl/Cargo.toml export_jsonl_rejects_unsafe_explicit_run_id_path_segment -- --nocapture` to verify learning export rejects unsafe explicit run IDs before dataset path construction.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` to verify the runtime hardening patch is formatting-clean.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` to verify the patch compiles cleanly under the repo lint baseline.
- Results:
  - All focused path-safety regressions passed.
  - Formatting passed after one wrapping-only adjustment in `resolve.rs`.
  - Clippy passed with no warnings.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1265__v0-86-runtime-validate-run-ids-as-safe-artifact-path-segments/sip.md
- Output card: .adl/v0.86/tasks/issue-1265__v0-86-runtime-validate-run-ids-as-safe-artifact-path-segments/sor.md
- Idempotency-Key: v0-86-runtime-validate-run-ids-as-safe-artifact-path-segments-adl-src-artifacts-rs-adl-src-resolve-rs-adl-src-learning-export-rs-adl-src-obsmem-indexing-rs-adl-src-obsmem-adapter-rs-adl-v0-86-tasks-issue-1265-v0-86-runtime-validate-run-ids-as-safe-artifact-path-segments-sip-md-adl-v0-86-tasks-issue-1265-v0-86-runtime-validate-run-ids-as-safe-artifact-path-segments-sor-md