### PR TITLE
[v0.87][WP-10] Tooling hardening + workflow stability

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs as unix_fs;
@@ -39,6 +39,57 @@ struct OpenPullRequest {
     base_ref_name: String,
     #[serde(rename = "isDraft")]
     is_draft: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DoctorPreflightJsonPullRequest {
+    number: u32,
+    head_ref_name: String,
+    state: &'static str,
+    url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoctorPreflightResult {
+    open_pr_count: usize,
+    open_prs: Vec<DoctorPreflightJsonPullRequest>,
+    status: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoctorReadyResult {
+    worktree: String,
+    source: String,
+    root_stp: String,
+    root_input: String,
+    root_output: String,
+    wt_stp: String,
+    wt_input: String,
+    wt_output: String,
+    status: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DoctorJsonOutput {
+    schema: &'static str,
+    issue: u32,
+    version: String,
+    slug: String,
+    branch: String,
+    mode: &'static str,
+    preflight_status: &'static str,
+    open_pr_count: usize,
+    open_prs: Vec<DoctorPreflightJsonPullRequest>,
+    ready_status: Option<&'static str>,
+    worktree: Option<String>,
+    source: Option<String>,
+    root_stp: Option<String>,
+    root_input: Option<String>,
+    root_output: Option<String>,
+    wt_stp: Option<String>,
+    wt_input: Option<String>,
+    wt_output: Option<String>,
+    doctor_status: &'static str,
 }
 
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
@@ -284,6 +335,7 @@ fn real_pr_ready(args: &[String]) -> Result<()> {
             slug: parsed.slug,
             no_fetch_issue: parsed.no_fetch_issue,
             mode: DoctorMode::Ready,
+            json: parsed.json,
         },
         "ready",
     )
@@ -304,6 +356,7 @@ fn real_pr_preflight(args: &[String]) -> Result<()> {
             slug: parsed.slug,
             no_fetch_issue: parsed.no_fetch_issue,
             mode: DoctorMode::Preflight,
+            json: parsed.json,
         },
         "preflight",
     )
@@ -512,43 +565,59 @@ fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
     let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
     let branch = issue_ref.branch_name("codex");
 
-    println!("ISSUE={}", parsed.issue);
-    println!("VERSION={version}");
-    println!("SLUG={slug}");
-    println!("BRANCH={branch}");
-
-    let preflight_ok = run_doctor_preflight(&repo, &version, &branch)?;
-    let ready_ok = match parsed.mode {
+    let preflight = run_doctor_preflight(&repo, &version, &branch)?;
+    let ready = match parsed.mode {
         DoctorMode::Preflight => None,
         DoctorMode::Ready | DoctorMode::Full => {
             Some(run_doctor_ready(&repo_root, &issue_ref, &branch)?)
         }
     };
-
-    match parsed.mode {
-        DoctorMode::Preflight => {
-            println!("DOCTOR_MODE=preflight");
-            println!(
-                "DOCTOR_STATUS={}",
-                if preflight_ok { "PASS" } else { "BLOCK" }
-            );
-        }
-        DoctorMode::Ready => {
-            println!("DOCTOR_MODE=ready");
-            println!(
-                "DOCTOR_STATUS={}",
-                if ready_ok.unwrap_or(false) {
-                    "PASS"
-                } else {
-                    "BLOCK"
-                }
-            );
-        }
+    let mode = doctor_mode_name(&parsed.mode);
+    let doctor_status = match parsed.mode {
+        DoctorMode::Preflight => preflight.status,
+        DoctorMode::Ready => ready.as_ref().map(|x| x.status).unwrap_or("BLOCK"),
         DoctorMode::Full => {
-            println!("DOCTOR_MODE=full");
-            let full_ok = preflight_ok && ready_ok.unwrap_or(false);
-            println!("DOCTOR_STATUS={}", if full_ok { "PASS" } else { "BLOCK" });
+            if preflight.status == "PASS" && ready.as_ref().map(|x| x.status) == Some("PASS") {
+                "PASS"
+            } else {
+                "BLOCK"
+            }
         }
+    };
+
+    if parsed.json {
+        print_json(&DoctorJsonOutput {
+            schema: "adl.pr.doctor.v1",
+            issue: parsed.issue,
+            version,
+            slug,
+            branch,
+            mode,
+            preflight_status: preflight.status,
+            open_pr_count: preflight.open_pr_count,
+            open_prs: preflight.open_prs,
+            ready_status: ready.as_ref().map(|x| x.status),
+            worktree: ready.as_ref().map(|x| x.worktree.clone()),
+            source: ready.as_ref().map(|x| x.source.clone()),
+            root_stp: ready.as_ref().map(|x| x.root_stp.clone()),
+            root_input: ready.as_ref().map(|x| x.root_input.clone()),
+            root_output: ready.as_ref().map(|x| x.root_output.clone()),
+            wt_stp: ready.as_ref().map(|x| x.wt_stp.clone()),
+            wt_input: ready.as_ref().map(|x| x.wt_input.clone()),
+            wt_output: ready.as_ref().map(|x| x.wt_output.clone()),
+            doctor_status,
+        })?;
+    } else {
+        println!("ISSUE={}", parsed.issue);
+        println!("VERSION={version}");
+        println!("SLUG={slug}");
+        println!("BRANCH={branch}");
+        print_doctor_preflight_text(&preflight);
+        if let Some(ready) = &ready {
+            print_doctor_ready_text(ready);
+        }
+        println!("DOCTOR_MODE={mode}");
+        println!("DOCTOR_STATUS={doctor_status}");
     }
     Ok(())
 }
@@ -584,28 +653,37 @@ fn resolve_doctor_scope_and_slug(
     Ok((version, slug))
 }
 
-fn run_doctor_preflight(repo: &str, version: &str, branch: &str) -> Result<bool> {
+fn run_doctor_preflight(repo: &str, version: &str, branch: &str) -> Result<DoctorPreflightResult> {
     let unresolved = unresolved_milestone_pr_wave(repo, version, Some(branch))?;
-    println!("OPEN_PR_COUNT={}", unresolved.len());
-    for pr in &unresolved {
-        println!(
-            "OPEN_PR=#{}|{}|{}|{}",
-            pr.number,
-            pr.head_ref_name,
-            if pr.is_draft { "draft" } else { "ready" },
-            pr.url
-        );
-    }
-    if unresolved.is_empty() {
-        println!("PREFLIGHT=PASS");
-        Ok(true)
+    let open_prs = unresolved
+        .iter()
+        .map(|pr| DoctorPreflightJsonPullRequest {
+            number: pr.number,
+            head_ref_name: pr.head_ref_name.clone(),
+            state: if pr.is_draft { "draft" } else { "ready" },
+            url: pr.url.clone(),
+        })
+        .collect::<Vec<_>>();
+    if open_prs.is_empty() {
+        Ok(DoctorPreflightResult {
+            open_pr_count: 0,
+            open_prs,
+            status: "PASS",
+        })
     } else {
-        println!("PREFLIGHT=BLOCK");
-        Ok(false)
+        Ok(DoctorPreflightResult {
+            open_pr_count: open_prs.len(),
+            open_prs,
+            status: "BLOCK",
+        })
     }
 }
 
-fn run_doctor_ready(repo_root: &Path, issue_ref: &IssueRef, branch: &str) -> Result<bool> {
+fn run_doctor_ready(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    branch: &str,
+) -> Result<DoctorReadyResult> {
     let worktree_path = issue_ref.default_worktree_path(
         repo_root,
         std::env::var_os("ADL_WORKTREE_ROOT")
@@ -669,28 +747,56 @@ fn run_doctor_ready(repo_root: &Path, issue_ref: &IssueRef, branch: &str) -> Res
         &wt_bundle_output,
     )?;
 
-    println!("WORKTREE={}", worktree_path.display());
-    println!("SOURCE={}", path_relative_to_repo(repo_root, &source_path));
-    println!("ROOT_STP={}", path_relative_to_repo(repo_root, &root_stp));
+    Ok(DoctorReadyResult {
+        worktree: path_relative_to_repo(repo_root, &worktree_path),
+        source: path_relative_to_repo(repo_root, &source_path),
+        root_stp: path_relative_to_repo(repo_root, &root_stp),
+        root_input: path_relative_to_repo(repo_root, &root_bundle_input),
+        root_output: path_relative_to_repo(repo_root, &root_bundle_output),
+        wt_stp: path_relative_to_repo(repo_root, &wt_stp),
+        wt_input: path_relative_to_repo(repo_root, &wt_bundle_input),
+        wt_output: path_relative_to_repo(repo_root, &wt_bundle_output),
+        status: "PASS",
+    })
+}
+
+fn doctor_mode_name(mode: &DoctorMode) -> &'static str {
+    match mode {
+        DoctorMode::Full => "full",
+        DoctorMode::Ready => "ready",
+        DoctorMode::Preflight => "preflight",
+    }
+}
+
+fn print_doctor_preflight_text(preflight: &DoctorPreflightResult) {
+    println!("OPEN_PR_COUNT={}", preflight.open_pr_count);
+    for pr in &preflight.open_prs {
+        println!(
+            "OPEN_PR=#{}|{}|{}|{}",
+            pr.number, pr.head_ref_name, pr.state, pr.url
+        );
+    }
+    println!("PREFLIGHT={}", preflight.status);
+}
+
+fn print_doctor_ready_text(ready: &DoctorReadyResult) {
+    println!("WORKTREE={}", ready.worktree);
+    println!("SOURCE={}", ready.source);
+    println!("ROOT_STP={}", ready.root_stp);
+    println!("ROOT_INPUT={}", ready.root_input);
+    println!("ROOT_OUTPUT={}", ready.root_output);
+    println!("WT_STP={}", ready.wt_stp);
+    println!("WT_INPUT={}", ready.wt_input);
+    println!("WT_OUTPUT={}", ready.wt_output);
+    println!("READY={}", ready.status);
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<()> {
     println!(
-        "ROOT_INPUT={}",
-        path_relative_to_repo(repo_root, &root_bundle_input)
+        "{}",
+        serde_json::to_string_pretty(value).context("failed to serialize pr command json")?
     );
-    println!(
-        "ROOT_OUTPUT={}",
-        path_relative_to_repo(repo_root, &root_bundle_output)
-    );
-    println!("WT_STP={}", path_relative_to_repo(repo_root, &wt_stp));
-    println!(
-        "WT_INPUT={}",
-        path_relative_to_repo(repo_root, &wt_bundle_input)
-    );
-    println!(
-        "WT_OUTPUT={}",
-        path_relative_to_repo(repo_root, &wt_bundle_output)
-    );
-    println!("READY=PASS");
-    Ok(true)
+    Ok(())
 }
 
 fn sync_completed_output_review_surfaces(

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -37,6 +37,7 @@ pub(crate) struct ReadyArgs {
     pub(crate) slug: Option<String>,
     pub(crate) version: Option<String>,
     pub(crate) no_fetch_issue: bool,
+    pub(crate) json: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,6 +46,7 @@ pub(crate) struct PreflightArgs {
     pub(crate) version: Option<String>,
     pub(crate) slug: Option<String>,
     pub(crate) no_fetch_issue: bool,
+    pub(crate) json: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,6 +63,7 @@ pub(crate) struct DoctorArgs {
     pub(crate) slug: Option<String>,
     pub(crate) no_fetch_issue: bool,
     pub(crate) mode: DoctorMode,
+    pub(crate) json: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -231,6 +234,7 @@ pub(crate) fn parse_preflight_args(args: &[String]) -> Result<PreflightArgs> {
         version: None,
         slug: None,
         no_fetch_issue: false,
+        json: false,
     };
     let mut i = 1;
     while i < args.len() {
@@ -244,6 +248,7 @@ pub(crate) fn parse_preflight_args(args: &[String]) -> Result<PreflightArgs> {
                 i += 1;
             }
             "--no-fetch-issue" => parsed.no_fetch_issue = true,
+            "--json" => parsed.json = true,
             other => bail!("preflight: unknown arg: {other}"),
         }
         i += 1;
@@ -264,6 +269,7 @@ pub(crate) fn parse_doctor_args(args: &[String]) -> Result<DoctorArgs> {
         slug: None,
         no_fetch_issue: false,
         mode: DoctorMode::Full,
+        json: false,
     };
     let mut i = 1;
     while i < args.len() {
@@ -287,6 +293,7 @@ pub(crate) fn parse_doctor_args(args: &[String]) -> Result<DoctorArgs> {
                 i += 1;
             }
             "--no-fetch-issue" => parsed.no_fetch_issue = true,
+            "--json" => parsed.json = true,
             other => bail!("doctor: unknown arg: {other}"),
         }
         i += 1;
@@ -306,6 +313,7 @@ pub(crate) fn parse_ready_args(args: &[String]) -> Result<ReadyArgs> {
         slug: None,
         version: None,
         no_fetch_issue: false,
+        json: false,
     };
     let mut i = 1;
     while i < args.len() {
@@ -319,6 +327,7 @@ pub(crate) fn parse_ready_args(args: &[String]) -> Result<ReadyArgs> {
                 i += 1;
             }
             "--no-fetch-issue" => parsed.no_fetch_issue = true,
+            "--json" => parsed.json = true,
             other => bail!("ready: unknown arg: {other}"),
         }
         i += 1;

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -245,12 +245,14 @@ fn parse_doctor_args_accepts_modes_and_rejects_unknown_arg() {
         "v0.87".to_string(),
         "--mode".to_string(),
         "full".to_string(),
+        "--json".to_string(),
         "--no-fetch-issue".to_string(),
     ])
     .expect("parse doctor");
     assert_eq!(parsed.issue, 1174);
     assert_eq!(parsed.slug.as_deref(), Some("doctor-test"));
     assert_eq!(parsed.version.as_deref(), Some("v0.87"));
+    assert!(parsed.json);
     assert!(parsed.no_fetch_issue);
     assert_eq!(parsed.mode, DoctorMode::Full);
 
@@ -271,12 +273,14 @@ fn parse_ready_args_accepts_flags_and_rejects_unknown_arg() {
         "ready-test".to_string(),
         "--version".to_string(),
         "v0.86".to_string(),
+        "--json".to_string(),
         "--no-fetch-issue".to_string(),
     ])
     .expect("parse ready");
     assert_eq!(parsed.issue, 1152);
     assert_eq!(parsed.slug.as_deref(), Some("ready-test"));
     assert_eq!(parsed.version.as_deref(), Some("v0.86"));
+    assert!(parsed.json);
     assert!(parsed.no_fetch_issue);
 
     let err = parse_ready_args(&["1152".to_string(), "--bogus".to_string()]).expect_err("err");
@@ -291,12 +295,14 @@ fn parse_preflight_args_accepts_flags_and_rejects_unknown_arg() {
         "preflight-test".to_string(),
         "--version".to_string(),
         "v0.86".to_string(),
+        "--json".to_string(),
         "--no-fetch-issue".to_string(),
     ])
     .expect("parse preflight");
     assert_eq!(parsed.issue, 1173);
     assert_eq!(parsed.slug.as_deref(), Some("preflight-test"));
     assert_eq!(parsed.version.as_deref(), Some("v0.86"));
+    assert!(parsed.json);
     assert!(parsed.no_fetch_issue);
 
     let err = parse_preflight_args(&["1173".to_string(), "--bogus".to_string()]).expect_err("err");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -19,8 +19,8 @@
 #   adl/tools/pr.sh run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
 #   adl/tools/pr.sh card    <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <input_card.md>] [--version <v0.2>]
 #   adl/tools/pr.sh output  <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <output_card.md>] [--version <v0.2>]
-#   adl/tools/pr.sh doctor  <issue> [--slug <slug>] [--no-fetch-issue] [--version <v0.2>] [--mode full|ready|preflight]
-#   adl/tools/pr.sh preflight <issue> [--slug <slug>] [--no-fetch-issue] [--version <v0.2>]
+#   adl/tools/pr.sh doctor  <issue> [--slug <slug>] [--no-fetch-issue] [--version <v0.2>] [--mode full|ready|preflight] [--json]
+#   adl/tools/pr.sh preflight <issue> [--slug <slug>] [--no-fetch-issue] [--version <v0.2>] [--json]
 #   adl/tools/pr.sh finish  <issue> --title "<title>" [-f <input_card.md>] [--output-card <output_card.md>] [--body "<extra body>"] [--paths "<p1,p2,...>"] [--no-checks] [--no-close] [--ready] [--allow-gitignore] [--no-open]
 #   adl/tools/pr.sh open
 #   adl/tools/pr.sh status
@@ -1608,8 +1608,9 @@ Commands:
   card    <issue> [input|output] ... [--version <v0.2>] [-f <input_card.md>]
   output  <issue> [input|output] ... [--version <v0.2>] [-f <output_card.md>]
   cards   <issue> [--version <v0.2>] [--no-fetch-issue]
-  doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight]
-  ready   <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
+  doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
+  ready   <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--json]
+  preflight <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--json]
   finish  <issue> --title "<title>" ... [-f <input_card.md>] [--output-card <output_card.md>] [--no-open] [--merge]
   open
   status
@@ -1655,7 +1656,7 @@ Examples:
   adl/tools/pr.sh init 17 --slug b6-default-system --no-fetch-issue --version v0.85
   adl/tools/pr.sh run 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh run adl/examples/v0-4-demo-deterministic-replay.adl.yaml --trace --allow-unsigned
-  adl/tools/pr.sh doctor 17 --slug b6-default-system --version v0.85
+  adl/tools/pr.sh doctor 17 --slug b6-default-system --version v0.85 --json
   adl/tools/pr.sh preflight 17 --slug b6-default-system --version v0.85
   adl/tools/pr.sh card  17 --help
   adl/tools/pr.sh card  17 --version v0.2
@@ -1756,37 +1757,40 @@ EOF
 usage_ready() {
   cat <<'EOF'
 Usage:
-  adl/tools/pr.sh ready <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
+  adl/tools/pr.sh ready <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--json]
 
 Notes:
 - Deprecated compatibility alias over `doctor --mode ready`.
 - Verifies that the issue is fully authoring-ready in both the root checkout and the issue worktree.
 - Prints READY=PASS on success and exits non-zero on the first missing or invalid bootstrap surface.
+- `--json` emits the stable `adl.pr.doctor.v1` machine-readable result.
 EOF
 }
 
 usage_preflight() {
   cat <<'EOF'
 Usage:
-  adl/tools/pr.sh preflight <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
+  adl/tools/pr.sh preflight <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--json]
 
 Notes:
 - Deprecated compatibility alias over `doctor --mode preflight`.
 - Reports whether unresolved open PRs already exist for the same milestone/version band.
 - Prints PREFLIGHT=PASS or PREFLIGHT=BLOCK.
+- `--json` emits the stable `adl.pr.doctor.v1` machine-readable result.
 EOF
 }
 
 usage_doctor() {
   cat <<'EOF'
 Usage:
-  adl/tools/pr.sh doctor <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight]
+  adl/tools/pr.sh doctor <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
 
 Notes:
 - Canonical readiness and drift diagnostic surface.
 - `--mode full` reports both milestone-wave preflight and worktree/card readiness.
 - `--mode ready` runs only the started-worktree readiness checks.
 - `--mode preflight` runs only the milestone-wave conflict/open-PR check.
+- `--json` emits the stable `adl.pr.doctor.v1` machine-readable result for automation.
 EOF
 }
 

--- a/adl/tools/test_pr_finish_delegates_to_rust.sh
+++ b/adl/tools/test_pr_finish_delegates_to_rust.sh
@@ -50,8 +50,9 @@ run_and_capture create --title "[v0.86][tools] Example" --slug example-create --
 run_and_capture init 1151 --slug example --no-fetch-issue --version v0.86
 run_and_capture start 1152 --slug rust-start --no-fetch-issue --version v0.86 --allow-open-pr-wave
 run_and_capture doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full
-run_and_capture ready 1152 --slug rust-start --no-fetch-issue --version v0.86
-run_and_capture preflight 1152 --slug rust-start --no-fetch-issue --version v0.86
+run_and_capture ready 1152 --slug rust-start --no-fetch-issue --version v0.86 --json
+run_and_capture preflight 1152 --slug rust-start --no-fetch-issue --version v0.86 --json
+run_and_capture doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full --json
 run_and_capture finish 1153 --title "Example" --no-checks --no-open
 
 args="$(cat "$TMP_CARGO_ARGS")"
@@ -75,13 +76,18 @@ args="$(cat "$TMP_CARGO_ARGS")"
   echo "$args" >&2
   exit 1
 }
-[[ "$args" == *"--bin adl -- pr ready 1152 --slug rust-start --no-fetch-issue --version v0.86"* ]] || {
+[[ "$args" == *"--bin adl -- pr ready 1152 --slug rust-start --no-fetch-issue --version v0.86 --json"* ]] || {
   echo "assertion failed: expected rust delegation for ready" >&2
   echo "$args" >&2
   exit 1
 }
-[[ "$args" == *"--bin adl -- pr preflight 1152 --slug rust-start --no-fetch-issue --version v0.86"* ]] || {
+[[ "$args" == *"--bin adl -- pr preflight 1152 --slug rust-start --no-fetch-issue --version v0.86 --json"* ]] || {
   echo "assertion failed: expected rust delegation for preflight" >&2
+  echo "$args" >&2
+  exit 1
+}
+[[ "$args" == *"--bin adl -- pr doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full --json"* ]] || {
+  echo "assertion failed: expected rust delegation for doctor" >&2
   echo "$args" >&2
   exit 1
 }

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md
@@ -350,10 +350,10 @@ To preserve useful `preflight` behavior without preserving a separate command,
 
 - `adl pr doctor`
   - default human-readable readiness report
+- `adl pr doctor --json`
+  - machine-readable readiness output for skills and automation
 - `adl pr doctor --strict`
   - exit non-zero on any blocking readiness issue
-- `adl pr doctor --json`
-  - machine-readable readiness output
 - `adl pr doctor --repair`
   - apply only bounded mechanical repairs that are clearly safe
 

--- a/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
+++ b/docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md
@@ -160,6 +160,7 @@ thin shell entrypoint.
 - `doctor`
   - reports readiness, detects workflow drift, surfaces deprecated usage,
     and provides migration guidance
+  - supports a machine-readable `--json` result for automation and skill callers
 
 ### Data / Artifacts
 
@@ -170,6 +171,8 @@ existing workflow artifacts are created, validated, and reconciled.
 - task-bundle artifacts under `.adl/.../tasks/...`
 - compatibility card locations under `.adl/cards/...`
 - deprecation and compatibility behavior for CLI entrypoints
+- machine-readable `doctor --json` diagnostics, with compatibility alias support
+  through `ready --json` and `preflight --json`
 
 ## Execution Flow
 


### PR DESCRIPTION
Closes #1301

## Summary
Delivered a bounded workflow-hardening slice by adding stable machine-readable JSON output to the live readiness surfaces. `adl pr doctor --json` now emits a structured `adl.pr.doctor.v1` payload, and the compatibility aliases `ready --json` and `preflight --json` route through the same structured output. The shell help, delegation coverage, parser coverage, and v0.87 PR tooling docs now match that automation-facing behavior.

## Artifacts
- Code:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd_args.rs`
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/tools/pr.sh`
  - `adl/tools/test_pr_finish_delegates_to_rust.sh`
- Docs:
  - `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
  - `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_ARCHITECTURE.md`
- Proof surfaces:
  - live `adl/tools/pr.sh doctor 1301 ... --mode full --json` output with repo-relative workflow paths
  - live `adl/tools/pr.sh ready 1301 ... --json` output proving compatibility alias coverage
- Generated runtime artifacts: not applicable for this tooling/control-plane task

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Checked formatting across the Rust control-plane surface.
  - `cargo test --manifest-path adl/Cargo.toml parse_doctor_args_accepts_modes_and_rejects_unknown_arg -- --nocapture`
    Proved the new doctor CLI flag surface parses cleanly.
  - `cargo test --manifest-path adl/Cargo.toml parse_ready_args_accepts_flags_and_rejects_unknown_arg -- --nocapture`
    Proved the ready compatibility alias accepts the JSON mode.
  - `cargo test --manifest-path adl/Cargo.toml parse_preflight_args_accepts_flags_and_rejects_unknown_arg -- --nocapture`
    Proved the preflight compatibility alias accepts the JSON mode.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_succeeds_when_invoked_from_started_worktree -- --nocapture`
    Proved the doctor flow still works on an actual started issue context.
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`
    Proved the broader PR control-plane suite still passes after the refactor.
  - `bash adl/tools/test_pr_finish_delegates_to_rust.sh`
    Proved shell-to-Rust delegation parity for doctor, ready, preflight, and finish.
  - `bash adl/tools/pr.sh doctor 1301 --slug v0-87-wp-10-tooling-hardening-workflow-stability --version v0.87 --mode full --json`
    Proved the live doctor JSON surface returns the expected structured payload for the current issue.
  - `bash adl/tools/pr.sh ready 1301 --slug v0-87-wp-10-tooling-hardening-workflow-stability --version v0.87 --no-fetch-issue --json`
    Proved the compatibility alias routes through the same structured payload surface.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Proved the control-plane hardening changes are lint-clean.
- Results:
  - PASS: all targeted parser, lifecycle, delegation, live-command, formatting, and clippy checks passed.

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1301__v0-87-wp-10-tooling-hardening-workflow-stability/sip.md
- Output card: .adl/v0.87/tasks/issue-1301__v0-87-wp-10-tooling-hardening-workflow-stability/sor.md
- Idempotency-Key: v0-87-wp-10-tooling-hardening-workflow-stability-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-args-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-tools-pr-sh-adl-tools-test-pr-finish-delegates-to-rust-sh-docs-milestones-v0-87-features-pr-tooling-simplification-feature-md-docs-milestones-v0-87-features-pr-tooling-simplification-architecture-md-adl-v0-87-tasks-issue-1301-v0-87-wp-10-tooling-hardening-workflow-stability-sip-md-adl-v0-87-tasks-issue-1301-v0-87-wp-10-tooling-hardening-workflow-stability-sor-md