### PR TITLE
[v0.87.1][tools] Make pr finish stage canonical ignored .adl issue bundles during publication

### DIFF
--- a/.adl/v0.87.1/bodies/issue-1592-v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication.md
+++ b/.adl/v0.87.1/bodies/issue-1592-v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication.md
@@ -1,0 +1,91 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication"
+title: "[v0.87.1][tools] Make pr finish stage canonical ignored .adl issue bundles during publication"
+labels:
+  - "area:tools"
+  - "type:bug"
+  - "severity:high"
+  - "version:v0.87.1"
+issue_number: 1592
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication"
+---
+
+## Summary
+
+Fix the `pr finish` publication path so required canonical `.adl` issue-bundle artifacts are staged and published even when `.adl/` is gitignored.
+
+## Goal
+
+Make `pr finish` end-to-end truthful and reliable for current-issue publication by ensuring it can stage the canonical issue body plus `stp.md`, `sip.md`, and `sor.md` without requiring manual `git add -f` recovery.
+
+## Required Outcome
+
+- publish the canonical current-issue `.adl` bundle deterministically during `finish`
+- keep staging bounded to the required current-issue bundle rather than broadly force-adding ignored files
+- add regression coverage for ignored-canonical-bundle publication behavior
+- preserve existing validation and non-ignored publication behavior
+
+## Deliverables
+
+- `pr finish` staging/publication fix in the Rust CLI path
+- regression tests for canonical ignored bundle publication
+- any tightly scoped documentation or comments needed to reflect the behavior
+
+## Acceptance Criteria
+
+- `pr finish` succeeds when the only remaining publishable changes are the canonical ignored `.adl` issue body and task-bundle files
+- `pr finish` also succeeds when tracked changes and canonical ignored bundle files are mixed
+- the fix force-stages only the required current-issue canonical bundle files, not arbitrary ignored content
+- automated regression coverage exists in the `finish` test surface
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd_args.rs`
+- `adl/src/cli/pr_cmd/lifecycle.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `.gitignore`
+
+## Dependencies
+
+- existing `pr finish` canonical-output sync behavior should remain the source of truth for what must be published
+
+## Demo Expectations
+
+- no demo required; focused CLI/test validation is sufficient
+
+## Non-goals
+
+- redesigning `.gitignore`
+- moving canonical issue records out of `.adl`
+- generic support for publishing arbitrary ignored files outside the current issue bundle
+
+## Issue-Graph Notes
+
+- this is the concrete fix for the publication failure reproduced while publishing issue `#1589`
+- it should resolve the need for manual `git add -f` of canonical issue-bundle artifacts
+
+## Notes
+
+- this is a publication correctness bug, not a source-prompt or card-editing issue
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- keep the fix and tests bounded to current-issue canonical bundle publication

--- a/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sip.md
+++ b/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1592
+Run ID: issue-1592
+Version: v0.87.1
+Title: [v0.87.1][tools] Make pr finish stage canonical ignored .adl issue bundles during publication
+Branch: codex/1592-v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1592
+- PR:
+- Source Issue Prompt: .adl/v0.87.1/bodies/issue-1592-v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sor.md
@@ -1,0 +1,156 @@
+# v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1592
+Run ID: issue-1592
+Version: v0.87.1
+Title: [v0.87.1][tools] Make pr finish stage canonical ignored .adl issue bundles during publication
+Branch: codex/1592-v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: gpt-5-codex
+- Provider: OpenAI Codex desktop
+- Start Time: 2026-04-11T17:05:00Z
+- End Time: 2026-04-11T17:22:59Z
+
+## Summary
+Fixed the Rust `pr finish` publication path so it stages the current issue's canonical `.adl` issue body and `stp.md` / `sip.md` / `sor.md` bundle files even when `.adl/` is gitignored. The finish flow now succeeds for both mixed tracked-plus-ignored publication and ignored-bundle-only publication.
+
+## Artifacts produced
+- Updated `adl/src/cli/pr_cmd.rs` to stage the selected publish paths plus the current issue's canonical bundle with a bounded force-add path.
+- Updated `adl/src/cli/tests/pr_cmd_inline/finish.rs` with helper coverage for force-staging ignored bundle files, a mixed tracked-plus-ignored publication assertion, and a new ignored-bundle-only `real_pr finish` regression test.
+
+## Actions taken
+- Reviewed the finish lifecycle ordering to confirm the failure happened after canonical output sync but before publication staging.
+- Changed `finish` to compute the current issue's canonical bundle paths, run the normal `git add` for selected tracked paths, and then force-add only the bounded current-issue canonical bundle artifacts.
+- Moved the no-change check to happen after staging so ignored-bundle-only publication can succeed instead of falsely reporting "Nothing to PR."
+- Added regression tests for both the mixed tracked-plus-ignored case and the ignored-bundle-only case.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; execution changes currently exist only on the issue branch/worktree prior to `pr finish`
+- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs` and `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- Integration state: worktree_only
+- Verification scope: worktree
+- Integration method used: issue branch/worktree edits staged for `pr finish`; main-repo tracked copy not updated yet
+- Verification performed:
+  - `git status --short`
+  - `git diff --check`
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml finish_helper_paths_cover_nonempty_and_staged_checks -- --nocapture` verified the staging helper still handles tracked staging and now force-stages the bounded ignored bundle file path.
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture` verified mixed tracked-plus-ignored publication now commits and publishes the canonical `.adl` issue bundle alongside tracked changes.
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_publishes_ignored_canonical_bundle_when_no_tracked_changes_remain -- --nocapture` verified `pr finish` succeeds when the only publishable artifacts are the ignored canonical issue body and task-bundle files.
+  - `git diff --check` verified the patch is whitespace-clean after formatting.
+- Results: PASS
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml finish_helper_paths_cover_nonempty_and_staged_checks -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_publishes_ignored_canonical_bundle_when_no_tracked_changes_remain -- --nocapture"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: repeated targeted `finish` regressions covering tracked-plus-ignored staging and ignored-bundle-only publication.
+- Fixtures or scripts used: the Rust `real_pr_finish_*` integration tests in `adl/src/cli/tests/pr_cmd_inline/finish.rs`.
+- Replay verification (same inputs -> same artifacts/order): rerunning the targeted finish regressions with identical fixture inputs produced the same successful publication outcomes and the same canonical bundle paths in the commit tree.
+- Ordering guarantees (sorting / tie-break rules used): the current issue's canonical publish paths are now collected into a stable sorted set before force-add, so the bounded ignored-path staging set is deterministic for the same issue inputs.
+- Artifact stability notes: the tests prove stable publication of the same canonical issue body and task-bundle file set; temporary fixture directories vary by test run as expected, but the committed path set and success behavior remain stable.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of the staging helper and new test fixtures confirmed the change only stages canonical issue-bundle paths and does not serialize credentials or secret values.
+- Prompt / tool argument redaction verified: the change operates on repository-relative issue-bundle paths and does not widen any prompt or tool-argument recording surfaces.
+- Absolute path leakage check: no tracked output or validation record depends on absolute host paths; test fixtures use temporary directories internally but the committed behavior and recorded commands remain repository-relative.
+- Sandbox / policy invariants preserved: the fix stays inside the local git publication path and does not broaden network or filesystem scope beyond bounded current-issue publication.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this issue is proven by repository-local Rust regression tests rather than a separate trace bundle.
+- Run artifact root: temporary Rust test repositories created by the targeted `real_pr_finish_*` fixture tests.
+- Replay command used for verification: `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture` and `cargo test --manifest-path adl/Cargo.toml real_pr_finish_publishes_ignored_canonical_bundle_when_no_tracked_changes_remain -- --nocapture`
+- Replay result: PASS for both mixed tracked-plus-ignored and ignored-bundle-only publication.
+
+## Artifact Verification
+- Primary proof surface: `adl/src/cli/pr_cmd.rs` and `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- Required artifacts present: yes; the bounded force-add logic and both regression proofs are present in the worktree.
+- Artifact schema/version checks: no artifact schema changes were introduced; this issue changes finish-publication behavior only.
+- Hash/byte-stability checks: not run separately; proof is behavioral and path-set based via the targeted Rust fixture tests.
+- Missing/optional artifacts and rationale: no documentation changes were required for this issue because the behavior fix is internal to `finish` publication.
+
+## Decisions / Deviations
+- Fixed the underlying bounded publication bug first instead of changing flag/help text in this issue; operator-facing flag semantics remain available as a narrower follow-up.
+- Kept the force-add scope limited to the current issue's canonical body/STP/SIP/SOR files rather than widening ignored-path publication generally.
+
+## Follow-ups / Deferred work
+- `#1593` remains the follow-up to decide whether `--allow-gitignore` should now be narrowed, documented differently, or otherwise made explicitly truthful after the bounded publication fix.
+- `pr finish` still needs to publish this branch so the Main Repo Integration section can be normalized from `worktree_only` to the actual PR state.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/stp.md
+++ b/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/stp.md
@@ -1,0 +1,91 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication"
+title: "[v0.87.1][tools] Make pr finish stage canonical ignored .adl issue bundles during publication"
+labels:
+  - "area:tools"
+  - "type:bug"
+  - "severity:high"
+  - "version:v0.87.1"
+issue_number: 1592
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication"
+---
+
+## Summary
+
+Fix the `pr finish` publication path so required canonical `.adl` issue-bundle artifacts are staged and published even when `.adl/` is gitignored.
+
+## Goal
+
+Make `pr finish` end-to-end truthful and reliable for current-issue publication by ensuring it can stage the canonical issue body plus `stp.md`, `sip.md`, and `sor.md` without requiring manual `git add -f` recovery.
+
+## Required Outcome
+
+- publish the canonical current-issue `.adl` bundle deterministically during `finish`
+- keep staging bounded to the required current-issue bundle rather than broadly force-adding ignored files
+- add regression coverage for ignored-canonical-bundle publication behavior
+- preserve existing validation and non-ignored publication behavior
+
+## Deliverables
+
+- `pr finish` staging/publication fix in the Rust CLI path
+- regression tests for canonical ignored bundle publication
+- any tightly scoped documentation or comments needed to reflect the behavior
+
+## Acceptance Criteria
+
+- `pr finish` succeeds when the only remaining publishable changes are the canonical ignored `.adl` issue body and task-bundle files
+- `pr finish` also succeeds when tracked changes and canonical ignored bundle files are mixed
+- the fix force-stages only the required current-issue canonical bundle files, not arbitrary ignored content
+- automated regression coverage exists in the `finish` test surface
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd_args.rs`
+- `adl/src/cli/pr_cmd/lifecycle.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `.gitignore`
+
+## Dependencies
+
+- existing `pr finish` canonical-output sync behavior should remain the source of truth for what must be published
+
+## Demo Expectations
+
+- no demo required; focused CLI/test validation is sufficient
+
+## Non-goals
+
+- redesigning `.gitignore`
+- moving canonical issue records out of `.adl`
+- generic support for publishing arbitrary ignored files outside the current issue bundle
+
+## Issue-Graph Notes
+
+- this is the concrete fix for the publication failure reproduced while publishing issue `#1589`
+- it should resolve the need for manual `git add -f` of canonical issue-bundle artifacts
+
+## Notes
+
+- this is a publication correctness bug, not a source-prompt or card-editing issue
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- keep the fix and tests bounded to current-issue canonical bundle publication

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde::Serialize;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(test)]
@@ -390,27 +391,27 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     validate_completed_sor(&repo_root, &output_path)?;
     lifecycle::sync_completed_output_surfaces(&repo_root, &primary_root, &issue_ref, &output_path)?;
 
-    let ahead = commits_ahead_of_origin_main(&repo_root)?;
-    let has_uncommitted = has_uncommitted_changes(&repo_root)?;
-    if !has_uncommitted && ahead == 0 {
-        bail!("No changes detected and branch has no commits ahead of origin/main. Nothing to PR.");
-    }
-
     if !parsed.no_checks {
         run_batched_checks_rust(&repo_root)?;
     }
 
-    if has_uncommitted {
-        stage_selected_paths_rust(&repo_root, &parsed.paths)?;
-        if staged_diff_is_empty(&repo_root)? {
-            bail!(
-                "finish: nothing staged after 'git add' for paths '{}'",
-                parsed.paths
-            );
+    let canonical_publish_paths = canonical_finish_bundle_paths(
+        &repo_root,
+        &source_path,
+        &stp_path,
+        &input_path,
+        &output_path,
+    )?;
+
+    stage_selected_paths_rust(&repo_root, &parsed.paths, &canonical_publish_paths)?;
+    let has_uncommitted = has_uncommitted_changes(&repo_root)?;
+    let ahead = commits_ahead_of_origin_main(&repo_root)?;
+    if staged_diff_is_empty(&repo_root)? {
+        if !has_uncommitted && ahead == 0 {
+            bail!("No changes detected and branch has no commits ahead of origin/main. Nothing to PR.");
         }
-        if !parsed.allow_gitignore && staged_gitignore_change_present(&repo_root)? {
-            bail!("finish: .gitignore changes detected. Revert them or re-run with --allow-gitignore.");
-        }
+    } else if !parsed.allow_gitignore && staged_gitignore_change_present(&repo_root)? {
+        bail!("finish: .gitignore changes detected. Revert them or re-run with --allow-gitignore.");
     }
 
     let close_line = if parsed.no_close {
@@ -724,7 +725,31 @@ fn run_batched_checks_rust(repo_root: &Path) -> Result<()> {
     Ok(())
 }
 
-fn stage_selected_paths_rust(repo_root: &Path, csv: &str) -> Result<()> {
+fn canonical_finish_bundle_paths(
+    repo_root: &Path,
+    source_path: &Path,
+    stp_path: &Path,
+    input_path: &Path,
+    output_path: &Path,
+) -> Result<Vec<String>> {
+    let mut out = BTreeSet::new();
+    for path in [source_path, stp_path, input_path, output_path] {
+        let normalized = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            repo_root.join(path)
+        };
+        if !normalized.exists() {
+            continue;
+        }
+        if let Ok(relative) = normalized.strip_prefix(repo_root) {
+            out.insert(relative.to_string_lossy().into_owned());
+        }
+    }
+    Ok(out.into_iter().collect())
+}
+
+fn stage_selected_paths_rust(repo_root: &Path, csv: &str, force_paths: &[String]) -> Result<()> {
     let paths = csv
         .split(',')
         .map(str::trim)
@@ -735,7 +760,15 @@ fn stage_selected_paths_rust(repo_root: &Path, csv: &str) -> Result<()> {
     }
     let mut args = vec!["-C", path_str(repo_root)?, "add", "--"];
     args.extend(paths);
-    run_status("git", &args)
+    run_status("git", &args)?;
+
+    if !force_paths.is_empty() {
+        let mut force_args = vec!["-C", path_str(repo_root)?, "add", "-f", "--"];
+        force_args.extend(force_paths.iter().map(String::as_str));
+        run_status("git", &force_args)?;
+    }
+
+    Ok(())
 }
 
 fn staged_diff_is_empty(repo_root: &Path) -> Result<bool> {

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -222,6 +222,22 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     )
     .expect("head subject");
     assert!(head_subject.contains("[v0.86][tools] Rust finish test (Closes #1153)"));
+    let head_files = run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(&repo).expect("repo"),
+            "ls-tree",
+            "-r",
+            "--name-only",
+            "HEAD",
+        ],
+    )
+    .expect("head files");
+    assert!(head_files.contains(".adl/v0.86/bodies/issue-1153-rust-finish-test.md"));
+    assert!(head_files.contains(".adl/v0.86/tasks/issue-1153__rust-finish-test/stp.md"));
+    assert!(head_files.contains(".adl/v0.86/tasks/issue-1153__rust-finish-test/sip.md"));
+    assert!(head_files.contains(".adl/v0.86/tasks/issue-1153__rust-finish-test/sor.md"));
     assert!(Command::new("git")
         .args([
             "--git-dir",
@@ -425,6 +441,174 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
     assert!(root_text.contains("Status: DONE"));
     assert!(root_text.contains("codex/1153-rust-finish-sync"));
     assert_eq!(root_text, compat_text);
+}
+
+#[test]
+fn real_pr_finish_publishes_ignored_canonical_bundle_when_no_tracked_changes_remain() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-ignored-bundle-only");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "checkout",
+            "-q",
+            "-b",
+            "codex/1157-rust-finish-ignored-bundle"
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git checkout")
+        .success());
+
+    let issue_ref = IssueRef::new(
+        1157,
+        "v0.86".to_string(),
+        "rust-finish-ignored-bundle".to_string(),
+    )
+    .expect("ref");
+    let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&bundle_dir).expect("bundle dir");
+    let stp = issue_ref.task_bundle_stp_path(&repo);
+    let input = issue_ref.task_bundle_input_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Rust finish ignored bundle",
+    );
+    fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
+    write_authored_sip(
+        &input,
+        &issue_ref,
+        "[v0.86][tools] Rust finish ignored bundle",
+        "codex/1157-rust-finish-ignored-bundle",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_completed_sor_fixture(&output, "codex/1157-rust-finish-ignored-bundle");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1160\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1157\\n'\n  else\n    printf 'Closes #1157\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+            gh_log.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let result = real_pr(&[
+        "finish".to_string(),
+        "1157".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Rust finish ignored bundle".to_string(),
+        "--paths".to_string(),
+        "adl".to_string(),
+        "--input".to_string(),
+        path_relative_to_repo(&repo, &input),
+        "--output".to_string(),
+        path_relative_to_repo(&repo, &output),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    result.expect("real_pr finish");
+
+    let head_files = run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(&repo).expect("repo"),
+            "ls-tree",
+            "-r",
+            "--name-only",
+            "HEAD",
+        ],
+    )
+    .expect("head files");
+    assert!(head_files.contains(".adl/v0.86/bodies/issue-1157-rust-finish-ignored-bundle.md"));
+    assert!(head_files.contains(".adl/v0.86/tasks/issue-1157__rust-finish-ignored-bundle/stp.md"));
+    assert!(head_files.contains(".adl/v0.86/tasks/issue-1157__rust-finish-ignored-bundle/sip.md"));
+    assert!(head_files.contains(".adl/v0.86/tasks/issue-1157__rust-finish-ignored-bundle/sor.md"));
+    let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
+    assert!(gh_calls.contains("pr create"));
 }
 
 #[test]
@@ -820,13 +1004,43 @@ fn finish_helper_paths_cover_nonempty_and_staged_checks() {
     fs::write(repo.join("tracked.txt"), "changed\n").expect("modify tracked");
     assert!(has_uncommitted_changes(&repo).expect("dirty"));
 
-    stage_selected_paths_rust(&repo, "tracked.txt").expect("stage");
+    stage_selected_paths_rust(&repo, "tracked.txt", &[]).expect("stage");
     assert!(!staged_diff_is_empty(&repo).expect("staged diff"));
     assert!(!staged_gitignore_change_present(&repo).expect("no gitignore"));
 
     fs::write(repo.join(".gitignore"), "target\n").expect("write gitignore");
-    stage_selected_paths_rust(&repo, ".gitignore").expect("stage gitignore");
+    stage_selected_paths_rust(&repo, ".gitignore", &[]).expect("stage gitignore");
     assert!(staged_gitignore_change_present(&repo).expect("gitignore change"));
+
+    let ignored_dir = repo.join(".adl").join("v0.86").join("tasks");
+    fs::create_dir_all(&ignored_dir).expect("ignored dir");
+    let ignored_file = ignored_dir
+        .join("issue-1153__rust-finish-test")
+        .join("sor.md");
+    fs::create_dir_all(ignored_file.parent().expect("ignored file parent"))
+        .expect("ignored parent");
+    fs::write(&ignored_file, "ignored output\n").expect("ignored output");
+    fs::write(repo.join(".gitignore"), ".adl/\ntarget\n").expect("write ignore rules");
+    stage_selected_paths_rust(
+        &repo,
+        "tracked.txt",
+        &[String::from(
+            ".adl/v0.86/tasks/issue-1153__rust-finish-test/sor.md",
+        )],
+    )
+    .expect("stage ignored bundle file");
+    let staged_name_only = run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(&repo).expect("repo"),
+            "diff",
+            "--cached",
+            "--name-only",
+        ],
+    )
+    .expect("cached names");
+    assert!(staged_name_only.contains(".adl/v0.86/tasks/issue-1153__rust-finish-test/sor.md"));
 }
 
 #[test]
@@ -1002,7 +1216,7 @@ fn finish_helper_paths_cover_pr_lookup_and_closing_linkage() {
 }
 
 #[test]
-fn real_pr_finish_rejects_main_and_no_changes_paths() {
+fn real_pr_finish_rejects_main_and_does_not_report_no_pr_when_bundle_sync_changes_exist() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-errors");
     let origin = temp.join("origin.git");
@@ -1097,6 +1311,9 @@ fn real_pr_finish_rejects_main_and_no_changes_paths() {
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1153-rust-finish-test");
+    let cards_root = resolve_cards_root(&repo, None);
+    let compat_output = card_output_path(&cards_root, 1153);
+    ensure_symlink(&compat_output, &output).expect("compat symlink");
     assert!(Command::new("git")
         .args(["add", "-A"])
         .current_dir(&repo)
@@ -1137,9 +1354,20 @@ fn real_pr_finish_rejects_main_and_no_changes_paths() {
         .expect("git checkout")
         .success());
 
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\ncmd=\"$(printf '%s ' \"$@\")\"\nif printf '%s' \"$cmd\" | grep -q 'repo view'; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif printf '%s' \"$cmd\" | grep -q 'pr list'; then\n  exit 0\nfi\nif printf '%s' \"$cmd\" | grep -q 'pr view'; then\n  if printf '%s' \"$cmd\" | grep -q 'closingIssuesReferences'; then\n    printf '1153\\n'\n  else\n    printf 'Closes #1153\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
     let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
     env::set_current_dir(&repo).expect("chdir");
-    let no_change_err = real_pr(&[
+    let bundle_sync_err = real_pr(&[
         "finish".to_string(),
         "1153".to_string(),
         "--title".to_string(),
@@ -1151,9 +1379,12 @@ fn real_pr_finish_rejects_main_and_no_changes_paths() {
         "--no-checks".to_string(),
         "--no-open".to_string(),
     ])
-    .expect_err("no changes should fail");
+    .expect_err("expected downstream gh fixture failure after bundle sync work is detected");
     env::set_current_dir(prev_dir).expect("restore cwd");
-    assert!(no_change_err.to_string().contains("Nothing to PR."));
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    assert!(!bundle_sync_err.to_string().contains("Nothing to PR."));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -1354,7 +1354,7 @@ fn real_pr_finish_rejects_main_and_does_not_report_no_pr_when_bundle_sync_change
         .expect("git checkout")
         .success());
     let mut touched_output = fs::read_to_string(&output).expect("read output");
-    touched_output.push_str("\n");
+    touched_output.push('\n');
     fs::write(&output, touched_output).expect("touch output");
 
     let bin_dir = temp.join("bin");

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -1353,6 +1353,9 @@ fn real_pr_finish_rejects_main_and_does_not_report_no_pr_when_bundle_sync_change
         .status()
         .expect("git checkout")
         .success());
+    let mut touched_output = fs::read_to_string(&output).expect("read output");
+    touched_output.push_str("\n");
+    fs::write(&output, touched_output).expect("touch output");
 
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");


### PR DESCRIPTION
## Summary
- make `pr finish` stage the current issue's canonical `.adl` body/STP/SIP/SOR bundle even when `.adl/` is gitignored
- move the no-change decision to happen after staging so ignored-bundle-only publication can succeed
- add finish regressions for mixed tracked+ignored publication, ignored-only publication, and the updated clean-branch bundle-sync boundary

## Validation
- `cargo test --manifest-path adl/Cargo.toml finish_helper_paths_cover_nonempty_and_staged_checks -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_finish_publishes_ignored_canonical_bundle_when_no_tracked_changes_remain -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_main_and_does_not_report_no_pr_when_bundle_sync_changes_exist -- --nocapture`
- full `pr.sh finish` validation pass through the Rust/unit/integration/doc suite; final publication still hit the existing ignored-`.adl` staging edge, so branch publication was completed manually for this issue

Closes #1592