### PR TITLE
[v0.87.1][docs] Create milestone directory and normalize template filenames

### DIFF
--- a/docs/milestones/v0.87.1/DECISIONS_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DECISIONS_v0.87.1.md
@@ -1,0 +1,30 @@
+# Decisions - v0.87.1
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Date: `2026-04-06`
+- Owner: `TBD`
+
+## Purpose
+Capture significant decisions (architecture, scope, process) at the time they are made.
+
+## How To Use
+- Add one row per decision.
+- Prefer links to issues/PRs over long prose.
+- Keep status current: `accepted`, `rejected`, `deferred`, `superseded`.
+
+## Decision Log
+| ID | Decision | Status | Rationale | Alternatives | Impact | Link |
+|---|---|---|---|---|---|---|
+| D-01 | Create the tracked `docs/milestones/v0.87.1/` shell before promoting `v0.87.1` feature docs. | accepted | The roadmap now treats runtime completion as its own sub-milestone, so it needs a public tracked surface first. | Delay milestone-shell creation until feature promotion time. | Enables consistent tracked docs and later feature promotion. | #1354 |
+| D-02 | Keep `v0.87.1` feature-doc promotion out of scope for the milestone-shell seed pass. | accepted | This issue is about structure and naming, not public promotion of internal planning docs. | Promote the runtime docs immediately. | Keeps the issue bounded and reduces accidental public overcommitment. | #1354 |
+
+## Open Questions
+- {{open_question_1}} (Owner: {{owner_oq1}}) (Issue: {{issue_oq1}})
+- {{open_question_2}} (Owner: {{owner_oq2}}) (Issue: {{issue_oq2}})
+
+## Exit Criteria
+- All milestone-critical decisions are logged with a rationale.
+- Deferred/rejected/superseded options are explicitly recorded.
+- Open questions have owners and tracking links.

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -1,0 +1,259 @@
+# Demo Matrix - v0.87.1
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Date: `2026-04-06`
+- Owner: `TBD`
+- Related issues / work packages: #1354
+
+## Purpose
+Define the canonical milestone demo program: which bounded demos exist, which milestone claims they prove, how to run them, and what artifacts or proof surfaces reviewers should inspect.
+
+## Status
+
+No milestone demos are defined yet. This seeded shell exists so later runtime-completion work can add bounded demo rows without inventing a new milestone structure.
+
+## How To Use
+- Use this document for runnable milestone evidence, not for broad feature brainstorming.
+- Keep demo rows and per-demo sections aligned so a reviewer can move from summary -> execution -> proof surface without reconstructing context by hand.
+- Prefer bounded, replayable, copy/paste-friendly commands over aspirational demo descriptions.
+- If a milestone claim cannot yet be shown through a runnable demo, say so explicitly and record the substitute proof surface.
+- Keep names stable across milestones where practical so comparisons remain easy.
+- If a section is not relevant, include a one-line rationale instead of deleting it.
+
+## Scope
+
+In scope for `{{milestone}}`:
+- {{in_scope_demo_area_1}}
+- {{in_scope_demo_area_2}}
+- {{in_scope_demo_area_3}}
+
+Out of scope for `{{milestone}}`:
+- {{out_of_scope_demo_area_1}}
+- {{out_of_scope_demo_area_2}}
+
+## Runtime Preconditions
+
+Working directory:
+
+```bash
+{{working_directory_command}}
+```
+
+Deterministic runtime / provider assumptions:
+
+```bash
+{{runtime_preconditions}}
+```
+
+Additional environment / fixture requirements:
+- {{env_requirement_1}}
+- {{env_requirement_2}}
+
+## Related Docs
+- Design contract: `{{design_doc}}`
+- WBS / milestone mapping: `{{wbs_doc}}`
+- Sprint / execution plan: `{{sprint_doc}}`
+- Release / checklist context: `{{release_or_checklist_doc}}`
+- Other proof-surface docs: {{other_related_docs}}
+
+## Demo Coverage Summary
+
+Use this table as the fast review surface for milestone coverage.
+
+| Demo ID | Demo title | Milestone claim / WP proved | Command entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
+|---|---|---|---|---|---|---|---|
+| D1 | {{demo_title_1}} | {{claim_or_wp_1}} | `{{command_stub_1}}` | `{{proof_surface_1}}` | {{success_signal_1}} | {{determinism_note_1}} | {{status_1}} |
+| D2 | {{demo_title_2}} | {{claim_or_wp_2}} | `{{command_stub_2}}` | `{{proof_surface_2}}` | {{success_signal_2}} | {{determinism_note_2}} | {{status_2}} |
+| D3 | {{demo_title_3}} | {{claim_or_wp_3}} | `{{command_stub_3}}` | `{{proof_surface_3}}` | {{success_signal_3}} | {{determinism_note_3}} | {{status_3}} |
+
+Status guidance:
+- `PLANNED` = intended but not yet validated
+- `READY` = runnable and locally validated
+- `BLOCKED` = known dependency or missing proof surface
+- `LANDED` = milestone evidence exists and is ready for review
+
+## Coverage Rules
+- Every major milestone claim should map to a runnable demo or an explicit alternate proof surface.
+- Every demo should name one primary proof surface that a reviewer can inspect directly.
+- Commands should be copy/paste-ready and should not require private local state.
+- Success signals should say what to check, not just “command exits 0”.
+- Determinism / replay notes should explain how stability is judged.
+
+## Demo Details
+
+Repeat one block per demo in the coverage summary.
+
+### {{demo_id_1}}) {{demo_title_1}}
+
+Description:
+- {{demo_description_1}}
+- {{demo_description_1b}}
+
+Milestone claims / work packages covered:
+- {{claim_detail_1a}}
+- {{claim_detail_1b}}
+
+Commands to run:
+
+```bash
+{{demo_commands_1}}
+```
+
+Expected artifacts:
+- `{{artifact_1a}}`
+- `{{artifact_1b}}`
+- `{{artifact_1c}}`
+
+Primary proof surface:
+- `{{primary_proof_surface_1}}`
+
+Secondary proof surfaces:
+- `{{secondary_proof_surface_1a}}`
+- `{{secondary_proof_surface_1b}}`
+
+Expected success signals:
+- {{success_detail_1a}}
+- {{success_detail_1b}}
+
+Determinism / replay notes:
+- {{determinism_detail_1a}}
+- {{determinism_detail_1b}}
+
+Reviewer checks:
+- {{reviewer_check_1a}}
+- {{reviewer_check_1b}}
+
+Known limits / caveats:
+- {{caveat_1}}
+
+---
+
+### {{demo_id_2}}) {{demo_title_2}}
+
+Description:
+- {{demo_description_2}}
+
+Milestone claims / work packages covered:
+- {{claim_detail_2a}}
+
+Commands to run:
+
+```bash
+{{demo_commands_2}}
+```
+
+Expected artifacts:
+- `{{artifact_2a}}`
+- `{{artifact_2b}}`
+
+Primary proof surface:
+- `{{primary_proof_surface_2}}`
+
+Expected success signals:
+- {{success_detail_2a}}
+
+Determinism / replay notes:
+- {{determinism_detail_2a}}
+
+Reviewer checks:
+- {{reviewer_check_2a}}
+
+Known limits / caveats:
+- {{caveat_2}}
+
+---
+
+### {{demo_id_3}}) {{demo_title_3}}
+
+Description:
+- {{demo_description_3}}
+
+Milestone claims / work packages covered:
+- {{claim_detail_3a}}
+
+Commands to run:
+
+```bash
+{{demo_commands_3}}
+```
+
+Expected artifacts:
+- `{{artifact_3a}}`
+
+Primary proof surface:
+- `{{primary_proof_surface_3}}`
+
+Expected success signals:
+- {{success_detail_3a}}
+
+Determinism / replay notes:
+- {{determinism_detail_3a}}
+
+Reviewer checks:
+- {{reviewer_check_3a}}
+
+Known limits / caveats:
+- {{caveat_3}}
+
+## Cross-Demo Validation
+
+Required baseline validation:
+
+```bash
+{{baseline_validation_commands}}
+```
+
+Cross-demo checks:
+- {{cross_demo_check_1}}
+- {{cross_demo_check_2}}
+- {{cross_demo_check_3}}
+
+Failure policy:
+- If one demo is blocked, record the blocker and say whether milestone review can proceed with an alternate proof surface.
+- If deterministic behavior is expected but not observed, record the exact unstable artifact or command output.
+
+## Determinism Evidence
+
+Evidence directory / run root:
+- `{{evidence_root}}`
+
+Repeatability approach:
+- {{repeatability_rule_1}}
+- {{repeatability_rule_2}}
+
+Normalization rules:
+- {{normalization_rule_1}}
+- {{normalization_rule_2}}
+
+Observed results summary:
+- {{determinism_result_1}}
+- {{determinism_result_2}}
+- {{determinism_result_3}}
+
+## Reviewer Sign-Off Surface
+
+For each demo, the reviewer should be able to answer:
+- What milestone claim does this demo prove?
+- Which command should be run first?
+- Which artifact or trace is the primary proof surface?
+- What deterministic or replay guarantee is being claimed?
+- What caveats or substitutions apply?
+
+Review owners:
+- {{review_owner_1}}
+- {{review_owner_2}}
+
+Review status:
+- {{review_status_note}}
+
+## Notes
+- {{note_1}}
+- {{note_2}}
+
+## Exit Criteria
+- The milestone’s major claims are mapped to bounded demos or explicit alternate proof surfaces.
+- Each demo has runnable commands, expected artifacts, and a clear success signal.
+- Determinism / replay expectations are explicit where required.
+- A reviewer can inspect the matrix and locate the primary proof surface for each demo without extra reconstruction work.

--- a/docs/milestones/v0.87.1/DESIGN_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DESIGN_v0.87.1.md
@@ -1,0 +1,74 @@
+# Design - v0.87.1
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Date: `2026-04-06`
+- Owner: `TBD`
+- Related issues: #1354
+
+## Purpose
+Define what we are building, why, and how we validate it — concisely, with links to issues/PRs.
+
+## Problem Statement
+`v0.87.1` did not yet have a tracked public milestone directory even though the roadmap now treats runtime completion as its own sub-milestone. The repo needs a canonical milestone shell before feature docs can be promoted into it.
+
+## Goals
+- create a coherent tracked milestone shell for `v0.87.1`
+- normalize the standard milestone filenames for the new sub-milestone
+
+## Non-Goals
+- promoting runtime feature docs into `docs/milestones/v0.87.1/features`
+- claiming implementation progress that has not happened yet
+
+## Scope
+### In scope
+- {{in_scope_1}}
+- {{in_scope_2}}
+
+### Out of scope
+- {{out_of_scope_1}}
+- {{out_of_scope_2}}
+
+## Requirements
+### Functional
+- {{functional_requirement_1}}
+- {{functional_requirement_2}}
+
+### Non-functional
+- Deterministic behavior and reproducible outputs.
+- Clear failure semantics and observability.
+- stable tracked milestone naming and navigation
+
+## Proposed Design
+### Overview
+{{architecture_summary}}
+
+### Interfaces / Data contracts
+- {{interface_or_contract_1}}
+- {{interface_or_contract_2}}
+
+### Execution semantics
+{{execution_semantics}}
+
+## Risks and Mitigations
+- Risk: {{risk_1}}
+  - Mitigation: {{mitigation_1}}
+- Risk: {{risk_2}}
+  - Mitigation: {{mitigation_2}}
+
+## Alternatives Considered
+- Option: {{alternative_1}}
+  - Tradeoff: {{tradeoff_1}}
+- Option: {{alternative_2}}
+  - Tradeoff: {{tradeoff_2}}
+
+## Validation Plan
+- Checks/tests: {{validation_checks}}
+- Success metrics: {{success_metrics}}
+- Rollback/fallback: {{rollback_plan}}
+
+## Exit Criteria
+- Goals/non-goals and scope boundaries are explicit.
+- Validation plan is actionable and referenced by the milestone checklist.
+- Major open questions are resolved or tracked in the decision log.

--- a/docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md
+++ b/docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md
@@ -1,0 +1,50 @@
+# Milestone Checklist - v0.87.1
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Target release date: `TBD`
+- Owner: `TBD`
+
+## Purpose
+Ship/no-ship gate for the milestone. Check items only when evidence exists.
+
+## Planning
+- [ ] Milestone goal defined (`{{goal_doc_link}}`)
+- [ ] Scope + non-goals documented (`{{scope_doc_link}}`)
+- [ ] WBS created and mapped to issues (`{{wbs_link}}`)
+- [ ] Decision log initialized (`{{decisions_link}}`)
+- [ ] Sprint plan created (`{{sprint_plan_link}}`)
+
+## Execution Discipline
+- [ ] Each issue has input/output cards under `.adl/cards/<issue>/`
+- [ ] Each burst writes artifacts under `.adl/reports/burst/<timestamp>/`
+- [ ] Draft PR opened for each issue before merge
+- [ ] Transient failures retried and documented
+- [ ] "Green-only merge" policy followed
+
+## Quality Gates
+- [ ] `cargo fmt` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo test` passes
+- [ ] CI is green on the merge target
+- [ ] Coverage signal is not red (or exception documented) (`{{coverage_link_or_note}}`)
+- [ ] No unresolved high-priority blockers (`{{blocker_report_link}}`)
+
+## Release Packaging
+- [ ] Release notes finalized (`{{release_notes_link}}`)
+- [ ] Tag verified: `{{tag_name}}`
+- [ ] GitHub Release drafted (`{{release_draft_link}}`)
+- [ ] Links validated in release body
+- [ ] Release published
+
+## Post-Release
+- [ ] Milestone/epic issues closed with release links
+- [ ] Deferred items moved to next milestone backlog
+- [ ] Follow-up bugs/tech debt captured as issues
+- [ ] Roadmap/status docs updated (`{{roadmap_update_link}}`)
+- [ ] Retrospective summary recorded (`{{retro_link}}`)
+
+## Exit Criteria
+- All required gates are checked, or each exception has an owner + due date.
+- Milestone can be audited end-to-end via the links captured above.

--- a/docs/milestones/v0.87.1/README.md
+++ b/docs/milestones/v0.87.1/README.md
@@ -1,0 +1,130 @@
+# v0.87.1 Milestone README
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Date: `2026-04-06`
+- Owner: `TBD`
+
+## Purpose
+Provide a single entry point for the milestone: what it is, why it matters, what is included, and how to navigate the canonical documents and artifacts.
+
+## How To Use
+- Start here before reading individual milestone documents.
+- Use this README to locate the canonical design, execution, and validation surfaces.
+- Keep this document concise and navigational; detailed content belongs in the linked docs.
+- Keep links up to date as files move or are renamed.
+
+## Overview
+
+`v0.87.1` is the runtime-completion sub-milestone that follows the seeded `v0.87` substrate and prepares the system for the later chronosense and bounded-agency work in `v0.88+`.
+
+This milestone focuses on:
+- making the runtime environment a first-class milestone surface
+- clarifying lifecycle, execution-boundary, and local-resilience scope
+- establishing a public tracked shell for runtime-completion work
+
+Key outcomes:
+- a tracked `docs/milestones/v0.87.1/` milestone shell
+- normalized canonical milestone filenames for the sub-milestone
+- a stable public surface for later promotion of `v0.87.1` feature docs
+
+## Scope Summary
+
+### In scope
+- milestone-shell creation and naming normalization
+- public tracked milestone docs for `v0.87.1`
+- documenting intended runtime-completion scope at a milestone level
+
+### Out of scope
+- feature-doc promotion into `docs/milestones/v0.87.1/features`
+- implementation claims beyond the seeded milestone shell
+
+## Document Map
+
+Canonical milestone documents:
+
+- Vision: `VISION_v0.87.1.md`
+- Design: `DESIGN_v0.87.1.md`
+- Work Breakdown Structure (WBS): `WBS_v0.87.1.md`
+- Sprint plan: `SPRINT_v0.87.1.md`
+- Decisions log: `DECISIONS_v0.87.1.md`
+- Demo matrix: `DEMO_MATRIX_v0.87.1.md`
+- Milestone checklist: `MILESTONE_CHECKLIST_v0.87.1.md`
+- Release plan / process: `RELEASE_PLAN_v0.87.1.md`
+- Release notes: `RELEASE_NOTES_v0.87.1.md`
+
+Supporting / domain-specific docs:
+- runtime planning docs remain under `.adl/docs/v0.87.1planning/`
+- feature-doc promotion is intentionally deferred until the milestone opens
+- roadmap placement context remains in `.adl/docs/TBD/FEATURE_SPRINT_MAP.md`
+
+## Execution Model
+
+This milestone is executed as a sequence of work packages (WPs):
+
+- WP-01: Design pass (docs + planning)
+- WP-02 - WP-12: Feature and system work
+- WP-13: Demo matrix and integration demos
+- WP-14: Coverage / quality gate
+- WP-15: Docs and review convergence
+- WP-16: Release ceremony
+
+Execution expectations:
+- Each WP is tracked by an issue and implemented via PRs.
+- Each issue produces structured artifacts (input/output cards, reports).
+- All work merges under green CI and passes quality gates.
+
+## Demo and Validation Surface
+
+Primary validation is defined in:
+- Demo matrix: `{{demo_matrix_doc}}`
+
+Additional validation surfaces:
+- Test suite results
+- Generated artifacts under `.adl/runs/`
+- Trace and replay outputs
+
+Success criteria:
+- {{success_criteria_1}}
+- {{success_criteria_2}}
+- {{success_criteria_3}}
+
+## Determinism and Reproducibility
+
+The milestone should demonstrate:
+- Deterministic or bounded-repeatable execution where required
+- Replayable traces and inspectable artifacts
+- Stable command entry points for demos
+
+Evidence locations:
+- {{determinism_evidence_path_1}}
+- {{determinism_evidence_path_2}}
+
+## Risks and Open Questions
+
+Known risks:
+- {{risk_1}}
+- {{risk_2}}
+
+Open questions:
+- {{open_question_1}}
+- {{open_question_2}}
+
+## Status
+
+Current status: seeded shell
+
+- Planning: active
+- Execution: not started
+- Validation: path/layout verified
+- Release readiness: not started
+
+## Exit Criteria
+
+- All canonical milestone documents are complete and internally consistent.
+- All WBS items are implemented or explicitly deferred.
+- Demo matrix is runnable and validated.
+- Quality gates (fmt, clippy, test, CI) are passing.
+- Milestone checklist is complete or exceptions are documented.
+- Release artifacts (notes, tag, docs) are ready.

--- a/docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md
+++ b/docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md
@@ -1,0 +1,57 @@
+# Release Notes - v0.87.1
+
+## Metadata
+- Product: `ADL`
+- Version: `v0.87.1`
+- Release date: `TBD`
+- Tag: `TBD`
+
+## How To Use
+- Keep statements implementation-accurate and test-validated.
+- Prefer concise bullets over marketing language.
+- Explicitly separate shipped behavior from "What's Next."
+
+# `ADL` `v0.87.1` Release Notes
+
+## Summary
+{{summary_paragraph}}
+
+## Highlights
+- {{highlight_1}}
+- {{highlight_2}}
+- {{highlight_3}}
+
+## What's New In Detail
+
+### {{area_1}}
+- {{detail_1a}}
+- {{detail_1b}}
+
+### {{area_2}}
+- {{detail_2a}}
+- {{detail_2b}}
+
+### {{area_3}}
+- {{detail_3a}}
+- {{detail_3b}}
+
+## Upgrade Notes
+- {{upgrade_note_1}}
+- {{upgrade_note_2}}
+
+## Known Limitations
+- {{limitation_1}}
+- {{limitation_2}}
+
+## Validation Notes
+- {{validation_note_1}}
+- {{validation_note_2}}
+
+## What's Next
+- {{next_1}}
+- {{next_2}}
+
+## Exit Criteria
+- Notes reflect only shipped behavior.
+- Known limitations and future work are explicitly separated.
+- Final text is ready to paste into GitHub Release UI without further editing.

--- a/docs/milestones/v0.87.1/RELEASE_PLAN_v0.87.1.md
+++ b/docs/milestones/v0.87.1/RELEASE_PLAN_v0.87.1.md
@@ -1,0 +1,46 @@
+# Release Plan - v0.87.1
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Release date: `TBD`
+- Release manager: `TBD`
+
+## How To Use
+- Execute sections in order and capture links for each completed step.
+- Keep this doc focused on shipping mechanics; use release notes for narrative.
+- Mark blockers immediately; do not publish until gates pass.
+
+## 1) Release Readiness
+- [ ] Milestone checklist complete (`{{milestone_checklist_link}}`)
+- [ ] Release notes approved (`{{release_notes_link}}`)
+- [ ] Go/no-go decision recorded (`{{decision_link}}`)
+
+## 2) Branch And Tag Preparation
+- [ ] Target branch confirmed (`{{target_branch}}`)
+- [ ] Working tree clean
+- [ ] Version string(s) validated (`{{version_validation_link}}`)
+- [ ] Tag created: `{{tag_name}}`
+- [ ] Tag pushed and verified
+
+## 3) GitHub Release Steps
+- [ ] GitHub Release draft created from `{{tag_name}}` (`{{release_draft_link}}`)
+- [ ] Release body populated from approved notes
+- [ ] Links to key PRs/issues included
+- [ ] Release visibility confirmed (draft/prerelease/final)
+- [ ] Release published
+
+## 4) Verification
+- [ ] Post-release CI status checked (`{{ci_run_link}}`)
+- [ ] Release links tested (docs, artifacts, notes)
+- [ ] Immediate regressions triaged and tracked (`{{triage_link}}`)
+
+## 5) Communication
+- [ ] Community announcement published (`{{announcement_link}}`)
+- [ ] Internal update posted (`{{internal_update_link}}`)
+- [ ] Roadmap/status updated (`{{roadmap_update_link}}`)
+
+## Exit Criteria
+- Tag and GitHub Release are published and accessible.
+- Verification completed with no unknown critical failures.
+- Communication links captured.

--- a/docs/milestones/v0.87.1/SPRINT_v0.87.1.md
+++ b/docs/milestones/v0.87.1/SPRINT_v0.87.1.md
@@ -1,0 +1,49 @@
+# Sprint Plan - v0.87.1
+
+## Metadata
+- Sprint: `Pending sprint plan`
+- Milestone: `v0.87.1`
+- Start date: `TBD`
+- End date: `TBD`
+- Owner: `TBD`
+
+## How To Use
+- Keep scope small enough to finish with green CI and merged PRs.
+- List work items in planned execution order.
+- Track blockers here (not scattered chat notes).
+
+## Sprint Goal
+Seed the tracked `v0.87.1` milestone shell and prepare it for later runtime-completion work.
+
+## Planned Scope
+- establish canonical milestone docs for `v0.87.1`
+- keep feature-doc promotion out of scope for this seed pass
+- populate sprint content when `v0.87.1` formally opens
+
+## Work Plan
+| Order | Item | Issue | Owner | Status |
+|---|---|---|---|---|
+| 1 | {{work_item_1}} | {{issue_1}} | {{owner_1}} | {{status_1}} |
+| 2 | {{work_item_2}} | {{issue_2}} | {{owner_2}} | {{status_2}} |
+| 3 | {{work_item_3}} | {{issue_3}} | {{owner_3}} | {{status_3}} |
+
+## Cadence Expectations
+- Use issue cards (`input`/`output`) for each item.
+- Keep changes scoped per issue; use draft PRs until checks pass.
+- Run required quality gates (fmt/clippy/test) for code changes.
+
+## Risks / Dependencies
+- Dependency: {{dependency_1}}
+  - Risk: {{risk_1}}
+  - Mitigation: {{mitigation_1}}
+
+## Demo / Review Plan
+- Demo artifact: {{demo_artifact}}
+- Review date: {{review_date}}
+- Sign-off owners: {{signoff_owners}}
+
+## Exit Criteria
+- All planned scope items completed or explicitly deferred with rationale.
+- Linked issues/PRs updated and traceable.
+- CI is green for merged work.
+- Sprint summary captured in milestone docs.

--- a/docs/milestones/v0.87.1/VISION_v0.87.1.md
+++ b/docs/milestones/v0.87.1/VISION_v0.87.1.md
@@ -1,0 +1,246 @@
+# Vision - v0.87.1
+
+## Metadata
+- Project: `ADL`
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Date: `2026-04-06`
+- Owner: `TBD`
+- Related issues: #1354
+
+## Purpose
+Define the milestone-level vision for the project: what changes at this stage, why it matters, and which strategic pillars it advances.
+
+## Status
+
+This document is intentionally seeded as a milestone shell. It records the intended direction of `v0.87.1` without pretending the detailed runtime plan has already been promoted or implemented.
+
+## How To Use
+- Write this as a milestone vision, not a full design spec.
+- Focus on direction, priorities, and intended outcomes rather than implementation details.
+- Keep the structure stable across milestones so changes in emphasis are easy to compare over time.
+- Prefer concrete milestone framing over vague aspiration.
+- Keep section titles stable unless there is a strong reason to change them.
+- If a section is not relevant, state that briefly rather than deleting the section.
+
+## Overview
+
+Version `v0.87.1` is the milestone where `ADL` evolves from a seeded execution substrate into a first-class runtime-completion surface.
+
+This release should establish or strengthen the foundation for:
+
+- runtime-environment execution as a first-class system concern
+- lifecycle and execution-boundary clarity
+- durable local-runtime resilience as a public milestone goal
+
+`v0.87.1` focuses on **runtime completion**.
+
+The goal is to make the project more useful to:
+
+- developers extending the runtime substrate
+- operators and reviewers who need a public milestone surface
+- future milestone owners building on a stable runtime base
+
+This milestone should strengthen the architectural or strategic pillars of:
+
+- {{pillar_1}}
+- {{pillar_2}}
+- {{pillar_3}}
+- {{pillar_4}}
+
+{{overview_close}}
+
+---
+
+# Core Goals
+
+`{{version}}` advances `{{project_name}}` in five major areas:
+
+1. {{goal_area_1}}
+2. {{goal_area_2}}
+3. {{goal_area_3}}
+4. {{goal_area_4}}
+5. {{goal_area_5}}
+
+---
+
+# 1. {{goal_area_1}}
+
+`{{version}}` improves `{{goal_area_1}}` so the project can `{{outcome_1}}`.
+
+Key objectives:
+
+- {{objective_1a}}
+- {{objective_1b}}
+- {{objective_1c}}
+- {{objective_1d}}
+
+These capabilities move the project toward **{{strategic_effect_1}}**.
+
+The system or product should guarantee:
+
+- {{guarantee_1a}}
+- {{guarantee_1b}}
+- {{guarantee_1c}}
+
+---
+
+# 2. {{goal_area_2}}
+
+`{{goal_area_2}}` must improve without sacrificing `{{constraint_2}}`.
+
+`{{version}}` introduces or improves:
+
+- {{improvement_2a}}
+- {{improvement_2b}}
+- {{improvement_2c}}
+- {{improvement_2d}}
+
+The goal is to move from `{{before_state_2}}` toward **{{after_state_2}}**.
+
+These changes should help users:
+
+- {{user_benefit_2a}}
+- {{user_benefit_2b}}
+
+---
+
+# 3. {{goal_area_3}}
+
+A central principle of `{{project_name}}` is **{{principle_3}}**.
+
+The project must not merely `{{anti_goal_3}}`. It must `{{desired_behavior_3}}`.
+
+`{{version}}` strengthens this pillar with:
+
+- {{capability_3a}}
+- {{capability_3b}}
+- {{capability_3c}}
+- {{capability_3d}}
+
+This work supports the broader principle of **{{broader_principle_3}}**.
+
+The result should make the project more:
+
+- {{quality_3a}}
+- {{quality_3b}}
+- {{quality_3c}}
+
+---
+
+# 4. {{goal_area_4}}
+
+`{{version}}` continues development of `{{goal_area_4}}`.
+
+The focus remains on **{{focus_4}}**, not `{{non_goal_4}}`.
+
+Key capabilities:
+
+- {{capability_4a}}
+- {{capability_4b}}
+- {{capability_4c}}
+- {{capability_4d}}
+
+This milestone should help the project better represent or support:
+
+- {{support_4a}}
+- {{support_4b}}
+- {{support_4c}}
+
+These improvements should guide the system toward `{{desired_state_4}}`.
+
+---
+
+# 5. {{goal_area_5}}
+
+To support real-world use, `{{version}}` must improve `{{goal_area_5}}`.
+
+Important targets include:
+
+- {{target_5a}}
+- {{target_5b}}
+- {{target_5c}}
+- {{target_5d}}
+
+This work should strengthen the development and operating workflow by improving:
+
+- {{workflow_benefit_5a}}
+- {{workflow_benefit_5b}}
+- {{workflow_benefit_5c}}
+
+{{close_5}}
+
+---
+
+# Special Focus: `{{special_focus_title}}`
+
+`{{special_focus_title}}` becomes a central focus of `{{version}}`.
+
+Previous releases `{{previous_special_focus_state}}`.
+
+`{{version}}` advances this area with:
+
+- {{special_focus_1}}
+- {{special_focus_2}}
+- {{special_focus_3}}
+- {{special_focus_4}}
+
+This area is responsible for ensuring that `{{special_focus_scope}}` remain:
+
+- {{special_quality_1}}
+- {{special_quality_2}}
+- {{special_quality_3}}
+
+This keeps the project aligned with `{{alignment_principle}}`.
+
+---
+
+# Milestone Context
+
+`{{previous_milestone}}` represents `{{previous_milestone_significance}}`.
+
+From `{{next_phase_start}}` onward the project will likely shift toward:
+
+- {{next_phase_item_1}}
+- {{next_phase_item_2}}
+- {{next_phase_item_3}}
+
+The goal is to have `{{future_goal}}` by **{{future_target_milestone}}**.
+
+`{{version}}` therefore focuses on `{{contextual_focus}}` before that stage.
+
+---
+
+# Long-Term Direction
+
+`{{project_name}}` is being designed as `{{long_term_identity}}`.
+
+Its long-term goals include:
+
+- {{long_term_goal_1}}
+- {{long_term_goal_2}}
+- {{long_term_goal_3}}
+- {{long_term_goal_4}}
+
+These principles aim to move the project beyond `{{old_mode}}` toward `{{new_mode}}`.
+
+---
+
+# Summary
+
+`{{version}}` is the milestone where `{{project_name}}` becomes:
+
+- {{summary_quality_1}}
+- {{summary_quality_2}}
+- {{summary_quality_3}}
+- {{summary_quality_4}}
+
+It strengthens `{{summary_strength_1}}`, advances `{{summary_strength_2}}`, improves `{{summary_strength_3}}`, and stabilizes `{{summary_strength_4}}`.
+
+These improvements prepare the project for `{{next_stage}}`.
+
+## Exit Criteria
+- The milestone's strategic priorities are explicit and internally consistent.
+- The five core goal areas and special focus section are filled with milestone-specific content.
+- The vision can be read without requiring implementation details from the design document.
+- The long-term direction clearly connects this milestone to the next phase of the roadmap.

--- a/docs/milestones/v0.87.1/WBS_v0.87.1.md
+++ b/docs/milestones/v0.87.1/WBS_v0.87.1.md
@@ -1,0 +1,65 @@
+# Work Breakdown Structure (WBS) - v0.87.1
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Date: `2026-04-06`
+- Owner: `TBD`
+
+## How To Use
+- Break work into independently-mergeable issues.
+- Keep each item measurable and testable.
+- Include deliverables + dependencies + issue links.
+- `WP-01` is **always** the milestone **design pass** (canonical docs + WBS + decisions + sprint plan + checklist).
+- Reserve the final WPs for the release tail in this order: `WP-13` demos, `WP-14` quality/coverage gate, `WP-15` docs/review convergence, `WP-16` release ceremony.
+
+## WBS Summary
+Initial milestone shell only. Work packages will be populated as `v0.87.1` opens and runtime-completion work is promoted from planning into the tracked milestone surface.
+
+## Work Packages
+| ID | Work Package | Description | Deliverable | Dependencies | Issue |
+|---|---|---|---|---|---|
+| WP-01 | Design pass (milestone docs + planning) | {{description_01}} | {{deliverable_01}} | {{deps_01}} | {{issue_01}} |
+| WP-02 | {{package_02}} | {{description_02}} | {{deliverable_02}} | {{deps_02}} | {{issue_02}} |
+| WP-03 | {{package_03}} | {{description_03}} | {{deliverable_03}} | {{deps_03}} | {{issue_03}} |
+| WP-04 | {{package_04}} | {{description_04}} | {{deliverable_04}} | {{deps_04}} | {{issue_04}} |
+| WP-05 | {{package_05}} | {{description_05}} | {{deliverable_05}} | {{deps_05}} | {{issue_05}} |
+| WP-06 | {{package_06}} | {{description_06}} | {{deliverable_06}} | {{deps_06}} | {{issue_06}} |
+| WP-07 | {{package_07}} | {{description_07}} | {{deliverable_07}} | {{deps_07}} | {{issue_07}} |
+| WP-08 | {{package_08}} | {{description_08}} | {{deliverable_08}} | {{deps_08}} | {{issue_08}} |
+| WP-09 | {{package_09}} | {{description_09}} | {{deliverable_09}} | {{deps_09}} | {{issue_09}} |
+| WP-10 | {{package_10}} | {{description_10}} | {{deliverable_10}} | {{deps_10}} | {{issue_10}} |
+| WP-11 | {{package_11}} | {{description_11}} | {{deliverable_11}} | {{deps_11}} | {{issue_11}} |
+| WP-12 | {{package_12}} | {{description_12}} | {{deliverable_12}} | {{deps_12}} | {{issue_12}} |
+| WP-13 | Demo matrix + integration demos | {{description_13}} | {{deliverable_13}} | {{deps_13}} | {{issue_13}} |
+| WP-14 | Coverage / quality gate (ratchet + exclusions) | {{description_14}} | {{deliverable_14}} | {{deps_14}} | {{issue_14}} |
+| WP-15 | Docs + review pass (repo-wide alignment) | {{description_15}} | {{deliverable_15}} | {{deps_15}} | {{issue_15}} |
+| WP-16 | Release ceremony (final validation + tag + notes + cleanup) | {{description_16}} | {{deliverable_16}} | {{deps_16}} | {{issue_16}} |
+
+## Sequencing
+- Phase 1: {{phase_1}}
+- Phase 2: {{phase_2}}
+- Phase 3: {{phase_3}}
+
+## Acceptance Mapping
+- WP-01 (Design pass) -> {{acceptance_criteria_01}}
+- WP-02 -> {{acceptance_criteria_02}}
+- WP-03 -> {{acceptance_criteria_03}}
+- WP-04 -> {{acceptance_criteria_04}}
+- WP-05 -> {{acceptance_criteria_05}}
+- WP-06 -> {{acceptance_criteria_06}}
+- WP-07 -> {{acceptance_criteria_07}}
+- WP-08 -> {{acceptance_criteria_08}}
+- WP-09 -> {{acceptance_criteria_09}}
+- WP-10 -> {{acceptance_criteria_10}}
+- WP-11 -> {{acceptance_criteria_11}}
+- WP-12 -> {{acceptance_criteria_12}}
+- WP-13 (Demos) -> {{acceptance_criteria_13}}
+- WP-14 (Quality gate) -> {{acceptance_criteria_14}}
+- WP-15 (Docs/review) -> {{acceptance_criteria_15}}
+- WP-16 (Release ceremony) -> {{acceptance_criteria_16}}
+
+## Exit Criteria
+- Every in-scope requirement maps to at least one WBS item.
+- Every WBS item has an owner, issue reference, and concrete deliverable.
+- Dependency order is explicit enough to execute deterministically.


### PR DESCRIPTION
## Summary
- create the tracked `docs/milestones/v0.87.1/` milestone shell
- seed the standard milestone doc set with normalized `v0.87.1` filenames
- tighten the copied templates so the new sub-milestone is navigable without promoting feature docs yet

## Validation
- `find docs/milestones/v0.87.1 -maxdepth 1 -type f | sed 's#.*/##' | sort`
- focused expected-vs-actual filename set check for the `v0.87.1` milestone file set

## Notes
- `adl/tools/pr.sh run 1354 --version v0.87.1` partially succeeded: it created the branch/worktree, then failed while materializing the full execution bundle with `ERROR: Version must match v0.85-style version format`
- that tooling defect is tracked separately in #1355
