### PR TITLE
[v0.87][WP-07] Trace-to-memory coherence

### DIFF
--- a/adl/src/cli/tests/run_state/persistence.rs
+++ b/adl/src/cli/tests/run_state/persistence.rs
@@ -338,7 +338,11 @@ fn derive_runtime_control_state_projects_memory_participation_for_prior_failed_r
     let prior_run_id = format!("prior-memory-{now}-{}", std::process::id());
     let prior_resolved = minimal_resolved_for_artifacts(prior_run_id.clone());
     let prior_out_dir = std::env::temp_dir().join(format!("adl-main-prior-memory-{now}"));
-    let prior_trace = trace::Trace::new(prior_run_id.clone(), "wf".to_string(), "0.86".to_string());
+    let mut prior_trace =
+        trace::Trace::new(prior_run_id.clone(), "wf".to_string(), "0.86".to_string());
+    prior_trace.step_started("s1", "agent", "local", "task", None);
+    prior_trace.step_finished("s1", false);
+    prior_trace.run_failed("prior failure");
     write_run_state_artifacts(
         &prior_resolved,
         &prior_trace,

--- a/adl/src/obsmem_adapter.rs
+++ b/adl/src/obsmem_adapter.rs
@@ -92,6 +92,7 @@ pub fn build_write_request_from_run_artifacts(
     let failure_code = indexed.failure_code;
     let summary = indexed.summary;
     let tags = indexed.tags;
+    let trace_event_refs = indexed.trace_event_refs;
 
     let mut citations = Vec::new();
     citations.push(citation_for_path(
@@ -119,6 +120,7 @@ pub fn build_write_request_from_run_artifacts(
         summary,
         tags,
         citations,
+        trace_event_refs,
     };
 
     req.normalize();
@@ -207,6 +209,7 @@ mod tests {
                     payload: e.summary.clone(),
                     score: "1.0".to_string(),
                     citations: e.citations.clone(),
+                    trace_event_refs: e.trace_event_refs.clone(),
                 })
                 .collect();
             hits.sort_by(|a, b| a.id.cmp(&b.id));
@@ -236,7 +239,7 @@ mod tests {
         .expect("write run_status");
         std::fs::write(
             run.join("logs").join("activation_log.json"),
-            r#"{"activation_log_version":1,"ordering":"append_only_emission_order","stable_ids":{"step_id":"x","delegation_id":"x","run_id":"x"},"events":[]}"#,
+            r#"{"activation_log_version":1,"ordering":"append_only_emission_order","stable_ids":{"step_id":"x","delegation_id":"x","run_id":"x"},"events":[{"kind":"StepStarted","step_id":"s1","agent_id":"a","provider_id":"local","task_id":"t","delegation_json":null},{"kind":"StepFinished","step_id":"s1","success":true}]}"#,
         )
         .expect("write activation log");
     }

--- a/adl/src/obsmem_contract.rs
+++ b/adl/src/obsmem_contract.rs
@@ -13,6 +13,17 @@ pub struct MemoryCitation {
     pub hash: String,
 }
 
+/// Deterministic reference back to the trace event(s) that support a memory
+/// record. v0.87 uses event sequence plus bounded identity fields as the
+/// "event_id or equivalent" coherence contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryTraceRef {
+    pub event_sequence: usize,
+    pub event_kind: String,
+    pub step_id: Option<String>,
+    pub delegation_id: Option<String>,
+}
+
 /// Contract payload used to write a normalized run summary into ObsMem.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryWriteRequest {
@@ -25,6 +36,7 @@ pub struct MemoryWriteRequest {
     pub summary: String,
     pub tags: Vec<String>,
     pub citations: Vec<MemoryCitation>,
+    pub trace_event_refs: Vec<MemoryTraceRef>,
 }
 
 impl MemoryWriteRequest {
@@ -37,6 +49,19 @@ impl MemoryWriteRequest {
             .sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.hash.cmp(&b.hash)));
         self.citations
             .dedup_by(|a, b| a.path == b.path && a.hash == b.hash);
+        self.trace_event_refs.sort_by(|a, b| {
+            a.event_sequence
+                .cmp(&b.event_sequence)
+                .then_with(|| a.event_kind.cmp(&b.event_kind))
+                .then_with(|| a.step_id.cmp(&b.step_id))
+                .then_with(|| a.delegation_id.cmp(&b.delegation_id))
+        });
+        self.trace_event_refs.dedup_by(|a, b| {
+            a.event_sequence == b.event_sequence
+                && a.event_kind == b.event_kind
+                && a.step_id == b.step_id
+                && a.delegation_id == b.delegation_id
+        });
     }
 
     /// Validate request semantics and privacy guards for contract ingestion.
@@ -76,10 +101,22 @@ impl MemoryWriteRequest {
                 ));
             }
         }
+        for trace_ref in &self.trace_event_refs {
+            if trace_ref.event_kind.trim().is_empty() {
+                return Err(ObsMemContractError::new(
+                    ObsMemContractErrorCode::InvalidRequest,
+                    "trace event refs require non-empty event_kind",
+                ));
+            }
+        }
 
         let text = format!(
-            "{}\n{}\n{:?}\n{:?}",
-            self.summary, self.trace_bundle_rel_path, self.tags, self.citations
+            "{}\n{}\n{:?}\n{:?}\n{:?}",
+            self.summary,
+            self.trace_bundle_rel_path,
+            self.tags,
+            self.citations,
+            self.trace_event_refs
         );
         if text.contains("/Users/")
             || text.contains("/home/")
@@ -157,6 +194,7 @@ pub struct MemoryRecord {
     pub payload: String,
     pub score: String,
     pub citations: Vec<MemoryCitation>,
+    pub trace_event_refs: Vec<MemoryTraceRef>,
 }
 
 /// Query response wrapper for deterministic hit lists.
@@ -308,6 +346,7 @@ mod tests {
                     payload: e.summary.clone(),
                     score: "1.0".to_string(),
                     citations: e.citations.clone(),
+                    trace_event_refs: e.trace_event_refs.clone(),
                 })
                 .collect();
 
@@ -336,6 +375,12 @@ mod tests {
             citations: vec![MemoryCitation {
                 path: "trace_bundle_v2/runs/run-001/steps.json".to_string(),
                 hash: "abc123".to_string(),
+            }],
+            trace_event_refs: vec![MemoryTraceRef {
+                event_sequence: 1,
+                event_kind: "step_finished".to_string(),
+                step_id: Some("s1".to_string()),
+                delegation_id: None,
             }],
         }
     }

--- a/adl/src/obsmem_demo.rs
+++ b/adl/src/obsmem_demo.rs
@@ -29,6 +29,8 @@ struct ObsMemIndexSummaryArtifact {
     workflow_id: String,
     indexed_entry_count: usize,
     step_context_count: usize,
+    trace_event_ref_count: usize,
+    trace_event_refs: Vec<crate::obsmem_contract::MemoryTraceRef>,
     source_artifacts: Vec<String>,
     tags: Vec<String>,
     write_ack: MemoryWriteAck,
@@ -124,6 +126,8 @@ pub fn emit_obsmem_demo_artifacts(runs_root: &Path, run_id: &str) -> Result<ObsM
         workflow_id: indexed.workflow_id.clone(),
         indexed_entry_count: 1,
         step_context_count: indexed.steps.len(),
+        trace_event_ref_count: indexed.trace_event_refs.len(),
+        trace_event_refs: indexed.trace_event_refs.clone(),
         source_artifacts: vec![
             format!("runs/{run_id}/run_summary.json"),
             format!("runs/{run_id}/run_status.json"),

--- a/adl/src/obsmem_indexing.rs
+++ b/adl/src/obsmem_indexing.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::instrumentation::{load_trace_artifact, TraceEventNormalized};
-use crate::obsmem_contract::{ObsMemContractError, ObsMemContractErrorCode};
+use crate::obsmem_contract::{MemoryTraceRef, ObsMemContractError, ObsMemContractErrorCode};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IndexedStepContext {
@@ -24,6 +24,7 @@ pub struct IndexedMemoryEntry {
     pub summary: String,
     pub tags: Vec<String>,
     pub steps: Vec<IndexedStepContext>,
+    pub trace_event_refs: Vec<MemoryTraceRef>,
 }
 
 impl IndexedMemoryEntry {
@@ -43,6 +44,19 @@ impl IndexedMemoryEntry {
                 && a.event_kind == b.event_kind
                 && a.context == b.context
         });
+        self.trace_event_refs.sort_by(|a, b| {
+            a.event_sequence
+                .cmp(&b.event_sequence)
+                .then_with(|| a.event_kind.cmp(&b.event_kind))
+                .then_with(|| a.step_id.cmp(&b.step_id))
+                .then_with(|| a.delegation_id.cmp(&b.delegation_id))
+        });
+        self.trace_event_refs.dedup_by(|a, b| {
+            a.event_sequence == b.event_sequence
+                && a.event_kind == b.event_kind
+                && a.step_id == b.step_id
+                && a.delegation_id == b.delegation_id
+        });
     }
 
     pub fn validate(&self) -> Result<(), ObsMemContractError> {
@@ -50,6 +64,12 @@ impl IndexedMemoryEntry {
             return Err(ObsMemContractError::new(
                 ObsMemContractErrorCode::InvalidRequest,
                 "indexed memory entry requires non-empty run_id and workflow_id",
+            ));
+        }
+        if self.trace_event_refs.is_empty() {
+            return Err(ObsMemContractError::new(
+                ObsMemContractErrorCode::InvalidRequest,
+                "indexed memory entry requires at least one trace event reference",
             ));
         }
         if self.summary.trim().is_empty() {
@@ -141,11 +161,18 @@ pub fn index_run_from_artifacts(
         }
     }
 
+    let trace_event_refs: Vec<MemoryTraceRef> = trace
+        .iter()
+        .enumerate()
+        .filter_map(|(sequence, event)| to_trace_ref(sequence, event))
+        .collect();
+
     let mut tags = vec![
         format!("run:{safe_run_id}"),
         format!("workflow:{workflow_id}"),
         format!("status:{status}"),
         format!("step_context_count:{}", steps.len()),
+        format!("trace_ref_count:{}", trace_event_refs.len()),
     ];
     if let Some(code) = failure_code.as_deref() {
         tags.push(format!("failure:{code}"));
@@ -165,10 +192,139 @@ pub fn index_run_from_artifacts(
         summary,
         tags,
         steps,
+        trace_event_refs,
     };
     entry.normalize();
     entry.validate()?;
     Ok(entry)
+}
+
+fn to_trace_ref(sequence: usize, event: &TraceEventNormalized) -> Option<MemoryTraceRef> {
+    match event {
+        TraceEventNormalized::SchedulerPolicy { .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "scheduler_policy".to_string(),
+            step_id: None,
+            delegation_id: None,
+        }),
+        TraceEventNormalized::RunFailed { .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "run_failed".to_string(),
+            step_id: None,
+            delegation_id: None,
+        }),
+        TraceEventNormalized::RunFinished { .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "run_finished".to_string(),
+            step_id: None,
+            delegation_id: None,
+        }),
+        TraceEventNormalized::StepStarted { step_id, .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "step_started".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: None,
+        }),
+        TraceEventNormalized::PromptAssembled { step_id, .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "prompt_assembled".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: None,
+        }),
+        TraceEventNormalized::StepOutputChunk { step_id, .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "step_output_chunk".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: None,
+        }),
+        TraceEventNormalized::DelegationRequested {
+            delegation_id,
+            step_id,
+            ..
+        } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "delegation_requested".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: Some(delegation_id.clone()),
+        }),
+        TraceEventNormalized::DelegationPolicyEvaluated {
+            delegation_id,
+            step_id,
+            ..
+        } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "delegation_policy_evaluated".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: Some(delegation_id.clone()),
+        }),
+        TraceEventNormalized::DelegationApproved {
+            delegation_id,
+            step_id,
+        } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "delegation_approved".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: Some(delegation_id.clone()),
+        }),
+        TraceEventNormalized::DelegationDenied {
+            delegation_id,
+            step_id,
+            ..
+        } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "delegation_denied".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: Some(delegation_id.clone()),
+        }),
+        TraceEventNormalized::DelegationDispatched {
+            delegation_id,
+            step_id,
+            ..
+        } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "delegation_dispatched".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: Some(delegation_id.clone()),
+        }),
+        TraceEventNormalized::DelegationResultReceived {
+            delegation_id,
+            step_id,
+            ..
+        } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "delegation_result_received".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: Some(delegation_id.clone()),
+        }),
+        TraceEventNormalized::DelegationCompleted {
+            delegation_id,
+            step_id,
+            ..
+        } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "delegation_completed".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: Some(delegation_id.clone()),
+        }),
+        TraceEventNormalized::StepFinished { step_id, .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "step_finished".to_string(),
+            step_id: Some(step_id.clone()),
+            delegation_id: None,
+        }),
+        TraceEventNormalized::CallEntered { caller_step_id, .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "call_entered".to_string(),
+            step_id: Some(caller_step_id.clone()),
+            delegation_id: None,
+        }),
+        TraceEventNormalized::CallExited { caller_step_id, .. } => Some(MemoryTraceRef {
+            event_sequence: sequence,
+            event_kind: "call_exited".to_string(),
+            step_id: Some(caller_step_id.clone()),
+            delegation_id: None,
+        }),
+    }
 }
 
 fn to_step_context(sequence: usize, event: &TraceEventNormalized) -> Option<IndexedStepContext> {
@@ -348,6 +504,12 @@ mod tests {
                     context: "provider=local".to_string(),
                 },
             ],
+            trace_event_refs: vec![MemoryTraceRef {
+                event_sequence: 0,
+                event_kind: "step_started".to_string(),
+                step_id: Some("s1".to_string()),
+                delegation_id: None,
+            }],
         };
         let err = entry
             .validate()
@@ -401,7 +563,16 @@ mod tests {
                     "delegation_id": "stable",
                     "run_id": "not replay-stable"
                 },
-                "events": []
+                "events": [
+                    {
+                        "kind": "StepStarted",
+                        "step_id": "s1",
+                        "agent_id": "a",
+                        "provider_id": "local",
+                        "task_id": "t",
+                        "delegation_json": null
+                    }
+                ]
             }))
             .expect("serialize activation"),
         )

--- a/adl/src/obsmem_retrieval_policy.rs
+++ b/adl/src/obsmem_retrieval_policy.rs
@@ -233,7 +233,7 @@ fn parse_score_hundredths(score: &str) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::obsmem_contract::{MemoryCitation, MemoryQueryResult, MemoryRecord};
+    use crate::obsmem_contract::{MemoryCitation, MemoryQueryResult, MemoryRecord, MemoryTraceRef};
 
     fn hit(id: &str, score: &str, tags: &[&str]) -> MemoryRecord {
         let mut t: Vec<String> = tags.iter().map(|s| (*s).to_string()).collect();
@@ -249,6 +249,12 @@ mod tests {
             citations: vec![MemoryCitation {
                 path: format!("runs/{id}/run_summary.json"),
                 hash: "det64:0000000000000001".to_string(),
+            }],
+            trace_event_refs: vec![MemoryTraceRef {
+                event_sequence: 0,
+                event_kind: "step_finished".to_string(),
+                step_id: Some("s1".to_string()),
+                delegation_id: None,
             }],
         }
     }

--- a/adl/src/obsmem_store.rs
+++ b/adl/src/obsmem_store.rs
@@ -173,6 +173,7 @@ impl ObsMemClient for FileObsMemClient {
                 payload: entry.summary.clone(),
                 score: "1.00".to_string(),
                 citations: entry.citations.clone(),
+                trace_event_refs: entry.trace_event_refs.clone(),
             })
             .collect();
         hits.sort_by(|a, b| {
@@ -221,6 +222,12 @@ mod tests {
             citations: vec![MemoryCitation {
                 path: format!("runs/{run_id}/run_summary.json"),
                 hash: "det64:0000000000000001".to_string(),
+            }],
+            trace_event_refs: vec![crate::obsmem_contract::MemoryTraceRef {
+                event_sequence: 0,
+                event_kind: "step_finished".to_string(),
+                step_id: Some("s1".to_string()),
+                delegation_id: None,
             }],
         };
         request.normalize();

--- a/adl/tests/obsmem_validation_tests.rs
+++ b/adl/tests/obsmem_validation_tests.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use ::adl::obsmem_contract::{MemoryCitation, MemoryQueryResult, MemoryRecord};
+use ::adl::obsmem_contract::{MemoryCitation, MemoryQueryResult, MemoryRecord, MemoryTraceRef};
 use ::adl::obsmem_indexing::index_run_from_artifacts;
 use ::adl::obsmem_retrieval_policy::{
     apply_policy_to_results, RetrievalOrder, RetrievalPolicyV1, RetrievalRequest,
@@ -96,6 +96,12 @@ fn make_record(id: &str, score: &str, tags: &[&str], workflow_id: &str) -> Memor
             path: format!("runs/{id}/run_summary.json"),
             hash: "det64:0000000000000001".to_string(),
         }],
+        trace_event_refs: vec![MemoryTraceRef {
+            event_sequence: 0,
+            event_kind: "step_finished".to_string(),
+            step_id: Some("s1".to_string()),
+            delegation_id: None,
+        }],
     }
 }
 
@@ -111,6 +117,7 @@ fn indexing_pipeline_produces_deterministic_entries_with_stable_sequence() {
     assert!(!left.workflow_id.trim().is_empty());
     assert!(!left.summary.trim().is_empty());
     assert!(left.tags.binary_search(&"run:run-a".to_string()).is_ok());
+    assert!(!left.trace_event_refs.is_empty());
     assert!(left
         .steps
         .iter()
@@ -280,6 +287,16 @@ fn end_to_end_hierarchical_demo_emits_obsmem_artifacts() {
             .and_then(serde_json::Value::as_array)
             .is_some(),
         "entries missing"
+    );
+    assert!(
+        query_json
+            .get("entries")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|entries| entries.first())
+            .and_then(|entry| entry.get("trace_event_refs"))
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|refs| !refs.is_empty()),
+        "trace_event_refs missing from query entries"
     );
 
     for forbidden in ["/Users/", "/home/", "gho_", "sk-"] {

--- a/docs/milestones/v0.87/features/SHARED_OBSMEM_IMPLEMENTATION.md
+++ b/docs/milestones/v0.87/features/SHARED_OBSMEM_IMPLEMENTATION.md
@@ -87,6 +87,11 @@ Each shared ObsMem record should minimally include:
 - `artifact_refs` (if payloads are external)
 - `summary` or structured observation fields
 
+For the bounded `v0.87` substrate, the runtime contract uses a deterministic
+`trace_event_refs` array as the concrete "event_id or equivalent" surface.
+Each item records the event sequence plus bounded step/delegation identity so a
+reviewer can walk from memory back to execution truth without hidden inference.
+
 ### Example record types
 - `obs.model_call`
 - `obs.decision`
@@ -221,6 +226,11 @@ Primary proof surface:
 
 Secondary proof surface:
 - `artifacts/v087/shared_obsmem/trace_links.json`
+
+For the current in-repo runtime/demo implementation, the equivalent proof lives
+in the ObsMem learning artifacts where each returned entry carries
+`trace_event_refs` and the index summary reports the trace-reference set used to
+justify the stored record.
 
 ## Acceptance Criteria
 

--- a/docs/milestones/v0.87/features/TRACE_OBSMEM_INGESTION.md
+++ b/docs/milestones/v0.87/features/TRACE_OBSMEM_INGESTION.md
@@ -78,6 +78,8 @@ Trace events are transformed into **ObsMem records**.
 - transformation MUST be deterministic
 - mapping MUST be explicit per event type
 - no implicit inference in v1
+- derived memory records MUST preserve explicit trace-event references using
+  event IDs or a deterministic equivalent
 
 ### Example Mapping
 
@@ -228,6 +230,9 @@ ObsMem MUST remain traceable back to source trace.
 
 - each record MUST include trace reference (event_id or equivalent)
 - reviewer MUST be able to trace memory → execution
+- in the v0.87 runtime contract, that equivalent is a stable list of
+  `trace_event_refs` carrying event sequence, event kind, and bounded step or
+  delegation identity
 
 ## Non-Goals (v1)
 


### PR DESCRIPTION
Closes #1298

## Summary
Implemented explicit trace-to-memory provenance for the bounded v0.87 ObsMem substrate. Memory write requests, indexed entries, stored records, and demo query results now carry deterministic `trace_event_refs`, so a reviewer can walk from a persisted memory record back to the supporting execution events without hidden inference.

## Artifacts
- Updated runtime contract and indexing surfaces:
  - `adl/src/obsmem_contract.rs`
  - `adl/src/obsmem_indexing.rs`
  - `adl/src/obsmem_adapter.rs`
  - `adl/src/obsmem_store.rs`
  - `adl/src/obsmem_demo.rs`
  - `adl/src/obsmem_retrieval_policy.rs`
- Updated proof and validation surfaces:
  - `adl/tests/obsmem_validation_tests.rs`
- Updated feature docs:
  - `docs/milestones/v0.87/features/TRACE_OBSMEM_INGESTION.md`
  - `docs/milestones/v0.87/features/SHARED_OBSMEM_IMPLEMENTATION.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml obsmem -- --nocapture`
    Verified the bounded ObsMem contract, indexing, store, retrieval, and demo surfaces remain coherent after adding explicit trace-event provenance.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the Rust surfaces remain formatted after the contract and fixture updates.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the expanded coherence path is warning-free across library, binary, and test targets.
- Results:
  - All listed commands passed.
  - The ObsMem test slice passed 43 targeted tests, including the hierarchical end-to-end demo proof.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1298__v0-87-wp-07-trace-to-memory-coherence/sip.md
- Output card: .adl/v0.87/tasks/issue-1298__v0-87-wp-07-trace-to-memory-coherence/sor.md
- Idempotency-Key: v0-87-wp-07-trace-to-memory-coherence-adl-v0-87-tasks-issue-1298-v0-87-wp-07-trace-to-memory-coherence-sip-md-adl-v0-87-tasks-issue-1298-v0-87-wp-07-trace-to-memory-coherence-sor-md