### PR TITLE
[v0.87.1][demo] Add ChatGPT provider demo + acceptance test

### DIFF
--- a/adl/examples/README.md
+++ b/adl/examples/README.md
@@ -30,6 +30,7 @@ ADL_OLLAMA_BIN=tools/mock_ollama_v0_4.sh cargo run -q --bin adl -- examples/v0-6
 - v0.87.1: no-network mock provider family proof (`v0-87-1-provider-mock-demo.adl.yaml`)
 - v0.87.1: bounded HTTP family proof (`v0-87-1-provider-http-demo.adl.yaml`)
 - v0.87.1: local Ollama family proof (`v0-87-1-provider-local-ollama-demo.adl.yaml`)
+- v0.87.1: ChatGPT family proof (`v0-87-1-provider-chatgpt-demo.adl.yaml`)
 
 ## See Also / Canonical Docs
 

--- a/adl/examples/v0-87-1-provider-chatgpt-demo.adl.yaml
+++ b/adl/examples/v0-87-1-provider-chatgpt-demo.adl.yaml
@@ -1,0 +1,34 @@
+version: "0.5"
+
+providers:
+  chatgpt_primary:
+    profile: "chatgpt:gpt-5.4"
+    config:
+      endpoint: "http://127.0.0.1:8787/complete"
+      auth:
+        type: bearer
+        env: OPENAI_API_KEY
+      headers:
+        X-Client: "adl-chatgpt-demo"
+      timeout_secs: 15
+      model_ref: "gpt-5.4"
+      provider_model_id: "gpt-5.4"
+
+agents:
+  chatgpt_agent:
+    provider: "chatgpt_primary"
+    model: "gpt-5.4"
+
+tasks:
+  echo_marker:
+    prompt:
+      user: "CHATGPT_PROVIDER_DEMO_OK"
+
+run:
+  name: "v0-87-1-provider-chatgpt-demo"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "chatgpt_echo"
+        agent: "chatgpt_agent"
+        task: "echo_marker"

--- a/adl/tools/demo_v0871_provider_chatgpt.sh
+++ b/adl/tools/demo_v0871_provider_chatgpt.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/provider_demo_common.sh"
+
+ROOT_DIR="$(provider_demo_repo_root)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0871/provider_chatgpt}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-87-1-provider-chatgpt-demo"
+EXAMPLE="adl/examples/v0-87-1-provider-chatgpt-demo.adl.yaml"
+PORT=8787
+TOKEN="${OPENAI_API_KEY:-chatgpt-demo-token}"
+SERVER_LOG="$OUT_DIR/chatgpt_adapter.log"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cd "$ROOT_DIR"
+
+python3 - "$PORT" "$TOKEN" >"$SERVER_LOG" 2>&1 <<'PY' &
+import http.server
+import json
+import socketserver
+import sys
+
+port = int(sys.argv[1])
+token = sys.argv[2]
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != "/complete":
+            self.send_response(404)
+            self.end_headers()
+            return
+        auth = self.headers.get("Authorization", "")
+        if auth != f"Bearer {token}":
+            self.send_response(401)
+            self.end_headers()
+            self.wfile.write(b'{"error":"unauthorized"}')
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        payload = json.loads(body.decode("utf-8"))
+        prompt = payload.get("prompt", "")
+        response = json.dumps({"output": f"CHATGPT_PROVIDER_DEMO_OK\n{prompt}"}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format, *args):
+        return
+
+with socketserver.TCPServer(("127.0.0.1", port), Handler) as httpd:
+    httpd.handle_request()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+sleep 1
+
+echo "Running v0.87.1 ChatGPT provider demo..."
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+OPENAI_API_KEY="$TOKEN" \
+  cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+    "$EXAMPLE" \
+    --run \
+    --trace \
+    --allow-unsigned \
+    --out "$STEP_OUT" \
+    | tee "$OUT_DIR/run_log.txt"
+
+SECONDARY_PROOF_SURFACES="$(printf '%s\n%s\n%s\n%s' \
+  "$RUNS_ROOT/$RUN_ID/run_status.json" \
+  "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json" \
+  "$OUT_DIR/run_log.txt" \
+  "$SERVER_LOG")"
+
+provider_demo_write_readme \
+  "$OUT_DIR" \
+  "v0.87.1 Provider Demo - ChatGPT" \
+  $'OPENAI_API_KEY=chatgpt-demo-token \\\nbash adl/tools/demo_v0871_provider_chatgpt.sh' \
+  "$RUNS_ROOT/$RUN_ID/run_summary.json" \
+  "$SECONDARY_PROOF_SURFACES" \
+  "stdout and run_log.txt include CHATGPT_PROVIDER_DEMO_OK, and the demo truthfully exercises the chatgpt:gpt-5.4 profile surface through the current bounded completion adapter contract"
+
+provider_demo_print_proof_surfaces \
+  "$RUNS_ROOT/$RUN_ID/run_summary.json" \
+  "$SECONDARY_PROOF_SURFACES"

--- a/adl/tools/test_demo_v0871_provider_chatgpt.sh
+++ b/adl/tools/test_demo_v0871_provider_chatgpt.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+ARTIFACT_ROOT="$TMPDIR_ROOT/artifacts"
+RUN_ID="v0-87-1-provider-chatgpt-demo"
+RUNTIME_ROOT="$ARTIFACT_ROOT/runtime"
+RUN_ROOT="$RUNTIME_ROOT/runs/$RUN_ID"
+README_FILE="$ARTIFACT_ROOT/README.md"
+SUMMARY_FILE="$RUN_ROOT/run_summary.json"
+STATUS_FILE="$RUN_ROOT/run_status.json"
+TRACE_FILE="$RUN_ROOT/logs/trace_v1.json"
+LOG_FILE="$ARTIFACT_ROOT/run_log.txt"
+SERVER_LOG="$ARTIFACT_ROOT/chatgpt_adapter.log"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0871_provider_chatgpt.sh "$ARTIFACT_ROOT" >/dev/null
+)
+
+[[ -f "$README_FILE" ]] || {
+  echo "assertion failed: README missing" >&2
+  exit 1
+}
+[[ -f "$SUMMARY_FILE" ]] || {
+  echo "assertion failed: run_summary.json missing" >&2
+  exit 1
+}
+[[ -f "$STATUS_FILE" ]] || {
+  echo "assertion failed: run_status.json missing" >&2
+  exit 1
+}
+[[ -f "$TRACE_FILE" ]] || {
+  echo "assertion failed: trace_v1.json missing" >&2
+  exit 1
+}
+[[ -f "$LOG_FILE" ]] || {
+  echo "assertion failed: run_log.txt missing" >&2
+  exit 1
+}
+[[ -f "$SERVER_LOG" ]] || {
+  echo "assertion failed: chatgpt_adapter.log missing" >&2
+  exit 1
+}
+
+grep -Fq '"run_id": "v0-87-1-provider-chatgpt-demo"' "$SUMMARY_FILE" || {
+  echo "assertion failed: run_summary.json missing run_id" >&2
+  exit 1
+}
+grep -Fq '"overall_status": "succeeded"' "$STATUS_FILE" || {
+  echo "assertion failed: run_status.json missing succeeded status" >&2
+  exit 1
+}
+grep -Fq 'CHATGPT_PROVIDER_DEMO_OK' "$LOG_FILE" || {
+  echo "assertion failed: run_log.txt missing ChatGPT provider output" >&2
+  exit 1
+}
+grep -Fq 'OPENAI_API_KEY=chatgpt-demo-token' "$README_FILE" || {
+  echo "assertion failed: README missing ChatGPT setup note" >&2
+  exit 1
+}
+
+echo "demo_v0871_provider_chatgpt: ok"

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -80,7 +80,7 @@ Shared wrapper helper:
 | local Ollama | bounded local provider demo plus acceptance coverage for `ollama` / `local_ollama`; canonical command `bash adl/tools/demo_v0871_provider_local_ollama.sh` | `#1485` |
 | bounded HTTP | bounded generic remote HTTP demo plus acceptance coverage for `http` / `http_remote`; canonical command `bash adl/tools/demo_v0871_provider_http.sh` | `#1486` |
 | mock | no-network mock provider demo plus acceptance coverage; canonical command `bash adl/tools/demo_v0871_provider_mock.sh` | `#1487` |
-| ChatGPT | `chatgpt:` family demo plus acceptance coverage using the current setup flow | `#1488` |
+| ChatGPT | `chatgpt:` family demo plus acceptance coverage using the current setup flow; canonical command `bash adl/tools/demo_v0871_provider_chatgpt.sh` | `#1488` |
 
 ## Demo Coverage Summary
 

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -46,3 +46,6 @@ adl provider setup openai --out ./.adl/provider-setup/openai
 
 Loopback demo note:
 - the `v0.87.1` bounded HTTP family demo uses `http://127.0.0.1:8787/complete` with a dummy bearer token as a local proof path for the ADL completion contract
+
+ChatGPT demo note:
+- the `v0.87.1` ChatGPT family demo uses the `chatgpt:gpt-5.4` profile plus a local bounded completion adapter on `http://127.0.0.1:8787/complete`; it proves the current setup/profile surface, not a raw vendor-native endpoint


### PR DESCRIPTION
Closes #1488

## Summary
- add a bounded ChatGPT-family demo that exercises the current chatgpt:gpt-5.4 profile/setup surface through a local completion adapter
- add a deterministic smoke test for the ChatGPT family wrapper path
- update provider setup and the v0.87.1 demo matrix so reviewers can find the truthful ChatGPT proof surface