### PR TITLE
[v0.87][docs] Check in Sprint/WBS review-phase updates

### DIFF
--- a/docs/milestones/v0.87/SPRINT_v0.87.md
+++ b/docs/milestones/v0.87/SPRINT_v0.87.md
@@ -13,7 +13,7 @@
 
 - Sprint 1: canonicalization and first substrate slices
 - Sprint 2: substrate expansion and convergence across trace, provider, shared memory, skills, tooling, and review
-- Sprint 3: documentation convergence, demos, quality gate, review package, and release closeout
+- Sprint 3: documentation convergence, demos, quality gate, internal review, 3rd party review, and release closeout
 
 The purpose of this file is to describe the sprint sequence for the whole milestone, not just the first kickoff tranche.
 
@@ -36,7 +36,7 @@ This milestone should leave ADL with:
 |---|---|---|---|
 | `v0.87-s1` | Lock the canonical milestone surfaces and land the first substrate slices | `WP-01`, `WP-02`, `WP-04`, `WP-06` | active / partially implemented |
 | `v0.87-s2` | Expand and connect the substrate across trace, provider, memory, skills, tooling, and review | `WP-03`, `WP-05`, `WP-07`, `WP-08`, `WP-09`, `WP-10`, `WP-11` | seeded / underway |
-| `v0.87-s3` | Converge docs, demos, quality gates, review package, and release tail | `WP-12`, `WP-13`, `WP-14`, `WP-15`, `WP-16` | planned |
+| `v0.87-s3` | Converge docs, demos, quality gates, internal review, 3rd party review, and release tail | `WP-12`, `WP-13`, `WP-14`, `WP-15`, `WP-15A`, `WP-16` | planned |
 
 ## Sprint 1
 
@@ -99,13 +99,14 @@ Expand the foundational substrate into a connected milestone surface: runtime tr
 ## Sprint 3
 
 ### Goal
-Converge the milestone into a reviewer-legible package with truthful demos, quality gates, docs, review outputs, and release closeout.
+Converge the milestone into a reviewer-legible package with truthful demos, quality gates, docs, internal review outputs, 3rd party review readiness, and release closeout.
 
 ### Scope
 - docs canonicalization and feature index truth
 - demo matrix execution and integration demos
 - quality gate and coverage posture
-- docs / review convergence
+- docs / internal review convergence
+- 3rd party review pass and resulting follow-up capture
 - release ceremony and milestone handoff
 
 ### Work Packages
@@ -114,14 +115,16 @@ Converge the milestone into a reviewer-legible package with truthful demos, qual
 | 1 | Documentation canonicalization + feature index | `WP-12` | `Daniel / Codex.app` | not yet issued |
 | 2 | Demo matrix + integration demos | `WP-13` | `Daniel / Codex.app` | not yet issued |
 | 3 | Coverage / quality gate | `WP-14` | `Daniel / Codex.app` | not yet issued |
-| 4 | Docs + review pass | `WP-15` | `Daniel / Codex.app` | not yet issued |
-| 5 | Release ceremony | `WP-16` | `Daniel / Codex.app` | not yet issued |
+| 4 | Docs + internal review pass | `WP-15` | `Daniel / Codex.app` | not yet issued |
+| 5 | 3rd party review pass | `WP-15A` | `Daniel / Codex.app` | not yet issued |
+| 6 | Release ceremony | `WP-16` | `Daniel / Codex.app` | not yet issued |
 
 ### Exit Criteria
 - canonical docs truthfully describe the implemented milestone
 - demo matrix is runnable or explicitly blocked with alternate proof surfaces
 - quality posture is recorded with real commands and justified exceptions
-- docs and review surfaces are coherent for an uninvolved reviewer
+- docs and internal review surfaces are coherent for an uninvolved reviewer
+- 3rd party review is completed or explicitly recorded with bounded follow-up disposition
 - release-tail validation and handoff are complete
 
 ## Current Execution Status
@@ -166,11 +169,12 @@ Current issue/PR posture:
   - `docs/milestones/v0.87/WBS_v0.87.md`
   - `docs/milestones/v0.87/FEATURE_DOCS_v0.87.md`
   - `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
-- Sign-off owners: `Daniel Austin`, `Codex.app`, internal review before wider exposure
+- Sign-off owners: `Daniel Austin`, `Codex.app`, internal review, and 3rd party review before release closeout
 
 ## Milestone Exit Criteria
 - Canonical `v0.87` milestone docs are filled, internally consistent, and aligned with the roadmap.
 - All three milestone sprints are described truthfully in this file.
 - The issue sequence is explicit for the foundational and convergence substrate work.
 - Sprint 3 release-tail work is defined before release closeout begins.
+- Internal review and 3rd party review are both completed or explicitly dispositioned before release closeout.
 - Scope remains bounded to `v0.87` substrate work; no silent pull-forward of `v0.88+` systems.

--- a/docs/milestones/v0.87/WBS_v0.87.md
+++ b/docs/milestones/v0.87/WBS_v0.87.md
@@ -36,6 +36,7 @@ The WBS below preserves mergeable slices, explicit dependencies, and a clean rel
 | WP-13 | Demo matrix + integration demos | Define and implement the milestone’s primary proof surfaces, including substrate demos for trace/provider/shared-memory/skills and the planned PR Demo preparation surfaces for later milestones. | `v0.87` demo matrix plus runnable integration demos with clear proof claims. | WP-03, WP-05, WP-07, WP-08, WP-11 | TBD |
 | WP-14 | Coverage / quality gate (ratchet + exclusions) | Enforce truthful quality posture for the milestone, including tests, validators, coverage/ratchet posture, and concrete command surfaces for auditing substrate correctness. | Final `v0.87` quality/coverage gate record with explicit exceptions if any. | WP-02 through WP-13 | TBD |
 | WP-15 | Docs + review pass (repo-wide alignment) | Converge milestone docs, proof surfaces, review artifacts, and entry-point docs so an internal/external reviewer can understand the implemented `v0.87` substrate truthfully. | Reviewed and aligned docs/review surface package for `v0.87`. | WP-12, WP-13, WP-14 | TBD |
+| WP-15A | 3rd-party review | Conduct external / 3rd-party review of the `v0.87` milestone, capture findings, and ensure all issues are either resolved or explicitly dispositioned before release closeout. | External review findings and disposition record for milestone closeout. | WP-15 | TBD |
 | WP-16 | Release ceremony (final validation + tag + notes + cleanup) | Perform final release-tail work for `v0.87`: validation evidence, checklist/release-note alignment, closeout record, and clean handoff into the next roadmap slice. | `v0.87` release-closeout package with final validation and milestone handoff. | WP-15 | TBD |
 
 ## Sequencing
@@ -59,6 +60,7 @@ The WBS below preserves mergeable slices, explicit dependencies, and a clean rel
 - WP-13 (Demos) -> `v0.87` has clear integration demos proving trace, provider portability, shared memory, and operational substrate behavior.
 - WP-14 (Quality gate) -> The milestone has a truthful, auditable quality/coverage posture with explicit command surfaces and justified exceptions.
 - WP-15 (Docs/review) -> Docs, proof surfaces, and review artifacts converge into a reviewer-legible, contradiction-free package.
+- WP-15A (3rd-party review) -> External review findings are captured and every finding is either resolved or explicitly dispositioned before release closeout.
 - WP-16 (Release ceremony) -> Final validation, release-tail docs, and milestone handoff are explicit, truthful, and auditable.
 
 ## Exit Criteria


### PR DESCRIPTION
Closes #1335

## Summary
Bound issue `1335` into an execution worktree, applied the Sprint/WBS review-phase cleanup on the issue branch, and prepared the branch for `pr finish`. The bound worktree passes `pr-ready`; `pr-preflight` is blocked only by unrelated draft PR `#1337`.

## Artifacts
- `.adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/stp.md`
- `.adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/sip.md`
- `.adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/sor.md`
- `docs/milestones/v0.87/SPRINT_v0.87.md`
- `docs/milestones/v0.87/WBS_v0.87.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type stp --phase authored --input .adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/stp.md`
    - verifies the authored STP remains contract-valid in the worktree.
  - `bash adl/tools/validate_structured_prompt.sh --type sip --phase authored --input .adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/sip.md`
    - verifies the authored SIP remains contract-valid in the worktree.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase in_progress --input .adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/sor.md`
    - verified the in-progress SOR before finish preparation.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/sor.md`
    - verifies the completed SOR remains machine-readable before `pr finish`.
- Results:
  - worktree-local `stp` contract validation passed
  - worktree-local `sip` contract validation passed
  - worktree-local `sor` in-progress contract validation passed
  - worktree-local `sor` completed contract validation pending rerun after this final record update
  - `pr-ready` returned `READY=PASS`
  - `pr-preflight` returned `PREFLIGHT=BLOCK` because draft PR `#1337` is already open for a different issue
  - `git diff --check` passed for the Sprint/WBS docs patch

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/sip.md
- Output card: .adl/v0.87/tasks/issue-1335__v0-87-docs-check-in-sprint-wbs-review-phase-updates/sor.md
- Idempotency-Key: v0-87-docs-check-in-sprint-wbs-review-phase-updates-docs-milestones-v0-87-sprint-v0-87-md-docs-milestones-v0-87-wbs-v0-87-md-adl-v0-87-tasks-issue-1335-v0-87-docs-check-in-sprint-wbs-review-phase-updates-sip-md-adl-v0-87-tasks-issue-1335-v0-87-docs-check-in-sprint-wbs-review-phase-updates-sor-md