### PR TITLE
[v0.87.1][skills] Normalize repo-code-review skill input schema and docs

### DIFF
--- a/.adl/v0.87.1/bodies/issue-1589-v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs.md
+++ b/.adl/v0.87.1/bodies/issue-1589-v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs.md
@@ -1,0 +1,93 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs"
+title: "[v0.87.1][skills] Normalize repo-code-review skill input schema and docs"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:task"
+  - "version:v0.87.1"
+issue_number: 1589
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs"
+---
+
+## Summary
+
+Normalize the `repo-code-review` skill to the same explicit input-schema standard used by the PR-phase and card-editor skills.
+
+## Goal
+
+Make the repo review skill machine-self-describing and automation-safe by adding a canonical input schema surface, wiring it into the manifest, and syncing the guide/test surfaces to match.
+
+## Required Outcome
+
+- add an explicit input schema document for `repo-code-review`
+- update the skill manifest to declare the schema id and reference doc
+- align the operational guide and any contract tests so the skill is documented and validated like the other normalized skills
+- preserve the current review behavior and output contract
+
+## Deliverables
+
+- schema doc under `adl/tools/skills/docs/`
+- updated `adl/tools/skills/repo-code-review/adl-skill.yaml`
+- any needed guide/test updates for schema parity
+
+## Acceptance Criteria
+
+- `repo-code-review` has a stable named input schema and reference doc in the manifest
+- the schema doc explains required fields, optional fields, and invocation shape clearly enough for automation use
+- operational docs describe the skill using the new schema surface
+- contract or fixture tests cover the new schema linkage
+- no review behavior or output contract is weakened
+
+## Repo Inputs
+
+- `adl/tools/skills/repo-code-review/adl-skill.yaml`
+- `adl/tools/skills/repo-code-review/SKILL.md`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- neighboring normalized skill manifests and schema docs
+- any skill contract tests for repo-local validation
+
+## Dependencies
+
+- existing normalized PR/editor skill schema patterns should be available for reuse
+
+## Demo Expectations
+
+- no runtime demo required; bounded skill-contract validation is sufficient
+
+## Non-goals
+
+- rewriting the repo review output contract
+- changing the substantive review methodology beyond schema clarity
+- broad skill-system redesign
+
+## Issue-Graph Notes
+
+- this is schema/contract parity work for an existing skill bundle
+- prefer the same machine-readable shape already used by `pr-init`, `pr-ready`, `pr-run`, `pr-finish`, `pr-closeout`, and the editor skills
+
+## Notes
+
+- the main gap is input-schema formalization, not output-contract coverage
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- validate both the manifest linkage and the repo review contract fixtures
+

--- a/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sip.md
+++ b/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1589
+Run ID: issue-1589
+Version: v0.87.1
+Title: [v0.87.1][skills] Normalize repo-code-review skill input schema and docs
+Branch: codex/1589-v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1589
+- PR:
+- Source Issue Prompt: .adl/v0.87.1/bodies/issue-1589-v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sor.md
@@ -1,0 +1,157 @@
+# v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1589
+Run ID: issue-1589
+Version: v0.87.1
+Title: [v0.87.1][skills] Normalize repo-code-review skill input schema and docs
+Branch: codex/1589-v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: gpt-5-codex
+- Provider: OpenAI Codex desktop
+- Start Time: 2026-04-11T16:49:00Z
+- End Time: 2026-04-11T17:02:13Z
+
+## Summary
+Normalized the `repo-code-review` skill to the same typed-input standard as the newer PR-phase and editor skills. The bundle now declares a structured input schema in the manifest, ships a canonical schema reference document, and has a dedicated contract test plus updated operator guidance.
+
+## Artifacts produced
+- Updated `adl/tools/skills/repo-code-review/adl-skill.yaml` to declare `repo_code_review.v1` structured input admission rules and explicit mode/policy validation.
+- Added `adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md` as the canonical input-schema reference for the skill.
+- Updated `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md` so human/operator usage matches the new typed invocation surface.
+- Added `adl/tools/test_repo_code_review_skill_contracts.sh` to prove the manifest, schema doc, and guide stay in sync.
+
+## Actions taken
+- Reviewed the existing `repo-code-review` skill bundle, compared it against schema-backed skills already in the repository, and confirmed the gap was input-contract formalization rather than output-contract coverage.
+- Added an `admission.input_schema` section to the skill manifest with a stable schema id, required top-level fields, supported modes, and explicit prevalidation rules.
+- Authored a bounded schema document that defines the canonical structured invocation shape, per-mode requirements, and validation expectations for automation.
+- Updated the operational guide so user-facing instructions point to the schema-backed invocation path instead of prose-only inputs.
+- Added and ran a dedicated contract test to keep the manifest, schema doc, and guide aligned over time.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; execution changes currently exist only on the issue branch/worktree prior to `pr finish`
+- Worktree-only paths remaining: `adl/tools/skills/repo-code-review/adl-skill.yaml`, `adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md`, `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`, and `adl/tools/test_repo_code_review_skill_contracts.sh`
+- Integration state: worktree_only
+- Verification scope: worktree
+- Integration method used: issue branch/worktree edits staged for `pr finish`; main-repo tracked copy not updated yet
+- Verification performed:
+  - `git status --short`
+  - `git diff --check`
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `bash adl/tools/test_repo_code_review_skill_contracts.sh` verified that the repo review skill manifest, schema doc, and operational guide expose the same structured input contract.
+  - `bash adl/tools/test_repo_review_contract.sh` verified the existing repo review output-contract fixtures still pass after the input-schema normalization.
+  - `git diff --check` verified there are no whitespace errors or malformed patch artifacts in the touched files.
+- Results: PASS
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash adl/tools/test_repo_code_review_skill_contracts.sh"
+      - "bash adl/tools/test_repo_review_contract.sh"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: true
+      approved: true
+```
+
+## Determinism Evidence
+- Determinism tests executed: repeated contract-oriented shell validations over the same manifest and documentation inputs.
+- Fixtures or scripts used: `adl/tools/test_repo_code_review_skill_contracts.sh` and `adl/tools/test_repo_review_contract.sh`.
+- Replay verification (same inputs -> same artifacts/order): rerunning the contract checks with unchanged inputs continues to produce the same PASS/FAIL disposition and validate the same bounded artifact set.
+- Ordering guarantees (sorting / tie-break rules used): the new input schema fixes the top-level contract shape and per-mode required fields, so accepted structured inputs are validated against a stable field set rather than ad hoc prose ordering.
+- Artifact stability notes: the touched artifacts are tracked text files with no generated timestamps or randomized content, so identical accepted edits produce stable repository content.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of the new schema doc, manifest rules, and contract test confirmed no secrets, tokens, or credential-bearing examples were introduced.
+- Prompt / tool argument redaction verified: the structured examples are bounded to schema fields and repository-relative commands; no user prompt transcripts or sensitive tool arguments are recorded.
+- Absolute path leakage check: checked the final SOR and touched tracked docs/scripts for unjustified host-specific paths; only the manifest `reference_doc` uses the repository's canonical absolute path format already established by the newer skills.
+- Sandbox / policy invariants preserved: the change is limited to skill metadata, documentation, and shell validation, with no widening of runtime permissions or file-write scope.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this normalization work did not generate a separate trace bundle beyond the tracked skill artifacts and validation commands.
+- Run artifact root: not applicable; proof is carried by the updated tracked files and contract-test results.
+- Replay command used for verification: `bash adl/tools/test_repo_code_review_skill_contracts.sh` and `bash adl/tools/test_repo_review_contract.sh`
+- Replay result: PASS; both contract checks are reproducible on the current branch state.
+
+## Artifact Verification
+- Primary proof surface: `adl/tools/skills/repo-code-review/adl-skill.yaml`, `adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md`, `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`, and `adl/tools/test_repo_code_review_skill_contracts.sh`
+- Required artifacts present: yes; the manifest, schema doc, operator guide updates, and dedicated contract test are all present in the worktree.
+- Artifact schema/version checks: the manifest now declares `repo_code_review.v1`, and the schema doc plus guide reference the same id and structured top-level shape.
+- Hash/byte-stability checks: not run separately; this issue relies on tracked-text review plus deterministic contract validation rather than emitted binary artifacts.
+- Missing/optional artifacts and rationale: no additional reference docs were needed because the existing review playbook and output contract already matched repository truth.
+
+## Decisions / Deviations
+- Normalized the input side of `repo-code-review` without changing its review-playbook or output-contract semantics, keeping the scope tightly bounded to schema/documentation parity.
+- Preserved the manifest's canonical absolute `reference_doc` style so the repo review skill matches the path conventions already used by the newer skill bundles.
+
+## Follow-ups / Deferred work
+- `pr finish` still needs to publish the branch and open the PR so the Main Repo Integration section can be normalized from `worktree_only` to the actual PR state.
+- If we want stricter machine enforcement later, the repo review skill could grow a typed validator that consumes `repo_code_review.v1` directly at invocation time rather than relying on manifest/schema alignment plus contract tests.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/stp.md
+++ b/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/stp.md
@@ -1,0 +1,93 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs"
+title: "[v0.87.1][skills] Normalize repo-code-review skill input schema and docs"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:task"
+  - "version:v0.87.1"
+issue_number: 1589
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs"
+---
+
+## Summary
+
+Normalize the `repo-code-review` skill to the same explicit input-schema standard used by the PR-phase and card-editor skills.
+
+## Goal
+
+Make the repo review skill machine-self-describing and automation-safe by adding a canonical input schema surface, wiring it into the manifest, and syncing the guide/test surfaces to match.
+
+## Required Outcome
+
+- add an explicit input schema document for `repo-code-review`
+- update the skill manifest to declare the schema id and reference doc
+- align the operational guide and any contract tests so the skill is documented and validated like the other normalized skills
+- preserve the current review behavior and output contract
+
+## Deliverables
+
+- schema doc under `adl/tools/skills/docs/`
+- updated `adl/tools/skills/repo-code-review/adl-skill.yaml`
+- any needed guide/test updates for schema parity
+
+## Acceptance Criteria
+
+- `repo-code-review` has a stable named input schema and reference doc in the manifest
+- the schema doc explains required fields, optional fields, and invocation shape clearly enough for automation use
+- operational docs describe the skill using the new schema surface
+- contract or fixture tests cover the new schema linkage
+- no review behavior or output contract is weakened
+
+## Repo Inputs
+
+- `adl/tools/skills/repo-code-review/adl-skill.yaml`
+- `adl/tools/skills/repo-code-review/SKILL.md`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- neighboring normalized skill manifests and schema docs
+- any skill contract tests for repo-local validation
+
+## Dependencies
+
+- existing normalized PR/editor skill schema patterns should be available for reuse
+
+## Demo Expectations
+
+- no runtime demo required; bounded skill-contract validation is sufficient
+
+## Non-goals
+
+- rewriting the repo review output contract
+- changing the substantive review methodology beyond schema clarity
+- broad skill-system redesign
+
+## Issue-Graph Notes
+
+- this is schema/contract parity work for an existing skill bundle
+- prefer the same machine-readable shape already used by `pr-init`, `pr-ready`, `pr-run`, `pr-finish`, `pr-closeout`, and the editor skills
+
+## Notes
+
+- the main gap is input-schema formalization, not output-contract coverage
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- validate both the manifest linkage and the repo review contract fixtures
+

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -1120,14 +1120,45 @@ Do not use it for:
 
 Minimum:
 
-- `repo_root_or_target_path`
+- `repo_root`
+- structured invocation should use `skill_input_schema: repo_code_review.v1`
 
 Optional:
 
+- `target_path`
 - `branch`
 - `diff_base`
 - `changed_paths`
 - `review_depth`
+
+### Input Schema
+
+Canonical schema:
+
+- `adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md`
+
+Schema id:
+
+- `repo_code_review.v1`
+
+Structured invocation shape:
+
+```yaml
+skill_input_schema: repo_code_review.v1
+mode: review_repository | review_path | review_branch | review_diff
+repo_root: /absolute/path
+target:
+  target_path: <path or null>
+  branch: <string or null>
+  diff_base: <string or null>
+  changed_paths:
+    - <path>
+policy:
+  review_depth: quick | standard | deep
+  include_generated_code: true | false
+  write_review_artifact: true | false
+  stop_after_review: true
+```
 
 ### Review Standard
 
@@ -1154,7 +1185,21 @@ This skill is findings-only and must not edit code.
 ### Example Invocation
 
 ```yaml
-Use $repo-code-review at /Users/daniel/git/agent-design-language/adl/tools/skills/repo-code-review/SKILL.md to review /Users/daniel/git/agent-design-language. Review the executable codebase first, include manifests and build configuration, run targeted local tests only when bounded and relevant, and write the review to .adl/reviews/<timestamp>-repo-review.md.
+Use $repo-code-review at /Users/daniel/git/agent-design-language/adl/tools/skills/repo-code-review/SKILL.md with:
+skill_input_schema: repo_code_review.v1
+mode: review_repository
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  target_path: null
+  branch: null
+  diff_base: null
+  changed_paths: []
+policy:
+  review_depth: standard
+  include_generated_code: false
+  write_review_artifact: true
+  stop_after_review: true
+Review the executable codebase first, include manifests and build configuration, run targeted local tests only when bounded and relevant, and write the review to .adl/reviews/<timestamp>-repo-review.md.
 ```
 
 ## Choosing The Right Skill

--- a/adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,298 @@
+# Repo Code Review Skill Input Schema
+
+## Metadata
+- Feature Name: `Repo Code Review Skill Input Schema`
+- Milestone Target: `v0.87.1`
+- Status: `proposed`
+- Owner: `Daniel Austin / Agent Logic`
+- Doc Role: `primary`
+- Supporting Docs: `adl/tools/skills/repo-code-review/SKILL.md`, `adl/tools/skills/repo-code-review/adl-skill.yaml`, `adl/tools/skills/repo-code-review/references/output-contract.md`
+- Feature Types: `schema`, `policy`, `artifact`
+- Proof Modes: `review`, `tests`
+
+## Template Rules
+
+- Every section is completed or explicitly marked `N/A` with justification.
+- This document defines the invocation contract for the `repo-code-review`
+  skill, not the markdown review artifact contract.
+
+## Purpose
+
+This feature defines a stable, explicit input schema for invoking the
+`repo-code-review` skill.
+
+The skill already has a strong review methodology and output contract, but its
+invocation surface is still mostly prose. That is workable for human use, but
+it is weaker than the newer PR-phase and editor skills when automation or
+sub-agent delegation needs to validate whether enough context is present before
+execution.
+
+This schema exists to make repo review invocation:
+
+- deterministic
+- validate-able before execution
+- portable across direct Codex use, ADL skill execution, and future wrappers
+- explicit about review mode, target, and policy
+
+## Context
+
+- Related milestone: `v0.87.1`
+- Related issues: `#1589`
+- Dependencies:
+  - `adl/tools/skills/repo-code-review/SKILL.md`
+  - `adl/tools/skills/repo-code-review/adl-skill.yaml`
+  - `adl/tools/skills/repo-code-review/references/output-contract.md`
+  - `docs/tooling/review-surface-format.md`
+
+The current repo review skill is already bounded in important ways:
+
+- findings-first output
+- no code edits
+- executable code and manifests reviewed before docs
+- targeted local tests only when bounded
+
+The missing piece is a stable machine-readable admission contract that callers
+can validate before invoking the skill.
+
+## Coverage / Ownership
+
+This document covers the input schema of the `repo-code-review` skill.
+
+- Covered surfaces:
+  - repo review invocation payload
+  - review-target mode selection
+  - bounded review-policy settings
+  - sub-agent and automation compatibility for schema validation
+- Related / supporting docs:
+  - `adl/tools/skills/repo-code-review/SKILL.md`
+  - `adl/tools/skills/repo-code-review/adl-skill.yaml`
+  - `adl/tools/skills/repo-code-review/references/output-contract.md`
+
+## Overview
+
+The `repo-code-review` skill should not rely only on prompts like “review this
+repo” when automation is involved.
+
+Instead, callers should pass a small structured object with:
+
+- explicit review mode
+- explicit repository root
+- explicit target selector data
+- explicit review-depth policy
+
+Key capabilities:
+
+- deterministic target selection
+- validation before sub-agent spawn or ADL admission
+- clear distinction between whole-repo, subtree, branch, and diff review
+- explicit review-depth policy
+- stable cross-tool invocation shape
+
+## Design
+
+### Core Concepts
+
+The main concepts introduced by this feature are:
+
+- **explicit review mode**
+  - callers state whether they are reviewing the whole repo, a path, a branch,
+    or a diff-oriented slice
+- **typed target payload**
+  - optional path, branch, diff base, and changed-path scope are passed in a
+    stable structure
+- **review policy**
+  - callers must say how deep the review should be and whether generated code
+    is included
+- **artifact intent**
+  - callers declare whether the review should be written to the default review
+    artifact path
+
+### Input Schema
+
+The canonical invocation shape is:
+
+```yaml
+skill_input_schema: repo_code_review.v1
+
+mode: review_repository | review_path | review_branch | review_diff
+repo_root: /absolute/path/to/repo
+
+target:
+  target_path: /absolute/or/repo-relative/path/or/null
+  branch: <string or null>
+  diff_base: <string or null>
+  changed_paths:
+    - <repo-relative-or-absolute path>
+
+policy:
+  review_depth: quick | standard | deep
+  include_generated_code: true | false
+  write_review_artifact: true | false
+  stop_after_review: true
+```
+
+### Mode Semantics
+
+#### `review_repository`
+
+Use this mode when the whole repository is the target.
+
+Required:
+
+- `repo_root`
+- `mode: review_repository`
+
+Optional:
+
+- `target.changed_paths`
+- `policy.review_depth`
+
+Expected behavior:
+
+- review the repository as a whole
+- prioritize executable code, manifests, config, and tests
+- emit one findings-first review artifact or response
+
+#### `review_path`
+
+Use this mode when a subtree or single path is the target.
+
+Required:
+
+- `repo_root`
+- `mode: review_path`
+- `target.target_path`
+
+Optional:
+
+- `target.changed_paths`
+- `policy.review_depth`
+
+Expected behavior:
+
+- review the requested path first
+- still include relevant manifests/config if they affect that path
+- emit one findings-first review artifact or response
+
+#### `review_branch`
+
+Use this mode when a branch-oriented review is intended.
+
+Required:
+
+- `repo_root`
+- `mode: review_branch`
+- `target.branch`
+
+Optional:
+
+- `target.changed_paths`
+- `policy.review_depth`
+
+Expected behavior:
+
+- review the repository with explicit attention to the named branch context
+- prefer changed-path concentration when the caller provides it
+- emit one findings-first review artifact or response
+
+#### `review_diff`
+
+Use this mode when the caller wants a diff-oriented or base-comparison review.
+
+Required:
+
+- `repo_root`
+- `mode: review_diff`
+- `target.diff_base`
+
+Optional:
+
+- `target.changed_paths`
+- `target.branch`
+- `policy.review_depth`
+
+Expected behavior:
+
+- review the changed surfaces relative to the diff base
+- still widen into manifests/config/tests when they materially affect changed
+  behavior
+- emit one findings-first review artifact or response
+
+### Policy Semantics
+
+#### `policy.review_depth`
+
+Allowed values:
+
+- `quick`
+  - tight, high-signal scan of the most relevant code and config surfaces
+- `standard`
+  - default findings-first review depth
+- `deep`
+  - wider repo sweep including maintainability and lower-severity issues
+
+This field should always be explicit.
+
+#### `policy.include_generated_code`
+
+- `false` by default for ordinary repo review
+- `true` only when the caller explicitly wants generated code included
+
+#### `policy.write_review_artifact`
+
+- `true` means the review should be written to `.adl/reviews/<timestamp>-repo-review.md`
+  unless ADL provides a more specific output path
+- `false` means the response may stay in-memory or inline
+
+#### `policy.stop_after_review`
+
+Must be `true`.
+
+The skill is findings-only and must not expand into implementation.
+
+## Validation Rules
+
+The caller should reject input when:
+
+- `repo_root` is not absolute
+- `skill_input_schema` is not `repo_code_review.v1`
+- `mode` is not one of the supported enum values
+- `mode: review_path` is used without `target.target_path`
+- `mode: review_branch` is used without `target.branch`
+- `mode: review_diff` is used without `target.diff_base`
+- `target.changed_paths` is present but not a path list
+- `policy.review_depth` is omitted
+- `policy.stop_after_review` is not `true`
+
+## Example Invocation
+
+```yaml
+skill_input_schema: repo_code_review.v1
+mode: review_repository
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  target_path: null
+  branch: null
+  diff_base: null
+  changed_paths: []
+policy:
+  review_depth: standard
+  include_generated_code: false
+  write_review_artifact: true
+  stop_after_review: true
+```
+
+## Acceptance Criteria
+
+- a canonical `repo_code_review.v1` input schema exists
+- the repo review skill manifest references this schema doc
+- required and optional fields are explicit enough for automation and
+  sub-agent use
+- operational documentation reflects the new schema surface
+- repo-local contract tests cover the linkage
+
+## Out Of Scope
+
+- changing the review output contract
+- changing the substantive findings methodology
+- turning repo review into an implementation skill

--- a/adl/tools/skills/repo-code-review/adl-skill.yaml
+++ b/adl/tools/skills/repo-code-review/adl-skill.yaml
@@ -7,19 +7,63 @@ codex_compat:
     - "name"
     - "description"
 admission:
+  input_schema:
+    id: "repo_code_review.v1"
+    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_repository"
+      - "review_path"
+      - "review_branch"
+      - "review_diff"
+    policy_fields:
+      - "review_depth"
+      - "include_generated_code"
+      - "write_review_artifact"
+      - "stop_after_review"
+    mode_requirements:
+      review_repository:
+        required_target_fields: []
+      review_path:
+        required_target_fields:
+          - "target_path"
+      review_branch:
+        required_target_fields:
+          - "branch"
+      review_diff:
+        required_target_fields:
+          - "diff_base"
   intent:
     - "repo_review"
     - "risk_assessment"
     - "release_readiness_review"
   required_inputs:
-    - "repo_root_or_target_path"
+    - "repo_root"
   optional_inputs:
+    - "target_path"
     - "branch"
     - "diff_base"
     - "changed_paths"
     - "review_depth"
+    - "include_generated_code"
+    - "write_review_artifact"
   stop_if_missing:
-    - "repo_root_or_target_path"
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_code_review.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "review_path_requires_target.target_path"
+    - "review_branch_requires_target.branch"
+    - "review_diff_requires_target.diff_base"
+    - "target.changed_paths_must_be_a_path_list_when_present"
+    - "policy.review_depth_must_be_explicit"
+    - "policy.stop_after_review_must_be_true"
 execution:
   mode: "findings_only"
   allow_code_edits: false
@@ -42,6 +86,7 @@ execution:
     - "largest_code_files"
     - "stateful_or_security_sensitive_code"
     - "tests"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
 boundaries:
   ignore_by_default:
     - "node_modules/**"

--- a/adl/tools/test_repo_code_review_skill_contracts.sh
+++ b/adl/tools/test_repo_code_review_skill_contracts.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/repo-code-review/SKILL.md" ]]
+[[ -f "${skills_root}/repo-code-review/adl-skill.yaml" ]]
+[[ -f "${skills_root}/repo-code-review/agents/openai.yaml" ]]
+[[ -f "${skills_root}/repo-code-review/references/review-playbook.md" ]]
+[[ -f "${skills_root}/repo-code-review/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "repo_code_review.v1"' "${skills_root}/repo-code-review/adl-skill.yaml"
+grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"' "${skills_root}/repo-code-review/adl-skill.yaml"
+grep -Fq "policy.review_depth_must_be_explicit" "${skills_root}/repo-code-review/adl-skill.yaml"
+grep -Fq "policy.stop_after_review_must_be_true" "${skills_root}/repo-code-review/adl-skill.yaml"
+grep -Fq "mode: review_repository | review_path | review_branch | review_diff" "${skills_root}/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"
+grep -Fq "skill_input_schema: repo_code_review.v1" "${skills_root}/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"
+grep -Fq "review_repository" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "repo_code_review.v1" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+
+echo "PASS test_repo_code_review_skill_contracts"


### PR DESCRIPTION
## Summary
- add a canonical `repo_code_review.v1` input schema surface for the `repo-code-review` skill
- document the schema in `adl/tools/skills/docs` and update the operational guide to use the structured invocation path
- add a dedicated contract test and carry the canonical issue bundle for #1589

## Validation
- `bash adl/tools/test_repo_code_review_skill_contracts.sh`
- `bash adl/tools/test_repo_review_contract.sh`
- full `pr.sh finish` validation pass (Rust/unit/integration/doc tests); publication then required manual force-add of ignored `.adl` bundle paths

Closes #1589