### PR TITLE
[v0.87.1][tools] Add milestone-doc drift checks to pr finish

### DIFF
--- a/.adl/v0.87.1/tasks/issue-1597__tools-add-milestone-doc-drift-checks-to-pr-finish/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1597__tools-add-milestone-doc-drift-checks-to-pr-finish/sor.md
@@ -1,0 +1,154 @@
+# tools-add-milestone-doc-drift-checks-to-pr-finish
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1597
+Run ID: issue-1597
+Version: v0.87.1
+Title: [v0.87.1][tools] Add milestone-doc drift checks to pr finish
+Branch: codex/1597-tools-add-milestone-doc-drift-checks-to-pr-finish
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5
+- Provider: openai
+- Start Time: 2026-04-11T17:20:00Z
+- End Time: 2026-04-11T17:52:47Z
+
+## Summary
+Added a bounded finish-time milestone-doc drift guard so `pr finish` blocks publication when the active milestone package is structurally stale, missing linked docs, or still carrying placeholder/template drift.
+
+## Artifacts produced
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd_validate.rs`
+
+## Actions taken
+- Added `validate_milestone_doc_drift_for_finish(...)` to inspect changed milestone-doc branches only when they touch the active `docs/milestones/<scope>/` package.
+- Enforced canonical milestone README / feature-doc linkage checks plus placeholder/template rejection for changed milestone markdown surfaces.
+- Added validator-level tests for a coherent package pass case and a missing feature-doc failure case.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; branch-local tracked edits are prepared for PR publication only
+- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd_validate.rs`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: branch-local tracked edits validated in the issue worktree and prepared for `pr finish`
+- Verification performed:
+  - `git status --short`
+    - verified the bounded finish-path validation change set on the issue branch.
+  - `git diff --check`
+    - verified the final diff is clean and publication-safe.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml milestone_doc_drift -- --nocapture`
+    - verified the bounded milestone-doc drift validator accepts a coherent package and rejects a broken linked feature-doc reference.
+  - `git diff --check`
+    - verified there are no whitespace or malformed patch artifacts in the final branch diff.
+- Results:
+  - all listed commands passed
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml milestone_doc_drift -- --nocapture"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: validator unit tests for missing-link rejection and coherent-package acceptance.
+- Fixtures or scripts used: deterministic temporary milestone packages assembled inside the Rust validator tests.
+- Replay verification (same inputs -> same artifacts/order): yes; the same coherent/broken fixture inputs produce the same pass/fail validator result.
+- Ordering guarantees (sorting / tie-break rules used): finish computes changed paths first, then runs the milestone-doc guard before any PR create/edit action.
+- Artifact stability notes: the guard is intentionally structural and version-local rather than a broader semantic review system.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual inspection of the validator inputs and tests for secret-free path-only checks.
+- Prompt / tool argument redaction verified: yes; the validator reads tracked milestone docs and changed paths only.
+- Absolute path leakage check: output record uses repository-relative paths only.
+- Sandbox / policy invariants preserved: yes; the guard blocks publication before network PR actions when drift is detected.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable for this tooling issue.
+- Run artifact root: not applicable.
+- Replay command used for verification: `cargo test --manifest-path adl/Cargo.toml milestone_doc_drift -- --nocapture`
+- Replay result: PASS.
+
+## Artifact Verification
+- Primary proof surface: `adl/src/cli/pr_cmd_validate.rs` and the validator test cases.
+- Required artifacts present: true
+- Artifact schema/version checks: not applicable beyond the bounded milestone-package integrity checks themselves.
+- Hash/byte-stability checks: not performed; deterministic validator tests are the proving surface here.
+- Missing/optional artifacts and rationale: no demo artifact or runtime trace bundle is required for this finish-time validation issue.
+
+## Decisions / Deviations
+- Kept the guard structural and limited to milestone-doc PRs instead of broadening into general repo-review automation.
+
+## Follow-ups / Deferred work
+- If later milestones need broader doc-semantic review, that should land as a separate bounded tool rather than widening this finish-time guard.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -25,7 +25,9 @@ use super::pr_cmd_prompt::{
     resolve_issue_scope_and_slug_from_local_state, validate_issue_prompt_exists,
     version_from_labels_csv, version_from_title,
 };
-use super::pr_cmd_validate::{validate_authored_prompt_surface, PromptSurfaceKind};
+use super::pr_cmd_validate::{
+    validate_authored_prompt_surface, validate_milestone_doc_drift_for_finish, PromptSurfaceKind,
+};
 use ::adl::control_plane::{
     card_output_path, resolve_cards_root, resolve_primary_checkout_root, sanitize_slug, IssueRef,
 };
@@ -415,6 +417,9 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
         bail!("finish: .gitignore changes detected. Revert them or re-run with --allow-gitignore.");
     }
 
+    let changed_paths = finish_changed_paths(&repo_root, has_uncommitted)?;
+    validate_milestone_doc_drift_for_finish(&repo_root, issue_ref.scope(), &changed_paths)?;
+
     let close_line = if parsed.no_close {
         None
     } else {
@@ -567,6 +572,35 @@ fn real_pr_closeout(args: &[String]) -> Result<()> {
         )
     );
     Ok(())
+}
+
+fn finish_changed_paths(repo_root: &Path, has_uncommitted: bool) -> Result<Vec<String>> {
+    let args = if has_uncommitted {
+        vec![
+            "-C",
+            path_str(repo_root)?,
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=ACMR",
+        ]
+    } else {
+        vec![
+            "-C",
+            path_str(repo_root)?,
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "origin/main...HEAD",
+        ]
+    };
+    let out = run_capture("git", &args)?;
+    Ok(out
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect())
 }
 
 fn print_json<T: Serialize>(value: &T) -> Result<()> {

--- a/adl/src/cli/pr_cmd_validate.rs
+++ b/adl/src/cli/pr_cmd_validate.rs
@@ -128,3 +128,213 @@ fn section_has_authored_content(text: &str, header: &str) -> bool {
     }
     false
 }
+
+pub(crate) fn validate_milestone_doc_drift_for_finish(
+    repo_root: &Path,
+    scope: &str,
+    changed_paths: &[String],
+) -> Result<()> {
+    let milestone_prefix = format!("docs/milestones/{scope}/");
+    if !changed_paths
+        .iter()
+        .any(|path| path.starts_with(&milestone_prefix))
+    {
+        return Ok(());
+    }
+
+    let milestone_root = repo_root.join("docs").join("milestones").join(scope);
+    let readme = milestone_root.join("README.md");
+    ensure_nonempty_doc(&readme, "finish: milestone README missing or empty")?;
+
+    let readme_text = fs::read_to_string(&readme)?;
+    for relative in extract_section_backtick_paths(&readme_text, "Canonical milestone documents:") {
+        ensure_doc_link_target(&milestone_root, &relative)?;
+    }
+    for relative in extract_section_backtick_paths(&readme_text, "Primary promoted feature docs:") {
+        ensure_doc_link_target(&milestone_root, &relative)?;
+    }
+
+    let feature_index = milestone_root.join(format!("FEATURE_DOCS_{scope}.md"));
+    if feature_index.is_file() {
+        ensure_nonempty_doc(&feature_index, "finish: feature-doc index is empty")?;
+        let feature_text = fs::read_to_string(&feature_index)?;
+        for relative in extract_all_backtick_feature_paths(&feature_text) {
+            ensure_doc_link_target(&milestone_root, &relative)?;
+        }
+    }
+
+    for relative in changed_paths
+        .iter()
+        .filter(|path| path.starts_with(&milestone_prefix) && path.ends_with(".md"))
+    {
+        let path = repo_root.join(relative);
+        let text = fs::read_to_string(&path)?;
+        let normalized = text.to_ascii_lowercase();
+        let placeholder_markers = [
+            "bootstrap-generated",
+            "placeholder stub",
+            "canonical readme template",
+            "canonical feature doc template",
+            "lorem ipsum",
+        ];
+        if placeholder_markers
+            .iter()
+            .any(|marker| normalized.contains(marker))
+        {
+            bail!(
+                "finish: milestone-doc drift check failed for '{}': placeholder/template text remains in the tracked milestone package",
+                relative
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_nonempty_doc(path: &Path, message: &str) -> Result<()> {
+    if !path.is_file() {
+        bail!("{message}: {}", path.display());
+    }
+    let text = fs::read_to_string(path)?;
+    if text.trim().is_empty() {
+        bail!("{message}: {}", path.display());
+    }
+    Ok(())
+}
+
+fn ensure_doc_link_target(milestone_root: &Path, relative: &str) -> Result<()> {
+    let candidate = milestone_root.join(relative);
+    if !candidate.is_file() {
+        bail!(
+            "finish: milestone-doc drift check failed; referenced path '{}' is missing from '{}'",
+            relative,
+            milestone_root.display()
+        );
+    }
+    Ok(())
+}
+
+fn extract_section_backtick_paths(text: &str, header: &str) -> Vec<String> {
+    let mut in_section = false;
+    let mut paths = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == header {
+            in_section = true;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if trimmed.is_empty() {
+            break;
+        }
+        if !trimmed.starts_with('-') {
+            break;
+        }
+        paths.extend(extract_backtick_paths(trimmed));
+    }
+    paths
+}
+
+fn extract_all_backtick_feature_paths(text: &str) -> Vec<String> {
+    text.lines()
+        .flat_map(|line| extract_backtick_paths(line.trim()))
+        .filter(|path| path.starts_with("features/") && path.ends_with(".md"))
+        .collect()
+}
+
+fn extract_backtick_paths(line: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut remainder = line;
+    while let Some(start) = remainder.find('`') {
+        let tail = &remainder[start + 1..];
+        let Some(end) = tail.find('`') else {
+            break;
+        };
+        let candidate = tail[..end].trim();
+        if !candidate.is_empty() && candidate.ends_with(".md") {
+            paths.push(candidate.to_string());
+        }
+        remainder = &tail[end + 1..];
+    }
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(prefix: &str) -> std::path::PathBuf {
+        let mut path = env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        path.push(format!("{prefix}-{}-{nanos}", std::process::id()));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    #[test]
+    fn milestone_doc_drift_check_rejects_missing_feature_doc_links() {
+        let repo = temp_dir("adl-milestone-drift-fail");
+        let milestone_root = repo.join("docs/milestones/v0.87.1");
+        let features_dir = milestone_root.join("features");
+        fs::create_dir_all(&features_dir).expect("features dir");
+        fs::write(
+            milestone_root.join("README.md"),
+            "# README\n\nCanonical milestone documents:\n- Feature-doc index: `FEATURE_DOCS_v0.87.1.md`\n\nPrimary promoted feature docs:\n- `features/REAL.md`\n",
+        )
+        .expect("write readme");
+        fs::write(
+            milestone_root.join("FEATURE_DOCS_v0.87.1.md"),
+            "# Feature Docs\n\n- `features/MISSING.md`\n",
+        )
+        .expect("write feature docs");
+        fs::write(features_dir.join("REAL.md"), "# Real feature\n").expect("write real feature");
+
+        let err = validate_milestone_doc_drift_for_finish(
+            &repo,
+            "v0.87.1",
+            &[String::from(
+                "docs/milestones/v0.87.1/FEATURE_DOCS_v0.87.1.md",
+            )],
+        )
+        .expect_err("missing feature doc should fail");
+        assert!(err
+            .to_string()
+            .contains("referenced path 'features/MISSING.md'"));
+    }
+
+    #[test]
+    fn milestone_doc_drift_check_accepts_coherent_milestone_package() {
+        let repo = temp_dir("adl-milestone-drift-pass");
+        let milestone_root = repo.join("docs/milestones/v0.87.1");
+        let features_dir = milestone_root.join("features");
+        fs::create_dir_all(&features_dir).expect("features dir");
+        fs::write(
+            milestone_root.join("README.md"),
+            "# README\n\nCanonical milestone documents:\n- Feature-doc index: `FEATURE_DOCS_v0.87.1.md`\n\nPrimary promoted feature docs:\n- `features/REAL.md`\n",
+        )
+        .expect("write readme");
+        fs::write(
+            milestone_root.join("FEATURE_DOCS_v0.87.1.md"),
+            "# Feature Docs\n\n- `features/REAL.md`\n",
+        )
+        .expect("write feature docs");
+        fs::write(features_dir.join("REAL.md"), "# Real feature\n").expect("write real feature");
+
+        validate_milestone_doc_drift_for_finish(
+            &repo,
+            "v0.87.1",
+            &[String::from(
+                "docs/milestones/v0.87.1/FEATURE_DOCS_v0.87.1.md",
+            )],
+        )
+        .expect("coherent milestone package should pass");
+    }
+}


### PR DESCRIPTION
Closes #1597

## Summary
- add a bounded milestone-doc drift validator to the finish path
- verify canonical milestone README and feature-doc links when milestone docs are touched
- reject obvious placeholder/template residue before publication

## Validation
- cargo test --manifest-path adl/Cargo.toml milestone_doc_drift -- --nocapture
- cargo fmt --manifest-path adl/Cargo.toml --all
- git diff --check