### PR TITLE
[v0.87.1][demo] Add local Ollama provider demo + acceptance test

### DIFF
--- a/adl/examples/README.md
+++ b/adl/examples/README.md
@@ -29,6 +29,7 @@ ADL_OLLAMA_BIN=tools/mock_ollama_v0_4.sh cargo run -q --bin adl -- examples/v0-6
 - v0.7: provider portability / HTTP profile compatibility proof surface
 - v0.87.1: no-network mock provider family proof (`v0-87-1-provider-mock-demo.adl.yaml`)
 - v0.87.1: bounded HTTP family proof (`v0-87-1-provider-http-demo.adl.yaml`)
+- v0.87.1: local Ollama family proof (`v0-87-1-provider-local-ollama-demo.adl.yaml`)
 
 ## See Also / Canonical Docs
 

--- a/adl/examples/v0-87-1-provider-local-ollama-demo.adl.yaml
+++ b/adl/examples/v0-87-1-provider-local-ollama-demo.adl.yaml
@@ -1,0 +1,26 @@
+version: "0.5"
+
+providers:
+  local_ollama_demo:
+    type: "local_ollama"
+    config:
+      model: "phi4-mini"
+
+agents:
+  local_writer:
+    provider: "local_ollama_demo"
+    model: "phi4-mini"
+
+tasks:
+  echo_marker:
+    prompt:
+      user: "LOCAL_OLLAMA_PROVIDER_DEMO_OK"
+
+run:
+  name: "v0-87-1-provider-local-ollama-demo"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "local_ollama_echo"
+        agent: "local_writer"
+        task: "echo_marker"

--- a/adl/tests/local_ollama_provider_tests.rs
+++ b/adl/tests/local_ollama_provider_tests.rs
@@ -1,0 +1,30 @@
+use ::adl::adl;
+use ::adl::provider::build_provider;
+
+mod helpers;
+use helpers::EnvVarGuard;
+
+fn provider_spec_from_yaml(yaml: &str) -> adl::ProviderSpec {
+    serde_yaml::from_str::<adl::ProviderSpec>(yaml).expect("failed to parse ProviderSpec YAML")
+}
+
+#[test]
+fn build_provider_accepts_local_ollama_kind() {
+    let spec = provider_spec_from_yaml(
+        r#"
+type: local_ollama
+config:
+  model: phi4-mini
+"#,
+    );
+
+    let mock = format!("{}/tools/mock_ollama_v0_4.sh", env!("CARGO_MANIFEST_DIR"));
+    let _env_guard = EnvVarGuard::set("ADL_OLLAMA_BIN", mock);
+
+    let provider = build_provider(&spec, Some("phi4-mini"))
+        .expect("build_provider should accept local_ollama");
+    let output = provider
+        .complete("LOCAL_OLLAMA_PROVIDER_TEST_OK")
+        .expect("local_ollama provider should complete with mock binary");
+    assert!(output.contains("LOCAL_OLLAMA_PROVIDER_TEST_OK"));
+}

--- a/adl/tests/local_ollama_provider_tests.rs
+++ b/adl/tests/local_ollama_provider_tests.rs
@@ -2,7 +2,7 @@ use ::adl::adl;
 use ::adl::provider::build_provider;
 
 mod helpers;
-use helpers::EnvVarGuard;
+use helpers::{unique_test_temp_dir, EnvVarGuard};
 
 fn provider_spec_from_yaml(yaml: &str) -> adl::ProviderSpec {
     serde_yaml::from_str::<adl::ProviderSpec>(yaml).expect("failed to parse ProviderSpec YAML")
@@ -10,6 +10,7 @@ fn provider_spec_from_yaml(yaml: &str) -> adl::ProviderSpec {
 
 #[test]
 fn build_provider_accepts_local_ollama_kind() {
+    let _temp_dir = unique_test_temp_dir("local-ollama-provider");
     let spec = provider_spec_from_yaml(
         r#"
 type: local_ollama

--- a/adl/tools/demo_v0871_provider_local_ollama.sh
+++ b/adl/tools/demo_v0871_provider_local_ollama.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/provider_demo_common.sh"
+
+ROOT_DIR="$(provider_demo_repo_root)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0871/provider_local_ollama}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-87-1-provider-local-ollama-demo"
+EXAMPLE="adl/examples/v0-87-1-provider-local-ollama-demo.adl.yaml"
+DEFAULT_OLLAMA_BIN="$ROOT_DIR/adl/tools/mock_ollama_v0_4.sh"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cd "$ROOT_DIR"
+
+echo "Running v0.87.1 local-Ollama provider demo..."
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+ADL_OLLAMA_BIN="${ADL_OLLAMA_BIN:-$DEFAULT_OLLAMA_BIN}" \
+  cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+    "$EXAMPLE" \
+    --run \
+    --trace \
+    --allow-unsigned \
+    --out "$STEP_OUT" \
+    | tee "$OUT_DIR/run_log.txt"
+
+SECONDARY_PROOF_SURFACES="$(printf '%s\n%s\n%s' \
+  "$RUNS_ROOT/$RUN_ID/run_status.json" \
+  "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json" \
+  "$OUT_DIR/run_log.txt")"
+
+provider_demo_write_readme \
+  "$OUT_DIR" \
+  "v0.87.1 Provider Demo - Local Ollama" \
+  $'ADL_OLLAMA_BIN=adl/tools/mock_ollama_v0_4.sh \\\nADL_RUNTIME_ROOT=artifacts/v0871/provider_local_ollama/runtime \\\nADL_RUNS_ROOT=artifacts/v0871/provider_local_ollama/runtime/runs \\\ncargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \\\n  adl/examples/v0-87-1-provider-local-ollama-demo.adl.yaml \\\n  --run \\\n  --trace \\\n  --allow-unsigned \\\n  --out artifacts/v0871/provider_local_ollama/out\n\n# shortcut\nbash adl/tools/demo_v0871_provider_local_ollama.sh' \
+  "$RUNS_ROOT/$RUN_ID/run_summary.json" \
+  "$SECONDARY_PROOF_SURFACES" \
+  "stdout and run_log.txt include LOCAL_OLLAMA_PROVIDER_DEMO_OK, and reviewers may override ADL_OLLAMA_BIN to point at a real local Ollama binary"
+
+provider_demo_print_proof_surfaces \
+  "$RUNS_ROOT/$RUN_ID/run_summary.json" \
+  "$SECONDARY_PROOF_SURFACES"

--- a/adl/tools/test_demo_v0871_provider_local_ollama.sh
+++ b/adl/tools/test_demo_v0871_provider_local_ollama.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+ARTIFACT_ROOT="$TMPDIR_ROOT/artifacts"
+RUN_ID="v0-87-1-provider-local-ollama-demo"
+RUNTIME_ROOT="$ARTIFACT_ROOT/runtime"
+RUN_ROOT="$RUNTIME_ROOT/runs/$RUN_ID"
+README_FILE="$ARTIFACT_ROOT/README.md"
+SUMMARY_FILE="$RUN_ROOT/run_summary.json"
+STATUS_FILE="$RUN_ROOT/run_status.json"
+TRACE_FILE="$RUN_ROOT/logs/trace_v1.json"
+LOG_FILE="$ARTIFACT_ROOT/run_log.txt"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0871_provider_local_ollama.sh "$ARTIFACT_ROOT" >/dev/null
+)
+
+[[ -f "$README_FILE" ]] || {
+  echo "assertion failed: README missing" >&2
+  exit 1
+}
+[[ -f "$SUMMARY_FILE" ]] || {
+  echo "assertion failed: run_summary.json missing" >&2
+  exit 1
+}
+[[ -f "$STATUS_FILE" ]] || {
+  echo "assertion failed: run_status.json missing" >&2
+  exit 1
+}
+[[ -f "$TRACE_FILE" ]] || {
+  echo "assertion failed: trace_v1.json missing" >&2
+  exit 1
+}
+[[ -f "$LOG_FILE" ]] || {
+  echo "assertion failed: run_log.txt missing" >&2
+  exit 1
+}
+
+grep -Fq '"run_id": "v0-87-1-provider-local-ollama-demo"' "$SUMMARY_FILE" || {
+  echo "assertion failed: run_summary.json missing run_id" >&2
+  exit 1
+}
+grep -Fq '"overall_status": "succeeded"' "$STATUS_FILE" || {
+  echo "assertion failed: run_status.json missing succeeded status" >&2
+  exit 1
+}
+grep -Fq 'LOCAL_OLLAMA_PROVIDER_DEMO_OK' "$LOG_FILE" || {
+  echo "assertion failed: run_log.txt missing local Ollama output" >&2
+  exit 1
+}
+grep -Fq 'ADL_OLLAMA_BIN=adl/tools/mock_ollama_v0_4.sh' "$README_FILE" || {
+  echo "assertion failed: README missing local Ollama precondition" >&2
+  exit 1
+}
+
+echo "demo_v0871_provider_local_ollama: ok"

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -77,7 +77,7 @@ Shared wrapper helper:
 
 | Provider family | Scope | Issue |
 |---|---|---|
-| local Ollama | bounded local provider demo plus acceptance coverage for `ollama` / `local_ollama` | `#1485` |
+| local Ollama | bounded local provider demo plus acceptance coverage for `ollama` / `local_ollama`; canonical command `bash adl/tools/demo_v0871_provider_local_ollama.sh` | `#1485` |
 | bounded HTTP | bounded generic remote HTTP demo plus acceptance coverage for `http` / `http_remote`; canonical command `bash adl/tools/demo_v0871_provider_http.sh` | `#1486` |
 | mock | no-network mock provider demo plus acceptance coverage; canonical command `bash adl/tools/demo_v0871_provider_mock.sh` | `#1487` |
 | ChatGPT | `chatgpt:` family demo plus acceptance coverage using the current setup flow | `#1488` |


### PR DESCRIPTION
Closes #1485

## Summary
- add a bounded local Ollama provider demo that defaults to the repo mock binary but can target a real local binary
- add focused local_ollama family coverage to keep the provider path honest
- update the example index and v0.87.1 demo matrix so reviewers can find the local-provider proof path