### PR TITLE
[v0.87.1][tools] Auto-attach PR janitor on PR open

### DIFF
--- a/.adl/v0.87.1/tasks/issue-1595__v0-87-1-tools-auto-attach-pr-janitor-on-pr-open/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1595__v0-87-1-tools-auto-attach-pr-janitor-on-pr-open/sor.md
@@ -1,0 +1,160 @@
+# v0-87-1-tools-auto-attach-pr-janitor-on-pr-open
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1595
+Run ID: issue-1595
+Version: v0.87.1
+Title: [v0.87.1][tools] Auto-attach PR janitor on PR open
+Branch: codex/1595-v0-87-1-tools-auto-attach-pr-janitor-on-pr-open
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5
+- Provider: openai
+- Start Time: 2026-04-11T16:45:00Z
+- End Time: 2026-04-11T17:52:47Z
+
+## Summary
+Added a repo-native janitor auto-attach hook to the finish path so a concrete `pr-janitor` run is launched as soon as PR publication succeeds, with explicit blocking behavior if attachment fails.
+
+## Artifacts produced
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd/github.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `adl/src/cli/tests/pr_cmd_inline/mod.rs`
+- `adl/tools/attach_pr_janitor.sh`
+- `adl/tools/skills/pr-finish/SKILL.md`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+
+## Actions taken
+- Added `attach_pr_janitor(...)` to the Rust GitHub helper layer and invoked it from `real_pr_finish(...)` after PR publication / ready-state handling.
+- Added `adl/tools/attach_pr_janitor.sh` as the concrete launcher that installs the operational skills, writes a validated janitor payload, and starts one bounded Codex janitor pass in the background.
+- Hardened finish-path tests to verify successful janitor attachment and explicit failure when auto-attach cannot start.
+- Updated the finish/janitor docs to reflect that repo-native finish now auto-attaches the in-flight PR janitor hook.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet; branch-local tracked edits are prepared for PR publication only
+- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/github.rs`, `adl/src/cli/tests/pr_cmd_inline/finish.rs`, `adl/src/cli/tests/pr_cmd_inline/mod.rs`, `adl/tools/attach_pr_janitor.sh`, `adl/tools/skills/pr-finish/SKILL.md`, `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: branch-local tracked edits validated in the issue worktree and prepared for `pr finish`
+- Verification performed:
+  - `git status --short`
+    - verified the bounded tracked change set that will be staged for publication.
+  - `git diff --check`
+    - verified there are no whitespace or malformed patch artifacts in the final branch diff.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture`
+    - verified the finish path still creates/updates PRs correctly, auto-attaches janitor on success, and fails explicitly when janitor attachment cannot start.
+  - `git diff --check`
+    - verified the final diff is clean and publication-safe.
+- Results:
+  - all listed commands passed
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: not_applicable
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: repeated finish-path fixture tests through `real_pr_finish`.
+- Fixtures or scripts used: Rust inline `pr_cmd` finish fixtures plus the deterministic janitor launcher command contract.
+- Replay verification (same inputs -> same artifacts/order): not applicable for background janitor process startup beyond the bounded fixture assertions.
+- Ordering guarantees (sorting / tie-break rules used): finish publishes the PR before janitor attach and blocks on attach failure, preserving stable lifecycle ordering.
+- Artifact stability notes: the janitor launcher writes one deterministic payload/log location rooted under `.adl/logs/pr-janitor/issue-<n>/`.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual inspection of the new launcher payload/log path handling plus test review for secret-free arguments.
+- Prompt / tool argument redaction verified: yes; the launcher passes only issue/branch/PR metadata and expected checks/policy fields.
+- Absolute path leakage check: output record uses repository-relative paths only.
+- Sandbox / policy invariants preserved: yes; the launcher uses repo-local skill install plus `codex exec --sandbox workspace-write`.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable for this tooling issue.
+- Run artifact root: `.adl/logs/pr-janitor/issue-<n>/` when janitor auto-attach runs.
+- Replay command used for verification: `cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture`
+- Replay result: PASS for bounded finish-path fixtures.
+
+## Artifact Verification
+- Primary proof surface: `adl/tools/attach_pr_janitor.sh` plus the finish-path Rust tests.
+- Required artifacts present: true
+- Artifact schema/version checks: existing finish-path contracts and skill docs remained structurally valid.
+- Hash/byte-stability checks: not performed; this change is validated by deterministic fixture behavior rather than artifact hashing.
+- Missing/optional artifacts and rationale: no demo artifact or runtime trace bundle is required for this workflow-tooling issue.
+
+## Decisions / Deviations
+- Implemented the first concrete janitor attachment behavior as a repo-native launcher hook rather than pretending the Rust CLI can directly spawn desktop-only subagents.
+
+## Follow-ups / Deferred work
+- `#1596` and `#1597` continue the same milestone-compression wave with automatic closeout and finish-time milestone-doc drift checks.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -47,8 +47,8 @@ use self::git_support::{
 #[cfg(test)]
 use self::github::pr_has_closing_linkage;
 use self::github::{
-    current_pr_url, ensure_issue_labels, ensure_pr_closing_linkage, format_open_pr_wave,
-    gh_issue_create, gh_issue_edit_body, gh_issue_title, issue_version,
+    attach_pr_janitor, current_pr_url, ensure_issue_labels, ensure_pr_closing_linkage,
+    format_open_pr_wave, gh_issue_create, gh_issue_edit_body, gh_issue_title, issue_version,
     unresolved_milestone_pr_wave,
 };
 
@@ -525,6 +525,15 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     if parsed.ready {
         let _ = run_status_allow_failure("gh", &["pr", "ready", "-R", &repo, &pr_url])?;
     }
+
+    attach_pr_janitor(
+        &repo_root,
+        &repo,
+        parsed.issue,
+        &branch,
+        &pr_url,
+        if parsed.ready { "ready" } else { "draft" },
+    )?;
 
     if !parsed.no_open {
         let _ = run_status_allow_failure("open", &[&pr_url])?;

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1,6 +1,7 @@
 use super::*;
 use serde::Deserialize;
 use std::collections::BTreeSet;
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -133,6 +134,60 @@ pub(super) fn ensure_pr_closing_linkage(
             pr_ref,
             issue,
             issue
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn attach_pr_janitor(
+    repo_root: &Path,
+    repo: &str,
+    issue: u32,
+    branch: &str,
+    pr_url: &str,
+    expected_pr_state: &str,
+) -> Result<()> {
+    if std::env::var("ADL_PR_JANITOR_DISABLE").ok().as_deref() == Some("1") {
+        return Ok(());
+    }
+
+    let command_path = std::env::var("ADL_PR_JANITOR_CMD")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| {
+            repo_root
+                .join("adl/tools/attach_pr_janitor.sh")
+                .display()
+                .to_string()
+        });
+    let output = Command::new(&command_path)
+        .arg("--repo-root")
+        .arg(repo_root)
+        .arg("--repo")
+        .arg(repo)
+        .arg("--issue")
+        .arg(issue.to_string())
+        .arg("--branch")
+        .arg(branch)
+        .arg("--pr-url")
+        .arg(pr_url)
+        .arg("--expected-pr-state")
+        .arg(expected_pr_state)
+        .output()
+        .with_context(|| format!("finish: failed to spawn PR janitor command '{command_path}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "finish: PR janitor auto-attach failed for issue #{} and PR '{}': {}{}",
+            issue,
+            pr_url,
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" (stdout: {})", stdout.trim())
+            }
         );
     }
     Ok(())

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -173,7 +173,9 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
+    let janitor_log = temp.join("janitor.log");
     let gh_path = bin_dir.join("gh");
+    let janitor_path = bin_dir.join("janitor");
     write_executable(
             &gh_path,
             &format!(
@@ -181,11 +183,22 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
                 gh_log.display()
             ),
         );
+    write_executable(
+        &janitor_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            janitor_log.display()
+        ),
+    );
 
     let old_path = env::var("PATH").unwrap_or_default();
+    let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
+    let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_PR_JANITOR_DISABLE", "0");
+        env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
     }
     env::set_current_dir(&repo).expect("chdir");
 
@@ -207,6 +220,16 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     env::set_current_dir(prev_dir).expect("restore cwd");
     unsafe {
         env::set_var("PATH", old_path);
+        if let Some(value) = old_janitor_cmd {
+            env::set_var("ADL_PR_JANITOR_CMD", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_CMD");
+        }
+        if let Some(value) = old_janitor_disable {
+            env::set_var("ADL_PR_JANITOR_DISABLE", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
     }
     result.expect("real_pr finish");
 
@@ -250,8 +273,172 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         .expect("verify pushed branch")
         .success());
     let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
+    let janitor_calls = fs::read_to_string(&janitor_log).expect("read janitor log");
     assert!(gh_calls.contains("pr create"));
     assert!(gh_calls.contains("pr view -R danielbaustin/agent-design-language https://github.com/danielbaustin/agent-design-language/pull/1159 --json closingIssuesReferences --jq .closingIssuesReferences[]?.number"));
+    assert!(janitor_calls.contains("--issue 1153"));
+    assert!(janitor_calls.contains("--branch codex/1153-rust-finish-test"));
+    assert!(janitor_calls
+        .contains("--pr-url https://github.com/danielbaustin/agent-design-language/pull/1159"));
+    assert!(janitor_calls.contains("--expected-pr-state draft"));
+}
+
+#[test]
+fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-janitor-fail");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["checkout", "-q", "-b", "codex/1154-rust-finish-test",])
+        .current_dir(&repo)
+        .status()
+        .expect("git checkout")
+        .success());
+
+    let issue_ref =
+        IssueRef::new(1154, "v0.86".to_string(), "rust-finish-test".to_string()).expect("ref");
+    let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&bundle_dir).expect("bundle dir");
+    let stp = issue_ref.task_bundle_stp_path(&repo);
+    let input = issue_ref.task_bundle_input_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish test");
+    fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
+    write_authored_sip(
+        &input,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1154-rust-finish-test",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_completed_sor_fixture(&output, "codex/1154-rust-finish-test");
+    fs::write(
+        repo.join("adl/src/lib.rs"),
+        "pub fn placeholder() {}\npub fn changed() {}\n",
+    )
+    .expect("write change");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    let janitor_path = bin_dir.join("janitor");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1160\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1154\\n'\n  else\n    printf 'Closes #1154\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+    );
+    write_executable(
+        &janitor_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'janitor attach failed' >&2\nexit 9\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
+    let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_PR_JANITOR_DISABLE", "0");
+        env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let result = real_pr(&[
+        "finish".to_string(),
+        "1154".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Rust finish test".to_string(),
+        "--paths".to_string(),
+        "adl".to_string(),
+        "--input".to_string(),
+        path_relative_to_repo(&repo, &input),
+        "--output".to_string(),
+        path_relative_to_repo(&repo, &output),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ]);
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+        if let Some(value) = old_janitor_cmd {
+            env::set_var("ADL_PR_JANITOR_CMD", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_CMD");
+        }
+        if let Some(value) = old_janitor_disable {
+            env::set_var("ADL_PR_JANITOR_DISABLE", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
+    }
+
+    let err = result.expect_err("finish should fail when janitor attach fails");
+    assert!(err
+        .to_string()
+        .contains("finish: PR janitor auto-attach failed"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/mod.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/mod.rs
@@ -18,7 +18,11 @@ fn unique_temp_dir(label: &str) -> PathBuf {
 }
 
 fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    cli_env_lock()
+    let guard = cli_env_lock();
+    unsafe {
+        env::set_var("ADL_PR_JANITOR_DISABLE", "1");
+    }
+    guard
 }
 
 fn write_executable(path: &Path, content: &str) {

--- a/adl/tools/attach_pr_janitor.sh
+++ b/adl/tools/attach_pr_janitor.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  adl/tools/attach_pr_janitor.sh --repo-root <path> --repo <owner/name> --issue <n> --branch <branch> --pr-url <url> --expected-pr-state <draft|ready>
+EOF
+}
+
+die() {
+  printf '%s\n' "ERROR: $*" >&2
+  exit 2
+}
+
+REPO_ROOT=""
+REPO=""
+ISSUE=""
+BRANCH=""
+PR_URL=""
+EXPECTED_PR_STATE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --issue) ISSUE="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    --pr-url) PR_URL="$2"; shift 2 ;;
+    --expected-pr-state) EXPECTED_PR_STATE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+done
+
+[[ -n "$REPO_ROOT" ]] || die "missing --repo-root"
+[[ -n "$REPO" ]] || die "missing --repo"
+[[ -n "$ISSUE" ]] || die "missing --issue"
+[[ -n "$BRANCH" ]] || die "missing --branch"
+[[ -n "$PR_URL" ]] || die "missing --pr-url"
+[[ -n "$EXPECTED_PR_STATE" ]] || die "missing --expected-pr-state"
+[[ -d "$REPO_ROOT" ]] || die "repo root not found: $REPO_ROOT"
+
+command -v codex >/dev/null 2>&1 || die "codex CLI not found in PATH"
+codex exec --help >/dev/null 2>&1 || die "codex exec --help failed"
+
+bash "$REPO_ROOT/adl/tools/install_adl_operational_skills.sh" >/dev/null
+
+ARTIFACT_ROOT="$REPO_ROOT/.adl/logs/pr-janitor/issue-${ISSUE}"
+mkdir -p "$ARTIFACT_ROOT"
+
+INPUT_FILE="$ARTIFACT_ROOT/input.yaml"
+PROMPT_FILE="$ARTIFACT_ROOT/prompt.md"
+RUN_LOG="$ARTIFACT_ROOT/codex.log"
+LAST_MESSAGE_FILE="$ARTIFACT_ROOT/last_message.md"
+PID_FILE="$ARTIFACT_ROOT/pid"
+
+cat >"$INPUT_FILE" <<EOF
+skill_input_schema: pr_janitor.v1
+mode: watch_pr_url
+repo_root: $REPO_ROOT
+target:
+  pr_number: null
+  pr_url: $PR_URL
+  branch: $BRANCH
+  issue_number: $ISSUE
+  expected_checks:
+    - adl-ci
+    - adl-coverage
+  expected_pr_state: $EXPECTED_PR_STATE
+  review_standard: standard
+policy:
+  repair_mode: inspect_only
+  allow_pr_inference: false
+  monitor_checks: true
+  monitor_conflicts: true
+  monitor_review_state: true
+  stop_after_janitor_pass: true
+EOF
+
+cat >"$PROMPT_FILE" <<EOF
+Use \$pr-janitor at $REPO_ROOT/adl/tools/skills/pr-janitor/SKILL.md with this validated input:
+
+\`\`\`yaml
+$(cat "$INPUT_FILE")
+\`\`\`
+
+Run one bounded janitor pass for this newly opened PR. Stop after the janitor pass and write a concise status summary.
+EOF
+
+nohup codex exec \
+  --full-auto \
+  --sandbox workspace-write \
+  --cd "$REPO_ROOT" \
+  --skip-git-repo-check \
+  --add-dir "$REPO_ROOT" \
+  --output-last-message "$LAST_MESSAGE_FILE" \
+  "$(cat "$PROMPT_FILE")" >"$RUN_LOG" 2>&1 < /dev/null &
+
+JANITOR_PID=$!
+printf '%s\n' "$JANITOR_PID" >"$PID_FILE"
+printf 'ATTACHED issue=%s pr=%s pid=%s log=%s\n' "$ISSUE" "$PR_URL" "$JANITOR_PID" "$RUN_LOG"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -34,6 +34,7 @@ The normal workflow is:
 3. `pr-ready`
 4. `pr-run`
 5. `pr-janitor`
+   - the repo finish path should auto-attach the janitor hook after PR publication so in-flight monitoring starts without an extra manual step
 6. `pr-finish`
 7. `pr-closeout` after the PR outcome or explicit non-PR closure disposition is settled
 
@@ -92,6 +93,7 @@ The current automation model is:
 - `pr-run` consumes doctor-backed readiness and performs bounded execution
 - `pr-janitor` watches a PR in flight and handles bounded blocker remediation
 - `pr-closeout` may now be triggered automatically by the repo control plane once merge or explicit closed/completed state is settled and safe
+- the repo-native finish flow may attach the janitor hook automatically after PR publication
 - `pr-finish` handles truthful closeout/publication
 - `pr-closeout` handles post-merge or post-closure local finalization
 - `pr-closeout` also covers truthful no-PR closure dispositions like superseded, duplicate, or docs-only-closed issues

--- a/adl/tools/skills/pr-finish/SKILL.md
+++ b/adl/tools/skills/pr-finish/SKILL.md
@@ -27,7 +27,7 @@ Current repo truth:
 2. `pr-ready` determines structural readiness
 3. `pr-run` performs the bounded implementation work
 4. `pr-finish` performs truthful closeout and PR publication/update
-5. `pr-janitor` monitors the in-flight PR after publication
+5. `pr-janitor` is auto-attached after publication through the repo hook and monitors the in-flight PR
 6. `pr-closeout` finalizes the local issue state after merge or intentional closure
 
 ## Required Inputs


### PR DESCRIPTION
Closes #1595

## Summary
- auto-attach the PR janitor from the finish flow after PR publication
- add the bounded janitor launcher script and finish-path wiring in the Rust control plane
- document and test the new finish behavior, including failure handling

## Validation
- cargo test --manifest-path adl/Cargo.toml real_pr_finish -- --nocapture
- cargo fmt --manifest-path adl/Cargo.toml --all
- git diff --check