### PR TITLE
[v0.87][docs] Add next-milestone planning handoff

### DIFF
--- a/docs/milestones/v0.87/SPRINT_v0.87.md
+++ b/docs/milestones/v0.87/SPRINT_v0.87.md
@@ -13,7 +13,7 @@
 
 - Sprint 1: canonicalization and first substrate slices
 - Sprint 2: substrate expansion and convergence across trace, provider, shared memory, skills, tooling, and review
-- Sprint 3: documentation convergence, demos, quality gate, internal review, 3rd party review, and release closeout
+- Sprint 3: documentation convergence, demos, quality gate, internal review, 3rd party review, release closeout, and next-milestone planning
 
 The purpose of this file is to describe the sprint sequence for the whole milestone, not just the first kickoff tranche.
 
@@ -36,7 +36,7 @@ This milestone should leave ADL with:
 |---|---|---|---|
 | `v0.87-s1` | Lock the canonical milestone surfaces and land the first substrate slices | `WP-01`, `WP-02`, `WP-04`, `WP-06` | active / partially implemented |
 | `v0.87-s2` | Expand and connect the substrate across trace, provider, memory, skills, tooling, and review | `WP-03`, `WP-05`, `WP-07`, `WP-08`, `WP-09`, `WP-10`, `WP-11` | seeded / underway |
-| `v0.87-s3` | Converge docs, demos, quality gates, internal review, 3rd party review, and release tail | `WP-12`, `WP-13`, `WP-14`, `WP-15`, `WP-15A`, `WP-16` | planned |
+| `v0.87-s3` | Converge docs, demos, quality gates, internal review, 3rd party review, release tail, and next-milestone planning | `WP-12`, `WP-13`, `WP-14`, `WP-15`, `WP-15A`, `WP-16`, `WP-17` | planned |
 
 ## Sprint 1
 
@@ -99,7 +99,7 @@ Expand the foundational substrate into a connected milestone surface: runtime tr
 ## Sprint 3
 
 ### Goal
-Converge the milestone into a reviewer-legible package with truthful demos, quality gates, docs, internal review outputs, 3rd party review readiness, and release closeout.
+Converge the milestone into a reviewer-legible package with truthful demos, quality gates, docs, internal review outputs, 3rd party review readiness, release closeout, and an explicit next-milestone planning handoff.
 
 ### Scope
 - docs canonicalization and feature index truth
@@ -108,6 +108,7 @@ Converge the milestone into a reviewer-legible package with truthful demos, qual
 - docs / internal review convergence
 - 3rd party review pass and resulting follow-up capture
 - release ceremony and milestone handoff
+- canonical `v0.87.1` milestone shell and planning package before `v0.87` closes
 
 ### Work Packages
 | Order | Item | Issue | Owner | Status |
@@ -118,6 +119,7 @@ Converge the milestone into a reviewer-legible package with truthful demos, qual
 | 4 | Docs + internal review pass | `WP-15` | `Daniel / Codex.app` | not yet issued |
 | 5 | 3rd party review pass | `WP-15A` | `Daniel / Codex.app` | not yet issued |
 | 6 | Release ceremony | `WP-16` | `Daniel / Codex.app` | not yet issued |
+| 7 | Next milestone planning (`v0.87.1`) | `#1354` | `Daniel / Codex.app` | merged |
 
 ### Exit Criteria
 - canonical docs truthfully describe the implemented milestone
@@ -126,13 +128,14 @@ Converge the milestone into a reviewer-legible package with truthful demos, qual
 - docs and internal review surfaces are coherent for an uninvolved reviewer
 - 3rd party review is completed or explicitly recorded with bounded follow-up disposition
 - release-tail validation and handoff are complete
+- the canonical `v0.87.1` milestone shell exists before `v0.87` closes
 
 ## Current Execution Status
 
 As of this plan revision:
 - Sprint 1 is in active implementation
 - Sprint 2 is seeded, preflighted, and partially underway
-- Sprint 3 is defined at the WBS level but not yet issued in detail
+- Sprint 3 is defined at the WBS level and includes the next-milestone planning handoff, though most release-tail issues are not yet issued in detail
 
 Current issue/PR posture:
 - `#1292` merged
@@ -145,7 +148,7 @@ Current issue/PR posture:
 - Prefer substrate-first sequencing:
   - Sprint 1: schema + provider + shared-memory foundation
   - Sprint 2: linkage + compatibility + skills + tooling + review
-  - Sprint 3: docs + demos + quality + release tail
+  - Sprint 3: docs + demos + quality + release tail + next-milestone planning
 - Run required quality gates (`fmt`, `clippy`, `test`, and any validator/demo command relevant to the changed surface).
 - Record proof surfaces as they land instead of reconstructing them later from memory.
 
@@ -177,4 +180,5 @@ Current issue/PR posture:
 - The issue sequence is explicit for the foundational and convergence substrate work.
 - Sprint 3 release-tail work is defined before release closeout begins.
 - Internal review and 3rd party review are both completed or explicitly dispositioned before release closeout.
+- The `v0.87.1` planning shell exists before `v0.87` is considered fully closed.
 - Scope remains bounded to `v0.87` substrate work; no silent pull-forward of `v0.88+` systems.

--- a/docs/milestones/v0.87/WBS_v0.87.md
+++ b/docs/milestones/v0.87/WBS_v0.87.md
@@ -7,7 +7,7 @@
 - Owner: `adl`
 
 ## WBS Summary
-`v0.87` is the milestone where ADL consolidates the bounded cognitive system from `v0.86` into a coherent, deterministic, and externally credible substrate. The work is organized around four core implementation bands—trace, provider portability, shared memory, and operational/control-plane stability—followed by the standard demo, quality, docs/review, and release tail.
+`v0.87` is the milestone where ADL consolidates the bounded cognitive system from `v0.86` into a coherent, deterministic, and externally credible substrate. The work is organized around four core implementation bands—trace, provider portability, shared memory, and operational/control-plane stability—followed by the standard demo, quality, docs/review, release tail, and next-milestone planning handoff.
 
 This milestone is intentionally substrate-heavy. It should improve:
 - cross-surface coherence (`contracts -> execution -> trace -> review -> docs`)
@@ -38,11 +38,12 @@ The WBS below preserves mergeable slices, explicit dependencies, and a clean rel
 | WP-15 | Docs + review pass (repo-wide alignment) | Converge milestone docs, proof surfaces, review artifacts, and entry-point docs so an internal/external reviewer can understand the implemented `v0.87` substrate truthfully. | Reviewed and aligned docs/review surface package for `v0.87`. | WP-12, WP-13, WP-14 | TBD |
 | WP-15A | 3rd-party review | Conduct external / 3rd-party review of the `v0.87` milestone, capture findings, and ensure all issues are either resolved or explicitly dispositioned before release closeout. | External review findings and disposition record for milestone closeout. | WP-15 | TBD |
 | WP-16 | Release ceremony (final validation + tag + notes + cleanup) | Perform final release-tail work for `v0.87`: validation evidence, checklist/release-note alignment, closeout record, and clean handoff into the next roadmap slice. | `v0.87` release-closeout package with final validation and milestone handoff. | WP-15 | TBD |
+| WP-17 | Next milestone planning (`v0.87.1`) | Prepare the canonical tracked planning package for `v0.87.1` before `v0.87` closes, including the next milestone shell, sprint/WBS framing, and the initial docs needed for runtime-completion work to begin from a coherent public surface. | Canonical `v0.87.1` milestone shell and planning package ready before `v0.87` closeout. | WP-15, WP-16 | #1354 |
 
 ## Sequencing
 - Phase 1: Canonical planning + substrate definition (`WP-01` through `WP-04`)
 - Phase 2: Shared substrate implementation and workflow hardening (`WP-05` through `WP-11`)
-- Phase 3: Canonical docs, demos, quality gate, review alignment, and release tail (`WP-12` through `WP-16`)
+- Phase 3: Canonical docs, demos, quality gate, review alignment, release tail, and next-milestone handoff (`WP-12` through `WP-17`)
 
 ## Acceptance Mapping
 - WP-01 (Design pass) -> Canonical milestone docs are filled, internally consistent, and aligned to the roadmap-defined `v0.87` substrate.
@@ -62,9 +63,11 @@ The WBS below preserves mergeable slices, explicit dependencies, and a clean rel
 - WP-15 (Docs/review) -> Docs, proof surfaces, and review artifacts converge into a reviewer-legible, contradiction-free package.
 - WP-15A (3rd-party review) -> External review findings are captured and every finding is either resolved or explicitly dispositioned before release closeout.
 - WP-16 (Release ceremony) -> Final validation, release-tail docs, and milestone handoff are explicit, truthful, and auditable.
+- WP-17 (Next milestone planning) -> `v0.87.1` canonical milestone docs exist before `v0.87` closeout and provide a coherent tracked starting point for runtime-completion work.
 
 ## Exit Criteria
 - Every in-scope `v0.87` requirement maps to at least one WBS item.
 - Every WBS item has a concrete deliverable and explicit dependency order.
 - The four major substrate bands—trace, provider, shared memory, and operational/control-plane stability—are all represented directly in the WBS.
 - The release tail remains bounded and downstream of implementation truth.
+- The next milestone planning package exists before `v0.87` is considered fully closed.


### PR DESCRIPTION
Closes #1360

## Summary
- add an explicit next-milestone planning handoff to the canonical `v0.87` WBS
- update the `v0.87` sprint plan so Sprint 3 includes the `v0.87.1` planning shell as a real release-tail deliverable
- tie the handoff to the already-landed `#1354` milestone-shell work

## Validation
- `git diff -- docs/milestones/v0.87/WBS_v0.87.md docs/milestones/v0.87/SPRINT_v0.87.md`
- direct readback of the updated milestone docs
