### PR TITLE
[v0.87.1][docs] Fix v0.2 release notes command drift and release-notes sanity check

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "adl"
 version = "0.87.0"
 edition = "2021"
+default-run = "adl"
 license = "MIT OR Apache-2.0"
 description = "ADL (Agent Design Language) reference runtime and CLI"
 

--- a/adl/tools/check_release_notes_commands.sh
+++ b/adl/tools/check_release_notes_commands.sh
@@ -8,6 +8,11 @@ release_notes="../docs/milestones/v0.86/RELEASE_NOTES_v0.86.md"
 demo_matrix_ref="DEMO_MATRIX_v0.86.md"
 tag_ref='Tag: `v0.86`'
 release_gate_ref='Release date: `Pending manual release ceremony`'
+v02_release_notes="../docs/milestones/v0.2/RELEASE_NOTES_v0.2.md"
+v02_run_dir_ref='Run from the `adl/` directory.'
+v02_plan_cmd='cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan'
+v02_examples_ref='adl/examples/README.md'
+v02_walkthrough_ref='adl/examples/v0-2-coordinator-agents-sdk.md'
 
 if ! grep -Fq "$demo_matrix_ref" "$release_notes"; then
   echo "missing demo-matrix reference in $release_notes: $demo_matrix_ref" >&2
@@ -21,6 +26,31 @@ fi
 
 if ! grep -Fq "$release_gate_ref" "$release_notes"; then
   echo "missing pre-ceremony release-date note in $release_notes: $release_gate_ref" >&2
+  exit 1
+fi
+
+if ! grep -Fq "$v02_run_dir_ref" "$v02_release_notes"; then
+  echo "missing adl runtime-directory note in $v02_release_notes: $v02_run_dir_ref" >&2
+  exit 1
+fi
+
+if ! grep -Fq "$v02_plan_cmd" "$v02_release_notes"; then
+  echo "missing current adl plan command in $v02_release_notes: $v02_plan_cmd" >&2
+  exit 1
+fi
+
+if grep -Fq 'cargo run --bin swarm --' "$v02_release_notes"; then
+  echo "obsolete swarm binary command still present in $v02_release_notes" >&2
+  exit 1
+fi
+
+if ! grep -Fq "$v02_examples_ref" "$v02_release_notes"; then
+  echo "missing current examples index reference in $v02_release_notes: $v02_examples_ref" >&2
+  exit 1
+fi
+
+if ! grep -Fq "$v02_walkthrough_ref" "$v02_release_notes"; then
+  echo "missing current walkthrough reference in $v02_release_notes: $v02_walkthrough_ref" >&2
   exit 1
 fi
 

--- a/docs/milestones/v0.2/RELEASE_NOTES_v0.2.md
+++ b/docs/milestones/v0.2/RELEASE_NOTES_v0.2.md
@@ -18,18 +18,18 @@ ADL v0.2 expands the reference runtime and examples while preserving the determi
 
 ## Flagship demo (copy/paste)
 
-Run from the `swarm/` directory.
+Run from the `adl/` directory.
 
 Inspect the coordinator plan (no provider call required):
 
 ```bash
-cargo run --bin swarm -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan
 ```
 
 Run the coordinator workflow (requires local Ollama provider setup):
 
 ```bash
-cargo run --bin adl -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace --out examples/out
+cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --run --trace --out examples/out
 ```
 
 If local provider setup is not ready yet, use the plan command above as the recommended quickstart and track demo UX polish in the following issues:
@@ -38,8 +38,8 @@ If local provider setup is not ready yet, use the plan command above as the reco
 
 ## More examples
 
-- Examples index: `swarm/examples/README.md`
-- Coordinator walkthrough: `swarm/examples/v0-2-coordinator-agents-sdk.md`
+- Examples index: `adl/examples/README.md`
+- Coordinator walkthrough: `adl/examples/v0-2-coordinator-agents-sdk.md`
 
 ## Key docs
 


### PR DESCRIPTION
Closes #1432

## Summary
Corrected stale `swarm`-era `v0.2` release-notes guidance, made the release-notes commands match the current `adl/` runtime layout, and tightened the repo-owned release-notes command check so this drift is caught in CI. Added `default-run = "adl"` so the documented plain `cargo run -- ...` commands are real and match the smoke extractor's expected shape.

## Artifacts
- updated `docs/milestones/v0.2/RELEASE_NOTES_v0.2.md`
- updated `adl/tools/check_release_notes_commands.sh`
- updated `adl/Cargo.toml`

## Validation
- Validation commands and their purpose:
  - `cargo run -- examples/v0-2-coordinator-agents-sdk.adl.yaml --print-plan`
    - verified the plain documented `cargo run -- ...` command now resolves to the `adl` binary and prints the coordinator plan from `adl/`
  - `bash tools/check_release_notes_commands.sh`
    - verified the repo-owned release-notes command check passes with the corrected `v0.2` guidance
  - `grep -E '^cargo run -- ' docs/milestones/v0.2/RELEASE_NOTES_v0.2.md`
    - verified the strict smoke extraction pattern now matches the release-notes command lines
- Results:
  - all three checks passed in the issue worktree

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1432__v0-87-1-docs-fix-v0-2-release-notes-command-drift-and-release-notes-sanity-check/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1432__v0-87-1-docs-fix-v0-2-release-notes-command-drift-and-release-notes-sanity-check/sor.md
- Idempotency-Key: v0-87-1-docs-fix-v0-2-release-notes-command-drift-and-release-notes-sanity-check-adl-cargo-toml-adl-tools-check-release-notes-commands-sh-docs-milestones-v0-2-release-notes-v0-2-md-adl-v0-87-1-tasks-issue-1432-v0-87-1-docs-fix-v0-2-release-notes-command-drift-and-release-notes-sanity-check-sip-md-adl-v0-87-1-tasks-issue-1432-v0-87-1-docs-fix-v0-2-release-notes-command-drift-and-release-notes-sanity-check-sor-md