### PR TITLE
[v0.87][tools] Fix GitHub skill issue creation to apply repo-standard labels

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -159,6 +160,7 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     validate_issue_body_for_create(&repo_root, &title, &normalized_labels, &slug, &create_body)?;
     let issue_url = gh_issue_create(&repo, &title, &create_body, &normalized_labels)?;
     let issue = parse_issue_number_from_url(&issue_url)?;
+    ensure_issue_labels(&repo, issue, &normalized_labels)?;
     let issue_ref = IssueRef::new(issue, version.clone(), slug.clone())?;
     let final_body = if body.trim().is_empty() {
         render_generated_issue_body(
@@ -1522,6 +1524,53 @@ fn gh_issue_create(repo: &str, title: &str, body: &str, labels_csv: &str) -> Res
         bail!("init: gh issue create returned empty output");
     }
     Ok(stdout)
+}
+
+fn issue_label_names(issue: u32, repo: &str) -> Result<Vec<String>> {
+    let labels = run_capture_allow_failure(
+        "gh",
+        &[
+            "issue",
+            "view",
+            &issue.to_string(),
+            "-R",
+            repo,
+            "--json",
+            "labels",
+            "-q",
+            ".labels[].name",
+        ],
+    )?
+    .unwrap_or_default();
+    Ok(labels
+        .lines()
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
+fn ensure_issue_labels(repo: &str, issue: u32, labels_csv: &str) -> Result<()> {
+    let expected: BTreeSet<String> = labels_csv
+        .split(',')
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    if expected.is_empty() {
+        bail!("create: expected at least one label for tracked issue creation");
+    }
+
+    let actual: BTreeSet<String> = issue_label_names(issue, repo)?.into_iter().collect();
+    let missing: Vec<String> = expected.difference(&actual).cloned().collect();
+    if !missing.is_empty() {
+        bail!(
+            "create: issue #{} is missing expected labels after gh issue create: {}",
+            issue,
+            missing.join(", ")
+        );
+    }
+    Ok(())
 }
 
 fn gh_issue_edit_body(repo: &str, issue: u32, body: &str) -> Result<()> {

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -461,7 +461,7 @@ fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
     write_executable(
             &gh_path,
             &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1202\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1202\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
                 gh_log.display(),
                 issue_body_log.display()
             ),
@@ -528,6 +528,51 @@ fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
 }
 
 #[test]
+fn real_pr_create_fails_when_created_issue_is_missing_requested_labels() {
+    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let repo = unique_temp_dir("adl-pr-real-create-missing-labels");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  printf 'https://github.com/example/repo/issues/1204\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  printf 'track:roadmap\\ntype:task\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Missing labels".to_string(),
+        "--slug".to_string(),
+        "v0-86-tools-missing-labels".to_string(),
+        "--labels".to_string(),
+        "track:roadmap,type:task,area:tools".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("missing labels should fail after create");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(err.to_string().contains(
+        "create: issue #1204 is missing expected labels after gh issue create: area:tools"
+    ));
+}
+
+#[test]
 fn real_pr_create_generates_concrete_body_when_none_is_supplied() {
     let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let repo = unique_temp_dir("adl-pr-real-create-generated-body");
@@ -541,7 +586,7 @@ fn real_pr_create_generates_concrete_body_when_none_is_supplied() {
     write_executable(
             &gh_path,
             &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1203\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+                "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1203\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
                 issue_body_log.display()
             ),
         );

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -125,6 +125,7 @@ Minimum:
 - one of:
   - `issue.number`
   - `issue.title`
+- for new tracked issues, explicit `issue.labels`
 
 Structured schema:
 
@@ -142,6 +143,13 @@ Structured schema:
 - `adl/tools/pr.sh init`
 - `adl pr create`
 - `adl pr init`
+
+For `create_and_bootstrap`, the expected machine-safe path is:
+
+- pass explicit repo-standard labels
+- create the issue
+- verify the created issue actually carries those labels
+- only then continue with source-prompt and root-bundle bootstrap
 
 ### Output And Stop Boundary
 

--- a/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md
@@ -152,15 +152,19 @@ Required:
 Optional:
 - `issue.slug`
 - `issue.version`
-- `issue.labels`
 - `issue.body`
 - `issue.body_file`
+
+Required for tracked issue creation:
+- `issue.labels`
 
 Disallowed:
 - `issue.number` as the primary driver of mode selection
 
 Expected behavior:
 - create the GitHub issue
+- require explicit repo-standard labels for tracked issue creation
+- verify the created issue actually carries those labels
 - capture the created issue number and URL
 - seed the canonical local source prompt and root bundle
 - validate mechanical bootstrap
@@ -206,8 +210,8 @@ Callers must validate all of the following before skill invocation:
 5. `policy.stop_after_bootstrap` is `true`
 6. if `issue.slug` is omitted, `policy.allow_slug_derivation` must be `true`
 7. if `issue.version` is omitted, `policy.version_source` must allow inference
-8. if `issue.labels` are omitted for new-issue creation, `policy.label_source`
-   must allow inference or normalization
+8. if `mode = create_and_bootstrap`, `issue.labels` must be present
+9. if `mode = create_and_bootstrap`, `policy.label_source` must be `explicit`
 
 ### Caller Responsibilities
 
@@ -220,6 +224,7 @@ The caller is responsible for:
 The skill is responsible for:
 - executing the bootstrap step truthfully
 - applying only the inference allowed by policy
+- verifying label application after tracked issue creation
 - returning exact created/resolved identities and paths
 
 ### Sub-Agent Invocation Guidance

--- a/adl/tools/skills/pr-init/SKILL.md
+++ b/adl/tools/skills/pr-init/SKILL.md
@@ -82,7 +82,7 @@ For new issue creation, prefer:
 - title
 - slug, if explicitly supplied
 - version or milestone scope, if known
-- labels, if known
+- labels matching the repo-standard tracked issue set
 - issue body or body file, if the user provides one
 
 For deterministic ADL execution, also prefer an explicit issue-metadata policy:
@@ -106,6 +106,8 @@ If no slug is given, derive one from the title using the repo's normal slug rule
 3. Prefer the Rust-owned path when available.
 4. For new issues:
    - create the GitHub issue correctly
+   - pass explicit repo-standard labels rather than relying on label inference
+   - verify the created issue actually has the expected labels before continuing
    - ensure the canonical local source issue prompt and root bundle exist
 5. For existing issues:
    - run the bootstrap/init phase
@@ -131,7 +133,9 @@ Use one of these modes:
 
 For `create_and_bootstrap`:
 - prefer the repository's standard issue-creation path
+- require explicit labels for tracked issue creation
 - create the GitHub issue with the correct title, labels, version, and body inputs
+- verify the created issue carries the requested labels before treating bootstrap as successful
 - capture the resulting issue number and URL
 - ensure the canonical local source prompt is generated or written in the expected location
 
@@ -156,6 +160,7 @@ Do not qualitatively rewrite STP or SIP content in this step beyond the mechanic
 
 Validation must confirm:
 - the GitHub issue exists or was created successfully
+- new tracked issues have the expected labels after creation
 - the canonical source issue prompt exists
 - the expected task-bundle directory exists
 - `stp.md`, `sip.md`, and `sor.md` exist in the bundle

--- a/adl/tools/skills/pr-init/adl-skill.yaml
+++ b/adl/tools/skills/pr-init/adl-skill.yaml
@@ -29,6 +29,7 @@ admission:
       create_and_bootstrap:
         required_issue_fields:
           - "title"
+          - "labels"
       bootstrap_existing_issue:
         required_issue_fields:
           - "number"
@@ -59,6 +60,8 @@ admission:
     - "at_most_one_of_issue.body_and_issue.body_file_may_be_set"
     - "policy.stop_after_bootstrap_must_be_true"
     - "slug_omission_requires_policy.allow_slug_derivation_true"
+    - "create_and_bootstrap_requires_explicit_issue.labels"
+    - "create_and_bootstrap_requires_policy.label_source_explicit"
 execution:
   mode: "auto_apply"
   allow_code_edits: false
@@ -78,7 +81,7 @@ execution:
     - "adl pr create"
     - "adl pr init"
   preferred_path: "rust_owned_control_plane_when_available"
-  validation_policy: "must_verify_issue_source_prompt_root_bundle_and_no_branch_or_worktree_side_effects"
+  validation_policy: "must_verify_issue_labels_source_prompt_root_bundle_and_no_branch_or_worktree_side_effects"
 boundaries:
   writes_limited_to:
     - ".adl/**"

--- a/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
+++ b/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
@@ -35,7 +35,7 @@ issue:
   title: null | "[v0.87][tools] Example issue"
   slug: null | "example-issue"
   version: null | "v0.87"
-  labels: null | "track:roadmap,type:task,area:tools"
+  labels: "track:roadmap,type:task,area:tools" | "<explicit repo-standard labels>"
   body: null | "<inline issue body>"
   body_file: null | "path/to/body.md"
 
@@ -57,11 +57,13 @@ Minimum practical payload:
 - `mode: create_and_bootstrap`
 - `repo_root`
 - `issue.title`
+- `issue.labels`
 - `policy.stop_after_bootstrap: true`
 
 Typical choices:
 - `issue.number: null`
 - `policy.body_source: generated` when you want the control plane to generate the first readable body
+- `policy.label_source: explicit` for tracked issue creation
 
 ### `bootstrap_existing_issue`
 
@@ -153,7 +155,9 @@ Before invocation, confirm:
 - exactly one mode contract is satisfied
 - at most one of `issue.body` and `issue.body_file` is set
 - `policy.stop_after_bootstrap` is `true`
-- any omitted slug/version/labels are allowed to be inferred by policy
+- any omitted slug/version are allowed to be inferred by policy
+- `create_and_bootstrap` includes explicit repo-standard labels
+- `create_and_bootstrap` uses `policy.label_source: explicit`
 
 ## Related Docs
 


### PR DESCRIPTION
Closes #1385

## Summary
Hardened tracked issue creation so `pr create` now fails loudly if the created GitHub issue does not actually carry the requested labels. Added a regression covering that failure mode and tightened the `pr-init` skill contract, schema, invocation template, and operator guide so new tracked issues require explicit repo-standard labels instead of relying on loose inference.

## Artifacts
- updated CLI create path: `adl/src/cli/pr_cmd.rs`
- updated create-path regressions: `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- updated tracked `pr-init` skill contract:
  - `adl/tools/skills/pr-init/SKILL.md`
  - `adl/tools/skills/pr-init/adl-skill.yaml`
  - `adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md`
  - `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
  - `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_creates_issue_and_bootstraps_root_bundle -- --nocapture`
    - verified the happy-path `pr create` flow still succeeds when GitHub reports the requested labels on the created issue
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_fails_when_created_issue_is_missing_requested_labels -- --nocapture`
    - verified `pr create` fails loudly when the created issue is missing a requested label
  - `bash adl/tools/pr.sh ready 1385`
    - verified readiness remains PASS for the bound execution state
  - `bash adl/tools/pr.sh doctor 1385 --json`
    - verified the canonical doctor JSON surface remains PASS with separate preflight/readiness reporting
  - `git diff --check`
    - verified patch cleanliness
- Results:
  - PASS: all listed commands succeeded

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1385__v0-87-tools-fix-github-skill-issue-creation-to-apply-repo-standard-labels/sip.md
- Output card: .adl/v0.87/tasks/issue-1385__v0-87-tools-fix-github-skill-issue-creation-to-apply-repo-standard-labels/sor.md
- Idempotency-Key: v0-87-tools-fix-github-skill-issue-creation-to-apply-repo-standard-labels-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-tools-skills-pr-init-skill-md-adl-tools-skills-pr-init-adl-skill-yaml-adl-tools-skills-docs-pr-init-skill-input-schema-md-docs-templates-pr-init-invocation-template-md-adl-tools-skills-docs-operational-skills-guide-md-adl-v0-87-tasks-issue-1385-v0-87-tools-fix-github-skill-issue-creation-to-apply-repo-standard-labels-sip-md-adl-v0-87-tasks-issue-1385-v0-87-tools-fix-github-skill-issue-creation-to-apply-repo-standard-labels-sor-md