### PR TITLE
[v0.87][WP-03] Trace instrumentation + artifact linkage

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -113,6 +113,11 @@ impl RunArtifactPaths {
         self.logs_dir().join("activation_log.json")
     }
 
+    /// Canonical Trace v1 artifact path.
+    pub fn trace_v1_json(&self) -> PathBuf {
+        self.logs_dir().join("trace_v1.json")
+    }
+
     /// Canonical bounded cluster-groundwork artifact path.
     pub fn cluster_groundwork_json(&self) -> PathBuf {
         self.meta_dir().join("cluster_groundwork.json")
@@ -470,6 +475,9 @@ mod tests {
         assert!(paths
             .activation_log_json()
             .ends_with(".adl/runs/artifact-path-accessors/logs/activation_log.json"));
+        assert!(paths
+            .trace_v1_json()
+            .ends_with(".adl/runs/artifact-path-accessors/logs/trace_v1.json"));
         assert!(paths
             .scores_json()
             .ends_with(".adl/runs/artifact-path-accessors/learning/scores.json"));

--- a/adl/src/cli/run_artifacts/runtime.rs
+++ b/adl/src/cli/run_artifacts/runtime.rs
@@ -12,6 +12,12 @@ use super::summary::{
 };
 use super::ControlPathSummaryContext;
 use super::*;
+use ::adl::trace_schema_v1::{
+    validate_trace_event_envelope_v1, ContractValidationResultV1, TraceActorTypeV1, TraceActorV1,
+    TraceContractValidationV1, TraceDecisionContextV1, TraceErrorV1, TraceEventEnvelopeV1,
+    TraceEventTypeV1, TraceEventV1, TraceScopeLevelV1, TraceScopeV1,
+};
+use serde_json::json;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn write_run_state_artifacts(
@@ -109,6 +115,9 @@ pub(crate) fn write_run_state_artifacts(
     let steps_json = serde_json::to_vec_pretty(&steps).context("serialize steps.json")?;
     let activation_log_path = run_paths.activation_log_json();
     instrumentation::write_trace_artifact(&activation_log_path, &tr.events)?;
+    let trace_v1 =
+        build_trace_v1_envelope(resolved, tr, &steps, start_ms, end_ms, status, failure)?;
+    let trace_v1_json = serde_json::to_vec_pretty(&trace_v1).context("serialize trace_v1.json")?;
     let cluster_groundwork = build_cluster_groundwork_artifact(resolved, &steps, tr);
     let cluster_groundwork_json = serde_json::to_vec_pretty(&cluster_groundwork)
         .context("serialize cluster_groundwork.json")?;
@@ -282,6 +291,7 @@ pub(crate) fn write_run_state_artifacts(
 
     artifacts::atomic_write(&run_paths.run_json(), &run_json)?;
     artifacts::atomic_write(&run_paths.steps_json(), &steps_json)?;
+    artifacts::atomic_write(&run_paths.trace_v1_json(), &trace_v1_json)?;
     artifacts::atomic_write(&run_paths.run_status_json(), &run_status_json)?;
     artifacts::atomic_write(&run_paths.run_summary_json(), &run_summary_json)?;
     artifacts::atomic_write(&run_paths.scores_json(), &scores_json)?;
@@ -376,6 +386,386 @@ pub(crate) fn write_run_state_artifacts(
     }
 
     Ok(run_dir)
+}
+
+fn build_trace_v1_envelope(
+    resolved: &resolve::AdlResolved,
+    tr: &trace::Trace,
+    steps: &[StepStateArtifact],
+    start_ms: u128,
+    end_ms: u128,
+    status: &str,
+    failure: Option<&anyhow::Error>,
+) -> Result<TraceEventEnvelopeV1> {
+    let mut events = Vec::new();
+    let mut next_id: u64 = 1;
+    let trace_id = resolved.run_id.clone();
+    let root_span_id = format!("run:{}", resolved.run_id);
+    let run_ref = artifact_ref(&resolved.run_id, "run.json");
+    let steps_ref = artifact_ref(&resolved.run_id, "steps.json");
+    let activation_log_ref = artifact_ref(&resolved.run_id, "logs/activation_log.json");
+
+    push_trace_v1_event(
+        &mut events,
+        &mut next_id,
+        TraceEventV1 {
+            event_id: String::new(),
+            timestamp: trace::format_iso_utc_ms(start_ms),
+            event_type: TraceEventTypeV1::RunStart,
+            trace_id: trace_id.clone(),
+            run_id: resolved.run_id.clone(),
+            span_id: root_span_id.clone(),
+            parent_span_id: None,
+            actor: TraceActorV1 {
+                r#type: TraceActorTypeV1::Agent,
+                id: resolved.workflow_id.clone(),
+            },
+            scope: TraceScopeV1 {
+                level: TraceScopeLevelV1::Run,
+                name: resolved.workflow_id.clone(),
+            },
+            inputs_ref: Some(run_ref.clone()),
+            outputs_ref: Some(activation_log_ref.clone()),
+            artifact_ref: Some(run_ref.clone()),
+            decision_context: None,
+            provider: None,
+            error: None,
+            contract_validation: None,
+        },
+    );
+
+    for event in &tr.events {
+        match event {
+            trace::TraceEvent::StepStarted {
+                ts_ms,
+                step_id,
+                agent_id,
+                ..
+            } => push_trace_v1_event(
+                &mut events,
+                &mut next_id,
+                TraceEventV1 {
+                    event_id: String::new(),
+                    timestamp: trace::format_iso_utc_ms(*ts_ms),
+                    event_type: TraceEventTypeV1::StepStart,
+                    trace_id: trace_id.clone(),
+                    run_id: resolved.run_id.clone(),
+                    span_id: format!("step:{step_id}"),
+                    parent_span_id: Some(root_span_id.clone()),
+                    actor: TraceActorV1 {
+                        r#type: TraceActorTypeV1::Agent,
+                        id: agent_id.clone(),
+                    },
+                    scope: TraceScopeV1 {
+                        level: TraceScopeLevelV1::Step,
+                        name: step_id.clone(),
+                    },
+                    inputs_ref: Some(steps_ref.clone()),
+                    outputs_ref: None,
+                    artifact_ref: Some(activation_log_ref.clone()),
+                    decision_context: None,
+                    provider: None,
+                    error: None,
+                    contract_validation: None,
+                },
+            ),
+            trace::TraceEvent::StepFinished {
+                ts_ms,
+                step_id,
+                success,
+                ..
+            } => {
+                let step_output_ref = step_artifact_ref(&resolved.run_id, steps, step_id);
+                push_trace_v1_event(
+                    &mut events,
+                    &mut next_id,
+                    TraceEventV1 {
+                        event_id: String::new(),
+                        timestamp: trace::format_iso_utc_ms(*ts_ms),
+                        event_type: TraceEventTypeV1::StepEnd,
+                        trace_id: trace_id.clone(),
+                        run_id: resolved.run_id.clone(),
+                        span_id: format!("step:{step_id}"),
+                        parent_span_id: Some(root_span_id.clone()),
+                        actor: TraceActorV1 {
+                            r#type: TraceActorTypeV1::Agent,
+                            id: resolved.workflow_id.clone(),
+                        },
+                        scope: TraceScopeV1 {
+                            level: TraceScopeLevelV1::Step,
+                            name: step_id.clone(),
+                        },
+                        inputs_ref: Some(steps_ref.clone()),
+                        outputs_ref: step_output_ref.clone().or(Some(steps_ref.clone())),
+                        artifact_ref: step_output_ref.or(Some(activation_log_ref.clone())),
+                        decision_context: None,
+                        provider: None,
+                        error: None,
+                        contract_validation: None,
+                    },
+                );
+                if !success {
+                    push_trace_v1_event(
+                        &mut events,
+                        &mut next_id,
+                        TraceEventV1 {
+                            event_id: String::new(),
+                            timestamp: trace::format_iso_utc_ms(*ts_ms),
+                            event_type: TraceEventTypeV1::Error,
+                            trace_id: trace_id.clone(),
+                            run_id: resolved.run_id.clone(),
+                            span_id: format!("step:{step_id}:error"),
+                            parent_span_id: Some(format!("step:{step_id}")),
+                            actor: TraceActorV1 {
+                                r#type: TraceActorTypeV1::System,
+                                id: "runtime".to_string(),
+                            },
+                            scope: TraceScopeV1 {
+                                level: TraceScopeLevelV1::Step,
+                                name: step_id.clone(),
+                            },
+                            inputs_ref: Some(steps_ref.clone()),
+                            outputs_ref: None,
+                            artifact_ref: Some(activation_log_ref.clone()),
+                            decision_context: None,
+                            provider: None,
+                            error: Some(TraceErrorV1 {
+                                code: "STEP_FAILURE".to_string(),
+                                message: format!("step '{step_id}' finished unsuccessfully"),
+                                details: None,
+                            }),
+                            contract_validation: None,
+                        },
+                    );
+                }
+            }
+            trace::TraceEvent::DelegationPolicyEvaluated {
+                ts_ms,
+                step_id,
+                action_kind,
+                target_id,
+                decision,
+                rule_id,
+                ..
+            } => {
+                let result = if decision.eq_ignore_ascii_case("allowed")
+                    || decision.eq_ignore_ascii_case("approved")
+                    || decision.eq_ignore_ascii_case("pass")
+                {
+                    ContractValidationResultV1::Pass
+                } else {
+                    ContractValidationResultV1::Fail
+                };
+                push_trace_v1_event(
+                    &mut events,
+                    &mut next_id,
+                    TraceEventV1 {
+                        event_id: String::new(),
+                        timestamp: trace::format_iso_utc_ms(*ts_ms),
+                        event_type: TraceEventTypeV1::ContractValidation,
+                        trace_id: trace_id.clone(),
+                        run_id: resolved.run_id.clone(),
+                        span_id: format!("step:{step_id}:policy"),
+                        parent_span_id: Some(format!("step:{step_id}")),
+                        actor: TraceActorV1 {
+                            r#type: TraceActorTypeV1::System,
+                            id: "policy-engine".to_string(),
+                        },
+                        scope: TraceScopeV1 {
+                            level: TraceScopeLevelV1::Step,
+                            name: step_id.clone(),
+                        },
+                        inputs_ref: Some(steps_ref.clone()),
+                        outputs_ref: None,
+                        artifact_ref: Some(activation_log_ref.clone()),
+                        decision_context: None,
+                        provider: None,
+                        error: None,
+                        contract_validation: Some(TraceContractValidationV1 {
+                            contract_id: "adl.delegation_policy".to_string(),
+                            result,
+                            details: Some(json!({
+                                "step_id": step_id,
+                                "action_kind": action_kind,
+                                "target_id": target_id,
+                                "decision": decision,
+                                "rule_id": rule_id,
+                            })),
+                        }),
+                    },
+                );
+            }
+            trace::TraceEvent::DelegationApproved { ts_ms, step_id, .. } => push_trace_v1_event(
+                &mut events,
+                &mut next_id,
+                TraceEventV1 {
+                    event_id: String::new(),
+                    timestamp: trace::format_iso_utc_ms(*ts_ms),
+                    event_type: TraceEventTypeV1::Approval,
+                    trace_id: trace_id.clone(),
+                    run_id: resolved.run_id.clone(),
+                    span_id: format!("step:{step_id}:approval"),
+                    parent_span_id: Some(format!("step:{step_id}")),
+                    actor: TraceActorV1 {
+                        r#type: TraceActorTypeV1::System,
+                        id: "policy-engine".to_string(),
+                    },
+                    scope: TraceScopeV1 {
+                        level: TraceScopeLevelV1::Step,
+                        name: step_id.clone(),
+                    },
+                    inputs_ref: Some(steps_ref.clone()),
+                    outputs_ref: None,
+                    artifact_ref: Some(activation_log_ref.clone()),
+                    decision_context: Some(TraceDecisionContextV1 {
+                        context: "delegation policy".to_string(),
+                        outcome: "approved".to_string(),
+                        rationale: None,
+                    }),
+                    provider: None,
+                    error: None,
+                    contract_validation: None,
+                },
+            ),
+            trace::TraceEvent::DelegationDenied {
+                ts_ms,
+                step_id,
+                action_kind,
+                target_id,
+                rule_id,
+                ..
+            } => push_trace_v1_event(
+                &mut events,
+                &mut next_id,
+                TraceEventV1 {
+                    event_id: String::new(),
+                    timestamp: trace::format_iso_utc_ms(*ts_ms),
+                    event_type: TraceEventTypeV1::Rejection,
+                    trace_id: trace_id.clone(),
+                    run_id: resolved.run_id.clone(),
+                    span_id: format!("step:{step_id}:rejection"),
+                    parent_span_id: Some(format!("step:{step_id}")),
+                    actor: TraceActorV1 {
+                        r#type: TraceActorTypeV1::System,
+                        id: "policy-engine".to_string(),
+                    },
+                    scope: TraceScopeV1 {
+                        level: TraceScopeLevelV1::Step,
+                        name: step_id.clone(),
+                    },
+                    inputs_ref: Some(steps_ref.clone()),
+                    outputs_ref: None,
+                    artifact_ref: Some(activation_log_ref.clone()),
+                    decision_context: Some(TraceDecisionContextV1 {
+                        context: format!("delegation policy {action_kind} -> {target_id}"),
+                        outcome: "denied".to_string(),
+                        rationale: rule_id.clone(),
+                    }),
+                    provider: None,
+                    error: None,
+                    contract_validation: None,
+                },
+            ),
+            trace::TraceEvent::RunFailed { ts_ms, message, .. } => push_trace_v1_event(
+                &mut events,
+                &mut next_id,
+                TraceEventV1 {
+                    event_id: String::new(),
+                    timestamp: trace::format_iso_utc_ms(*ts_ms),
+                    event_type: TraceEventTypeV1::Error,
+                    trace_id: trace_id.clone(),
+                    run_id: resolved.run_id.clone(),
+                    span_id: format!("run:{}:error", resolved.run_id),
+                    parent_span_id: Some(root_span_id.clone()),
+                    actor: TraceActorV1 {
+                        r#type: TraceActorTypeV1::System,
+                        id: "runtime".to_string(),
+                    },
+                    scope: TraceScopeV1 {
+                        level: TraceScopeLevelV1::Run,
+                        name: resolved.workflow_id.clone(),
+                    },
+                    inputs_ref: Some(run_ref.clone()),
+                    outputs_ref: None,
+                    artifact_ref: Some(activation_log_ref.clone()),
+                    decision_context: None,
+                    provider: None,
+                    error: Some(TraceErrorV1 {
+                        code: "RUN_FAILURE".to_string(),
+                        message: message.clone(),
+                        details: None,
+                    }),
+                    contract_validation: None,
+                },
+            ),
+            _ => {}
+        }
+    }
+
+    let run_end_outcome = if status == "success" {
+        "success".to_string()
+    } else if status == "paused" {
+        "paused".to_string()
+    } else {
+        "failure".to_string()
+    };
+    push_trace_v1_event(
+        &mut events,
+        &mut next_id,
+        TraceEventV1 {
+            event_id: String::new(),
+            timestamp: trace::format_iso_utc_ms(end_ms),
+            event_type: TraceEventTypeV1::RunEnd,
+            trace_id,
+            run_id: resolved.run_id.clone(),
+            span_id: root_span_id,
+            parent_span_id: None,
+            actor: TraceActorV1 {
+                r#type: TraceActorTypeV1::Agent,
+                id: resolved.workflow_id.clone(),
+            },
+            scope: TraceScopeV1 {
+                level: TraceScopeLevelV1::Run,
+                name: resolved.workflow_id.clone(),
+            },
+            inputs_ref: Some(run_ref),
+            outputs_ref: Some(steps_ref),
+            artifact_ref: Some(activation_log_ref),
+            decision_context: Some(TraceDecisionContextV1 {
+                context: "run completion".to_string(),
+                outcome: run_end_outcome,
+                rationale: failure.map(|err| err.to_string()),
+            }),
+            provider: None,
+            error: None,
+            contract_validation: None,
+        },
+    );
+
+    let envelope = TraceEventEnvelopeV1 {
+        schema_version: "trace.v1".to_string(),
+        events,
+    };
+    validate_trace_event_envelope_v1(&envelope)?;
+    Ok(envelope)
+}
+
+fn push_trace_v1_event(events: &mut Vec<TraceEventV1>, next_id: &mut u64, mut event: TraceEventV1) {
+    event.event_id = format!("trace-v1-{:04}", *next_id);
+    *next_id = next_id.saturating_add(1);
+    events.push(event);
+}
+
+fn artifact_ref(run_id: &str, relative_path: &str) -> String {
+    format!("artifacts/{run_id}/{relative_path}")
+}
+
+fn step_artifact_ref(run_id: &str, steps: &[StepStateArtifact], step_id: &str) -> Option<String> {
+    let rel = steps
+        .iter()
+        .find(|step| step.step_id == step_id)
+        .and_then(|step| step.output_artifact_path.as_deref())?;
+    Some(artifact_ref(run_id, rel))
 }
 
 fn read_required_json_artifact<T>(control_path_dir: &Path, file_name: &str) -> Result<T>

--- a/adl/src/cli/tests/run_state/persistence.rs
+++ b/adl/src/cli/tests/run_state/persistence.rs
@@ -1,4 +1,7 @@
 use super::*;
+use ::adl::trace_schema_v1::{
+    validate_trace_event_envelope_v1, TraceEventEnvelopeV1, TraceEventTypeV1,
+};
 
 #[test]
 fn write_run_state_and_load_resume_round_trip() {
@@ -57,6 +60,25 @@ fn write_run_state_and_load_resume_round_trip() {
         run_dir.join("meta/ARTIFACT_MODEL.json").is_file(),
         "artifact model v1 requires version marker"
     );
+    assert!(
+        run_dir.join("logs/trace_v1.json").is_file(),
+        "wp-03 requires canonical trace_v1.json artifact"
+    );
+
+    let trace_v1: TraceEventEnvelopeV1 = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("logs/trace_v1.json")).expect("read trace_v1.json"),
+    )
+    .expect("parse trace_v1.json");
+    validate_trace_event_envelope_v1(&trace_v1).expect("trace v1 must validate");
+    let event_types: Vec<TraceEventTypeV1> = trace_v1
+        .events
+        .iter()
+        .map(|event| event.event_type.clone())
+        .collect();
+    assert!(event_types.contains(&TraceEventTypeV1::RunStart));
+    assert!(event_types.contains(&TraceEventTypeV1::StepStart));
+    assert!(event_types.contains(&TraceEventTypeV1::StepEnd));
+    assert!(event_types.contains(&TraceEventTypeV1::RunEnd));
 
     let resume =
         load_resume_state(&run_dir.join("run.json"), &resolved).expect("load resume state");


### PR DESCRIPTION
## Summary
- add the Trace v1 schema and validation surface to the runtime branch
- export canonical logs/trace_v1.json artifacts from real run-state writing with explicit artifact refs
- add run-state persistence coverage proving the new Trace v1 artifact is present and validates

Closes #1294