### PR TITLE
[v0.87][tools] Add symlink install mode for operational skills

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -21,8 +21,11 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 From repo root:
 
 ```bash
-# install or resync the canonical operational skill bundles into $CODEX_HOME/skills
+# install or resync the canonical operational skill bundles into $CODEX_HOME/skills (default: copy mode)
 bash adl/tools/install_adl_operational_skills.sh
+
+# install the same bundles as symlinks so Codex reads the tracked repo copies directly
+ADL_OPERATIONAL_SKILLS_INSTALL_MODE=symlink bash adl/tools/install_adl_operational_skills.sh
 
 # install or resync the legacy adl_pr_cycle compatibility skill from the tracked contract
 bash adl/tools/install_adl_pr_cycle_skill.sh

--- a/adl/tools/install_adl_operational_skills.sh
+++ b/adl/tools/install_adl_operational_skills.sh
@@ -10,11 +10,21 @@ fi
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 source_root="${repo_root}/adl/tools/skills"
 dest_root="${codex_home}/skills"
+install_mode="${ADL_OPERATIONAL_SKILLS_INSTALL_MODE:-copy}"
 
 if [[ ! -d "${source_root}" ]]; then
   echo "install_adl_operational_skills.sh: source skills root missing: ${source_root}" >&2
   exit 1
 fi
+
+case "${install_mode}" in
+  copy|symlink)
+    ;;
+  *)
+    echo "install_adl_operational_skills.sh: unsupported install mode: ${install_mode} (expected copy or symlink)" >&2
+    exit 1
+    ;;
+esac
 
 mkdir -p "${dest_root}"
 
@@ -26,15 +36,30 @@ for source_dir in "${source_root}"/*; do
   dest_dir="${dest_root}/${skill_name}"
 
   rm -rf "${dest_dir}"
-  mkdir -p "${dest_dir}"
-  cp -R "${source_dir}/." "${dest_dir}/"
-  if ! diff -qr "${source_dir}" "${dest_dir}" >/dev/null; then
-    echo "install_adl_operational_skills.sh: install verification failed for ${dest_dir}" >&2
-    exit 1
-  fi
+  case "${install_mode}" in
+    copy)
+      mkdir -p "${dest_dir}"
+      cp -R "${source_dir}/." "${dest_dir}/"
+      if ! diff -qr "${source_dir}" "${dest_dir}" >/dev/null; then
+        echo "install_adl_operational_skills.sh: install verification failed for ${dest_dir}" >&2
+        exit 1
+      fi
+      ;;
+    symlink)
+      ln -s "${source_dir}" "${dest_dir}"
+      if [[ ! -L "${dest_dir}" ]]; then
+        echo "install_adl_operational_skills.sh: expected symlink install for ${dest_dir}" >&2
+        exit 1
+      fi
+      if [[ "$(cd "${dest_dir}" && pwd -P)" != "$(cd "${source_dir}" && pwd -P)" ]]; then
+        echo "install_adl_operational_skills.sh: symlink verification failed for ${dest_dir}" >&2
+        exit 1
+      fi
+      ;;
+  esac
 
   installed_any=1
-  echo "INSTALLED ${dest_dir}"
+  echo "INSTALLED ${dest_dir} (${install_mode})"
 done
 
 if [[ "${installed_any}" -ne 1 ]]; then

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -5,26 +5,43 @@ repo_root="$(git rev-parse --show-toplevel)"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 
-export CODEX_HOME="${tmpdir}/codex-home"
+assert_skill_bundle() {
+  local root="$1"
 
+  for skill in pr-init pr-ready pr-run pr-finish pr-janitor repo-code-review; do
+    [[ -d "${root}/skills/${skill}" ]]
+  done
+
+  [[ -f "${root}/skills/pr-init/SKILL.md" ]]
+  [[ -f "${root}/skills/pr-ready/SKILL.md" ]]
+  [[ -f "${root}/skills/pr-run/SKILL.md" ]]
+  [[ -f "${root}/skills/pr-finish/SKILL.md" ]]
+  [[ -f "${root}/skills/pr-janitor/SKILL.md" ]]
+  [[ -f "${root}/skills/repo-code-review/SKILL.md" ]]
+
+  grep -Fq "qualitative card review" "${root}/skills/pr-init/SKILL.md"
+  grep -Fq "execution_readiness" "${root}/skills/pr-ready/references/output-contract.md"
+  grep -Fq "perform the bounded implementation work" "${root}/skills/pr-run/SKILL.md"
+  grep -Fq "truthful closeout" "${root}/skills/pr-finish/SKILL.md"
+  grep -Fq "failed checks or merge conflicts" "${root}/skills/pr-janitor/SKILL.md"
+  grep -Fq "findings-first" "${root}/skills/repo-code-review/SKILL.md"
+}
+
+export CODEX_HOME="${tmpdir}/codex-home-copy"
 bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null
+assert_skill_bundle "${CODEX_HOME}"
+[[ ! -L "${CODEX_HOME}/skills/pr-init" ]]
 
-for skill in pr-init pr-ready pr-run pr-finish pr-janitor repo-code-review; do
-  [[ -d "${CODEX_HOME}/skills/${skill}" ]]
-done
+export CODEX_HOME="${tmpdir}/codex-home-symlink"
+ADL_OPERATIONAL_SKILLS_INSTALL_MODE=symlink bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null
+assert_skill_bundle "${CODEX_HOME}"
+[[ -L "${CODEX_HOME}/skills/pr-init" ]]
+[[ -L "${CODEX_HOME}/skills/pr-ready" ]]
+[[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]
 
-[[ -f "${CODEX_HOME}/skills/pr-init/SKILL.md" ]]
-[[ -f "${CODEX_HOME}/skills/pr-ready/SKILL.md" ]]
-[[ -f "${CODEX_HOME}/skills/pr-run/SKILL.md" ]]
-[[ -f "${CODEX_HOME}/skills/pr-finish/SKILL.md" ]]
-[[ -f "${CODEX_HOME}/skills/pr-janitor/SKILL.md" ]]
-[[ -f "${CODEX_HOME}/skills/repo-code-review/SKILL.md" ]]
-
-grep -Fq "qualitative card review" "${CODEX_HOME}/skills/pr-init/SKILL.md"
-grep -Fq "execution_readiness" "${CODEX_HOME}/skills/pr-ready/references/output-contract.md"
-grep -Fq "perform the bounded implementation work" "${CODEX_HOME}/skills/pr-run/SKILL.md"
-grep -Fq "truthful closeout" "${CODEX_HOME}/skills/pr-finish/SKILL.md"
-grep -Fq "failed checks or merge conflicts" "${CODEX_HOME}/skills/pr-janitor/SKILL.md"
-grep -Fq "findings-first" "${CODEX_HOME}/skills/repo-code-review/SKILL.md"
+if ADL_OPERATIONAL_SKILLS_INSTALL_MODE=bogus bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null 2>&1; then
+  echo "expected invalid install mode to fail" >&2
+  exit 1
+fi
 
 echo "PASS test_install_adl_operational_skills"


### PR DESCRIPTION
Closes #1351

## Summary
Added an explicit symlink install mode for the tracked operational skill bundles while preserving copy mode as the default. Updated the installer verification path, expanded the installer regression test to cover copy mode, symlink mode, and invalid mode rejection, and documented both usage modes in the tooling README.

## Artifacts
- updated installer: `adl/tools/install_adl_operational_skills.sh`
- updated installer regression: `adl/tools/test_install_adl_operational_skills.sh`
- updated operator documentation: `adl/tools/README.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    - verifies default copy installs, explicit symlink installs, and invalid install-mode rejection
  - `bash adl/tools/test_five_command_regression_suite.sh`
    - verifies the broader authoring and five-command substrate still passes with the installer changes in place
  - `git diff --check`
    - verifies the edited files are patch-clean
- Results:
  - `bash adl/tools/test_install_adl_operational_skills.sh`: PASS
  - `bash adl/tools/test_five_command_regression_suite.sh`: PASS
  - `git diff --check`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1351__v0-87-tools-add-symlink-install-mode-for-operational-skills/sip.md
- Output card: .adl/v0.87/tasks/issue-1351__v0-87-tools-add-symlink-install-mode-for-operational-skills/sor.md
- Idempotency-Key: v0-87-tools-add-symlink-install-mode-for-operational-skills-adl-v0-87-tasks-issue-1351-v0-87-tools-add-symlink-install-mode-for-operational-skills-sip-md-adl-v0-87-tasks-issue-1351-v0-87-tools-add-symlink-install-mode-for-operational-skills-sor-md