### PR TITLE
[v0.86][docs] Promote v0.87 feature docs into milestone features

### DIFF
--- a/docs/milestones/v0.87/features/OPERATIONAL_SKILLS_SUBSTRATE.md
+++ b/docs/milestones/v0.87/features/OPERATIONAL_SKILLS_SUBSTRATE.md
@@ -1,0 +1,390 @@
+
+
+# OPERATIONAL SKILLS SUBSTRATE v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Purpose: Define the first real operational skills substrate for ADL and establish the bridge between ADL-native skills and Codex-compatible skill packaging.
+
+## Purpose
+
+Define **operational skills** as first-class, bounded, reusable execution surfaces in ADL.
+
+This document specifies:
+- what a skill is in ADL
+- how skills are packaged, discovered, and invoked
+- how skills relate to review, tooling, and control-plane behavior
+- how ADL skill structure can remain compatible with simple Codex-style skill discovery while still supporting stronger ADL contracts
+
+This is the **feature-owner doc** for the operational skills substrate in `v0.87`.
+
+## Core Principle
+
+> A skill is not just a prompt. A skill is a bounded operational unit with defined inputs, outputs, invocation rules, and reviewable execution behavior.
+
+In ADL, skills exist to make workflow behavior:
+- reusable
+- deterministic in structure
+- reviewable
+- composable
+
+## Why This Matters in `v0.87`
+
+`v0.87` is a substrate milestone. Operational skills belong here because they turn ad hoc workflow behavior into explicit, reusable control-plane surfaces.
+
+Skills are required to make later systems cleaner and more deterministic, including:
+- preflight and readiness checks
+- review and remediation support
+- control-plane operations
+- later cognitive and delegation flows
+
+Without a real skills substrate, too much behavior remains trapped in:
+- shell scripts
+- issue-specific prompts
+- undocumented workflow habits
+
+## Scope
+
+### In scope
+- skill packaging model
+- skill discovery model
+- invocation modes
+- output structure
+- bounded compatibility with Codex skill layout
+- initial workflow-oriented skill set for `v0.87`
+
+### Out of scope
+- full cognitive skill market/catalog
+- autonomous skill learning
+- advanced aptitude-based skill routing
+- policy/governance layers beyond bounded invocation and output contracts
+
+## Skill Definition
+
+A skill is a reusable execution unit with:
+- identity
+- instructions
+- optional helpers/references/assets
+- bounded invocation rules
+- structured output expectations
+
+Minimum ADL concept:
+- skill identity
+- skill instructions
+- invocation boundary
+- output contract
+
+## Design Goals
+
+1. **Bounded and explicit**
+   - Skills must have clear start/end boundaries.
+   - Skills are not open-ended personalities.
+
+2. **Deterministic in structure**
+   - Content may vary, but output family and required sections must remain stable.
+
+3. **Composable**
+   - Skills should be usable by humans, main agents, and sub-agents.
+
+4. **Reviewable**
+   - A reviewer should be able to understand what skill ran, what it was supposed to do, and what it produced.
+
+5. **Codex-compatible where useful**
+   - ADL should preserve compatibility with the simple Codex-discoverable `SKILL.md` directory model where practical.
+   - ADL may add stronger structure around it.
+
+## Skill Packaging Model
+
+### Canonical ADL packaging
+
+Each skill lives in its own directory.
+
+Canonical minimal structure:
+
+```text
+<skills-root>/
+└── my-skill/
+    └── SKILL.md
+```
+
+Extended structure:
+
+```text
+<skills-root>/
+└── my-skill/
+    ├── SKILL.md
+    ├── references/
+    │   └── examples.md
+    ├── scripts/
+    │   └── helper.py
+    ├── assets/
+    │   └── template.txt
+    └── adl-skill.yaml
+```
+
+### Compatibility principle
+
+Codex-compatible discovery expects:
+- one folder per skill
+- `SKILL.md` at the root of the skill folder
+
+ADL should preserve that simple packaging rule so the same skill can be:
+- discovered by Codex-style systems
+- enriched by ADL-specific metadata and validation
+
+### Required file
+
+`SKILL.md` is required.
+
+### Optional files
+
+- `adl-skill.yaml`
+  - ADL-only structured metadata and stronger contract fields
+- `references/`
+  - docs/examples loaded when needed
+- `scripts/`
+  - helper scripts the skill may call
+- `assets/`
+  - templates or static resources
+- `agents/`
+  - optional UI or environment-specific metadata when needed
+
+## Skill Metadata Model
+
+### Minimum required metadata
+
+Every skill must define:
+- `name`
+- `purpose`
+- `inputs`
+- `outputs`
+- `invocation_modes`
+
+This can live in:
+- frontmatter inside `SKILL.md`
+- or in `adl-skill.yaml`
+
+### Recommended ADL metadata fields
+
+- `name`
+- `version`
+- `description`
+- `owner`
+- `allowed_tools`
+- `input_contract`
+- `output_contract`
+- `safe_repairs_allowed`
+- `stop_conditions`
+- `review_requirements`
+
+## Invocation Model
+
+ADL supports three invocation modes.
+
+### 1. Explicit Invocation
+
+A caller names the skill directly.
+
+Examples:
+- main agent invokes a skill by name/path
+- sub-agent is instructed to use a specific skill path
+
+This is the most deterministic path.
+
+### 2. Triggered Invocation
+
+A workflow surface or prompt pattern triggers a skill automatically when conditions match.
+
+This must remain bounded and explicit.
+
+### 3. Agent-Selected Invocation
+
+An agent selects a skill from an available set.
+
+This is allowed only when:
+- skill availability is explicit
+- the agent has access to required context/resources
+- later routing/aptitude layers justify the selection
+
+For `v0.87`, explicit invocation is the primary model.
+
+## Sub-Agent Use
+
+Operational skills must be usable by sub-agents when:
+- the skill is available in that environment
+- the sub-agent has access to required tools/files
+- the calling prompt explicitly references the skill when deterministic use is required
+
+This means the substrate must assume:
+- main-agent and sub-agent usage are both valid
+- availability and resource access matter more than role name alone
+
+## Discovery Model
+
+### v1 discovery assumptions
+
+A skill is discoverable when:
+- it is located in the configured skills root
+- it has a folder of its own
+- `SKILL.md` exists at the root of that folder
+
+### ADL extension
+
+ADL may load optional metadata from `adl-skill.yaml` when present.
+
+If absent:
+- the skill remains valid
+- ADL falls back to `SKILL.md` plus defaults
+
+This preserves Codex compatibility while enabling stronger ADL semantics.
+
+## Execution Contract
+
+Each skill execution should have a bounded contract:
+
+### Inputs
+- explicit task/request
+- relevant local context
+- optional workflow surfaces or issue/card references
+
+### Outputs
+- structured result
+- status
+- findings/warnings/errors as applicable
+- explicit stop condition
+
+### Stop condition
+A skill must know when it is done.
+
+For example:
+- emit readiness result and stop
+- emit review findings and stop
+- apply bounded safe repair and stop
+
+## Output Model
+
+Every skill should emit a stable output family.
+
+Recommended structure:
+
+- `skill_name`
+- `version`
+- `status`
+- `summary`
+- `findings` (if applicable)
+- `actions_taken` (if applicable)
+- `deferred_items` (if applicable)
+- `evidence` / references
+- `stop_reason`
+
+### Key rule
+
+The output must be:
+- reviewable
+- bounded
+- stable in shape
+
+This is more important than making wording identical.
+
+## Initial `v0.87` Skill Set
+
+The initial `v0.87` substrate should support at least the following bounded workflow-oriented skills:
+
+- `preflight-check`
+  - determines readiness to begin an issue/task
+- `card-review`
+  - reviews issue cards for truth, completeness, and scope discipline
+- `repo-review` or equivalent bounded review surface
+  - produces structured findings over code/repo state
+- bounded bootstrap/recovery helper flows
+  - recover from safe, known workflow-state problems
+
+These are substrate skills, not later cognitive/social skills.
+
+## Safety and Repair Boundaries
+
+Skills may optionally perform bounded safe repairs, but only when clearly allowed.
+
+Examples:
+- small deterministic formatting/consistency fix
+- safe bootstrap/recovery step
+
+Not allowed in v1 unless explicitly authorized by the skill contract:
+- broad refactors
+- speculative rewrites
+- hidden state mutation
+
+## Tool and Resource Access
+
+Skill execution must declare or constrain what it needs.
+
+Examples:
+- repository files
+- local scripts
+- issue/card files
+- specific tools
+
+If a sub-agent runs a skill, the same access requirements still apply.
+
+## Reviewability Requirements
+
+A skill execution must be reviewable after the fact.
+
+At minimum, a reviewer should be able to answer:
+- which skill ran?
+- what inputs/context did it rely on?
+- what did it produce?
+- did it make changes?
+- why did it stop?
+
+## Integration with `v0.87` Surfaces
+
+### Trace
+- skill invocation should eventually emit trace-compatible events
+- this is a natural follow-on for the trace substrate work in `v0.87`
+
+### Review surfaces
+- skills must produce outputs that can be embedded in cards, reports, or review flows
+
+### Control plane
+- skills should reduce shell/prompt fragility by making workflow behavior explicit
+
+### Demo matrix
+- at least one demo should prove that an operational skill can be invoked and produce a structured bounded result
+
+## Acceptance Criteria
+
+The operational skills substrate is acceptable for `v0.87` when:
+- a canonical packaging model exists
+- `SKILL.md`-rooted discovery is preserved for Codex compatibility
+- ADL-specific metadata/extensions are defined without breaking minimal compatibility
+- at least one real operational skill is packaged in the canonical structure
+- explicit path/name invocation works for deterministic use
+- the skill produces a stable, reviewable output shape
+- sub-agent use is supported conceptually and does not contradict the packaging/invocation model
+
+## Open Questions
+
+- Should `adl-skill.yaml` be required eventually, or remain optional?
+- Which metadata belongs in `SKILL.md` frontmatter vs YAML?
+- What is the first canonical skills root for ADL in-repo use?
+- Which initial skills are mandatory for `v0.87` milestone truth?
+
+## Non-Goals (v1)
+
+- full aptitude-driven skill routing
+- autonomous skill self-discovery across arbitrary environments
+- long-term skill learning or optimization
+- a large general-purpose public skills catalog
+
+## Next Steps
+
+Derive or align the following docs/features from this substrate:
+- concrete initial skill docs (`preflight-check`, `card-review`, etc.)
+- output template / schema doc
+- skills demo surface for `v0.87`
+- later control-plane and trace integration work
+
+The operational skills substrate is the bridge between ad hoc workflow behavior and a reusable, reviewable ADL control plane.

--- a/docs/milestones/v0.87/features/PROVIDER_SUBSTRATE_FEATURE.md
+++ b/docs/milestones/v0.87/features/PROVIDER_SUBSTRATE_FEATURE.md
@@ -1,0 +1,255 @@
+
+
+# PROVIDER SUBSTRATE FEATURE v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Work package: `WP-12`
+- Purpose: Define the canonical provider substrate for ADL in `v0.87`, including declarative capability, deterministic invocation, and trace-integrated execution.
+
+## Purpose
+
+Define the **provider substrate** for ADL.
+
+This document specifies:
+- the provider abstraction contract
+- the declarative capability model (v1)
+- the transport/invocation boundary
+- how provider execution integrates with trace
+- determinism and portability requirements
+
+This is the **canonical feature doc** for provider/transport in `v0.87`.
+
+## Core Principle
+
+> Providers in `v0.87` are declarative, deterministic execution endpoints with explicit capability surfaces.
+
+They are NOT:
+- dynamic capability discovery systems
+- adaptive routing systems
+- optimization engines
+
+They are a **stable substrate boundary**.
+
+## Why This Matters in `v0.87`
+
+`v0.87` is a substrate milestone.
+
+Provider/transport must be:
+- stable
+- inspectable
+- trace-integrated
+
+Without this:
+- trace cannot reliably attribute execution
+- memory (ObsMem) cannot ground observations
+- review surfaces cannot assign responsibility
+
+## Scope
+
+### In scope
+- provider abstraction contract
+- declarative capability definition (static)
+- deterministic invocation interface
+- transport normalization (bounded)
+- trace integration (`model_ref`, `provider_ref`)
+
+### Out of scope
+- dynamic capability inference
+- provider arbitration or routing logic
+- optimization strategies
+- multi-provider orchestration policies
+- adaptive or learning-based provider selection
+
+## Provider Definition
+
+A provider is a **named execution backend** capable of performing model inference.
+
+Examples:
+- OpenAI API
+- Anthropic API
+- local Ollama runtime
+- CLI-based model invocation
+
+In ADL, providers are treated uniformly via a **declarative contract**.
+
+## Provider Identity
+
+Each provider must define:
+- `provider_id`
+- `provider_type` (e.g., `http`, `local`, `cli`)
+- `models` (set of supported model identifiers)
+
+Each invocation must resolve to:
+- `provider_ref`
+- `model_ref`
+
+These MUST be present in trace.
+
+## Declarative Capability Model (v1)
+
+Capabilities are declared statically.
+
+They are NOT inferred at runtime.
+
+### Minimal capability fields (v1)
+
+Each model may declare:
+- `max_context_tokens`
+- `supports_streaming` (bool)
+- `supports_tools` (bool)
+- `supports_system_prompt` (bool)
+
+Optional (bounded):
+- `max_output_tokens`
+
+These fields exist to support:
+- validation
+- planning
+- trace interpretation
+
+They are NOT used for dynamic optimization in `v0.87`.
+
+## Transport Model
+
+Transport defines **how a provider is invoked**, not what it can do.
+
+### Supported transport types (v1)
+
+- `http`
+- `local`
+- `cli`
+
+Each provider must define:
+- transport type
+- endpoint or execution path
+- required configuration (auth, headers, etc.)
+
+### Normalization requirement
+
+All transports must normalize into a **single invocation interface**.
+
+This ensures:
+- deterministic execution
+- trace consistency
+- portability across providers
+
+## Invocation Contract
+
+Provider invocation must be:
+- explicit
+- deterministic
+- fully traceable
+
+### Required inputs
+
+- `provider_id`
+- `model_id`
+- prompt/messages (structured)
+- invocation parameters (temperature, etc.)
+
+### Required outputs
+
+- response content
+- usage metadata (if available)
+- error information (if applicable)
+
+## Trace Integration
+
+Every provider invocation MUST emit trace events.
+
+### Required trace fields
+
+- `event_type = MODEL_INVOCATION`
+- `provider_ref`
+- `model_ref`
+- `input_ref` (artifact or inline)
+- `output_ref` (artifact or inline)
+- `duration_ms`
+- `status`
+
+This ensures:
+- full attribution of execution
+- replay compatibility
+- linkage to ObsMem
+
+## Determinism Requirements
+
+Provider execution is deterministic when:
+- invocation inputs are fully specified
+- provider + model are explicitly identified
+- parameters are explicitly defined
+
+Allowed variability:
+- stochastic model outputs
+
+Not allowed:
+- implicit provider selection
+- hidden parameter defaults
+- missing provider/model identity in trace
+
+## Portability Contract
+
+The provider substrate must ensure:
+
+- ADL workflows do not depend on a single provider
+- provider differences are normalized at the boundary
+- trace remains consistent across providers
+
+This enables:
+- swapping providers without breaking contracts
+- reproducible execution surfaces
+
+## Relationship to Other Substrates
+
+### Trace
+- provider invocations are primary trace events
+- provider identity anchors execution provenance
+
+### ObsMem
+- model calls generate observation records (`obs.model_call`)
+- provider/model identity must be preserved in memory
+
+### Review Surface
+- findings may reference provider behavior
+- provider identity must be stable for review credibility
+
+### Skills
+- skills may invoke providers
+- they must not bypass the provider abstraction
+
+## Acceptance Criteria
+
+The provider substrate is acceptable for `v0.87` when:
+
+- a canonical provider abstraction exists
+- capabilities are declarative and static
+- invocation is deterministic and explicit
+- all model calls emit proper trace events
+- provider/model identity is preserved across trace, memory, and review
+- transport differences are normalized behind the interface
+
+## Open Questions
+
+- what is the minimal configuration format for provider definitions?
+- how are credentials injected in a deterministic but secure way?
+- what is the initial set of supported providers in-repo?
+
+## Non-Goals (v1)
+
+- intelligent routing across providers
+- cost/performance optimization layers
+- dynamic capability learning
+- provider reputation systems
+
+## Next Steps
+
+Derive or align the following from this doc:
+- provider schema/config doc
+- provider implementation issues
+- trace instrumentation validation for provider calls
+- demo coverage using at least two providers
+
+The provider substrate in `v0.87` establishes a clean, deterministic boundary between ADL and model execution backends.

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
@@ -1,0 +1,575 @@
+# PR Tooling Simplification Architecture
+
+## Overview
+
+- Topic: simplify and shrink the PR lifecycle tooling
+- Milestone Target: `v0.87`
+- Date: `2026-03-31`
+- Status: `Planning`
+- Scope: `adl/tools/pr.sh`, `adl/tools/card_paths.sh`, and Rust `adl pr`
+
+## Why This Document Exists
+
+`adl/tools/pr.sh` has grown from a convenience wrapper into a large workflow
+control plane.
+
+Today the behavior is split across:
+- shell orchestration in `adl/tools/pr.sh`
+- shell path and compatibility logic in `adl/tools/card_paths.sh`
+- partially migrated Rust control-plane logic in `adl/src/cli/pr_cmd.rs`
+- shared Rust path/domain logic in `adl/src/control_plane.rs`
+
+This makes the tooling harder to understand, harder to test, and harder to
+change safely because the same workflow concepts now exist in more than one
+implementation.
+
+The goal of this design is to make the system smaller by making ownership
+clearer.
+
+This work is planned for `v0.87` as part of the next milestone's
+operational/control-plane consolidation.
+
+## Current State Snapshot
+
+Observed in the repository as of `2026-03-31`:
+
+- `adl/tools/pr.sh` is about `3113` lines.
+- `adl/tools/card_paths.sh` is about `320` lines.
+- `adl/src/cli/pr_cmd.rs` is about `5071` lines.
+- `pr.sh` already delegates several lifecycle commands to Rust when available:
+  - `create`
+  - `init`
+  - `start`
+  - `ready`
+  - `preflight`
+  - `finish`
+- `create` no longer has a real shell fallback.
+- `run`, `card`, `output`, `cards`, `status`, and `open` still live in shell.
+- path/domain logic already exists in both shell and Rust.
+
+Interpretation:
+
+- the long-term direction has already been chosen informally: Rust is becoming
+  the owner of the PR control plane
+- the current architecture still pays the complexity cost of both systems
+- the biggest source of accidental complexity is duplicated ownership, not just
+  raw line count
+
+## Primary Problems
+
+### 1. Split-Brain Ownership
+
+The same concepts are implemented in both shell and Rust:
+
+- issue normalization
+- slug normalization
+- task-bundle path rules
+- worktree conventions
+- card location rules
+- workflow bootstrapping behavior
+
+This increases drift risk and makes every change more expensive.
+
+### 2. Shell Owns Too Much Product Logic
+
+The shell script is not just invoking tools. It also owns:
+
+- repository state transitions
+- worktree safety policy
+- bootstrap repair behavior
+- markdown mutation
+- prompt and card generation flow
+- validation and readiness checks
+
+That is product logic, not glue.
+
+### 3. Command Surface Exposes Internal Workflow Steps
+
+The current interface includes:
+
+- `create`
+- `init`
+- `start`
+- `run`
+- `card`
+- `output`
+- `cards`
+- `ready`
+- `preflight`
+- `finish`
+- `open`
+- `status`
+
+Several of these are internal authoring phases rather than user-level intents.
+This makes the tool feel bigger than it needs to be and forces the
+implementation to preserve many intermediate states.
+
+### 4. Shell Is Doing Structured Data Work
+
+`pr.sh` uses `awk`, `sed`, temp files, and ad hoc parsing for document
+manipulation and validation.
+
+That style is workable for small wrappers, but brittle for a control plane with
+many invariants and compatibility rules.
+
+## Design Goals
+
+The rearchitecture should:
+
+- make `pr.sh` tiny enough to reason about in one screen
+- make Rust the single owner of PR lifecycle behavior
+- reduce the public command surface to a few user-facing intents
+- centralize path rules and workflow invariants in typed code
+- preserve backward compatibility during migration
+- avoid a risky one-shot rewrite
+
+## Non-Goals
+
+This design does not require:
+
+- eliminating shell entrypoints immediately
+- changing the underlying git and `gh` tools
+- redesigning ADL cards, STP, SIP, or SOR formats
+- rewriting demo tooling that is not part of the PR lifecycle
+
+## Proposed Target Architecture
+
+### External Shape
+
+The desired user-facing model is:
+
+- `adl pr create`
+- `adl pr start`
+- `adl pr finish`
+- `adl pr doctor`
+- optional: `adl pr open`
+
+Command meanings:
+
+- `create`
+  - create a GitHub issue and canonical local source prompt
+- `start`
+  - ensure the issue is fully bootstrapped for execution
+  - includes what is currently split across `init` and `start`
+- `finish`
+  - validate, stage, commit, push, and create or update the PR
+- `doctor`
+  - report readiness and repairable workflow drift
+  - absorbs the current `ready`, `preflight`, and most of `status`
+- `open`
+  - convenience browser action only
+
+### Compatibility Shape
+
+During migration:
+
+- `adl/tools/pr.sh` remains as the compatibility entrypoint
+- it delegates directly to `adl pr ...`
+- retired commands remain as aliases temporarily
+- deprecated commands should print a short migration hint
+
+Examples:
+
+- `init` becomes an alias for `start --bootstrap-only` or a deprecated synonym
+  during transition
+- `ready` and `preflight` become aliases for `doctor`
+- `card`, `output`, and `cards` become either hidden maintenance commands or
+  internal Rust helpers rather than prominent user commands
+
+## Ownership Model
+
+### Shell Ownership
+
+Shell should own only:
+
+- locating the repo root
+- selecting a cached Rust binary when available
+- falling back to `cargo run`
+- preserving old command entrypoints during transition
+
+Shell should not own:
+
+- workflow policy
+- path construction
+- worktree safety rules
+- card generation
+- prompt generation
+- PR body generation
+- readiness validation
+- repair logic
+
+### Rust Ownership
+
+Rust should own:
+
+- all PR lifecycle state transitions
+- all issue/task-bundle/card path rules
+- all prompt and card rendering
+- all readiness and bootstrap validation
+- all git and `gh` orchestration wrappers
+- all deprecation and compatibility policy
+
+## Proposed Module Structure
+
+Recommended internal Rust split:
+
+- `control_plane`
+  - `IssueRef`
+  - slug normalization
+  - primary checkout resolution
+  - cards root and task-bundle path logic
+- `cli/pr/args`
+  - argument parsing and command-specific option structs
+- `cli/pr/github`
+  - `gh issue/pr` wrappers
+- `cli/pr/git`
+  - fetch, branch, worktree, stage, and ahead-of-main helpers
+- `cli/pr/bootstrap`
+  - ensure source issue prompt
+  - ensure root/worktree STP
+  - ensure input/output cards
+- `cli/pr/render`
+  - generated issue bodies
+  - generated prompts
+  - generated PR bodies
+- `cli/pr/doctor`
+  - readiness inspection
+  - bounded repair logic
+- `cli/pr/commands`
+  - `create`
+  - `start`
+  - `finish`
+  - `doctor`
+  - `open`
+
+The main architectural rule is:
+
+- domain rules and helpers should be reusable library code
+- command handlers should be thin orchestration layers
+
+## Simplified Control Flow
+
+### `create`
+
+1. Parse title, labels, optional body inputs.
+2. Normalize slug and version.
+3. Create GitHub issue.
+4. Write canonical local source issue prompt.
+5. Print next-step guidance.
+
+### `start`
+
+1. Resolve issue title, slug, and version.
+2. Validate milestone-wave policy.
+3. Ensure branch and worktree.
+4. Ensure canonical source prompt exists.
+5. Ensure root and worktree bootstrap surfaces exist.
+6. Validate authored readiness for execution.
+7. Print worktree, branch, and artifact locations.
+
+### `finish`
+
+1. Resolve canonical workflow surfaces.
+2. Run checks.
+3. Stage selected paths.
+4. Commit if needed.
+5. Push branch.
+6. Create or update PR.
+7. Ensure closing linkage.
+8. Optionally mark ready/open/merge.
+
+### `doctor`
+
+1. Resolve target issue context.
+2. Inspect source prompt, task bundle, cards, branch, and worktree.
+3. Report:
+   - ready
+   - ready with repairs
+   - blocked
+4. Apply only small bounded repairs when safe.
+
+## Specific Simplifications
+
+### 1. Merge `init` Into `start`
+
+The current `init` and `start` split creates extra states and duplicate logic.
+
+Recommended rule:
+
+- `start` is the single command for “make this issue executable”
+
+Optional compatibility:
+
+- keep `init` as a deprecated alias for one release window
+
+### 2. Replace `ready`, `preflight`, and `status` With `doctor`
+
+These commands are all variants of readiness inspection.
+
+Recommended rule:
+
+- one inspection command
+- optional modes for terse or detailed output
+
+This reduces both implementation branching and mental overhead for users.
+
+#### `preflight` Consolidation Decision
+
+`preflight` should be absorbed into `doctor`.
+
+Recommended transition:
+
+- `doctor` becomes the canonical readiness command
+- `preflight` remains temporarily as a deprecated alias to `doctor`
+- `ready` also becomes a deprecated alias to `doctor`
+- docs and examples stop teaching `preflight` as a first-class command
+
+Rationale:
+
+- `preflight` asks whether execution can safely proceed
+- `ready` asks whether the workflow surfaces are execution-ready
+- `status` reports the current workflow state
+
+These are different slices of the same underlying concern:
+
+- inspect workflow health
+- report readiness
+- identify drift
+- optionally apply small safe repairs
+
+That combined concern is a better fit for one command than three.
+
+#### Suggested `doctor` Modes
+
+To preserve useful `preflight` behavior without preserving a separate command,
+`doctor` can expose explicit modes:
+
+- `adl pr doctor`
+  - default human-readable readiness report
+- `adl pr doctor --strict`
+  - exit non-zero on any blocking readiness issue
+- `adl pr doctor --json`
+  - machine-readable readiness output
+- `adl pr doctor --repair`
+  - apply only bounded mechanical repairs that are clearly safe
+
+This preserves the inspection use cases while simplifying the command model.
+
+### 3. Demote `card`, `output`, and `cards`
+
+These are useful maintenance operations, but they should not define the public
+shape of the workflow.
+
+Recommended rule:
+
+- keep them as internal helpers or expert-level subcommands
+- do not treat them as core lifecycle steps
+
+### 4. Eliminate Duplicate Path Logic
+
+`adl/tools/card_paths.sh` and `adl/src/control_plane.rs` should not both be
+authoritative.
+
+Recommended rule:
+
+- Rust owns all canonical path logic
+- shell wrappers call Rust instead of reimplementing path behavior
+
+### 5. Remove Structured Markdown Mutation From Shell
+
+All document rewriting should happen in Rust where:
+
+- invariants can be typed
+- tests can be more precise
+- parsing and rewriting can be centralized
+
+## Minimal End-State For `pr.sh`
+
+The desired shell entrypoint should look conceptually like:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN="$ROOT/adl/target/debug/adl"
+
+if [[ -x "$BIN" ]]; then
+  exec "$BIN" pr "$@"
+fi
+
+exec cargo run --quiet --manifest-path "$ROOT/adl/Cargo.toml" --bin adl -- pr "$@"
+```
+
+Small additions are acceptable for compatibility aliases and friendly error
+messages, but `pr.sh` should no longer implement lifecycle behavior itself.
+
+## Migration Plan
+
+### Phase 1: Freeze New Shell Logic
+
+Policy:
+
+- do not add new business logic to `adl/tools/pr.sh`
+- all new PR lifecycle behavior goes into Rust
+
+Success criteria:
+
+- shell line count stops growing
+- new behavior lands only in Rust
+
+### Phase 2: Finish Rust Ownership Of Existing Lifecycle Commands
+
+Rust becomes the sole implementation for:
+
+- `create`
+- `start`
+- `finish`
+- `ready`
+- `preflight`
+
+Then remove shell fallbacks for:
+
+- `start`
+- `finish`
+- `ready`
+- `preflight`
+
+Success criteria:
+
+- lifecycle behavior works with Rust-only implementations
+- shell only dispatches
+
+### Phase 3: Port Remaining Shell Commands Or Retire Them
+
+Decide for each remaining shell-owned command:
+
+- `run`
+  - keep as a separate wrapper if it is really an ADL runtime convenience
+  - otherwise move to Rust and keep one CLI surface
+- `card`
+- `output`
+- `cards`
+- `status`
+- `open`
+
+Recommended outcomes:
+
+- `open` may remain trivial shell or move to Rust
+- `status`, `ready`, and `preflight` converge into `doctor`
+- `card`, `output`, and `cards` move to Rust and become secondary commands
+- `run` is evaluated separately because it is adjacent but not identical to PR
+  lifecycle control
+
+### Phase 4: Collapse Public Command Surface
+
+Public docs and examples should converge on:
+
+- `create`
+- `start`
+- `finish`
+- `doctor`
+- `open`
+
+Compatibility aliases remain temporarily.
+
+Success criteria:
+
+- new users can learn the workflow from four main commands
+- implementation no longer revolves around historical subcommand sprawl
+
+### Phase 5: Shrink Or Remove Shell Compatibility Layer
+
+After callers and docs have moved:
+
+- reduce `adl/tools/pr.sh` to a tiny shim
+- optionally replace it with a stable thin wrapper permanently
+
+Success criteria:
+
+- `pr.sh` is small and boring
+- Rust is the only owner of lifecycle behavior
+
+## Testing Strategy
+
+Prefer tests at three levels:
+
+- unit tests
+  - slug normalization
+  - path resolution
+  - branch/worktree naming
+  - prompt rendering
+  - PR body rendering
+- integration tests
+  - fake `git` and `gh` process boundaries
+  - full `create`, `start`, `finish`, and `doctor` flows
+- compatibility tests
+  - `adl/tools/pr.sh ...` still maps correctly to Rust commands
+
+Important rule:
+
+- parity tests should validate behavior, not shell implementation details
+
+## Rollout Policy
+
+Behavior changes should be intentional and visible.
+
+Recommended policy:
+
+- keep old commands as aliases before removing them
+- print migration hints for deprecated commands
+- update docs and examples in parallel with code changes
+- prefer one command-shape change per PR wave rather than a giant cutover
+
+Suggested readiness-command alias policy:
+
+- `preflight` invokes `doctor` and prints a deprecation note
+- `ready` invokes `doctor` and prints a deprecation note
+
+## Risks
+
+### Risk: Rust Becomes A Bigger Monolith
+
+Moving logic to Rust is not enough by itself.
+
+Mitigation:
+
+- split by domain modules
+- keep command handlers thin
+- move reusable rules into library code, not giant command files
+
+### Risk: Shell And Rust Drift During Migration
+
+Mitigation:
+
+- freeze new shell business logic
+- remove shell fallbacks as soon as Rust parity is proven
+
+### Risk: User Workflow Breakage
+
+Mitigation:
+
+- compatibility aliases
+- migration hints
+- phased documentation updates
+
+## Decision Summary
+
+Recommended decisions:
+
+- Rust is the long-term owner of PR tooling behavior.
+- `adl/tools/pr.sh` becomes a compatibility shim, not a workflow engine.
+- `init` should be merged into `start`.
+- `ready`, `preflight`, and `status` should converge into `doctor`.
+- `card`, `output`, and `cards` should be demoted from core lifecycle commands.
+- canonical path and workflow rules must have exactly one implementation owner.
+
+## Definition Of Success
+
+This effort is successful when:
+
+- `pr.sh` is tiny and contains almost no business logic
+- users mostly learn and use four main commands
+- Rust owns all lifecycle rules and state transitions
+- path logic exists in one authoritative implementation
+- the command surface is easier to remember and the code is easier to change

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
@@ -1,0 +1,297 @@
+# PR Tooling Simplification
+
+## Metadata
+- Feature Name: `PR Tooling Simplification`
+- Milestone Target: `v0.87`
+- Status: `planned`
+- Owner: `Daniel Austin / Agent Logic`
+- Doc Role: `primary`
+- Supporting Docs: `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- Feature Types: `architecture`, `policy`, `artifact`
+- Proof Modes: `tests`, `review`
+
+## Template Rules
+
+- Every section is completed or explicitly marked `N/A` with justification.
+- Demo- and schema-specific requirements are marked `N/A` where this feature is
+  control-plane and workflow architecture rather than a user-facing runtime
+  feature.
+
+## Purpose
+
+This feature simplifies the ADL PR lifecycle tooling by reducing duplicated
+workflow ownership and shrinking the public command surface.
+
+Today the PR flow is split across large shell scripts and a partially migrated
+Rust control plane. That split makes the tooling harder to understand, harder to
+test, and harder to evolve safely.
+
+This feature exists to make one implementation authoritative, make the command
+model easier to learn, and turn `adl/tools/pr.sh` back into a thin
+compatibility wrapper instead of a workflow engine.
+
+## Context
+
+- Related milestone: `v0.87`
+- Related issues: `N/A yet; derive from future implementation slices`
+- Dependencies:
+  - `adl/tools/pr.sh`
+  - `adl/tools/card_paths.sh`
+  - `adl/src/control_plane.rs`
+  - `adl/src/cli/pr_cmd.rs`
+  - `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+
+This feature fits into the broader ADL architecture as workflow control-plane
+cleanup. It does not change the meaning of STP/SIP/SOR artifacts or the GitHub
+review flow. Instead, it changes where the lifecycle rules live and how users
+invoke them.
+
+## Milestone Positioning
+
+This feature is part of the `v0.87` operational/control-plane substrate.
+
+It exists to consolidate workflow ownership and reduce execution drift before
+later milestones introduce deeper cognitive, memory, and convergence features.
+
+By stabilizing the PR lifecycle under a single Rust-owned control plane, this
+feature ensures that subsequent features (AEE, Gödel agent, and higher-order
+agency layers) are built on a predictable and deterministic execution surface.
+
+## Coverage / Ownership
+
+This document is the primary feature-level owner for the PR tooling
+simplification effort.
+
+- Primary owner doc: `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- Covered surfaces:
+  - `adl/tools/pr.sh`
+  - `adl/tools/card_paths.sh`
+  - `adl/src/control_plane.rs`
+  - `adl/src/cli/pr_cmd.rs`
+  - PR lifecycle command surface and compatibility policy
+- Related / supporting docs:
+  - `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+
+## Overview
+
+This feature makes Rust the single owner of PR lifecycle behavior and reduces
+the workflow to a few user-facing intents.
+
+Key capabilities:
+- thin-shell delegation from `adl/tools/pr.sh` into Rust `adl pr`
+- a reduced command model centered on `create`, `start`, `finish`, and
+  `doctor`
+- one authoritative implementation of path rules, bootstrap rules, readiness
+  checks, and PR lifecycle policy
+
+This feature should be understood as control-plane consolidation rather than
+simple tooling cleanup. It establishes a stable execution surface for all
+subsequent workflow-driven features and reduces ambiguity in how PR lifecycle
+operations are performed.
+
+## Design
+
+### Core Concepts
+
+The main concepts introduced or clarified by this feature are:
+
+- **single ownership**
+  - PR lifecycle rules should have one implementation owner
+- **intent-oriented commands**
+  - users should invoke a few high-level commands rather than many internal
+    workflow phases
+- **compatibility wrapper**
+  - shell remains as a launcher and migration surface, not as the product logic
+- **control-plane consolidation**
+  - lifecycle behavior is centralized in Rust and treated as core system
+    infrastructure rather than auxiliary tooling
+
+### Architecture
+
+The feature restructures the PR tooling around a Rust-owned control plane with a
+thin shell entrypoint.
+
+- Inputs (explicit sources / triggers):
+  - user invocation of `adl/tools/pr.sh ...` or `adl pr ...`
+  - repository state
+  - git worktree state
+  - GitHub issue and PR state through `gh`
+  - canonical local workflow artifacts under `.adl/`
+- Outputs (artifacts / side effects):
+  - canonical issue prompt, STP, SIP, and SOR bootstrap surfaces
+  - branch and worktree creation or reuse
+  - staged commits and pushed branches
+  - created or updated GitHub PRs
+  - readiness and drift diagnostics from `doctor`
+- Interfaces (APIs, CLI, files, schemas):
+  - `adl/tools/pr.sh`
+  - `adl pr create`
+  - `adl pr start`
+  - `adl pr finish`
+  - `adl pr doctor`
+  - optional `adl pr open`
+  - legacy aliases for `init`, `ready`, and `preflight` during migration
+- Invariants (must always hold):
+  - Rust is the sole owner of canonical PR lifecycle behavior
+  - shell compatibility layers do not reimplement workflow policy
+  - canonical path rules have exactly one authoritative implementation
+  - readiness inspection is consolidated under `doctor`
+  - human review remains preserved through draft-oriented PR flow unless
+    explicitly overridden
+
+### Command Semantics
+
+- `create`
+  - initializes issue-level artifacts and task-bundle scaffolding
+- `start`
+  - creates or reuses worktree/branch and transitions into active execution
+- `finish`
+  - validates outputs, stages changes, and completes PR lifecycle steps
+- `doctor`
+  - reports readiness, detects workflow drift, surfaces deprecated usage,
+    and provides migration guidance
+
+### Data / Artifacts
+
+This feature does not introduce a brand-new artifact family. It governs how
+existing workflow artifacts are created, validated, and reconciled.
+
+- canonical issue prompts under `.adl/.../bodies/`
+- task-bundle artifacts under `.adl/.../tasks/...`
+- compatibility card locations under `.adl/cards/...`
+- deprecation and compatibility behavior for CLI entrypoints
+
+## Execution Flow
+
+This is an artifact-bearing workflow feature, so execution flow applies.
+
+1. A user invokes `adl/tools/pr.sh` or `adl pr`.
+2. The thin shell wrapper delegates to Rust `adl pr`.
+3. The Rust control plane resolves the requested lifecycle intent:
+   - `create`
+   - `start`
+   - `finish`
+   - `doctor`
+4. Rust applies canonical path rules, bootstrap rules, and readiness checks.
+5. Rust performs the required side effects through `git` and `gh`.
+6. Rust reports workflow state, readiness, drift diagnostics, and migration hints back to the user.
+
+## Determinism and Constraints
+
+- Determinism guarantees (what must be repeatable and how):
+  - canonical path resolution must be deterministic for the same repo state and
+    issue inputs
+  - slug normalization and issue-derived branch naming must be deterministic
+  - readiness inspection must produce stable results for the same repository and
+    workflow state
+  - deprecated commands must map predictably to the same Rust-owned behavior as
+    their canonical replacements
+- Constraints (performance, ordering, limits):
+  - shell should remain minimal and should not accumulate new business logic
+  - migration should be incremental rather than a one-shot rewrite
+  - compatibility aliases should preserve user workflows during transition
+  - git and GitHub side effects must remain explicit and reviewable
+
+## Integration Points
+
+| System / Surface | Integration Type | Description |
+| --- | --- | --- |
+| `git` worktree and branch state | read/write | Used for branch creation, worktree management, staging, commit flow, and readiness validation. |
+| GitHub CLI `gh` | read/write | Used for issue fetch/create, PR create/edit/view, and readiness-related repository metadata. |
+| `.adl/` workflow artifacts | read/write | Source prompts, task bundles, and compatibility cards remain the canonical local workflow surfaces. |
+| shell compatibility entrypoint | trigger | `adl/tools/pr.sh` remains as the user-facing launcher during migration but delegates to Rust. |
+| Rust control-plane library | read/write/trigger | Shared domain logic and command handlers provide the authoritative lifecycle behavior. |
+
+## Validation
+
+This feature is primarily validated through tests, command compatibility, and
+manual review of the simplified command surface.
+
+### Demo (if applicable)
+- Demo script(s): `N/A`
+- Expected behavior: `N/A; this is workflow/control-plane architecture rather than a milestone demo feature`
+
+### Deterministic / Replay
+- Replay requirements:
+  - command-to-command mapping must remain stable during migration
+  - path and readiness computations should be reproducible from repository state
+- Determinism guarantees:
+  - deterministic slug, path, and branch derivation
+  - deterministic `doctor` readiness classification for identical state
+
+### Schema / Artifact Validation
+- Schemas involved: `N/A; no new artifact schema is introduced by this feature`
+- Artifact checks:
+  - existing issue prompt, task-bundle, and compatibility card surfaces still
+    resolve correctly
+  - shell compatibility entrypoint invokes the Rust-owned command path without
+    behavioral drift
+
+### Tests
+- Test surfaces:
+  - unit tests for slug normalization, path resolution, and command alias rules
+  - integration tests for `create`, `start`, `finish`, and `doctor`
+  - compatibility tests verifying `pr.sh` delegates correctly
+
+### Review / Proof Surface
+- Review method (manual/automated): `both`
+- Evidence location:
+  - Rust unit and integration tests
+  - command-level compatibility tests
+  - `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+
+## Acceptance Criteria
+
+- Functional correctness (what must work):
+  - `create`, `start`, `finish`, and `doctor` are sufficient to represent the
+    primary PR lifecycle
+  - `preflight` and `ready` are absorbed into `doctor` via compatibility aliases
+    during migration
+  - `init` is merged into `start` conceptually and operationally
+- Determinism / replay correctness:
+  - canonical path, slug, and branch derivations remain stable
+  - readiness reporting remains stable for identical repository state
+- Validation completeness (tests/schema/demo/review as applicable):
+  - Rust-owned lifecycle behavior is covered by tests
+  - compatibility behavior is explicitly tested
+  - docs point users to the simplified command model
+
+## Risks
+
+- Primary risks (failure modes):
+  - Rust command code could become a new monolith if the migration only moves
+    code without improving module boundaries
+  - shell and Rust behavior could drift during transition
+  - command consolidation could break existing user habits or scripts
+- Mitigations:
+  - split Rust code by domain rather than one giant command file
+  - freeze new shell business logic immediately
+  - keep deprecated aliases temporarily and emit migration hints
+  - validate compatibility paths with tests
+
+## Future Work
+
+- Follow-ups / extensions:
+  - decide whether `run` remains a separate wrapper or moves into the same Rust
+    command surface
+  - decide whether `card`, `output`, and `cards` remain expert-level commands or
+    become internal helpers only
+- Known gaps / deferrals:
+  - milestone placement is `v0.87` (operational/control-plane substrate milestone)
+  - implementation sequencing and issue decomposition remain to be planned in
+    follow-on work
+
+## Notes
+
+This feature doc is the concise product-facing summary for the effort.
+
+The more detailed design and migration reasoning lives in:
+
+- `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+
+The key simplification decisions are:
+
+- Rust owns the PR lifecycle behavior
+- `adl/tools/pr.sh` becomes a thin compatibility shim
+- `preflight`, `ready`, and most of `status` collapse into `doctor`
+- `start` absorbs the current `init` behavior

--- a/docs/milestones/v0.87/features/REVIEW_SURFACE_FORMALIZATION.md
+++ b/docs/milestones/v0.87/features/REVIEW_SURFACE_FORMALIZATION.md
@@ -1,0 +1,328 @@
+
+
+# REVIEW SURFACE FORMALIZATION v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Work package: `WP-11`
+- Purpose: Define the canonical review surface for ADL so findings, evidence, and action guidance are emitted in a bounded, deterministic, and reviewer-usable form.
+
+## Purpose
+
+Define the **review surface** as a first-class output substrate in ADL.
+
+This document specifies:
+- what a review surface is
+- what sections it must contain
+- how review outputs relate to trace, artifacts, skills, and cards
+- how automated and human review surfaces should stay structurally compatible
+
+This is the **feature-owner doc** for review-surface formalization in `v0.87`.
+
+## Core Principle
+
+> A review surface is not commentary. It is a structured, bounded record that turns execution and inspection into findings, evidence, and next-step guidance.
+
+A valid review surface must be:
+- truthful
+- bounded
+- evidence-bearing
+- reviewable by a human without hidden context
+- stable enough for automated consumption
+
+## Why This Matters in `v0.87`
+
+`v0.87` is a substrate milestone focused on coherence and reviewer-facing credibility.
+
+Without formalized review surfaces, the system risks:
+- ad hoc narrative reviews
+- inconsistent findings formats
+- unclear severity meaning
+- missing evidence or trigger conditions
+- reviews that cannot be compared across issues or milestones
+
+A canonical review surface is required so that:
+- trace can be interpreted consistently
+- skills can emit usable findings
+- issue output cards can embed or link structured review results
+- internal and 3rd-party review can inspect the same truth surface
+
+## Scope
+
+### In scope
+- canonical structure for review outputs
+- severity model
+- required fields for findings
+- system-level assessment section
+- action-plan section
+- relationships to trace, artifacts, cards, and reports
+- compatibility between manual review and skill-generated review
+
+### Out of scope
+- full UI for review browsing
+- policy/governance adjudication beyond bounded findings/output
+- later aptitude/governance/social review models
+
+## Review Surface Definition
+
+A review surface is the canonical bounded output of a review operation.
+
+A review operation may be:
+- human-driven
+- skill-driven
+- CLI/report-driven
+- CI-driven
+
+All of these must converge on the same structural output family.
+
+## Design Goals
+
+1. **Stable structure**
+   - The required sections and finding fields must remain stable.
+
+2. **Evidence first**
+   - Every nontrivial finding must point to concrete evidence.
+
+3. **Deterministic shape**
+   - Wording may vary, but shape and required sections must not drift.
+
+4. **Human + machine compatibility**
+   - A human should be able to read it.
+   - A tool should be able to parse it.
+
+5. **Boundedness**
+   - A review should end with explicit status and next-step guidance.
+
+## Canonical Review Surface Structure
+
+Every review surface should contain the following major sections in order:
+
+1. `Metadata`
+2. `Scope`
+3. `Findings`
+4. `System-Level Assessment`
+5. `Recommended Action Plan`
+6. `Follow-ups / Deferred Work`
+7. `Final Assessment`
+
+These may be represented in:
+- markdown with stable headings
+- structured YAML/JSON plus a rendered markdown view
+- issue output cards embedding the same sections
+
+## Metadata Section
+
+Required metadata fields:
+- `review_type`
+- `subject`
+- `scope`
+- `reviewer`
+- `date`
+- `input_surfaces`
+- `output_location` (if persisted)
+
+Examples of `review_type`:
+- `repo_review`
+- `card_review`
+- `trace_review`
+- `demo_review`
+- `release_review`
+
+## Scope Section
+
+The scope section must state:
+- what was reviewed
+- what was not reviewed
+- whether the review is code-focused, docs-focused, trace-focused, or mixed
+- whether the review is pre-merge, post-merge, or release-tail
+
+This prevents findings from being overinterpreted.
+
+## Findings Section
+
+The findings section is mandatory.
+
+Each finding must include:
+- `id`
+- `severity`
+- `title`
+- `location`
+- `description`
+- `impact`
+- `trigger`
+- `evidence`
+- `fix_direction`
+
+### Severity Model
+
+Canonical severity levels:
+- `P1` — correctness / contract violation / release-blocking defect
+- `P2` — trust / security / integrity / serious design flaw
+- `P3` — architectural risk / maintainability / non-blocking design debt
+- `P4` — hygiene / portability / lower-severity cleanup
+
+### Evidence Requirements
+
+Every significant finding must cite concrete evidence such as:
+- file path + function or block
+- trace event IDs
+- artifact references
+- validator output
+- command output
+
+### Trigger Requirements
+
+Every significant finding should include a concrete trigger or reproduction condition.
+
+This is especially important for:
+- correctness defects
+- trust-boundary issues
+- workflow/control-plane issues
+
+## System-Level Assessment
+
+This section is required.
+
+It must summarize:
+- dominant risk themes
+- clustering of findings
+- implications for system maturity
+- what the findings say about the subsystem being reviewed
+
+This prevents the review surface from becoming only a list of isolated defects.
+
+Examples of acceptable themes:
+- control-plane contract correctness
+- provider attribution drift
+- trace completeness gaps
+- shell ownership fragility
+
+## Recommended Action Plan
+
+This section is required.
+
+It must separate findings into action bands such as:
+- fix immediately
+- fix before milestone closeout
+- defer to later milestone
+
+This section should make execution sequencing clear without rewriting the roadmap.
+
+## Follow-ups / Deferred Work
+
+This section captures:
+- explicit deferrals
+- ownership or follow-up location
+- known non-blocking debt
+
+Deferrals must not disappear into prose.
+
+## Final Assessment
+
+This section should answer:
+- Is the reviewed surface trustworthy?
+- Is it ready for the next gate (merge, internal review, 3rd-party review, release)?
+- What remains before approval?
+
+The output should end in a bounded conclusion, not trail off.
+
+## Review Surface Variants
+
+The same canonical structure should support several bounded variants.
+
+### 1. Skill-generated review
+
+A skill-generated review must:
+- follow the canonical structure
+- preserve severity/evidence/trigger fields
+- remain bounded and explicit
+
+### 2. Human-authored review
+
+A human-authored review may use freer wording, but must preserve:
+- the same major sections
+- the same finding fields
+- the same severity model
+
+### 3. Card-embedded review
+
+Issue output cards may embed a compact version of the surface if they still preserve:
+- findings
+- evidence
+- final assessment
+
+### 4. Report/CLI review
+
+CLI or report-generated reviews may serialize the canonical fields into JSON/YAML and render markdown from them.
+
+## Integration with `v0.87` Substrates
+
+### Trace
+- reviews should cite trace events or artifact references when available
+- trace review surfaces should be structurally compatible with repo/code reviews
+
+### Operational Skills
+- review-oriented skills must emit this surface shape
+- examples include `card-review` and `repo-review`
+
+### Issue Cards
+- input/output cards may link or embed review surfaces
+- output cards should summarize how findings were handled
+
+### Demo Matrix
+- demos that produce findings or inspection outputs should reference the same review structure
+
+### `.adl/reports/`
+- persisted review reports should use this canonical structure so they remain comparable across issues and milestones
+
+## Determinism Requirements
+
+A review surface is deterministic when:
+- required sections are always present
+- finding fields are always present when a finding exists
+- severity model is stable
+- ordering is stable enough for comparison
+
+Allowed variability:
+- exact prose wording
+- human-authored explanation depth
+
+Not allowed:
+- silently missing sections
+- missing evidence for serious findings
+- changing severity semantics between reviews
+
+## Acceptance Criteria
+
+The review-surface formalization is acceptable for `v0.87` when:
+- a canonical review structure is defined
+- the P1–P4 severity model is defined and used consistently
+- every major review surface can emit findings with evidence and triggers
+- system-level assessment and action-plan sections are required
+- the same structure works for both skill-generated and human-authored review
+- output cards and `.adl/reports/` can reference or embed the same review family without contradiction
+
+## Open Questions
+
+- Should the canonical source of truth be markdown-first, schema-first, or dual-format?
+- What is the first required structured serialization format, if any?
+- Which `v0.87` reviews are mandatory to claim review-surface success?
+
+## Non-Goals (v1)
+
+- advanced statistical review analytics
+- governance/policy adjudication engine
+- a full review UI
+- general-purpose external reporting platform
+
+## Next Steps
+
+Derive or align the following from this doc:
+- concrete review skill docs (`card-review`, `repo-review`)
+- review output template/schema doc
+- trace review report surfaces
+- issue output-card conventions for embedding or linking findings
+
+Review surface formalization makes ADL review outputs consistent, comparable, and credible enough for real internal and external evaluation.

--- a/docs/milestones/v0.87/features/SHARED_OBSMEM_IMPLEMENTATION.md
+++ b/docs/milestones/v0.87/features/SHARED_OBSMEM_IMPLEMENTATION.md
@@ -1,0 +1,259 @@
+
+
+# SHARED OBSMEM IMPLEMENTATION v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Purpose: Define the bounded implementation scope for shared ObsMem in `v0.87` as a real substrate layer tied to trace and review surfaces.
+
+## Purpose
+
+Define the **shared ObsMem implementation scope** for `v0.87`.
+
+This document specifies:
+- what shared ObsMem means in `v0.87`
+- what is in scope for the first real implementation
+- how shared ObsMem relates to trace, artifacts, and review
+- what later memory/social/governance features are explicitly deferred
+
+This is the implementation-facing scope doc for the shared-memory substrate in `v0.87`.
+
+This doc is the bounded `v0.87` implementation owner for shared memory.
+It intentionally stops short of the later-layer social-memory semantics explored
+in `SHARED_SOCIAL_MEMORY.md`.
+
+## Core Principle
+
+> Shared ObsMem in `v0.87` is a bounded, inspectable, trace-linked shared memory substrate.
+
+It is **not** yet:
+- full social memory
+- governance-aware memory
+- implicit long-term learning
+- open-ended summarization
+
+In `v0.87`, shared ObsMem exists to make execution-derived observations available across runs and surfaces in a controlled, reviewable way.
+
+## Why It Belongs in `v0.87`
+
+`v0.87` is a substrate milestone. Shared ObsMem belongs here because later milestones depend on a real shared-memory base.
+
+Without a real shared-memory substrate:
+- trace remains isolated from memory
+- replay/review cannot connect execution history to persistent observations
+- later identity, reputation, and social memory layers would float without foundation
+
+So the `v0.87` goal is not to finish memory as a whole. The goal is to land the first **credible shared-memory layer**.
+
+## Scope Summary
+
+### In scope for `v0.87`
+- shared-memory records derived from trace
+- deterministic ingestion from completed execution traces
+- bounded indexing and retrieval
+- explicit record identity and provenance
+- trace-linked reviewability
+- storage discipline for shared, reusable observations across runs
+
+### Out of scope for `v0.87`
+- social memory semantics
+- governance / citizenship / reputation reasoning
+- autonomous summarization or memory rewriting
+- adaptive policy or learning behavior
+- identity-rich longitudinal world models
+- full reasoning-graph integration
+
+## Definition of Shared ObsMem in `v0.87`
+
+Shared ObsMem in `v0.87` means:
+- memory records are not tied only to one ephemeral run context
+- multiple later runs or review surfaces can query them
+- each memory record remains grounded in source trace and artifact references
+
+This is a **shared substrate**, not yet a fully social substrate.
+
+## Shared ObsMem Record Model
+
+Each shared ObsMem record should minimally include:
+- `record_id`
+- `record_type`
+- `trace_ref` (event_id or equivalent)
+- `run_id`
+- `agent_id` (when available)
+- `timestamp`
+- `model_ref` (when applicable)
+- `artifact_refs` (if payloads are external)
+- `summary` or structured observation fields
+
+### Example record types
+- `obs.model_call`
+- `obs.decision`
+- `obs.validation_result`
+- `obs.error`
+- `obs.step_outcome`
+
+These are implementation-oriented observation records, not later social/reputation records.
+
+## Relationship to Trace
+
+Shared ObsMem is derived from trace.
+
+Rules:
+- trace remains the authoritative execution record
+- ObsMem stores structured observations derived from trace
+- every shared ObsMem record MUST be traceable back to a source event or bounded event set
+
+This means a reviewer must be able to answer:
+- where did this memory come from?
+- what execution produced it?
+- what artifact or event supports it?
+
+## Relationship to Artifacts
+
+ObsMem does not absorb artifact payloads wholesale.
+
+Rules:
+- large payloads remain in artifact storage
+- ObsMem stores references to payloads when needed
+- bounded summaries/observation fields may be stored directly
+
+This preserves:
+- storage discipline
+- reviewability
+- replay compatibility
+
+## Storage and Access Model
+
+### Storage
+
+For `v0.87`, storage may be simple, but it must be explicit and bounded.
+
+Acceptable early characteristics:
+- deterministic record schema
+- stable keys/IDs
+- explicit storage location/backend
+- no hidden mutation
+
+The backend may still evolve later, but the substrate contract must be real now.
+
+### Access
+
+Shared ObsMem access in `v0.87` should support bounded retrieval by:
+- `run_id`
+- `agent_id`
+- `record_type`
+- `trace_ref`
+- simple time ordering
+
+This is enough for substrate truth and demoability without overcommitting to later retrieval intelligence.
+
+## Ingestion Model
+
+Shared ObsMem ingestion should follow the trace ingestion rules already defined elsewhere.
+
+For `v0.87`:
+- ingestion happens from completed trace + artifact truth
+- mappings from trace event types to ObsMem record types must be explicit
+- ingestion must be deterministic and idempotent
+
+Examples:
+- `MODEL_INVOCATION` → `obs.model_call`
+- `DECISION` → `obs.decision`
+- `CONTRACT_VALIDATION` → `obs.validation_result`
+- `ERROR` → `obs.error`
+
+## Retrieval Model
+
+Retrieval in `v0.87` must remain bounded and inspectable.
+
+The goal is not “smart memory.” The goal is:
+- deterministic queryability
+- traceable provenance
+- support for review, demos, and later systems
+
+Retrieval should therefore:
+- return structured records
+- preserve provenance fields
+- never hide source trace/artifact context
+
+## Determinism Requirements
+
+Shared ObsMem implementation is acceptable only if:
+- the same trace produces the same memory records
+- record identity and record shape are stable
+- retrieval ordering is explicit and explainable
+- no hidden summarization or mutation occurs
+
+Allowed variability:
+- runtime-generated IDs if their generation rules are stable and documented
+
+Not allowed:
+- probabilistic summarization in v1
+- silent record rewriting
+- memory records with no trace provenance
+
+## Reviewability Requirements
+
+A reviewer must be able to:
+- inspect a memory record
+- locate the source trace event
+- follow any artifact reference
+- understand why the record exists
+
+This is mandatory for `v0.87` because the milestone is about external credibility and reviewer-facing proof surfaces.
+
+## Demo Surface for `v0.87`
+
+The shared ObsMem demo should prove:
+- memory records are created from real execution traces
+- records can be queried in a bounded way
+- records preserve provenance back to trace/artifacts
+
+Expected artifact family:
+- `artifacts/v087/shared_obsmem/README.md`
+- `artifacts/v087/shared_obsmem/memory_entries.json`
+- `artifacts/v087/shared_obsmem/trace_links.json`
+
+Primary proof surface:
+- `artifacts/v087/shared_obsmem/memory_entries.json`
+
+Secondary proof surface:
+- `artifacts/v087/shared_obsmem/trace_links.json`
+
+## Acceptance Criteria
+
+The shared ObsMem implementation is acceptable for `v0.87` when:
+- a real shared-memory record model exists
+- records are derived deterministically from trace
+- records preserve provenance to trace and artifacts
+- bounded retrieval works over real stored records
+- demo surfaces prove the shared-memory substrate without inflating later social/governance claims
+- the implementation is clearly a foundation layer, not a disguised later-milestone memory system
+
+## Open Questions
+
+- what exact storage backend should be used first?
+- what minimal indexing set is required for the first usable implementation?
+- should summaries be fully structured in v1, or is limited textual summary acceptable when provenance is preserved?
+- what is the first canonical in-repo location or module boundary for shared ObsMem implementation?
+
+## Non-Goals (v1)
+
+- social relationship memory
+- citizenship / reputation memory
+- governance-aware memory transformations
+- probabilistic learning from memory
+- full reasoning-graph or hypothesis-engine integration
+
+## Next Steps
+
+Derive or align the following from this doc:
+- shared ObsMem schema / record-format doc
+- ingestion implementation issue(s)
+- retrieval/query surface doc or issue
+- demo implementation for `D3`
+- later linkages into identity, reputation, and reasoning-graph work
+
+Shared ObsMem in `v0.87` is the bridge from isolated execution history to persistent, shared, and reviewable cognitive substrate memory.

--- a/docs/milestones/v0.87/features/TRACE_ARTIFACT_MODEL.md
+++ b/docs/milestones/v0.87/features/TRACE_ARTIFACT_MODEL.md
@@ -1,0 +1,218 @@
+
+
+# TRACE ARTIFACT MODEL v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Parent: `TRACE_SYSTEM_ARCHITECTURE.md`
+- Depends on:
+  - `TRACE_SCHEMA_V1.md`
+  - `TRACE_RUNTIME_EMISSION.md`
+
+## Purpose
+
+Define the **artifact model** for ADL trace.
+
+This document specifies:
+- what artifacts are
+- how artifacts are stored and referenced
+- how artifacts relate to trace events
+- how artifacts support replay, validation, and review
+
+This is the **feature-owner doc** for artifact handling in `v0.87`.
+
+## Core Principle
+
+> Trace describes execution. Artifacts contain execution payloads.
+
+Execution truth is the combination of:
+- trace (structure, decisions, causality)
+- artifacts (inputs, outputs, data)
+
+Neither alone is sufficient.
+
+## Artifact Definition
+
+An artifact is any **persisted payload** referenced by trace events.
+
+Examples:
+- model inputs
+- model outputs
+- tool inputs/outputs
+- skill intermediate data
+- contract validation payloads
+
+Artifacts MUST NOT be embedded directly in trace events (except small metadata).
+
+## Storage Model
+
+Artifacts are stored in a deterministic directory structure:
+
+```
+artifacts/<run_id>/<scope>/<artifact_id>.<ext>
+```
+
+### Required Properties
+
+- paths MUST be deterministic
+- artifacts MUST be immutable once written
+- artifact IDs MUST be unique within a run
+
+### Scope Examples
+
+- `steps/`
+- `models/`
+- `tools/`
+- `skills/`
+- `contracts/`
+
+## Artifact Types
+
+Artifacts SHOULD be typed via metadata.
+
+Common types:
+- `model_input`
+- `model_output`
+- `tool_input`
+- `tool_output`
+- `memory_snapshot`
+- `contract_payload`
+
+Type information MAY be included in trace event fields.
+
+## Artifact References
+
+Trace events reference artifacts via fields such as:
+
+- `inputs_ref`
+- `outputs_ref`
+- `artifact_ref`
+
+### Requirements
+
+- references MUST be resolvable
+- references MUST point to existing artifacts
+- references MUST be stable across review and replay
+
+## Write Semantics
+
+Artifacts MUST be written **before** the trace event that references them.
+
+### Rules
+
+- no dangling references
+- write must succeed before event emission
+- failures MUST produce ERROR events
+
+## Read Semantics
+
+Consumers of trace (reviewers, tools) MUST:
+
+- resolve artifact paths
+- load payloads on demand
+- avoid assuming payloads are embedded in trace
+
+## Relationship to Trace
+
+Each relevant trace event MUST reference artifacts when payloads exist.
+
+Examples:
+
+- `MODEL_INVOCATION` → input + output artifacts
+- `TOOL_INVOCATION` → input + output artifacts
+- `CONTRACT_VALIDATION` → validation payload artifact
+
+## Determinism Requirements
+
+- artifact paths MUST be reproducible from trace context
+- artifact naming MUST be consistent across runs (modulo run_id)
+
+Allowed variability:
+- content of model outputs
+
+## Replay Support
+
+Artifacts enable **logical replay** of execution.
+
+Replay requires:
+- trace structure
+- artifact payloads
+
+Replay system MUST:
+- follow trace order
+- load artifacts at each step
+- reconstruct decision flow
+
+## Validation Requirements
+
+Artifact validation includes:
+
+- referenced artifacts exist
+- artifact format is readable
+- artifact matches expected type
+
+Failures MUST be surfaced during validation.
+
+## Review Workflow
+
+Reviewer flow:
+
+1. inspect trace event
+2. follow artifact reference
+3. examine payload
+4. correlate with subsequent events
+
+Artifacts are essential for understanding model behavior.
+
+## Size and Performance Considerations
+
+- artifacts MAY be large
+- runtime SHOULD avoid copying large payloads unnecessarily
+- compression MAY be applied (future)
+
+## Security Considerations
+
+- artifacts MAY contain sensitive data
+- access control is out of scope for v1 but must be considered
+- artifact paths must not allow traversal vulnerabilities
+
+## Non-Goals (v1)
+
+- distributed artifact storage
+- remote artifact retrieval
+- deduplication across runs
+
+## Open Questions
+
+- standard serialization formats (JSON vs others)
+- artifact size limits
+- streaming artifacts vs full writes
+
+## Implementation Notes
+
+Artifact handling must be integrated with:
+
+- runtime execution engine
+- provider adapters
+- tool and skill layers
+
+A shared artifact utility layer is recommended.
+
+## Acceptance Criteria
+
+- all payloads are stored as artifacts
+- all artifact references resolve correctly
+- no payload duplication inside trace events
+- artifact paths are deterministic
+- reviewer can access all payloads via references
+
+## Next Steps
+
+Future extensions:
+- artifact indexing for ObsMem
+- artifact compression strategies
+- integration with replay tooling
+
+Artifact modeling completes the trace + artifact execution truth model.

--- a/docs/milestones/v0.87/features/TRACE_OBSMEM_INGESTION.md
+++ b/docs/milestones/v0.87/features/TRACE_OBSMEM_INGESTION.md
@@ -1,0 +1,198 @@
+
+
+
+# TRACE → OBSMEM INGESTION v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Parent: `TRACE_SYSTEM_ARCHITECTURE.md`
+- Depends on:
+  - `TRACE_SCHEMA_V1.md`
+  - `TRACE_RUNTIME_EMISSION.md`
+  - `TRACE_ARTIFACT_MODEL.md`
+  - `TRACE_VALIDATION_AND_REVIEW.md`
+
+## Purpose
+
+Define how **trace data is ingested into ObsMem (Observational Memory)**.
+
+This document specifies:
+- what data from trace is persisted into memory
+- how events are transformed into memory records
+- how artifacts are referenced or summarized
+- how ingestion supports retrieval, learning, and reasoning
+
+This is the **feature-owner doc** for trace → ObsMem ingestion in `v0.87`.
+
+For `v0.87`, this ingestion surface feeds bounded shared ObsMem records, not
+the later-layer social-memory semantics described in `SHARED_SOCIAL_MEMORY.md`.
+
+## Core Principle
+
+> ObsMem does not store raw execution—it stores **structured observations derived from execution**.
+
+Trace is the authoritative execution record.
+ObsMem is a **derived, queryable memory layer**.
+
+## Ingestion Model
+
+Ingestion is a **post-execution pipeline** that consumes:
+
+- trace events
+- artifact references
+
+and produces:
+
+- ObsMem records
+
+### Key Constraint
+
+Ingestion MUST NOT modify or reinterpret trace data destructively.
+
+## What Gets Ingested
+
+Not all trace data is stored directly.
+
+### Categories of ingestion
+
+1. **Event-derived observations**
+2. **Decision records**
+3. **Outcome summaries**
+4. **Error records**
+
+### Examples
+
+- MODEL_INVOCATION → model usage record
+- DECISION → decision node in memory graph
+- CONTRACT_VALIDATION → validation outcome record
+- ERROR → failure record
+
+## Transformation Rules
+
+Trace events are transformed into **ObsMem records**.
+
+### Requirements
+
+- transformation MUST be deterministic
+- mapping MUST be explicit per event type
+- no implicit inference in v1
+
+### Example Mapping
+
+- `MODEL_INVOCATION` → `obs.model_call`
+- `DECISION` → `obs.decision`
+- `ERROR` → `obs.error`
+
+## Artifact Handling
+
+Artifacts are not fully copied into ObsMem.
+
+### Rules
+
+- ObsMem MUST store references to artifacts
+- selective summarization MAY occur (future)
+- large payloads MUST remain external
+
+## Memory Structure
+
+ObsMem records SHOULD support:
+
+- indexing by run_id
+- indexing by agent_id
+- indexing by event type
+- graph relationships (decision chains, step sequences)
+
+This aligns with future reasoning graph work.
+
+## Identity Integration
+
+ObsMem ingestion MUST include identity context:
+
+- agent_id
+- run_id
+- model_ref (where applicable)
+
+This enables:
+- continuity
+- longitudinal reasoning
+- identity-based retrieval
+
+## Temporal Structure
+
+ObsMem records MUST preserve temporal order.
+
+### Requirements
+
+- timestamps preserved
+- ordering derivable from trace
+
+This supports:
+- replay-like reasoning
+- causal analysis
+
+## Determinism Requirements
+
+- same trace MUST produce identical ObsMem records
+- ingestion MUST be idempotent
+- no hidden randomness
+
+## Validation Requirements
+
+Ingestion MUST validate:
+
+- source trace is valid
+- artifact references resolve
+- required fields exist
+
+Failures MUST:
+- be logged
+- not corrupt existing memory
+
+## Review and Audit
+
+ObsMem MUST remain traceable back to source trace.
+
+### Requirements
+
+- each record MUST include trace reference (event_id or equivalent)
+- reviewer MUST be able to trace memory → execution
+
+## Non-Goals (v1)
+
+- learning or model adaptation
+- probabilistic summarization
+- cross-run inference
+
+## Open Questions
+
+- schema for ObsMem records (flat vs graph-first)
+- storage backend (sqlite, redb, etc.)
+- indexing strategies
+
+## Implementation Notes
+
+Initial implementation may be:
+
+- ingestion pipeline integrated with review pipeline
+- simple record store
+
+Future separation likely as ObsMem evolves.
+
+## Acceptance Criteria
+
+- ingestion runs on completed traces
+- records are deterministic and reproducible
+- all key events produce corresponding ObsMem records
+- artifact references are preserved
+- memory records can be traced back to source events
+
+## Next Steps
+
+Future extensions:
+- reasoning graph integration (v0.9+)
+- hypothesis engine inputs
+- retrieval APIs
+
+ObsMem ingestion is the bridge from execution to persistent cognitive memory.

--- a/docs/milestones/v0.87/features/TRACE_REVIEW_PIPELINE.md
+++ b/docs/milestones/v0.87/features/TRACE_REVIEW_PIPELINE.md
@@ -1,0 +1,235 @@
+
+
+# TRACE REVIEW PIPELINE v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Parent: `TRACE_SYSTEM_ARCHITECTURE.md`
+- Depends on:
+  - `TRACE_SCHEMA_V1.md`
+  - `TRACE_RUNTIME_EMISSION.md`
+  - `TRACE_ARTIFACT_MODEL.md`
+  - `TRACE_VALIDATION_AND_REVIEW.md`
+
+## Purpose
+
+Define the **review pipeline** for ADL traces.
+
+This document specifies:
+- how trace data flows through validation and review stages
+- how automated and human review are composed
+- how findings are produced and surfaced
+- how the pipeline integrates with demos, CI, and future control-plane features
+
+This is the **feature-owner doc** for trace review pipeline in `v0.87`.
+
+## Core Principle
+
+> Review is not a single step; it is a pipeline that transforms execution into understanding.
+
+The pipeline must:
+- validate correctness
+- expose decisions
+- surface failures
+- enable reconstruction
+
+Boundary note:
+- this doc owns orchestration, staging, and report generation
+- `TRACE_VALIDATION_AND_REVIEW.md` owns what counts as valid trace and what
+  reviewers must be able to see
+- `TRACE_SCHEMA_V1.md` owns event/field requirements
+
+## Pipeline Overview
+
+The trace review pipeline consists of ordered stages:
+
+1. **Ingestion**
+2. **Validation**
+3. **Enrichment (optional v1-light)**
+4. **Analysis**
+5. **Review Output Generation**
+
+Each stage MUST be deterministic given the same trace + artifacts.
+
+## Stage 1: Ingestion
+
+Inputs:
+- trace event stream
+- artifact directory
+
+Responsibilities:
+- load trace events
+- index artifacts
+- build initial in-memory representation
+
+### Requirements
+
+- ingestion MUST fail if required artifacts are missing
+- ingestion MUST preserve event ordering
+
+## Stage 2: Validation
+
+Per `TRACE_VALIDATION_AND_REVIEW.md`:
+
+- schema validation
+- structural validation
+- semantic validation
+
+### Output
+
+- validation report
+- list of errors/warnings
+
+### Behavior
+
+- hard failures MAY halt pipeline (configurable in future)
+- soft failures MUST be recorded
+
+## Stage 3: Enrichment (v1-light)
+
+Optional but recommended minimal enrichment:
+
+- derive step summaries
+- annotate spans with duration
+- attach simple derived metadata
+
+### Constraints
+
+- enrichment MUST NOT alter original trace data
+- enrichment MUST be deterministic
+
+## Stage 4: Analysis
+
+Analysis extracts meaning from validated trace.
+
+### Responsibilities
+
+- identify decision points
+- map execution flow
+- correlate inputs → outputs
+- detect anomalies (missing events, unexpected paths)
+
+### Outputs
+
+- structured findings
+- anomaly list
+- execution summary
+
+## Stage 5: Review Output Generation
+
+Generate human- and machine-consumable outputs.
+
+### Outputs
+
+- review report (markdown or structured)
+- summary of execution
+- list of issues
+- trace-to-artifact navigation hints
+
+This stage feeds:
+- output cards
+- CI reports
+- `.adl/reports/` artifacts
+
+## Pipeline Interfaces
+
+### Input Interface
+
+- trace file(s)
+- artifact root path
+
+### Output Interface
+
+- structured report object
+- human-readable report file
+
+## Determinism Requirements
+
+- same input MUST produce identical review outputs (excluding timestamps)
+- no nondeterministic ordering
+- no hidden state
+
+## Integration Points
+
+### Demo Matrix (v0.87)
+
+- each demo MUST produce trace
+- pipeline MUST validate and review demo traces
+- output MUST be inspectable in demo artifacts
+
+### Output Cards
+
+- output cards SHOULD reference review findings
+- review summaries SHOULD be embedded or linked
+
+### CI / Automation
+
+- pipeline MAY be run in CI
+- failures MAY fail builds (future tightening)
+
+### `.adl/reports/`
+
+- review outputs SHOULD be persisted here
+
+## Decision Traceability
+
+Pipeline MUST preserve and expose:
+
+- DECISION events
+- APPROVAL / REJECTION / REVISION
+- CONTRACT_VALIDATION outcomes
+
+Reviewer must see:
+- what was decided
+- why (if available)
+- what changed as a result
+
+## Error Handling
+
+- pipeline MUST handle ERROR events explicitly
+- errors MUST appear in final report
+- upstream context MUST be included
+
+## Acceptance Criteria
+
+- pipeline runs end-to-end on demo traces
+- validation issues are correctly surfaced
+- decisions are clearly visible in output
+- artifact references are navigable
+- reviewer can reconstruct execution without inference
+
+## Non-Goals (v1)
+
+- full graphical UI
+- distributed review pipelines
+- advanced statistical analysis
+
+## Open Questions
+
+- standard report schema vs markdown-only
+- CLI tooling vs embedded library first
+- thresholds for failing CI
+
+## Implementation Notes
+
+Initial implementation may be:
+
+- CLI tool (`adl trace review`)
+- library used by demos and tests
+
+Core components:
+- ingestion loader
+- validator
+- analyzer
+- report generator
+
+## Next Steps
+
+Future extensions:
+- Freedom Gate integration (policy review stage)
+- ObsMem ingestion hooks
+- replay-assisted review
+
+The review pipeline is the bridge between execution and understanding in ADL.

--- a/docs/milestones/v0.87/features/TRACE_RUNTIME_EMISSION.md
+++ b/docs/milestones/v0.87/features/TRACE_RUNTIME_EMISSION.md
@@ -1,0 +1,229 @@
+
+
+# TRACE RUNTIME EMISSION v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Parent: `TRACE_SYSTEM_ARCHITECTURE.md`
+- Depends on: `TRACE_SCHEMA_V1.md`
+
+## Purpose
+
+Define how trace events are **emitted at runtime** by the ADL execution engine.
+
+This document specifies:
+- where in the execution lifecycle events are emitted
+- how spans and context are created and propagated
+- how schema compliance is enforced
+- how emission integrates with providers, tools, skills, and memory
+
+This is the **feature-owner doc** for runtime trace emission in `v0.87`.
+
+## Design Constraints
+
+- MUST conform strictly to `TRACE_SCHEMA_V1.md`
+- MUST emit events as part of execution (not post-hoc)
+- MUST maintain span hierarchy explicitly
+- MUST be deterministic in structure
+- MUST not depend on ObsMem or review system
+
+## Emission Model
+
+Trace emission is **inline with execution**, not asynchronous logging.
+
+Every significant execution boundary triggers event emission.
+
+### Core Principle
+
+> If a reviewer cannot reconstruct a decision without inference, an event is missing.
+
+## Execution Hooks
+
+The runtime must emit events at the following points:
+
+### Run Lifecycle
+
+- On run start → `RUN_START`
+- On run end → `RUN_END`
+
+### Step Lifecycle
+
+- Before step execution → `STEP_START`
+- After step execution → `STEP_END`
+
+### Model Invocation
+
+- Immediately before or after model call → `MODEL_INVOCATION`
+
+Must include:
+- provider block
+- inputs_ref
+- outputs_ref
+
+### Tool Invocation
+
+- On tool execution → `TOOL_INVOCATION`
+
+### Skill Execution
+
+- On skill entry → `SKILL_EXECUTION`
+
+### Memory Interaction
+
+- On read → `MEMORY_READ`
+- On write → `MEMORY_WRITE`
+
+### Contract Validation
+
+- After validation → `CONTRACT_VALIDATION`
+
+### Decision Points
+
+- When branching or committing to a path → `DECISION`
+
+### Inline Control Outcomes
+
+- On inline approval during execution/control handling → `APPROVAL`
+- On inline rejection during execution/control handling → `REJECTION`
+- On inline revision during execution/control handling → `REVISION`
+
+These events belong to runtime emission only when the outcome occurs **during**
+execution or a bounded control-path step.
+
+Post-run review-pipeline findings and recommendations are produced by
+`TRACE_REVIEW_PIPELINE.md` and `REVIEW_SURFACE_FORMALIZATION.md`, not emitted
+here as runtime facts.
+
+### Error Handling
+
+- On any failure → `ERROR`
+
+## Span Management
+
+### Requirements
+
+- A root span MUST be created at run start
+- Each step MUST create a child span
+- Tool/model/skill calls MUST create nested spans
+
+### Rules
+
+- Spans MUST be created before emitting events within them
+- Span closure must align with lifecycle boundaries
+- Parent-child relationships MUST be explicit
+
+## Trace Context Propagation
+
+Trace context must be passed through all execution layers:
+
+Context fields:
+- `trace_id`
+- `run_id`
+- `span_id`
+- `parent_span_id`
+- `agent_id`
+
+### Propagation Rules
+
+- Context MUST be passed to:
+  - model providers
+  - tools
+  - skills
+  - memory layer
+- New spans MUST derive from current context
+
+## Event Construction
+
+Each emitted event MUST:
+
+1. Be schema-valid (`TRACE_SCHEMA_V1.md`)
+2. Include correct span and parent references
+3. Include required subtype fields
+4. Reference artifacts instead of embedding payloads
+
+## Artifact Interaction
+
+Runtime must:
+
+- write inputs/outputs to artifact store BEFORE emitting references
+- ensure paths follow:
+  `artifacts/<run_id>/...`
+- ensure references are stable and resolvable
+
+## Provider Integration
+
+For every `MODEL_INVOCATION`:
+
+- runtime MUST populate:
+  - `vendor`
+  - `transport`
+  - `model_ref`
+  - `provider_model_id` (if available)
+
+- provider adapters MUST supply raw provider identifiers
+- runtime MUST normalize into schema
+
+## Determinism Requirements
+
+- Event emission order MUST be deterministic within a span
+- No hidden or implicit operations
+- All control decisions MUST emit events
+
+Allowed variability:
+- timestamps
+- run_id / trace_id
+
+## Failure Handling
+
+- On failure, runtime MUST emit `ERROR`
+- Error event MUST include structured error payload
+- Span MUST still close properly if possible
+
+## Validation Surface
+
+Primary validation mechanisms:
+- Demo matrix trace scenarios (v0.87)
+- Output cards referencing emitted events
+- Direct inspection of trace logs and artifact tree
+
+### Acceptance Criteria
+
+- Every execution path produces a complete trace
+- No missing required events
+- Span hierarchy is correct and consistent
+- Artifact references resolve
+- Provider attribution is complete
+- Reviewer can reconstruct execution without inference
+
+## Non-Goals (v1)
+
+- Async/batched trace pipelines
+- Streaming trace to external systems
+- Performance optimization of emission
+
+## Open Questions
+
+- Should emission be synchronous or buffered within a step?
+- Performance overhead limits for trace emission
+- Standard helpers/macros for emission in Rust runtime
+
+## Implementation Notes
+
+Expected implementation areas:
+- execution engine core
+- provider adapters
+- tool execution layer
+- skill framework
+
+All must integrate with a unified trace emitter.
+
+## Next Steps
+
+Dependent docs:
+- `TRACE_ARTIFACT_MODEL.md`
+- `TRACE_REVIEW_PIPELINE.md`
+- `TRACE_OBSMEM_INGESTION.md`
+
+All runtime emission must remain aligned with schema and architecture.

--- a/docs/milestones/v0.87/features/TRACE_SCHEMA_V1.md
+++ b/docs/milestones/v0.87/features/TRACE_SCHEMA_V1.md
@@ -1,0 +1,205 @@
+
+
+# TRACE SCHEMA v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Parent: `TRACE_SYSTEM_ARCHITECTURE.md`
+
+## Purpose
+
+Define the **canonical schema and event vocabulary** for Trace v1.
+
+This document specifies:
+- the event schema (required/optional fields)
+- the canonical event types
+- validation rules
+- minimal guarantees required for review-grade reconstruction
+
+This is the **feature-owner doc** for trace schema in `v0.87`.
+
+## Design Constraints (from Architecture)
+
+- Trace is the **authoritative structural record**.
+- Artifacts carry payload truth; trace references them.
+- Spans are **explicit and required**.
+- Schema must be **stable and deterministic**.
+- Provider attribution must separate `model_ref` and `provider_model_id`.
+
+## Core Schema
+
+### TraceEvent (canonical)
+
+Required fields:
+- `event_id`: string (UUID or stable unique id)
+- `timestamp`: string (ISO-8601)
+- `event_type`: enum (see below)
+- `trace_id`: string
+- `run_id`: string
+- `span_id`: string
+- `parent_span_id`: string (nullable only for root span)
+- `actor`: object
+- `scope`: object
+
+Optional fields (but recommended when applicable):
+- `inputs_ref`: string (artifact path)
+- `outputs_ref`: string (artifact path)
+- `artifact_ref`: string (artifact path for single-payload or non-input/output references)
+- `decision_context`: object (required for `DECISION`, `APPROVAL`, `REJECTION`, `REVISION`)
+- `provider`: object (required for MODEL_INVOCATION)
+- `error`: object (required for ERROR)
+- `contract_validation`: object (required for CONTRACT_VALIDATION)
+
+### Actor
+
+- `type`: enum (`agent`, `tool`, `provider`, `skill`, `system`)
+- `id`: string
+
+### Scope
+
+- `level`: enum (`run`, `step`, `substep`, `tool`, `model`, `skill`)
+- `name`: string
+
+### Provider (for MODEL_INVOCATION)
+
+- `vendor`: string (normalized)
+- `transport`: string
+- `model_ref`: string (ADL canonical)
+- `provider_model_id`: string (raw provider identifier, optional but strongly recommended)
+
+### Error
+
+- `code`: string
+- `message`: string
+- `details`: object (optional)
+
+### ContractValidation
+
+- `contract_id`: string
+- `result`: enum (`pass`, `fail`)
+- `details`: object
+
+## Event Vocabulary (v1)
+
+Canonical event types:
+- `RUN_START`
+- `RUN_END`
+- `STEP_START`
+- `STEP_END`
+- `MODEL_INVOCATION`
+- `TOOL_INVOCATION`
+- `SKILL_EXECUTION`
+- `MEMORY_READ`
+- `MEMORY_WRITE`
+- `CONTRACT_VALIDATION`
+- `DECISION`
+- `APPROVAL`
+- `REJECTION`
+- `REVISION`
+- `ERROR`
+
+### Event Semantics
+
+- `RUN_*`: lifecycle of full execution
+- `STEP_*`: logical planning/execution units
+- `MODEL_INVOCATION`: LLM call (must include provider block)
+- `TOOL_INVOCATION`: external tool execution
+- `SKILL_EXECUTION`: reusable operational unit
+- `MEMORY_*`: interaction with ObsMem
+- `CONTRACT_VALIDATION`: schema/contract checks
+- `DECISION`: branching or reasoning commitment
+- `APPROVAL / REJECTION / REVISION`: inline control or review outcomes recorded as explicit trace events
+- `ERROR`: failure event with structured payload
+
+### DecisionContext
+
+For `DECISION`, `APPROVAL`, `REJECTION`, and `REVISION`, `decision_context`
+MUST include:
+- `context`: what was being decided
+- `outcome`: what was approved, rejected, revised, or committed
+- `rationale`: optional but strongly recommended explanation or basis
+
+## Span Requirements
+
+- Every event MUST belong to a span
+- Spans MUST form a valid tree (no cycles)
+- Root span corresponds to the run
+- Parent-child relationships MUST be explicit (no inference)
+
+## Ordering Guarantees
+
+- Events MUST be totally ordered within a span
+- Cross-span ordering is defined by timestamps + parent relationships
+- Timestamps MUST be monotonic within a span
+
+## Artifact References
+
+- `inputs_ref`, `outputs_ref`, and `artifact_ref` MUST point to:
+  `artifacts/<run_id>/...`
+- References MUST resolve to actual stored files
+- Large payloads MUST NOT be embedded in events
+
+## Validation Rules
+
+A trace is **valid (v1)** if:
+
+1. All required fields are present for every event
+2. All event types are from the canonical vocabulary
+3. Span tree is well-formed (single root, no orphan spans)
+4. Required subtype fields are present:
+   - MODEL_INVOCATION → `provider`
+   - ERROR → `error`
+   - CONTRACT_VALIDATION → `contract_validation`
+   - DECISION / APPROVAL / REJECTION / REVISION → `decision_context`
+5. Artifact references resolve
+6. No missing required lifecycle events:
+   - at least one `RUN_START` and `RUN_END`
+
+## Minimal Completeness Requirements
+
+For a run to be review-valid:
+
+- All step boundaries MUST be traced (`STEP_START` / `STEP_END`)
+- All model/tool/skill executions MUST emit events
+- All contract checks MUST emit `CONTRACT_VALIDATION`
+- All failures MUST emit `ERROR`
+- All control decisions SHOULD emit `DECISION` (required for complex flows)
+
+## Validation Surface
+
+Primary validation mechanisms:
+- Demo matrix trace scenarios (v0.87)
+- Output cards referencing event IDs
+- Reviewer inspection of trace + artifact tree
+
+Acceptance criteria:
+- A reviewer can reconstruct execution solely from:
+  (trace structure + artifact payloads)
+- Event stream is schema-valid and complete
+- Provider attribution is present for all model calls
+- No implicit behavior (all control decisions are explicit events)
+
+## Non-Goals (v1)
+
+- Cross-run aggregation schemas
+- Compression or storage optimization
+- Signed/cryptographic trace
+- Visualization/UI schema
+
+## Open Questions
+
+- Exact timestamp precision requirements (ms vs ns)
+- Whether `DECISION` should be required or context-dependent
+- Whether any additional decision subtype fields are needed beyond `decision_context`
+
+## Next Steps
+
+Dependent feature docs:
+1. `TRACE_RUNTIME_EMISSION.md`
+2. `TRACE_ARTIFACT_MODEL.md`
+3. `TRACE_REVIEW_PIPELINE.md`
+4. `TRACE_OBSMEM_INGESTION.md`
+
+Each must conform strictly to this schema.

--- a/docs/milestones/v0.87/features/TRACE_VALIDATION_AND_REVIEW.md
+++ b/docs/milestones/v0.87/features/TRACE_VALIDATION_AND_REVIEW.md
@@ -1,0 +1,234 @@
+
+
+# TRACE VALIDATION AND REVIEW v1
+
+## Metadata
+- Owner: `adl`
+- Status: `draft`
+- Target milestone: `v0.87`
+- Parent: `TRACE_SYSTEM_ARCHITECTURE.md`
+- Depends on:
+  - `TRACE_SCHEMA_V1.md`
+  - `TRACE_RUNTIME_EMISSION.md`
+  - `TRACE_ARTIFACT_MODEL.md`
+
+## Purpose
+
+Define how traces are **validated and reviewed** in ADL.
+
+This document specifies:
+- what constitutes a valid trace
+- how traces are inspected and reconstructed
+- how reviewers (human or automated) interact with trace data
+- how trace supports correctness, auditability, and control
+
+This is the **feature-owner doc** for trace validation and review in `v0.87`.
+
+## Core Principle
+
+> Trace exists to make execution **legible, auditable, and reconstructable**.
+
+Validation ensures correctness.
+Review ensures understanding.
+
+Boundary note:
+- this doc defines what makes a trace valid and review-grade
+- `TRACE_REVIEW_PIPELINE.md` defines how those checks and review outputs are
+  orchestrated end-to-end
+- this doc owns semantics and required visibility, not pipeline staging
+
+## Validation Model
+
+Validation operates at three levels:
+
+### 1. Schema Validation
+
+Every event MUST conform to `TRACE_SCHEMA_V1.md`.
+
+Checks include:
+- required fields present
+- correct types
+- valid enum values
+- valid references (e.g., span_id, trace_id)
+
+Failure mode:
+- event is rejected or marked invalid
+
+### 2. Structural Validation
+
+The trace MUST form a coherent execution structure.
+
+Checks include:
+- span hierarchy is well-formed (no orphan spans)
+- parent/child relationships are consistent
+- spans open and close correctly
+- event ordering is valid within spans
+
+Failure examples:
+- missing STEP_END
+- invalid parent_span_id
+- overlapping or broken span boundaries
+
+### 3. Semantic Validation
+
+Trace MUST reflect meaningful execution behavior.
+
+Checks include:
+- required events are present (e.g., CONTRACT_VALIDATION after step)
+- decisions are explicitly recorded
+- errors are captured as ERROR events
+- provider attribution is present for MODEL_INVOCATION
+
+This is the layer that prevents "silent execution".
+
+## Review Model
+
+Review is the process of **reconstructing execution from trace + artifacts**.
+
+### Inputs to Review
+
+- trace event stream
+- artifact references (inputs/outputs)
+- provider metadata
+
+### Reviewer Goals
+
+A reviewer must be able to:
+
+- understand what happened
+- understand why decisions were made
+- verify correctness
+- identify failures or inconsistencies
+
+### Reconstruction Requirements
+
+Trace MUST support:
+
+- step-by-step replay (logical, not necessarily executable)
+- identification of all decision points
+- inspection of all inputs and outputs
+
+## Review Surfaces
+
+### Human Review
+
+- reading trace logs
+- inspecting artifacts
+- correlating events with execution steps
+
+### Automated Review
+
+- validation checks (schema + structure + semantics)
+- invariant enforcement
+- anomaly detection (missing events, invalid flows)
+
+Future:
+- policy-driven review (Freedom Gate integration)
+
+## Decision Visibility
+
+All meaningful decisions MUST be visible in trace.
+
+Required decision-related events:
+- `DECISION`
+- `APPROVAL`
+- `REJECTION`
+- `REVISION`
+
+Each must include:
+- context (what was being decided)
+- rationale (if available)
+- outcome
+
+## Contract Visibility
+
+Contract validation MUST be explicitly recorded.
+
+`CONTRACT_VALIDATION` events must include:
+- contract reference
+- validation result (pass/fail)
+- failure details (if any)
+
+This is critical for auditability.
+
+## Artifact Role in Review
+
+Trace references artifacts; artifacts contain payload truth.
+
+Reviewer workflow:
+1. read event
+2. follow artifact reference
+3. inspect payload
+
+Trace alone is insufficient without artifact resolution.
+
+## Failure and Error Review
+
+On failure:
+
+- `ERROR` event MUST be present
+- must include structured error information
+- must be associated with correct span
+
+Reviewer must be able to:
+- identify where failure occurred
+- understand cause
+- trace upstream context
+
+## Determinism and Reproducibility
+
+Trace must support reproducibility at the logical level.
+
+Reviewer should be able to:
+- follow the same sequence of steps
+- understand all inputs and outputs
+- reproduce reasoning path (not necessarily model output)
+
+## Validation Surface
+
+Validation is exercised via:
+
+- demo matrix scenarios (v0.87)
+- output cards referencing trace
+- automated validation checks
+
+## Acceptance Criteria
+
+- All events are schema-valid
+- Span hierarchy is correct
+- No missing required events
+- All decisions are visible
+- All contract validations are recorded
+- Artifact references resolve correctly
+- Reviewer can reconstruct execution without inference
+
+## Non-Goals (v1)
+
+- Full UI for trace visualization
+- Distributed trace aggregation
+- Advanced analytics or metrics dashboards
+
+## Open Questions
+
+- Should validation occur inline during execution or post-run?
+- How strict should semantic validation be in v1?
+- Standard tooling for trace inspection (CLI vs UI)
+
+## Implementation Notes
+
+Validation responsibilities likely split across:
+
+- runtime (basic validation)
+- tooling (deeper validation)
+- CI / demo validation checks
+
+Review is initially manual + CLI-based.
+
+## Next Steps
+
+Future extensions:
+- policy enforcement (Freedom Gate)
+- ObsMem ingestion validation
+- replay tooling
+
+Trace validation and review form the foundation for trust in ADL execution.


### PR DESCRIPTION
---
issue_card_schema: adl.issue.v1
slug: "v0-87-docs-promote-feature-docs-into-milestone-features-dir"
title: "[v0.86][docs] Promote feature docs into docs/milestones/v0.87/features"
labels:
  - "track:roadmap"
  - "type:task"
  - "version:v0.86"
status: "active"
action: "move"
required_outcome_type:
  - "docs"
repo_inputs:
  - ".adl/docs/v0.87planning"
  - "docs/milestones/v0.87/README.md"
canonical_files:
  - "docs/milestones/v0.87/features"
demo_required: false
demo_names: []
issue_graph_notes:
  - "Promotes v0.87 feature-defining docs into the milestone features directory without broad rewrite."
pr_start:
  enabled: true
  slug: "v0-87-docs-promote-feature-docs-into-milestone-features-dir"
---

# [v0.86][docs] Promote feature docs into docs/milestones/v0.87/features

## Summary

Promote the canonical `v0.87` feature-defining docs from planning into `docs/milestones/v0.87/features` so the milestone has an explicit feature-doc surface rather than leaving those docs only under `.adl/docs/v0.87planning`.

## Goal

Create the bounded promotion issue for the `v0.87` feature-doc set and use it to move the approved feature docs into the milestone `features/` directory with minimal doc churn.

## Required Outcome

This issue must ship a docs-only promotion pass that:
- copies or moves the approved `v0.87` feature docs into `docs/milestones/v0.87/features`
- updates any immediate milestone index/readme references required to keep the new feature-doc surface legible
- performs the minimum internal path/reference hygiene needed so promoted milestone copies do not falsely present `.adl/docs/v0.87planning/...` as their canonical home
- preserves document meaning and does not broaden into a general roadmap rewrite

## Deliverables

- promoted `v0.87` feature docs under `docs/milestones/v0.87/features`
- any minimal reference/index updates needed for the new milestone feature-doc surface
- validation evidence showing the promoted files exist in the milestone tree and remain consistent with the approved planning source

## Acceptance Criteria

- the approved `v0.87` feature docs exist under `docs/milestones/v0.87/features`
- no promoted doc is silently rewritten beyond the minimum needed for milestone placement or local reference hygiene
- promoted milestone copies do not retain stale self-references that incorrectly identify the planning directory as their canonical location
- milestone-level references point to the promoted feature surface where appropriate
- the work remains bounded to `v0.87` feature-doc promotion and does not spill into broader multi-milestone reconciliation

## Repo Inputs

- `.adl/docs/v0.87planning`
- `docs/milestones/v0.87/README.md`
- `docs/milestones/v0.87/VISION_v0.87.md`
- `docs/milestones/v0.87/WBS_v0.87.md`
- `docs/milestones/v0.87/SPRINT_v0.87.md`

## Dependencies

- approved `v0.87` feature-doc selection and placement decisions

## Demo Expectations

- no new demo is required
- any existing milestone proof surfaces referenced by promoted docs must remain truthful

## Non-goals

- rewriting the promoted feature docs into a different conceptual model
- promoting docs for milestones other than `v0.87`
- broad cleanup of unrelated planning directories

## Issue-Graph Notes

- This is a milestone-surface promotion task, not a new feature-definition task.
- It should follow the current `v0.87` planning alignment work rather than precede it.

## Notes

- Keep the promotion surgical.
- Preserve the distinction between planning/admin docs and true feature-defining docs.
- Approved promotion set for this issue:
  - `PR_TOOLING_SIMPLIFICATION_FEATURE.md`
  - `PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
  - `PROVIDER_SUBSTRATE_FEATURE.md`
  - `OPERATIONAL_SKILLS_SUBSTRATE.md`
  - `REVIEW_SURFACE_FORMALIZATION.md`
  - `TRACE_SCHEMA_V1.md`
  - `TRACE_RUNTIME_EMISSION.md`
  - `TRACE_ARTIFACT_MODEL.md`
  - `TRACE_VALIDATION_AND_REVIEW.md`
  - `TRACE_REVIEW_PIPELINE.md`
  - `TRACE_OBSMEM_INGESTION.md`
  - `SHARED_OBSMEM_IMPLEMENTATION.md`
- Not part of this promotion issue:
  - `PROVIDER_AND_TRANSPORT_MODEL.md`
  - `SHARED_SOCIAL_MEMORY.md`
  - `TRACE_SYSTEM_ARCHITECTURE.md`
- `docs/milestones/v0.87/FEATURE_DOCS_v0.87.md` is intentionally out of scope for this issue and will be handled later.

## Tooling Notes

- This issue body is authored to satisfy the current `pr start` source-prompt validator.
