### PR TITLE
[v0.88][demo] Sanitize live-provider artifacts after #1537

### DIFF
--- a/adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml
+++ b/adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml
@@ -10,7 +10,7 @@ providers:
   live_anthropic:
     type: "anthropic"
     config:
-      provider_model_id: "claude-3-5-haiku-latest"
+      provider_model_id: "claude-haiku-4-5-20251001"
       max_tokens: 220
       timeout_secs: 90
 
@@ -20,7 +20,7 @@ agents:
     model: "gpt-4o-mini"
   claude_guest:
     provider: "live_anthropic"
-    model: "claude-3-5-haiku-latest"
+    model: "claude-haiku-4-5-20251001"
 
 tasks:
   chatgpt_opening:

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -145,7 +145,7 @@ fn template_for_family(family: &str) -> Result<&'static ProviderSetupTemplate> {
             provider_id: "anthropic_primary",
             agent_id: "anthropic_agent",
             model_ref: "reasoning/default",
-            provider_model_id: "claude-3-5-haiku-latest",
+            provider_model_id: "claude-haiku-4-5-20251001",
             endpoint_hint: None,
             notes: "Use this for the Rust-native Anthropic provider path. The default endpoint is Anthropic's Messages API; override config.endpoint only for tests or a trusted compatible endpoint.",
         },

--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -44,7 +44,7 @@ bash adl/tools/normalize_adl_cards.sh --root "$(pwd)" --version v0.87.1
 # run the bounded Claude + ChatGPT discussion demo through the real runtime
 bash adl/tools/demo_v0871_multi_agent_discussion.sh
 
-# run the live-provider Claude + ChatGPT discussion demo using $HOME/keys/openai.key and $HOME/keys/claude.key
+# run the live-provider Claude + ChatGPT discussion demo using env vars or explicit key-file overrides
 bash adl/tools/demo_v0871_real_multi_agent_discussion.sh
 
 # validate the generated bounded multi-agent transcript artifact

--- a/adl/tools/demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/demo_v088_real_multi_agent_discussion.sh
@@ -12,17 +12,17 @@ TRANSCRIPT_CONTRACT="$OUT_DIR/transcript_contract.json"
 MANIFEST="$OUT_DIR/demo_manifest.json"
 INVOCATIONS="$OUT_DIR/provider_invocations.json"
 README_OUT="$OUT_DIR/README.md"
-OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
-ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-}"
+ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-}"
 
 load_key() {
   local env_name="$1"
-  local key_file="$2"
+  local key_file="${2:-}"
   if [[ -n "${!env_name:-}" ]]; then
     return 0
   fi
-  if [[ ! -s "$key_file" ]]; then
-    echo "missing required key file for $env_name: $key_file" >&2
+  if [[ -z "$key_file" || ! -s "$key_file" ]]; then
+    echo "missing required credential source for $env_name; set $env_name or the matching ADL_*_KEY_FILE override" >&2
     return 1
   fi
   local key_value=""
@@ -41,10 +41,38 @@ load_key() {
     break
   done <"$key_file"
   if [[ -z "$key_value" ]]; then
-    echo "empty required key file for $env_name: $key_file" >&2
+    echo "empty required credential source for $env_name" >&2
     return 1
   fi
   export "$env_name=$key_value"
+}
+
+sanitize_generated_artifacts() {
+  export ADL_SANITIZE_OUT_DIR="$OUT_DIR"
+  export ADL_SANITIZE_OUT_REAL
+  ADL_SANITIZE_OUT_REAL="$(cd "$OUT_DIR" && pwd -P)"
+  export ADL_SANITIZE_ROOT_DIR="$ROOT_DIR"
+  export ADL_SANITIZE_ROOT_REAL
+  ADL_SANITIZE_ROOT_REAL="$(cd "$ROOT_DIR" && pwd -P)"
+  export ADL_SANITIZE_OPENAI_KEY_FILE="$OPENAI_KEY_FILE"
+  export ADL_SANITIZE_ANTHROPIC_KEY_FILE="$ANTHROPIC_KEY_FILE"
+  find "$OUT_DIR" -type f \( -name '*.json' -o -name '*.md' -o -name '*.txt' \) -print0 |
+    xargs -0 perl -0pi -e '
+      for my $name (qw(
+        ADL_SANITIZE_OUT_REAL
+        ADL_SANITIZE_OUT_DIR
+        ADL_SANITIZE_ROOT_REAL
+        ADL_SANITIZE_ROOT_DIR
+        ADL_SANITIZE_OPENAI_KEY_FILE
+        ADL_SANITIZE_ANTHROPIC_KEY_FILE
+      )) {
+        my $value = $ENV{$name} // "";
+        next if $value eq "";
+        my $replacement = $name =~ /KEY_FILE/ ? "<credential_file>" :
+          ($name =~ /ROOT/ ? "<repo_root>" : "<output_dir>");
+        s/\Q$value\E/$replacement/g;
+      }
+    '
 }
 
 load_key OPENAI_API_KEY "$OPENAI_KEY_FILE"
@@ -106,14 +134,14 @@ cat >"$MANIFEST" <<EOF
   "title": "Rust-native live ChatGPT + Claude multi-agent tea discussion demo",
   "execution_mode": "runtime_native_live_providers",
   "provider_mode": "rust_native_openai_and_anthropic",
-  "credential_policy": "operator_env_or_home_keys_no_secret_material_recorded",
+  "credential_policy": "operator_env_or_explicit_key_file_no_secret_material_recorded",
   "steps": 5,
   "proof_surfaces": {
-    "transcript": "$TRANSCRIPT",
-    "transcript_contract": "$TRANSCRIPT_CONTRACT",
-    "provider_invocations": "$INVOCATIONS",
-    "run_summary": "$RUNS_ROOT/$RUN_ID/run_summary.json",
-    "trace": "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json"
+    "transcript": "transcript.md",
+    "transcript_contract": "transcript_contract.json",
+    "provider_invocations": "provider_invocations.json",
+    "run_summary": "runtime/runs/$RUN_ID/run_summary.json",
+    "trace": "runtime/runs/$RUN_ID/logs/trace_v1.json"
   }
 }
 EOF
@@ -129,8 +157,8 @@ bash adl/tools/demo_v088_real_multi_agent_discussion.sh
 
 Credential loading:
 - Uses \`OPENAI_API_KEY\` and \`ANTHROPIC_API_KEY\` when already set.
-- Otherwise reads local operator-managed keys from \`\\\$HOME/keys/openai.key\` and \`\\\$HOME/keys/claude.key\`.
-- Secret values and raw Authorization headers are not written to generated artifacts.
+- Otherwise reads operator-selected key files only when \`ADL_OPENAI_KEY_FILE\` and \`ADL_ANTHROPIC_KEY_FILE\` are set.
+- Secret values, key-file paths, and raw Authorization headers are not written to generated artifacts.
 
 What this proves:
 - one ADL runtime workflow with two named live provider families
@@ -138,9 +166,9 @@ What this proves:
 - five sequential turns with saved-state handoff, runtime conversation metadata, and transcript contract validation
 
 Primary proof surfaces:
-- \`$TRANSCRIPT\`
-- \`$INVOCATIONS\`
-- \`$RUNS_ROOT/$RUN_ID/run_summary.json\`
+- \`transcript.md\`
+- \`provider_invocations.json\`
+- \`runtime/runs/$RUN_ID/run_summary.json\`
 EOF
 
 python3 "$ROOT_DIR/adl/tools/validate_multi_agent_transcript.py" \
@@ -148,8 +176,10 @@ python3 "$ROOT_DIR/adl/tools/validate_multi_agent_transcript.py" \
   --contract "$TRANSCRIPT_CONTRACT" \
   >/dev/null
 
-echo "Rust-native live multi-agent discussion proof surface:"
-echo "  $TRANSCRIPT"
-echo "  $INVOCATIONS"
-echo "  $RUNS_ROOT/$RUN_ID/run_summary.json"
-echo "  $RUNS_ROOT/$RUN_ID/logs/trace_v1.json"
+sanitize_generated_artifacts
+
+echo "Rust-native live multi-agent discussion proof surface under the output directory:"
+echo "  transcript.md"
+echo "  provider_invocations.json"
+echo "  runtime/runs/$RUN_ID/run_summary.json"
+echo "  runtime/runs/$RUN_ID/logs/trace_v1.json"

--- a/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
-ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-}"
+ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-}"
 
-if [[ -z "${OPENAI_API_KEY:-}" && ! -s "$OPENAI_KEY_FILE" ]]; then
-  echo "SKIP: missing OPENAI_API_KEY and $OPENAI_KEY_FILE" >&2
+if [[ -z "${OPENAI_API_KEY:-}" && ( -z "$OPENAI_KEY_FILE" || ! -s "$OPENAI_KEY_FILE" ) ]]; then
+  echo "SKIP: missing OPENAI_API_KEY or ADL_OPENAI_KEY_FILE" >&2
   exit 0
 fi
-if [[ -z "${ANTHROPIC_API_KEY:-}" && ! -s "$ANTHROPIC_KEY_FILE" ]]; then
-  echo "SKIP: missing ANTHROPIC_API_KEY and $ANTHROPIC_KEY_FILE" >&2
+if [[ -z "${ANTHROPIC_API_KEY:-}" && ( -z "$ANTHROPIC_KEY_FILE" || ! -s "$ANTHROPIC_KEY_FILE" ) ]]; then
+  echo "SKIP: missing ANTHROPIC_API_KEY or ADL_ANTHROPIC_KEY_FILE" >&2
   exit 0
 fi
 
@@ -84,6 +84,10 @@ if [[ -n "${ANTHROPIC_API_KEY:-}" ]] && grep -R -F "$ANTHROPIC_API_KEY" "$OUT_DI
 fi
 if grep -R -E 'Authorization:|Bearer |x-api-key' "$OUT_DIR" >/dev/null 2>&1; then
   echo "assertion failed: credential header material leaked into artifacts" >&2
+  exit 1
+fi
+if grep -R -E '/Users/|/private/tmp|/tmp/|HOME/keys|openai\.key|claude\.key' "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: local file path leaked into generated artifacts" >&2
   exit 1
 fi
 

--- a/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
+++ b/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
@@ -13,11 +13,11 @@ bash adl/tools/demo_v088_real_multi_agent_discussion.sh
 
 The demo uses operator-managed credentials only:
 
-- `OPENAI_API_KEY` if already set, otherwise `$HOME/keys/openai.key`
-- `ANTHROPIC_API_KEY` if already set, otherwise `$HOME/keys/claude.key`
+- `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` when already set
+- explicit `ADL_OPENAI_KEY_FILE` and `ADL_ANTHROPIC_KEY_FILE` overrides when the operator chooses key-file loading
 
-Secret values and raw credential headers must not be printed or written to
-generated artifacts.
+Secret values, key-file paths, and raw credential headers must not be printed
+or written to generated artifacts.
 
 ## Proof Surfaces
 

--- a/docs/records/v0.88/tasks/issue-1537/sor.md
+++ b/docs/records/v0.88/tasks/issue-1537/sor.md
@@ -40,6 +40,8 @@ Implemented Rust-native OpenAI and Anthropic provider adapters for the ADL runti
 - Added loopback unit tests for native OpenAI and Anthropic request translation, representative response parsing, missing-auth handling, and provider substrate validation.
 - Updated `adl provider setup openai` and `adl provider setup anthropic` to emit native provider snippets instead of generic bounded HTTP gateway snippets.
 - Added a shell-only live demo wrapper for key loading, runtime execution, transcript assembly, manifest generation, and artifact leak checks.
+- Updated the v0.88 live demo Anthropic model to `claude-haiku-4-5-20251001` after live validation showed the previous Haiku names were rejected by the operator's Anthropic API surface.
+- Removed hard-coded local key-file defaults and sanitized generated proof artifacts so they do not record operator-local paths or credential-file locations.
 
 ## Main Repo Integration (REQUIRED)
 - Main-repo paths updated: tracked repository paths are updated on the issue branch and will be published by the finish-created PR.
@@ -79,9 +81,10 @@ Rules:
   - `cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture` verified provider setup templates, including native OpenAI/Anthropic output.
   - `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml --print-plan --allow-unsigned` verified the new demo resolves to five ordered runtime steps.
   - `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY ADL_OPENAI_KEY_FILE=<missing> ADL_ANTHROPIC_KEY_FILE=<missing> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh` verified the live demo test skips cleanly when credentials are unavailable.
-  - `bash adl/tools/demo_v088_real_multi_agent_discussion.sh <temporary local artifact directory>` exercised the real live-provider path with local operator-managed keys.
-- Results: formatting and targeted Rust tests passed; the real live-provider run successfully completed the OpenAI turn and then stopped at the Anthropic API boundary with a sanitized non-retryable insufficient-credits response.
-- Post-rebase retry result: after the operator attempted to add Anthropic API credits, the live demo was retried and still stopped at the Anthropic API boundary with the same sanitized insufficient-credits response; OpenAI turn execution still succeeded and the generated artifact secret scan still returned no matches.
+  - `ADL_OPENAI_KEY_FILE=<operator key file> ADL_ANTHROPIC_KEY_FILE=<operator key file> bash adl/tools/demo_v088_real_multi_agent_discussion.sh <temporary local artifact directory>` exercised the real live-provider path with operator-managed keys.
+  - `ADL_OPENAI_KEY_FILE=<operator key file> ADL_ANTHROPIC_KEY_FILE=<operator key file> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh` verified the real live-provider path and generated artifact leak checks through the repo test wrapper.
+- Results: formatting and targeted Rust tests passed; the real live-provider run initially completed the OpenAI turn and then stopped at the Anthropic API boundary with sanitized account/model errors. After switching the demo to `claude-haiku-4-5-20251001` and using an operator-provided Anthropic key-file override, the five-turn live demo completed successfully with three OpenAI invocations and two Anthropic invocations.
+- Post-rebase retry result: live validation showed the older Haiku model aliases returned `404 Not Found`; `claude-haiku-4-5-20251001` completed successfully.
 
 Validation command/path rules:
 - Prefer repository-relative paths in recorded commands and artifact references.
@@ -94,7 +97,7 @@ Validation command/path rules:
 ```yaml
 verification_summary:
   validation:
-    status: PARTIAL
+    status: PASS
     checks_run:
       - "cargo fmt --manifest-path adl/Cargo.toml --all --check"
       - "cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings"
@@ -105,7 +108,8 @@ verification_summary:
       - "cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture"
       - "cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml --print-plan --allow-unsigned"
       - "env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY ADL_OPENAI_KEY_FILE=<missing> ADL_ANTHROPIC_KEY_FILE=<missing> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh"
-      - "bash adl/tools/demo_v088_real_multi_agent_discussion.sh <temporary local artifact directory>"
+      - "ADL_OPENAI_KEY_FILE=<operator key file> ADL_ANTHROPIC_KEY_FILE=<operator key file> bash adl/tools/demo_v088_real_multi_agent_discussion.sh <temporary local artifact directory>"
+      - "ADL_OPENAI_KEY_FILE=<operator key file> ADL_ANTHROPIC_KEY_FILE=<operator key file> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh"
   determinism:
     status: PASS
     replay_verified: true
@@ -136,10 +140,10 @@ Rules:
 - If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
 
 ## Security / Privacy Checks
-- Secret leakage scan performed: grep-based scan of generated local live-demo artifacts for Authorization headers, bearer header material, `x-api-key`, and key-shaped tokens returned no matches.
+- Secret leakage scan performed: grep-based scan of generated local live-demo artifacts for Authorization headers, bearer header material, `x-api-key`, key-file paths, local absolute artifact paths, and key-shaped tokens returned no matches after artifact sanitization.
 - Prompt / tool argument redaction verified: provider invocation records store provider family, model, status, timestamp, and character counts only; they do not store prompts, outputs, keys, or raw request headers.
 - Absolute path leakage check: this output card uses repository-relative paths and replaces temporary local artifact roots with explicit placeholders.
-- Sandbox / policy invariants preserved: secrets were loaded only from environment variables or local operator-managed key files and were never printed; CI-safe test behavior skips when credentials are absent.
+- Sandbox / policy invariants preserved: secrets were loaded only from environment variables or explicit operator-managed key-file overrides and were never printed; CI-safe test behavior skips when credentials are absent.
 
 Rules:
 - State what was checked and how it was checked.
@@ -149,14 +153,14 @@ Rules:
 - Trace bundle path(s): generated during the local live run under the temporary artifact root; not committed because live-provider artifacts are operator-local and credential-adjacent.
 - Run artifact root: temporary local artifact directory used for operator validation; not a repository artifact.
 - Replay command used for verification: `cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml --print-plan --allow-unsigned`.
-- Replay result: PASS for deterministic plan replay; live execution PARTIAL because Anthropic returned insufficient account credits after OpenAI completed turn 1.
+- Replay result: PASS for deterministic plan replay; live execution PASS after the Anthropic model was updated to `claude-haiku-4-5-20251001`.
 
 ## Artifact Verification
 - Primary proof surface: `adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml`, `adl/tools/demo_v088_real_multi_agent_discussion.sh`, `adl/tools/test_demo_v088_real_multi_agent_discussion.sh`, and `demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md`.
 - Required artifacts present: true; all required tracked implementation and documentation artifacts exist on the issue branch.
 - Artifact schema/version checks: native provider invocation records use `adl.native_provider_invocations.v1`; transcript contract uses the existing `multi_agent_discussion_transcript.v1` shape.
 - Hash/byte-stability checks: not applicable to live model text outputs; deterministic code/test artifacts are source-controlled and stable under git diff.
-- Missing/optional artifacts and rationale: a complete five-turn live transcript was not produced because the local Anthropic account returned an insufficient-credits API error; this is an external account-state block, not a Rust adapter or orchestration failure.
+- Missing/optional artifacts and rationale: complete five-turn live transcript artifacts were produced in a temporary operator-local artifact directory; they are not committed because they are live-provider outputs and are model-dependent.
 
 ## Decisions / Deviations
 
@@ -167,8 +171,7 @@ Rules:
 ## Follow-ups / Deferred work
 
 - Consider a later profile migration issue if `chatgpt:` and `claude:` should expand directly to native vendor provider kinds.
-- Re-run the full live demo when the local Anthropic account has sufficient API credits.
-- The live demo was retried after an attempted Anthropic credit update; the account still reported insufficient API credits.
+- Continue keeping live-provider artifacts local-only because they are model-dependent and credential-adjacent.
 
 Global rule:
 - No section header may be left empty.

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -61,10 +61,10 @@ Claude family note:
 
 Live multi-agent demo note:
 - `adl/tools/demo_v0871_real_multi_agent_discussion.sh` is the operator-run live-provider companion to the deterministic multi-agent demo
-- it reads `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` from the environment when set, otherwise from `$HOME/keys/openai.key` and `$HOME/keys/claude.key`
+- it reads `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` from the environment when set, or from explicit operator-selected key-file overrides when provided
 - it starts a local adapter that bridges ADL's current `{"prompt": "..."} -> {"output": "..."}` HTTP contract to vendor-native OpenAI and Anthropic APIs
 - generated artifacts record provider family/model/status metadata only; they must not include secret values or raw credential headers
 
 v0.88 native provider demo note:
-- `bash adl/tools/demo_v088_real_multi_agent_discussion.sh` demonstrates direct Rust-native OpenAI and Anthropic runtime invocation using operator-managed keys from environment variables or `$HOME/keys`
-- generated demo artifacts record provider family, model, HTTP status, and prompt/output character counts, but never raw secret values or Authorization headers
+- `bash adl/tools/demo_v088_real_multi_agent_discussion.sh` demonstrates direct Rust-native OpenAI and Anthropic runtime invocation using operator-managed keys from environment variables or explicit key-file overrides
+- generated demo artifacts record provider family, model, HTTP status, and prompt/output character counts, but never raw secret values, key-file paths, or Authorization headers


### PR DESCRIPTION
## Summary
- remove hard-coded local key-file defaults from the v0.88 live provider demo
- sanitize generated proof artifacts so local output paths and credential-file paths are not recorded
- update the issue-1537 SOR and provider/demo docs to reflect the successful Claude Haiku 4.5 live run

Closes #1537

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all --check
- cargo test --manifest-path adl/Cargo.toml provider_setup -- --nocapture
- env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY ADL_OPENAI_KEY_FILE= ADL_ANTHROPIC_KEY_FILE= bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh
- ADL_OPENAI_KEY_FILE=<operator key file> ADL_ANTHROPIC_KEY_FILE=<operator key file> bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh

No API key values or key-file paths are included in this PR body.
