### PR TITLE
[v0.87][WP-09] PR tooling / control-plane consolidation

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::pr_cmd_args::{
-    parse_create_args, parse_finish_args, parse_init_args, parse_preflight_args, parse_ready_args,
-    parse_start_args,
+    parse_create_args, parse_doctor_args, parse_finish_args, parse_init_args, parse_preflight_args,
+    parse_ready_args, parse_start_args, DoctorArgs, DoctorMode,
 };
 #[cfg(test)]
 use super::pr_cmd_prompt::load_issue_prompt;
@@ -43,13 +43,16 @@ struct OpenPullRequest {
 
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
-        bail!("pr requires a subcommand: create | init | start | ready | preflight | finish");
+        bail!(
+            "pr requires a subcommand: create | init | start | doctor | ready | preflight | finish"
+        );
     };
 
     match subcommand {
         "create" => real_pr_create(&args[1..]),
         "init" => real_pr_init(&args[1..]),
         "start" => real_pr_start(&args[1..]),
+        "doctor" => real_pr_doctor(&args[1..]),
         "ready" => real_pr_ready(&args[1..]),
         "preflight" => real_pr_preflight(&args[1..]),
         "finish" => real_pr_finish(&args[1..]),
@@ -267,169 +270,48 @@ fn real_pr_start(args: &[String]) -> Result<()> {
 }
 
 fn real_pr_ready(args: &[String]) -> Result<()> {
+    eprintln!(
+        "• Deprecated compatibility path: prefer `adl/tools/pr.sh doctor {} --mode ready ...`.",
+        args.first()
+            .cloned()
+            .unwrap_or_else(|| "<issue>".to_string())
+    );
     let parsed = parse_ready_args(args)?;
-    let repo_root = primary_checkout_root()?;
-    let repo = default_repo(&repo_root)?;
-
-    let (version, slug) =
-        if let (Some(version), Some(slug)) = (parsed.version.clone(), parsed.slug.clone()) {
-            (version, slug)
-        } else {
-            let inferred = resolve_issue_scope_and_slug_from_local_state(&repo_root, parsed.issue)?;
-            (
-                parsed
-                    .version
-                    .clone()
-                    .or(inferred.as_ref().map(|x| x.0.clone()))
-                    .unwrap_or_else(|| DEFAULT_VERSION.to_string()),
-                parsed
-                    .slug
-                    .clone()
-                    .or(inferred.map(|x| x.1))
-                    .ok_or_else(|| {
-                        anyhow!("ready: could not infer slug; pass --slug or run start first")
-                    })?,
-            )
-        };
-
-    let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
-    let branch = issue_ref.branch_name("codex");
-    let managed_root = std::env::var_os("ADL_WORKTREE_ROOT").map(PathBuf::from);
-    let worktree_path = issue_ref.default_worktree_path(&repo_root, managed_root.as_deref());
-    let source_path = resolve_issue_prompt_path(&repo_root, &issue_ref)?;
-    let root_stp = issue_ref.task_bundle_stp_path(&repo_root);
-    let wt_stp = issue_ref.task_bundle_stp_path(&worktree_path);
-
-    let root_bundle_input = issue_ref.task_bundle_input_path(&repo_root);
-    let root_bundle_output = issue_ref.task_bundle_output_path(&repo_root);
-    let wt_bundle_input = issue_ref.task_bundle_input_path(&worktree_path);
-    let wt_bundle_output = issue_ref.task_bundle_output_path(&worktree_path);
-
-    validate_issue_prompt_exists(&source_path)?;
-    validate_bootstrap_stp(&repo_root, &source_path)?;
-    validate_authored_prompt_surface("ready", &source_path, PromptSurfaceKind::IssuePrompt)?;
-    if !root_stp.is_file() {
-        bail!("ready: missing root stp: {}", root_stp.display());
-    }
-    validate_bootstrap_stp(&repo_root, &root_stp)?;
-    validate_authored_prompt_surface("ready", &root_stp, PromptSurfaceKind::Stp)?;
-    if !worktree_path.is_dir() {
-        bail!("ready: missing worktree: {}", worktree_path.display());
-    }
-    let wt_branch = run_capture(
-        "git",
-        &[
-            "-C",
-            path_str(&worktree_path)?,
-            "rev-parse",
-            "--abbrev-ref",
-            "HEAD",
-        ],
-    )?;
-    if wt_branch.trim() != branch {
-        bail!(
-            "ready: worktree branch mismatch for {}",
-            worktree_path.display()
-        );
-    }
-    if !wt_stp.is_file() {
-        bail!("ready: missing worktree stp: {}", wt_stp.display());
-    }
-    validate_bootstrap_stp(&worktree_path, &wt_stp)?;
-    validate_authored_prompt_surface("ready", &wt_stp, PromptSurfaceKind::Stp)?;
-    validate_ready_cards(
-        &repo_root,
-        parsed.issue,
-        issue_ref.slug(),
-        wt_branch.trim(),
-        &root_bundle_input,
-        &root_bundle_output,
-    )?;
-    validate_ready_cards(
-        &worktree_path,
-        parsed.issue,
-        issue_ref.slug(),
-        wt_branch.trim(),
-        &wt_bundle_input,
-        &wt_bundle_output,
-    )?;
-
-    println!("ISSUE={}", parsed.issue);
-    println!("VERSION={version}");
-    println!("SLUG={slug}");
-    println!("BRANCH={branch}");
-    println!("WORKTREE={}", worktree_path.display());
-    println!("SOURCE={}", path_relative_to_repo(&repo_root, &source_path));
-    println!("ROOT_STP={}", path_relative_to_repo(&repo_root, &root_stp));
-    println!(
-        "ROOT_INPUT={}",
-        path_relative_to_repo(&repo_root, &root_bundle_input)
-    );
-    println!(
-        "ROOT_OUTPUT={}",
-        path_relative_to_repo(&repo_root, &root_bundle_output)
-    );
-    println!("WT_STP={}", path_relative_to_repo(&repo_root, &wt_stp));
-    println!(
-        "WT_INPUT={}",
-        path_relative_to_repo(&repo_root, &wt_bundle_input)
-    );
-    println!(
-        "WT_OUTPUT={}",
-        path_relative_to_repo(&repo_root, &wt_bundle_output)
-    );
-    println!("READY=PASS");
-    let _ = repo; // keep parity with init/create remote-based inference
-    Ok(())
+    run_doctor(
+        DoctorArgs {
+            issue: parsed.issue,
+            version: parsed.version,
+            slug: parsed.slug,
+            no_fetch_issue: parsed.no_fetch_issue,
+            mode: DoctorMode::Ready,
+        },
+        "ready",
+    )
 }
 
 fn real_pr_preflight(args: &[String]) -> Result<()> {
+    eprintln!(
+        "• Deprecated compatibility path: prefer `adl/tools/pr.sh doctor {} --mode preflight ...`.",
+        args.first()
+            .cloned()
+            .unwrap_or_else(|| "<issue>".to_string())
+    );
     let parsed = parse_preflight_args(args)?;
-    let repo_root = repo_root()?;
-    let repo = default_repo(&repo_root)?;
+    run_doctor(
+        DoctorArgs {
+            issue: parsed.issue,
+            version: parsed.version,
+            slug: parsed.slug,
+            no_fetch_issue: parsed.no_fetch_issue,
+            mode: DoctorMode::Preflight,
+        },
+        "preflight",
+    )
+}
 
-    let (version, slug) =
-        if let (Some(version), Some(slug)) = (parsed.version.clone(), parsed.slug.clone()) {
-            (version, slug)
-        } else {
-            let inferred = resolve_issue_scope_and_slug_from_local_state(&repo_root, parsed.issue)?;
-            (
-                parsed
-                    .version
-                    .clone()
-                    .or(inferred.as_ref().map(|x| x.0.clone()))
-                    .unwrap_or_else(|| DEFAULT_VERSION.to_string()),
-                parsed
-                    .slug
-                    .clone()
-                    .or(inferred.map(|x| x.1))
-                    .unwrap_or_else(|| format!("issue-{}", parsed.issue)),
-            )
-        };
-
-    let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug)?;
-    let branch = issue_ref.branch_name("codex");
-    let unresolved = unresolved_milestone_pr_wave(&repo, &version, Some(&branch))?;
-
-    println!("ISSUE={}", parsed.issue);
-    println!("VERSION={version}");
-    println!("BRANCH={branch}");
-    println!("OPEN_PR_COUNT={}", unresolved.len());
-    for pr in &unresolved {
-        println!(
-            "OPEN_PR=#{}|{}|{}|{}",
-            pr.number,
-            pr.head_ref_name,
-            if pr.is_draft { "draft" } else { "ready" },
-            pr.url
-        );
-    }
-    if unresolved.is_empty() {
-        println!("PREFLIGHT=PASS");
-    } else {
-        println!("PREFLIGHT=BLOCK");
-    }
-    Ok(())
+fn real_pr_doctor(args: &[String]) -> Result<()> {
+    let parsed = parse_doctor_args(args)?;
+    run_doctor(parsed, "doctor")
 }
 
 fn real_pr_finish(args: &[String]) -> Result<()> {
@@ -621,6 +503,194 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
 
     println!("{pr_url}");
     Ok(())
+}
+
+fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
+    let repo_root = primary_checkout_root()?;
+    let repo = default_repo(&repo_root)?;
+    let (version, slug) = resolve_doctor_scope_and_slug(&repo_root, &parsed, label)?;
+    let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
+    let branch = issue_ref.branch_name("codex");
+
+    println!("ISSUE={}", parsed.issue);
+    println!("VERSION={version}");
+    println!("SLUG={slug}");
+    println!("BRANCH={branch}");
+
+    let preflight_ok = run_doctor_preflight(&repo, &version, &branch)?;
+    let ready_ok = match parsed.mode {
+        DoctorMode::Preflight => None,
+        DoctorMode::Ready | DoctorMode::Full => {
+            Some(run_doctor_ready(&repo_root, &issue_ref, &branch)?)
+        }
+    };
+
+    match parsed.mode {
+        DoctorMode::Preflight => {
+            println!("DOCTOR_MODE=preflight");
+            println!(
+                "DOCTOR_STATUS={}",
+                if preflight_ok { "PASS" } else { "BLOCK" }
+            );
+        }
+        DoctorMode::Ready => {
+            println!("DOCTOR_MODE=ready");
+            println!(
+                "DOCTOR_STATUS={}",
+                if ready_ok.unwrap_or(false) {
+                    "PASS"
+                } else {
+                    "BLOCK"
+                }
+            );
+        }
+        DoctorMode::Full => {
+            println!("DOCTOR_MODE=full");
+            let full_ok = preflight_ok && ready_ok.unwrap_or(false);
+            println!("DOCTOR_STATUS={}", if full_ok { "PASS" } else { "BLOCK" });
+        }
+    }
+    Ok(())
+}
+
+fn resolve_doctor_scope_and_slug(
+    repo_root: &Path,
+    parsed: &DoctorArgs,
+    label: &str,
+) -> Result<(String, String)> {
+    if let (Some(version), Some(slug)) = (parsed.version.clone(), parsed.slug.clone()) {
+        return Ok((version, slug));
+    }
+    let inferred = resolve_issue_scope_and_slug_from_local_state(repo_root, parsed.issue)?;
+    let version = parsed
+        .version
+        .clone()
+        .or(inferred.as_ref().map(|x| x.0.clone()))
+        .unwrap_or_else(|| DEFAULT_VERSION.to_string());
+    let slug = match parsed.mode {
+        DoctorMode::Preflight => parsed
+            .slug
+            .clone()
+            .or(inferred.map(|x| x.1))
+            .unwrap_or_else(|| format!("issue-{}", parsed.issue)),
+        DoctorMode::Ready | DoctorMode::Full => parsed.slug.clone().or(inferred.map(|x| x.1)).ok_or_else(|| {
+            if label == "ready" {
+                anyhow!("ready: could not infer slug; pass --slug or run start first")
+            } else {
+                anyhow!("doctor: could not infer slug for readiness check; pass --slug or create the execution context first")
+            }
+        })?,
+    };
+    Ok((version, slug))
+}
+
+fn run_doctor_preflight(repo: &str, version: &str, branch: &str) -> Result<bool> {
+    let unresolved = unresolved_milestone_pr_wave(repo, version, Some(branch))?;
+    println!("OPEN_PR_COUNT={}", unresolved.len());
+    for pr in &unresolved {
+        println!(
+            "OPEN_PR=#{}|{}|{}|{}",
+            pr.number,
+            pr.head_ref_name,
+            if pr.is_draft { "draft" } else { "ready" },
+            pr.url
+        );
+    }
+    if unresolved.is_empty() {
+        println!("PREFLIGHT=PASS");
+        Ok(true)
+    } else {
+        println!("PREFLIGHT=BLOCK");
+        Ok(false)
+    }
+}
+
+fn run_doctor_ready(repo_root: &Path, issue_ref: &IssueRef, branch: &str) -> Result<bool> {
+    let worktree_path = issue_ref.default_worktree_path(
+        repo_root,
+        std::env::var_os("ADL_WORKTREE_ROOT")
+            .map(PathBuf::from)
+            .as_deref(),
+    );
+    let source_path = resolve_issue_prompt_path(repo_root, issue_ref)?;
+    let root_stp = issue_ref.task_bundle_stp_path(repo_root);
+    let wt_stp = issue_ref.task_bundle_stp_path(&worktree_path);
+    let root_bundle_input = issue_ref.task_bundle_input_path(repo_root);
+    let root_bundle_output = issue_ref.task_bundle_output_path(repo_root);
+    let wt_bundle_input = issue_ref.task_bundle_input_path(&worktree_path);
+    let wt_bundle_output = issue_ref.task_bundle_output_path(&worktree_path);
+
+    validate_issue_prompt_exists(&source_path)?;
+    validate_bootstrap_stp(repo_root, &source_path)?;
+    validate_authored_prompt_surface("doctor", &source_path, PromptSurfaceKind::IssuePrompt)?;
+    if !root_stp.is_file() {
+        bail!("doctor: missing root stp: {}", root_stp.display());
+    }
+    validate_bootstrap_stp(repo_root, &root_stp)?;
+    validate_authored_prompt_surface("doctor", &root_stp, PromptSurfaceKind::Stp)?;
+    if !worktree_path.is_dir() {
+        bail!("doctor: missing worktree: {}", worktree_path.display());
+    }
+    let wt_branch = run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(&worktree_path)?,
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+        ],
+    )?;
+    if wt_branch.trim() != branch {
+        bail!(
+            "doctor: worktree branch mismatch for {}",
+            worktree_path.display()
+        );
+    }
+    if !wt_stp.is_file() {
+        bail!("doctor: missing worktree stp: {}", wt_stp.display());
+    }
+    validate_bootstrap_stp(&worktree_path, &wt_stp)?;
+    validate_authored_prompt_surface("doctor", &wt_stp, PromptSurfaceKind::Stp)?;
+    validate_ready_cards(
+        repo_root,
+        issue_ref.issue_number(),
+        issue_ref.slug(),
+        wt_branch.trim(),
+        &root_bundle_input,
+        &root_bundle_output,
+    )?;
+    validate_ready_cards(
+        &worktree_path,
+        issue_ref.issue_number(),
+        issue_ref.slug(),
+        wt_branch.trim(),
+        &wt_bundle_input,
+        &wt_bundle_output,
+    )?;
+
+    println!("WORKTREE={}", worktree_path.display());
+    println!("SOURCE={}", path_relative_to_repo(repo_root, &source_path));
+    println!("ROOT_STP={}", path_relative_to_repo(repo_root, &root_stp));
+    println!(
+        "ROOT_INPUT={}",
+        path_relative_to_repo(repo_root, &root_bundle_input)
+    );
+    println!(
+        "ROOT_OUTPUT={}",
+        path_relative_to_repo(repo_root, &root_bundle_output)
+    );
+    println!("WT_STP={}", path_relative_to_repo(repo_root, &wt_stp));
+    println!(
+        "WT_INPUT={}",
+        path_relative_to_repo(repo_root, &wt_bundle_input)
+    );
+    println!(
+        "WT_OUTPUT={}",
+        path_relative_to_repo(repo_root, &wt_bundle_output)
+    );
+    println!("READY=PASS");
+    Ok(true)
 }
 
 fn sync_completed_output_review_surfaces(

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -48,6 +48,22 @@ pub(crate) struct PreflightArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DoctorMode {
+    Full,
+    Ready,
+    Preflight,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DoctorArgs {
+    pub(crate) issue: u32,
+    pub(crate) version: Option<String>,
+    pub(crate) slug: Option<String>,
+    pub(crate) no_fetch_issue: bool,
+    pub(crate) mode: DoctorMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FinishArgs {
     pub(crate) issue: u32,
     pub(crate) title: String,
@@ -229,6 +245,49 @@ pub(crate) fn parse_preflight_args(args: &[String]) -> Result<PreflightArgs> {
             }
             "--no-fetch-issue" => parsed.no_fetch_issue = true,
             other => bail!("preflight: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+    Ok(parsed)
+}
+
+pub(crate) fn parse_doctor_args(args: &[String]) -> Result<DoctorArgs> {
+    let issue_raw = args
+        .first()
+        .ok_or_else(|| anyhow!("doctor: missing <issue> number"))?;
+    let issue = issue_raw
+        .parse::<u32>()
+        .with_context(|| format!("invalid issue number: {issue_raw}"))?;
+    let mut parsed = DoctorArgs {
+        issue,
+        version: None,
+        slug: None,
+        no_fetch_issue: false,
+        mode: DoctorMode::Full,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--slug" => {
+                parsed.slug = Some(require_value(args, i, "doctor", "--slug")?);
+                i += 1;
+            }
+            "--version" => {
+                parsed.version = Some(require_value(args, i, "doctor", "--version")?);
+                i += 1;
+            }
+            "--mode" => {
+                let mode = require_value(args, i, "doctor", "--mode")?;
+                parsed.mode = match mode.as_str() {
+                    "full" => DoctorMode::Full,
+                    "ready" => DoctorMode::Ready,
+                    "preflight" => DoctorMode::Preflight,
+                    other => bail!("doctor: unsupported mode: {other}"),
+                };
+                i += 1;
+            }
+            "--no-fetch-issue" => parsed.no_fetch_issue = true,
+            other => bail!("doctor: unknown arg: {other}"),
         }
         i += 1;
     }

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -227,12 +227,40 @@ fn parse_create_args_rejects_missing_title_and_conflicting_body_inputs() {
 #[test]
 fn real_pr_dispatch_rejects_missing_and_unknown_subcommands() {
     let err = real_pr(&[]).expect_err("missing subcommand");
-    assert!(err
-        .to_string()
-        .contains("pr requires a subcommand: create | init | start | ready | preflight | finish"));
+    assert!(err.to_string().contains(
+        "pr requires a subcommand: create | init | start | doctor | ready | preflight | finish"
+    ));
 
     let err = real_pr(&["bogus".to_string()]).expect_err("unknown subcommand");
     assert!(err.to_string().contains("unknown pr subcommand: bogus"));
+}
+
+#[test]
+fn parse_doctor_args_accepts_modes_and_rejects_unknown_arg() {
+    let parsed = parse_doctor_args(&[
+        "1174".to_string(),
+        "--slug".to_string(),
+        "doctor-test".to_string(),
+        "--version".to_string(),
+        "v0.87".to_string(),
+        "--mode".to_string(),
+        "full".to_string(),
+        "--no-fetch-issue".to_string(),
+    ])
+    .expect("parse doctor");
+    assert_eq!(parsed.issue, 1174);
+    assert_eq!(parsed.slug.as_deref(), Some("doctor-test"));
+    assert_eq!(parsed.version.as_deref(), Some("v0.87"));
+    assert!(parsed.no_fetch_issue);
+    assert_eq!(parsed.mode, DoctorMode::Full);
+
+    let err = parse_doctor_args(&[
+        "1174".to_string(),
+        "--mode".to_string(),
+        "bogus".to_string(),
+    ])
+    .expect_err("err");
+    assert!(err.to_string().contains("doctor: unsupported mode"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -182,6 +182,134 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
 }
 
 #[test]
+fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
+    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = unique_temp_dir("adl-pr-doctor-worktree-cwd");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "doctor from worktree\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1197, "v0.86", "doctor-worktree-cwd").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Doctor worktree cwd");
+    real_pr(&[
+        "start".to_string(),
+        "1197".to_string(),
+        "--slug".to_string(),
+        "doctor-worktree-cwd".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Doctor worktree cwd".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr start");
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    let root_sip = issue_ref.task_bundle_input_path(&repo);
+    let wt_sip = issue_ref.task_bundle_input_path(&worktree);
+    write_authored_sip(
+        &root_sip,
+        &issue_ref,
+        "[v0.86][tools] Doctor worktree cwd",
+        "codex/1197-doctor-worktree-cwd",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_sip(
+        &wt_sip,
+        &issue_ref,
+        "[v0.86][tools] Doctor worktree cwd",
+        "codex/1197-doctor-worktree-cwd",
+        &issue_ref.issue_prompt_path(&worktree),
+        &worktree,
+    );
+    env::set_current_dir(&worktree).expect("chdir worktree");
+
+    let doctor = real_pr(&[
+        "doctor".to_string(),
+        "1197".to_string(),
+        "--slug".to_string(),
+        "doctor-worktree-cwd".to_string(),
+        "--mode".to_string(),
+        "full".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    doctor.expect("doctor from worktree");
+}
+
+#[test]
 fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
     let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = unique_temp_dir("adl-pr-ready-worktree-cwd");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -19,6 +19,7 @@
 #   adl/tools/pr.sh run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
 #   adl/tools/pr.sh card    <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <input_card.md>] [--version <v0.2>]
 #   adl/tools/pr.sh output  <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <output_card.md>] [--version <v0.2>]
+#   adl/tools/pr.sh doctor  <issue> [--slug <slug>] [--no-fetch-issue] [--version <v0.2>] [--mode full|ready|preflight]
 #   adl/tools/pr.sh preflight <issue> [--slug <slug>] [--no-fetch-issue] [--version <v0.2>]
 #   adl/tools/pr.sh finish  <issue> --title "<title>" [-f <input_card.md>] [--output-card <output_card.md>] [--body "<extra body>"] [--paths "<p1,p2,...>"] [--no-checks] [--no-close] [--ready] [--allow-gitignore] [--no-open]
 #   adl/tools/pr.sh open
@@ -1563,6 +1564,7 @@ cmd_ready() {
     return 0
   fi
   require_rust_pr_delegate
+  note "Deprecated compatibility path: prefer 'adl/tools/pr.sh doctor <issue> --mode ready ...'."
   delegate_pr_command_to_rust ready "$@"
 }
 
@@ -1572,7 +1574,17 @@ cmd_preflight() {
     return 0
   fi
   require_rust_pr_delegate
+  note "Deprecated compatibility path: prefer 'adl/tools/pr.sh doctor <issue> --mode preflight ...'."
   delegate_pr_command_to_rust preflight "$@"
+}
+
+cmd_doctor() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_doctor
+    return 0
+  fi
+  require_rust_pr_delegate
+  delegate_pr_command_to_rust doctor "$@"
 }
 
 cmd_open() {
@@ -1596,6 +1608,7 @@ Commands:
   card    <issue> [input|output] ... [--version <v0.2>] [-f <input_card.md>]
   output  <issue> [input|output] ... [--version <v0.2>] [-f <output_card.md>]
   cards   <issue> [--version <v0.2>] [--no-fetch-issue]
+  doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight]
   ready   <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
   finish  <issue> --title "<title>" ... [-f <input_card.md>] [--output-card <output_card.md>] [--no-open] [--merge]
   open
@@ -1624,7 +1637,9 @@ Notes:
 - `pr create` creates the GitHub issue and bootstraps the local root STP/SIP/SOR bundle for a new issue.
 - `pr init <issue> ...` bootstraps the same local root bundle for an issue that already exists.
 - `pr run <issue> ...` is the preferred public execution-context binder for issue work.
+- `pr doctor <issue> ...` is the preferred public readiness and drift diagnostic surface.
 - `pr start <issue> ...` remains only as a legacy alias over the same Rust binding path and is no longer part of the taught public flow.
+- `pr ready` and `pr preflight` remain only as deprecated compatibility aliases over `pr doctor`.
 - PRs are created as DRAFT by default to preserve human review.
 - Uses "Closes #N" by default so GitHub auto-closes issues when merged.
 - run is a bounded v0.85 wrapper over the Rust adl runtime; browser/editor direct invocation remains follow-on work.
@@ -1640,6 +1655,7 @@ Examples:
   adl/tools/pr.sh init 17 --slug b6-default-system --no-fetch-issue --version v0.85
   adl/tools/pr.sh run 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
+  adl/tools/pr.sh doctor 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh preflight 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh card  17 --help
   adl/tools/pr.sh card  17 --version v0.2
@@ -1743,6 +1759,7 @@ Usage:
   adl/tools/pr.sh ready <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
 
 Notes:
+- Deprecated compatibility alias over `doctor --mode ready`.
 - Verifies that the issue is fully authoring-ready in both the root checkout and the issue worktree.
 - Prints READY=PASS on success and exits non-zero on the first missing or invalid bootstrap surface.
 EOF
@@ -1754,8 +1771,22 @@ Usage:
   adl/tools/pr.sh preflight <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
 
 Notes:
+- Deprecated compatibility alias over `doctor --mode preflight`.
 - Reports whether unresolved open PRs already exist for the same milestone/version band.
 - Prints PREFLIGHT=PASS or PREFLIGHT=BLOCK.
+EOF
+}
+
+usage_doctor() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh doctor <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight]
+
+Notes:
+- Canonical readiness and drift diagnostic surface.
+- `--mode full` reports both milestone-wave preflight and worktree/card readiness.
+- `--mode ready` runs only the started-worktree readiness checks.
+- `--mode preflight` runs only the milestone-wave conflict/open-PR check.
 EOF
 }
 
@@ -1777,6 +1808,7 @@ main() {
     init) cmd_init "$@" ;;
     run) cmd_run "$@" ;;
     start) cmd_start "$@" ;;
+    doctor) cmd_doctor "$@" ;;
     ready) cmd_ready "$@" ;;
     preflight) cmd_preflight "$@" ;;
     finish) cmd_finish "$@" ;;

--- a/adl/tools/test_pr_doctor_prefers_built_binary.sh
+++ b/adl/tools/test_pr_doctor_prefers_built_binary.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mockbin="$tmpdir/mockbin"
+mkdir -p "$repo/adl/tools" "$repo/adl/target/debug" "$mockbin"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+touch "$repo/adl/Cargo.toml"
+sleep 1
+
+cat >"$repo/adl/target/debug/adl" <<'EOF_ADL'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TMP_ADL_ARGS"
+EOF_ADL
+chmod +x "$repo/adl/target/debug/adl"
+
+cat >"$mockbin/cargo" <<'EOF_CARGO'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "cargo should not be called when built adl binary is fresh" >&2
+exit 99
+EOF_CARGO
+chmod +x "$mockbin/cargo"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "init"
+)
+
+TMP_ADL_ARGS="$tmpdir/adl_args.txt"
+export TMP_ADL_ARGS
+export PATH="$mockbin:$PATH"
+
+(
+  cd "$repo"
+  "$BASH_BIN" adl/tools/pr.sh doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full >/dev/null
+)
+
+args="$(cat "$TMP_ADL_ARGS")"
+[[ "$args" == *"pr doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full"* ]] || {
+  echo "assertion failed: expected built adl binary delegation for doctor" >&2
+  echo "$args" >&2
+  exit 1
+}
+
+echo "pr.sh doctor built-binary delegation: ok"

--- a/adl/tools/test_pr_finish_delegates_to_rust.sh
+++ b/adl/tools/test_pr_finish_delegates_to_rust.sh
@@ -49,6 +49,7 @@ run_and_capture() {
 run_and_capture create --title "[v0.86][tools] Example" --slug example-create --version v0.86
 run_and_capture init 1151 --slug example --no-fetch-issue --version v0.86
 run_and_capture start 1152 --slug rust-start --no-fetch-issue --version v0.86 --allow-open-pr-wave
+run_and_capture doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full
 run_and_capture ready 1152 --slug rust-start --no-fetch-issue --version v0.86
 run_and_capture preflight 1152 --slug rust-start --no-fetch-issue --version v0.86
 run_and_capture finish 1153 --title "Example" --no-checks --no-open
@@ -66,6 +67,11 @@ args="$(cat "$TMP_CARGO_ARGS")"
 }
 [[ "$args" == *"--bin adl -- pr start 1152 --slug rust-start --no-fetch-issue --version v0.86 --allow-open-pr-wave"* ]] || {
   echo "assertion failed: expected rust delegation for start" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"--bin adl -- pr doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full"* ]] || {
+  echo "assertion failed: expected rust delegation for doctor" >&2
   echo "$args" >&2
   exit 1
 }

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
@@ -175,6 +175,7 @@ Examples:
 - `create` remains as a compatibility path while bootstrap semantics settle,
   but the long-term public model should collapse new-issue bootstrap into `init`
 - `ready` and `preflight` become aliases for `doctor`
+- the bounded consolidation target for WP-09 is to make that aliasing true in the live control plane, not only in docs
 - `card`, `output`, and `cards` become either hidden maintenance commands or
   internal Rust helpers rather than prominent user commands
 

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
@@ -138,7 +138,8 @@ thin shell entrypoint.
   - Rust is the sole owner of canonical PR lifecycle behavior
   - shell compatibility layers do not reimplement workflow policy
   - canonical path rules have exactly one authoritative implementation
-  - readiness inspection is consolidated under `doctor`
+- readiness inspection is consolidated under `doctor`
+- in current repo truth, `doctor` is the canonical diagnostic surface and `ready` / `preflight` remain as deprecated compatibility aliases
   - worktree creation is delayed until execution time in the intended model
   - human review remains preserved through draft-oriented PR flow unless
     explicitly overridden


### PR DESCRIPTION
Closes #1300

## Summary
Implemented a bounded control-plane consolidation slice by making "doctor" a real canonical PR-tooling command in both the Rust and shell surfaces. "ready" and "preflight" now remain as deprecated compatibility aliases over the same control-plane path, and the feature docs now describe that live repo truth instead of only the target architecture.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd_args.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
- `adl/tools/pr.sh`
- `adl/tools/test_pr_finish_delegates_to_rust.sh`
- `adl/tools/test_pr_doctor_prefers_built_binary.sh`
- `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
- `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml parse_doctor_args_accepts_modes_and_rejects_unknown_arg -- --nocapture`
    verifies the new doctor parser surface, including accepted modes and bounded error handling
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_succeeds_when_invoked_from_started_worktree -- --nocapture`
    verifies the canonical doctor path can execute the combined preflight plus readiness flow successfully against a started issue worktree
  - `bash adl/tools/test_pr_finish_delegates_to_rust.sh`
    verifies shell-to-Rust delegation now includes the new doctor surface while preserving the compatibility aliases
  - `bash adl/tools/test_pr_doctor_prefers_built_binary.sh`
    verifies the shell wrapper prefers the built Rust binary for doctor delegation when available
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    verifies formatting for the Rust code after the control-plane change
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    verifies the bounded consolidation slice passes linting at the repo standard
- Results:
  - all listed validation commands passed
  - the new doctor parser, lifecycle, and shell delegation proofs all succeeded
  - formatting and clippy passed after one normal formatter pass

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1300__v0-87-wp-09-pr-tooling-control-plane-consolidation/sip.md
- Output card: .adl/v0.87/tasks/issue-1300__v0-87-wp-09-pr-tooling-control-plane-consolidation/sor.md
- Idempotency-Key: v0-87-wp-09-pr-tooling-control-plane-consolidation-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-rs-adl-tools-pr-sh-adl-tools-test-pr-finish-delegates-to-rust-sh-adl-tools-test-pr-doctor-prefers-built-binary-sh-docs-milestones-v0-87-features-pr-tooling-simplification-feature-md-docs-milestones-v0-87-features-pr-tooling-simplification-architecture-md-adl-v0-87-tasks-issue-1300-v0-87-wp-09-pr-tooling-control-plane-consolidation-sip-md-adl-v0-87-tasks-issue-1300-v0-87-wp-09-pr-tooling-control-plane-consolidation-sor-md