### PR TITLE
[v0.87][chore] Reorganize completed cards into milestone retirement directories

### DIFF
--- a/docs/codex_playbook.md
+++ b/docs/codex_playbook.md
@@ -12,7 +12,7 @@ Source-of-truth governance: `../CONTRIBUTING.md` (canonical).
 Workflow loop:
 
 ```
-start -> cards -> execute -> review -> finish -> merge -> cleanup
+init -> ready -> run -> review -> finish -> merge -> cleanup
 ```
 
 Card semantics:
@@ -21,14 +21,18 @@ Card semantics:
 - The canonical local draft prompt bundle is `.adl/<scope>/tasks/<task-id>__<slug>/`.
 - Until workflow tooling writes that layout directly, `.adl/cards/` and `.adl/issues/...` remain compatibility inputs that should be synced into the canonical bundle view.
 - Compatibility links remain under `.adl/cards/` for adjacent tooling during migration.
+- GitHub issue state is the source of truth for whether a card is active or complete.
+- Active/current issue cards stay flat under `.adl/cards/<issue>/` while the milestone is in flight.
+- Closed/completed cards may be archived under `.adl/cards/completed/<milestone>/<issue>/` after or as part of milestone closeout so the active top-level card list stays workable.
 - Templates live under `adl/templates/cards/` (versioned).
 - Tasks can be non-code; the same card-based trace applies.
 
 Fast path (copy/paste):
 
 ```bash
-adl/tools/pr.sh start <issue>
-adl/tools/pr.sh cards <issue>
+adl/tools/pr.sh init <issue>
+adl/tools/pr.sh ready <issue>
+adl/tools/pr.sh run <issue>
 # do the work + tests
 adl/tools/pr.sh finish <issue> --title "adl: <short description>" \
   -f .adl/v0.85/tasks/<task-id>__<slug>/sip.md \
@@ -36,7 +40,7 @@ adl/tools/pr.sh finish <issue> --title "adl: <short description>" \
 ```
 
 Recovery (common pitfalls):
-- **Wrong branch:** `git switch main` -> `adl/tools/pr.sh start <issue>`
+- **Wrong branch:** `git switch main` -> rerun the appropriate `pr run <issue>` bind step
 - **Finish after manual commit:** `adl/tools/pr.sh finish ...` still works; it will commit staged changes.
 - **Issue vs PR number confusion:** always use the **issue** number for cards/branches.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -19,12 +19,13 @@ Use this page when you need to orient quickly in the ADL repo.
 
 Default workflow uses `adl_pr_cycle` with the real authoring control plane:
 - `pr init`
-- `pr start`
+- `pr ready`
 - `pr run`
 - `pr finish`
 
 Canonical local STPs live under `.adl/v0.85/tasks/<task-id>__<slug>/`, compatibility cards live under `.adl/cards/<issue>/`, and repo-local execution clones live under `.worktrees/adl-wp-<issue>/`.
-The browser/editor adapter remains narrower than the full control plane; only the validated `pr start` adapter is browser-direct in v0.85.
+GitHub issue state is the source of truth for whether a card is active or complete. Active/current cards stay flat under `.adl/cards/<issue>/` while milestone work is in flight; completed cards may be archived later under `.adl/cards/completed/<milestone>/<issue>/`.
+The browser/editor adapter remains narrower than the full control plane; execution work should follow the `pr ready` -> `pr run` path rather than the older `pr start` model.
 
 ## Reading Order
 


### PR DESCRIPTION
Closes #1396

## Summary
Documented the active-vs-archived card policy in tracked workflow docs and created the local archive bucket shape for future closed-card moves. This worktree currently has no completed cards to archive.

## Artifacts
- updated `docs/codex_playbook.md`
- updated `docs/onboarding.md`
- local archive bucket `.adl/cards/completed/v0.87/` created and left empty because no completed cards were present in this checkout

## Validation
- Validation commands and their purpose:
  - `git -C .worktrees/adl-wp-1396 status --short`
    - verified the tracked change set is bounded to the two intended policy docs
  - `rg -n "completed cards may be archived|Active/current cards stay flat|pr ready|pr run|pr start" docs/codex_playbook.md docs/onboarding.md -S`
    - verified the tracked docs now contain the archive policy and newer lifecycle wording
  - `find .adl/cards -maxdepth 3 -type d | sort`
    - verified the active card directory remains flat and the empty archive bucket exists
  - `ls -1 .adl/cards`
    - verified the top-level card list remains flat for active issue directories plus archive buckets
  - `ls -1 .adl/cards/completed/v0.87 | sort`
    - verified the archive bucket is present and empty in this checkout
- Results:
  - all validation commands passed

## Local Artifacts
- Input card:  .adl/cards/1396/input_1396.md
- Output card: .adl/v0.87/tasks/issue-1396__v0-87-chore-reorganize-completed-cards-into-milestone-retirement-directories/sor.md
- Idempotency-Key: v0-87-chore-reorganize-completed-cards-into-milestone-retirement-directories-docs-codex-playbook-md-docs-onboarding-md-adl-cards-1396-input-1396-md-adl-v0-87-tasks-issue-1396-v0-87-chore-reorganize-completed-cards-into-milestone-retirement-directories-sor-md