### PR TITLE
[v0.86][tools] Align issue-bootstrap skill with init-run-doctor workflow

### DIFF
--- a/.adl/skills/issue-bootstrap/SKILL.md
+++ b/.adl/skills/issue-bootstrap/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: issue-bootstrap
+description: Create and bootstrap a tracked issue for the PR lifecycle. Use when the user wants to create a GitHub issue from a title/slug/labels/body, generate the canonical local source issue prompt plus initial STP/SIP/SOR bundle in the correct locations, validate the bootstrap surfaces, and stop before any branch or worktree creation.
+---
+
+# Issue Bootstrap
+
+This skill owns the bounded issue-bootstrap phase for the PR tooling workflow.
+
+Its job is to:
+- create or locate the GitHub issue
+- ensure the canonical local source issue prompt exists
+- seed the initial root task bundle surfaces
+- validate that the issue is ready for the next lifecycle step
+- stop at the mechanical bootstrap boundary before branch creation, worktree creation, or implementation work
+
+This is an execution skill, not a review-only skill.
+Keep mechanical work separate from qualitative review.
+
+## Design Basis
+
+This skill should track the repository's canonical PR tooling planning docs.
+
+At the moment, the canonical repo docs are:
+- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+
+Within this skill bundle, the operational details live in:
+- `references/bootstrap-playbook.md`
+- `references/output-contract.md`
+
+If those docs move, prefer the moved tracked canonical copies over stale path references. Do not silently invent a new workflow model from memory when the repo docs have changed.
+
+## Current Compatibility Model
+
+The intended workflow model treats issue bootstrap as Step 1.
+
+Current repo truth:
+1. new issues are created and bootstrapped with `pr create`
+2. existing issues are bootstrapped with `pr init`
+3. qualitative STP/SIP review is a separate step
+4. `pr run` is the later execution-time binder
+5. `doctor` remains the diagnostic and drift-review surface
+
+Skill-model boundary:
+- this skill covers only Step 1: issue bootstrap
+- later qualitative STP/SIP editing is a separate skill or human-review phase
+- later execution-time branch/worktree creation belongs to the run skill
+
+Treat `create` and `init` as two command shapes for the same bounded bootstrap phase:
+- `create` when a new GitHub issue must be created
+- `init` when the issue already exists
+
+Do not teach `create` as a later workflow step, and do not teach `start` as the public execution binder.
+
+## Entry Conditions
+
+Run this skill when all of the following are true:
+- the user wants to create or bootstrap a tracked issue
+- the target repository is known
+- the task should stop after issue creation, root bundle generation, and bootstrap validation
+
+Do not use this skill for:
+- qualitative rewriting of the STP or SIP
+- branch or worktree creation
+- implementation work
+- PR publication
+- post-bootstrap readiness/doctor checks for an existing worktree
+
+## Required Inputs
+
+At minimum, gather:
+- repository root
+- one of:
+  - existing issue number to bootstrap
+  - title for a new issue
+
+For new issue creation, prefer:
+- title
+- slug, if explicitly supplied
+- version or milestone scope, if known
+- labels, if known
+- issue body or body file, if the user provides one
+
+For deterministic ADL execution, also prefer an explicit issue-metadata policy:
+- how version is chosen
+- how labels are chosen or normalized
+- whether body content is user-authored or bootstrap-generated
+
+If no slug is given, derive one from the title using the repo's normal slug rules.
+
+## Quick Start
+
+1. Resolve whether the request is:
+   - `bootstrap-existing-issue`
+   - `create-and-bootstrap-new-issue`
+2. Prefer the Rust-owned path when available.
+3. For new issues:
+   - create the GitHub issue correctly
+   - ensure the canonical local source issue prompt exists
+4. Run the bootstrap/init phase:
+   - seed the task-bundle `stp.md`
+   - seed the initial `sip.md`
+   - seed the initial `sor.md`
+   - ensure canonical compatibility links exist when the repo expects them
+5. Validate the resulting surfaces mechanically.
+6. Emit a structured readiness result for qualitative card review and stop.
+
+## Workflow
+
+### 1. Determine Mode
+
+Use one of these modes:
+
+- `create_and_bootstrap`
+  - use when the user gives a title or asks to create a new issue
+- `bootstrap_existing_issue`
+  - use when the user already has an issue number and only wants the bundle/bootstrap step
+
+### 2. Create or Resolve the GitHub Issue
+
+For `create_and_bootstrap`:
+- prefer the repository's standard issue-creation path
+- create the GitHub issue with the correct title, labels, version, and body inputs
+- capture the resulting issue number and URL
+- ensure the canonical local source prompt is generated or written in the expected location
+
+For `bootstrap_existing_issue`:
+- resolve the issue title and scope using the standard repo flow
+- infer or confirm slug/version using the repo's existing rules
+
+### 3. Seed Canonical Bootstrap Surfaces
+
+Ensure the repo's canonical bootstrap surfaces exist in the right places:
+- source issue prompt
+- root task-bundle `stp.md`
+- root task-bundle `sip.md`
+- root task-bundle `sor.md`
+- any required compatibility links such as canonical `.adl/cards/...` pointers if the workflow still uses them
+
+Prefer the repo's existing templates and control-plane logic over hand-written file generation.
+
+Do not qualitatively rewrite STP or SIP content in this step beyond the mechanical bootstrap required by the repo's standard control-plane behavior.
+
+### 4. Validate and Review the Bootstrap Result
+
+Validation must confirm:
+- the GitHub issue exists or was created successfully
+- the canonical source issue prompt exists
+- the expected task-bundle directory exists
+- `stp.md`, `sip.md`, and `sor.md` exist in the bundle
+- compatibility links exist when the repo expects them
+- the bootstrap step did not create a branch or worktree
+- the surfaces are mechanically complete and ready for the qualitative card-review step
+
+Review the result for obvious bootstrap defects such as:
+- empty or missing prompt surfaces
+- missing source prompt linkage
+- wrong version/scope placement
+- slug/path mismatches
+- missing bundle files
+- compatibility links missing or pointing at the wrong target
+
+If the compatibility path created obviously placeholder or contradictory bootstrap output that is not ready for the next step, emit a blocked result instead of pretending the issue is ready.
+
+This step may confirm bootstrap completeness, but it must not perform the deeper qualitative review that turns STP/SIP into execution-ready instructions.
+
+### 5. Stop Boundary
+
+This skill must stop after bootstrap creation and validation of the root bundle.
+
+It must not:
+- create or switch branches
+- create worktrees
+- start implementation
+- run `pr run`
+- run `pr finish`
+
+The immediate handoff is to qualitative card review.
+Only after that does the later run skill bind branch/worktree execution context.
+
+## Parallelism
+
+This skill is a good candidate for parallel execution across distinct issues when write targets do not overlap.
+
+Parallel execution is allowed only when each invocation has a disjoint target such as:
+- different issue numbers
+- different slugs
+- different task-bundle directories
+
+Within one issue bootstrap, keep the operations serialized.
+
+## Preferred Commands
+
+Prefer repo-native control-plane commands such as:
+- `adl/tools/pr.sh create`
+- `adl/tools/pr.sh init`
+- `adl pr create`
+- `adl pr init`
+
+Use existing templates, validation helpers, and path logic from the repository. Do not recreate bundle contents manually unless the repo-native path is unavailable and the user explicitly wants a fallback.
+
+## Output
+
+Return findings/status in a concise structured shape.
+
+When writing an artifact for ADL, use the contract in `references/output-contract.md`.
+
+Default success result should make these explicit:
+- issue number
+- issue URL
+- title
+- slug
+- version/scope
+- source prompt path
+- bundle directory
+- `stp.md` path
+- `sip.md` path
+- `sor.md` path
+- validation status
+- next step: qualitative card review
+- later-step handoff after review: issue-mode `pr run`
+
+## Failure Modes
+
+Common failure modes:
+- `gh` unavailable or unauthenticated
+- title/slug resolution fails
+- version/scope inference is missing or inconsistent
+- source issue prompt cannot be created or found
+- templates or contracts are missing
+- bundle files were not seeded correctly
+- validation fails
+
+If the issue or bundle is only partially created, report exactly which surfaces exist and which do not.
+
+## Boundaries
+
+This skill may:
+- inspect repo state
+- call the repo's issue creation/bootstrap commands
+- write the canonical bootstrap files for the issue
+- validate the resulting prompt and bundle surfaces
+- emit a readiness decision for the qualitative review step
+
+This skill must not:
+- qualitatively rewrite STP or SIP beyond normal bootstrap generation
+- implement the issue
+- mutate unrelated issues
+- create branches or worktrees
+- silently skip validation
+- claim readiness if required bootstrap surfaces are missing
+
+## ADL Compatibility
+
+This skill is Codex-compatible through frontmatter discovery.
+
+For stricter ADL execution, also use:
+- `adl-skill.yaml`
+- `references/bootstrap-playbook.md`
+- `references/output-contract.md`
+
+## Resources
+
+- Playbook: `references/bootstrap-playbook.md`
+- Output contract: `references/output-contract.md`
+- PR tooling feature doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- PR tooling architecture doc: `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`

--- a/.adl/skills/issue-bootstrap/adl-skill.yaml
+++ b/.adl/skills/issue-bootstrap/adl-skill.yaml
@@ -1,0 +1,73 @@
+version: "0.1"
+kind: "adl-skill"
+id: "issue-bootstrap"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  intent:
+    - "issue_creation"
+    - "issue_bootstrap"
+    - "pr_init_bootstrap"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "issue_number"
+    - "title"
+    - "slug"
+    - "version"
+    - "labels"
+    - "body"
+    - "body_file"
+  stop_if_missing:
+    - "repo_root"
+  require_one_of:
+    - "issue_number"
+    - "title"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: false
+  parallelism_policy: "parallel_across_distinct_issue_targets_only"
+  workflow_step: "step_1_issue_bootstrap"
+  stop_before:
+    - "qualitative_stp_sip_review"
+    - "branch_creation"
+    - "worktree_creation"
+    - "implementation"
+    - "pr_finish"
+  preferred_commands:
+    - "adl/tools/pr.sh create"
+    - "adl/tools/pr.sh init"
+    - "adl pr create"
+    - "adl pr init"
+  preferred_path: "rust_owned_control_plane_when_available"
+  validation_policy: "must_verify_issue_source_prompt_root_bundle_and_no_branch_or_worktree_side_effects"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+    - "GitHub issue body and metadata for the created issue"
+  must_not_write:
+    - "worktrees/**"
+    - ".git/worktrees/**"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-issue-bootstrap.md"
+  required_sections:
+    - "status"
+    - "mode"
+    - "issue"
+    - "paths"
+    - "validation"
+    - "next_step"
+    - "handoff"
+    - "notes"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/.adl/skills/issue-bootstrap/agents/openai.yaml
+++ b/.adl/skills/issue-bootstrap/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Issue Bootstrap
+short_description: Create and bootstrap an issue for the PR lifecycle
+default_prompt: Create or bootstrap a tracked issue, seed the root task bundle, validate it, and stop before branch or worktree creation. Treat this as the mechanical bootstrap step that hands off to qualitative review and later issue-mode run.

--- a/.adl/skills/issue-bootstrap/references/bootstrap-playbook.md
+++ b/.adl/skills/issue-bootstrap/references/bootstrap-playbook.md
@@ -1,0 +1,114 @@
+# Issue Bootstrap Playbook
+
+Use this file after the main skill triggers and you are ready to execute the issue-bootstrap step.
+
+Planning basis:
+- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- `/Users/daniel/git/agent-design-language/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
+- this skill bundle's `SKILL.md` and reference files
+
+If the repo relocates those docs, follow the relocated canonical copies instead of these exact paths.
+
+## Purpose
+
+Turn a requested issue into a valid tracked bootstrap state for the next lifecycle step.
+
+The bootstrap result should leave the repository with:
+- a GitHub issue
+- a canonical local source issue prompt
+- a root task bundle with `stp.md`, `sip.md`, and `sor.md`
+- validation evidence that qualitative card review can begin
+
+This step is mechanical only.
+
+It must not:
+- qualitatively rewrite STP or SIP beyond standard bootstrap generation
+- create a branch
+- create a worktree
+- begin implementation
+
+## Execution Modes
+
+### Mode A: Create And Bootstrap
+
+Use this when the request starts from a title or new issue request.
+
+Expected path:
+1. create the GitHub issue
+2. capture issue number and URL
+3. generate or seed the canonical source issue prompt
+4. run the init/bootstrap phase
+5. validate the result
+6. stop
+
+### Mode B: Bootstrap Existing Issue
+
+Use this when the issue already exists and only needs the local bootstrap bundle.
+
+Expected path:
+1. resolve issue metadata using the repo's standard flow
+2. infer or confirm slug/version
+3. ensure the canonical source issue prompt exists
+4. run the init/bootstrap phase
+5. validate the result
+6. stop
+
+## Validation Checklist
+
+Confirm all of these before returning success:
+- issue number exists
+- issue URL exists for newly created issues
+- source issue prompt exists at the canonical path
+- task-bundle directory exists
+- `stp.md` exists
+- `sip.md` exists
+- `sor.md` exists
+- compatibility card links exist if the repo expects them
+- no branch was created
+- no worktree was created
+- the next step is clearly identified as qualitative card review
+
+## Review Questions
+
+Ask these questions after bootstrap:
+- Did the issue land in the expected version/scope path?
+- Does the slug match the canonical path layout?
+- Do the source prompt and bundle point at the same issue identity?
+- Did any expected bootstrap surface fail to appear?
+- Did the operation accidentally broaden into start/worktree behavior?
+- Did the process remain mechanical rather than silently editing review content?
+
+## Parallel Safety
+
+Parallel execution is safe only when invocations do not share issue targets or bundle paths.
+
+Safe examples:
+- create/bootstrap issue A and issue B at the same time
+- bootstrap separate existing issues with different task-bundle roots
+
+Unsafe examples:
+- two bootstrap runs targeting the same issue number
+- a bootstrap run overlapping with issue-mode `pr run` for the same issue
+
+## Current Compatibility Note
+
+The skill should prefer the Rust-owned control-plane path when available.
+
+Current command truth:
+- use `adl pr create` or `adl/tools/pr.sh create` when a new issue must be created
+- use `adl pr init` or `adl/tools/pr.sh init` when the issue already exists
+- hand off to qualitative review after bootstrap
+- only after review does issue-mode `pr run` bind branch and worktree context
+
+Do not teach `pr start` as the public execution binder for this workflow.
+
+## Failure Handling
+
+If the process fails:
+- report whether the GitHub issue was created
+- report whether the source prompt exists
+- report whether the bundle directory exists
+- report which of `stp.md`, `sip.md`, `sor.md` exist
+- report whether any compatibility links were created
+- stop without attempting branch/worktree repair
+- hand off to review or human follow-up only after the missing bootstrap surfaces are made explicit

--- a/.adl/skills/issue-bootstrap/references/output-contract.md
+++ b/.adl/skills/issue-bootstrap/references/output-contract.md
@@ -1,0 +1,58 @@
+# Output Contract
+
+When ADL expects structured issue-bootstrap output, use this shape.
+
+```yaml
+status: complete | partial | blocked | failed
+mode: create_and_bootstrap | bootstrap_existing_issue
+issue:
+  number: <issue number or null>
+  url: <issue url or null>
+  title: <title>
+  slug: <slug>
+  version: <version or scope>
+paths:
+  source_prompt: <path or null>
+  bundle_dir: <path or null>
+  stp: <path or null>
+  sip: <path or null>
+  sor: <path or null>
+validation:
+  issue_created_or_resolved: true | false
+  source_prompt_present: true | false
+  bundle_dir_present: true | false
+  stp_present: true | false
+  sip_present: true | false
+  sor_present: true | false
+  compatibility_links_present: true | false | not_applicable
+  branch_created: true | false
+  worktree_created: true | false
+next_step:
+  recommended_phase: qualitative_card_review
+  recommended_command: <command, skill, or manual phase>
+  handoff_reason: <short explanation>
+handoff:
+  ready_for_card_review: true | false
+  ready_for_execution: true | false
+  notes:
+    - <optional handoff note>
+notes:
+  - <optional note>
+```
+
+## Rules
+
+- If `status: complete`, all required bootstrap surfaces must be present and both `branch_created` and `worktree_created` must be `false`.
+- If `status: complete`, `ready_for_card_review` should normally be `true` and `ready_for_execution` should normally be `false`.
+- If the issue exists but one or more bundle surfaces are missing, use `partial` or `blocked`, not `complete`.
+- If bootstrap output is obviously contradictory or not ready for the next step, use `blocked`.
+- Report exact paths when they are known.
+- Do not claim readiness for issue-mode `pr run` or execution unless a later qualitative review step has actually been completed.
+
+## Default Artifact Location
+
+When writing the bootstrap result to disk by default, use:
+
+```text
+.adl/reviews/<timestamp>-issue-bootstrap.md
+```

--- a/.adl/v0.86/bodies/issue-1310-v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow.md
+++ b/.adl/v0.86/bodies/issue-1310-v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow.md
@@ -1,0 +1,102 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow"
+title: "[v0.86][tools] Bring issue-bootstrap skill into alignment with init-run-doctor workflow"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.86"
+issue_number: 1310
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - ".adl/skills/issue-bootstrap/"
+  - "docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md"
+  - "docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md"
+  - "adl/tools/pr.sh"
+canonical_files:
+  - ".adl/skills/issue-bootstrap/SKILL.md"
+  - ".adl/skills/issue-bootstrap/adl-skill.yaml"
+  - ".adl/skills/issue-bootstrap/agents/openai.yaml"
+  - ".adl/skills/issue-bootstrap/references/bootstrap-playbook.md"
+  - ".adl/skills/issue-bootstrap/references/output-contract.md"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Bootstrap-generated from GitHub issue metadata because no canonical local issue prompt existed yet."
+pr_start:
+  enabled: true
+  slug: "v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow"
+---
+
+## Summary
+Bring the issue-bootstrap skill and its supporting contracts up to date with the current PR lifecycle so it becomes a trustworthy source for subagent-driven issue bootstrap.
+
+## Goal
+Make the issue-bootstrap skill reflect the current public model truthfully: init for mechanical bootstrap, qualitative card review as a separate step, run as the execution-time binder, and doctor as the diagnostic surface.
+
+## Required Outcome
+This issue must ship:
+- a corrected issue-bootstrap skill that no longer teaches the superseded create-start lifecycle as the long-term model
+- aligned supporting files so the skill, manifest, playbook, and output contract agree with each other
+- corrected canonical doc references so the skill points at real source material in the repository
+- proof that the skill can be used as the durable source for automated issue bootstrap without leaking obsolete workflow steps
+
+## Deliverables
+
+- updated .adl/skills/issue-bootstrap/SKILL.md
+- updated skill manifest and supporting agent metadata
+- updated bootstrap playbook and output contract
+- validation notes proving the skill boundaries, handoff, and references are truthful
+
+## Acceptance Criteria
+
+- the skill teaches init as the bootstrap step and run as the later execution-time binder
+- the skill preserves doctor as the review and drift-diagnostic surface
+- the skill no longer points at missing or misplaced source docs
+- the manifest, playbook, and output contract are consistent with the main skill file
+- the skill is explicit enough to become the last manually created issue before issue-bootstrap is delegated to subagents
+
+## Repo Inputs
+
+- .adl/skills/issue-bootstrap/
+- docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
+- docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+- adl/tools/pr.sh
+- current git tracking and ignore rules for `.adl/`
+
+## Dependencies
+
+- issue #1303 for the init-run workflow shift
+- issue #1304 for the broader issue-bootstrap skill direction
+
+## Demo Expectations
+
+- no runtime demo is required
+- proof should be a coherent skill bundle plus validation against current repo truth
+
+## Non-goals
+
+- creating the other three workflow skills in this issue
+- changing the actual control-plane commands again here
+- implementing qualitative review or execution behavior inside the bootstrap skill
+
+## Issue-Graph Notes
+
+- This should become the final manual issue-creation cleanup before issue-bootstrap can be delegated permanently.
+- The result should be strong enough that later skills can be written directly from the docs and skill bundle.
+
+## Notes
+
+- Treat the current repo truth as authoritative over any stale language inside the existing skill files.
+- Do not preserve references to ignored planning files as canonical sources unless this issue also makes those files real and durable.
+
+## Tooling Notes
+
+- The skill must stop at mechanical bootstrap and hand off cleanly to qualitative review.

--- a/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sip.md
+++ b/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sip.md
@@ -1,0 +1,196 @@
+# ADL Input Card
+
+Task ID: issue-1310
+Run ID: issue-1310
+Version: v0.86
+Title: [v0.86][tools] Bring issue-bootstrap skill into alignment with init-run-doctor workflow
+Branch: codex/1310-v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1310
+- PR:
+- Source Issue Prompt: .adl/v0.86/bodies/issue-1310-v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow.md
+- Docs: docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md; docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+- Other: .adl/skills/issue-bootstrap/; .gitignore
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Bring the issue-bootstrap skill bundle into line with the current bootstrap-review-run-doctor model without changing the control-plane commands again.
+
+## Required Outcome
+
+- Update the skill, manifest, playbook, and output contract so they agree on the current workflow truth.
+- Remove or correct references that treat ignored or missing planning paths as canonical when the repo does not actually provide them.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The skill describes Step 1 as mechanical bootstrap for new or existing issues without teaching `start` as the later binder.
+- The handoff after bootstrap is qualitative card review, then `run`, with `doctor` preserved as the diagnostic surface.
+- The skill bundle points at source docs that actually exist in the repository.
+- The manifest, playbook, and output contract agree with the main skill file on boundaries, commands, and handoff language.
+
+## Inputs
+- linked source issue prompt
+- .adl/skills/issue-bootstrap/SKILL.md
+- .adl/skills/issue-bootstrap/adl-skill.yaml
+- .adl/skills/issue-bootstrap/agents/openai.yaml
+- .adl/skills/issue-bootstrap/references/bootstrap-playbook.md
+- .adl/skills/issue-bootstrap/references/output-contract.md
+- docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
+- docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+- .gitignore
+
+## Target Files / Surfaces
+- .adl/skills/issue-bootstrap/SKILL.md
+- .adl/skills/issue-bootstrap/adl-skill.yaml
+- .adl/skills/issue-bootstrap/agents/openai.yaml
+- .adl/skills/issue-bootstrap/references/bootstrap-playbook.md
+- .adl/skills/issue-bootstrap/references/output-contract.md
+- .adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sor.md
+
+## Validation Plan
+- Commands to run:
+  - inspect the skill bundle and current feature docs
+  - verify tracked-vs-ignored path truth for any referenced planning files
+  - run the smallest repo-native validation that proves the skill remains aligned with current lifecycle commands
+- Tests to run:
+  - any bounded command or lint checks needed to prove the updated skill reflects current repo truth
+- Artifacts or traces:
+  - updated issue-bootstrap skill bundle
+  - completed output card
+- Reviewer checks:
+  - confirm the skill can be used as the final manual issue-bootstrap source without obsolete `create/start` long-term teaching
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: updated skill bundle plus output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the control-plane commands again
+- creating the other three workflow skills in this issue
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sor.md
+++ b/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sor.md
@@ -1,0 +1,168 @@
+# v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1310
+Run ID: issue-1310
+Version: v0.86
+Title: [v0.86][tools] Bring issue-bootstrap skill into alignment with init-run-doctor workflow
+Branch: codex/1310-v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow
+Status: IN_PROGRESS
+
+Execution:
+- Actor: Codex
+- Model: GPT-5 Codex
+- Provider: OpenAI
+- Start Time: 2026-04-02T14:24:00Z
+- End Time: 2026-04-02T14:42:00Z
+
+## Summary
+This run brings the issue-bootstrap skill bundle up to current workflow truth by making the skill describe mechanical bootstrap as the Step 1 concern, qualitative card review as the immediate handoff, issue-mode `pr run` as the later execution-time binder, and `doctor` as the diagnostic surface. It also removes stale reliance on ignored planning-path references and aligns the main skill file, manifest, playbook, agent metadata, and output contract.
+
+## Artifacts produced
+- Updated `.adl/skills/issue-bootstrap/SKILL.md`.
+- Updated `.adl/skills/issue-bootstrap/adl-skill.yaml`.
+- Updated `.adl/skills/issue-bootstrap/agents/openai.yaml`.
+- Updated `.adl/skills/issue-bootstrap/references/bootstrap-playbook.md`.
+- Updated `.adl/skills/issue-bootstrap/references/output-contract.md`.
+- Updated issue execution surfaces for `#1310` so the worktree-local source prompt, STP, and SIP match the reviewed scope.
+
+## Actions taken
+- Created `#1310` through the canonical issue-bootstrap flow and rewrote the root issue prompt, STP, and SIP to reflect the real reviewed scope before execution.
+- Bound the issue with `pr run` to create the branch and worktree at execution time.
+- Materialized the ignored issue-bootstrap skill bundle into the issue worktree so the fix could live on the branch instead of only in the primary checkout.
+- Reworked the skill bundle so it points at tracked feature and architecture docs, treats `create` and `init` as Step 1 bootstrap shapes, hands off to qualitative review and then issue-mode `pr run`, and preserves `doctor` as a diagnostic surface rather than a lifecycle phase.
+- Synced the corrected source prompt and task cards into the started worktree after `pr run` had copied the pre-edit bootstrap bundle.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: `.adl/skills/issue-bootstrap/SKILL.md`, `.adl/skills/issue-bootstrap/adl-skill.yaml`, `.adl/skills/issue-bootstrap/agents/openai.yaml`, `.adl/skills/issue-bootstrap/references/bootstrap-playbook.md`, `.adl/skills/issue-bootstrap/references/output-contract.md`
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: tracked repair in the issue branch worktree, including force-staging ignored `.adl/skills` paths for PR publication.
+- Verification performed:
+  - `find .adl/skills/issue-bootstrap -maxdepth 2 -type f | sort` to verify the expected skill bundle surfaces exist in the worktree.
+  - `rg -n "pr start|run/start|\\.adl/docs/v0.87planning/PR_TOOLING_SKILLS|later-step handoff after review" .adl/skills/issue-bootstrap` to verify stale lifecycle teaching and dead planning-path references were removed or reduced to truthful diagnostic notes.
+  - `diff -u <root sip> <worktree sip>` to verify the corrected execution card was synced into the started worktree after binding.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `find .adl/skills/issue-bootstrap -maxdepth 2 -type f | sort` to verify the skill bundle contains the expected five files.
+  - `rg -n "pr start|run/start|\\.adl/docs/v0.87planning/PR_TOOLING_SKILLS|later-step handoff after review" .adl/skills/issue-bootstrap` to verify no stale bootstrap-to-start teaching or dead planning-doc reference remained in the bundle.
+  - `git check-ignore -v .adl/skills/issue-bootstrap/SKILL.md .adl/skills/issue-bootstrap/adl-skill.yaml .adl/skills/issue-bootstrap/references/bootstrap-playbook.md .adl/skills/issue-bootstrap/references/output-contract.md` to verify these paths are still ignored by default and therefore require intentional force-staging.
+  - `diff -u /Users/daniel/git/agent-design-language/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sip.md /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1310/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/sip.md` to verify the corrected input card was synced into the execution worktree.
+- Results:
+  - The issue-bootstrap bundle exists with the expected file set.
+  - The bundle now teaches qualitative review followed by issue-mode `pr run`, with `doctor` preserved as a diagnostic surface.
+  - The dead `.adl/docs/v0.87planning/PR_TOOLING_SKILLS.md` planning reference was removed from the skill bundle.
+  - The ignored `.adl/skills` paths are intentionally outside default git tracking and must be force-added for publication.
+  - The corrected execution card now matches between root and worktree copies.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "find .adl/skills/issue-bootstrap -maxdepth 2 -type f | sort"
+      - "rg -n \"pr start|run/start|\\.adl/docs/v0.87planning/PR_TOOLING_SKILLS|later-step handoff after review\" .adl/skills/issue-bootstrap"
+      - "git check-ignore -v .adl/skills/issue-bootstrap/SKILL.md .adl/skills/issue-bootstrap/adl-skill.yaml .adl/skills/issue-bootstrap/references/bootstrap-playbook.md .adl/skills/issue-bootstrap/references/output-contract.md"
+      - "diff -u <root sip> <worktree sip>"
+  determinism:
+    status: PARTIAL
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: repeated file-discovery and text-scan checks over the same skill bundle.
+- Fixtures or scripts used: `find`, `rg`, and `diff` over the bounded skill-bundle surfaces.
+- Replay verification (same inputs -> same artifacts/order): rerunning the same scans over the same checkout yields the same file set and the same absence of stale planning-path references.
+- Ordering guarantees (sorting / tie-break rules used): `find ... | sort` was used so the recorded bundle order is stable.
+- Artifact stability notes: this issue updates markdown and YAML skill surfaces only; no runtime artifact schema changed.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review plus targeted `rg` checks over the edited skill bundle found no secrets or tokens.
+- Prompt / tool argument redaction verified: the updated skill language describes workflow behavior only and does not embed sensitive prompt/tool payloads.
+- Absolute path leakage check: the skill bundle still contains intentional absolute repository paths in instructional references; the output record itself avoids recording new unjustified host-path details beyond required proof commands.
+- Sandbox / policy invariants preserved: the skill remains explicitly bounded to mechanical bootstrap and still forbids branch/worktree creation and implementation work.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this issue does not produce runtime trace bundles.
+- Run artifact root: not applicable; this is a skill-bundle repair.
+- Replay command used for verification: `find .adl/skills/issue-bootstrap -maxdepth 2 -type f | sort` and the targeted `rg` check over the same bundle.
+- Replay result: PASS. The same bundle surfaces and corrected lifecycle wording are reproduced on repeated inspection.
+
+## Artifact Verification
+- Primary proof surface: the updated issue-bootstrap skill bundle under `.adl/skills/issue-bootstrap/`.
+- Required artifacts present: yes.
+- Artifact schema/version checks: `adl-skill.yaml` remains on the existing `version: "0.1"` schema and no new manifest fields were introduced beyond a populated `notes` required section declaration.
+- Hash/byte-stability checks: not run; this issue relies on bounded text-surface verification rather than byte-hash proof.
+- Missing/optional artifacts and rationale: no additional planning doc was added under `.adl/docs/v0.87planning/` because the current repo does not track that path reliably; the skill now points at tracked feature docs and its own local references instead.
+
+## Decisions / Deviations
+- The skill now treats `pr create` and `pr init` as two current command shapes for the same Step 1 bootstrap concern rather than claiming `init` alone already owns new-issue creation.
+- The bundle intentionally keeps a negative reference to `pr start` only to say it should not be taught as the public execution binder.
+- The ignored skill bundle had to be copied into the started worktree explicitly because `pr run` does not mirror ignored `.adl/skills` content automatically.
+
+## Follow-ups / Deferred work
+- Use this corrected bundle as the source for the next three workflow skills rather than re-deriving the lifecycle model from memory.
+- If `.adl/docs/v0.87planning/` is meant to become a tracked planning corpus later, add that as a separate docs issue instead of letting skills point at ignored paths by assumption.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/stp.md
+++ b/.adl/v0.86/tasks/issue-1310__v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow/stp.md
@@ -1,0 +1,103 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow"
+title: "[v0.86][tools] Bring issue-bootstrap skill into alignment with init-run-doctor workflow"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.86"
+issue_number: 1310
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - ".adl/skills/issue-bootstrap/"
+  - "docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md"
+  - "docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md"
+  - "adl/tools/pr.sh"
+  - ".gitignore"
+canonical_files:
+  - ".adl/skills/issue-bootstrap/SKILL.md"
+  - ".adl/skills/issue-bootstrap/adl-skill.yaml"
+  - ".adl/skills/issue-bootstrap/agents/openai.yaml"
+  - ".adl/skills/issue-bootstrap/references/bootstrap-playbook.md"
+  - ".adl/skills/issue-bootstrap/references/output-contract.md"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Bootstrap-generated from GitHub issue metadata because no canonical local issue prompt existed yet."
+pr_start:
+  enabled: true
+  slug: "v0-86-tools-bring-issue-bootstrap-skill-into-alignment-with-init-run-doctor-workflow"
+---
+
+## Summary
+Bring the issue-bootstrap skill and its supporting contracts up to date with the current PR lifecycle so it becomes a trustworthy source for subagent-driven issue bootstrap.
+
+## Goal
+Make the issue-bootstrap skill reflect the current public model truthfully: init for mechanical bootstrap, qualitative card review as a separate step, run as the execution-time binder, and doctor as the diagnostic surface.
+
+## Required Outcome
+This issue must ship:
+- a corrected issue-bootstrap skill that no longer teaches the superseded create-start lifecycle as the long-term model
+- aligned supporting files so the skill, manifest, playbook, and output contract agree with each other
+- corrected canonical doc references so the skill points at real source material in the repository
+- proof that the skill can be used as the durable source for automated issue bootstrap without leaking obsolete workflow steps
+
+## Deliverables
+
+- updated .adl/skills/issue-bootstrap/SKILL.md
+- updated skill manifest and supporting agent metadata
+- updated bootstrap playbook and output contract
+- validation notes proving the skill boundaries, handoff, and references are truthful
+
+## Acceptance Criteria
+
+- the skill teaches init as the bootstrap step and run as the later execution-time binder
+- the skill preserves doctor as the review and drift-diagnostic surface
+- the skill no longer points at missing or misplaced source docs
+- the manifest, playbook, and output contract are consistent with the main skill file
+- the skill is explicit enough to become the last manually created issue before issue-bootstrap is delegated to subagents
+
+## Repo Inputs
+
+- .adl/skills/issue-bootstrap/
+- docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
+- docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+- adl/tools/pr.sh
+- .gitignore
+
+## Dependencies
+
+- issue #1303 for the init-run workflow shift
+- issue #1304 for the broader issue-bootstrap skill direction
+
+## Demo Expectations
+
+- no runtime demo is required
+- proof should be a coherent skill bundle plus validation against current repo truth
+
+## Non-goals
+
+- creating the other three workflow skills in this issue
+- changing the actual control-plane commands again here
+- implementing qualitative review or execution behavior inside the bootstrap skill
+
+## Issue-Graph Notes
+
+- This should become the final manual issue-creation cleanup before issue-bootstrap can be delegated permanently.
+- The result should be strong enough that later skills can be written directly from the docs and skill bundle.
+
+## Notes
+
+- Treat the current repo truth as authoritative over any stale language inside the existing skill files.
+- Explicitly resolve the mismatch between tracked feature docs and ignored `.adl/docs` planning paths.
+
+## Tooling Notes
+
+- The skill must stop at mechanical bootstrap and hand off cleanly to qualitative review.


### PR DESCRIPTION
## Summary
- align the issue-bootstrap skill bundle with the current bootstrap -> review -> run workflow truth
- remove stale planning-path and create/start long-term teaching drift
- preserve doctor as the diagnostic surface and qualitative review as the immediate handoff

Closes #1310