### PR TITLE
[v0.87.1][runtime] Add first-class Claude provider-family parity

### DIFF
--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -111,6 +111,17 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
             endpoint_hint: "https://api.example.invalid/v1/complete",
             notes: "Use this when you want the ChatGPT/GPT-5 family surface. Keep the endpoint pointed at an ADL-compatible completion endpoint and supply your own OpenAI key through the generated env file.",
         },
+        "claude" => &ProviderSetupTemplate {
+            family: "claude",
+            profile: "claude:claude-3-7-sonnet",
+            env_var: "ANTHROPIC_API_KEY",
+            provider_id: "claude_primary",
+            agent_id: "claude_agent",
+            model_ref: "claude-3-7-sonnet",
+            provider_model_id: "claude-3-7-sonnet-latest",
+            endpoint_hint: "https://api.example.invalid/v1/complete",
+            notes: "Use this when you want the first-class Claude family surface. Keep the endpoint pointed at an ADL-compatible completion endpoint and supply your Anthropic credential through the generated env file.",
+        },
         "openai" => &ProviderSetupTemplate {
             family: "openai",
             profile: "http:gpt-4.1-mini",
@@ -168,7 +179,7 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
         },
         other => {
             return Err(anyhow!(
-                "unsupported provider setup family '{other}' (supported: chatgpt, openai, anthropic, gemini, deepseek, http)"
+                "unsupported provider setup family '{other}' (supported: chatgpt, claude, openai, anthropic, gemini, deepseek, http)"
             ))
         }
     };
@@ -303,6 +314,25 @@ mod tests {
     }
 
     #[test]
+    fn provider_setup_writes_expected_bundle_for_claude() {
+        let repo = temp_repo("claude");
+        real_provider_in_repo(&["setup".to_string(), "claude".to_string()], &repo)
+            .expect("claude setup should succeed");
+
+        let out = repo.join(".adl/provider-setup/claude");
+        let provider_text =
+            fs::read_to_string(out.join("provider.adl.yaml")).expect("provider yaml");
+        let env_text = fs::read_to_string(out.join(".env.example")).expect("env example");
+        let readme = fs::read_to_string(out.join("README.md")).expect("readme");
+
+        assert!(provider_text.contains("profile: \"claude:claude-3-7-sonnet\""));
+        assert!(provider_text.contains("provider: \"claude_primary\""));
+        assert!(provider_text.contains("env: ANTHROPIC_API_KEY"));
+        assert!(env_text.contains("ANTHROPIC_API_KEY=replace-me"));
+        assert!(readme.contains("first-class Claude family surface"));
+    }
+
+    #[test]
     fn provider_setup_supports_explicit_out_and_force() {
         let repo = temp_repo("out-force");
         let out = repo.join("custom/provider-setup/openai");
@@ -393,6 +423,7 @@ mod tests {
     fn provider_setup_supports_all_declared_families() {
         let families = [
             ("chatgpt", "chatgpt:gpt-5.4", "OPENAI_API_KEY"),
+            ("claude", "claude:claude-3-7-sonnet", "ANTHROPIC_API_KEY"),
             ("openai", "http:gpt-4.1-mini", "OPENAI_API_KEY"),
             ("anthropic", "http:claude-3-7-sonnet", "ANTHROPIC_API_KEY"),
             ("gemini", "http:gemini-2.0-flash", "GEMINI_API_KEY"),

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -58,6 +58,7 @@ Examples:
   adl demo demo-e-multi-agent-card-pipeline --run --trace --out ./out
   adl demo demo-f-obsmem-retrieval --run --trace --out ./out
   adl provider setup chatgpt
+  adl provider setup claude
   adl provider setup anthropic --out ./.adl/provider-setup/anthropic
   adl godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary \"step failed with deterministic parse error\" --evidence-ref runs/run-745-a/run_status.json
   adl godel inspect --run-id run-745-a --runs-dir .adl/runs

--- a/adl/src/provider.rs
+++ b/adl/src/provider.rs
@@ -307,6 +307,20 @@ fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProfilePreset> 
             },
         );
     }
+    // Claude-facing presets (same bounded HTTP substrate, distinct profile family)
+    for (name, model) in [
+        ("claude:claude-3-7-sonnet", "claude-3-7-sonnet-latest"),
+        ("claude:claude-3-5-haiku", "claude-3-5-haiku-latest"),
+    ] {
+        m.insert(
+            name,
+            ProviderProfilePreset {
+                kind: "http",
+                default_model: Some(model),
+                endpoint: Some(HTTP_PROFILE_PLACEHOLDER_ENDPOINT),
+            },
+        );
+    }
     m
 }
 
@@ -962,6 +976,20 @@ mod tests {
     fn profile_endpoint_validation_allows_loopback_http_for_local_harnesses() {
         validate_profile_endpoint("p1", "http:gpt-4o-mini", "http://127.0.0.1:8787/complete")
             .expect("loopback http should remain allowed");
+    }
+
+    #[test]
+    fn provider_profile_registry_includes_first_class_claude_profiles() {
+        let names = provider_profile_names();
+        assert!(names.contains(&"claude:claude-3-7-sonnet".to_string()));
+        assert!(names.contains(&"claude:claude-3-5-haiku".to_string()));
+
+        let preset = provider_profile_registry()
+            .get("claude:claude-3-7-sonnet")
+            .copied()
+            .expect("claude sonnet preset");
+        assert_eq!(preset.kind, "http");
+        assert_eq!(preset.default_model, Some("claude-3-7-sonnet-latest"));
     }
 
     #[test]

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -119,6 +119,8 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
             match family {
                 "ollama" => return "ollama".to_string(),
                 "mock" => return "mock".to_string(),
+                "chatgpt" => return "openai".to_string(),
+                "claude" => return "anthropic".to_string(),
                 "http" => {}
                 _ => {}
             }
@@ -383,6 +385,26 @@ mod tests {
         assert_eq!(substrate.vendor, "openai");
         assert_eq!(substrate.transport, ProviderTransportV1::Http);
         assert_eq!(substrate.default_model_ref.as_deref(), Some("gpt-4.1-mini"));
+    }
+
+    #[test]
+    fn provider_substrate_infers_first_class_claude_profile_vendor() {
+        let mut spec = provider_spec("http");
+        spec.profile = Some("claude:claude-3-7-sonnet".to_string());
+        spec.config.insert(
+            "endpoint".to_string(),
+            json!("http://127.0.0.1:8787/complete"),
+        );
+        spec.default_model = Some("claude-3-7-sonnet-latest".to_string());
+
+        let substrate = provider_substrate_v1("claude_primary", &spec).expect("substrate");
+        assert_eq!(substrate.provider_id, "claude_primary");
+        assert_eq!(substrate.vendor, "anthropic");
+        assert_eq!(substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(
+            substrate.default_model_ref.as_deref(),
+            Some("claude-3-7-sonnet-latest")
+        );
     }
 
     #[test]

--- a/adl/tests/provider_tests.rs
+++ b/adl/tests/provider_tests.rs
@@ -1071,6 +1071,61 @@ run:
 }
 
 #[test]
+fn expand_provider_profiles_accepts_claude_profile_with_endpoint_override() {
+    let doc = adl_doc_from_yaml(
+        r#"
+version: "0.5"
+providers:
+  p1:
+    profile: "claude:claude-3-7-sonnet"
+    config:
+      endpoint: "https://api.anthropic.com/v1/complete"
+      auth:
+        type: "bearer"
+        env: "ANTHROPIC_API_KEY"
+      timeout_secs: 20
+agents:
+  a1:
+    provider: "p1"
+    model: "claude-3-7-sonnet"
+tasks:
+  t1:
+    prompt:
+      user: "u"
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: "a1"
+        task: "t1"
+"#,
+    );
+    let expanded = expand_provider_profiles(&doc).expect("profile expansion should succeed");
+    let provider = &expanded.providers["p1"];
+    assert_eq!(provider.kind, "http");
+    assert_eq!(
+        provider.profile.as_deref(),
+        Some("claude:claude-3-7-sonnet")
+    );
+    assert_eq!(
+        provider.default_model.as_deref(),
+        Some("claude-3-7-sonnet-latest")
+    );
+    assert_eq!(
+        provider.config.get("endpoint").and_then(|v| v.as_str()),
+        Some("https://api.anthropic.com/v1/complete")
+    );
+    assert_eq!(
+        provider
+            .config
+            .get("auth")
+            .and_then(|v| v.get("env"))
+            .and_then(|v| v.as_str()),
+        Some("ANTHROPIC_API_KEY")
+    );
+}
+
+#[test]
 fn provider_profile_names_include_chatgpt_family() {
     let names = provider_profile_names();
     for required in [
@@ -1079,6 +1134,17 @@ fn provider_profile_names_include_chatgpt_family() {
         "chatgpt:gpt-5.3-codex",
         "chatgpt:gpt-5.2",
     ] {
+        assert!(
+            names.iter().any(|name| name == required),
+            "missing provider profile {required}"
+        );
+    }
+}
+
+#[test]
+fn provider_profile_names_include_claude_family() {
+    let names = provider_profile_names();
+    for required in ["claude:claude-3-7-sonnet", "claude:claude-3-5-haiku"] {
         assert!(
             names.iter().any(|name| name == required),
             "missing provider profile {required}"

--- a/docs/records/v0.87.1/tasks/issue-1500/sor.md
+++ b/docs/records/v0.87.1/tasks/issue-1500/sor.md
@@ -1,0 +1,151 @@
+# v0-87-1-runtime-add-first-class-claude-provider-family-parity-with-chatgpt-profiles
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1500
+Run ID: issue-1500
+Version: v0.87.1
+Title: [v0.87.1][runtime] Add first-class Claude provider-family parity with ChatGPT profiles
+Branch: codex/1500-v0-87-1-runtime-add-first-class-claude-provider-family-parity-with-chatgpt-profiles
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: openai
+- Start Time: 2026-04-10T00:46:47Z
+- End Time: 2026-04-10T00:51:28Z
+
+## Summary
+
+Added a first-class `claude:` provider/profile family alongside the existing `chatgpt:` family. The implementation keeps Claude on the bounded HTTP completion substrate, adds `adl provider setup claude`, documents the operator-facing setup path, and preserves the existing generic `anthropic` compatibility family.
+
+## Artifacts produced
+- updated provider profile registry with `claude:claude-3-7-sonnet` and `claude:claude-3-5-haiku`
+- updated provider substrate vendor inference for first-class `claude:` profiles
+- updated provider setup command support for `adl provider setup claude`
+- updated provider setup documentation and CLI usage examples
+- focused provider/profile tests for Claude setup, profile expansion, profile listing, and substrate vendor inference
+
+## Actions taken
+- added `claude:` profile presets to `adl/src/provider.rs`
+- mapped `claude:` profiles to the Anthropic vendor in `adl/src/provider_substrate.rs`
+- added `provider setup claude` support in `adl/src/cli/provider_cmd.rs`
+- updated CLI usage examples in `adl/src/cli/usage.rs`
+- updated `docs/tooling/PROVIDER_SETUP.md` to list and explain the Claude family
+- added focused Rust coverage in `adl/tests/provider_tests.rs` and existing provider command/substrate test modules
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; tracked changes are present on the issue branch/worktree pending `pr finish`
+- Worktree-only paths remaining: `adl/src/provider.rs`, `adl/src/provider_substrate.rs`, `adl/src/cli/provider_cmd.rs`, `adl/src/cli/usage.rs`, `adl/tests/provider_tests.rs`, `docs/tooling/PROVIDER_SETUP.md`
+- Integration state: worktree_only
+- Verification scope: worktree
+- Integration method used: issue branch/worktree edits before PR publication
+- Verification performed:
+  - `cargo test --manifest-path adl/Cargo.toml provider_profile_registry_includes_first_class_claude_profiles -- --nocapture`
+    - verified the internal provider profile registry exposes the first-class Claude profiles
+  - `cargo test --manifest-path adl/Cargo.toml provider_setup_writes_expected_bundle_for_claude -- --nocapture`
+    - verified `adl provider setup claude` writes the expected local setup bundle
+  - `cargo test --manifest-path adl/Cargo.toml provider_substrate_infers_first_class_claude_profile_vendor -- --nocapture`
+    - verified provider substrate maps `claude:` profiles to the Anthropic vendor on the bounded HTTP transport
+  - `cargo test --manifest-path adl/Cargo.toml provider_setup_supports_all_declared_families -- --nocapture`
+    - verified the declared setup-family table includes the new Claude family
+  - `cargo test --manifest-path adl/Cargo.toml provider_ -- --nocapture`
+    - verified broader provider/profile/provider-substrate behavior still passes
+  - `git diff --check`
+    - verified the patch has no whitespace errors
+- Result: PASS
+
+## Validation
+- `cargo test --manifest-path adl/Cargo.toml provider_profile_registry_includes_first_class_claude_profiles -- --nocapture`
+  - passed
+- `cargo test --manifest-path adl/Cargo.toml provider_setup_writes_expected_bundle_for_claude -- --nocapture`
+  - passed
+- `cargo test --manifest-path adl/Cargo.toml provider_substrate_infers_first_class_claude_profile_vendor -- --nocapture`
+  - passed
+- `cargo test --manifest-path adl/Cargo.toml provider_setup_supports_all_declared_families -- --nocapture`
+  - passed
+- `cargo test --manifest-path adl/Cargo.toml expand_provider_profiles_accepts_claude_profile_with_endpoint_override -- --nocapture`
+  - passed
+- `cargo test --manifest-path adl/Cargo.toml provider_profile_names_include_claude_family -- --nocapture`
+  - passed
+- `cargo test --manifest-path adl/Cargo.toml provider_ -- --nocapture`
+  - passed
+- `git diff --check`
+  - passed
+- Results:
+  - first-class Claude profile, setup, and provider-substrate paths are covered
+  - existing provider test surface still passes
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - cargo test --manifest-path adl/Cargo.toml provider_profile_registry_includes_first_class_claude_profiles -- --nocapture
+      - cargo test --manifest-path adl/Cargo.toml provider_setup_writes_expected_bundle_for_claude -- --nocapture
+      - cargo test --manifest-path adl/Cargo.toml provider_substrate_infers_first_class_claude_profile_vendor -- --nocapture
+      - cargo test --manifest-path adl/Cargo.toml provider_setup_supports_all_declared_families -- --nocapture
+      - cargo test --manifest-path adl/Cargo.toml expand_provider_profiles_accepts_claude_profile_with_endpoint_override -- --nocapture
+      - cargo test --manifest-path adl/Cargo.toml provider_profile_names_include_claude_family -- --nocapture
+      - cargo test --manifest-path adl/Cargo.toml provider_ -- --nocapture
+      - git diff --check
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: provider profile registry, provider setup, profile expansion, and provider substrate focused tests
+- Fixtures or scripts used: Rust unit/integration tests only
+- Replay verification (same inputs -> same artifacts/order): the setup-family and profile-registry tests verify stable family/profile expansion for fixed inputs
+- Ordering guarantees (sorting / tie-break rules used): provider profile names are derived from the existing sorted registry surface; broader `provider_` tests passed
+- Artifact stability notes: generated provider setup content is deterministic for the `claude` family template
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review plus generated setup tests; no real credentials were introduced
+- Prompt / tool argument redaction verified: yes; provider setup writes placeholder env values only
+- Absolute path leakage check: passed; final recorded artifact paths are repository-relative
+- Sandbox / policy invariants preserved: yes
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this issue did not run an ADL trace demo
+- Run artifact root: not applicable; validation used unit/integration tests
+- Replay command used for verification: `cargo test --manifest-path adl/Cargo.toml provider_ -- --nocapture`
+- Replay result: passed
+
+## Artifact Verification
+- Primary proof surface: provider/profile code and focused tests listed in this card
+- Required artifacts present: yes
+- Artifact schema/version checks: no artifact schema changes were made
+- Hash/byte-stability checks: not applicable; no generated persistent artifact was checked in
+- Missing/optional artifacts and rationale: no demo artifact is required because this is provider-family parity work
+
+## Decisions / Deviations
+- Kept the existing `anthropic` setup family intact as the generic compatibility path.
+- Added `claude:` as the first-class model-family surface while retaining the bounded HTTP completion contract.
+- Did not add a new Claude demo because the issue scope is provider-family parity, not a demo-bearing proof.
+
+## Follow-ups / Deferred work
+- Future work may update multi-agent demos to use `claude:` directly where that improves clarity.

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -5,6 +5,7 @@ remote provider family.
 
 Current supported families:
 - `chatgpt`
+- `claude`
 - `openai`
 - `anthropic`
 - `gemini`
@@ -41,6 +42,7 @@ Example:
 
 ```bash
 adl provider setup chatgpt
+adl provider setup claude
 adl provider setup openai --out ./.adl/provider-setup/openai
 ```
 
@@ -49,3 +51,6 @@ Loopback demo note:
 
 ChatGPT demo note:
 - the `v0.87.1` ChatGPT family demo uses the `chatgpt:gpt-5.4` profile plus a local bounded completion adapter on `http://127.0.0.1:8787/complete`; it proves the current setup/profile surface, not a raw vendor-native endpoint
+
+Claude family note:
+- the first-class Claude setup surface uses `claude:claude-3-7-sonnet` plus the same bounded ADL completion contract; it is distinct from the generic `anthropic` compatibility setup so Claude can be referenced symmetrically with ChatGPT in multi-agent workflows


### PR DESCRIPTION
Closes #1500

## Summary
Added a first-class `claude:` provider/profile family alongside the existing `chatgpt:` family. The implementation keeps Claude on the bounded HTTP completion substrate, adds `adl provider setup claude`, documents the operator-facing setup path, and preserves the existing generic `anthropic` compatibility family.

## Artifacts
- updated provider profile registry with `claude:claude-3-7-sonnet` and `claude:claude-3-5-haiku`
- updated provider substrate vendor inference for first-class `claude:` profiles
- updated provider setup command support for `adl provider setup claude`
- updated provider setup documentation and CLI usage examples
- focused provider/profile tests for Claude setup, profile expansion, profile listing, and substrate vendor inference

## Validation
- `cargo test --manifest-path adl/Cargo.toml provider_profile_registry_includes_first_class_claude_profiles -- --nocapture`
  - passed
- `cargo test --manifest-path adl/Cargo.toml provider_setup_writes_expected_bundle_for_claude -- --nocapture`
  - passed
- `cargo test --manifest-path adl/Cargo.toml provider_substrate_infers_first_class_claude_profile_vendor -- --nocapture`
  - passed
- `cargo test --manifest-path adl/Cargo.toml provider_setup_supports_all_declared_families -- --nocapture`
  - passed
- `cargo test --manifest-path adl/Cargo.toml expand_provider_profiles_accepts_claude_profile_with_endpoint_override -- --nocapture`
  - passed
- `cargo test --manifest-path adl/Cargo.toml provider_profile_names_include_claude_family -- --nocapture`
  - passed
- `cargo test --manifest-path adl/Cargo.toml provider_ -- --nocapture`
  - passed
- `git diff --check`
  - passed
- Results:
  - first-class Claude profile, setup, and provider-substrate paths are covered
  - existing provider test surface still passes

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1500__v0-87-1-runtime-add-first-class-claude-provider-family-parity-with-chatgpt-profiles/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1500__v0-87-1-runtime-add-first-class-claude-provider-family-parity-with-chatgpt-profiles/sor.md
- Idempotency-Key: v0-87-1-runtime-add-first-class-claude-provider-family-parity-adl-src-provider-rs-adl-src-provider-substrate-rs-adl-src-cli-provider-cmd-rs-adl-src-cli-usage-rs-adl-tests-provider-tests-rs-docs-tooling-provider-setup-md-adl-v0-87-1-tasks-issue-1500-v0-87-1-runtime-add-first-class-claude-provider-family-parity-with-chatgpt-profiles-sip-md-adl-v0-87-1-tasks-issue-1500-v0-87-1-runtime-add-first-class-claude-provider-family-parity-with-chatgpt-profiles-sor-md