### PR TITLE
[v0.87.1][tools] Ensure SOR is finalized before PR open and published on a tracked review surface

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -440,7 +440,8 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     validate_authored_prompt_surface("finish", &stp_path, PromptSurfaceKind::Stp)?;
     validate_authored_prompt_surface("finish", &input_path, PromptSurfaceKind::Sip)?;
     validate_completed_sor(&repo_root, &output_path)?;
-    sync_completed_output_review_surfaces(&repo_root, &primary_root, &issue_ref, &output_path)?;
+    let tracked_review_output =
+        sync_completed_output_review_surfaces(&repo_root, &primary_root, &issue_ref, &output_path)?;
 
     let ahead = commits_ahead_of_origin_main(&repo_root)?;
     let has_uncommitted = has_uncommitted_changes(&repo_root)?;
@@ -454,6 +455,7 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
 
     if has_uncommitted {
         stage_selected_paths_rust(&repo_root, &parsed.paths)?;
+        stage_explicit_path_rust(&repo_root, &tracked_review_output)?;
         if staged_diff_is_empty(&repo_root)? {
             bail!(
                 "finish: nothing staged after 'git add' for paths '{}'",
@@ -1130,7 +1132,7 @@ fn sync_completed_output_review_surfaces(
     primary_root: &Path,
     issue_ref: &IssueRef,
     completed_output_path: &Path,
-) -> Result<()> {
+) -> Result<PathBuf> {
     let normalized_output_path = if completed_output_path.is_absolute() {
         completed_output_path.to_path_buf()
     } else {
@@ -1153,10 +1155,27 @@ fn sync_completed_output_review_surfaces(
         validate_completed_sor(repo_root, &canonical_root_output)?;
     }
 
+    let tracked_review_output = issue_ref.public_task_record_output_path(repo_root);
+    let copied_to_tracked =
+        !(same_filesystem_target(&normalized_output_path, &tracked_review_output)?);
+    if copied_to_tracked {
+        if let Some(parent) = tracked_review_output.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&normalized_output_path, &tracked_review_output).with_context(|| {
+            format!(
+                "finish: failed to sync completed output card '{}' to tracked review surface '{}'",
+                normalized_output_path.display(),
+                tracked_review_output.display()
+            )
+        })?;
+        validate_completed_sor(repo_root, &tracked_review_output)?;
+    }
+
     let cards_root = resolve_cards_root(primary_root, None);
     let review_output = card_output_path(&cards_root, issue_ref.issue_number());
     ensure_symlink(&review_output, &canonical_root_output)?;
-    Ok(())
+    Ok(tracked_review_output)
 }
 
 fn same_filesystem_target(left: &Path, right: &Path) -> Result<bool> {
@@ -1503,6 +1522,13 @@ fn stage_selected_paths_rust(repo_root: &Path, csv: &str) -> Result<()> {
     let mut args = vec!["-C", path_str(repo_root)?, "add", "--"];
     args.extend(paths);
     run_status("git", &args)
+}
+
+fn stage_explicit_path_rust(repo_root: &Path, path: &Path) -> Result<()> {
+    run_status(
+        "git",
+        &["-C", path_str(repo_root)?, "add", "--", path_str(path)?],
+    )
 }
 
 fn staged_diff_is_empty(repo_root: &Path) -> Result<bool> {

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -422,9 +422,12 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_review_mirror() {
 
     let root_text = fs::read_to_string(&root_output).expect("root output text");
     let compat_text = fs::read_to_string(&compat_output).expect("compat output text");
+    let tracked_output = issue_ref.public_task_record_output_path(&worktree);
+    let tracked_text = fs::read_to_string(&tracked_output).expect("tracked output text");
     assert!(root_text.contains("Status: DONE"));
     assert!(root_text.contains("codex/1153-rust-finish-sync"));
     assert_eq!(root_text, compat_text);
+    assert_eq!(root_text, tracked_text);
 }
 
 #[test]

--- a/adl/src/control_plane.rs
+++ b/adl/src/control_plane.rs
@@ -93,6 +93,20 @@ impl IssueRef {
             .join("sor.md")
     }
 
+    pub fn public_task_record_dir_path(&self, checkout_root: &Path) -> PathBuf {
+        checkout_root
+            .join("docs")
+            .join("records")
+            .join(&self.scope)
+            .join("tasks")
+            .join(self.task_issue_id())
+    }
+
+    pub fn public_task_record_output_path(&self, checkout_root: &Path) -> PathBuf {
+        self.public_task_record_dir_path(checkout_root)
+            .join("sor.md")
+    }
+
     pub fn branch_name(&self, prefix: &str) -> String {
         format!("{prefix}/{}-{}", self.issue_number, self.slug)
     }
@@ -244,6 +258,14 @@ mod tests {
             PathBuf::from(
                 "/repo/.adl/v0.86/tasks/issue-1150__implement-rust-control-plane-core-models"
             )
+        );
+        assert_eq!(
+            issue.public_task_record_dir_path(repo_root),
+            PathBuf::from("/repo/docs/records/v0.86/tasks/issue-1150")
+        );
+        assert_eq!(
+            issue.public_task_record_output_path(repo_root),
+            PathBuf::from("/repo/docs/records/v0.86/tasks/issue-1150/sor.md")
         );
         assert_eq!(
             issue.branch_name("codex"),

--- a/adl/tools/card_paths.sh
+++ b/adl/tools/card_paths.sh
@@ -124,6 +124,18 @@ task_bundle_output_path() {
   echo "$(task_bundle_dir_path "$issue" "$scope" "$slug")/sor.md"
 }
 
+public_task_record_dir_path() {
+  local issue="$1" scope="$2"
+  local root
+  root="$(card_primary_checkout_root)"
+  echo "$root/docs/records/$scope/tasks/$(task_issue_id "$issue")"
+}
+
+public_task_record_output_path() {
+  local issue="$1" scope="$2"
+  echo "$(public_task_record_dir_path "$issue" "$scope")/sor.md"
+}
+
 card_dir_path() {
   local issue
   issue="$(card_issue_normalize "$1")" || return 1

--- a/adl/tools/skills/pr-finish/SKILL.md
+++ b/adl/tools/skills/pr-finish/SKILL.md
@@ -9,8 +9,9 @@ This skill owns the closeout and publication phase of the PR workflow.
 
 Its job is to:
 - confirm the issue has completed its bounded execution work
-- validate the output record and finish inputs truthfully
+- validate and, when needed, normalize the output record before PR publication
 - stage only the intended tracked paths
+- ensure the finalized SOR is published on the tracked review surface
 - create or update the reviewable PR surface
 - emit a structured finish result
 - stop before silent merge or issue closure unless explicitly directed
@@ -76,6 +77,7 @@ If multiple surfaces disagree materially, report `blocked`.
 Before closeout:
 - confirm the issue work actually exists on the branch/worktree
 - confirm the output record exists and is not still a bootstrap stub
+- confirm the output record is finalized before any PR create/update action
 - confirm the intended staged paths are explicit or deterministically derived
 - confirm validation claims in the output record are truthful
 

--- a/adl/tools/skills/pr-finish/references/output-contract.md
+++ b/adl/tools/skills/pr-finish/references/output-contract.md
@@ -8,6 +8,8 @@ target:
   worktree_path: <path or null>
 finish_state:
   output_record_present: true | false
+  sor_finalized_before_pr_open: true | false
+  tracked_review_surface_published: true | false
   staged_paths_validated: true | false
   pr_state: created | updated | blocked
 findings:

--- a/adl/tools/test_pr_finish_default_stage_root.sh
+++ b/adl/tools/test_pr_finish_default_stage_root.sh
@@ -139,6 +139,88 @@ export ADL_PR_RUST_BIN="$REAL_ADL_BIN"
 (
   cd "$repo"
 
+  mkdir -p .adl/v0.86/bodies
+  cat > .adl/v0.86/bodies/issue-1021-finish-default-root.md <<'EOF_PROMPT'
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "finish-default-root"
+title: "[v0.85][authoring] Harden pr finish command behavior"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:task"
+  - "version:v0.86"
+issue_number: 1021
+status: "active"
+action: "edit"
+depends_on: []
+milestone_sprint: "unplanned"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "https://github.com/example/repo/issues/1021"
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Authored shell test fixture."
+pr_start:
+  enabled: true
+  slug: "finish-default-root"
+---
+
+# [v0.85][authoring] Harden pr finish command behavior
+
+## Summary
+
+Authored prompt for finish-shell regression coverage.
+
+## Goal
+
+Provide authored prompt content so lifecycle setup can proceed.
+
+## Required Outcome
+
+This test issue ships code only.
+
+## Deliverables
+
+- authored issue prompt content
+
+## Acceptance Criteria
+
+- lifecycle setup accepts this prompt
+
+## Repo Inputs
+
+- https://github.com/example/repo/issues/1021
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- none
+
+## Non-goals
+
+- bootstrap placeholder content
+
+## Issue-Graph Notes
+
+- shell regression fixture
+
+## Notes
+
+- generated inside shell tests
+
+## Tooling Notes
+
+- authored fixture, not bootstrap fallback
+EOF_PROMPT
+
   "$BASH_BIN" adl/tools/pr.sh start 1021 --slug finish-default-root --no-fetch-issue >/dev/null
   "$BASH_BIN" adl/tools/pr.sh cards 1021 --no-fetch-issue >/dev/null
   worktree="$repo/.worktrees/adl-wp-1021"
@@ -258,6 +340,7 @@ EOF_SOR
   changed="$(git -C "$worktree" show --name-only --format=oneline HEAD)"
   assert_contains "adl/tools/README.md" "$changed" "finish stages code path by default"
   assert_contains "docs/tooling/README.md" "$changed" "finish stages docs path by default"
+  assert_contains "docs/records/v0.86/tasks/issue-1021/sor.md" "$changed" "finish stages tracked sor review surface"
 )
 
 echo "pr.sh finish default repo-root staging: ok"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -119,6 +119,10 @@ bash ./adl/tools/pr.sh finish <issue_num> \
   --output-card .adl/cards/<issue_num>/output_<issue_num>.md
 ```
 
+Finish should only open or update the PR after the SOR is finalized, and the finalized output record should be published onto the tracked review surface under:
+
+- `docs/records/<scope>/tasks/issue-<padded_issue>/sor.md`
+
 ## 8) Report
 
 Write a per-issue report under:

--- a/docs/records/README.md
+++ b/docs/records/README.md
@@ -14,3 +14,5 @@ The canonical organizing unit is the task, not the GitHub issue.
 External trackers such as GitHub may project or mirror a task, but they are integrations rather than the core ontology.
 
 Local `.adl/` artifacts may still be used for drafting and generation, but the public record belongs here once an artifact becomes authoritative.
+
+For the current PR workflow, a completed `sor.md` should be published here before or as part of PR open/update rather than living only under ignored `.adl/` paths.

--- a/docs/records/v0.87.1/tasks/issue-1449/sor.md
+++ b/docs/records/v0.87.1/tasks/issue-1449/sor.md
@@ -1,0 +1,148 @@
+# [v0.87.1][tools] Ensure SOR is finalized before PR open and published on a tracked review surface
+
+Task ID: issue-1449
+Run ID: issue-1449
+Version: v0.87.1
+Title: [v0.87.1][tools] Ensure SOR is finalized before PR open and published on a tracked review surface
+Branch: codex/1449-v0-87-1-tools-ensure-sor-is-finalized-before-pr-open-and-published-on-a-tracked-review-surface
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: gpt-5.4
+- Provider: OpenAI
+- Start Time: 2026-04-08T17:00:00Z
+- End Time: 2026-04-08T17:33:53Z
+
+## Summary
+Tightened the finish workflow so a completed SOR is published onto a tracked review surface under `docs/records/<scope>/tasks/issue-<padded>/sor.md` before PR publication, while preserving the local `.adl` task-bundle and `.adl/cards` compatibility mirrors. The finish path now stages that tracked SOR automatically, and the finish docs/contracts/tests teach the corrected SOR-before-open behavior.
+
+## Artifacts produced
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/control_plane.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `adl/tools/card_paths.sh`
+- `adl/tools/test_pr_finish_default_stage_root.sh`
+- `adl/tools/skills/pr-finish/SKILL.md`
+- `adl/tools/skills/pr-finish/references/output-contract.md`
+- `docs/default_workflow.md`
+- `docs/records/README.md`
+
+## Actions taken
+- added control-plane helpers for the tracked public SOR path under `docs/records/<scope>/tasks/issue-<padded>/`
+- updated `real_pr_finish` to sync the finalized SOR to that tracked review surface and stage it even when `--paths` would otherwise miss it
+- kept the canonical `.adl` task-bundle SOR sync and `.adl/cards` compatibility mirror intact
+- extended the Rust finish regressions to verify the tracked `docs/records` SOR publication path
+- updated the shell finish harness to assert the tracked SOR path is staged and to seed an authored issue prompt fixture for newer lifecycle validation
+- updated the finish skill contract and default workflow docs so they teach SOR finalization before PR open and tracked review-surface publication
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet
+- Worktree-only paths remaining:
+  - `adl/src/cli/pr_cmd.rs`
+  - `adl/src/control_plane.rs`
+  - `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+  - `adl/tools/card_paths.sh`
+  - `adl/tools/test_pr_finish_default_stage_root.sh`
+  - `adl/tools/skills/pr-finish/SKILL.md`
+  - `adl/tools/skills/pr-finish/references/output-contract.md`
+  - `docs/default_workflow.md`
+  - `docs/records/README.md`
+- Integration state: worktree_only
+- Verification scope: worktree
+- Integration method used: bounded worktree update pending `pr finish`
+- Verification performed:
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture`
+  - `bash adl/tools/test_pr_finish_default_stage_root.sh`
+- Result: PASS
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture` to verify the Rust finish path syncs the completed SOR to the tracked `docs/records` review surface without regressing existing finish behavior
+  - `bash adl/tools/test_pr_finish_default_stage_root.sh` to verify the shell harness stages the tracked SOR review surface by default during finish
+  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` to confirm formatting remained clean after the control-plane and doc updates
+- Results:
+  - the focused Rust finish regressions passed
+  - the shell finish harness passed
+  - formatting check passed
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture"
+      - "bash adl/tools/test_pr_finish_default_stage_root.sh"
+      - "cargo fmt --manifest-path adl/Cargo.toml --all --check"
+  determinism:
+    status: PARTIAL
+    replay_verified: unknown
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed:
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture`
+  - `bash adl/tools/test_pr_finish_default_stage_root.sh`
+- Fixtures or scripts used:
+  - Rust finish regression fixtures in `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+  - shell finish harness in `adl/tools/test_pr_finish_default_stage_root.sh`
+- Replay verification (same inputs -> same artifacts/order):
+  - the focused finish regressions repeatedly exercised the tracked SOR publication path under `docs/records/<scope>/tasks/issue-<padded>/sor.md`; local pre-finish branch publication has not been replay-verified yet
+- Ordering guarantees (sorting / tie-break rules used):
+  - the tracked publication path is deterministically derived from milestone scope and padded issue id rather than ad hoc output naming
+- Artifact stability notes:
+  - the tracked SOR path is stable across reruns for the same issue and no schema change was introduced to the SOR itself
+
+## Security / Privacy Checks
+- Secret leakage scan performed:
+  - reviewed the changed code, docs, and tests; no secrets or tokens were introduced
+- Prompt / tool argument redaction verified:
+  - the change does not add prompt capture or tool-argument logging to the published review surface
+- Absolute path leakage check:
+  - recorded commands and paths in this SOR are repository-relative
+- Sandbox / policy invariants preserved:
+  - yes; the change stayed within finish/control-plane/docs/test surfaces
+
+## Replay Artifacts
+- Trace bundle path(s):
+  - not applicable; this is a finish/publication workflow issue
+- Run artifact root:
+  - not applicable
+- Replay command used for verification:
+  - the focused Rust and shell finish regressions listed above
+- Replay result:
+  - passed; expected tracked-publication behavior was reproduced without manual intervention
+
+## Artifact Verification
+- Primary proof surface:
+  - the tracked SOR publication path under `docs/records/<scope>/tasks/issue-<padded>/sor.md` as exercised by the focused finish regressions
+- Required artifacts present:
+  - yes
+- Artifact schema/version checks:
+  - the finish path still runs completed-phase SOR validation and the regressions verified that behavior while adding the tracked review surface
+- Hash/byte-stability checks:
+  - not separately run; path-level and completed-SOR validation behavior were the relevant proof standard here
+- Missing/optional artifacts and rationale:
+  - no full clippy or full-suite run was required for this bounded finish/publication change; the focused finish regressions and formatting check provided the intended proof surface
+
+## Decisions / Deviations
+- kept `.adl` task-bundle and `.adl/cards` output mirrors as local compatibility surfaces instead of turning this issue into a full public-record migration
+- updated the older shell harness to seed an authored issue prompt fixture because newer lifecycle validation no longer accepts bootstrap-stub prompts in that test path
+- kept this pre-finish SOR truthful to the current `worktree_only` state rather than claiming `pr_open` before publication actually happens
+
+## Follow-ups / Deferred work
+- after merge, `pr-closeout` should finalize the local closeout state and prune the 1449 worktree


### PR DESCRIPTION
Closes #1449

## Summary
Tightened the finish workflow so a completed SOR is published onto a tracked review surface under `docs/records/<scope>/tasks/issue-<padded>/sor.md` before PR publication, while preserving the local `.adl` task-bundle and `.adl/cards` compatibility mirrors. The finish path now stages that tracked SOR automatically, and the finish docs/contracts/tests teach the corrected SOR-before-open behavior.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/control_plane.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
- `adl/tools/card_paths.sh`
- `adl/tools/test_pr_finish_default_stage_root.sh`
- `adl/tools/skills/pr-finish/SKILL.md`
- `adl/tools/skills/pr-finish/references/output-contract.md`
- `docs/default_workflow.md`
- `docs/records/README.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture` to verify the Rust finish path syncs the completed SOR to the tracked `docs/records` review surface without regressing existing finish behavior
  - `bash adl/tools/test_pr_finish_default_stage_root.sh` to verify the shell harness stages the tracked SOR review surface by default during finish
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` to confirm formatting remained clean after the control-plane and doc updates
- Results:
  - the focused Rust finish regressions passed
  - the shell finish harness passed
  - formatting check passed

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1449__v0-87-1-tools-ensure-sor-is-finalized-before-pr-open-and-published-on-a-tracked-review-surface/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1449__v0-87-1-tools-ensure-sor-is-finalized-before-pr-open-and-published-on-a-tracked-review-surface/sor.md
- Idempotency-Key: v0-87-1-tools-ensure-sor-is-finalized-before-pr-open-and-published-on-a-tracked-review-surface-adl-docs-adl-v0-87-1-tasks-issue-1449-v0-87-1-tools-ensure-sor-is-finalized-before-pr-open-and-published-on-a-tracked-review-surface-sip-md-adl-v0-87-1-tasks-issue-1449-v0-87-1-tools-ensure-sor-is-finalized-before-pr-open-and-published-on-a-tracked-review-surface-sor-md