### PR TITLE
[v0.87.1][review] Make D13L live-provider readiness explicit in validation policy

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -12,7 +12,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `demo_v0871_suite.sh`: canonical `v0.87.1` WP-13 demo-suite entrypoint for the implemented provider, operator, runtime-state, review-surface, and multi-agent proof surfaces.
 - `normalize_adl_cards.sh`: repairs `.adl/cards/<issue>/` compatibility links and materializes missing bootstrap `sor.md` files for existing task bundles.
 - `demo_v0871_multi_agent_discussion.sh`: canonical `v0.87.1` bounded multi-agent discussion proof wrapper for a five-turn Claude + ChatGPT runtime demo.
-- `demo_v0871_real_multi_agent_discussion.sh`: live-provider companion demo that calls real OpenAI and Anthropic APIs through a local ADL completion adapter using operator-managed keys.
+- `demo_v0871_real_multi_agent_discussion.sh`: live-provider companion demo that calls real OpenAI and Anthropic APIs through a local ADL completion adapter using operator-managed keys; a missing-credentials skip in the paired test is a non-proving disposition, not live-provider proof.
 - `real_multi_agent_provider_adapter.py`: local adapter that translates ADL's bounded HTTP completion contract to vendor-native OpenAI and Anthropic calls without recording secret material.
 - `validate_multi_agent_transcript.py`: validates the bounded multi-agent transcript artifact contract for the D13 discussion demo.
 - `worktree_doctor.sh`, `worktree_prune.sh`: deterministic worktree governance and safe cleanup helpers.

--- a/adl/tools/demo_v0871_real_multi_agent_discussion.sh
+++ b/adl/tools/demo_v0871_real_multi_agent_discussion.sh
@@ -224,6 +224,10 @@ What this proves:
 - real OpenAI and Anthropic calls through ADL's current local HTTP completion adapter boundary
 - five sequential turns with saved-state handoff, runtime conversation metadata, and transcript contract validation
 
+Proof boundary:
+- This command is the credentialed live-provider proof path for D13L.
+- If operator credentials are unavailable, use \`adl/tools/test_demo_v0871_real_multi_agent_discussion.sh\`; its skip path is explicitly non-proving and does not satisfy the live-provider proof claim on its own.
+
 Primary proof surfaces:
 - \`$TRANSCRIPT\`
 - \`$INVOCATIONS\`

--- a/adl/tools/test_demo_v0871_real_multi_agent_discussion.sh
+++ b/adl/tools/test_demo_v0871_real_multi_agent_discussion.sh
@@ -5,11 +5,31 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
 ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
 
+emit_disposition() {
+  local status="$1"
+  local reason="$2"
+  python3 - "$status" "$reason" <<'PY'
+import json
+import sys
+
+status, reason = sys.argv[1:3]
+payload = {
+    "demo_id": "D13L",
+    "validation_disposition": status,
+    "reason": reason,
+    "credentialed_proof": status == "credentialed_proof_passed",
+}
+print("ADL_VALIDATION_DISPOSITION=" + json.dumps(payload, sort_keys=True), file=sys.stderr)
+PY
+}
+
 if [[ -z "${OPENAI_API_KEY:-}" && ! -s "$OPENAI_KEY_FILE" ]]; then
+  emit_disposition "skipped_non_proving" "missing_openai_credentials"
   echo "SKIP: missing OPENAI_API_KEY and $OPENAI_KEY_FILE" >&2
   exit 0
 fi
 if [[ -z "${ANTHROPIC_API_KEY:-}" && ! -s "$ANTHROPIC_KEY_FILE" ]]; then
+  emit_disposition "skipped_non_proving" "missing_anthropic_credentials"
   echo "SKIP: missing ANTHROPIC_API_KEY and $ANTHROPIC_KEY_FILE" >&2
   exit 0
 fi
@@ -87,4 +107,5 @@ if grep -R -E 'Authorization:|Bearer |x-api-key' "$OUT_DIR" >/dev/null 2>&1; the
   exit 1
 fi
 
+emit_disposition "credentialed_proof_passed" "live_provider_artifacts_verified"
 echo "demo_v0871_real_multi_agent_discussion: ok"

--- a/demos/v0.87.1/real_chatgpt_claude_multi_agent_discussion_demo.md
+++ b/demos/v0.87.1/real_chatgpt_claude_multi_agent_discussion_demo.md
@@ -7,6 +7,14 @@ The deterministic demo remains the CI-safe proof surface. This live demo proves
 that the same bounded multi-agent shape can call real OpenAI and Anthropic
 models through ADL's current local HTTP completion boundary.
 
+Proof boundary:
+- A credentialed run that completes and writes the named invocation/transcript
+  artifacts is the proving path for D13L.
+- A no-credential run of
+  `adl/tools/test_demo_v0871_real_multi_agent_discussion.sh` may exit
+  successfully for local ergonomics, but that outcome is an explicit
+  non-proving skip disposition rather than live-provider proof.
+
 ## Command
 
 ```bash

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -135,14 +135,14 @@ Use this table as the fast review surface for milestone coverage.
 | D11 | Quality Gate Walkthrough | `WP-14` quality gate | `bash adl/tools/demo_v0871_quality_gate.sh` | `artifacts/v0871/quality_gate/quality_gate_record.json` | Tests, validators, and bounded demo checks are reviewable in one place with per-check logs | Same repo state should preserve gate outcome and log inventory | READY |
 | D12 | Release Review Package | `WP-16` through `WP-20` review/remediation/planning/release tail | `bash adl/tools/demo_v0871_release_review_package.sh` | `artifacts/v0871/release_review_package/release_review_package_manifest.json` | Review, remediation, planning, and release artifacts are coherent and navigable from one package root | Package layout and key entrypoints remain stable for the bounded release-review surface | READY |
 | D13 | Claude + ChatGPT Tea Discussion | bounded multi-agent runtime discussion proof (`#1490`, `#1491`, `#1501`, `#1502`) | `bash adl/tools/demo_v0871_multi_agent_discussion.sh` | `artifacts/v0871/multi_agent_discussion/transcript.md` | Reviewer can inspect five explicit turns, two named agents, runtime turn metadata, the transcript contract, and the paired runtime trace/summaries | Fixed shim outputs should preserve transcript shape and turn ordering | READY |
-| D13L | Live Claude + ChatGPT Tea Discussion | live-provider companion proof for D13 (`#1500`, `#1501`, `#1502`, `#1533`) | `bash adl/tools/demo_v0871_real_multi_agent_discussion.sh` | `artifacts/v0871/real_multi_agent_discussion/provider_invocations.json` plus `transcript.md` | Reviewer can inspect real OpenAI and Anthropic invocation metadata, five explicit turns, runtime turn metadata, and transcript contract proof without secret leakage when valid operator credentials and provider account credit are available | Live model text is non-deterministic; runtime artifact shape, turn ordering, accepted contract shape, and non-secret invocation metadata remain stable | READY_WITH_OPERATOR_CREDENTIALS |
+| D13L | Live Claude + ChatGPT Tea Discussion | live-provider companion proof for D13 (`#1500`, `#1501`, `#1502`, `#1533`) | `bash adl/tools/demo_v0871_real_multi_agent_discussion.sh` | `artifacts/v0871/real_multi_agent_discussion/provider_invocations.json` plus `transcript.md` | Reviewer can inspect real OpenAI and Anthropic invocation metadata, five explicit turns, runtime turn metadata, and transcript contract proof without secret leakage when valid operator credentials and provider account credit are available; a no-credential test skip is a bounded non-proving disposition, not live-provider proof | Live model text is non-deterministic; runtime artifact shape, turn ordering, accepted contract shape, and non-secret invocation metadata remain stable | READY_WITH_OPERATOR_CREDENTIALS |
 
 Provider demo wrappers also archive successful bounded runtime roots into `.adl/trace-archive/milestones/v0.87.1/runs/<run_id>/` and print that canonical archive location (`#1520`, `#1521`). The original `artifacts/v0871/.../runtime/runs/<run_id>/` proof surfaces remain the immediate demo outputs; the archive is the durable local trace index for later review/export.
 
 Status guidance:
 - `PLANNED` = intended but not yet validated
 - `READY` = runnable and locally validated
-- `READY_WITH_OPERATOR_CREDENTIALS` = runnable with operator-managed live-provider credentials and active provider account access; not required for CI-safe demo-suite validation
+- `READY_WITH_OPERATOR_CREDENTIALS` = runnable with operator-managed live-provider credentials and active provider account access; missing-credential skips remain non-proving and do not satisfy the live-provider proof claim; not required for CI-safe demo-suite validation
 - `BLOCKED` = known dependency or missing proof surface
 - `LANDED` = milestone evidence exists and is ready for review
 
@@ -213,6 +213,7 @@ Expected success signals:
 - The suite exits successfully.
 - The manifest includes D1-D5, D8-D13, and the provider-family packages.
 - D13L is discoverable from this matrix and `demos/v0.87.1/real_chatgpt_claude_multi_agent_discussion_demo.md`, but is not required for the CI-safe D0 suite.
+- A skipped no-credential validation run for D13L is acceptable for bounded local ergonomics, but reviewers should treat it as an explicit non-proof disposition until a credentialed pass produces the live-provider artifacts named in the D13L row.
 - The demo issue inventory above names every `v0.87.1` demo/proof issue so reviewers can find demos that are not part of the D0 runtime suite.
 
 Determinism / replay notes:

--- a/docs/tooling/PROVIDER_SETUP.md
+++ b/docs/tooling/PROVIDER_SETUP.md
@@ -61,9 +61,11 @@ Claude family note:
 
 Live multi-agent demo note:
 - `adl/tools/demo_v0871_real_multi_agent_discussion.sh` is the operator-run live-provider companion to the deterministic multi-agent demo
+- `adl/tools/test_demo_v0871_real_multi_agent_discussion.sh` preserves local ergonomics by exiting successfully when operator credentials are unavailable, but it now emits an explicit machine-readable non-proving skip disposition instead of implying live-provider proof
 - it reads `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` from the environment when set, or from explicit operator-selected key-file overrides when provided
 - it starts a local adapter that bridges ADL's current `{"prompt": "..."} -> {"output": "..."}` HTTP contract to vendor-native OpenAI and Anthropic APIs
 - generated artifacts record provider family/model/status metadata only; they must not include secret values or raw credential headers
+- a real D13L proof claim requires the credentialed path to complete and write the invocation/transcript artifacts named in the demo matrix
 
 v0.88 native provider demo note:
 - `bash adl/tools/demo_v088_real_multi_agent_discussion.sh` demonstrates direct Rust-native OpenAI and Anthropic runtime invocation using operator-managed keys from environment variables or explicit key-file overrides


### PR DESCRIPTION
Closes #1557

## Summary
Made D13L validation semantics explicit by distinguishing a successful no-credential skip from real credentialed live-provider proof. The live test now emits a machine-readable disposition, and the demo matrix plus operator-facing docs now state that skipped local validation is non-proving.

## Artifacts
- Updated `adl/tools/test_demo_v0871_real_multi_agent_discussion.sh` to emit explicit structured validation dispositions for skip and credentialed-proof paths.
- Updated `docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md` so D13L readiness text treats missing-credential skips as non-proving.
- Updated `docs/tooling/PROVIDER_SETUP.md`, `demos/v0.87.1/real_chatgpt_claude_multi_agent_discussion_demo.md`, `adl/tools/demo_v0871_real_multi_agent_discussion.sh`, and `adl/tools/README.md` to keep operator/reviewer wording aligned with the new proof boundary.

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/test_demo_v0871_real_multi_agent_discussion.sh adl/tools/demo_v0871_real_multi_agent_discussion.sh` verified shell syntax after the test/wrapper updates.
  - `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY ADL_OPENAI_KEY_FILE=<missing-openai-key-file> ADL_ANTHROPIC_KEY_FILE=<missing-claude-key-file> bash adl/tools/test_demo_v0871_real_multi_agent_discussion.sh` verified that the no-credential path still exits successfully while emitting an explicit `skipped_non_proving` disposition.
  - `git diff --check` verified there are no whitespace or patch-format regressions.
  - `rg -n "skipped_non_proving|non-proving|READY_WITH_OPERATOR_CREDENTIALS" adl/tools docs/milestones/v0.87.1 docs/tooling demos/v0.87.1 -S` verified the revised reviewer/operator wording is present on all intended truth surfaces.
- Results:
  - All listed validation commands passed.
  - The skip-path validation emitted `ADL_VALIDATION_DISPOSITION={"credentialed_proof": false, "demo_id": "D13L", "reason": "missing_openai_credentials", "validation_disposition": "skipped_non_proving"}` before the human-readable skip line.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Makes D13L live-provider readiness truthful by distinguishing non-proving no-credential skips from real credentialed proof in the live demo test and review surfaces. Closes #1557

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1557__v0-87-1-review-make-d13l-live-provider-readiness-explicit-in-validation-policy/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1557__v0-87-1-review-make-d13l-live-provider-readiness-explicit-in-validation-policy/sor.md
- Idempotency-Key: v0-87-1-review-make-d13l-live-provider-readiness-explicit-in-validation-policy-adl-tools-docs-milestones-v0-87-1-docs-tooling-demos-v0-87-1-adl-v0-87-1-tasks-issue-1557-v0-87-1-review-make-d13l-live-provider-readiness-explicit-in-validation-policy-sip-md-adl-v0-87-1-tasks-issue-1557-v0-87-1-review-make-d13l-live-provider-readiness-explicit-in-validation-policy-sor-md