### PR TITLE
[v0.87][release] Update ADL crate/package version surfaces to 0.87.0 before release

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.86.0"
+version = "0.87.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ADL (Agent Design Language) reference runtime and CLI"


### PR DESCRIPTION
Closes #1425

## Summary
- update the ADL crate version from 0.86.0 to 0.87.0
- carry the matching root package version entry in Cargo.lock
- isolate the external review release-readiness fix without widening scope

## Validation
- verified the diff is limited to adl/Cargo.toml and the matching adl/Cargo.lock package entry