### PR TITLE
[v0.87.1][skills] Investigate pr-init subagent timeout / partial-completion behavior during multi-issue bootstrap

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -291,6 +291,7 @@ It:
 - seeds the root `stp.md`, `sip.md`, and `sor.md`
 - validates that the bootstrap surfaces exist and are mechanically complete
 - stops before branch/worktree creation or implementation
+- handles exactly one issue target per invocation
 
 ### When To Use It
 
@@ -351,6 +352,7 @@ Expected output includes:
 - `stp.md`, `sip.md`, `sor.md` paths
 - validation result
 - handoff state for qualitative review
+- if bootstrap is interrupted after issue creation, a `partial` result that names the created issue and the exact missing bundle surfaces
 
 It must stop before:
 
@@ -358,6 +360,18 @@ It must stop before:
 - branch creation
 - worktree creation
 - implementation
+
+### Multi-Issue Bootstrap Pattern
+
+If you are bootstrapping many issues:
+
+- use one `pr-init` invocation per issue
+- prefer one sub-agent per issue when parallelizing
+- wait for one structured `pr-init` result per issue
+- aggregate those per-issue results outside the skill
+
+Do not ask one long-running `pr-init` invocation to bootstrap many issues as a
+single batch.
 
 ### Example Invocation
 

--- a/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md
@@ -93,6 +93,7 @@ Key capabilities:
 - clear separation between required and inferred fields
 - consistent new-issue versus existing-issue behavior
 - better error reporting when inputs are incomplete
+- one issue target per invocation, even when many issues are bootstrapped in parallel
 
 ## Design
 
@@ -212,6 +213,7 @@ Callers must validate all of the following before skill invocation:
 7. if `issue.version` is omitted, `policy.version_source` must allow inference
 8. if `mode = create_and_bootstrap`, `issue.labels` must be present
 9. if `mode = create_and_bootstrap`, `policy.label_source` must be `explicit`
+10. exactly one issue target is carried per invocation payload
 
 ### Caller Responsibilities
 
@@ -220,6 +222,8 @@ The caller is responsible for:
 - validating it before invocation
 - rejecting incomplete or contradictory input early
 - passing the validated object to the sub-agent or ADL executor
+- spawning one sub-agent per issue when bootstrapping many issues in parallel
+- aggregating per-issue results outside the skill rather than batching many issues into one invocation
 
 The skill is responsible for:
 - executing the bootstrap step truthfully
@@ -265,6 +269,9 @@ attribute to input validation versus skill execution.
 For day-to-day use, prefer copying the tracked template and only changing the
 issue-specific fields rather than rewriting this example from memory.
 
+For multi-issue bootstrap, do not ask one sub-agent to create many issues in a
+single `pr-init` invocation. Use one validated payload per issue.
+
 ## Data / Artifacts
 
 This feature introduces an invocation schema, not a new workflow artifact
@@ -279,9 +286,11 @@ family.
 1. Caller assembles candidate `pr-init` inputs.
 2. Caller validates the input object against `pr_init.v1`.
 3. Caller invokes the skill only if validation passes.
-4. The skill executes the mechanical bootstrap step.
-5. The skill emits a structured result and handoff status for qualitative card
+4. If many issues are being bootstrapped, caller fans out one invocation per issue.
+5. The skill executes the mechanical bootstrap step.
+6. The skill emits a structured result and handoff status for qualitative card
    review.
+7. Caller aggregates the per-issue results after all issue-targeted invocations finish.
 
 ## Determinism and Constraints
 
@@ -302,6 +311,7 @@ family.
 | --- | --- | --- |
 | `adl/tools/skills/pr-init/` | read | Defines the skill contract that this schema feeds. |
 | sub-agent spawn prompt | trigger | Receives the validated structured payload rather than loose prose. |
+| multi-issue parent coordinator | aggregate | Fans out one payload per issue and collects one result per issue. |
 | future ADL admission layer | read/validate | Can reject invalid invocation objects before execution. |
 | GitHub issue bootstrap flow | read/write | Consumes validated issue metadata only after admission succeeds. |
 
@@ -357,6 +367,7 @@ skill invocation tests.
   - the schema is documented in one canonical place
   - the `pr-init` skill can be invoked from a validated structured payload
   - sub-agent use no longer depends on “just pass a text string”
+  - multi-issue bootstrap no longer depends on one long-running ambiguous batch invocation
 
 ## Risks
 

--- a/adl/tools/skills/pr-init/SKILL.md
+++ b/adl/tools/skills/pr-init/SKILL.md
@@ -13,6 +13,7 @@ Its job is to:
 - seed the initial root task bundle surfaces
 - validate that the issue is ready for the next lifecycle step
 - stop at the mechanical bootstrap boundary before branch creation, worktree creation, or implementation work
+- handle exactly one issue target per invocation
 
 This is an execution skill, not a review-only skill.
 Keep mechanical work separate from qualitative review.
@@ -101,22 +102,26 @@ If no slug is given, derive one from the title using the repo's normal slug rule
 1. Resolve whether the request is:
    - `bootstrap-existing-issue`
    - `create-and-bootstrap-new-issue`
-2. If using structured invocation, start from the canonical tracked template
+2. If the caller needs multiple issues bootstrapped:
+   - use one `pr-init` invocation per issue
+   - prefer one subagent per issue when parallelizing
+   - aggregate completion outside the skill instead of asking one invocation to bootstrap many issues
+3. If using structured invocation, start from the canonical tracked template
    rather than writing the payload from scratch.
-3. Prefer the Rust-owned path when available.
-4. For new issues:
+4. Prefer the Rust-owned path when available.
+5. For new issues:
    - create the GitHub issue correctly
    - pass explicit repo-standard labels rather than relying on label inference
    - verify the created issue actually has the expected labels before continuing
    - ensure the canonical local source issue prompt and root bundle exist
-5. For existing issues:
+6. For existing issues:
    - run the bootstrap/init phase
    - seed the task-bundle `stp.md`
    - seed the initial `sip.md`
    - seed the initial `sor.md`
    - ensure canonical compatibility links exist when the repo expects them
-6. Validate the resulting surfaces mechanically.
-7. Emit a structured readiness result for qualitative card review and stop.
+7. Validate the resulting surfaces mechanically.
+8. Emit a structured readiness result for qualitative card review and stop.
 
 ## Workflow
 
@@ -128,6 +133,9 @@ Use one of these modes:
   - use when the user gives a title or asks to create a new issue
 - `bootstrap_existing_issue`
   - use when the user already has an issue number and only wants the bundle/bootstrap step
+
+Exactly one issue target is allowed per invocation.
+If the caller has many issues, they must invoke this skill once per issue.
 
 ### 2. Create or Resolve the GitHub Issue
 
@@ -208,6 +216,13 @@ Parallel execution is allowed only when each invocation has a disjoint target su
 - different task-bundle directories
 
 Within one `pr init` run, keep the operations serialized.
+Do not batch multiple issues into one invocation.
+
+Recommended multi-issue pattern:
+- parent agent validates one `pr_init.v1` payload per issue
+- spawn one subagent per issue
+- each subagent returns one per-issue `pr-init` result
+- parent agent aggregates the results after all subagents finish
 
 ## Preferred Commands
 
@@ -242,6 +257,9 @@ Default success result should make these explicit:
 - validation status
 - next step: qualitative card review
 - later-step handoff after review: issue-mode `pr run`
+
+For multi-issue workflows, this output describes one issue only.
+The caller must aggregate multiple per-issue results outside the skill.
 
 ## Failure Modes
 

--- a/adl/tools/skills/pr-init/adl-skill.yaml
+++ b/adl/tools/skills/pr-init/adl-skill.yaml
@@ -57,6 +57,7 @@ admission:
     - "skill_input_schema_must_equal_pr_init.v1_when_structured_input_is_used"
     - "mode_must_match_supported_enum"
     - "exactly_one_mode_contract_must_be_satisfied"
+    - "exactly_one_issue_target_per_invocation"
     - "at_most_one_of_issue.body_and_issue.body_file_may_be_set"
     - "policy.stop_after_bootstrap_must_be_true"
     - "slug_omission_requires_policy.allow_slug_derivation_true"
@@ -66,7 +67,7 @@ execution:
   mode: "auto_apply"
   allow_code_edits: false
   allow_network: true
-  allow_subagents: false
+  allow_subagents: true
   parallelism_policy: "parallel_across_distinct_issue_targets_only"
   workflow_step: "step_1_pr_init"
   stop_before:
@@ -81,6 +82,7 @@ execution:
     - "adl pr create"
     - "adl pr init"
   preferred_path: "rust_owned_control_plane_when_available"
+  invocation_pattern: "one_issue_per_invocation_parent_aggregates_multi_issue_results"
   validation_policy: "must_verify_issue_labels_source_prompt_root_bundle_and_no_branch_or_worktree_side_effects"
 boundaries:
   writes_limited_to:

--- a/adl/tools/skills/pr-init/references/output-contract.md
+++ b/adl/tools/skills/pr-init/references/output-contract.md
@@ -2,6 +2,10 @@
 
 When ADL expects structured `pr-init` output, use this shape.
 
+This contract describes exactly one issue target per invocation.
+If a caller bootstraps many issues, each issue should produce its own result and
+the parent should aggregate them outside the skill.
+
 ```yaml
 status: complete | partial | blocked | failed
 mode: create_and_bootstrap | bootstrap_existing_issue
@@ -45,7 +49,9 @@ notes:
 - If `status: complete`, all required bootstrap surfaces must be present and both `branch_created` and `worktree_created` must be `false`.
 - If `status: complete`, `ready_for_card_review` should normally be `true` and `ready_for_execution` should normally be `false`.
 - If the issue exists but one or more bundle surfaces are missing, use `partial` or `blocked`, not `complete`.
+- If a subagent or caller times out after issue creation but before all bootstrap surfaces are verified, use `partial` and report the exact created issue identity plus the exact missing surfaces.
 - If bootstrap output is obviously contradictory or not ready for the next step, use `blocked`.
+- Do not report multiple issues in one `pr-init` result.
 - Report exact paths when they are known.
 - Do not claim readiness for issue-mode `pr run` or execution unless a later qualitative review step has actually been completed.
 

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -19,6 +19,7 @@ run_check adl/tools/test_pr_finish_delegates_to_rust.sh
 run_check adl/tools/test_pr_start_template_validation.sh
 run_check adl/tools/test_install_adl_pr_cycle_skill.sh
 run_check adl/tools/test_install_adl_operational_skills.sh
+run_check adl/tools/test_pr_init_skill_contracts.sh
 run_check adl/tools/test_card_editor_skill_contracts.sh
 run_check adl/tools/test_pr_closeout_skill_contracts.sh
 run_check adl/tools/test_pr_run.sh

--- a/adl/tools/test_pr_init_skill_contracts.sh
+++ b/adl/tools/test_pr_init_skill_contracts.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/pr-init/SKILL.md" ]]
+[[ -f "${skills_root}/pr-init/adl-skill.yaml" ]]
+[[ -f "${skills_root}/pr-init/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/PR_INIT_SKILL_INPUT_SCHEMA.md" ]]
+[[ -f "${repo_root}/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md" ]]
+
+grep -Fq "handle exactly one issue target per invocation" "${skills_root}/pr-init/SKILL.md"
+grep -Fq "one subagent per issue" "${skills_root}/pr-init/SKILL.md"
+grep -Fq 'allow_subagents: true' "${skills_root}/pr-init/adl-skill.yaml"
+grep -Fq 'exactly_one_issue_target_per_invocation' "${skills_root}/pr-init/adl-skill.yaml"
+grep -Fq 'one_issue_per_invocation_parent_aggregates_multi_issue_results' "${skills_root}/pr-init/adl-skill.yaml"
+grep -Fq "Do not report multiple issues in one \`pr-init\` result." "${skills_root}/pr-init/references/output-contract.md"
+grep -Fq "one issue target per invocation" "${skills_root}/docs/PR_INIT_SKILL_INPUT_SCHEMA.md"
+grep -Fq "one validated payload per issue" "${repo_root}/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md"
+grep -Fq "one \`pr-init\` invocation per issue" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+
+echo "PASS test_pr_init_skill_contracts"

--- a/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
+++ b/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
@@ -18,6 +18,7 @@ This template is a caller artifact. It does not replace the underlying schema in
 - Use repo-root-stable paths in examples.
 - Make the stop boundary explicit.
 - Do not imply branch creation, worktree creation, or implementation work in this template.
+- Carry exactly one issue target per invocation.
 
 ## Canonical Invocation Envelope
 
@@ -146,6 +147,25 @@ It must not continue into:
 - `pr run`
 - implementation
 - `pr finish`
+
+## Multi-Issue Bootstrap Rule
+
+If you need many issues bootstrapped:
+
+- do not batch many issues into one `pr-init` invocation
+- create one validated payload per issue
+- prefer one sub-agent per issue when running in parallel
+- aggregate the per-issue results outside the skill
+
+This keeps completion semantics clear and avoids one long-running sub-agent
+being mistaken for a partial or hung bootstrap when several issues are created
+successfully.
+
+If one sub-agent times out or returns early:
+
+- treat that issue as a per-issue `partial` bootstrap result
+- inspect which surfaces exist for that issue
+- re-run only that issue’s `pr-init` invocation rather than repeating the whole batch
 
 ## Caller Checklist
 


### PR DESCRIPTION
## Summary
- clarify that `pr-init` handles exactly one issue target per invocation even when bootstrap is parallelized
- make the manifest consistent with documented subagent use and define per-issue `partial` results for interrupted bootstrap
- add a focused `pr-init` contract regression and wire it into the regression harness

## Validation
- bash adl/tools/test_pr_init_skill_contracts.sh
- git diff --check

## Notes
- This is a bounded contract/docs remediation. It does not change issue-creation correctness.
- The fix is aimed at observability and deterministic completion semantics for multi-issue bootstrap.

Closes #1445