### PR TITLE
[v0.86][runtime] Reduce raw host-path leakage in pause artifacts

### DIFF
--- a/adl/src/cli/run_artifacts.rs
+++ b/adl/src/cli/run_artifacts.rs
@@ -64,6 +64,38 @@ pub(crate) struct PauseStateArtifact {
     pub(crate) pause: execute::PauseState,
 }
 
+fn normalize_pause_adl_ref(path: &Path) -> String {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            std::path::Component::ParentDir => parts.push("..".to_string()),
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {}
+        }
+    }
+    if parts.is_empty() {
+        "<unknown>".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
+fn sanitize_pause_adl_path(adl_path: &Path) -> String {
+    if !adl_path.is_absolute() {
+        return normalize_pause_adl_ref(adl_path);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Ok(rel) = adl_path.strip_prefix(&cwd) {
+            return normalize_pause_adl_ref(rel);
+        }
+    }
+    if let Some(file_name) = adl_path.file_name() {
+        return format!("external:/{}", file_name.to_string_lossy());
+    }
+    "external:/<unknown>".to_string()
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct StepStateArtifact {
     pub(crate) step_id: String,
@@ -2908,7 +2940,7 @@ pub(crate) fn write_run_state_artifacts(
             workflow_id: resolved.workflow_id.clone(),
             version: resolved.doc.version.clone(),
             status: "paused".to_string(),
-            adl_path: adl_path.display().to_string(),
+            adl_path: sanitize_pause_adl_path(adl_path),
             execution_plan_hash: execution_plan_hash(&resolved.execution_plan)?,
             steering_history: steering_history.to_vec(),
             pause: pause_payload.clone(),

--- a/adl/src/cli/tests/run_state.rs
+++ b/adl/src/cli/tests/run_state.rs
@@ -406,6 +406,68 @@ fn write_run_state_and_load_resume_round_trip() {
         run_dir.join("pause_state.json").exists(),
         "paused runs must persist pause_state.json"
     );
+    let pause_artifact =
+        run_artifacts::load_pause_state_artifact(&run_dir.join("pause_state.json"))
+            .expect("load pause state");
+    assert_eq!(pause_artifact.adl_path, "examples/adl-0.1.yaml");
+    let _ = std::fs::remove_dir_all(run_dir);
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+#[test]
+fn write_run_state_artifacts_sanitizes_external_absolute_adl_path_in_pause_state() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let run_id = format!("pause-sanitize-{now}-{}", std::process::id());
+    let resolved = minimal_resolved_for_artifacts(run_id.clone());
+    let out_dir = std::env::temp_dir().join(format!("adl-main-out-sanitize-{now}"));
+    let runs_root = unique_temp_dir("adl-main-runs-pause-sanitize");
+    let _runs_guard = EnvGuard::set("ADL_RUNS_ROOT", &runs_root.to_string_lossy());
+
+    let mut tr = trace::Trace::new(run_id.clone(), "wf".to_string(), "0.5".to_string());
+    tr.step_started("s1", "a1", "p1", "t1", None);
+    tr.step_finished("s1", true);
+
+    let pause = execute::PauseState {
+        paused_step_id: "s1".to_string(),
+        reason: Some("review".to_string()),
+        completed_step_ids: vec!["s1".to_string()],
+        remaining_step_ids: vec![],
+        saved_state: HashMap::new(),
+        completed_outputs: HashMap::new(),
+    };
+
+    let absolute_adl = std::env::temp_dir().join("adl-sensitive-host-path-demo.adl.yaml");
+    let run_dir = write_run_state_artifacts(
+        &resolved,
+        &tr,
+        &absolute_adl,
+        &out_dir,
+        100,
+        150,
+        "paused",
+        Some(&pause),
+        &[],
+        &runtime_control_for("paused", &tr),
+        None,
+        None,
+    )
+    .expect("write run artifacts");
+
+    let pause_artifact =
+        run_artifacts::load_pause_state_artifact(&run_dir.join("pause_state.json"))
+            .expect("load pause state");
+    assert_eq!(
+        pause_artifact.adl_path,
+        "external:/adl-sensitive-host-path-demo.adl.yaml"
+    );
+    assert!(
+        !pause_artifact.adl_path.starts_with('/'),
+        "pause artifact should not retain raw host absolute paths"
+    );
+
     let _ = std::fs::remove_dir_all(run_dir);
     let _ = std::fs::remove_dir_all(out_dir);
 }


### PR DESCRIPTION
Closes #1267

## Summary
Reduced host-path leakage in pause artifacts by sanitizing the persisted "adl_path" field instead of recording raw host absolute paths. Relative ADL inputs stay legible, absolute paths under the current working tree collapse to repo-relative references, and external absolute paths degrade to a minimal "external:/<filename>" reference. Resume correctness remains intact because `#1264` already moved trust to the explicit `--adl` argument rather than the pause artifact.

## Artifacts
- Sanitized pause-path persistence helper and write-path update in "adl/src/cli/run_artifacts.rs".
- Focused pause-state regressions in "adl/src/cli/tests/run_state.rs".
- Completed execution record in this output card.

## Validation
- Validation commands and their purpose:
  - "cargo test --manifest-path adl/Cargo.toml write_run_state_and_load_resume_round_trip -- --nocapture" verified that paused-run roundtrip behavior still works and that a normal relative ADL path is persisted as the expected relative reference.
  - "cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_sanitizes_external_absolute_adl_path_in_pause_state -- --nocapture" verified that an external absolute ADL path is sanitized and no longer persisted as a raw host absolute path.
  - "cargo fmt --manifest-path adl/Cargo.toml --all --check" verified formatting remained clean after the pause-state changes.
  - "cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings" verified the updated runtime writer and tests remained warning-free.
- Results:
  - Focused pause-state regressions passed.
  - Formatting passed.
  - Clippy passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- absolute_path_leakage_detected: false means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1267__v0-86-runtime-reduce-raw-host-path-leakage-in-pause-artifacts/sip.md
- Output card: .adl/v0.86/tasks/issue-1267__v0-86-runtime-reduce-raw-host-path-leakage-in-pause-artifacts/sor.md
- Idempotency-Key: v0-86-runtime-reduce-raw-host-path-leakage-in-pause-artifacts-adl-src-cli-run-artifacts-rs-adl-src-cli-tests-run-state-rs-adl-v0-86-tasks-issue-1267-v0-86-runtime-reduce-raw-host-path-leakage-in-pause-artifacts-sip-md-adl-v0-86-tasks-issue-1267-v0-86-runtime-reduce-raw-host-path-leakage-in-pause-artifacts-sor-md