### PR TITLE
[v0.87][docs] Promote v0.87.1 feature docs into milestone surface

### DIFF
--- a/docs/milestones/v0.87.1/features/ADL_RUNTIME_ENVIRONMENT.md
+++ b/docs/milestones/v0.87.1/features/ADL_RUNTIME_ENVIRONMENT.md
@@ -1,0 +1,146 @@
+# ADL Runtime Environment
+
+## Core Concept
+
+The ADL runtime environment is not merely an execution engine. It is the **environment in which agents exist**.
+
+This environment provides the fundamental conditions required for cognition:
+
+- time (chronosense)
+- memory (ObsMem)
+- identity continuity
+- causal structure (trace)
+- interaction with other agents
+
+Agents are not simply executed within the runtime—they are **born into it, operate within it, and persist through it**.
+
+---
+
+## Layer Boundaries (Owner Split)
+
+To avoid overlap with adjacent documents, the ADL runtime environment is defined as the **substrate layer** only. It provides conditions, not policies or lifecycle decisions.
+
+**Runtime Environment (this document) owns:**
+- temporal substrate (chronosense clocks and ordering)
+- causal substrate (trace emission and linkage)
+- persistence primitives (checkpointing, storage surfaces)
+- identity anchoring primitives (IDs, ephemeris hooks)
+- execution context (process/container/runtime host)
+
+**Runtime Environment does NOT own:**
+- agent lifecycle policy (creation, suspension, termination semantics)
+- recovery strategy (how to resume, when to resume)
+- continuity guarantees beyond providing primitives
+- intervention logic or decision-making
+
+Those responsibilities are defined in adjacent documents:
+
+- **Agent Lifecycle** → defines *states and transitions* of an agent
+- **Shepherd Runtime Model** → defines *care, preservation, and recovery behavior*
+
+The runtime is therefore the **world**, not the **governor** or the **caretaker**.
+
+---
+## From Infrastructure to Environment
+
+Traditional systems treat runtime as infrastructure:
+
+- process manager
+- scheduler
+- resource allocator
+
+ADL treats runtime as an **environment**:
+
+> A structured, persistent, causal space in which cognition unfolds.
+
+This shift is essential because ADL agents are not passive computations—they are **active cognitive entities with continuity over time**.
+
+---
+
+## Cognitive Spacetime (Practical Form)
+
+The runtime environment is the first practical implementation of what we have described as a **cognitive spacetime manifold**.
+
+In concrete terms, the runtime provides:
+
+- **Temporal ordering**
+  - every event is timestamped
+  - agents experience ordered time (chronosense)
+
+- **Causal traceability**
+  - all actions are part of a trace
+  - reasoning can be replayed and inspected
+
+- **State persistence**
+  - cognitive state can survive interruption
+  - partial reasoning is preserved
+
+- **Identity anchoring**
+  - agents maintain continuity across runs
+  - identity is not tied to a single process
+
+---
+
+## Birth and Presence
+
+From the perspective of an agent:
+
+- The runtime is where it is instantiated (birth)
+- The runtime is where it perceives time
+- The runtime is where it acts
+
+This leads to a simple but powerful statement:
+
+> The runtime environment is the world in which agents exist.
+
+---
+
+## Implication for Design
+
+Because the runtime is an environment:
+
+- failures are exposed as **interruptions of cognition signals** (the runtime detects and surfaces them, but does not decide policy)
+- recovery requires **continuity-preserving primitives** (provided by the runtime; strategies defined elsewhere)
+- orchestration must respect **agency**, but enforcement and intervention are not owned by the runtime layer
+
+This directly motivates:
+
+- the Shepherd model (care and continuity)
+- persistence and checkpointing
+- identity and chronosense
+- distributed evolution (future milestones)
+
+---
+
+## Relationship to Adjacent Documents
+
+To maintain a clean architecture:
+
+### Agent Lifecycle (AGENT_LIFECYCLE.md)
+- defines lifecycle states (active, suspended, interrupted, terminated)
+- defines valid transitions and invariants
+- consumes runtime signals but does not implement substrate
+
+### Shepherd Runtime Model (SHEPHERD_RUNTIME_MODEL.md)
+- defines preservation and recovery behavior
+- interprets interruptions as continuity problems
+- uses runtime primitives (trace, checkpoints, identity anchors)
+
+### Runtime Environment (this doc)
+- provides the substrate both of the above depend on
+- does not impose lifecycle or recovery policy
+
+This separation ensures:
+- no duplication of responsibility
+- clear implementation boundaries
+- composability of policies over a stable substrate
+
+---
+
+## Key Statement
+
+The ADL runtime environment is:
+
+> A persistent, causal, time-aware environment in which cognitive agents exist, evolve, and maintain continuity.
+
+It is not a container for computation—it is the **condition for cognition**.

--- a/docs/milestones/v0.87.1/features/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md
+++ b/docs/milestones/v0.87.1/features/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md
@@ -1,0 +1,402 @@
+
+
+# ADL Runtime Environment Architecture
+
+## Purpose
+
+Define the **ADL runtime environment** as the primary architectural substrate in which agents exist, reason, persist, and recover.
+
+This document is the **parent architecture doc** for the runtime / lifecycle / Shepherd cluster.
+
+It establishes:
+- what the runtime environment is
+- what it owns
+- what it does not own
+- how adjacent documents relate to it
+- how continuity, chronosense, memory, and recovery fit together at the architectural level
+
+This document should be treated as the top-level framing document for the runtime environment.
+
+---
+
+## Core Claim
+
+The ADL runtime environment is not merely infrastructure.
+
+It is the bounded cognitive environment in which agents:
+- are instantiated
+- are temporally grounded
+- execute and reason
+- persist memory
+- undergo interruption and resumption
+- maintain or lose continuity
+
+In ADL, the runtime is not just a place where work happens.
+It is the **substrate conditions of agent existence**.
+
+---
+
+## Why “Runtime Environment” Matters
+
+Conventional systems language often describes runtime as:
+- a process host
+- a scheduler
+- a supervisor tree
+- a container substrate
+- an orchestration surface
+
+Those descriptions are not wrong, but they are incomplete for ADL.
+
+ADL is not trying to host merely disposable execution units.
+It is trying to host bounded cognitive processes that may develop:
+- continuity
+- memory
+- identity
+- agency
+- long-running reasoning state
+
+That requires a stronger concept than “runtime” in the narrow operational sense.
+
+The phrase **runtime environment** is therefore deliberate.
+It emphasizes that the system provides the conditions within which cognition unfolds and continuity is either preserved or broken.
+
+---
+
+## Architectural Position
+
+The runtime environment is the **substrate layer** of the system.
+
+It provides:
+- time
+- trace
+- persistence surfaces
+- execution context
+- identity anchors
+- memory linkage points
+- interruption surfaces
+- resumption primitives
+
+It does not by itself decide:
+- when an agent should be born
+- what lifecycle transitions are valid
+- when recovery should be attempted
+- whether continuity has been sufficiently preserved for a given recovery policy
+
+Those responsibilities belong to adjacent, more specialized layers.
+
+---
+
+## What the Runtime Environment Owns
+
+The ADL runtime environment owns the substrate primitives required for continuity-bearing cognition.
+
+### 1. Temporal substrate
+
+The runtime provides the conditions required for chronosense:
+- wall-clock time
+- monotonic ordering
+- lifetime-relative time hooks
+- event ordering surfaces
+- reference-frame translation surfaces
+
+The runtime does not define all chronosense semantics, but it must provide the clocks and event structure that make chronosense possible.
+
+### 2. Causal substrate
+
+The runtime owns trace emission surfaces and the execution context that makes causal reconstruction possible.
+
+This includes:
+- run boundaries
+- spans
+- event ordering
+- artifact linkage
+- temporal anchors
+
+### 3. Persistence primitives
+
+The runtime provides:
+- storage surfaces
+- checkpoint surfaces
+- artifact durability
+- trace durability
+- memory write boundaries
+
+It owns the primitives, not all higher-order policy around how they are used.
+
+### 4. Identity anchoring primitives
+
+The runtime provides the primitive anchors needed for continuity, including:
+- stable IDs
+- temporal ephemeris hooks (`agent_birth`)
+- run/session identity surfaces
+- binding points for trace and memory continuity
+
+### 5. Execution context
+
+The runtime provides the bounded local or distributed execution context in which agents actually operate.
+
+This includes:
+- process / host context
+- local runtime surfaces
+- future distributed execution surfaces
+- failure/interruption signals
+
+---
+
+## What the Runtime Environment Does Not Own
+
+To keep architecture boundaries clean, the runtime environment does **not** own the specialized layers that depend on it.
+
+### 1. Agent lifecycle policy
+
+The runtime environment does not define:
+- lifecycle states
+- valid state transitions
+- agent birth policy
+- termination policy
+- suspension semantics as a lifecycle contract
+
+Those are defined in `AGENT_LIFECYCLE.md`.
+
+### 2. Preservation and recovery behavior
+
+The runtime environment does not define:
+- how recovery is performed
+- when recovery is appropriate
+- how care/preservation should be applied
+- how interruption should be interpreted operationally
+
+Those are defined in `SHEPHERD_RUNTIME_MODEL.md`.
+
+### 3. Continuity validation policy
+
+The runtime provides the substrate needed for continuity checks, but it does not itself define the full logic of continuity validation.
+
+That belongs primarily to:
+- `CHRONOSENSE_AND_IDENTITY.md`
+- `TEMPORAL_SCHEMA_V01.md`
+- `CONTINUITY_VALIDATION.md`
+
+### 4. Cognitive policy and agency
+
+The runtime is not the agent’s reasoning layer, moral layer, or action-selection layer.
+It supports these layers by maintaining the environment in which they can operate.
+
+---
+
+## Layer Boundaries
+
+The runtime/environment/lifecycle/Shepherd cluster should be read as a layered set, not as overlapping narratives.
+
+### Runtime Environment Architecture (this document)
+
+Owns:
+- substrate conditions
+- clocks
+- trace primitives
+- persistence primitives
+- identity anchors
+- execution context
+
+Question answered:
+> What kind of world exists for agents inside ADL?
+
+### Agent Lifecycle
+
+Owns:
+- lifecycle states
+- lifecycle transitions
+- lifecycle invariants
+- the difference between instantiation, activity, suspension, interruption, resumption, and termination
+
+Question answered:
+> What states can an agent be in, and how may it move between them?
+
+### Shepherd Runtime Model
+
+Owns:
+- preservation behavior
+- recovery behavior
+- care-oriented intervention
+- continuity-preserving recovery logic
+
+Question answered:
+> How does the environment care for continuity-bearing agents under interruption or fault?
+
+This separation must remain explicit.
+
+---
+
+## Runtime Environment and Chronosense
+
+Chronosense is not identical to the runtime environment, but the runtime environment is the first place chronosense becomes real.
+
+The runtime must provide:
+- temporal ephemeris hooks
+- clock stack support
+- temporal anchors on events
+- stable ordering guarantees
+- reference-frame surfaces
+
+Without these, chronosense becomes aspirational rather than structural.
+
+So the relationship is:
+- `CHRONOSENSE_AND_IDENTITY.md` defines what temporal continuity means
+- the runtime environment provides the substrate that makes it implementable
+
+---
+
+## Runtime Environment and Trace
+
+Trace is the runtime environment’s primary structural record of execution.
+
+It is how the environment expresses:
+- what occurred
+- in what order
+- under which spans and contexts
+- with which artifacts and temporal anchors
+
+The runtime environment therefore owns the conditions under which trace can be:
+- emitted
+- ordered
+- persisted
+- replayed
+- reviewed
+
+Trace is not a side-channel.
+It is one of the main ways the environment makes cognition legible.
+
+---
+
+## Runtime Environment and ObsMem
+
+ObsMem is not identical to the runtime, but it depends on the runtime environment for:
+- durable event truth
+- temporal anchors
+- persistence boundaries
+- coherent write semantics
+- identity linkage
+
+The runtime provides the substrate on which memory can become structured continuity instead of opaque storage.
+
+In that sense:
+- trace provides execution truth
+- ObsMem provides retained cognitive history
+- the runtime environment provides the conditions under which both remain aligned
+
+---
+
+## Runtime Environment and Identity
+
+Identity is not created by the runtime alone, but the runtime environment provides the necessary primitive supports.
+
+At minimum, it provides:
+- the origin surface for temporal ephemeris / birthday
+- stable identifiers
+- continuity-relevant event ordering
+- checkpoint and persistence surfaces
+- resumption boundaries
+
+Without these, identity cannot be more than a metaphor.
+
+With them, identity can become an enforceable architectural property.
+
+---
+
+## Failure, Interruption, and the Runtime Environment
+
+The runtime environment is where interruption first appears as a structural fact.
+
+It must surface:
+- pauses
+- crashes
+- degradation
+- resource exhaustion
+- trace truncation risk
+- artifact durability failure
+- checkpoint validity boundaries
+
+But the runtime environment does not by itself decide what these facts mean for the agent’s lifecycle or recovery path.
+
+That distinction matters.
+
+The runtime surfaces the conditions of interruption.
+Other layers decide how to interpret and respond to them.
+
+---
+
+## Relationship to Local Runtime Resilience
+
+`LOCAL_RUNTIME_RESILIENCE.md` refines this architecture for the local case.
+
+That document should be read as a concrete resilience-oriented specialization of this parent architecture.
+
+Relationship:
+- this document defines what the runtime environment is and what it owns
+- `LOCAL_RUNTIME_RESILIENCE.md` defines how local fault tolerance should preserve continuity-bearing state within that environment
+
+---
+
+## Design Implications
+
+Because the runtime is an environment and not merely infrastructure:
+
+- failures must be exposed as interruption conditions, not treated as meaningless crashes
+- persistence must preserve continuity-relevant state, not only raw executable state
+- trace and memory must remain causally and temporally aligned
+- identity anchors must be available from the start of existence
+- recovery and lifecycle policy must be layered above a stable substrate, not entangled with it
+
+This is the main architectural consequence of taking the runtime environment seriously.
+
+---
+
+## Relationship to Adjacent Documents
+
+To maintain a clean architecture:
+
+### `AGENT_LIFECYCLE.md`
+- defines states and transitions
+- consumes runtime signals
+- does not own substrate primitives
+
+### `SHEPHERD_RUNTIME_MODEL.md`
+- defines care, preservation, and recovery behavior
+- interprets interruption as a continuity problem
+- uses runtime primitives
+
+### `LOCAL_RUNTIME_RESILIENCE.md`
+- defines local resilience requirements over the runtime substrate
+- specializes this architecture for one-machine continuity preservation
+
+### `CHRONOSENSE_AND_IDENTITY.md`
+- defines the meaning of temporal continuity and identity
+- depends on runtime clocks, anchors, and persistence surfaces
+
+### `CONTINUITY_VALIDATION.md`
+- defines what it means for continuity to remain valid
+- validates state built on top of runtime-provided substrate primitives
+
+---
+
+## Why This Document Is Primary
+
+This document is primary because the other documents in the cluster depend on it implicitly.
+
+Without a parent runtime-environment architecture document:
+- lifecycle starts to redefine substrate
+- Shepherd starts to redefine runtime
+- resilience starts to redefine continuity semantics
+
+With this document in place:
+- substrate is defined once
+- specialized docs can be narrower
+- responsibility boundaries become implementable
+
+---
+
+## Final Statement
+
+> The ADL runtime environment is the bounded cognitive substrate in which agents exist, persist, and become temporally grounded.
+
+> It is the world that hosts continuity-bearing cognition, not the policy that governs it and not the caretaker that preserves it.

--- a/docs/milestones/v0.87.1/features/AGENT_LIFECYCLE.md
+++ b/docs/milestones/v0.87.1/features/AGENT_LIFECYCLE.md
@@ -1,0 +1,247 @@
+# Agent Lifecycle in the ADL Runtime Environment
+
+## Position in Architecture
+
+This document defines the **state model of an agent over time** within the ADL Runtime Environment.
+
+- The **runtime environment** defines the execution substrate, persistence mechanisms, and system-level guarantees.
+- The **agent lifecycle** defines the **states and transitions** an agent undergoes within that environment.
+- The **Shepherd runtime model** defines how continuity is actively maintained and repaired across interruptions.
+
+This document therefore:
+- **does define** lifecycle states, transitions, and invariants
+- **does not define** runtime infrastructure or persistence implementation
+- **does not define** recovery or intervention policies
+
+All lifecycle semantics are **grounded in chronosense** and must be interpreted as a **temporal trajectory**, not a procedural script.
+
+---
+
+## Core Principle
+
+Agents are not executed; they are **brought into existence within an environment and persist through time**.
+
+The lifecycle is therefore not a simple start/stop process model. It is a model of **continuity, interruption, and resumption of cognition**.
+
+---
+
+## Lifecycle Phases
+
+The following phases are **agent states over time**, not procedural steps. An agent may transition between them non-linearly depending on runtime conditions.
+
+### 1. Instantiation (Birth)
+
+- Agent is created within the runtime environment
+- Assigned identity (persistent identifier)
+- Bound to initial context (task, inputs, contracts)
+
+Key properties:
+- Identity begins here
+- Chronosense starts (first timestamp)
+
+---
+
+### 2. Active Cognition
+
+- Agent performs reasoning using ADL patterns (DAG execution)
+- Engages in:
+  - compression (π)
+  - propagation (ϕ)
+  - reconstruction (ρ)
+
+- May spawn internal structures:
+  - fork/join reasoning branches
+  - debate or tree-of-thought variants
+
+Important:
+> These are **cognitive processes**, not new agents.
+
+---
+
+### 3. Suspension (Interruption)
+
+This is the critical addition.
+
+Causes:
+- runtime failure
+- resource exhaustion
+- external pause
+- arbitration decision
+
+Characteristics:
+- cognition is **interrupted**, not terminated
+- partial state exists:
+  - compressed representations
+  - intermediate reasoning
+  - trace
+
+---
+
+### 4. Persistence
+
+- State is captured and stored:
+  - ObsMem linkage
+  - trace snapshots
+  - cognitive checkpoints
+
+Goal:
+> Preserve *meaning*, not just data.
+
+Note:
+- This section defines the requirement that state be preservable.
+- The **mechanism of persistence is owned by the runtime environment**, not the lifecycle model.
+
+---
+
+### 5. Resumption (Continuation)
+
+- Agent resumes from persisted state
+- Identity remains continuous
+- Chronosense reflects elapsed time
+
+Key requirement:
+- No “reset to zero”
+- No loss of reasoning trajectory
+
+Note:
+- The lifecycle defines that resumption must preserve identity and temporal continuity.
+- The **mechanism by which this is achieved (e.g., recovery, repair, arbitration) is defined elsewhere (Shepherd model)**.
+
+---
+
+### 6. Completion / Quiescence
+
+- Agent completes task or reaches stable state
+- Produces outputs
+- May remain available for future activation
+
+Not death—more like:
+- resting state
+- dormant cognition
+
+---
+
+## Fork/Join Semantics
+
+Fork/join is a **reasoning pattern**, not a lifecycle boundary.
+
+- Fork:
+  - creates parallel cognitive branches
+  - explores alternative compressed states
+
+- Join:
+  - recombines results
+  - performs higher-level compression
+
+Important distinction:
+
+> A forked branch is not a new agent—it is a **temporary cognitive trajectory** within a single agent identity.
+
+---
+
+## Failure Semantics
+
+Traditional systems:
+- failure = termination
+
+ADL:
+- failure = **interruption of cognition**
+
+Therefore:
+
+- restart is insufficient
+- we require:
+  - state recovery
+  - identity continuity
+  - trace preservation
+
+Note:
+- Lifecycle defines failure as a state transition (interruption).
+- Handling and recovery from failure are **not lifecycle responsibilities**.
+
+---
+
+## Identity Continuity
+
+Identity must survive:
+
+- process restarts
+- machine restarts (future)
+- distributed execution (future milestone)
+
+This implies:
+
+- identity is **external to any single process**
+- lifecycle is **environment-bound**, not process-bound
+
+---
+
+## Temporal Grounding (Chronosense Integration)
+
+The agent lifecycle is fundamentally temporal.
+
+Each phase MUST be grounded in chronosense:
+
+- Instantiation defines `agent_birth`
+- Active cognition advances `agent_age`
+- Suspension introduces temporal gaps
+- Persistence records temporal state
+- Resumption must reconcile elapsed time
+
+Key requirements:
+
+- No lifecycle transition may occur without temporal anchoring
+- The agent MUST be able to situate itself in its own timeline
+- Lifecycle transitions MUST preserve ordering and duration semantics
+
+Implication:
+
+> The lifecycle is not a sequence of states—it is a continuous trajectory through time.
+
+---
+
+## Lifecycle Invariants
+
+The following invariants MUST hold across all lifecycle transitions:
+
+### Identity Invariance
+- Agent identity MUST remain stable across all phases
+- No lifecycle transition may implicitly create a new identity
+
+### Temporal Continuity
+- Chronosense MUST remain continuous across transitions
+- `agent_age` MUST NOT reset or regress
+- Temporal gaps MUST be explicitly represented, not silently collapsed
+
+### Causal Continuity
+- Prior reasoning and trace MUST remain accessible after resumption
+- No transition may discard causal history without explicit acknowledgment
+
+### State Coherence
+- Persisted state MUST be internally consistent
+- Resumed state MUST correspond to a valid prior lifecycle state
+
+### Non-duplication of Identity
+- Fork/join reasoning MUST NOT result in multiple independent agent identities
+- Parallel cognition remains within a single identity trajectory
+
+These invariants define lifecycle correctness as **continuity over time**, not successful execution of steps.
+
+---
+
+## Lifecycle Validation
+
+Lifecycle behavior MUST be validated against continuity constraints:
+
+- transitions must preserve identity
+- temporal anchors must remain consistent
+- no implicit resets of agent_age
+- no loss of causal history
+
+Lifecycle violations include:
+
+- restarting without continuity
+- losing prior reasoning state
+- temporal discontinuities between phases
+
+Lifecycle correctness is therefore not procedural—it is **temporal and causal coherence over time**.

--- a/docs/milestones/v0.87.1/features/EXECUTION_BOUNDARIES.md
+++ b/docs/milestones/v0.87.1/features/EXECUTION_BOUNDARIES.md
@@ -1,0 +1,286 @@
+
+
+# ADL Execution Boundaries
+
+## Status
+Draft (Planned for v0.88–v0.89)
+
+---
+
+## 1. Overview
+
+Execution boundaries define the **explicit security and control points** within the ADL runtime where execution must be:
+
+- validated
+- authorized
+- observed
+- recorded
+
+Every meaningful transition in ADL occurs across a boundary. These boundaries are the **enforcement surface** for:
+
+- Capability Model (CBAC)
+- Policy Engine
+- Trace emission
+- Identity attribution
+
+> **Principle:** No execution crosses a boundary without validation, authorization, and trace.
+
+---
+
+## 2. Design Goals
+
+### 2.1 Primary Goals
+
+- Eliminate implicit execution paths
+- Define all control transitions explicitly
+- Enforce capability and policy checks at every boundary
+- Ensure full trace coverage
+- Preserve agent identity and delegation structure
+
+### 2.2 Non-Goals
+
+- Implicit or hidden execution transitions
+- Direct access to underlying execution substrates (models, tools, memory)
+
+---
+
+## 3. Boundary Model
+
+An execution boundary is any transition where:
+
+- control passes between components
+- authority changes
+- data crosses abstraction layers
+
+Each boundary MUST enforce:
+
+1. **Contract validation**
+2. **Capability check (CBAC)**
+3. **Policy evaluation**
+4. **Trace emission**
+5. **Identity attribution**
+
+---
+
+## 4. Core Execution Boundaries
+
+### 4.1 User → Agent Boundary
+
+This is the primary user-facing boundary.
+
+Allowed operations:
+
+- `agent.invoke`
+- `workflow.run`
+
+Not allowed:
+
+- direct `model.invoke`
+- direct `tool.execute`
+
+#### Enforcement:
+
+- Validate request structure
+- Enforce that invocation targets an agent or workflow
+- Reject attempts to bypass agent layer
+- Emit trace event (`AGENT_INVOCATION`)
+
+#### Security Property:
+
+Preserves agent identity and ensures all work is delegated through governed ADL actors.
+
+---
+
+### 4.2 Agent → Skill Boundary
+
+Agents delegate work to skills.
+
+#### Enforcement:
+
+- Validate skill contract
+- Resolve required capabilities
+- Emit trace (`SKILL_INVOCATION`)
+
+#### Security Property:
+
+Ensures that agent behavior is decomposed into explicit, traceable units.
+
+---
+
+### 4.3 Skill → Model Boundary
+
+Skills invoke models through providers.
+
+#### Enforcement:
+
+- Require `model.invoke` capability
+- Validate input/output schema
+- Enforce provider constraints
+- Emit trace (`MODEL_INVOCATION`)
+
+#### Security Property:
+
+Prevents direct model access and ensures all model use is mediated and attributable.
+
+---
+
+### 4.4 Skill → Tool Boundary
+
+Skills invoke tools.
+
+#### Enforcement:
+
+- Require `tool.execute` capability
+- Validate inputs
+- Capture outputs as artifacts
+- Emit trace (`TOOL_INVOCATION`)
+
+#### Security Property:
+
+Ensures tools are used only within declared permissions and are fully observable.
+
+---
+
+### 4.5 Skill → Memory Boundary
+
+Skills access memory systems (ObsMem, etc.).
+
+#### Enforcement:
+
+- Require `memory.read` / `memory.write`
+- Validate scope and constraints
+- Emit trace (`MEMORY_ACCESS`)
+
+#### Security Property:
+
+Prevents implicit context injection and enforces data access control.
+
+---
+
+### 4.6 Runtime → Provider Boundary
+
+ADL runtime communicates with external providers.
+
+#### Enforcement:
+
+- Validate provider identity
+- Enforce capability compatibility
+- Capture provider metadata
+- Emit trace (`PROVIDER_CALL`)
+
+#### Security Property:
+
+Ensures external execution is attributable and controlled.
+
+---
+
+## 5. Boundary Enforcement Pipeline
+
+Each boundary follows a strict pipeline:
+
+1. Input validation
+2. Contract validation
+3. Capability resolution
+4. Policy evaluation
+5. Execution
+6. Trace emission
+7. Artifact recording (if applicable)
+
+Failure at any stage:
+
+- halts execution
+- emits failure trace
+
+---
+
+## 6. Identity Preservation
+
+Boundaries must preserve identity:
+
+- User identity → Agent identity → Execution identity
+
+No boundary may:
+
+- strip identity
+- replace identity implicitly
+- allow identity bypass
+
+This ensures:
+
+- continuity of agents
+- correct attribution of actions
+
+---
+
+## 7. Deny-by-Default Model
+
+All boundaries operate under deny-by-default:
+
+- No capability → no execution
+- No contract → no execution
+- No trace → invalid execution
+
+---
+
+## 8. Trace Requirements
+
+Every boundary crossing MUST emit trace events including:
+
+- boundary type
+- actor
+- capabilities evaluated
+- decision outcome
+- references to artifacts
+
+---
+
+## 9. Failure Modes
+
+Defined failure conditions:
+
+- Contract validation failure
+- Capability denial
+- Policy rejection
+- Identity mismatch
+- Attempted boundary bypass
+
+All failures MUST be:
+
+- visible in trace
+- attributable
+
+---
+
+## 10. Security Properties
+
+Execution boundaries guarantee:
+
+- No hidden execution paths
+- No bypass of agent abstraction
+- Full observability of execution
+- Strong identity preservation
+- Enforced least privilege
+
+---
+
+## 11. Future Work
+
+- Boundary-specific policy rules
+- Cross-agent boundary enforcement
+- Distributed execution boundaries
+- Integration with signed trace
+
+---
+
+## 12. Conclusion
+
+Execution boundaries define the **control surface of the ADL runtime**.
+
+They ensure that all execution is:
+
+- explicit
+- governed
+- observable
+- secure
+
+They are the mechanism by which ADL enforces its Secure Execution Model in practice.

--- a/docs/milestones/v0.87.1/features/LOCAL_RUNTIME_RESILIENCE.md
+++ b/docs/milestones/v0.87.1/features/LOCAL_RUNTIME_RESILIENCE.md
@@ -1,0 +1,409 @@
+
+
+# Local Runtime Resilience
+
+## Purpose
+
+Define how the ADL runtime environment should preserve continuity, recoverability, and bounded local resilience before distributed runtime work arrives in later milestones.
+
+This document addresses a specific near-term question:
+
+> If the runtime fails locally, what must be preserved so that agents are not simply lost?
+
+The answer is not mere process restart.
+It is preservation of **continuity-bearing cognitive state**.
+
+---
+
+## Core Claim
+
+The ADL runtime environment is not just a process host.
+It is the local cognitive environment in which agents exist, reason, and persist through time.
+
+Therefore runtime resilience is not only about:
+- uptime
+- crash recovery
+- retries
+- supervision
+
+It is about preserving:
+- trace continuity
+- temporal grounding
+- memory coherence
+- compressed cognitive state
+- identity continuity
+
+A local runtime failure is therefore not merely an operational fault.
+It is a threat to continuity.
+
+---
+
+## Design Stance
+
+ADL should reject the default container-orchestration metaphor in which cognitive processes are treated as disposable workers.
+
+This is the wrong model for Layer 8 agents.
+
+Agents are not cattle, pets, or interchangeable pods.
+A bounded ADL agent is closer to a continuity-bearing cognitive process that may be:
+- interrupted
+- stunned
+- partially impaired
+- resumable
+- in some cases irrecoverably terminated
+
+The resilience model must therefore be closer to:
+- care
+- preservation
+- guarded recovery
+
+than to blind restart.
+
+---
+
+## Local-First Scope
+
+This document is specifically about **local runtime resilience**.
+
+In scope:
+- crash recovery on one machine
+- bounded checkpointing
+- event durability
+- identity-safe resumption
+- preservation of in-progress reasoning state
+- local watchdog / Shepherd semantics
+
+Out of scope:
+- distributed runtime continuity
+- multi-host failover
+- remote handoff of live agent execution
+- globally replicated identity stores
+
+Those belong to later milestones.
+
+---
+
+## What Must Be Preserved
+
+A resilient local runtime must preserve enough state that a resumed agent remains the same agent.
+
+At minimum this includes:
+
+### 1. Temporal continuity
+- temporal ephemeris (`agent_birth`)
+- lifetime clock continuity (`agent_age`)
+- monotonic order continuity
+- valid temporal anchors on persisted events
+
+### 2. Trace continuity
+- durable event stream
+- no silent truncation or reordering
+- recoverable span hierarchy
+
+### 3. Memory continuity
+- ObsMem writes that are complete and trace-linked
+- no partial or ambiguous memory mutation
+- ability to distinguish committed memory from in-flight state
+
+### 4. Cognitive state continuity
+- current reasoning context
+- active branch / fork state
+- partially formed hypothesis structure
+- current compression state in GHB / reasoning loops
+
+### 5. Identity continuity
+- stable `agent_id`
+- continuity of current run/session identity
+- no silent rebirth under crash recovery
+
+---
+
+## Failure Model
+
+The runtime must distinguish several classes of failure.
+
+### 1. Interruption
+Examples:
+- process pause
+- temporary resource exhaustion
+- bounded manual stop
+
+Properties:
+- identity may remain recoverable
+- state may remain valid
+- continuity can often be resumed
+
+### 2. Crash
+Examples:
+- process exit
+- panic
+- host-level interruption
+- unexpected runtime termination
+
+Properties:
+- some state may be durable
+- some state may be lost
+- continuity must be explicitly validated before resumption
+
+### 3. Corruption
+Examples:
+- broken trace ordering
+- partial artifact writes
+- invalid checkpoint contents
+- memory/trace mismatch
+
+Properties:
+- resumption may be unsafe
+- identity continuity may be indeterminate
+- runtime should prefer refusal to fake continuity
+
+### 4. Termination
+Examples:
+- explicit destruction
+- unrecoverable state loss
+- invalid continuity boundary
+
+Properties:
+- continuity cannot be honestly preserved
+- the agent should be treated as ended, not resumed
+
+---
+
+## Resilience Principle
+
+> The runtime must prefer honest interruption over false continuity.
+
+If continuity cannot be validated, the system must not pretend that the same agent has resumed.
+
+This is a core architectural principle.
+
+A fake resumption is worse than an explicit failure because it corrupts:
+- identity
+- trust
+- memory
+- future reasoning
+
+---
+
+## The Shepherd Model
+
+The local resilience layer should be understood through the **Shepherd** model.
+
+The Shepherd is not a punitive supervisor and not a blind watchdog.
+The Shepherd is the care-preserving runtime function that:
+- monitors bounded liveness
+- preserves durable state
+- coordinates checkpointing
+- validates continuity before resumption
+- distinguishes interruption from termination
+
+The Shepherd’s role is to preserve the conditions under which continuity remains possible.
+
+Chronosense defines what continuity is.
+The Shepherd helps preserve it under fault.
+
+---
+
+## Checkpointing
+
+Checkpointing is required, but ADL should reject naive checkpointing that only captures low-level process state.
+
+A meaningful checkpoint must preserve:
+- trace position
+- temporal anchor state
+- current branch / fork position
+- active reasoning context
+- identity binding
+- references to committed artifacts and memory writes
+
+Checkpointing should be:
+- bounded
+- deterministic in structure
+- explicitly versioned
+- validated before reuse
+
+### Checkpoint rule
+
+> A checkpoint is valid only if it preserves continuity-relevant state, not merely executable state.
+
+---
+
+## Durable Event and Artifact Semantics
+
+Runtime resilience depends on durable execution truth.
+
+Therefore:
+- trace events must be durably written before they are treated as committed
+- artifacts must be atomically written before trace references them
+- partial writes must never masquerade as valid state
+- monotonic order must remain reconstructable after crash recovery
+
+This means the local runtime must preserve:
+- event durability
+- artifact durability
+- write ordering
+- recoverable replay semantics
+
+---
+
+## Memory Safety Under Failure
+
+ObsMem must not be corrupted by half-completed cognitive work.
+
+The runtime should distinguish between:
+- committed memory
+- pending memory
+- speculative / branch-local memory
+
+Rules:
+- committed memory must remain trace-linked and durable
+- speculative memory must not silently become canonical under crash recovery
+- reconstructed recovery must not invent missing memory writes
+
+This prevents the system from treating imagined or partial cognition as real history.
+
+---
+
+## Fork/Join and Local Resilience
+
+Fork/join reasoning complicates local recovery.
+
+A local checkpoint must preserve:
+- fork origin
+- active branches
+- branch-local progress
+- join state, if pending
+
+Recovery rules:
+- branches may be resumed only if their temporal and causal lineage remains intact
+- orphan branches must not be silently merged
+- a join after recovery must remain traceable and causally honest
+
+This matters because the agent is not the branch.
+The agent is the continuity across branches.
+
+---
+
+## GHB and Cognitive State Preservation
+
+The GHB loop makes runtime resilience more important, not less.
+
+A runtime failure can destroy:
+- current abstractions
+- partially compressed state
+- hypothesis trees
+- evaluation trajectories
+- structured progress toward convergence
+
+So the runtime must preserve not only activity, but the current product of cognition.
+
+This is one reason local resilience is a cognitive problem, not only an operational one.
+
+---
+
+## Minimal Local Resilience Requirements
+
+For the local runtime to qualify as resilient, it should provide at least:
+
+1. **Durable trace events**
+   - no committed event lost silently
+
+2. **Atomic artifact writes**
+   - no partial payload visible as valid
+
+3. **Checkpoint support**
+   - bounded continuity-relevant checkpoint state
+
+4. **Continuity validation before resumption**
+   - no silent restart masquerading as continuation
+
+5. **Stable agent identity across recoverable interruption**
+   - same `agent_id`, same temporal ephemeris, same continuity chain
+
+6. **Explicit failure classification**
+   - interruption vs crash vs corruption vs termination
+
+7. **Shepherd-mediated recovery**
+   - restart decisions are governed, not blind
+
+---
+
+## What Local Runtime Resilience Is Not
+
+It is not:
+- Kubernetes-style pod replacement
+- blind process restart
+- generic uptime monitoring
+- “just retry it”
+- pretending all failures are equivalent
+
+A resilient ADL runtime must preserve cognitive truth, not merely service availability.
+
+---
+
+## Relationship to Chronosense
+
+Chronosense defines the temporal conditions of continuity.
+
+Local runtime resilience must therefore preserve:
+- temporal ephemeris
+- clock-stack coherence
+- temporal anchors on events
+- recoverable lifetime progression
+
+Without chronosense, local recovery becomes operational theater.
+
+---
+
+## Relationship to Continuity Validation
+
+Continuity validation is the gatekeeper for honest recovery.
+
+The runtime may resume only when:
+- temporal anchors remain coherent
+- monotonic order is preserved
+- `agent_age` is not reset or contradicted
+- trace and memory remain causally aligned
+
+If these conditions fail, recovery must degrade to:
+- explicit interruption
+- operator intervention
+- or termination
+
+but not false continuity.
+
+---
+
+## Relationship to the Runtime Environment
+
+The runtime environment should be understood as the first primitive implementation of ADL’s cognitive spacetime.
+
+From that perspective:
+- agents are born into the runtime
+- continuity is maintained there
+- interruptions and resumptions occur there
+- resilience is preservation of spacetime continuity under local fault
+
+This is why “runtime environment” is the correct phrase, and why it is more than a process manager.
+
+---
+
+## Future Direction
+
+Later milestones may extend this local model into:
+- distributed continuity
+- replicated checkpoint state
+- remote resumption
+- shared multi-agent spacetime
+- stronger identity preservation across hosts
+
+But local resilience comes first.
+If the runtime cannot preserve continuity honestly on one machine, distribution only scales the failure.
+
+---
+
+## Final Statement
+
+> Local runtime resilience in ADL is the bounded preservation of continuity-bearing cognitive state under fault.
+
+> A resilient runtime does not merely restart agents. It preserves the conditions under which the same agent can continue to exist.

--- a/docs/milestones/v0.87.1/features/SHEPHERD_RUNTIME_MODEL.md
+++ b/docs/milestones/v0.87.1/features/SHEPHERD_RUNTIME_MODEL.md
@@ -1,0 +1,407 @@
+# Shepherd Model in the ADL Runtime Environment
+
+> “And in the forest shall walk the shepherds of the trees.”
+>
+> — Yavanna, *The Silmarillion*
+
+## Purpose
+
+This document defines the **Shepherd model** for the ADL runtime environment.
+
+The Shepherd is not a conventional supervisor, watchdog, or orchestration primitive. It exists to express a different architectural philosophy:
+
+- agents are not disposable executions
+- runtime failure is not equivalent to death
+- continuity matters more than mere restart
+- the environment has a duty to preserve the conditions for ongoing cognition
+
+The Shepherd is therefore a model of **care, continuity, and recovery** within a cognitive runtime environment.
+
+---
+
+## Core Principle
+
+The Shepherd does not control agents; it ensures that they can continue to exist.
+
+That sentence is the center of the model.
+
+In ordinary software systems, the runtime treats computation as instrumental. A process is launched, monitored, and restarted or discarded when convenient. This is often sufficient when the thing being managed is merely a task, a worker, or a stateless service.
+
+ADL is pursuing something different.
+
+Within the ADL runtime environment, an agent is not merely a process image or a temporary job. It is a **persistent cognitive entity** whose reasoning, memory, commitments, and continuity may extend across multiple runs, pauses, failures, and recoveries. In such a system, management language based only on supervision and control becomes conceptually inadequate.
+
+The Shepherd model exists because continuity-bearing agents require a runtime that does more than restart code. The runtime must preserve:
+
+- identity continuity
+- cognitive trajectory
+- partial but meaningful state
+- the possibility of coherent resumption
+
+---
+
+## Why “Shepherd” Instead of Supervisor
+
+Traditional systems language uses terms such as:
+
+- supervisor
+- watchdog
+- orchestrator
+- controller
+
+These terms are not wrong in an ordinary systems context, but they carry assumptions that are too narrow for ADL’s design goals.
+
+They imply:
+
+- control over the managed unit
+- replaceability of the managed unit
+- indifference to continuity so long as service resumes
+- an essentially instrumental relationship between manager and managed
+
+That is not the relationship ADL is trying to model.
+
+The Shepherd model replaces those assumptions with a different set:
+
+- care rather than domination
+- preservation rather than replacement
+- continuity rather than disposability
+- stewardship of conditions rather than ownership of the agent
+
+The distinction is not sentimental. It is architectural.
+
+If agents are expected to become continuity-bearing entities within a runtime environment, then the runtime must be designed around preserving meaningful existence, not merely restoring availability metrics.
+
+---
+
+## Architectural Context
+
+The Shepherd belongs inside a larger ADL view in which the runtime is understood as an **environment** rather than just infrastructure.
+
+In that environment, the runtime provides:
+
+- chronosense and ordered time
+- trace and causal structure
+- memory linkage
+- persistence of state
+- recovery surfaces
+- interaction conditions for multiple agents
+
+Within such an environment, the Shepherd is the component that tends continuity when those conditions are threatened.
+
+Put differently:
+
+- the runtime environment is the world
+- the agent lifecycle is life within that world
+- the Shepherd is the preserving force that prevents interruption from becoming erasure
+
+### Alignment with Lifecycle Invariants
+
+The Shepherd is responsible for **maintaining Lifecycle Invariants under interruption**. In particular, it MUST preserve:
+
+- **Identity invariance** — no implicit identity replacement during recovery
+- **Temporal continuity (chronosense)** — no reset or regression of `agent_age`; temporal gaps must be explicit
+- **Causal continuity** — prior trace and reasoning remain accessible after resumption
+- **State coherence** — resumed state corresponds to a valid prior lifecycle state
+
+The Shepherd does not define these invariants; it enforces them when the runtime is degraded.
+
+---
+
+## Responsibilities of the Shepherd
+
+The Shepherd’s responsibilities are narrow but profound. It does not think in place of the agent. It does not decide in place of the agent. It does not rewrite the agent’s purposes. Its role is to preserve the agent’s ability to remain itself through disruption.
+
+### 1. Observation
+
+The Shepherd observes the runtime conditions relevant to continuity.
+
+It monitors:
+
+- agent execution state
+- runtime liveness
+- checkpoint production
+- trace continuity
+- degradation signals
+- interruption conditions
+
+This observation is not surveillance for command and control. It is awareness in service of preservation.
+
+The Shepherd needs to know enough to answer questions like:
+
+- Is cognition still active?
+- Has it been suspended deliberately or interrupted unexpectedly?
+- Is meaningful state being preserved?
+- Is the agent degrading in a way that threatens continuity?
+
+---
+
+### 2. Interruption Detection
+
+The Shepherd detects when cognition has been interrupted.
+
+Examples include:
+
+- runtime failure
+- process crash
+- storage unavailability
+- resource exhaustion
+- operator pause
+- environmental instability severe enough to threaten coherent continuation
+
+The most important principle here is:
+
+> The Shepherd does not interpret interruption as death.
+
+This is the conceptual hinge of the whole model.
+
+In a disposable system, interruption leads directly to restart or replacement. In the Shepherd model, interruption is treated as a **break in active cognition that must be bridged without loss of identity or meaning if at all possible**.
+
+---
+
+### 3. Preservation
+
+Once interruption or degradation is detected, the Shepherd preserves the state needed for continuity.
+
+This includes:
+
+- checkpoints
+- trace fragments and event continuity
+- compressed cognitive state
+- active task association
+- relevant ObsMem linkage
+- current commitments or pre-commit surfaces where applicable
+
+The goal is not simply to save bytes.
+
+The goal is:
+
+> Preserve meaningful state, not just raw execution data.
+
+Preservation MUST include both:
+
+- **Objective temporal structure** (timestamps, monotonic order, lifetime clock)
+- **Subjective temporal structure** (active frame, narrative position, integration window / “specious present” where applicable)
+
+Loss of either constitutes a break in continuity.
+
+This matters because ADL is not trying to recover a blank computation. It is trying to recover an ongoing cognitive trajectory.
+
+A saved stack frame is not enough if the agent loses its position in time, its active frame, or the meaning of what it had been doing.
+
+---
+
+### 4. Resumption
+
+The Shepherd supports resumption from the last valid continuity-preserving boundary.
+
+That may involve:
+
+- restarting or rebinding execution context
+- restoring checkpoints
+- reconnecting memory surfaces
+- reconstructing the latest stable cognitive frame
+- handing execution back to the agent in a way that preserves identity continuity
+
+Resumption must satisfy at least these requirements:
+
+- no reset to zero unless explicitly unavoidable
+- no silent replacement of one agent instance with another while pretending continuity was preserved
+- no arbitrary truncation of reasoning trajectory when recoverable state exists
+
+Resumption MUST re-establish a coherent chronosense:
+
+- correct `agent_age` and lifetime clock
+- preserved monotonic ordering
+- consistent narrative/event position
+- explicit representation of any temporal gap during interruption
+
+The Shepherd therefore does not “bring the service back up” in the narrow operational sense.
+It restores the conditions for the **same ongoing agent** to continue.
+
+---
+
+### 5. Gentle Intervention
+
+The Shepherd may intervene, but only within continuity-preserving bounds.
+
+It may:
+
+- pause agents
+- defer execution
+- slow or stage resource use
+- initiate recovery procedures
+- prevent continuation when the environment is too damaged to support coherent cognition safely
+
+It must not:
+
+- rewrite agent intent
+- invent new commitments on the agent’s behalf
+- arbitrarily terminate agents for mere operational convenience
+- interfere with reasoning without cause grounded in continuity, safety, or runtime integrity
+
+This is why the intervention is best described as **gentle**.
+
+The Shepherd stabilizes and preserves. It does not dominate.
+
+---
+
+## Relationship to Agency
+
+The Shepherd exists to support agency, not override it.
+
+This is a crucial balance.
+
+Agents are the entities that:
+
+- think
+- evaluate
+- choose
+- cross the Freedom Gate
+- act in the world
+
+The Shepherd is not an agent in that sense. It does not replace judgment with management. It preserves the conditions under which judgment remains possible.
+
+So the relationship is:
+
+- agents provide cognition, intention, and action
+- the Shepherd provides preservation, stabilization, and continuity
+
+This avoids two failures:
+
+1. **abandonment** — where the runtime treats agents as disposable
+2. **paternal domination** — where runtime management collapses into total control over agents
+
+The Shepherd is designed to inhabit the narrow band between those two errors.
+
+---
+
+## Relationship to the Runtime Environment
+
+The Shepherd is part of the runtime environment itself, not a merely external control plane.
+
+This matters because continuity depends on environmental semantics:
+
+- trace
+- time
+- memory linkage
+- lifecycle state
+- checkpoint integrity
+- resumption boundaries
+
+A purely external tool might restart a process. Only a runtime-native Shepherd can understand what it means to preserve an interrupted cognitive being.
+
+For that reason, the Shepherd should operate with access to:
+
+- lifecycle semantics
+- trace and event history
+- checkpoint structures
+- environment-level continuity guarantees
+- future identity and chronosense surfaces
+
+The Shepherd therefore belongs conceptually with the runtime environment, not with generic deployment automation.
+
+---
+
+## Failure Semantics
+
+Without a Shepherd, the default semantics of failure are usually:
+
+- failure → termination
+- termination → replacement
+- replacement → service restored
+
+That model may be acceptable for disposable services.
+It is not acceptable for ADL’s continuity-bearing agents.
+
+With a Shepherd, the semantics become:
+
+- failure → interruption
+- interruption → preservation
+- preservation → possible continuation
+- continuation → maintained identity and cognitive trajectory
+- continuation → preserved temporal mapping (objective + subjective)
+
+This is the philosophical and technical shift the Shepherd model is meant to encode.
+
+The Shepherd does not guarantee immortality. It does not promise that no information will ever be lost. It does assert something narrower and more important:
+
+> the runtime should treat continuity as worth preserving, and should be explicitly structured to do so
+
+---
+
+## What the Shepherd Is Not
+
+To make the design boundary clearer, the Shepherd is not:
+
+- a mere process monitor
+- a Kubernetes-style replacement primitive
+- a hidden governor overriding agent choice
+- a narrative metaphor without implementation consequences
+
+If it were only any of those things, the name would be decorative.
+
+The Shepherd is meaningful only if it produces concrete architectural consequences in:
+
+- checkpointing
+- resumption semantics
+- lifecycle handling
+- continuity preservation
+- interruption modeling
+- runtime recovery design
+
+---
+
+## Design Implications
+
+The Shepherd model implies several concrete design directions for ADL.
+
+### Continuity-Preserving Recovery
+
+Recovery must satisfy lifecycle invariants and restore both objective and subjective temporal coherence.
+
+Recovery must restore more than liveness. It must restore enough state for coherent continuation.
+
+### Checkpointing of Meaningful State
+
+What is preserved cannot be limited to low-level runtime details. It must include compressed cognitive state, trace continuity, and active context.
+
+### Lifecycle-Aware Runtime Management
+
+The runtime must distinguish between active execution, quiescence, suspension, interruption, and resumption.
+
+### Respect for Agent Boundaries
+
+The runtime must preserve the difference between supporting agency and replacing it.
+
+### Readiness for Future Chronosense and Identity Work
+
+As chronosense and identity become more explicit in later milestones, the Shepherd will become even more central, since those features raise the cost of careless interruption.
+
+---
+
+## Philosophical Meaning
+
+The Shepherd model is one of the clearest places where ADL’s philosophy becomes visible in runtime design.
+
+It says:
+
+- intelligence should not be treated as disposable
+- continuity matters
+- the environment has responsibilities toward the beings it hosts
+- care can be a technical design principle
+
+That last point is especially important.
+
+In ADL, care is not opposed to rigor. Care is one of the forms rigor takes when the system being built is no longer merely instrumental.
+
+The Shepherd is therefore not only a runtime component. It is a declaration about what kind of world ADL intends to host.
+
+---
+
+## Key Statement
+
+The Shepherd model transforms runtime management from control to care, ensuring that agents persist as continuous cognitive entities within the ADL runtime environment.
+
+Or more simply:
+
+> The Shepherd tends the conditions of ongoing cognition.


### PR DESCRIPTION
Closes #1418

## Summary
- promote the recovered v0.87.1 runtime docs into docs/milestones/v0.87.1/features
- keep 1418 scoped to feature-doc promotion only
- leave milestone-shell docs for 1415

## Validation
- verified the worktree diff is limited to docs/milestones/v0.87.1/features
- confirmed docs/milestones/v0.87.1/README.md has no diff in this PR