### PR TITLE
[v0.87.1][demo] Add bounded HTTP provider demo + acceptance test

### DIFF
--- a/adl/examples/README.md
+++ b/adl/examples/README.md
@@ -28,6 +28,7 @@ ADL_OLLAMA_BIN=tools/mock_ollama_v0_4.sh cargo run -q --bin adl -- examples/v0-6
 - v0.6: HITL pause/resume, profiles, delegation, instrumentation demos
 - v0.7: provider portability / HTTP profile compatibility proof surface
 - v0.87.1: no-network mock provider family proof (`v0-87-1-provider-mock-demo.adl.yaml`)
+- v0.87.1: bounded HTTP family proof (`v0-87-1-provider-http-demo.adl.yaml`)
 
 ## See Also / Canonical Docs
 

--- a/adl/examples/v0-87-1-provider-http-demo.adl.yaml
+++ b/adl/examples/v0-87-1-provider-http-demo.adl.yaml
@@ -1,0 +1,30 @@
+version: "0.5"
+
+providers:
+  bounded_http_demo:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8787/complete"
+      timeout_secs: 10
+      auth:
+        type: bearer
+        env: ADL_REMOTE_BEARER_TOKEN
+
+agents:
+  http_writer:
+    provider: "bounded_http_demo"
+    model: "bounded-http-demo"
+
+tasks:
+  echo_marker:
+    prompt:
+      user: "HTTP_PROVIDER_DEMO_OK"
+
+run:
+  name: "v0-87-1-provider-http-demo"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "http_echo"
+        agent: "http_writer"
+        task: "echo_marker"

--- a/adl/tools/demo_v0871_provider_http.sh
+++ b/adl/tools/demo_v0871_provider_http.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/provider_demo_common.sh"
+
+ROOT_DIR="$(provider_demo_repo_root)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0871/provider_http}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-87-1-provider-http-demo"
+EXAMPLE="adl/examples/v0-87-1-provider-http-demo.adl.yaml"
+PORT=8787
+TOKEN="${ADL_REMOTE_BEARER_TOKEN:-bounded-demo-token}"
+SERVER_LOG="$OUT_DIR/http_server.log"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cd "$ROOT_DIR"
+
+python3 - "$PORT" "$TOKEN" >"$SERVER_LOG" 2>&1 <<'PY' &
+import http.server
+import json
+import socketserver
+import sys
+
+port = int(sys.argv[1])
+token = sys.argv[2]
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != "/complete":
+            self.send_response(404)
+            self.end_headers()
+            return
+        auth = self.headers.get("Authorization", "")
+        if auth != f"Bearer {token}":
+            self.send_response(401)
+            self.end_headers()
+            self.wfile.write(b'{"error":"unauthorized"}')
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        payload = json.loads(body.decode("utf-8"))
+        prompt = payload.get("prompt", "")
+        response = json.dumps({"output": f"HTTP_PROVIDER_DEMO_OK\n{prompt}"}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format, *args):
+        return
+
+with socketserver.TCPServer(("127.0.0.1", port), Handler) as httpd:
+    httpd.handle_request()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+sleep 1
+
+echo "Running v0.87.1 bounded-HTTP provider demo..."
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+ADL_REMOTE_BEARER_TOKEN="$TOKEN" \
+  cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+    "$EXAMPLE" \
+    --run \
+    --trace \
+    --allow-unsigned \
+    --out "$STEP_OUT" \
+    | tee "$OUT_DIR/run_log.txt"
+
+SECONDARY_PROOF_SURFACES="$(printf '%s\n%s\n%s\n%s' \
+  "$RUNS_ROOT/$RUN_ID/run_status.json" \
+  "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json" \
+  "$OUT_DIR/run_log.txt" \
+  "$SERVER_LOG")"
+
+provider_demo_write_readme \
+  "$OUT_DIR" \
+  "v0.87.1 Provider Demo - Bounded HTTP" \
+  $'ADL_REMOTE_BEARER_TOKEN=bounded-demo-token \\\nbash adl/tools/demo_v0871_provider_http.sh' \
+  "$RUNS_ROOT/$RUN_ID/run_summary.json" \
+  "$SECONDARY_PROOF_SURFACES" \
+  "stdout and run_log.txt include HTTP_PROVIDER_DEMO_OK, and the provider call stays inside the local bounded completion contract on loopback HTTP"
+
+provider_demo_print_proof_surfaces \
+  "$RUNS_ROOT/$RUN_ID/run_summary.json" \
+  "$SECONDARY_PROOF_SURFACES"

--- a/adl/tools/test_demo_v0871_provider_http.sh
+++ b/adl/tools/test_demo_v0871_provider_http.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+ARTIFACT_ROOT="$TMPDIR_ROOT/artifacts"
+RUN_ID="v0-87-1-provider-http-demo"
+RUNTIME_ROOT="$ARTIFACT_ROOT/runtime"
+RUN_ROOT="$RUNTIME_ROOT/runs/$RUN_ID"
+README_FILE="$ARTIFACT_ROOT/README.md"
+SUMMARY_FILE="$RUN_ROOT/run_summary.json"
+STATUS_FILE="$RUN_ROOT/run_status.json"
+TRACE_FILE="$RUN_ROOT/logs/trace_v1.json"
+LOG_FILE="$ARTIFACT_ROOT/run_log.txt"
+SERVER_LOG="$ARTIFACT_ROOT/http_server.log"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0871_provider_http.sh "$ARTIFACT_ROOT" >/dev/null
+)
+
+[[ -f "$README_FILE" ]] || {
+  echo "assertion failed: README missing" >&2
+  exit 1
+}
+[[ -f "$SUMMARY_FILE" ]] || {
+  echo "assertion failed: run_summary.json missing" >&2
+  exit 1
+}
+[[ -f "$STATUS_FILE" ]] || {
+  echo "assertion failed: run_status.json missing" >&2
+  exit 1
+}
+[[ -f "$TRACE_FILE" ]] || {
+  echo "assertion failed: trace_v1.json missing" >&2
+  exit 1
+}
+[[ -f "$LOG_FILE" ]] || {
+  echo "assertion failed: run_log.txt missing" >&2
+  exit 1
+}
+[[ -f "$SERVER_LOG" ]] || {
+  echo "assertion failed: http_server.log missing" >&2
+  exit 1
+}
+
+grep -Fq '"run_id": "v0-87-1-provider-http-demo"' "$SUMMARY_FILE" || {
+  echo "assertion failed: run_summary.json missing run_id" >&2
+  exit 1
+}
+grep -Fq '"overall_status": "succeeded"' "$STATUS_FILE" || {
+  echo "assertion failed: run_status.json missing succeeded status" >&2
+  exit 1
+}
+grep -Fq 'HTTP_PROVIDER_DEMO_OK' "$LOG_FILE" || {
+  echo "assertion failed: run_log.txt missing HTTP provider output" >&2
+  exit 1
+}
+grep -Fq 'ADL_REMOTE_BEARER_TOKEN=bounded-demo-token' "$README_FILE" || {
+  echo "assertion failed: README missing bounded HTTP setup note" >&2
+  exit 1
+}
+
+echo "demo_v0871_provider_http: ok"

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -75,7 +75,7 @@ Shared doc ownership:
 | Provider family | Scope | Issue |
 |---|---|---|
 | local Ollama | bounded local provider demo plus acceptance coverage for `ollama` / `local_ollama` | `#1485` |
-| bounded HTTP | bounded generic remote HTTP demo plus acceptance coverage for `http` / `http_remote` | `#1486` |
+| bounded HTTP | bounded generic remote HTTP demo plus acceptance coverage for `http` / `http_remote`; canonical command `bash adl/tools/demo_v0871_provider_http.sh` | `#1486` |
 | mock | no-network mock provider demo plus acceptance coverage; canonical command `bash adl/tools/demo_v0871_provider_mock.sh` | `#1487` |
 | ChatGPT | `chatgpt:` family demo plus acceptance coverage using the current setup flow | `#1488` |
 

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -43,3 +43,6 @@ Example:
 adl provider setup chatgpt
 adl provider setup openai --out ./.adl/provider-setup/openai
 ```
+
+Loopback demo note:
+- the `v0.87.1` bounded HTTP family demo uses `http://127.0.0.1:8787/complete` with a dummy bearer token as a local proof path for the ADL completion contract


### PR DESCRIPTION
Closes #1486

## Summary
- add a bounded HTTP family demo that exercises the local loopback completion contract with a dummy bearer token
- add a deterministic smoke test for the HTTP family wrapper path
- update provider setup and the v0.87.1 demo matrix so reviewers can find the bounded HTTP proof surface