### PR TITLE
[v0.87][tools] Make doctor lifecycle-aware before run phase

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -58,14 +58,15 @@ struct DoctorPreflightResult {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DoctorReadyResult {
-    worktree: String,
+    lifecycle_state: &'static str,
+    worktree: Option<String>,
     source: String,
     root_stp: String,
     root_input: String,
     root_output: String,
-    wt_stp: String,
-    wt_input: String,
-    wt_output: String,
+    wt_stp: Option<String>,
+    wt_input: Option<String>,
+    wt_output: Option<String>,
     status: &'static str,
 }
 
@@ -80,6 +81,7 @@ struct DoctorJsonOutput {
     preflight_status: &'static str,
     open_pr_count: usize,
     open_prs: Vec<DoctorPreflightJsonPullRequest>,
+    lifecycle_state: Option<&'static str>,
     ready_status: Option<&'static str>,
     worktree: Option<String>,
     source: Option<String>,
@@ -596,15 +598,16 @@ fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
             preflight_status: preflight.status,
             open_pr_count: preflight.open_pr_count,
             open_prs: preflight.open_prs,
+            lifecycle_state: ready.as_ref().map(|x| x.lifecycle_state),
             ready_status: ready.as_ref().map(|x| x.status),
-            worktree: ready.as_ref().map(|x| x.worktree.clone()),
+            worktree: ready.as_ref().and_then(|x| x.worktree.clone()),
             source: ready.as_ref().map(|x| x.source.clone()),
             root_stp: ready.as_ref().map(|x| x.root_stp.clone()),
             root_input: ready.as_ref().map(|x| x.root_input.clone()),
             root_output: ready.as_ref().map(|x| x.root_output.clone()),
-            wt_stp: ready.as_ref().map(|x| x.wt_stp.clone()),
-            wt_input: ready.as_ref().map(|x| x.wt_input.clone()),
-            wt_output: ready.as_ref().map(|x| x.wt_output.clone()),
+            wt_stp: ready.as_ref().and_then(|x| x.wt_stp.clone()),
+            wt_input: ready.as_ref().and_then(|x| x.wt_input.clone()),
+            wt_output: ready.as_ref().and_then(|x| x.wt_output.clone()),
             doctor_status,
         })?;
     } else {
@@ -706,7 +709,28 @@ fn run_doctor_ready(
     }
     validate_bootstrap_stp(repo_root, &root_stp)?;
     validate_authored_prompt_surface("doctor", &root_stp, PromptSurfaceKind::Stp)?;
+    validate_initialized_cards(
+        issue_ref.issue_number(),
+        issue_ref.slug(),
+        &root_bundle_input,
+        &root_bundle_output,
+    )?;
     if !worktree_path.is_dir() {
+        let root_branch = field_line_value(&root_bundle_input, "Branch")?;
+        if branch_indicates_unbound_state(&root_branch) {
+            return Ok(DoctorReadyResult {
+                lifecycle_state: "pre_run",
+                worktree: None,
+                source: path_relative_to_repo(repo_root, &source_path),
+                root_stp: path_relative_to_repo(repo_root, &root_stp),
+                root_input: path_relative_to_repo(repo_root, &root_bundle_input),
+                root_output: path_relative_to_repo(repo_root, &root_bundle_output),
+                wt_stp: None,
+                wt_input: None,
+                wt_output: None,
+                status: "PASS",
+            });
+        }
         bail!("doctor: missing worktree: {}", worktree_path.display());
     }
     let wt_branch = run_capture(
@@ -748,14 +772,15 @@ fn run_doctor_ready(
     )?;
 
     Ok(DoctorReadyResult {
-        worktree: path_relative_to_repo(repo_root, &worktree_path),
+        lifecycle_state: "run_bound",
+        worktree: Some(path_relative_to_repo(repo_root, &worktree_path)),
         source: path_relative_to_repo(repo_root, &source_path),
         root_stp: path_relative_to_repo(repo_root, &root_stp),
         root_input: path_relative_to_repo(repo_root, &root_bundle_input),
         root_output: path_relative_to_repo(repo_root, &root_bundle_output),
-        wt_stp: path_relative_to_repo(repo_root, &wt_stp),
-        wt_input: path_relative_to_repo(repo_root, &wt_bundle_input),
-        wt_output: path_relative_to_repo(repo_root, &wt_bundle_output),
+        wt_stp: Some(path_relative_to_repo(repo_root, &wt_stp)),
+        wt_input: Some(path_relative_to_repo(repo_root, &wt_bundle_input)),
+        wt_output: Some(path_relative_to_repo(repo_root, &wt_bundle_output)),
         status: "PASS",
     })
 }
@@ -780,14 +805,23 @@ fn print_doctor_preflight_text(preflight: &DoctorPreflightResult) {
 }
 
 fn print_doctor_ready_text(ready: &DoctorReadyResult) {
-    println!("WORKTREE={}", ready.worktree);
+    println!("LIFECYCLE_STATE={}", ready.lifecycle_state);
+    if let Some(worktree) = &ready.worktree {
+        println!("WORKTREE={worktree}");
+    }
     println!("SOURCE={}", ready.source);
     println!("ROOT_STP={}", ready.root_stp);
     println!("ROOT_INPUT={}", ready.root_input);
     println!("ROOT_OUTPUT={}", ready.root_output);
-    println!("WT_STP={}", ready.wt_stp);
-    println!("WT_INPUT={}", ready.wt_input);
-    println!("WT_OUTPUT={}", ready.wt_output);
+    if let Some(wt_stp) = &ready.wt_stp {
+        println!("WT_STP={wt_stp}");
+    }
+    if let Some(wt_input) = &ready.wt_input {
+        println!("WT_INPUT={wt_input}");
+    }
+    if let Some(wt_output) = &ready.wt_output {
+        println!("WT_OUTPUT={wt_output}");
+    }
     println!("READY={}", ready.status);
 }
 
@@ -1803,11 +1837,15 @@ fn ensure_bootstrap_cards(
             source_path,
             &bundle_output,
         )?;
+    } else if field_line_value(&bundle_input, "Branch")?.trim() != branch {
+        replace_field_line_in_file(&bundle_input, "Branch", branch)?;
     }
     if !bundle_output.is_file()
         || !output_card_title_matches_slug(&bundle_output, issue_ref.slug())?
     {
         write_output_card(root, &bundle_output, issue_ref, title, branch)?;
+    } else if field_line_value(&bundle_output, "Branch")?.trim() != branch {
+        replace_field_line_in_file(&bundle_output, "Branch", branch)?;
     }
 
     let cards_root = resolve_cards_root(root, None);
@@ -2019,6 +2057,13 @@ fn replace_exact_line(text: &mut String, from: &str, to: &str) {
     }
 }
 
+fn replace_field_line_in_file(path: &Path, label: &str, value: &str) -> Result<()> {
+    let mut text = fs::read_to_string(path)?;
+    replace_field_line(&mut text, label, value);
+    fs::write(path, text)?;
+    Ok(())
+}
+
 fn ensure_symlink(link_path: &Path, target: &Path) -> Result<()> {
     if let Some(parent) = link_path.parent() {
         fs::create_dir_all(parent)?;
@@ -2144,6 +2189,32 @@ fn validate_ready_cards(
     Ok(())
 }
 
+fn validate_initialized_cards(
+    issue: u32,
+    slug: &str,
+    input_path: &Path,
+    output_path: &Path,
+) -> Result<()> {
+    let expected = format!("issue-{:04}", issue);
+    if field_line_value(input_path, "Task ID")? != expected {
+        bail!("doctor: input card Task ID mismatch");
+    }
+    if field_line_value(input_path, "Run ID")? != expected {
+        bail!("doctor: input card Run ID mismatch");
+    }
+    if field_line_value(output_path, "Task ID")? != expected {
+        bail!("doctor: output card Task ID mismatch");
+    }
+    if field_line_value(output_path, "Run ID")? != expected {
+        bail!("doctor: output card Run ID mismatch");
+    }
+    if !output_card_title_matches_slug(output_path, slug)? {
+        bail!("doctor: output card title mismatch");
+    }
+    validate_authored_prompt_surface("doctor", input_path, PromptSurfaceKind::Sip)?;
+    Ok(())
+}
+
 fn field_line_value(path: &Path, label: &str) -> Result<String> {
     let prefix = format!("{label}:");
     let text = fs::read_to_string(path)?;
@@ -2161,6 +2232,14 @@ fn branch_matches_started_state(recorded: &str, actual_branch: &str) -> bool {
         return true;
     }
     recorded.starts_with("TBD (run pr.sh start ")
+}
+
+fn branch_indicates_unbound_state(recorded: &str) -> bool {
+    let recorded = recorded.trim();
+    recorded.is_empty()
+        || recorded.eq_ignore_ascii_case("not bound yet")
+        || recorded.starts_with("TBD (run pr.sh start ")
+        || recorded.starts_with("TBD (run pr.sh run ")
 }
 
 fn ensure_source_issue_prompt(

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -182,6 +182,127 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
 }
 
 #[test]
+fn real_pr_doctor_full_reports_pre_run_ready_without_worktree() {
+    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = unique_temp_dir("adl-pr-doctor-pre-run");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "doctor pre-run\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1196, "v0.86", "doctor-pre-run").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Doctor pre-run");
+    real_pr(&[
+        "init".to_string(),
+        "1196".to_string(),
+        "--slug".to_string(),
+        "doctor-pre-run".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Doctor pre-run".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let root_sip = issue_ref.task_bundle_input_path(&repo);
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    write_authored_sip(
+        &root_sip,
+        &issue_ref,
+        "[v0.86][tools] Doctor pre-run",
+        "not bound yet",
+        &source_path,
+        &repo,
+    );
+
+    let doctor = real_pr(&[
+        "doctor".to_string(),
+        "1196".to_string(),
+        "--slug".to_string(),
+        "doctor-pre-run".to_string(),
+        "--mode".to_string(),
+        "full".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+        "--json".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    doctor.expect("doctor pre-run");
+    assert!(!issue_ref.default_worktree_path(&repo, None).exists());
+}
+
+#[test]
 fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
     let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = unique_temp_dir("adl-pr-doctor-worktree-cwd");
@@ -307,6 +428,129 @@ fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
 
     env::set_current_dir(prev_dir).expect("restore cwd");
     doctor.expect("doctor from worktree");
+}
+
+#[test]
+fn real_pr_start_rewrites_unbound_root_input_card_branch() {
+    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = unique_temp_dir("adl-pr-start-rewrites-unbound");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "start rewrites unbound root card\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1199, "v0.86", "start-rewrites-unbound").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Start rewrites unbound");
+    real_pr(&[
+        "init".to_string(),
+        "1199".to_string(),
+        "--slug".to_string(),
+        "start-rewrites-unbound".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Start rewrites unbound".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let root_sip = issue_ref.task_bundle_input_path(&repo);
+    let mut root_sip_text = fs::read_to_string(&root_sip).expect("read root sip");
+    root_sip_text = root_sip_text.replace(
+        "Branch: codex/1199-start-rewrites-unbound",
+        "Branch: not bound yet",
+    );
+    fs::write(&root_sip, root_sip_text).expect("rewrite root sip branch");
+
+    let start = real_pr(&[
+        "start".to_string(),
+        "1199".to_string(),
+        "--slug".to_string(),
+        "start-rewrites-unbound".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Start rewrites unbound".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    start.expect("real_pr start after unbound root card");
+    assert_eq!(
+        field_line_value(&root_sip, "Branch").expect("root branch"),
+        "codex/1199-start-rewrites-unbound"
+    );
+    assert!(issue_ref
+        .task_bundle_input_path(&issue_ref.default_worktree_path(&repo, None))
+        .is_file());
 }
 
 #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1761,7 +1761,9 @@ Usage:
 
 Notes:
 - Deprecated compatibility alias over `doctor --mode ready`.
-- Verifies that the issue is fully authoring-ready in both the root checkout and the issue worktree.
+- Reports structural execution-readiness.
+- Pre-run issues may pass without a bound worktree when the root bundle is authored and execution has not started yet.
+- Started issues still validate the issue worktree and started-worktree cards strictly.
 - Prints READY=PASS on success and exits non-zero on the first missing or invalid bootstrap surface.
 - `--json` emits the stable `adl.pr.doctor.v1` machine-readable result.
 EOF
@@ -1787,8 +1789,10 @@ Usage:
 
 Notes:
 - Canonical readiness and drift diagnostic surface.
-- `--mode full` reports both milestone-wave preflight and worktree/card readiness.
-- `--mode ready` runs only the started-worktree readiness checks.
+- `--mode full` reports milestone-wave preflight plus lifecycle-aware readiness.
+- `--mode ready` reports structural execution-readiness for both pre-run and run-bound issues.
+- Pre-run issues may be reported as ready without a worktree when execution has not yet been bound.
+- Run-bound issues still validate the bound worktree and cards strictly.
 - `--mode preflight` runs only the milestone-wave conflict/open-PR check.
 - `--json` emits the stable `adl.pr.doctor.v1` machine-readable result for automation.
 EOF

--- a/adl/tools/skills/pr-ready/SKILL.md
+++ b/adl/tools/skills/pr-ready/SKILL.md
@@ -38,7 +38,9 @@ The intended workflow model treats `doctor` as the canonical automation surface,
 Current repo truth:
 1. `doctor --json` is the canonical structured readiness surface
 2. compatibility surfaces may still include `pr ready` and `pr preflight`
-3. doctor validates execution-readiness surfaces for an existing worktree/task context
+3. doctor reports lifecycle-aware readiness:
+   - pre-run issues may be ready before a worktree exists
+   - run-bound issues must still validate the bound worktree/task context
 4. preflight-compatible checks still report milestone/open-PR blocking state
 5. the skill may combine doctor output, compatibility aliases, and direct inspection to produce one readiness result
 
@@ -108,8 +110,9 @@ If there is no concrete target, stop and report `blocked` with the missing targe
    - `ready_with_repairs`
    - `blocked`
 7. Report preflight or scheduling gates separately from execution readiness when the issue structure itself is sound.
-8. Apply only clearly safe bounded repairs if permitted.
-9. Emit a structured readiness result and stop.
+8. Treat missing worktree before `pr-run` as expected pre-run state when the root bundle is authored and execution has not yet been bound.
+9. Apply only clearly safe bounded repairs if permitted.
+10. Emit a structured readiness result and stop.
 
 ## Workflow
 

--- a/adl/tools/skills/pr-ready/references/ready-playbook.md
+++ b/adl/tools/skills/pr-ready/references/ready-playbook.md
@@ -43,7 +43,7 @@ Check where applicable:
 - source prompt presence
 - STP/SIP/SOR presence
 - compatibility card links
-- branch/worktree presence and branch match
+- branch/worktree presence and branch match when execution has already been bound
 - obvious bootstrap placeholder drift in execution-critical surfaces
 - open milestone PR blocking state if preflight gating is relevant
 
@@ -82,6 +82,11 @@ Current repo-native command truth is:
 - `doctor --json` is the canonical automation surface
 - `ready`
 - `preflight`
+
+Lifecycle note:
+- a missing worktree is not automatically blocking before `pr-run`
+- if the root bundle is authored and execution has not yet been bound, report a pre-run ready state instead of failing on missing worktree
+- once execution is bound, missing or mismatched worktree state remains blocking
 
 The skill should treat `ready` and `preflight` as compatibility inputs to the doctor/readiness result, not as the final automation model.
 


### PR DESCRIPTION
Closes #1353

## Summary
Made the doctor/readiness path lifecycle-aware so pre-run issues can return a truthful ready result without a bound worktree, while run-bound issues still enforce worktree/card checks. Also taught the execution binder to rewrite unbound root card branches when entering run phase, updated the public shell help, and tightened the `pr-ready` skill wording to match the lifecycle.

## Artifacts
- updated control-plane doctor/readiness logic: `adl/src/cli/pr_cmd.rs`
- updated lifecycle regression coverage: `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
- updated shell help text: `adl/tools/pr.sh`
- updated skill guidance: `adl/tools/skills/pr-ready/SKILL.md`
- updated skill playbook guidance: `adl/tools/skills/pr-ready/references/ready-playbook.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_reports_pre_run_ready_without_worktree -- --nocapture`
    - verifies doctor returns a PASS pre-run result without a worktree when the root bundle is authored
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_rewrites_unbound_root_input_card_branch -- --nocapture`
    - verifies execution binding rewrites an unbound root SIP branch and materializes the worktree-local bundle
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_succeeds_when_invoked_from_started_worktree -- --nocapture`
    - verifies strict run-bound doctor behavior still passes for a started issue worktree
  - `cargo test --manifest-path adl/Cargo.toml real_pr_ready_succeeds_when_invoked_from_started_worktree -- --nocapture`
    - verifies the `ready` compatibility alias still reports PASS for a started issue worktree
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- pr doctor 1353 --slug v0-87-tools-make-doctor-lifecycle-aware-before-run-phase --version v0.87 --json`
    - verifies the live issue now reports a structured doctor PASS with lifecycle-aware output
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- pr start 1353 --slug v0-87-tools-make-doctor-lifecycle-aware-before-run-phase --title "[v0.87][tools] Make doctor lifecycle-aware before run phase" --no-fetch-issue --version v0.87`
    - verifies the live issue can enter run phase and materialize worktree-local cards after root-card repair
  - `git diff --check`
    - verifies the tracked patch is whitespace-clean
- Results:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_reports_pre_run_ready_without_worktree -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_rewrites_unbound_root_input_card_branch -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_succeeds_when_invoked_from_started_worktree -- --nocapture`: PASS
  - `cargo test --manifest-path adl/Cargo.toml real_pr_ready_succeeds_when_invoked_from_started_worktree -- --nocapture`: PASS
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- pr doctor 1353 ... --json`: PASS
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- pr start 1353 ...`: PASS
  - `git diff --check`: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1353__v0-87-tools-make-doctor-lifecycle-aware-before-run-phase/sip.md
- Output card: .adl/v0.87/tasks/issue-1353__v0-87-tools-make-doctor-lifecycle-aware-before-run-phase/sor.md
- Idempotency-Key: v0-87-tools-make-doctor-lifecycle-aware-before-run-phase-adl-v0-87-tasks-issue-1353-v0-87-tools-make-doctor-lifecycle-aware-before-run-phase-sip-md-adl-v0-87-tasks-issue-1353-v0-87-tools-make-doctor-lifecycle-aware-before-run-phase-sor-md