### PR TITLE
tools: archive local run artifacts by milestone

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -12,6 +12,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `normalize_adl_cards.sh`: repairs `.adl/cards/<issue>/` compatibility links and materializes missing bootstrap `sor.md` files for existing task bundles.
 - `demo_v0871_multi_agent_discussion.sh`: canonical `v0.87.1` bounded multi-agent discussion proof wrapper for a five-turn Claude + ChatGPT runtime demo.
 - `worktree_doctor.sh`, `worktree_prune.sh`: deterministic worktree governance and safe cleanup helpers.
+- `archive_run_artifacts.sh`: dry-run/apply helper that inventories local run roots and copies unique run artifacts into `.adl/trace-archive/milestones/<milestone>/runs/`.
 - `adl tooling ...`: Rust-owned tooling surface for prompt/card/review validation helpers, with legacy wrapper scripts preserved at the historical `adl/tools/*` paths.
 - `burst_worktree.sh`, `burst_continue.sh`: burst lane/worktree helpers.
 - `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks.
@@ -54,6 +55,12 @@ bash ./adl/tools/pr.sh run <issue_num> --slug <slug>
 
 # dry-run safe cleanup of merged clean worktrees + stale registrations
 ./adl/tools/worktree_prune.sh
+
+# inventory local run artifacts without deleting or moving the source data
+./adl/tools/archive_run_artifacts.sh --include-worktrees
+
+# copy unique run artifacts into .adl/trace-archive/milestones/
+./adl/tools/archive_run_artifacts.sh --include-worktrees --apply
 
 # run standard checks
 ./adl/tools/batched_checks.sh

--- a/adl/tools/archive_run_artifacts.sh
+++ b/adl/tools/archive_run_artifacts.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+archive_run_artifacts.sh -- inventory or copy local ADL run artifacts into a milestone archive
+
+Usage:
+  adl/tools/archive_run_artifacts.sh [--repo-root DIR] [--archive-root DIR] [--apply] [--include-worktrees] [--force]
+
+Defaults:
+  --repo-root     repository root containing .adl/runs
+  --archive-root  <repo-root>/.adl/trace-archive
+
+Behavior:
+  - dry-runs by default
+  - copies, never deletes, when --apply is supplied
+  - copies only the first discovered run for each milestone + run-id pair
+  - writes MANIFEST.tsv and README.md under the archive root
+  - organizes copied runs under milestones/<milestone>/runs/<run-id>
+USAGE
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+archive_root=""
+apply=0
+include_worktrees=0
+force=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      repo_root="$(cd "$2" && pwd)"
+      shift 2
+      ;;
+    --archive-root)
+      archive_root="$2"
+      shift 2
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    --include-worktrees)
+      include_worktrees=1
+      shift
+      ;;
+    --force)
+      force=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$archive_root" ]]; then
+  archive_root="$repo_root/.adl/trace-archive"
+fi
+
+sanitize_path_part() {
+  printf '%s' "$1" | sed 's#[^A-Za-z0-9._-]#-#g; s#--*#-#g; s#^-##; s#-$##'
+}
+
+relpath() {
+  local path="$1"
+  case "$path" in
+    "$repo_root"/*) printf '%s' "${path#"$repo_root"/}" ;;
+    "$repo_root") printf '.' ;;
+    *) printf '%s' "$path" ;;
+  esac
+}
+
+stat_mtime() {
+  local path="$1"
+  stat -f '%m' "$path" 2>/dev/null || stat -c '%Y' "$path" 2>/dev/null || printf '0'
+}
+
+infer_milestone() {
+  local run_id="$1"
+  local root="$2"
+  local text="$run_id $root"
+
+  if [[ "$text" =~ v0-87-1|v0871|v0\.87\.1 ]]; then
+    printf 'v0.87.1'
+  elif [[ "$text" =~ v0-87|v087|v0\.87 ]]; then
+    printf 'v0.87'
+  elif [[ "$text" =~ v0-86|v086|v0\.86 ]]; then
+    printf 'v0.86'
+  elif [[ "$text" =~ v0-85|v085|v0\.85 ]]; then
+    printf 'v0.85'
+  elif [[ "$text" =~ v075|v0-75|v0\.75 ]]; then
+    printf 'v0.75'
+  elif [[ "$text" =~ v0-7|v07|v0\.7 ]]; then
+    printf 'v0.7'
+  elif [[ "$text" =~ v0-6|v06|v0\.6 ]]; then
+    printf 'v0.6'
+  elif [[ "$text" =~ v0-5|v05|v0\.5 ]]; then
+    printf 'v0.5'
+  elif [[ "$text" =~ v0-4|v04|v0\.4 ]]; then
+    printf 'v0.4'
+  elif [[ "$text" =~ v0-3|v03|v0\.3 ]]; then
+    printf 'v0.3'
+  elif [[ "$text" =~ v0-2|v02|v0\.2 ]]; then
+    printf 'v0.2'
+  else
+    printf 'unclassified'
+  fi
+}
+
+has_run_artifact() {
+  local run_dir="$1"
+  [[ -f "$run_dir/run.json" || -f "$run_dir/run_summary.json" || -f "$run_dir/run_status.json" || -f "$run_dir/logs/trace_v1.json" ]]
+}
+
+source_kind_for_root() {
+  local root="$1"
+  case "$root" in
+    "$repo_root/.adl/runs") printf 'repo-adl-runs' ;;
+    "$repo_root/.adl/reports/"*) printf 'report-runs' ;;
+    "$repo_root/.worktrees/"*) printf 'worktree-adl-runs' ;;
+    "$repo_root/artifacts/"*) printf 'artifacts-runtime-runs' ;;
+    *) printf 'external-runs' ;;
+  esac
+}
+
+discover_roots() {
+  local candidate
+
+  candidate="$repo_root/.adl/runs"
+  [[ -d "$candidate" ]] && printf '%s\n' "$candidate"
+
+  if [[ -d "$repo_root/.adl/reports" ]]; then
+    find "$repo_root/.adl/reports" -path '*/runs' -type d -print 2>/dev/null
+  fi
+
+  if [[ -d "$repo_root/artifacts" ]]; then
+    find "$repo_root/artifacts" -path '*/runtime/runs' -type d -print 2>/dev/null
+  fi
+
+  if [[ "$include_worktrees" -eq 1 && -d "$repo_root/.worktrees" ]]; then
+    for candidate in "$repo_root"/.worktrees/*/.adl/runs; do
+      [[ -d "$candidate" ]] && printf '%s\n' "$candidate"
+    done
+    for candidate in "$repo_root"/.worktrees/*/artifacts/*/runtime/runs; do
+      [[ -d "$candidate" ]] && printf '%s\n' "$candidate"
+    done
+  fi
+}
+
+copy_run() {
+  local src="$1"
+  local dest="$2"
+
+  if [[ -e "$dest" && "$force" -ne 1 ]]; then
+    return 10
+  fi
+
+  if [[ -e "$dest" && "$force" -eq 1 ]]; then
+    rm -rf "$dest"
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  cp -R "$src" "$dest"
+}
+
+tmp_manifest="$(mktemp "${TMPDIR:-/tmp}/adl-run-archive.XXXXXX")"
+tmp_seen="$(mktemp "${TMPDIR:-/tmp}/adl-run-archive-seen.XXXXXX")"
+trap 'rm -f "$tmp_manifest" "$tmp_seen"' EXIT
+
+printf 'source_root\tsource_kind\trun_id\tmilestone\tarchive_path\tstatus\tknown_artifact_count\thas_run_summary\thas_trace\tmtime_epoch\n' >"$tmp_manifest"
+
+seen=0
+copied=0
+skipped=0
+existing=0
+duplicates=0
+roots=0
+
+while IFS= read -r runs_root; do
+  [[ -n "$runs_root" && -d "$runs_root" ]] || continue
+  roots=$((roots + 1))
+  source_kind="$(source_kind_for_root "$runs_root")"
+  while IFS= read -r run_dir; do
+    [[ -d "$run_dir" ]] || continue
+    if ! has_run_artifact "$run_dir"; then
+      continue
+    fi
+
+    seen=$((seen + 1))
+    run_id="$(basename "$run_dir")"
+    milestone="$(infer_milestone "$run_id" "$runs_root")"
+    dest="$archive_root/milestones/$milestone/runs/$run_id"
+    key="$milestone	$run_id"
+
+    status="would-copy"
+    if grep -Fqx "$key" "$tmp_seen"; then
+      duplicates=$((duplicates + 1))
+      status="duplicate-skipped"
+    else
+      printf '%s\n' "$key" >>"$tmp_seen"
+      if [[ "$apply" -ne 1 ]]; then
+        skipped=$((skipped + 1))
+      elif [[ -e "$dest" && "$force" -ne 1 ]]; then
+        existing=$((existing + 1))
+        status="already-archived"
+      elif copy_run "$run_dir" "$dest"; then
+        {
+          printf 'source_root=%s\n' "$(relpath "$runs_root")"
+          printf 'source_run=%s\n' "$(relpath "$run_dir")"
+          printf 'source_kind=%s\n' "$source_kind"
+          printf 'milestone=%s\n' "$milestone"
+        } >"$dest/ARCHIVE_SOURCE.txt"
+        copied=$((copied + 1))
+        status="copied"
+      else
+        existing=$((existing + 1))
+        status="exists"
+      fi
+    fi
+
+    known_artifact_count=0
+    has_summary="no"
+    has_trace="no"
+    [[ -f "$run_dir/run.json" ]] && known_artifact_count=$((known_artifact_count + 1))
+    [[ -f "$run_dir/run_status.json" ]] && known_artifact_count=$((known_artifact_count + 1))
+    [[ -f "$run_dir/steps.json" ]] && known_artifact_count=$((known_artifact_count + 1))
+    if [[ -f "$run_dir/run_summary.json" ]]; then
+      has_summary="yes"
+      known_artifact_count=$((known_artifact_count + 1))
+    fi
+    if [[ -f "$run_dir/logs/trace_v1.json" ]]; then
+      has_trace="yes"
+      known_artifact_count=$((known_artifact_count + 1))
+    fi
+    mtime="$(stat_mtime "$run_dir")"
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$(relpath "$runs_root")" \
+      "$source_kind" \
+      "$run_id" \
+      "$milestone" \
+      "$(relpath "$dest")" \
+      "$status" \
+      "$known_artifact_count" \
+      "$has_summary" \
+      "$has_trace" \
+      "$mtime" >>"$tmp_manifest"
+  done < <(find "$runs_root" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null | sort)
+done < <(discover_roots | awk '!seen[$0]++')
+
+mkdir -p "$archive_root"
+cp "$tmp_manifest" "$archive_root/MANIFEST.tsv"
+unique_candidates="$(wc -l <"$tmp_seen" | tr -d ' ')"
+
+{
+  printf '# ADL Trace Archive\n\n'
+  printf 'Generated by: `adl/tools/archive_run_artifacts.sh`\n\n'
+  printf '%s\n' "- Mode: \`$([[ "$apply" -eq 1 ]] && printf apply || printf dry-run)\`"
+  printf '%s\n' "- Roots inspected: \`$roots\`"
+  printf '%s\n' "- Runs discovered: \`$seen\`"
+  printf '%s\n' "- Unique archive candidates: \`$unique_candidates\`"
+  printf '%s\n' "- Runs copied: \`$copied\`"
+  printf '%s\n' "- Already archived destinations: \`$existing\`"
+  printf '%s\n' "- Unique dry-run entries: \`$skipped\`"
+  printf '%s\n\n' "- Duplicate source entries skipped: \`$duplicates\`"
+  printf '## Unique Archive Counts\n\n'
+  awk -F '\t' 'NR > 1 && $6 != "duplicate-skipped" {count[$4]++} END {for (m in count) print "- `" m "`: `" count[m] "`"}' "$tmp_manifest" | sort
+  printf '\n## Source Entry Counts\n\n'
+  awk -F '\t' 'NR > 1 {count[$4]++} END {for (m in count) print "- `" m "`: `" count[m] "`"}' "$tmp_manifest" | sort
+  printf '\n## Files\n\n'
+  printf '%s\n' '- `MANIFEST.tsv`: run-level source, milestone, archive path, and artifact-presence inventory'
+  printf '%s\n' '- `milestones/<milestone>/runs/<run-id>/`: copied run artifacts when `--apply` is used'
+  printf '\nThis tool copies run artifacts only. It does not delete or prune source directories.\n'
+  printf 'When duplicate `milestone + run-id` entries exist, the first discovered copy is selected and later sources remain recorded as `duplicate-skipped` in `MANIFEST.tsv`.\n'
+} >"$archive_root/README.md"
+
+echo "trace archive root: $(relpath "$archive_root")"
+echo "manifest: $(relpath "$archive_root/MANIFEST.tsv")"
+echo "runs discovered: $seen"
+echo "runs copied: $copied"
+echo "duplicate sources skipped: $duplicates"
+echo "mode: $([[ "$apply" -eq 1 ]] && printf apply || printf dry-run)"

--- a/adl/tools/test_archive_run_artifacts.sh
+++ b/adl/tools/test_archive_run_artifacts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/adl-archive-runs-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/.adl/runs/v0-3-demo/logs"
+printf '{}\n' >"$TMP/.adl/runs/v0-3-demo/run_summary.json"
+printf '{}\n' >"$TMP/.adl/runs/v0-3-demo/logs/trace_v1.json"
+
+mkdir -p "$TMP/.adl/runs/retry-success"
+printf '{}\n' >"$TMP/.adl/runs/retry-success/run.json"
+
+mkdir -p "$TMP/.adl/reports/demo-example/runs/review-godel-demo"
+printf '{}\n' >"$TMP/.adl/reports/demo-example/runs/review-godel-demo/run_status.json"
+
+mkdir -p "$TMP/artifacts/v0871/provider_mock/runtime/runs/v0-87-1-provider-mock-demo/logs"
+printf '{}\n' >"$TMP/artifacts/v0871/provider_mock/runtime/runs/v0-87-1-provider-mock-demo/run_summary.json"
+printf '{}\n' >"$TMP/artifacts/v0871/provider_mock/runtime/runs/v0-87-1-provider-mock-demo/logs/trace_v1.json"
+
+"$ROOT/adl/tools/archive_run_artifacts.sh" --repo-root "$TMP" >/tmp/adl-archive-dry-run.out
+
+[[ -f "$TMP/.adl/trace-archive/MANIFEST.tsv" ]]
+[[ ! -d "$TMP/.adl/trace-archive/milestones/v0.3/runs/v0-3-demo" ]]
+grep -q $'v0-3-demo\tv0.3' "$TMP/.adl/trace-archive/MANIFEST.tsv"
+grep -q $'retry-success\tunclassified' "$TMP/.adl/trace-archive/MANIFEST.tsv"
+grep -q $'v0-87-1-provider-mock-demo\tv0.87.1' "$TMP/.adl/trace-archive/MANIFEST.tsv"
+
+"$ROOT/adl/tools/archive_run_artifacts.sh" --repo-root "$TMP" --apply >/tmp/adl-archive-apply.out
+
+[[ -f "$TMP/.adl/trace-archive/milestones/v0.3/runs/v0-3-demo/run_summary.json" ]]
+[[ -f "$TMP/.adl/trace-archive/milestones/unclassified/runs/retry-success/run.json" ]]
+[[ -f "$TMP/.adl/trace-archive/milestones/unclassified/runs/review-godel-demo/run_status.json" ]]
+[[ -f "$TMP/.adl/trace-archive/milestones/v0.87.1/runs/v0-87-1-provider-mock-demo/run_summary.json" ]]
+[[ -f "$TMP/.adl/trace-archive/milestones/v0.87.1/runs/v0-87-1-provider-mock-demo/ARCHIVE_SOURCE.txt" ]]
+
+echo "PASS archive_run_artifacts"

--- a/docs/records/v0.87.1/tasks/issue-1518/sor.md
+++ b/docs/records/v0.87.1/tasks/issue-1518/sor.md
@@ -1,0 +1,140 @@
+# v0-87-1-tools-inventory-and-consolidate-scattered-run-artifacts
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1518
+Run ID: issue-1518
+Version: v0.87.1
+Title: [v0.87.1][tools] Inventory and consolidate scattered run artifacts
+Branch: codex/1518-v0-87-1-tools-inventory-and-consolidate-scattered-run-artifacts
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: GPT-5.4
+- Provider: ChatGPT
+- Start Time: 2026-04-10T00:47:00Z
+- End Time: 2026-04-10T01:09:42Z
+
+## Summary
+
+Added a safe run-artifact archive helper that inventories local ADL run roots, classifies runs by inferred milestone, records duplicate sources, and copies only the first discovered run for each `milestone + run-id` pair into a canonical local archive. Ran it against the primary checkout with worktrees included; the archive now preserves the unique discovered local runs under `.adl/trace-archive/milestones/` without deleting source data.
+
+## Artifacts produced
+
+- `adl/tools/archive_run_artifacts.sh`
+- `adl/tools/test_archive_run_artifacts.sh`
+- `adl/tools/README.md`
+- `.adl/trace-archive/README.md` in the primary checkout local runtime area
+- `.adl/trace-archive/MANIFEST.tsv` in the primary checkout local runtime area
+- `.adl/trace-archive/milestones/<milestone>/runs/<run-id>/` copied local run artifacts in the primary checkout local runtime area
+
+## Actions taken
+
+- Implemented `archive_run_artifacts.sh` with dry-run/apply modes, `--repo-root`, `--archive-root`, `--include-worktrees`, and idempotent duplicate handling.
+- Added focused regression coverage in `test_archive_run_artifacts.sh`.
+- Documented the new helper in `adl/tools/README.md`.
+- Ran a dry-run against the primary checkout local data with worktrees included.
+- Ran apply against the primary checkout local data with worktrees included.
+- Preserved 282 unique run artifacts under `.adl/trace-archive/milestones/` and recorded 6,503 duplicate source entries as `duplicate-skipped` in the manifest.
+
+## Main Repo Integration (REQUIRED)
+
+- Main-repo paths updated: `adl/tools/archive_run_artifacts.sh`, `adl/tools/test_archive_run_artifacts.sh`, `adl/tools/README.md`
+- Worktree-only paths remaining: none for tracked changes; the local runtime archive under `.adl/trace-archive/` is intentionally untracked local operator data
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: issue worktree changes prepared for PR; local `.adl/trace-archive` generated in the primary checkout because the source data lives there and `.adl` remains untracked
+- Verification performed:
+  - `git status --short` confirmed the tracked worktree change set is limited to the new tool, test, and README update.
+  - `find .adl/trace-archive/milestones -mindepth 3 -maxdepth 3 -type d | wc -l` from the primary checkout confirmed the local archive contains 281 run directories after the first apply pass.
+  - `sed -n '1,100p' .adl/trace-archive/README.md` from the primary checkout confirmed the local archive summary was generated.
+- Result: PASS
+- Result notes: tracked changes are ready for PR; local run data is preserved in the primary checkout archive without deleting original sources.
+
+## Validation
+
+- Validation commands and their purpose:
+  - `bash adl/tools/test_archive_run_artifacts.sh`: verifies dry-run manifest generation, milestone inference, apply-mode copying, and source metadata creation.
+  - `bash -n adl/tools/archive_run_artifacts.sh adl/tools/test_archive_run_artifacts.sh`: verifies shell syntax for the new tool and test.
+  - `bash adl/tools/archive_run_artifacts.sh --repo-root <primary-checkout> --archive-root <primary-checkout>/.adl/trace-archive --include-worktrees`: verifies full dry-run discovery across the primary checkout and worktrees.
+  - `bash adl/tools/archive_run_artifacts.sh --repo-root <primary-checkout> --archive-root <primary-checkout>/.adl/trace-archive --include-worktrees --apply`: copies the unique discovered run artifacts into the canonical local archive.
+- Results: all commands completed successfully.
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash adl/tools/test_archive_run_artifacts.sh"
+      - "bash -n adl/tools/archive_run_artifacts.sh adl/tools/test_archive_run_artifacts.sh"
+      - "archive dry-run against the primary checkout with worktrees included"
+      - "archive apply against the primary checkout with worktrees included"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+
+- Determinism tests executed: `bash adl/tools/test_archive_run_artifacts.sh`
+- Fixtures or scripts used: the test creates a temporary fixture repo with root `.adl/runs`, `.adl/reports/*/runs`, and `artifacts/v0871/.../runtime/runs` inputs.
+- Replay verification (same inputs -> same artifacts/order): the test reruns dry-run and apply paths against deterministic fixture names and checks expected archive paths.
+- Ordering guarantees (sorting / tie-break rules used): run directories are sorted inside each root, and root discovery preserves priority order so repo-local `.adl/runs` wins over duplicate worktree copies.
+- Artifact stability notes: duplicate source entries remain in `MANIFEST.tsv`, but only the first discovered `milestone + run-id` pair is copied.
+
+## Security / Privacy Checks
+
+- Secret leakage scan performed: no secret-bearing content was added; the script copies existing local run artifacts only when explicitly invoked.
+- Prompt / tool argument redaction verified: the manifest records source roots, run ids, milestones, archive paths, status, and artifact-presence flags; it does not inspect or print prompt payloads.
+- Absolute path leakage check: tracked docs and output card use repo-relative paths or `<primary-checkout>` placeholders for local-only archive commands.
+- Sandbox / policy invariants preserved: the tool defaults to dry-run, copies only with `--apply`, and never deletes or prunes source directories.
+
+## Replay Artifacts
+
+- Trace bundle path(s): not applicable; this task preserves run artifacts rather than producing an ADL runtime trace bundle.
+- Run artifact root: `.adl/trace-archive/milestones/`
+- Replay command used for verification: `bash adl/tools/test_archive_run_artifacts.sh`
+- Replay result: PASS
+
+## Artifact Verification
+
+- Primary proof surface: `.adl/trace-archive/README.md`
+- Required artifacts present: yes; `.adl/trace-archive/MANIFEST.tsv` and milestone-organized run copies were generated locally.
+- Artifact schema/version checks: not applicable; this issue adds a TSV manifest/report, not a new runtime schema.
+- Hash/byte-stability checks: not applicable; source artifact bytes are copied without transformation, and full content hashing is deferred to future trace provenance work.
+- Missing/optional artifacts and rationale: v0.87/v0.87.1 provider-demo traces were not found in the current obvious roots; that recovery/capture gap is tracked in #1520.
+
+## Decisions / Deviations
+
+- Chose copy-only archive behavior instead of moving or deleting source run directories so cleanup remains reversible.
+- Chose first-discovered duplicate handling to avoid copying thousands of repeated worktree `.adl/runs` directories.
+- Kept the archive under `.adl/trace-archive` because `.adl` is already the local untracked runtime area and this issue is about local operational data preservation.
+
+## Follow-ups / Deferred work
+
+- #1473 should use this archive as the preservation baseline before cleaning the visible `.adl/runs` surface.
+- #1519 should add first-class trace manifest/provenance for future runs.
+- #1520 should make provider/demo scripts preserve traces into the canonical archive automatically.
+- #1521 should make export/discovery commands archive-aware.


### PR DESCRIPTION
Closes #1518

## Summary
Added a safe run-artifact archive helper that inventories local ADL run roots, classifies runs by inferred milestone, records duplicate sources, and copies only the first discovered run for each `milestone + run-id` pair into a canonical local archive. Ran it against the primary checkout with worktrees included; the archive now preserves the unique discovered local runs under `.adl/trace-archive/milestones/` without deleting source data.

## Artifacts
- `adl/tools/archive_run_artifacts.sh`
- `adl/tools/test_archive_run_artifacts.sh`
- `adl/tools/README.md`
- `.adl/trace-archive/README.md` in the primary checkout local runtime area
- `.adl/trace-archive/MANIFEST.tsv` in the primary checkout local runtime area
- `.adl/trace-archive/milestones/<milestone>/runs/<run-id>/` copied local run artifacts in the primary checkout local runtime area

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_archive_run_artifacts.sh`: verifies dry-run manifest generation, milestone inference, apply-mode copying, and source metadata creation.
  - `bash -n adl/tools/archive_run_artifacts.sh adl/tools/test_archive_run_artifacts.sh`: verifies shell syntax for the new tool and test.
  - `bash adl/tools/archive_run_artifacts.sh --repo-root <primary-checkout> --archive-root <primary-checkout>/.adl/trace-archive --include-worktrees`: verifies full dry-run discovery across the primary checkout and worktrees.
  - `bash adl/tools/archive_run_artifacts.sh --repo-root <primary-checkout> --archive-root <primary-checkout>/.adl/trace-archive --include-worktrees --apply`: copies the unique discovered run artifacts into the canonical local archive.
- Results: all commands completed successfully.

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1518__v0-87-1-tools-inventory-and-consolidate-scattered-run-artifacts/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1518__v0-87-1-tools-inventory-and-consolidate-scattered-run-artifacts/sor.md
- Idempotency-Key: tools-archive-local-run-artifacts-by-milestone-adl-tools-archive-run-artifacts-sh-adl-tools-test-archive-run-artifacts-sh-adl-tools-readme-md-adl-v0-87-1-tasks-issue-1518-v0-87-1-tools-inventory-and-consolidate-scattered-run-artifacts-sip-md-adl-v0-87-1-tasks-issue-1518-v0-87-1-tools-inventory-and-consolidate-scattered-run-artifacts-sor-md