### PR TITLE
[v0.87][tools] Add structured issue bootstrap invocation template for Codex and subagents

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -38,7 +38,7 @@ The normal workflow is:
 
 Tracked skill bundles live under:
 
-- [`adl/tools/skills`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills)
+- `adl/tools/skills`
 
 Each skill bundle typically contains:
 
@@ -58,7 +58,7 @@ For deterministic use, prefer structured invocation over loose prose.
 The general pattern is:
 
 ```yaml
-Use $<skill-name> at /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/<skill-name>/SKILL.md with this validated input:
+Use $<skill-name> at /Users/daniel/git/agent-design-language/adl/tools/skills/<skill-name>/SKILL.md with this validated input:
 
 skill_input_schema: <schema-id>
 mode: <mode>
@@ -128,7 +128,7 @@ Minimum:
 
 Structured schema:
 
-- [`PR_INIT_SKILL_INPUT_SCHEMA.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md)
+- `adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md`
 - schema id: `pr_init.v1`
 
 ### Supported Modes
@@ -163,8 +163,11 @@ It must stop before:
 
 ### Example Invocation
 
+Canonical template:
+- `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+
 ```yaml
-Use $pr-init at /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/pr-init/SKILL.md with this validated input:
+Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
 
 skill_input_schema: pr_init.v1
 mode: create_and_bootstrap
@@ -226,7 +229,7 @@ Minimum:
 
 Structured schema:
 
-- [`PR_READY_SKILL_INPUT_SCHEMA.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/docs/PR_READY_SKILL_INPUT_SCHEMA.md)
+- `adl/tools/skills/docs/PR_READY_SKILL_INPUT_SCHEMA.md`
 - schema id: `pr_ready.v1`
 
 ### Supported Modes
@@ -273,7 +276,7 @@ It must stop before:
 ### Example Invocation
 
 ```yaml
-Use $pr-ready at /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/pr-ready/SKILL.md with this validated input:
+Use $pr-ready at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-ready/SKILL.md with this validated input:
 
 skill_input_schema: pr_ready.v1
 mode: diagnose_issue
@@ -341,7 +344,7 @@ Minimum:
 
 Structured schema:
 
-- [`PR_RUN_SKILL_INPUT_SCHEMA.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/docs/PR_RUN_SKILL_INPUT_SCHEMA.md)
+- `adl/tools/skills/docs/PR_RUN_SKILL_INPUT_SCHEMA.md`
 - schema id: `pr_run.v1`
 
 ### Supported Modes
@@ -385,7 +388,7 @@ It must stop before:
 ### Example Invocation
 
 ```yaml
-Use $pr-run at /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/pr-run/SKILL.md with this validated input:
+Use $pr-run at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-run/SKILL.md with this validated input:
 
 skill_input_schema: pr_run.v1
 mode: run_issue
@@ -456,7 +459,7 @@ Minimum:
 
 Structured schema:
 
-- [`PR_JANITOR_SKILL_INPUT_SCHEMA.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/docs/PR_JANITOR_SKILL_INPUT_SCHEMA.md)
+- `adl/tools/skills/docs/PR_JANITOR_SKILL_INPUT_SCHEMA.md`
 - schema id: `pr_janitor.v1`
 
 ### Supported Modes
@@ -493,7 +496,7 @@ It must stop before:
 ### Example Invocation
 
 ```yaml
-Use $pr-janitor at /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/pr-janitor/SKILL.md with this validated input:
+Use $pr-janitor at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-janitor/SKILL.md with this validated input:
 
 skill_input_schema: pr_janitor.v1
 mode: watch_pr
@@ -549,8 +552,8 @@ Do not use it for:
 
 Use the tracked finish schema and skill contract:
 
-- [`PR_FINISH_SKILL_INPUT_SCHEMA.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/docs/PR_FINISH_SKILL_INPUT_SCHEMA.md)
-- [`pr-finish/SKILL.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/pr-finish/SKILL.md)
+- `adl/tools/skills/docs/PR_FINISH_SKILL_INPUT_SCHEMA.md`
+- `adl/tools/skills/pr-finish/SKILL.md`
 
 ### Output And Stop Boundary
 
@@ -619,7 +622,7 @@ This skill is findings-only and must not edit code.
 ### Example Invocation
 
 ```yaml
-Use $repo-code-review at /Users/daniel/git/agent-design-language/.worktrees/adl-wp-1299/adl/tools/skills/repo-code-review/SKILL.md to review /Users/daniel/git/agent-design-language. Review the executable codebase first, include manifests and build configuration, run targeted local tests only when bounded and relevant, and write the review to .adl/reviews/<timestamp>-repo-review.md.
+Use $repo-code-review at /Users/daniel/git/agent-design-language/adl/tools/skills/repo-code-review/SKILL.md to review /Users/daniel/git/agent-design-language. Review the executable codebase first, include manifests and build configuration, run targeted local tests only when bounded and relevant, and write the review to .adl/reviews/<timestamp>-repo-review.md.
 ```
 
 ## Choosing The Right Skill

--- a/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md
@@ -6,7 +6,7 @@
 - Status: `proposed`
 - Owner: `Daniel Austin / Agent Logic`
 - Doc Role: `primary`
-- Supporting Docs: `adl/tools/skills/pr-init/SKILL.md`, `adl/tools/skills/pr-init/adl-skill.yaml`, `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
+- Supporting Docs: `adl/tools/skills/pr-init/SKILL.md`, `adl/tools/skills/pr-init/adl-skill.yaml`, `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`, `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
 - Feature Types: `schema`, `policy`, `artifact`
 - Proof Modes: `review`, `tests`
 
@@ -39,6 +39,7 @@ validate-able, and portable across:
   - `adl/tools/skills/pr-init/SKILL.md`
   - `adl/tools/skills/pr-init/adl-skill.yaml`
   - `adl/tools/skills/pr-init/references/output-contract.md`
+  - `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
   - `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
 
 The current `pr-init` skill already distinguishes two real execution
@@ -72,6 +73,7 @@ This document covers the input schema of the `pr-init` skill.
 - Related / supporting docs:
   - `adl/tools/skills/pr-init/SKILL.md`
   - `adl/tools/skills/pr-init/adl-skill.yaml`
+  - `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
   - `docs/milestones/v0.87/features/PR_TOOLING_SIMPLIFICATION_FEATURE.md`
 
 ## Overview
@@ -225,6 +227,9 @@ The skill is responsible for:
 Sub-agent prompts should embed the structured payload directly rather than
 describing the task loosely in prose.
 
+The canonical caller template now lives at:
+- `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+
 Recommended shape:
 
 ```yaml
@@ -251,6 +256,9 @@ policy:
 
 This keeps the invocation inspectable and makes failure reasons easier to
 attribute to input validation versus skill execution.
+
+For day-to-day use, prefer copying the tracked template and only changing the
+issue-specific fields rather than rewriting this example from memory.
 
 ## Data / Artifacts
 

--- a/adl/tools/skills/pr-init/SKILL.md
+++ b/adl/tools/skills/pr-init/SKILL.md
@@ -29,6 +29,9 @@ Within this skill bundle, the operational details live in:
 - `references/init-playbook.md`
 - `references/output-contract.md`
 
+The canonical caller-facing invocation template lives at:
+- `/Users/daniel/git/agent-design-language/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+
 If those docs move, prefer the moved tracked canonical copies over stale path references. Do not silently invent a new workflow model from memory when the repo docs have changed.
 
 ## Current Compatibility Model
@@ -87,6 +90,10 @@ For deterministic ADL execution, also prefer an explicit issue-metadata policy:
 - how labels are chosen or normalized
 - whether body content is user-authored or bootstrap-generated
 
+When the caller can provide structured input, prefer the tracked invocation
+template in:
+- `/Users/daniel/git/agent-design-language/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
+
 If no slug is given, derive one from the title using the repo's normal slug rules.
 
 ## Quick Start
@@ -94,18 +101,20 @@ If no slug is given, derive one from the title using the repo's normal slug rule
 1. Resolve whether the request is:
    - `bootstrap-existing-issue`
    - `create-and-bootstrap-new-issue`
-2. Prefer the Rust-owned path when available.
-3. For new issues:
+2. If using structured invocation, start from the canonical tracked template
+   rather than writing the payload from scratch.
+3. Prefer the Rust-owned path when available.
+4. For new issues:
    - create the GitHub issue correctly
    - ensure the canonical local source issue prompt and root bundle exist
-4. For existing issues:
+5. For existing issues:
    - run the bootstrap/init phase
    - seed the task-bundle `stp.md`
    - seed the initial `sip.md`
    - seed the initial `sor.md`
    - ensure canonical compatibility links exist when the repo expects them
-5. Validate the resulting surfaces mechanically.
-6. Emit a structured readiness result for qualitative card review and stop.
+6. Validate the resulting surfaces mechanically.
+7. Emit a structured readiness result for qualitative card review and stop.
 
 ## Workflow
 
@@ -198,6 +207,9 @@ Prefer repo-native control-plane commands such as:
 - `adl/tools/pr.sh init`
 - `adl pr create`
 - `adl pr init`
+
+For caller payload shape, prefer the canonical tracked template:
+- `/Users/daniel/git/agent-design-language/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
 
 Use existing templates, validation helpers, and path logic from the repository. Do not recreate bundle contents manually unless the repo-native path is unavailable and the user explicitly wants a fallback.
 

--- a/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
+++ b/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
@@ -1,0 +1,163 @@
+# PR Init Invocation Template
+
+## Purpose
+
+This is the canonical caller-facing template for invoking the `pr-init` skill.
+
+Use it when you want to:
+- create and bootstrap a new tracked issue
+- bootstrap an existing tracked issue
+- invoke `pr-init` from Codex CLI, a sub-agent, or a future wrapper without reconstructing the payload from loose prose
+
+This template is a caller artifact. It does not replace the underlying schema in:
+- `adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md`
+
+## Template Rules
+
+- Keep the payload valid against `pr_init.v1`.
+- Use repo-root-stable paths in examples.
+- Make the stop boundary explicit.
+- Do not imply branch creation, worktree creation, or implementation work in this template.
+
+## Canonical Invocation Envelope
+
+Copy this shape and replace the placeholder values.
+
+```yaml
+Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
+
+skill_input_schema: pr_init.v1
+mode: create_and_bootstrap | bootstrap_existing_issue
+repo_root: /Users/daniel/git/agent-design-language
+
+issue:
+  number: null | <issue number>
+  title: null | "[v0.87][tools] Example issue"
+  slug: null | "example-issue"
+  version: null | "v0.87"
+  labels: null | "track:roadmap,type:task,area:tools"
+  body: null | "<inline issue body>"
+  body_file: null | "path/to/body.md"
+
+policy:
+  version_source: explicit | infer
+  label_source: explicit | infer | normalize
+  body_source: authored | generated | infer
+  allow_slug_derivation: true | false
+  stop_after_bootstrap: true
+```
+
+## Mode Notes
+
+### `create_and_bootstrap`
+
+Use when a new GitHub issue must be created.
+
+Minimum practical payload:
+- `mode: create_and_bootstrap`
+- `repo_root`
+- `issue.title`
+- `policy.stop_after_bootstrap: true`
+
+Typical choices:
+- `issue.number: null`
+- `policy.body_source: generated` when you want the control plane to generate the first readable body
+
+### `bootstrap_existing_issue`
+
+Use when the GitHub issue already exists and only the local bootstrap surfaces must be created or reconciled.
+
+Minimum practical payload:
+- `mode: bootstrap_existing_issue`
+- `repo_root`
+- `issue.number`
+- `policy.stop_after_bootstrap: true`
+
+Typical choices:
+- `issue.title: null`
+- `issue.labels: null`
+- `issue.body: null`
+- `issue.body_file: null`
+
+## Example: New Issue Bootstrap
+
+```yaml
+Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
+
+skill_input_schema: pr_init.v1
+mode: create_and_bootstrap
+repo_root: /Users/daniel/git/agent-design-language
+issue:
+  number: null
+  title: "[v0.87][tools] Example issue"
+  slug: "v0-87-tools-example-issue"
+  version: "v0.87"
+  labels: "track:roadmap,type:task,area:tools"
+  body: null
+  body_file: null
+policy:
+  version_source: explicit
+  label_source: explicit
+  body_source: generated
+  allow_slug_derivation: false
+  stop_after_bootstrap: true
+```
+
+## Example: Existing Issue Bootstrap
+
+```yaml
+Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
+
+skill_input_schema: pr_init.v1
+mode: bootstrap_existing_issue
+repo_root: /Users/daniel/git/agent-design-language
+issue:
+  number: 1374
+  title: null
+  slug: "v0-87-tools-add-structured-issue-bootstrap-invocation-template-for-codex-and-subagents"
+  version: "v0.87"
+  labels: null
+  body: null
+  body_file: null
+policy:
+  version_source: explicit
+  label_source: infer
+  body_source: infer
+  allow_slug_derivation: false
+  stop_after_bootstrap: true
+```
+
+## Stop Boundary
+
+This template is only for `pr-init`.
+
+It must stop after:
+- issue creation or resolution
+- source-prompt creation
+- root bundle creation
+- bootstrap validation
+
+It must not continue into:
+- qualitative card review
+- branch creation
+- worktree creation
+- `pr run`
+- implementation
+- `pr finish`
+
+## Caller Checklist
+
+Before invocation, confirm:
+- `repo_root` is absolute
+- the mode is correct for the task
+- exactly one mode contract is satisfied
+- at most one of `issue.body` and `issue.body_file` is set
+- `policy.stop_after_bootstrap` is `true`
+- any omitted slug/version/labels are allowed to be inferred by policy
+
+## Related Docs
+
+- `adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md`
+- `adl/tools/skills/pr-init/SKILL.md`
+- `adl/tools/skills/pr-init/adl-skill.yaml`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`


### PR DESCRIPTION
Closes #1374

## Summary
Added a tracked canonical invocation template for `pr-init` at `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md` and updated the `pr-init` skill, its input schema, and the operational skills guide to reference that template truthfully. The result is a caller-facing, copyable invocation shape for Codex and subagents that stays aligned with the tracked schema and stop boundary.

## Artifacts
- `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
- `adl/tools/skills/pr-init/SKILL.md`
- `adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `git diff -- adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md adl/tools/skills/pr-init/SKILL.md docs/templates/PR_INIT_INVOCATION_TEMPLATE.md` to confirm the branch only changed the intended docs/skills surfaces
  - `rg -n "PR_INIT_INVOCATION_TEMPLATE.md|adl/tools/skills/pr-init/SKILL.md|PR_INIT_SKILL_INPUT_SCHEMA.md" adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md adl/tools/skills/pr-init/SKILL.md docs/templates/PR_INIT_INVOCATION_TEMPLATE.md` to verify the new template and truth-aligned references are wired through the guide, schema, and skill
  - `bash adl/tools/pr.sh finish 1374 --title "[v0.87][tools] Add structured issue bootstrap invocation template for Codex and subagents" --paths "adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md,adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md,adl/tools/skills/pr-init/SKILL.md,docs/templates/PR_INIT_INVOCATION_TEMPLATE.md" --output-card .adl/v0.87/tasks/issue-1374__v0-87-tools-add-structured-issue-bootstrap-invocation-template-for-codex-and-subagents/sor.md` to run the repo-native finish validation, stage the intended paths, commit, push, and open the draft PR
- Results:
  - reference checks passed
  - finish validation and publication passed

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1374__v0-87-tools-add-structured-issue-bootstrap-invocation-template-for-codex-and-subagents/sip.md
- Output card: .adl/v0.87/tasks/issue-1374__v0-87-tools-add-structured-issue-bootstrap-invocation-template-for-codex-and-subagents/sor.md
- Idempotency-Key: v0-87-tools-add-structured-issue-bootstrap-invocation-template-for-codex-and-subagents-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-docs-pr-init-skill-input-schema-md-adl-tools-skills-pr-init-skill-md-docs-templates-pr-init-invocation-template-md-adl-v0-87-tasks-issue-1374-v0-87-tools-add-structured-issue-bootstrap-invocation-template-for-codex-and-subagents-sip-md-adl-v0-87-tasks-issue-1374-v0-87-tools-add-structured-issue-bootstrap-invocation-template-for-codex-and-subagents-sor-md