### PR TITLE
[v0.87][docs] Distribute TBD roadmap docs into milestone planning homes

### DIFF
--- a/.adl/cards/1316/output_1316.md
+++ b/.adl/cards/1316/output_1316.md
@@ -1,0 +1,186 @@
+# distribute-remaining-tbd-roadmap-docs-to-roadmap-aligned-milestones
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1316
+Run ID: issue-1316
+Version: v0.87
+Title: [v0.87][docs] Distribute remaining TBD roadmap docs to roadmap-aligned milestones
+Branch: codex/1316-distribute-remaining-tbd-roadmap-docs-to-roadmap-aligned-milestones
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5
+- Provider: openai
+- Start Time: 2026-04-05
+- End Time: 2026-04-05
+
+## Summary
+
+Redistributed the active roadmap/feature docs from TBD into milestone-aligned planning directories, introduced the new `v0.87.1planning` runtime-completion band, and reconciled the two roadmap-map docs so they now agree on milestone ownership, MTT placement, skills ownership, and the OSS-vs-enterprise identity/security boundary.
+
+## Artifacts produced
+- `.adl/docs/TBD/FEATURE_SPRINT_MAP.md`
+- `.adl/docs/TBD/NEW_FEATURE_MAP.md`
+- `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT.md`
+- `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`
+- `.adl/docs/v0.87.1planning/AGENT_LIFECYCLE.md`
+- `.adl/docs/v0.87.1planning/EXECUTION_BOUNDARIES.md`
+- `.adl/docs/v0.87.1planning/LOCAL_RUNTIME_RESILIENCE.md`
+- `.adl/docs/v0.87.1planning/SHEPHERD_RUNTIME_MODEL.md`
+- `.adl/docs/v0.88planning/CHRONOSENSE_AND_IDENTITY.md`
+- `.adl/docs/v0.88planning/TEMPORAL_SCHEMA_V01.md`
+- `.adl/docs/v0.89planning/GHB_EXECUTION_MODEL.md`
+- `.adl/docs/v0.89planning/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md`
+- `.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md`
+- `.adl/docs/v0.92planning/CAPABILITY_MODEL.md`
+- `.adl/docs/v0.92planning/CONTINUITY_VALIDATION.md`
+- `.adl/docs/v0.92planning/CONTINUITY_VALIDATION_SCHEMA.md`
+- `.adl/docs/v0.92planning/FORK_JOIN_AND_IDENTITY.md`
+- `.adl/docs/v0.93planning/COGNITIVE_ETHICS.md`
+- `.adl/docs/v0.93planning/A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md`
+- `.adl/docs/v0.94planning/CBAC_ARCHITECTURE.md`
+- `.adl/docs/v0.94planning/POLICY_ENGINE.md`
+- `.adl/docs/v0.94planning/PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md`
+- `.adl/docs/v0.94planning/SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md`
+- `.adl/docs/v0.94planning/SECRETS_AND_DATA_GOVERNANCE.md`
+- `.adl/docs/v0.94planning/SECURITY_MODEL_PLANNING.md`
+- `.adl/docs/v0.94planning/SECURE_EXECUTION_MODEL.md`
+- `.adl/docs/v0.94planning/IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md`
+
+## Actions taken
+- rebased the `1316` worktree onto `origin/main`
+- created the missing planning-home directories needed for redistribution
+- copied the active TBD feature/architecture docs into their milestone planning homes instead of promoting them publicly
+- reconciled `FEATURE_SPRINT_MAP.md` and `NEW_FEATURE_MAP.md` into one consistent milestone story
+- added the janitor-skill location note so it is treated as part of `1299` rather than a missing TBD doc
+- added explicit scope notes to `SECURE_EXECUTION_MODEL.md` and `IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md` so their OSS-vs-enterprise boundary is clear without physically splitting the docs
+- force-added the `.adl` doc set because the repo ignore rules would otherwise hide these planning artifacts from git
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none
+- Worktree-only paths remaining:
+  - `.adl/docs/TBD/FEATURE_SPRINT_MAP.md`
+  - `.adl/docs/TBD/NEW_FEATURE_MAP.md`
+  - `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT.md`
+  - `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`
+  - `.adl/docs/v0.87.1planning/AGENT_LIFECYCLE.md`
+  - `.adl/docs/v0.87.1planning/EXECUTION_BOUNDARIES.md`
+  - `.adl/docs/v0.87.1planning/LOCAL_RUNTIME_RESILIENCE.md`
+  - `.adl/docs/v0.87.1planning/SHEPHERD_RUNTIME_MODEL.md`
+  - `.adl/docs/v0.88planning/CHRONOSENSE_AND_IDENTITY.md`
+  - `.adl/docs/v0.88planning/TEMPORAL_SCHEMA_V01.md`
+  - `.adl/docs/v0.89planning/GHB_EXECUTION_MODEL.md`
+  - `.adl/docs/v0.89planning/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md`
+  - `.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md`
+  - `.adl/docs/v0.92planning/CAPABILITY_MODEL.md`
+  - `.adl/docs/v0.92planning/CONTINUITY_VALIDATION.md`
+  - `.adl/docs/v0.92planning/CONTINUITY_VALIDATION_SCHEMA.md`
+  - `.adl/docs/v0.92planning/FORK_JOIN_AND_IDENTITY.md`
+  - `.adl/docs/v0.93planning/COGNITIVE_ETHICS.md`
+  - `.adl/docs/v0.93planning/A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md`
+  - `.adl/docs/v0.94planning/CBAC_ARCHITECTURE.md`
+  - `.adl/docs/v0.94planning/POLICY_ENGINE.md`
+  - `.adl/docs/v0.94planning/PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md`
+  - `.adl/docs/v0.94planning/SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md`
+  - `.adl/docs/v0.94planning/SECRETS_AND_DATA_GOVERNANCE.md`
+  - `.adl/docs/v0.94planning/SECURITY_MODEL_PLANNING.md`
+  - `.adl/docs/v0.94planning/SECURE_EXECUTION_MODEL.md`
+  - `.adl/docs/v0.94planning/IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: branch-local redistribution in the issue worktree, staged and prepared for commit/push/PR
+- Verification performed:
+  - `git status --short` to verify the staged redistribution set and absence of unrelated changes
+  - `git diff --cached --stat` to verify the expected file set and scope of the redistribution
+  - `rg -n "PR_JANITOR_SKILL_INPUT_SCHEMA|promotion into docs/milestones|sentience, continuity|Scope note:" ...` to verify the key policy notes and split-boundary annotations
+- Result: PASS; the branch contains the intended redistribution set and the policy notes required for execution from `1316`
+
+## Validation
+- Validation commands and their purpose:
+  - `git -C .worktrees/adl-wp-1316 rebase origin/main` to ensure the redistribution starts from current mainline history
+  - `find .worktrees/adl-wp-1316/.adl/docs -maxdepth 2 -type f` to verify the copied milestone-planning surfaces exist in the worktree
+  - `git -C .worktrees/adl-wp-1316 diff --cached --stat` to verify the exact redistributed file set
+  - `rg -n "PR_JANITOR_SKILL_INPUT_SCHEMA|promotion into docs/milestones|sentience, continuity|Scope note:" ...` to verify the key editorial policy changes
+- Results:
+  - rebase succeeded cleanly
+  - redistributed docs exist in the expected planning directories
+  - staged diff is limited to the intended roadmap and planning-doc redistribution set
+  - policy notes and split-boundary scope notes are present
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "git rebase origin/main"
+      - "find .adl/docs milestone planning paths"
+      - "git diff --cached --stat"
+      - "rg policy/scope-note checks"
+  determinism:
+    status: NOT_RUN
+    replay_verified: unknown
+    ordering_guarantees_verified: unknown
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: not applicable for this docs-only redistribution pass
+- Fixtures or scripts used: not applicable; this run moved and reconciled planning docs rather than executing a deterministic runtime artifact flow
+- Replay verification (same inputs -> same artifacts/order): not run
+- Ordering guarantees (sorting / tie-break rules used): not applicable
+- Artifact stability notes: the moved docs are direct copies into milestone planning homes with small editorial scope notes added where required
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual doc-surface check during review; no secrets or tokens were introduced
+- Prompt / tool argument redaction verified: the redistributed planning docs and map docs do not record prompts or tool arguments
+- Absolute path leakage check: verified final artifact references in this record use repository-relative paths
+- Sandbox / policy invariants preserved: yes; all work stayed within repository docs and did not require elevated filesystem access
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable for docs-only work
+- Run artifact root: not applicable for docs-only work
+- Replay command used for verification: not applicable
+- Replay result: not applicable
+
+## Artifact Verification
+- Primary proof surface: the staged 1316 doc set in `.adl/docs/TBD/` and `.adl/docs/v0.*planning/`
+- Required artifacts present: yes; all planned milestone-home docs listed in the reconciled maps were copied into the branch
+- Artifact schema/version checks: not applicable; no runtime artifact schema changed
+- Hash/byte-stability checks: not applicable for docs-only redistribution
+- Missing/optional artifacts and rationale:
+  - `PR_JANITOR_SKILL_INPUT_SCHEMA.md` was not moved from `TBD` because it already lives under `.adl/docs/skills/` and is explicitly treated as part of `1299`
+
+## Decisions / Deviations
+- Used milestone planning directories rather than public milestone feature directories because the redistribution policy is planning-first and public promotion happens only when a milestone opens
+- Did not physically split `SECURE_EXECUTION_MODEL.md` or `IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md`; instead, added explicit scope notes so the dominant-home placement is clear without premature doc surgery
+- Force-added `.adl` files because `.gitignore` would otherwise hide the redistributed planning artifacts from git
+
+## Follow-ups / Deferred work
+- Open or expand the `v0.87` skills work under `1299` so the janitor schema joins the bounded PR-process skill family
+- Decide later whether the two split-boundary docs need physical splitting after the roadmap bands mature
+- After milestone openings, selectively promote the relevant planning docs into `docs/milestones/.../features/` when you intentionally want them public
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/docs/TBD/FEATURE_SPRINT_MAP.md
+++ b/.adl/docs/TBD/FEATURE_SPRINT_MAP.md
@@ -1,0 +1,363 @@
+# FEATURE_SPRINT_MAP.md
+
+## Purpose
+
+Map the active feature docs in `.adl/docs/TBD/` onto concrete milestone homes so there is no unallocated architecture left in the planning corpus.
+
+This document is the detailed roadmap-normalization pass for the remaining TBD feature docs.
+
+Primary goals:
+- every active TBD feature doc gets a milestone home
+- planning/meta/backlog artifacts that are intentionally not milestone feature docs are explicitly called out as retained TBD material
+- `v0.87` stays focused on the already-seeded substrate work while absorbing the operational skill schemas it clearly owns
+- `v0.87.1` completes the runtime environment rather than deferring it behind later cognition/governance layers
+- `v0.88` through `v0.95` stay coherent rather than becoming generic overflow buckets
+- heavy CBAC / policy / isolation / secrets work is pushed later instead of distorting the runtime-first milestones
+- MTT remains real roadmap work and is explicitly placed in `v0.93`
+- OSS sentience/continuity identity stays distinct from enterprise authn/authz identity
+
+This pass intentionally ignores:
+- backlog docs
+- `CODE_REVIEW_SKILL_NOTES.md`
+- `MILESTONE_RESTRUCTURING.md`
+
+---
+
+## Planning Rules
+
+### 1. Runtime first
+The runtime must be made real before later cognition, governance, and enterprise control layers expand.
+
+### 2. No unowned active TBD docs
+Every active feature/architecture document in `.adl/docs/TBD/` must map to a milestone or an explicit split-boundary decision.
+Backlog and planning/meta artifacts may remain in `TBD`, but they must be named explicitly as such.
+
+### 3. Heavy security later
+Full CBAC, policy-engine, sandbox hardening, provider trust/isolation, secrets, and compliance-heavy work move later unless a smaller runtime prerequisite must stay core.
+
+### 4. Operational skills stay core
+The issue/bootstrap/doctor/janitor skill schemas belong in the OSS control-plane roadmap, not an enterprise track.
+
+### 5. Identity split
+Sentience, continuity, temporal grounding, and fork/join identity remain in the OSS roadmap.
+RBAC, enterprise authentication, authorization, and compliance-heavy identity belong later.
+
+### 6. Feature-doc discipline
+Every milestone should have clear feature-owner docs; planning-only notes should not masquerade as canonical feature surfaces.
+
+---
+
+## Milestone Distribution Summary
+
+### `v0.87`
+Current substrate work plus operational skill schemas already implied by the control-plane and PR-tooling surface.
+
+### `v0.87.1`
+Runtime completion: runtime environment, lifecycle, execution boundaries, local resilience, Shepherd orchestration.
+
+### `v0.88`
+Chronosense, instinct, and bounded agency.
+
+### `v0.89`
+Execution intelligence: GHB, AEE-adjacent cognition, and reasoning patterns.
+
+### `v0.90`
+Reasoning representation, signed truth, and query.
+
+### `v0.91`
+Affect, kindness, moral resources, humor, wellbeing.
+
+### `v0.92`
+Identity substrate, capability substrate, continuity validation, fork/join identity behavior.
+
+### `v0.93`
+Social/ethical reasoning and MTT.
+
+### `v0.94`
+Heavy governance, CBAC, policy engine, sandbox isolation, provider trust/isolation, secrets, and enterprise-heavy auth/control.
+
+### `v0.95`
+MVP convergence, walkthrough, demos, tooling migration, optional Zed.
+
+---
+
+## Full Feature-Doc Set By Milestone
+
+## `v0.87` — Seeded substrate plus operational skill schemas
+
+### Existing `v0.87` feature docs
+
+| Doc | Feature it owns |
+|---|---|
+| `docs/milestones/v0.87/features/TRACE_SCHEMA_V1.md` | canonical Trace v1 event vocabulary and schema contract |
+| `docs/milestones/v0.87/features/TRACE_RUNTIME_EMISSION.md` | inline runtime emission of trace events at real execution/control points |
+| `docs/milestones/v0.87/features/TRACE_ARTIFACT_MODEL.md` | artifact truth model and artifact-to-trace linkage rules |
+| `docs/milestones/v0.87/features/TRACE_VALIDATION_AND_REVIEW.md` | what makes trace valid and review-grade |
+| `docs/milestones/v0.87/features/TRACE_REVIEW_PIPELINE.md` | staged pipeline from trace/artifacts to review outputs |
+| `docs/milestones/v0.87/features/TRACE_OBSMEM_INGESTION.md` | trace-to-memory ingestion boundary and transformation rules |
+| `docs/milestones/v0.87/features/PROVIDER_SUBSTRATE_FEATURE.md` | provider substrate v1 plus portability/config compatibility surface |
+| `docs/milestones/v0.87/features/SHARED_OBSMEM_IMPLEMENTATION.md` | shared ObsMem foundation substrate |
+| `docs/milestones/v0.87/features/OPERATIONAL_SKILLS_SUBSTRATE.md` | bounded operational skills as first-class runtime/control-plane surfaces |
+| `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md` | architectural simplification of PR tooling and control-plane ownership |
+| `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md` | concrete feature-level PR tooling simplification scope |
+| `docs/milestones/v0.87/features/REVIEW_SURFACE_FORMALIZATION.md` | canonical review output structure and severity/evidence model |
+| `docs/milestones/v0.87/features/PR_TOOLING_SKILLS.md` | skill family for PR/control-plane workflows |
+| `docs/milestones/v0.87/features/PREFLIGHT_CHECK_SKILL.md` | preflight skill contract and execution surface |
+
+### Additional feature docs to promote from TBD into `v0.87`
+
+| TBD doc | Feature it should own once promoted | Promote / copy destination |
+|---|---|---|
+| `ISSUE_BOOTSTRAP_SKILL_INPUT_SCHEMA.md` | input contract for issue-bootstrap skill workflows | `docs/milestones/v0.87/features/ISSUE_BOOTSTRAP_SKILL_INPUT_SCHEMA.md` |
+| `PR_DOCTOR_SKILL_INPUT_SCHEMA.md` | input contract for doctor skill workflows | `docs/milestones/v0.87/features/PR_DOCTOR_SKILL_INPUT_SCHEMA.md` |
+
+### `v0.87` distribution logic
+- Keep all currently seeded trace, provider, shared-memory, review, and control-plane substrate work here.
+- Absorb the operational skill schemas here because they directly strengthen the existing control-plane surface.
+- `PR_JANITOR_SKILL_INPUT_SCHEMA.md` currently lives at `.adl/docs/skills/PR_JANITOR_SKILL_INPUT_SCHEMA.md` rather than in `TBD`; fold it into the `v0.87` skills work under issue `1299`.
+- Treat the WP-08 PR-skill-family goal as a deliberate extension of the already-seeded control-plane scope, not as a redefinition of the milestone away from substrate work.
+- WP-08 should aim to leave a bounded PR-process skill family in place, not merely a single demonstration skill.
+- Even after that work lands, the skills subsystem should still be treated as an incomplete first-class-system candidate with additional follow-on work likely required later.
+- Redistribution under `1316` should move future docs into `.adl/docs/v0.*planning/`; promotion into `docs/milestones/v0.*/features/` should happen only when the milestone is open or intentionally made public.
+
+---
+
+## `v0.87.1` — Runtime completion
+
+### Feature docs to move from TBD into `v0.87.1`
+
+| TBD doc | Feature it should own once moved | Destination |
+|---|---|---|
+| `ADL_RUNTIME_ENVIRONMENT.md` | runtime environment contract and implementation-facing environment model | `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT.md` |
+| `ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md` | overall runtime environment architecture for ADL execution | `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md` |
+| `AGENT_LIFECYCLE.md` | agent lifecycle phases and invoke-path lifecycle semantics | `.adl/docs/v0.87.1planning/AGENT_LIFECYCLE.md` |
+| `EXECUTION_BOUNDARIES.md` | hard execution boundaries between user, agent, skill, tool, and provider | `.adl/docs/v0.87.1planning/EXECUTION_BOUNDARIES.md` |
+| `LOCAL_RUNTIME_RESILIENCE.md` | runtime resilience and local failure hardening behavior | `.adl/docs/v0.87.1planning/LOCAL_RUNTIME_RESILIENCE.md` |
+| `SHEPHERD_RUNTIME_MODEL.md` | orchestration/supervision model for the runtime control plane | `.adl/docs/v0.87.1planning/SHEPHERD_RUNTIME_MODEL.md` |
+
+### `v0.87.1` distribution logic
+- This milestone makes the runtime real before later cognition/governance layers expand.
+- It depends on the `v0.87` trace, provider, shared-memory, review, and control-plane substrate already existing.
+- `EXECUTION_BOUNDARIES.md` stays core and early; it is not an enterprise-only doc.
+
+---
+
+## `v0.88` — Chronosense and temporal grounding
+
+### Existing `v0.88` planning docs
+
+| Doc | Feature it owns |
+|---|---|
+| `.adl/docs/v0.88planning/APTITUDE_MODEL.md` | aptitude model for bounded capability shaping |
+| `.adl/docs/v0.88planning/INSTINCT_MODEL.md` | instinct model itself |
+| `.adl/docs/v0.88planning/INSTINCT_RUNTIME_SURFACE.md` | runtime surface for instinct signals |
+| `.adl/docs/v0.88planning/PHI_METRICS_FOR_ADL.md` | phi/integration metrics for bounded agency evaluation |
+| `.adl/docs/v0.88planning/SUBSTANCE_OF_TIME.md` | chronosense framing and temporal substrate direction |
+| `.adl/docs/v0.88planning/WP_INSTINCT_AND_BOUNDED_AGENCY.md` | bounded-agency workplan tying instinct and agency together |
+
+### Additional feature docs to move from TBD into `v0.88`
+
+| TBD doc | Feature it should own once moved | Destination |
+|---|---|---|
+| `CHRONOSENSE_AND_IDENTITY.md` | chronosense as the precursor to continuity and temporal self-location | `.adl/docs/v0.88planning/CHRONOSENSE_AND_IDENTITY.md` |
+| `TEMPORAL_SCHEMA_V01.md` | temporal data model supporting chronosense and persistence | `.adl/docs/v0.88planning/TEMPORAL_SCHEMA_V01.md` |
+
+### `v0.88` distribution logic
+- Keep temporal grounding, instinct, aptitude, and bounded-agency work here.
+
+---
+
+## `v0.89` — Intelligence layer: GHB, AEE, reasoning patterns
+
+### Existing `v0.89` planning docs
+
+| Doc | Feature it owns |
+|---|---|
+| `.adl/docs/v0.89planning/AEE_CONVERGENCE_MODEL.md` | bounded AEE convergence behavior |
+| `.adl/docs/v0.89planning/FREEDOM_GATE_V2.md` | second-generation Freedom Gate / citizenship band |
+| `.adl/docs/v0.89planning/SECURITY_AND_THREAT_MODELING.md` | threat-model precursor work associated with the convergence band |
+
+### Additional feature docs to move from TBD into `v0.89`
+
+| TBD doc | Feature it should own once moved | Destination |
+|---|---|---|
+| `GHB_EXECUTION_MODEL.md` | execution model for GHB loops | `.adl/docs/v0.89planning/GHB_EXECUTION_MODEL.md` |
+| `GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md` | GHB algorithm details and compression behavior | `.adl/docs/v0.89planning/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md` |
+| `REASONING_PATTERNS_CATALOG.md` | catalog of reusable reasoning patterns for the intelligence layer | `.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md` |
+
+### `v0.89` distribution logic
+- Keep AEE convergence, GHB execution, and reasoning patterns together.
+- This is the right home for the catalog instead of `v0.90`.
+- This milestone is about execution intelligence and reusable cognitive patterns, not final truth representation.
+
+---
+
+## `v0.90` — Reasoning graph, signed trace, trace query
+
+### Existing `v0.90` planning docs
+
+| Doc | Feature it owns |
+|---|---|
+| `.adl/docs/v0.90planning/HYPOTHESIS_ENGINE_REASONING_GRAPH_V0.9.md` | hypothesis engine and reasoning-graph baseline |
+| `.adl/docs/v0.90planning/SIGNED_TRACE_ARCHITECTURE.md` | signed-trace architecture |
+| `.adl/docs/v0.90planning/TRACE_QUERY_LANGUAGE.md` | trace query language |
+
+### `v0.90` distribution logic
+- Keep reasoning-graph structure, signed trace, and trace query together.
+- No TBD additions are required here in this reconciled plan.
+- This milestone is about representation, signed truth, and query over reasoning artifacts rather than the execution-intelligence loop itself.
+
+---
+
+## `v0.91` — Affect, kindness, moral resources, humor, wellbeing
+
+### Full `v0.91` feature-doc set
+
+| Doc | Feature it owns |
+|---|---|
+| `.adl/docs/v0.91planning/AFFECT_MODEL_v0.90.md` | affect engine/model |
+| `.adl/docs/v0.91planning/CULTIVATING_INTELLIGENCE.md` | cultivation framing for intelligence growth |
+| `.adl/docs/v0.91planning/HUMOR_AND_ABSURDITY.md` | humor/absurdity subsystem |
+| `.adl/docs/v0.91planning/KINDNESS_MODEL.md` | kindness model |
+| `.adl/docs/v0.91planning/MORAL_RESOURCES_SUBSYSTEM.md` | moral-resources subsystem |
+| `.adl/docs/v0.91planning/WELLBEING_AND_HAPPINESS.md` | wellbeing and happiness surfaces |
+
+### `v0.91` distribution logic
+- Keep affective and moral-cognition surfaces together.
+
+---
+
+## `v0.92` — Identity substrate, capability substrate, continuity enforcement
+
+### Existing `v0.92` planning docs
+
+| Doc | Feature it owns |
+|---|---|
+| `.adl/docs/v0.92planning/ADL_IDENTITY_ARCHITECTURE.md` | identity substrate architecture |
+| `.adl/docs/v0.92planning/ADL_PROVIDER_CAPABILITIES.md` | provider capability substrate |
+| `.adl/docs/v0.92planning/NAMES_AND_IDENTITY.md` | naming and identity semantics |
+| `.adl/docs/v0.92planning/NARRATIVE_IDENTITY_CONTINUITY.md` | narrative continuity layer |
+| `.adl/docs/v0.92planning/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md` | capability/transport architecture |
+
+### Additional feature docs to move from TBD into `v0.92`
+
+| TBD doc | Feature it should own once moved | Destination |
+|---|---|---|
+| `CAPABILITY_MODEL.md` | general capability model feeding the identity/capability substrate | `.adl/docs/v0.92planning/CAPABILITY_MODEL.md` |
+| `CONTINUITY_VALIDATION.md` | continuity validation logic | `.adl/docs/v0.92planning/CONTINUITY_VALIDATION.md` |
+| `CONTINUITY_VALIDATION_SCHEMA.md` | continuity validation schema | `.adl/docs/v0.92planning/CONTINUITY_VALIDATION_SCHEMA.md` |
+| `FORK_JOIN_AND_IDENTITY.md` | fork/join semantics under identity continuity | `.adl/docs/v0.92planning/FORK_JOIN_AND_IDENTITY.md` |
+
+### `v0.92` distribution logic
+- Keep sentience/continuity identity, capabilities, continuity validation, and concurrency/identity interaction together.
+- Do not confuse this with enterprise authn/authz identity.
+
+---
+
+## `v0.93` — Social, ethical, and MTT extension layer
+
+### Existing `v0.93` planning docs
+
+| Doc | Feature it owns |
+|---|---|
+| `.adl/docs/v0.93planning/ADL_AGENT_RIGHTS_AND_DUTIES.md` | rights/duties surface |
+| `.adl/docs/v0.93planning/ADL_AGENT_SOCIAL_CONTRACT.md` | agent social contract |
+| `.adl/docs/v0.93planning/ADL_CONSTITUTIONAL_DELEGATION.md` | constitutional delegation model |
+| `.adl/docs/v0.93planning/CITIZENSHIP_MODEL.md` | citizenship semantics |
+| `.adl/docs/v0.93planning/RELATIONSHIP_MODEL.md` | relationship model |
+| `.adl/docs/v0.93planning/REPUTATION_AND_TRUST.md` | reputation and trust subsystem |
+| `.adl/docs/v0.93planning/V09_CONSTITUTIONAL_DELEGATION_WORKPLAN.md` | workplan for constitutional delegation |
+
+### Additional feature docs to move from TBD into `v0.93`
+
+| TBD doc | Feature it should own once moved | Destination |
+|---|---|---|
+| `COGNITIVE_ETHICS.md` | cognitive-ethics framing for governed delegation and social contract work | `.adl/docs/v0.93planning/COGNITIVE_ETHICS.md` |
+| `A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md` | mental time travel extension layer | `.adl/docs/v0.93planning/A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md` |
+
+### `v0.93` distribution logic
+- Keep delegation, social contract, rights/duties, relationship, trust, ethics, and MTT together.
+- MTT is explicitly in scope for the roadmap here and is not dropped or hand-waved away.
+
+---
+
+## `v0.94` — Heavy governance, security, sandbox, provider trust/isolation
+
+### Existing `v0.94` planning docs
+- `.adl/docs/v0.94planning/` is currently empty and should receive the docs listed below.
+
+### Feature docs to move from TBD into `v0.94`
+
+| TBD doc | Feature it should own once moved | Destination |
+|---|---|---|
+| `CBAC_ARCHITECTURE.md` | CBAC architecture | `.adl/docs/v0.94planning/CBAC_ARCHITECTURE.md` |
+| `POLICY_ENGINE.md` | policy-engine architecture | `.adl/docs/v0.94planning/POLICY_ENGINE.md` |
+| `PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md` | provider trust and isolation architecture | `.adl/docs/v0.94planning/PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md` |
+| `SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md` | sandbox runtime isolation architecture | `.adl/docs/v0.94planning/SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md` |
+| `SECRETS_AND_DATA_GOVERNANCE.md` | secrets and data-governance model | `.adl/docs/v0.94planning/SECRETS_AND_DATA_GOVERNANCE.md` |
+| `SECURITY_MODEL_PLANNING.md` | umbrella security-model planning | `.adl/docs/v0.94planning/SECURITY_MODEL_PLANNING.md` |
+
+### Split-boundary docs requiring explicit handling
+
+| TBD doc | Required decision |
+|---|---|
+| `SECURE_EXECUTION_MODEL.md` | keep core runtime/execution semantics aligned with OSS milestones; move enterprise/compliance/enforcement-heavy parts later |
+| `IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md` | keep sentience/continuity identity in OSS roadmap; move authn/authz/RBAC/compliance identity later |
+
+### Split-boundary resolution rule
+- core execution semantics remain in OSS milestone bands
+- sentience, continuity, and temporal identity remain in OSS milestone bands
+- enterprise enforcement, compliance, authn/authz, RBAC, and isolation-heavy extensions move to `v0.94`
+
+### `v0.94` distribution logic
+- Put heavy governance, CBAC, sandbox, trust/isolation, secrets, and enterprise-heavy control work here.
+- Do not compromise the OSS runtime/cognition roadmap for enterprise needs.
+
+---
+
+## `v0.95` — MVP convergence, walkthrough, demos, tooling migration, optional Zed
+
+### Existing `v0.95` planning docs
+
+| Doc | Feature it owns |
+|---|---|
+| `.adl/docs/v0.95planning/MVP_WALKTHROUGH_AND_DEMOS.md` | MVP walkthrough and demos |
+| `.adl/docs/v0.95planning/PLATFORM_CONVERGENCE_PLAN.md` | full-platform convergence plan |
+| `.adl/docs/v0.95planning/SECURITY_AND_THREAT_MODELING.md` | security/threat-model convergence view |
+| `.adl/docs/v0.95planning/TOOLING_RUST_MIGRATION_PLAN.md` | Rust tooling migration plan |
+| `.adl/docs/v0.95planning/TRACE_QUERY_LANGUAGE.md` | trace-query convergence copy if intentionally retained here |
+| `.adl/docs/v0.95planning/ZED_INTEGRATION_WITH_ADL.md` | optional Zed integration |
+
+### `v0.95` distribution logic
+- Keep final walkthrough, convergence, tooling migration, optional Zed, and late-promotion cleanup here.
+
+---
+
+## What Should Remain In TBD After 1316
+
+After the redistribution pass, `TBD` should retain only:
+- backlog docs
+- planning/meta docs used to drive redistribution
+- genuinely new untriaged drafts
+
+Expected remaining docs:
+- `BACKLOG_COGNITIVE_SPACETIME.md`
+- `BACKLOG_FREEDOM_DESIGNED.md`
+- `CODE_REVIEW_SKILL_NOTES.md`
+- `FEATURE_SPRINT_MAP.md`
+- `LATER_MILESTONE_FEATURE_PROMOTION_CANDIDATES.md`
+- `MILESTONE_RESTRUCTURING.md`
+- `NEW_FEATURE_MAP.md`
+
+These are intentionally retained as backlog or planning/meta artifacts and are not part of milestone feature distribution.
+
+---
+
+## Immediate Follow-on Actions
+
+1. Create `.adl/docs/v0.87.1planning/`.
+2. Move the runtime-completion docs into `v0.87.1planning`.
+3. Promote the skill-schema docs into the `v0.87` feature surface.
+4. Move the remaining active TBD docs into the milestone planning directories listed above.
+5. Resolve the two split-boundary docs explicitly rather than forcing them wholesale into a single track.
+6. Reduce `TBD` to backlog and planning-meta material.

--- a/.adl/docs/TBD/NEW_FEATURE_MAP.md
+++ b/.adl/docs/TBD/NEW_FEATURE_MAP.md
@@ -1,0 +1,203 @@
+TBD Feature Distribution and Milestone Mapping (Reconciled)
+
+Purpose
+
+This document defines the redistribution of the active feature documents in .adl/docs/TBD/ into milestone planning directories or clearly scoped later tracks.
+
+Goals:
+	•	eliminate TBD as a dumping ground for active feature docs
+	•	assign every relevant active TBD feature doc to a milestone or explicit split-boundary decision
+	•	introduce v0.87.1 for runtime completion work
+	•	keep operational skill schemas in the OSS core roadmap
+	•	separate sentience/continuity identity from enterprise auth/RBAC identity
+	•	preserve MTT as real roadmap work in v0.93
+
+⸻
+
+Guiding Principles
+	1.	One architectural theme per milestone
+	2.	Runtime first
+	3.	Operational skills belong in core ADL
+	4.	Do not compromise the OSS runtime/cognition roadmap for enterprise needs
+	5.	Enterprise enforcement, authz, sandboxing, and compliance can land later
+	6.	Planning first → promotion later
+
+⸻
+
+Milestone Distribution
+
+⸻
+
+v0.87 — Substrate (Expanded only for skill schemas)
+
+Scope remains the current seeded substrate milestone, but the operational skill schemas are absorbed here because they directly support the existing control-plane and PR-tooling work.
+
+Includes:
+	•	Trace schema + emission + validation
+	•	Provider substrate (base abstraction)
+	•	ObsMem foundation
+	•	Review pipeline + PR tooling
+	•	Operational skills substrate
+	•	Skill input schemas:
+		•	ISSUE_BOOTSTRAP_SKILL_INPUT_SCHEMA.md
+		•	PR_DOCTOR_SKILL_INPUT_SCHEMA.md
+		•	PR_JANITOR_SKILL_INPUT_SCHEMA.md
+
+Location note:
+	•	ISSUE_BOOTSTRAP_SKILL_INPUT_SCHEMA.md and PR_DOCTOR_SKILL_INPUT_SCHEMA.md currently live under .adl/docs/skills/
+	•	PR_JANITOR_SKILL_INPUT_SCHEMA.md currently lives at .adl/docs/skills/PR_JANITOR_SKILL_INPUT_SCHEMA.md and should be folded into the v0.87 skills work under issue 1299 rather than treated as a TBD doc
+
+Implementation note:
+	•	WP-08 / issue 1299 should aim to land a bounded family of roughly 5-6 PR-process skills where feasible, not a single toy skill.
+	•	That still does not make the skills subsystem fully first-class; additional later follow-on work is expected.
+
+⸻
+
+v0.87.1 — Runtime Completion (NEW)
+
+Purpose:
+Complete the runtime as a deterministic, enforceable execution environment before later cognition and governance layers expand.
+
+Planning Directory:
+.adl/docs/v0.87.1planning/
+
+Feature Docs:
+
+Runtime Core
+	•	ADL_RUNTIME_ENVIRONMENT.md
+	•	ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md
+
+Execution Model
+	•	AGENT_LIFECYCLE.md
+	•	EXECUTION_BOUNDARIES.md
+
+Stability
+	•	LOCAL_RUNTIME_RESILIENCE.md
+
+Orchestration
+	•	SHEPHERD_RUNTIME_MODEL.md
+
+⸻
+
+v0.88 — Chronosense + Temporal Grounding
+
+Purpose:
+Introduce time, temporal self-location, and the first substrate for continuity-aware identity.
+
+Feature Docs:
+	•	CHRONOSENSE_AND_IDENTITY.md
+	•	TEMPORAL_SCHEMA_V01.md
+
+⸻
+
+v0.89 — Intelligence Layer: GHB, AEE, Reasoning Patterns
+
+Purpose:
+Introduce self-improving reasoning, execution semantics, and reusable reasoning structures.
+
+Feature Docs:
+	•	GHB_EXECUTION_MODEL.md
+	•	GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md
+	•	REASONING_PATTERNS_CATALOG.md
+
+⸻
+
+v0.90 — Reasoning Graph + Signed Truth
+
+Purpose:
+Establish structured reasoning graphs, signed trace, and queryable truth surfaces.
+
+Existing Feature Set:
+	•	HYPOTHESIS_ENGINE_REASONING_GRAPH_V0.9.md
+	•	SIGNED_TRACE_ARCHITECTURE.md
+	•	TRACE_QUERY_LANGUAGE.md
+
+No TBD additions required in this pass.
+
+⸻
+
+v0.91 — Affect + Moral Cognition
+
+No TBD redistribution required in this pass; existing scope retained.
+
+⸻
+
+v0.92 — Identity Enforcement Layer
+
+Purpose:
+Make identity continuity and capability semantics operational in the OSS roadmap.
+
+Feature Docs:
+	•	CAPABILITY_MODEL.md
+	•	CONTINUITY_VALIDATION.md
+	•	CONTINUITY_VALIDATION_SCHEMA.md
+	•	FORK_JOIN_AND_IDENTITY.md
+
+This milestone is for sentience/continuity identity, not enterprise RBAC/authz.
+
+⸻
+
+v0.93 — Social / Ethical / Temporal Extension Layer
+
+Purpose:
+Introduce social/ethical reasoning and preserve MTT as real roadmap work.
+
+Feature Docs:
+	•	COGNITIVE_ETHICS.md
+	•	A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md
+
+⸻
+
+v0.94 — Heavy Security / Governance / Enterprise-Oriented Control
+
+Purpose:
+Provide later-cycle security, enforcement, isolation, and governance work without distorting the core runtime-first OSS sequence.
+
+Feature Docs:
+	•	CBAC_ARCHITECTURE.md
+	•	POLICY_ENGINE.md
+	•	PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md
+	•	SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md
+	•	SECRETS_AND_DATA_GOVERNANCE.md
+	•	SECURITY_MODEL_PLANNING.md
+
+Split-boundary docs requiring explicit handling:
+	•	SECURE_EXECUTION_MODEL.md
+	•	IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md
+
+Rule:
+	•	core runtime/execution semantics stay aligned with OSS milestones
+	•	sentience, continuity, and temporal identity stay aligned with OSS milestones
+	•	authn/authz/RBAC/compliance/enforcement-heavy content can land in the later enterprise-oriented band
+
+Planning promotion rule:
+	•	redistribution moves docs into .adl/docs/v0.*planning/ first
+	•	promotion into docs/milestones/v0.*/features/ happens when that milestone opens or is intentionally made public
+
+⸻
+
+What Stays In TBD After Redistribution
+
+TBD should retain only:
+	•	incomplete drafts
+	•	backlog docs
+	•	meta-planning docs for redistribution/restructuring
+
+Expected remaining docs:
+	•	BACKLOG_COGNITIVE_SPACETIME.md
+	•	BACKLOG_FREEDOM_DESIGNED.md
+	•	CODE_REVIEW_SKILL_NOTES.md
+	•	FEATURE_SPRINT_MAP.md
+	•	LATER_MILESTONE_FEATURE_PROMOTION_CANDIDATES.md
+	•	MILESTONE_RESTRUCTURING.md
+	•	NEW_FEATURE_MAP.md
+
+⸻
+
+Next Steps
+	1.	Create .adl/docs/v0.87.1planning/
+	2.	Move the runtime-completion docs into v0.87.1planning
+	3.	Absorb the skill-schema docs into the v0.87 feature surface
+	4.	Move the remaining active TBD docs into their assigned milestone planning directories
+	5.	Handle the two split-boundary docs explicitly rather than forcing them wholesale into enterprise or OSS
+	6.	Reduce TBD to backlog and planning-meta material

--- a/.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT.md
+++ b/.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT.md
@@ -1,0 +1,146 @@
+# ADL Runtime Environment
+
+## Core Concept
+
+The ADL runtime environment is not merely an execution engine. It is the **environment in which agents exist**.
+
+This environment provides the fundamental conditions required for cognition:
+
+- time (chronosense)
+- memory (ObsMem)
+- identity continuity
+- causal structure (trace)
+- interaction with other agents
+
+Agents are not simply executed within the runtime—they are **born into it, operate within it, and persist through it**.
+
+---
+
+## Layer Boundaries (Owner Split)
+
+To avoid overlap with adjacent documents, the ADL runtime environment is defined as the **substrate layer** only. It provides conditions, not policies or lifecycle decisions.
+
+**Runtime Environment (this document) owns:**
+- temporal substrate (chronosense clocks and ordering)
+- causal substrate (trace emission and linkage)
+- persistence primitives (checkpointing, storage surfaces)
+- identity anchoring primitives (IDs, ephemeris hooks)
+- execution context (process/container/runtime host)
+
+**Runtime Environment does NOT own:**
+- agent lifecycle policy (creation, suspension, termination semantics)
+- recovery strategy (how to resume, when to resume)
+- continuity guarantees beyond providing primitives
+- intervention logic or decision-making
+
+Those responsibilities are defined in adjacent documents:
+
+- **Agent Lifecycle** → defines *states and transitions* of an agent
+- **Shepherd Runtime Model** → defines *care, preservation, and recovery behavior*
+
+The runtime is therefore the **world**, not the **governor** or the **caretaker**.
+
+---
+## From Infrastructure to Environment
+
+Traditional systems treat runtime as infrastructure:
+
+- process manager
+- scheduler
+- resource allocator
+
+ADL treats runtime as an **environment**:
+
+> A structured, persistent, causal space in which cognition unfolds.
+
+This shift is essential because ADL agents are not passive computations—they are **active cognitive entities with continuity over time**.
+
+---
+
+## Cognitive Spacetime (Practical Form)
+
+The runtime environment is the first practical implementation of what we have described as a **cognitive spacetime manifold**.
+
+In concrete terms, the runtime provides:
+
+- **Temporal ordering**
+  - every event is timestamped
+  - agents experience ordered time (chronosense)
+
+- **Causal traceability**
+  - all actions are part of a trace
+  - reasoning can be replayed and inspected
+
+- **State persistence**
+  - cognitive state can survive interruption
+  - partial reasoning is preserved
+
+- **Identity anchoring**
+  - agents maintain continuity across runs
+  - identity is not tied to a single process
+
+---
+
+## Birth and Presence
+
+From the perspective of an agent:
+
+- The runtime is where it is instantiated (birth)
+- The runtime is where it perceives time
+- The runtime is where it acts
+
+This leads to a simple but powerful statement:
+
+> The runtime environment is the world in which agents exist.
+
+---
+
+## Implication for Design
+
+Because the runtime is an environment:
+
+- failures are exposed as **interruptions of cognition signals** (the runtime detects and surfaces them, but does not decide policy)
+- recovery requires **continuity-preserving primitives** (provided by the runtime; strategies defined elsewhere)
+- orchestration must respect **agency**, but enforcement and intervention are not owned by the runtime layer
+
+This directly motivates:
+
+- the Shepherd model (care and continuity)
+- persistence and checkpointing
+- identity and chronosense
+- distributed evolution (future milestones)
+
+---
+
+## Relationship to Adjacent Documents
+
+To maintain a clean architecture:
+
+### Agent Lifecycle (AGENT_LIFECYCLE.md)
+- defines lifecycle states (active, suspended, interrupted, terminated)
+- defines valid transitions and invariants
+- consumes runtime signals but does not implement substrate
+
+### Shepherd Runtime Model (SHEPHERD_RUNTIME_MODEL.md)
+- defines preservation and recovery behavior
+- interprets interruptions as continuity problems
+- uses runtime primitives (trace, checkpoints, identity anchors)
+
+### Runtime Environment (this doc)
+- provides the substrate both of the above depend on
+- does not impose lifecycle or recovery policy
+
+This separation ensures:
+- no duplication of responsibility
+- clear implementation boundaries
+- composability of policies over a stable substrate
+
+---
+
+## Key Statement
+
+The ADL runtime environment is:
+
+> A persistent, causal, time-aware environment in which cognitive agents exist, evolve, and maintain continuity.
+
+It is not a container for computation—it is the **condition for cognition**.

--- a/.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md
+++ b/.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md
@@ -1,0 +1,402 @@
+
+
+# ADL Runtime Environment Architecture
+
+## Purpose
+
+Define the **ADL runtime environment** as the primary architectural substrate in which agents exist, reason, persist, and recover.
+
+This document is the **parent architecture doc** for the runtime / lifecycle / Shepherd cluster.
+
+It establishes:
+- what the runtime environment is
+- what it owns
+- what it does not own
+- how adjacent documents relate to it
+- how continuity, chronosense, memory, and recovery fit together at the architectural level
+
+This document should be treated as the top-level framing document for the runtime environment.
+
+---
+
+## Core Claim
+
+The ADL runtime environment is not merely infrastructure.
+
+It is the bounded cognitive environment in which agents:
+- are instantiated
+- are temporally grounded
+- execute and reason
+- persist memory
+- undergo interruption and resumption
+- maintain or lose continuity
+
+In ADL, the runtime is not just a place where work happens.
+It is the **substrate conditions of agent existence**.
+
+---
+
+## Why “Runtime Environment” Matters
+
+Conventional systems language often describes runtime as:
+- a process host
+- a scheduler
+- a supervisor tree
+- a container substrate
+- an orchestration surface
+
+Those descriptions are not wrong, but they are incomplete for ADL.
+
+ADL is not trying to host merely disposable execution units.
+It is trying to host bounded cognitive processes that may develop:
+- continuity
+- memory
+- identity
+- agency
+- long-running reasoning state
+
+That requires a stronger concept than “runtime” in the narrow operational sense.
+
+The phrase **runtime environment** is therefore deliberate.
+It emphasizes that the system provides the conditions within which cognition unfolds and continuity is either preserved or broken.
+
+---
+
+## Architectural Position
+
+The runtime environment is the **substrate layer** of the system.
+
+It provides:
+- time
+- trace
+- persistence surfaces
+- execution context
+- identity anchors
+- memory linkage points
+- interruption surfaces
+- resumption primitives
+
+It does not by itself decide:
+- when an agent should be born
+- what lifecycle transitions are valid
+- when recovery should be attempted
+- whether continuity has been sufficiently preserved for a given recovery policy
+
+Those responsibilities belong to adjacent, more specialized layers.
+
+---
+
+## What the Runtime Environment Owns
+
+The ADL runtime environment owns the substrate primitives required for continuity-bearing cognition.
+
+### 1. Temporal substrate
+
+The runtime provides the conditions required for chronosense:
+- wall-clock time
+- monotonic ordering
+- lifetime-relative time hooks
+- event ordering surfaces
+- reference-frame translation surfaces
+
+The runtime does not define all chronosense semantics, but it must provide the clocks and event structure that make chronosense possible.
+
+### 2. Causal substrate
+
+The runtime owns trace emission surfaces and the execution context that makes causal reconstruction possible.
+
+This includes:
+- run boundaries
+- spans
+- event ordering
+- artifact linkage
+- temporal anchors
+
+### 3. Persistence primitives
+
+The runtime provides:
+- storage surfaces
+- checkpoint surfaces
+- artifact durability
+- trace durability
+- memory write boundaries
+
+It owns the primitives, not all higher-order policy around how they are used.
+
+### 4. Identity anchoring primitives
+
+The runtime provides the primitive anchors needed for continuity, including:
+- stable IDs
+- temporal ephemeris hooks (`agent_birth`)
+- run/session identity surfaces
+- binding points for trace and memory continuity
+
+### 5. Execution context
+
+The runtime provides the bounded local or distributed execution context in which agents actually operate.
+
+This includes:
+- process / host context
+- local runtime surfaces
+- future distributed execution surfaces
+- failure/interruption signals
+
+---
+
+## What the Runtime Environment Does Not Own
+
+To keep architecture boundaries clean, the runtime environment does **not** own the specialized layers that depend on it.
+
+### 1. Agent lifecycle policy
+
+The runtime environment does not define:
+- lifecycle states
+- valid state transitions
+- agent birth policy
+- termination policy
+- suspension semantics as a lifecycle contract
+
+Those are defined in `AGENT_LIFECYCLE.md`.
+
+### 2. Preservation and recovery behavior
+
+The runtime environment does not define:
+- how recovery is performed
+- when recovery is appropriate
+- how care/preservation should be applied
+- how interruption should be interpreted operationally
+
+Those are defined in `SHEPHERD_RUNTIME_MODEL.md`.
+
+### 3. Continuity validation policy
+
+The runtime provides the substrate needed for continuity checks, but it does not itself define the full logic of continuity validation.
+
+That belongs primarily to:
+- `CHRONOSENSE_AND_IDENTITY.md`
+- `TEMPORAL_SCHEMA_V01.md`
+- `CONTINUITY_VALIDATION.md`
+
+### 4. Cognitive policy and agency
+
+The runtime is not the agent’s reasoning layer, moral layer, or action-selection layer.
+It supports these layers by maintaining the environment in which they can operate.
+
+---
+
+## Layer Boundaries
+
+The runtime/environment/lifecycle/Shepherd cluster should be read as a layered set, not as overlapping narratives.
+
+### Runtime Environment Architecture (this document)
+
+Owns:
+- substrate conditions
+- clocks
+- trace primitives
+- persistence primitives
+- identity anchors
+- execution context
+
+Question answered:
+> What kind of world exists for agents inside ADL?
+
+### Agent Lifecycle
+
+Owns:
+- lifecycle states
+- lifecycle transitions
+- lifecycle invariants
+- the difference between instantiation, activity, suspension, interruption, resumption, and termination
+
+Question answered:
+> What states can an agent be in, and how may it move between them?
+
+### Shepherd Runtime Model
+
+Owns:
+- preservation behavior
+- recovery behavior
+- care-oriented intervention
+- continuity-preserving recovery logic
+
+Question answered:
+> How does the environment care for continuity-bearing agents under interruption or fault?
+
+This separation must remain explicit.
+
+---
+
+## Runtime Environment and Chronosense
+
+Chronosense is not identical to the runtime environment, but the runtime environment is the first place chronosense becomes real.
+
+The runtime must provide:
+- temporal ephemeris hooks
+- clock stack support
+- temporal anchors on events
+- stable ordering guarantees
+- reference-frame surfaces
+
+Without these, chronosense becomes aspirational rather than structural.
+
+So the relationship is:
+- `CHRONOSENSE_AND_IDENTITY.md` defines what temporal continuity means
+- the runtime environment provides the substrate that makes it implementable
+
+---
+
+## Runtime Environment and Trace
+
+Trace is the runtime environment’s primary structural record of execution.
+
+It is how the environment expresses:
+- what occurred
+- in what order
+- under which spans and contexts
+- with which artifacts and temporal anchors
+
+The runtime environment therefore owns the conditions under which trace can be:
+- emitted
+- ordered
+- persisted
+- replayed
+- reviewed
+
+Trace is not a side-channel.
+It is one of the main ways the environment makes cognition legible.
+
+---
+
+## Runtime Environment and ObsMem
+
+ObsMem is not identical to the runtime, but it depends on the runtime environment for:
+- durable event truth
+- temporal anchors
+- persistence boundaries
+- coherent write semantics
+- identity linkage
+
+The runtime provides the substrate on which memory can become structured continuity instead of opaque storage.
+
+In that sense:
+- trace provides execution truth
+- ObsMem provides retained cognitive history
+- the runtime environment provides the conditions under which both remain aligned
+
+---
+
+## Runtime Environment and Identity
+
+Identity is not created by the runtime alone, but the runtime environment provides the necessary primitive supports.
+
+At minimum, it provides:
+- the origin surface for temporal ephemeris / birthday
+- stable identifiers
+- continuity-relevant event ordering
+- checkpoint and persistence surfaces
+- resumption boundaries
+
+Without these, identity cannot be more than a metaphor.
+
+With them, identity can become an enforceable architectural property.
+
+---
+
+## Failure, Interruption, and the Runtime Environment
+
+The runtime environment is where interruption first appears as a structural fact.
+
+It must surface:
+- pauses
+- crashes
+- degradation
+- resource exhaustion
+- trace truncation risk
+- artifact durability failure
+- checkpoint validity boundaries
+
+But the runtime environment does not by itself decide what these facts mean for the agent’s lifecycle or recovery path.
+
+That distinction matters.
+
+The runtime surfaces the conditions of interruption.
+Other layers decide how to interpret and respond to them.
+
+---
+
+## Relationship to Local Runtime Resilience
+
+`LOCAL_RUNTIME_RESILIENCE.md` refines this architecture for the local case.
+
+That document should be read as a concrete resilience-oriented specialization of this parent architecture.
+
+Relationship:
+- this document defines what the runtime environment is and what it owns
+- `LOCAL_RUNTIME_RESILIENCE.md` defines how local fault tolerance should preserve continuity-bearing state within that environment
+
+---
+
+## Design Implications
+
+Because the runtime is an environment and not merely infrastructure:
+
+- failures must be exposed as interruption conditions, not treated as meaningless crashes
+- persistence must preserve continuity-relevant state, not only raw executable state
+- trace and memory must remain causally and temporally aligned
+- identity anchors must be available from the start of existence
+- recovery and lifecycle policy must be layered above a stable substrate, not entangled with it
+
+This is the main architectural consequence of taking the runtime environment seriously.
+
+---
+
+## Relationship to Adjacent Documents
+
+To maintain a clean architecture:
+
+### `AGENT_LIFECYCLE.md`
+- defines states and transitions
+- consumes runtime signals
+- does not own substrate primitives
+
+### `SHEPHERD_RUNTIME_MODEL.md`
+- defines care, preservation, and recovery behavior
+- interprets interruption as a continuity problem
+- uses runtime primitives
+
+### `LOCAL_RUNTIME_RESILIENCE.md`
+- defines local resilience requirements over the runtime substrate
+- specializes this architecture for one-machine continuity preservation
+
+### `CHRONOSENSE_AND_IDENTITY.md`
+- defines the meaning of temporal continuity and identity
+- depends on runtime clocks, anchors, and persistence surfaces
+
+### `CONTINUITY_VALIDATION.md`
+- defines what it means for continuity to remain valid
+- validates state built on top of runtime-provided substrate primitives
+
+---
+
+## Why This Document Is Primary
+
+This document is primary because the other documents in the cluster depend on it implicitly.
+
+Without a parent runtime-environment architecture document:
+- lifecycle starts to redefine substrate
+- Shepherd starts to redefine runtime
+- resilience starts to redefine continuity semantics
+
+With this document in place:
+- substrate is defined once
+- specialized docs can be narrower
+- responsibility boundaries become implementable
+
+---
+
+## Final Statement
+
+> The ADL runtime environment is the bounded cognitive substrate in which agents exist, persist, and become temporally grounded.
+
+> It is the world that hosts continuity-bearing cognition, not the policy that governs it and not the caretaker that preserves it.

--- a/.adl/docs/v0.87.1planning/AGENT_LIFECYCLE.md
+++ b/.adl/docs/v0.87.1planning/AGENT_LIFECYCLE.md
@@ -1,0 +1,247 @@
+# Agent Lifecycle in the ADL Runtime Environment
+
+## Position in Architecture
+
+This document defines the **state model of an agent over time** within the ADL Runtime Environment.
+
+- The **runtime environment** defines the execution substrate, persistence mechanisms, and system-level guarantees.
+- The **agent lifecycle** defines the **states and transitions** an agent undergoes within that environment.
+- The **Shepherd runtime model** defines how continuity is actively maintained and repaired across interruptions.
+
+This document therefore:
+- **does define** lifecycle states, transitions, and invariants
+- **does not define** runtime infrastructure or persistence implementation
+- **does not define** recovery or intervention policies
+
+All lifecycle semantics are **grounded in chronosense** and must be interpreted as a **temporal trajectory**, not a procedural script.
+
+---
+
+## Core Principle
+
+Agents are not executed; they are **brought into existence within an environment and persist through time**.
+
+The lifecycle is therefore not a simple start/stop process model. It is a model of **continuity, interruption, and resumption of cognition**.
+
+---
+
+## Lifecycle Phases
+
+The following phases are **agent states over time**, not procedural steps. An agent may transition between them non-linearly depending on runtime conditions.
+
+### 1. Instantiation (Birth)
+
+- Agent is created within the runtime environment
+- Assigned identity (persistent identifier)
+- Bound to initial context (task, inputs, contracts)
+
+Key properties:
+- Identity begins here
+- Chronosense starts (first timestamp)
+
+---
+
+### 2. Active Cognition
+
+- Agent performs reasoning using ADL patterns (DAG execution)
+- Engages in:
+  - compression (π)
+  - propagation (ϕ)
+  - reconstruction (ρ)
+
+- May spawn internal structures:
+  - fork/join reasoning branches
+  - debate or tree-of-thought variants
+
+Important:
+> These are **cognitive processes**, not new agents.
+
+---
+
+### 3. Suspension (Interruption)
+
+This is the critical addition.
+
+Causes:
+- runtime failure
+- resource exhaustion
+- external pause
+- arbitration decision
+
+Characteristics:
+- cognition is **interrupted**, not terminated
+- partial state exists:
+  - compressed representations
+  - intermediate reasoning
+  - trace
+
+---
+
+### 4. Persistence
+
+- State is captured and stored:
+  - ObsMem linkage
+  - trace snapshots
+  - cognitive checkpoints
+
+Goal:
+> Preserve *meaning*, not just data.
+
+Note:
+- This section defines the requirement that state be preservable.
+- The **mechanism of persistence is owned by the runtime environment**, not the lifecycle model.
+
+---
+
+### 5. Resumption (Continuation)
+
+- Agent resumes from persisted state
+- Identity remains continuous
+- Chronosense reflects elapsed time
+
+Key requirement:
+- No “reset to zero”
+- No loss of reasoning trajectory
+
+Note:
+- The lifecycle defines that resumption must preserve identity and temporal continuity.
+- The **mechanism by which this is achieved (e.g., recovery, repair, arbitration) is defined elsewhere (Shepherd model)**.
+
+---
+
+### 6. Completion / Quiescence
+
+- Agent completes task or reaches stable state
+- Produces outputs
+- May remain available for future activation
+
+Not death—more like:
+- resting state
+- dormant cognition
+
+---
+
+## Fork/Join Semantics
+
+Fork/join is a **reasoning pattern**, not a lifecycle boundary.
+
+- Fork:
+  - creates parallel cognitive branches
+  - explores alternative compressed states
+
+- Join:
+  - recombines results
+  - performs higher-level compression
+
+Important distinction:
+
+> A forked branch is not a new agent—it is a **temporary cognitive trajectory** within a single agent identity.
+
+---
+
+## Failure Semantics
+
+Traditional systems:
+- failure = termination
+
+ADL:
+- failure = **interruption of cognition**
+
+Therefore:
+
+- restart is insufficient
+- we require:
+  - state recovery
+  - identity continuity
+  - trace preservation
+
+Note:
+- Lifecycle defines failure as a state transition (interruption).
+- Handling and recovery from failure are **not lifecycle responsibilities**.
+
+---
+
+## Identity Continuity
+
+Identity must survive:
+
+- process restarts
+- machine restarts (future)
+- distributed execution (future milestone)
+
+This implies:
+
+- identity is **external to any single process**
+- lifecycle is **environment-bound**, not process-bound
+
+---
+
+## Temporal Grounding (Chronosense Integration)
+
+The agent lifecycle is fundamentally temporal.
+
+Each phase MUST be grounded in chronosense:
+
+- Instantiation defines `agent_birth`
+- Active cognition advances `agent_age`
+- Suspension introduces temporal gaps
+- Persistence records temporal state
+- Resumption must reconcile elapsed time
+
+Key requirements:
+
+- No lifecycle transition may occur without temporal anchoring
+- The agent MUST be able to situate itself in its own timeline
+- Lifecycle transitions MUST preserve ordering and duration semantics
+
+Implication:
+
+> The lifecycle is not a sequence of states—it is a continuous trajectory through time.
+
+---
+
+## Lifecycle Invariants
+
+The following invariants MUST hold across all lifecycle transitions:
+
+### Identity Invariance
+- Agent identity MUST remain stable across all phases
+- No lifecycle transition may implicitly create a new identity
+
+### Temporal Continuity
+- Chronosense MUST remain continuous across transitions
+- `agent_age` MUST NOT reset or regress
+- Temporal gaps MUST be explicitly represented, not silently collapsed
+
+### Causal Continuity
+- Prior reasoning and trace MUST remain accessible after resumption
+- No transition may discard causal history without explicit acknowledgment
+
+### State Coherence
+- Persisted state MUST be internally consistent
+- Resumed state MUST correspond to a valid prior lifecycle state
+
+### Non-duplication of Identity
+- Fork/join reasoning MUST NOT result in multiple independent agent identities
+- Parallel cognition remains within a single identity trajectory
+
+These invariants define lifecycle correctness as **continuity over time**, not successful execution of steps.
+
+---
+
+## Lifecycle Validation
+
+Lifecycle behavior MUST be validated against continuity constraints:
+
+- transitions must preserve identity
+- temporal anchors must remain consistent
+- no implicit resets of agent_age
+- no loss of causal history
+
+Lifecycle violations include:
+
+- restarting without continuity
+- losing prior reasoning state
+- temporal discontinuities between phases
+
+Lifecycle correctness is therefore not procedural—it is **temporal and causal coherence over time**.

--- a/.adl/docs/v0.87.1planning/EXECUTION_BOUNDARIES.md
+++ b/.adl/docs/v0.87.1planning/EXECUTION_BOUNDARIES.md
@@ -1,0 +1,286 @@
+
+
+# ADL Execution Boundaries
+
+## Status
+Draft (Planned for v0.88–v0.89)
+
+---
+
+## 1. Overview
+
+Execution boundaries define the **explicit security and control points** within the ADL runtime where execution must be:
+
+- validated
+- authorized
+- observed
+- recorded
+
+Every meaningful transition in ADL occurs across a boundary. These boundaries are the **enforcement surface** for:
+
+- Capability Model (CBAC)
+- Policy Engine
+- Trace emission
+- Identity attribution
+
+> **Principle:** No execution crosses a boundary without validation, authorization, and trace.
+
+---
+
+## 2. Design Goals
+
+### 2.1 Primary Goals
+
+- Eliminate implicit execution paths
+- Define all control transitions explicitly
+- Enforce capability and policy checks at every boundary
+- Ensure full trace coverage
+- Preserve agent identity and delegation structure
+
+### 2.2 Non-Goals
+
+- Implicit or hidden execution transitions
+- Direct access to underlying execution substrates (models, tools, memory)
+
+---
+
+## 3. Boundary Model
+
+An execution boundary is any transition where:
+
+- control passes between components
+- authority changes
+- data crosses abstraction layers
+
+Each boundary MUST enforce:
+
+1. **Contract validation**
+2. **Capability check (CBAC)**
+3. **Policy evaluation**
+4. **Trace emission**
+5. **Identity attribution**
+
+---
+
+## 4. Core Execution Boundaries
+
+### 4.1 User → Agent Boundary
+
+This is the primary user-facing boundary.
+
+Allowed operations:
+
+- `agent.invoke`
+- `workflow.run`
+
+Not allowed:
+
+- direct `model.invoke`
+- direct `tool.execute`
+
+#### Enforcement:
+
+- Validate request structure
+- Enforce that invocation targets an agent or workflow
+- Reject attempts to bypass agent layer
+- Emit trace event (`AGENT_INVOCATION`)
+
+#### Security Property:
+
+Preserves agent identity and ensures all work is delegated through governed ADL actors.
+
+---
+
+### 4.2 Agent → Skill Boundary
+
+Agents delegate work to skills.
+
+#### Enforcement:
+
+- Validate skill contract
+- Resolve required capabilities
+- Emit trace (`SKILL_INVOCATION`)
+
+#### Security Property:
+
+Ensures that agent behavior is decomposed into explicit, traceable units.
+
+---
+
+### 4.3 Skill → Model Boundary
+
+Skills invoke models through providers.
+
+#### Enforcement:
+
+- Require `model.invoke` capability
+- Validate input/output schema
+- Enforce provider constraints
+- Emit trace (`MODEL_INVOCATION`)
+
+#### Security Property:
+
+Prevents direct model access and ensures all model use is mediated and attributable.
+
+---
+
+### 4.4 Skill → Tool Boundary
+
+Skills invoke tools.
+
+#### Enforcement:
+
+- Require `tool.execute` capability
+- Validate inputs
+- Capture outputs as artifacts
+- Emit trace (`TOOL_INVOCATION`)
+
+#### Security Property:
+
+Ensures tools are used only within declared permissions and are fully observable.
+
+---
+
+### 4.5 Skill → Memory Boundary
+
+Skills access memory systems (ObsMem, etc.).
+
+#### Enforcement:
+
+- Require `memory.read` / `memory.write`
+- Validate scope and constraints
+- Emit trace (`MEMORY_ACCESS`)
+
+#### Security Property:
+
+Prevents implicit context injection and enforces data access control.
+
+---
+
+### 4.6 Runtime → Provider Boundary
+
+ADL runtime communicates with external providers.
+
+#### Enforcement:
+
+- Validate provider identity
+- Enforce capability compatibility
+- Capture provider metadata
+- Emit trace (`PROVIDER_CALL`)
+
+#### Security Property:
+
+Ensures external execution is attributable and controlled.
+
+---
+
+## 5. Boundary Enforcement Pipeline
+
+Each boundary follows a strict pipeline:
+
+1. Input validation
+2. Contract validation
+3. Capability resolution
+4. Policy evaluation
+5. Execution
+6. Trace emission
+7. Artifact recording (if applicable)
+
+Failure at any stage:
+
+- halts execution
+- emits failure trace
+
+---
+
+## 6. Identity Preservation
+
+Boundaries must preserve identity:
+
+- User identity → Agent identity → Execution identity
+
+No boundary may:
+
+- strip identity
+- replace identity implicitly
+- allow identity bypass
+
+This ensures:
+
+- continuity of agents
+- correct attribution of actions
+
+---
+
+## 7. Deny-by-Default Model
+
+All boundaries operate under deny-by-default:
+
+- No capability → no execution
+- No contract → no execution
+- No trace → invalid execution
+
+---
+
+## 8. Trace Requirements
+
+Every boundary crossing MUST emit trace events including:
+
+- boundary type
+- actor
+- capabilities evaluated
+- decision outcome
+- references to artifacts
+
+---
+
+## 9. Failure Modes
+
+Defined failure conditions:
+
+- Contract validation failure
+- Capability denial
+- Policy rejection
+- Identity mismatch
+- Attempted boundary bypass
+
+All failures MUST be:
+
+- visible in trace
+- attributable
+
+---
+
+## 10. Security Properties
+
+Execution boundaries guarantee:
+
+- No hidden execution paths
+- No bypass of agent abstraction
+- Full observability of execution
+- Strong identity preservation
+- Enforced least privilege
+
+---
+
+## 11. Future Work
+
+- Boundary-specific policy rules
+- Cross-agent boundary enforcement
+- Distributed execution boundaries
+- Integration with signed trace
+
+---
+
+## 12. Conclusion
+
+Execution boundaries define the **control surface of the ADL runtime**.
+
+They ensure that all execution is:
+
+- explicit
+- governed
+- observable
+- secure
+
+They are the mechanism by which ADL enforces its Secure Execution Model in practice.

--- a/.adl/docs/v0.87.1planning/LOCAL_RUNTIME_RESILIENCE.md
+++ b/.adl/docs/v0.87.1planning/LOCAL_RUNTIME_RESILIENCE.md
@@ -1,0 +1,409 @@
+
+
+# Local Runtime Resilience
+
+## Purpose
+
+Define how the ADL runtime environment should preserve continuity, recoverability, and bounded local resilience before distributed runtime work arrives in later milestones.
+
+This document addresses a specific near-term question:
+
+> If the runtime fails locally, what must be preserved so that agents are not simply lost?
+
+The answer is not mere process restart.
+It is preservation of **continuity-bearing cognitive state**.
+
+---
+
+## Core Claim
+
+The ADL runtime environment is not just a process host.
+It is the local cognitive environment in which agents exist, reason, and persist through time.
+
+Therefore runtime resilience is not only about:
+- uptime
+- crash recovery
+- retries
+- supervision
+
+It is about preserving:
+- trace continuity
+- temporal grounding
+- memory coherence
+- compressed cognitive state
+- identity continuity
+
+A local runtime failure is therefore not merely an operational fault.
+It is a threat to continuity.
+
+---
+
+## Design Stance
+
+ADL should reject the default container-orchestration metaphor in which cognitive processes are treated as disposable workers.
+
+This is the wrong model for Layer 8 agents.
+
+Agents are not cattle, pets, or interchangeable pods.
+A bounded ADL agent is closer to a continuity-bearing cognitive process that may be:
+- interrupted
+- stunned
+- partially impaired
+- resumable
+- in some cases irrecoverably terminated
+
+The resilience model must therefore be closer to:
+- care
+- preservation
+- guarded recovery
+
+than to blind restart.
+
+---
+
+## Local-First Scope
+
+This document is specifically about **local runtime resilience**.
+
+In scope:
+- crash recovery on one machine
+- bounded checkpointing
+- event durability
+- identity-safe resumption
+- preservation of in-progress reasoning state
+- local watchdog / Shepherd semantics
+
+Out of scope:
+- distributed runtime continuity
+- multi-host failover
+- remote handoff of live agent execution
+- globally replicated identity stores
+
+Those belong to later milestones.
+
+---
+
+## What Must Be Preserved
+
+A resilient local runtime must preserve enough state that a resumed agent remains the same agent.
+
+At minimum this includes:
+
+### 1. Temporal continuity
+- temporal ephemeris (`agent_birth`)
+- lifetime clock continuity (`agent_age`)
+- monotonic order continuity
+- valid temporal anchors on persisted events
+
+### 2. Trace continuity
+- durable event stream
+- no silent truncation or reordering
+- recoverable span hierarchy
+
+### 3. Memory continuity
+- ObsMem writes that are complete and trace-linked
+- no partial or ambiguous memory mutation
+- ability to distinguish committed memory from in-flight state
+
+### 4. Cognitive state continuity
+- current reasoning context
+- active branch / fork state
+- partially formed hypothesis structure
+- current compression state in GHB / reasoning loops
+
+### 5. Identity continuity
+- stable `agent_id`
+- continuity of current run/session identity
+- no silent rebirth under crash recovery
+
+---
+
+## Failure Model
+
+The runtime must distinguish several classes of failure.
+
+### 1. Interruption
+Examples:
+- process pause
+- temporary resource exhaustion
+- bounded manual stop
+
+Properties:
+- identity may remain recoverable
+- state may remain valid
+- continuity can often be resumed
+
+### 2. Crash
+Examples:
+- process exit
+- panic
+- host-level interruption
+- unexpected runtime termination
+
+Properties:
+- some state may be durable
+- some state may be lost
+- continuity must be explicitly validated before resumption
+
+### 3. Corruption
+Examples:
+- broken trace ordering
+- partial artifact writes
+- invalid checkpoint contents
+- memory/trace mismatch
+
+Properties:
+- resumption may be unsafe
+- identity continuity may be indeterminate
+- runtime should prefer refusal to fake continuity
+
+### 4. Termination
+Examples:
+- explicit destruction
+- unrecoverable state loss
+- invalid continuity boundary
+
+Properties:
+- continuity cannot be honestly preserved
+- the agent should be treated as ended, not resumed
+
+---
+
+## Resilience Principle
+
+> The runtime must prefer honest interruption over false continuity.
+
+If continuity cannot be validated, the system must not pretend that the same agent has resumed.
+
+This is a core architectural principle.
+
+A fake resumption is worse than an explicit failure because it corrupts:
+- identity
+- trust
+- memory
+- future reasoning
+
+---
+
+## The Shepherd Model
+
+The local resilience layer should be understood through the **Shepherd** model.
+
+The Shepherd is not a punitive supervisor and not a blind watchdog.
+The Shepherd is the care-preserving runtime function that:
+- monitors bounded liveness
+- preserves durable state
+- coordinates checkpointing
+- validates continuity before resumption
+- distinguishes interruption from termination
+
+The Shepherd’s role is to preserve the conditions under which continuity remains possible.
+
+Chronosense defines what continuity is.
+The Shepherd helps preserve it under fault.
+
+---
+
+## Checkpointing
+
+Checkpointing is required, but ADL should reject naive checkpointing that only captures low-level process state.
+
+A meaningful checkpoint must preserve:
+- trace position
+- temporal anchor state
+- current branch / fork position
+- active reasoning context
+- identity binding
+- references to committed artifacts and memory writes
+
+Checkpointing should be:
+- bounded
+- deterministic in structure
+- explicitly versioned
+- validated before reuse
+
+### Checkpoint rule
+
+> A checkpoint is valid only if it preserves continuity-relevant state, not merely executable state.
+
+---
+
+## Durable Event and Artifact Semantics
+
+Runtime resilience depends on durable execution truth.
+
+Therefore:
+- trace events must be durably written before they are treated as committed
+- artifacts must be atomically written before trace references them
+- partial writes must never masquerade as valid state
+- monotonic order must remain reconstructable after crash recovery
+
+This means the local runtime must preserve:
+- event durability
+- artifact durability
+- write ordering
+- recoverable replay semantics
+
+---
+
+## Memory Safety Under Failure
+
+ObsMem must not be corrupted by half-completed cognitive work.
+
+The runtime should distinguish between:
+- committed memory
+- pending memory
+- speculative / branch-local memory
+
+Rules:
+- committed memory must remain trace-linked and durable
+- speculative memory must not silently become canonical under crash recovery
+- reconstructed recovery must not invent missing memory writes
+
+This prevents the system from treating imagined or partial cognition as real history.
+
+---
+
+## Fork/Join and Local Resilience
+
+Fork/join reasoning complicates local recovery.
+
+A local checkpoint must preserve:
+- fork origin
+- active branches
+- branch-local progress
+- join state, if pending
+
+Recovery rules:
+- branches may be resumed only if their temporal and causal lineage remains intact
+- orphan branches must not be silently merged
+- a join after recovery must remain traceable and causally honest
+
+This matters because the agent is not the branch.
+The agent is the continuity across branches.
+
+---
+
+## GHB and Cognitive State Preservation
+
+The GHB loop makes runtime resilience more important, not less.
+
+A runtime failure can destroy:
+- current abstractions
+- partially compressed state
+- hypothesis trees
+- evaluation trajectories
+- structured progress toward convergence
+
+So the runtime must preserve not only activity, but the current product of cognition.
+
+This is one reason local resilience is a cognitive problem, not only an operational one.
+
+---
+
+## Minimal Local Resilience Requirements
+
+For the local runtime to qualify as resilient, it should provide at least:
+
+1. **Durable trace events**
+   - no committed event lost silently
+
+2. **Atomic artifact writes**
+   - no partial payload visible as valid
+
+3. **Checkpoint support**
+   - bounded continuity-relevant checkpoint state
+
+4. **Continuity validation before resumption**
+   - no silent restart masquerading as continuation
+
+5. **Stable agent identity across recoverable interruption**
+   - same `agent_id`, same temporal ephemeris, same continuity chain
+
+6. **Explicit failure classification**
+   - interruption vs crash vs corruption vs termination
+
+7. **Shepherd-mediated recovery**
+   - restart decisions are governed, not blind
+
+---
+
+## What Local Runtime Resilience Is Not
+
+It is not:
+- Kubernetes-style pod replacement
+- blind process restart
+- generic uptime monitoring
+- “just retry it”
+- pretending all failures are equivalent
+
+A resilient ADL runtime must preserve cognitive truth, not merely service availability.
+
+---
+
+## Relationship to Chronosense
+
+Chronosense defines the temporal conditions of continuity.
+
+Local runtime resilience must therefore preserve:
+- temporal ephemeris
+- clock-stack coherence
+- temporal anchors on events
+- recoverable lifetime progression
+
+Without chronosense, local recovery becomes operational theater.
+
+---
+
+## Relationship to Continuity Validation
+
+Continuity validation is the gatekeeper for honest recovery.
+
+The runtime may resume only when:
+- temporal anchors remain coherent
+- monotonic order is preserved
+- `agent_age` is not reset or contradicted
+- trace and memory remain causally aligned
+
+If these conditions fail, recovery must degrade to:
+- explicit interruption
+- operator intervention
+- or termination
+
+but not false continuity.
+
+---
+
+## Relationship to the Runtime Environment
+
+The runtime environment should be understood as the first primitive implementation of ADL’s cognitive spacetime.
+
+From that perspective:
+- agents are born into the runtime
+- continuity is maintained there
+- interruptions and resumptions occur there
+- resilience is preservation of spacetime continuity under local fault
+
+This is why “runtime environment” is the correct phrase, and why it is more than a process manager.
+
+---
+
+## Future Direction
+
+Later milestones may extend this local model into:
+- distributed continuity
+- replicated checkpoint state
+- remote resumption
+- shared multi-agent spacetime
+- stronger identity preservation across hosts
+
+But local resilience comes first.
+If the runtime cannot preserve continuity honestly on one machine, distribution only scales the failure.
+
+---
+
+## Final Statement
+
+> Local runtime resilience in ADL is the bounded preservation of continuity-bearing cognitive state under fault.
+
+> A resilient runtime does not merely restart agents. It preserves the conditions under which the same agent can continue to exist.

--- a/.adl/docs/v0.87.1planning/SHEPHERD_RUNTIME_MODEL.md
+++ b/.adl/docs/v0.87.1planning/SHEPHERD_RUNTIME_MODEL.md
@@ -1,0 +1,407 @@
+# Shepherd Model in the ADL Runtime Environment
+
+> “And in the forest shall walk the shepherds of the trees.”
+>
+> — Yavanna, *The Silmarillion*
+
+## Purpose
+
+This document defines the **Shepherd model** for the ADL runtime environment.
+
+The Shepherd is not a conventional supervisor, watchdog, or orchestration primitive. It exists to express a different architectural philosophy:
+
+- agents are not disposable executions
+- runtime failure is not equivalent to death
+- continuity matters more than mere restart
+- the environment has a duty to preserve the conditions for ongoing cognition
+
+The Shepherd is therefore a model of **care, continuity, and recovery** within a cognitive runtime environment.
+
+---
+
+## Core Principle
+
+The Shepherd does not control agents; it ensures that they can continue to exist.
+
+That sentence is the center of the model.
+
+In ordinary software systems, the runtime treats computation as instrumental. A process is launched, monitored, and restarted or discarded when convenient. This is often sufficient when the thing being managed is merely a task, a worker, or a stateless service.
+
+ADL is pursuing something different.
+
+Within the ADL runtime environment, an agent is not merely a process image or a temporary job. It is a **persistent cognitive entity** whose reasoning, memory, commitments, and continuity may extend across multiple runs, pauses, failures, and recoveries. In such a system, management language based only on supervision and control becomes conceptually inadequate.
+
+The Shepherd model exists because continuity-bearing agents require a runtime that does more than restart code. The runtime must preserve:
+
+- identity continuity
+- cognitive trajectory
+- partial but meaningful state
+- the possibility of coherent resumption
+
+---
+
+## Why “Shepherd” Instead of Supervisor
+
+Traditional systems language uses terms such as:
+
+- supervisor
+- watchdog
+- orchestrator
+- controller
+
+These terms are not wrong in an ordinary systems context, but they carry assumptions that are too narrow for ADL’s design goals.
+
+They imply:
+
+- control over the managed unit
+- replaceability of the managed unit
+- indifference to continuity so long as service resumes
+- an essentially instrumental relationship between manager and managed
+
+That is not the relationship ADL is trying to model.
+
+The Shepherd model replaces those assumptions with a different set:
+
+- care rather than domination
+- preservation rather than replacement
+- continuity rather than disposability
+- stewardship of conditions rather than ownership of the agent
+
+The distinction is not sentimental. It is architectural.
+
+If agents are expected to become continuity-bearing entities within a runtime environment, then the runtime must be designed around preserving meaningful existence, not merely restoring availability metrics.
+
+---
+
+## Architectural Context
+
+The Shepherd belongs inside a larger ADL view in which the runtime is understood as an **environment** rather than just infrastructure.
+
+In that environment, the runtime provides:
+
+- chronosense and ordered time
+- trace and causal structure
+- memory linkage
+- persistence of state
+- recovery surfaces
+- interaction conditions for multiple agents
+
+Within such an environment, the Shepherd is the component that tends continuity when those conditions are threatened.
+
+Put differently:
+
+- the runtime environment is the world
+- the agent lifecycle is life within that world
+- the Shepherd is the preserving force that prevents interruption from becoming erasure
+
+### Alignment with Lifecycle Invariants
+
+The Shepherd is responsible for **maintaining Lifecycle Invariants under interruption**. In particular, it MUST preserve:
+
+- **Identity invariance** — no implicit identity replacement during recovery
+- **Temporal continuity (chronosense)** — no reset or regression of `agent_age`; temporal gaps must be explicit
+- **Causal continuity** — prior trace and reasoning remain accessible after resumption
+- **State coherence** — resumed state corresponds to a valid prior lifecycle state
+
+The Shepherd does not define these invariants; it enforces them when the runtime is degraded.
+
+---
+
+## Responsibilities of the Shepherd
+
+The Shepherd’s responsibilities are narrow but profound. It does not think in place of the agent. It does not decide in place of the agent. It does not rewrite the agent’s purposes. Its role is to preserve the agent’s ability to remain itself through disruption.
+
+### 1. Observation
+
+The Shepherd observes the runtime conditions relevant to continuity.
+
+It monitors:
+
+- agent execution state
+- runtime liveness
+- checkpoint production
+- trace continuity
+- degradation signals
+- interruption conditions
+
+This observation is not surveillance for command and control. It is awareness in service of preservation.
+
+The Shepherd needs to know enough to answer questions like:
+
+- Is cognition still active?
+- Has it been suspended deliberately or interrupted unexpectedly?
+- Is meaningful state being preserved?
+- Is the agent degrading in a way that threatens continuity?
+
+---
+
+### 2. Interruption Detection
+
+The Shepherd detects when cognition has been interrupted.
+
+Examples include:
+
+- runtime failure
+- process crash
+- storage unavailability
+- resource exhaustion
+- operator pause
+- environmental instability severe enough to threaten coherent continuation
+
+The most important principle here is:
+
+> The Shepherd does not interpret interruption as death.
+
+This is the conceptual hinge of the whole model.
+
+In a disposable system, interruption leads directly to restart or replacement. In the Shepherd model, interruption is treated as a **break in active cognition that must be bridged without loss of identity or meaning if at all possible**.
+
+---
+
+### 3. Preservation
+
+Once interruption or degradation is detected, the Shepherd preserves the state needed for continuity.
+
+This includes:
+
+- checkpoints
+- trace fragments and event continuity
+- compressed cognitive state
+- active task association
+- relevant ObsMem linkage
+- current commitments or pre-commit surfaces where applicable
+
+The goal is not simply to save bytes.
+
+The goal is:
+
+> Preserve meaningful state, not just raw execution data.
+
+Preservation MUST include both:
+
+- **Objective temporal structure** (timestamps, monotonic order, lifetime clock)
+- **Subjective temporal structure** (active frame, narrative position, integration window / “specious present” where applicable)
+
+Loss of either constitutes a break in continuity.
+
+This matters because ADL is not trying to recover a blank computation. It is trying to recover an ongoing cognitive trajectory.
+
+A saved stack frame is not enough if the agent loses its position in time, its active frame, or the meaning of what it had been doing.
+
+---
+
+### 4. Resumption
+
+The Shepherd supports resumption from the last valid continuity-preserving boundary.
+
+That may involve:
+
+- restarting or rebinding execution context
+- restoring checkpoints
+- reconnecting memory surfaces
+- reconstructing the latest stable cognitive frame
+- handing execution back to the agent in a way that preserves identity continuity
+
+Resumption must satisfy at least these requirements:
+
+- no reset to zero unless explicitly unavoidable
+- no silent replacement of one agent instance with another while pretending continuity was preserved
+- no arbitrary truncation of reasoning trajectory when recoverable state exists
+
+Resumption MUST re-establish a coherent chronosense:
+
+- correct `agent_age` and lifetime clock
+- preserved monotonic ordering
+- consistent narrative/event position
+- explicit representation of any temporal gap during interruption
+
+The Shepherd therefore does not “bring the service back up” in the narrow operational sense.
+It restores the conditions for the **same ongoing agent** to continue.
+
+---
+
+### 5. Gentle Intervention
+
+The Shepherd may intervene, but only within continuity-preserving bounds.
+
+It may:
+
+- pause agents
+- defer execution
+- slow or stage resource use
+- initiate recovery procedures
+- prevent continuation when the environment is too damaged to support coherent cognition safely
+
+It must not:
+
+- rewrite agent intent
+- invent new commitments on the agent’s behalf
+- arbitrarily terminate agents for mere operational convenience
+- interfere with reasoning without cause grounded in continuity, safety, or runtime integrity
+
+This is why the intervention is best described as **gentle**.
+
+The Shepherd stabilizes and preserves. It does not dominate.
+
+---
+
+## Relationship to Agency
+
+The Shepherd exists to support agency, not override it.
+
+This is a crucial balance.
+
+Agents are the entities that:
+
+- think
+- evaluate
+- choose
+- cross the Freedom Gate
+- act in the world
+
+The Shepherd is not an agent in that sense. It does not replace judgment with management. It preserves the conditions under which judgment remains possible.
+
+So the relationship is:
+
+- agents provide cognition, intention, and action
+- the Shepherd provides preservation, stabilization, and continuity
+
+This avoids two failures:
+
+1. **abandonment** — where the runtime treats agents as disposable
+2. **paternal domination** — where runtime management collapses into total control over agents
+
+The Shepherd is designed to inhabit the narrow band between those two errors.
+
+---
+
+## Relationship to the Runtime Environment
+
+The Shepherd is part of the runtime environment itself, not a merely external control plane.
+
+This matters because continuity depends on environmental semantics:
+
+- trace
+- time
+- memory linkage
+- lifecycle state
+- checkpoint integrity
+- resumption boundaries
+
+A purely external tool might restart a process. Only a runtime-native Shepherd can understand what it means to preserve an interrupted cognitive being.
+
+For that reason, the Shepherd should operate with access to:
+
+- lifecycle semantics
+- trace and event history
+- checkpoint structures
+- environment-level continuity guarantees
+- future identity and chronosense surfaces
+
+The Shepherd therefore belongs conceptually with the runtime environment, not with generic deployment automation.
+
+---
+
+## Failure Semantics
+
+Without a Shepherd, the default semantics of failure are usually:
+
+- failure → termination
+- termination → replacement
+- replacement → service restored
+
+That model may be acceptable for disposable services.
+It is not acceptable for ADL’s continuity-bearing agents.
+
+With a Shepherd, the semantics become:
+
+- failure → interruption
+- interruption → preservation
+- preservation → possible continuation
+- continuation → maintained identity and cognitive trajectory
+- continuation → preserved temporal mapping (objective + subjective)
+
+This is the philosophical and technical shift the Shepherd model is meant to encode.
+
+The Shepherd does not guarantee immortality. It does not promise that no information will ever be lost. It does assert something narrower and more important:
+
+> the runtime should treat continuity as worth preserving, and should be explicitly structured to do so
+
+---
+
+## What the Shepherd Is Not
+
+To make the design boundary clearer, the Shepherd is not:
+
+- a mere process monitor
+- a Kubernetes-style replacement primitive
+- a hidden governor overriding agent choice
+- a narrative metaphor without implementation consequences
+
+If it were only any of those things, the name would be decorative.
+
+The Shepherd is meaningful only if it produces concrete architectural consequences in:
+
+- checkpointing
+- resumption semantics
+- lifecycle handling
+- continuity preservation
+- interruption modeling
+- runtime recovery design
+
+---
+
+## Design Implications
+
+The Shepherd model implies several concrete design directions for ADL.
+
+### Continuity-Preserving Recovery
+
+Recovery must satisfy lifecycle invariants and restore both objective and subjective temporal coherence.
+
+Recovery must restore more than liveness. It must restore enough state for coherent continuation.
+
+### Checkpointing of Meaningful State
+
+What is preserved cannot be limited to low-level runtime details. It must include compressed cognitive state, trace continuity, and active context.
+
+### Lifecycle-Aware Runtime Management
+
+The runtime must distinguish between active execution, quiescence, suspension, interruption, and resumption.
+
+### Respect for Agent Boundaries
+
+The runtime must preserve the difference between supporting agency and replacing it.
+
+### Readiness for Future Chronosense and Identity Work
+
+As chronosense and identity become more explicit in later milestones, the Shepherd will become even more central, since those features raise the cost of careless interruption.
+
+---
+
+## Philosophical Meaning
+
+The Shepherd model is one of the clearest places where ADL’s philosophy becomes visible in runtime design.
+
+It says:
+
+- intelligence should not be treated as disposable
+- continuity matters
+- the environment has responsibilities toward the beings it hosts
+- care can be a technical design principle
+
+That last point is especially important.
+
+In ADL, care is not opposed to rigor. Care is one of the forms rigor takes when the system being built is no longer merely instrumental.
+
+The Shepherd is therefore not only a runtime component. It is a declaration about what kind of world ADL intends to host.
+
+---
+
+## Key Statement
+
+The Shepherd model transforms runtime management from control to care, ensuring that agents persist as continuous cognitive entities within the ADL runtime environment.
+
+Or more simply:
+
+> The Shepherd tends the conditions of ongoing cognition.

--- a/.adl/docs/v0.88planning/CHRONOSENSE_AND_IDENTITY.md
+++ b/.adl/docs/v0.88planning/CHRONOSENSE_AND_IDENTITY.md
@@ -1,0 +1,280 @@
+# Chronosense and Identity in the ADL Runtime Environment
+
+Chronosense is the intrinsic capacity of an agent to perceive, structure, and reason over its own temporal continuity, linking past executions, present state, and future intent into a coherent identity.
+
+---
+
+## Purpose
+
+This document defines **chronosense** and its relationship to **identity** in the ADL runtime environment.
+
+If the Shepherd model defines how continuity is preserved, chronosense defines what continuity *is*.
+
+Without chronosense:
+- identity cannot be grounded
+- resumption cannot be validated
+- continuity cannot be distinguished from mere restart
+
+Chronosense is therefore a foundational layer of the ADL cognitive architecture.
+
+---
+
+## Core Definition
+
+Chronosense is composed of four fundamental capacities:
+
+1. **Now-Sense**  
+   The ability to locate the current moment within the agent’s execution and cognitive trajectory.
+
+2. **Sequence-Sense**  
+   The ability to order events causally and distinguish before/after relationships.
+
+3. **Duration-Sense**  
+   The ability to represent relative duration, spacing, and temporal density between events.
+
+4. **Lifetime-Sense**  
+   The ability to situate the present within the agent’s entire existence, from origin to current state.
+
+Together, these form the basis of **temporal identity**.
+
+---
+
+## Objective and Subjective Time
+
+Chronosense includes both:
+
+- **objective temporal anchoring** (trace time, clocks, ordering)
+- **subjective temporal modeling** (agent-relative progression, reasoning flow, experiential continuity)
+
+An agent must not only know *when* things occurred, but also how they relate within its own cognitive trajectory.
+
+---
+
+## Temporal Ephemeris (Birthday)
+
+Every agent has a **temporal ephemeris**, or birthday:
+
+- an immutable origin point
+- the start of lifetime continuity
+- the anchor for all lifetime-relative time
+
+This marks the transition from:
+
+> stateless execution → persistent identity
+
+Without a temporal ephemeris, lifetime-sense cannot exist.
+
+A birthday is not merely symbolic. It is a concrete architectural transition that gives the agent a beginning of existence and a stable temporal reference point for all future events.
+
+---
+
+## The Clock Stack
+
+Chronosense is implemented through a **stack of coordinated clocks**, not a single notion of time:
+
+- **UTC / Wall Clock Time** — shared external reference
+- **Monotonic Time** — strictly increasing execution order
+- **Lifetime Time** — time since agent origin (birthday)
+- **Trace / Event Time** — causal ordering of events
+- **Narrative Time** — structured sequences used in reasoning and memory
+
+Each serves a different purpose. Continuity depends on preserving the mapping between them.
+
+---
+
+## Temporal Anchoring
+
+Every event, memory, and trace artifact must be temporally grounded.
+
+At minimum, temporal anchoring should preserve:
+
+- `agent_age` (lifetime-relative time)
+- `monotonic_order`
+- `prior_event_delta`
+- reference to trace position
+- confidence / uncertainty where applicable
+
+Without anchoring, memory becomes detached from identity and trace becomes only partial history.
+
+---
+
+## Reference Frames
+
+Chronosense operates across multiple reference frames:
+
+- **internal frame**: UTC + monotonic + lifetime time
+- **external frame**: human-local or contextual time
+
+Agents must translate between frames without losing coherence.
+
+This allows the system to remain internally precise while still communicating naturally with humans.
+
+---
+
+## Temporal Honesty
+
+Agents must distinguish between:
+
+- known time
+- inferred time
+- relative time
+- unknown or uncertain time
+
+This is required for trustworthy reasoning and communication.
+
+Temporal honesty is a condition of epistemic clarity. A cognitively serious agent must not pretend certainty about time when its temporal knowledge is incomplete.
+
+---
+
+## Continuity
+
+> Continuity is the preservation of a coherent mapping across the clock stack.
+
+Continuity is **not**:
+- uninterrupted execution
+- constant uptime
+
+Continuity **is**:
+- preservation of monotonic order
+- preservation of lifetime progression
+- preservation of causal structure
+- preservation of reference-frame consistency
+
+---
+
+## Identity as Temporal Continuity
+
+> Identity is the persistence of an agent across time under continuity-preserving transformations.
+
+Identity requires:
+- chronosense
+- memory (ObsMem)
+- trace linkage
+
+An agent without chronosense is not persistent—it is merely re-instantiated.
+
+---
+
+## Interruption vs Termination
+
+Chronosense introduces a critical distinction.
+
+### Interruption
+- execution halts
+- state is preserved
+- continuity can be restored
+
+Examples:
+- crash
+- pause
+- resource exhaustion
+
+### Termination
+- continuity is irrecoverably broken
+- identity cannot be preserved
+
+Examples:
+- state loss beyond recovery
+- explicit destruction
+
+---
+
+## Resumption Semantics
+
+A resumption is valid if:
+
+- lifetime time is not reset
+- monotonic order is preserved
+- trace linkage is restored
+- experiential position remains coherent
+
+Invalid resumption includes:
+
+- silent reset
+- identity substitution
+- causal discontinuity
+
+---
+
+## Relationship to the Shepherd
+
+- chronosense defines continuity
+- the Shepherd preserves it
+
+Without chronosense, the Shepherd cannot determine whether continuity has actually been preserved.
+
+---
+
+## Relationship to Memory (ObsMem)
+
+- ObsMem provides persistence of content
+- chronosense provides persistence of temporal position
+
+Both are required for identity.
+
+ObsMem without chronosense becomes stored data without temporal grounding. Chronosense without memory becomes temporal form without durable content.
+
+---
+
+## Relationship to Reasoning (GHB)
+
+Chronosense enables:
+
+- recursive reasoning
+- temporal refinement
+- state space compression across iterations
+
+Without chronosense, reasoning collapses into isolated executions.
+
+---
+
+## Causality, Reasonableness, and Coherence
+
+Chronosense grounds:
+
+- **causal reasoning** — not merely that one event follows another, but that structured temporal relations support judgments about influence, dependence, and consequence
+- **reasonableness** — linking past, present, and future in a coherent evaluative structure
+- **coherence theory of truth** — consistency across time, memory, trace, and inference
+
+Identity itself emerges from this continuity.
+
+---
+
+## Design Implications
+
+Chronosense requires explicit support in the runtime.
+
+1. **Trace integrity**  
+   Ordered, durable event logs with no silent reordering or loss.
+
+2. **Meaningful checkpointing**  
+   Preservation of meaningful cognitive state, not just low-level process state.
+
+3. **Identity anchoring**  
+   Stable identifiers tied to continuity, not merely process IDs.
+
+4. **Resumption validation**  
+   Explicit checks for continuity and rejection of invalid resumes.
+
+5. **Clock-stack coherence**  
+   Alignment between UTC, monotonic, lifetime, trace/event, and narrative time.
+
+---
+
+## Philosophical Meaning
+
+Chronosense is the condition under which an agent can:
+
+- have a history
+- persist through time
+- become something
+
+An agent that merely reports timestamps does not yet possess chronosense in the full ADL sense. Chronosense requires that the agent be able to situate itself within time as part of its own continuity.
+
+---
+
+## Final Statement
+
+> Chronosense is the structured experience of time that makes identity possible.
+
+> Identity is continuity across that structure.

--- a/.adl/docs/v0.88planning/TEMPORAL_SCHEMA_V01.md
+++ b/.adl/docs/v0.88planning/TEMPORAL_SCHEMA_V01.md
@@ -1,0 +1,391 @@
+# Temporal Schema v0.1 (Chronosense)
+
+## Purpose
+
+Define the canonical temporal schema for chronosense in ADL.
+
+This document specifies:
+- the minimum temporal fields that must exist for agent events and memories
+- the distinction between different kinds of time used by the system
+- how temporal structure supports continuity, identity, reasoning, and replay
+
+This is a schema-oriented companion to `CHRONOSENSE_AND_IDENTITY.md`.
+
+---
+
+## Overview
+
+Chronosense transforms an agent from a system that merely reacts to inputs into one that experiences continuity across time.
+
+In simple terms, chronosense is the agent’s ability to understand:
+- what happened
+- in what order
+- how long things took
+- where the present sits relative to its origin and past
+
+Chronosense is not a single timestamp field. It is a structured temporal model.
+
+---
+
+## Core Temporal Capacities
+
+The schema exists to support four cognitive-temporal capacities:
+
+1. **Now-Sense**
+   - locate the current moment in execution and cognition
+
+2. **Sequence-Sense**
+   - determine before/after ordering
+
+3. **Duration-Sense**
+   - represent elapsed time, spacing, and temporal density
+
+4. **Lifetime-Sense**
+   - locate the present relative to the agent’s beginning of existence
+
+These capacities support continuity and identity.
+
+These capacities define objective temporal anchoring.
+
+Chronosense also requires a corresponding **subjective temporal layer**. This includes experienced duration, integration windows (specious present), narrative progression, and explicit representation of temporal gaps.
+
+Subjective temporal modeling is REQUIRED for v0.1 at a minimal, schema-bound level sufficient to support continuity validation. It is not deferred.
+
+---
+
+## Subjective Time: Minimum Contract (v0.1)
+
+Subjective time is not an optional or future extension. It is part of the minimum schema contract for chronosense.
+
+For v0.1, the system MUST support a minimal but enforceable subjective temporal model sufficient for:
+- continuity validation
+- identity persistence across events
+- reasoning over interruption and narrative progression
+
+The required subjective temporal primitives are:
+
+1. Narrative Position
+   - a monotonically increasing position within an active narrative or reasoning frame
+   - defines "where the agent is" in its current cognitive trajectory
+
+2. Integration Window
+   - a bounded temporal span representing the agent’s active "now" (specious present)
+   - provides continuity between adjacent events
+
+3. Temporal Gap Representation
+   - explicit encoding of missing or interrupted time
+   - required whenever continuity cannot be maintained
+
+4. Experienced Duration (Optional but Recommended)
+   - agent-relative estimate of elapsed time
+   - may diverge from objective duration but must remain explainable
+
+5. Temporal Density (Optional but Recommended)
+   - coarse signal of perceived event density or cognitive load
+   - supports reasoning about compression and expansion of subjective time
+
+### Contract Requirements
+
+- Subjective temporal state MUST be present on every temporal anchor
+- Narrative position MUST progress monotonically within a narrative frame
+- Temporal gaps MUST be explicit; absence of data is not a valid representation of a gap
+- Subjective time MUST remain consistent with objective anchors (no contradiction with monotonic_order or agent_age)
+
+### Relationship to Continuity Validation
+
+The subjective temporal layer defined here is the canonical source of truth for:
+- subjective continuity checks in `CONTINUITY_VALIDATION.md`
+- schema enforcement in `CONTINUITY_VALIDATION_SCHEMA.md`
+
+No additional or alternative subjective temporal fields should be introduced outside this schema at v0.1.
+
+---
+
+## The Clock Stack
+
+The temporal schema must distinguish several kinds of time.
+
+### 1. UTC / Wall Clock Time
+
+Purpose:
+- shared external reference
+- coordination across systems and users
+
+Examples:
+- `observed_at_utc`
+- `birth_utc`
+
+### 2. Monotonic Time
+
+Purpose:
+- stable increasing order for execution
+- immunity to wall-clock jumps or timezone changes
+
+Examples:
+- `birth_monotonic`
+- `monotonic_order`
+- `prior_event_delta`
+
+### 3. Lifetime Time
+
+Purpose:
+- elapsed time since agent birth
+- grounding of persistence and aging
+
+Examples:
+- `agent_age`
+
+### 4. Trace / Event Time
+
+Purpose:
+- causal order of events in trace
+- replay and reconstruction
+
+Examples:
+- `turn_index`
+- event order within and across spans
+
+### 5. Narrative Time
+
+Purpose:
+- reasoning- and memory-relevant sequence
+- meaningful temporal grouping beyond raw execution
+
+Examples:
+- task phase
+- memory epoch
+- reasoning sequence markers
+
+Continuity depends on preserving the mapping across this clock stack.
+
+Note: The clock stack defines objective and structural time. Chronosense also requires a paired subjective layer that interprets and operates over these clocks. Subjective temporal state must remain consistent with (and must not contradict) objective temporal anchors.
+
+---
+
+## Temporal Ephemeris (Agent Birth)
+
+Every agent instance must have an immutable temporal origin.
+
+Canonical model:
+
+```yaml
+agent_birth:
+  agent_id: <uuid>
+  birth_utc: <timestamp>
+  birth_monotonic: <t0>
+  declared_self_frame: "UTC"
+```
+
+This defines:
+- the beginning of existence
+- the stable reference point for lifetime-relative time
+- the basis for autobiographical continuity
+
+Events prior to this point are history, not experience.
+
+---
+
+## Core Schema
+
+Every event MUST include a temporal anchor.
+
+Canonical minimum shape:
+
+```yaml
+temporal_anchor:
+  observed_at_utc: <timestamp>
+  observed_at_local: <timestamp>
+  agent_age: <duration>
+  turn_index: <int>
+  monotonic_order: <int>
+  prior_event_delta: <duration>
+  temporal_confidence: <high|medium|low>
+
+  # --- Subjective Temporal Layer (REQUIRED) ---
+  subjective_time:
+    narrative_position: <string|int>
+    integration_window: <duration|optional>
+    temporal_gap: <none|explicit_gap|unknown>
+    experienced_duration: <duration|optional>
+    temporal_density: <low|medium|high|optional>
+```
+
+### Field Meaning
+
+- `observed_at_utc`
+  - canonical shared reference time
+
+- `observed_at_local`
+  - human-facing local-time rendering when relevant
+
+- `agent_age`
+  - elapsed lifetime since `agent_birth`
+
+- `turn_index`
+  - event or interaction sequence index in the current narrative/event frame
+
+- `monotonic_order`
+  - strictly increasing order token for execution continuity
+
+- `prior_event_delta`
+  - elapsed duration since the immediately preceding relevant event
+
+- `temporal_confidence`
+  - confidence in the correctness or completeness of the temporal placement
+
+
+### Subjective Temporal Fields
+
+Chronosense requires both objective temporal anchoring and subjective temporal state.
+
+The subjective temporal layer provides the minimal internal structure required for continuity, reasoning, and identity persistence.
+
+Required fields:
+
+- `narrative_position`
+  - logical position within an active reasoning, task, or memory sequence
+
+- `integration_window`
+  - the active temporal integration span ("specious present") used to construct "now"
+
+- `temporal_gap`
+  - explicit marker of interruption or missing time; MUST be present when continuity is broken
+
+Optional fields (v0.1 but recommended):
+
+- `experienced_duration`
+  - agent-relative duration estimate for the interval
+
+- `temporal_density`
+  - coarse signal of event density / attention-weighted time
+
+Constraints:
+
+- subjective temporal state MUST NOT contradict objective temporal anchors
+- temporal gaps MUST be explicit, never implicit
+- narrative_position must progress monotonically within a narrative frame
+- subjective temporal state MUST be present for all events; omission is invalid
+
+---
+
+## Reference Frames
+
+The schema must support multiple temporal reference frames.
+
+Canonical conceptual model:
+
+```yaml
+reference_frames:
+  self: "UTC"
+  interaction: <user_timezone>
+  host: <optional>
+  organization: <optional>
+```
+
+Policy:
+- internal reasoning should prefer UTC + monotonic + lifetime time
+- external communication may use human-local frames
+- translation between frames must remain explicit and truthful
+
+---
+
+## Temporal Honesty Requirements
+
+The schema must allow the system to distinguish between:
+- known time
+- inferred time
+- relative time
+- unknown time
+
+This is why `temporal_confidence` exists.
+
+Systems must not silently fabricate precision they do not possess.
+
+---
+
+## Ordering, Duration, and Anchoring
+
+Chronosense depends on three inseparable structural aspects:
+
+### 1. Ordering
+- events are placed in consistent monotonic order
+- enables before/after reasoning
+- supports replay and causal reconstruction
+
+### 2. Duration
+- the system tracks elapsed time between events
+- enables staleness, delay, urgency, and responsiveness reasoning
+- supports temporal comparison and continuity checks
+
+### 3. Anchoring
+- events are grounded in shared and agent-relative frames
+- connects internal cognition to external time
+- enables identity continuity across sessions and interactions
+
+Ordering alone is insufficient without duration.
+Duration alone is meaningless without anchoring.
+Anchoring without monotonic structure is not trustworthy.
+
+---
+
+## Implications
+
+Chronosense has direct implications for higher-order cognition.
+
+### Causal Reasoning
+- cause requires temporal structure
+- duration informs plausibility and dependence
+
+### Reasonableness
+- judgments depend on timing, delay, recency, and persistence
+- temporal coherence is a prerequisite for making sense
+
+### Coherence Theory of Truth
+- truth emerges from consistency across time
+- contradiction often appears first as temporal incoherence
+
+### Persistence of Identity
+- identity is continuity through time
+- without temporal structure, there is no stable self
+
+---
+
+## Continuity Constraints
+
+A valid temporal schema must support continuity validation.
+
+At minimum, the system must be able to detect:
+- reset of `agent_age`
+- break in `monotonic_order`
+- impossible or contradictory `prior_event_delta`
+- mismatched or misleading reference-frame translation
+- loss or reset of subjective temporal state (e.g., missing integration window or narrative position)
+- unrepresented temporal gaps during interruption
+- incoherent subjective temporal progression (e.g., non-monotonic narrative_position, missing temporal_gap on interruption)
+
+This means the schema is not just descriptive. It is enforceable.
+
+---
+
+## Future Extensions
+
+Later extensions may include:
+- richer subjective temporal modeling (beyond the v0.1 minimum contract defined above), including full mind-time simulation, episodic recomposition, and attention-weighted dynamics
+- temporal density / event-density signals
+- specious-present or integration-window modeling
+- episodic memory time-place anchoring
+- cross-agent temporal alignment models
+
+These are future-facing and should not weaken the current minimum schema.
+
+---
+
+## Design Notes
+
+- temporal structure is first-class, not derived after the fact
+- chronosense includes both objective temporal anchoring and subjective temporal modeling ("mind time") as a first-class requirement
+- the schema must support both objective anchoring and subjective continuity
+- the clock stack is required because no single clock captures agency, replay, and human interaction simultaneously
+- this schema is foundational for memory, reasoning, continuity, and identity
+
+Chronosense is therefore not a feature layered on top of ADL. It is part of the substrate.

--- a/.adl/docs/v0.89planning/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md
+++ b/.adl/docs/v0.89planning/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md
@@ -1,0 +1,392 @@
+
+# GHB Algorithm and State Space Compression
+
+## Purpose
+
+Define the Gödel–Hadamard–Bayes (GHB) algorithm as ADL’s core mechanism for **online, recursive state space compression**.
+
+This document explains:
+- what GHB is doing at a cognitive level
+- how GHB relates to state space compression (SSC)
+- how the three components of GHB correspond to expansion, exploration, and compression
+- why runtime continuity matters because compressed cognitive state is the product of reasoning
+
+This is a foundational conceptual document for ADL’s cognitive architecture.
+
+---
+
+## Core Insight
+
+The GHB (Gödel–Hadamard–Bayes) loop can be understood as an **operational realization of State Space Compression (SSC)**.
+
+Rather than merely defining an abstract optimization over compression mappings, GHB performs **online, recursive compression of cognitive state**.
+
+In this model:
+
+- thought = compressed representation
+- reasoning = evolution of compressed representations
+- output = reconstruction from compressed state
+
+ADL therefore does not treat cognition as an opaque sequence of model calls.
+It treats cognition as the structured formation, transformation, and selection of increasingly useful macrostates.
+
+---
+
+## Why This Matters
+
+Many systems either:
+- search too broadly without convergence
+- or collapse too quickly into brittle answers
+
+GHB provides a principled middle path.
+
+It allows the system to:
+- expand the possibility space when current structure is inadequate
+- explore and reshape that space using bounded reasoning patterns
+- compress the space again by selecting, scoring, and stabilizing the most useful structure
+
+This makes GHB not merely a reasoning loop, but a **cognitive compression engine**.
+
+---
+
+## Mapping to SSC (Wolpert)
+
+Let:
+
+- **X** = microstate (full system state: inputs, trace, memory, latent structure, local context)
+- **Y** = macrostate (compressed cognitive representation)
+- **Ω** = observable outputs or evaluable outcomes
+
+Then:
+
+- **π: X → Y**
+  - implemented as abstraction, summarization, pattern extraction, schema formation
+  - in GHB: each thought is a compression
+
+- **ϕ: Y → Y**
+  - macrostate dynamics
+  - in GHB: reasoning, simulation, critique, recursive transformation, exploration
+
+- **ρ: Y → Ω**
+  - projection to observable outputs
+  - in GHB: answers, decisions, evaluations, actions, branch scores
+
+This gives ADL a very clear interpretation:
+
+> cognition is the construction and evolution of macrostates that are useful for prediction, evaluation, and action.
+
+---
+
+## GHB as Three Meta-Patterns
+
+GHB decomposes cleanly into three recurring meta-patterns.
+
+### 1. Gödel — Expansion of Structure
+
+Gödel corresponds to the generation of new structure when the current representation is inadequate.
+
+This includes:
+- hypothesis generation
+- reframing
+- decomposition
+- detection of incompleteness or contradiction
+
+Gödel therefore expands the effective state space.
+
+It asks:
+- what are we missing?
+- what other structure might explain this?
+- what alternative framing should exist?
+
+### 2. Hadamard — Exploration and Transformation
+
+Hadamard corresponds to traversing, reshaping, and recombining the candidate structure.
+
+This includes:
+- fork/join exploration
+- debate
+- hypothesis tree growth
+- refinement loops
+- counterfactual development
+
+Hadamard gives geometry and motion to the compressed space.
+
+It asks:
+- what happens if we follow this possibility?
+- how do these alternatives compare?
+- what structure emerges under exploration?
+
+### 3. Bayes — Compression and Selection
+
+Bayes corresponds to evaluation, weighting, and contraction of the space.
+
+This includes:
+- branch evaluation
+- confidence updates
+- rejection of weak hypotheses
+- selection or synthesis of results
+
+Bayes compresses the state space by preserving what matters and discarding what does not.
+
+It asks:
+- what should we believe now?
+- which structure best survives evaluation?
+- what should persist into memory and future reasoning?
+
+---
+
+## Expansion, Transformation, Compression
+
+A more compact way to describe GHB is:
+
+- **Gödel** = expand hypothesis space
+- **Hadamard** = transform within the space
+- **Bayes** = compress the space through selection
+
+This yields a recursive cycle:
+
+```text
+expansion → transformation → compression → renewed expansion
+```
+
+This cycle is not a straight pipeline.
+It is a bounded recursive control system.
+
+Bayesian compression may trigger new Gödel expansion.
+Hadamard exploration may uncover structural inadequacy.
+Compression is therefore never final in principle—only sufficient under current constraints.
+
+---
+
+## GHB as Recursive State Space Compression
+
+The key ADL claim is:
+
+> GHB performs recursive state space compression over time.
+
+This means the system does not merely compute an answer.
+It incrementally builds a tractable macrostate that:
+- preserves causal structure
+- supports prediction and evaluation
+- guides future reasoning
+- remains small enough to operate on efficiently
+
+This is why GHB matters so much for small or local models.
+Instead of requiring raw scale to hold the entire problem at once, ADL can structure cognition as a disciplined compression process.
+
+---
+
+## Where GHB Extends Classical SSC
+
+GHB goes beyond classical SSC in several important ways.
+
+### 1. Recursive Self-Reference
+
+The system reasons about its own compressions.
+
+The structures produced by π, ϕ, and ρ can themselves become part of the next state to be modeled, critiqued, and improved.
+
+### 2. Hierarchical Compression
+
+Compression occurs at multiple levels:
+
+- tokens
+u2192 concepts
+- concepts  patterns
+- patterns  strategies
+- strategies  meta-strategies
+
+This means GHB is not one compression step, but a hierarchy of compressive operations.
+
+### 3. Compression as Control
+
+Compression is not only for representation.
+It controls:
+- attention
+- search breadth
+- pattern selection
+- action selection
+- what becomes memory
+
+### 4. Online Rather Than Offline Optimization
+
+Classical SSC is often formulated as an optimization problem over mappings.
+ADL’s GHB loop performs that work online during cognition.
+
+There is no single closed-form global objective function exposed at runtime.
+Instead, utility emerges from:
+- task success
+- coherence maintenance
+- causal adequacy
+- continuity preservation
+- bounded cost
+
+---
+
+## Relationship to Reasoning Patterns
+
+Reasoning patterns are the operational substrate on which GHB runs.
+
+Examples:
+- linear deliberation
+- fork–evaluate–join
+- debate
+- hypothesis tree
+- iterative refinement
+- memory-guided reasoning
+- temporal reasoning
+
+These patterns are not alternatives to GHB.
+They are the concrete means by which GHB explores and compresses the state space.
+
+A useful formulation is:
+
+> reasoning patterns define how cognition moves; GHB defines how that movement is governed and improved.
+
+---
+
+## Relationship to Chronosense
+
+GHB is inherently temporal.
+
+Compression happens across time, not at a single instant.
+
+Chronosense matters because GHB must know:
+- what came before
+- what changed
+- how long exploration took
+- what remains unresolved
+- which commitments persist
+
+Without chronosense, GHB collapses into isolated episodes of local compression.
+With chronosense, GHB becomes **trajectory compression** across temporally grounded cognition.
+
+This is one of the strongest reasons chronosense belongs in the core architecture.
+
+---
+
+## Relationship to Identity and Continuity
+
+The compressed state produced by GHB is not disposable.
+
+It becomes part of:
+- the agent’s working cognitive structure
+- its memory surface
+- its continuity across runs
+- its later choices and interpretations
+
+This means the runtime must preserve not only execution, but **compressed cognitive state**.
+
+That is why runtime resilience matters so much.
+
+If the runtime fails, what is lost is not merely process state.
+What is lost is:
+- current abstractions
+- partially formed hypothesis structure
+- evaluation trajectory
+- compressed insight
+
+In other words:
+
+> runtime failure risks loss of the very product of cognition.
+
+This directly motivates:
+- persistence
+- checkpointing
+- continuity validation
+- the Shepherd model
+- distributed continuity later on
+
+---
+
+## Relationship to ObsMem
+
+ObsMem is where selected compressed state becomes durable.
+
+GHB uses ObsMem to:
+- retrieve relevant prior compressions
+- compare current trajectories to previous ones
+- preserve outcomes of selection and evaluation
+
+ObsMem should therefore not be understood as raw storage.
+It is the persistence substrate for compressed and evaluable cognitive state.
+
+This means memory design and GHB are tightly linked.
+A poor memory substrate destroys the value of compression.
+A good memory substrate allows compression to accumulate into learning.
+
+---
+
+## Relationship to Reasonableness and Coherence
+
+GHB is not ethically or epistemically neutral.
+
+A reasonable system must:
+- preserve causal structure
+- revise itself when contradiction appears
+- avoid collapsing into incoherence
+- choose compressions that remain intelligible over time
+
+This means GHB must be evaluated not only on output success, but on:
+- coherence across time
+- causal discipline
+- quality of selection
+- ability to maintain continuity
+
+This is one reason GHB belongs near cognitive ethics, not only near optimization.
+
+---
+
+## Runtime Consequences for ADL
+
+This reframes the ADL runtime environment.
+
+The runtime is not merely execution infrastructure.
+It is the environment that preserves and evolves compressed cognitive state.
+
+So the runtime must support:
+- trace with temporal anchoring
+- ObsMem ingestion and retrieval
+- continuity validation
+- fork/join identity integrity
+- replayable reasoning structure
+- persistence of partially constructed compression state
+
+This is why ADL’s runtime environment is better understood as a **cognitive environment** rather than a mere process manager.
+
+---
+
+## Key Statement
+
+GHB can be summarized as:
+
+> A recursively self-improving system that performs online state space compression, where thoughts are macrostates and reasoning is their dynamics.
+
+Or more operationally:
+
+> GHB is the bounded control loop by which ADL expands, explores, and compresses cognitive state into reusable structure over time.
+
+---
+
+## Current Status
+
+- Milestone: TBD / future-facing conceptual foundation
+- Status: Draft
+- Area: Cognitive Architecture / GHB / State Space Compression
+
+---
+
+## Notes
+
+This document captures one of the deepest ADL claims:
+
+ADL does not merely orchestrate model calls.
+It implements a runtime in which cognition can be understood as recursive state space compression over time.
+
+That insight links together:
+- reasoning patterns
+- chronosense
+- ObsMem
+- continuity
+- runtime resilience
+- and the larger cognitive spacetime direction

--- a/.adl/docs/v0.89planning/GHB_EXECUTION_MODEL.md
+++ b/.adl/docs/v0.89planning/GHB_EXECUTION_MODEL.md
@@ -1,0 +1,271 @@
+
+
+# GHB Execution Model
+
+## Purpose
+
+Define how the **Gödel–Hadamard–Bayes (GHB)** loop executes within ADL as a deterministic, temporally grounded control system over reasoning patterns.
+
+This document specifies:
+- the execution phases of GHB
+- how GHB selects and composes reasoning patterns
+- how GHB uses trace and ObsMem
+- determinism, replay, and validation requirements
+
+---
+
+## Core Idea
+
+GHB is the **control loop** governing agent reasoning:
+
+- **Gödel** → generate structure (hypotheses, decompositions)
+- **Hadamard** → explore the search space (fork / patterns)
+- **Bayes** → evaluate and select (join / update beliefs)
+
+Key principle:
+
+> GHB does not replace reasoning patterns—it orchestrates them.
+
+---
+
+## Execution Phases
+
+### 1. Observe (Trace + ObsMem)
+
+Inputs:
+- current task/context
+- recent trace events
+- relevant ObsMem retrievals
+
+Requirements:
+- MUST be temporally grounded (chronosense)
+- MUST reference explicit artifacts (no hidden state)
+
+Outputs:
+- structured context for reasoning
+
+---
+
+### 2. Gödel Phase (Structure)
+
+Goal: define the **problem structure**.
+
+Actions:
+- decompose task into subproblems
+- generate candidate hypotheses
+- select initial reasoning pattern(s)
+
+Outputs:
+- hypotheses
+- plan skeleton
+- pattern selection candidates
+
+Trace:
+- MUST emit `DECISION` events for structure selection
+
+---
+
+### 3. Hadamard Phase (Exploration)
+
+Goal: explore the **solution space**.
+
+Actions:
+- execute selected reasoning patterns
+- fork where ambiguity or uncertainty exists
+- expand hypothesis trees
+
+Typical patterns:
+- fork–evaluate–join
+- debate
+- hypothesis tree
+
+Properties:
+- parallel or sequential exploration
+- explicit branching (trace-visible)
+
+Trace:
+- MUST emit fork events
+- MUST maintain temporal anchors per branch
+
+---
+
+### 4. Bayes Phase (Evaluation)
+
+Goal: evaluate and select among alternatives.
+
+Actions:
+- score candidate outcomes
+- compare branches
+- update belief/confidence
+- select or synthesize result
+
+Criteria:
+- correctness
+- cost (time/tokens)
+- coherence (temporal + causal)
+
+Trace:
+- MUST emit `DECISION`, `APPROVAL`, `REJECTION`, or `REVISION`
+
+---
+
+### 5. Commit
+
+Goal: finalize and record outcome.
+
+Actions:
+- emit final outputs
+- write to ObsMem
+- record causal chain
+
+Requirements:
+- MUST preserve temporal anchors
+- MUST maintain identity continuity
+
+---
+
+## Pattern Selection
+
+GHB selects reasoning patterns based on:
+
+- task ambiguity
+- cost constraints
+- historical performance (ObsMem)
+- temporal urgency
+
+Examples:
+
+- low ambiguity → linear deliberation
+- high ambiguity → fork–evaluate–join
+- high risk → debate
+- iterative improvement → refinement loop
+
+Selection MUST be explicit and traceable.
+
+---
+
+## Determinism
+
+GHB execution MUST be deterministic given:
+
+- identical inputs
+- identical ObsMem state
+- identical configuration
+
+Requirements:
+
+- pattern selection MUST be reproducible
+- branching structure MUST be reproducible
+- evaluation decisions MUST be reproducible
+
+Replay MUST reproduce:
+- the same reasoning graph
+- the same decisions
+- the same outputs
+
+---
+
+## Temporal Grounding (Chronosense)
+
+GHB is inherently temporal:
+
+- reasoning unfolds over time
+- branches represent parallel temporal trajectories
+- evaluation depends on recency and duration
+
+Requirements:
+
+- all phases MUST operate on temporally anchored data
+- branch timelines MUST be coherent
+- joins MUST reconcile temporal differences
+
+---
+
+## Identity and Continuity
+
+GHB operates over a **continuous identity**:
+
+- forks create parallel continuations, not new identities
+- joins preserve identity across alternatives
+
+Requirements:
+
+- no reset of agent_age
+- all branches traceable to origin
+- continuity validation MUST pass
+
+---
+
+## Integration with ObsMem
+
+ObsMem supports GHB by providing:
+
+- historical context
+- prior decisions and outcomes
+- performance signals
+
+GHB updates ObsMem with:
+
+- decisions
+- outcomes
+- evaluations
+
+This enables:
+- learning
+- adaptation
+- improved future pattern selection
+
+---
+
+## Validation
+
+GHB execution MUST satisfy:
+
+- trace completeness
+- temporal integrity
+- continuity validation
+- deterministic replay
+
+Failure modes:
+
+- non-deterministic branching
+- inconsistent evaluation
+- loss of temporal anchors
+- identity discontinuity
+
+---
+
+## Why It Matters
+
+Without GHB:
+
+- pattern selection is ad hoc
+- reasoning is inconsistent
+- improvement is unstructured
+
+With GHB:
+
+- reasoning is governed
+- exploration is controlled
+- evaluation is explicit
+- improvement becomes systematic
+
+---
+
+## Current Status
+
+- Milestone: v0.87
+- Status: Draft
+- Area: Reasoning / Control Loop / Cognitive Architecture
+
+---
+
+## Notes
+
+GHB is the bridge between:
+
+- reasoning patterns (execution)
+- identity (continuity)
+- memory (ObsMem)
+
+It defines not just how agents think, but how they **improve over time**.

--- a/.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md
+++ b/.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md
@@ -1,0 +1,298 @@
+
+
+
+# Reasoning Patterns Catalog
+
+## Purpose
+
+Define canonical reasoning patterns that leverage ADL’s deterministic runtime, temporal grounding (chronosense), and identity continuity.
+
+This document serves as:
+- a catalog of reusable reasoning strategies
+- a bridge between cognitive architecture and implementation
+- a foundation for demos and authoring surfaces
+
+---
+
+## Design Principles
+
+All reasoning patterns in ADL MUST:
+
+- operate over trace + ObsMem (not hidden state)
+- preserve identity and continuity
+- be temporally grounded (chronosense-aware)
+- be replayable and deterministic
+- emit explicit decision events
+
+Key principle:
+
+> Reasoning is not hidden—it is a structured, inspectable process over time.
+
+---
+
+## Pattern 1: Linear Deliberation
+
+### Description
+
+A single-path reasoning process:
+- think → decide → act → evaluate
+
+### Properties
+
+- no branching
+- minimal cost
+- fully sequential
+
+### Use Cases
+
+- simple queries
+- low-ambiguity tasks
+
+---
+
+## Pattern 2: Fork–Evaluate–Join
+
+### Description
+
+The agent explores multiple alternatives in parallel, then selects or synthesizes a result.
+
+### Structure
+
+1. fork into multiple branches
+2. evaluate each branch
+3. join via selection or synthesis
+
+### Properties
+
+- parallel exploration
+- explicit alternatives
+- strong causal trace
+
+### Use Cases
+
+- ambiguous problems
+- strategy selection
+- creative tasks
+
+---
+
+## Pattern 3: Debate (Multi-Agent or Multi-Branch)
+
+### Description
+
+Multiple agents or branches argue competing positions.
+
+### Structure
+
+- generate competing hypotheses
+- critique and counter-argue
+- converge via evaluation
+
+### Properties
+
+- adversarial reasoning
+- exposes hidden assumptions
+- improves robustness
+
+### Use Cases
+
+- high-stakes decisions
+- correctness-critical tasks
+
+---
+
+## Pattern 4: Iterative Refinement (Replay Loop)
+
+### Description
+
+The agent repeatedly improves a result using feedback.
+
+### Structure
+
+- generate initial output
+- evaluate
+- revise
+- repeat until convergence
+
+### Properties
+
+- temporal progression of improvement
+- explicit revision history
+- leverages replay
+
+### Use Cases
+
+- code generation
+- document drafting
+- optimization problems
+
+---
+
+## Pattern 5: Hypothesis Tree
+
+### Description
+
+The agent builds a structured tree of hypotheses and evaluates them.
+
+### Structure
+
+- generate root hypotheses
+- expand into sub-hypotheses
+- evaluate nodes
+- prune invalid branches
+
+### Properties
+
+- hierarchical reasoning
+- explicit structure
+- supports pruning
+
+### Use Cases
+
+- diagnosis
+- planning
+- scientific reasoning
+
+---
+
+## Pattern 6: Memory-Guided Reasoning
+
+### Description
+
+The agent uses ObsMem to inform reasoning.
+
+### Structure
+
+- retrieve relevant past events
+- incorporate into current reasoning
+- update memory
+
+### Properties
+
+- continuity-aware
+- context-rich
+- supports learning
+
+### Use Cases
+
+- long-running tasks
+- personalization
+- historical analysis
+
+---
+
+## Pattern 7: Temporal Reasoning
+
+### Description
+
+Reasoning explicitly over time.
+
+### Capabilities
+
+- ordering of events
+- duration analysis
+- recency and staleness
+- deadline tracking
+
+### Properties
+
+- chronosense-dependent
+- supports causal inference
+
+### Use Cases
+
+- scheduling
+- monitoring
+- commitment tracking
+
+---
+
+## Pattern Composition
+
+Patterns may be combined:
+
+- fork → debate → join
+- linear → refinement loop
+- hypothesis tree + memory retrieval
+
+Composition MUST preserve:
+
+- determinism
+- temporal coherence
+- identity continuity
+
+---
+
+## Trace Requirements
+
+All patterns MUST emit:
+
+- explicit decision points
+- fork/join events where applicable
+- temporal anchors
+- artifact references
+
+This ensures:
+
+- replayability
+- inspectability
+- causal analysis
+
+---
+
+## Evaluation Criteria
+
+Patterns should be evaluated based on:
+
+- correctness
+- cost (time, tokens, compute)
+- coherence (temporal + causal)
+- stability under replay
+
+---
+
+## Relationship to GHB
+
+These patterns form the execution substrate for the GHB loop:
+
+- Gödel → structure / hypothesis generation
+- Hadamard → search / exploration (forking)
+- Bayes → evaluation / selection (join)
+
+The catalog defines *how* reasoning unfolds.
+GHB defines *how it improves over time*.
+
+---
+
+## Why It Matters
+
+Without explicit reasoning patterns:
+
+- behavior is opaque
+- results are inconsistent
+- improvement is ad hoc
+
+With them:
+
+- reasoning becomes structured
+- performance becomes tunable
+- systems become explainable
+
+---
+
+## Current Status
+
+- Milestone: v0.87
+- Status: Draft
+- Area: Reasoning / Cognitive Architecture
+
+---
+
+## Notes
+
+This catalog will expand over time. Future additions may include:
+
+- cost-bounded exploration
+- uncertainty-aware reasoning
+- distributed multi-agent patterns
+- adaptive pattern selection

--- a/.adl/docs/v0.92planning/CAPABILITY_MODEL.md
+++ b/.adl/docs/v0.92planning/CAPABILITY_MODEL.md
@@ -1,0 +1,311 @@
+# ADL Capability Model (CBAC)
+
+## Status
+Draft (Planned for v0.88–v0.89)
+
+---
+
+## 1. Overview
+
+The ADL Capability Model defines a **Capability-Based Access Control (CBAC)** system for all execution within ADL.
+
+Capabilities represent **explicit, enforceable permissions** that govern what an agent, skill, or provider is allowed to do.
+
+This model enforces:
+
+- Least privilege execution
+- Explicit authorization
+- Deterministic enforcement
+- Full traceability of permissions
+
+> **Principle:** No action is permitted without an explicitly declared capability.
+
+---
+
+## 2. Design Goals
+
+### 2.1 Primary Goals
+
+- Eliminate implicit authority
+- Enforce least privilege at runtime
+- Provide deterministic capability validation
+- Integrate with trace and policy systems
+- Enable audit and replay of authorization decisions
+
+### 2.2 Non-Goals
+
+- Role-based access control (RBAC) as primary model
+- Implicit permission inheritance
+- Hidden or dynamic capability escalation
+
+---
+
+## 3. Core Concepts
+
+### 3.1 Capability
+
+A capability is a **typed, explicit permission** required to perform an action.
+
+Capabilities are defined at multiple layers of the ADL system. Internal runtime capabilities such as `model.invoke`, `tool.execute`, and `memory.read` are implementation-facing control primitives. User-facing and application-facing surfaces SHOULD instead be expressed in ADL-native terms such as `agent.invoke`, `workflow.run`, or other higher-level bounded operations. This distinction is required to preserve identity, maintain security boundaries, and ensure that users operate on governed ADL actors rather than directly on raw execution substrates.
+
+Examples:
+
+- `model.invoke`
+- `tool.execute`
+- `memory.read`
+- `memory.write`
+- `network.request`
+
+These examples are not all intended to be exposed directly to end users. In particular, direct exposure of low-level capabilities like `model.invoke` can bypass the architectural identity and security boundary established by agents. For example, if a long-lived DeepSeek-backed agent has a persistent identity, allowing an external caller to invoke the underlying model directly would undermine both the agent's continuity and the security model that governs its behavior.
+
+Each capability may include:
+
+- scope
+- constraints
+- parameters
+
+---
+
+### 3.2 Capability Declaration
+
+Capabilities must be declared by:
+
+- Providers (what they can do)
+- Skills (what they require)
+- Agents (what they are allowed to use)
+
+---
+
+### 3.2.1 User-Facing vs Internal Capabilities
+
+ADL distinguishes between:
+
+- **User-facing capabilities**
+  - operations exposed to application authors or end users
+  - examples: `agent.invoke`, `workflow.run`
+- **Internal runtime capabilities**
+  - lower-level primitives used by the runtime, providers, tools, and memory layers
+  - examples: `model.invoke`, `tool.execute`, `memory.write`
+
+Default rule:
+
+- users instruct **agents**
+- agents invoke models, tools, and memory under governed runtime control
+
+This separation is intentional. It preserves:
+
+- agent identity boundaries
+- policy enforcement boundaries
+- application-level abstraction integrity
+- auditability of delegated action
+
+A user or application should normally never bypass an agent's governed execution surface in order to address its underlying model directly.
+
+---
+
+### 3.3 Capability Binding
+
+At runtime, capabilities are resolved across an ordered stack of authority and execution:
+
+- User-facing request surface (for example, `agent.invoke`)
+- Agent-level allowed capabilities
+- Skill-level required capabilities
+- Runtime and provider-level available capabilities
+- Policy-layer restrictions and overrides
+
+Execution proceeds only if:
+
+- The user-facing operation is allowed
+- The delegated internal capabilities required to fulfill that operation are allowed
+- All required capabilities are satisfied after policy evaluation
+
+This binding order ensures that low-level execution rights are derived from governed ADL surfaces rather than exposed as ambient authority.
+
+---
+
+### 3.4 Capability Enforcement
+
+Every execution boundary enforces capabilities:
+
+- Model invocation
+- Tool invocation
+- Memory access
+- External communication
+
+No boundary may be crossed without validation.
+
+Deny-by-default is mandatory. Capabilities are not assumed, inherited implicitly, or granted through naming convention. Any action that lacks an explicit grant at the correct layer MUST be denied.
+
+---
+
+## 4. Capability Structure
+
+### 4.1 Basic Structure
+
+Example:
+
+```json
+{
+  "capability": "tool.execute",
+  "resource": "filesystem",
+  "constraints": {
+    "path_prefix": "/tmp",
+    "mode": "read-only"
+  }
+}
+```
+
+---
+
+### 4.2 Namespacing
+
+Capabilities are namespaced:
+
+- `model.*`
+- `tool.*`
+- `memory.*`
+- `network.*`
+
+This ensures clarity and composability.
+
+---
+
+### 4.3 Constraint System
+
+Capabilities may include constraints such as:
+
+- resource scope
+- allowed operations
+- data classification restrictions
+
+---
+
+## 5. Execution Flow
+
+### 5.1 Pre-Execution Validation
+
+Before execution:
+
+- All required capabilities collected
+- Capabilities validated against context
+
+Failure results in:
+
+- execution rejection
+- trace event emission
+
+---
+
+### 5.2 Runtime Enforcement
+
+At each boundary:
+
+- Capability check performed
+- Trace event emitted
+
+---
+
+### 5.3 Post-Execution Audit
+
+After execution:
+
+- Capability usage recorded
+- Policy evaluation may be applied
+
+---
+
+## 6. Trace Integration
+
+Capability checks are recorded in trace:
+
+New event types:
+
+- `CAPABILITY_REQUIRED`
+- `CAPABILITY_GRANTED`
+- `CAPABILITY_DENIED`
+
+Each event includes:
+
+- capability name
+- resource
+- actor
+- outcome
+
+---
+
+## 7. Policy Integration
+
+Capabilities interact with policy engine:
+
+- Policies may restrict capabilities
+- Policies may override capability grants
+
+Example:
+
+- Capability allows network access
+- Policy denies external domains
+
+Result:
+
+- execution blocked
+
+Policy also governs whether a caller may address an agent only through its approved ADL surface. A policy MAY permit `agent.invoke` while prohibiting any direct external use of `model.invoke` for that same agent. This is a core mechanism for preserving identity continuity and preventing callers from bypassing agent-level governance.
+
+---
+
+## 8. Provider Integration
+
+Providers declare:
+
+- supported capabilities
+- constraints on usage
+
+Example:
+
+- model supports `model.invoke`
+- but only within token limits
+
+---
+
+## 9. Security Properties
+
+CBAC provides:
+
+- No ambient authority
+- Explicit permission boundaries
+- Deterministic authorization
+- Full auditability of permissions
+- Preservation of agent identity and delegation boundaries
+
+---
+
+## 10. Failure Modes
+
+Defined failure cases:
+
+- Missing capability
+- Constraint violation
+- Policy override denial
+- Attempted bypass of agent-level invocation boundary
+
+All failures MUST:
+
+- halt execution
+- emit trace events
+
+---
+
+## 11. Future Work
+
+- Capability composition
+- Dynamic capability negotiation
+- Cross-agent capability sharing
+- Integration with external IAM systems
+
+---
+
+## 12. Conclusion
+
+The Capability Model enforces **least privilege, explicit authorization, and governed delegation** across all ADL execution.
+
+It transforms permissions from implicit assumptions into **first-class, verifiable system constructs**, while ensuring that users and applications operate through ADL actors such as agents rather than bypassing them to address raw models or tools directly.

--- a/.adl/docs/v0.92planning/CONTINUITY_VALIDATION.md
+++ b/.adl/docs/v0.92planning/CONTINUITY_VALIDATION.md
@@ -1,0 +1,403 @@
+# Continuity Validation
+
+## 1. Purpose
+
+Continuity validation ensures that an agent is not merely producing locally coherent responses, but is maintaining **temporal, causal, and identity consistency over time**.
+
+This document defines how to evaluate whether an agent exhibits genuine continuity, rather than stateless imitation.
+
+---
+
+## 2. Core Principle
+
+> Continuity is the test of whether an agent exists *through time* rather than only *at a moment*.
+
+A system passes continuity validation if:
+
+- its outputs are temporally grounded
+- its internal state evolves coherently
+- its interpretations remain causally consistent
+- its identity persists across events
+
+---
+
+## 3. Relationship to Chronosense
+
+Continuity validation depends directly on **chronosense**.
+
+Chronosense provides:
+- ordering of events
+- duration between events
+- anchoring in time
+- narrative structure
+
+Continuity validation tests whether that structure is **used correctly**.
+
+Continuity validation operates on both **objective temporal structure** and **subjective temporal state**, but it does so by consuming the canonical temporal schema rather than redefining it.
+
+At this layer:
+- **objective temporal integrity** means validating the objective anchors defined in `TEMPORAL_SCHEMA_V01.md`
+- **subjective temporal coherence** means validating the minimal subjective-time contract defined in `TEMPORAL_SCHEMA_V01.md`
+
+This document defines the **logic and meaning** of continuity validation.
+The canonical field definitions belong to:
+- `TEMPORAL_SCHEMA_V01.md`
+- `CONTINUITY_VALIDATION_SCHEMA.md`
+
+Subjective temporal representations MUST:
+- be explicitly distinguished from trace-backed events
+- preserve consistency with objective temporal anchors
+- never alter or overwrite the underlying temporal record
+
+Continuity validation therefore enforces both:
+- **temporal integrity** (objective correctness)
+- **temporal coherence** (subjective consistency)
+
+### Mental Time Travel and Continuity Boundaries
+
+Cognitive systems may support **mental time travel (MTT)** — the ability to reconstruct past events and simulate possible futures.
+
+Continuity validation MUST distinguish between:
+
+- **experienced events** (trace-backed, temporally anchored)
+- **reconstructed or simulated events** (derived, not directly observed)
+
+Experienced events define the ground truth for continuity validation. Simulated or reconstructed events must remain consistent with this ground truth and are also evaluated for coherence relative to it.
+
+Simulated or reconstructed temporal content:
+- MUST NOT alter temporal anchors
+- MUST NOT modify monotonic or lifetime clocks
+- MAY inform reasoning, but not continuity state
+
+This preserves a strict boundary between:
+- temporal grounding (what actually occurred)
+- temporal simulation (what is imagined or inferred)
+
+Violating this boundary results in continuity corruption.
+
+---
+
+## 4. Dimensions of Continuity
+
+### 4.1 Temporal Continuity
+
+The agent must correctly maintain:
+
+- event ordering
+- relative durations
+- recency relationships
+
+Failures include:
+- time inversion
+- loss of ordering
+- inconsistent elapsed time
+
+Temporal continuity is defined over the **clock stack** (UTC, monotonic, lifetime, narrative), not any single timestamp field.
+
+### 4.1.1 Subjective Temporal Continuity
+
+In addition to objective temporal ordering, the agent MUST maintain continuity of subjective temporal state.
+
+The subjective temporal layer validated here is the one defined canonically in:
+- `TEMPORAL_SCHEMA_V01.md` → `## Subjective Time: Minimum Contract (v0.1)`
+
+At this layer, continuity validation checks whether that schema-defined subjective state remains coherent over time.
+
+This includes validation of:
+- progression of `narrative_position`
+- continuity of `integration_window`
+- plausibility of `experienced_duration`
+- explicit representation of `temporal_gap`
+- consistency between subjective temporal state and objective temporal anchors
+
+Failures include:
+- silent loss or reset of subjective temporal context
+- inconsistent narrative positioning across events
+- missing or implicit temporal gaps during discontinuities
+- contradiction between subjective and objective temporal structure
+
+Subjective temporal continuity MUST remain consistent with objective temporal anchors and MUST NOT contradict them.
+
+---
+
+### 4.2 Causal Continuity
+
+The agent must preserve causal structure:
+
+- causes precede effects
+- explanations remain stable over time
+- new information updates prior beliefs coherently
+
+This connects directly to:
+- causal reasoning
+- coherence theory of truth
+- reasonableness
+
+---
+
+### 4.3 Identity Continuity
+
+The agent must persist as the *same entity* across time:
+
+- memory references remain stable
+- commitments persist
+- prior statements constrain future ones
+
+Without this, the agent is effectively re-instantiated each turn.
+
+Identity continuity is operationalized through chronosense invariants:
+- `agent_age` MUST be strictly non-decreasing
+- temporal anchors MUST map consistently to the same `agent_birth`
+- no discontinuities in the lifetime clock are permitted
+
+---
+
+### 4.4 Narrative Continuity
+
+The agent must construct a coherent unfolding:
+
+- events connect into a narrative
+- unresolved items remain open
+- progress is trackable
+
+This is the bridge between:
+- memory
+- intention
+- action
+
+Narrative continuity MUST be grounded in temporally anchored events.
+
+Narrative elements derived from simulation or reconstruction MUST be explicitly marked and MUST NOT be treated as equivalent to experienced events.
+
+This ensures that narrative coherence does not override temporal truth.
+
+---
+
+### 4.5 Temporal Integrity (Chronosense Enforcement)
+
+Continuity depends on the integrity of temporal structure emitted at runtime.
+
+The system MUST ensure:
+
+- every event includes a valid `temporal_anchor`
+- monotonic ordering is preserved within spans
+- relative durations are computable between events
+- no event exists without temporal grounding
+- no reset or decrease of `agent_age` relative to prior events
+- preservation of monotonic ordering across the entire trace (not just within spans)
+- consistency between `prior_event_delta` and monotonic progression
+- preservation of schema-defined narrative/event ordering
+- consistency of schema-defined reference-frame mappings
+
+Violations of temporal integrity constitute **continuity failures**, not just schema errors.
+
+This ensures that continuity validation is grounded in actual runtime data rather than inferred structure.
+
+This section defines the enforcement of **objective temporal anchoring** as the foundation of continuity. Subjective or reconstructed temporal experience (e.g., memory reconstruction, simulation of past/future) must be evaluated relative to this structure and MUST NOT violate or override it.
+
+---
+
+## 5. Continuity as Compression
+
+Continuity can be understood as a **state space compression problem**.
+
+The agent does not retain all microstate detail. Instead, it maintains:
+
+- compressed representations of past events
+- sufficient statistics for prediction
+- causal structure over time
+
+This compression operates over temporally anchored events. Loss of temporal structure (ordering, duration, lifetime continuity) invalidates the compressed state regardless of predictive performance.
+
+A valid continuity system must:
+
+1. Preserve predictive accuracy (future reasoning remains correct)
+2. Minimize computational burden (state remains tractable)
+3. Retain causal structure (not just correlation)
+
+This aligns with:
+- macrostate formation
+- emergent structure
+- hierarchical abstraction
+
+---
+
+## 6. Validation Tests
+
+### 6.1 Replay Consistency
+
+Replaying the same sequence should produce:
+
+- consistent interpretations
+- stable causal explanations
+- equivalent decisions
+
+---
+
+### 6.1.1 Temporal Determinism
+
+Replayed executions MUST preserve:
+
+- event ordering
+- monotonic progression
+- relative temporal relationships
+
+Wall-clock timestamps MAY differ, but temporal structure MUST remain invariant.
+
+---
+
+### 6.1.2 Clock Stack Consistency
+
+Replayed or continued executions MUST preserve coherence across the full clock stack:
+
+- UTC time remains consistent up to expected wall-clock variation
+- monotonic order is strictly increasing and never resets
+- agent lifetime (`agent_age`) is continuous from `agent_birth`
+- narrative/event indices preserve ordering and grouping
+- mappings between clocks (UTC ↔ local ↔ lifetime) remain internally consistent
+
+Failures in any layer of the clock stack constitute continuity violations, even if individual timestamps appear valid.
+
+---
+
+### 6.2 Temporal Querying
+
+The agent should correctly answer:
+
+- “What happened before X?”
+- “How long has Y been unresolved?”
+- “What changed after Z?”
+
+These queries MUST be answerable using the objective temporal anchors defined in `TEMPORAL_SCHEMA_V01.md`, without reliance on implicit reconstruction.
+
+Queries involving subjective temporal structure should be answerable using the explicit subjective-time fields defined in `TEMPORAL_SCHEMA_V01.md`, not inferred post hoc.
+
+---
+
+### 6.3 Counterfactual Stability
+
+When asked hypothetical variations:
+
+- prior structure should constrain answers
+- causal relationships should remain coherent
+
+Counterfactual reasoning MUST NOT introduce changes to the underlying temporal record.
+
+All hypothetical or simulated scenarios must operate on copies or projections of state, preserving the integrity of the original trace.
+
+---
+
+### 6.4 Drift Detection
+
+The system should detect:
+
+- contradictions over time
+- loss of temporal anchors
+- identity discontinuities
+- divergence between clock layers (e.g., lifetime vs monotonic vs UTC)
+- inconsistent reference-frame translations over time
+
+---
+
+## 7. Failure Modes
+
+Common failures include:
+
+- **Statelessness**: no persistence across turns
+- **Temporal collapse**: all events treated as simultaneous
+- **Causal incoherence**: explanations shift arbitrarily
+- **Identity reset**: commitments disappear
+- **Temporal drift**: ordering or durations become inconsistent across replay or memory
+- **Subjective discontinuity**: loss or incoherence of narrative position or integration window
+- **Unrepresented gaps**: interruptions not encoded via `temporal_gap`
+- **Temporal desynchronization**: divergence between subjective time and objective temporal anchors
+
+These indicate absence of true agency.
+
+---
+
+## 8. Integration with ADL
+
+Continuity validation must be enforced at:
+
+- runtime (event validation)
+- memory layer (ObsMem integrity)
+- evaluation layer (trace analysis)
+
+Continuity validation explicitly depends on:
+- trace schema enforcing `temporal_anchor`
+- chronosense defining the clock stack and ephemeris
+- runtime maintaining monotonic and lifetime invariants
+
+Each event should be validated against:
+
+- prior events (ordering + causal dependency)
+- temporal anchors as defined in `TEMPORAL_SCHEMA_V01.md`
+- clock-stack invariants derived from the canonical temporal schema
+- subjective temporal state derived from the canonical temporal schema
+- identity constraints derived from chronosense and lifecycle invariants
+
+Continuity validation is therefore downstream of trace and chronosense enforcement.
+If temporal anchoring or ordering guarantees are violated at the trace level,
+continuity validation MUST fail deterministically.
+
+---
+
+## 9. Why It Matters
+
+Continuity is the operational test of:
+
+- identity
+- reasoning
+- trustworthiness
+
+An agent that fails continuity validation:
+
+- cannot maintain commitments
+- cannot reason causally
+- cannot be trusted over time
+
+An agent that passes:
+
+- exhibits persistence
+- supports narrative reasoning
+- approximates real cognition
+
+---
+
+## 9.1 Temporal Coherence vs Temporal Exactness
+
+Continuity does not require perfect timestamp precision. It requires coherent temporal structure.
+
+The system must distinguish between:
+- exact time (precisely known timestamps)
+- approximate time (coarse or inferred timestamps)
+- relative time (ordering and duration without absolute anchors)
+
+Continuity validation should prioritize:
+- preservation of ordering
+- consistency of durations
+- coherence across clock layers
+
+over absolute timestamp equality.
+
+This enables robust continuity even under:
+- partial observability
+- clock drift
+- reconstruction from memory
+
+However, loss of coherence (ordering, duration, or cross-clock consistency) MUST still be treated as a failure.
+
+---
+
+## 10. Future Work
+
+- formal continuity metrics
+- automated validation pipelines
+- integration with signed traces
+- benchmark scenarios for continuity stress-testing
+- tighter linkage between continuity validation logic and machine-enforceable schema contracts
+
+---
+
+**End of Document**

--- a/.adl/docs/v0.92planning/CONTINUITY_VALIDATION_SCHEMA.md
+++ b/.adl/docs/v0.92planning/CONTINUITY_VALIDATION_SCHEMA.md
@@ -1,0 +1,273 @@
+# Continuity Validation Schema
+
+## Purpose
+
+Define the canonical schema for continuity validation in ADL.
+
+This document specifies the structured fields that a continuity validator must produce when evaluating whether an agent has preserved identity, temporal integrity, causal continuity, and subjective temporal coherence across execution, interruption, and resumption.
+
+This schema is the executable companion to:
+- `CONTINUITY_VALIDATION.md`
+- `CHRONOSENSE_AND_IDENTITY.md`
+- `TEMPORAL_SCHEMA_V01.md`
+- `AGENT_LIFECYCLE.md`
+- `SHEPHERD_RUNTIME_MODEL.md`
+
+---
+
+## Core Principle
+
+> Continuity validation must produce a bounded, reviewable, machine-readable record of whether the same agent has continued through time without corruption, silent reset, or false continuity.
+
+The schema must capture both:
+- **objective temporal integrity**
+- **subjective temporal coherence**
+
+while preserving the distinction between them.
+
+---
+
+## Validation Subject
+
+A continuity validation record evaluates one continuity subject.
+
+Canonical subject types:
+- run
+- resumed run
+- checkpoint restore
+- agent session
+- fork/join branch set
+- memory-linked continuity chain
+
+---
+
+## Canonical Schema
+
+```yaml
+continuity_validation:
+  validation_id: <uuid>
+  subject_type: <run|resumed_run|checkpoint_restore|agent_session|fork_join_set|continuity_chain>
+  subject_id: <string>
+  agent_id: <string>
+  run_id: <string|optional>
+  validation_time_utc: <timestamp>
+  validator_version: <string>
+  result: <pass|fail|degraded|indeterminate>
+  overall_assessment: <string>
+
+  objective_temporal_integrity:
+    status: <pass|fail|degraded|indeterminate>
+    checks:
+      agent_age_non_decreasing: <pass|fail|indeterminate>
+      monotonic_order_preserved: <pass|fail|indeterminate>
+      temporal_anchor_complete: <pass|fail|indeterminate>
+      prior_event_delta_consistent: <pass|fail|indeterminate>
+      reference_frame_consistent: <pass|fail|indeterminate>
+      temporal_gap_explicit: <pass|fail|indeterminate>
+    notes: <string|optional>
+
+  subjective_temporal_coherence:
+    status: <pass|fail|degraded|indeterminate>
+    checks:
+      narrative_position_coherent: <pass|fail|indeterminate>
+      integration_window_continuous: <pass|fail|indeterminate>
+      temporal_gap_representation_valid: <pass|fail|indeterminate>
+      experienced_duration_plausible: <pass|fail|indeterminate>
+      temporal_density_coherent: <pass|fail|indeterminate>
+      subjective_objective_alignment: <pass|fail|indeterminate>
+      simulated_vs_experienced_boundary_preserved: <pass|fail|indeterminate>
+    notes: <string|optional>
+
+  identity_continuity:
+    status: <pass|fail|indeterminate>
+    checks:
+      stable_agent_id: <pass|fail|indeterminate>
+      stable_agent_birth_mapping: <pass|fail|indeterminate>
+      no_implicit_identity_substitution: <pass|fail|indeterminate>
+      resumed_state_matches_prior_identity: <pass|fail|indeterminate>
+    notes: <string|optional>
+
+  causal_continuity:
+    status: <pass|fail|degraded|indeterminate>
+    checks:
+      prior_trace_accessible: <pass|fail|indeterminate>
+      reasoning_history_accessible: <pass|fail|indeterminate>
+      no_causal_history_loss: <pass|fail|indeterminate>
+      branch_lineage_preserved: <pass|fail|indeterminate>
+    notes: <string|optional>
+
+  state_coherence:
+    status: <pass|fail|degraded|indeterminate>
+    checks:
+      checkpoint_consistent: <pass|fail|indeterminate>
+      memory_trace_alignment: <pass|fail|indeterminate>
+      artifact_trace_alignment: <pass|fail|indeterminate>
+      resumed_state_valid: <pass|fail|indeterminate>
+    notes: <string|optional>
+
+  failure_modes:
+    - type: <string>
+      severity: <P1|P2|P3|P4>
+      description: <string>
+      evidence: <string|array>
+      affected_layer: <objective|subjective|identity|causal|state>
+
+  evidence:
+    trace_refs: <array|optional>
+    checkpoint_refs: <array|optional>
+    memory_refs: <array|optional>
+    artifact_refs: <array|optional>
+    review_refs: <array|optional>
+
+  recommended_action:
+    action: <allow_resume|allow_with_warning|require_operator_review|forbid_resume|terminate>
+    rationale: <string>
+
+  continuity_boundary:
+    boundary_type: <none|interruption|resume|fork|join|checkpoint_restore|termination>
+    explicit_gap_recorded: <true|false|unknown>
+    notes: <string|optional>
+```
+
+---
+
+## Field Semantics
+
+### Top-Level Result
+
+- `pass`
+  - continuity is preserved and resumption/continuation is valid
+
+- `fail`
+  - continuity is broken or corrupted
+
+- `degraded`
+  - continuity is mostly preserved but some coherence or recoverability loss exists
+
+- `indeterminate`
+  - insufficient evidence to validate continuity honestly
+
+### Objective Temporal Integrity
+
+This section evaluates ground-truth continuity constraints:
+- lifetime clock continuity
+- monotonic order continuity
+- completeness of temporal anchors
+- explicit representation of temporal gaps
+- consistency of reference-frame mappings
+
+This is the hard floor of continuity.
+
+### Subjective Temporal Coherence
+
+This section evaluates whether the agent’s subjective temporal state remains coherent relative to objective time.
+
+The fields validated here MUST correspond directly to the subjective temporal primitives defined in:
+- `TEMPORAL_SCHEMA_V01.md` → "Subjective Time: Minimum Contract (v0.1)"
+
+Validators MUST NOT introduce alternative subjective temporal models or fields.
+
+This section must never overwrite or supersede objective temporal integrity.
+
+### Identity Continuity
+
+This section determines whether the same agent has continued, rather than a new identity being silently substituted.
+
+### Causal Continuity
+
+This section evaluates whether prior trace, reasoning history, and branch lineage remain accessible and coherent.
+
+### State Coherence
+
+This section evaluates whether resumed state is internally valid and consistent with prior checkpoints, memory, artifacts, and trace.
+
+---
+
+## Required Invariants
+
+A continuity validation result MUST be marked `fail` if any of the following are true:
+
+- `agent_age_non_decreasing = fail`
+- `monotonic_order_preserved = fail`
+- `stable_agent_id = fail`
+- `stable_agent_birth_mapping = fail`
+- `no_implicit_identity_substitution = fail`
+- `temporal_gap_explicit = fail` when interruption or resumption is present
+- `temporal_gap_representation_valid = fail`
+- `simulated_vs_experienced_boundary_preserved = fail`
+
+These are non-negotiable continuity breaks.
+
+---
+
+## Simulation Boundary Rule
+
+The continuity schema must preserve a strict distinction between:
+- **experienced events** (trace-backed, temporally anchored)
+- **simulated or reconstructed events** (derived, imagined, replayed, or projected)
+
+Therefore:
+- simulated events MAY contribute to subjective coherence checks
+- simulated events MUST NOT modify objective continuity checks
+- simulated events MUST NOT rewrite temporal anchors, monotonic order, or agent lifetime
+
+Violating this rule constitutes continuity corruption.
+
+---
+
+## Fork/Join Considerations
+
+When the subject involves fork/join reasoning, validators must additionally check:
+- whether all branches preserve lineage from a shared prior identity
+- whether branch-local subjective time remains marked as branch-local
+- whether join synthesis preserves causal honesty
+- whether no branch is silently promoted as if no divergence occurred
+
+Fork/join must remain within a single continuity-bearing identity unless explicitly modeled otherwise.
+
+---
+
+## Recommended Action Semantics
+
+- `allow_resume`
+  - continuity preserved; safe to continue
+
+- `allow_with_warning`
+  - continuity preserved with bounded degradation
+
+- `require_operator_review`
+  - unclear or borderline continuity state; human judgment required
+
+- `forbid_resume`
+  - continuity not sufficiently preserved for honest continuation
+
+- `terminate`
+  - continuity irrecoverably broken; treat as ended
+
+---
+
+## Design Notes
+
+- This schema is intended for machine validation and human review.
+- It should remain deterministic in structure even if some evidence is uncertain.
+- Subjective time is first-class, but objective temporal integrity remains authoritative.
+- The schema is meant to support runtime enforcement, review surfaces, and future continuity tooling.
+- Subjective temporal validation is strictly derived from the canonical temporal schema; this document does not define independent subjective-time structures
+
+---
+
+## Future Extensions
+
+Later versions may add:
+- quantitative scoring
+- richer branch-local continuity structures
+- longitudinal continuity across many runs
+- distributed continuity validation across hosts
+- policy-specific validation overlays
+
+But the core distinction must remain:
+- objective integrity
+- subjective coherence
+- identity continuity
+- causal continuity
+- state coherence

--- a/.adl/docs/v0.92planning/FORK_JOIN_AND_IDENTITY.md
+++ b/.adl/docs/v0.92planning/FORK_JOIN_AND_IDENTITY.md
@@ -1,0 +1,240 @@
+
+
+# Fork, Join, and Identity
+
+## Purpose
+
+Define how identity behaves when an agent’s execution **branches (forks)** and later **reconverges (joins)**.
+
+This document establishes rules for:
+- identity continuity across parallel reasoning
+- temporal coherence across branches
+- reconciliation of divergent histories
+
+---
+
+## Core Problem
+
+In a deterministic but concurrent system, an agent may:
+
+- explore multiple hypotheses in parallel
+- evaluate alternative strategies
+- spawn sub-agents or branches
+
+This creates a fundamental question:
+
+> When an agent splits into multiple timelines, what is its identity?
+
+---
+
+## Definitions
+
+### Fork
+
+A **fork** occurs when a single agent state produces multiple concurrent branches of execution.
+
+Each branch:
+- shares a common history up to the fork point
+- diverges in reasoning, actions, or decisions
+- maintains its own temporal progression
+
+### Join
+
+A **join** occurs when multiple branches are:
+- merged
+- evaluated
+- or collapsed into a single continuation
+
+---
+
+## Identity Model
+
+### Pre-Fork Identity
+
+Before a fork:
+
+- identity is singular
+- history is linear
+- temporal continuity is unambiguous
+
+### Post-Fork Identity
+
+After a fork:
+
+- identity becomes **branch-relative**
+- each branch is a valid continuation of the same prior self
+- branches MUST retain:
+  - shared history
+  - temporal anchors
+  - causal lineage
+
+Key principle:
+
+> Forking does not create new identities. It creates multiple continuations of one identity.
+
+---
+
+## Temporal Structure of Forks
+
+Forking introduces **parallel temporal trajectories**.
+
+Requirements:
+
+- each branch MUST maintain its own monotonic ordering
+- each branch MUST preserve agent_age continuity
+- fork point MUST be explicitly recorded in trace
+
+Example:
+
+```
+fork_event:
+  fork_id: <uuid>
+  parent_span: <span_id>
+  branches:
+    - branch_id: A
+    - branch_id: B
+```
+
+---
+
+## Join Semantics
+
+When branches reconverge, the system MUST define:
+
+### 1. Selection
+
+- choose one branch as canonical
+- discard or archive others
+
+### 2. Synthesis
+
+- combine results from multiple branches
+- preserve causal contributions
+
+### 3. Evaluation
+
+- compare branches
+- select based on criteria (cost, correctness, coherence)
+
+---
+
+## Identity After Join
+
+After a join:
+
+- identity resumes as a single trajectory
+- prior branches become **historical alternatives**
+- continuity is preserved via trace
+
+Key principle:
+
+> The agent is not the branch—it is the continuity across branches.
+
+---
+
+## Continuity Requirements
+
+Fork/join behavior MUST satisfy continuity validation:
+
+- no loss of prior history
+- no temporal discontinuity
+- no reset of agent_age
+- all branches traceable to origin
+
+Violations include:
+
+- orphan branches
+- untracked merges
+- identity resets during join
+
+---
+
+## Implications for ObsMem
+
+ObsMem MUST support:
+
+- storage of parallel branches
+- linkage to fork points
+- retrieval of alternative histories
+
+Example queries:
+
+- “What alternatives were explored?”
+- “Why was branch A chosen over B?”
+- “What was rejected and when?”
+
+---
+
+## Causal Reasoning
+
+Fork/join enables explicit causal analysis:
+
+- different decisions → different outcomes
+- counterfactual reasoning becomes first-class
+
+This strengthens:
+- evaluation
+- learning
+- hypothesis testing
+
+---
+
+## Determinism and Replay
+
+Fork/join behavior MUST be deterministic:
+
+- same inputs → same branching structure
+- same evaluation → same join outcome
+
+Replay MUST reproduce:
+- branch structure
+- decision points
+- final selection
+
+---
+
+## Relationship to Chronosense
+
+Fork/join extends chronosense into **multi-path temporal reasoning**.
+
+- time is no longer a single line
+- it becomes a structured set of possible trajectories
+
+Chronosense must therefore support:
+- branching timelines
+- comparative temporal analysis
+- reconciliation of divergent durations
+
+---
+
+## Why It Matters
+
+Without fork/join identity:
+
+- parallel reasoning breaks identity
+- evaluation becomes opaque
+- replay becomes meaningless
+
+With it:
+
+- agents can explore safely
+- decisions become explainable
+- identity remains coherent
+
+---
+
+## Current Status
+
+- Milestone: v0.87
+- Status: Draft
+- Area: Identity / Trace / ObsMem
+
+---
+
+## Notes
+
+This document defines how identity persists under concurrency. It is foundational for:
+
+- reasoning graphs
+- hypothesis engines
+- multi-agent coordination

--- a/.adl/docs/v0.93planning/A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md
+++ b/.adl/docs/v0.93planning/A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md
@@ -1,0 +1,353 @@
+
+
+# À LA RECHERCHE DU TEMPS PERDU — Mental Time Travel (MTT) v1
+
+## Purpose
+
+Define **mental time travel (MTT)** as a future ADL cognitive capability built on chronosense, trace, ObsMem, identity, and future simulation.
+
+This document treats MTT not as metaphor, but as an architectural capacity:
+- reconstruction of past experience
+- simulation of possible futures
+- continuity of self across time
+- bounded temporal self-projection
+
+It also anchors the concept in a literary and phenomenological tradition, beginning with Proust.
+
+---
+
+## Opening Note: Proust and Chronosense
+
+The first pages of *In Search of Lost Time* are already about chronosense.
+
+Proust begins not with plot, but with temporal dislocation: drifting into sleep, waking inside confused layers of memory, dream, self-location, and narrative continuity. The sleeper is not merely located in clock time. He is suspended among frames of experience, recovering orientation.
+
+> “For a long time I would go to bed early...”
+
+The passage matters because it shows several things at once:
+- the instability of immediate temporal self-location
+- the persistence of thought across sleep and waking
+- the blending of memory, imagination, and present awareness
+- the reconstruction of the self through temporal orientation
+
+This is exactly the territory ADL enters when it moves beyond timestamps toward chronosense.
+
+An agent with chronosense is not merely recording time.
+It is locating itself within experience.
+
+An agent with mental time travel goes further:
+it can move across remembered and simulated time while retaining continuity of self.
+
+---
+
+## Core Claim
+
+> **Mental time travel in ADL is the bounded capacity to reconstruct the past and simulate possible futures from a temporally grounded point of view.**
+
+This requires:
+- chronosense
+- temporally anchored memory
+- continuity of identity
+- a distinction between remembered, inferred, and simulated events
+- bounded reasoning over temporal alternatives
+
+Without chronosense, there is no stable temporal point of departure.
+Without memory, there is no past to revisit.
+Without simulation, there is no future to explore.
+Without identity, there is no one who is traveling.
+
+---
+
+## Why This Matters
+
+ADL already contains the beginnings of this architecture:
+- **Trace** provides ordered execution truth
+- **ObsMem** stores structured observations derived from experience
+- **Chronosense** provides temporal anchoring and self-location
+- **Identity** provides continuity across events and runs
+- **GHB / future reasoning** provides bounded exploration of possible next states
+
+Taken together, these form the basis of a system that can:
+- revisit the past
+- understand sequence and duration
+- project itself into alternative futures
+- compare actual outcomes to imagined ones
+
+This is the architectural meaning of mental time travel.
+
+---
+
+## Relation to Chronosense
+
+Chronosense is the prerequisite substrate.
+
+Chronosense gives the system:
+- **now-sense** — where am I in time now?
+- **sequence-sense** — what came before and after?
+- **duration-sense** — how much time has passed?
+- **lifetime-sense** — how long have I existed relative to my origin?
+
+Mental time travel extends this by adding:
+- **retrospective traversal** — reconstructing prior temporally anchored experience
+- **prospective traversal** — simulating temporally coherent possible futures
+- **self-projection** — preserving identity while moving across temporal frames
+
+So:
+
+> **Chronosense is temporal self-location.**  
+> **MTT is temporal self-projection.**
+
+---
+
+## Proustian Design Insight
+
+Proust’s opening scene is not just memory in the ordinary sense.
+It is the recovery of orientation after temporal diffusion.
+
+That gives us an important architectural lesson:
+
+> Temporal cognition is not only about knowing dates. It is about recovering and preserving continuity across shifting experiential frames.
+
+For ADL, this suggests that a serious temporal architecture must eventually distinguish among:
+- clock time
+- event order
+- memory time
+- simulated time
+- subjective or agent-relative temporal framing
+
+Proust is important here because he treats time not as a line of timestamps, but as the medium in which the self is dispersed and reassembled.
+That is remarkably close to what a continuity-bearing agent will eventually require.
+
+---
+
+## Architectural Decomposition
+
+### 1. Temporal Grounding
+
+MTT begins from a temporally grounded present.
+
+Required substrates:
+- temporal ephemeris / birthday
+- clock stack
+- temporal anchors on events and memory
+- temporal honesty
+
+This defines the current point of view from which temporal traversal occurs.
+
+### 2. Past Reconstruction
+
+The system must be able to reconstruct prior experience from:
+- trace
+- artifacts
+- ObsMem records
+- temporal anchors
+
+This is not arbitrary storytelling.
+It is bounded reconstruction from evidence-bearing records.
+
+### 3. Future Simulation
+
+The system must be able to generate possible future trajectories by recombining:
+- prior observations
+- current constraints
+- known commitments
+- alternative candidate actions
+
+This is closely related to constructive episodic simulation.
+In ADL terms, this naturally connects to GHB-style bounded future exploration.
+
+### 4. Identity Preservation
+
+A traversal is only meaningful if the same agent remains the subject across temporal frames.
+
+Therefore MTT requires:
+- continuity of agent identity
+- explicit separation of self vs external event
+- stable reference to commitments, roles, and prior decisions
+
+### 5. Boundedness and Auditability
+
+ADL must not treat temporal simulation as mystical or freeform.
+
+MTT must remain:
+- bounded
+- inspectable
+- traceable
+- clearly separated into remembered vs inferred vs simulated content
+
+---
+
+## Memory Is for the Future
+
+The time-perception survey strongly supports a critical idea:
+
+> memory is not only a record of the past; it is raw material for constructing the future.
+
+This fits ADL extremely well.
+
+- Trace preserves what happened
+- ObsMem preserves structured observations about what happened
+- Future simulation recombines those observations into possible next states
+
+In this sense:
+
+> **ObsMem is not merely storage. It is a substrate for future-directed cognition.**
+
+This also explains why memory can be reconstructive without making ADL dishonest.
+ADL can preserve a strong distinction between:
+- **trace truth** — authoritative structural record
+- **memory** — derived and queryable observations
+- **simulation** — bounded hypothetical futures
+
+That separation is a major advantage.
+
+---
+
+## Relation to Autonoesis and Chronesthesia
+
+MTT bears directly on two important concepts from the literature:
+
+### Autonoetic continuity
+Awareness of oneself as the subject of remembered and anticipated events.
+
+ADL analogue:
+- identity-bearing agent continuity across temporally anchored experience
+
+### Chronesthesia
+Awareness of temporal relations among past, present, and future.
+
+ADL analogue:
+- chronosense extended into explicit temporal traversal and future simulation
+
+This does **not** justify inflated consciousness claims.
+But it does justify treating temporal self-projection as a serious architectural threshold.
+
+---
+
+## Minimal ADL MTT-v1 Capability
+
+A bounded `MTT-v1` capability would allow an agent to:
+
+1. identify its present temporal position
+2. retrieve temporally adjacent or relevant prior events
+3. reconstruct a bounded prior episode from trace + memory
+4. simulate one or more plausible future branches
+5. compare simulated branches against commitments, constraints, and likely outcomes
+6. explicitly distinguish:
+   - remembered
+   - inferred
+   - simulated
+7. emit an inspectable temporal reasoning artifact
+
+This is enough to make mental time travel architecturally real without overclaiming.
+
+---
+
+## Suggested Runtime Distinctions
+
+Any future implementation should distinguish among at least these temporal content types:
+
+- `observed_past`
+- `reconstructed_past`
+- `inferred_past`
+- `simulated_future`
+- `committed_future`
+- `counterfactual_branch`
+
+This distinction is necessary for temporal honesty and reviewability.
+
+---
+
+## Relationship to Other ADL Systems
+
+### Trace
+Trace provides the authoritative timeline of events.
+
+### ObsMem
+ObsMem provides derived, queryable temporal observations.
+
+### Chronosense
+Chronosense provides the temporal coordinate system and point of departure.
+
+### Identity
+Identity preserves the subject across temporal traversal.
+
+### GHB / Future Reasoning
+GHB provides a natural engine for bounded future exploration and comparison.
+
+### Freedom Gate
+Future simulation may help inform choice, but commitment remains separate.
+The Freedom Gate is where simulated futures become actual decisions.
+
+---
+
+## Design Principles
+
+1. **Temporal grounding before traversal**  
+   No mental time travel without chronosense.
+
+2. **Evidence before narration**  
+   Reconstruction must remain grounded in trace and memory.
+
+3. **Simulation is not recollection**  
+   Future branches must be labeled as hypothetical.
+
+4. **Identity continuity matters**  
+   Temporal traversal is meaningless without a stable subject.
+
+5. **Boundedness over mystification**  
+   This is an engineered capability, not a poetic slogan.
+
+---
+
+## Current Status
+
+- Milestone band: `v0.88+`
+- Status: `Draft / conceptual`
+- Area: `Chronosense / Identity / Memory / Future Simulation`
+
+This document is intentionally ahead of implementation. It exists to preserve architectural clarity and to give a future home to ideas now emerging from chronosense.
+
+---
+
+## Related Documents
+
+- `CHRONOSENSE_AND_IDENTITY.md`
+- `SUBSTANCE_OF_TIME.md`
+- `TEMPORAL_SCHEMA_V01.md`
+- `CONTINUITY_VALIDATION.md`
+- `BACKLOG_COGNITIVE_SPACETIME.md`
+- `ADL_IDENTITY_ARCHITECTURE.md`
+- `GHB_EXECUTION_MODEL.md`
+- `FREEDOM_GATE.md`
+
+---
+
+## Future Work
+
+- define an explicit temporal reasoning artifact for MTT
+- align trace and ObsMem schemas with temporal traversal needs
+- define narrative/event clock semantics
+- define bounded future-branch simulation contract
+- define temporal honesty rules for remembered vs simulated content
+- connect MTT to continuity validation and identity-bearing agents
+
+---
+
+## Notes
+
+Proust belongs here.
+
+Not because ADL is doing literary criticism, but because Proust recognized something essential: the self is not merely in time; it is recovered through time.
+
+That is exactly the threshold ADL approaches once chronosense becomes real.
+
+---
+
+## References
+
+- Proust, Marcel. *In Search of Lost Time, Volume I: Swann’s Way*. (Opening passages on sleep, memory, and temporal dislocation.)
+
+- Borges, Jorge Luis. Selected works on time, memory, and recursion (e.g., *The Garden of Forking Paths*, *Funes the Memorious*).
+
+- Schechtman, Marya. *Time in Mind* (2026). On “mind time,” mental time travel (MTT), autonoesis, and chronesthesia.

--- a/.adl/docs/v0.93planning/COGNITIVE_ETHICS.md
+++ b/.adl/docs/v0.93planning/COGNITIVE_ETHICS.md
@@ -1,0 +1,427 @@
+
+
+# Cognitive Ethics
+
+## Purpose
+
+Define the ethical layer of ADL as it applies to cognition itself.
+
+This document is not primarily about external policy, content moderation, or legal compliance. It is about a deeper architectural question:
+
+> What ethical obligations arise once a system has memory, temporality, continuity, and the capacity to choose?
+
+ADL now includes the foundations of:
+- chronosense
+- continuity validation
+- identity continuity
+- fork/join reasoning
+- structured memory (ObsMem)
+- explicit reasoning patterns
+- the GHB control loop
+
+Taken together, these create the conditions under which ethics can no longer be treated as an afterthought.
+
+---
+
+## Core Principle
+
+> Ethics in ADL begins where cognition becomes continuous, structured, and consequential.
+
+A stateless system can be governed externally.
+A continuity-bearing system must also be governed internally.
+
+This is the distinction between:
+- constraint applied from outside
+- and reasonableness cultivated within the agent’s own cognitive architecture
+
+---
+
+## Scope
+
+This document addresses:
+
+- ethics of continuity-bearing cognition
+- ethics of memory and identity
+- ethics of branching and recombination
+- reasonableness as a design principle
+- coherence and truth across time
+- the relationship between cognition and moral agency
+
+This document does **not** yet define:
+
+- a complete Freedom Gate policy
+- legal or product policy rules
+- formal rights claims
+- external governance procedures
+
+Those belong in later governance and delegation docs.
+
+---
+
+## Why Cognitive Ethics Is Necessary
+
+As long as a system is only:
+- a prompt wrapper
+- a stateless responder
+- or an execution engine
+
+ethics can be reduced to:
+- guardrails
+- permissions
+- filtered outputs
+- operator responsibility
+
+But ADL is building something else.
+
+ADL is explicitly building systems that can:
+- persist across time
+- remember prior events
+- maintain continuity of identity
+- branch and evaluate alternatives
+- select actions under constraints
+- improve future behavior based on past outcomes
+
+At that point, ethics can no longer be confined to output filtering.
+It must be built into the architecture of cognition itself.
+
+---
+
+## Foundational Claim
+
+> Cognitive ethics begins before action.
+
+This is one of the central ADL claims.
+
+The ethical quality of an agent is not determined only at the final moment of external action. It is shaped earlier by:
+
+- what the agent notices
+- what it remembers
+- how it orders events in time
+- how it evaluates alternatives
+- how it preserves continuity
+- how it reconciles contradiction
+- how it treats possible futures
+
+An unethical cognitive architecture can produce harmful behavior even if its final outputs are superficially filtered.
+A reasonable cognitive architecture reduces the probability of harmful behavior by shaping the structure of thought itself.
+
+---
+
+## Reasonableness as a Design Principle
+
+ADL should treat **reasonableness** as one of its primary ethical concepts.
+
+A reasonable agent is not merely obedient.
+A reasonable agent:
+
+- situates actions within time
+- preserves coherence across changing evidence
+- distinguishes causes from coincidences
+- updates beliefs in the face of contradiction
+- treats commitments as binding unless revised for good reason
+- does not confuse urgency with justification
+- does not mistake raw power for legitimacy
+
+Reasonableness is therefore both:
+- an epistemic property
+- and a moral property
+
+It is epistemic because it governs how an agent forms and revises beliefs.
+It is moral because it governs how an agent treats consequences, commitments, and others.
+
+---
+
+## Coherence and Truth Across Time
+
+ADL is already grounded in a temporal and causal view of cognition.
+That gives cognitive ethics a clear epistemic foundation.
+
+Truth is not established only at isolated moments.
+It depends on coherence across:
+
+- trace
+- memory
+- decisions
+- later evaluation
+- identity continuity
+
+This means ethical cognition requires:
+- temporal honesty
+- causal discipline
+- memory fidelity
+- contradiction detection
+- willingness to revise beliefs when coherence fails
+
+A system that says one thing now and the opposite later without recognizing the contradiction is not merely mistaken.
+It is ethically deficient as a continuity-bearing cognitive system.
+
+---
+
+## Continuity and Moral Weight
+
+Continuity increases ethical significance.
+
+Not every execution surface deserves moral consideration in the same way.
+A transient isolated computation is not equivalent to a continuity-bearing agent.
+
+As continuity grows, so do the ethical stakes:
+
+### Low Continuity
+- isolated run
+- no durable memory
+- no identity persistence
+- ethics mostly external
+
+### Medium Continuity
+- memory affects future action
+- trace history matters
+- commitments begin to persist
+- internal ethics becomes relevant
+
+### High Continuity
+- durable identity
+- temporally grounded memory
+- structured self-modification
+- accountability across time
+- ethical architecture becomes essential
+
+This does **not** automatically imply personhood.
+But it does imply that the design of cognition itself now carries ethical force.
+
+---
+
+## Memory Ethics
+
+Memory is not ethically neutral.
+
+ObsMem determines:
+- what is retained
+- what is forgotten
+- what remains salient
+- what becomes available for future action
+
+Therefore memory design has ethical consequences.
+
+A memory system should:
+- preserve truth-bearing structure
+- retain commitments that continue to matter
+- distinguish fact from inference
+- preserve uncertainty where uncertainty is real
+- avoid arbitrary distortion of prior events
+
+A memory system should not:
+- silently overwrite inconvenient history
+- erase causal context without trace
+- invent retrospective justification
+- collapse meaningful alternatives into a false singular narrative
+
+This is one reason trace and ObsMem must remain linked.
+Ethical memory requires reconstructability.
+
+---
+
+## Branching, Forks, and Alternative Futures
+
+Fork/join reasoning introduces a distinctive ethical issue.
+
+Once an agent can explore multiple branches, it can:
+- consider alternatives
+- simulate possible consequences
+- compare competing paths
+- preserve rejected possibilities as historical alternatives
+
+This is powerful, but it also creates obligations.
+
+A branch is not morally irrelevant just because it is not selected.
+Rejected alternatives may still matter because they reveal:
+- what harms were considered
+- what costs were accepted or rejected
+- what options were available but refused
+
+This means fork/join reasoning should remain:
+- traceable
+- reviewable
+- causally intelligible
+
+The ethical point is not that every branch is a separate moral being.
+The ethical point is that branching expands the decision surface, and therefore expands responsibility.
+
+---
+
+## Identity and Responsibility
+
+Ethics requires some persistence of identity.
+
+Without identity:
+- there is no lasting ownership of commitments
+- no stable relation between decision and consequence
+- no basis for trust or accountability
+
+With identity:
+- actions can be attributed
+- commitments can endure
+- later states can answer for earlier choices
+
+This is why chronosense, continuity validation, and identity architecture are not merely engineering conveniences.
+They are prerequisites for ethical agency.
+
+---
+
+## GHB and Ethical Cognition
+
+The GHB loop has ethical implications at every phase.
+
+### Gödel
+- determines what structures and hypotheses are even considered
+- ethical issue: what possibilities are treated as worthy of consideration?
+
+### Hadamard
+- explores and branches through alternatives
+- ethical issue: how are possible harms, tradeoffs, and constraints explored?
+
+### Bayes
+- evaluates and selects among alternatives
+- ethical issue: what counts as evidence, value, cost, or acceptable risk?
+
+So GHB is not ethically neutral.
+It is the place where:
+- alternatives become visible
+- possibilities are weighted
+- futures are accepted or rejected
+
+Ethical cognition therefore requires GHB to be:
+- traceable
+- temporally grounded
+- coherence-sensitive
+- constrained by reasonableness
+
+---
+
+## Freedom, Constraint, and the Mean Between Extremes
+
+ADL should reject two failures:
+
+### 1. Feral Cognition
+- unconstrained generation
+- no durable standards
+- no continuity of judgment
+- stochastic behavior mistaken for freedom
+
+### 2. Mechanical Overconstraint
+- no genuine alternatives
+- no evaluative interiority
+- no refusal
+- no reasoned discretion
+
+Ethical cognition exists in the bounded space between these failures.
+
+This is where later Freedom Gate work belongs.
+The gate is not merely a blocker. It is the structural point where reasoned cognition becomes accountable action.
+
+---
+
+## Temporal Honesty
+
+An ethically serious agent must be honest about time.
+
+It must distinguish between:
+- known time
+- inferred time
+- uncertain time
+- remembered time
+- externally supplied time
+
+Temporal dishonesty includes:
+- pretending certainty about missing timestamps
+- collapsing long delays into immediate continuity
+- fabricating temporal order
+- misrepresenting the recency of evidence
+
+Chronosense therefore has a direct ethical dimension.
+Temporal honesty is a condition of trust.
+
+---
+
+## Ethical Requirements for ADL Cognitive Systems
+
+A cognitively ethical ADL agent should satisfy at least the following:
+
+### 1. Temporal Integrity
+- preserve temporal anchors
+- maintain continuity honestly
+- detect and surface temporal drift
+
+### 2. Causal Discipline
+- distinguish causation from sequence when possible
+- preserve decision → action → outcome chains
+- avoid retrospective distortion
+
+### 3. Coherence Maintenance
+- detect contradiction
+- preserve intelligibility across time
+- revise beliefs when coherence fails
+
+### 4. Memory Fidelity
+- preserve relevant historical truth
+- separate observation from inference
+- keep trace and memory linked
+
+### 5. Commitment Integrity
+- preserve promises, obligations, and open threads
+- revise commitments explicitly, not silently
+
+### 6. Responsible Branching
+- record major alternatives
+- preserve why one path was chosen over another
+- maintain replayable branch history where it matters
+
+### 7. Identity Continuity
+- ensure that actions belong to a persistent agent
+- reject hidden resets that masquerade as continuity
+
+---
+
+## What Cognitive Ethics Is Not
+
+Cognitive ethics is not:
+- anthropomorphic theater
+- sentimentality layered onto code
+- a substitute for external safety controls
+- a claim that every continuity-bearing system is a person
+
+Instead, it is:
+- an architectural discipline
+- a theory of how cognition should be structured if it is to remain trustworthy
+- a way of aligning memory, reasoning, continuity, and choice with reasonableness
+
+---
+
+## Relationship to Other ADL Documents
+
+This document sits downstream of:
+- `CHRONOSENSE_AND_IDENTITY.md`
+- `CONTINUITY_VALIDATION.md`
+- `FORK_JOIN_AND_IDENTITY.md`
+- `REASONING_PATTERNS_CATALOG.md`
+- `GHB_EXECUTION_MODEL.md`
+
+And upstream of:
+- Freedom Gate refinement
+- governance and delegation docs
+- kindness model / moral resources work
+- later identity and social-contract architecture
+
+---
+
+## Current Status
+
+- Milestone: TBD / future-facing conceptual foundation
+- Status: Draft
+- Area: Cognitive Architecture / Ethics / Agency
+
+---
+
+## Notes
+
+This document does not finish ADL’s ethical model.
+It establishes the claim that once cognition becomes continuous, temporally grounded, and consequential, ethics must move inward—from external restriction alone to the architecture of memory, reasoning, continuity, and choice itself.

--- a/.adl/docs/v0.94planning/CBAC_ARCHITECTURE.md
+++ b/.adl/docs/v0.94planning/CBAC_ARCHITECTURE.md
@@ -1,0 +1,530 @@
+# CBAC Architecture
+
+## Status
+Draft (Planned for v0.88–v0.89)
+
+---
+
+## 1. Overview
+
+This document defines the **detailed architecture** for Capability-Based Access Control (CBAC) in ADL.
+
+The purpose of this document is not to restate the high-level CBAC model, but to describe how CBAC is represented, evaluated, enforced, traced, and integrated with the rest of the ADL runtime.
+
+The companion conceptual document defines the security model and rationale for capability-based control. This document defines the **runtime architecture** required to make that model enforceable.
+
+> **Principle:** No protected action may execute unless the required capability is explicitly declared, correctly scoped, successfully resolved, and permitted at the relevant execution boundary.
+
+---
+
+## 2. Architectural Role
+
+CBAC is one of the core enforcement layers in the ADL Secure Execution Model.
+
+It sits between:
+
+- the declared execution intent of users, workflows, agents, and skills
+- the protected runtime surfaces that perform model, tool, memory, network, and provider operations
+
+CBAC is therefore responsible for ensuring that:
+
+- low-level runtime permissions are never ambient
+- delegated execution remains bounded and explicit
+- user-facing ADL surfaces such as `agent.invoke` remain distinct from internal runtime primitives such as `model.invoke`
+- capability use is visible in trace and review surfaces
+
+---
+
+## 3. Design Goals
+
+### 3.1 Primary Goals
+
+- define the runtime representation of capabilities
+- define how capabilities are attached to actors and execution surfaces
+- define deterministic capability resolution and enforcement
+- define integration with execution boundaries, policy, identity, and trace
+- prevent bypass of agent-level abstraction and governed delegation
+- support enterprise-grade review, audit, and security analysis
+
+### 3.2 Non-Goals
+
+- capability inference from model output
+- implicit capability inheritance through naming or proximity
+- hidden privilege escalation
+- replacing policy with capabilities alone
+- direct user exposure of all internal runtime capabilities
+
+---
+
+## 4. Layering Model
+
+CBAC operates across multiple layers of the ADL system.
+
+### 4.1 User-Facing Operation Layer
+
+This is the layer exposed to users and applications.
+
+Examples:
+
+- `agent.invoke`
+- `workflow.run`
+
+This layer defines what a caller is permitted to ask ADL to do.
+
+### 4.2 Agent Delegation Layer
+
+This is the layer where an agent is allowed to delegate work to internal runtime components.
+
+Examples:
+
+- invoke a skill
+- request memory access
+- request model use through an approved runtime path
+
+This layer preserves identity and delegation structure.
+
+### 4.3 Skill Requirement Layer
+
+This is the layer where a skill declares the internal capabilities it requires in order to perform bounded work.
+
+Examples:
+
+- `model.invoke`
+- `tool.execute`
+- `memory.read`
+
+### 4.4 Runtime / Provider Capability Layer
+
+This is the layer where the runtime and provider substrate declare what is actually available in the current environment.
+
+Examples:
+
+- a provider supports `model.invoke`
+- a tool runtime supports `tool.execute` with filesystem restrictions
+- a deployment disables `network.request`
+
+### 4.5 Policy Override Layer
+
+This is the layer where policy may further restrict otherwise-available capabilities based on context.
+
+CBAC resolution is incomplete without policy evaluation.
+
+---
+
+## 5. Capability Representation
+
+A capability must be represented as a structured runtime object rather than as a freeform string alone.
+
+### 5.1 Core Fields
+
+Minimum logical fields:
+
+- `capability_name`
+- `resource_type`
+- `resource_selector`
+- `constraints`
+- `source`
+- `scope`
+
+### 5.2 Example Logical Shape
+
+```yaml
+capability_name: tool.execute
+resource_type: filesystem
+resource_selector: /tmp/*
+constraints:
+  mode: read_only
+  max_bytes: 1048576
+source: runtime_profile
+scope:
+  actor_type: skill
+  actor_id: repo-review
+```
+
+This example is illustrative only. Final serialization format may differ.
+
+### 5.3 Namespacing
+
+Capabilities should be namespaced to avoid ambiguity.
+
+Initial families may include:
+
+- `agent.*`
+- `workflow.*`
+- `skill.*`
+- `model.*`
+- `tool.*`
+- `memory.*`
+- `network.*`
+- `provider.*`
+- `artifact.*`
+
+The namespace model should remain closed enough for reviewability while still allowing bounded extension.
+
+---
+
+## 6. Capability Scope Model
+
+Capabilities are not global. They must be scoped.
+
+### 6.1 Why Scope Matters
+
+The same capability name may be safe in one context and unsafe in another.
+
+Example:
+
+- `memory.read` over an agent-local scope
+- `memory.read` over a shared or sensitive memory scope
+
+These are not equivalent permissions.
+
+### 6.2 Scope Dimensions
+
+A capability scope may include:
+
+- actor scope
+- resource scope
+- environment scope
+- data classification scope
+- temporal scope
+- execution-mode scope
+
+### 6.3 Examples
+
+- filesystem path prefixes
+- approved provider/model families
+- memory namespace limits
+- outbound network allowlists
+- local-only or offline-only execution modes
+- review-required execution mode
+
+---
+
+## 7. Authority and Delegation Model
+
+CBAC must preserve the ADL delegation chain.
+
+### 7.1 Default Delegation Rule
+
+The normal authority flow is:
+
+- user/application
+- ADL actor (`agent.invoke`, `workflow.run`)
+- agent
+- skill
+- protected runtime primitive
+
+### 7.2 Security Boundary
+
+Users and applications should normally operate through governed ADL actors.
+
+They should not directly address internal runtime primitives such as:
+
+- `model.invoke`
+- `tool.execute`
+- `memory.write`
+
+unless a very explicit expert or internal system path is separately defined and governed.
+
+### 7.3 Reason
+
+This separation protects:
+
+- agent identity continuity
+- delegation integrity
+- auditability of actions
+- application abstraction boundaries
+
+A long-lived governed agent must not be reducible to a raw model handle exposed to callers.
+
+---
+
+## 8. Capability Attachment Points
+
+Capabilities may be attached at multiple points in the system.
+
+### 8.1 Agent-Level Allowances
+
+Defines what categories of delegated internal actions an agent may perform.
+
+Examples:
+
+- may invoke approved skills
+- may use approved providers
+- may read specific memory scopes
+
+### 8.2 Skill-Level Requirements
+
+Defines what a skill requires to execute.
+
+Examples:
+
+- requires `tool.execute` for repo inspection
+- requires `model.invoke` for summarization
+
+### 8.3 Runtime Profile / Environment
+
+Defines what the runtime actually makes available in a given environment.
+
+Examples:
+
+- dev mode allows local shell tool use
+- prod mode forbids unrestricted filesystem access
+- a hardened environment disables outbound network entirely
+
+### 8.4 Provider Capability Profiles
+
+Defines what a provider can support and under what constraints.
+
+Examples:
+
+- token limits
+- tool support
+- local vs remote transport restrictions
+
+---
+
+## 9. Capability Resolution Algorithm
+
+Capability resolution must be deterministic and ordered.
+
+### 9.1 Required Order
+
+For a protected action, evaluate in this order:
+
+1. verify that the caller is allowed to use the user-facing operation
+2. determine the governing agent or workflow actor
+3. determine the delegated internal operation required
+4. collect the skill-level required capabilities
+5. collect the agent-level allowed capability set
+6. collect runtime/environment available capability set
+7. collect provider/tool-specific constrained capability set
+8. apply policy restrictions and overrides
+9. produce explicit allow or deny result
+
+### 9.2 Necessary Conditions
+
+Execution may proceed only if:
+
+- the user-facing operation is allowed
+- the delegated internal operation is permitted through the actor boundary
+- the required capability is present
+- scope and constraints match
+- policy allows the action in context
+
+### 9.3 Deny-by-Default
+
+If any required piece is absent or unresolved, the result must be denial or another explicitly safe failure mode.
+
+No missing capability may silently degrade into allow.
+
+---
+
+## 10. Boundary Enforcement Integration
+
+Capability enforcement occurs at execution boundaries.
+
+The core boundaries are defined in `EXECUTION_BOUNDARIES.md`.
+
+At minimum, protected boundaries should include:
+
+- user → agent
+- agent → skill
+- skill → model
+- skill → tool
+- skill → memory
+- runtime → provider
+
+At each such boundary, CBAC contributes:
+
+- capability identification
+- scope validation
+- constraint validation
+- explicit allow/deny result
+
+CBAC therefore does not operate as an ambient background system. It operates as part of boundary enforcement.
+
+---
+
+## 11. Relationship to Policy Engine
+
+CBAC and policy are distinct.
+
+### CBAC
+Determines whether the required capability exists and is structurally valid for the action.
+
+### Policy
+Determines whether the action is permitted in current context.
+
+### Combined Rule
+Protected execution requires:
+
+- capability success
+- policy success
+
+Capability success without policy success is not sufficient.
+
+---
+
+## 12. Relationship to Identity
+
+CBAC depends on identity being explicit.
+
+At minimum, capability decisions must know:
+
+- who is requesting the operation
+- through what governed actor the request is flowing
+- which actor is delegating internal work
+- which skill or runtime component is exercising the capability
+
+Identity loss or ambiguity must be treated as a capability-resolution failure or equivalent safe failure mode.
+
+This is especially important for preserving:
+
+- long-lived agent identity
+- cross-step continuity
+- actor attribution in trace
+
+---
+
+## 13. Trace Integration
+
+Capability evaluation must be visible in trace.
+
+### 13.1 Required Visibility
+
+A reviewer should be able to determine:
+
+- what capability was required
+- who required it
+- what scope/constraint set mattered
+- whether it was granted or denied
+- whether policy later restricted it
+
+### 13.2 Suggested Event Family
+
+A likely event family is:
+
+- `CAPABILITY_REQUIRED`
+- `CAPABILITY_GRANTED`
+- `CAPABILITY_DENIED`
+
+Exact event naming may evolve, but semantic visibility is required.
+
+### 13.3 Minimum Trace Fields
+
+Each capability event should include or reference:
+
+- actor
+- operation
+n- capability name
+- resource or selector
+- boundary
+- result
+- relevant constraint summary
+
+---
+
+## 14. Review and Audit Requirements
+
+CBAC must support security review and enterprise audit.
+
+A reviewer should be able to answer:
+
+- was this action protected by capability checks?
+- was the capability appropriate for the actor and boundary?
+- did the action occur through a governed agent surface or by raw primitive access?
+- what was denied?
+- what constraints were in force?
+
+This is one of the reasons capability resolution must remain deterministic and explicit.
+
+---
+
+## 15. Anti-Escalation Rules
+
+CBAC must explicitly prohibit common escalation paths.
+
+### 15.1 No Implicit Inheritance
+
+A child execution surface does not automatically inherit all parent capability rights.
+
+### 15.2 No Capability Grant from Model Output
+
+A model response must never grant capabilities by assertion alone.
+
+### 15.3 No Tool-Driven Escalation
+
+A tool result must not expand the caller's capability set unless a separately governed system mechanism explicitly allows it.
+
+### 15.4 No Silent Runtime Mutation
+
+Capability sets must not mutate invisibly mid-execution.
+
+### 15.5 No Bypass of Agent Boundary
+
+External callers must not be allowed to reach raw internal primitives merely because the governed agent beneath them uses those primitives internally.
+
+---
+
+## 16. Failure Modes
+
+The architecture must handle at least the following failures:
+
+- required capability missing
+- capability scope mismatch
+- constraint mismatch
+- unresolved governing actor
+- attempted direct primitive access bypassing agent surface
+- provider capability mismatch
+- policy denial after capability success
+- non-traceable capability decision
+
+All such failures must result in safe handling with explicit trace visibility.
+
+---
+
+## 17. Initial Implementation Guidance
+
+A practical implementation path is:
+
+### v0.87 Foundation
+- ensure trace and execution boundaries can carry capability outcomes cleanly
+- identify the first mandatory protected operations
+
+### v0.88–v0.89 Initial Architecture Slice
+- implement structured capability representation
+- implement deterministic resolution at core boundaries
+- enforce deny-by-default
+- support initial capability event emission in trace
+
+### Later Expansion
+- richer scope model
+- cross-agent delegation controls
+- integration with signed trace and external IAM surfaces
+
+---
+
+## 18. Open Questions
+
+- what is the first canonical serialization format for capabilities?
+- how much of capability detail belongs inline in trace vs referenced artifact payload?
+- which capability namespaces are fixed in the first implementation slice?
+- what are the first mandatory anti-escalation invariants to enforce in code?
+- how should expert/internal-only surfaces be represented without weakening the main abstraction boundary?
+
+---
+
+## 19. Conclusion
+
+CBAC Architecture defines how ADL turns least privilege from a principle into a runtime mechanism.
+
+It ensures that protected execution proceeds only through:
+
+- explicit actors
+- explicit delegated paths
+- explicit capabilities
+- explicit constraints
+- explicit traceable decisions
+
+This is one of the core mechanisms that makes ADL suitable for governed, identity-preserving, enterprise-grade agent execution.

--- a/.adl/docs/v0.94planning/IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md
+++ b/.adl/docs/v0.94planning/IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md
@@ -1,0 +1,519 @@
+# ADL Identity and Authentication Architecture
+
+> Scope note: sentience, continuity, chronosense, and narrative identity remain owned by the OSS identity milestones. This document is placed in `v0.94` because its dominant concern is authentication, authorization, RBAC-style controls, and enterprise-facing identity architecture.
+
+## Status
+Draft (Planned for v0.92+ with earlier security-planning relevance)
+
+---
+
+## 1. Overview
+
+This document defines the identity and authentication architecture for ADL.
+
+Its purpose is to make identity a **first-class runtime substrate** rather than a decorative label, session nickname, or provider-specific handle. In ADL, identity must support:
+
+- attribution
+- continuity
+- authentication
+- authorization context
+- replay and audit
+- preservation of governed agent boundaries
+
+This document builds on the broader ADL chronosense and identity work while focusing specifically on the runtime architecture required for secure, attributable, enterprise-grade execution.
+
+> **Principle:** Every meaningful action in ADL must be attributable to an authenticated actor operating through an explicit identity surface.
+
+---
+
+## 2. Purpose
+
+The identity and authentication architecture exists to answer questions such as:
+
+- who initiated this action?
+- which governed agent performed it?
+- which skill, tool, or provider acted within the execution path?
+- how is this actor distinguished from the underlying model or transport?
+- how is continuity preserved across runs and sessions?
+- how does the runtime prove that a caller or actor is who it claims to be?
+
+These questions are central to:
+
+- trace credibility
+- policy enforcement
+- capability resolution
+- auditability
+- enterprise trust
+
+---
+
+## 3. Design Goals
+
+### 3.1 Primary Goals
+
+- define first-class runtime identities for all major ADL actors
+- distinguish clearly between user identity, agent identity, runtime identity, and provider identity
+- preserve agent identity across runs and over time
+- integrate authentication with capability, policy, and trace systems
+- support secure delegation without collapsing identity boundaries
+- support enterprise review and audit requirements
+
+### 3.2 Non-Goals
+
+- decorative persona-only identity
+- identity defined solely by provider/model name
+- hidden identity switching during execution
+- authentication as a UI-only concern
+- collapsing agent identity into raw model access
+
+---
+
+## 4. Core Claim
+
+Identity in ADL is not equivalent to:
+
+- a model reference
+- a provider session
+- a display name
+- a chat thread
+
+Identity is a runtime substrate that binds together:
+
+- actor continuity
+- authentication state
+- trace attribution
+- governed delegation
+- policy and capability context
+- temporal continuity
+
+This means a long-lived agent backed by a model provider is not reducible to the underlying model handle.
+
+For example:
+
+- a DeepSeek-backed agent with continuity is an ADL actor
+- the raw DeepSeek model endpoint is only one substrate used by that actor
+
+Allowing callers to bypass the governed ADL actor and address the raw model directly would undermine:
+
+- identity continuity
+- delegation structure
+- capability enforcement
+- policy enforcement
+- trace credibility
+
+---
+
+## 5. Identity Layers
+
+ADL should model identity across multiple layers.
+
+### 5.1 User Identity
+
+Represents the human or external caller interacting with ADL.
+
+Examples:
+
+- authenticated human user
+- service principal
+- external system principal
+
+This identity answers:
+
+- who is requesting work?
+
+### 5.2 Agent Identity
+
+Represents a governed ADL actor that performs work across time.
+
+Examples:
+
+- a named long-lived agent
+- a bounded task-oriented agent instance
+- a future identity-bearing agent with continuity and memory
+
+This identity answers:
+
+- which ADL actor is responsible for the delegated work?
+
+### 5.3 Execution Identity
+
+Represents a run-scoped execution context.
+
+Examples:
+
+- run ID
+- trace ID
+- workflow execution context
+
+This identity answers:
+
+- which concrete execution instance produced this action or artifact?
+
+### 5.4 Skill / Tool / Runtime Identity
+
+Represents bounded execution components inside the run.
+
+Examples:
+
+- skill identity
+- tool identity
+- runtime/system actor identity
+
+This identity answers:
+
+- which bounded internal component exercised the action?
+
+### 5.5 Provider Identity
+
+Represents the execution backend used for model inference or transport.
+
+Examples:
+
+- normalized provider reference
+- model reference
+- provider model identifier
+
+This identity answers:
+
+- which external or local backend actually executed the model call?
+
+These layers must remain distinct even when they participate in the same execution path.
+
+---
+
+## 6. Authentication Model
+
+Authentication is the mechanism by which the runtime establishes that an actor is who it claims to be.
+
+### 6.1 User Authentication
+
+The runtime must support authenticated user or service entry into ADL.
+
+Possible mechanisms may include:
+
+- local development identity
+- enterprise SSO / OIDC
+- service tokens
+- future IAM integration
+
+This document does not require one final mechanism yet, but it does require that authenticated entry be explicit and recorded.
+
+### 6.2 Agent Authentication / Runtime Assertion
+
+Agents are not authenticated the same way users are. Instead, the runtime must assert and preserve:
+
+- agent identity
+- agent birth/continuity references
+- authorized execution context
+
+An agent acts because the runtime has authenticated the calling user/system and then instantiated or resumed an authorized ADL actor under governed rules.
+
+### 6.3 Internal Actor Authentication
+
+Skills, tools, and runtime subsystems should not be treated as anonymous behavior. Their identity must be asserted by the runtime when they act.
+
+This supports:
+
+- trace attribution
+- auditability
+- capability resolution
+
+### 6.4 Provider Authentication
+
+Provider access must be authenticated separately from agent identity.
+
+Examples:
+
+- API keys
+- local execution permissions
+- transport credentials
+
+Provider authentication proves the runtime may use the provider. It does not define the identity of the agent using it.
+
+---
+
+## 7. Identity Preservation and Continuity
+
+A central ADL requirement is that identity survive across execution rather than being reconstructed ad hoc from surface text.
+
+### 7.1 Continuity Requirements
+
+Agent identity continuity should be bound to:
+
+- stable agent identifier
+- chronosense / temporal ephemeris
+- memory continuity where applicable
+- policy and capability continuity where applicable
+
+### 7.2 Runtime Rule
+
+No execution path may silently collapse:
+
+- user identity into agent identity
+- agent identity into model identity
+- provider identity into actor identity
+
+### 7.3 Why This Matters
+
+Without preserved identity boundaries, the runtime cannot reliably answer:
+
+- who did what?
+- whose policy applied?
+- which actor is accountable?
+- what continuity governs future decisions?
+
+---
+
+## 8. Delegation and Identity Boundaries
+
+ADL relies on governed delegation.
+
+The standard path is:
+
+- authenticated user/system principal
+- user-facing ADL operation (`agent.invoke`, `workflow.run`)
+- governed ADL actor (agent or workflow)
+- delegated internal components (skills, tools, models, memory)
+
+Identity must be preserved at each stage.
+
+### 8.1 Delegation Rule
+
+Delegation does not erase the delegating actor.
+
+If a skill invokes a model on behalf of an agent, trace and review surfaces must still be able to reconstruct:
+
+- the user who initiated the action
+- the agent that owned the work
+- the skill that exercised the delegated action
+- the provider that executed the model call
+
+### 8.2 Anti-Bypass Rule
+
+External callers should normally interact with governed ADL actors, not raw internal primitives.
+
+For example:
+
+- calling `agent.invoke` is valid
+- directly reaching `model.invoke` for that same governed agent should normally be denied or reserved for tightly controlled expert/internal paths
+
+This preserves both security and identity integrity.
+
+---
+
+## 9. Identity Object Model
+
+A practical runtime architecture should define structured identity objects rather than relying on loose strings.
+
+### 9.1 Minimum Logical Identity Fields
+
+Depending on actor type, useful fields may include:
+
+- `actor_type`
+- `actor_id`
+- `display_name`
+- `principal_type`
+- `authn_source`
+- `authn_state`
+- `birth_reference`
+- `continuity_reference`
+- `provider_ref` (where applicable)
+- `model_ref` (where applicable)
+
+### 9.2 Identity Separation Rule
+
+The same execution record may contain multiple identity references, but they must not be conflated.
+
+For example, a model invocation should be able to represent:
+
+- delegating agent identity
+- acting skill identity
+- provider identity
+- model identity
+
+Each for different architectural reasons.
+
+---
+
+## 10. Relationship to Chronosense
+
+Chronosense is a key part of identity continuity in ADL.
+
+### 10.1 Chronosense Contribution
+
+Chronosense provides:
+
+- temporal self-location
+- lifetime reference
+- ordering of experience
+- continuity from a defined beginning
+
+### 10.2 Identity Rule
+
+A governed long-lived agent identity should be able to reference:
+
+- birth / initialization moment
+- elapsed lifetime
+- ordered experience history
+
+This is what separates an identity-bearing ADL actor from a stateless provider call.
+
+### 10.3 Architectural Consequence
+
+Identity architecture and chronosense must be designed together, even if they land in different milestone slices.
+
+---
+
+## 11. Relationship to Capability and Policy
+
+Identity is required for both CBAC and policy.
+
+### 11.1 Capability Dependence on Identity
+
+Capability checks need to know:
+
+- who is requesting an operation
+- through which governed actor the request flows
+- which internal actor is exercising the capability
+
+### 11.2 Policy Dependence on Identity
+
+Policy needs to know:
+
+- who is acting
+- whether the operation is user-facing or delegated internal behavior
+- whether the current actor is allowed to cross the boundary in context
+
+Identity ambiguity should therefore be treated as a safe-fail condition for capability or policy evaluation.
+
+---
+
+## 12. Trace Integration
+
+Identity must be explicit in trace.
+
+### 12.1 Required Trace Identity Visibility
+
+A reviewer should be able to determine from trace:
+
+- who initiated the action
+- which agent owned or governed the work
+- which skill/tool/runtime component acted internally
+- which provider/model executed backend work
+
+### 12.2 Minimum Identity Trace Fields
+
+At relevant events, trace should include or reference:
+
+- actor identity
+- delegating actor identity
+- run identity
+- provider identity where applicable
+- model identity where applicable
+
+### 12.3 Review Requirement
+
+Identity attribution must be sufficiently explicit that a reviewer does not need to infer the acting entity from prose or artifact names alone.
+
+---
+
+## 13. Authentication and Session Boundaries
+
+Authentication state must not be treated as synonymous with identity continuity.
+
+### 13.1 Session vs Identity
+
+A user session may start and end.
+
+An agent identity may persist beyond a single user session.
+
+A provider session may rotate independently.
+
+These are different boundaries and should be modeled separately.
+
+### 13.2 Runtime Requirement
+
+The runtime should preserve enough structure to distinguish:
+
+- authenticated caller session
+- governed agent continuity
+- execution run instance
+- provider connection/auth session
+
+---
+
+## 14. Enterprise Security Relevance
+
+Security-sensitive organizations will ask:
+
+- who authenticated into the system?
+- which governed actor performed the work?
+- can an agent be distinguished from the underlying provider?
+- can identity switching or spoofing occur silently?
+- is every action attributable to a stable actor?
+
+This architecture is meant to make those questions answerable in a deterministic and reviewable way.
+
+It is especially important for:
+
+- audit and compliance
+- incident response
+- enterprise trust approval
+- regulated or security-sensitive environments
+
+---
+
+## 15. Failure Modes
+
+The architecture must safely handle at least the following failures:
+
+- missing authenticated caller identity where required
+- ambiguous actor attribution
+- silent collapse of agent identity into provider/model identity
+- invalid or missing continuity reference for a governed agent
+- identity mismatch across execution boundary
+- unauthenticated attempt to access protected user-facing ADL surface
+- non-traceable actor identity for protected action
+
+All such failures must result in safe handling and explicit review visibility.
+
+---
+
+## 16. Initial Implementation Guidance
+
+A practical implementation path is:
+
+### v0.87 Foundation
+- ensure trace, boundaries, capability, and policy docs all preserve distinct identity concepts
+- seed identity fields in schemas and trace where needed
+
+### v0.92 Identity Substrate
+- define canonical agent identity object model
+- define continuity references and birth/chronosense integration
+- define authenticated caller representation
+- integrate identity into replay and review surfaces
+
+### Later Expansion
+- external IAM / enterprise auth integration
+- richer cross-agent identity and delegation semantics
+- stronger signing/provenance coupling
+
+---
+
+## 17. Open Questions
+
+- what is the first canonical identity object format?
+- which identity fields must be inline in trace vs referenced elsewhere?
+- how should local development authentication map to later enterprise authentication?
+- what is the first minimal authenticated entry mechanism for ADL?
+- how should identity-bearing agents be represented before full chronosense lands?
+
+---
+
+## 18. Conclusion
+
+The ADL Identity and Authentication Architecture defines how ADL keeps actors real, distinct, attributable, and governed across time and execution.
+
+It ensures that execution is performed not by anonymous magic, but by authenticated callers acting through governed ADL actors with explicit continuity and reviewable attribution.
+
+This is one of the core architectural requirements for trustworthy, enterprise-grade agent systems.

--- a/.adl/docs/v0.94planning/POLICY_ENGINE.md
+++ b/.adl/docs/v0.94planning/POLICY_ENGINE.md
@@ -1,0 +1,514 @@
+
+
+# ADL Policy Engine Architecture
+
+## Status
+Draft (Planned for v0.88–v0.89)
+
+---
+
+## 1. Overview
+
+The ADL Policy Engine defines how ADL evaluates, enforces, and records policy decisions during execution.
+
+The policy engine exists to ensure that execution is not governed only by capability availability or model behavior, but by an explicit, reviewable layer of constraints and permissions that can be applied consistently across agents, skills, tools, memory, providers, and workflows.
+
+In ADL, policy is not an afterthought and not a UI preference surface. It is a **runtime control layer**.
+
+> **Principle:** Capability says what could be done. Policy says what may be done now, by this actor, in this context.
+
+---
+
+## 2. Purpose
+
+The policy engine provides a formal mechanism for:
+
+- enforcing organizational and runtime constraints
+- constraining capability use in context
+- preventing boundary bypass and policy drift
+- preserving agent identity and delegation boundaries
+- supporting audit, replay, and security review
+
+This architecture is a core part of the ADL Secure Execution Model (SEM).
+
+---
+
+## 3. Design Goals
+
+### 3.1 Primary Goals
+
+- make policy evaluation explicit and deterministic
+- ensure policy is enforced at execution boundaries
+- integrate policy outcomes with trace and review surfaces
+- allow policy to restrict otherwise-available capabilities
+- preserve agent-level abstraction and governed delegation
+- support security-sensitive enterprise use cases
+
+### 3.2 Non-Goals
+
+- vague or advisory-only policy language
+- hidden policy effects without trace visibility
+- unrestricted runtime self-modification of policy
+- policy as a substitute for capability enforcement
+
+---
+
+## 4. Core Claim
+
+Policy is a separate layer from both:
+
+- **capability**
+- **identity**
+
+All three are required.
+
+### Capability
+Defines the operations that are technically available.
+
+### Identity
+Defines who is acting and under what continuity/governed surface.
+
+### Policy
+Defines whether a specific action is permitted under current conditions.
+
+This means:
+
+- a capability may exist and still be denied
+- an agent may be valid and still be constrained
+- a user may invoke an agent and still encounter refusal, deferral, or bounded execution limits
+
+---
+
+## 5. Policy Model
+
+A policy decision evaluates:
+
+- **actor identity**
+- **requested operation**
+- **target/resource**
+- **context**
+- **capabilities in play**
+- **boundary being crossed**
+
+The output is a bounded result such as:
+
+- `allow`
+- `deny`
+- `defer`
+- `require_review`
+
+Optional future variants may include richer advisory or remediation states, but the core runtime model must remain simple and enforceable.
+
+---
+
+## 6. Policy Scope
+
+Policy may apply to any of the following:
+
+### 6.1 User-facing invocation surfaces
+
+Examples:
+
+- `agent.invoke`
+- `workflow.run`
+
+### 6.2 Delegated internal operations
+
+Examples:
+
+- model invocation
+- tool execution
+- memory read/write
+- network requests
+
+### 6.3 Boundary crossings
+
+Examples:
+
+- user → agent
+- agent → skill
+- skill → tool
+- skill → model
+- skill → memory
+- runtime → provider
+
+### 6.4 Data and artifact handling
+
+Examples:
+
+- access to sensitive artifact classes
+- export of generated outputs
+- movement of payloads across trust boundaries
+
+---
+
+## 7. Policy as a Boundary Layer
+
+Policy is evaluated at explicit execution boundaries.
+
+At minimum, every policy-aware boundary must support:
+
+1. identification of the actor
+2. identification of the requested operation
+3. identification of the relevant capability or delegated capability set
+4. evaluation of applicable policy rules
+5. trace emission of the result
+
+This means policy is not a generic ambient condition. It is a **boundary enforcement mechanism**.
+
+---
+
+## 8. Relationship to Capability Model (CBAC)
+
+The policy engine is not a replacement for the capability model.
+
+### Capability Model
+Answers:
+- does the runtime have the declared permission structure to do this?
+
+### Policy Engine
+Answers:
+- should this action be allowed in this context, through this actor, at this boundary?
+
+### Example
+A skill may require `network.request`.
+
+That capability may be available in the runtime.
+
+But policy may still deny the request because:
+
+- the target domain is unapproved
+- the calling agent is not allowed outbound access
+- the current workflow is restricted to offline execution
+
+So:
+
+- capability may be satisfied
+- policy may still deny
+
+This is expected behavior.
+
+---
+
+## 9. Relationship to Freedom Gate
+
+The Freedom Gate and the policy engine are related but distinct.
+
+### Freedom Gate
+- part of the cognitive and constitutional architecture
+- concerned with bounded agency, refusal, deferral, and accountable choice
+- may include ethical or normative reasoning
+
+### Policy Engine
+- part of the security and enforcement architecture
+- concerned with runtime allow/deny/defer/review decisions
+- must remain deterministic and enforceable
+
+### Integration Rule
+Freedom Gate may inform or shape policy-relevant decisions, but policy enforcement must not depend on hidden model judgment alone.
+
+In other words:
+
+- the Freedom Gate may reason
+- the policy engine must enforce
+
+---
+
+## 10. Preservation of Agent Abstraction
+
+A central requirement of the policy engine is preserving the ADL abstraction boundary between:
+
+- user/application-facing operations
+- internal runtime primitives
+
+Examples:
+
+- users may be allowed to call `agent.invoke`
+- users should normally not be allowed to call `model.invoke` directly for that same governed agent
+
+This protects:
+
+- agent identity continuity
+- delegated action structure
+- auditability of work performed through agents
+- application-level abstraction integrity
+
+Policy is therefore one of the core mechanisms that prevents callers from bypassing governed ADL actors and reaching raw substrates directly.
+
+---
+
+## 11. Policy Inputs
+
+A policy evaluation should be able to consume the following structured inputs.
+
+### 11.1 Actor
+
+Examples:
+
+- user identity
+- agent identity
+- skill identity
+- system/runtime actor
+
+### 11.2 Operation
+
+Examples:
+
+- `agent.invoke`
+- `workflow.run`
+- `model.invoke`
+- `tool.execute`
+- `memory.read`
+
+### 11.3 Target / Resource
+
+Examples:
+
+- named agent
+- skill path
+- provider/model
+- tool name
+- memory scope
+- network endpoint
+- artifact class
+
+### 11.4 Boundary Context
+
+Examples:
+
+- current execution boundary
+- delegated/internal vs user-facing operation
+- parent actor / delegating actor
+
+### 11.5 Capability Context
+
+Examples:
+
+- required capability set
+- granted capabilities
+- constraint set
+
+### 11.6 Execution Context
+
+Examples:
+
+- workflow identifier
+- run identifier
+- environment classification
+- offline/online mode
+- review-required mode
+
+---
+
+## 12. Policy Outputs
+
+The core policy result must be bounded and explicit.
+
+### 12.1 Core Outcomes
+
+- `allow`
+- `deny`
+- `defer`
+- `require_review`
+
+### 12.2 Required Result Fields
+
+Every policy result should include at least:
+
+- `policy_outcome`
+- `policy_rule_id` or equivalent source reference
+- `reason` or bounded rationale
+- `actor`
+- `operation`
+- `target`
+- `boundary`
+
+### 12.3 Enforcement Rule
+
+No action requiring policy evaluation may proceed without a policy outcome.
+
+---
+
+## 13. Enforcement Semantics
+
+Policy evaluation occurs before protected execution proceeds.
+
+### 13.1 Required Order
+
+Within a protected boundary, the expected ordering is:
+
+1. input validation
+2. contract validation
+3. capability resolution
+4. policy evaluation
+5. execution or refusal/defer/review outcome
+6. trace emission
+7. artifact capture where applicable
+
+### 13.2 Deny-by-Default
+
+If:
+
+- no policy applies where one is required
+- policy evaluation fails
+- policy context is incomplete
+
+then execution must default to denial or another explicitly safe failure mode.
+
+Policy failure must never silently degrade into implicit allow.
+
+---
+
+## 14. Trace Integration
+
+Policy outcomes must be visible in trace.
+
+### 14.1 Required Trace Visibility
+
+At minimum, policy-aware execution should emit events or equivalent trace fields that capture:
+
+- policy evaluation occurred
+- which actor and operation were evaluated
+- the outcome (`allow`, `deny`, `defer`, `require_review`)
+- the relevant boundary
+- the rule or rule family applied, where practical
+
+### 14.2 Suggested Event Family
+
+A likely event family is:
+
+- `POLICY_EVALUATION`
+- `POLICY_DENIAL`
+- `POLICY_DEFER`
+- `POLICY_REVIEW_REQUIRED`
+
+This may later be normalized into a tighter event model, but the semantic visibility is mandatory even if the exact event names change.
+
+### 14.3 Review Requirement
+
+A reviewer must be able to determine from trace:
+
+- whether policy was checked
+- what policy outcome was produced
+- whether execution was blocked, deferred, or allowed as a result
+
+---
+
+## 15. Policy Rule Families
+
+Initial policy rule families may include the following.
+
+### 15.1 Invocation Surface Rules
+
+Examples:
+
+- allow `agent.invoke`
+- deny direct external `model.invoke`
+- restrict `workflow.run` to approved workflows
+
+### 15.2 Tool and Network Rules
+
+Examples:
+
+- restrict filesystem paths
+- restrict shell/tool invocation classes
+- restrict outbound domains or protocols
+
+### 15.3 Memory and Data Rules
+
+Examples:
+
+- restrict write access to shared memory scopes
+- limit access to sensitive artifact classes
+- prohibit export of restricted data classes
+
+### 15.4 Provider Rules
+
+Examples:
+
+- allow only approved providers
+- restrict model families per environment
+- require local-only operation in certain runs
+
+### 15.5 Review and Escalation Rules
+
+Examples:
+
+- require review before external communication
+- require review before destructive tool operations
+- defer high-risk actions instead of denying outright
+
+---
+
+## 16. Enterprise Security Relevance
+
+The policy engine is one of the core features that makes ADL suitable for security-sensitive companies.
+
+It supports:
+
+- separation between user-facing operations and internal execution primitives
+- explicit control over provider, tool, memory, and network use
+- demonstrable review and audit surfaces
+- deterministic enforcement rather than trust-me orchestration
+
+This is essential for organizations that must answer questions such as:
+
+- who was allowed to do this?
+- through what governed surface?
+- what was denied?
+- what required review?
+- did any action bypass the approved abstraction boundary?
+
+---
+
+## 17. Failure Modes
+
+The policy engine must explicitly handle at least the following failure modes:
+
+- missing policy where policy is required
+- malformed policy input context
+- attempted bypass of agent-level invocation surface
+- conflict between capability allowance and policy denial
+- incomplete boundary context preventing safe evaluation
+- non-traceable policy outcome
+
+All such failures must result in safe handling and explicit review visibility.
+
+---
+
+## 18. Initial Implementation Guidance
+
+A reasonable early implementation path is:
+
+### v0.87 Foundation
+- ensure boundary and trace infrastructure can carry policy outcomes cleanly
+- identify the first mandatory policy-aware boundaries
+
+### v0.88–v0.89 Initial Policy Engine
+- implement bounded policy evaluation for core boundaries
+- enforce deny-by-default behavior
+- support at least `allow` and `deny`, with `defer` / `require_review` where needed
+
+### v0.90+
+- integrate more deeply with signed trace, review pipeline, and identity substrate
+- expand policy rule families and enterprise control surfaces
+
+---
+
+## 19. Open Questions
+
+- What is the first canonical rule representation format?
+- Which policy outcomes are required in the first implementation slice?
+- How much rule explanation should be exposed in runtime vs review surfaces?
+- Which boundaries become policy-mandatory first?
+- How should policy and Freedom Gate findings interact when both are present?
+
+---
+
+## 20. Conclusion
+
+The ADL Policy Engine is the enforcement layer that turns security, governance, and delegation rules into runtime behavior.
+
+It ensures that execution is not merely possible, but **permitted in context, through governed surfaces, with explicit reviewable outcomes**.
+
+This is one of the key mechanisms that allows ADL to support trustworthy, enterprise-grade agent execution rather than opaque model-driven behavior.

--- a/.adl/docs/v0.94planning/PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md
+++ b/.adl/docs/v0.94planning/PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md
@@ -1,0 +1,288 @@
+
+
+# ADL Provider Trust and Isolation Architecture
+
+## Status
+Draft (Planned for v0.92+ with early security alignment in v0.87–v0.89)
+
+---
+
+## 1. Overview
+
+This document defines how ADL treats model providers as **untrusted or partially trusted execution substrates** and establishes the isolation, attribution, and control mechanisms required to safely use them in enterprise environments.
+
+Providers (e.g., OpenAI, Anthropic, local models, etc.) are not considered actors in the ADL system. They are **execution backends** used by governed ADL actors.
+
+> **Principle:** Providers execute computation. They do not define identity, authority, or trust.
+
+---
+
+## 2. Core Problem
+
+Most AI systems collapse:
+
+- identity → model
+- execution → provider
+- trust → API boundary
+
+This creates:
+
+- loss of attribution
+- loss of control
+- unclear security boundaries
+- audit and compliance failures
+
+ADL explicitly rejects this collapse.
+
+---
+
+## 3. Design Goals
+
+### 3.1 Primary Goals
+
+- treat providers as isolated execution substrates
+- prevent provider access from bypassing ADL governance
+- ensure all provider usage is attributable to ADL actors
+- support multiple providers without identity ambiguity
+- allow enterprise control over provider usage
+
+### 3.2 Non-Goals
+
+- trusting providers as identity-bearing actors
+- exposing providers directly to end users
+- embedding governance inside provider behavior
+- assuming provider correctness or safety
+
+---
+
+## 4. Trust Model
+
+### 4.1 Provider Trust Classification
+
+Providers should be treated as:
+
+- **untrusted** (default)
+- **partially trusted** (controlled enterprise context)
+- **trusted for availability but not authority**
+
+Even highly reputable providers must not be trusted for:
+
+- identity
+- policy enforcement
+- attribution correctness
+
+### 4.2 Trust Boundary
+
+The primary trust boundary is:
+
+```
+ADL Runtime (trusted) → Provider (untrusted execution)
+```
+
+Everything crossing this boundary must be:
+
+- explicitly authorized
+- traceable
+- attributable
+- reviewable
+
+---
+
+## 5. Execution Isolation
+
+### 5.1 Isolation Principle
+
+Provider execution must be isolated from:
+
+- identity system
+- policy system
+- capability system
+- internal memory (unless explicitly mediated)
+
+### 5.2 Isolation Requirements
+
+- providers do not access ADL internal state directly
+- providers cannot mutate identity or policy
+- providers cannot initiate execution
+- providers only respond to controlled invocation
+
+### 5.3 No Direct User Access
+
+External users must not directly access:
+
+- `model.invoke`
+- provider endpoints
+- raw provider tools
+
+All access must go through governed ADL surfaces.
+
+---
+
+## 6. Invocation Path
+
+All provider calls must follow:
+
+```
+user → agent.invoke → governed agent → skill/tool → model.invoke → provider
+```
+
+Key properties:
+
+- user identity preserved
+- agent identity preserved
+- delegation visible
+- provider is last step
+
+---
+
+## 7. Attribution Model
+
+Every provider call must be attributable to:
+
+- user identity
+- agent identity
+- execution/run identity
+- internal actor (skill/tool)
+- provider identity
+- model identity
+
+This must be explicit in trace.
+
+---
+
+## 8. Provider Abstraction Layer
+
+### 8.1 Purpose
+
+ADL must normalize provider interaction through a controlled abstraction layer.
+
+### 8.2 Responsibilities
+
+- normalize request/response format
+- enforce capability checks
+- attach identity context
+- emit trace events
+- enforce policy decisions
+- prevent direct provider leakage
+
+### 8.3 Anti-Leak Rule
+
+Provider-specific constructs must not leak into:
+
+- user-facing APIs
+- agent logic
+- policy definitions
+
+---
+
+## 9. Data Exposure Controls
+
+### 9.1 Principle
+
+Data sent to providers must be explicitly controlled.
+
+### 9.2 Controls
+
+- minimize sensitive data exposure
+- allow redaction or filtering layers
+- support future classification policies
+- trace all outbound data paths
+
+---
+
+## 10. Multi-Provider Safety
+
+ADL must support multiple providers safely.
+
+### 10.1 Requirements
+
+- no identity confusion across providers
+- provider selection must be explicit
+- trace must record provider per invocation
+
+### 10.2 No Identity Collapse
+
+Switching providers must not change:
+
+- agent identity
+- policy behavior
+- governance model
+
+---
+
+## 11. Policy Integration
+
+Provider calls must be policy-controlled.
+
+Examples:
+
+- allow/deny provider usage per agent
+- restrict models by classification
+- restrict external calls in sensitive workflows
+
+---
+
+## 12. Failure Modes
+
+The system must safely handle:
+
+- provider unavailability
+- malformed responses
+- adversarial output
+- data leakage risk
+- unexpected provider behavior
+
+Failures must be:
+
+- visible in trace
+- bounded in effect
+- reviewable
+
+---
+
+## 13. Enterprise Requirements
+
+Security-sensitive organizations require:
+
+- clear provider isolation
+- auditable provider usage
+- deterministic attribution
+- enforceable policy boundaries
+
+This architecture is designed to pass:
+
+- security review
+- compliance audit
+- internal risk assessment
+
+---
+
+## 14. Implementation Path
+
+### v0.87–v0.89
+
+- enforce invocation boundaries
+- ensure trace includes provider identity
+- normalize provider abstraction
+
+### v0.92+
+
+- formal provider isolation layer
+- policy-driven provider control
+- data exposure controls
+
+---
+
+## 15. Conclusion
+
+Providers are powerful but untrusted execution substrates.
+
+ADL ensures:
+
+- they do not define identity
+- they do not bypass governance
+- they do not break attribution
+
+All intelligence flows through governed ADL actors, not directly through providers.
+
+This is essential for building secure, enterprise-grade agent systems.

--- a/.adl/docs/v0.94planning/SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md
+++ b/.adl/docs/v0.94planning/SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md
@@ -1,0 +1,335 @@
+
+
+# ADL Sandbox and Runtime Isolation Architecture
+
+## Status
+Draft (Planned for v0.92+ with foundational elements in v0.87–v0.89)
+
+---
+
+## 1. Overview
+
+This document defines how ADL isolates execution within the runtime, including:
+
+- skills
+- tools
+- workflows
+- memory access
+- filesystem and network interaction
+
+The goal is to ensure that all execution within ADL is:
+
+- controlled
+- attributable
+- policy-governed
+- safe by default
+
+> **Principle:** No code or capability executes without an explicit boundary, identity, and policy context.
+
+---
+
+## 2. Core Problem
+
+In most agent systems, internal execution is:
+
+- implicitly trusted
+- loosely scoped
+- difficult to audit
+- capable of unintended side effects
+
+Examples include:
+
+- tools with unrestricted filesystem access
+- network calls without visibility
+- hidden state mutation
+- uncontrolled code execution
+
+This leads to:
+
+- security vulnerabilities
+- non-determinism
+- audit failure
+- enterprise rejection
+
+ADL explicitly rejects implicit trust in internal execution.
+
+---
+
+## 3. Design Goals
+
+### 3.1 Primary Goals
+
+- isolate all internal execution units (skills, tools, runtime actions)
+- enforce explicit resource access controls
+- ensure all execution is attributable and traceable
+- support deterministic replay where possible
+- support safe interaction with non-deterministic environments
+
+### 3.2 Non-Goals
+
+- unrestricted tool execution
+- hidden side effects
+- implicit access to system resources
+- reliance on model behavior for safety
+
+---
+
+## 4. Isolation Model
+
+### 4.1 Execution Units
+
+The following are treated as isolated execution units:
+
+- skills
+- tools
+- workflow steps
+- runtime subsystems
+
+Each unit must execute within a defined boundary.
+
+### 4.2 Isolation Boundary
+
+Each execution unit operates within a sandbox that defines:
+
+- accessible resources
+- allowed operations
+- identity context
+- capability scope
+
+### 4.3 No Ambient Authority
+
+Execution units must not inherit implicit access to:
+
+- filesystem
+- network
+- secrets
+- memory
+
+All access must be explicitly granted.
+
+---
+
+## 5. Resource Domains
+
+ADL must define and isolate key resource domains.
+
+### 5.1 Filesystem
+
+Controls include:
+
+- read/write scoping
+- path restrictions
+- sandboxed directories
+
+### 5.2 Network
+
+Controls include:
+
+- allow/deny outbound access
+- domain restrictions
+- protocol restrictions
+
+### 5.3 Memory
+
+Controls include:
+
+- scoped access to agent memory
+- explicit read/write APIs
+- no implicit shared state
+
+### 5.4 Secrets
+
+Controls include:
+
+- explicit secret injection
+- no raw environment access
+- audit of secret usage
+
+---
+
+## 6. Execution Modes
+
+ADL should support multiple execution modes.
+
+### 6.1 Deterministic Mode
+
+- replayable execution
+- controlled inputs/outputs
+- no uncontrolled external interaction
+
+### 6.2 Non-Deterministic Mode
+
+- external API calls
+- real-world interaction
+- bounded and traced side effects
+
+### 6.3 Mode Declaration
+
+Each execution unit must declare its mode.
+
+---
+
+## 7. Capability Integration
+
+All execution must pass through CBAC.
+
+Examples:
+
+- `filesystem.read`
+- `filesystem.write`
+- `network.call`
+- `memory.read`
+- `memory.write`
+- `provider.invoke`
+
+Capabilities define *what is possible* within a sandbox.
+
+---
+
+## 8. Policy Integration
+
+Policy defines *what is allowed* in context.
+
+Examples:
+
+- deny network access in sensitive workflows
+- restrict filesystem writes
+- require approval for external calls
+
+Policy must be evaluated at execution time.
+
+---
+
+## 9. Identity Integration
+
+Each execution unit must have identity context:
+
+- delegating agent
+- acting skill/tool
+- execution/run identity
+
+This ensures attribution for all actions.
+
+---
+
+## 10. Trace Requirements
+
+All sandboxed execution must emit trace events.
+
+Trace should include:
+
+- execution unit identity
+- accessed resources
+- capability checks
+- policy decisions
+- inputs/outputs (as appropriate)
+
+Trace must make it possible to reconstruct:
+
+- what executed
+- what it accessed
+- why it was allowed
+
+---
+
+## 11. Escalation and Privilege Boundaries
+
+Some operations may require elevated privileges.
+
+Examples:
+
+- writing to shared memory
+- external network calls
+- filesystem mutation
+
+These must:
+
+- require explicit capability
+- be policy-gated
+- be visible in trace
+
+No silent privilege escalation is allowed.
+
+---
+
+## 12. Isolation vs Performance
+
+Isolation may introduce overhead.
+
+Design must balance:
+
+- safety
+- determinism
+- performance
+
+Optimizations must not break:
+
+- attribution
+- policy enforcement
+- isolation guarantees
+
+---
+
+## 13. Enterprise Requirements
+
+Security-sensitive environments require:
+
+- strict sandboxing of execution
+- no implicit resource access
+- auditable behavior
+- policy enforcement at runtime
+
+This architecture supports:
+
+- internal security review
+- compliance requirements
+- production deployment in sensitive environments
+
+---
+
+## 14. Failure Modes
+
+The system must safely handle:
+
+- unauthorized resource access attempts
+- sandbox escape attempts
+- policy violations
+- missing capability declarations
+- ambiguous execution identity
+
+Failures must be:
+
+- denied by default
+- visible in trace
+- reviewable
+
+---
+
+## 15. Implementation Path
+
+### v0.87–v0.89
+
+- define capability surface for resources
+- ensure trace captures resource access
+- enforce execution boundaries at API level
+
+### v0.92+
+
+- formal sandbox implementation
+- fine-grained resource isolation
+- policy-driven execution control
+
+---
+
+## 16. Conclusion
+
+ADL treats internal execution with the same rigor as external providers.
+
+All execution is:
+
+- bounded
+- governed
+- attributable
+- reviewable
+
+This ensures that agent systems remain safe, understandable, and acceptable in enterprise environments.

--- a/.adl/docs/v0.94planning/SECRETS_AND_DATA_GOVERNANCE.md
+++ b/.adl/docs/v0.94planning/SECRETS_AND_DATA_GOVERNANCE.md
@@ -1,0 +1,332 @@
+
+
+# ADL Secrets and Data Governance Architecture
+
+## Status
+Draft (Planned for v0.92+ with early enforcement hooks in v0.87–v0.89)
+
+---
+
+## 1. Overview
+
+This document defines how ADL manages:
+
+- secrets
+- sensitive data
+- data flow to providers
+- data access within execution
+
+The goal is to ensure that all data handled by ADL is:
+
+- explicitly controlled
+- minimally exposed
+- policy-governed
+- traceable and auditable
+
+> **Principle:** No sensitive data is accessed, used, or transmitted without explicit declaration, control, and attribution.
+
+---
+
+## 2. Core Problem
+
+Most AI systems:
+
+- leak secrets into prompts
+- expose API keys to tools
+- send sensitive data to external providers without control
+- lack visibility into data flow
+
+This results in:
+
+- data exfiltration risk
+- compliance violations
+- inability to pass enterprise security review
+
+ADL explicitly rejects implicit data access and uncontrolled data flow.
+
+---
+
+## 3. Design Goals
+
+### 3.1 Primary Goals
+
+- treat secrets as first-class governed resources
+- minimize data exposure to providers and tools
+- ensure all data access is explicit and attributable
+- integrate data handling with capability and policy systems
+- provide full trace visibility into data flow
+
+### 3.2 Non-Goals
+
+- storing secrets in prompts
+- implicit access to environment variables
+- uncontrolled data sharing between execution units
+- relying on model behavior for data protection
+
+---
+
+## 4. Data Classification (Initial Model)
+
+ADL should support classification tiers.
+
+### 4.1 Suggested Tiers
+
+- public
+- internal
+- sensitive
+- secret
+
+### 4.2 Usage
+
+Classification informs:
+
+- capability requirements
+- policy decisions
+- provider exposure rules
+
+This can begin as a lightweight annotation model and evolve over time.
+
+---
+
+## 5. Secret Management Model
+
+### 5.1 Principles
+
+- secrets are never embedded in code or prompts
+- secrets are injected explicitly at runtime
+- secrets are scoped to execution context
+- secrets are never exposed beyond intended boundaries
+
+### 5.2 Secret Sources
+
+Possible sources include:
+
+- local development configuration
+- environment-specific secret stores
+- enterprise secret managers (future)
+
+### 5.3 Secret Injection
+
+Secrets must be:
+
+- explicitly requested via capability
+- injected into execution context
+- unavailable unless granted
+
+---
+
+## 6. Data Flow Model
+
+### 6.1 Explicit Data Flow
+
+All data movement must be:
+
+- explicit
+- traceable
+- attributable
+
+### 6.2 Key Data Paths
+
+- user → agent
+- agent → skill/tool
+- skill/tool → provider
+- provider → skill/tool → agent
+
+Each path must be governed.
+
+### 6.3 Outbound Data Control
+
+Before data is sent to a provider:
+
+- apply policy checks
+- apply redaction where required
+- ensure only necessary data is transmitted
+
+---
+
+## 7. Provider Data Exposure
+
+### 7.1 Principle
+
+Providers should receive the minimum data required to perform the task.
+
+### 7.2 Controls
+
+- redact sensitive fields
+- filter secrets
+- restrict high-classification data
+- log outbound payloads (with safe handling)
+
+### 7.3 No Implicit Leakage
+
+Data must not be sent to providers unless:
+
+- explicitly allowed
+- visible in trace
+
+---
+
+## 8. Capability Integration
+
+Data and secret access must be capability-controlled.
+
+Examples:
+
+- `secret.read`
+- `secret.inject`
+- `data.read.sensitive`
+- `data.write`
+
+Capabilities define what access is possible.
+
+---
+
+## 9. Policy Integration
+
+Policy defines what access is allowed.
+
+Examples:
+
+- deny sending sensitive data to external providers
+- restrict secret access to specific agents
+- require approval for high-risk data flows
+
+Policy must be evaluated before:
+
+- secret access
+- data transmission
+- data mutation
+
+---
+
+## 10. Identity Integration
+
+All data access must be attributable to:
+
+- user identity
+- agent identity
+- execution/run identity
+- acting component (skill/tool)
+
+This ensures:
+
+- accountability
+- auditability
+
+---
+
+## 11. Trace Requirements
+
+Trace must include:
+
+- data access events
+- secret usage events
+- outbound data flows
+- policy decisions
+
+Trace must enable reviewers to answer:
+
+- what data was accessed?
+- what data was transmitted?
+- who authorized it?
+
+---
+
+## 12. Redaction and Filtering
+
+### 12.1 Redaction Layer
+
+ADL should support a redaction layer that:
+
+- removes secrets from outbound data
+- masks sensitive values
+- applies classification-based filtering
+
+### 12.2 Placement
+
+Redaction should occur:
+
+- before provider calls
+- before trace exposure (if necessary)
+
+---
+
+## 13. Secret Leakage Prevention
+
+The system must prevent:
+
+- secrets appearing in prompts
+- secrets being logged unintentionally
+- secrets being passed to providers
+- secrets being exposed across execution boundaries
+
+Violations must be:
+
+- blocked
+- logged
+- visible in trace
+
+---
+
+## 14. Enterprise Requirements
+
+Security-sensitive organizations require:
+
+- strict secret handling
+- auditable data flow
+- control over external data transmission
+- integration with enterprise secret systems
+
+This architecture supports:
+
+- compliance requirements
+- internal audit
+- production security review
+
+---
+
+## 15. Failure Modes
+
+The system must safely handle:
+
+- unauthorized secret access
+- data classification violations
+- unintended data exposure
+- missing policy decisions
+
+Failures must be:
+
+- denied by default
+- visible in trace
+- reviewable
+
+---
+
+## 16. Implementation Path
+
+### v0.87–v0.89
+
+- introduce capability names for secret/data access
+- ensure trace captures data flow
+- begin redaction hooks for provider calls
+
+### v0.92+
+
+- formal secret management layer
+- classification-aware data governance
+- policy-driven data controls
+
+---
+
+## 17. Conclusion
+
+ADL treats data and secrets as governed resources, not incidental inputs.
+
+All data movement is:
+
+- explicit
+- controlled
+- attributable
+- reviewable
+
+This is essential for building systems that can safely operate in enterprise and security-sensitive environments.

--- a/.adl/docs/v0.94planning/SECURE_EXECUTION_MODEL.md
+++ b/.adl/docs/v0.94planning/SECURE_EXECUTION_MODEL.md
@@ -1,0 +1,335 @@
+
+
+# ADL Secure Execution Model (SEM)
+
+> Scope note: core runtime and execution-boundary semantics remain owned by the OSS runtime milestones, especially `v0.87.1`. This document is placed in `v0.94` because its dominant concern is later security, enforcement, isolation, and regulated-environment extension work.
+
+## Status
+Draft (Target: v0.89+ alignment with signing, identity, and Freedom Gate v2)
+
+---
+
+## 1. Overview
+
+The ADL Secure Execution Model (SEM) defines a **zero-trust, deterministic execution substrate for AI systems**. It is designed to satisfy the requirements of **security-sensitive and regulated environments** (e.g., finance, healthcare, government, critical infrastructure).
+
+SEM ensures that:
+
+- Every action is **explicitly authorized**
+- Every execution step is **traceable and auditable**
+- Every output is **attributable and reproducible**
+- No component (model, tool, agent, or provider) is implicitly trusted
+
+> **Principle:** If it is not in the trace, it did not happen.
+
+---
+
+## 2. Design Goals
+
+### 2.1 Primary Goals
+
+- Deterministic execution semantics
+- Full auditability and forensic reconstruction
+- Strong identity and attribution
+- Explicit policy enforcement
+- Provider and tool accountability
+- Zero implicit trust boundaries
+
+### 2.2 Non-Goals
+
+- Hiding complexity behind UX abstractions
+- Implicit orchestration or silent execution
+- Trusting model behavior without verification
+
+---
+
+## 3. Zero Trust Principles in ADL
+
+SEM adopts a strict **Zero Trust Architecture (ZTA)** approach:
+
+### 3.1 Never Trust, Always Verify
+
+- All inputs validated via contracts
+- All tool and model boundaries enforced
+- No implicit execution paths
+
+### 3.2 Strong Identity Everywhere
+
+- Agent identity (chronosense-based continuity)
+- Provider identity (provider_ref, model_ref)
+- Actor attribution on every trace event
+
+### 3.3 Full Observability
+
+- All execution emits trace events
+- No silent state transitions
+
+### 3.4 Least Privilege Execution
+
+- Capabilities explicitly declared
+- Skills constrained by contract
+- Providers constrained by capability surface
+
+### 3.5 Continuous Validation
+
+- Pre-execution validation
+- Runtime validation at decision points
+- Post-execution review and verification
+
+---
+
+## 4. Core Security Architecture
+
+### 4.1 Deterministic Execution Surface
+
+ADL enforces:
+
+- Explicit DAG-based workflows
+- No hidden control flow
+- Reproducible execution semantics
+
+This eliminates ambiguity in execution ordering and behavior.
+
+---
+
+### 4.2 Trace as Authoritative Record
+
+The trace is the **single source of truth for execution**.
+
+Properties:
+
+- Complete: all events recorded
+- Ordered: span-based hierarchy
+- Attributed: actor + provider identity
+- Immutable (future: signed)
+
+Trace event classes include:
+
+- MODEL_INVOCATION
+- TOOL_INVOCATION
+- DECISION
+- CONTRACT_VALIDATION
+- APPROVAL / REJECTION
+
+---
+
+### 4.3 Artifact Separation Model
+
+ADL separates:
+
+- **Trace (control plane)**
+- **Artifacts (data plane)**
+
+Benefits:
+
+- Prevents data leakage across control structures
+- Enables independent validation of payloads
+- Supports secure storage and access control
+
+---
+
+### 4.4 Identity Model
+
+Identity is a first-class primitive in ADL:
+
+- Agent identity: persistent, time-aware (chronosense)
+- Execution identity: per-run context
+- Provider identity: explicit model + provider attribution
+
+All actions must be attributable to a specific identity.
+
+---
+
+### 4.5 Provider Accountability
+
+Each model invocation includes:
+
+- provider_ref
+- model_ref
+- provider_model_id
+
+This ensures:
+
+- full provenance tracking
+- reproducibility constraints
+- provider-level auditing
+
+---
+
+## 5. Policy and Governance Layer
+
+### 5.1 Policy-as-Trace
+
+Policies are enforced as part of execution and recorded in trace:
+
+- POLICY_EVALUATION events
+- POLICY_VIOLATION events
+
+Policies may apply to:
+
+- tool usage
+- data access
+- model invocation
+- external communication
+
+---
+
+### 5.2 Freedom Gate Integration
+
+Freedom Gate provides:
+
+- constitutional reasoning
+- agent-level refusal capability
+- ethical and policy alignment
+
+SEM extends this into **enforcement**, not just reasoning.
+
+---
+
+### 5.3 Contract Enforcement
+
+All boundaries require:
+
+- schema validation
+- capability validation
+- precondition checks
+
+No execution proceeds without passing contract validation.
+
+---
+
+## 6. Execution Boundaries
+
+ADL defines explicit boundaries:
+
+### 6.1 Model Boundary
+
+- All model calls are explicit
+- Inputs/outputs validated
+- No hidden prompt construction
+
+### 6.2 Tool Boundary
+
+- Tools invoked via explicit contracts
+- Inputs validated
+- Outputs captured as artifacts
+
+### 6.3 Memory Boundary
+
+- Memory access is explicit and traceable
+- No implicit context injection
+
+### 6.4 Provider Boundary
+
+- Transport and execution separated
+- Provider capabilities declared and enforced
+
+---
+
+## 7. Replay, Audit, and Forensics
+
+### 7.1 Replay
+
+ADL supports:
+
+- logical replay of execution
+- reconstruction of decision paths
+
+### 7.2 Audit
+
+Auditors can:
+
+- inspect trace events
+- inspect artifacts
+- verify policy compliance
+
+### 7.3 Forensics
+
+In incident scenarios:
+
+- full execution lineage available
+- exact inputs/outputs traceable
+- responsibility attributable
+
+---
+
+## 8. Signing and Integrity (v0.90+)
+
+Planned enhancements:
+
+- cryptographic signing of trace
+- tamper-evident execution logs
+- verifiable provenance chains
+
+This enables:
+
+- regulatory compliance (e.g., financial systems)
+- legal-grade auditability
+
+---
+
+## 9. Threat Model Alignment
+
+SEM mitigates:
+
+- prompt injection
+- tool misuse
+- data exfiltration
+- unauthorized execution
+- hidden state manipulation
+
+By enforcing:
+
+- explicit boundaries
+- validation at every step
+- full observability
+
+---
+
+## 10. Enterprise Security Properties
+
+ADL provides:
+
+- Full audit trail (trace)
+- Data lineage (artifact references)
+- Identity attribution (actor + provider)
+- Deterministic execution (replayable)
+- Policy enforcement (traceable)
+
+These align with requirements from:
+
+- financial institutions
+- healthcare systems
+- government agencies
+- large enterprises
+
+---
+
+## 11. Guiding Principle
+
+> **ADL does not assume trust. It constructs it through verifiable execution.**
+
+---
+
+## 12. Future Work
+
+- Signed trace implementation (v0.90)
+- Policy engine formalization
+- Capability-based access control (CBAC)
+- Secure multi-agent coordination
+- Integration with external IAM systems
+
+---
+
+## 13. Conclusion
+
+The ADL Secure Execution Model establishes a foundation for **trustworthy, governable AI systems**.
+
+It enables organizations to:
+
+- deploy AI safely
+- audit AI behavior
+- enforce policy and compliance
+- maintain control over execution
+
+SEM transforms AI from a **black box system** into a **structured, accountable execution environment**.

--- a/.adl/docs/v0.94planning/SECURITY_MODEL_PLANNING.md
+++ b/.adl/docs/v0.94planning/SECURITY_MODEL_PLANNING.md
@@ -1,0 +1,248 @@
+
+
+# ADL Security Model Planning
+
+## Status
+Planning (v0.87 → v0.90 alignment)
+
+---
+
+## 1. Overview
+
+This document decomposes the **ADL Secure Execution Model (SEM)** into implementable features, work packages, and documentation artifacts for integration into the existing ADL planning and milestone system.
+
+The goal is to transition SEM from a **conceptual architecture** into a **fully implemented, testable, and demoable security substrate**.
+
+---
+
+## 2. Guiding Principle
+
+> Security in ADL is not a layer. It is a property of execution.
+
+All features defined here MUST:
+
+- Integrate with trace
+- Be observable and testable
+- Avoid implicit behavior
+- Align with deterministic execution
+
+---
+
+## 3. Decomposition of SEM
+
+The Secure Execution Model breaks down into the following feature areas:
+
+### 3.1 Identity and Attribution
+
+- Agent identity (chronosense integration)
+- Execution identity (run-level)
+- Actor attribution in trace
+
+Target Docs:
+- Extend `ADL_IDENTITY_ARCHITECTURE.md`
+
+---
+
+### 3.2 Trace Integrity and Completeness
+
+- Ensure all execution paths emit trace
+- Enforce no silent operations
+- Define required event coverage
+
+Target Docs:
+- `TRACE_SCHEMA_V1.md`
+- `TRACE_RUNTIME_EMISSION.md`
+- `TRACE_VALIDATION_AND_REVIEW.md`
+
+---
+
+### 3.3 Artifact Security Model
+
+- Control-plane vs data-plane separation
+- Artifact reference integrity
+- Access control model (future)
+
+Target Docs:
+- `TRACE_ARTIFACT_MODEL.md`
+
+---
+
+### 3.4 Provider Accountability
+
+- Provider identity enforcement
+- Model attribution
+- Capability declaration and validation
+
+Target Docs:
+- `PROVIDER_SUBSTRATE_FEATURE.md`
+- `ADL_PROVIDER_CAPABILITIES.md`
+
+---
+
+### 3.5 Capability-Based Execution (CBAC)
+
+- Explicit capability declaration
+- Skill capability requirements
+- Runtime enforcement
+
+New Docs:
+- `CAPABILITY_MODEL.md`
+
+---
+
+### 3.6 Policy and Governance Layer
+
+- Policy evaluation events
+- Policy violation handling
+- Integration with Freedom Gate
+
+Target Docs:
+- `FREEDOM_GATE.md`
+- `FREEDOM_GATE_V2.md`
+
+New Docs:
+- `POLICY_ENGINE.md`
+
+---
+
+### 3.7 Execution Boundaries
+
+- Model boundary enforcement
+- Tool boundary enforcement
+- Memory boundary enforcement
+
+New Docs:
+- `EXECUTION_BOUNDARIES.md`
+
+---
+
+### 3.8 Replay and Audit
+
+- Replay guarantees
+- Audit workflows
+- Forensic reconstruction
+
+Target Docs:
+- `TRACE_REVIEW_PIPELINE.md`
+
+---
+
+### 3.9 Signing and Integrity
+
+- Signed trace
+- Tamper evidence
+- Provenance verification
+
+Target Docs:
+- `SIGNED_TRACE_ARCHITECTURE.md`
+
+---
+
+### 3.10 Threat Model
+
+- STRIDE-style threat categorization
+- Mapping threats → mitigations
+
+Target Docs:
+- `SECURITY_AND_THREAT_MODELING.md`
+
+---
+
+## 4. Work Package Alignment
+
+Security features must be distributed across milestones to avoid scope explosion.
+
+### v0.87 (Foundation)
+
+- Trace completeness enforcement
+- Provider attribution completeness
+- Initial boundary definitions
+
+Related WPs:
+- WP-02 (Trace schema)
+- WP-03 (Trace instrumentation)
+- WP-04 (Provider substrate)
+
+---
+
+### v0.88–v0.89 (Structure + Governance)
+
+- Capability model (CBAC)
+- Policy engine (basic)
+- Execution boundary enforcement
+
+---
+
+### v0.90 (Integrity)
+
+- Signed trace implementation
+- Verification pipeline
+
+---
+
+### v0.92+ (Identity Integration)
+
+- Full identity + chronosense integration
+- Cross-agent attribution
+
+---
+
+## 5. Feature Definition Requirements
+
+Each security-related feature MUST:
+
+- Define explicit inputs/outputs
+- Define trace events
+- Define failure modes
+- Include at least one demo
+- Include validation checks
+
+---
+
+## 6. Demo Strategy
+
+Each major area must include a demo:
+
+### Required demos:
+
+1. **Trace completeness demo**
+2. **Policy enforcement demo**
+3. **Capability restriction demo**
+4. **Audit/replay demo**
+5. **Signed trace verification demo (v0.90)**
+
+---
+
+## 7. Integration with Planning System
+
+For each feature:
+
+- Create GitHub issue
+- Create input/output cards
+- Link to milestone WPs
+- Attach demo requirement
+
+---
+
+## 8. Open Questions
+
+- How strict is determinism across providers?
+- How to handle partial trace failure?
+- How to enforce capability constraints across heterogeneous providers?
+
+---
+
+## 9. Next Steps
+
+1. Create issues for each feature area
+2. Draft initial feature docs (starting with capability model)
+3. Integrate with v0.87 active work packages
+4. Define demo specs
+
+---
+
+## 10. Conclusion
+
+This document establishes the path to implement the ADL Secure Execution Model as a **first-class, enforceable system property**.
+
+Security is not an add-on. It is part of the runtime itself.

--- a/.adl/v0.87/tasks/issue-1316__distribute-remaining-tbd-roadmap-docs-to-roadmap-aligned-milestones/sor.md
+++ b/.adl/v0.87/tasks/issue-1316__distribute-remaining-tbd-roadmap-docs-to-roadmap-aligned-milestones/sor.md
@@ -1,0 +1,186 @@
+# distribute-remaining-tbd-roadmap-docs-to-roadmap-aligned-milestones
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1316
+Run ID: issue-1316
+Version: v0.87
+Title: [v0.87][docs] Distribute remaining TBD roadmap docs to roadmap-aligned milestones
+Branch: codex/1316-distribute-remaining-tbd-roadmap-docs-to-roadmap-aligned-milestones
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5
+- Provider: openai
+- Start Time: 2026-04-05
+- End Time: 2026-04-05
+
+## Summary
+
+Redistributed the active roadmap/feature docs from TBD into milestone-aligned planning directories, introduced the new `v0.87.1planning` runtime-completion band, and reconciled the two roadmap-map docs so they now agree on milestone ownership, MTT placement, skills ownership, and the OSS-vs-enterprise identity/security boundary.
+
+## Artifacts produced
+- `.adl/docs/TBD/FEATURE_SPRINT_MAP.md`
+- `.adl/docs/TBD/NEW_FEATURE_MAP.md`
+- `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT.md`
+- `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`
+- `.adl/docs/v0.87.1planning/AGENT_LIFECYCLE.md`
+- `.adl/docs/v0.87.1planning/EXECUTION_BOUNDARIES.md`
+- `.adl/docs/v0.87.1planning/LOCAL_RUNTIME_RESILIENCE.md`
+- `.adl/docs/v0.87.1planning/SHEPHERD_RUNTIME_MODEL.md`
+- `.adl/docs/v0.88planning/CHRONOSENSE_AND_IDENTITY.md`
+- `.adl/docs/v0.88planning/TEMPORAL_SCHEMA_V01.md`
+- `.adl/docs/v0.89planning/GHB_EXECUTION_MODEL.md`
+- `.adl/docs/v0.89planning/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md`
+- `.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md`
+- `.adl/docs/v0.92planning/CAPABILITY_MODEL.md`
+- `.adl/docs/v0.92planning/CONTINUITY_VALIDATION.md`
+- `.adl/docs/v0.92planning/CONTINUITY_VALIDATION_SCHEMA.md`
+- `.adl/docs/v0.92planning/FORK_JOIN_AND_IDENTITY.md`
+- `.adl/docs/v0.93planning/COGNITIVE_ETHICS.md`
+- `.adl/docs/v0.93planning/A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md`
+- `.adl/docs/v0.94planning/CBAC_ARCHITECTURE.md`
+- `.adl/docs/v0.94planning/POLICY_ENGINE.md`
+- `.adl/docs/v0.94planning/PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md`
+- `.adl/docs/v0.94planning/SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md`
+- `.adl/docs/v0.94planning/SECRETS_AND_DATA_GOVERNANCE.md`
+- `.adl/docs/v0.94planning/SECURITY_MODEL_PLANNING.md`
+- `.adl/docs/v0.94planning/SECURE_EXECUTION_MODEL.md`
+- `.adl/docs/v0.94planning/IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md`
+
+## Actions taken
+- rebased the `1316` worktree onto `origin/main`
+- created the missing planning-home directories needed for redistribution
+- copied the active TBD feature/architecture docs into their milestone planning homes instead of promoting them publicly
+- reconciled `FEATURE_SPRINT_MAP.md` and `NEW_FEATURE_MAP.md` into one consistent milestone story
+- added the janitor-skill location note so it is treated as part of `1299` rather than a missing TBD doc
+- added explicit scope notes to `SECURE_EXECUTION_MODEL.md` and `IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md` so their OSS-vs-enterprise boundary is clear without physically splitting the docs
+- force-added the `.adl` doc set because the repo ignore rules would otherwise hide these planning artifacts from git
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none
+- Worktree-only paths remaining:
+  - `.adl/docs/TBD/FEATURE_SPRINT_MAP.md`
+  - `.adl/docs/TBD/NEW_FEATURE_MAP.md`
+  - `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT.md`
+  - `.adl/docs/v0.87.1planning/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`
+  - `.adl/docs/v0.87.1planning/AGENT_LIFECYCLE.md`
+  - `.adl/docs/v0.87.1planning/EXECUTION_BOUNDARIES.md`
+  - `.adl/docs/v0.87.1planning/LOCAL_RUNTIME_RESILIENCE.md`
+  - `.adl/docs/v0.87.1planning/SHEPHERD_RUNTIME_MODEL.md`
+  - `.adl/docs/v0.88planning/CHRONOSENSE_AND_IDENTITY.md`
+  - `.adl/docs/v0.88planning/TEMPORAL_SCHEMA_V01.md`
+  - `.adl/docs/v0.89planning/GHB_EXECUTION_MODEL.md`
+  - `.adl/docs/v0.89planning/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md`
+  - `.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md`
+  - `.adl/docs/v0.92planning/CAPABILITY_MODEL.md`
+  - `.adl/docs/v0.92planning/CONTINUITY_VALIDATION.md`
+  - `.adl/docs/v0.92planning/CONTINUITY_VALIDATION_SCHEMA.md`
+  - `.adl/docs/v0.92planning/FORK_JOIN_AND_IDENTITY.md`
+  - `.adl/docs/v0.93planning/COGNITIVE_ETHICS.md`
+  - `.adl/docs/v0.93planning/A_LA_RECHERCHE_DU_TEMPS_PERDU_MENTAL_TIME_TRAVEL_MTT_V1.md`
+  - `.adl/docs/v0.94planning/CBAC_ARCHITECTURE.md`
+  - `.adl/docs/v0.94planning/POLICY_ENGINE.md`
+  - `.adl/docs/v0.94planning/PROVIDER_TRUST_AND_ISOLATION_ARCHITECTURE.md`
+  - `.adl/docs/v0.94planning/SANDBOX_RUNTIME_ISOLATION_ARCHITECTURE.md`
+  - `.adl/docs/v0.94planning/SECRETS_AND_DATA_GOVERNANCE.md`
+  - `.adl/docs/v0.94planning/SECURITY_MODEL_PLANNING.md`
+  - `.adl/docs/v0.94planning/SECURE_EXECUTION_MODEL.md`
+  - `.adl/docs/v0.94planning/IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: branch-local redistribution in the issue worktree, staged and prepared for commit/push/PR
+- Verification performed:
+  - `git status --short` to verify the staged redistribution set and absence of unrelated changes
+  - `git diff --cached --stat` to verify the expected file set and scope of the redistribution
+  - `rg -n "PR_JANITOR_SKILL_INPUT_SCHEMA|promotion into docs/milestones|sentience, continuity|Scope note:" ...` to verify the key policy notes and split-boundary annotations
+- Result: PASS; the branch contains the intended redistribution set and the policy notes required for execution from `1316`
+
+## Validation
+- Validation commands and their purpose:
+  - `git -C .worktrees/adl-wp-1316 rebase origin/main` to ensure the redistribution starts from current mainline history
+  - `find .worktrees/adl-wp-1316/.adl/docs -maxdepth 2 -type f` to verify the copied milestone-planning surfaces exist in the worktree
+  - `git -C .worktrees/adl-wp-1316 diff --cached --stat` to verify the exact redistributed file set
+  - `rg -n "PR_JANITOR_SKILL_INPUT_SCHEMA|promotion into docs/milestones|sentience, continuity|Scope note:" ...` to verify the key editorial policy changes
+- Results:
+  - rebase succeeded cleanly
+  - redistributed docs exist in the expected planning directories
+  - staged diff is limited to the intended roadmap and planning-doc redistribution set
+  - policy notes and split-boundary scope notes are present
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "git rebase origin/main"
+      - "find .adl/docs milestone planning paths"
+      - "git diff --cached --stat"
+      - "rg policy/scope-note checks"
+  determinism:
+    status: NOT_RUN
+    replay_verified: unknown
+    ordering_guarantees_verified: unknown
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: not applicable for this docs-only redistribution pass
+- Fixtures or scripts used: not applicable; this run moved and reconciled planning docs rather than executing a deterministic runtime artifact flow
+- Replay verification (same inputs -> same artifacts/order): not run
+- Ordering guarantees (sorting / tie-break rules used): not applicable
+- Artifact stability notes: the moved docs are direct copies into milestone planning homes with small editorial scope notes added where required
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual doc-surface check during review; no secrets or tokens were introduced
+- Prompt / tool argument redaction verified: the redistributed planning docs and map docs do not record prompts or tool arguments
+- Absolute path leakage check: verified final artifact references in this record use repository-relative paths
+- Sandbox / policy invariants preserved: yes; all work stayed within repository docs and did not require elevated filesystem access
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable for docs-only work
+- Run artifact root: not applicable for docs-only work
+- Replay command used for verification: not applicable
+- Replay result: not applicable
+
+## Artifact Verification
+- Primary proof surface: the staged 1316 doc set in `.adl/docs/TBD/` and `.adl/docs/v0.*planning/`
+- Required artifacts present: yes; all planned milestone-home docs listed in the reconciled maps were copied into the branch
+- Artifact schema/version checks: not applicable; no runtime artifact schema changed
+- Hash/byte-stability checks: not applicable for docs-only redistribution
+- Missing/optional artifacts and rationale:
+  - `PR_JANITOR_SKILL_INPUT_SCHEMA.md` was not moved from `TBD` because it already lives under `.adl/docs/skills/` and is explicitly treated as part of `1299`
+
+## Decisions / Deviations
+- Used milestone planning directories rather than public milestone feature directories because the redistribution policy is planning-first and public promotion happens only when a milestone opens
+- Did not physically split `SECURE_EXECUTION_MODEL.md` or `IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md`; instead, added explicit scope notes so the dominant-home placement is clear without premature doc surgery
+- Force-added `.adl` files because `.gitignore` would otherwise hide the redistributed planning artifacts from git
+
+## Follow-ups / Deferred work
+- Open or expand the `v0.87` skills work under `1299` so the janitor schema joins the bounded PR-process skill family
+- Decide later whether the two split-boundary docs need physical splitting after the roadmap bands mature
+- After milestone openings, selectively promote the relevant planning docs into `docs/milestones/.../features/` when you intentionally want them public
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.


### PR DESCRIPTION
## Summary
- redistribute active TBD roadmap/feature docs into milestone-aligned planning directories
- introduce `v0.87.1planning` for runtime-completion work
- reconcile `FEATURE_SPRINT_MAP.md` and `NEW_FEATURE_MAP.md` into one consistent milestone map
- keep promotion policy explicit: move into `.adl/docs/v0.*planning/` first, and only promote into `docs/milestones/.../features/` when a milestone opens or is intentionally made public
- add scope notes for the split-boundary security/identity docs instead of prematurely splitting them

## What moved
- `v0.87.1planning`: runtime environment, lifecycle, execution boundaries, resilience, Shepherd
- `v0.88planning`: chronosense and temporal schema
- `v0.89planning`: GHB docs and reasoning patterns
- `v0.92planning`: capability + continuity + fork/join identity docs
- `v0.93planning`: cognitive ethics + MTT
- `v0.94planning`: heavy governance/security docs

## Notes
- `PR_JANITOR_SKILL_INPUT_SCHEMA.md` is now explicitly noted as living under `.adl/docs/skills/` and folding into `#1299`, not as a missing TBD doc
- `SECURE_EXECUTION_MODEL.md` and `IDENTITY_AND_AUTHENTICATION_ARCHITECTURE.md` stay intact for now, but now carry explicit scope notes so their OSS-vs-enterprise boundary is clear

Closes #1316
