### PR TITLE
[v0.87.1][tools] Prevent pr create test fixtures from hitting the live GitHub tracker

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -39,8 +39,9 @@ use self::git_support::{branch_checked_out_worktree_path, infer_repo_from_remote
 use self::git_support::{
     commits_ahead_of_origin_main, current_branch, default_repo, ensure_git_metadata_writable,
     ensure_local_branch_exists, ensure_not_on_main_branch, ensure_worktree_for_branch,
-    fetch_origin_main_with_fallback, has_uncommitted_changes, path_str, primary_checkout_root,
-    repo_root, run_capture, run_capture_allow_failure, run_status, run_status_allow_failure,
+    fetch_origin_main_with_fallback, has_uncommitted_changes, issue_create_repo, path_str,
+    primary_checkout_root, repo_root, run_capture, run_capture_allow_failure, run_status,
+    run_status_allow_failure,
 };
 #[cfg(test)]
 use self::github::pr_has_closing_linkage;
@@ -74,7 +75,7 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
 fn real_pr_create(args: &[String]) -> Result<()> {
     let parsed = parse_create_args(args)?;
     let repo_root = repo_root()?;
-    let repo = default_repo(&repo_root)?;
+    let repo = issue_create_repo(&repo_root)?;
 
     let title = parsed.title_arg.clone().unwrap_or_default();
     let mut slug = parsed.slug.clone().unwrap_or_default();

--- a/adl/src/cli/pr_cmd/git_support.rs
+++ b/adl/src/cli/pr_cmd/git_support.rs
@@ -60,6 +60,22 @@ pub(super) fn default_repo(repo_root: &Path) -> Result<String> {
     Ok(format!("local/{base}"))
 }
 
+pub(super) fn issue_create_repo(repo_root: &Path) -> Result<String> {
+    let remote = run_capture_allow_failure(
+        "git",
+        &["-C", path_str(repo_root)?, "remote", "get-url", "origin"],
+    )?;
+    if let Some(url) = remote {
+        if let Some(inferred) = infer_repo_from_remote(&url) {
+            return Ok(inferred);
+        }
+    }
+
+    bail!(
+        "create: refusing to infer the GitHub issue target from ambient gh context; configure git origin with a GitHub owner/repo remote before running create"
+    )
+}
+
 pub(super) fn infer_repo_from_remote(url: &str) -> Option<String> {
     let trimmed = url.trim();
     let candidate = trimmed

--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -281,6 +281,7 @@ fn same_filesystem_target(left: &Path, right: &Path) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::tests::env_lock;
     use std::env;
     use std::os::unix::fs::PermissionsExt;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -305,6 +306,7 @@ mod tests {
 
     #[test]
     fn issue_is_closed_and_completed_parses_completed_state() {
+        let _guard = env_lock();
         let temp = temp_dir("adl-pr-lifecycle-gh");
         let bin_dir = temp.join("bin");
         fs::create_dir_all(&bin_dir).expect("bin dir");

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -52,7 +52,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-fn env_lock() -> MutexGuard<'static, ()> {
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
     match ENV_LOCK.get_or_init(|| Mutex::new(())).lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -404,7 +404,7 @@ fn parse_start_args_accepts_prefix_and_rejects_unknown_arg() {
 
 #[test]
 fn real_pr_init_seeds_stp_from_generated_source_prompt() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-init");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
@@ -447,7 +447,7 @@ fn real_pr_init_seeds_stp_from_generated_source_prompt() {
 
 #[test]
 fn real_pr_init_existing_stp_is_left_untouched() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-init-existing");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
@@ -488,7 +488,7 @@ fn real_pr_init_existing_stp_is_left_untouched() {
 
 #[test]
 fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-create");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
@@ -569,7 +569,7 @@ fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
 
 #[test]
 fn real_pr_create_fails_when_created_issue_is_missing_requested_labels() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-create-missing-labels");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
@@ -614,7 +614,7 @@ fn real_pr_create_fails_when_created_issue_is_missing_requested_labels() {
 
 #[test]
 fn real_pr_create_generates_concrete_body_when_none_is_supplied() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-create-generated-body");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
@@ -676,7 +676,7 @@ fn real_pr_create_generates_concrete_body_when_none_is_supplied() {
 
 #[test]
 fn real_pr_create_rejects_issue_body_that_cannot_pass_source_prompt_validation() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-create-invalid-body");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
@@ -719,4 +719,64 @@ fn real_pr_create_rejects_issue_body_that_cannot_pass_source_prompt_validation()
     assert!(err
         .to_string()
         .contains("create: issue body cannot satisfy source-prompt validation"));
+}
+
+#[test]
+fn real_pr_create_rejects_missing_origin_before_spawning_gh_issue_create() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-real-create-no-origin");
+    assert!(Command::new("git")
+        .arg("init")
+        .arg("-q")
+        .current_dir(&repo)
+        .status()
+        .expect("git init")
+        .success());
+    copy_bootstrap_support_files(&repo);
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = repo.join("gh.log");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            gh_log.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[v0.87.1][tools] Guard create repo target".to_string(),
+        "--slug".to_string(),
+        "v0-87-1-tools-guard-create-repo-target".to_string(),
+        "--body".to_string(),
+        "## Summary\n\nGuard issue creation against ambient repo inference.\n\n## Goal\n\nRequire a real GitHub origin before issue creation.\n\n## Required Outcome\n\nThis issue ships tooling code and tests.\n\n## Deliverables\n\n- create-path guard\n\n## Acceptance Criteria\n\n- create fails before gh issue create when origin is missing\n\n## Repo Inputs\n\n- adl/src/cli/pr_cmd.rs\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- broader lifecycle redesign\n\n## Issue-Graph Notes\n\n- regression test\n\n## Notes\n\n- none\n\n## Tooling Notes\n\n- gh should not be spawned on this path\n".to_string(),
+        "--labels".to_string(),
+        "track:roadmap,type:task,area:tools".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ])
+    .expect_err("missing origin should fail before gh issue create");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(err
+        .to_string()
+        .contains("refusing to infer the GitHub issue target from ambient gh context"));
+    assert!(
+        !gh_log.exists(),
+        "gh should not be spawned when origin is missing"
+    );
 }

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -71,7 +71,7 @@ fn render_pr_body_uses_output_sections_and_rejects_issue_template_text() {
 
 #[test]
 fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-create");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -240,7 +240,7 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
 
 #[test]
 fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-sync-output");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -429,7 +429,7 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
 
 #[test]
 fn real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_copy() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-primary-prompt");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -619,7 +619,7 @@ fn real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_c
 
 #[test]
 fn real_pr_finish_updates_existing_pr_and_marks_ready() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-edit");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -778,7 +778,7 @@ fn real_pr_finish_updates_existing_pr_and_marks_ready() {
 
 #[test]
 fn finish_helper_paths_cover_nonempty_and_staged_checks() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-finish-helpers");
     init_git_repo(&repo);
     assert!(Command::new("git")
@@ -831,7 +831,7 @@ fn finish_helper_paths_cover_nonempty_and_staged_checks() {
 
 #[test]
 fn finish_helper_paths_cover_ahead_count_and_batch_checks() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-batch-checks");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -946,7 +946,7 @@ fn finish_helper_paths_cover_ahead_count_and_batch_checks() {
 
 #[test]
 fn finish_helper_paths_cover_pr_lookup_and_closing_linkage() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-gh-helpers");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -1003,7 +1003,7 @@ fn finish_helper_paths_cover_pr_lookup_and_closing_linkage() {
 
 #[test]
 fn real_pr_finish_rejects_main_and_no_changes_paths() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-errors");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -1158,7 +1158,7 @@ fn real_pr_finish_rejects_main_and_no_changes_paths() {
 
 #[test]
 fn real_pr_finish_rejects_not_started_output_card_before_publication() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-not-started");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn real_pr_start_bootstraps_worktree_and_ready_passes() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-ready");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -184,7 +184,7 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
 
 #[test]
 fn real_pr_doctor_full_reports_pre_run_ready_without_worktree() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-doctor-pre-run");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -305,7 +305,7 @@ fn real_pr_doctor_full_reports_pre_run_ready_without_worktree() {
 
 #[test]
 fn real_pr_doctor_full_accepts_pre_run_analysis_issue_with_partial_worktree_residue() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-doctor-pre-run-partial-worktree");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -436,7 +436,7 @@ fn real_pr_doctor_full_accepts_pre_run_analysis_issue_with_partial_worktree_resi
 
 #[test]
 fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-doctor-worktree-cwd");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -564,7 +564,7 @@ fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
 
 #[test]
 fn real_pr_start_rewrites_unbound_root_input_card_branch() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-rewrites-unbound");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -685,7 +685,7 @@ fn real_pr_start_rewrites_unbound_root_input_card_branch() {
 
 #[test]
 fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-ready-worktree-cwd");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -811,7 +811,7 @@ fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
 
 #[test]
 fn real_pr_preflight_reports_open_milestone_prs() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-preflight");
     init_git_repo(&repo);
     let bin_dir = repo.join("bin");
@@ -848,7 +848,7 @@ fn real_pr_preflight_reports_open_milestone_prs() {
 
 #[test]
 fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-blocks-wave");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
@@ -961,7 +961,7 @@ fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
 
 #[test]
 fn real_pr_ready_requires_slug_when_local_state_missing() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-ready-missing-slug");
     init_git_repo(&repo);
     let prev_dir = env::current_dir().expect("cwd");
@@ -975,7 +975,7 @@ fn real_pr_ready_requires_slug_when_local_state_missing() {
 
 #[test]
 fn real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-doctor-closed-issue-reconcile");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");

--- a/adl/src/cli/tests/pr_cmd_inline/mod.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/mod.rs
@@ -2,9 +2,9 @@ use super::*;
 use crate::cli::pr_cmd_cards::write_output_card;
 use crate::cli::pr_cmd_prompt::{infer_wp_from_title, render_generated_issue_prompt};
 use crate::cli::pr_cmd_validate::bootstrap_stub_reason;
+use crate::cli::tests::env_lock as cli_env_lock;
 use adl::control_plane::{card_input_path, card_stp_path};
 use std::env;
-use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn unique_temp_dir(label: &str) -> PathBuf {
@@ -17,9 +17,8 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    cli_env_lock()
 }
 
 fn write_executable(path: &Path, content: &str) {
@@ -46,7 +45,7 @@ fn init_git_repo(dir: &Path) {
             "remote",
             "add",
             "origin",
-            "https://github.com/danielbaustin/agent-design-language.git"
+            "https://github.com/owner/repo.git"
         ])
         .current_dir(dir)
         .status()

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -1,8 +1,60 @@
 use super::*;
 
 #[test]
+fn issue_create_repo_requires_github_origin_remote() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-create-repo-guard");
+    assert!(Command::new("git")
+        .arg("init")
+        .arg("-q")
+        .current_dir(&repo)
+        .status()
+        .expect("git init")
+        .success());
+
+    let err = issue_create_repo(&repo).expect_err("missing origin should fail");
+    assert!(err
+        .to_string()
+        .contains("refusing to infer the GitHub issue target from ambient gh context"));
+
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://gitlab.example.com/example/repo.git"
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote add")
+        .success());
+
+    let err = issue_create_repo(&repo).expect_err("non-github origin should fail");
+    assert!(err
+        .to_string()
+        .contains("refusing to infer the GitHub issue target from ambient gh context"));
+
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/example/repo.git"
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+
+    assert_eq!(
+        issue_create_repo(&repo).expect("github origin"),
+        "example/repo"
+    );
+}
+
+#[test]
 fn default_repo_falls_back_to_local_name_when_remote_and_gh_are_unavailable() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-default-repo-fallback");
     assert!(Command::new("git")
         .arg("init")
@@ -40,7 +92,7 @@ fn default_repo_falls_back_to_local_name_when_remote_and_gh_are_unavailable() {
 
 #[test]
 fn default_repo_uses_gh_repo_when_remote_is_unparseable() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-default-repo-gh");
     assert!(Command::new("git")
         .arg("init")
@@ -75,7 +127,7 @@ fn default_repo_uses_gh_repo_when_remote_is_unparseable() {
 
 #[test]
 fn fetch_origin_main_with_fallback_reuses_local_origin_main_and_errors_when_missing() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-fetch-fallback");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -106,7 +158,7 @@ fn fetch_origin_main_with_fallback_reuses_local_origin_main_and_errors_when_miss
 
 #[test]
 fn ensure_worktree_for_branch_rejects_branch_checked_out_elsewhere() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-worktree-conflict");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -130,7 +182,7 @@ fn ensure_worktree_for_branch_rejects_branch_checked_out_elsewhere() {
 
 #[test]
 fn ensure_local_branch_exists_covers_existing_remote_and_new_branch_paths() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-ensure-branch");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -163,7 +215,7 @@ fn ensure_local_branch_exists_covers_existing_remote_and_new_branch_paths() {
 
 #[test]
 fn issue_version_prefers_labels_and_falls_back_to_title() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-issue-version");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -196,7 +248,7 @@ fn issue_version_prefers_labels_and_falls_back_to_title() {
 
 #[test]
 fn ensure_source_issue_prompt_replaces_existing_bootstrap_stub_when_github_body_is_authored() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-replace-bootstrap-stub");
     init_git_repo(&repo);
 
@@ -266,7 +318,7 @@ fn ensure_source_issue_prompt_replaces_existing_bootstrap_stub_when_github_body_
 
 #[test]
 fn ensure_source_issue_prompt_preserves_authored_front_matter_from_github_body() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-preserve-authored-front-matter");
     init_git_repo(&repo);
 
@@ -315,7 +367,7 @@ fn ensure_source_issue_prompt_preserves_authored_front_matter_from_github_body()
 
 #[test]
 fn current_pr_url_filters_empty_and_null_results() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-current-url");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -355,7 +407,7 @@ fn current_pr_url_filters_empty_and_null_results() {
 
 #[test]
 fn branch_checked_out_worktree_path_returns_none_without_match() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-worktree-none");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -379,7 +431,7 @@ fn branch_checked_out_worktree_path_returns_none_without_match() {
 
 #[test]
 fn ensure_worktree_for_branch_reuses_matching_path_and_creates_new_one() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-worktree-reuse-create");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
@@ -442,7 +494,7 @@ fn resolve_issue_prompt_path_accepts_legacy_issue_bodies_location() {
 
 #[test]
 fn real_pr_start_rejects_missing_slug_or_empty_sanitized_title_in_no_fetch_mode() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-start-preconditions");
     init_git_repo(&repo);
     let prev_dir = env::current_dir().expect("cwd");
@@ -474,7 +526,7 @@ fn real_pr_start_rejects_missing_slug_or_empty_sanitized_title_in_no_fetch_mode(
 
 #[test]
 fn real_pr_ready_accepts_started_issue_when_output_branch_is_bootstrap_placeholder() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-ready-branch-placeholder");
     let origin = repo.join("origin.git");
     init_git_repo(&repo);
@@ -636,7 +688,7 @@ fn bootstrap_stub_reason_detects_issue_prompt_and_sip_templates() {
 fn ensure_git_metadata_writable_rejects_unwritable_git_dir() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-git-metadata-write");
     init_git_repo(&repo);
     let prev_dir = env::current_dir().expect("cwd");
@@ -677,7 +729,7 @@ fn ensure_git_metadata_writable_rejects_unwritable_git_dir() {
 
 #[test]
 fn ensure_bootstrap_cards_creates_bundle_and_compat_links() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-bootstrap-cards");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);
@@ -735,7 +787,7 @@ fn ensure_bootstrap_cards_creates_bundle_and_compat_links() {
 
 #[test]
 fn ensure_bootstrap_cards_rewrites_existing_bootstrap_stub_input_card() {
-    let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-bootstrap-cards-rewrite");
     init_git_repo(&repo);
     copy_bootstrap_support_files(&repo);


### PR DESCRIPTION
Closes #1573

## Summary
Prevented `adl pr create` from targeting an ambient GitHub repository when `origin` is missing or unparseable, and removed the live project remote from the shared temp-repo test harness so a failed `gh` stub can no longer create bogus live issues. Added regression coverage for both the create-path guard and the repo-target helper, and closed the accidental tracker artifacts `#1566` and `#1567`.

## Artifacts
- Create-path repo-target guard: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/git_support.rs`
- Regression tests: `adl/src/cli/tests/pr_cmd_inline/basics.rs`, `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`
- Safer shared test harness origin: `adl/src/cli/tests/pr_cmd_inline/mod.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_ -- --nocapture` verified the create-path regression set, including the missing-origin guard and the existing successful/stubbed create flows.
  - `cargo test --manifest-path adl/Cargo.toml issue_create_repo_requires_github_origin_remote -- --nocapture` verified the new helper rejects missing and non-GitHub origins and accepts a valid GitHub origin.
  - `cargo test --manifest-path adl/Cargo.toml ensure_source_issue_prompt_replaces_existing_bootstrap_stub_when_github_body_is_authored -- --nocapture` verified the shared temp-repo harness change did not break representative prompt-repair helper behavior.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified Rust formatting is clean after the helper and regression updates.
  - `git diff --check` verified the tracked diff has no whitespace or patch-format errors.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.87.1/tasks/issue-1573__v0-87-1-tools-prevent-pr-create-test-fixtures-from-hitting-the-live-github-tracker/sor.md` verified this output record satisfies the completed SOR contract.
- Results:
  - PASS for create-path regression coverage, helper regression coverage, representative shared-harness compatibility coverage, formatting, diff hygiene, and completed-SOR validation.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1573__v0-87-1-tools-prevent-pr-create-test-fixtures-from-hitting-the-live-github-tracker/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1573__v0-87-1-tools-prevent-pr-create-test-fixtures-from-hitting-the-live-github-tracker/sor.md
- Idempotency-Key: v0-87-1-tools-prevent-pr-create-test-fixtures-from-hitting-the-live-github-tracker-adl-v0-87-1-tasks-issue-1573-v0-87-1-tools-prevent-pr-create-test-fixtures-from-hitting-the-live-github-tracker-sip-md-adl-v0-87-1-tasks-issue-1573-v0-87-1-tools-prevent-pr-create-test-fixtures-from-hitting-the-live-github-tracker-sor-md