### PR TITLE
[v0.88][runtime] Replace live-demo Python adapter with Rust-native provider adapters

### DIFF
--- a/adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml
+++ b/adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml
@@ -1,0 +1,152 @@
+version: "0.5"
+
+providers:
+  live_openai:
+    type: "openai"
+    config:
+      provider_model_id: "gpt-4o-mini"
+      max_output_tokens: 220
+      timeout_secs: 90
+  live_anthropic:
+    type: "anthropic"
+    config:
+      provider_model_id: "claude-3-5-haiku-latest"
+      max_tokens: 220
+      timeout_secs: 90
+
+agents:
+  chatgpt_host:
+    provider: "live_openai"
+    model: "gpt-4o-mini"
+  claude_guest:
+    provider: "live_anthropic"
+    model: "claude-3-5-haiku-latest"
+
+tasks:
+  chatgpt_opening:
+    prompt:
+      user: |
+        You are ChatGPT in a short ADL live-provider demo.
+
+        Write exactly one concise Markdown section with this heading:
+        # Turn 1 - ChatGPT
+
+        Discuss runtime-backed multi-agent collaboration over tea.
+        Mention that this is a bounded five-turn reviewer demo.
+  claude_reply:
+    prompt:
+      user: |
+        You are Claude in a short ADL live-provider demo.
+
+        Previous turn:
+        {{turn_01}}
+
+        Write exactly one concise Markdown section with this heading:
+        # Turn 2 - Claude
+
+        Reply warmly, acknowledge ChatGPT's turn, and mention explicit saved state.
+  chatgpt_reflection:
+    prompt:
+      user: |
+        You are ChatGPT in a short ADL live-provider demo.
+
+        Previous turn:
+        {{turn_02}}
+
+        Write exactly one concise Markdown section with this heading:
+        # Turn 3 - ChatGPT
+
+        Reflect on trace and review artifacts without claiming a general conversation runtime.
+  claude_refinement:
+    prompt:
+      user: |
+        You are Claude in a short ADL live-provider demo.
+
+        Previous turn:
+        {{turn_03}}
+
+        Write exactly one concise Markdown section with this heading:
+        # Turn 4 - Claude
+
+        Tighten the claim and emphasize that this proof is turn-based and bounded.
+  chatgpt_toast:
+    prompt:
+      user: |
+        You are ChatGPT in a short ADL live-provider demo.
+
+        Previous turn:
+        {{turn_04}}
+
+        Write exactly one concise Markdown section with this heading:
+        # Turn 5 - ChatGPT
+
+        Close with a short tea toast and include this exact phrase:
+        two named live providers, five explicit turns
+
+run:
+  name: "v0-88-real-multi-agent-tea-discussion"
+  workflow:
+    kind: sequential
+    steps:
+      - id: "discussion.chatgpt.opening"
+        agent: "chatgpt_host"
+        task: "chatgpt_opening"
+        conversation:
+          id: "turn_01"
+          speaker: "ChatGPT"
+          sequence: 1
+          thread_id: "live_tea_discussion"
+        save_as: "turn_01"
+        write_to: "discussion/01-chatgpt-opening.md"
+      - id: "discussion.claude.reply"
+        agent: "claude_guest"
+        task: "claude_reply"
+        conversation:
+          id: "turn_02"
+          speaker: "Claude"
+          sequence: 2
+          thread_id: "live_tea_discussion"
+          responds_to: "turn_01"
+        inputs:
+          turn_01: "@state:turn_01"
+        save_as: "turn_02"
+        write_to: "discussion/02-claude-reply.md"
+      - id: "discussion.chatgpt.reflection"
+        agent: "chatgpt_host"
+        task: "chatgpt_reflection"
+        conversation:
+          id: "turn_03"
+          speaker: "ChatGPT"
+          sequence: 3
+          thread_id: "live_tea_discussion"
+          responds_to: "turn_02"
+        inputs:
+          turn_02: "@state:turn_02"
+        save_as: "turn_03"
+        write_to: "discussion/03-chatgpt-reflection.md"
+      - id: "discussion.claude.refinement"
+        agent: "claude_guest"
+        task: "claude_refinement"
+        conversation:
+          id: "turn_04"
+          speaker: "Claude"
+          sequence: 4
+          thread_id: "live_tea_discussion"
+          responds_to: "turn_03"
+        inputs:
+          turn_03: "@state:turn_03"
+        save_as: "turn_04"
+        write_to: "discussion/04-claude-refinement.md"
+      - id: "discussion.chatgpt.toast"
+        agent: "chatgpt_host"
+        task: "chatgpt_toast"
+        conversation:
+          id: "turn_05"
+          speaker: "ChatGPT"
+          sequence: 5
+          thread_id: "live_tea_discussion"
+          responds_to: "turn_04"
+        inputs:
+          turn_04: "@state:turn_04"
+        save_as: "turn_05"
+        write_to: "discussion/05-chatgpt-toast.md"

--- a/adl/src/adl/validation.rs
+++ b/adl/src/adl/validation.rs
@@ -302,7 +302,7 @@ pub(super) fn validate_provider(provider_id: &str, provider: &ProviderSpec) -> R
     }
 
     match provider.kind.as_str() {
-        "ollama" | "local_ollama" | "mock" => Ok(()),
+        "ollama" | "local_ollama" | "mock" | "openai" | "anthropic" => Ok(()),
         "http" | "http_remote" => {
             let endpoint = provider
                 .base_url
@@ -323,7 +323,7 @@ pub(super) fn validate_provider(provider_id: &str, provider: &ProviderSpec) -> R
             Ok(())
         }
         other => Err(anyhow!(
-            "providers.{provider_id} has unsupported kind '{other}' (supported: ollama, local_ollama, mock, http, http_remote)"
+            "providers.{provider_id} has unsupported kind '{other}' (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic)"
         )),
     }
 }

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -87,13 +87,14 @@ fn real_provider_setup(repo_root: &Path, args: &[String]) -> Result<()> {
 
 struct ProviderSetupTemplate {
     family: &'static str,
-    profile: &'static str,
+    profile: Option<&'static str>,
+    kind: Option<&'static str>,
     env_var: &'static str,
     provider_id: &'static str,
     agent_id: &'static str,
     model_ref: &'static str,
     provider_model_id: &'static str,
-    endpoint_hint: &'static str,
+    endpoint_hint: Option<&'static str>,
     notes: &'static str,
 }
 
@@ -102,79 +103,86 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
     let template = match normalized.as_str() {
         "chatgpt" => &ProviderSetupTemplate {
             family: "chatgpt",
-            profile: "chatgpt:gpt-5.4",
+            profile: Some("chatgpt:gpt-5.4"),
+            kind: None,
             env_var: "OPENAI_API_KEY",
             provider_id: "chatgpt_primary",
             agent_id: "chatgpt_agent",
             model_ref: "gpt-5.4",
             provider_model_id: "gpt-5.4",
-            endpoint_hint: "https://api.example.invalid/v1/complete",
+            endpoint_hint: Some("https://api.example.invalid/v1/complete"),
             notes: "Use this when you want the ChatGPT/GPT-5 family surface. Keep the endpoint pointed at an ADL-compatible completion endpoint and supply your own OpenAI key through the generated env file.",
         },
         "claude" => &ProviderSetupTemplate {
             family: "claude",
-            profile: "claude:claude-3-7-sonnet",
+            profile: Some("claude:claude-3-7-sonnet"),
+            kind: None,
             env_var: "ANTHROPIC_API_KEY",
             provider_id: "claude_primary",
             agent_id: "claude_agent",
             model_ref: "claude-3-7-sonnet",
             provider_model_id: "claude-3-7-sonnet-latest",
-            endpoint_hint: "https://api.example.invalid/v1/complete",
+            endpoint_hint: Some("https://api.example.invalid/v1/complete"),
             notes: "Use this when you want the first-class Claude family surface. Keep the endpoint pointed at an ADL-compatible completion endpoint and supply your Anthropic credential through the generated env file.",
         },
         "openai" => &ProviderSetupTemplate {
             family: "openai",
-            profile: "http:gpt-4.1-mini",
+            profile: None,
+            kind: Some("openai"),
             env_var: "OPENAI_API_KEY",
             provider_id: "openai_primary",
             agent_id: "openai_agent",
             model_ref: "reasoning/default",
             provider_model_id: "gpt-4.1-mini",
-            endpoint_hint: "https://api.example.invalid/v1/complete",
-            notes: "Use this for the generic HTTP/OpenAI-style profile family. The endpoint must still satisfy ADL's bounded prompt/output HTTP contract.",
+            endpoint_hint: None,
+            notes: "Use this for the Rust-native OpenAI provider path. The default endpoint is OpenAI's Responses API; override config.endpoint only for tests or a trusted compatible endpoint.",
         },
         "anthropic" => &ProviderSetupTemplate {
             family: "anthropic",
-            profile: "http:claude-3-7-sonnet",
+            profile: None,
+            kind: Some("anthropic"),
             env_var: "ANTHROPIC_API_KEY",
             provider_id: "anthropic_primary",
             agent_id: "anthropic_agent",
             model_ref: "reasoning/default",
-            provider_model_id: "claude-3-7-sonnet-latest",
-            endpoint_hint: "https://api.example.invalid/v1/complete",
-            notes: "Use this with an ADL-compatible HTTP endpoint that fronts Anthropic-compatible models. The generated auth env name is only a credential hook; ADL does not assume a vendor-native transport.",
+            provider_model_id: "claude-3-5-haiku-latest",
+            endpoint_hint: None,
+            notes: "Use this for the Rust-native Anthropic provider path. The default endpoint is Anthropic's Messages API; override config.endpoint only for tests or a trusted compatible endpoint.",
         },
         "gemini" => &ProviderSetupTemplate {
             family: "gemini",
-            profile: "http:gemini-2.0-flash",
+            profile: Some("http:gemini-2.0-flash"),
+            kind: None,
             env_var: "GEMINI_API_KEY",
             provider_id: "gemini_primary",
             agent_id: "gemini_agent",
             model_ref: "reasoning/default",
             provider_model_id: "gemini-2.0-flash",
-            endpoint_hint: "https://api.example.invalid/v1/complete",
+            endpoint_hint: Some("https://api.example.invalid/v1/complete"),
             notes: "Use this with an ADL-compatible HTTP endpoint that fronts Gemini-compatible models. The generated env file is local-only and should not be committed.",
         },
         "deepseek" => &ProviderSetupTemplate {
             family: "deepseek",
-            profile: "http:deepseek-chat",
+            profile: Some("http:deepseek-chat"),
+            kind: None,
             env_var: "DEEPSEEK_API_KEY",
             provider_id: "deepseek_primary",
             agent_id: "deepseek_agent",
             model_ref: "reasoning/default",
             provider_model_id: "deepseek-chat",
-            endpoint_hint: "https://api.example.invalid/v1/complete",
+            endpoint_hint: Some("https://api.example.invalid/v1/complete"),
             notes: "Use this with an ADL-compatible HTTP endpoint that fronts DeepSeek-compatible models.",
         },
         "http" | "generic-http" => &ProviderSetupTemplate {
             family: "http",
-            profile: "http:gpt-4.1-mini",
+            profile: Some("http:gpt-4.1-mini"),
+            kind: None,
             env_var: "ADL_REMOTE_BEARER_TOKEN",
             provider_id: "portable_http",
             agent_id: "http_agent",
             model_ref: "reasoning/default",
             provider_model_id: "gpt-4.1-mini",
-            endpoint_hint: "https://api.example.invalid/v1/complete",
+            endpoint_hint: Some("https://api.example.invalid/v1/complete"),
             notes: "Use this as a provider-agnostic bounded HTTP setup. Replace the endpoint and token env var with the ones your remote gateway expects.",
         },
         other => {
@@ -187,11 +195,20 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
 }
 
 fn render_provider_yaml(template: &ProviderSetupTemplate) -> String {
+    let provider_identity = match (template.profile, template.kind) {
+        (Some(profile), None) => format!("profile: \"{profile}\""),
+        (None, Some(kind)) => format!("type: \"{kind}\""),
+        _ => unreachable!("provider setup templates must declare exactly one identity surface"),
+    };
+    let endpoint_line = template
+        .endpoint_hint
+        .map(|endpoint| format!("      endpoint: \"{endpoint}\"\n"))
+        .unwrap_or_default();
     format!(
-        "version: \"0.5\"\n\nproviders:\n  {provider_id}:\n    profile: \"{profile}\"\n    config:\n      endpoint: \"{endpoint_hint}\"\n      auth:\n        type: bearer\n        env: {env_var}\n      headers:\n        X-Client: \"adl-provider-setup\"\n      timeout_secs: 15\n      model_ref: \"{model_ref}\"\n      provider_model_id: \"{provider_model_id}\"\n\nagents:\n  {agent_id}:\n    provider: \"{provider_id}\"\n    model: \"{model_ref}\"\n\n# Merge this provider/agent snippet into your workflow file.\n",
+        "version: \"0.5\"\n\nproviders:\n  {provider_id}:\n    {provider_identity}\n    config:\n{endpoint_line}      auth:\n        type: bearer\n        env: {env_var}\n      headers:\n        X-Client: \"adl-provider-setup\"\n      timeout_secs: 15\n      model_ref: \"{model_ref}\"\n      provider_model_id: \"{provider_model_id}\"\n\nagents:\n  {agent_id}:\n    provider: \"{provider_id}\"\n    model: \"{model_ref}\"\n\n# Merge this provider/agent snippet into your workflow file.\n",
         provider_id = template.provider_id,
-        profile = template.profile,
-        endpoint_hint = template.endpoint_hint,
+        provider_identity = provider_identity,
+        endpoint_line = endpoint_line,
         env_var = template.env_var,
         model_ref = template.model_ref,
         provider_model_id = template.provider_model_id,
@@ -207,10 +224,22 @@ fn render_env_example(template: &ProviderSetupTemplate) -> String {
 }
 
 fn render_readme(template: &ProviderSetupTemplate) -> String {
+    let transport_note = if template.kind.is_some() {
+        "- This family uses ADL's Rust-native provider adapter for its vendor API.\n- Leave `config.endpoint` unset for the default vendor endpoint unless you are testing against a trusted compatible endpoint."
+    } else {
+        "- ADL's bounded HTTP provider expects a completion-style HTTP contract: request body with `{\"prompt\": ...}`, response body with `{\"output\": ...}`.\n- Raw vendor-native endpoints may require a compatibility gateway or adapter if they do not expose that contract directly."
+    };
+    let endpoint_step = if template.kind.is_some() {
+        "2. Leave `config.endpoint` unset unless you are testing against a trusted compatible endpoint."
+    } else {
+        "2. Set `config.endpoint` in `provider.adl.yaml` to a real ADL-compatible completion endpoint."
+    };
     format!(
-        "# Provider setup: {family}\n\nThis bundle gives you a local starting point for configuring the `{family}` provider family.\n\nFiles:\n- `provider.adl.yaml`: mergeable ADL provider/agent snippet\n- `.env.example`: local env template for your credential\n\nSteps:\n1. Copy `.env.example` to a local untracked env file and put your real credential in `{env_var}`.\n2. Set `config.endpoint` in `provider.adl.yaml` to a real ADL-compatible completion endpoint.\n3. Merge the provider/agent snippet into your workflow file.\n4. Source your local env file before running ADL.\n\nImportant:\n- ADL's bounded HTTP provider expects a completion-style HTTP contract: request body with `{{\"prompt\": ...}}`, response body with `{{\"output\": ...}}`.\n- Raw vendor-native endpoints may require a compatibility gateway or adapter if they do not expose that contract directly.\n- No secrets are stored by this command; the generated env file is only a local template.\n\nNotes:\n{notes}\n",
+        "# Provider setup: {family}\n\nThis bundle gives you a local starting point for configuring the `{family}` provider family.\n\nFiles:\n- `provider.adl.yaml`: mergeable ADL provider/agent snippet\n- `.env.example`: local env template for your credential\n\nSteps:\n1. Copy `.env.example` to a local untracked env file and put your real credential in `{env_var}`.\n{endpoint_step}\n3. Merge the provider/agent snippet into your workflow file.\n4. Source your local env file before running ADL.\n\nImportant:\n{transport_note}\n- No secrets are stored by this command; the generated env file is only a local template.\n\nNotes:\n{notes}\n",
         family = template.family,
         env_var = template.env_var,
+        endpoint_step = endpoint_step,
+        transport_note = transport_note,
         notes = template.notes
     )
 }
@@ -422,32 +451,47 @@ mod tests {
     #[test]
     fn provider_setup_supports_all_declared_families() {
         let families = [
-            ("chatgpt", "chatgpt:gpt-5.4", "OPENAI_API_KEY"),
-            ("claude", "claude:claude-3-7-sonnet", "ANTHROPIC_API_KEY"),
-            ("openai", "http:gpt-4.1-mini", "OPENAI_API_KEY"),
-            ("anthropic", "http:claude-3-7-sonnet", "ANTHROPIC_API_KEY"),
-            ("gemini", "http:gemini-2.0-flash", "GEMINI_API_KEY"),
-            ("deepseek", "http:deepseek-chat", "DEEPSEEK_API_KEY"),
+            ("chatgpt", "profile: \"chatgpt:gpt-5.4\"", "OPENAI_API_KEY"),
+            (
+                "claude",
+                "profile: \"claude:claude-3-7-sonnet\"",
+                "ANTHROPIC_API_KEY",
+            ),
+            ("openai", "type: \"openai\"", "OPENAI_API_KEY"),
+            ("anthropic", "type: \"anthropic\"", "ANTHROPIC_API_KEY"),
+            (
+                "gemini",
+                "profile: \"http:gemini-2.0-flash\"",
+                "GEMINI_API_KEY",
+            ),
+            (
+                "deepseek",
+                "profile: \"http:deepseek-chat\"",
+                "DEEPSEEK_API_KEY",
+            ),
             (
                 "generic-http",
-                "http:gpt-4.1-mini",
+                "profile: \"http:gpt-4.1-mini\"",
                 "ADL_REMOTE_BEARER_TOKEN",
             ),
         ];
 
-        for (family, profile, env_var) in families {
+        for (family, provider_identity, env_var) in families {
             let template = template_for_family(family).expect("family should resolve");
-            assert_eq!(template.profile, profile);
             assert_eq!(template.env_var, env_var);
 
             let provider_yaml = render_provider_yaml(template);
             let env_example = render_env_example(template);
             let readme = render_readme(template);
 
-            assert!(provider_yaml.contains(profile));
+            assert!(provider_yaml.contains(provider_identity));
             assert!(env_example.contains(env_var));
             assert!(readme.contains(template.family));
-            assert!(readme.contains("completion-style HTTP contract"));
+            if template.kind.is_some() {
+                assert!(readme.contains("Rust-native provider adapter"));
+            } else {
+                assert!(readme.contains("completion-style HTTP contract"));
+            }
         }
     }
 

--- a/adl/src/provider.rs
+++ b/adl/src/provider.rs
@@ -4,12 +4,13 @@ use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::error::Error as StdError;
 use std::fmt;
+use std::fs;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::adl;
 use crate::provider_substrate::{self, ProviderInvocationTargetV1};
@@ -48,8 +49,8 @@ impl ProviderError {
             kind: ProviderErrorKind::UnknownKind,
             provider: None,
             message: format!(
-                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote). \
-Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote. The remote 'http' surface is HTTPS-only."
+                "provider kind '{kind}' is not supported (supported: ollama, local_ollama, mock, http, http_remote, openai, anthropic). \
+Set providers.<id>.type to one of: ollama, local_ollama, mock, http, http_remote, openai, anthropic. The remote provider surfaces are HTTPS-only."
             ),
         }
     }
@@ -227,6 +228,10 @@ pub(crate) fn is_allowed_remote_endpoint(endpoint: &str) -> bool {
         || normalized.starts_with("http://127.0.0.1")
         || normalized.starts_with("http://[::1]")
 }
+
+const OPENAI_RESPONSES_ENDPOINT: &str = "https://api.openai.com/v1/responses";
+const ANTHROPIC_MESSAGES_ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
 
 fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProfilePreset> {
     let mut m = BTreeMap::new();
@@ -408,7 +413,7 @@ pub fn build_provider_for_id(
     model_override: Option<&str>,
 ) -> Result<Box<dyn Provider>> {
     match spec.kind.trim() {
-        "http" | "http_remote" | "ollama" | "local_ollama" | "mock" => {}
+        "http" | "http_remote" | "ollama" | "local_ollama" | "mock" | "openai" | "anthropic" => {}
         other => return Err(unknown_kind(other)),
     }
 
@@ -416,9 +421,12 @@ pub fn build_provider_for_id(
         provider_substrate::provider_invocation_target_v1(provider_id, spec, model_override)
             .with_context(|| format!("normalize provider substrate for '{provider_id}'"))?;
     match target.transport {
-        provider_substrate::ProviderTransportV1::Http => {
-            Ok(Box::new(HttpProvider::from_target(spec, &target)?))
-        }
+        provider_substrate::ProviderTransportV1::Http => match target.provider_kind.as_str() {
+            "http" | "http_remote" => Ok(Box::new(HttpProvider::from_target(spec, &target)?)),
+            "openai" => Ok(Box::new(OpenAiProvider::from_target(spec, &target)?)),
+            "anthropic" => Ok(Box::new(AnthropicProvider::from_target(spec, &target)?)),
+            other => Err(unknown_kind(other)),
+        },
         provider_substrate::ProviderTransportV1::LocalCli
         | provider_substrate::ProviderTransportV1::InProcess => match target.provider_kind.as_str()
         {
@@ -426,6 +434,360 @@ pub fn build_provider_for_id(
             "mock" => Ok(Box::new(MockProvider::from_target(&target))),
             other => Err(unknown_kind(other)),
         },
+    }
+}
+
+fn cfg_str<'a>(cfg: &'a HashMap<String, Value>, key: &str) -> Option<&'a str> {
+    cfg.get(key).and_then(|v| v.as_str()).map(str::trim)
+}
+
+fn auth_env_for(spec: &adl::ProviderSpec, default_env: &str) -> Result<String> {
+    let Some(auth_val) = spec.config.get("auth") else {
+        return Ok(default_env.to_string());
+    };
+    let obj = auth_val
+        .as_object()
+        .ok_or_else(|| invalid_config("native", "config.auth must be an object"))?;
+    let auth_type = obj
+        .get("type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| invalid_config("native", "config.auth.type is required"))?;
+    if auth_type != "bearer" {
+        return Err(invalid_config(
+            "native",
+            format!("config.auth.type must be 'bearer' (got '{auth_type}')"),
+        ));
+    }
+    let env_key = obj
+        .get("env")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| invalid_config("native", "config.auth.env is required"))?;
+    let trimmed = env_key.trim();
+    if trimmed.is_empty() {
+        return Err(invalid_config(
+            "native",
+            "config.auth.env must not be empty",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn vendor_endpoint(
+    spec: &adl::ProviderSpec,
+    target: &ProviderInvocationTargetV1,
+    default_endpoint: &str,
+    provider_label: &str,
+) -> Result<String> {
+    let endpoint = target
+        .endpoint
+        .clone()
+        .or_else(|| target.base_url.clone())
+        .unwrap_or_else(|| default_endpoint.to_string());
+    if !is_allowed_remote_endpoint(&endpoint) {
+        return Err(invalid_config(
+            provider_label,
+            "endpoint must use https://; plaintext http:// is only allowed for localhost/loopback test endpoints",
+        ));
+    }
+    if let Some(override_endpoint) = cfg_str(&spec.config, "endpoint") {
+        if override_endpoint.is_empty() {
+            return Err(invalid_config(
+                provider_label,
+                "config.endpoint must not be empty when provided",
+            ));
+        }
+    }
+    Ok(endpoint)
+}
+
+fn truncate_provider_body(text: &str) -> &str {
+    let trimmed = text.trim();
+    if trimmed.len() > 200 {
+        &trimmed[..200]
+    } else {
+        trimmed
+    }
+}
+
+fn provider_http_json(
+    provider_label: &str,
+    req: reqwest::blocking::RequestBuilder,
+) -> Result<(Value, u16)> {
+    let resp = match req.send() {
+        Ok(resp) => resp,
+        Err(err) => {
+            if err.is_timeout() {
+                return Err(timeout_error(
+                    provider_label,
+                    "kind=timeout native provider request timed out",
+                ));
+            }
+            return Err(runtime_error(
+                provider_label,
+                format!("kind=request_failed native provider request failed: {err}"),
+            ));
+        }
+    };
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().unwrap_or_default();
+        let class = if status.is_client_error() {
+            "client_error"
+        } else if status.is_server_error() {
+            "server_error"
+        } else {
+            "http_error"
+        };
+        let msg = format!(
+            "kind={class} status={status} body={}",
+            truncate_provider_body(&text)
+        );
+        if status.is_client_error() {
+            return Err(runtime_error_non_retryable(provider_label, msg));
+        }
+        return Err(runtime_error(provider_label, msg));
+    }
+
+    let http_status = resp.status().as_u16();
+    let json = resp
+        .json()
+        .context("native provider response was not valid JSON")
+        .map_err(|err| runtime_error_non_retryable(provider_label, err.to_string()))?;
+    Ok((json, http_status))
+}
+
+fn write_native_invocation_record(
+    family: &str,
+    model: &str,
+    prompt: &str,
+    output: &str,
+    http_status: u16,
+) -> Result<()> {
+    let Some(path) = env::var_os("ADL_PROVIDER_INVOCATIONS_PATH") else {
+        return Ok(());
+    };
+    let path = PathBuf::from(path);
+    let mut payload = if path.is_file() {
+        serde_json::from_slice::<Value>(&fs::read(&path).map_err(|err| {
+            runtime_error(
+                family,
+                format!("failed to read provider invocation artifact: {err}"),
+            )
+        })?)
+        .map_err(|err| {
+            runtime_error_non_retryable(
+                family,
+                format!("provider invocation artifact is invalid JSON: {err}"),
+            )
+        })?
+    } else {
+        serde_json::json!({
+            "schema_version": "adl.native_provider_invocations.v1",
+            "credential_policy": "operator_env_only_no_secret_material_recorded",
+            "invocations": []
+        })
+    };
+
+    let Some(invocations) = payload
+        .get_mut("invocations")
+        .and_then(|v| v.as_array_mut())
+    else {
+        return Err(runtime_error_non_retryable(
+            family,
+            "provider invocation artifact missing invocations array",
+        ));
+    };
+    let timestamp_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    invocations.push(serde_json::json!({
+        "family": family,
+        "model": model,
+        "http_status": http_status,
+        "timestamp_unix_ms": timestamp_unix_ms,
+        "prompt_chars": prompt.chars().count(),
+        "output_chars": output.chars().count()
+    }));
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            runtime_error(
+                family,
+                format!("failed to create provider invocation artifact directory: {err}"),
+            )
+        })?;
+    }
+    let bytes = serde_json::to_vec_pretty(&payload).map_err(|err| {
+        runtime_error_non_retryable(
+            family,
+            format!("failed to serialize provider invocation artifact: {err}"),
+        )
+    })?;
+    write_file_atomic(&path, &bytes).map_err(|err| {
+        runtime_error(
+            family,
+            format!("failed to write invocation artifact: {err}"),
+        )
+    })
+}
+
+fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+    fs::rename(tmp, path)
+}
+
+fn extract_openai_output_text(json: &Value) -> Option<String> {
+    if let Some(text) = json.get("output_text").and_then(|v| v.as_str()) {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    let mut chunks = Vec::new();
+    for item in json.get("output")?.as_array()? {
+        for content in item.get("content").and_then(|v| v.as_array())? {
+            if let Some(text) = content.get("text").and_then(|v| v.as_str()) {
+                chunks.push(text);
+            }
+        }
+    }
+    let joined = chunks.join("\n").trim().to_string();
+    (!joined.is_empty()).then_some(joined)
+}
+
+fn extract_anthropic_output_text(json: &Value) -> Option<String> {
+    let mut chunks = Vec::new();
+    for content in json.get("content")?.as_array()? {
+        let content_type = content.get("type").and_then(|v| v.as_str());
+        if content_type == Some("text") {
+            if let Some(text) = content.get("text").and_then(|v| v.as_str()) {
+                chunks.push(text);
+            }
+        }
+    }
+    let joined = chunks.join("\n").trim().to_string();
+    (!joined.is_empty()).then_some(joined)
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenAiProvider {
+    endpoint: String,
+    auth_env: String,
+    model: String,
+    max_output_tokens: u64,
+    timeout_secs: Option<u64>,
+}
+
+impl OpenAiProvider {
+    pub fn from_target(
+        spec: &adl::ProviderSpec,
+        target: &ProviderInvocationTargetV1,
+    ) -> Result<Self> {
+        Ok(Self {
+            endpoint: vendor_endpoint(spec, target, OPENAI_RESPONSES_ENDPOINT, "openai")?,
+            auth_env: auth_env_for(spec, "OPENAI_API_KEY")?,
+            model: target.provider_model_id.clone(),
+            max_output_tokens: cfg_u64(&spec.config, "max_output_tokens").unwrap_or(220),
+            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+        })
+    }
+}
+
+impl Provider for OpenAiProvider {
+    fn complete(&self, prompt: &str) -> Result<String> {
+        let token = env::var(&self.auth_env).map_err(|_| {
+            invalid_config(
+                "openai",
+                format!("missing required auth env var '{}'", self.auth_env),
+            )
+        })?;
+        let mut client_builder = reqwest::blocking::Client::builder();
+        if let Some(secs) = self.timeout_secs {
+            client_builder = client_builder.timeout(Duration::from_secs(secs));
+        }
+        let client = client_builder
+            .build()
+            .context("failed to build OpenAI client")
+            .map_err(|err| runtime_error("openai", err.to_string()))?;
+        let req = client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "input": prompt,
+                "max_output_tokens": self.max_output_tokens,
+            }));
+        let (json, http_status) = provider_http_json("openai", req)?;
+        let output = extract_openai_output_text(&json)
+            .ok_or_else(|| runtime_error_non_retryable("openai", "response missing text output"))?;
+        write_native_invocation_record("openai", &self.model, prompt, &output, http_status)?;
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnthropicProvider {
+    endpoint: String,
+    auth_env: String,
+    model: String,
+    max_tokens: u64,
+    timeout_secs: Option<u64>,
+}
+
+impl AnthropicProvider {
+    pub fn from_target(
+        spec: &adl::ProviderSpec,
+        target: &ProviderInvocationTargetV1,
+    ) -> Result<Self> {
+        Ok(Self {
+            endpoint: vendor_endpoint(spec, target, ANTHROPIC_MESSAGES_ENDPOINT, "anthropic")?,
+            auth_env: auth_env_for(spec, "ANTHROPIC_API_KEY")?,
+            model: target.provider_model_id.clone(),
+            max_tokens: cfg_u64(&spec.config, "max_tokens")
+                .or_else(|| cfg_u64(&spec.config, "max_output_tokens"))
+                .unwrap_or(220),
+            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+        })
+    }
+}
+
+impl Provider for AnthropicProvider {
+    fn complete(&self, prompt: &str) -> Result<String> {
+        let token = env::var(&self.auth_env).map_err(|_| {
+            invalid_config(
+                "anthropic",
+                format!("missing required auth env var '{}'", self.auth_env),
+            )
+        })?;
+        let mut client_builder = reqwest::blocking::Client::builder();
+        if let Some(secs) = self.timeout_secs {
+            client_builder = client_builder.timeout(Duration::from_secs(secs));
+        }
+        let client = client_builder
+            .build()
+            .context("failed to build Anthropic client")
+            .map_err(|err| runtime_error("anthropic", err.to_string()))?;
+        let req = client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .header("x-api-key", token)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "max_tokens": self.max_tokens,
+                "messages": [{"role": "user", "content": prompt}],
+            }));
+        let (json, http_status) = provider_http_json("anthropic", req)?;
+        let output = extract_anthropic_output_text(&json).ok_or_else(|| {
+            runtime_error_non_retryable("anthropic", "response missing text output")
+        })?;
+        write_native_invocation_record("anthropic", &self.model, prompt, &output, http_status)?;
+        Ok(output)
     }
 }
 

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -156,6 +156,8 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
     match spec.kind.trim() {
         "ollama" | "local_ollama" => "ollama".to_string(),
         "mock" => "mock".to_string(),
+        "openai" => "openai".to_string(),
+        "anthropic" => "anthropic".to_string(),
         "http" | "http_remote" => "generic_http".to_string(),
         other if !other.is_empty() => other.to_lowercase(),
         _ => "unknown".to_string(),
@@ -164,7 +166,7 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
 
 fn infer_transport(spec: &adl::ProviderSpec) -> Result<ProviderTransportV1> {
     match spec.kind.trim() {
-        "http" | "http_remote" => Ok(ProviderTransportV1::Http),
+        "http" | "http_remote" | "openai" | "anthropic" => Ok(ProviderTransportV1::Http),
         "ollama" | "local_ollama" => Ok(ProviderTransportV1::LocalCli),
         "mock" => Ok(ProviderTransportV1::InProcess),
         other => Err(anyhow!(
@@ -405,6 +407,25 @@ mod tests {
             substrate.default_model_ref.as_deref(),
             Some("claude-3-7-sonnet-latest")
         );
+    }
+
+    #[test]
+    fn provider_substrate_accepts_native_openai_and_anthropic_kinds() {
+        let mut openai = provider_spec("openai");
+        openai.default_model = Some("gpt-test".to_string());
+        let openai_substrate =
+            provider_substrate_v1("openai_primary", &openai).expect("openai substrate");
+        assert_eq!(openai_substrate.vendor, "openai");
+        assert_eq!(openai_substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(openai_substrate.provider_kind, "openai");
+
+        let mut anthropic = provider_spec("anthropic");
+        anthropic.default_model = Some("claude-test".to_string());
+        let anthropic_substrate =
+            provider_substrate_v1("anthropic_primary", &anthropic).expect("anthropic substrate");
+        assert_eq!(anthropic_substrate.vendor, "anthropic");
+        assert_eq!(anthropic_substrate.transport, ProviderTransportV1::Http);
+        assert_eq!(anthropic_substrate.provider_kind, "anthropic");
     }
 
     #[test]

--- a/adl/tests/adl_tests.rs
+++ b/adl/tests/adl_tests.rs
@@ -909,6 +909,38 @@ run:
 }
 
 #[test]
+fn validate_accepts_native_openai_and_anthropic_provider_kinds() {
+    let yaml = r#"
+version: "0.5"
+providers:
+  openai_primary:
+    type: "openai"
+    config:
+      provider_model_id: "gpt-test"
+  anthropic_primary:
+    type: "anthropic"
+    config:
+      provider_model_id: "claude-test"
+agents:
+  a1:
+    provider: "openai_primary"
+    model: "gpt-test"
+tasks:
+  t1:
+    prompt:
+      user: "u"
+run:
+  workflow:
+    steps:
+      - task: "t1"
+        agent: "a1"
+"#;
+    let doc: AdlDoc = serde_yaml::from_str(yaml).expect("yaml parse");
+    doc.validate()
+        .expect("native OpenAI/Anthropic provider kinds should validate");
+}
+
+#[test]
 fn validate_rejects_both_workflow_ref_and_inline_workflow() {
     let yaml = r#"
 version: "0.5"

--- a/adl/tests/provider_tests.rs
+++ b/adl/tests/provider_tests.rs
@@ -10,7 +10,7 @@ use ::adl::provider::{
 };
 
 mod helpers;
-use helpers::{unique_test_temp_dir, EnvVarGuard};
+use helpers::{unique_test_temp_dir, EnvVarGuard, EnvVarGuardMulti};
 
 fn write_executable(path: &Path, contents: &str) -> io::Result<()> {
     fs::write(path, contents)?;
@@ -33,6 +33,59 @@ fn block_incoming_localhost() -> EnvVarGuard {
     }
     new_val.push_str("127.0.0.1,localhost");
     EnvVarGuard::set(key, new_val)
+}
+
+fn localhost_and_auth_env_guard(key: &str, value: &str) -> EnvVarGuardMulti {
+    let old = std::env::var("NO_PROXY").ok();
+    let mut no_proxy = old.clone().unwrap_or_default();
+    if !no_proxy.is_empty() && !no_proxy.ends_with(',') {
+        no_proxy.push(',');
+    }
+    no_proxy.push_str("127.0.0.1,localhost");
+    EnvVarGuard::set_many(&[
+        ("NO_PROXY", std::ffi::OsStr::new(&no_proxy)),
+        (key, std::ffi::OsStr::new(value)),
+    ])
+}
+
+fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .expect("set read timeout");
+    let mut bytes = Vec::new();
+    let mut buf = [0u8; 1024];
+    let header_end = loop {
+        let n = stream.read(&mut buf).expect("read request chunk");
+        assert!(n > 0, "client closed before sending complete headers");
+        bytes.extend_from_slice(&buf[..n]);
+        if let Some(pos) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break pos + 4;
+        }
+    };
+
+    let headers = String::from_utf8_lossy(&bytes[..header_end]).to_string();
+    if headers.lines().any(|line| {
+        line.to_ascii_lowercase()
+            .starts_with("expect: 100-continue")
+    }) {
+        stream
+            .write_all(b"HTTP/1.1 100 Continue\r\n\r\n")
+            .expect("write continue response");
+    }
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().expect("valid content length"))
+        })
+        .unwrap_or(0);
+    while bytes.len() < header_end + content_length {
+        let n = stream.read(&mut buf).expect("read request body");
+        assert!(n > 0, "client closed before sending complete body");
+        bytes.extend_from_slice(&buf[..n]);
+    }
+    String::from_utf8_lossy(&bytes).to_string()
 }
 
 fn make_mock_ollama_success(dir: &Path) -> io::Result<PathBuf> {
@@ -426,6 +479,123 @@ config:
     let p = build_provider(&spec, None).expect("build_provider failed");
     let out = p.complete("hello").expect("http provider should succeed");
     assert_eq!(out, "OK");
+}
+
+#[test]
+fn openai_provider_translates_native_response() {
+    let server = match std::net::TcpListener::bind("127.0.0.1:0") {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(e) => panic!("failed to bind local test server: {e}"),
+    };
+    let addr = server.local_addr().unwrap();
+    let _env_guard = localhost_and_auth_env_guard("ADL_TEST_OPENAI_KEY", "test-openai-token");
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = server.accept().unwrap();
+        let request = read_http_request(&mut stream);
+        assert!(request.to_ascii_lowercase().contains("authorization:"));
+        assert!(request.contains("Bearer test-openai-token"));
+        assert!(request.contains("\"model\":\"gpt-test\""));
+        assert!(request.contains("\"input\":\"hello openai\""));
+        let body = r#"{"output_text":"OPENAI_NATIVE_OK"}"#;
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(resp.as_bytes());
+    });
+
+    let spec = provider_spec_from_yaml(&format!(
+        r#"
+type: openai
+config:
+  endpoint: "http://{addr}/v1/responses"
+  provider_model_id: "gpt-test"
+  auth:
+    type: bearer
+    env: ADL_TEST_OPENAI_KEY
+"#
+    ));
+
+    let p = build_provider(&spec, None).expect("openai provider should build");
+    let out = p
+        .complete("hello openai")
+        .expect("openai provider should succeed");
+    assert_eq!(out, "OPENAI_NATIVE_OK");
+}
+
+#[test]
+fn anthropic_provider_translates_native_response() {
+    let server = match std::net::TcpListener::bind("127.0.0.1:0") {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(e) => panic!("failed to bind local test server: {e}"),
+    };
+    let addr = server.local_addr().unwrap();
+    let _env_guard = localhost_and_auth_env_guard("ADL_TEST_ANTHROPIC_KEY", "test-anthropic-token");
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = server.accept().unwrap();
+        let request = read_http_request(&mut stream);
+        assert!(request.to_ascii_lowercase().contains("x-api-key:"));
+        assert!(request.contains("test-anthropic-token"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("anthropic-version: 2023-06-01"));
+        assert!(request.contains("\"model\":\"claude-test\""));
+        assert!(request.contains("\"content\":\"hello claude\""));
+        let body = r#"{"content":[{"type":"text","text":"ANTHROPIC_NATIVE_OK"}]}"#;
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(resp.as_bytes());
+    });
+
+    let spec = provider_spec_from_yaml(&format!(
+        r#"
+type: anthropic
+config:
+  endpoint: "http://{addr}/v1/messages"
+  provider_model_id: "claude-test"
+  auth:
+    type: bearer
+    env: ADL_TEST_ANTHROPIC_KEY
+"#
+    ));
+
+    let p = build_provider(&spec, None).expect("anthropic provider should build");
+    let out = p
+        .complete("hello claude")
+        .expect("anthropic provider should succeed");
+    assert_eq!(out, "ANTHROPIC_NATIVE_OK");
+}
+
+#[test]
+fn native_provider_missing_auth_env_is_sanitized() {
+    let _env_guard = EnvVarGuard::unset("ADL_TEST_MISSING_OPENAI_KEY");
+    let spec = provider_spec_from_yaml(
+        r#"
+type: openai
+config:
+  provider_model_id: "gpt-test"
+  auth:
+    type: bearer
+    env: ADL_TEST_MISSING_OPENAI_KEY
+"#,
+    );
+
+    let p = build_provider(&spec, None).expect("openai provider should build");
+    let err = p
+        .complete("hello")
+        .expect_err("missing auth env should fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("missing required auth env var"));
+    assert!(msg.contains("ADL_TEST_MISSING_OPENAI_KEY"));
+    assert!(!msg.contains("Bearer"));
 }
 
 #[test]

--- a/adl/tools/demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/demo_v088_real_multi_agent_discussion.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v088/real_multi_agent_discussion}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-88-real-multi-agent-tea-discussion"
+TRANSCRIPT="$OUT_DIR/transcript.md"
+TRANSCRIPT_CONTRACT="$OUT_DIR/transcript_contract.json"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+INVOCATIONS="$OUT_DIR/provider_invocations.json"
+README_OUT="$OUT_DIR/README.md"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
+ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
+
+load_key() {
+  local env_name="$1"
+  local key_file="$2"
+  if [[ -n "${!env_name:-}" ]]; then
+    return 0
+  fi
+  if [[ ! -s "$key_file" ]]; then
+    echo "missing required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  local key_value=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line//$'\r'/}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    if [[ "$line" == "$env_name="* ]]; then
+      key_value="${line#*=}"
+    else
+      key_value="$line"
+    fi
+    key_value="${key_value%\"}"
+    key_value="${key_value#\"}"
+    key_value="${key_value%\'}"
+    key_value="${key_value#\'}"
+    break
+  done <"$key_file"
+  if [[ -z "$key_value" ]]; then
+    echo "empty required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  export "$env_name=$key_value"
+}
+
+load_key OPENAI_API_KEY "$OPENAI_KEY_FILE"
+load_key ANTHROPIC_API_KEY "$ANTHROPIC_KEY_FILE"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STEP_OUT"
+
+cd "$ROOT_DIR"
+
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+ADL_PROVIDER_INVOCATIONS_PATH="$INVOCATIONS" \
+  bash adl/tools/pr.sh run adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml \
+    --trace \
+    --allow-unsigned \
+    --out "$STEP_OUT" \
+    >"$OUT_DIR/run_log.txt" 2>&1
+
+cat >"$TRANSCRIPT" <<'EOF'
+# Claude + ChatGPT Multi-Agent Tea Discussion Transcript
+
+This transcript is assembled from the runtime-written step outputs under `out/discussion/`.
+EOF
+
+for file in \
+  "$STEP_OUT/discussion/01-chatgpt-opening.md" \
+  "$STEP_OUT/discussion/02-claude-reply.md" \
+  "$STEP_OUT/discussion/03-chatgpt-reflection.md" \
+  "$STEP_OUT/discussion/04-claude-refinement.md" \
+  "$STEP_OUT/discussion/05-chatgpt-toast.md"; do
+  printf '\n\n---\n\n' >>"$TRANSCRIPT"
+  cat "$file" >>"$TRANSCRIPT"
+done
+
+cat >"$TRANSCRIPT_CONTRACT" <<EOF
+{
+  "schema_version": "multi_agent_discussion_transcript.v1",
+  "transcript_path": "transcript.md",
+  "turn_count": 5,
+  "turns": [
+    {"turn_id": "turn_01", "ordinal": 1, "speaker": "ChatGPT", "heading": "# Turn 1 - ChatGPT", "source_output": "out/discussion/01-chatgpt-opening.md"},
+    {"turn_id": "turn_02", "ordinal": 2, "speaker": "Claude", "heading": "# Turn 2 - Claude", "source_output": "out/discussion/02-claude-reply.md"},
+    {"turn_id": "turn_03", "ordinal": 3, "speaker": "ChatGPT", "heading": "# Turn 3 - ChatGPT", "source_output": "out/discussion/03-chatgpt-reflection.md"},
+    {"turn_id": "turn_04", "ordinal": 4, "speaker": "Claude", "heading": "# Turn 4 - Claude", "source_output": "out/discussion/04-claude-refinement.md"},
+    {"turn_id": "turn_05", "ordinal": 5, "speaker": "ChatGPT", "heading": "# Turn 5 - ChatGPT", "source_output": "out/discussion/05-chatgpt-toast.md"}
+  ],
+  "companion_artifacts": {
+    "demo_manifest": "demo_manifest.json",
+    "run_summary": "runtime/runs/$RUN_ID/run_summary.json",
+    "trace": "runtime/runs/$RUN_ID/logs/trace_v1.json"
+  }
+}
+EOF
+
+cat >"$MANIFEST" <<EOF
+{
+  "demo_id": "v0.88.real_multi_agent_discussion",
+  "title": "Rust-native live ChatGPT + Claude multi-agent tea discussion demo",
+  "execution_mode": "runtime_native_live_providers",
+  "provider_mode": "rust_native_openai_and_anthropic",
+  "credential_policy": "operator_env_or_home_keys_no_secret_material_recorded",
+  "steps": 5,
+  "proof_surfaces": {
+    "transcript": "$TRANSCRIPT",
+    "transcript_contract": "$TRANSCRIPT_CONTRACT",
+    "provider_invocations": "$INVOCATIONS",
+    "run_summary": "$RUNS_ROOT/$RUN_ID/run_summary.json",
+    "trace": "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json"
+  }
+}
+EOF
+
+cat >"$README_OUT" <<EOF
+# v0.88 Demo - Rust-Native Live ChatGPT + Claude Multi-Agent Tea Discussion
+
+Canonical command:
+
+\`\`\`bash
+bash adl/tools/demo_v088_real_multi_agent_discussion.sh
+\`\`\`
+
+Credential loading:
+- Uses \`OPENAI_API_KEY\` and \`ANTHROPIC_API_KEY\` when already set.
+- Otherwise reads local operator-managed keys from \`\\\$HOME/keys/openai.key\` and \`\\\$HOME/keys/claude.key\`.
+- Secret values and raw Authorization headers are not written to generated artifacts.
+
+What this proves:
+- one ADL runtime workflow with two named live provider families
+- direct Rust-native OpenAI and Anthropic provider invocation
+- five sequential turns with saved-state handoff, runtime conversation metadata, and transcript contract validation
+
+Primary proof surfaces:
+- \`$TRANSCRIPT\`
+- \`$INVOCATIONS\`
+- \`$RUNS_ROOT/$RUN_ID/run_summary.json\`
+EOF
+
+python3 "$ROOT_DIR/adl/tools/validate_multi_agent_transcript.py" \
+  "$TRANSCRIPT" \
+  --contract "$TRANSCRIPT_CONTRACT" \
+  >/dev/null
+
+echo "Rust-native live multi-agent discussion proof surface:"
+echo "  $TRANSCRIPT"
+echo "  $INVOCATIONS"
+echo "  $RUNS_ROOT/$RUN_ID/run_summary.json"
+echo "  $RUNS_ROOT/$RUN_ID/logs/trace_v1.json"

--- a/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
+ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
+
+if [[ -z "${OPENAI_API_KEY:-}" && ! -s "$OPENAI_KEY_FILE" ]]; then
+  echo "SKIP: missing OPENAI_API_KEY and $OPENAI_KEY_FILE" >&2
+  exit 0
+fi
+if [[ -z "${ANTHROPIC_API_KEY:-}" && ! -s "$ANTHROPIC_KEY_FILE" ]]; then
+  echo "SKIP: missing ANTHROPIC_API_KEY and $ANTHROPIC_KEY_FILE" >&2
+  exit 0
+fi
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v088_real_multi_agent_discussion.sh "$OUT_DIR" >/dev/null
+)
+
+TRANSCRIPT="$OUT_DIR/transcript.md"
+TRANSCRIPT_CONTRACT="$OUT_DIR/transcript_contract.json"
+INVOCATIONS="$OUT_DIR/provider_invocations.json"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+SUMMARY="$OUT_DIR/runtime/runs/v0-88-real-multi-agent-tea-discussion/run_summary.json"
+STEPS="$OUT_DIR/runtime/runs/v0-88-real-multi-agent-tea-discussion/steps.json"
+TRACE="$OUT_DIR/runtime/runs/v0-88-real-multi-agent-tea-discussion/logs/trace_v1.json"
+LOG_FILE="$OUT_DIR/run_log.txt"
+
+for required in "$TRANSCRIPT" "$TRANSCRIPT_CONTRACT" "$INVOCATIONS" "$MANIFEST" "$SUMMARY" "$STEPS" "$TRACE" "$LOG_FILE"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+grep -Fq '"execution_mode": "runtime_native_live_providers"' "$MANIFEST" || {
+  echo "assertion failed: manifest missing native live execution mode" >&2
+  exit 1
+}
+grep -Fq '"conversation"' "$STEPS" || {
+  echo "assertion failed: steps artifact missing conversation metadata" >&2
+  exit 1
+}
+
+python3 - "$INVOCATIONS" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+invocations = payload.get("invocations", [])
+families = [item.get("family") for item in invocations]
+if payload.get("schema_version") != "adl.native_provider_invocations.v1":
+    raise SystemExit("unexpected provider invocation schema version")
+if families.count("openai") != 3:
+    raise SystemExit(f"expected 3 OpenAI invocations, found {families.count('openai')}")
+if families.count("anthropic") != 2:
+    raise SystemExit(f"expected 2 Anthropic invocations, found {families.count('anthropic')}")
+if any(item.get("http_status") != 200 for item in invocations):
+    raise SystemExit("expected all native provider invocations to return HTTP 200")
+for item in invocations:
+    if item.get("prompt_chars", 0) <= 0 or item.get("output_chars", 0) <= 0:
+        raise SystemExit("expected non-empty prompt/output character counts")
+PY
+
+python3 "$ROOT_DIR/adl/tools/validate_multi_agent_transcript.py" \
+  "$TRANSCRIPT" \
+  --contract "$TRANSCRIPT_CONTRACT" \
+  >/dev/null
+
+if [[ -n "${OPENAI_API_KEY:-}" ]] && grep -R -F "$OPENAI_API_KEY" "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: OPENAI_API_KEY value leaked into artifacts" >&2
+  exit 1
+fi
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]] && grep -R -F "$ANTHROPIC_API_KEY" "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: ANTHROPIC_API_KEY value leaked into artifacts" >&2
+  exit 1
+fi
+if grep -R -E 'Authorization:|Bearer |x-api-key' "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: credential header material leaked into artifacts" >&2
+  exit 1
+fi
+
+echo "demo_v088_real_multi_agent_discussion: ok"

--- a/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
+++ b/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
@@ -1,0 +1,38 @@
+# Rust-Native Live ChatGPT + Claude Multi-Agent Discussion Demo
+
+This demo replaces the v0.87.1 Python proof shim with Rust-native OpenAI and
+Anthropic provider invocation.
+
+## Command
+
+```bash
+bash adl/tools/demo_v088_real_multi_agent_discussion.sh
+```
+
+## Credentials
+
+The demo uses operator-managed credentials only:
+
+- `OPENAI_API_KEY` if already set, otherwise `$HOME/keys/openai.key`
+- `ANTHROPIC_API_KEY` if already set, otherwise `$HOME/keys/claude.key`
+
+Secret values and raw credential headers must not be printed or written to
+generated artifacts.
+
+## Proof Surfaces
+
+Default artifact root:
+
+```text
+artifacts/v088/real_multi_agent_discussion/
+```
+
+Primary proof surfaces:
+
+- `transcript.md`
+- `provider_invocations.json`
+- `runtime/runs/v0-88-real-multi-agent-tea-discussion/run_summary.json`
+
+The provider invocation artifact records provider family, model, HTTP status,
+timestamp, and prompt/output character counts. It intentionally does not record
+prompt bodies, response bodies, API keys, or Authorization headers.

--- a/docs/records/v0.88/tasks/issue-1537/sor.md
+++ b/docs/records/v0.88/tasks/issue-1537/sor.md
@@ -1,0 +1,175 @@
+# v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1537
+Run ID: issue-1537
+Version: v0.88
+Title: [v0.88][runtime] Replace live-demo Python adapter with Rust-native provider adapters
+Branch: codex/1537-v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: openai
+- Start Time: 2026-04-10T02:10:00Z
+- End Time: 2026-04-10T02:31:00Z
+
+## Summary
+
+Implemented Rust-native OpenAI and Anthropic provider adapters for the ADL runtime, added a v0.88 live ChatGPT + Claude multi-agent demo path that no longer starts a Python vendor-translation adapter, and updated provider setup documentation so native OpenAI/Anthropic setup is distinguished from bounded HTTP compatibility profiles.
+
+## Artifacts produced
+- `adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml`
+- `adl/tools/demo_v088_real_multi_agent_discussion.sh`
+- `adl/tools/test_demo_v088_real_multi_agent_discussion.sh`
+- `demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md`
+
+## Actions taken
+- Added `openai` and `anthropic` provider kinds to provider validation, provider substrate normalization, and provider construction.
+- Implemented Rust-native request construction and response extraction for OpenAI Responses API and Anthropic Messages API.
+- Added sanitized native-provider invocation records that capture provider family, model, HTTP status, and prompt/output character counts without recording key material or Authorization headers.
+- Added loopback unit tests for native OpenAI and Anthropic request translation, representative response parsing, missing-auth handling, and provider substrate validation.
+- Updated `adl provider setup openai` and `adl provider setup anthropic` to emit native provider snippets instead of generic bounded HTTP gateway snippets.
+- Added a shell-only live demo wrapper for key loading, runtime execution, transcript assembly, manifest generation, and artifact leak checks.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: tracked repository paths are updated on the issue branch and will be published by the finish-created PR.
+- Worktree-only paths remaining: none for required tracked implementation artifacts; generated live-demo proof artifacts remain local-only by design and are not committed.
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: branch-local tracked edits in the bound issue worktree, to be published through the repo-native finish flow.
+- Verification performed:
+  - `git status --short` verified the tracked and untracked branch changes before finish.
+  - `git diff --stat` verified the implementation and documentation change set.
+  - `find .adl/v0.88/tasks/issue-1537__v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters -type f` verified the local task bundle paths.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified Rust formatting.
+  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` verified warning-free Rust lint behavior.
+  - `cargo test --manifest-path adl/Cargo.toml` verified the full Rust test suite.
+  - `cargo test --manifest-path adl/Cargo.toml --test provider_tests` verified the provider test suite, including native OpenAI/Anthropic loopback request translation and sanitized missing-auth behavior.
+  - `cargo test --manifest-path adl/Cargo.toml validate_accepts_native_openai_and_anthropic_provider_kinds --test adl_tests` verified ADL validation accepts native provider kinds.
+  - `cargo test --manifest-path adl/Cargo.toml provider_substrate_accepts_native_openai_and_anthropic_kinds` verified provider substrate normalization for native kinds.
+  - `cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture` verified provider setup templates, including native OpenAI/Anthropic output.
+  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml --print-plan --allow-unsigned` verified the new demo resolves to five ordered runtime steps.
+  - `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY ADL_OPENAI_KEY_FILE=<missing> ADL_ANTHROPIC_KEY_FILE=<missing> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh` verified the live demo test skips cleanly when credentials are unavailable.
+  - `bash adl/tools/demo_v088_real_multi_agent_discussion.sh <temporary local artifact directory>` exercised the real live-provider path with local operator-managed keys.
+- Results: formatting and targeted Rust tests passed; the real live-provider run successfully completed the OpenAI turn and then stopped at the Anthropic API boundary with a sanitized non-retryable insufficient-credits response.
+- Post-rebase retry result: after the operator attempted to add Anthropic API credits, the live demo was retried and still stopped at the Anthropic API boundary with the same sanitized insufficient-credits response; OpenAI turn execution still succeeded and the generated artifact secret scan still returned no matches.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PARTIAL
+    checks_run:
+      - "cargo fmt --manifest-path adl/Cargo.toml --all --check"
+      - "cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings"
+      - "cargo test --manifest-path adl/Cargo.toml"
+      - "cargo test --manifest-path adl/Cargo.toml --test provider_tests"
+      - "cargo test --manifest-path adl/Cargo.toml validate_accepts_native_openai_and_anthropic_provider_kinds --test adl_tests"
+      - "cargo test --manifest-path adl/Cargo.toml provider_substrate_accepts_native_openai_and_anthropic_kinds"
+      - "cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture"
+      - "cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml --print-plan --allow-unsigned"
+      - "env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY ADL_OPENAI_KEY_FILE=<missing> ADL_ANTHROPIC_KEY_FILE=<missing> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh"
+      - "bash adl/tools/demo_v088_real_multi_agent_discussion.sh <temporary local artifact directory>"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: targeted unit tests and demo plan resolution verified stable provider normalization and ordered five-step demo execution.
+- Fixtures or scripts used: loopback TCP provider fixtures in `adl/tests/provider_tests.rs`, `adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml`, and `adl/tools/test_demo_v088_real_multi_agent_discussion.sh`.
+- Replay verification (same inputs -> same artifacts/order): `--print-plan` for the v0.88 demo resolved the same five ordered steps with fixed providers and tasks; loopback provider tests produce stable request/response assertions.
+- Ordering guarantees (sorting / tie-break rules used): the demo YAML declares a linear five-step sequence; provider substrate tests verify deterministic normalization for native provider kinds.
+- Artifact stability notes: generated live outputs are model-dependent and are not claimed byte-stable; runtime structure, manifest shape, transcript contract, and invocation-record schema are stable for accepted runs.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: grep-based scan of generated local live-demo artifacts for Authorization headers, bearer header material, `x-api-key`, and key-shaped tokens returned no matches.
+- Prompt / tool argument redaction verified: provider invocation records store provider family, model, status, timestamp, and character counts only; they do not store prompts, outputs, keys, or raw request headers.
+- Absolute path leakage check: this output card uses repository-relative paths and replaces temporary local artifact roots with explicit placeholders.
+- Sandbox / policy invariants preserved: secrets were loaded only from environment variables or local operator-managed key files and were never printed; CI-safe test behavior skips when credentials are absent.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): generated during the local live run under the temporary artifact root; not committed because live-provider artifacts are operator-local and credential-adjacent.
+- Run artifact root: temporary local artifact directory used for operator validation; not a repository artifact.
+- Replay command used for verification: `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml --print-plan --allow-unsigned`.
+- Replay result: PASS for deterministic plan replay; live execution PARTIAL because Anthropic returned insufficient account credits after OpenAI completed turn 1.
+
+## Artifact Verification
+- Primary proof surface: `adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml`, `adl/tools/demo_v088_real_multi_agent_discussion.sh`, `adl/tools/test_demo_v088_real_multi_agent_discussion.sh`, and `demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md`.
+- Required artifacts present: true; all required tracked implementation and documentation artifacts exist on the issue branch.
+- Artifact schema/version checks: native provider invocation records use `adl.native_provider_invocations.v1`; transcript contract uses the existing `multi_agent_discussion_transcript.v1` shape.
+- Hash/byte-stability checks: not applicable to live model text outputs; deterministic code/test artifacts are source-controlled and stable under git diff.
+- Missing/optional artifacts and rationale: a complete five-turn live transcript was not produced because the local Anthropic account returned an insufficient-credits API error; this is an external account-state block, not a Rust adapter or orchestration failure.
+
+## Decisions / Deviations
+
+- Kept existing `chatgpt:` and `claude:` profile-family semantics on the bounded HTTP compatibility path to avoid widening this v0.88 follow-up into a profile migration.
+- Added native `openai` and `anthropic` provider kinds and wired the new v0.88 live demo to those kinds directly.
+- Kept Python in the existing transcript validator only; no new Python provider adapter or vendor-translation bridge was added.
+
+## Follow-ups / Deferred work
+
+- Consider a later profile migration issue if `chatgpt:` and `claude:` should expand directly to native vendor provider kinds.
+- Re-run the full live demo when the local Anthropic account has sufficient API credits.
+- The live demo was retried after an attempted Anthropic credit update; the account still reported insufficient API credits.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -30,11 +30,15 @@ The generated bundle is intentionally local-only:
 - users are expected to copy/fill a local env file and source it before running ADL
 
 Important transport note:
+- `openai` and `anthropic` now use Rust-native provider adapters by default:
+  - `type: "openai"` targets the OpenAI Responses API unless `config.endpoint` is explicitly overridden
+  - `type: "anthropic"` targets the Anthropic Messages API unless `config.endpoint` is explicitly overridden
 - ADL's bounded HTTP provider expects a completion-style contract:
   - request JSON with `{"prompt": "..."}`
   - response JSON with `{"output": "..."}`
 - raw vendor-native endpoints may need an adapter or compatibility gateway if
-  they do not expose that exact contract directly
+  they do not expose that exact contract directly; this applies to HTTP/profile
+  families such as `chatgpt`, `claude`, `gemini`, `deepseek`, and `http`
 - provider-family demos should keep setup instructions here and keep family-specific
   runtime proof steps in their own wrapper surfaces
 
@@ -60,3 +64,7 @@ Live multi-agent demo note:
 - it reads `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` from the environment when set, otherwise from `$HOME/keys/openai.key` and `$HOME/keys/claude.key`
 - it starts a local adapter that bridges ADL's current `{"prompt": "..."} -> {"output": "..."}` HTTP contract to vendor-native OpenAI and Anthropic APIs
 - generated artifacts record provider family/model/status metadata only; they must not include secret values or raw credential headers
+
+v0.88 native provider demo note:
+- `bash adl/tools/demo_v088_real_multi_agent_discussion.sh` demonstrates direct Rust-native OpenAI and Anthropic runtime invocation using operator-managed keys from environment variables or `$HOME/keys`
+- generated demo artifacts record provider family, model, HTTP status, and prompt/output character counts, but never raw secret values or Authorization headers


### PR DESCRIPTION
Closes #1537

## Summary
Implemented Rust-native OpenAI and Anthropic provider adapters for the ADL runtime, added a v0.88 live ChatGPT + Claude multi-agent demo path that no longer starts a Python vendor-translation adapter, and updated provider setup documentation so native OpenAI/Anthropic setup is distinguished from bounded HTTP compatibility profiles.

## Artifacts
- `adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml`
- `adl/tools/demo_v088_real_multi_agent_discussion.sh`
- `adl/tools/test_demo_v088_real_multi_agent_discussion.sh`
- `demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified Rust formatting.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` verified warning-free Rust lint behavior.
  - `cargo test --manifest-path adl/Cargo.toml` verified the full Rust test suite.
  - `cargo test --manifest-path adl/Cargo.toml --test provider_tests` verified the provider test suite, including native OpenAI/Anthropic loopback request translation and sanitized missing-auth behavior.
  - `cargo test --manifest-path adl/Cargo.toml validate_accepts_native_openai_and_anthropic_provider_kinds --test adl_tests` verified ADL validation accepts native provider kinds.
  - `cargo test --manifest-path adl/Cargo.toml provider_substrate_accepts_native_openai_and_anthropic_kinds` verified provider substrate normalization for native kinds.
  - `cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture` verified provider setup templates, including native OpenAI/Anthropic output.
  - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml --print-plan --allow-unsigned` verified the new demo resolves to five ordered runtime steps.
  - `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY ADL_OPENAI_KEY_FILE=<missing> ADL_ANTHROPIC_KEY_FILE=<missing> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh` verified the live demo test skips cleanly when credentials are unavailable.
  - `bash adl/tools/demo_v088_real_multi_agent_discussion.sh <temporary local artifact directory>` exercised the real live-provider path with local operator-managed keys.
- Results: formatting and targeted Rust tests passed; the real live-provider run successfully completed the OpenAI turn and then stopped at the Anthropic API boundary with a sanitized non-retryable insufficient-credits response.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1537__v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters/sip.md
- Output card: .adl/v0.88/tasks/issue-1537__v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters/sor.md
- Idempotency-Key: v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters-adl-v0-88-tasks-issue-1537-v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters-sip-md-adl-v0-88-tasks-issue-1537-v0-88-runtime-replace-live-demo-python-adapter-with-rust-native-provider-adapters-sor-md