### PR TITLE
[v0.86][tools] Retire pr start from the taught public lifecycle

### DIFF
--- a/.adl/skills/issue-bootstrap/SKILL.md
+++ b/.adl/skills/issue-bootstrap/SKILL.md
@@ -51,7 +51,7 @@ Treat `create` and `init` as two command shapes for the same bounded bootstrap p
 - `create` when a new GitHub issue must be created
 - `init` when the issue already exists
 
-Do not teach `create` as a later workflow step, and do not teach `start` as the public execution binder.
+Do not teach `create` as a later workflow step. Teach qualitative review first, then issue-mode `run` as the binder.
 
 ## Entry Conditions
 
@@ -97,8 +97,9 @@ If no slug is given, derive one from the title using the repo's normal slug rule
 2. Prefer the Rust-owned path when available.
 3. For new issues:
    - create the GitHub issue correctly
-   - ensure the canonical local source issue prompt exists
-4. Run the bootstrap/init phase:
+   - ensure the canonical local source issue prompt and root bundle exist
+4. For existing issues:
+   - run the bootstrap/init phase
    - seed the task-bundle `stp.md`
    - seed the initial `sip.md`
    - seed the initial `sor.md`
@@ -177,7 +178,7 @@ It must not:
 - run `pr finish`
 
 The immediate handoff is to qualitative card review.
-Only after that does the later run skill bind branch/worktree execution context.
+Only after that does issue-mode `run` bind branch/worktree execution context.
 
 ## Parallelism
 

--- a/.adl/skills/issue-bootstrap/references/bootstrap-playbook.md
+++ b/.adl/skills/issue-bootstrap/references/bootstrap-playbook.md
@@ -75,7 +75,7 @@ Ask these questions after bootstrap:
 - Does the slug match the canonical path layout?
 - Do the source prompt and bundle point at the same issue identity?
 - Did any expected bootstrap surface fail to appear?
-- Did the operation accidentally broaden into start/worktree behavior?
+- Did the operation accidentally broaden into branch/worktree behavior?
 - Did the process remain mechanical rather than silently editing review content?
 
 ## Parallel Safety
@@ -99,8 +99,6 @@ Current command truth:
 - use `adl pr init` or `adl/tools/pr.sh init` when the issue already exists
 - hand off to qualitative review after bootstrap
 - only after review does issue-mode `pr run` bind branch and worktree context
-
-Do not teach `pr start` as the public execution binder for this workflow.
 
 ## Failure Handling
 

--- a/.adl/v0.86/tasks/issue-1312__v0-86-tools-retire-pr-start-from-the-public-lifecycle-and-remove-it-from-issue-bootstrap-skill-guidance/sor.md
+++ b/.adl/v0.86/tasks/issue-1312__v0-86-tools-retire-pr-start-from-the-public-lifecycle-and-remove-it-from-issue-bootstrap-skill-guidance/sor.md
@@ -1,0 +1,161 @@
+# v0-86-tools-retire-pr-start-from-the-public-lifecycle-and-remove-it-from-issue-bootstrap-skill-guidance
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1312
+Run ID: issue-1312
+Version: v0.86
+Title: [v0.86][tools] Retire pr start from the public lifecycle and remove it from issue-bootstrap skill guidance
+Branch: codex/1312-v0-86-tools-retire-pr-start-from-the-public-lifecycle-and-remove-it-from-issue-bootstrap-skill-guidance
+Status: IN_PROGRESS
+
+Execution:
+- Actor: Codex
+- Model: GPT-5 Codex
+- Provider: OpenAI
+- Start Time: 2026-04-02T15:08:00Z
+- End Time: 2026-04-02T15:20:00Z
+
+## Summary
+This run retires `pr start` from the taught public lifecycle without breaking the legacy alias itself. The public help, PR tooling docs, and issue-bootstrap skill bundle now teach the bootstrap -> qualitative review -> issue-mode `pr run` -> review/closeout model, with `doctor` separate and `start` reduced to legacy-background status only.
+
+## Artifacts produced
+- Updated `adl/tools/pr.sh`.
+- Updated `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`.
+- Updated `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`.
+- Updated `.adl/skills/issue-bootstrap/SKILL.md`.
+- Updated `.adl/skills/issue-bootstrap/references/bootstrap-playbook.md`.
+
+## Actions taken
+- Removed `start` from the public `pr.sh --help` command list, flag guidance, and examples while keeping a narrow legacy-alias note.
+- Reframed PR tooling docs so `start` is no longer taught as an active public lifecycle step.
+- Rebuilt the issue-bootstrap skill wording so it teaches bootstrap, qualitative review, and issue-mode `pr run` without start-era ambiguity.
+- Kept the underlying `start` dispatch path in code as a legacy alias during migration instead of deleting compatibility outright in this issue.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: `adl/tools/pr.sh`, `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`, `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`, `.adl/skills/issue-bootstrap/SKILL.md`, `.adl/skills/issue-bootstrap/references/bootstrap-playbook.md`
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: tracked repair in the issue branch worktree, with the legacy alias preserved in code but removed from the taught command surface.
+- Verification performed:
+  - `bash adl/tools/pr.sh --help | sed -n '1,90p'` to verify the taught public command surface no longer lists `start`.
+  - `rg -n "\bstart\b" docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md .adl/skills/issue-bootstrap adl/tools/pr.sh -g '!**/target/**'` to verify remaining `start` mentions are legacy/internal rather than active public guidance.
+  - `git status --short --untracked-files=all` to verify the branch contains only the intended retirement-surface edits.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `bash adl/tools/pr.sh --help | sed -n '1,90p'` to verify the public help surface teaches `run` but no longer lists `start` as a command.
+  - `rg -n "\bstart\b" docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md .adl/skills/issue-bootstrap adl/tools/pr.sh -g '!**/target/**'` to audit where `start` still appears after the cleanup.
+  - `git status --short --untracked-files=all` to verify the branch changed only the intended help/docs/skill surfaces.
+- Results:
+  - Public help now teaches `create`, `init`, `run`, `finish`, and other non-legacy commands without listing `start`.
+  - Remaining `start` mentions are limited to the legacy alias implementation, a narrow legacy note in help, and architecture text that explicitly marks it as a legacy alias.
+  - The issue-bootstrap skill bundle no longer teaches `start` as part of the normal handoff.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash adl/tools/pr.sh --help | sed -n '1,90p'"
+      - "rg -n \"\\bstart\\b\" docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md .adl/skills/issue-bootstrap adl/tools/pr.sh -g '!**/target/**'"
+      - "git status --short --untracked-files=all"
+  determinism:
+    status: PARTIAL
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: repeated help-surface and grep-based audits over the same checkout.
+- Fixtures or scripts used: `pr.sh --help`, `rg`, and `git status`.
+- Replay verification (same inputs -> same artifacts/order): rerunning the help output and grep sweep on the same branch yields the same taught command surface and the same legacy-only `start` locations.
+- Ordering guarantees (sorting / tie-break rules used): grep output is stable for the same files and checkout state.
+- Artifact stability notes: this issue changes only shell/docs/skill text surfaces and keeps runtime behavior unchanged except for public command teaching.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review plus targeted grep over changed text surfaces found no secrets or tokens.
+- Prompt / tool argument redaction verified: the changed help/docs/skill surfaces describe workflow commands only.
+- Absolute path leakage check: the output record uses repository-relative references and does not introduce unjustified absolute host paths.
+- Sandbox / policy invariants preserved: the issue does not widen command privileges; it narrows the taught public surface while preserving legacy compatibility under the hood.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this issue does not produce runtime trace bundles.
+- Run artifact root: not applicable; this is a docs/help/skill control-plane cleanup.
+- Replay command used for verification: `bash adl/tools/pr.sh --help | sed -n '1,90p'` and the targeted `rg` audit.
+- Replay result: PASS. The taught public surface consistently omits `start` while the legacy alias remains visible only in bounded compatibility locations.
+
+## Artifact Verification
+- Primary proof surface: the updated `pr.sh` help output plus the aligned PR tooling docs and issue-bootstrap skill bundle.
+- Required artifacts present: yes.
+- Artifact schema/version checks: not applicable; no runtime or card schema changed.
+- Hash/byte-stability checks: not run; textual verification was sufficient for this bounded lifecycle-teaching change.
+- Missing/optional artifacts and rationale: none.
+
+## Decisions / Deviations
+- `start` remains implemented as a legacy alias in code, but it is intentionally no longer listed as part of the public command model.
+- This issue does not resolve the separate long-term `create` versus `init` bootstrap simplification question; it only removes `start` from the taught downstream binder role.
+
+## Follow-ups / Deferred work
+- Use the updated issue-bootstrap skill for the next issue and confirm that no manual command interpretation is needed.
+- If the legacy alias is no longer used after migration, a later issue can delete the `start` dispatch path entirely instead of merely retiring it from teaching.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -15,7 +15,7 @@
 #   adl/tools/pr.sh help
 #   adl/tools/pr.sh create  --title "<title>" [--slug <slug>] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v0.85>]
 #   adl/tools/pr.sh init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v0.85>]
-#   adl/tools/pr.sh start   <issue> [--slug <slug>] [--title "<title>"] [--prefix codex] [--no-fetch-issue] [--version <v0.85>]
+#   adl/tools/pr.sh run     <issue> [--slug <slug>] [--title "<title>"] [--prefix codex] [--no-fetch-issue] [--version <v0.85>] [--allow-open-pr-wave]
 #   adl/tools/pr.sh run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
 #   adl/tools/pr.sh card    <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <input_card.md>] [--version <v0.2>]
 #   adl/tools/pr.sh output  <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <output_card.md>] [--version <v0.2>]
@@ -27,7 +27,7 @@
 # Examples:
 #   adl/tools/pr.sh create --title "[v0.86][tools] Example task" --labels track:roadmap,type:task,area:tools --version v0.86
 #   adl/tools/pr.sh init  14 --slug b6-default-system --no-fetch-issue --version v0.85
-#   adl/tools/pr.sh start 14 --slug b6-default-system
+#   adl/tools/pr.sh run 14 --slug b6-default-system --version v0.85
 #   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
 #   adl/tools/pr.sh card  14 --version v0.2
 #   adl/tools/pr.sh card  14 input
@@ -502,7 +502,7 @@ This issue currently defaults to a required outcome type of \`$outcome_type\`. R
 ## Acceptance Criteria
 
 - the issue title and labels are reflected in the local source prompt
-- the task can proceed through \`pr init\`, \`pr start\`, and card editing without manual bootstrap repair
+- the task can proceed through \`pr init\`, issue-mode \`pr run\`, and card editing without manual bootstrap repair
 
 ## Repo Inputs
 
@@ -1593,7 +1593,6 @@ Commands:
   init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v>]
   run     <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
   run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
-  start   <issue> [--slug <slug>] [--title "<title>"] [--prefix <pfx>] [--no-fetch-issue] [--version <v>]
   card    <issue> [input|output] ... [--version <v0.2>] [-f <input_card.md>]
   output  <issue> [input|output] ... [--version <v0.2>] [-f <output_card.md>]
   cards   <issue> [--version <v0.2>] [--no-fetch-issue]
@@ -1606,7 +1605,7 @@ Flags:
   (create)  --version <v0.85>                 Override detected version (otherwise inferred from labels/title).
   (init)    --version <v0.85>                 Override detected version (otherwise inferred from issue labels version:vX.Y)
   (init)    --no-fetch-issue                  Do not fetch issue title/labels; requires --slug.
-  (run issue-mode) same flags as `start`; preferred public execution-context binder.
+  (run issue-mode) --slug <slug> --title "<title>" --prefix <pfx> --no-fetch-issue --version <v> --allow-open-pr-wave
   (run adl-mode) --runs-root <dir>            Override canonical run artifact root (default: <repo>/.adl/runs or ADL_RUNS_ROOT).
   (card)    -f, --file <input_card.md>         Output path for the generated input card (default: <cards_root>/<issue>/input_<issue>.md)
   (output)  -f, --file <output_card.md>        Output path for the generated output card (default: <cards_root>/<issue>/output_<issue>.md)
@@ -1616,16 +1615,16 @@ Flags:
   (finish) --output-card <output_card.md>          REQUIRED: output card path (must exist)
   (finish) --merge                              Opt-in: ready + squash-merge + delete branch.
   (finish) --idempotent                         Safe no-op only when existing merged PR matches current finish inputs.
-  (card/start) --slug <slug>                   Use an explicit slug instead of fetching the issue title.
-  (start)   --title "<title>"                  Optional; accepted for UX symmetry and used to derive slug when --slug is omitted.
-  (start)   --version <v0.85>                  Override detected version when the caller already knows the intended milestone band.
-  (start)   --allow-open-pr-wave               Override the open milestone PR wave guard.
+  (card/run) --slug <slug>                     Use an explicit slug instead of fetching the issue title.
+  (run)     --title "<title>"                  Optional; accepted for UX symmetry and used to derive slug when --slug is omitted.
+  (run)     --version <v0.85>                  Override detected version when the caller already knows the intended milestone band.
+  (run)     --allow-open-pr-wave               Override the open milestone PR wave guard.
 
 Notes:
 - `pr create` creates the GitHub issue and bootstraps the local root STP/SIP/SOR bundle for a new issue.
 - `pr init <issue> ...` bootstraps the same local root bundle for an issue that already exists.
 - `pr run <issue> ...` is the preferred public execution-context binder for issue work.
-- `pr start <issue> ...` remains as a compatibility shim over the same Rust binding path.
+- `pr start <issue> ...` remains only as a legacy alias over the same Rust binding path and is no longer part of the taught public flow.
 - PRs are created as DRAFT by default to preserve human review.
 - Uses "Closes #N" by default so GitHub auto-closes issues when merged.
 - run is a bounded v0.85 wrapper over the Rust adl runtime; browser/editor direct invocation remains follow-on work.
@@ -1641,7 +1640,6 @@ Examples:
   adl/tools/pr.sh init 17 --slug b6-default-system --no-fetch-issue --version v0.85
   adl/tools/pr.sh run 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
-  adl/tools/pr.sh start 17 --slug b6-default-system
   adl/tools/pr.sh preflight 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh card  17 --help
   adl/tools/pr.sh card  17 --version v0.2

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
@@ -39,7 +39,7 @@ Observed in the repository as of `2026-03-31`:
 - `pr.sh` already delegates several lifecycle commands to Rust when available:
   - `create`
   - `init`
-  - `start`
+  - legacy alias `start`
   - `ready`
   - `preflight`
   - `finish`
@@ -89,7 +89,7 @@ The current interface includes:
 
 - `create`
 - `init`
-- `start`
+- legacy alias `start`
 - `run`
 - `card`
 - `output`
@@ -174,7 +174,6 @@ Examples:
 
 - `create` remains as a compatibility path while bootstrap semantics settle,
   but the long-term public model should collapse new-issue bootstrap into `init`
-- `start` becomes a compatibility shim during transition rather than the long-term public binder
 - `ready` and `preflight` become aliases for `doctor`
 - `card`, `output`, and `cards` become either hidden maintenance commands or
   internal Rust helpers rather than prominent user commands
@@ -243,7 +242,7 @@ Recommended internal Rust split:
   - `run`
   - `finish` during transition where explicit closeout remains separate
   - `doctor`
-  - compatibility shims for `create` and `start`
+  - compatibility shims for `create`, `ready`, and `preflight`
 
 The main architectural rule is:
 
@@ -565,7 +564,7 @@ Recommended decisions:
 
 - Rust is the long-term owner of PR tooling behavior.
 - `adl/tools/pr.sh` becomes a compatibility shim, not a workflow engine.
-- `init` should be merged into `start`.
+- `start` should be retired from the taught public lifecycle and retained only as a narrow legacy alias while callers migrate.
 - `ready`, `preflight`, and `status` should converge into `doctor`.
 - `card`, `output`, and `cards` should be demoted from core lifecycle commands.
 - canonical path and workflow rules must have exactly one implementation owner.

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
@@ -132,7 +132,7 @@ thin shell entrypoint.
   - `adl pr run`
   - `adl pr finish` during compatibility and closeout transition
   - `adl pr doctor`
-  - compatibility support for `create`, `start`, `ready`, and `preflight`
+  - compatibility support for `create`, `ready`, and `preflight`
     during migration
 - Invariants (must always hold):
   - Rust is the sole owner of canonical PR lifecycle behavior


### PR DESCRIPTION
## Summary
- retire  from the taught public lifecycle while preserving only a narrow legacy alias
- align the public help/docs with the bootstrap -> review -> run -> review/closeout model
- rebuild the issue-bootstrap skill so it no longer carries start-era guidance

Closes #1312