### PR TITLE
[v0.87.1][tools] Isolate provider demo wrapper ports so acceptance tests are parallel-safe

### DIFF
--- a/adl/tools/demo_v0871_provider_chatgpt.sh
+++ b/adl/tools/demo_v0871_provider_chatgpt.sh
@@ -10,59 +10,28 @@ RUNS_ROOT="$RUNTIME_ROOT/runs"
 STEP_OUT="$OUT_DIR/out"
 RUN_ID="v0-87-1-provider-chatgpt-demo"
 EXAMPLE="adl/examples/v0-87-1-provider-chatgpt-demo.adl.yaml"
-PORT=8788
 TOKEN="${OPENAI_API_KEY:-chatgpt-demo-token}"
 SERVER_LOG="$OUT_DIR/chatgpt_adapter.log"
+PORT_FILE="$OUT_DIR/chatgpt_adapter.port"
+GENERATED_EXAMPLE="$OUT_DIR/v0-87-1-provider-chatgpt-demo.runtime.adl.yaml"
 
 rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"
 
 cd "$ROOT_DIR"
 
-python3 - "$PORT" "$TOKEN" >"$SERVER_LOG" 2>&1 <<'PY' &
-import http.server
-import json
-import socketserver
-import sys
-
-port = int(sys.argv[1])
-token = sys.argv[2]
-
-class ReusableTCPServer(socketserver.TCPServer):
-    allow_reuse_address = True
-
-class Handler(http.server.BaseHTTPRequestHandler):
-    def do_POST(self):
-        if self.path != "/complete":
-            self.send_response(404)
-            self.end_headers()
-            return
-        auth = self.headers.get("Authorization", "")
-        if auth != f"Bearer {token}":
-            self.send_response(401)
-            self.end_headers()
-            self.wfile.write(b'{"error":"unauthorized"}')
-            return
-        length = int(self.headers.get("Content-Length", "0"))
-        body = self.rfile.read(length)
-        payload = json.loads(body.decode("utf-8"))
-        prompt = payload.get("prompt", "")
-        response = json.dumps({"output": f"CHATGPT_PROVIDER_DEMO_OK\n{prompt}"}).encode("utf-8")
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(response)))
-        self.end_headers()
-        self.wfile.write(response)
-
-    def log_message(self, format, *args):
-        return
-
-with ReusableTCPServer(("127.0.0.1", port), Handler) as httpd:
-    httpd.handle_request()
-PY
+provider_demo_start_single_request_completion_server \
+  "$SERVER_LOG" \
+  "$PORT_FILE" \
+  "$TOKEN" \
+  "CHATGPT_PROVIDER_DEMO_OK"
 SERVER_PID=$!
 trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
-sleep 1
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+provider_demo_materialize_loopback_example \
+  "$EXAMPLE" \
+  "$GENERATED_EXAMPLE" \
+  "http://127.0.0.1:$PORT/complete"
 
 echo "Running v0.87.1 ChatGPT provider demo..."
 ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
@@ -71,7 +40,7 @@ OPENAI_API_KEY="$TOKEN" \
 ADL_MILESTONE="v0.87.1" \
 ADL_DEMO_NAME="provider_chatgpt" \
   cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
-    "$EXAMPLE" \
+    "$GENERATED_EXAMPLE" \
     --run \
     --trace \
     --allow-unsigned \

--- a/adl/tools/demo_v0871_provider_http.sh
+++ b/adl/tools/demo_v0871_provider_http.sh
@@ -10,59 +10,28 @@ RUNS_ROOT="$RUNTIME_ROOT/runs"
 STEP_OUT="$OUT_DIR/out"
 RUN_ID="v0-87-1-provider-http-demo"
 EXAMPLE="adl/examples/v0-87-1-provider-http-demo.adl.yaml"
-PORT=8787
 TOKEN="${ADL_REMOTE_BEARER_TOKEN:-bounded-demo-token}"
 SERVER_LOG="$OUT_DIR/http_server.log"
+PORT_FILE="$OUT_DIR/http_server.port"
+GENERATED_EXAMPLE="$OUT_DIR/v0-87-1-provider-http-demo.runtime.adl.yaml"
 
 rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"
 
 cd "$ROOT_DIR"
 
-python3 - "$PORT" "$TOKEN" >"$SERVER_LOG" 2>&1 <<'PY' &
-import http.server
-import json
-import socketserver
-import sys
-
-port = int(sys.argv[1])
-token = sys.argv[2]
-
-class ReusableTCPServer(socketserver.TCPServer):
-    allow_reuse_address = True
-
-class Handler(http.server.BaseHTTPRequestHandler):
-    def do_POST(self):
-        if self.path != "/complete":
-            self.send_response(404)
-            self.end_headers()
-            return
-        auth = self.headers.get("Authorization", "")
-        if auth != f"Bearer {token}":
-            self.send_response(401)
-            self.end_headers()
-            self.wfile.write(b'{"error":"unauthorized"}')
-            return
-        length = int(self.headers.get("Content-Length", "0"))
-        body = self.rfile.read(length)
-        payload = json.loads(body.decode("utf-8"))
-        prompt = payload.get("prompt", "")
-        response = json.dumps({"output": f"HTTP_PROVIDER_DEMO_OK\n{prompt}"}).encode("utf-8")
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(response)))
-        self.end_headers()
-        self.wfile.write(response)
-
-    def log_message(self, format, *args):
-        return
-
-with ReusableTCPServer(("127.0.0.1", port), Handler) as httpd:
-    httpd.handle_request()
-PY
+provider_demo_start_single_request_completion_server \
+  "$SERVER_LOG" \
+  "$PORT_FILE" \
+  "$TOKEN" \
+  "HTTP_PROVIDER_DEMO_OK"
 SERVER_PID=$!
 trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
-sleep 1
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+provider_demo_materialize_loopback_example \
+  "$EXAMPLE" \
+  "$GENERATED_EXAMPLE" \
+  "http://127.0.0.1:$PORT/complete"
 
 echo "Running v0.87.1 bounded-HTTP provider demo..."
 ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
@@ -71,7 +40,7 @@ ADL_REMOTE_BEARER_TOKEN="$TOKEN" \
 ADL_MILESTONE="v0.87.1" \
 ADL_DEMO_NAME="provider_http" \
   cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
-    "$EXAMPLE" \
+    "$GENERATED_EXAMPLE" \
     --run \
     --trace \
     --allow-unsigned \

--- a/adl/tools/provider_demo_common.sh
+++ b/adl/tools/provider_demo_common.sh
@@ -5,6 +5,100 @@ provider_demo_repo_root() {
   cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
 }
 
+provider_demo_start_single_request_completion_server() {
+  local log_path="$1"
+  local port_file="$2"
+  local token="$3"
+  local output_prefix="$4"
+
+  python3 - "$port_file" "$token" "$output_prefix" >"$log_path" 2>&1 <<'PY' &
+import http.server
+import json
+import socketserver
+import sys
+
+port_file, token, output_prefix = sys.argv[1:4]
+
+class ReusableTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != "/complete":
+            self.send_response(404)
+            self.end_headers()
+            return
+        auth = self.headers.get("Authorization", "")
+        if auth != f"Bearer {token}":
+            self.send_response(401)
+            self.end_headers()
+            self.wfile.write(b'{"error":"unauthorized"}')
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        payload = json.loads(body.decode("utf-8"))
+        prompt = payload.get("prompt", "")
+        response = json.dumps({"output": f"{output_prefix}\n{prompt}"}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format, *args):
+        return
+
+with ReusableTCPServer(("127.0.0.1", 0), Handler) as httpd:
+    with open(port_file, "w", encoding="utf-8") as fh:
+        fh.write(str(httpd.server_address[1]))
+    httpd.handle_request()
+PY
+}
+
+provider_demo_wait_for_port() {
+  local port_file="$1"
+  local attempts="${2:-100}"
+  local sleep_secs="${3:-0.1}"
+  local port=""
+  local i
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -s "$port_file" ]]; then
+      port="$(<"$port_file")"
+      if [[ "$port" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$port"
+        return 0
+      fi
+    fi
+    sleep "$sleep_secs"
+  done
+  echo "timed out waiting for demo server port in $port_file" >&2
+  return 1
+}
+
+provider_demo_materialize_loopback_example() {
+  local template_path="$1"
+  local output_path="$2"
+  local endpoint="$3"
+
+  python3 - "$template_path" "$output_path" "$endpoint" <<'PY'
+import pathlib
+import re
+import sys
+
+template_path, output_path, endpoint = sys.argv[1:4]
+text = pathlib.Path(template_path).read_text(encoding="utf-8")
+updated, count = re.subn(
+    r'endpoint:\s*"http://127\.0\.0\.1:\d+/complete"',
+    f'endpoint: "{endpoint}"',
+    text,
+    count=1,
+)
+if count != 1:
+    raise SystemExit(f"expected exactly one loopback completion endpoint in {template_path}")
+pathlib.Path(output_path).write_text(updated, encoding="utf-8")
+PY
+}
+
 provider_demo_write_readme() {
   local out_dir="$1"
   local title="$2"

--- a/adl/tools/test_demo_v0871_provider_parallel.sh
+++ b/adl/tools/test_demo_v0871_provider_parallel.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+HTTP_ROOT="$TMPDIR_ROOT/provider_http"
+CHATGPT_ROOT="$TMPDIR_ROOT/provider_chatgpt"
+HTTP_LOG="$TMPDIR_ROOT/provider_http.stdout.log"
+CHATGPT_LOG="$TMPDIR_ROOT/provider_chatgpt.stdout.log"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0871_provider_http.sh "$HTTP_ROOT" >"$HTTP_LOG" 2>&1
+) &
+HTTP_PID=$!
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0871_provider_chatgpt.sh "$CHATGPT_ROOT" >"$CHATGPT_LOG" 2>&1
+) &
+CHATGPT_PID=$!
+
+wait "$HTTP_PID"
+wait "$CHATGPT_PID"
+
+HTTP_SUMMARY="$HTTP_ROOT/runtime/runs/v0-87-1-provider-http-demo/run_summary.json"
+CHATGPT_SUMMARY="$CHATGPT_ROOT/runtime/runs/v0-87-1-provider-chatgpt-demo/run_summary.json"
+
+[[ -f "$HTTP_SUMMARY" ]] || {
+  echo "assertion failed: HTTP parallel summary missing" >&2
+  exit 1
+}
+[[ -f "$CHATGPT_SUMMARY" ]] || {
+  echo "assertion failed: ChatGPT parallel summary missing" >&2
+  exit 1
+}
+
+grep -Fq 'HTTP_PROVIDER_DEMO_OK' "$HTTP_LOG" || {
+  echo "assertion failed: HTTP parallel run missing provider output" >&2
+  exit 1
+}
+grep -Fq 'CHATGPT_PROVIDER_DEMO_OK' "$CHATGPT_LOG" || {
+  echo "assertion failed: ChatGPT parallel run missing provider output" >&2
+  exit 1
+}
+
+python3 - "$HTTP_ROOT/http_server.port" "$CHATGPT_ROOT/chatgpt_adapter.port" <<'PY'
+import pathlib
+import sys
+
+http_port = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").strip()
+chatgpt_port = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8").strip()
+if not http_port.isdigit() or not chatgpt_port.isdigit():
+    raise SystemExit("expected numeric port files for parallel provider demos")
+if http_port == chatgpt_port:
+    raise SystemExit("expected isolated loopback ports for concurrent provider demos")
+PY
+
+echo "demo_v0871_provider_parallel: ok"


### PR DESCRIPTION
Makes the v0.87.1 HTTP and ChatGPT provider demo wrappers parallel-safe by replacing fixed loopback ports with per-run dynamic endpoint materialization and adding a bounded concurrent validation path. Closes #1556