### PR TITLE
[v0.87.1][tools] Make closeout automatic after merge/closure

### DIFF
--- a/.adl/v0.87.1/tasks/issue-1596__v0-87-1-tools-make-closeout-automatic-after-merge-closure/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1596__v0-87-1-tools-make-closeout-automatic-after-merge-closure/sor.md
@@ -1,0 +1,166 @@
+# v0-87-1-tools-make-closeout-automatic-after-merge-closure
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1596
+Run ID: issue-1596
+Version: v0.87.1
+Title: [v0.87.1][tools] Make closeout automatic after merge/closure
+Branch: codex/1596-v0-87-1-tools-make-closeout-automatic-after-merge-closure
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5
+- Provider: openai
+- Start Time: 2026-04-11T17:00:00Z
+- End Time: 2026-04-11T17:52:47Z
+
+## Summary
+Added a real Rust-owned `adl pr closeout` surface, reused the same closeout lifecycle path from doctor, and wired merge-mode finish into automatic closeout once the issue reaches `CLOSED/COMPLETED`.
+
+## Artifacts produced
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd/doctor.rs`
+- `adl/src/cli/pr_cmd/lifecycle.rs`
+- `adl/src/cli/pr_cmd_args.rs`
+- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
+- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
+- `adl/src/cli/usage.rs`
+- `adl/tools/pr.sh`
+- `adl/tools/skills/pr-closeout/SKILL.md`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+
+## Actions taken
+- Added `parse_closeout_args(...)` plus a new `real_pr_closeout(...)` command in the Rust PR control plane.
+- Added shared lifecycle helpers to verify `CLOSED/COMPLETED` state, wait for post-merge closure, reconcile the canonical bundle, and safely prune the matching issue worktree.
+- Reused the same closeout path from `doctor` for closed/completed issue recovery so drift repair no longer follows a separate code path.
+- Taught `adl/tools/pr.sh` and the operator docs about the new `closeout` command and the automatic control-plane-triggered closeout behavior.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; branch-local tracked edits are prepared for PR publication only
+- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/doctor.rs`, `adl/src/cli/pr_cmd/lifecycle.rs`, `adl/src/cli/pr_cmd_args.rs`, `adl/src/cli/tests/pr_cmd_inline/basics.rs`, `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`, `adl/src/cli/usage.rs`, `adl/tools/pr.sh`, `adl/tools/skills/pr-closeout/SKILL.md`, `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: branch-local tracked edits validated in the issue worktree and prepared for `pr finish`
+- Verification performed:
+  - `git status --short`
+    - verified the bounded closeout-related tracked paths on the issue branch.
+  - `git diff --check`
+    - verified the final diff is clean and publication-safe.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml closeout -- --nocapture`
+    - verified the new closeout argument parsing surface and closeout-focused command plumbing.
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree -- --nocapture`
+    - verified closed/completed reconciliation now runs through the shared closeout path and prunes the matching issue worktree safely.
+  - `git diff --check`
+    - verified there are no whitespace or malformed patch artifacts in the final branch diff.
+- Results:
+  - all listed commands passed
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml closeout -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree -- --nocapture"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: closeout parser tests plus the closed/completed reconciliation lifecycle test.
+- Fixtures or scripts used: deterministic Rust inline `pr_cmd` lifecycle fixtures with mocked GitHub issue state and synthetic duplicate bundle/worktree state.
+- Replay verification (same inputs -> same artifacts/order): yes; the lifecycle fixture repeatedly produces the same reconciled `DONE` / `merged` / `main_repo` output and worktree-prune outcome.
+- Ordering guarantees (sorting / tie-break rules used): closeout verifies closed/completed state before reconciliation and prunes the issue worktree only after bundle truth is normalized.
+- Artifact stability notes: the closeout path now centralizes previously split post-merge reconciliation behavior in one lifecycle pipeline.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual inspection of the new closeout helpers and tests for secret-free lifecycle inputs.
+- Prompt / tool argument redaction verified: yes; the closeout surface uses issue/branch/worktree metadata only.
+- Absolute path leakage check: output record uses repository-relative paths only.
+- Sandbox / policy invariants preserved: yes; pruning is issue-targeted and refuses dirty worktrees.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable for this tooling issue.
+- Run artifact root: not applicable.
+- Replay command used for verification: `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree -- --nocapture`
+- Replay result: PASS.
+
+## Artifact Verification
+- Primary proof surface: the shared closeout lifecycle helpers in `adl/src/cli/pr_cmd/lifecycle.rs` and the closed/completed reconciliation fixture.
+- Required artifacts present: true
+- Artifact schema/version checks: CLI usage, `pr.sh`, and skill docs were kept aligned with the new closeout surface.
+- Hash/byte-stability checks: not performed; lifecycle fixtures are the proving surface here.
+- Missing/optional artifacts and rationale: no demo artifact or runtime trace bundle is required for this workflow-tooling issue.
+
+## Decisions / Deviations
+- Implemented a real `adl pr closeout` control-plane surface first, then reused it from merge-mode finish and doctor rather than embedding more post-merge heuristics in multiple places.
+
+## Follow-ups / Deferred work
+- `#1597` adds finish-time milestone-doc drift checks so release-tail doc issues are blocked before publication instead of being discovered later in review.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::pr_cmd_args::{
-    parse_create_args, parse_doctor_args, parse_finish_args, parse_init_args, parse_preflight_args,
-    parse_ready_args, parse_start_args, DoctorArgs, DoctorMode,
+    parse_closeout_args, parse_create_args, parse_doctor_args, parse_finish_args, parse_init_args,
+    parse_preflight_args, parse_ready_args, parse_start_args, DoctorArgs, DoctorMode,
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
@@ -56,7 +56,7 @@ const DEFAULT_NEW_LABELS: &str = "track:roadmap,type:task,area:tools";
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
-            "pr requires a subcommand: create | init | start | doctor | ready | preflight | finish"
+            "pr requires a subcommand: create | init | start | doctor | ready | preflight | finish | closeout"
         );
     };
 
@@ -68,6 +68,7 @@ pub(crate) fn real_pr(args: &[String]) -> Result<()> {
         "ready" => real_pr_ready(&args[1..]),
         "preflight" => real_pr_preflight(&args[1..]),
         "finish" => real_pr_finish(&args[1..]),
+        "closeout" => real_pr_closeout(&args[1..]),
         other => bail!("unknown pr subcommand: {other}"),
     }
 }
@@ -509,6 +510,13 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
                 &pr_url,
             ],
         )?;
+        lifecycle::wait_for_issue_closed_and_completed(parsed.issue, &repo)?;
+        lifecycle::closeout_closed_completed_issue_bundle(
+            &repo_root,
+            &primary_root,
+            &issue_ref,
+            &output_path,
+        )?;
         println!("{pr_url}");
         return Ok(());
     }
@@ -522,6 +530,41 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     println!("{pr_url}");
+    Ok(())
+}
+
+fn real_pr_closeout(args: &[String]) -> Result<()> {
+    let parsed = parse_closeout_args(args)?;
+    let repo_root = repo_root()?;
+    let primary_root = primary_checkout_root()?;
+    let repo = default_repo(&primary_root)?;
+    let inferred = resolve_issue_scope_and_slug_from_local_state(&primary_root, parsed.issue)?
+        .unwrap_or((
+            parsed
+                .version
+                .clone()
+                .unwrap_or_else(|| DEFAULT_VERSION.to_string()),
+            parsed
+                .slug
+                .clone()
+                .unwrap_or_else(|| format!("issue-{}", parsed.issue)),
+        ));
+    let issue_ref = IssueRef::new(parsed.issue, inferred.0, inferred.1)?;
+    let output_path = issue_ref.task_bundle_output_path(&primary_root);
+    lifecycle::ensure_issue_closed_completed_for_closeout(parsed.issue, &repo)?;
+    lifecycle::closeout_closed_completed_issue_bundle(
+        &repo_root,
+        &primary_root,
+        &issue_ref,
+        &output_path,
+    )?;
+    println!(
+        "{}",
+        path_relative_to_repo(
+            &primary_root,
+            &issue_ref.task_bundle_dir_path(&primary_root)
+        )
+    );
     Ok(())
 }
 

--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -208,7 +208,8 @@ fn run_doctor_ready(
     validate_bootstrap_stp(repo_root, &source_path)?;
     validate_authored_prompt_surface("doctor", &source_path, PromptSurfaceKind::IssuePrompt)?;
     if closed_completed {
-        lifecycle::reconcile_closed_completed_issue_bundle(
+        lifecycle::closeout_closed_completed_issue_bundle(
+            repo_root,
             repo_root,
             issue_ref,
             &root_bundle_output,

--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -378,6 +378,86 @@ mod tests {
         fs::set_permissions(path, perms).expect("chmod");
     }
 
+    fn init_repo_with_origin(repo: &Path, origin: &Path) {
+        fs::create_dir_all(repo).expect("repo dir");
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(repo)
+            .status()
+            .expect("git init")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                path_str(origin).expect("origin path")
+            ])
+            .current_dir(repo)
+            .status()
+            .expect("git remote add")
+            .success());
+        assert!(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo)
+            .status()
+            .expect("git config name")
+            .success());
+        assert!(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo)
+            .status()
+            .expect("git config email")
+            .success());
+        fs::write(repo.join("README.md"), "seed\n").expect("seed readme");
+        assert!(Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(repo)
+            .status()
+            .expect("git add")
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(repo)
+            .status()
+            .expect("git commit")
+            .success());
+        assert!(Command::new("git")
+            .args(["branch", "-M", "main"])
+            .current_dir(repo)
+            .status()
+            .expect("git branch")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "init",
+                "--bare",
+                "-q",
+                path_str(origin).expect("origin path")
+            ])
+            .current_dir(repo)
+            .status()
+            .expect("git init bare")
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "remote",
+                "set-url",
+                "origin",
+                path_str(origin).expect("origin path"),
+            ])
+            .current_dir(repo)
+            .status()
+            .expect("git remote set-url")
+            .success());
+        assert!(Command::new("git")
+            .args(["push", "-q", "-u", "origin", "main"])
+            .current_dir(repo)
+            .status()
+            .expect("git push")
+            .success());
+    }
+
     #[test]
     fn issue_is_closed_and_completed_parses_completed_state() {
         let _guard = env_lock();
@@ -399,6 +479,82 @@ mod tests {
             env::set_var("PATH", old_path);
         }
         assert!(result);
+    }
+
+    #[test]
+    fn issue_is_closed_and_completed_returns_false_for_empty_or_open_state() {
+        let _guard = env_lock();
+        let temp = temp_dir("adl-pr-lifecycle-gh-open");
+        let bin_dir = temp.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        write_executable(
+            &bin_dir.join("gh"),
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"${1:-}\" == \"issue\" ]]; then\n  printf '{\"state\":\"OPEN\",\"stateReason\":null}\\n'\nfi\n",
+        );
+        let old_path = env::var("PATH").unwrap_or_default();
+        unsafe {
+            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        }
+
+        let result = issue_is_closed_and_completed(1410, "owner/repo").expect("open state");
+
+        unsafe {
+            env::set_var("PATH", old_path);
+        }
+        assert!(!result);
+    }
+
+    #[test]
+    fn ensure_issue_closed_completed_for_closeout_rejects_unfinished_issue() {
+        let _guard = env_lock();
+        let temp = temp_dir("adl-pr-lifecycle-closeout-guard");
+        let bin_dir = temp.join("bin");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        write_executable(
+            &bin_dir.join("gh"),
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '{\"state\":\"CLOSED\",\"stateReason\":\"NOT_PLANNED\"}\\n'\n",
+        );
+        let old_path = env::var("PATH").unwrap_or_default();
+        unsafe {
+            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        }
+
+        let err = ensure_issue_closed_completed_for_closeout(1410, "owner/repo")
+            .expect_err("should reject unfinished closeout");
+
+        unsafe {
+            env::set_var("PATH", old_path);
+        }
+        assert!(err
+            .to_string()
+            .contains("is not closed with COMPLETED state yet"));
+    }
+
+    #[test]
+    fn wait_for_issue_closed_and_completed_succeeds_after_retry() {
+        let _guard = env_lock();
+        let temp = temp_dir("adl-pr-lifecycle-closeout-wait");
+        let bin_dir = temp.join("bin");
+        let counter = temp.join("counter.txt");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        write_executable(
+            &bin_dir.join("gh"),
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\ncounter=\"{}\"\ncount=0\nif [[ -f \"$counter\" ]]; then\n  count=$(cat \"$counter\")\nfi\ncount=$((count + 1))\nprintf '%s' \"$count\" > \"$counter\"\nif [[ \"$count\" -lt 2 ]]; then\n  printf '{{\"state\":\"OPEN\",\"stateReason\":null}}\\n'\nelse\n  printf '{{\"state\":\"CLOSED\",\"stateReason\":\"COMPLETED\"}}\\n'\nfi\n",
+                counter.display()
+            ),
+        );
+        let old_path = env::var("PATH").unwrap_or_default();
+        unsafe {
+            env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        }
+
+        wait_for_issue_closed_and_completed(1410, "owner/repo").expect("wait succeeds");
+
+        unsafe {
+            env::set_var("PATH", old_path);
+        }
+        assert_eq!(fs::read_to_string(&counter).expect("counter"), "2");
     }
 
     #[test]
@@ -454,5 +610,47 @@ mod tests {
         assert!(same_filesystem_target(&left, &left).expect("same path"));
         assert!(same_filesystem_target(&left, &right).expect("same target"));
         assert!(!same_filesystem_target(&left, &temp.join("missing.txt")).expect("missing"));
+    }
+
+    #[test]
+    fn prune_issue_worktree_noops_when_worktree_is_missing() {
+        let _guard = env_lock();
+        let temp = temp_dir("adl-pr-lifecycle-prune-missing");
+        let repo = temp.join("repo");
+        let origin = temp.join("origin.git");
+        init_repo_with_origin(&repo, &origin);
+        let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+
+        prune_issue_worktree(&repo, &repo, &issue_ref).expect("missing worktree is fine");
+    }
+
+    #[test]
+    fn prune_issue_worktree_rejects_dirty_worktree() {
+        let _guard = env_lock();
+        let temp = temp_dir("adl-pr-lifecycle-prune-dirty");
+        let repo = temp.join("repo");
+        let origin = temp.join("origin.git");
+        init_repo_with_origin(&repo, &origin);
+        let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+        let worktree = issue_ref.default_worktree_path(&repo, None);
+
+        assert!(Command::new("git")
+            .args([
+                "-C",
+                path_str(&repo).expect("repo path"),
+                "worktree",
+                "add",
+                path_str(&worktree).expect("worktree path"),
+                "-b",
+                "codex/1410-canonical-slug",
+                "main",
+            ])
+            .status()
+            .expect("git worktree add")
+            .success());
+        fs::write(worktree.join("DIRTY.txt"), "dirty\n").expect("dirty file");
+
+        prune_issue_worktree(&repo, &repo, &issue_ref).expect_err("dirty worktree rejected");
+        assert!(worktree.is_dir());
     }
 }

--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -1,7 +1,10 @@
 use super::*;
 use serde::Deserialize;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 struct GithubIssueLifecycleState {
@@ -33,6 +36,29 @@ pub(super) fn issue_is_closed_and_completed(issue: u32, repo: &str) -> Result<bo
     let state: GithubIssueLifecycleState =
         serde_json::from_str(trimmed).context("failed to parse gh issue state json")?;
     Ok(state.state == "CLOSED" && state.state_reason.as_deref() == Some("COMPLETED"))
+}
+
+pub(super) fn ensure_issue_closed_completed_for_closeout(issue: u32, repo: &str) -> Result<()> {
+    if !issue_is_closed_and_completed(issue, repo)? {
+        bail!(
+            "closeout: issue #{} is not closed with COMPLETED state yet; refusing automatic closeout",
+            issue
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn wait_for_issue_closed_and_completed(issue: u32, repo: &str) -> Result<()> {
+    for _ in 0..10 {
+        if issue_is_closed_and_completed(issue, repo)? {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    bail!(
+        "finish: issue #{} did not reach CLOSED/COMPLETED state after merge; closeout cannot proceed automatically",
+        issue
+    );
 }
 
 pub(super) fn reconcile_closed_completed_issue_bundle(
@@ -116,6 +142,16 @@ pub(super) fn reconcile_closed_completed_issue_bundle(
     let review_output = card_output_path(&cards_root, issue_ref.issue_number());
     ensure_symlink(&review_output, canonical_output)?;
     Ok(())
+}
+
+pub(super) fn closeout_closed_completed_issue_bundle(
+    repo_root: &Path,
+    primary_root: &Path,
+    issue_ref: &IssueRef,
+    canonical_output: &Path,
+) -> Result<()> {
+    reconcile_closed_completed_issue_bundle(primary_root, issue_ref, canonical_output)?;
+    prune_issue_worktree(repo_root, primary_root, issue_ref)
 }
 
 fn matching_task_bundle_dirs(repo_root: &Path, issue_ref: &IssueRef) -> Result<Vec<PathBuf>> {
@@ -276,6 +312,44 @@ fn same_filesystem_target(left: &Path, right: &Path) -> Result<bool> {
         return Ok(left_canonical == right_canonical);
     }
     Ok(false)
+}
+
+fn prune_issue_worktree(repo_root: &Path, primary_root: &Path, issue_ref: &IssueRef) -> Result<()> {
+    let worktree_path = issue_ref.default_worktree_path(
+        primary_root,
+        std::env::var_os("ADL_WORKTREE_ROOT")
+            .map(PathBuf::from)
+            .as_deref(),
+    );
+    if !worktree_path.is_dir() {
+        return Ok(());
+    }
+    if has_uncommitted_changes(&worktree_path)? {
+        bail!(
+            "closeout: refusing to prune dirty worktree '{}'",
+            worktree_path.display()
+        );
+    }
+    let current_dir = env::current_dir().context("closeout: determine current directory")?;
+    if current_dir.starts_with(&worktree_path) {
+        env::set_current_dir(primary_root).with_context(|| {
+            format!(
+                "closeout: failed to leave worktree '{}' before pruning",
+                worktree_path.display()
+            )
+        })?;
+    }
+    run_status(
+        "git",
+        &[
+            "-C",
+            path_str(repo_root)?,
+            "worktree",
+            "remove",
+            path_str(&worktree_path)?,
+        ],
+    )?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/adl/src/cli/pr_cmd_args.rs
+++ b/adl/src/cli/pr_cmd_args.rs
@@ -83,6 +83,14 @@ pub(crate) struct FinishArgs {
     pub(crate) idempotent: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CloseoutArgs {
+    pub(crate) issue: u32,
+    pub(crate) slug: Option<String>,
+    pub(crate) version: Option<String>,
+    pub(crate) no_fetch_issue: bool,
+}
+
 pub(crate) fn parse_init_args(args: &[String]) -> Result<InitArgs> {
     let issue_raw = args
         .first()
@@ -435,6 +443,38 @@ pub(crate) fn parse_finish_args(args: &[String]) -> Result<FinishArgs> {
         bail!("finish: --merge requires checks; remove --no-checks");
     }
 
+    Ok(parsed)
+}
+
+pub(crate) fn parse_closeout_args(args: &[String]) -> Result<CloseoutArgs> {
+    let issue_raw = args
+        .first()
+        .ok_or_else(|| anyhow!("closeout: missing <issue> number"))?;
+    let issue = issue_raw
+        .parse::<u32>()
+        .with_context(|| format!("invalid issue number: {issue_raw}"))?;
+    let mut parsed = CloseoutArgs {
+        issue,
+        slug: None,
+        version: None,
+        no_fetch_issue: false,
+    };
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--slug" => {
+                parsed.slug = Some(require_value(args, i, "closeout", "--slug")?);
+                i += 1;
+            }
+            "--version" => {
+                parsed.version = Some(require_value(args, i, "closeout", "--version")?);
+                i += 1;
+            }
+            "--no-fetch-issue" => parsed.no_fetch_issue = true,
+            other => bail!("closeout: unknown arg: {other}"),
+        }
+        i += 1;
+    }
     Ok(parsed)
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -39,6 +39,23 @@ fn render_generated_issue_prompt_is_detected_as_bootstrap_stub() {
 }
 
 #[test]
+fn parse_closeout_args_accepts_expected_flags() {
+    let parsed = parse_closeout_args(&[
+        "1596".to_string(),
+        "--slug".to_string(),
+        "closeout-test".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+        "--no-fetch-issue".to_string(),
+    ])
+    .expect("parse closeout");
+    assert_eq!(parsed.issue, 1596);
+    assert_eq!(parsed.slug.as_deref(), Some("closeout-test"));
+    assert_eq!(parsed.version.as_deref(), Some("v0.87.1"));
+    assert!(parsed.no_fetch_issue);
+}
+
+#[test]
 fn render_generated_issue_prompt_uses_workflow_skill_bootstrap_template_for_tools_skill_titles() {
     let content = render_generated_issue_prompt(
         1443,

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -1543,7 +1543,5 @@ fn real_pr_closeout_refuses_issue_that_is_not_completed() {
     env::set_current_dir(prev_dir).expect("restore cwd");
 
     let err = closeout.expect_err("closeout should refuse unfinished issue");
-    assert!(err
-        .to_string()
-        .contains("refusing automatic closeout"));
+    assert!(err.to_string().contains("refusing automatic closeout"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -1250,3 +1250,300 @@ verification_summary:
     assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
     assert!(!worktree.exists());
 }
+
+#[test]
+fn real_pr_closeout_reconciles_closed_completed_issue_bundle() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-closeout-success");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "closeout success\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(
+        1596,
+        "v0.87.1",
+        "v0-87-1-tools-make-closeout-automatic-after-merge-closure",
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.87.1][tools] Make closeout automatic after merge/closure",
+    );
+    real_pr(&[
+        "init".to_string(),
+        "1596".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--title".to_string(),
+        "[v0.87.1][tools] Make closeout automatic after merge/closure".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let sip_path = issue_ref.task_bundle_input_path(&repo);
+    write_authored_sip(
+        &sip_path,
+        &issue_ref,
+        "[v0.87.1][tools] Make closeout automatic after merge/closure",
+        "codex/1596-v0-87-1-tools-make-closeout-automatic-after-merge-closure",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    let sor_path = issue_ref.task_bundle_output_path(&repo);
+    write_completed_sor_fixture(
+        &sor_path,
+        "codex/1596-v0-87-1-tools-make-closeout-automatic-after-merge-closure",
+    );
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "codex/1596-v0-87-1-tools-make-closeout-automatic-after-merge-closure",
+            path_str(&worktree).expect("worktree path"),
+            "origin/main",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git worktree add")
+        .success());
+    assert!(worktree.is_dir(), "closeout fixture worktree should exist");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2 $3 $4\" == \"issue view 1596 -R\" ]]; then\n  echo '{\"state\":\"CLOSED\",\"stateReason\":\"COMPLETED\"}'\n  exit 0\nfi\nexit 1\n",
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let closeout = real_pr(&[
+        "closeout".to_string(),
+        "1596".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ]);
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    closeout.expect("closeout closed reconcile");
+
+    let canonical_text = fs::read_to_string(&sor_path).expect("read canonical sor");
+    assert!(canonical_text.contains("Status: DONE"));
+    assert!(canonical_text.contains("- Integration state: merged"));
+    assert!(canonical_text.contains("- Verification scope: main_repo"));
+    assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
+    assert!(!worktree.exists());
+}
+
+#[test]
+fn real_pr_closeout_refuses_issue_that_is_not_completed() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-closeout-refuse");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "closeout refusal\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(
+        1596,
+        "v0.87.1",
+        "v0-87-1-tools-make-closeout-automatic-after-merge-closure",
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.87.1][tools] Make closeout automatic after merge/closure",
+    );
+    real_pr(&[
+        "init".to_string(),
+        "1596".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--title".to_string(),
+        "[v0.87.1][tools] Make closeout automatic after merge/closure".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2 $3 $4\" == \"issue view 1596 -R\" ]]; then\n  echo '{\"state\":\"OPEN\",\"stateReason\":\"REOPENED\"}'\n  exit 0\nfi\nexit 1\n",
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let closeout = real_pr(&[
+        "closeout".to_string(),
+        "1596".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ]);
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    let err = closeout.expect_err("closeout should refuse unfinished issue");
+    assert!(err
+        .to_string()
+        .contains("refusing automatic closeout"));
+}

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -1186,6 +1186,23 @@ verification_summary:
     )
     .expect("write stale sor");
 
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "codex/1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed",
+            path_str(&worktree).expect("worktree path"),
+            "origin/main",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git worktree add")
+        .success());
+    assert!(worktree.is_dir(), "closeout fixture worktree should exist");
+
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_path = bin_dir.join("gh");
@@ -1231,5 +1248,5 @@ verification_summary:
     assert!(canonical_text.contains("- Integration state: merged"));
     assert!(canonical_text.contains("- Verification scope: main_repo"));
     assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
-    assert!(!issue_ref.default_worktree_path(&repo, None).exists());
+    assert!(!worktree.exists());
 }

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -14,6 +14,7 @@ pub fn usage() -> &'static str {
   adl pr run <adl.yaml> [--trace] [--allow-unsigned] [--runs-root <dir>] [--out <dir>]
   adl pr doctor <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   adl pr finish <issue> --title <title> [--body <text>] [--paths <csv>] [-f|--input <path>] [--output-card <path>] [--no-checks] [--no-close] [--ready] [--merge] [--no-open]
+  adl pr closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
   adl godel run --run-id <id> --workflow-id <id> --failure-code <code> --failure-summary <text> [--evidence-ref <path> ...] [--runs-dir <dir>]
   adl godel inspect --run-id <id> [--runs-dir <dir>]
   adl godel evaluate --failure-code <code> --experiment-result <ok|blocked> --score-delta <int>

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1717,6 +1717,15 @@ cmd_finish() {
   delegate_pr_command_to_rust finish "$@"
 }
 
+cmd_closeout() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    usage_closeout
+    return 0
+  fi
+  require_rust_pr_delegate
+  delegate_pr_command_to_rust closeout "$@"
+}
+
 cmd_status() {
   require_cmd git
   note "Branch: $(current_branch)"
@@ -1772,6 +1781,7 @@ Commands:
   run     <adl.yaml> [--trace] [--print-plan] [--print-prompts] [--resume <run.json>] [--steer <steering.json>] [--overlay <overlay.json>] [--out <dir>] [--runs-root <dir>] [--quiet] [--open] [--allow-unsigned]
   doctor  <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   finish  <issue> --title "<title>" ... [-f <input_card.md>] [--output-card <output_card.md>] [--no-open] [--merge]
+  closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
 
 Compatibility / maintenance commands:
   card    <issue> [input|output] ... [--version <v0.2>] [-f <input_card.md>]
@@ -1806,6 +1816,7 @@ Notes:
 - `pr init <issue> ...` bootstraps the same local root bundle for an issue that already exists.
 - `pr run <issue> ...` is the preferred public execution-context binder for issue work.
 - `pr doctor <issue> ...` is the preferred public readiness and drift diagnostic surface.
+- `pr closeout <issue> ...` finalizes a closed issue locally and safely prunes its execution worktree when possible.
 - `pr start <issue> ...` remains only as a legacy alias over the same Rust binding path and is no longer part of the taught public flow.
 - `pr ready` and `pr preflight` remain only as deprecated compatibility aliases over `pr doctor`.
 - `card`, `output`, `cards`, `open`, and `status` are maintenance-oriented compatibility surfaces rather than the preferred workflow entrypoints.
@@ -1976,6 +1987,18 @@ Notes:
 EOF
 }
 
+usage_closeout() {
+  cat <<'EOF'
+Usage:
+  adl/tools/pr.sh closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
+
+Behavior:
+- verifies the issue is already CLOSED/COMPLETED
+- reconciles the canonical task bundle and closed-output truth
+- prunes the matching issue worktree when it is safe to do so
+EOF
+}
+
 main() {
   local cmd="${1:-}"; shift || true
   case "$cmd" in
@@ -1988,6 +2011,7 @@ main() {
     ready) cmd_ready "$@" ;;
     preflight) cmd_preflight "$@" ;;
     finish) cmd_finish "$@" ;;
+    closeout) cmd_closeout "$@" ;;
     card) cmd_card "$@" ;;
     output) cmd_output "$@" ;;
     output-card) cmd_output "$@" ;;

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -91,6 +91,7 @@ The current automation model is:
 - the canonical machine-readable diagnostic surface is doctor JSON
 - `pr-run` consumes doctor-backed readiness and performs bounded execution
 - `pr-janitor` watches a PR in flight and handles bounded blocker remediation
+- `pr-closeout` may now be triggered automatically by the repo control plane once merge or explicit closed/completed state is settled and safe
 - `pr-finish` handles truthful closeout/publication
 - `pr-closeout` handles post-merge or post-closure local finalization
 - `pr-closeout` also covers truthful no-PR closure dispositions like superseded, duplicate, or docs-only-closed issues

--- a/adl/tools/skills/pr-closeout/SKILL.md
+++ b/adl/tools/skills/pr-closeout/SKILL.md
@@ -30,6 +30,8 @@ Current repo truth:
 5. `pr-janitor` monitors the in-flight PR until human review and merge/closure settle
 6. `pr-closeout` finalizes the local issue state after that PR outcome is known
 
+The repo control plane may now trigger the same closeout behavior automatically after merge or explicit closed/completed state when the lifecycle evidence is unambiguous.
+
 This skill is intentionally later than `pr-finish`.
 
 ## Required Inputs


### PR DESCRIPTION
Closes #1596

## Summary
- add a real adl pr closeout surface in the Rust control plane and shell wrapper
- auto-run canonical closeout when merge/closed-completed state is confirmed
- share closeout logic across finish and doctor paths, including safe worktree pruning

## Validation
- cargo test --manifest-path adl/Cargo.toml closeout -- --nocapture
- cargo test --manifest-path adl/Cargo.toml real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree -- --nocapture
- cargo fmt --manifest-path adl/Cargo.toml --all
- git diff --check