### PR TITLE
[v0.87][tools] Fix worktree_prune.sh empty-array apply crash

### DIFF
--- a/adl/tools/test_worktree_prune.sh
+++ b/adl/tools/test_worktree_prune.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOCTOR_SRC="$ROOT_DIR/adl/tools/worktree_doctor.sh"
+PRUNE_SRC="$ROOT_DIR/adl/tools/worktree_prune.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+managed_root="$tmpdir/managed"
+mkdir -p "$repo/adl/tools" "$managed_root"
+cp "$DOCTOR_SRC" "$repo/adl/tools/worktree_doctor.sh"
+cp "$PRUNE_SRC" "$repo/adl/tools/worktree_prune.sh"
+chmod +x "$repo/adl/tools/worktree_doctor.sh" "$repo/adl/tools/worktree_prune.sh"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "base" > README.md
+  git add README.md
+  git commit -q -m "init"
+  git branch -M main
+)
+
+assert_contains() {
+  local pattern="$1" text="$2" label="$3"
+  grep -Fq "$pattern" <<<"$text" || {
+    echo "assertion failed ($label): expected to find '$pattern'" >&2
+    echo "$text" >&2
+    exit 1
+  }
+}
+
+assert_path_missing() {
+  local path="$1" label="$2"
+  [[ ! -e "$path" ]] || {
+    echo "assertion failed ($label): expected path to be removed: $path" >&2
+    exit 1
+  }
+}
+
+managed_root="$(cd "$managed_root" && pwd -P)"
+
+(
+  cd "$repo"
+  git branch codex/900-merged >/dev/null 2>&1 || true
+  git worktree add -q "$managed_root/adl-wp-900" codex/900-merged
+
+  out="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --apply)"
+  assert_contains "Registered clean merged worktrees removable: 1" "$out" "empty remove_dirs apply run"
+  assert_contains "Directory removals eligible: 0" "$out" "empty remove_dirs apply run"
+  assert_contains "Applying cleanup" "$out" "empty remove_dirs apply run"
+  assert_path_missing "$managed_root/adl-wp-900" "registered worktree removed"
+
+  mkdir -p "$managed_root/rogue-clean"
+  out2="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --apply)"
+  assert_contains "Registered clean merged worktrees removable: 0" "$out2" "non-empty remove_dirs apply run"
+  assert_contains "Directory removals eligible: 1" "$out2" "non-empty remove_dirs apply run"
+  assert_contains "Applying cleanup" "$out2" "non-empty remove_dirs apply run"
+  assert_path_missing "$managed_root/rogue-clean" "managed scratch removed"
+)
+
+echo "worktree prune apply regression: ok"

--- a/adl/tools/worktree_prune.sh
+++ b/adl/tools/worktree_prune.sh
@@ -107,15 +107,19 @@ fi
 
 echo "Applying cleanup..."
 
-for path in "${remove_registered[@]}"; do
-  echo "git -C $repo worktree remove $path"
-  git -C "$repo" worktree remove "$path"
-done
+if (( ${#remove_registered[@]} > 0 )); then
+  for path in "${remove_registered[@]}"; do
+    echo "git -C $repo worktree remove $path"
+    git -C "$repo" worktree remove "$path"
+  done
+fi
 
-for path in "${remove_dirs[@]}"; do
-  echo "rm -rf $path"
-  rm -rf "$path"
-done
+if (( ${#remove_dirs[@]} > 0 )); then
+  for path in "${remove_dirs[@]}"; do
+    echo "rm -rf $path"
+    rm -rf "$path"
+  done
+fi
 
 if [[ "$prune_needed" == "yes" ]]; then
   echo "git -C $repo worktree prune --verbose"


### PR DESCRIPTION
Closes #1405

## Summary
Fixed the `set -u` crash in `adl/tools/worktree_prune.sh` by guarding both removal loops, and added a focused regression that proves `--apply` succeeds with an empty `remove_dirs` set and still removes a real scratch directory.

## Artifacts
- `adl/tools/worktree_prune.sh`
- `adl/tools/test_worktree_prune.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_worktree_prune.sh`
    - validates the empty-array `--apply` path and the non-empty scratch-removal path.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/cards/1405/output_1405.md`
    - validates this finished SOR record after the cleanup.
- Results:
  - both listed commands passed

## Local Artifacts
- Input card:  .adl/cards/1405/input_1405.md
- Output card: .adl/cards/1405/output_1405.md
- Idempotency-Key: v0-87-tools-fix-worktree-prune-sh-empty-array-apply-crash-adl-tools-worktree-prune-sh-adl-tools-test-worktree-prune-sh-adl-cards-1405-input-1405-md-adl-cards-1405-output-1405-md