### PR TITLE
[v0.87][WP-11] Review-surface formalization

### DIFF
--- a/adl/tools/skills/repo-code-review/references/output-contract.md
+++ b/adl/tools/skills/repo-code-review/references/output-contract.md
@@ -1,43 +1,72 @@
 # Output Contract
 
-When ADL expects structured review output, use this shape.
+Use the canonical review-surface structure from:
+- `docs/tooling/review-surface-format.md`
 
-```yaml
-status: complete | partial | blocked
-target: <repo path or review target>
-findings:
-  - priority: P0 | P1 | P2 | P3 | P4 | P5
-    file: <path>
-    line: <1-based line or null>
-    title: <short finding title>
-    impact: <why it matters>
-    trigger: <how the problem appears>
-    evidence: <brief concrete explanation>
-assumptions:
-  - <assumption>
-coverage_summary:
-  reviewed:
-    - <high-signal area>
-  skipped:
-    - <ignored or unreviewed area>
-manifest_and_config_reviewed:
-  - <manifest or config path>
-validation_performed:
-  - inventory
-  - static_reading
-  - tests_read | targeted_tests_run | no_tests_run
-follow_up:
-  - <optional next action>
+The default repo-review profile is markdown with these exact sections in this order:
+
+```md
+## Metadata
+- Review Type: repo_review
+- Subject: <repo path or review target>
+- Reviewer: <human or skill id>
+- Date: <UTC timestamp or calendar date>
+- Input Surfaces:
+  - <path or command>
+- Output Location: <path or none>
+
+## Scope
+- Reviewed: <high-signal reviewed areas>
+- Not Reviewed: <explicit exclusions>
+- Review Mode: code | docs | trace | mixed
+- Gate: pre-merge | post-merge | release-tail
+
+## Findings
+1. [P1] Short title
+Location: <path:line or artifact>
+Impact: <behavioral consequence>
+Trigger: <how it appears>
+Evidence: <concrete evidence>
+Fix Direction: <bounded repair direction>
+
+## System-Level Assessment
+<synthesis paragraph>
+
+## Recommended Action Plan
+- Fix now: <items>
+- Fix before milestone closeout: <items>
+- Defer: <items>
+
+## Follow-ups / Deferred Work
+- <follow-up or explicit none>
+
+## Final Assessment
+<bounded conclusion>
 ```
 
 ## Rules
 
-- `findings` must come first in any human-readable rendering.
-- If there are no significant findings, emit `findings: []` and explain residual risk under `coverage_summary` or `follow_up`.
+- `Findings` must be the first analytical section after `Metadata` and `Scope`.
+- If there are no significant findings, say `No material findings.` explicitly in the `Findings` section and use `Final Assessment` to record residual risk.
 - Do not claim dynamic validation unless commands were actually run.
-- If tests were not run, say so explicitly and include the reason.
+- If tests were not run, say so explicitly in `Scope`, `System-Level Assessment`, or `Final Assessment`.
 - Use `P4` and `P5` only for concrete, non-speculative issues.
-- Do not omit top-level manifests or dependency/build/toolchain config from `manifest_and_config_reviewed` unless the user explicitly scoped them out.
+- Top-level manifests and dependency/build/toolchain config must be reflected in the reviewed scope unless the user explicitly scoped them out.
+- Do not emit absolute host paths, secrets, raw prompts, or raw tool arguments.
+
+## Validator
+
+Repo-local validator:
+
+```text
+adl/tools/verify_repo_review_contract.rb
+```
+
+Fixture test:
+
+```text
+adl/tools/test_repo_review_contract.sh
+```
 
 ## Default Artifact Location
 

--- a/adl/tools/skills/repo-code-review/references/review-playbook.md
+++ b/adl/tools/skills/repo-code-review/references/review-playbook.md
@@ -52,6 +52,22 @@ Use P4 and P5 sparingly:
 
 Do not report speculative, aesthetic, or preference-only comments as P4/P5.
 
+## Output Shape
+
+Write the review using the canonical section order from:
+- `docs/tooling/review-surface-format.md`
+
+For repo review, always include:
+- `Metadata`
+- `Scope`
+- `Findings`
+- `System-Level Assessment`
+- `Recommended Action Plan`
+- `Follow-ups / Deferred Work`
+- `Final Assessment`
+
+Findings remain first in substance, but the artifact must still include the metadata and scope sections ahead of them.
+
 ## Evidence Standard
 
 Prefer:

--- a/adl/tools/test_repo_review_contract.sh
+++ b/adl/tools/test_repo_review_contract.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERIFY="$ROOT/adl/tools/verify_repo_review_contract.rb"
+GOOD="$ROOT/docs/tooling/examples/repo-review/good_repo_review.md"
+BAD="$ROOT/docs/tooling/examples/repo-review/bad_repo_review.md"
+
+ruby "$VERIFY" --review "$GOOD" >/dev/null
+
+if ruby "$VERIFY" --review "$BAD" >/dev/null 2>&1; then
+  echo "assertion failed: invalid repo review unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "repo review contract fixtures passed"

--- a/adl/tools/verify_repo_review_contract.rb
+++ b/adl/tools/verify_repo_review_contract.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+
+REQUIRED_HEADINGS = [
+  "Metadata",
+  "Scope",
+  "Findings",
+  "System-Level Assessment",
+  "Recommended Action Plan",
+  "Follow-ups / Deferred Work",
+  "Final Assessment"
+].freeze
+
+FINDING_RE = /^\d+\.\s+\[(P[1-5])\]\s+.+$/
+ABSOLUTE_HOST_PATH_RE = %r{(?:^|[\s`'"])/(Users|home|tmp|var/folders)/}.freeze
+
+def parse_args
+  options = {}
+  OptionParser.new do |opts|
+    opts.banner = "Usage: verify_repo_review_contract.rb --review <markdown>"
+    opts.on("--review PATH", "Review markdown path") { |value| options[:review] = value }
+  end.parse!
+
+  abort("missing --review") unless options[:review]
+  options
+end
+
+def assert!(condition, message)
+  abort(message) unless condition
+end
+
+def section_body(text, heading)
+  match = text.match(/^## #{Regexp.escape(heading)}\n(.*?)(?=^## |\z)/m)
+  match && match[1]
+end
+
+options = parse_args
+review_path = File.expand_path(options[:review], Dir.pwd)
+assert!(File.file?(review_path), "review artifact not found: #{review_path}")
+text = File.read(review_path)
+
+assert!(!text.match?(ABSOLUTE_HOST_PATH_RE), "review artifact contains absolute host path")
+
+headings = text.scan(/^## (.+)$/).flatten
+assert!(headings == REQUIRED_HEADINGS, "review headings must match canonical order exactly")
+
+metadata = section_body(text, "Metadata")
+scope = section_body(text, "Scope")
+findings = section_body(text, "Findings")
+assessment = section_body(text, "System-Level Assessment")
+action_plan = section_body(text, "Recommended Action Plan")
+follow_ups = section_body(text, "Follow-ups / Deferred Work")
+final_assessment = section_body(text, "Final Assessment")
+
+assert!(metadata && metadata.include?("Review Type:"), "Metadata must include Review Type")
+assert!(metadata.include?("Subject:"), "Metadata must include Subject")
+assert!(metadata.include?("Reviewer:"), "Metadata must include Reviewer")
+assert!(scope && scope.include?("Reviewed:"), "Scope must include Reviewed")
+assert!(scope.include?("Not Reviewed:"), "Scope must include Not Reviewed")
+assert!(scope.include?("Review Mode:"), "Scope must include Review Mode")
+assert!(scope.include?("Gate:"), "Scope must include Gate")
+
+findings_lines = findings.to_s.lines.map(&:rstrip)
+has_explicit_no_findings = findings_lines.any? { |line| line.strip == "No material findings." }
+finding_titles = findings_lines.select { |line| line.match?(FINDING_RE) }
+assert!(has_explicit_no_findings || !finding_titles.empty?, "Findings must contain explicit findings or 'No material findings.'")
+
+unless finding_titles.empty?
+  expected_order = finding_titles.sort_by do |line|
+    match = line.match(FINDING_RE)
+    [match[1].delete("P").to_i, line]
+  end
+  assert!(finding_titles == expected_order, "Findings must be ordered by severity and stable title ordering")
+end
+
+assert!(assessment && !assessment.strip.empty?, "System-Level Assessment must not be empty")
+assert!(action_plan && action_plan.include?("Fix now:"), "Recommended Action Plan must include Fix now")
+assert!(action_plan.include?("Fix before milestone closeout:"), "Recommended Action Plan must include Fix before milestone closeout")
+assert!(action_plan.include?("Defer:"), "Recommended Action Plan must include Defer")
+assert!(follow_ups && !follow_ups.strip.empty?, "Follow-ups / Deferred Work must not be empty")
+assert!(final_assessment && !final_assessment.strip.empty?, "Final Assessment must not be empty")
+
+puts "PASS: repo review contract valid for #{review_path}"

--- a/docs/milestones/v0.87/features/REVIEW_SURFACE_FORMALIZATION.md
+++ b/docs/milestones/v0.87/features/REVIEW_SURFACE_FORMALIZATION.md
@@ -325,4 +325,18 @@ Derive or align the following from this doc:
 - trace review report surfaces
 - issue output-card conventions for embedding or linking findings
 
+## First Implementation Surface
+
+The first bounded `v0.87` implementation surface for this contract is:
+- `docs/tooling/review-surface-format.md`
+- `adl/tools/skills/repo-code-review/references/output-contract.md`
+- `adl/tools/verify_repo_review_contract.rb`
+- `adl/tools/test_repo_review_contract.sh`
+
+This gives `WP-11` one real review surface that is:
+- human-readable
+- deterministic enough to validate locally
+- structurally aligned with the canonical review sections
+ 
+
 Review surface formalization makes ADL review outputs consistent, comparable, and credible enough for real internal and external evaluation.

--- a/docs/tooling/examples/repo-review/bad_repo_review.md
+++ b/docs/tooling/examples/repo-review/bad_repo_review.md
@@ -1,0 +1,12 @@
+## Metadata
+- Review Type: repo_review
+- Reviewer: repo-code-review
+
+## Scope
+- Reviewed: provider code
+
+## Findings
+- vague issue with no priority
+
+## Final Assessment
+looks okay

--- a/docs/tooling/examples/repo-review/good_repo_review.md
+++ b/docs/tooling/examples/repo-review/good_repo_review.md
@@ -1,0 +1,44 @@
+## Metadata
+- Review Type: repo_review
+- Subject: adl/
+- Reviewer: repo-code-review
+- Date: 2026-04-06
+- Input Surfaces:
+  - adl/src/provider.rs
+  - Cargo.toml
+- Output Location: .adl/reviews/20260406-120000-repo-review.md
+
+## Scope
+- Reviewed: provider selection, retry classification, top-level Rust manifests
+- Not Reviewed: external service integrations and non-Rust tooling
+- Review Mode: code
+- Gate: pre-merge
+
+## Findings
+1. [P2] Provider retry policy treats deterministic schema failures as retriable
+Location: adl/src/provider.rs:161
+Impact: wastes retry budget and obscures the real configuration failure mode
+Trigger: malformed or unsupported provider policy response
+Evidence: retry classification path still maps deterministic policy/schema failures into the retryable bucket
+Fix Direction: classify deterministic provider schema/policy failures separately and stop retrying them
+
+2. [P4] Provider tests are concentrated in one large surface
+Location: adl/src/provider.rs
+Impact: slows safe review and makes targeted regression additions harder
+Trigger: adding or auditing provider-edge behavior
+Evidence: provider logic and many edge tests are still coupled in one large review surface
+Fix Direction: split focused provider-edge tests into narrower modules over time
+
+## System-Level Assessment
+The reviewed surface is directionally sound, but failure-classification behavior is still doing too much in one place. The dominant risk is not missing functionality; it is that deterministic provider errors can still look transient and mislead both operators and reviewers.
+
+## Recommended Action Plan
+- Fix now: stop retrying deterministic provider schema/policy failures
+- Fix before milestone closeout: add focused regression coverage for deterministic provider failure classes
+- Defer: split remaining oversized provider review surfaces if they continue to slow safe iteration
+
+## Follow-ups / Deferred Work
+- Consider a later cleanup issue if provider-edge tests continue growing in one file
+
+## Final Assessment
+This reviewed surface is not yet trustworthy enough for merge without the retry-classification fix, but it is bounded and ready for a targeted repair.

--- a/docs/tooling/review-surface-format.md
+++ b/docs/tooling/review-surface-format.md
@@ -1,0 +1,155 @@
+# ADL Review Surface Format
+
+Status: Draft (v0.87)
+Applies to: human-authored and skill-generated review artifacts
+Primary milestone feature: `docs/milestones/v0.87/features/REVIEW_SURFACE_FORMALIZATION.md`
+
+## Purpose
+
+Define the canonical review-surface contract for ADL review artifacts.
+
+This document turns the feature-level review-surface design into an operational format that:
+- humans can read quickly
+- skills can emit consistently
+- validators can check deterministically
+
+This is the shared contract for review artifacts such as:
+- repository code reviews
+- card reviews
+- trace or demo reviews
+- internal and external readiness reviews
+
+## Canonical Major Sections
+
+Every review artifact in the `adl.review_surface.v1` family must contain these sections in this order:
+
+1. `Metadata`
+2. `Scope`
+3. `Findings`
+4. `System-Level Assessment`
+5. `Recommended Action Plan`
+6. `Follow-ups / Deferred Work`
+7. `Final Assessment`
+
+## Metadata
+
+The `Metadata` section must state:
+- review type
+- review subject
+- reviewer identity
+- review date
+- input surfaces
+- output location if persisted
+
+## Scope
+
+The `Scope` section must state:
+- what was reviewed
+- what was not reviewed
+- whether the review is code-focused, docs-focused, trace-focused, or mixed
+- whether the review is pre-merge, post-merge, or release-tail
+
+## Findings
+
+The `Findings` section is mandatory.
+
+If findings exist, each finding must include:
+- priority (`P1` through `P4`; `P5` allowed only when justified)
+- title
+- location
+- impact
+- trigger
+- evidence
+- fix direction
+
+If no material findings exist, the section must say so explicitly.
+
+## System-Level Assessment
+
+This section must summarize:
+- the dominant risk themes
+- what the finding pattern says about subsystem maturity
+- whether the reviewed surface is trustworthy enough for the next gate
+
+## Recommended Action Plan
+
+This section must separate action into bands:
+- fix now
+- fix before milestone closeout
+- defer
+
+## Follow-ups / Deferred Work
+
+This section records:
+- explicit deferrals
+- ownership or follow-up references
+- known non-blocking debt
+
+## Final Assessment
+
+This section must answer:
+- Is the reviewed surface trustworthy?
+- Is it ready for the next gate?
+- What remains before approval?
+
+## Markdown Profile
+
+The default human-readable profile is markdown with the exact section headings above.
+
+For findings-first reviews such as repository code review, use this shape:
+
+```md
+## Metadata
+- Review Type: repo_review
+- Subject: <repo root or target>
+- Reviewer: <human or skill id>
+- Date: <UTC timestamp or calendar date>
+- Input Surfaces:
+  - <path or command>
+- Output Location: <path or none>
+
+## Scope
+- Reviewed: <paths or subsystem summary>
+- Not Reviewed: <explicit exclusions>
+- Review Mode: code | docs | trace | mixed
+- Gate: pre-merge | post-merge | release-tail
+
+## Findings
+1. [P1] Short title
+Location: <path:line or artifact>
+Impact: <behavioral consequence>
+Trigger: <how it appears>
+Evidence: <concrete evidence>
+Fix Direction: <bounded repair direction>
+
+## System-Level Assessment
+<short synthesis paragraph>
+
+## Recommended Action Plan
+- Fix now: <items>
+- Fix before milestone closeout: <items>
+- Defer: <items>
+
+## Follow-ups / Deferred Work
+- <follow-up or explicit none>
+
+## Final Assessment
+<bounded conclusion>
+```
+
+## Determinism Rules
+
+- section order is fixed
+- section headings are fixed
+- findings must be ordered by severity, then stable local ordering
+- if a review contains no material findings, that absence must be explicit
+- no absolute host paths
+- no secrets, raw prompts, or raw tool arguments
+
+## First v0.87 Implementation Surface
+
+The first bounded implementation surface for this contract is:
+- the `repo-code-review` skill output contract
+- plus the repo-local validator and fixture test for repo review markdown artifacts
+
+Later review surfaces may serialize the same contract differently, but must preserve the same major structure and finding semantics.


### PR DESCRIPTION
Closes #1302

## Summary
Formalized the canonical v0.87 review-surface contract into a tracked tooling doc, aligned the repo-code-review skill to that contract, and added a repo-local validator plus fixtures so one real review surface is now deterministic and testable instead of only described in milestone prose.

## Artifacts
- `docs/tooling/review-surface-format.md`
- `docs/tooling/examples/repo-review/good_repo_review.md`
- `docs/tooling/examples/repo-review/bad_repo_review.md`
- `adl/tools/verify_repo_review_contract.rb`
- `adl/tools/test_repo_review_contract.sh`
- `adl/tools/skills/repo-code-review/references/output-contract.md`
- `adl/tools/skills/repo-code-review/references/review-playbook.md`
- `docs/milestones/v0.87/features/REVIEW_SURFACE_FORMALIZATION.md`

## Validation
- `bash adl/tools/test_repo_review_contract.sh`
  - verified the new repo-review contract validator accepts the good fixture and rejects the bad fixture
- `bash adl/tools/test_review_card_surface.sh`
  - verified the pre-existing reviewer-surface helper still emits the expected deterministic fixture
- `bash adl/tools/test_review_output_provenance.sh`
  - verified the pre-existing review-output provenance validator still passes its good fixture and rejects its bad fixture
- `bash adl/tools/test_install_adl_operational_skills.sh`
  - verified the operational skill bundle still installs and the updated repo-code-review skill remains consumable
- Results: all validation commands passed

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1302__v0-87-wp-11-review-surface-formalization/sip.md
- Output card: .adl/v0.87/tasks/issue-1302__v0-87-wp-11-review-surface-formalization/sor.md
- Idempotency-Key: v0-87-wp-11-review-surface-formalization-adl-v0-87-tasks-issue-1302-v0-87-wp-11-review-surface-formalization-sip-md-adl-v0-87-tasks-issue-1302-v0-87-wp-11-review-surface-formalization-sor-md