### PR TITLE
[v0.87.1][skills] Enforce repo-code-review contract checks in CI and batched checks

### DIFF
--- a/.adl/v0.87.1/bodies/issue-1594-v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks.md
+++ b/.adl/v0.87.1/bodies/issue-1594-v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks.md
@@ -1,0 +1,90 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks"
+title: "[v0.87.1][skills] Enforce repo-code-review contract checks in CI and batched checks"
+labels:
+  - "area:tools"
+  - "type:bug"
+  - "severity:medium"
+  - "version:v0.87.1"
+issue_number: 1594
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks"
+---
+
+## Summary
+
+Add the new repo-review skill contract test to the repository’s normal enforcement surfaces so manifest/schema/guide drift cannot merge silently.
+
+## Goal
+
+Make the repo-review skill self-protecting by ensuring its dedicated contract test runs in CI and in the repo’s local batched-check path or another clearly documented equivalent preflight surface.
+
+## Required Outcome
+
+- wire the repo-review contract test into CI
+- wire the same contract test into the local batched-check path or a clearly intentional equivalent
+- keep the added coverage repo-local, deterministic, and low-noise
+- ensure failures point clearly at manifest/schema/guide drift
+
+## Deliverables
+
+- CI update to execute the repo-review contract test
+- local batched-check or equivalent preflight update to execute the same test
+- any concise docs/readme update needed so operators know it is enforced
+
+## Acceptance Criteria
+
+- the repo-review contract test runs in CI
+- the repo-review contract test runs in local batched checks or another documented default preflight surface
+- the added coverage does not materially destabilize the normal check path
+- failures clearly indicate repo-review contract drift rather than a vague shell failure
+
+## Repo Inputs
+
+- `.github/workflows/ci.yaml`
+- `adl/tools/batched_checks.sh`
+- `adl/tools/test_repo_code_review_skill_contracts.sh`
+- `adl/tools/README.md`
+
+## Dependencies
+
+- the repo-review skill contract test should already exist and pass locally before this issue is executed
+
+## Demo Expectations
+
+- no demo required; targeted shell/CI validation is sufficient
+
+## Non-goals
+
+- broad CI redesign
+- adding every skill contract test to every check surface
+- changing the repo-review skill contract itself beyond what is needed for clear enforcement
+
+## Issue-Graph Notes
+
+- this issue hardens the repo-review skill after its schema normalization work
+- it should remain narrow and enforcement-focused
+
+## Notes
+
+- the current gap is enforcement coverage, not missing contract-test content
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- prefer the same shell-test invocation in both CI and local batched checks where practical

--- a/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sip.md
+++ b/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1594
+Run ID: issue-1594
+Version: v0.87.1
+Title: [v0.87.1][skills] Enforce repo-code-review contract checks in CI and batched checks
+Branch: codex/1594-v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1594
+- PR:
+- Source Issue Prompt: .adl/v0.87.1/bodies/issue-1594-v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sor.md
@@ -1,0 +1,153 @@
+# v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1594
+Run ID: issue-1594
+Version: v0.87.1
+Title: [v0.87.1][skills] Enforce repo-code-review contract checks in CI and batched checks
+Branch: codex/1594-v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: GPT-5 Codex
+- Provider: OpenAI
+- Start Time: 2026-04-11T18:00:00Z
+- End Time: 2026-04-11T18:07:27Z
+
+## Summary
+Wired the repo-code-review contract test into both GitHub CI and the local batched-check surface, and updated the tools README so the new guard is visible to operators.
+
+## Artifacts produced
+- `.github/workflows/ci.yaml`
+- `adl/tools/batched_checks.sh`
+- `adl/tools/README.md`
+
+## Actions taken
+- Added a dedicated `repo-code-review contract check` step to `adl-ci` before the Rust formatter, clippy, and test phases.
+- Added the same contract script to `adl/tools/batched_checks.sh` so local batched validation matches CI coverage.
+- Updated the tools README to note that batched checks include the repo-code-review contract guard.
+- Opened PR `#1605` with the enforcement wiring and operator-facing note.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1605
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: committed on the issue branch, pushed to origin, and opened as PR `#1605`
+- Verification performed:
+  - `git status --short` to confirm the branch was clean after the publish commit
+  - `git ls-files .github/workflows/ci.yaml adl/tools/batched_checks.sh adl/tools/README.md` to verify the tracked proof surface is present on the issue branch
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `bash adl/tools/test_repo_code_review_skill_contracts.sh` to verify the repo-code-review manifest/schema/operator-guide contract remains intact
+  - `bash -n adl/tools/batched_checks.sh` to verify the updated local batched-check wrapper remains syntactically valid
+  - `git diff --check` to verify no whitespace or patch-format regressions remain
+- Results: PASS. All targeted validations completed successfully.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash adl/tools/test_repo_code_review_skill_contracts.sh"
+      - "bash -n adl/tools/batched_checks.sh"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: not_applicable
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: reran the repo-code-review contract script after wiring it into CI and batched checks
+- Fixtures or scripts used: `adl/tools/test_repo_code_review_skill_contracts.sh`
+- Replay verification (same inputs -> same artifacts/order): confirmed for the contract script; the same repository state produced the same PASS result
+- Ordering guarantees (sorting / tie-break rules used): not applicable because this issue wires an existing deterministic script into fixed CI and local check order
+- Artifact stability notes: the change surface is limited to one CI workflow, one local batch wrapper, and one README note
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of touched diffs; no secrets or credential material were introduced
+- Prompt / tool argument redaction verified: yes; the change only adds a local contract script invocation and a README note
+- Absolute path leakage check: passed via review of the final SOR and touched repo files; only repository-relative paths are recorded here
+- Sandbox / policy invariants preserved: yes; the issue only adds deterministic validation steps and does not expand runtime privileges
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; no ADL runtime trace bundle was produced for this validation-enforcement fix
+- Run artifact root: not applicable; validation used repository-local scripts only
+- Replay command used for verification: `bash adl/tools/test_repo_code_review_skill_contracts.sh`
+- Replay result: PASS
+
+## Artifact Verification
+- Primary proof surface: PR `#1605` plus the tracked files `.github/workflows/ci.yaml`, `adl/tools/batched_checks.sh`, and `adl/tools/README.md`
+- Required artifacts present: yes; all issue-specific tracked artifacts are present on the pushed branch
+- Artifact schema/version checks: satisfied indirectly by the contract script added to both CI and batched checks
+- Hash/byte-stability checks: not run; issue scope is bounded to deterministic validation wiring and documentation
+- Missing/optional artifacts and rationale: no additional artifacts were required beyond the tracked CI, tooling, and documentation surfaces
+
+## Decisions / Deviations
+- Added a small README note even though the issue could have been closed without it, because operator discoverability is part of making the new guard usable.
+
+## Follow-ups / Deferred work
+- The repo-code-review contract script still contains an absolute `reference_doc` assertion and may merit a later portability cleanup, but that was intentionally left out of this enforcement-only issue.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/stp.md
+++ b/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/stp.md
@@ -1,0 +1,90 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks"
+title: "[v0.87.1][skills] Enforce repo-code-review contract checks in CI and batched checks"
+labels:
+  - "area:tools"
+  - "type:bug"
+  - "severity:medium"
+  - "version:v0.87.1"
+issue_number: 1594
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks"
+---
+
+## Summary
+
+Add the new repo-review skill contract test to the repository’s normal enforcement surfaces so manifest/schema/guide drift cannot merge silently.
+
+## Goal
+
+Make the repo-review skill self-protecting by ensuring its dedicated contract test runs in CI and in the repo’s local batched-check path or another clearly documented equivalent preflight surface.
+
+## Required Outcome
+
+- wire the repo-review contract test into CI
+- wire the same contract test into the local batched-check path or a clearly intentional equivalent
+- keep the added coverage repo-local, deterministic, and low-noise
+- ensure failures point clearly at manifest/schema/guide drift
+
+## Deliverables
+
+- CI update to execute the repo-review contract test
+- local batched-check or equivalent preflight update to execute the same test
+- any concise docs/readme update needed so operators know it is enforced
+
+## Acceptance Criteria
+
+- the repo-review contract test runs in CI
+- the repo-review contract test runs in local batched checks or another documented default preflight surface
+- the added coverage does not materially destabilize the normal check path
+- failures clearly indicate repo-review contract drift rather than a vague shell failure
+
+## Repo Inputs
+
+- `.github/workflows/ci.yaml`
+- `adl/tools/batched_checks.sh`
+- `adl/tools/test_repo_code_review_skill_contracts.sh`
+- `adl/tools/README.md`
+
+## Dependencies
+
+- the repo-review skill contract test should already exist and pass locally before this issue is executed
+
+## Demo Expectations
+
+- no demo required; targeted shell/CI validation is sufficient
+
+## Non-goals
+
+- broad CI redesign
+- adding every skill contract test to every check surface
+- changing the repo-review skill contract itself beyond what is needed for clear enforcement
+
+## Issue-Graph Notes
+
+- this issue hardens the repo-review skill after its schema normalization work
+- it should remain narrow and enforcement-focused
+
+## Notes
+
+- the current gap is enforcement coverage, not missing contract-test content
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- prefer the same shell-test invocation in both CI and local batched checks where practical

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,10 @@ jobs:
         run: bash adl/tools/check_pr_closing_linkage.sh
         working-directory: .
 
+      - name: repo-code-review contract check
+        run: bash adl/tools/test_repo_code_review_skill_contracts.sh
+        working-directory: .
+
       - name: fmt
         run: cargo fmt --all -- --check
 

--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -19,7 +19,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `archive_run_artifacts.sh`: dry-run/apply helper that inventories local run roots, copies unique run artifacts into `.adl/trace-archive/milestones/<milestone>/runs/`, and can move archived active `.adl/runs` entries into `.adl/trace-archive/source-roots/`.
 - `adl tooling ...`: Rust-owned tooling surface for prompt/card/review validation helpers, with legacy wrapper scripts preserved at the historical `adl/tools/*` paths.
 - `burst_worktree.sh`, `burst_continue.sh`: burst lane/worktree helpers.
-- `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks.
+- `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks, including the repo-code-review skill contract guard.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
 - `report_large_rust_modules.sh`: non-blocking Rust implementation-module size report for maintainability review.
 - `open_artifact.sh`: convenience opener for cards/reports.

--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -36,6 +36,7 @@ bash -n "$ROOT/adl/tools/codex_pr.sh"
 bash -n "$ROOT/adl/tools/codexw.sh"
 echo "Skipping codex_pr sanity check (no --paths configured)."
 sh "$ROOT/adl/tools/codexw.sh" --help >/dev/null 2>&1
+run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_review_skill_contracts.sh"
 
 echo "• Running adl checks (batched)…"
 (


### PR DESCRIPTION
Closes #1594

## Summary
- enforce the repo-code-review contract script in GitHub CI before Rust checks
- run the same contract script from `adl/tools/batched_checks.sh`
- note the new guard in `adl/tools/README.md`

## Validation
- `bash adl/tools/test_repo_code_review_skill_contracts.sh`
- `bash -n adl/tools/batched_checks.sh`
- `git diff --check`
