### PR TITLE
[v0.87.1][tools] Prevent local git refresh helpers from checking out main in managed worktree flows

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -290,7 +290,6 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     fetch_origin_main_with_fallback()?;
     ensure_local_branch_exists(&branch)?;
     ensure_worktree_for_branch(&worktree_path, &branch)?;
-    ensure_primary_checkout_on_main(&repo_root)?;
 
     let source_path = ensure_source_issue_prompt(
         &repo_root,
@@ -2053,43 +2052,6 @@ fn ensure_worktree_for_branch(worktree_path: &Path, branch: &str) -> Result<()> 
         "• Reusing existing worktree path: {}",
         worktree_path.display()
     );
-    Ok(())
-}
-
-fn ensure_primary_checkout_on_main(repo_root: &Path) -> Result<()> {
-    let current = run_capture(
-        "git",
-        &[
-            "-C",
-            path_str(repo_root)?,
-            "rev-parse",
-            "--abbrev-ref",
-            "HEAD",
-        ],
-    )?;
-    let current = current.trim().to_string();
-    let dirty = !run_status_allow_failure("git", &["-C", path_str(repo_root)?, "diff", "--quiet"])?
-        || !run_status_allow_failure(
-            "git",
-            &["-C", path_str(repo_root)?, "diff", "--cached", "--quiet"],
-        )?
-        || !run_capture(
-            "git",
-            &["-C", path_str(repo_root)?, "status", "--porcelain"],
-        )
-        .unwrap_or_default()
-        .trim()
-        .is_empty();
-    if current != "main" && dirty {
-        bail!(
-            "start: primary checkout ({}) is on '{}' with local changes. Remediation: commit/stash there, switch to main, then rerun.",
-            repo_root.display(),
-            current
-        );
-    }
-    if current != "main" {
-        run_status("git", &["-C", path_str(repo_root)?, "switch", "main"])?;
-    }
     Ok(())
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -676,64 +676,6 @@ fn ensure_git_metadata_writable_rejects_unwritable_git_dir() {
 }
 
 #[test]
-fn ensure_primary_checkout_on_main_handles_dirty_and_clean_non_main_states() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
-    let repo = unique_temp_dir("adl-pr-primary-main");
-    init_git_repo(&repo);
-    assert!(Command::new("git")
-        .args(["config", "user.name", "Test User"])
-        .current_dir(&repo)
-        .status()
-        .expect("git config")
-        .success());
-    assert!(Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(&repo)
-        .status()
-        .expect("git config")
-        .success());
-    fs::write(repo.join("README.md"), "hello\n").expect("write readme");
-    assert!(Command::new("git")
-        .args(["add", "README.md"])
-        .current_dir(&repo)
-        .status()
-        .expect("git add")
-        .success());
-    assert!(Command::new("git")
-        .args(["commit", "-q", "-m", "init"])
-        .current_dir(&repo)
-        .status()
-        .expect("git commit")
-        .success());
-    assert!(Command::new("git")
-        .args(["branch", "-M", "main"])
-        .current_dir(&repo)
-        .status()
-        .expect("git branch")
-        .success());
-    assert!(Command::new("git")
-        .args(["checkout", "-q", "-b", "codex/1153-test"])
-        .current_dir(&repo)
-        .status()
-        .expect("git checkout")
-        .success());
-
-    fs::write(repo.join("README.md"), "dirty\n").expect("dirty write");
-    let err = ensure_primary_checkout_on_main(&repo).expect_err("dirty non-main should fail");
-    assert!(err.to_string().contains("with local changes"));
-
-    assert!(Command::new("git")
-        .args(["restore", "README.md"])
-        .current_dir(&repo)
-        .status()
-        .expect("git restore")
-        .success());
-    ensure_primary_checkout_on_main(&repo).expect("clean non-main should switch");
-    let branch = current_branch(&repo).expect("branch");
-    assert_eq!(branch, "main");
-}
-
-#[test]
 fn ensure_bootstrap_cards_creates_bundle_and_compat_links() {
     let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let repo = unique_temp_dir("adl-pr-bootstrap-cards");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1812,7 +1812,7 @@ Usage:
 Notes:
 - Deprecated compatibility shim. Prefer `adl/tools/pr.sh run <issue> ...`.
 - Creates or reuses issue worktree at .worktrees/adl-wp-<issue> by default.
-- Keeps the primary checkout on main.
+- Leaves the primary checkout on its current branch.
 - `--version` overrides inferred issue version when the caller already knows the intended milestone band.
 - Refuses to start a later issue when an open PR wave already exists for the same milestone band unless `--allow-open-pr-wave` is passed.
 EOF

--- a/adl/tools/test_pr_cards_primary_root.sh
+++ b/adl/tools/test_pr_cards_primary_root.sh
@@ -13,6 +13,7 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 repo="$tmpdir/repo"
 worktree="$tmpdir/repo-worktree"
+origin="$tmpdir/origin.git"
 mkdir -p "$repo/adl/tools" "$repo/adl/templates/cards"
 cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
 cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
@@ -28,7 +29,11 @@ chmod +x "$repo/adl/tools/pr.sh"
   git add -A
   git commit -q -m "init"
   git branch -m main
-  git worktree add -q -b codex/301-linked-worktree "$worktree" main
+  git init --bare -q "$origin"
+  git remote add origin "$origin"
+  git push -q -u origin main
+  git fetch -q origin main
+  git worktree add -q -b codex/301-linked-worktree "$worktree" origin/main
 )
 
 (
@@ -37,11 +42,11 @@ chmod +x "$repo/adl/tools/pr.sh"
   "$BASH_BIN" adl/tools/pr.sh output 301 --no-fetch-issue --slug linked-worktree >/dev/null
 )
 
-[[ -f "$repo/.adl/v0.3/tasks/issue-0301__linked-worktree/sip.md" ]] || { echo "assertion failed: expected primary checkout canonical input card" >&2; exit 1; }
-[[ -f "$repo/.adl/v0.3/tasks/issue-0301__linked-worktree/sor.md" ]] || { echo "assertion failed: expected primary checkout canonical output card" >&2; exit 1; }
-[[ -L "$repo/.adl/cards/301/input_301.md" ]] || { echo "assertion failed: expected primary checkout input compatibility link" >&2; exit 1; }
-[[ -L "$repo/.adl/cards/301/output_301.md" ]] || { echo "assertion failed: expected primary checkout output compatibility link" >&2; exit 1; }
-[[ ! -e "$worktree/.adl/v0.3/tasks/issue-0301__linked-worktree/sip.md" ]] || { echo "assertion failed: unexpected linked worktree canonical input card" >&2; exit 1; }
-[[ ! -e "$worktree/.adl/v0.3/tasks/issue-0301__linked-worktree/sor.md" ]] || { echo "assertion failed: unexpected linked worktree canonical output card" >&2; exit 1; }
+[[ -f "$worktree/.adl/v0.86/tasks/issue-0301__linked-worktree/sip.md" ]] || { echo "assertion failed: expected linked worktree canonical input card" >&2; exit 1; }
+[[ -f "$worktree/.adl/v0.86/tasks/issue-0301__linked-worktree/sor.md" ]] || { echo "assertion failed: expected linked worktree canonical output card" >&2; exit 1; }
+[[ -L "$worktree/.adl/cards/301/input_301.md" ]] || { echo "assertion failed: expected linked worktree input compatibility link" >&2; exit 1; }
+[[ -L "$worktree/.adl/cards/301/output_301.md" ]] || { echo "assertion failed: expected linked worktree output compatibility link" >&2; exit 1; }
+[[ ! -e "$repo/.adl/v0.86/tasks/issue-0301__linked-worktree/sip.md" ]] || { echo "assertion failed: unexpected primary checkout canonical input card" >&2; exit 1; }
+[[ ! -e "$repo/.adl/v0.86/tasks/issue-0301__linked-worktree/sor.md" ]] || { echo "assertion failed: unexpected primary checkout canonical output card" >&2; exit 1; }
 
-echo "pr.sh linked worktree cards root resolution: ok"
+echo "pr.sh linked worktree cards root isolation: ok"

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -61,10 +61,99 @@ assert_contains() {
   }
 }
 
+seed_issue_prompt() {
+  local issue="$1" slug="$2" path
+  path=".adl/v0.86/bodies/issue-${issue}-${slug}.md"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path" <<EOF
+---
+issue_card_schema: adl.issue.v1
+wp: "test"
+slug: "${slug}"
+title: "[v0.86][tools] ${slug}"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.86"
+issue_number: ${issue}
+status: "active"
+action: "edit"
+depends_on: []
+milestone_sprint: "test"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files:
+  - "adl/tools/pr.sh"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Test fixture prompt for worktree-safe lifecycle coverage."
+pr_start:
+  enabled: false
+  slug: "${slug}"
+---
+
+# [v0.86][tools] ${slug}
+
+## Summary
+
+Exercise the issue worktree lifecycle with an authored prompt surface.
+
+## Goal
+
+Create or reuse the requested issue worktree without switching the primary checkout away from the user's current branch.
+
+## Required Outcome
+
+The lifecycle command should bind the issue worktree from origin/main and leave the primary checkout untouched.
+
+## Deliverables
+
+- issue worktree
+- root and worktree task bundles
+
+## Acceptance Criteria
+
+- The command prints the expected worktree and branch.
+- The primary checkout remains on its original branch.
+
+## Repo Inputs
+
+- local test fixture
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- No demo is required for this tooling fixture.
+
+## Non-goals
+
+- real GitHub issue mutation
+
+## Issue-Graph Notes
+
+- This is a local test-only issue prompt.
+
+## Notes
+
+- Keep this fixture concrete so lifecycle validation does not reject it as a stub.
+
+## Tooling Notes
+
+- Use origin/main as the branch base for worktree creation.
+EOF
+}
+
 (
   cd "$repo"
   export ADL_PR_RUST_BIN="$REAL_ADL_BIN"
 
+  seed_issue_prompt 999 test-smoke
   out1="$("$BASH_BIN" adl/tools/pr.sh start 999 --slug test-smoke --no-fetch-issue)"
   assert_contains "WORKTREE" "$out1" "start prints worktree"
   assert_contains "BRANCH codex/999-test-smoke" "$out1" "start prints branch"
@@ -144,6 +233,7 @@ assert_contains() {
 
   custom_root="$tmpdir/custom-managed"
   mkdir -p "$custom_root"
+  seed_issue_prompt 995 root-override
   out4="$(ADL_WORKTREE_ROOT="$custom_root" "$BASH_BIN" adl/tools/pr.sh start 995 --slug root-override --no-fetch-issue)"
   assert_contains "WORKTREE $custom_root/adl-wp-995" "$out4" "custom managed root"
   [[ -d "$custom_root/adl-wp-995" ]] || {
@@ -162,6 +252,7 @@ fi
 exec "$(command -v git)" "\$@"
 EOF
   chmod +x "$fakebin/git"
+  seed_issue_prompt 994 fetch-fallback
   out_fetch_fallback="$(PATH="$fakebin:$PATH" "$BASH_BIN" adl/tools/pr.sh start 994 --slug fetch-fallback --no-fetch-issue)"
   fetch_wt="$repo/.worktrees/adl-wp-994"
   fetch_wt="$(cd "$fetch_wt" && pwd -P)"
@@ -178,6 +269,7 @@ EOF
 exit 1
 EOF
   chmod +x "$fakecargo/cargo"
+  seed_issue_prompt 989 rust-delegate-fallback
   out_rust_fallback="$(PATH="$fakecargo:$PATH" "$BASH_BIN" adl/tools/pr.sh start 989 --slug rust-delegate-fallback --no-fetch-issue)"
   rust_fallback_wt="$(cd "$repo/.worktrees/adl-wp-989" && pwd -P)"
   assert_contains "WORKTREE $rust_fallback_wt" "$out_rust_fallback" "rust fallback still creates worktree"
@@ -202,21 +294,24 @@ EOF
   git branch codex/997-guardrail origin/main
   git switch -q -c codex/996-dirty origin/main
   echo "keep-me" > untracked.txt
-  set +e
-  bad2="$("$BASH_BIN" adl/tools/pr.sh start 997 --slug guardrail --no-fetch-issue 2>&1)"
-  status=$?
-  set -e
-  [[ "$status" -ne 0 ]] || {
-    echo "assertion failed: expected dirty primary checkout guard to fail" >&2
+  seed_issue_prompt 997 guardrail
+  out_dirty="$("$BASH_BIN" adl/tools/pr.sh start 997 --slug guardrail --no-fetch-issue)"
+  dirty_wt="$(cd "$repo/.worktrees/adl-wp-997" && pwd -P)"
+  assert_contains "WORKTREE $dirty_wt" "$out_dirty" "dirty primary checkout still starts issue worktree"
+  [[ "$(git rev-parse --abbrev-ref HEAD)" == "codex/996-dirty" ]] || {
+    echo "assertion failed: primary checkout should stay on the user's dirty branch" >&2
     exit 1
   }
-  assert_contains "with local changes" "$bad2" "dirty guard message"
-  assert_contains "commit/stash there, switch to main, then rerun" "$bad2" "dirty guard remediation"
+  [[ -f untracked.txt ]] || {
+    echo "assertion failed: dirty primary checkout file should remain untouched" >&2
+    exit 1
+  }
 
   git switch -q main
   rm -f untracked.txt
   mkdir -p "$repo/.adl/locks/pr-bootstrap.lock"
   echo "999999" > "$repo/.adl/locks/pr-bootstrap.lock/pid"
+  seed_issue_prompt 993 stale-lock-recovery
   stale_lock_out="$("$BASH_BIN" adl/tools/pr.sh start 993 --slug stale-lock-recovery --no-fetch-issue)"
   stale_wt="$(cd "$repo/.worktrees/adl-wp-993" && pwd -P)"
   assert_contains "WORKTREE $stale_wt" "$stale_lock_out" "stale lock recovery still starts"
@@ -267,6 +362,7 @@ EOF
   assert_contains "unresolved open PR wave detected for v0.86" "$blocked_start" "start guard message"
   assert_contains "#1169 [draft]" "$blocked_start" "start guard lists open pr"
 
+  seed_issue_prompt 990 blocked-wave
   allowed_start="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh start 990 --slug blocked-wave --version v0.86 --no-fetch-issue --allow-open-pr-wave)"
   assert_contains "STATE  FULLY_STARTED" "$allowed_start" "override bypasses start guard"
 

--- a/docs/records/v0.87.1/tasks/issue-1528/sor.md
+++ b/docs/records/v0.87.1/tasks/issue-1528/sor.md
@@ -1,0 +1,163 @@
+# v0-87-1-tools-prevent-local-git-refresh-helpers-from-checking-out-main-in-managed-worktree-flows
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1528
+Run ID: issue-1528
+Version: v0.87.1
+Title: [v0.87.1][tools] Prevent local git refresh helpers from checking out main in managed worktree flows
+Branch: codex/1528-v0-87-1-tools-prevent-local-git-refresh-helpers-from-checking-out-main-in-managed-worktree-flows
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: GPT-5.4
+- Provider: ChatGPT
+- Start Time: 2026-04-09T18:24:00-07:00
+- End Time: 2026-04-09T18:40:00-07:00
+
+## Summary
+
+Fixed the tracked PR execution path that switched the primary checkout to `main` after creating an issue worktree. The run/start flow now creates branches from `origin/main`, creates or reuses the issue worktree, and leaves the user's primary checkout on its current branch.
+
+## Artifacts produced
+- Updated PR lifecycle implementation in `adl/src/cli/pr_cmd.rs`.
+- Updated shell compatibility help in `adl/tools/pr.sh`.
+- Updated focused tests in `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`, `adl/tools/test_pr_cards_primary_root.sh`, and `adl/tools/test_pr_start_worktree_safe.sh`.
+
+## Actions taken
+- Removed the Rust `ensure_primary_checkout_on_main` call and helper so `pr run/start` no longer switches the primary checkout to `main`.
+- Updated linked-worktree card test setup to create the fixture branch from `origin/main`, not local `main`.
+- Aligned the linked-worktree card test with current worktree-local `.adl` artifact isolation.
+- Updated the worktree safety script to seed authored issue prompts and assert that dirty/non-main primary checkout state remains untouched.
+- Updated start command help text to state that the primary checkout remains on its current branch.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`, `adl/tools/pr.sh`, `adl/tools/test_pr_cards_primary_root.sh`, `adl/tools/test_pr_start_worktree_safe.sh`
+- Worktree-only paths remaining: none for tracked changes; local ignored `.adl` task cards remain untracked workflow state by design.
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: issue worktree branch prepared for PR
+- Verification performed:
+  - `git status --short --branch`
+  - focused validation commands listed below
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo fmt --manifest-path adl/Cargo.toml --check`: verified Rust formatting remained stable.
+  - `bash -n adl/tools/pr.sh adl/tools/test_pr_start_worktree_safe.sh adl/tools/test_pr_cards_primary_root.sh`: verified edited shell scripts parse.
+  - `bash adl/tools/test_pr_cards_primary_root.sh`: verified linked-worktree card artifacts are isolated in the worktree and the fixture uses `origin/main`.
+  - `bash adl/tools/test_pr_start_worktree_safe.sh`: verified issue worktree creation/reuse leaves the primary checkout on its current branch, including a dirty non-main branch.
+  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`: verified PR lifecycle Rust coverage after removing the primary-checkout switch.
+- Results: all listed validation commands passed.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo fmt --manifest-path adl/Cargo.toml --check"
+      - "bash -n adl/tools/pr.sh adl/tools/test_pr_start_worktree_safe.sh adl/tools/test_pr_cards_primary_root.sh"
+      - "bash adl/tools/test_pr_cards_primary_root.sh"
+      - "bash adl/tools/test_pr_start_worktree_safe.sh"
+      - "cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: focused shell lifecycle tests and Rust `pr_cmd` tests.
+- Fixtures or scripts used: temporary git repositories created by the shell tests and Rust tests.
+- Replay verification (same inputs -> same artifacts/order): the shell tests recreate clean temporary repositories and verify stable worktree, branch, and artifact paths.
+- Ordering guarantees (sorting / tie-break rules used): not changed by this issue.
+- Artifact stability notes: generated task bundle paths remain derived from issue number, version, and slug.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: no secrets were added; changed files are code/tests/help text only.
+- Prompt / tool argument redaction verified: no prompt or tool argument logging behavior was added.
+- Absolute path leakage check: output record uses repository-relative paths except this local execution card path, which remains ignored workflow state.
+- Sandbox / policy invariants preserved: all tracked edits were made in the #1528 issue worktree, not on `main`.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): none; no runtime trace was required.
+- Run artifact root: not applicable for this tooling fix.
+- Replay command used for verification: `bash adl/tools/test_pr_start_worktree_safe.sh` and `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`.
+- Replay result: passed.
+
+## Artifact Verification
+- Primary proof surface: PR diff plus focused validation commands.
+- Required artifacts present: yes, all tracked changed files are present in the issue branch.
+- Artifact schema/version checks: no schema changes.
+- Hash/byte-stability checks: not applicable; no binary or generated release artifact was produced.
+- Missing/optional artifacts and rationale: no demo trace is required for this workflow safety fix.
+
+## Decisions / Deviations
+
+- The local ignored `adl/.local/fix-git.sh` was hardened separately in the primary checkout because it is not tracked and therefore cannot be carried by this PR.
+- The actual tracked root cause was broader than the local helper: `pr run/start` itself switched the primary checkout to `main`; that behavior was removed.
+
+## Follow-ups / Deferred work
+
+- No follow-up is required for the tracked root-cause fix.
+- If the team wants `adl/.local/fix-git.sh` to be durable for everyone, promote it into tracked tooling in a separate issue instead of keeping it under ignored `.local`.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.


### PR DESCRIPTION
Closes #1528

## Summary
Fixed the tracked PR execution path that switched the primary checkout to `main` after creating an issue worktree. The run/start flow now creates branches from `origin/main`, creates or reuses the issue worktree, and leaves the user's primary checkout on its current branch.

## Artifacts
- Updated PR lifecycle implementation in `adl/src/cli/pr_cmd.rs`.
- Updated shell compatibility help in `adl/tools/pr.sh`.
- Updated focused tests in `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`, `adl/tools/test_pr_cards_primary_root.sh`, and `adl/tools/test_pr_start_worktree_safe.sh`.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`: verified Rust formatting remained stable.
  - `bash -n adl/tools/pr.sh adl/tools/test_pr_start_worktree_safe.sh adl/tools/test_pr_cards_primary_root.sh`: verified edited shell scripts parse.
  - `bash adl/tools/test_pr_cards_primary_root.sh`: verified linked-worktree card artifacts are isolated in the worktree and the fixture uses `origin/main`.
  - `bash adl/tools/test_pr_start_worktree_safe.sh`: verified issue worktree creation/reuse leaves the primary checkout on its current branch, including a dirty non-main branch.
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd -- --nocapture`: verified PR lifecycle Rust coverage after removing the primary-checkout switch.
- Results: all listed validation commands passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1528__v0-87-1-tools-prevent-local-git-refresh-helpers-from-checking-out-main-in-managed-worktree-flows/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1528__v0-87-1-tools-prevent-local-git-refresh-helpers-from-checking-out-main-in-managed-worktree-flows/sor.md
- Idempotency-Key: v0-87-1-tools-prevent-local-git-refresh-helpers-from-checking-out-main-in-managed-worktree-flows-adl-v0-87-1-tasks-issue-1528-v0-87-1-tools-prevent-local-git-refresh-helpers-from-checking-out-main-in-managed-worktree-flows-sip-md-adl-v0-87-1-tasks-issue-1528-v0-87-1-tools-prevent-local-git-refresh-helpers-from-checking-out-main-in-managed-worktree-flows-sor-md