### PR TITLE
[v0.87.1][tools] Make --allow-gitignore truthful for pr finish publication

### DIFF
--- a/.adl/v0.87.1/bodies/issue-1593-v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication.md
+++ b/.adl/v0.87.1/bodies/issue-1593-v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication.md
@@ -1,0 +1,91 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication"
+title: "[v0.87.1][tools] Make --allow-gitignore truthful for pr finish publication"
+labels:
+  - "area:tools"
+  - "type:bug"
+  - "severity:medium"
+  - "version:v0.87.1"
+issue_number: 1593
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication"
+---
+
+## Summary
+
+Fix the `pr finish --allow-gitignore` contract so the flag’s behavior matches what operators reasonably infer from its name.
+
+## Goal
+
+Ensure `--allow-gitignore` either truthfully enables the bounded ignored-path publication behavior required by `finish` or is narrowed/renamed so it no longer implies staging support that does not exist.
+
+## Required Outcome
+
+- define the intended semantics of `--allow-gitignore` for `pr finish`
+- align staging/publication behavior with that contract, or narrow the flag so it cannot mislead operators
+- add regression coverage for the resolved behavior
+- keep the semantics bounded to `finish` publication, not arbitrary ignored-file handling
+
+## Deliverables
+
+- `pr finish` flag-behavior fix or contract tightening
+- updated tests covering the resolved semantics
+- any needed help text or documentation adjustments
+
+## Acceptance Criteria
+
+- `--allow-gitignore` behavior matches its operator-facing meaning for `pr finish`
+- `finish` no longer implies ignored required outputs will be staged when they will not be
+- automated tests cover the resolved flag contract
+- the resulting behavior is deterministic and bounded to the current issue/publication path
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd_args.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `adl/tools/pr.sh`
+- any relevant finish/help documentation
+
+## Dependencies
+
+- issue-level publication behavior for canonical ignored bundle files should already be fixed or be fixed in parallel
+
+## Demo Expectations
+
+- no demo required; focused CLI/test validation is sufficient
+
+## Non-goals
+
+- redesigning global gitignore policy
+- adding generic ignored-file publication support outside `finish`
+- broad CLI flag cleanup unrelated to this contract
+
+## Issue-Graph Notes
+
+- this is closely related to the canonical ignored-bundle publication defect but focuses specifically on the operator-facing flag contract
+- it should land as a bounded follow-on or companion fix, not a general CLI redesign
+
+## Notes
+
+- today the flag suppresses the `.gitignore` diff guard but does not change ignored-path staging behavior
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- cover both the happy path and the misleading current behavior in tests

--- a/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sip.md
+++ b/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1593
+Run ID: issue-1593
+Version: v0.87.1
+Title: [v0.87.1][tools] Make --allow-gitignore truthful for pr finish publication
+Branch: codex/1593-v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1593
+- PR:
+- Source Issue Prompt: .adl/v0.87.1/bodies/issue-1593-v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sor.md
@@ -1,0 +1,155 @@
+# v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1593
+Run ID: issue-1593
+Version: v0.87.1
+Title: [v0.87.1][tools] Make --allow-gitignore truthful for pr finish publication
+Branch: codex/1593-v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: GPT-5 Codex
+- Provider: OpenAI
+- Start Time: 2026-04-11T17:48:00Z
+- End Time: 2026-04-11T18:07:27Z
+
+## Summary
+Clarified the `pr finish` contract so `--allow-gitignore` only covers staged ignore-policy changes, while canonical issue bundle files are explicitly described as automatically staged. Added regression coverage for the updated guard behavior and parser acceptance.
+
+## Artifacts produced
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `adl/tools/pr.sh`
+
+## Actions taken
+- Updated the `pr finish` `.gitignore` guard error text to describe the actual post-1592 behavior.
+- Tightened `adl/tools/pr.sh` help text so canonical issue-bundle staging and `--allow-gitignore` scope are no longer ambiguous.
+- Added parser coverage for `--allow-gitignore` and a regression test proving staged `.gitignore` changes are rejected without the flag.
+- Opened PR `#1606` stacked on PR `#1599` so the contract cleanup is reviewed against the runtime fix it describes.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1606
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: committed on the issue branch, pushed to origin, and opened as stacked PR `#1606`
+- Verification performed:
+  - `git status --short` to confirm the branch was clean after the publish commit
+  - `git ls-files adl/src/cli/pr_cmd.rs adl/src/cli/tests/pr_cmd_inline/finish.rs adl/tools/pr.sh` to verify the tracked proof surface is present on the issue branch
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `bash -n adl/tools/pr.sh` to verify the updated shell help surface remains syntactically valid
+  - `cargo test --manifest-path adl/Cargo.toml parse_finish_args_requires_title_and_accepts_finish_flags -- --nocapture` to verify parser acceptance of the updated finish flag set
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag -- --nocapture` to verify the new guard contract and explanatory error path
+  - `git diff --check` to verify no whitespace or patch-format regressions remain
+- Results: PASS. All targeted validations completed successfully.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash -n adl/tools/pr.sh"
+      - "cargo test --manifest-path adl/Cargo.toml parse_finish_args_requires_title_and_accepts_finish_flags -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag -- --nocapture"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: not_applicable
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: repeated targeted Rust test runs over the same parser and finish guard paths
+- Fixtures or scripts used: built-in Rust unit and inline integration tests under `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- Replay verification (same inputs -> same artifacts/order): confirmed for the targeted tests; rerunning the same test filters produced the same pass result and error-path semantics
+- Ordering guarantees (sorting / tie-break rules used): not applicable because this issue changes operator-facing wording and guard behavior, not emitted ordering logic
+- Artifact stability notes: the proof surface is limited to one Rust command module, one inline test module, and one shell help surface
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of touched diffs; no secrets or credential material were introduced
+- Prompt / tool argument redaction verified: yes; the new wording only documents flag scope and does not emit sensitive inputs
+- Absolute path leakage check: passed via review of the final SOR and touched repo files; only repository-relative paths are recorded here
+- Sandbox / policy invariants preserved: yes; the change does not widen ignored-path staging and keeps generic ignored-file publication blocked
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; no ADL runtime trace bundle was produced for this CLI/help-text fix
+- Run artifact root: not applicable; validation used targeted repository tests only
+- Replay command used for verification: not applicable beyond rerunning the targeted cargo tests listed above
+- Replay result: not applicable
+
+## Artifact Verification
+- Primary proof surface: PR `#1606` plus the tracked files `adl/src/cli/pr_cmd.rs`, `adl/src/cli/tests/pr_cmd_inline/finish.rs`, and `adl/tools/pr.sh`
+- Required artifacts present: yes; all issue-specific tracked artifacts are present on the pushed branch
+- Artifact schema/version checks: not applicable; no schema-bearing documents changed in this issue
+- Hash/byte-stability checks: not run; issue scope is bounded to source and help-text updates validated through tests
+- Missing/optional artifacts and rationale: no additional artifacts were required beyond the tracked code and the canonical issue record
+
+## Decisions / Deviations
+- Stacked PR `#1606` on `#1599` because the contract clarification depends on the runtime publication behavior introduced by issue `#1592`.
+
+## Follow-ups / Deferred work
+- A future cleanup can rename `--allow-gitignore` to a more self-describing flag, but this issue intentionally kept the public surface stable.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/stp.md
+++ b/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/stp.md
@@ -1,0 +1,91 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication"
+title: "[v0.87.1][tools] Make --allow-gitignore truthful for pr finish publication"
+labels:
+  - "area:tools"
+  - "type:bug"
+  - "severity:medium"
+  - "version:v0.87.1"
+issue_number: 1593
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication"
+---
+
+## Summary
+
+Fix the `pr finish --allow-gitignore` contract so the flag’s behavior matches what operators reasonably infer from its name.
+
+## Goal
+
+Ensure `--allow-gitignore` either truthfully enables the bounded ignored-path publication behavior required by `finish` or is narrowed/renamed so it no longer implies staging support that does not exist.
+
+## Required Outcome
+
+- define the intended semantics of `--allow-gitignore` for `pr finish`
+- align staging/publication behavior with that contract, or narrow the flag so it cannot mislead operators
+- add regression coverage for the resolved behavior
+- keep the semantics bounded to `finish` publication, not arbitrary ignored-file handling
+
+## Deliverables
+
+- `pr finish` flag-behavior fix or contract tightening
+- updated tests covering the resolved semantics
+- any needed help text or documentation adjustments
+
+## Acceptance Criteria
+
+- `--allow-gitignore` behavior matches its operator-facing meaning for `pr finish`
+- `finish` no longer implies ignored required outputs will be staged when they will not be
+- automated tests cover the resolved flag contract
+- the resulting behavior is deterministic and bounded to the current issue/publication path
+
+## Repo Inputs
+
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd_args.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `adl/tools/pr.sh`
+- any relevant finish/help documentation
+
+## Dependencies
+
+- issue-level publication behavior for canonical ignored bundle files should already be fixed or be fixed in parallel
+
+## Demo Expectations
+
+- no demo required; focused CLI/test validation is sufficient
+
+## Non-goals
+
+- redesigning global gitignore policy
+- adding generic ignored-file publication support outside `finish`
+- broad CLI flag cleanup unrelated to this contract
+
+## Issue-Graph Notes
+
+- this is closely related to the canonical ignored-bundle publication defect but focuses specifically on the operator-facing flag contract
+- it should land as a bounded follow-on or companion fix, not a general CLI redesign
+
+## Notes
+
+- today the flag suppresses the `.gitignore` diff guard but does not change ignored-path staging behavior
+
+## Tooling Notes
+
+- use the ADL PR lifecycle
+- cover both the happy path and the misleading current behavior in tests

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -414,7 +414,9 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
             bail!("No changes detected and branch has no commits ahead of origin/main. Nothing to PR.");
         }
     } else if !parsed.allow_gitignore && staged_gitignore_change_present(&repo_root)? {
-        bail!("finish: .gitignore changes detected. Revert them or re-run with --allow-gitignore.");
+        bail!(
+            "finish: staged .gitignore or adl/.gitignore changes detected. Revert them or re-run with --allow-gitignore. Canonical issue bundle files are staged automatically."
+        );
     }
 
     let changed_paths = finish_changed_paths(&repo_root, has_uncommitted)?;

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -13,6 +13,7 @@ fn parse_finish_args_requires_title_and_accepts_finish_flags() {
         "adl,docs".to_string(),
         "--no-checks".to_string(),
         "--ready".to_string(),
+        "--allow-gitignore".to_string(),
         "--no-open".to_string(),
     ])
     .expect("parse finish");
@@ -21,6 +22,7 @@ fn parse_finish_args_requires_title_and_accepts_finish_flags() {
     assert_eq!(parsed.paths, "adl,docs");
     assert!(parsed.no_checks);
     assert!(parsed.ready);
+    assert!(parsed.allow_gitignore);
     assert!(parsed.no_open);
 }
 
@@ -1575,6 +1577,136 @@ fn real_pr_finish_rejects_main_and_does_not_report_no_pr_when_bundle_sync_change
         env::set_var("PATH", old_path);
     }
     assert!(!bundle_sync_err.to_string().contains("Nothing to PR."));
+}
+
+#[test]
+fn real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-gitignore-guard");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    let issue_ref =
+        IssueRef::new(1153, "v0.86".to_string(), "rust-finish-test".to_string()).expect("ref");
+    let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&bundle_dir).expect("bundle dir");
+    write_authored_issue_prompt(&repo, &issue_ref, "Example");
+    fs::copy(issue_ref.issue_prompt_path(&repo), issue_ref.task_bundle_stp_path(&repo))
+        .expect("seed stp");
+    write_authored_sip(
+        &issue_ref.task_bundle_input_path(&repo),
+        &issue_ref,
+        "Example",
+        "codex/1153-rust-finish-test",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_completed_sor_fixture(
+        &issue_ref.task_bundle_output_path(&repo),
+        "codex/1153-rust-finish-test",
+    );
+    let cards_root = resolve_cards_root(&repo, None);
+    let compat_output = card_output_path(&cards_root, 1153);
+    ensure_symlink(&compat_output, &issue_ref.task_bundle_output_path(&repo))
+        .expect("compat symlink");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["checkout", "-q", "-b", "codex/1153-rust-finish-test"])
+        .current_dir(&repo)
+        .status()
+        .expect("git checkout")
+        .success());
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("write gitignore");
+    assert!(Command::new("git")
+        .args(["add", ".gitignore"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add gitignore")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let err = real_pr(&[
+        "finish".to_string(),
+        "1153".to_string(),
+        "--title".to_string(),
+        "Example".to_string(),
+        "--input".to_string(),
+        path_relative_to_repo(&repo, &issue_ref.task_bundle_input_path(&repo)),
+        "--output".to_string(),
+        path_relative_to_repo(&repo, &issue_ref.task_bundle_output_path(&repo)),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ])
+    .expect_err("gitignore guard should block finish");
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    assert!(err
+        .to_string()
+        .contains("staged .gitignore or adl/.gitignore changes detected"));
+    assert!(err
+        .to_string()
+        .contains("Canonical issue bundle files are staged automatically"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -1613,8 +1613,11 @@ fn real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag() {
     let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
     fs::create_dir_all(&bundle_dir).expect("bundle dir");
     write_authored_issue_prompt(&repo, &issue_ref, "Example");
-    fs::copy(issue_ref.issue_prompt_path(&repo), issue_ref.task_bundle_stp_path(&repo))
-        .expect("seed stp");
+    fs::copy(
+        issue_ref.issue_prompt_path(&repo),
+        issue_ref.task_bundle_stp_path(&repo),
+    )
+    .expect("seed stp");
     write_authored_sip(
         &issue_ref.task_bundle_input_path(&repo),
         &issue_ref,

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1824,7 +1824,8 @@ Notes:
 - Uses "Closes #N" by default so GitHub auto-closes issues when merged.
 - run is a bounded v0.85 wrapper over the Rust adl runtime; browser/editor direct invocation remains follow-on work.
 - Runs Rust checks in adl/ by default (fmt, clippy -D warnings, test).
-- finish stages repo-root changes by default (ignored paths remain skipped; use --paths to narrow scope).
+- finish stages repo-root changes by default, and force-stages the canonical issue bundle even when `.adl/` is gitignored; use --paths to narrow tracked scope.
+- `--allow-gitignore` only permits staged `.gitignore` / `adl/.gitignore` changes during finish publication; it does not widen generic ignored-path staging.
 - Templates are stored in adl/templates/cards/ (legacy fallback: .adl/templates/).
 - Cards are stored locally under cards_root and are not committed to git.
   cards_root resolves as: ADL_CARDS_ROOT (if set) else <primary-checkout>/.adl/cards.


### PR DESCRIPTION
Closes #1593

## Summary
- clarify that `--allow-gitignore` only permits staged ignore-policy changes during `pr finish`
- make the runtime error explicit that canonical issue bundle files are staged automatically
- pin the post-1592 contract with a regression test and parser coverage

## Validation
- `bash -n adl/tools/pr.sh`
- `cargo test --manifest-path adl/Cargo.toml parse_finish_args_requires_title_and_accepts_finish_flags -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag -- --nocapture`
- `git diff --check`

## Notes
- stacked on #1599 because this contract cleanup depends on the `#1592` runtime staging fix
