### PR TITLE
[v0.86][tools] Move worktree creation from pr start to pr run

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -124,6 +124,8 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     if create_body != final_body {
         gh_issue_edit_body(&repo, issue, &final_body)?;
     }
+    let (stp_path, bundle_input, bundle_output, bundle_dir) =
+        bootstrap_root_task_bundle(&repo_root, &issue_ref, &title, &source_path)?;
 
     println!("• Created:");
     println!("  ISSUE_URL  {issue_url}");
@@ -134,8 +136,24 @@ fn real_pr_create(args: &[String]) -> Result<()> {
         "  SOURCE     {}",
         path_relative_to_repo(&repo_root, &source_path)
     );
-    println!("  NEXT       adl/tools/pr.sh init {issue} --slug {slug} --version {version}");
-    println!("  STATE      ISSUE_CREATED");
+    println!(
+        "  STP        {}",
+        path_relative_to_repo(&repo_root, &stp_path)
+    );
+    println!(
+        "  READ       {}",
+        path_relative_to_repo(&repo_root, &bundle_input)
+    );
+    println!(
+        "  WRITE      {}",
+        path_relative_to_repo(&repo_root, &bundle_output)
+    );
+    println!(
+        "  BUNDLE     {}",
+        path_relative_to_repo(&repo_root, &bundle_dir)
+    );
+    println!("  NEXT       qualitative STP/SIP review, then adl/tools/pr.sh run {issue} --slug {slug} --version {version}");
+    println!("  STATE      ISSUE_AND_BUNDLE_READY");
     eprintln!("• Done.");
     Ok(())
 }
@@ -144,6 +162,11 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     let parsed = parse_start_args(args)?;
     let repo_root = repo_root()?;
     let repo = default_repo(&repo_root)?;
+
+    eprintln!(
+        "• Deprecated compatibility path: prefer `adl/tools/pr.sh run {}` for execution-context binding.",
+        parsed.issue
+    );
 
     let mut title = parsed.title_arg.clone().unwrap_or_default();
     let mut slug = parsed.slug.clone().unwrap_or_default();
@@ -679,27 +702,8 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     let source_path =
         ensure_source_issue_prompt(&repo_root, &repo, &issue_ref, &title, None, &version)?;
     validate_issue_prompt_exists(&source_path)?;
-
-    let stp_path = issue_ref.task_bundle_stp_path(&repo_root);
-    let bundle_dir = issue_ref.task_bundle_dir_path(&repo_root);
-    let init_branch = issue_ref.branch_name("codex");
-    eprintln!("• Initializing task bundle: {}", bundle_dir.display());
-    if !stp_path.is_file() {
-        if let Some(parent) = stp_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::copy(&source_path, &stp_path).with_context(|| {
-            format!(
-                "failed to seed task-bundle stp from '{}' to '{}'",
-                source_path.display(),
-                stp_path.display()
-            )
-        })?;
-    } else {
-        eprintln!("• STP already exists: {}", stp_path.display());
-    }
-    let (bundle_input, bundle_output) =
-        ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &init_branch, &source_path)?;
+    let (stp_path, bundle_input, bundle_output, bundle_dir) =
+        bootstrap_root_task_bundle(&repo_root, &issue_ref, &title, &source_path)?;
 
     println!("• Initialized:");
     println!(
@@ -727,6 +731,35 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     println!("  STATE    ISSUE_AND_BUNDLE_READY");
     eprintln!("• Done.");
     Ok(())
+}
+
+fn bootstrap_root_task_bundle(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    source_path: &Path,
+) -> Result<(PathBuf, PathBuf, PathBuf, PathBuf)> {
+    let stp_path = issue_ref.task_bundle_stp_path(repo_root);
+    let bundle_dir = issue_ref.task_bundle_dir_path(repo_root);
+    let init_branch = issue_ref.branch_name("codex");
+    eprintln!("• Initializing task bundle: {}", bundle_dir.display());
+    if !stp_path.is_file() {
+        if let Some(parent) = stp_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source_path, &stp_path).with_context(|| {
+            format!(
+                "failed to seed task-bundle stp from '{}' to '{}'",
+                source_path.display(),
+                stp_path.display()
+            )
+        })?;
+    } else {
+        eprintln!("• STP already exists: {}", stp_path.display());
+    }
+    let (bundle_input, bundle_output) =
+        ensure_bootstrap_cards(repo_root, issue_ref, title, &init_branch, source_path)?;
+    Ok((stp_path, bundle_input, bundle_output, bundle_dir))
 }
 
 fn repo_root() -> Result<PathBuf> {

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -388,7 +388,7 @@ fn real_pr_init_existing_stp_is_left_untouched() {
 }
 
 #[test]
-fn real_pr_create_creates_issue_without_bootstrapping_bundle() {
+fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
     let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let repo = unique_temp_dir("adl-pr-real-create");
     init_git_repo(&repo);
@@ -449,8 +449,19 @@ fn real_pr_create_creates_issue_without_bootstrapping_bundle() {
     assert!(prompt.contains("## Summary"));
     assert!(prompt.contains("## Tooling Notes"));
     assert!(
-        !repo.join(".adl/v0.86/tasks").exists(),
-        "create should not bootstrap the local task bundle"
+        repo.join(".adl/v0.86/tasks/issue-1202__v0-86-tools-simplified-init-path/stp.md")
+            .is_file(),
+        "create should bootstrap the root stp"
+    );
+    assert!(
+        repo.join(".adl/v0.86/tasks/issue-1202__v0-86-tools-simplified-init-path/sip.md")
+            .is_file(),
+        "create should bootstrap the root sip"
+    );
+    assert!(
+        repo.join(".adl/v0.86/tasks/issue-1202__v0-86-tools-simplified-init-path/sor.md")
+            .is_file(),
+        "create should bootstrap the root sor"
     );
     let issue_body = fs::read_to_string(&issue_body_log).expect("issue body");
     assert!(issue_body.contains("## Summary"));

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1025,6 +1025,13 @@ cmd_run() {
     return 0
   fi
 
+  if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+    require_rust_pr_delegate
+    note "Issue-mode run: binding execution context for issue $1"
+    delegate_pr_command_to_rust start "$@"
+    return 0
+  fi
+
   local adl_path="${1:-}"
   [[ -n "$adl_path" ]] || die_with_usage "run: missing <adl.yaml>" usage_run
   shift || true
@@ -1489,14 +1496,14 @@ cmd_cards() {
     note "Input card exists: $input_path"
   else
     note "Creating input card: $input_path"
-    seed_input_card "$input_path" "$issue" "$title" "TBD (run pr.sh start $issue)" "$version" "$output_path"
+    seed_input_card "$input_path" "$issue" "$title" "TBD (run pr.sh run $issue)" "$version" "$output_path"
   fi
 
   if ensure_nonempty_file "$output_path"; then
     note "Output card exists: $output_path"
   else
     note "Creating output card: $output_path"
-    seed_output_card "$output_path" "$issue" "$title" "TBD (run pr.sh start $issue)" "$version"
+    seed_output_card "$output_path" "$issue" "$title" "TBD (run pr.sh run $issue)" "$version"
   fi
 
   sync_legacy_links_for_issue "$issue" "$version" "$cards_slug"
@@ -1530,6 +1537,7 @@ cmd_start() {
     return 0
   fi
   require_rust_pr_delegate
+  note "Deprecated compatibility path: prefer 'adl/tools/pr.sh run <issue> ...' for execution-context binding."
   delegate_pr_command_to_rust start "$@"
 }
 
@@ -1583,6 +1591,7 @@ Commands:
   help
   create  --title "<title>" [--slug <slug>] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v>]
   init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v>]
+  run     <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
   run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
   start   <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>]
   card    <issue> [input|output] ... [--version <v0.2>] [-f <input_card.md>]
@@ -1597,7 +1606,8 @@ Flags:
   (create)  --version <v0.85>                 Override detected version (otherwise inferred from labels/title).
   (init)    --version <v0.85>                 Override detected version (otherwise inferred from issue labels version:vX.Y)
   (init)    --no-fetch-issue                  Do not fetch issue title/labels; requires --slug.
-  (run)     --runs-root <dir>                 Override canonical run artifact root (default: <repo>/.adl/runs or ADL_RUNS_ROOT).
+  (run issue-mode) same flags as `start`; preferred public execution-context binder.
+  (run adl-mode) --runs-root <dir>            Override canonical run artifact root (default: <repo>/.adl/runs or ADL_RUNS_ROOT).
   (card)    -f, --file <input_card.md>         Output path for the generated input card (default: <cards_root>/<issue>/input_<issue>.md)
   (output)  -f, --file <output_card.md>        Output path for the generated output card (default: <cards_root>/<issue>/output_<issue>.md)
   (cards)   --version <v0.2>                   Override detected version (otherwise inferred from issue labels version:vX.Y)
@@ -1612,9 +1622,10 @@ Flags:
   (start)   --allow-open-pr-wave               Override the open milestone PR wave guard.
 
 Notes:
-- `pr create` creates the GitHub issue when issue creation is needed.
-- `pr init <issue> ...` bootstraps the local root STP/SIP/SOR bundle for an existing issue.
-- `pr start <issue> ...` binds the issue to a concrete branch/worktree execution context.
+- `pr create` creates the GitHub issue and bootstraps the local root STP/SIP/SOR bundle for a new issue.
+- `pr init <issue> ...` bootstraps the same local root bundle for an issue that already exists.
+- `pr run <issue> ...` is the preferred public execution-context binder for issue work.
+- `pr start <issue> ...` remains as a compatibility shim over the same Rust binding path.
 - PRs are created as DRAFT by default to preserve human review.
 - Uses "Closes #N" by default so GitHub auto-closes issues when merged.
 - run is a bounded v0.85 wrapper over the Rust adl runtime; browser/editor direct invocation remains follow-on work.
@@ -1628,6 +1639,7 @@ Examples:
   adl/tools/pr.sh help
   adl/tools/pr.sh create --title "[v0.86][tools] Example issue" --labels "track:roadmap,type:task,area:tools"
   adl/tools/pr.sh init 17 --slug b6-default-system --no-fetch-issue --version v0.85
+  adl/tools/pr.sh run 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
   adl/tools/pr.sh start 17 --slug b6-default-system
   adl/tools/pr.sh preflight 17 --slug b6-default-system --version v0.85
@@ -1649,9 +1661,9 @@ Usage:
   adl/tools/pr.sh create --title "<title>" [--slug <slug>] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v>]
 
 Notes:
-- Creates the GitHub issue only.
-- Does not bootstrap the local task bundle or worktree.
-- After create, run `adl/tools/pr.sh init <issue> ...` and then `adl/tools/pr.sh start <issue> ...`.
+- Creates the GitHub issue and bootstraps the local root STP/SIP/SOR bundle.
+- Does not create the branch or worktree execution context.
+- After create, do qualitative STP/SIP review and then run `adl/tools/pr.sh run <issue> ...`.
 EOF
 }
 
@@ -1674,6 +1686,7 @@ Usage:
   adl/tools/pr.sh start <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
 
 Notes:
+- Deprecated compatibility shim. Prefer `adl/tools/pr.sh run <issue> ...`.
 - Creates or reuses issue worktree at .worktrees/adl-wp-<issue> by default.
 - Keeps the primary checkout on main.
 - `--version` overrides inferred issue version when the caller already knows the intended milestone band.
@@ -1684,12 +1697,16 @@ EOF
 usage_run() {
   cat <<'EOF'
 Usage:
+  adl/tools/pr.sh run <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
   adl/tools/pr.sh run <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
 
 Notes:
-- This is a bounded v0.85 control-plane wrapper over `cargo run --bin adl -- ...`.
-- The primary proof surface is the canonical run artifact set under `.adl/runs/<run_id>/`.
-- Browser/editor direct invocation remains follow-on work; this command is the truthful supported run path today.
+- Issue mode:
+  - preferred public binder for execution-time branch and worktree creation
+  - delegates to the Rust PR control-plane binder
+- ADL file mode:
+  - bounded v0.85 control-plane wrapper over `cargo run --bin adl -- ...`
+  - primary proof surface is the canonical run artifact set under `.adl/runs/<run_id>/`
 EOF
 }
 

--- a/adl/tools/test_pr_create.sh
+++ b/adl/tools/test_pr_create.sh
@@ -39,7 +39,7 @@ help_out="$(
 )"
 
 assert_contains 'adl/tools/pr.sh create --title "<title>"' "$help_out" "create help usage"
-assert_contains 'Creates the GitHub issue only.' "$help_out" "create help semantics"
-assert_contains 'Does not bootstrap the local task bundle or worktree.' "$help_out" "create help no bootstrap"
+assert_contains 'Creates the GitHub issue and bootstraps the local root STP/SIP/SOR bundle.' "$help_out" "create help semantics"
+assert_contains 'Does not create the branch or worktree execution context.' "$help_out" "create help no worktree"
 
 echo "pr.sh create help: ok"

--- a/adl/tools/test_pr_run_issue_mode.sh
+++ b/adl/tools/test_pr_run_issue_mode.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASH_BIN="$(command -v bash)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_contains() {
+  local pattern="$1" text="$2" label="$3"
+  grep -Fq "$pattern" <<<"$text" || {
+    echo "assertion failed ($label): expected to find '$pattern'" >&2
+    echo "actual output:" >&2
+    echo "$text" >&2
+    exit 1
+  }
+}
+
+repo="$TMP_DIR/repo"
+mkdir -p "$repo/adl/tools"
+cp "$ROOT_DIR/adl/tools/pr.sh" "$repo/adl/tools/pr.sh"
+cp "$ROOT_DIR/adl/tools/card_paths.sh" "$repo/adl/tools/card_paths.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  touch README.md
+  git add README.md
+  git commit -q -m "init"
+)
+
+mock_bin="$TMP_DIR/mock-adl"
+cat >"$mock_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"$ADL_PR_RUN_CAPTURE"
+EOF
+chmod +x "$mock_bin"
+
+capture_file="$TMP_DIR/capture.txt"
+run_out="$(
+  cd "$repo" &&
+    ADL_PR_RUST_BIN="$mock_bin" \
+    ADL_PR_RUN_CAPTURE="$capture_file" \
+    "$BASH_BIN" adl/tools/pr.sh run 1303 --slug example-slug --version v0.86
+)"
+
+captured="$(cat "$capture_file")"
+assert_contains 'Issue-mode run: binding execution context for issue 1303' "$run_out" "issue-mode note"
+assert_contains 'pr start 1303 --slug example-slug --version v0.86' "$captured" "delegates to start binder"
+
+echo "pr.sh run issue-mode delegation: ok"

--- a/docs/milestones/v0.85/EDITING_ARCHITECTURE.md
+++ b/docs/milestones/v0.85/EDITING_ARCHITECTURE.md
@@ -39,7 +39,7 @@ Today it effectively manages:
 
 The long-term goal is to evolve this into a structured, validated, file-backed control plane. The immediate v0.85 goal is to ship usable editor surfaces while beginning that control-plane evolution without destabilizing the milestone.
 
-A key emerging insight is that `pr start` is likely to become the operational backbone of the editing system. Even if the longer-term lifecycle grows to include additional commands such as `init`, `create`, `run`, and `finish`, `pr start` is the first command that binds an authored task to a concrete execution context. That makes it the natural spine of the near-term control plane.
+A key emerging insight is that the public lifecycle should distinguish clearly between mechanical bootstrap and execution-context binding. New issues should not require a separate `create` then `init` ceremony, and branch/worktree binding should happen at execution time rather than during early authoring.
 
 ## Command Status For v0.85
 
@@ -47,10 +47,10 @@ This document follows the canonical command-status model in the editing five-com
 
 | Command | Current state | Repo truth | Notes |
 | --- | --- | --- | --- |
-| `pr init` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | local bootstrap for the canonical root task bundle |
-| `pr create` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | GitHub issue creation/reconciliation command |
-| `pr start` | implemented | active backbone command today | real and mature enough to anchor the current control plane |
-| `pr run` | implemented | live command in `adl/tools/pr.sh` | bounded execution wrapper over the ADL runtime |
+| `pr init` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | bootstrap for the canonical root task bundle when the issue already exists |
+| `pr create` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | GitHub issue creation plus root-bundle bootstrap for new issues |
+| `pr start` | compatibility | deprecated public step | compatibility shim for older execution-context binding flows |
+| `pr run` | implemented | live command in `adl/tools/pr.sh` | preferred public binder for issue execution context plus the existing ADL runtime wrapper |
 | `pr finish` | implemented | active mature workflow command today | real, but still subject to reliability/polish work |
 
 ## Key Capabilities
@@ -119,7 +119,7 @@ A command layer that orchestrates the artifact lifecycle and enforces validation
 
 This is currently centered on `pr.sh`, but should evolve into a proper programmatic subsystem.
 
-In the near term, the most important command in that subsystem is `pr start`, because it turns a validated authored task into a bound execution context with a worktree, branch, implementation prompt, and output-record expectations. Over time, other lifecycle commands may expand around it, but `pr start` is the clearest candidate for the first strong Rust control-plane command.
+In the near term, the most important command boundary in that subsystem is the transition from reviewed root cards into a bound execution context with a worktree, branch, implementation prompt, and output-record expectations. That boundary should live under `pr run`, not require a separate public `pr start` step before qualitative review is done.
 
 The control plane should manage:
 - issue creation
@@ -149,15 +149,14 @@ The intended file-backed target-state workflow is:
 1. Author structured task prompt
 2. Validate the structured task prompt locally
 3. Promote the authoritative structured task prompt into tracked public task-bundle records
-4. Run `pr create` when issue creation is needed
-5. Create or reconcile the GitHub issue from the tracked structured task prompt when GitHub is part of the workflow
-6. Run `pr start`
-7. Create or reconcile the bound execution context and paired implementation artifacts
-8. Author/refine structured implementation prompt
-9. Promote authoritative implementation/output artifacts into tracked public records at the lifecycle points where they become official
-10. Run the execution pass
-11. Review structured output record and evidence
-12. Either revise the structured implementation prompt for another pass or run `pr finish`
+4. Run `pr create` when issue creation is needed, or `pr init` when the issue already exists
+5. Review and refine the root STP/SIP authoring surfaces
+6. Run `pr run` to create or reconcile the bound execution context and paired implementation artifacts
+7. Author/refine structured implementation prompt if the execution step requires it
+8. Promote authoritative implementation/output artifacts into tracked public records at the lifecycle points where they become official
+9. Run the execution pass
+10. Review structured output record and evidence
+11. Either revise the structured implementation prompt for another pass or run `pr finish`
 
 This means the major artifacts become:
 - structured task prompt = design-layer artifact
@@ -186,18 +185,17 @@ The workflow should close the loop without requiring direct manual `gh` usage in
 
 The intended command path is:
 - validate authored task
-- `pr create` when issue creation is needed
-- `pr init`
-- `pr start`
+- `pr create` for new issues or `pr init` for issues that already exist
+- qualitative STP/SIP review
 - `pr run`
 - review/repair loop as needed
 - `pr finish`
 
 This only becomes a reliable closed loop if validation is enforced at every transition.
 
-Operationally, `pr init`, `pr create`, `pr start`, `pr run`, and `pr finish` now exist as explicit lifecycle commands. The remaining work is to keep their responsibilities non-overlapping and continue migrating their durable control-plane logic into Rust so the bash layer stays thin.
+Operationally, `pr create`, `pr init`, `pr run`, and `pr finish` are the public lifecycle surface we actually want. `pr start` remains only as a compatibility shim while the older flow is retired. The remaining work is to keep those responsibilities non-overlapping and continue migrating their durable control-plane logic into Rust so the bash layer stays thin.
 
-The architecture should therefore treat `pr start` as the anchor command for the current system, while `pr create`, execution orchestration, and finish/repair behavior become increasingly formalized around it. This is one reason the longer-term control plane should move into Rust: the backbone command should not remain trapped in brittle bash if it is going to carry more general lifecycle responsibility.
+The architecture should therefore treat the reviewed root bundle as the anchor artifact for the current system, while `pr create`/`pr init` handle mechanical bootstrap and `pr run` handles execution binding. This is one reason the longer-term control plane should move into Rust: the backbone lifecycle transitions should not remain trapped in brittle bash.
 
 ### Why the Editing System Must Be File-Backed
 
@@ -640,10 +638,10 @@ five-command execution plan.
 
 | Command | Current state | Repo truth | Notes |
 | --- | --- | --- | --- |
-| `pr init` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | local bootstrap for the canonical root task bundle |
-| `pr create` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | GitHub issue creation/reconciliation command |
-| `pr start` | implemented | active backbone command today | real and mature enough to anchor the current control plane |
-| `pr run` | implemented | live command in `adl/tools/pr.sh` | bounded execution wrapper over the ADL runtime |
+| `pr init` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | bootstrap for the canonical root task bundle when the issue already exists |
+| `pr create` | implemented | live command in `adl/tools/pr.sh` and `adl pr` | GitHub issue creation plus root-bundle bootstrap for new issues |
+| `pr start` | compatibility | deprecated public step | compatibility shim for older execution-context binding flows |
+| `pr run` | implemented | live command in `adl/tools/pr.sh` | preferred public binder for issue execution context plus the existing ADL runtime wrapper |
 | `pr finish` | implemented | active mature workflow command today | real, but still subject to reliability/polish work |
 
 ## Related Documents


### PR DESCRIPTION
Closes #1303

## Summary
This run shifts the public issue lifecycle toward the new four-step model by making "pr create" bootstrap the root issue bundle immediately, keeping "pr init" as the equivalent bootstrap step for existing issues, and making "pr run <issue> ..." the preferred public execution-context binder. The implementation keeps the current Rust lifecycle core intact by routing issue-mode "pr run" through the existing Rust "start" handler as a compatibility layer, while marking "pr start" as deprecated in shell help, shell behavior, Rust output, and milestone architecture docs.

## Artifacts
- Updated "adl/src/cli/pr_cmd.rs" to share bundle bootstrap logic between "create" and "init", extend "create" to write the root STP/SIP/SOR set, and mark "start" as deprecated compatibility.
- Updated "adl/tools/pr.sh" so "pr run <issue> ..." binds execution context in issue mode and so shell help reflects the new preferred flow.
- Updated "adl/src/cli/tests/pr_cmd_inline/basics.rs" to assert that "create" now bootstraps the root bundle.
- Updated "adl/tools/test_pr_create.sh" for the new bootstrap semantics.
- Added "adl/tools/test_pr_run_issue_mode.sh" to prove issue-mode "pr run" delegates correctly.
- Updated "docs/milestones/v0.85/EDITING_ARCHITECTURE.md" to document the new public flow and the deprecation of "pr start".

## Validation
- Validation commands and their purpose:
  - "cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture" to verify the Rust PR lifecycle behavior, including create/bootstrap semantics.
  - "cargo fmt --manifest-path adl/Cargo.toml --all --check" to verify formatting invariants after the Rust lifecycle changes.
  - "cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings" to verify the Rust changes remain warning-free.
  - "bash adl/tools/test_pr_create.sh" to verify shell create behavior and help text for the new bootstrap semantics.
  - "bash adl/tools/test_pr_run.sh" to verify the existing runtime wrapper path still behaves correctly.
  - "bash adl/tools/test_pr_run_issue_mode.sh" to verify issue-mode "pr run" delegates to the Rust lifecycle binder correctly.
  - "bash adl/tools/test_pr_start_template_validation.sh" to verify deprecated "start" compatibility still validates template surfaces correctly.
  - "bash adl/tools/test_pr_help_and_card_open.sh" to verify shell help and card-opening surfaces still reflect the supported command model.
  - "git status --short" to verify the exact tracked repository paths changed before publish.
  - "git diff --stat -- adl docs" to verify the final changed surface matches the intended code-and-doc scope.
- Results:
  - All listed Rust and shell validation commands passed locally.
  - The changed surface remained bounded to the intended lifecycle code, tests, shell wrapper, and architecture documentation.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.86/tasks/issue-1303__v0-86-tools-move-worktree-creation-from-pr-start-to-pr-run/sip.md
- Output card: .adl/v0.86/tasks/issue-1303__v0-86-tools-move-worktree-creation-from-pr-start-to-pr-run/sor.md
- Idempotency-Key: v0-86-tools-move-worktree-creation-from-pr-start-to-pr-run-adl-docs-adl-v0-86-tasks-issue-1303-v0-86-tools-move-worktree-creation-from-pr-start-to-pr-run-sip-md-adl-v0-86-tasks-issue-1303-v0-86-tools-move-worktree-creation-from-pr-start-to-pr-run-sor-md