### PR TITLE
[v0.87][tools] Finalize local task-bundle closeout when issues are actually closed

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -44,6 +44,13 @@ struct OpenPullRequest {
     is_draft: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct GithubIssueLifecycleState {
+    state: String,
+    #[serde(rename = "stateReason")]
+    state_reason: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct DoctorPreflightJsonPullRequest {
     number: u32,
@@ -581,7 +588,7 @@ fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
     let ready = match parsed.mode {
         DoctorMode::Preflight => None,
         DoctorMode::Ready | DoctorMode::Full => {
-            Some(run_doctor_ready(&repo_root, &issue_ref, &branch)?)
+            Some(run_doctor_ready(&repo_root, &repo, &issue_ref, &branch)?)
         }
     };
     let mode = doctor_mode_name(&parsed.mode);
@@ -694,6 +701,7 @@ fn run_doctor_preflight(repo: &str, version: &str, branch: &str) -> Result<Docto
 
 fn run_doctor_ready(
     repo_root: &Path,
+    repo: &str,
     issue_ref: &IssueRef,
     branch: &str,
 ) -> Result<DoctorReadyResult> {
@@ -710,15 +718,39 @@ fn run_doctor_ready(
     let root_bundle_output = issue_ref.task_bundle_output_path(repo_root);
     let wt_bundle_input = issue_ref.task_bundle_input_path(&worktree_path);
     let wt_bundle_output = issue_ref.task_bundle_output_path(&worktree_path);
+    let closed_completed = issue_is_closed_and_completed(issue_ref.issue_number(), repo)?;
 
     validate_issue_prompt_exists(&source_path)?;
     validate_bootstrap_stp(repo_root, &source_path)?;
     validate_authored_prompt_surface("doctor", &source_path, PromptSurfaceKind::IssuePrompt)?;
+    if closed_completed {
+        reconcile_closed_completed_issue_bundle(repo_root, issue_ref, &root_bundle_output)?;
+    }
     if !root_stp.is_file() {
         bail!("doctor: missing root stp: {}", root_stp.display());
     }
     validate_bootstrap_stp(repo_root, &root_stp)?;
     validate_authored_prompt_surface("doctor", &root_stp, PromptSurfaceKind::Stp)?;
+    if closed_completed {
+        validate_initialized_cards(
+            issue_ref.issue_number(),
+            issue_ref.slug(),
+            &root_bundle_input,
+            &root_bundle_output,
+        )?;
+        return Ok(DoctorReadyResult {
+            lifecycle_state: "closed",
+            worktree: None,
+            source: path_relative_to_repo(repo_root, &source_path),
+            root_stp: path_relative_to_repo(repo_root, &root_stp),
+            root_input: path_relative_to_repo(repo_root, &root_bundle_input),
+            root_output: path_relative_to_repo(repo_root, &root_bundle_output),
+            wt_stp: None,
+            wt_input: None,
+            wt_output: None,
+            status: "PASS",
+        });
+    }
     validate_initialized_cards(
         issue_ref.issue_number(),
         issue_ref.slug(),
@@ -821,6 +853,228 @@ fn run_doctor_ready(
         wt_output: Some(path_relative_to_repo(repo_root, &wt_bundle_output)),
         status: "PASS",
     })
+}
+
+fn issue_is_closed_and_completed(issue: u32, repo: &str) -> Result<bool> {
+    let Some(raw) = run_capture_allow_failure(
+        "gh",
+        &[
+            "issue",
+            "view",
+            &issue.to_string(),
+            "-R",
+            repo,
+            "--json",
+            "state,stateReason",
+        ],
+    )?
+    else {
+        return Ok(false);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(false);
+    }
+    let state: GithubIssueLifecycleState =
+        serde_json::from_str(trimmed).context("failed to parse gh issue state json")?;
+    Ok(state.state == "CLOSED" && state.state_reason.as_deref() == Some("COMPLETED"))
+}
+
+fn reconcile_closed_completed_issue_bundle(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    canonical_output: &Path,
+) -> Result<()> {
+    let bundle_dir = issue_ref.task_bundle_dir_path(repo_root);
+    if let Some(parent) = bundle_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let duplicates = matching_task_bundle_dirs(repo_root, issue_ref)?;
+    if !bundle_dir.exists() {
+        if let Some(existing) = duplicates.first() {
+            fs::rename(existing, &bundle_dir).with_context(|| {
+                format!(
+                    "doctor: failed to reconcile duplicate task bundle '{}' into canonical '{}'",
+                    existing.display(),
+                    bundle_dir.display()
+                )
+            })?;
+        } else {
+            fs::create_dir_all(&bundle_dir)?;
+        }
+    }
+
+    if !ensure_nonempty_file_path(canonical_output)? {
+        for duplicate in matching_task_bundle_dirs(repo_root, issue_ref)? {
+            if duplicate == bundle_dir {
+                continue;
+            }
+            let candidate = duplicate.join("sor.md");
+            if ensure_nonempty_file_path(&candidate)? {
+                fs::copy(&candidate, canonical_output).with_context(|| {
+                    format!(
+                        "doctor: failed to restore canonical sor from duplicate '{}'",
+                        candidate.display()
+                    )
+                })?;
+                break;
+            }
+        }
+
+        if !ensure_nonempty_file_path(canonical_output)? {
+            let cards_root = resolve_cards_root(repo_root, None);
+            let review_output = card_output_path(&cards_root, issue_ref.issue_number());
+            if ensure_nonempty_file_path(&review_output)? {
+                fs::copy(&review_output, canonical_output).with_context(|| {
+                    format!(
+                        "doctor: failed to restore canonical sor from review card '{}'",
+                        review_output.display()
+                    )
+                })?;
+            }
+        }
+    }
+
+    if !ensure_nonempty_file_path(canonical_output)? {
+        bail!(
+            "doctor: closed issue is missing canonical sor: {}",
+            canonical_output.display()
+        );
+    }
+
+    normalize_closed_completed_output_card(canonical_output)?;
+    validate_completed_sor(repo_root, canonical_output)?;
+
+    for duplicate in matching_task_bundle_dirs(repo_root, issue_ref)? {
+        if duplicate != bundle_dir {
+            fs::remove_dir_all(&duplicate).with_context(|| {
+                format!(
+                    "doctor: failed to remove duplicate closed task bundle '{}'",
+                    duplicate.display()
+                )
+            })?;
+        }
+    }
+
+    let cards_root = resolve_cards_root(repo_root, None);
+    let review_output = card_output_path(&cards_root, issue_ref.issue_number());
+    ensure_symlink(&review_output, canonical_output)?;
+    Ok(())
+}
+
+fn matching_task_bundle_dirs(repo_root: &Path, issue_ref: &IssueRef) -> Result<Vec<PathBuf>> {
+    let tasks_dir = repo_root.join(".adl").join(issue_ref.scope()).join("tasks");
+    if !tasks_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let prefix = format!("{}__", issue_ref.task_issue_id());
+    let mut matches = Vec::new();
+    for entry in fs::read_dir(&tasks_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&prefix) {
+            matches.push(entry.path());
+        }
+    }
+    matches.sort();
+    Ok(matches)
+}
+
+fn normalize_closed_completed_output_card(path: &Path) -> Result<()> {
+    let mut text = fs::read_to_string(path)?;
+    replace_field_line_in_text(&mut text, "Status", "DONE");
+    replace_first_exact_line(
+        &mut text,
+        "- Integration state: worktree_only | pr_open | merged",
+        "- Integration state: merged",
+    );
+    replace_first_exact_line(
+        &mut text,
+        "- Integration state: worktree_only",
+        "- Integration state: merged",
+    );
+    replace_first_exact_line(
+        &mut text,
+        "- Integration state: pr_open",
+        "- Integration state: merged",
+    );
+    replace_first_exact_line(
+        &mut text,
+        "- Verification scope: worktree | pr_branch | main_repo",
+        "- Verification scope: main_repo",
+    );
+    replace_first_exact_line(
+        &mut text,
+        "- Verification scope: worktree",
+        "- Verification scope: main_repo",
+    );
+    replace_first_exact_line(
+        &mut text,
+        "- Verification scope: pr_branch",
+        "- Verification scope: main_repo",
+    );
+    replace_first_prefixed_line(
+        &mut text,
+        "- Worktree-only paths remaining:",
+        "- Worktree-only paths remaining: none",
+    );
+    fs::write(path, text)?;
+    Ok(())
+}
+
+fn replace_field_line_in_text(text: &mut String, label: &str, value: &str) {
+    let prefix = format!("{label}:");
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if line.starts_with(&prefix) {
+            out.push(format!("{prefix} {value}"));
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    *text = out.join("\n");
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+}
+
+fn replace_first_exact_line(text: &mut String, from: &str, to: &str) {
+    let mut out = Vec::new();
+    let mut replaced = false;
+    for line in text.lines() {
+        if !replaced && line == from {
+            out.push(to.to_string());
+            replaced = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    *text = out.join("\n");
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+}
+
+fn replace_first_prefixed_line(text: &mut String, prefix: &str, to: &str) {
+    let mut out = Vec::new();
+    let mut replaced = false;
+    for line in text.lines() {
+        if !replaced && line.starts_with(prefix) {
+            out.push(to.to_string());
+            replaced = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    *text = out.join("\n");
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
 }
 
 fn doctor_mode_name(mode: &DoctorMode) -> &'static str {

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -974,3 +974,264 @@ fn real_pr_ready_requires_slug_when_local_state_missing() {
         .to_string()
         .contains("ready: could not infer slug; pass --slug or run start first"));
 }
+
+#[test]
+fn real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree() {
+    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = unique_temp_dir("adl-pr-doctor-closed-issue-reconcile");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "doctor closed reconcile\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(
+        1410,
+        "v0.87",
+        "v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed",
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.87][tools] Finalize local task-bundle closeout when issues are actually closed",
+    );
+    real_pr(&[
+        "init".to_string(),
+        "1410".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--title".to_string(),
+        "[v0.87][tools] Finalize local task-bundle closeout when issues are actually closed"
+            .to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let canonical_bundle = issue_ref.task_bundle_dir_path(&repo);
+    let duplicate_bundle = repo
+        .join(".adl")
+        .join("v0.87")
+        .join("tasks")
+        .join("issue-1410__closeout-drift-legacy");
+    fs::rename(&canonical_bundle, &duplicate_bundle).expect("move bundle to duplicate");
+
+    let duplicate_sip = duplicate_bundle.join("sip.md");
+    write_authored_sip(
+        &duplicate_sip,
+        &issue_ref,
+        "[v0.87][tools] Finalize local task-bundle closeout when issues are actually closed",
+        "codex/1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+
+    fs::write(
+        duplicate_bundle.join("sor.md"),
+        r#"# v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed
+
+Task ID: issue-1410
+Run ID: issue-1410
+Version: v0.87
+Title: [v0.87][tools] Finalize local task-bundle closeout when issues are actually closed
+Branch: codex/1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed
+Status: IN_PROGRESS
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: local test harness
+- Start Time: 2026-04-07T00:00:00Z
+- End Time: 2026-04-07T00:05:00Z
+
+## Summary
+Closed issue bundle drift was repaired.
+## Artifacts produced
+- adl/src/cli/pr_cmd.rs
+## Actions taken
+- Reconciled a stale local closeout record.
+## Main Repo Integration (REQUIRED)
+- Tracked paths prepared for main-repo integration:
+  - `adl/src/cli/pr_cmd.rs`
+- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: branch-local tracked edits committed and prepared for PR
+- Verification performed:
+  - `git diff -- adl/src/cli/pr_cmd.rs`
+    - verifies the tracked change intended for the PR.
+- Result: PASS
+## Validation
+- Validation commands and their purpose:
+  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.87/tasks/issue-1410__closeout-drift-legacy/sor.md`
+    - verifies this completed execution record remains structurally valid.
+- Results:
+  - all listed commands passed
+## Verification Summary
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "completed SOR validation"
+  determinism:
+    status: PASS
+    replay_verified: not_applicable
+    ordering_guarantees_verified: not_applicable
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+## Determinism Evidence
+- Determinism tests executed: completed SOR validation
+- Replay verification (same inputs -> same artifacts/order): not applicable
+- Ordering guarantees (sorting / tie-break rules used): not applicable
+- Artifact stability notes: not applicable
+## Security / Privacy Checks
+- Secret leakage scan performed: manual inspection
+- Prompt / tool argument redaction verified: yes
+- Absolute path leakage check: repo-relative paths only
+- Sandbox / policy invariants preserved: yes
+## Replay Artifacts
+- Trace bundle path(s): not applicable
+- Run artifact root: not applicable
+- Replay command used for verification: not applicable
+- Replay result: not applicable
+## Artifact Verification
+- Primary proof surface: `.adl/v0.87/tasks/issue-1410__closeout-drift-legacy/sor.md`
+- Required artifacts present: true
+- Artifact schema/version checks: completed-phase SOR validation passed
+- Hash/byte-stability checks: not performed
+- Missing/optional artifacts and rationale: no runtime trace required for this tooling issue
+## Decisions / Deviations
+- none
+## Follow-ups / Deferred work
+- none
+"#,
+    )
+    .expect("write stale sor");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  echo '[]'\n  exit 0\nfi\nif [[ \"$1 $2 $3 $4\" == \"issue view 1410 -R\" ]]; then\n  echo '{\"state\":\"CLOSED\",\"stateReason\":\"COMPLETED\"}'\n  exit 0\nfi\nexit 1\n",
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let doctor = real_pr(&[
+        "doctor".to_string(),
+        "1410".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--mode".to_string(),
+        "full".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87".to_string(),
+        "--json".to_string(),
+    ]);
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    doctor.expect("doctor closed reconcile");
+
+    let canonical_output = issue_ref.task_bundle_output_path(&repo);
+    let canonical_text = fs::read_to_string(&canonical_output).expect("read canonical sor");
+    assert!(
+        canonical_bundle.is_dir(),
+        "canonical bundle should exist after reconciliation"
+    );
+    assert!(
+        !duplicate_bundle.exists(),
+        "duplicate bundle should be removed after reconciliation"
+    );
+    assert!(canonical_text.contains("Status: DONE"));
+    assert!(canonical_text.contains("- Integration state: merged"));
+    assert!(canonical_text.contains("- Verification scope: main_repo"));
+    assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
+    assert!(!issue_ref.default_worktree_path(&repo, None).exists());
+}


### PR DESCRIPTION
Closes #1410

## Summary
Updated `pr doctor` so closed/completed issues can reconcile their local task bundle to merged truth without requiring a live worktree. Added a focused lifecycle regression covering duplicate-bundle recovery, output-card restoration, and final closeout normalization.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
- `.adl/v0.87/tasks/issue-1410__v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed/sor.md`

## Validation
- `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree -- --nocapture`
  - verified doctor/full reconciles a closed/completed issue bundle without requiring a live worktree
- `cargo fmt --manifest-path adl/Cargo.toml --all --check`
  - verified the branch remains rustfmt-clean after the doctor reconciliation changes
- `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
  - verified the new control-plane helpers and lifecycle test compile cleanly under strict linting
- `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`
  - verified the full PR control-plane suite after the closed/completed reconciliation path was added
- Results: all scoped validations passed

## Local Artifacts
- Input card:  .adl/v0.87/tasks/issue-1410__v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed/sip.md
- Output card: .adl/v0.87/tasks/issue-1410__v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed/sor.md
- Idempotency-Key: v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed-adl-v0-87-tasks-issue-1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed-sip-md-adl-v0-87-tasks-issue-1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed-sor-md