### PR TITLE
[v0.86][tools] Mirror full .adl template set into started worktrees

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -211,6 +211,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
 
     let root_stp = ensure_task_bundle_stp(&repo_root, &issue_ref, &source_path)?;
     let worktree_source = ensure_local_issue_prompt_copy(&worktree_path, &issue_ref, &source_path)?;
+    mirror_adl_templates_into_worktree(&repo_root, &worktree_path)?;
     let worktree_stp = ensure_task_bundle_stp(&worktree_path, &issue_ref, &worktree_source)?;
     validate_authored_prompt_surface("start", &root_stp, PromptSurfaceKind::Stp)?;
     validate_authored_prompt_surface("start", &worktree_stp, PromptSurfaceKind::Stp)?;
@@ -1539,6 +1540,34 @@ fn ensure_local_issue_prompt_copy(
         fs::copy(canonical_source_path, &local_source_path)?;
     }
     Ok(local_source_path)
+}
+
+fn mirror_adl_templates_into_worktree(repo_root: &Path, worktree_root: &Path) -> Result<()> {
+    let source_templates = repo_root.join(".adl/templates");
+    if !source_templates.is_dir() {
+        return Ok(());
+    }
+    let target_templates = worktree_root.join(".adl/templates");
+    copy_directory_contents(&source_templates, &target_templates)
+}
+
+fn copy_directory_contents(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_directory_contents(&source_path, &target_path)?;
+        } else if file_type.is_file() {
+            if let Some(parent) = target_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&source_path, &target_path)?;
+        }
+    }
+    Ok(())
 }
 
 fn ensure_bootstrap_cards(

--- a/adl/src/cli/tests/pr_cmd_inline.rs
+++ b/adl/src/cli/tests/pr_cmd_inline.rs
@@ -941,6 +941,18 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1152, "v0.86", "rust-start-ready-test").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust start ready test");
+    let local_templates = repo.join(".adl/templates");
+    fs::create_dir_all(local_templates.join("nested")).expect("create local templates");
+    fs::write(
+        local_templates.join("README_TEMPLATE.md"),
+        "# canonical readme template\n",
+    )
+    .expect("write readme template");
+    fs::write(
+        local_templates.join("nested/FEATURE_DOC_TEMPLATE.md"),
+        "# canonical feature doc template\n",
+    )
+    .expect("write nested feature template");
 
     real_pr(&[
         "start".to_string(),
@@ -1012,6 +1024,16 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     assert!(issue_ref.task_bundle_stp_path(&worktree).is_file());
     assert!(issue_ref.task_bundle_input_path(&worktree).is_file());
     assert!(issue_ref.task_bundle_output_path(&worktree).is_file());
+    assert_eq!(
+        fs::read_to_string(worktree.join(".adl/templates/README_TEMPLATE.md"))
+            .expect("read mirrored template"),
+        "# canonical readme template\n"
+    );
+    assert_eq!(
+        fs::read_to_string(worktree.join(".adl/templates/nested/FEATURE_DOC_TEMPLATE.md"))
+            .expect("read mirrored nested template"),
+        "# canonical feature doc template\n"
+    );
     let root_cards = resolve_cards_root(&repo, None);
     assert!(card_input_path(&root_cards, 1152)
         .symlink_metadata()


### PR DESCRIPTION
Closes #1254

## Summary
Fixed the started-worktree template mirroring gap by making the Rust `pr start` path recursively copy the full `.adl/templates/` tree from the primary checkout into the started worktree before worktree-local task execution proceeds. Added regression coverage proving both top-level and nested template files appear in the started worktree and remain compatible with `ready`.

## Artifacts
- Updated `adl/src/cli/pr_cmd.rs`
- Updated `adl/src/cli/tests/pr_cmd_inline.rs`
- Completed output card for `#1254`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path Cargo.toml real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture`
    verifies that `pr start` mirrors both top-level and nested `.adl/templates/` files into the started worktree and that `ready` still passes afterward
  - `cargo test --manifest-path Cargo.toml pr_cmd -- --nocapture`
    verifies the broader PR lifecycle suite still passes after the new template-mirroring step
  - `cargo fmt --manifest-path Cargo.toml --all --check`
    verifies the Rust changes are formatted
  - `cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings`
    verifies the change is warning-clean under the repo lint gate
- Results:
  - all listed validation commands passed locally

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1254__v0-86-tools-mirror-full-adl-template-set-into-started-worktrees/sip.md
- Output card: .adl/v0.86/tasks/issue-1254__v0-86-tools-mirror-full-adl-template-set-into-started-worktrees/sor.md
- Idempotency-Key: v0-86-tools-mirror-full-adl-template-set-into-started-worktrees-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-rs-adl-v0-86-tasks-issue-1254-v0-86-tools-mirror-full-adl-template-set-into-started-worktrees-sip-md-adl-v0-86-tasks-issue-1254-v0-86-tools-mirror-full-adl-template-set-into-started-worktrees-sor-md