### PR TITLE
[v0.86][WP-23] Seed canonical v0.87 milestone planning docs

### DIFF
--- a/docs/milestones/v0.87/DECISIONS_v0.87.md
+++ b/docs/milestones/v0.87/DECISIONS_v0.87.md
@@ -1,30 +1,41 @@
-# Decisions Template
+# Decisions: v0.87
 
 ## Metadata
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Date: `{{date}}`
-- Owner: `{{owner}}`
+- Milestone: `v0.87`
+- Version: `0.87`
+- Date: `2026`
+- Owner: `adl`
 
 ## Purpose
-Capture significant decisions (architecture, scope, process) at the time they are made.
+Capture milestone-critical architecture, scope, and process decisions for `v0.87` as they are made.
 
-## How To Use
-- Add one row per decision.
-- Prefer links to issues/PRs over long prose.
-- Keep status current: `accepted`, `rejected`, `deferred`, `superseded`.
+This milestone is a substrate/consolidation milestone. The decisions recorded here should explain:
+- why `v0.87` is focused on coherence rather than scope expansion
+- how trace, provider portability, shared memory, and operational/control-plane work are prioritized
+- what was intentionally deferred to later milestones
 
 ## Decision Log
 | ID | Decision | Status | Rationale | Alternatives | Impact | Link |
 |---|---|---|---|---|---|---|
-| D-01 | {{decision_1}} | {{status_1}} | {{rationale_1}} | {{alternatives_1}} | {{impact_1}} | {{link_1}} |
-| D-02 | {{decision_2}} | {{status_2}} | {{rationale_2}} | {{alternatives_2}} | {{impact_2}} | {{link_2}} |
+| D-01 | Treat `v0.87` as a substrate/consolidation milestone rather than a new capability milestone. | accepted | `v0.86` expanded the system substantially, especially in tooling, validation, and bounded cognition. `v0.87` must make the existing system coherent, deterministic, and externally credible before later milestones deepen identity, governance, and higher-order cognition. | Continue direct capability expansion into `v0.88+` themes immediately. | Keeps milestone scope disciplined and makes external review more credible. | `docs/milestones/v0.87/VISION_v0.87.md` |
+| D-02 | Define the canonical `v0.87` substrate spine as `contracts -> execution -> trace -> review -> documentation`. | accepted | The milestone needs one explicit execution truth model so contracts, trace, review, and docs do not drift independently. | Improve surfaces independently without a unifying model. | Gives the design, checklist, and review surfaces a common architectural center. | `docs/milestones/v0.87/DESIGN_v0.87.md` |
+| D-03 | Pull trace v1 forward into `v0.87` as foundational substrate work. | accepted | Later work depends on reconstruction-oriented execution truth. Signed trace can remain later, but base trace vocabulary and event structure must land early. | Delay all trace work until the later provenance/signing band. | Makes trace the ground-truth substrate for demos, review, and later governance/identity work. | `docs/milestones/v0.87/WBS_v0.87.md` |
+| D-04 | Treat provider / transport redesign as a first-class `v0.87` work band. | accepted | Real Gödel/AEE/provider portability later will fail if provider handling remains brittle or string-based. The substrate must separate vendor, transport, and model identity now. | Leave provider handling ad hoc and defer redesign until later routing/capability milestones. | Enables portable configs, cleaner trace attribution, and a credible common-provider story. | `.adl/docs/roadmaps/ROAD_TO_v0.95.md` |
+| D-05 | Place shared ObsMem foundation work in `v0.87`, but keep later social/governance memory out of scope. | accepted | Shared memory is needed as a substrate layer, but full social memory and governance-aware memory belong later. | Delay all shared-memory work, or over-expand `v0.87` into social/governance memory systems. | Keeps the milestone realistic while still landing the shared-memory base later milestones require. | `docs/milestones/v0.87/WBS_v0.87.md` |
+| D-06 | Treat operational skills as a real substrate surface in `v0.87`. | accepted | Skills are not just convenience wrappers; they are reusable, bounded operational surfaces that help make review, workflow, and later cognition more structured and deterministic. | Keep workflow logic ad hoc or defer skills until later feature milestones. | Supports reproducible workflow behavior and canonical review/operational output surfaces. | `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md` |
+| D-07 | Continue moving workflow/control-plane ownership out of shell scripts and into the canonical control plane. | accepted | Recent review findings show shell-heavy workflow ownership is fragile and can drift from public contracts. | Leave shell wrappers as the long-term source of workflow behavior. | Improves determinism, worktree safety, and the credibility of the tooling substrate. | `#1192` |
+| D-08 | Reserve PR Demo work in `v0.87` for planning/preparation only, not real social/identity execution. | accepted | `v0.87` is not yet the milestone for identity-bearing persistent agents or governed multi-agent social behavior. Demo work here should prepare later PR Demo execution without inflating milestone claims. | Claim early PR Demo execution in `v0.87`. | Keeps demo claims honest and aligns roadmap expectations with actual substrate readiness. | `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md` |
+| D-09 | Keep `v0.87` bounded and do not silently pull `v0.88+` systems forward. | accepted | The roadmap now has explicit homes for chronosense, aptitudes, AEE 1.0, Freedom Gate v2, identity, governance, and PR Demo execution. Pulling them forward would collapse milestone discipline. | Opportunistically absorb later systems during implementation. | Protects roadmap coherence and makes handoff into later milestones cleaner. | `.adl/docs/roadmaps/ROAD_TO_v0.95.md` |
+| D-10 | Require reviewer-facing proof surfaces and artifact-backed demos for milestone credibility. | accepted | `v0.87` is intended to support internal and external evaluation. Claims must be inspectable through real artifact roots, demo surfaces, and review outputs. | Rely on prose descriptions or partially specified proof surfaces. | Raises the bar for milestone truthfulness and improves reviewer experience. | `docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md` |
 
 ## Open Questions
-- {{open_question_1}} (Owner: {{owner_oq1}}) (Issue: {{issue_oq1}})
-- {{open_question_2}} (Owner: {{owner_oq2}}) (Issue: {{issue_oq2}})
+- Which exact issue sequence should be used for the first substrate implementation slice after the canonical docs land? (Owner: `Daniel Austin`) (Issue: `TBD`)
+- Should trace v1 or control-plane consolidation be the very first implementation-heavy slice once sprint 1 planning is complete? (Owner: `Daniel Austin`) (Issue: `TBD`)
+- What is the minimum provider set required to claim provider portability credibly in `v0.87` demos? (Owner: `Daniel Austin`) (Issue: `TBD`)
+- Which initial operational skills are mandatory for the first bounded substrate proof in `v0.87`? (Owner: `Daniel Austin`) (Issue: `TBD`)
 
 ## Exit Criteria
-- All milestone-critical decisions are logged with a rationale.
-- Deferred/rejected/superseded options are explicitly recorded.
-- Open questions have owners and tracking links.
+- All milestone-critical architectural and scope decisions are logged with rationale.
+- Deferred alternatives and intentionally later-milestone work are explicitly represented.
+- Open questions that affect execution order or milestone truth have owners and tracking hooks.
+- The recorded decisions align with the roadmap, design, WBS, sprint plan, demo matrix, and release plan.

--- a/docs/milestones/v0.87/DEMO_MATRIX_v0.87.md
+++ b/docs/milestones/v0.87/DEMO_MATRIX_v0.87.md
@@ -1,58 +1,64 @@
-# Demo Matrix Template
+# Demo Matrix: v0.87
 
 ## Metadata
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Date: `{{date}}`
-- Owner: `{{owner}}`
-- Related issues / work packages: {{issues_or_wps}}
+- Milestone: `v0.87`
+- Version: `0.87`
+- Date: `2026`
+- Owner: `adl`
+- Related issues / work packages: `WP-02` through `WP-16` (issue numbers TBD)
 
 ## Purpose
-Define the canonical milestone demo program: which bounded demos exist, which milestone claims they prove, how to run them, and what artifacts or proof surfaces reviewers should inspect.
+Define the canonical milestone demo program for `v0.87`: which bounded demos exist, which substrate claims they prove, how to run them, and what artifacts or proof surfaces reviewers should inspect.
 
-## How To Use
-- Use this document for runnable milestone evidence, not for broad feature brainstorming.
-- Keep demo rows and per-demo sections aligned so a reviewer can move from summary -> execution -> proof surface without reconstructing context by hand.
-- Prefer bounded, replayable, copy/paste-friendly commands over aspirational demo descriptions.
-- If a milestone claim cannot yet be shown through a runnable demo, say so explicitly and record the substitute proof surface.
-- Keep names stable across milestones where practical so comparisons remain easy.
-- If a section is not relevant, include a one-line rationale instead of deleting it.
+This milestone is substrate-heavy. The demos therefore focus on:
+- trace truth
+- provider portability
+- shared-memory coherence
+- operational/control-plane stability
+- reviewer-facing proof surfaces
+
+They are intended to prove that `v0.87` makes ADL more coherent, deterministic, and externally credible.
 
 ## Scope
 
-In scope for `{{milestone}}`:
-- {{in_scope_demo_area_1}}
-- {{in_scope_demo_area_2}}
-- {{in_scope_demo_area_3}}
+In scope for `v0.87`:
+- trace v1 substrate and reconstruction-oriented proof surfaces
+- provider / transport substrate portability and configuration truth
+- shared ObsMem foundation with trace-linked memory behavior
+- operational skills and control-plane/tooling substrate
+- canonical reviewer-facing proof surfaces for the substrate
 
-Out of scope for `{{milestone}}`:
-- {{out_of_scope_demo_area_1}}
-- {{out_of_scope_demo_area_2}}
+Out of scope for `v0.87`:
+- identity-bearing persistent agents
+- full PR Demo society behavior
+- capability-aware routing and later social/governance layers
 
 ## Runtime Preconditions
 
 Working directory:
 
 ```bash
-{{working_directory_command}}
+cd /Users/daniel/git/agent-design-language
 ```
 
 Deterministic runtime / provider assumptions:
 
 ```bash
-{{runtime_preconditions}}
+# Use repo-owned commands and fixtures only.
+# Prefer deterministic/local provider or mock/fixture-backed runs where possible.
+# Record exact commands used in issue output cards.
 ```
 
 Additional environment / fixture requirements:
-- {{env_requirement_1}}
-- {{env_requirement_2}}
+- repository is on the intended branch/worktree for the reviewed `v0.87` issue
+- any required local/mock provider or fixture data is documented in the issue or demo helper script
 
 ## Related Docs
-- Design contract: `{{design_doc}}`
-- WBS / milestone mapping: `{{wbs_doc}}`
-- Sprint / execution plan: `{{sprint_doc}}`
-- Release / checklist context: `{{release_or_checklist_doc}}`
-- Other proof-surface docs: {{other_related_docs}}
+- Design contract: `docs/milestones/v0.87/DESIGN_v0.87.md`
+- WBS / milestone mapping: `docs/milestones/v0.87/WBS_v0.87.md`
+- Sprint / execution plan: `docs/milestones/v0.87/SPRINT_v0.87.md`
+- Release / checklist context: `docs/milestones/v0.87/RELEASE_PLAN_v0.87.md`, `docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md`
+- Other proof-surface docs: `docs/milestones/v0.87/FEATURE_DOCS_v0.87.md`, `docs/milestones/v0.87/README.md`
 
 ## Demo Coverage Summary
 
@@ -60,9 +66,12 @@ Use this table as the fast review surface for milestone coverage.
 
 | Demo ID | Demo title | Milestone claim / WP proved | Command entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
 |---|---|---|---|---|---|---|---|
-| D1 | {{demo_title_1}} | {{claim_or_wp_1}} | `{{command_stub_1}}` | `{{proof_surface_1}}` | {{success_signal_1}} | {{determinism_note_1}} | {{status_1}} |
-| D2 | {{demo_title_2}} | {{claim_or_wp_2}} | `{{command_stub_2}}` | `{{proof_surface_2}}` | {{success_signal_2}} | {{determinism_note_2}} | {{status_2}} |
-| D3 | {{demo_title_3}} | {{claim_or_wp_3}} | `{{command_stub_3}}` | `{{proof_surface_3}}` | {{success_signal_3}} | {{determinism_note_3}} | {{status_3}} |
+| D1 | Trace v1 substrate truth | `WP-02`, `WP-03` | `TBD: trace v1 demo command` | `artifacts/v087/trace_v1/...` | stable structured trace events emitted for major control points | event vocabulary and structure should be stable even if timestamps vary | PLANNED |
+| D2 | Provider portability substrate | `WP-04`, `WP-05` | `TBD: provider substrate demo command` | `artifacts/v087/provider_portability/...` | one agent/config surface can target multiple providers through the new substrate without brittle provider-native core strings | compare normalized config/output surfaces across provider targets | PLANNED |
+| D3 | Shared ObsMem foundation coherence | `WP-06`, `WP-07` | `TBD: shared obsmem demo command` | `artifacts/v087/shared_obsmem/...` | shared-memory entry creation/retrieval can be tied back to execution/trace truth | replay judged by stable memory schema and trace-linkage, not by identical timestamps | PLANNED |
+| D4 | Operational skills substrate | `WP-08`, `WP-11` | `TBD: skill demo command` | `artifacts/v087/skills/...` | a bounded operational skill produces structured findings/output using the canonical output family | output schema and required sections should remain stable | PLANNED |
+| D5 | Control-plane / PR tooling substrate | `WP-09`, `WP-10` | `TBD: control-plane demo command` | `artifacts/v087/control_plane/...` | bounded workflow/control-plane command executes deterministically and records a truthful operational surface | replay judged by command surface, output structure, and workflow semantics | PLANNED |
+| D6 | Reviewer-facing substrate package | `WP-12`, `WP-13`, `WP-15` | `TBD: review-surface package command or checklist flow` | `docs/milestones/v0.87/README.md` plus linked proof surfaces | an uninvolved reviewer can locate the milestone docs, first command, and primary proof surfaces without guesswork | stability is judged by legibility and proof-surface consistency across reruns | PLANNED |
 
 Status guidance:
 - `PLANNED` = intended but not yet validated
@@ -71,162 +80,317 @@ Status guidance:
 - `LANDED` = milestone evidence exists and is ready for review
 
 ## Coverage Rules
-- Every major milestone claim should map to a runnable demo or an explicit alternate proof surface.
+- Every major substrate band in `v0.87` should map to a runnable demo or an explicit alternate proof surface.
 - Every demo should name one primary proof surface that a reviewer can inspect directly.
-- Commands should be copy/paste-ready and should not require private local state.
-- Success signals should say what to check, not just “command exits 0”.
-- Determinism / replay notes should explain how stability is judged.
+- Commands should be copy/paste-ready once implementation lands.
+- Success signals should say what to inspect, not just “command exits 0”.
+- Determinism / replay notes should explain how stability is judged for substrate-heavy demos.
+- Where a demo is not yet runnable, the matrix must remain truthful and say `PLANNED` rather than implying completion.
 
 ## Demo Details
 
-Repeat one block per demo in the coverage summary.
-
-### {{demo_id_1}}) {{demo_title_1}}
+### D1) Trace v1 substrate truth
 
 Description:
-- {{demo_description_1}}
-- {{demo_description_1b}}
+- prove that `v0.87` emits a stable, bounded trace vocabulary for the milestone’s major control points
+- show that trace is reconstruction-oriented and linked to the actual artifact/proof surfaces produced by the run
 
 Milestone claims / work packages covered:
-- {{claim_detail_1a}}
-- {{claim_detail_1b}}
+- trace v1 schema and event taxonomy are authoritative
+- runtime/control surfaces emit reviewable trace events tied to real execution
 
 Commands to run:
 
 ```bash
-{{demo_commands_1}}
+TBD: trace v1 demo command
 ```
 
 Expected artifacts:
-- `{{artifact_1a}}`
-- `{{artifact_1b}}`
-- `{{artifact_1c}}`
+- `artifacts/v087/trace_v1/trace.jsonl`
+- `artifacts/v087/trace_v1/README.md`
+- `artifacts/v087/trace_v1/summary.json`
 
 Primary proof surface:
-- `{{primary_proof_surface_1}}`
+- `artifacts/v087/trace_v1/trace.jsonl`
 
 Secondary proof surfaces:
-- `{{secondary_proof_surface_1a}}`
-- `{{secondary_proof_surface_1b}}`
+- `artifacts/v087/trace_v1/summary.json`
+- linked output card / validator notes for the implementing issue
 
 Expected success signals:
-- {{success_detail_1a}}
-- {{success_detail_1b}}
+- major control decisions appear as stable structured event types
+- the trace can be inspected to reconstruct the bounded path taken by the demo
 
 Determinism / replay notes:
-- {{determinism_detail_1a}}
-- {{determinism_detail_1b}}
+- event structure and vocabulary should remain stable across reruns
+- timestamps or run identifiers may vary; those should not be treated as a determinism failure by themselves
 
 Reviewer checks:
-- {{reviewer_check_1a}}
-- {{reviewer_check_1b}}
+- confirm that the emitted event set matches the documented trace vocabulary
+- confirm that trace entries point back to real outputs or proof surfaces rather than narrative-only claims
 
 Known limits / caveats:
-- {{caveat_1}}
+- signed trace is out of scope for `v0.87`; this demo proves trace truth, not cryptographic provenance
 
 ---
 
-### {{demo_id_2}}) {{demo_title_2}}
+### D2) Provider portability substrate
 
 Description:
-- {{demo_description_2}}
+- prove that provider configuration is now modeled through explicit vendor / transport / model separation
+- show that the same higher-level authoring/config surface can target multiple common providers through the substrate
 
 Milestone claims / work packages covered:
-- {{claim_detail_2a}}
+- provider / transport substrate v1 is real and usable
+- compatibility and portability do not depend on brittle provider-native strings leaking into core authoring surfaces
 
 Commands to run:
 
 ```bash
-{{demo_commands_2}}
+TBD: provider substrate demo command
 ```
 
 Expected artifacts:
-- `{{artifact_2a}}`
-- `{{artifact_2b}}`
+- `artifacts/v087/provider_portability/README.md`
+- `artifacts/v087/provider_portability/config_normalized.json`
+- `artifacts/v087/provider_portability/provider_results.json`
 
 Primary proof surface:
-- `{{primary_proof_surface_2}}`
+- `artifacts/v087/provider_portability/provider_results.json`
+
+Secondary proof surfaces:
+- `artifacts/v087/provider_portability/config_normalized.json`
+- implementing issue notes describing tested provider targets and compatibility expectations
 
 Expected success signals:
-- {{success_detail_2a}}
+- one canonical config surface resolves cleanly through the substrate to multiple provider targets
+- provider/model attribution is explicit and structurally consistent
 
 Determinism / replay notes:
-- {{determinism_detail_2a}}
+- normalized config structure should be stable
+- if provider outputs vary, determinism is judged on configuration, routing, and proof-surface structure rather than identical textual model output
 
 Reviewer checks:
-- {{reviewer_check_2a}}
+- confirm that `vendor`, `transport`, `model_ref`, and provider-model mapping are all visible in the proof surface
+- confirm that the demo no longer relies on ad hoc provider-native strings in the core surface being reviewed
 
 Known limits / caveats:
-- {{caveat_2}}
+- capability-aware routing is out of scope for `v0.87`; this demo proves substrate portability, not later intelligent provider selection
 
 ---
 
-### {{demo_id_3}}) {{demo_title_3}}
+### D3) Shared ObsMem foundation coherence
 
 Description:
-- {{demo_description_3}}
+- prove that a shared-memory substrate exists and can persist/retrieve bounded context across runs or shared surfaces
+- show that memory entries are explainable through trace-linked execution truth rather than opaque storage behavior
 
 Milestone claims / work packages covered:
-- {{claim_detail_3a}}
+- shared ObsMem foundation is real
+- trace and shared-memory behavior are coherent and reviewable together
 
 Commands to run:
 
 ```bash
-{{demo_commands_3}}
+TBD: shared obsmem demo command
 ```
 
 Expected artifacts:
-- `{{artifact_3a}}`
+- `artifacts/v087/shared_obsmem/README.md`
+- `artifacts/v087/shared_obsmem/memory_entries.json`
+- `artifacts/v087/shared_obsmem/trace_links.json`
 
 Primary proof surface:
-- `{{primary_proof_surface_3}}`
+- `artifacts/v087/shared_obsmem/memory_entries.json`
+
+Secondary proof surfaces:
+- `artifacts/v087/shared_obsmem/trace_links.json`
+- implementing issue notes describing the bounded indexing/retrieval rules used
 
 Expected success signals:
-- {{success_detail_3a}}
+- shared-memory entries are created/retrieved through a bounded, inspectable interface
+- each persisted/retrieved entry can be tied to the execution truth that produced it
 
 Determinism / replay notes:
-- {{determinism_detail_3a}}
+- schema, field structure, and trace-link behavior should be stable across reruns
+- exact IDs or timestamps may vary if documented as runtime-generated fields
 
 Reviewer checks:
-- {{reviewer_check_3a}}
+- confirm that memory is shared/foundation-oriented, not merely an isolated local cache disguised as shared state
+- confirm that trace-linkage explains why a given entry exists and where it came from
 
 Known limits / caveats:
-- {{caveat_3}}
+- this is the shared-memory foundation layer, not full social memory or governance-aware memory
+
+---
+
+### D4) Operational skills substrate
+
+Description:
+- prove that an operational skill can be invoked through the new substrate and produce structured review/operational output
+- show that the skill output family is stable enough for real workflow use and later review surfaces
+
+Milestone claims / work packages covered:
+- operational skills substrate is real and bounded
+- review output structure is canonical rather than ad hoc
+
+Commands to run:
+
+```bash
+TBD: skill demo command
+```
+
+Expected artifacts:
+- `artifacts/v087/skills/README.md`
+- `artifacts/v087/skills/skill_output.yaml`
+- `artifacts/v087/skills/findings.json`
+
+Primary proof surface:
+- `artifacts/v087/skills/skill_output.yaml`
+
+Secondary proof surfaces:
+- `artifacts/v087/skills/findings.json`
+- implementing issue notes describing the invoked skill and why it is the bounded proof case for `v0.87`
+
+Expected success signals:
+- the invoked skill produces structured findings/output with required sections present
+- the result is usable as a real operational/review surface rather than freeform prose
+
+Determinism / replay notes:
+- output schema and required sections should remain stable across reruns
+- content may vary if the underlying proof surface changes; schema drift is the primary failure condition
+
+Reviewer checks:
+- confirm that the skill output includes findings/evidence/next-step structure rather than only a summary narrative
+- confirm that the skill is bounded and deterministic enough to qualify as a substrate surface, not a freeform assistant interaction
+
+Known limits / caveats:
+- this proves the first operational skill substrate, not the full future skill catalog
+
+---
+
+### D5) Control-plane / PR tooling substrate
+
+Description:
+- prove that a bounded workflow/control-plane path is more deterministic and less shell-fragile than the earlier behavior it replaces
+- show that workflow state and outputs are legible as an operational proof surface
+
+Milestone claims / work packages covered:
+- control-plane consolidation is underway in real surfaces
+- worktree / repo-root / PR lifecycle handling is becoming more reproducible and reviewable
+
+Commands to run:
+
+```bash
+TBD: control-plane demo command
+```
+
+Expected artifacts:
+- `artifacts/v087/control_plane/README.md`
+- `artifacts/v087/control_plane/operation_log.txt`
+- `artifacts/v087/control_plane/result.json`
+
+Primary proof surface:
+- `artifacts/v087/control_plane/result.json`
+
+Secondary proof surfaces:
+- `artifacts/v087/control_plane/operation_log.txt`
+- implementing issue notes describing the command contract and expected workflow behavior
+
+Expected success signals:
+- the command surface behaves deterministically and reports a truthful bounded operational result
+- repo/worktree handling is explicit and legible enough for reviewer inspection
+
+Determinism / replay notes:
+- replay is judged on command contract, state transitions, and output structure
+- environment-specific details may vary if clearly marked as non-semantic runtime metadata
+
+Reviewer checks:
+- confirm that the control-plane surface does not silently depend on fragile shell-only ownership for core workflow logic
+- confirm that the result surface is operationally meaningful rather than just a wrapper around hidden behavior
+
+Known limits / caveats:
+- this demo proves bounded control-plane improvement, not complete elimination of all shell wrappers or all future tooling debt
+
+---
+
+### D6) Reviewer-facing substrate package
+
+Description:
+- prove that an uninvolved reviewer can navigate the milestone using canonical docs and first proof surfaces without reconstructing context by hand
+- show that `v0.87` is legible as a substrate milestone rather than a collection of isolated tasks
+
+Milestone claims / work packages covered:
+- canonical docs and review package are truthful and reviewer-usable
+- demo matrix, README, and linked proof surfaces form a coherent review entry surface
+
+Commands to run:
+
+```bash
+TBD: review-surface package command or checklist flow
+```
+
+Expected artifacts:
+- `docs/milestones/v0.87/README.md`
+- `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
+- linked implementing issue output cards and artifact roots
+
+Primary proof surface:
+- `docs/milestones/v0.87/README.md`
+
+Secondary proof surfaces:
+- `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
+- implementing issue output cards for the milestone tail review/docs work
+
+Expected success signals:
+- a reviewer can identify the first command, first doc, and primary proof surface for each major substrate band
+- the docs do not contradict the implemented proof surfaces they point to
+
+Determinism / replay notes:
+- stability is judged on cross-doc consistency and proof-surface truth, not on byte-identical generated outputs
+
+Reviewer checks:
+- confirm that the README and demo matrix point to the same bounded milestone story
+- confirm that there is no silent drift between implementation truth and the review package
+
+Known limits / caveats:
+- this is a reviewer-facing substrate package, not a full external/3rd-party review report
 
 ## Cross-Demo Validation
 
 Required baseline validation:
 
 ```bash
-{{baseline_validation_commands}}
+TBD: baseline validation commands for v0.87 once the first substrate demos land
 ```
 
 Cross-demo checks:
-- {{cross_demo_check_1}}
-- {{cross_demo_check_2}}
-- {{cross_demo_check_3}}
+- trace references used by D1–D5 should agree with the canonical event vocabulary
+- provider, memory, skills, and control-plane demos should all point back to the same `v0.87` canonical docs and first reviewer entry surfaces
+- no demo may claim later-milestone capabilities (identity, society, capability routing, governed delegation) as already implemented
 
 Failure policy:
 - If one demo is blocked, record the blocker and say whether milestone review can proceed with an alternate proof surface.
 - If deterministic behavior is expected but not observed, record the exact unstable artifact or command output.
+- If the milestone remains partially substrate-only, say so explicitly rather than inflating the demo claims.
 
 ## Determinism Evidence
 
 Evidence directory / run root:
-- `{{evidence_root}}`
+- `artifacts/v087/`
 
 Repeatability approach:
-- {{repeatability_rule_1}}
-- {{repeatability_rule_2}}
+- judge determinism on stable structure, event vocabulary, schema shape, and proof-surface truth rather than requiring byte-identical runtime metadata
+- rerun each substrate demo at least enough times to confirm that the claimed stable properties actually hold
 
 Normalization rules:
-- {{normalization_rule_1}}
-- {{normalization_rule_2}}
+- normalize or ignore timestamps, run IDs, and other documented runtime-generated metadata where they are not semantic
+- do not normalize away structural drift in schemas, event vocabularies, or command/result surfaces
 
 Observed results summary:
-- {{determinism_result_1}}
-- {{determinism_result_2}}
-- {{determinism_result_3}}
+- initial state: all demos are `PLANNED`
+- update each demo row and detailed section as issues land and local validation occurs
+- use output cards as the canonical place to record concrete rerun evidence for each landed demo
 
 ## Reviewer Sign-Off Surface
 
@@ -238,18 +402,19 @@ For each demo, the reviewer should be able to answer:
 - What caveats or substitutions apply?
 
 Review owners:
-- {{review_owner_1}}
-- {{review_owner_2}}
+- `Daniel Austin`
+- `Codex.app`
+- internal ADL review before wider exposure
 
 Review status:
-- {{review_status_note}}
+- `v0.87` demo program seeded; concrete command surfaces and statuses should be updated issue-by-issue as substrate work lands.
 
 ## Notes
-- {{note_1}}
-- {{note_2}}
+- `v0.87` is a substrate milestone. Demo claims should stay honest and bounded to that reality.
+- PR Demo work in `v0.87` is planning/preparation only; real PR Demo execution remains a later-milestone concern.
 
 ## Exit Criteria
-- The milestone’s major claims are mapped to bounded demos or explicit alternate proof surfaces.
-- Each demo has runnable commands, expected artifacts, and a clear success signal.
+- The milestone’s major substrate claims are mapped to bounded demos or explicit alternate proof surfaces.
+- Each demo has runnable commands, expected artifacts, and a clear success signal once landed.
 - Determinism / replay expectations are explicit where required.
 - A reviewer can inspect the matrix and locate the primary proof surface for each demo without extra reconstruction work.

--- a/docs/milestones/v0.87/DESIGN_v0.87.md
+++ b/docs/milestones/v0.87/DESIGN_v0.87.md
@@ -1,74 +1,292 @@
-# Design Template
+# Design: v0.87 Coherent Cognitive Substrate
 
 ## Metadata
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Date: `{{date}}`
-- Owner: `{{owner}}`
-- Related issues: {{issues}}
+- Milestone: `v0.87`
+- Version: `0.87`
+- Date: `2026`
+- Owner: `adl`
+- Related issues: TBD
 
 ## Purpose
-Define what we are building, why, and how we validate it — concisely, with links to issues/PRs.
+Define the integrated design for v0.87 as the milestone that **consolidates, aligns, and stabilizes** the ADL cognitive substrate following the expansion of v0.86.
+
+This milestone ensures that all major system surfaces—contracts, execution, review, trace, and documentation—form a **coherent, deterministic, and externally credible system**.
+
+v0.87 is not about introducing new cognitive capabilities. It is about making the existing system **correct, consistent, inspectable, and trustworthy**.
+
+---
 
 ## Problem Statement
-{{problem_statement}}
+
+v0.86 successfully introduced a bounded cognitive system with:
+- cognitive loop
+- arbitration
+- fast/slow reasoning
+- Freedom Gate
+- evaluation and bounded execution
+
+However, the system now risks:
+
+- divergence between docs and implementation
+- inconsistent contract enforcement
+- partial or informal review outputs
+- tooling fragility (worktrees, PR flows, automation boundaries)
+- lack of system-level coherence across surfaces
+
+Without consolidation, ADL risks becoming:
+- powerful but unreliable
+- expressive but inconsistent
+- difficult to evaluate externally
+
+v0.87 addresses this by defining a **coherent substrate design** that aligns all system surfaces.
+
+---
 
 ## Goals
-- {{goal_1}}
-- {{goal_2}}
+
+- Ensure **end-to-end system coherence** across execution, contracts, trace, and review
+- Strengthen **contract and validation integrity**
+- Formalize **review and verification surfaces** as structured outputs
+- Align **canonical documentation with actual system behavior**
+- Stabilize **tooling and developer workflows**
+- Eliminate inconsistencies and undefined behavior
+- Prepare the system for **external (3rd party) evaluation**
 
 ## Non-Goals
-- {{non_goal_1}}
-- {{non_goal_2}}
+
+- Introducing new cognitive subsystems (Gödel agent, GHB loop, identity)
+- Expanding affect or instinct models
+- Implementing full ObsMem or reasoning graph systems
+- Implementing delegation or Freedom Gate v2
+- Expanding scope beyond v0.86 feature surface
 
 ## Scope
 ### In scope
-- {{in_scope_1}}
-- {{in_scope_2}}
+- system-wide contract alignment
+- validation consistency across inputs/outputs
+- structured review surfaces and outputs
+- trace alignment with actual execution
+- canonical documentation updates
+- tooling stabilization (PR flow, worktrees, automation)
+- system-level coherence across all surfaces
 
 ### Out of scope
-- {{out_of_scope_1}}
-- {{out_of_scope_2}}
+- new cognitive architecture components
+- identity and persistence systems
+- delegation frameworks
+- advanced reasoning graph systems
 
 ## Requirements
 ### Functional
-- {{functional_requirement_1}}
-- {{functional_requirement_2}}
+- Define one coherent execution truth across contracts, execution, trace, review, and documentation.
+- Standardize review outputs so findings, system-level assessment, and action plans are structurally consistent.
+- Make trace sufficient to reconstruct actual major control decisions.
+- Tighten validation so strict and loose modes are explicit, bounded, and predictable.
+- Canonicalize documentation so milestone docs describe implemented behavior truthfully.
+- Stabilize tooling behavior across PR flows, worktrees, and automation boundaries.
 
 ### Non-functional
 - Deterministic behavior and reproducible outputs.
 - Clear failure semantics and observability.
-- {{non_functional_requirement_1}}
+- Tooling and review surfaces must be reliable enough for credible external evaluation.
 
 ## Proposed Design
 ### Overview
-{{architecture_summary}}
+
+v0.87 defines ADL as a **closed-loop, deterministic, inspectable system**:
+
+contracts → execution → trace → review → documentation
+
+All five surfaces must agree.
+
+No surface is allowed to diverge silently.
+
+### 1. System Coherence Model
+
+All system components must align along a single execution truth.
+
+#### Requirement
+Every system surface must reflect the same underlying behavior:
+- contracts define allowed structure
+- execution follows contracts
+- trace records actual execution
+- review evaluates trace + behavior
+- documentation describes actual behavior
+
+#### Constraint
+No component may:
+- invent behavior not present in execution
+- omit behavior that materially affects correctness
+- reinterpret contracts inconsistently
+
+### 2. Contract and Validation Layer
+
+#### Objective
+Make contracts **strict, consistent, and reliable**.
+
+#### Design
+- All inputs and outputs must pass through validation
+- Unknown or undefined fields must be rejected in strict mode
+- Loose mode must be explicitly defined and bounded
+- Error reporting must be structured and deterministic
+
+#### Required outputs
+Validation failures must include:
+- location
+- reason
+- expected vs actual
+
+#### Constraint
+Contracts are the **source of truth**, not optional hints.
+
+### 3. Execution and Trace Alignment
+
+#### Objective
+Ensure trace reflects **actual execution**, not approximations.
+
+#### Design
+- Every major control decision must produce a trace event
+- Trace must include:
+  - inputs
+  - decisions (arbitration, routing, gate)
+  - outputs
+- Trace must be ordered and reproducible
+
+#### Constraint
+Trace must be sufficient to:
+- reconstruct system behavior
+- support review and debugging
+
+### 4. Review and Verification Surface
+
+#### Objective
+Define review as a **first-class system output**, not an ad hoc process.
+
+#### Required structure
+Each review must include:
+
+**Findings**
+- Severity (P1–P4)
+- Location
+- Description
+- Impact
+- Trigger
+- Evidence
+- Fix Direction
+
+**System-Level Assessment**
+- dominant risk themes
+- clustering of issues
+- system maturity implications
+
+**Recommended Action Plan**
+- fix now
+- fix before milestone close
+- defer to future milestone
+
+#### Additional requirements
+- must analyze trust boundaries
+- must detect test misalignment
+- must explain failure modes causally
+
+### 5. Documentation Canonicalization
+
+#### Objective
+Ensure documentation is a **reliable interface to the system**.
+
+#### Design
+- canonical docs must match implementation
+- remove duplicate or outdated docs
+- enforce consistent structure across milestones
+- link design ↔ implementation ↔ demos
+
+#### Constraint
+Documentation must not:
+- describe unimplemented behavior as real
+- contradict runtime behavior
+
+### 6. Tooling and Workflow Stability
+
+#### Objective
+Stabilize development workflow for reliable iteration.
+
+#### Design
+- standardize PR tooling behavior (`pr.sh` flows)
+- ensure worktree-safe operations
+- reduce environment-sensitive failures
+- enforce predictable automation boundaries
+
+#### Constraint
+Tooling must be:
+- reproducible
+- deterministic
+- minimally surprising
 
 ### Interfaces / Data contracts
-- {{interface_or_contract_1}}
-- {{interface_or_contract_2}}
+
+**Validation Output**
+- field
+- error_type
+- expected
+- actual
+
+**Trace Event**
+- event_type
+- timestamp
+- inputs
+- decision
+- outputs
+
+**Review Output**
+- findings[]
+- system_assessment
+- action_plan
 
 ### Execution semantics
-{{execution_semantics}}
+
+1. Inputs enter through explicit validated contract boundaries.
+2. Execution proceeds according to canonical runtime behavior.
+3. Major control decisions emit trace events.
+4. Review consumes code, behavior, and trace/proof surfaces to produce structured findings.
+5. Documentation is reconciled against implemented truth and validated proof surfaces.
+6. Tooling and workflow surfaces preserve reproducibility across daily development and milestone closeout.
 
 ## Risks and Mitigations
-- Risk: {{risk_1}}
-  - Mitigation: {{mitigation_1}}
-- Risk: {{risk_2}}
-  - Mitigation: {{mitigation_2}}
+- Risk: hidden inconsistencies remain across surfaces.
+  - Mitigation: enforce trace + review + doc alignment against implemented truth.
+- Risk: contracts become too rigid for practical use.
+  - Mitigation: keep strict vs loose modes explicit and bounded.
+- Risk: review becomes superficial or formulaic.
+  - Mitigation: require structured findings plus causal explanations and system-level synthesis.
+- Risk: tooling instability blocks progress or undermines trust.
+  - Mitigation: prioritize reproducibility, worktree safety, and simple automation boundaries.
 
 ## Alternatives Considered
-- Option: {{alternative_1}}
-  - Tradeoff: {{tradeoff_1}}
-- Option: {{alternative_2}}
-  - Tradeoff: {{tradeoff_2}}
+- Option: continue capability expansion immediately after v0.86.
+  - Tradeoff: would increase feature surface area while leaving correctness, review, and tooling drift unresolved.
+- Option: do a docs-only cleanup milestone.
+  - Tradeoff: would improve language but fail to strengthen the actual contract, trace, review, and tooling substrate.
 
 ## Validation Plan
-- Checks/tests: {{validation_checks}}
-- Success metrics: {{success_metrics}}
-- Rollback/fallback: {{rollback_plan}}
+- Checks/tests:
+  - verify contracts reject invalid inputs deterministically
+  - verify trace captures all major decisions needed for reconstruction
+  - verify review outputs follow the required structure
+  - verify documentation matches runtime behavior and proof surfaces
+  - verify tooling works consistently across environments and worktrees
+- Success metrics:
+  - system surfaces are aligned (contracts, execution, trace, review, docs)
+  - validation is consistent and reliable
+  - trace is complete and reconstructable
+  - review is structured and actionable
+  - documentation is accurate and canonical
+  - tooling is stable and predictable
+- Rollback/fallback:
+  - if full cross-surface convergence is not achieved, preserve a truthful reduced v0.87 scope that still improves contract integrity, review structure, and tooling stability without claiming full substrate coherence.
 
 ## Exit Criteria
-- Goals/non-goals and scope boundaries are explicit.
-- Validation plan is actionable and referenced by the milestone checklist.
-- Major open questions are resolved or tracked in the decision log.
+- All system surfaces are consistent and mutually reinforcing.
+- No known contradictions remain between docs and implementation.
+- Review and validation are structured and enforced.
+- Tooling is stable for daily development use.
+- The system is ready for credible external evaluation.

--- a/docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md
+++ b/docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md
@@ -1,50 +1,226 @@
-# Milestone Checklist Template
+# Milestone Checklist: v0.87
 
 ## Metadata
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Target release date: `{{target_release_date}}`
-- Owner: `{{owner}}`
+- Milestone: `v0.87`
+- Version: `0.87`
+- Type: **Substrate consolidation**
+- Status: `IN PROGRESS`
+
+---
 
 ## Purpose
-Ship/no-ship gate for the milestone. Check items only when evidence exists.
 
-## Planning
-- [ ] Milestone goal defined (`{{goal_doc_link}}`)
-- [ ] Scope + non-goals documented (`{{scope_doc_link}}`)
-- [ ] WBS created and mapped to issues (`{{wbs_link}}`)
-- [ ] Decision log initialized (`{{decisions_link}}`)
-- [ ] Sprint plan created (`{{sprint_plan_link}}`)
+This checklist ensures that `v0.87`:
 
-## Execution Discipline
-- [ ] Each issue has input/output cards under `.adl/cards/<issue>/`
-- [ ] Each burst writes artifacts under `.adl/reports/burst/<timestamp>/`
-- [ ] Draft PR opened for each issue before merge
-- [ ] Transient failures retried and documented
-- [ ] "Green-only merge" policy followed
+- is **real**, not aspirational
+- is **inspectable by a 3rd party**
+- is **deterministic in structure**
+- has **clear proof surfaces**
 
-## Quality Gates
-- [ ] `cargo fmt` passes
-- [ ] `cargo clippy --all-targets -- -D warnings` passes
-- [ ] `cargo test` passes
-- [ ] CI is green on the merge target
-- [ ] Coverage signal is not red (or exception documented) (`{{coverage_link_or_note}}`)
-- [ ] No unresolved high-priority blockers (`{{blocker_report_link}}`)
+No item is considered complete without **artifact-backed verification**.
 
-## Release Packaging
-- [ ] Release notes finalized (`{{release_notes_link}}`)
-- [ ] Tag verified: `{{tag_name}}`
-- [ ] GitHub Release drafted (`{{release_draft_link}}`)
-- [ ] Links validated in release body
-- [ ] Release published
+---
 
-## Post-Release
-- [ ] Milestone/epic issues closed with release links
-- [ ] Deferred items moved to next milestone backlog
-- [ ] Follow-up bugs/tech debt captured as issues
-- [ ] Roadmap/status docs updated (`{{roadmap_update_link}}`)
-- [ ] Retrospective summary recorded (`{{retro_link}}`)
+## 1. Trace v1 (Ground Truth)
 
-## Exit Criteria
-- All required gates are checked, or each exception has an owner + due date.
-- Milestone can be audited end-to-end via the links captured above.
+### Requirements
+- [ ] Trace schema v1 defined and stable
+- [ ] All executions emit trace v1
+- [ ] Trace includes:
+  - [ ] timestamps
+  - [ ] durations
+  - [ ] model/provider identity
+  - [ ] input/output references
+- [ ] Trace supports reconstruction of execution
+
+### Verification
+- [ ] Demo D1 produces trace artifacts
+- [ ] Artifacts exist under `artifacts/v087/trace_v1/`
+- [ ] Reviewer can:
+  - [ ] locate trace files
+  - [ ] follow execution flow from trace alone
+
+---
+
+## 2. Provider Substrate Normalization
+
+### Requirements
+- [ ] Provider abstraction implemented:
+  - [ ] `vendor`
+  - [ ] `transport`
+  - [ ] `model_ref`
+- [ ] No provider-specific logic leaks into runtime paths
+- [ ] Configurations portable across providers
+
+### Verification
+- [ ] Demo D2 runs successfully across ≥2 providers
+- [ ] Artifacts under `artifacts/v087/provider_portability/`
+- [ ] Reviewer can:
+  - [ ] swap provider with minimal config change
+  - [ ] observe equivalent structured outputs
+
+---
+
+## 3. Shared ObsMem Foundation
+
+### Requirements
+- [ ] Shared memory structure defined
+- [ ] Memory linked to trace IDs
+- [ ] Memory is:
+  - [ ] inspectable
+  - [ ] deterministic in structure
+  - [ ] explainable via trace
+
+### Verification
+- [ ] Demo D3 produces memory artifacts
+- [ ] Artifacts under `artifacts/v087/shared_obsmem/`
+- [ ] Reviewer can:
+  - [ ] trace memory entries back to execution
+  - [ ] understand memory contents without hidden state
+
+---
+
+## 4. Operational Skills Substrate
+
+### Requirements
+- [ ] At least one operational skill implemented (e.g. preflight-check)
+- [ ] Skills produce structured outputs
+- [ ] Skills are:
+  - [ ] bounded
+  - [ ] deterministic in structure
+  - [ ] reusable
+
+### Verification
+- [ ] Demo D4 runs skill successfully
+- [ ] Artifacts under `artifacts/v087/skills/`
+- [ ] Reviewer can:
+  - [ ] inspect skill output
+  - [ ] understand decision logic from output
+
+---
+
+## 5. Control Plane Determinism
+
+### Requirements
+- [ ] Worktree workflows are stable
+- [ ] PR tooling behaves deterministically
+- [ ] Repo-root detection is robust
+- [ ] Scripts safe from `.adl/` and `tmp/`
+
+### Verification
+- [ ] Demo D5 executes control-plane flows
+- [ ] Artifacts under `artifacts/v087/control_plane/`
+- [ ] Reviewer can:
+  - [ ] reproduce workflows
+  - [ ] run commands without environment fragility
+
+---
+
+## 6. Demo Matrix Completeness
+
+### Requirements
+- [ ] Demo matrix defined in `DEMO_MATRIX_v0.87.md`
+- [ ] Each demo includes:
+  - [ ] command
+  - [ ] inputs
+  - [ ] outputs
+  - [ ] success signal
+
+### Verification
+- [ ] All demos run end-to-end
+- [ ] All demos produce artifacts
+- [ ] No demo depends on hidden setup
+
+---
+
+## 7. Documentation Alignment
+
+### Requirements
+- [ ] All canonical docs present:
+  - [ ] VISION
+  - [ ] DESIGN
+  - [ ] WBS
+  - [ ] SPRINT
+  - [ ] DEMO MATRIX
+  - [ ] RELEASE PLAN
+  - [ ] CHECKLIST
+- [ ] Docs match implementation exactly
+- [ ] No speculative or aspirational claims
+
+### Verification
+- [ ] Spot-check doc ↔ code alignment
+- [ ] Reviewer can:
+  - [ ] follow docs to real artifacts
+  - [ ] verify claims independently
+
+---
+
+## 8. Internal Review (Pre-3rd Party)
+
+### Requirements
+- [ ] Skill-based repo review completed
+- [ ] All findings resolved or explicitly tracked
+- [ ] No critical or high-severity issues remain
+
+### Verification
+- [ ] Review artifacts under `.adl/reviews/`
+- [ ] Output cards reflect fixes
+- [ ] Repo passes internal scrutiny without guidance
+
+---
+
+## 9. Reviewer Experience (Critical)
+
+### Requirements
+- [ ] Clear entry point (`README.md`)
+- [ ] Demo matrix is easy to follow
+- [ ] Artifact directories are consistent and discoverable
+
+### Verification
+- [ ] A fresh reviewer can:
+  - [ ] clone repo
+  - [ ] run a demo within minutes
+  - [ ] locate artifacts without assistance
+  - [ ] understand what is being proven
+
+---
+
+## 10. Determinism & Reproducibility
+
+### Requirements
+- [ ] Outputs are structurally deterministic
+- [ ] Schemas enforced across surfaces
+- [ ] No hidden state required for success
+
+### Verification
+- [ ] Re-running demos produces:
+  - [ ] structurally equivalent outputs
+- [ ] Differences limited to:
+  - [ ] timestamps
+  - [ ] non-semantic variations
+
+---
+
+## 11. Exit Criteria
+
+All of the following must be true:
+
+- [ ] All demos are `READY` or `LANDED`
+- [ ] All artifact directories populated
+- [ ] Docs fully aligned with implementation
+- [ ] Internal review issues resolved
+- [ ] Reviewer experience validated
+- [ ] No blocking issues remain
+
+---
+
+## Final Gate
+
+Before marking `v0.87` complete:
+
+- [ ] "Could a skeptical engineer understand this without us?"
+- [ ] "Is every claim backed by a visible artifact?"
+- [ ] "Does the system behave deterministically in structure?"
+- [ ] "Are we showing reality, not aspiration?"
+
+If any answer is **no**, the milestone is **not complete**.

--- a/docs/milestones/v0.87/README.md
+++ b/docs/milestones/v0.87/README.md
@@ -1,132 +1,159 @@
-
-
-# Milestone README Template
+# Milestone README: v0.87
 
 ## Metadata
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Date: `{{date}}`
-- Owner: `{{owner}}`
+- Milestone: `v0.87`
+- Version: `0.87`
+- Date: `2026`
+- Owner: `adl`
 
 ## Purpose
-Provide a single entry point for the milestone: what it is, why it matters, what is included, and how to navigate the canonical documents and artifacts.
+Provide the single canonical entry point for `v0.87`: what the milestone is, why it matters, what is in scope, how to navigate the canonical docs, and which proof surfaces a reviewer should inspect first.
 
-## How To Use
-- Start here before reading individual milestone documents.
-- Use this README to locate the canonical design, execution, and validation surfaces.
-- Keep this document concise and navigational; detailed content belongs in the linked docs.
-- Keep links up to date as files move or are renamed.
+This README is intentionally concise and navigational. It should help an uninvolved reviewer understand `v0.87` as a **substrate milestone** without reconstructing context from issue threads or chat history.
 
 ## Overview
 
-`{{milestone}}` represents the stage where `{{project_name}}` moves from `{{previous_state}}` to `{{target_state}}`.
+`v0.87` is the milestone where ADL moves from a bounded cognitive system that was proven in pieces in `v0.86` to a more **coherent, deterministic, and externally credible substrate**.
 
 This milestone focuses on:
-- {{focus_1}}
-- {{focus_2}}
-- {{focus_3}}
+- trace as execution truth
+- provider / transport normalization and portability
+- shared ObsMem foundation and trace-linked memory coherence
+- operational skills and control-plane/tooling stabilization
+- reviewer-facing proof surfaces and canonical milestone docs
 
 Key outcomes:
-- {{outcome_1}}
-- {{outcome_2}}
-- {{outcome_3}}
+- a canonical substrate spine: `contracts -> execution -> trace -> review -> documentation`
+- real, bounded proof surfaces for trace, provider portability, shared memory, skills, and control-plane behavior
+- milestone docs and review surfaces that truthfully reflect implementation and are usable by an uninvolved reviewer
 
 ## Scope Summary
 
 ### In scope
-- {{in_scope_1}}
-- {{in_scope_2}}
-- {{in_scope_3}}
+- Trace v1 schema, event model, and runtime/control-surface emission
+- Provider / transport substrate v1 with explicit `vendor`, `transport`, and `model_ref` separation
+- Shared ObsMem foundation tied to execution/trace truth
+- Operational skills substrate and structured review outputs
+- Control-plane / PR tooling stabilization and workflow determinism
+- Demo matrix, docs, review package, and release-tail truth surfaces
 
 ### Out of scope
-- {{out_of_scope_1}}
-- {{out_of_scope_2}}
+- Persistent identity, chronosense, and later `v0.9+` personhood/continuity work
+- PR Demo execution, capability-aware routing, and later governance / delegation / Freedom Gate evolution
+
+## Start Here
+
+If you are new to this milestone, read in this order:
+
+1. `docs/milestones/v0.87/VISION_v0.87.md`
+2. `docs/milestones/v0.87/DESIGN_v0.87.md`
+3. `docs/milestones/v0.87/WBS_v0.87.md`
+4. `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
+5. `docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md`
+
+If you want the fastest reviewer path, jump to:
+- demo matrix: `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
+- milestone checklist: `docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md`
+- release plan: `docs/milestones/v0.87/RELEASE_PLAN_v0.87.md`
 
 ## Document Map
 
 Canonical milestone documents:
-
-- Vision: `{{vision_doc}}`
-- Design: `{{design_doc}}`
-- Work Breakdown Structure (WBS): `{{wbs_doc}}`
-- Sprint plan: `{{sprint_doc}}`
-- Decisions log: `{{decisions_doc}}`
-- Demo matrix: `{{demo_matrix_doc}}`
-- Milestone checklist: `{{checklist_doc}}`
-- Release plan / process: `{{release_process_doc}}`
-- Release notes: `{{release_notes_doc}}`
+- Vision: `docs/milestones/v0.87/VISION_v0.87.md`
+- Design: `docs/milestones/v0.87/DESIGN_v0.87.md`
+- Work Breakdown Structure (WBS): `docs/milestones/v0.87/WBS_v0.87.md`
+- Sprint plan: `docs/milestones/v0.87/SPRINT_v0.87.md`
+- Decisions log: `docs/milestones/v0.87/DECISIONS_v0.87.md`
+- Demo matrix: `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
+- Milestone checklist: `docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md`
+- Release plan: `docs/milestones/v0.87/RELEASE_PLAN_v0.87.md`
+- Release notes: `docs/milestones/v0.87/RELEASE_NOTES_v0.87.md`
 
 Supporting / domain-specific docs:
-- {{supporting_doc_1}}
-- {{supporting_doc_2}}
-- {{supporting_doc_3}}
+- Feature docs index: `docs/milestones/v0.87/FEATURE_DOCS_v0.87.md`
+- Roadmap context: `.adl/docs/roadmaps/ROAD_TO_v0.95.md`
+- Review artifacts: `.adl/reviews/`
 
 ## Execution Model
 
 This milestone is executed as a sequence of work packages (WPs):
 
-- WP-01: Design pass (docs + planning)
-- WP-02 – WP-12: Feature and system work
-- WP-13: Demo matrix and integration demos
-- WP-14: Coverage / quality gate
-- WP-15: Docs and review convergence
-- WP-16: Release ceremony
+- `WP-01`: design pass (docs + planning)
+- `WP-02` – `WP-11`: substrate implementation bands
+- `WP-12`: documentation canonicalization + feature index
+- `WP-13`: demo matrix and integration demos
+- `WP-14`: coverage / quality gate
+- `WP-15`: docs and review convergence
+- `WP-16`: release ceremony
 
 Execution expectations:
-- Each WP is tracked by an issue and implemented via PRs.
-- Each issue produces structured artifacts (input/output cards, reports).
-- All work merges under green CI and passes quality gates.
+- each WP is tracked by one or more issues and implemented through bounded PRs
+- each issue should produce structured input/output cards and validation evidence
+- the milestone should remain substrate-first and should not silently absorb `v0.88+` systems
+- all claims should be backed by runnable demos, artifact roots, review outputs, or release-tail validation
 
 ## Demo and Validation Surface
 
 Primary validation is defined in:
-- Demo matrix: `{{demo_matrix_doc}}`
+- demo matrix: `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
 
-Additional validation surfaces:
-- Test suite results
-- Generated artifacts under `.adl/runs/`
-- Trace and replay outputs
+Primary bounded demos:
+- `D1`: Trace v1 substrate truth
+- `D2`: Provider portability substrate
+- `D3`: Shared ObsMem foundation coherence
+- `D4`: Operational skills substrate
+- `D5`: Control-plane / PR tooling substrate
+- `D6`: Reviewer-facing substrate package
+
+Primary artifact root:
+- `artifacts/v087/`
 
 Success criteria:
-- {{success_criteria_1}}
-- {{success_criteria_2}}
-- {{success_criteria_3}}
+- each major substrate claim maps to a bounded demo or explicit alternate proof surface
+- a reviewer can identify the first command, primary artifact, and expected success signal for each demo
+- no demo inflates later-milestone capabilities that are intentionally out of scope
 
 ## Determinism and Reproducibility
 
-The milestone should demonstrate:
-- Deterministic or bounded-repeatable execution where required
-- Replayable traces and inspectable artifacts
-- Stable command entry points for demos
+`v0.87` should demonstrate:
+- deterministic or bounded-repeatable execution where required
+- stable structured schemas and event vocabularies
+- replayable or inspectable substrate artifacts
+- stable command entry points once demos land
 
 Evidence locations:
-- {{determinism_evidence_path_1}}
-- {{determinism_evidence_path_2}}
+- `artifacts/v087/`
+- issue output cards for implementing/demo/validation issues
+- `.adl/reviews/` for internal review outputs
+
+Determinism notes:
+- determinism for this milestone is judged primarily by stable structure, schemas, event vocabularies, and proof-surface truth
+- timestamps, run IDs, or other documented runtime-generated metadata may vary and should not be treated as failures by themselves
 
 ## Risks and Open Questions
 
 Known risks:
-- {{risk_1}}
-- {{risk_2}}
+- provider and tooling redesign may sprawl if not kept tightly bounded to substrate v1 goals
+- late `v0.86` closeout fixes may temporarily force small roadmap/doc adjustments while `v0.87` planning begins
 
 Open questions:
-- {{open_question_1}}
-- {{open_question_2}}
+- which exact issue sequence should start the first implementation-heavy slice after doc seeding
+- whether trace v1 or control-plane consolidation should land first as the strongest initial substrate proof
+- what the minimum provider set is for a credible portability claim in `v0.87`
 
 ## Status
 
-Current status: {{status}}
+Current status: `PLANNING / EARLY EXECUTION`
 
-- Planning: {{planning_status}}
-- Execution: {{execution_status}}
-- Validation: {{validation_status}}
-- Release readiness: {{release_status}}
+- Planning: canonical doc set seeded and being reviewed
+- Execution: first `v0.87` issue sequence is being prepared
+- Validation: demo matrix and checklist seeded; concrete command surfaces still landing
+- Release readiness: not ready yet; this README describes the intended canonical review path once issues land
 
 ## Exit Criteria
 
 - All canonical milestone documents are complete and internally consistent.
-- All WBS items are implemented or explicitly deferred.
-- Demo matrix is runnable and validated.
-- Quality gates (fmt, clippy, test, CI) are passing.
-- Milestone checklist is complete or exceptions are documented.
-- Release artifacts (notes, tag, docs) are ready.
+- All in-scope WBS items are implemented or explicitly deferred.
+- Demo matrix is runnable and validated or blocked truthfully with alternate proof surfaces.
+- Quality gates, review surfaces, and release-tail evidence are recorded truthfully.
+- A skeptical uninvolved reviewer can use this README to locate the first doc, first command, and primary proof surfaces without additional reconstruction.

--- a/docs/milestones/v0.87/RELEASE_NOTES_v0.87.md
+++ b/docs/milestones/v0.87/RELEASE_NOTES_v0.87.md
@@ -1,57 +1,66 @@
-# Release Notes Template
+# Release Notes: v0.87
 
 ## Metadata
-- Product: `{{product_name}}`
-- Version: `{{version}}`
-- Release date: `{{release_date}}`
-- Tag: `{{tag_name}}`
+- Product: `Agent Design Language (ADL)`
+- Version: `0.87`
+- Release date: `TBD`
+- Tag: `TBD`
 
-## How To Use
-- Keep statements implementation-accurate and test-validated.
-- Prefer concise bullets over marketing language.
-- Explicitly separate shipped behavior from "What's Next."
+## Purpose
+Capture the release notes for `v0.87` as a truthful, implementation-aligned summary of the milestone.
 
-# `{{product_name}}` `{{version}}` Release Notes
+This is a substrate release. The notes should emphasize:
+- what became more coherent and credible
+- which foundational surfaces are now real
+- what remains intentionally out of scope for later milestones
+
+No statement in this document should imply shipped behavior that is not backed by implementation, demos, or reviewable proof surfaces.
+
+# `Agent Design Language (ADL)` `0.87` Release Notes
 
 ## Summary
-{{summary_paragraph}}
+`v0.87` is the milestone where ADL consolidates the bounded cognitive system from `v0.86` into a more coherent, deterministic, and externally credible substrate. This release strengthens the foundations that later milestones will depend on by tightening trace truth, provider portability, shared-memory coherence, operational skills, and control-plane stability.
+
+Rather than expanding into identity, governance, or higher-order cognition, `v0.87` focuses on making the existing system more correct, more inspectable, and easier for internal and external reviewers to evaluate truthfully.
 
 ## Highlights
-- {{highlight_1}}
-- {{highlight_2}}
-- {{highlight_3}}
+- Trace v1 becomes a first-class substrate surface for reconstruction-oriented execution truth.
+- Provider handling is normalized around explicit vendor / transport / model separation.
+- Shared ObsMem and operational/control-plane surfaces are advanced as real, reviewable substrate layers.
 
 ## What's New In Detail
 
-### {{area_1}}
-- {{detail_1a}}
-- {{detail_1b}}
+### Trace v1 and execution truth
+- ADL introduces a more explicit trace substrate so major control decisions can be recorded as structured, reviewable events.
+- Trace is treated as execution truth for reconstruction and review, rather than as narrative commentary layered on top of runtime behavior.
 
-### {{area_2}}
-- {{detail_2a}}
-- {{detail_2b}}
+### Provider, memory, and operational substrate work
+- Provider/transport handling is pushed toward an explicit substrate model with cleaner portability across common providers.
+- Shared ObsMem work is advanced as a bounded foundation layer tied to execution truth instead of opaque memory behavior.
+- Operational skills and control-plane/tooling work are treated as core substrate surfaces rather than auxiliary convenience scripts.
 
-### {{area_3}}
-- {{detail_3a}}
-- {{detail_3b}}
+### Review, docs, and reviewer-facing proof surfaces
+- Review output expectations are strengthened around findings, evidence, triggers, and system-level assessment.
+- Canonical milestone docs are aligned more tightly to implementation and proof surfaces.
+- The milestone demo program is structured around bounded substrate proofs so a reviewer can inspect what is actually being claimed.
 
 ## Upgrade Notes
-- {{upgrade_note_1}}
-- {{upgrade_note_2}}
+- `v0.87` should be understood as a substrate/consolidation release, not as a new agent-capability release.
+- Reviewer-facing proof now depends more explicitly on trace, artifact roots, and structured demo/review surfaces; downstream milestone docs and issue cards should reference these surfaces directly.
 
 ## Known Limitations
-- {{limitation_1}}
-- {{limitation_2}}
+- Persistent identity, chronosense, and other later `v0.9+` cognitive/personhood surfaces are not part of `v0.87`.
+- PR Demo execution, capability-aware routing, and later governance/delegation layers remain intentionally out of scope for this milestone.
 
 ## Validation Notes
-- {{validation_note_1}}
-- {{validation_note_2}}
+- Final milestone claims should be backed by the `v0.87` demo matrix, issue output cards, review artifacts, and release-tail validation evidence.
+- Determinism in this release is judged primarily by stable structure, schemas, event vocabulary, and proof-surface truth rather than by byte-identical runtime metadata.
 
 ## What's Next
-- {{next_1}}
-- {{next_2}}
+- `v0.88` is expected to deepen persistence, instinct, aptitudes, and bounded agency on top of the more credible substrate established here.
+- Later milestones will build identity, Freedom Gate evolution, governance, and PR Demo execution on top of the trace/provider/shared-memory/control-plane foundations strengthened in `v0.87`.
 
 ## Exit Criteria
-- Notes reflect only shipped behavior.
-- Known limitations and future work are explicitly separated.
-- Final text is ready to paste into GitHub Release UI without further editing.
+- Notes reflect only shipped or demonstrably landed `v0.87` behavior.
+- Known limitations and future work are explicitly separated from shipped surfaces.
+- Final text is ready to paste into GitHub Release UI without further editing once release date and tag are known.

--- a/docs/milestones/v0.87/RELEASE_PLAN_v0.87.md
+++ b/docs/milestones/v0.87/RELEASE_PLAN_v0.87.md
@@ -1,46 +1,230 @@
-# Release Process Template
+# Release Plan: v0.87
 
 ## Metadata
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Release date: `{{release_date}}`
-- Release manager: `{{release_manager}}`
+- Milestone: `v0.87`
+- Version: `0.87`
+- Target window: `TBD`
+- Release type: **Substrate consolidation release**
+- Owner: `adl`
+- Status: `PLANNING`
 
-## How To Use
-- Execute sections in order and capture links for each completed step.
-- Keep this doc focused on shipping mechanics; use release notes for narrative.
-- Mark blockers immediately; do not publish until gates pass.
+---
 
-## 1) Release Readiness
-- [ ] Milestone checklist complete (`{{milestone_checklist_link}}`)
-- [ ] Release notes approved (`{{release_notes_link}}`)
-- [ ] Go/no-go decision recorded (`{{decision_link}}`)
+## Purpose
 
-## 2) Branch And Tag Preparation
-- [ ] Target branch confirmed (`{{target_branch}}`)
-- [ ] Working tree clean
-- [ ] Version string(s) validated (`{{version_validation_link}}`)
-- [ ] Tag created: `{{tag_name}}`
-- [ ] Tag pushed and verified
+`v0.87` is a **substrate milestone** focused on making ADL more:
 
-## 3) GitHub Release Steps
-- [ ] GitHub Release draft created from `{{tag_name}}` (`{{release_draft_link}}`)
-- [ ] Release body populated from approved notes
-- [ ] Links to key PRs/issues included
-- [ ] Release visibility confirmed (draft/prerelease/final)
-- [ ] Release published
+- deterministic
+- structurally coherent
+- reviewable by third parties
+- internally consistent across subsystems
 
-## 4) Verification
-- [ ] Post-release CI status checked (`{{ci_run_link}}`)
-- [ ] Release links tested (docs, artifacts, notes)
-- [ ] Immediate regressions triaged and tracked (`{{triage_link}}`)
+This release does **not** expand higher-level agent capabilities.
+Instead, it strengthens the **foundations required for identity, cognition, and delegation in later milestones**.
 
-## 5) Communication
-- [ ] Community announcement published (`{{announcement_link}}`)
-- [ ] Internal update posted (`{{internal_update_link}}`)
-- [ ] Roadmap/status updated (`{{roadmap_update_link}}`)
+---
+
+## Release Themes
+
+### 1. Trace as Ground Truth
+- Trace v1 becomes the **authoritative execution record**
+- Trace supports **reconstruction, not narration**
+- All major subsystems align to trace surfaces
+
+---
+
+### 2. Provider Substrate Normalization
+- Replace provider-specific handling with:
+  - `vendor`
+  - `transport`
+  - `model_ref`
+- Enable **portable configurations across providers**
+
+---
+
+### 3. Shared Memory Foundation (ObsMem)
+- Introduce **shared, trace-linked memory**
+- Memory must be:
+  - inspectable
+  - deterministic in structure
+  - explainable via trace
+
+---
+
+### 4. Operational Substrate (Skills + Control Plane)
+- Establish **bounded operational skills**
+- Improve **control-plane determinism**:
+  - worktrees
+  - PR workflows
+  - repo-root handling
+
+---
+
+### 5. Reviewer-Facing Proof Surfaces
+- External reviewers can:
+  - find entry points
+  - run bounded demos
+  - inspect artifacts
+- Remove dependence on implicit knowledge
+
+---
+
+## Scope
+
+### In Scope
+- Trace v1 schema and emission
+- Provider / transport abstraction
+- Shared ObsMem foundation
+- Operational skills substrate
+- Control-plane/tooling stabilization
+- Demo matrix and review surfaces
+
+### Out of Scope
+- Persistent identity / chronosense
+- Gödel agent expansion
+- PR Demo execution
+- Capability-aware routing
+- Governance / Freedom Gate evolution
+
+---
+
+## Release Artifacts
+
+### Documentation
+- `docs/milestones/v0.87/VISION_v0.87.md`
+- `docs/milestones/v0.87/DESIGN_v0.87.md`
+- `docs/milestones/v0.87/WBS_v0.87.md`
+- `docs/milestones/v0.87/SPRINT_v0.87.md`
+- `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
+- `docs/milestones/v0.87/RELEASE_PLAN_v0.87.md`
+- `docs/milestones/v0.87/MILESTONE_CHECKLIST_v0.87.md`
+- `docs/milestones/v0.87/README.md`
+
+### Runtime / Substrate Surfaces
+- Trace v1 artifacts (`artifacts/v087/trace_v1/`)
+- Provider portability artifacts (`artifacts/v087/provider_portability/`)
+- Shared ObsMem artifacts (`artifacts/v087/shared_obsmem/`)
+- Skills output artifacts (`artifacts/v087/skills/`)
+- Control-plane artifacts (`artifacts/v087/control_plane/`)
+
+### Cards / Proof
+- Input/output cards for each issue
+- Validation notes embedded in output cards
+- Review artifacts under `.adl/reviews/`
+
+---
+
+## Demo Strategy
+
+This milestone uses a **bounded demo model** aligned to substrate proof:
+
+| Demo | Focus |
+|------|------|
+| D1 | Trace v1 truth |
+| D2 | Provider portability |
+| D3 | Shared ObsMem |
+| D4 | Operational skills |
+| D5 | Control plane |
+| D6 | Reviewer package |
+
+Rules:
+- Each demo has a **primary proof surface**
+- Success is **inspection-based**, not just exit codes
+- Determinism judged by **structure, not identical bytes**
+
+---
+
+## Execution Plan
+
+### Phase 1 — Substrate Implementation
+- Land trace v1 surfaces
+- Land provider abstraction
+- Land shared ObsMem foundation
+- Stabilize control-plane primitives
+
+### Phase 2 — Integration & Alignment
+- Align all surfaces to trace
+- Normalize schemas and outputs
+- Ensure cross-subsystem consistency
+
+### Phase 3 — Demo & Proof Surfaces
+- Populate artifact directories
+- Implement demo entry points
+- Validate determinism expectations
+
+### Phase 4 — Internal Review
+- Perform skill-based repo review
+- Resolve all findings
+- Ensure doc ↔ implementation alignment
+
+### Phase 5 — Pre-Release Hardening
+- Run full demo matrix
+- Verify reviewer usability
+- Freeze scope
+
+### Phase 6 — 3rd Party Review
+- Provide:
+  - README entry point
+  - demo matrix
+  - artifact roots
+- Capture external findings
+
+---
+
+## Risks
+
+### 1. Substrate Incompleteness
+Risk: surfaces appear designed but not real
+Mitigation: require artifact-backed demos for every claim
+
+### 2. Hidden Non-Determinism
+Risk: instability masked by narrative
+Mitigation: enforce schema + trace consistency checks
+
+### 3. Tooling Fragility
+Risk: control-plane still shell-dependent
+Mitigation: require structured outputs + explicit contracts
+
+### 4. Reviewer Confusion
+Risk: unclear entry points or proof surfaces
+Mitigation: README + demo matrix must align perfectly
+
+---
+
+## Success Criteria
+
+The release is successful if:
+
+- Trace v1 is **visible and authoritative**
+- Provider abstraction is **real and inspectable**
+- Shared memory is **trace-linked and explainable**
+- Skills produce **structured, reviewable output**
+- Control-plane workflows are **predictable**
+- A new reviewer can:
+  - run a demo
+  - locate artifacts
+  - understand what is being proven
+
+---
 
 ## Exit Criteria
-- Tag and GitHub Release are published and accessible.
-- Verification completed with no unknown critical failures.
-- Communication links captured.
+
+- All planned demos move to `READY` or `LANDED`
+- Each demo has:
+  - command
+  - artifacts
+  - success signal
+- Docs match implementation exactly
+- Internal review issues resolved
+- 3rd party review completed or unblocked
+
+---
+
+## Notes
+
+- `v0.87` is a **foundation milestone**, not a capability milestone
+- Do not inflate claims beyond substrate reality
+- This release sets the stage for:
+  - identity (v0.9)
+  - cognition (Gödel / GHB expansion)
+  - delegation (Freedom Gate evolution)

--- a/docs/milestones/v0.87/SPRINT_v0.87.md
+++ b/docs/milestones/v0.87/SPRINT_v0.87.md
@@ -1,49 +1,61 @@
-# Sprint Template
+# Sprint Plan: v0.87
 
 ## Metadata
-- Sprint: `{{sprint_id}}`
-- Milestone: `{{milestone}}`
-- Start date: `{{start_date}}`
-- End date: `{{end_date}}`
-- Owner: `{{owner}}`
-
-## How To Use
-- Keep scope small enough to finish with green CI and merged PRs.
-- List work items in planned execution order.
-- Track blockers here (not scattered chat notes).
+- Sprint: `v0.87-s1`
+- Milestone: `v0.87`
+- Start date: `2026`
+- End date: `TBD`
+- Owner: `adl`
 
 ## Sprint Goal
-{{sprint_goal}}
+Establish the first executable slice of `v0.87` by locking the canonical milestone docs and beginning the substrate work that everything else depends on: trace v1, provider/transport substrate planning, and control-plane/tooling stabilization.
+
+This sprint should leave `v0.87` with:
+- canonical docs that match the roadmap
+- a clear first work sequence for trace, provider, and operational substrate work
+- at least one real implementation slice underway or completed in the foundational substrate band
 
 ## Planned Scope
-- {{scope_item_1}}
-- {{scope_item_2}}
-- {{scope_item_3}}
+- Canonicalize the milestone doc set for `v0.87` (vision, design, WBS, sprint, checklist, demo matrix, release plan, release notes, decisions, feature-doc index)
+- Begin the trace/provider/control-plane substrate sequence with issue-ready planning and the first implementation slice
+- Keep scope tightly bounded to foundational substrate work; do not pull `v0.88+` systems into this sprint
 
 ## Work Plan
 | Order | Item | Issue | Owner | Status |
 |---|---|---|---|---|
-| 1 | {{work_item_1}} | {{issue_1}} | {{owner_1}} | {{status_1}} |
-| 2 | {{work_item_2}} | {{issue_2}} | {{owner_2}} | {{status_2}} |
-| 3 | {{work_item_3}} | {{issue_3}} | {{owner_3}} | {{status_3}} |
+| 1 | Seed and align canonical `v0.87` milestone docs | `#1252` | `Daniel / Codex.app` | `planned` |
+| 2 | Evaluate and scope ADL git/control-plane consolidation for `v0.87` | `#1192` | `Daniel / Codex.app` | `planned` |
+| 3 | Create first trace/provider/shared-memory/skills substrate issues from the canonical docs | `TBD` | `Daniel` | `planned` |
+| 4 | Start the first foundational substrate implementation slice (prefer trace v1 or control-plane ownership surface) | `TBD` | `Daniel / Codex.app` | `planned` |
 
 ## Cadence Expectations
-- Use issue cards (`input`/`output`) for each item.
-- Keep changes scoped per issue; use draft PRs until checks pass.
-- Run required quality gates (fmt/clippy/test) for code changes.
+- Use issue cards (`input` / `output`) for every execution item.
+- Keep each issue mergeable, narrow, and truthfully documented.
+- Prefer substrate-first sequencing: trace → provider → shared memory → skills/tooling.
+- Use draft PRs until checks pass and proof surfaces are reviewable.
+- Run required quality gates (`fmt`, `clippy`, `test`, and any validator/demo command relevant to the changed substrate surface).
 
 ## Risks / Dependencies
-- Dependency: {{dependency_1}}
-  - Risk: {{risk_1}}
-  - Mitigation: {{mitigation_1}}
+- Dependency: `v0.86` Sprint 7 closeout must finish cleanly enough that `v0.87` docs are not immediately invalidated.
+  - Risk: late `v0.86` fixes may force doc or roadmap churn.
+  - Mitigation: keep `v0.87` sprint-1 scope on foundational substrate work and update canonical docs only after closeout truth is stable.
+
+- Dependency: provider/transport redesign touches core architectural surfaces.
+  - Risk: vague scope or over-expansion into later capability-routing work.
+  - Mitigation: keep sprint scope at provider substrate v1 only: vendor/transport/model separation, `model_ref`, compatibility path, and issue decomposition.
+
+- Dependency: tooling/control-plane work can sprawl.
+  - Risk: PR/worktree fixes turn into a broad rewrite.
+  - Mitigation: prefer bounded consolidation slices that reduce shell ownership and improve determinism without redesigning the whole workflow layer at once.
 
 ## Demo / Review Plan
-- Demo artifact: {{demo_artifact}}
-- Review date: {{review_date}}
-- Sign-off owners: {{signoff_owners}}
+- Demo artifact: `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md` plus at least one first substrate proof surface (likely trace or tooling-oriented)
+- Review date: `TBD`
+- Sign-off owners: `Daniel Austin`, `Codex.app`, internal review before wider exposure
 
 ## Exit Criteria
-- All planned scope items completed or explicitly deferred with rationale.
-- Linked issues/PRs updated and traceable.
-- CI is green for merged work.
-- Sprint summary captured in milestone docs.
+- Canonical `v0.87` milestone docs are filled, internally consistent, and aligned with the roadmap.
+- The first `v0.87` issue sequence is explicit for trace, provider, shared memory, and operational/control-plane work.
+- At least one foundational substrate implementation slice is underway or completed with traceable issue/PR surfaces.
+- Scope remains bounded to `v0.87` substrate work; no silent pull-forward of `v0.88+` systems.
+- Sprint summary and any deferrals are captured truthfully in milestone docs.

--- a/docs/milestones/v0.87/VISION_v0.87.md
+++ b/docs/milestones/v0.87/VISION_v0.87.md
@@ -1,239 +1,235 @@
-# Vision Template
+# Vision: v0.87
 
 ## Metadata
-- Project: `{{project_name}}`
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Date: `{{date}}`
-- Owner: `{{owner}}`
-- Related issues: {{issues}}
+- Project: `Agent Design Language (ADL)`
+- Milestone: `v0.87`
+- Version: `0.87`
+- Date: `2026`
+- Owner: `Agent Logic, Inc.`
+- Related issues: TBD
 
 ## Purpose
-Define the milestone-level vision for the project: what changes at this stage, why it matters, and which strategic pillars it advances.
-
-## How To Use
-- Write this as a milestone vision, not a full design spec.
-- Focus on direction, priorities, and intended outcomes rather than implementation details.
-- Keep the structure stable across milestones so changes in emphasis are easy to compare over time.
-- Prefer concrete milestone framing over vague aspiration.
-- Keep section titles stable unless there is a strong reason to change them.
-- If a section is not relevant, state that briefly rather than deleting the section.
+Define the milestone-level vision for v0.87: consolidating the gains of v0.86 into a coherent, reliable, and externally credible system, while preparing the substrate for identity, delegation, and higher-order cognition in v0.9+.
 
 ## Overview
 
-Version `{{version}}` is the milestone where `{{project_name}}` evolves from `{{previous_state}}` into `{{target_state}}`.
+Version `0.87` is the milestone where ADL evolves from a **feature-rich but internally-focused system** into a **cohesive, externally credible cognitive substrate**.
 
 This release should establish or strengthen the foundation for:
 
-- {{foundation_1}}
-- {{foundation_2}}
-- {{foundation_3}}
+- end-to-end system coherence (contracts → execution → review → trace)
+- production-grade reliability of the control plane
+- canonical documentation aligned with actual behavior
 
-`{{version}}` focuses on **{{primary_focus}}**.
+`0.87` focuses on **consolidation, correctness, and architectural alignment**.
 
 The goal is to make the project more useful to:
 
-- {{audience_1}}
-- {{audience_2}}
-- {{audience_3}}
+- developers building real agents on ADL
+- internal contributors extending the system safely
+- external reviewers evaluating ADL as a serious architecture
 
 This milestone should strengthen the architectural or strategic pillars of:
 
-- {{pillar_1}}
-- {{pillar_2}}
-- {{pillar_3}}
-- {{pillar_4}}
+- determinism
+- observability (trace + memory alignment)
+- contract integrity
+- system coherence across surfaces
 
-{{overview_close}}
+This is a **credibility milestone**: the system must behave as described, and be described as it behaves.
 
 ---
 
 # Core Goals
 
-`{{version}}` advances `{{project_name}}` in five major areas:
+`0.87` advances ADL in five major areas:
 
-1. {{goal_area_1}}
-2. {{goal_area_2}}
-3. {{goal_area_3}}
-4. {{goal_area_4}}
-5. {{goal_area_5}}
+1. System Coherence
+2. Contract and Validation Integrity
+3. Review and Verification Surfaces
+4. Documentation Alignment (Canonicalization)
+5. Tooling Stability and Developer Workflow
 
 ---
 
-# 1. {{goal_area_1}}
+# 1. System Coherence
 
-`{{version}}` improves `{{goal_area_1}}` so the project can `{{outcome_1}}`.
+`0.87` improves system coherence so the project can behave as a **single integrated cognitive system**, not a collection of features.
 
 Key objectives:
 
-- {{objective_1a}}
-- {{objective_1b}}
-- {{objective_1c}}
-- {{objective_1d}}
+- align execution, contracts, validation, and trace into a unified flow
+- eliminate inconsistencies between subsystems
+- ensure predictable behavior across all entry points (CLI, runtime, tools)
+- reduce hidden or implicit behavior
 
-These capabilities move the project toward **{{strategic_effect_1}}**.
+These capabilities move the project toward **a deterministic, explainable cognitive substrate**.
 
-The system or product should guarantee:
+The system should guarantee:
 
-- {{guarantee_1a}}
-- {{guarantee_1b}}
-- {{guarantee_1c}}
+- the same input + contracts always produce the same structured behavior
+- trace reflects actual execution, not approximations
+- no silent divergence between components
 
 ---
 
-# 2. {{goal_area_2}}
+# 2. Contract and Validation Integrity
 
-`{{goal_area_2}}` must improve without sacrificing `{{constraint_2}}`.
+Contract integrity must improve without sacrificing developer usability.
 
-`{{version}}` introduces or improves:
+`0.87` introduces or improves:
 
-- {{improvement_2a}}
-- {{improvement_2b}}
-- {{improvement_2c}}
-- {{improvement_2d}}
+- stricter validation paths for inputs, outputs, and schemas
+- elimination of undefined or loosely interpreted fields
+- consistent error handling and reporting
+- clearer boundary between strict and loose modes
 
-The goal is to move from `{{before_state_2}}` toward **{{after_state_2}}**.
+The goal is to move from **"mostly enforced contracts"** toward **fully reliable contract enforcement**.
 
 These changes should help users:
 
-- {{user_benefit_2a}}
-- {{user_benefit_2b}}
+- trust that failures are real and meaningful
+- detect issues earlier in the workflow
 
 ---
 
-# 3. {{goal_area_3}}
+# 3. Review and Verification Surfaces
 
-A central principle of `{{project_name}}` is **{{principle_3}}**.
+A central principle of ADL is **reasoned, inspectable correctness**.
 
-The project must not merely `{{anti_goal_3}}`. It must `{{desired_behavior_3}}`.
+The project must not merely execute workflows. It must **be able to evaluate and justify them**.
 
-`{{version}}` strengthens this pillar with:
+`0.87` strengthens this pillar with:
 
-- {{capability_3a}}
-- {{capability_3b}}
-- {{capability_3c}}
-- {{capability_3d}}
+- standardized review outputs (structured findings, severity, evidence)
+- system-level synthesis in review surfaces
+- explicit trust-boundary analysis
+- alignment between automated review and human reasoning
 
-This work supports the broader principle of **{{broader_principle_3}}**.
+This work supports the broader principle of **Popperian criticism within agent systems**.
 
 The result should make the project more:
 
-- {{quality_3a}}
-- {{quality_3b}}
-- {{quality_3c}}
+- trustworthy
+- auditable
+- self-correcting
 
 ---
 
-# 4. {{goal_area_4}}
+# 4. Documentation Alignment (Canonicalization)
 
-`{{version}}` continues development of `{{goal_area_4}}`.
+`0.87` continues development of documentation as a **first-class system component**.
 
-The focus remains on **{{focus_4}}**, not `{{non_goal_4}}`.
+The focus remains on **accuracy and alignment**, not expansion.
 
 Key capabilities:
 
-- {{capability_4a}}
-- {{capability_4b}}
-- {{capability_4c}}
-- {{capability_4d}}
+- canonical docs reflect actual runtime behavior
+- removal of outdated or duplicated documents
+- consistent structure across milestones
+- explicit linkage between design, vision, and implementation
 
-This milestone should help the project better represent or support:
+This milestone should help the project better represent:
 
-- {{support_4a}}
-- {{support_4b}}
-- {{support_4c}}
+- its true capabilities
+- its architectural intent
+- its operational guarantees
 
-These improvements should guide the system toward `{{desired_state_4}}`.
+These improvements should guide the system toward **documentation as a reliable interface to the system**.
 
 ---
 
-# 5. {{goal_area_5}}
+# 5. Tooling Stability and Developer Workflow
 
-To support real-world use, `{{version}}` must improve `{{goal_area_5}}`.
+To support real-world use, `0.87` must improve developer workflow and tooling reliability.
 
 Important targets include:
 
-- {{target_5a}}
-- {{target_5b}}
-- {{target_5c}}
-- {{target_5d}}
+- stable PR tooling and card workflows
+- predictable worktree and repo interactions
+- reduction of fragile or environment-dependent behavior
+- clearer automation boundaries
 
-This work should strengthen the development and operating workflow by improving:
+This work should strengthen the development workflow by improving:
 
-- {{workflow_benefit_5a}}
-- {{workflow_benefit_5b}}
-- {{workflow_benefit_5c}}
+- reproducibility
+- developer confidence
+- speed of iteration without loss of correctness
 
-{{close_5}}
+This is especially important because a large portion of recent progress has come through tooling.
 
 ---
 
-# Special Focus: `{{special_focus_title}}`
+# Special Focus: System Credibility
 
-`{{special_focus_title}}` becomes a central focus of `{{version}}`.
+System credibility becomes a central focus of `0.87`.
 
-Previous releases `{{previous_special_focus_state}}`.
+Previous releases emphasized rapid capability expansion.
 
-`{{version}}` advances this area with:
+`0.87` advances this area with:
 
-- {{special_focus_1}}
-- {{special_focus_2}}
-- {{special_focus_3}}
-- {{special_focus_4}}
+- elimination of known inconsistencies
+- alignment between claims and behavior
+- stronger guarantees around correctness and trace
+- readiness for external (3rd party) evaluation
 
-This area is responsible for ensuring that `{{special_focus_scope}}` remain:
+This area is responsible for ensuring that **all exposed system surfaces** remain:
 
-- {{special_quality_1}}
-- {{special_quality_2}}
-- {{special_quality_3}}
+- correct
+- consistent
+- explainable
 
-This keeps the project aligned with `{{alignment_principle}}`.
+This keeps the project aligned with **the principle of reasonableness and truthfulness in system design**.
 
 ---
 
 # Milestone Context
 
-`{{previous_milestone}}` represents `{{previous_milestone_significance}}`.
+`v0.86` represents a major expansion in:
 
-From `{{next_phase_start}}` onward the project will likely shift toward:
+- tooling
+- review surfaces
+- validation layers
 
-- {{next_phase_item_1}}
-- {{next_phase_item_2}}
-- {{next_phase_item_3}}
+From `v0.9` onward the project will likely shift toward:
 
-The goal is to have `{{future_goal}}` by **{{future_target_milestone}}**.
+- identity (persistent agents)
+- delegation and Freedom Gate
+- higher-order cognitive structures (Gödel agent, GHB loop)
 
-`{{version}}` therefore focuses on `{{contextual_focus}}` before that stage.
+The goal is to have a **stable, credible substrate** by **v0.9**.
+
+`0.87` therefore focuses on **making the current system solid and trustworthy** before that transition.
 
 ---
 
 # Long-Term Direction
 
-`{{project_name}}` is being designed as `{{long_term_identity}}`.
+ADL is being designed as a **deterministic cognitive architecture for agents**.
 
 Its long-term goals include:
 
-- {{long_term_goal_1}}
-- {{long_term_goal_2}}
-- {{long_term_goal_3}}
-- {{long_term_goal_4}}
+- persistent identity across time
+- safe and reasoned delegation
+- self-improving reasoning systems (GHB loop)
+- distributed cognitive systems with shared reality (CSM)
 
-These principles aim to move the project beyond `{{old_mode}}` toward `{{new_mode}}`.
+These principles aim to move the project beyond **prompt orchestration** toward **engineered proto-sentience with constraints**.
 
 ---
 
 # Summary
 
-`{{version}}` is the milestone where `{{project_name}}` becomes:
+`0.87` is the milestone where ADL becomes:
 
-- {{summary_quality_1}}
-- {{summary_quality_2}}
-- {{summary_quality_3}}
-- {{summary_quality_4}}
+- coherent
+- reliable
+- externally credible
+- aligned with its own architecture
 
-It strengthens `{{summary_strength_1}}`, advances `{{summary_strength_2}}`, improves `{{summary_strength_3}}`, and stabilizes `{{summary_strength_4}}`.
+It strengthens determinism, advances contract integrity, improves review surfaces, and stabilizes tooling.
 
-These improvements prepare the project for `{{next_stage}}`.
+These improvements prepare the project for **identity, delegation, and higher-order cognition in v0.9+**.
 
 ## Exit Criteria
 - The milestone's strategic priorities are explicit and internally consistent.

--- a/docs/milestones/v0.87/WBS_v0.87.md
+++ b/docs/milestones/v0.87/WBS_v0.87.md
@@ -1,65 +1,68 @@
-# Work Breakdown Structure (WBS) Template
+# Work Breakdown Structure (WBS): v0.87
 
 ## Metadata
-- Milestone: `{{milestone}}`
-- Version: `{{version}}`
-- Date: `{{date}}`
-- Owner: `{{owner}}`
-
-## How To Use
-- Break work into independently-mergeable issues.
-- Keep each item measurable and testable.
-- Include deliverables + dependencies + issue links.
-- `WP-01` is **always** the milestone **design pass** (canonical docs + WBS + decisions + sprint plan + checklist).
-- Reserve the final WPs for the release tail in this order: `WP-13` demos, `WP-14` quality/coverage gate, `WP-15` docs/review convergence, `WP-16` release ceremony.
+- Milestone: `v0.87`
+- Version: `0.87`
+- Date: `2026`
+- Owner: `adl`
 
 ## WBS Summary
-{{wbs_summary}}
+`v0.87` is the milestone where ADL consolidates the bounded cognitive system from `v0.86` into a coherent, deterministic, and externally credible substrate. The work is organized around four core implementation bands—trace, provider portability, shared memory, and operational/control-plane stability—followed by the standard demo, quality, docs/review, and release tail.
+
+This milestone is intentionally substrate-heavy. It should improve:
+- cross-surface coherence (`contracts -> execution -> trace -> review -> docs`)
+- provider/model correctness and portability
+- shared observable memory foundations
+- deterministic operational workflows and PR tooling
+- reviewer-facing proof and demo surfaces
+
+The WBS below preserves mergeable slices, explicit dependencies, and a clean release tail.
 
 ## Work Packages
 | ID | Work Package | Description | Deliverable | Dependencies | Issue |
 |---|---|---|---|---|---|
-| WP-01 | Design pass (milestone docs + planning) | {{description_01}} | {{deliverable_01}} | {{deps_01}} | {{issue_01}} |
-| WP-02 | {{package_02}} | {{description_02}} | {{deliverable_02}} | {{deps_02}} | {{issue_02}} |
-| WP-03 | {{package_03}} | {{description_03}} | {{deliverable_03}} | {{deps_03}} | {{issue_03}} |
-| WP-04 | {{package_04}} | {{description_04}} | {{deliverable_04}} | {{deps_04}} | {{issue_04}} |
-| WP-05 | {{package_05}} | {{description_05}} | {{deliverable_05}} | {{deps_05}} | {{issue_05}} |
-| WP-06 | {{package_06}} | {{description_06}} | {{deliverable_06}} | {{deps_06}} | {{issue_06}} |
-| WP-07 | {{package_07}} | {{description_07}} | {{deliverable_07}} | {{deps_07}} | {{issue_07}} |
-| WP-08 | {{package_08}} | {{description_08}} | {{deliverable_08}} | {{deps_08}} | {{issue_08}} |
-| WP-09 | {{package_09}} | {{description_09}} | {{deliverable_09}} | {{deps_09}} | {{issue_09}} |
-| WP-10 | {{package_10}} | {{description_10}} | {{deliverable_10}} | {{deps_10}} | {{issue_10}} |
-| WP-11 | {{package_11}} | {{description_11}} | {{deliverable_11}} | {{deps_11}} | {{issue_11}} |
-| WP-12 | {{package_12}} | {{description_12}} | {{deliverable_12}} | {{deps_12}} | {{issue_12}} |
-| WP-13 | Demo matrix + integration demos | {{description_13}} | {{deliverable_13}} | {{deps_13}} | {{issue_13}} |
-| WP-14 | Coverage / quality gate (ratchet + exclusions) | {{description_14}} | {{deliverable_14}} | {{deps_14}} | {{issue_14}} |
-| WP-15 | Docs + review pass (repo-wide alignment) | {{description_15}} | {{deliverable_15}} | {{deps_15}} | {{issue_15}} |
-| WP-16 | Release ceremony (final validation + tag + notes + cleanup) | {{description_16}} | {{deliverable_16}} | {{deps_16}} | {{issue_16}} |
+| WP-01 | Design pass (milestone docs + planning) | Fill and align canonical `v0.87` milestone docs: vision, design, WBS, sprint, checklist, demo matrix, release plan, release notes, decisions, and feature-doc index. | Canonical `docs/milestones/v0.87/` doc set aligned to roadmap and substrate scope. | none | TBD |
+| WP-02 | Trace v1 schema + event model | Define and implement the first authoritative trace substrate for `v0.87`, including stable event naming, canonical event schema, and the minimum event set needed for reconstruction and review. | Trace v1 schema, event taxonomy, and implementation surfaces for stable structured events. | WP-01 | TBD |
+| WP-03 | Trace instrumentation + artifact linkage | Instrument the runtime and adjacent tooling so major decisions and outputs emit trace events and trace links cleanly to artifacts/proof surfaces. | Runtime trace emission aligned to actual execution, with artifact ↔ trace linkage. | WP-02 | TBD |
+| WP-04 | Provider / transport substrate v1 | Redesign provider handling around explicit vendor / transport / model separation, stable `model_ref`, provider-model mapping, and adapter boundaries for common providers. | Provider/transport substrate v1 with deterministic configuration and extensible adapter model. | WP-01 | TBD |
+| WP-05 | Provider portability + config compatibility | Thread the new provider substrate through real config surfaces, preserve compatibility where needed, and ensure agents can target common providers without brittle provider-native strings in core authoring surfaces. | Working provider portability path plus backward-compatible profile expansion where required. | WP-04 | TBD |
+| WP-06 | Shared ObsMem foundation | Establish the first shared-memory substrate across runs/surfaces with bounded indexing, retrieval, and storage discipline. This is a foundation layer, not full social memory. | Shared ObsMem base interfaces and implementation surface for cross-run/shared retrieval. | WP-01 | TBD |
+| WP-07 | Trace ↔ memory coherence | Align shared-memory entries with trace and execution truth so retrieval and persisted context can be explained, reviewed, and tied back to actual events. | Trace-aware shared-memory behavior and documented coherence rules. | WP-03, WP-06 | TBD |
+| WP-08 | Operational skills substrate | Implement the first operational skill substrate, including bounded invocation, common output shape, and at least the first real workflow skills (for example preflight/review-oriented surfaces). | Operational skills v1 with deterministic invocation and structured outputs. | WP-01, WP-03 | TBD |
+| WP-09 | PR tooling / control-plane consolidation | Continue moving workflow ownership into the canonical control plane so PR/worktree/card behavior is less fragile, less shell-dependent, and more deterministic. | Strengthened Rust-/control-plane-owned workflow surfaces with thinner shell wrappers. | WP-01 | TBD |
+| WP-10 | Tooling hardening + workflow stability | Harden day-to-day developer workflow around worktrees, repo-root handling, validation boundaries, and automation expectations so the substrate is credible in practice. | Stable operational workflow surfaces for daily use and milestone closeout. | WP-08, WP-09 | TBD |
+| WP-11 | Review-surface formalization | Convert review into a canonical structured output surface: findings, impact, triggers, evidence, fix direction, system-level assessment, and action plan. | Standardized review/verification output contract and at least one real implementation surface using it. | WP-03, WP-08 | TBD |
+| WP-12 | Documentation canonicalization + feature index | Align milestone docs and feature-doc index with implemented `v0.87` behavior, dependencies, and proof surfaces without inflating scope. | Canonical `v0.87` docs and feature-doc map that truthfully reflect implementation. | WP-02, WP-05, WP-07, WP-11 | TBD |
+| WP-13 | Demo matrix + integration demos | Define and implement the milestone’s primary proof surfaces, including substrate demos for trace/provider/shared-memory/skills and the planned PR Demo preparation surfaces for later milestones. | `v0.87` demo matrix plus runnable integration demos with clear proof claims. | WP-03, WP-05, WP-07, WP-08, WP-11 | TBD |
+| WP-14 | Coverage / quality gate (ratchet + exclusions) | Enforce truthful quality posture for the milestone, including tests, validators, coverage/ratchet posture, and concrete command surfaces for auditing substrate correctness. | Final `v0.87` quality/coverage gate record with explicit exceptions if any. | WP-02 through WP-13 | TBD |
+| WP-15 | Docs + review pass (repo-wide alignment) | Converge milestone docs, proof surfaces, review artifacts, and entry-point docs so an internal/external reviewer can understand the implemented `v0.87` substrate truthfully. | Reviewed and aligned docs/review surface package for `v0.87`. | WP-12, WP-13, WP-14 | TBD |
+| WP-16 | Release ceremony (final validation + tag + notes + cleanup) | Perform final release-tail work for `v0.87`: validation evidence, checklist/release-note alignment, closeout record, and clean handoff into the next roadmap slice. | `v0.87` release-closeout package with final validation and milestone handoff. | WP-15 | TBD |
 
 ## Sequencing
-- Phase 1: {{phase_1}}
-- Phase 2: {{phase_2}}
-- Phase 3: {{phase_3}}
+- Phase 1: Canonical planning + substrate definition (`WP-01` through `WP-04`)
+- Phase 2: Shared substrate implementation and workflow hardening (`WP-05` through `WP-11`)
+- Phase 3: Canonical docs, demos, quality gate, review alignment, and release tail (`WP-12` through `WP-16`)
 
 ## Acceptance Mapping
-- WP-01 (Design pass) -> {{acceptance_criteria_01}}
-- WP-02 -> {{acceptance_criteria_02}}
-- WP-03 -> {{acceptance_criteria_03}}
-- WP-04 -> {{acceptance_criteria_04}}
-- WP-05 -> {{acceptance_criteria_05}}
-- WP-06 -> {{acceptance_criteria_06}}
-- WP-07 -> {{acceptance_criteria_07}}
-- WP-08 -> {{acceptance_criteria_08}}
-- WP-09 -> {{acceptance_criteria_09}}
-- WP-10 -> {{acceptance_criteria_10}}
-- WP-11 -> {{acceptance_criteria_11}}
-- WP-12 -> {{acceptance_criteria_12}}
-- WP-13 (Demos) -> {{acceptance_criteria_13}}
-- WP-14 (Quality gate) -> {{acceptance_criteria_14}}
-- WP-15 (Docs/review) -> {{acceptance_criteria_15}}
-- WP-16 (Release ceremony) -> {{acceptance_criteria_16}}
+- WP-01 (Design pass) -> Canonical milestone docs are filled, internally consistent, and aligned to the roadmap-defined `v0.87` substrate.
+- WP-02 -> Trace v1 has an explicit schema, stable event vocabulary, and a bounded but authoritative event model.
+- WP-03 -> Trace events are emitted from real execution/control points and link coherently to artifacts/proof surfaces.
+- WP-04 -> Provider/transport substrate v1 is explicit, deterministic, and no longer conflates vendor, transport, and model identity.
+- WP-05 -> Common providers can be targeted through the new substrate without brittle core-surface dependence on provider-native strings.
+- WP-06 -> Shared ObsMem foundation exists as a real shared-memory layer, not just isolated local memory behavior.
+- WP-07 -> Shared-memory behavior is explainable through trace/execution history and does not drift silently from runtime truth.
+- WP-08 -> Operational skills have a real invocation substrate and structured outputs, with at least initial workflow-oriented skills implemented.
+- WP-09 -> PR/control-plane behavior is more centralized, deterministic, and less shell-fragile than before.
+- WP-10 -> Daily workflow and milestone-closeout tooling are reproducible, worktree-safe, and minimally surprising.
+- WP-11 -> Review outputs are structured, evidence-bearing, and suitable for real internal/external review surfaces.
+- WP-12 -> Canonical docs and feature index truthfully describe the implemented `v0.87` substrate and its proof surfaces.
+- WP-13 (Demos) -> `v0.87` has clear integration demos proving trace, provider portability, shared memory, and operational substrate behavior.
+- WP-14 (Quality gate) -> The milestone has a truthful, auditable quality/coverage posture with explicit command surfaces and justified exceptions.
+- WP-15 (Docs/review) -> Docs, proof surfaces, and review artifacts converge into a reviewer-legible, contradiction-free package.
+- WP-16 (Release ceremony) -> Final validation, release-tail docs, and milestone handoff are explicit, truthful, and auditable.
 
 ## Exit Criteria
-- Every in-scope requirement maps to at least one WBS item.
-- Every WBS item has an owner, issue reference, and concrete deliverable.
-- Dependency order is explicit enough to execute deterministically.
+- Every in-scope `v0.87` requirement maps to at least one WBS item.
+- Every WBS item has a concrete deliverable and explicit dependency order.
+- The four major substrate bands—trace, provider, shared memory, and operational/control-plane stability—are all represented directly in the WBS.
+- The release tail remains bounded and downstream of implementation truth.


### PR DESCRIPTION
Closes #1228

## Summary
- move the edited v0.87 milestone docs off main and onto the issue branch
- seed the canonical v0.87 milestone planning set under docs/milestones/v0.87
- remove copied template preambles from the milestone docs while preserving the authored v0.87 content

## Scope
- README
- VISION
- DESIGN
- WBS
- SPRINT
- DECISIONS
- DEMO_MATRIX
- MILESTONE_CHECKLIST
- RELEASE_PLAN
- RELEASE_NOTES

## Notes
- FEATURE_DOCS_v0.87.md is intentionally left alone for later feature-doc work
- this PR is milestone planning/docs only; no runtime or tooling behavior changes
