### PR TITLE
[v0.87][tools] Ensure published PRs auto-close their source issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,10 @@ jobs:
         run: bash adl/tools/check_no_new_legacy_swarm_refs.sh
         working-directory: .
 
+      - name: guardrail (issue PR closing linkage)
+        run: bash adl/tools/check_pr_closing_linkage.sh
+        working-directory: .
+
       - name: fmt
         run: cargo fmt --all -- --check
 

--- a/adl/tools/check_pr_closing_linkage.sh
+++ b/adl/tools/check_pr_closing_linkage.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT_NAME="${GITHUB_EVENT_NAME:-}"
+EVENT_PATH="${GITHUB_EVENT_PATH:-}"
+HEAD_REF="${GITHUB_HEAD_REF:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --event-name)
+      EVENT_NAME="${2:-}"
+      shift 2
+      ;;
+    --event-path)
+      EVENT_PATH="${2:-}"
+      shift 2
+      ;;
+    --head-ref)
+      HEAD_REF="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage:
+  check_pr_closing_linkage.sh [--event-name <name>] [--event-path <path>] [--head-ref <ref>]
+
+Enforces that pull requests from codex/<issue>-... branches contain a real GitHub
+closing keyword for that issue in the PR body so the source issue auto-closes on merge.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+  echo "skip: event '${EVENT_NAME:-unknown}' is not pull_request"
+  exit 0
+fi
+
+if [[ -z "$HEAD_REF" ]]; then
+  echo "ERROR: missing pull request head ref" >&2
+  exit 1
+fi
+
+if [[ ! "$HEAD_REF" =~ ^codex/([0-9]+)- ]]; then
+  echo "skip: head ref '$HEAD_REF' is not an issue-linked codex branch"
+  exit 0
+fi
+
+ISSUE_NUMBER="${BASH_REMATCH[1]}"
+
+if [[ -z "$EVENT_PATH" || ! -f "$EVENT_PATH" ]]; then
+  echo "ERROR: missing GitHub event payload at '$EVENT_PATH'" >&2
+  exit 1
+fi
+
+PR_BODY="$(
+python3 - "$EVENT_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+event_path = Path(sys.argv[1])
+data = json.loads(event_path.read_text())
+body = data.get("pull_request", {}).get("body") or ""
+print(body)
+PY
+)"
+
+if python3 -c '
+import re
+import sys
+
+issue = sys.argv[1]
+body = sys.stdin.read()
+pattern = re.compile(rf"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#?{re.escape(issue)}\b", re.IGNORECASE)
+if pattern.search(body):
+    raise SystemExit(0)
+raise SystemExit(1)
+' "$ISSUE_NUMBER" <<<"$PR_BODY"; then
+  echo "closing linkage OK for issue #$ISSUE_NUMBER"
+  exit 0
+fi
+
+echo "ERROR: PR body for branch '$HEAD_REF' is missing closing linkage for issue #$ISSUE_NUMBER" >&2
+echo "Add a real closing keyword such as 'Closes #$ISSUE_NUMBER' to the PR body." >&2
+exit 1

--- a/adl/tools/test_pr_closing_linkage.sh
+++ b/adl/tools/test_pr_closing_linkage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/check_pr_closing_linkage.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+make_event() {
+  local path="$1"
+  local body="$2"
+  python3 - "$path" "$body" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+body = sys.argv[2]
+path.write_text(json.dumps({"pull_request": {"body": body}}))
+PY
+}
+
+event_ok="$TMPDIR/ok.json"
+make_event "$event_ok" "Closes #1414"
+bash "$SCRIPT" --event-name pull_request --event-path "$event_ok" --head-ref "codex/1414-remediation"
+
+event_fix="$TMPDIR/fix.json"
+make_event "$event_fix" $'Some notes\n\nFixes #1414'
+bash "$SCRIPT" --event-name pull_request --event-path "$event_fix" --head-ref "codex/1414-remediation"
+
+event_bad="$TMPDIR/bad.json"
+make_event "$event_bad" "Refs #1414"
+if bash "$SCRIPT" --event-name pull_request --event-path "$event_bad" --head-ref "codex/1414-remediation"; then
+  echo "expected failure for missing closing linkage" >&2
+  exit 1
+fi
+
+event_other="$TMPDIR/other.json"
+make_event "$event_other" "Refs #1414"
+bash "$SCRIPT" --event-name push --event-path "$event_other" --head-ref "codex/1414-remediation"
+bash "$SCRIPT" --event-name pull_request --event-path "$event_other" --head-ref "feature/no-issue-branch"
+
+echo "test_pr_closing_linkage.sh: PASS"


### PR DESCRIPTION
Closes #1359

## Summary
- add a CI guard that requires real closing linkage for issue-linked codex PR branches
- fail PRs from `codex/<issue>-...` branches when the PR body lacks a closing keyword for that issue
- add a focused shell test for the new guardrail

## Validation
- `bash -n adl/tools/check_pr_closing_linkage.sh adl/tools/test_pr_closing_linkage.sh`
- `bash adl/tools/test_pr_closing_linkage.sh`
