### PR TITLE
[v0.86][WP-21] Review findings remediation

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.8.0"
+version = "0.86.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.8.0"
+version = "0.86.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ADL (Agent Design Language) reference runtime and CLI"

--- a/adl/README.md
+++ b/adl/README.md
@@ -26,7 +26,7 @@ It provides:
 - Recent stable runtime milestone: **v0.8**
 - Current closure milestone in the main repo: **v0.85**
 - Next active milestone: **v0.86**
-- Current crate version on `main`: **0.8.0**
+- Current crate version on `main`: **0.86.0**
 
 This README describes the runtime as it exists on the current `main` branch and points to the relevant milestone and demo surfaces in the parent repository.
 


### PR DESCRIPTION
Closes #1226

## Summary
- align the runtime crate/package version surfaces to `0.86.0`
- fold the external v0.86 review findings into the canonical remediation tracker
- defer the non-blocking ADR and maintainability follow-ups into #1288 and #1289

## Validation
- `cargo metadata --format-version 1 --no-deps | jq -r .packages[] | select(.name=="adl") | .version`\n- `cargo check --locked -q`