### PR TITLE
[v0.87][tools] Support dot-suffixed milestone versions in issue bootstrap

### DIFF
--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -99,6 +99,10 @@ fn version_can_be_inferred_from_labels_or_title() {
         version_from_title("[v0.86][WP-15] Implement local agent demo program"),
         Some("v0.86".to_string())
     );
+    assert_eq!(
+        version_from_title("[v0.87.1][tools] Support dot suffixed milestone versions"),
+        Some("v0.87.1".to_string())
+    );
     assert_eq!(version_from_title("No version title"), None);
 }
 
@@ -197,6 +201,22 @@ fn parse_create_args_accepts_issue_creation_flags() {
         Some("track:roadmap,type:task,area:tools")
     );
     assert_eq!(parsed.version.as_deref(), Some("v0.86"));
+}
+
+#[test]
+fn parse_create_args_accepts_dot_suffixed_version() {
+    let parsed = parse_create_args(&[
+        "--title".to_string(),
+        "[v0.87.1][tools] Dot suffixed milestone support".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ])
+    .expect("parse");
+    assert_eq!(
+        parsed.title_arg.as_deref(),
+        Some("[v0.87.1][tools] Dot suffixed milestone support")
+    );
+    assert_eq!(parsed.version.as_deref(), Some("v0.87.1"));
 }
 
 #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -13,9 +13,9 @@
 # - Rust toolchain for `adl/` checks (fmt, clippy, test)
 #
 #   adl/tools/pr.sh help
-#   adl/tools/pr.sh create  --title "<title>" [--slug <slug>] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v0.85>]
-#   adl/tools/pr.sh init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v0.85>]
-#   adl/tools/pr.sh run     <issue> [--slug <slug>] [--title "<title>"] [--prefix codex] [--no-fetch-issue] [--version <v0.85>] [--allow-open-pr-wave]
+#   adl/tools/pr.sh create  --title "<title>" [--slug <slug>] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v0.85|v0.87.1>]
+#   adl/tools/pr.sh init    <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v0.85|v0.87.1>]
+#   adl/tools/pr.sh run     <issue> [--slug <slug>] [--title "<title>"] [--prefix codex] [--no-fetch-issue] [--version <v0.85|v0.87.1>] [--allow-open-pr-wave]
 #   adl/tools/pr.sh run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
 #   adl/tools/pr.sh card    <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <input_card.md>] [--version <v0.2>]
 #   adl/tools/pr.sh output  <issue> [input|output] [--slug <slug>] [--no-fetch-issue] [-f <output_card.md>] [--version <v0.2>]
@@ -424,7 +424,7 @@ infer_wp_from_title() {
 
 version_from_title() {
   local title="$1"
-  if [[ "$title" =~ \[(v[0-9]+\.[0-9]+)\] ]]; then
+  if [[ "$title" =~ \[(v[0-9]+\.[0-9]+(\.[0-9]+)*)\] ]]; then
     printf '%s\n' "${BASH_REMATCH[1]}"
   fi
 }
@@ -1616,8 +1616,8 @@ Commands:
   status
 
 Flags:
-  (create)  --version <v0.85>                 Override detected version (otherwise inferred from labels/title).
-  (init)    --version <v0.85>                 Override detected version (otherwise inferred from issue labels version:vX.Y)
+  (create)  --version <v0.85|v0.87.1>         Override detected version (otherwise inferred from labels/title).
+  (init)    --version <v0.85|v0.87.1>         Override detected version (otherwise inferred from issue labels or title version:vX.Y[.Z...])
   (init)    --no-fetch-issue                  Do not fetch issue title/labels; requires --slug.
   (run issue-mode) --slug <slug> --title "<title>" --prefix <pfx> --no-fetch-issue --version <v> --allow-open-pr-wave
   (run adl-mode) --runs-root <dir>            Override canonical run artifact root (default: <repo>/.adl/runs or ADL_RUNS_ROOT).
@@ -1631,7 +1631,7 @@ Flags:
   (finish) --idempotent                         Safe no-op only when existing merged PR matches current finish inputs.
   (card/run) --slug <slug>                     Use an explicit slug instead of fetching the issue title.
   (run)     --title "<title>"                  Optional; accepted for UX symmetry and used to derive slug when --slug is omitted.
-  (run)     --version <v0.85>                  Override detected version when the caller already knows the intended milestone band.
+  (run)     --version <v0.85|v0.87.1>          Override detected version when the caller already knows the intended milestone band.
   (run)     --allow-open-pr-wave               Override the open milestone PR wave guard.
 
 Notes:
@@ -1685,7 +1685,7 @@ EOF
 usage_init() {
   cat <<'EOF'
 Usage:
-  adl/tools/pr.sh init <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v0.85>]
+  adl/tools/pr.sh init <issue> [--slug <slug>] [--title "<title>"] [--no-fetch-issue] [--version <v0.85|v0.87.1>]
 
 Notes:
 - Initializes the canonical local task-bundle authoring surface.

--- a/adl/tools/test_pr_init.sh
+++ b/adl/tools/test_pr_init.sh
@@ -58,6 +58,14 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
     printf '%s\n' "track:roadmap" "version:v0.86" "area:docs" "type:design"
     exit 0
   fi
+  if [[ "$issue" == "46" && "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
+    echo "[v0.87.1][tools] Dot suffixed milestone prompt"
+    exit 0
+  fi
+  if [[ "$issue" == "46" && "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
+    printf '%s\n' "track:roadmap" "version:v0.87.1" "area:tools" "type:task"
+    exit 0
+  fi
 fi
 exit 1
 EOF
@@ -197,6 +205,24 @@ assert_contains() {
   }
   grep -Fq 'title: "[v0.86][WP-03] Generated loop prompt"' "$repo/.adl/v0.86/bodies/issue-43-v0-86-wp-03-generated-loop-prompt.md" || {
     echo "assertion failed: expected generated source prompt title" >&2
+    exit 1
+  }
+
+  out4="$("$BASH_BIN" adl/tools/pr.sh init 46)"
+  assert_contains "STP      .adl/v0.87.1/tasks/issue-0046__v0-87-1-tools-dot-suffixed-milestone-prompt/stp.md" "$out4" "dot-suffixed stp path"
+  assert_contains "READ     .adl/v0.87.1/tasks/issue-0046__v0-87-1-tools-dot-suffixed-milestone-prompt/sip.md" "$out4" "dot-suffixed sip path"
+  assert_contains "WRITE    .adl/v0.87.1/tasks/issue-0046__v0-87-1-tools-dot-suffixed-milestone-prompt/sor.md" "$out4" "dot-suffixed sor path"
+  assert_contains "SOURCE   .adl/v0.87.1/bodies/issue-46-v0-87-1-tools-dot-suffixed-milestone-prompt.md" "$out4" "dot-suffixed source path"
+  [[ -f "$repo/.adl/v0.87.1/bodies/issue-46-v0-87-1-tools-dot-suffixed-milestone-prompt.md" ]] || {
+    echo "assertion failed: expected generated dot-suffixed source issue prompt" >&2
+    exit 1
+  }
+  [[ -f "$repo/.adl/v0.87.1/tasks/issue-0046__v0-87-1-tools-dot-suffixed-milestone-prompt/sip.md" ]] || {
+    echo "assertion failed: expected dot-suffixed task-bundle sip" >&2
+    exit 1
+  }
+  grep -Fq "Version: v0.87.1" "$repo/.adl/v0.87.1/tasks/issue-0046__v0-87-1-tools-dot-suffixed-milestone-prompt/sip.md" || {
+    echo "assertion failed: expected dot-suffixed version in generated sip" >&2
     exit 1
   }
 

--- a/adl/tools/test_pr_issue_version_inference.sh
+++ b/adl/tools/test_pr_issue_version_inference.sh
@@ -12,9 +12,14 @@ STP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_task_prompt.contract.yaml"
 SIP_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_implementation_prompt.contract.yaml"
 SOR_CONTRACT_SRC="$ROOT_DIR/adl/schemas/structured_output_record.contract.yaml"
 BASH_BIN="$(command -v bash)"
+REAL_ADL_BIN="$ROOT_DIR/adl/target/debug/adl"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
+
+if [[ ! -x "$REAL_ADL_BIN" ]]; then
+  cargo build --manifest-path "$ROOT_DIR/adl/Cargo.toml" --bin adl >/dev/null
+fi
 
 origin="$tmpdir/origin.git"
 repo="$tmpdir/repo"
@@ -41,15 +46,22 @@ printf '%s\n' "$*" >>"$LOG_FILE"
 if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
   issue="${3:-}"
   shift 3
-  if [[ "$issue" != "975" ]]; then
+  if [[ "$issue" != "975" && "$issue" != "976" ]]; then
     exit 1
   fi
-  if [[ "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
+  if [[ "$issue" == "975" && "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
     echo "version:v0.85"
     exit 0
   fi
-  if [[ "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
+  if [[ "$issue" == "976" && "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
+    exit 0
+  fi
+  if [[ "$issue" == "975" && "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
     echo "[v0.85][process] Infer current milestone card version from issue title when labels are missing"
+    exit 0
+  fi
+  if [[ "$issue" == "976" && "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
+    echo "[v0.87.1][process] Infer dot suffixed milestone card version from issue title when labels are missing"
     exit 0
   fi
 fi
@@ -91,6 +103,7 @@ assert_contains() {
   cd "$repo"
   export PATH="$bindir:$PATH"
   export GH_LOG_FILE="$gh_log"
+  export ADL_PR_RUST_BIN="$REAL_ADL_BIN"
 
   out_init="$("$BASH_BIN" adl/tools/pr.sh init 975 --slug v085-process-infer-card-version-from-issue-title)"
   assert_contains "STATE    ISSUE_AND_BUNDLE_READY" "$out_init" "init ready state"
@@ -128,6 +141,28 @@ assert_contains() {
   }
   [[ ! -e "$repo/.adl/v0.3/tasks/issue-0975__v085-process-infer-card-version-from-issue-title" ]] || {
     echo "assertion failed: unexpected v0.3 fallback task bundle after start" >&2
+    exit 1
+  }
+
+  out_init_dot="$("$BASH_BIN" adl/tools/pr.sh init 976 --slug v0871-process-infer-dot-suffixed-version-from-title)"
+  assert_contains "STATE    ISSUE_AND_BUNDLE_READY" "$out_init_dot" "dot-suffixed init ready state"
+  [[ -f ".adl/v0.87.1/tasks/issue-0976__v0871-process-infer-dot-suffixed-version-from-title/sip.md" ]] || {
+    echo "assertion failed: expected canonical input card under the root .adl/v0.87.1/tasks" >&2
+    exit 1
+  }
+  grep -Fq "Version: v0.87.1" ".adl/v0.87.1/tasks/issue-0976__v0871-process-infer-dot-suffixed-version-from-title/sip.md" || {
+    echo "assertion failed: expected input card version v0.87.1" >&2
+    exit 1
+  }
+
+  out_start_dot="$("$BASH_BIN" adl/tools/pr.sh start 976 --slug v0871-process-infer-dot-suffixed-version-from-title)"
+  assert_contains "WORKTREE $(canon_path "$repo/.worktrees/adl-wp-976")" "$out_start_dot" "dot-suffixed start prints worktree path"
+  [[ -f "$repo/.worktrees/adl-wp-976/.adl/v0.87.1/tasks/issue-0976__v0871-process-infer-dot-suffixed-version-from-title/sip.md" ]] || {
+    echo "assertion failed: expected start to create input card inside worktree-local v0.87.1 task bundle" >&2
+    exit 1
+  }
+  [[ ! -e "$repo/.adl/v0.3/tasks/issue-0976__v0871-process-infer-dot-suffixed-version-from-title" ]] || {
+    echo "assertion failed: unexpected v0.3 fallback task bundle for dot-suffixed version after start" >&2
     exit 1
   }
 

--- a/adl/tools/test_structured_prompt_validation.sh
+++ b/adl/tools/test_structured_prompt_validation.sh
@@ -214,6 +214,14 @@ EOF
 "$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_valid.md"
 "$VALIDATOR" --type sor --phase bootstrap --input "$tmpdir/sor_valid.md"
 
+cp "$tmpdir/sip_valid.md" "$tmpdir/sip_dot_version_valid.md"
+perl -0pi -e 's/Version: v0\.85/Version: v0.87.1/' "$tmpdir/sip_dot_version_valid.md"
+"$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_dot_version_valid.md"
+
+cp "$tmpdir/sor_valid.md" "$tmpdir/sor_dot_version_valid.md"
+perl -0pi -e 's/Version: v0\.85/Version: v0.87.1/' "$tmpdir/sor_dot_version_valid.md"
+"$VALIDATOR" --type sor --phase bootstrap --input "$tmpdir/sor_dot_version_valid.md"
+
 cat >"$tmpdir/sip_blank_context_invalid.md" <<'EOF'
 # ADL Input Card
 

--- a/adl/tools/validate_structured_prompt.sh
+++ b/adl/tools/validate_structured_prompt.sh
@@ -57,7 +57,7 @@ strip_quotes() {
 
 valid_slug() { [[ "$1" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; }
 valid_task_id() { [[ "$1" =~ ^issue-[0-9]{4}$ ]]; }
-valid_version() { [[ "$1" =~ ^v[0-9]+\.[0-9]+$ ]]; }
+valid_version() { [[ "$1" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)*$ ]]; }
 valid_branch() { [[ "$1" =~ ^codex/[a-z0-9][a-z0-9-]*$ ]]; }
 valid_bool() { [[ "$1" == "true" || "$1" == "false" ]]; }
 valid_github_issue_url() { [[ "$1" =~ ^https://github\.com/[^/]+/[^/]+/issues/[0-9]+$ ]]; }
@@ -284,7 +284,7 @@ validate_sip() {
   require_sip_sections "$file"
   v="$(trim "$(md_field "$file" "Task ID")")"; require_nonblank "Task ID" "$v"; valid_task_id "$v" || die "Task ID must match issue-0000"
   v="$(trim "$(md_field "$file" "Run ID")")"; require_nonblank "Run ID" "$v"; valid_task_id "$v" || die "Run ID must match issue-0000"
-  v="$(trim "$(md_field "$file" "Version")")"; require_nonblank "Version" "$v"; valid_version "$v" || die "Version must match v0.85-style version format"
+  v="$(trim "$(md_field "$file" "Version")")"; require_nonblank "Version" "$v"; valid_version "$v" || die "Version must match milestone version format (for example v0.85 or v0.87.1)"
   v="$(trim "$(md_field "$file" "Title")")"; require_nonblank "Title" "$v"
   v="$(trim "$(md_field "$file" "Branch")")"; require_nonblank "Branch" "$v"; valid_branch "$v" || die "Branch must be a codex/ branch"
   v="$(trim "$(md_block_field "$file" "Context" "Issue")")"; require_nonblank "Context.Issue" "$v"; valid_github_issue_url "$v" || die "Context.Issue must be a GitHub issue URL"
@@ -304,7 +304,7 @@ validate_sor() {
   require_sor_sections "$file"
   v="$(trim "$(md_field "$file" "Task ID")")"; require_nonblank "Task ID" "$v"; valid_task_id "$v" || die "Task ID must match issue-0000"
   v="$(trim "$(md_field "$file" "Run ID")")"; require_nonblank "Run ID" "$v"; valid_task_id "$v" || die "Run ID must match issue-0000"
-  v="$(trim "$(md_field "$file" "Version")")"; require_nonblank "Version" "$v"; valid_version "$v" || die "Version must match v0.85-style version format"
+  v="$(trim "$(md_field "$file" "Version")")"; require_nonblank "Version" "$v"; valid_version "$v" || die "Version must match milestone version format (for example v0.85 or v0.87.1)"
   v="$(trim "$(md_field "$file" "Title")")"; require_nonblank "Title" "$v"
   v="$(trim "$(md_field "$file" "Branch")")"; require_nonblank "Branch" "$v"; valid_branch "$v" || die "Branch must be a codex/ branch"
   status="$(trim "$(md_field "$file" "Status")")"; require_nonblank "Status" "$status"; [[ "$status" =~ ^(NOT_STARTED|IN_PROGRESS|DONE|FAILED)$ ]] || die "Status must be one of: NOT_STARTED, IN_PROGRESS, DONE, FAILED"

--- a/docs/tooling/editor/task_bundle_editor.js
+++ b/docs/tooling/editor/task_bundle_editor.js
@@ -426,10 +426,10 @@ function validate(model) {
     results.push({ ok: true, text: "Run ID uses the normalized task-id format." });
   }
 
-  if (modelArtifactKey === "sip" && !/^v[0-9]+\.[0-9]+$/.test(metadata.version || "")) {
-    results.push({ ok: false, text: "Version should use the vN.N format." });
+  if (modelArtifactKey === "sip" && !/^v[0-9]+\.[0-9]+(\.[0-9]+)*$/.test(metadata.version || "")) {
+    results.push({ ok: false, text: "Version should use the milestone format vN.N or vN.N.P." });
   } else if (modelArtifactKey === "sip") {
-    results.push({ ok: true, text: "Version uses the normalized vN.N format." });
+    results.push({ ok: true, text: "Version uses the normalized milestone version format." });
   }
 
   const enumRules = ENUM_RULES[modelArtifactKey] || {};


### PR DESCRIPTION
## Summary
- accept dot-suffixed milestone versions like `v0.87.1` in structured prompt validation
- allow shell title inference to preserve dotted milestone versions
- add focused shell and Rust coverage for dot-suffixed bootstrap flows
- align the task bundle editor version guidance with the new milestone format

## Validation
- `bash adl/tools/test_structured_prompt_validation.sh`
- `bash adl/tools/test_pr_init.sh`
- `bash adl/tools/test_pr_issue_version_inference.sh`
- `bash adl/tools/test_pr_finish_delegates_to_rust.sh`
- `cargo test --manifest-path adl/Cargo.toml version_can_be_inferred_from_labels_or_title -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml parse_create_args_accepts_dot_suffixed_version -- --nocapture`
- `git diff --check`

Closes #1355