### PR TITLE
[v0.87][WP-19] Next milestone planning

### DIFF
--- a/docs/milestones/v0.87.1/DECISIONS_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DECISIONS_v0.87.1.md
@@ -4,7 +4,7 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Date: `2026-04-06`
-- Owner: `TBD`
+- Owner: `Daniel Austin`
 
 ## Purpose
 Capture significant decisions (architecture, scope, process) at the time they are made.
@@ -18,11 +18,12 @@ Capture significant decisions (architecture, scope, process) at the time they ar
 | ID | Decision | Status | Rationale | Alternatives | Impact | Link |
 |---|---|---|---|---|---|---|
 | D-01 | Create the tracked `docs/milestones/v0.87.1/` shell before promoting `v0.87.1` feature docs. | accepted | The roadmap now treats runtime completion as its own sub-milestone, so it needs a public tracked surface first. | Delay milestone-shell creation until feature promotion time. | Enables consistent tracked docs and later feature promotion. | #1354 |
-| D-02 | Keep `v0.87.1` feature-doc promotion out of scope for the milestone-shell seed pass. | accepted | This issue is about structure and naming, not public promotion of internal planning docs. | Promote the runtime docs immediately. | Keeps the issue bounded and reduces accidental public overcommitment. | #1354 |
+| D-02 | Promote the `v0.87.1` runtime feature-doc set into the tracked milestone surface so planning, demos, and review can anchor to concrete runtime architecture. | superseded | The milestone is now a real runtime-completion effort, so the promoted feature docs must be part of the canonical tracked review surface rather than deferred. | Keep the feature-doc set out of scope and rely on shell-only planning docs. | Makes milestone planning auditable against the actual runtime architecture and removes shell-era ambiguity. | #1415 |
+| D-03 | Treat `v0.87.1` as a large runtime-completion milestone rather than a docs-only seed shell. | accepted | The project needs one milestone that actually completes the runtime substrate with implementation, demos, review surfaces, and release mechanics before moving into later cognitive work. | Keep `v0.87.1` as documentation-only scaffolding. | Makes the milestone implementation-heavy and forces the docs, review surfaces, and proof plan to match that reality. | #1415 |
+| D-04 | Preserve explicit internal review, external review preparation, review-remediation, next-milestone planning, and release ceremony as separate closeout steps. | accepted | Large substrate milestones need an auditable review tail rather than collapsing closeout into one vague final issue. | Collapse review and release work into fewer tail issues. | Keeps closeout traceable, reviewable, and easier to execute deterministically. | #1415 |
 
 ## Open Questions
-- {{open_question_1}} (Owner: {{owner_oq1}}) (Issue: {{issue_oq1}})
-- {{open_question_2}} (Owner: {{owner_oq2}}) (Issue: {{issue_oq2}})
+- Which bounded runtime demos should be treated as the primary reviewer entry surfaces for the milestone? (Owner: `Daniel Austin`) (Issue: `TBD`)
 
 ## Exit Criteria
 - All milestone-critical decisions are logged with a rationale.

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -4,15 +4,15 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Date: `2026-04-06`
-- Owner: `TBD`
-- Related issues / work packages: #1354
+- Owner: `Daniel Austin`
+- Related issues / work packages: `#1354`, `WP-13`
 
 ## Purpose
 Define the canonical milestone demo program: which bounded demos exist, which milestone claims they prove, how to run them, and what artifacts or proof surfaces reviewers should inspect.
 
 ## Status
 
-No milestone demos are defined yet. This seeded shell exists so later runtime-completion work can add bounded demo rows without inventing a new milestone structure.
+This is the planned proof program for a large runtime-completion milestone. The runtime demo set is expected to include roughly a dozen bounded demos spanning execution environment, lifecycle, trace alignment, resilience, operator surfaces, and reviewer entry artifacts.
 
 ## How To Use
 - Use this document for runnable milestone evidence, not for broad feature brainstorming.
@@ -24,39 +24,44 @@ No milestone demos are defined yet. This seeded shell exists so later runtime-co
 
 ## Scope
 
-In scope for `{{milestone}}`:
-- {{in_scope_demo_area_1}}
-- {{in_scope_demo_area_2}}
-- {{in_scope_demo_area_3}}
+In scope for `v0.87.1`:
+- runtime environment demos
+- lifecycle and execution-boundary demos
+- trace-aligned runtime execution demos
+- resilience, restartability, and failure-handling demos
+- operator/review-surface demos
+- mapping between milestone claims and bounded demo surfaces
 
-Out of scope for `{{milestone}}`:
-- {{out_of_scope_demo_area_1}}
-- {{out_of_scope_demo_area_2}}
+Out of scope for `v0.87.1`:
+- broad speculative demos not tied to runtime-completion claims
+- later cognitive demos intended for `v0.88+`
 
 ## Runtime Preconditions
 
 Working directory:
 
 ```bash
-{{working_directory_command}}
+cd agent-design-language
 ```
 
-Deterministic runtime / provider assumptions:
+Baseline repository/runtime validation:
 
 ```bash
-{{runtime_preconditions}}
+cargo build
 ```
 
 Additional environment / fixture requirements:
-- {{env_requirement_1}}
-- {{env_requirement_2}}
+- local Rust toolchain installed
+- demo scripts should be runnable from the repository root
+- each demo should write stable artifacts or review surfaces under documented locations
+- demos should prefer local or mocked providers unless a specific external dependency is part of the milestone claim
 
 ## Related Docs
-- Design contract: `{{design_doc}}`
-- WBS / milestone mapping: `{{wbs_doc}}`
-- Sprint / execution plan: `{{sprint_doc}}`
-- Release / checklist context: `{{release_or_checklist_doc}}`
-- Other proof-surface docs: {{other_related_docs}}
+- Design contract: `docs/milestones/v0.87.1/DESIGN_v0.87.1.md`
+- WBS / milestone mapping: `docs/milestones/v0.87.1/WBS_v0.87.1.md`
+- Sprint / execution plan: `docs/milestones/v0.87.1/SPRINT_v0.87.1.md`
+- Release / checklist context: `docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md`
+- Other proof-surface docs: Trace v1 artifacts and runtime outputs from v0.87
 
 ## Demo Coverage Summary
 
@@ -64,9 +69,19 @@ Use this table as the fast review surface for milestone coverage.
 
 | Demo ID | Demo title | Milestone claim / WP proved | Command entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
 |---|---|---|---|---|---|---|---|
-| D1 | {{demo_title_1}} | {{claim_or_wp_1}} | `{{command_stub_1}}` | `{{proof_surface_1}}` | {{success_signal_1}} | {{determinism_note_1}} | {{status_1}} |
-| D2 | {{demo_title_2}} | {{claim_or_wp_2}} | `{{command_stub_2}}` | `{{proof_surface_2}}` | {{success_signal_2}} | {{determinism_note_2}} | {{status_2}} |
-| D3 | {{demo_title_3}} | {{claim_or_wp_3}} | `{{command_stub_3}}` | `{{proof_surface_3}}` | {{success_signal_3}} | {{determinism_note_3}} | {{status_3}} |
+| D1 | Runtime Environment Bring-Up | `WP-02` runtime environment completion | `adl/tools/demo_v0871_runtime_environment.sh` | runtime environment artifact set | Runtime environment initializes cleanly with documented contracts | Stable env inputs should preserve artifact shape | PLANNED |
+| D2 | Lifecycle Phases And Boundaries | `WP-03` execution boundaries and lifecycle | `adl/tools/demo_v0871_lifecycle.sh` | lifecycle phase trace / summary | `init -> execute -> complete/teardown` is explicit and reviewable | Fixed scenario should preserve lifecycle phase ordering | PLANNED |
+| D3 | Trace-Aligned Runtime Execution | `WP-04` trace-aligned runtime execution | `adl/tools/demo_v0871_trace_runtime.sh` | runtime trace artifact set | Runtime actions map coherently to trace events and outputs | Replay should preserve execution-to-trace shape | PLANNED |
+| D4 | Local Failure Handling | `WP-05` local runtime resilience | `adl/tools/demo_v0871_resilience_failure.sh` | failure-handling artifact set | Failure is bounded, explained, and leaves inspectable artifacts | Same induced failure should preserve failure classification | PLANNED |
+| D4A | Shepherd Preservation And Recovery | `WP-05`, `WP-07` Shepherd preservation + continuity discipline | `adl/tools/demo_v0871_shepherd_recovery.sh` | Shepherd recovery artifact set | Interrupted work is preserved, resumed, or dispositioned under explicit runtime rules | Fixed interruption scenario should preserve preservation and recovery classification | PLANNED |
+| D5 | Restartability And Recovery | `WP-05`, `WP-07` resilience + state discipline | `adl/tools/demo_v0871_restartability.sh` | restart/recovery artifact set | Bounded run can resume or restart under documented rules | Restart behavior should remain stable under fixed state | PLANNED |
+| D6 | Operator Invocation Surface | `WP-06` operator surfaces | `adl/tools/demo_v0871_operator_surface.sh` | operator invocation summary | Operator entrypoints are clear, stable, and reviewer-usable | Same command contract should preserve invocation shape | PLANNED |
+| D7 | Runtime State / Persistence Discipline | `WP-07` state / persistence discipline | `adl/tools/demo_v0871_runtime_state.sh` | runtime state artifact set | State is inspectable, bounded, and cleaned up deterministically | Stable inputs should preserve state layout rules | PLANNED |
+| D8 | Review Surface Walkthrough | `WP-08` runtime review surfaces | `adl/tools/demo_v0871_review_surface.sh` | review manifest / guide | Reviewer can locate primary proof surfaces from one entrypoint | Artifact layout and manifest names remain stable | PLANNED |
+| D9 | Integrated Runtime Path | `WP-02` through `WP-08` integrated runtime completion | `adl/tools/demo_v0871_integrated_runtime.sh` | integrated runtime artifact set | One run demonstrates the authoritative runtime path end-to-end | Replay judged by control-path and artifact-shape stability | PLANNED |
+| D10 | Docs-To-Runtime Consistency Check | `WP-09`, `WP-15` docs/review convergence | `adl/tools/demo_v0871_docs_review.sh` | reviewer entry surfaces | Reviewer can move from docs to runtime proof without contradiction | Navigation and proof mapping should remain stable | PLANNED |
+| D11 | Quality Gate Walkthrough | `WP-14` quality gate | `adl/tools/demo_v0871_quality_gate.sh` | quality-gate record | Tests, validators, and coverage posture are reviewable in one place | Same repo state should preserve gate outcome | PLANNED |
+| D12 | Release Review Package | `WP-16` through `WP-20` review/remediation/planning/release tail | `adl/tools/demo_v0871_release_review_package.sh` | release review package | Review, remediation, planning, and release artifacts are coherent and navigable | Package layout and key entrypoints remain stable | PLANNED |
 
 Status guidance:
 - `PLANNED` = intended but not yet validated
@@ -81,156 +96,54 @@ Status guidance:
 - Success signals should say what to check, not just “command exits 0”.
 - Determinism / replay notes should explain how stability is judged.
 
+## Demo -> Feature Mapping
+- `D1` -> `ADL_RUNTIME_ENVIRONMENT.md`, `ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`
+- `D2` -> `AGENT_LIFECYCLE.md`, `EXECUTION_BOUNDARIES.md`
+- `D3` -> `ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`, `AGENT_LIFECYCLE.md`
+- `D4` -> `LOCAL_RUNTIME_RESILIENCE.md`
+- `D4A` -> `SHEPHERD_RUNTIME_MODEL.md`, `LOCAL_RUNTIME_RESILIENCE.md`
+- `D5` -> `LOCAL_RUNTIME_RESILIENCE.md`, `SHEPHERD_RUNTIME_MODEL.md`, `AGENT_LIFECYCLE.md`
+- `D6` -> `ADL_RUNTIME_ENVIRONMENT.md`, `EXECUTION_BOUNDARIES.md`
+- `D7` -> `AGENT_LIFECYCLE.md`, `SHEPHERD_RUNTIME_MODEL.md`
+- `D8` -> `ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`, `SHEPHERD_RUNTIME_MODEL.md`
+- `D9` -> all promoted `v0.87.1` runtime feature docs
+- `D10` -> `FEATURE_DOCS_v0.87.1.md` and all promoted `v0.87.1` runtime feature docs
+- `D11` -> milestone review and validation surfaces derived from the promoted runtime feature set
+- `D12` -> review, remediation, planning, and release surfaces for the runtime milestone
+
 ## Demo Details
 
-Repeat one block per demo in the coverage summary.
-
-### {{demo_id_1}}) {{demo_title_1}}
-
-Description:
-- {{demo_description_1}}
-- {{demo_description_1b}}
-
-Milestone claims / work packages covered:
-- {{claim_detail_1a}}
-- {{claim_detail_1b}}
-
-Commands to run:
-
-```bash
-{{demo_commands_1}}
-```
-
-Expected artifacts:
-- `{{artifact_1a}}`
-- `{{artifact_1b}}`
-- `{{artifact_1c}}`
-
-Primary proof surface:
-- `{{primary_proof_surface_1}}`
-
-Secondary proof surfaces:
-- `{{secondary_proof_surface_1a}}`
-- `{{secondary_proof_surface_1b}}`
-
-Expected success signals:
-- {{success_detail_1a}}
-- {{success_detail_1b}}
-
-Determinism / replay notes:
-- {{determinism_detail_1a}}
-- {{determinism_detail_1b}}
-
-Reviewer checks:
-- {{reviewer_check_1a}}
-- {{reviewer_check_1b}}
-
-Known limits / caveats:
-- {{caveat_1}}
-
----
-
-### {{demo_id_2}}) {{demo_title_2}}
-
-Description:
-- {{demo_description_2}}
-
-Milestone claims / work packages covered:
-- {{claim_detail_2a}}
-
-Commands to run:
-
-```bash
-{{demo_commands_2}}
-```
-
-Expected artifacts:
-- `{{artifact_2a}}`
-- `{{artifact_2b}}`
-
-Primary proof surface:
-- `{{primary_proof_surface_2}}`
-
-Expected success signals:
-- {{success_detail_2a}}
-
-Determinism / replay notes:
-- {{determinism_detail_2a}}
-
-Reviewer checks:
-- {{reviewer_check_2a}}
-
-Known limits / caveats:
-- {{caveat_2}}
-
----
-
-### {{demo_id_3}}) {{demo_title_3}}
-
-Description:
-- {{demo_description_3}}
-
-Milestone claims / work packages covered:
-- {{claim_detail_3a}}
-
-Commands to run:
-
-```bash
-{{demo_commands_3}}
-```
-
-Expected artifacts:
-- `{{artifact_3a}}`
-
-Primary proof surface:
-- `{{primary_proof_surface_3}}`
-
-Expected success signals:
-- {{success_detail_3a}}
-
-Determinism / replay notes:
-- {{determinism_detail_3a}}
-
-Reviewer checks:
-- {{reviewer_check_3a}}
-
-Known limits / caveats:
-- {{caveat_3}}
+Per-demo detail sections will be filled as the runtime milestone opens. This matrix already defines the bounded demo inventory the milestone is expected to implement and review.
 
 ## Cross-Demo Validation
 
 Required baseline validation:
 
 ```bash
-{{baseline_validation_commands}}
+cargo build
 ```
 
 Cross-demo checks:
-- {{cross_demo_check_1}}
-- {{cross_demo_check_2}}
-- {{cross_demo_check_3}}
+- the integrated runtime path must be consistent with the specialized demo rows
+- reviewer entry surfaces must point to real demo proof roots
+- the runtime demo set should remain bounded, deterministic, and reviewable
 
 Failure policy:
-- If one demo is blocked, record the blocker and say whether milestone review can proceed with an alternate proof surface.
-- If deterministic behavior is expected but not observed, record the exact unstable artifact or command output.
+- if the runtime demos do not prove the milestone claims truthfully, the milestone cannot be considered complete
 
 ## Determinism Evidence
 
 Evidence directory / run root:
-- `{{evidence_root}}`
+- runtime demo artifact roots will be defined per demo as implementation lands
 
 Repeatability approach:
-- {{repeatability_rule_1}}
-- {{repeatability_rule_2}}
+- runtime control-path shape, artifact naming, and reviewer entry surfaces should remain stable for fixed inputs
 
 Normalization rules:
-- {{normalization_rule_1}}
-- {{normalization_rule_2}}
+- none required
 
 Observed results summary:
-- {{determinism_result_1}}
-- {{determinism_result_2}}
-- {{determinism_result_3}}
+- planned; to be filled with real demo outcomes as `v0.87.1` lands
 
 ## Reviewer Sign-Off Surface
 
@@ -242,15 +155,14 @@ For each demo, the reviewer should be able to answer:
 - What caveats or substitutions apply?
 
 Review owners:
-- {{review_owner_1}}
-- {{review_owner_2}}
+- Daniel Austin
+- 3rd party reviewer
 
 Review status:
-- {{review_status_note}}
+- pending
 
 ## Notes
-- {{note_1}}
-- {{note_2}}
+- `v0.87.1` is expected to ship a substantial runtime demo program rather than a placeholder matrix.
 
 ## Exit Criteria
 - The milestone’s major claims are mapped to bounded demos or explicit alternate proof surfaces.

--- a/docs/milestones/v0.87.1/DESIGN_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DESIGN_v0.87.1.md
@@ -4,71 +4,77 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Date: `2026-04-06`
-- Owner: `TBD`
-- Related issues: #1354
+- Owner: `Daniel Austin / Agent Logic`
+- Related issues: `#1354`, `#1415`
 
 ## Purpose
 Define what we are building, why, and how we validate it — concisely, with links to issues/PRs.
 
 ## Problem Statement
-`v0.87.1` did not yet have a tracked public milestone directory even though the roadmap now treats runtime completion as its own sub-milestone. The repo needs a canonical milestone shell before feature docs can be promoted into it.
+`v0.87.1` needs to complete the runtime substrate that `v0.87` seeded. The repo now has trace, provider, shared-memory, skill, and review foundations, but it does not yet have one complete runtime milestone that unifies execution environment, lifecycle, trace alignment, resilience, operator surfaces, and reviewer-facing proof.
 
 ## Goals
-- create a coherent tracked milestone shell for `v0.87.1`
-- normalize the standard milestone filenames for the new sub-milestone
+- complete the runtime environment and lifecycle surface for ADL
+- unify runtime execution, trace, resilience, operator, and review surfaces into one milestone
+- provide the demo, quality, and review proof needed for a large runtime milestone
 
 ## Non-Goals
-- promoting runtime feature docs into `docs/milestones/v0.87.1/features`
-- claiming implementation progress that has not happened yet
+- later cognitive features planned for `v0.88+`
+- speculative runtime expansion that is not required for runtime completion
 
 ## Scope
 ### In scope
-- {{in_scope_1}}
-- {{in_scope_2}}
+- complete the v0.87.1 runtime environment, lifecycle, trace-alignment, resilience, operator, and review surfaces
+- establish the runtime demo and proof program for the milestone
+- align the v0.87.1 milestone docs to the implemented runtime
 
 ### Out of scope
-- {{out_of_scope_1}}
-- {{out_of_scope_2}}
+- future cognitive systems beyond runtime completion
+- unbounded infrastructure or orchestration work outside the local deterministic runtime scope
 
 ## Requirements
 ### Functional
-- {{functional_requirement_1}}
-- {{functional_requirement_2}}
+- milestone docs must exist under `docs/milestones/v0.87.1` with standard naming
+- documents and implementation must reflect runtime completion focus (environment, lifecycle, determinism, resilience, operator surfaces, reviewability)
+- design must be consistent with `VISION_v0.87.1`, the WBS, sprint plan, and roadmap sequencing
 
 ### Non-functional
 - Deterministic behavior and reproducible outputs.
 - Clear failure semantics and observability.
 - stable tracked milestone naming and navigation
+- reviewer-legible proof surfaces and deterministic command entrypoints
 
 ## Proposed Design
 ### Overview
-{{architecture_summary}}
+This milestone implements runtime completion as a real, bounded system surface. It uses the seeded `v0.87` substrate as a foundation, then adds the missing runtime environment, lifecycle, resilience, operator, and review surfaces needed for a coherent local runtime. The design ties implementation, docs, demos, quality gates, and review surfaces together so the runtime can be inspected as one milestone rather than as scattered partial features.
 
 ### Interfaces / Data contracts
-- {{interface_or_contract_1}}
-- {{interface_or_contract_2}}
+- milestone-doc contract: the canonical docs under `docs/milestones/v0.87.1/` must exist, be discoverable, and match implementation truth
+- runtime contract: environment, lifecycle, trace, resilience, operator, and review surfaces must agree across docs and runtime behavior
+- review contract: demos, quality-gate surfaces, and review artifacts must be sufficient for internal and external review
 
 ### Execution semantics
-{{execution_semantics}}
+This milestone is executed as a large implementation-and-proof milestone. Work proceeds by completing runtime surfaces, proving them through a bounded demo program, converging docs and review surfaces, then closing with internal review, external review preparation, remediation, release, and next-milestone handoff.
 
 ## Risks and Mitigations
-- Risk: {{risk_1}}
-  - Mitigation: {{mitigation_1}}
-- Risk: {{risk_2}}
-  - Mitigation: {{mitigation_2}}
+- Risk: runtime surfaces land piecemeal without one coherent integrated path
+  - Mitigation: keep demos, review surfaces, and docs centered on one authoritative runtime story
+- Risk: doc claims drift from implementation while the runtime is still moving quickly
+  - Mitigation: enforce cross-document review and alignment continuously during execution
 
 ## Alternatives Considered
-- Option: {{alternative_1}}
-  - Tradeoff: {{tradeoff_1}}
-- Option: {{alternative_2}}
-  - Tradeoff: {{tradeoff_2}}
+- Option: keep `v0.87.1` as a docs-first seed shell only
+  - Tradeoff: lowers immediate pressure but fails to deliver the runtime milestone the roadmap now needs
+- Option: fold runtime completion back into `v0.87`
+  - Tradeoff: avoids a sub-milestone but muddies the already-bounded `v0.87` closeout
 
 ## Validation Plan
-- Checks/tests: {{validation_checks}}
-- Success metrics: {{success_metrics}}
-- Rollback/fallback: {{rollback_plan}}
+- Checks/tests: validate docs, runtime demos, quality-gate surfaces, and review artifacts appropriate to changed surfaces
+- Success metrics: the runtime is coherent, demo-backed, reviewable, and truthfully described by the canonical milestone docs
+- Rollback/fallback: if a runtime slice proves too large, cut bounded follow-on issues rather than widening the milestone silently
 
 ## Exit Criteria
-- Goals/non-goals and scope boundaries are explicit.
-- Validation plan is actionable and referenced by the milestone checklist.
-- Major open questions are resolved or tracked in the decision log.
+- goals/non-goals and scope boundaries are explicit
+- validation plan is actionable and referenced by the milestone checklist
+- runtime-completion claims are tied to proof surfaces
+- major open questions are resolved or tracked in the decision log

--- a/docs/milestones/v0.87.1/FEATURE_DOCS_v0.87.1.md
+++ b/docs/milestones/v0.87.1/FEATURE_DOCS_v0.87.1.md
@@ -1,0 +1,48 @@
+# Feature Docs - v0.87.1
+
+## Metadata
+- Milestone: `v0.87.1`
+- Version: `v0.87.1`
+- Date: `2026-04-07`
+- Owner: `Daniel Austin`
+
+## Purpose
+Provide one canonical index for the promoted `v0.87.1` feature docs so reviewers can map milestone planning, work packages, demos, and runtime architecture to the concrete feature surfaces.
+
+## How To Use
+- Start here when you want the promoted runtime feature set for `v0.87.1`.
+- Use this index with `README.md`, `WBS_v0.87.1.md`, and `DEMO_MATRIX_v0.87.1.md`.
+- Keep filenames, status lines, and scope language aligned with the milestone docs.
+
+## Scope Interpretation
+
+`v0.87.1` is the runtime-completion milestone. It includes the runtime primitives needed for:
+- execution environment
+- lifecycle control
+- execution-boundary enforcement
+- trace alignment
+- local resilience and Shepherd preservation
+- operator and review surfaces
+
+It does not attempt to complete the richer higher-order systems planned for later milestones, including broader chronosense, identity, instinct, and bounded-agency layers beyond the runtime primitives required here.
+
+## Feature Index
+
+| Feature doc | Primary concern | Main WPs |
+|---|---|---|
+| `features/ADL_RUNTIME_ENVIRONMENT.md` | runtime environment surface and contracts | `WP-02`, `WP-06` |
+| `features/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md` | runtime environment architecture and integration shape | `WP-02`, `WP-04`, `WP-08` |
+| `features/AGENT_LIFECYCLE.md` | lifecycle states, transitions, and continuity rules | `WP-03`, `WP-04`, `WP-07` |
+| `features/EXECUTION_BOUNDARIES.md` | explicit execution-boundary enforcement and control points | `WP-03`, `WP-04`, `WP-06` |
+| `features/LOCAL_RUNTIME_RESILIENCE.md` | local failure handling, restartability, and resilience guarantees | `WP-05`, `WP-07` |
+| `features/SHEPHERD_RUNTIME_MODEL.md` | preservation, recovery, and runtime stewardship model | `WP-05`, `WP-07`, `WP-08` |
+
+## Review Guidance
+- Treat the README, WBS, sprint plan, and demo matrix as the milestone-level planning surface.
+- Treat the files in `features/` as the promoted runtime architecture and behavior surface.
+- Any contradiction between milestone planning docs and these feature docs is a defect and must be resolved before review closeout.
+
+## Exit Criteria
+- Every promoted feature doc is linked from this index.
+- WBS and demo coverage remain consistent with the promoted feature set.
+- Status language in the feature docs matches the actual `v0.87.1` milestone scope.

--- a/docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md
+++ b/docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md
@@ -4,17 +4,17 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Target release date: `TBD`
-- Owner: `TBD`
+- Owner: `Daniel Austin`
 
 ## Purpose
 Ship/no-ship gate for the milestone. Check items only when evidence exists.
 
 ## Planning
-- [ ] Milestone goal defined (`{{goal_doc_link}}`)
-- [ ] Scope + non-goals documented (`{{scope_doc_link}}`)
-- [ ] WBS created and mapped to issues (`{{wbs_link}}`)
-- [ ] Decision log initialized (`{{decisions_link}}`)
-- [ ] Sprint plan created (`{{sprint_plan_link}}`)
+- [ ] Milestone goal defined (`docs/milestones/v0.87.1/VISION_v0.87.1.md`)
+- [ ] Scope + non-goals documented (`docs/milestones/v0.87.1/VISION_v0.87.1.md`)
+- [ ] WBS created and mapped to issues (`docs/milestones/v0.87.1/WBS_v0.87.1.md`)
+- [ ] Decision log initialized (`docs/milestones/v0.87.1/DECISIONS_v0.87.1.md`)
+- [ ] Sprint plan created (`docs/milestones/v0.87.1/SPRINT_v0.87.1.md`)
 
 ## Execution Discipline
 - [ ] Each issue has input/output cards under `.adl/cards/<issue>/`
@@ -22,19 +22,27 @@ Ship/no-ship gate for the milestone. Check items only when evidence exists.
 - [ ] Draft PR opened for each issue before merge
 - [ ] Transient failures retried and documented
 - [ ] "Green-only merge" policy followed
+- [ ] Canonical milestone docs remain aligned with implementation and proof surfaces throughout execution
 
 ## Quality Gates
 - [ ] `cargo fmt` passes
 - [ ] `cargo clippy --all-targets -- -D warnings` passes
 - [ ] `cargo test` passes
 - [ ] CI is green on the merge target
-- [ ] Coverage signal is not red (or exception documented) (`{{coverage_link_or_note}}`)
-- [ ] No unresolved high-priority blockers (`{{blocker_report_link}}`)
+- [ ] Coverage signal is not red (or exception documented)
+- [ ] No unresolved high-priority blockers (tracked via GitHub issues for v0.87.1)
+- [ ] Runtime demo program passes or each non-passing demo has an explicit bounded disposition
+
+## Review Surfaces
+- [ ] Demo matrix finalized (`docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md`)
+- [ ] Internal review complete
+- [ ] External / 3rd-party review package prepared
+- [ ] Accepted findings remediated or explicitly deferred with owner and rationale
 
 ## Release Packaging
-- [ ] Release notes finalized (`{{release_notes_link}}`)
-- [ ] Tag verified: `{{tag_name}}`
-- [ ] GitHub Release drafted (`{{release_draft_link}}`)
+- [ ] Release notes finalized (`docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md`)
+- [ ] Tag verified: `v0.87.1`
+- [ ] GitHub Release drafted (GitHub Releases UI)
 - [ ] Links validated in release body
 - [ ] Release published
 
@@ -42,8 +50,8 @@ Ship/no-ship gate for the milestone. Check items only when evidence exists.
 - [ ] Milestone/epic issues closed with release links
 - [ ] Deferred items moved to next milestone backlog
 - [ ] Follow-up bugs/tech debt captured as issues
-- [ ] Roadmap/status docs updated (`{{roadmap_update_link}}`)
-- [ ] Retrospective summary recorded (`{{retro_link}}`)
+- [ ] Roadmap/status docs updated (`docs/milestones/ROADMAP.md` or equivalent)
+- [ ] Retrospective summary recorded (project notes or milestone issue thread)
 
 ## Exit Criteria
 - All required gates are checked, or each exception has an owner + due date.

--- a/docs/milestones/v0.87.1/README.md
+++ b/docs/milestones/v0.87.1/README.md
@@ -4,7 +4,7 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Date: `2026-04-06`
-- Owner: `TBD`
+- Owner: `Daniel Austin`
 
 ## Purpose
 Provide a single entry point for the milestone: what it is, why it matters, what is included, and how to navigate the canonical documents and artifacts.
@@ -17,28 +17,34 @@ Provide a single entry point for the milestone: what it is, why it matters, what
 
 ## Overview
 
-`v0.87.1` is the runtime-completion sub-milestone that follows the seeded `v0.87` substrate and prepares the system for the later chronosense and bounded-agency work in `v0.88+`.
+`v0.87.1` is the runtime-completion milestone that follows the seeded `v0.87` substrate and turns it into a full runtime system with real lifecycle, execution-boundary, resilience, operator, and review surfaces.
 
 This milestone focuses on:
-- making the runtime environment a first-class milestone surface
-- clarifying lifecycle, execution-boundary, and local-resilience scope
-- establishing a public tracked shell for runtime-completion work
+- runtime-environment execution as a first-class system concern
+- lifecycle and execution-boundary completion
+- deterministic trace-aligned runtime observability
+- local runtime resilience, Shepherd preservation, and failure handling
+- operator and review surfaces for real execution and review
+- multiple runnable demos and proof surfaces for the runtime
 
 Key outcomes:
-- a tracked `docs/milestones/v0.87.1/` milestone shell
-- normalized canonical milestone filenames for the sub-milestone
-- a stable public surface for later promotion of `v0.87.1` feature docs
+- a real runtime-completion implementation surface with many thousands of lines of code
+- canonical milestone documents that truthfully describe the runtime
+- a runnable demo program and review package proving the runtime is real
+- a stable public surface for later chronosense and bounded-agency work
 
 ## Scope Summary
 
 ### In scope
-- milestone-shell creation and naming normalization
-- public tracked milestone docs for `v0.87.1`
-- documenting intended runtime-completion scope at a milestone level
+- runtime environment, lifecycle, and execution-boundary implementation
+- deterministic trace-aligned runtime completion
+- local runtime resilience, Shepherd preservation, restartability, and failure isolation
+- operator/review surfaces, demos, and proof artifacts
+- public tracked milestone docs and feature-doc index for `v0.87.1`
 
 ### Out of scope
-- feature-doc promotion into `docs/milestones/v0.87.1/features`
-- implementation claims beyond the seeded milestone shell
+- richer chronosense, identity, instinct, and bounded-agency systems planned for later milestones beyond the runtime primitives needed here
+- speculative long-horizon runtime features that are not required for runtime completion
 
 ## Document Map
 
@@ -48,6 +54,7 @@ Canonical milestone documents:
 - Design: `DESIGN_v0.87.1.md`
 - Work Breakdown Structure (WBS): `WBS_v0.87.1.md`
 - Sprint plan: `SPRINT_v0.87.1.md`
+- Feature-doc index: `FEATURE_DOCS_v0.87.1.md`
 - Decisions log: `DECISIONS_v0.87.1.md`
 - Demo matrix: `DEMO_MATRIX_v0.87.1.md`
 - Milestone checklist: `MILESTONE_CHECKLIST_v0.87.1.md`
@@ -55,76 +62,91 @@ Canonical milestone documents:
 - Release notes: `RELEASE_NOTES_v0.87.1.md`
 
 Supporting / domain-specific docs:
-- runtime planning docs remain under `.adl/docs/v0.87.1planning/`
-- feature-doc promotion is intentionally deferred until the milestone opens
-- roadmap placement context remains in `.adl/docs/TBD/FEATURE_SPRINT_MAP.md`
+- promoted runtime feature docs live under `docs/milestones/v0.87.1/features/`
+- runtime planning notes may still exist under `.adl/docs/v0.87.1planning/`, but tracked milestone truth lives under `docs/milestones/v0.87.1/`
+- roadmap and sequencing context remain in adjacent roadmap docs where needed
+
+Primary promoted feature docs:
+- `features/ADL_RUNTIME_ENVIRONMENT.md`
+- `features/ADL_RUNTIME_ENVIRONMENT_ARCHITECTURE.md`
+- `features/AGENT_LIFECYCLE.md`
+- `features/EXECUTION_BOUNDARIES.md`
+- `features/LOCAL_RUNTIME_RESILIENCE.md`
+- `features/SHEPHERD_RUNTIME_MODEL.md`
 
 ## Execution Model
 
 This milestone is executed as a sequence of work packages (WPs):
 
 - WP-01: Design pass (docs + planning)
-- WP-02 - WP-12: Feature and system work
+- WP-02 - WP-12: Runtime implementation, lifecycle completion, operator surfaces, and validation work
 - WP-13: Demo matrix and integration demos
 - WP-14: Coverage / quality gate
 - WP-15: Docs and review convergence
-- WP-16: Release ceremony
+- WP-16: Internal review
+- WP-17: External / 3rd-party review preparation
+- WP-18: Review findings remediation
+- WP-19: Next milestone planning
+- WP-20: Release ceremony
 
 Execution expectations:
-- Each WP is tracked by an issue and implemented via PRs.
-- Each issue produces structured artifacts (input/output cards, reports).
-- All work merges under green CI and passes quality gates.
+- Each WP is tracked by an issue and implemented through bounded PRs where needed.
+- Each issue should produce structured artifacts (input/output cards, reports) when execution begins.
+- This milestone is implementation-heavy and should culminate in a demonstrable runtime, not just planning alignment.
 
 ## Demo and Validation Surface
 
 Primary validation is defined in:
-- Demo matrix: `{{demo_matrix_doc}}`
+- Demo matrix: `docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md`
 
 Additional validation surfaces:
-- Test suite results
-- Generated artifacts under `.adl/runs/`
-- Trace and replay outputs
+- runtime demos and generated proof surfaces
+- milestone docs themselves
+- release/checklist surfaces
+- baseline repository validation via `cargo build`, tests, and milestone demo commands
 
 Success criteria:
-- {{success_criteria_1}}
-- {{success_criteria_2}}
-- {{success_criteria_3}}
+- milestone docs are complete, placeholder-free, and mutually consistent
+- release/checklist/review surfaces exist and are navigable
+- milestone scope remains truthful and bounded to runtime completion work
+- runtime demos and review surfaces prove the system, not just the plan
 
 ## Determinism and Reproducibility
 
 The milestone should demonstrate:
-- Deterministic or bounded-repeatable execution where required
-- Replayable traces and inspectable artifacts
-- Stable command entry points for demos
+- deterministic or bounded-repeatable runtime execution where required
+- replayable traces and inspectable runtime artifacts
+- stable command entry points for milestone demos
 
 Evidence locations:
-- {{determinism_evidence_path_1}}
-- {{determinism_evidence_path_2}}
+- `docs/milestones/v0.87.1/`
+- milestone review / checklist / release-plan surfaces
+- generated runtime and review artifacts for the milestone demos
 
 ## Risks and Open Questions
 
 Known risks:
-- {{risk_1}}
-- {{risk_2}}
+- mismatch between milestone docs and the evolving runtime implementation
+- under-specifying the runtime proof surface so review happens against fragments instead of the integrated system
 
 Open questions:
-- {{open_question_1}}
-- {{open_question_2}}
+- which runtime feature docs should be promoted first as implementation lands
+- how much of the runtime review package should be demo-driven versus artifact-driven
 
 ## Status
 
-Current status: seeded shell
+Current status: planning active / implementation not yet started
 
 - Planning: active
 - Execution: not started
-- Validation: path/layout verified
+- Validation: milestone structure and planning direction in progress
 - Release readiness: not started
 
 ## Exit Criteria
 
-- All canonical milestone documents are complete and internally consistent.
-- All WBS items are implemented or explicitly deferred.
-- Demo matrix is runnable and validated.
-- Quality gates (fmt, clippy, test, CI) are passing.
-- Milestone checklist is complete or exceptions are documented.
-- Release artifacts (notes, tag, docs) are ready.
+- All canonical milestone documents are complete, internally consistent, and placeholder-free.
+- All WBS items are completed or explicitly deferred.
+- Demo matrix and validation surfaces truthfully reflect the runtime-completion milestone and its proof claims.
+- Baseline repository validation, runtime demos, and review surfaces succeed or are explicitly dispositioned.
+- Milestone checklist is complete or exceptions are documented with owner and rationale.
+- Release artifacts (notes, tag plan, release plan, docs) are ready for review.

--- a/docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md
+++ b/docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md
@@ -3,8 +3,8 @@
 ## Metadata
 - Product: `ADL`
 - Version: `v0.87.1`
-- Release date: `TBD`
-- Tag: `TBD`
+- Release date: `Pending release gate`
+- Tag: `v0.87.1`
 
 ## How To Use
 - Keep statements implementation-accurate and test-validated.
@@ -14,42 +14,42 @@
 # `ADL` `v0.87.1` Release Notes
 
 ## Summary
-{{summary_paragraph}}
+`v0.87.1` completes the first full runtime milestone for ADL. It turns the seeded execution substrate from `v0.87` into a coherent runtime system with explicit lifecycle boundaries, trace-aligned execution, local resilience, operator surfaces, review surfaces, and a substantial demo-backed proof program.
 
 ## Highlights
-- {{highlight_1}}
-- {{highlight_2}}
-- {{highlight_3}}
+- Runtime environment and lifecycle completion surfaces landed for `v0.87.1`
+- Deterministic trace-aligned runtime and local resilience surfaces are part of the milestone scope
+- Review, checklist, demo-matrix, and release surfaces are aligned to a real runtime implementation milestone
 
 ## What's New In Detail
 
-### {{area_1}}
-- {{detail_1a}}
-- {{detail_1b}}
+### Runtime Completion Milestone
+- Established `v0.87.1` as the milestone for runtime completion rather than a documentation-only follow-on
+- Aligned the canonical milestone docs (`VISION`, `DESIGN`, `WBS`, `SPRINT`, `DEMO_MATRIX`, `MILESTONE_CHECKLIST`, `RELEASE_PLAN`, `DECISIONS`, `RELEASE_NOTES`) to the real runtime implementation path
 
-### {{area_2}}
-- {{detail_2a}}
-- {{detail_2b}}
+### Runtime Scope
+- Framed `v0.87.1` around runtime environment, execution boundaries, lifecycle, trace alignment, local resilience, operator surfaces, and runtime review surfaces
+- Preserved later cognitive features as out of scope so the milestone stays centered on runtime completion
 
-### {{area_3}}
-- {{detail_3a}}
-- {{detail_3b}}
+### Proof, Review, And Release Discipline
+- Defined a substantial runtime demo program and reviewer entry surfaces for the milestone
+- Preserved explicit internal review, external review preparation, remediation, next-milestone planning, and release ceremony steps in the closeout tail
 
 ## Upgrade Notes
-- {{upgrade_note_1}}
-- {{upgrade_note_2}}
+- `v0.87.1` is expected to ship real runtime implementation and proof surfaces, so upgrade notes should be finalized from the actual landed behavior before release
+- Existing `v0.87` implementation surfaces remain the starting substrate, but `v0.87.1` is intended to supersede them with a completed runtime story
 
 ## Known Limitations
-- {{limitation_1}}
-- {{limitation_2}}
+- Final release text must be updated from actual landed runtime behavior before publish
+- Some runtime surfaces may still be intentionally deferred if bounded follow-on issues are recorded explicitly
 
 ## Validation Notes
-- {{validation_note_1}}
-- {{validation_note_2}}
+- Validation for this release must cover milestone docs, runtime demos, review surfaces, and standard repository quality gates
+- `cargo build` is a baseline validation command, not the only proof surface for the milestone
 
 ## What's Next
-- {{next_1}}
-- {{next_2}}
+- Carry forward deferred runtime work and the next milestone package after `v0.87.1` closeout
+- Carry the project forward into `v0.88` once runtime substrate work is complete
 
 ## Exit Criteria
 - Notes reflect only shipped behavior.

--- a/docs/milestones/v0.87.1/RELEASE_PLAN_v0.87.1.md
+++ b/docs/milestones/v0.87.1/RELEASE_PLAN_v0.87.1.md
@@ -4,7 +4,7 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Release date: `TBD`
-- Release manager: `TBD`
+- Release manager: Daniel Austin
 
 ## How To Use
 - Execute sections in order and capture links for each completed step.
@@ -12,33 +12,35 @@
 - Mark blockers immediately; do not publish until gates pass.
 
 ## 1) Release Readiness
-- [ ] Milestone checklist complete (`{{milestone_checklist_link}}`)
-- [ ] Release notes approved (`{{release_notes_link}}`)
-- [ ] Go/no-go decision recorded (`{{decision_link}}`)
+- [ ] Milestone checklist complete (`docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md`)
+- [ ] Release notes approved (`docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md`)
+- [ ] Go/no-go decision recorded (`docs/milestones/v0.87.1/DECISIONS_v0.87.1.md` or milestone issue thread)
+- [ ] Internal review and external review-prep outcomes dispositioned
+- [ ] Next-milestone planning package prepared before release closeout
 
 ## 2) Branch And Tag Preparation
-- [ ] Target branch confirmed (`{{target_branch}}`)
+- [ ] Target branch confirmed (main)
 - [ ] Working tree clean
-- [ ] Version string(s) validated (`{{version_validation_link}}`)
-- [ ] Tag created: `{{tag_name}}`
+- [ ] Version string(s) validated (milestone docs + release notes reviewed for v0.87.1 consistency)
+- [ ] Tag created: v0.87.1
 - [ ] Tag pushed and verified
 
 ## 3) GitHub Release Steps
-- [ ] GitHub Release draft created from `{{tag_name}}` (`{{release_draft_link}}`)
+- [ ] GitHub Release draft created from v0.87.1 (GitHub Releases UI)
 - [ ] Release body populated from approved notes
 - [ ] Links to key PRs/issues included
 - [ ] Release visibility confirmed (draft/prerelease/final)
 - [ ] Release published
 
 ## 4) Verification
-- [ ] Post-release CI status checked (`{{ci_run_link}}`)
+- [ ] Post-release CI status checked (GitHub Actions / CI runs for main)
 - [ ] Release links tested (docs, artifacts, notes)
-- [ ] Immediate regressions triaged and tracked (`{{triage_link}}`)
+- [ ] Immediate regressions triaged and tracked (GitHub issues / milestone thread)
 
 ## 5) Communication
-- [ ] Community announcement published (`{{announcement_link}}`)
-- [ ] Internal update posted (`{{internal_update_link}}`)
-- [ ] Roadmap/status updated (`{{roadmap_update_link}}`)
+- [ ] Community announcement published (release notes / GitHub Release or explicitly skipped if this milestone remains internal)
+- [ ] Internal update posted (project notes / milestone thread)
+- [ ] Roadmap/status updated (docs/milestones/ROADMAP.md or equivalent)
 
 ## Exit Criteria
 - Tag and GitHub Release are published and accessible.

--- a/docs/milestones/v0.87.1/SPRINT_v0.87.1.md
+++ b/docs/milestones/v0.87.1/SPRINT_v0.87.1.md
@@ -1,49 +1,134 @@
 # Sprint Plan - v0.87.1
 
 ## Metadata
-- Sprint: `Pending sprint plan`
+- Sprint plan: `v0.87.1`
 - Milestone: `v0.87.1`
 - Start date: `TBD`
 - End date: `TBD`
-- Owner: `TBD`
+- Owner: `Daniel Austin`
 
 ## How To Use
 - Keep scope small enough to finish with green CI and merged PRs.
 - List work items in planned execution order.
 - Track blockers here (not scattered chat notes).
 
+## Role Of This Document
+
+This sprint plan defines the executable structure of `v0.87.1`.
+
+It maps Work Packages from the WBS into ordered implementation and review phases that can be executed deterministically.
+
+This document must remain fully consistent with:
+- the WBS
+- the milestone vision
+- the milestone design
+- the milestone README
+
+Any divergence is a defect and must be corrected immediately.
+
+## Working Rules
+
+- Execute work in strict dependency order.
+- Every WP must produce concrete runtime behavior, docs, artifacts, demos, or bounded review surfaces.
+- Demos, traces, and structured review outputs are required evidence for major runtime claims.
+- Keep all canonical documents aligned continuously.
+- Do not defer consistency work to the end.
+- Treat runtime completion as the milestone center of gravity.
+
 ## Sprint Goal
-Seed the tracked `v0.87.1` milestone shell and prepare it for later runtime-completion work.
+Complete the first full runtime milestone for ADL: execution environment, lifecycle, trace alignment, resilience, operator surfaces, demos, review, release, and handoff.
 
 ## Planned Scope
-- establish canonical milestone docs for `v0.87.1`
-- keep feature-doc promotion out of scope for this seed pass
-- populate sprint content when `v0.87.1` formally opens
+- runtime environment, lifecycle, and execution-boundary completion
+- deterministic trace-aligned execution and review surfaces
+- local runtime resilience, Shepherd preservation, and state discipline
+- operator surfaces and a large multi-demo proof program
+- docs/review convergence, internal review, external review prep, remediation, release, and next-milestone handoff
 
-## Work Plan
-| Order | Item | Issue | Owner | Status |
-|---|---|---|---|---|
-| 1 | {{work_item_1}} | {{issue_1}} | {{owner_1}} | {{status_1}} |
-| 2 | {{work_item_2}} | {{issue_2}} | {{owner_2}} | {{status_2}} |
-| 3 | {{work_item_3}} | {{issue_3}} | {{owner_3}} | {{status_3}} |
+## Sprint Structure
+
+### Sprint 1 - Runtime Foundations
+Goal:
+Establish canonical milestone truth, runtime environment, lifecycle, trace alignment, resilience, and operator surfaces.
+
+Current scope:
+- `WP-01` design pass
+- `WP-02` runtime environment completion
+- `WP-03` execution boundaries and lifecycle
+- `WP-04` trace-aligned runtime execution
+- `WP-05` local runtime resilience + Shepherd preservation
+- `WP-06` operator surfaces
+- `WP-07` runtime state / persistence discipline
+- `WP-08` runtime review surfaces
+
+Proof surfaces:
+- one authoritative runtime-environment surface
+- bounded lifecycle phases with real execution boundaries
+- trace/runtime alignment that can be inspected by a reviewer
+- local resilience, Shepherd preservation, and restart semantics visible in implementation or artifacts
+- stable operator entrypoints and review surfaces
+
+### Sprint 2 - Convergence, Demos, And Quality
+Goal:
+Prove the runtime through integrated demos, quality gates, and doc/review convergence.
+
+Current scope:
+- `WP-09` cross-document consistency pass
+- `WP-10` acceptance criteria finalization
+- `WP-11` sprint plan alignment
+- `WP-12` checklist / release-gate completion
+- `WP-13` demo matrix and integration demos
+- `WP-14` coverage / quality gate
+- `WP-15` docs + review pass
+
+Proof surfaces:
+- canonical docs no longer contradict the runtime implementation
+- demo matrix defines and proves the runtime claims
+- quality posture is auditable
+- reviewer entry surfaces are coherent for an uninvolved reviewer
+
+### Sprint 3 - Review, Release, And Handoff
+Goal:
+Review the completed runtime milestone, remediate findings, release it, and prepare the next milestone.
+
+Current scope:
+- `WP-16` internal review
+- `WP-17` external / 3rd-party review preparation
+- `WP-18` review findings remediation
+- `WP-19` next milestone planning
+- `WP-20` release ceremony
+
+Proof surfaces:
+- internal review findings are recorded and actionable
+- external review package is legible and runnable
+- accepted findings are remediated or explicitly deferred
+- release artifacts are complete
+- next-milestone planning package exists before closeout
 
 ## Cadence Expectations
 - Use issue cards (`input`/`output`) for each item.
 - Keep changes scoped per issue; use draft PRs until checks pass.
-- Run required quality gates (fmt/clippy/test) for code changes.
+- Run required quality gates (`fmt`, `clippy`, `test`, demo validators, and milestone review checks) for the changed surfaces.
+- Issue references may remain `TBD` while `v0.87.1` is being finalized in planning, but they must be filled as the milestone opens.
 
 ## Risks / Dependencies
-- Dependency: {{dependency_1}}
-  - Risk: {{risk_1}}
-  - Mitigation: {{mitigation_1}}
+- Dependency: upstream v0.87 artifacts (trace, provider, skills) remain stable
+  - Risk: doc drift or mismatch with implemented substrate
+  - Mitigation: anchor language to v0.87 canonical docs and avoid speculative claims
+
+- Dependency: runtime work can sprawl across lifecycle, state, review, and operator surfaces
+  - Risk: the milestone lands partial runtime slices without one coherent proof story
+  - Mitigation: keep demo matrix, quality gate, and review surfaces centered on the integrated runtime
 
 ## Demo / Review Plan
-- Demo artifact: {{demo_artifact}}
-- Review date: {{review_date}}
-- Sign-off owners: {{signoff_owners}}
+- Demo artifact: milestone doc walkthrough (VISION → DESIGN → WBS → SPRINT → CHECKLIST)
+- Primary runtime proof program: `docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md`
+- Review date: TBD
+- Sign-off owners: Daniel Austin, internal review, 3rd party reviewer
 
 ## Exit Criteria
-- All planned scope items completed or explicitly deferred with rationale.
+- All WPs (`WP-01` through `WP-20`) are complete or explicitly deferred with rationale.
 - Linked issues/PRs updated and traceable.
 - CI is green for merged work.
-- Sprint summary captured in milestone docs.
+- Demo matrix, quality gate, and review surfaces are complete.
+- Sprint summary is captured in milestone docs.

--- a/docs/milestones/v0.87.1/VISION_v0.87.1.md
+++ b/docs/milestones/v0.87.1/VISION_v0.87.1.md
@@ -5,15 +5,15 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Date: `2026-04-06`
-- Owner: `TBD`
-- Related issues: #1354
+- Owner: `Daniel Austin / Agent Logic`
+- Related issues: `#1354`, `#1415`
 
 ## Purpose
 Define the milestone-level vision for the project: what changes at this stage, why it matters, and which strategic pillars it advances.
 
 ## Status
 
-This document is intentionally seeded as a milestone shell. It records the intended direction of `v0.87.1` without pretending the detailed runtime plan has already been promoted or implemented.
+This document defines the milestone-level direction for a real runtime-completion milestone. It should read as the strategic frame for a large implementation milestone, not as a placeholder shell.
 
 ## How To Use
 - Write this as a milestone vision, not a full design spec.
@@ -25,13 +25,15 @@ This document is intentionally seeded as a milestone shell. It records the inten
 
 ## Overview
 
-Version `v0.87.1` is the milestone where `ADL` evolves from a seeded execution substrate into a first-class runtime-completion surface.
+Version `v0.87.1` is the milestone where `ADL` evolves from a seeded execution substrate into a first-class runtime-completion system.
 
 This release should establish or strengthen the foundation for:
 
 - runtime-environment execution as a first-class system concern
-- lifecycle and execution-boundary clarity
+- lifecycle and execution-boundary completion
 - durable local-runtime resilience as a public milestone goal
+- operator and review surfaces that make the runtime externally legible
+- demo-backed proof that the runtime is real
 
 `v0.87.1` focuses on **runtime completion**.
 
@@ -43,201 +45,202 @@ The goal is to make the project more useful to:
 
 This milestone should strengthen the architectural or strategic pillars of:
 
-- {{pillar_1}}
-- {{pillar_2}}
-- {{pillar_3}}
-- {{pillar_4}}
-
-{{overview_close}}
+- deterministic runtime completion
+- execution boundaries and lifecycle clarity
+- trace-aligned runtime observability
+- local runtime resilience
+- operator and review surface quality
 
 ---
 
 # Core Goals
 
-`{{version}}` advances `{{project_name}}` in five major areas:
+`v0.87.1` advances `ADL` in five major areas:
 
-1. {{goal_area_1}}
-2. {{goal_area_2}}
-3. {{goal_area_3}}
-4. {{goal_area_4}}
-5. {{goal_area_5}}
+1. Runtime Environment Completion
+2. Execution Boundaries & Lifecycle
+3. Deterministic Trace-Aligned Execution
+4. Local Runtime Resilience
+5. Operator & Review Surfaces
 
 ---
 
-# 1. {{goal_area_1}}
+# 1. Runtime Environment Completion
 
-`{{version}}` improves `{{goal_area_1}}` so the project can `{{outcome_1}}`.
+`v0.87.1` improves Runtime Environment Completion so the project can execute ADL workflows reliably within a well-defined runtime environment.
 
 Key objectives:
 
-- {{objective_1a}}
-- {{objective_1b}}
-- {{objective_1c}}
-- {{objective_1d}}
+- define runtime entrypoints and environment contracts
+- standardize runtime configuration and invocation patterns
+- ensure consistent environment setup across local runs
+- align runtime behavior with trace emission
+- turn the runtime into a demonstrable public milestone surface
 
-These capabilities move the project toward **{{strategic_effect_1}}**.
+These capabilities move the project toward **a complete, reproducible runtime surface**.
 
 The system or product should guarantee:
 
-- {{guarantee_1a}}
-- {{guarantee_1b}}
-- {{guarantee_1c}}
+- stable runtime entrypoints
+- consistent environment initialization
+- predictable execution semantics
+- reviewer-legible proof of runtime behavior
 
 ---
 
-# 2. {{goal_area_2}}
+# 2. Execution Boundaries & Lifecycle
 
-`{{goal_area_2}}` must improve without sacrificing `{{constraint_2}}`.
+Execution Boundaries & Lifecycle must improve without sacrificing determinism.
 
-`{{version}}` introduces or improves:
+`v0.87.1` introduces or improves:
 
-- {{improvement_2a}}
-- {{improvement_2b}}
-- {{improvement_2c}}
-- {{improvement_2d}}
+- explicit execution boundaries for all runs
+- defined agent lifecycle phases (init, execute, complete, teardown)
+- boundary enforcement at runtime edges
+- lifecycle hooks aligned with trace
 
-The goal is to move from `{{before_state_2}}` toward **{{after_state_2}}**.
+The goal is to move from implicit, loosely defined execution flow toward **explicit, bounded, lifecycle-driven execution**.
 
 These changes should help users:
 
-- {{user_benefit_2a}}
-- {{user_benefit_2b}}
+- understand where and how execution occurs
+- reason about failures and boundaries
 
 ---
 
-# 3. {{goal_area_3}}
+# 3. Deterministic Trace-Aligned Execution
 
-A central principle of `{{project_name}}` is **{{principle_3}}**.
+A central principle of `ADL` is **determinism with observable truth**.
 
-The project must not merely `{{anti_goal_3}}`. It must `{{desired_behavior_3}}`.
+The project must not merely rely on implicit or non-reproducible behavior. It must produce identical outcomes given identical inputs with trace as ground truth.
 
-`{{version}}` strengthens this pillar with:
+`v0.87.1` strengthens this pillar with:
 
-- {{capability_3a}}
-- {{capability_3b}}
-- {{capability_3c}}
-- {{capability_3d}}
+- trace emission integrated with runtime phases
+- alignment between execution steps and trace artifacts
+- replayability of bounded runs
+- clear mapping from runtime actions to trace records
 
-This work supports the broader principle of **{{broader_principle_3}}**.
+This work supports the broader principle of **trace as authoritative narrative of execution**.
 
 The result should make the project more:
 
-- {{quality_3a}}
-- {{quality_3b}}
-- {{quality_3c}}
+- reproducible
+- auditable
+- explainable
 
 ---
 
-# 4. {{goal_area_4}}
+# 4. Local Runtime Resilience
 
-`{{version}}` continues development of `{{goal_area_4}}`.
+`v0.87.1` continues development of Local Runtime Resilience.
 
-The focus remains on **{{focus_4}}**, not `{{non_goal_4}}`.
+The focus remains on **stability and recovery in local environments**, not distributed or cloud-scale orchestration.
 
 Key capabilities:
 
-- {{capability_4a}}
-- {{capability_4b}}
-- {{capability_4c}}
-- {{capability_4d}}
+- graceful failure handling
+- restartability of bounded runs
+- isolation of failing components
+- minimal state corruption on failure
 
 This milestone should help the project better represent or support:
 
-- {{support_4a}}
-- {{support_4b}}
-- {{support_4c}}
+- developer iteration
+- reliable demos
+- predictable local execution
 
-These improvements should guide the system toward `{{desired_state_4}}`.
+These improvements should guide the system toward resilient local runtime suitable for development and demonstration.
 
 ---
 
-# 5. {{goal_area_5}}
+# 5. Operator & Review Surfaces
 
-To support real-world use, `{{version}}` must improve `{{goal_area_5}}`.
+To support real-world use, `v0.87.1` must improve Operator & Review Surfaces.
 
 Important targets include:
 
-- {{target_5a}}
-- {{target_5b}}
-- {{target_5c}}
-- {{target_5d}}
+- clear runtime invocation surfaces
+- standardized demo and execution scripts
+- artifact organization for review
+- consistent output surfaces for verification
 
 This work should strengthen the development and operating workflow by improving:
 
-- {{workflow_benefit_5a}}
-- {{workflow_benefit_5b}}
-- {{workflow_benefit_5c}}
-
-{{close_5}}
+- easier validation of milestone capabilities
+- reduced operator error
+- faster review cycles
+- stronger external credibility of the runtime milestone
 
 ---
 
-# Special Focus: `{{special_focus_title}}`
+# Special Focus: `Runtime Completion`
 
-`{{special_focus_title}}` becomes a central focus of `{{version}}`.
+`Runtime Completion` becomes a central focus of `v0.87.1`.
 
-Previous releases `{{previous_special_focus_state}}`.
+Previous releases established trace v1 and the initial runtime substrate.
 
-`{{version}}` advances this area with:
+`v0.87.1` advances this area with:
 
-- {{special_focus_1}}
-- {{special_focus_2}}
-- {{special_focus_3}}
-- {{special_focus_4}}
+- complete runtime environment definition
+- unify execution, trace, and lifecycle
+- ensure bounded, deterministic runs
+- expose stable operator surfaces
+- prove the runtime through multiple bounded demos and review artifacts
 
-This area is responsible for ensuring that `{{special_focus_scope}}` remain:
+This area is responsible for ensuring that runtime execution and lifecycle remain:
 
-- {{special_quality_1}}
-- {{special_quality_2}}
-- {{special_quality_3}}
+- deterministic
+- bounded
+- observable
 
-This keeps the project aligned with `{{alignment_principle}}`.
+This keeps the project aligned with substrate-level governance.
 
 ---
 
 # Milestone Context
 
-`{{previous_milestone}}` represents `{{previous_milestone_significance}}`.
+`v0.87` represents established trace v1, provider substrate, and operational skills.
 
-From `{{next_phase_start}}` onward the project will likely shift toward:
+From `v0.88` onward the project will likely shift toward:
 
-- {{next_phase_item_1}}
-- {{next_phase_item_2}}
-- {{next_phase_item_3}}
+- chronosense and identity
+- instinct and bounded agency
+- temporal schema and continuity
 
-The goal is to have `{{future_goal}}` by **{{future_target_milestone}}**.
+The goal is to have a coherent, persistent cognitive system by **v0.92**.
 
-`{{version}}` therefore focuses on `{{contextual_focus}}` before that stage.
+`v0.87.1` therefore focuses on completing the runtime substrate before layering cognitive features, and on doing so through a real implementation milestone with substantial code, demos, and review surfaces.
 
 ---
 
 # Long-Term Direction
 
-`{{project_name}}` is being designed as `{{long_term_identity}}`.
+`ADL` is being designed as a deterministic runtime environment for cognitive agents.
 
 Its long-term goals include:
 
-- {{long_term_goal_1}}
-- {{long_term_goal_2}}
-- {{long_term_goal_3}}
-- {{long_term_goal_4}}
+- enable reliable agent execution
+- support multi-agent reasoning systems
+- provide traceable and auditable cognition
+- establish a substrate for governed agency
 
-These principles aim to move the project beyond `{{old_mode}}` toward `{{new_mode}}`.
+These principles aim to move the project beyond ad-hoc, model-centric execution toward substrate-governed, deterministic orchestration.
 
 ---
 
 # Summary
 
-`{{version}}` is the milestone where `{{project_name}}` becomes:
+`v0.87.1` is the milestone where `ADL` becomes:
 
-- {{summary_quality_1}}
-- {{summary_quality_2}}
-- {{summary_quality_3}}
-- {{summary_quality_4}}
+- runnable
+- bounded
+- deterministic
+- reviewable
 
-It strengthens `{{summary_strength_1}}`, advances `{{summary_strength_2}}`, improves `{{summary_strength_3}}`, and stabilizes `{{summary_strength_4}}`.
+It strengthens runtime completeness, advances execution clarity, improves trace alignment, stabilizes local resilience, and makes the runtime externally reviewable through a substantial demo and proof program.
 
-These improvements prepare the project for `{{next_stage}}`.
+These improvements prepare the project for higher-level cognitive features (identity, instinct, continuity).
 
 ## Exit Criteria
 - The milestone's strategic priorities are explicit and internally consistent.

--- a/docs/milestones/v0.87.1/WBS_v0.87.1.md
+++ b/docs/milestones/v0.87.1/WBS_v0.87.1.md
@@ -4,60 +4,70 @@
 - Milestone: `v0.87.1`
 - Version: `v0.87.1`
 - Date: `2026-04-06`
-- Owner: `TBD`
+- Owner: `Daniel Austin`
 
 ## How To Use
 - Break work into independently-mergeable issues.
 - Keep each item measurable and testable.
 - Include deliverables + dependencies + issue links.
 - `WP-01` is **always** the milestone **design pass** (canonical docs + WBS + decisions + sprint plan + checklist).
-- Reserve the final WPs for the release tail in this order: `WP-13` demos, `WP-14` quality/coverage gate, `WP-15` docs/review convergence, `WP-16` release ceremony.
+- Reserve the final WPs for the release tail in this order: demos, quality/coverage gate, docs/review convergence, internal review, external review preparation, review-findings remediation or explicit deferral capture, next-milestone planning, and release ceremony.
 
 ## WBS Summary
-Initial milestone shell only. Work packages will be populated as `v0.87.1` opens and runtime-completion work is promoted from planning into the tracked milestone surface.
+`v0.87.1` is the runtime-completion milestone for ADL. It is the point where the runtime stops being a seeded planning surface and becomes a full implementation target with real execution lifecycle, deterministic trace alignment, local resilience, operator surfaces, review surfaces, and runnable demos.
+
+This milestone is not satisfied by a public shell alone. It requires substantial runtime implementation, strong proof surfaces, and the full review-and-release tail needed for a large substrate milestone.
 
 ## Work Packages
 | ID | Work Package | Description | Deliverable | Dependencies | Issue |
 |---|---|---|---|---|---|
-| WP-01 | Design pass (milestone docs + planning) | {{description_01}} | {{deliverable_01}} | {{deps_01}} | {{issue_01}} |
-| WP-02 | {{package_02}} | {{description_02}} | {{deliverable_02}} | {{deps_02}} | {{issue_02}} |
-| WP-03 | {{package_03}} | {{description_03}} | {{deliverable_03}} | {{deps_03}} | {{issue_03}} |
-| WP-04 | {{package_04}} | {{description_04}} | {{deliverable_04}} | {{deps_04}} | {{issue_04}} |
-| WP-05 | {{package_05}} | {{description_05}} | {{deliverable_05}} | {{deps_05}} | {{issue_05}} |
-| WP-06 | {{package_06}} | {{description_06}} | {{deliverable_06}} | {{deps_06}} | {{issue_06}} |
-| WP-07 | {{package_07}} | {{description_07}} | {{deliverable_07}} | {{deps_07}} | {{issue_07}} |
-| WP-08 | {{package_08}} | {{description_08}} | {{deliverable_08}} | {{deps_08}} | {{issue_08}} |
-| WP-09 | {{package_09}} | {{description_09}} | {{deliverable_09}} | {{deps_09}} | {{issue_09}} |
-| WP-10 | {{package_10}} | {{description_10}} | {{deliverable_10}} | {{deps_10}} | {{issue_10}} |
-| WP-11 | {{package_11}} | {{description_11}} | {{deliverable_11}} | {{deps_11}} | {{issue_11}} |
-| WP-12 | {{package_12}} | {{description_12}} | {{deliverable_12}} | {{deps_12}} | {{issue_12}} |
-| WP-13 | Demo matrix + integration demos | {{description_13}} | {{deliverable_13}} | {{deps_13}} | {{issue_13}} |
-| WP-14 | Coverage / quality gate (ratchet + exclusions) | {{description_14}} | {{deliverable_14}} | {{deps_14}} | {{issue_14}} |
-| WP-15 | Docs + review pass (repo-wide alignment) | {{description_15}} | {{deliverable_15}} | {{deps_15}} | {{issue_15}} |
-| WP-16 | Release ceremony (final validation + tag + notes + cleanup) | {{description_16}} | {{deliverable_16}} | {{deps_16}} | {{issue_16}} |
+| WP-01 | Design pass (milestone docs + planning) | Align canonical `v0.87.1` docs, planning, and roadmap framing for the runtime-completion milestone | Complete canonical milestone docs aligned to runtime completion scope | none | TBD |
+| WP-02 | Runtime environment completion | Define and implement the first authoritative runtime-environment surface for `v0.87.1`, including entrypoints, env contracts, and configuration expectations | Working runtime environment substrate and docs that match it | WP-01 | TBD |
+| WP-03 | Execution boundaries & lifecycle | Implement and document explicit lifecycle phases and runtime boundaries (`init`, `execute`, `complete`, `teardown`) | Bounded lifecycle model with real implementation and review surfaces | WP-01, WP-02 | TBD |
+| WP-04 | Trace-aligned runtime execution | Align runtime lifecycle phases with Trace v1 events, artifacts, and replay expectations | Runtime execution mapped coherently to trace/proof surfaces | WP-02, WP-03 | TBD |
+| WP-05 | Local runtime resilience + Shepherd preservation | Implement local failure handling, restartability, bounded recovery semantics, and Shepherd preservation behavior for interrupted or failed runtime work | Resilient local runtime behaviors and documented Shepherd guarantees | WP-02, WP-03 | TBD |
+| WP-06 | Operator surfaces | Standardize invocation patterns, runtime commands, demo scripts, and artifact layout | Stable operator entrypoints and reviewable artifact conventions | WP-02, WP-03 | TBD |
+| WP-07 | Runtime state / persistence discipline | Define and implement state, restart, continuity, and cleanup discipline for bounded local runs | Inspectable runtime state/persistence surface with deterministic cleanup and continuity behavior | WP-03, WP-05 | TBD |
+| WP-08 | Runtime review surfaces | Standardize runtime review outputs, inspection surfaces, and verification artifacts | Reviewable runtime output surfaces for internal and external inspection | WP-04, WP-06, WP-07 | TBD |
+| WP-09 | Cross-document consistency pass | Enforce agreement between VISION, DESIGN, WBS, SPRINT, CHECKLIST, README, and promoted runtime surfaces | No contradictions across milestone docs and implementation claims | WP-02..WP-08 | TBD |
+| WP-10 | Acceptance criteria finalization | Define measurable acceptance criteria for each WP and the overall runtime-completion milestone | Completed Acceptance Mapping section with runtime-specific proof expectations | WP-09 | TBD |
+| WP-11 | Sprint plan alignment | Ensure SPRINT doc reflects WBS sequencing, review tail, and release structure | Updated SPRINT with explicit implementation and review phases | WP-01, WP-10 | TBD |
+| WP-12 | Checklist / release-gate completion | Populate checklist and release-gate surfaces with runtime-specific validation expectations | Complete milestone checklist and release-gate mapping | WP-10, WP-11 | TBD |
+| WP-13 | Demo matrix + integration demos | Define and implement the milestone demo program across runtime environment, lifecycle, resilience, operator, and review surfaces | Real demo matrix and runnable runtime demos with clear proof claims | WP-04, WP-05, WP-06, WP-08 | TBD |
+| WP-14 | Coverage / quality gate (ratchet + exclusions) | Establish truthful quality posture for the runtime milestone, including tests, validators, demos, and justified exceptions | Auditable quality/coverage posture for the runtime-completion milestone | WP-02 through WP-13 | TBD |
+| WP-15 | Docs + review pass (repo-wide alignment) | Converge milestone docs, runtime proof surfaces, and reviewer entry docs so an uninvolved reviewer can understand the implemented runtime truthfully | Reviewed and aligned docs/review package for `v0.87.1` | WP-13, WP-14 | TBD |
+| WP-16 | Internal review | Perform bounded internal review of milestone truth, runtime behavior, and proof surfaces | Internal review record with actionable findings | WP-15 | TBD |
+| WP-17 | External / 3rd-party review preparation | Prepare `v0.87.1` for external review legibility and proof-surface clarity | External-review-ready package for the runtime milestone | WP-16 | TBD |
+| WP-18 | Review findings remediation | Remediate accepted review findings or record explicit bounded deferrals with ownership before closeout | Updated artifacts plus tracked deferrals/ownership | WP-16, WP-17 | TBD |
+| WP-19 | Next milestone planning | Prepare the next milestone planning package before `v0.87.1` closeout | Explicit next-milestone planning materials and tracked follow-on work | WP-18 | TBD |
+| WP-20 | Release ceremony (final validation + tag + notes + cleanup) | Perform final validation, release-note alignment, cleanup, and milestone closeout for the runtime milestone | Ready-to-merge runtime milestone state and release artifacts | WP-19 | TBD |
 
 ## Sequencing
-- Phase 1: {{phase_1}}
-- Phase 2: {{phase_2}}
-- Phase 3: {{phase_3}}
+- Phase 1: WP-01..WP-08 (runtime foundations, lifecycle, resilience, operator and review surfaces)
+- Phase 2: WP-09..WP-12 (alignment, acceptance, sprint, checklist, and release-gate preparation)
+- Phase 3: WP-13..WP-20 (demos, quality, docs/review, internal review, external review prep, remediation, next-milestone planning, and release)
 
 ## Acceptance Mapping
-- WP-01 (Design pass) -> {{acceptance_criteria_01}}
-- WP-02 -> {{acceptance_criteria_02}}
-- WP-03 -> {{acceptance_criteria_03}}
-- WP-04 -> {{acceptance_criteria_04}}
-- WP-05 -> {{acceptance_criteria_05}}
-- WP-06 -> {{acceptance_criteria_06}}
-- WP-07 -> {{acceptance_criteria_07}}
-- WP-08 -> {{acceptance_criteria_08}}
-- WP-09 -> {{acceptance_criteria_09}}
-- WP-10 -> {{acceptance_criteria_10}}
-- WP-11 -> {{acceptance_criteria_11}}
-- WP-12 -> {{acceptance_criteria_12}}
-- WP-13 (Demos) -> {{acceptance_criteria_13}}
-- WP-14 (Quality gate) -> {{acceptance_criteria_14}}
-- WP-15 (Docs/review) -> {{acceptance_criteria_15}}
-- WP-16 (Release ceremony) -> {{acceptance_criteria_16}}
+- WP-01 (Design pass) -> milestone docs are aligned and explicit about the runtime-completion milestone
+- WP-02 -> runtime environment surface exists in docs and implementation
+- WP-03 -> lifecycle phases are explicit, bounded, and implemented
+- WP-04 -> runtime execution maps coherently to trace artifacts and replay expectations
+- WP-05 -> local runtime resilience, failure handling, and Shepherd preservation expectations are real and reviewable
+- WP-06 -> operator surfaces are stable and reviewer-usable
+- WP-07 -> state/persistence and continuity semantics are deterministic and inspectable
+- WP-08 -> runtime review surfaces exist and are usable for milestone inspection
+- WP-09 -> no contradictions remain across docs and implementation claims
+- WP-10 -> measurable acceptance criteria are defined for each WP and the milestone overall
+- WP-11 -> sprint sequencing mirrors the WBS and review tail
+- WP-12 -> checklist and release-gate surfaces are complete and actionable
+- WP-13 (Demos) -> runtime demos prove the major milestone claims
+- WP-14 (Quality gate) -> tests, demos, and quality-gate posture are truthful and auditable
+- WP-15 (Docs/review) -> docs and reviewer entry surfaces converge around actual runtime truth
+- WP-16 (Internal review) -> internal review findings are recorded and actionable
+- WP-17 (External review prep) -> external review package is legible and runnable
+- WP-18 (Review findings remediation) -> accepted review findings are remediated or explicitly deferred with owner and rationale
+- WP-19 (Next milestone planning) -> next-milestone planning materials exist before closeout
+- WP-20 (Release ceremony) -> milestone is validated, cleaned up, and releasable
 
 ## Exit Criteria
 - Every in-scope requirement maps to at least one WBS item.

--- a/docs/milestones/v0.87.1/features/EXECUTION_BOUNDARIES.md
+++ b/docs/milestones/v0.87.1/features/EXECUTION_BOUNDARIES.md
@@ -3,7 +3,7 @@
 # ADL Execution Boundaries
 
 ## Status
-Draft (Planned for v0.88–v0.89)
+Active milestone feature for `v0.87.1` runtime completion
 
 ---
 
@@ -283,4 +283,8 @@ They ensure that all execution is:
 - observable
 - secure
 
+<<<<<<< HEAD
 They are the mechanism by which ADL enforces its Secure Execution Model in practice.
+=======
+They are the mechanism by which ADL enforces its Secure Execution Model in practice.
+>>>>>>> 6762024 (docs: align v0.87.1 planning to runtime milestone)


### PR DESCRIPTION
Closes #1415

## Summary
- rewrite the v0.87.1 milestone docs as a real runtime-completion milestone
- add the promoted v0.87.1 feature-doc index and tracked feature set
- align WBS, sprint, demo, review, and closeout surfaces to the runtime architecture

## Validation
- docs-only review pass in the 1415 worktree
- compared promoted feature docs against the rewritten milestone planning docs
