### PR TITLE
[v0.87.1][tools] Enforce GitHub issue metadata parity with canonical .adl v0.87.1 issue prompts

### DIFF
--- a/.adl/v0.87.1/bodies/issue-1607-v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts.md
+++ b/.adl/v0.87.1/bodies/issue-1607-v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts.md
@@ -1,0 +1,105 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "tools"
+slug: "v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts"
+title: "[v0.87.1][tools] Enforce GitHub issue metadata parity with canonical .adl v0.87.1 issue prompts"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:task"
+  - "version:v0.87.1"
+issue_number: 1607
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "adl/src/cli/pr_cmd.rs"
+  - "adl/src/cli/pr_cmd/github.rs"
+  - "adl/src/cli/pr_cmd_cards.rs"
+  - "adl/src/cli/tests/pr_cmd_inline/basics.rs"
+  - "adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs"
+  - "adl/src/cli/tests/pr_cmd_inline/lifecycle.rs"
+  - "adl/tools/pr.sh"
+canonical_files:
+  - "adl/src/cli/pr_cmd.rs"
+  - "adl/src/cli/pr_cmd/github.rs"
+  - "adl/src/cli/pr_cmd_cards.rs"
+  - "adl/tools/pr.sh"
+  - "adl/tools/check_issue_metadata_parity.sh"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Observed while reconciling v0.87.1 issue tracker metadata drift on 2026-04-11."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts"
+---
+
+# [v0.87.1][tools] Enforce GitHub issue metadata parity with canonical .adl v0.87.1 issue prompts
+
+## Summary
+
+Prevent tracker drift where GitHub issues for a milestone are missing the canonical version prefix and/or the matching `version:<milestone>` label even though the local `.adl/<milestone>` issue prompt carries them.
+
+## Goal
+
+Enforce GitHub issue title/label parity with the canonical local issue prompt during issue creation/bootstrap, detect duplicate prompt identities for the same issue number, and provide a bounded audit surface for milestone metadata drift.
+
+## Required Outcome
+
+Deliver a bounded tooling fix that keeps GitHub issue metadata aligned with the canonical `.adl` prompt identity and proves the behavior with regression coverage and an audit/check surface.
+
+## Deliverables
+
+- issue creation/bootstrap enforcement for version-prefixed titles and matching `version:<milestone>` labels
+- control-plane detection of duplicate per-issue prompt identities for the same issue number
+- a bounded audit/check that can scan a milestone issue set for metadata drift
+- regression coverage for missing-version metadata and split-identity cases like `#1597`
+
+## Acceptance Criteria
+
+- issue creation/bootstrap enforces title prefix and version-label parity with the canonical local issue prompt
+- the control plane rejects or clearly warns on duplicate per-issue prompt identities for the same issue number
+- a bounded audit/check detects tracker metadata drift across a milestone issue set
+- regression coverage covers the `#1597`-style split identity case and missing-version tracker metadata
+
+## Repo Inputs
+
+- https://github.com/danielbaustin/agent-design-language/issues/1607
+- adl/src/cli/pr_cmd.rs
+- adl/src/cli/pr_cmd/github.rs
+- adl/src/cli/pr_cmd_cards.rs
+- adl/src/cli/tests/pr_cmd_inline/basics.rs
+- adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+- adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+- adl/tools/pr.sh
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- No demo required; this is a tooling/control-plane correctness issue.
+
+## Non-goals
+
+- broad issue-tracker redesign outside the current PR control plane
+- retroactively repairing every existing issue in this same change unless needed for validation fixtures
+
+## Issue-Graph Notes
+
+- Observed while manually repairing tracker metadata for `#1525`, `#1581`, `#1591`, and `#1597`.
+- This issue should reduce future need for manual tracker reconciliation.
+
+## Notes
+
+- Current drift surfaces affect milestone queries, card binding, and reviewer trust.
+
+## Tooling Notes
+
+- Likely touch points include GitHub issue creation/bootstrap helpers, local prompt bootstrap helpers, and one bounded audit/check script.
+- Validation should include focused Rust tests plus the new metadata audit/check surface.

--- a/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sip.md
+++ b/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1607
+Run ID: issue-1607
+Version: v0.87.1
+Title: [v0.87.1][tools] Enforce GitHub issue metadata parity with canonical .adl v0.87.1 issue prompts
+Branch: codex/1607-v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1607
+- PR:
+- Source Issue Prompt: .adl/v0.87.1/bodies/issue-1607-v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md
@@ -1,0 +1,163 @@
+# v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1607
+Run ID: issue-1607
+Version: v0.87.1
+Title: [v0.87.1][tools] Enforce GitHub issue metadata parity with canonical .adl v0.87.1 issue prompts
+Branch: codex/1607-v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: GPT-5 Codex
+- Provider: OpenAI
+- Start Time: 2026-04-11T19:55:00Z
+- End Time: 2026-04-11T20:35:00Z
+
+## Summary
+Enforced GitHub issue metadata parity in the PR control plane by normalizing version-prefixed titles, repairing missing or stale version labels during `pr create` and `pr init`/`pr run`, rejecting duplicate local issue identities, and adding a milestone audit script for tracker metadata drift.
+
+## Artifacts produced
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd/github.rs`
+- `adl/src/cli/pr_cmd_prompt.rs`
+- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
+- `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`
+- `adl/tools/check_issue_metadata_parity.sh`
+- `adl/tools/test_check_issue_metadata_parity.sh`
+
+## Actions taken
+- Replaced the bootstrap source prompt/STP for issue `#1607` with an authored, reviewable execution target before binding execution.
+- Added title normalization for version-prefixed issue titles so manual/bootstrap drift is corrected to the canonical milestone title form.
+- Added GitHub issue metadata parity enforcement that repairs missing labels, removes stale version labels, and aligns the GitHub issue title with the expected canonical title.
+- Added duplicate local issue-identity detection so split prompt/task-bundle variants for the same issue number are rejected instead of silently selected.
+- Added a bounded audit/check script for milestone metadata drift plus a focused shell test for the new audit surface.
+- Added regression coverage for title normalization, duplicate local identities, and init-time repair of missing GitHub version metadata.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1620
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: managed issue worktree with committed branch push and open pull request; canonical `.adl` issue bundle was force-staged for publication
+- Verification performed:
+  - `git status --short`
+    - verifies the branch contains only the intended tracked changes before publication.
+  - `rg --files .adl/v0.87.1/bodies .adl/v0.87.1/tasks adl/src/cli adl/tools | rg '1607|check_issue_metadata_parity|pr_cmd.rs$|pr_cmd_prompt.rs$|github.rs$|repo_helpers.rs$|basics.rs$'`
+    - verifies the expected proof surfaces exist in the worktree.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml normalize_issue_title_for_version_adds_or_replaces_prefix -- --nocapture`
+    - verifies milestone title normalization.
+  - `cargo test --manifest-path adl/Cargo.toml ensure_no_duplicate_issue_identities_rejects_duplicate_prompt_or_task_bundle -- --nocapture`
+    - verifies duplicate local identity rejection.
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_init_repairs_missing_version_metadata_on_github_issue -- --nocapture`
+    - verifies bootstrap/init repairs missing GitHub version metadata.
+  - `bash adl/tools/test_check_issue_metadata_parity.sh`
+    - verifies the new metadata audit/check surface detects drift and passes after correction.
+  - `bash -n adl/tools/check_issue_metadata_parity.sh adl/tools/test_check_issue_metadata_parity.sh`
+    - verifies shell syntax for the new audit scripts.
+  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`
+    - verifies formatting compliance.
+  - `git diff --check`
+    - verifies no whitespace or patch-format regressions remain.
+- Results: PASS. All targeted validations completed successfully.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml normalize_issue_title_for_version_adds_or_replaces_prefix -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml ensure_no_duplicate_issue_identities_rejects_duplicate_prompt_or_task_bundle -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_init_repairs_missing_version_metadata_on_github_issue -- --nocapture"
+      - "bash adl/tools/test_check_issue_metadata_parity.sh"
+      - "bash -n adl/tools/check_issue_metadata_parity.sh adl/tools/test_check_issue_metadata_parity.sh"
+      - "cargo fmt --manifest-path adl/Cargo.toml --all -- --check"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: title normalization unit coverage, duplicate-identity rejection coverage, and a stateful init fixture that deterministically repairs missing GitHub metadata
+- Fixtures or scripts used: Rust inline tests under `adl/src/cli/tests/pr_cmd_inline/` plus `adl/tools/test_check_issue_metadata_parity.sh`
+- Replay verification (same inputs -> same artifacts/order): confirmed for the targeted test fixtures; the same fake-GitHub metadata inputs produce the same normalized title, label repair, and duplicate-identity verdicts
+- Ordering guarantees (sorting / tie-break rules used): duplicate local identities are sorted before rendering the rejection message, and the audit script scans canonical prompts in sorted order
+- Artifact stability notes: the new audit/check surface is deterministic for identical local prompt sets and GitHub metadata responses
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of touched diffs and fixture scripts; no secrets or credential material were introduced
+- Prompt / tool argument redaction verified: yes; the new scripts and tests operate only on issue titles, labels, and local prompt metadata
+- Absolute path leakage check: passed via review of the final SOR and audit script outputs; only repository-relative paths are recorded in the issue artifacts
+- Sandbox / policy invariants preserved: yes; the change only edits GitHub issue metadata through bounded `gh issue edit` operations and local deterministic audit logic
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; no ADL runtime trace bundle was produced for this control-plane tooling issue
+- Run artifact root: not applicable; validation used repository-local tests and audit scripts only
+- Replay command used for verification: reran the targeted Rust tests and `adl/tools/test_check_issue_metadata_parity.sh`
+- Replay result: PASS
+
+## Artifact Verification
+- Primary proof surface: the touched control-plane sources plus `adl/tools/check_issue_metadata_parity.sh` and its test fixture
+- Required artifacts present: yes; all named code, test, and audit-script surfaces are present in the issue worktree
+- Artifact schema/version checks: the canonical source prompt/STP and completed SOR remain structurally valid for the v0.87.1 issue flow
+- Hash/byte-stability checks: not run; the issue relies on deterministic targeted tests and audit-script validation rather than artifact hashing
+- Missing/optional artifacts and rationale: no demo artifact is required because this is a metadata/control-plane correctness issue
+
+## Decisions / Deviations
+- Closed GitHub issue `#1604` separately as duplicate/stale because current main already contains the broader canonical ignored `.adl` publication fix from `#1592` / PR `#1599`.
+
+## Follow-ups / Deferred work
+- If future tracker hygiene needs broader retroactive repair, use the new audit/check surface to identify remaining drift and schedule bounded follow-on fixes rather than widening this issue.

--- a/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/stp.md
+++ b/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/stp.md
@@ -1,0 +1,105 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "tools"
+slug: "v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts"
+title: "[v0.87.1][tools] Enforce GitHub issue metadata parity with canonical .adl v0.87.1 issue prompts"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:task"
+  - "version:v0.87.1"
+issue_number: 1607
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "adl/src/cli/pr_cmd.rs"
+  - "adl/src/cli/pr_cmd/github.rs"
+  - "adl/src/cli/pr_cmd_cards.rs"
+  - "adl/src/cli/tests/pr_cmd_inline/basics.rs"
+  - "adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs"
+  - "adl/src/cli/tests/pr_cmd_inline/lifecycle.rs"
+  - "adl/tools/pr.sh"
+canonical_files:
+  - "adl/src/cli/pr_cmd.rs"
+  - "adl/src/cli/pr_cmd/github.rs"
+  - "adl/src/cli/pr_cmd_cards.rs"
+  - "adl/tools/pr.sh"
+  - "adl/tools/check_issue_metadata_parity.sh"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Observed while reconciling v0.87.1 issue tracker metadata drift on 2026-04-11."
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts"
+---
+
+# [v0.87.1][tools] Enforce GitHub issue metadata parity with canonical .adl v0.87.1 issue prompts
+
+## Summary
+
+Prevent tracker drift where GitHub issues for a milestone are missing the canonical version prefix and/or the matching `version:<milestone>` label even though the local `.adl/<milestone>` issue prompt carries them.
+
+## Goal
+
+Enforce GitHub issue title/label parity with the canonical local issue prompt during issue creation/bootstrap, detect duplicate prompt identities for the same issue number, and provide a bounded audit surface for milestone metadata drift.
+
+## Required Outcome
+
+Deliver a bounded tooling fix that keeps GitHub issue metadata aligned with the canonical `.adl` prompt identity and proves the behavior with regression coverage and an audit/check surface.
+
+## Deliverables
+
+- issue creation/bootstrap enforcement for version-prefixed titles and matching `version:<milestone>` labels
+- control-plane detection of duplicate per-issue prompt identities for the same issue number
+- a bounded audit/check that can scan a milestone issue set for metadata drift
+- regression coverage for missing-version metadata and split-identity cases like `#1597`
+
+## Acceptance Criteria
+
+- issue creation/bootstrap enforces title prefix and version-label parity with the canonical local issue prompt
+- the control plane rejects or clearly warns on duplicate per-issue prompt identities for the same issue number
+- a bounded audit/check detects tracker metadata drift across a milestone issue set
+- regression coverage covers the `#1597`-style split identity case and missing-version tracker metadata
+
+## Repo Inputs
+
+- https://github.com/danielbaustin/agent-design-language/issues/1607
+- adl/src/cli/pr_cmd.rs
+- adl/src/cli/pr_cmd/github.rs
+- adl/src/cli/pr_cmd_cards.rs
+- adl/src/cli/tests/pr_cmd_inline/basics.rs
+- adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+- adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+- adl/tools/pr.sh
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- No demo required; this is a tooling/control-plane correctness issue.
+
+## Non-goals
+
+- broad issue-tracker redesign outside the current PR control plane
+- retroactively repairing every existing issue in this same change unless needed for validation fixtures
+
+## Issue-Graph Notes
+
+- Observed while manually repairing tracker metadata for `#1525`, `#1581`, `#1591`, and `#1597`.
+- This issue should reduce future need for manual tracker reconciliation.
+
+## Notes
+
+- Current drift surfaces affect milestone queries, card binding, and reviewer trust.
+
+## Tooling Notes
+
+- Likely touch points include GitHub issue creation/bootstrap helpers, local prompt bootstrap helpers, and one bounded audit/check script.
+- Validation should include focused Rust tests plus the new metadata audit/check surface.

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -20,7 +20,8 @@ use super::pr_cmd_cards::{
 #[cfg(test)]
 use super::pr_cmd_prompt::load_issue_prompt;
 use super::pr_cmd_prompt::{
-    infer_required_outcome_type, normalize_labels_csv, parse_issue_number_from_url,
+    ensure_no_duplicate_issue_identities, infer_required_outcome_type,
+    normalize_issue_title_for_version, normalize_labels_csv, parse_issue_number_from_url,
     render_generated_issue_body, resolve_issue_body, resolve_issue_prompt_path,
     resolve_issue_scope_and_slug_from_local_state, validate_issue_prompt_exists,
     version_from_labels_csv, version_from_title,
@@ -49,7 +50,7 @@ use self::git_support::{
 #[cfg(test)]
 use self::github::pr_has_closing_linkage;
 use self::github::{
-    attach_pr_janitor, current_pr_url, ensure_issue_labels, ensure_pr_closing_linkage,
+    attach_pr_janitor, current_pr_url, ensure_issue_metadata_parity, ensure_pr_closing_linkage,
     format_open_pr_wave, gh_issue_create, gh_issue_edit_body, gh_issue_title, issue_version,
     unresolved_milestone_pr_wave,
 };
@@ -81,10 +82,10 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     let repo_root = repo_root()?;
     let repo = issue_create_repo(&repo_root)?;
 
-    let title = parsed.title_arg.clone().unwrap_or_default();
+    let raw_title = parsed.title_arg.clone().unwrap_or_default();
     let mut slug = parsed.slug.clone().unwrap_or_default();
     if slug.is_empty() {
-        slug = sanitize_slug(&title);
+        slug = sanitize_slug(&raw_title);
     } else {
         slug = sanitize_slug(&slug);
     }
@@ -99,9 +100,16 @@ fn real_pr_create(args: &[String]) -> Result<()> {
             .labels
             .as_deref()
             .and_then(version_from_labels_csv)
-            .or_else(|| version_from_title(&title))
+            .or_else(|| version_from_title(&raw_title))
             .unwrap_or_else(|| DEFAULT_VERSION.to_string())
     };
+    let title = normalize_issue_title_for_version(&raw_title, &version);
+    if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
+        slug = sanitize_slug(&title);
+        if slug.is_empty() {
+            bail!("create: title produced empty slug after normalization");
+        }
+    }
 
     let normalized_labels = normalize_labels_csv(
         parsed.labels.as_deref().unwrap_or(DEFAULT_NEW_LABELS),
@@ -120,8 +128,9 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     validate_issue_body_for_create(&repo_root, &title, &normalized_labels, &slug, &create_body)?;
     let issue_url = gh_issue_create(&repo, &title, &create_body, &normalized_labels)?;
     let issue = parse_issue_number_from_url(&issue_url)?;
-    ensure_issue_labels(&repo, issue, &normalized_labels)?;
+    ensure_issue_metadata_parity(&repo, issue, &title, &normalized_labels)?;
     let issue_ref = IssueRef::new(issue, version.clone(), slug.clone())?;
+    ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
     let final_body = if body.trim().is_empty() {
         render_generated_issue_body(
             &title,
@@ -222,8 +231,49 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     } else {
         issue_version(parsed.issue, &repo)?.unwrap_or_else(|| DEFAULT_VERSION.to_string())
     };
+    title = normalize_issue_title_for_version(&title, &version);
+    if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
+        slug = sanitize_slug(&title);
+        if slug.is_empty() {
+            bail!("start: title produced empty slug after normalization");
+        }
+    }
+    let fetched_labels = if parsed.no_fetch_issue {
+        String::new()
+    } else {
+        run_capture_allow_failure(
+            "gh",
+            &[
+                "issue",
+                "view",
+                &parsed.issue.to_string(),
+                "-R",
+                &repo,
+                "--json",
+                "labels",
+                "-q",
+                ".labels[].name",
+            ],
+        )?
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(",")
+    };
+    let normalized_labels = normalize_labels_csv(
+        if fetched_labels.trim().is_empty() {
+            DEFAULT_NEW_LABELS
+        } else {
+            &fetched_labels
+        },
+        &version,
+    );
 
     let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
+    ensure_issue_metadata_parity(&repo, parsed.issue, &title, &normalized_labels)?;
+    ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
     let branch = issue_ref.branch_name(&parsed.prefix);
     let unresolved = unresolved_milestone_pr_wave(&repo, &version, Some(&branch))?;
     if !parsed.allow_open_pr_wave && !unresolved.is_empty() {
@@ -664,7 +714,48 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     } else {
         issue_version(issue, &repo)?.unwrap_or_else(|| DEFAULT_VERSION.to_string())
     };
+    title = normalize_issue_title_for_version(&title, &version);
+    if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
+        slug = sanitize_slug(&title);
+        if slug.is_empty() {
+            bail!("init: title produced empty slug after normalization");
+        }
+    }
+    let fetched_labels = if parsed.no_fetch_issue {
+        String::new()
+    } else {
+        run_capture_allow_failure(
+            "gh",
+            &[
+                "issue",
+                "view",
+                &issue.to_string(),
+                "-R",
+                &repo,
+                "--json",
+                "labels",
+                "-q",
+                ".labels[].name",
+            ],
+        )?
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(",")
+    };
+    let normalized_labels = normalize_labels_csv(
+        if fetched_labels.trim().is_empty() {
+            DEFAULT_NEW_LABELS
+        } else {
+            &fetched_labels
+        },
+        &version,
+    );
     let issue_ref = IssueRef::new(issue, version.clone(), slug.clone())?;
+    ensure_issue_metadata_parity(&repo, issue, &title, &normalized_labels)?;
+    ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
     let source_path = ensure_source_issue_prompt(
         &repo_root,
         &repo,

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -272,7 +272,9 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     );
 
     let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
-    ensure_issue_metadata_parity(&repo, parsed.issue, &title, &normalized_labels)?;
+    if !parsed.no_fetch_issue {
+        ensure_issue_metadata_parity(&repo, parsed.issue, &title, &normalized_labels)?;
+    }
     ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
     let branch = issue_ref.branch_name(&parsed.prefix);
     let unresolved = unresolved_milestone_pr_wave(&repo, &version, Some(&branch))?;
@@ -754,7 +756,9 @@ fn real_pr_init(args: &[String]) -> Result<()> {
         &version,
     );
     let issue_ref = IssueRef::new(issue, version.clone(), slug.clone())?;
-    ensure_issue_metadata_parity(&repo, issue, &title, &normalized_labels)?;
+    if !parsed.no_fetch_issue {
+        ensure_issue_metadata_parity(&repo, issue, &title, &normalized_labels)?;
+    }
     ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
     let source_path = ensure_source_issue_prompt(
         &repo_root,

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -287,7 +287,56 @@ fn issue_label_names(issue: u32, repo: &str) -> Result<Vec<String>> {
         .collect())
 }
 
-pub(super) fn ensure_issue_labels(repo: &str, issue: u32, labels_csv: &str) -> Result<()> {
+fn gh_issue_edit_title(repo: &str, issue: u32, title: &str) -> Result<()> {
+    run_status(
+        "gh",
+        &[
+            "issue",
+            "edit",
+            &issue.to_string(),
+            "-R",
+            repo,
+            "--title",
+            title,
+        ],
+    )
+    .with_context(|| format!("create: gh issue edit title failed for issue #{issue}"))
+}
+
+fn gh_issue_add_labels(repo: &str, issue: u32, labels: &[String]) -> Result<()> {
+    if labels.is_empty() {
+        return Ok(());
+    }
+    let issue_s = issue.to_string();
+    let mut args = vec!["issue", "edit", issue_s.as_str(), "-R", repo];
+    for label in labels {
+        args.push("--add-label");
+        args.push(label);
+    }
+    run_status("gh", &args)
+        .with_context(|| format!("create: gh issue add labels failed for issue #{issue}"))
+}
+
+fn gh_issue_remove_labels(repo: &str, issue: u32, labels: &[String]) -> Result<()> {
+    if labels.is_empty() {
+        return Ok(());
+    }
+    let issue_s = issue.to_string();
+    let mut args = vec!["issue", "edit", issue_s.as_str(), "-R", repo];
+    for label in labels {
+        args.push("--remove-label");
+        args.push(label);
+    }
+    run_status("gh", &args)
+        .with_context(|| format!("create: gh issue remove labels failed for issue #{issue}"))
+}
+
+pub(super) fn ensure_issue_metadata_parity(
+    repo: &str,
+    issue: u32,
+    expected_title: &str,
+    labels_csv: &str,
+) -> Result<()> {
     let expected: BTreeSet<String> = labels_csv
         .split(',')
         .map(str::trim)
@@ -298,13 +347,57 @@ pub(super) fn ensure_issue_labels(repo: &str, issue: u32, labels_csv: &str) -> R
         bail!("create: expected at least one label for tracked issue creation");
     }
 
+    let current_title = gh_issue_title(issue, repo)?.unwrap_or_default();
+    if current_title != expected_title {
+        gh_issue_edit_title(repo, issue, expected_title)?;
+    }
+
     let actual: BTreeSet<String> = issue_label_names(issue, repo)?.into_iter().collect();
     let missing: Vec<String> = expected.difference(&actual).cloned().collect();
+    let stale_versions: Vec<String> = actual
+        .iter()
+        .filter(|label| label.starts_with("version:") && !expected.contains(*label))
+        .cloned()
+        .collect();
+
     if !missing.is_empty() {
+        gh_issue_add_labels(repo, issue, &missing)?;
+    }
+    if !stale_versions.is_empty() {
+        gh_issue_remove_labels(repo, issue, &stale_versions)?;
+    }
+
+    let final_title = gh_issue_title(issue, repo)?.unwrap_or_default();
+    if final_title != expected_title {
         bail!(
-            "create: issue #{} is missing expected labels after gh issue create: {}",
+            "create: issue #{} title mismatch after metadata parity enforcement: expected '{}', got '{}'",
             issue,
-            missing.join(", ")
+            expected_title,
+            final_title
+        );
+    }
+    let final_labels: BTreeSet<String> = issue_label_names(issue, repo)?.into_iter().collect();
+    let final_missing: Vec<String> = expected.difference(&final_labels).cloned().collect();
+    let final_stale_versions: Vec<String> = final_labels
+        .iter()
+        .filter(|label| label.starts_with("version:") && !expected.contains(*label))
+        .cloned()
+        .collect();
+    if !final_missing.is_empty() || !final_stale_versions.is_empty() {
+        let mut problems = Vec::new();
+        if !final_missing.is_empty() {
+            problems.push(format!("missing labels: {}", final_missing.join(", ")));
+        }
+        if !final_stale_versions.is_empty() {
+            problems.push(format!(
+                "unexpected version labels: {}",
+                final_stale_versions.join(", ")
+            ));
+        }
+        bail!(
+            "create: issue #{} metadata drift remains after parity enforcement: {}",
+            issue,
+            problems.join("; ")
         );
     }
     Ok(())

--- a/adl/src/cli/pr_cmd_prompt.rs
+++ b/adl/src/cli/pr_cmd_prompt.rs
@@ -51,7 +51,103 @@ pub(crate) fn resolve_issue_scope_and_slug_from_local_state(
         }
     }
     matches.sort();
+    if matches.len() > 1 {
+        let candidates = matches
+            .iter()
+            .map(|(version, slug)| format!("{version}:{slug}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "duplicate local task-bundle identities detected for issue #{}: {}",
+            issue,
+            candidates
+        );
+    }
     Ok(matches.into_iter().next())
+}
+
+pub(crate) fn normalize_issue_title_for_version(title: &str, version: &str) -> String {
+    let trimmed = title.trim();
+    if trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+    let expected_prefix = format!("[{version}]");
+    if trimmed.starts_with(&expected_prefix) {
+        return trimmed.to_string();
+    }
+    if let Some(rest) = trimmed.strip_prefix("[v") {
+        if let Some(end) = rest.find(']') {
+            return format!("{expected_prefix}{}", &rest[end + 1..]);
+        }
+    }
+    format!("{expected_prefix}{trimmed}")
+}
+
+pub(crate) fn ensure_no_duplicate_issue_identities(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    let adl_root = repo_root.join(".adl");
+    if !adl_root.is_dir() {
+        return Ok(());
+    }
+
+    let body_prefix = format!("issue-{:04}-", issue_ref.issue_number());
+    let task_prefix = format!("issue-{:04}__", issue_ref.issue_number());
+    let canonical_body = issue_ref.issue_prompt_path(repo_root);
+    let canonical_bundle = issue_ref.task_bundle_dir_path(repo_root);
+    let mut duplicates = Vec::new();
+
+    for scope_entry in fs::read_dir(&adl_root)? {
+        let scope_entry = scope_entry?;
+        let scope_path = scope_entry.path();
+
+        let bodies = scope_path.join("bodies");
+        if bodies.is_dir() {
+            for entry in fs::read_dir(&bodies)? {
+                let entry = entry?;
+                let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with(&body_prefix) && path != canonical_body {
+                    duplicates.push(path);
+                }
+            }
+        }
+
+        let tasks = scope_path.join("tasks");
+        if tasks.is_dir() {
+            for entry in fs::read_dir(&tasks)? {
+                let entry = entry?;
+                let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with(&task_prefix) && path != canonical_bundle {
+                    duplicates.push(path);
+                }
+            }
+        }
+    }
+
+    duplicates.sort();
+    duplicates.dedup();
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+
+    let rendered = duplicates
+        .iter()
+        .map(|path| {
+            path.strip_prefix(repo_root)
+                .unwrap_or(path)
+                .display()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    bail!(
+        "duplicate local issue identities detected for issue #{}; keep one canonical prompt/task bundle only: {}",
+        issue_ref.issue_number(),
+        rendered
+    );
 }
 
 pub(crate) fn render_generated_issue_prompt(

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -107,6 +107,62 @@ fn normalize_labels_csv_replaces_version_label() {
 }
 
 #[test]
+fn normalize_issue_title_for_version_adds_or_replaces_prefix() {
+    assert_eq!(
+        normalize_issue_title_for_version("[tools] Example", "v0.87.1"),
+        "[v0.87.1][tools] Example"
+    );
+    assert_eq!(
+        normalize_issue_title_for_version("[v0.86][tools] Example", "v0.87.1"),
+        "[v0.87.1][tools] Example"
+    );
+    assert_eq!(
+        normalize_issue_title_for_version("[v0.87.1][tools] Example", "v0.87.1"),
+        "[v0.87.1][tools] Example"
+    );
+}
+
+#[test]
+fn ensure_no_duplicate_issue_identities_rejects_duplicate_prompt_or_task_bundle() {
+    let repo = unique_temp_dir("adl-pr-duplicate-identities");
+    let issue_ref = IssueRef::new(
+        1153,
+        "v0.87.1".to_string(),
+        "v0-87-1-tools-metadata-parity".to_string(),
+    )
+    .expect("issue ref");
+
+    let canonical_body = issue_ref.issue_prompt_path(&repo);
+    let canonical_task = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(canonical_body.parent().expect("body parent")).expect("body dir");
+    fs::create_dir_all(&canonical_task).expect("task dir");
+    fs::write(
+        &canonical_body,
+        "---\ntitle: \"x\"\nlabels:\n  - \"version:v0.87.1\"\nissue_number: 1153\n---\n\n# x\n",
+    )
+    .expect("write canonical body");
+
+    let duplicate_body = repo.join(".adl/v0.87.1/bodies/issue-1153-metadata-parity-legacy.md");
+    let duplicate_task = repo.join(".adl/v0.87.1/tasks/issue-1153__metadata-parity-legacy");
+    fs::create_dir_all(duplicate_body.parent().expect("dup body parent")).expect("dup body dir");
+    fs::create_dir_all(&duplicate_task).expect("dup task dir");
+    fs::write(
+        &duplicate_body,
+        "---\ntitle: \"y\"\nlabels:\n  - \"version:v0.87.1\"\nissue_number: 1153\n---\n\n# y\n",
+    )
+    .expect("write dup body");
+
+    let err = ensure_no_duplicate_issue_identities(&repo, &issue_ref)
+        .expect_err("duplicates should fail");
+    assert!(err
+        .to_string()
+        .contains("duplicate local issue identities detected"));
+    assert!(err
+        .to_string()
+        .contains("issue-1153-metadata-parity-legacy"));
+}
+
+#[test]
 fn infer_repo_from_remote_supports_https_and_ssh() {
     assert_eq!(
         infer_repo_from_remote("https://github.com/danielbaustin/agent-design-language.git"),

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -574,7 +574,7 @@ fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
     write_executable(
             &gh_path,
             &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1202\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1202\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.86][tools] Simplified init path\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
                 gh_log.display(),
                 issue_body_log.display()
             ),
@@ -652,7 +652,7 @@ fn real_pr_create_fails_when_created_issue_is_missing_requested_labels() {
     let gh_path = bin_dir.join("gh");
     write_executable(
         &gh_path,
-        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  printf 'https://github.com/example/repo/issues/1204\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  printf 'track:roadmap\\ntype:task\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  printf 'https://github.com/example/repo/issues/1204\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.86][tools] Missing labels\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:roadmap\\ntype:task\\nversion:v0.86\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
     );
 
     let old_path = env::var("PATH").unwrap_or_default();
@@ -680,9 +680,9 @@ fn real_pr_create_fails_when_created_issue_is_missing_requested_labels() {
         env::set_var("PATH", old_path);
     }
 
-    assert!(err.to_string().contains(
-        "create: issue #1204 is missing expected labels after gh issue create: area:tools"
-    ));
+    assert!(err
+        .to_string()
+        .contains("create: issue #1204 metadata drift remains after parity enforcement: missing labels: area:tools"));
 }
 
 #[test]
@@ -699,7 +699,7 @@ fn real_pr_create_generates_concrete_body_when_none_is_supplied() {
     write_executable(
             &gh_path,
             &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1203\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
+                "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"issue create\" ]]; then\n  i=1\n  while [[ $i -le $# ]]; do\n    arg=\"${{@:$i:1}}\"\n    if [[ \"$arg\" == \"--body\" ]]; then\n      next=$((i+1))\n      printf '%s' \"${{@:$next:1}}\" > '{}'\n      break\n    fi\n    i=$((i+1))\n  done\n  printf 'https://github.com/example/repo/issues/1203\\n'\n  exit 0\nfi\nif [[ \"$1 $2\" == \"issue view\" ]]; then\n  if printf '%s\\n' \"$*\" | grep -q -- '--json title'; then\n    printf '[v0.86][tools] Generated issue body\\n'\n    exit 0\n  fi\n  if printf '%s\\n' \"$*\" | grep -q -- '--json labels'; then\n    printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\n'\n    exit 0\n  fi\nfi\nif [[ \"$1 $2\" == \"issue edit\" ]]; then\n  exit 0\nfi\nexit 1\n",
                 issue_body_log.display()
             ),
         );

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -366,6 +366,84 @@ fn ensure_source_issue_prompt_preserves_authored_front_matter_from_github_body()
 }
 
 #[test]
+fn real_pr_init_repairs_missing_version_metadata_on_github_issue() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-init-metadata-parity");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote add")
+        .success());
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = repo.join("gh.log");
+    let title_state = repo.join("gh-title.txt");
+    let labels_state = repo.join("gh-labels.txt");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nTITLE_FILE='{}'\nLABELS_FILE='{}'\nread_title() {{ if [[ -f \"$TITLE_FILE\" ]]; then cat \"$TITLE_FILE\"; else printf '[tools] Metadata parity\\n'; fi; }}\nread_labels() {{ if [[ -f \"$LABELS_FILE\" ]]; then cat \"$LABELS_FILE\"; else printf 'track:roadmap\\ntype:task\\narea:tools\\n'; fi; }}\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json title -q .title\"* ]]; then\n  read_title\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json labels -q .labels[].name\"* ]]; then\n  read_labels\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json body -q .body\"* ]]; then\n  cat <<'EOF'\n## Summary\n\nRepair missing version metadata during init.\n\n## Goal\n\nKeep GitHub issue metadata aligned with the canonical local prompt.\n\n## Required Outcome\n\nThis issue ships tooling code and tests.\n\n## Deliverables\n\n- metadata parity enforcement\n\n## Acceptance Criteria\n\n- init repairs the missing version title prefix and version label\n\n## Repo Inputs\n\n- adl/src/cli/pr_cmd.rs\n\n## Dependencies\n\n- none\n\n## Demo Expectations\n\n- none\n\n## Non-goals\n\n- broader tracker redesign\n\n## Issue-Graph Notes\n\n- regression fixture\n\n## Notes\n\n- none\n\n## Tooling Notes\n\n- ensure bootstrap is truthful\nEOF\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity\"* ]]; then\n  printf '%s\\n' '[v0.87.1][tools] Metadata parity' > \"$TITLE_FILE\"\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo\"* && \"$*\" == *\"--add-label\"* ]]; then\n  cat <<'EOF' > \"$LABELS_FILE\"\ntrack:roadmap\ntype:task\narea:tools\nversion:v0.87.1\nEOF\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            title_state.display(),
+            labels_state.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    real_pr(&[
+        "init".to_string(),
+        "1153".to_string(),
+        "--slug".to_string(),
+        "v0-87-1-tools-metadata-parity".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ])
+    .expect("real_pr init");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert_eq!(
+        fs::read_to_string(&title_state).expect("title state"),
+        "[v0.87.1][tools] Metadata parity\n"
+    );
+    let labels = fs::read_to_string(&labels_state).expect("labels state");
+    assert!(labels.contains("version:v0.87.1"));
+
+    let issue_ref = IssueRef::new(
+        1153,
+        "v0.87.1".to_string(),
+        "v0-87-1-tools-metadata-parity".to_string(),
+    )
+    .expect("issue ref");
+    let prompt = fs::read_to_string(issue_ref.issue_prompt_path(&repo)).expect("read prompt");
+    assert!(prompt.contains("title: \"[v0.87.1][tools] Metadata parity\""));
+
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(
+        gh_log.contains("issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity")
+    );
+    assert!(gh_log.contains("issue edit 1153 -R owner/repo --add-label version:v0.87.1"));
+}
+
+#[test]
 fn current_pr_url_filters_empty_and_null_results() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-current-url");

--- a/adl/tools/check_issue_metadata_parity.sh
+++ b/adl/tools/check_issue_metadata_parity.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSION=""
+REPO=""
+
+usage() {
+  cat <<'EOF'
+Usage: check_issue_metadata_parity.sh --version <vX.Y[.Z]> [--root <repo-root>] [--repo <owner/repo>]
+
+Scans canonical local issue prompts under .adl/<version>/bodies/ and verifies
+that the corresponding GitHub issue title and labels remain aligned with the
+local prompt metadata.
+
+Checks:
+- exact title parity with the canonical local issue prompt
+- presence of all prompt-declared labels on GitHub
+- presence of the matching version:<milestone> label on GitHub
+- duplicate local prompt/task-bundle identities for the same issue number
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root)
+      ROOT="${2:-}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$VERSION" ]]; then
+  echo "check_issue_metadata_parity: --version is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+python3 - "$ROOT" "$VERSION" "$REPO" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+version = sys.argv[2]
+repo = sys.argv[3]
+body_dir = root / ".adl" / version / "bodies"
+adl_dir = root / ".adl"
+
+if not body_dir.is_dir():
+    print(f"check_issue_metadata_parity: missing body dir {body_dir}", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_prompt(path: Path):
+    text = path.read_text()
+    if not text.startswith("---\n"):
+        raise RuntimeError(f"{path}: missing front matter")
+    _, rest = text.split("---\n", 1)
+    fm_text, _ = rest.split("\n---\n", 1)
+    lines = fm_text.splitlines()
+    title = None
+    issue_number = None
+    labels = []
+    in_labels = False
+    for line in lines:
+        if line.startswith("title: "):
+            title = line.split(":", 1)[1].strip().strip('"')
+            in_labels = False
+        elif line.startswith("issue_number: "):
+            issue_number = int(line.split(":", 1)[1].strip())
+            in_labels = False
+        elif line.startswith("labels:"):
+            in_labels = True
+        elif in_labels and line.startswith("  - "):
+            labels.append(line.split("  - ", 1)[1].strip().strip('"'))
+        elif line and not line.startswith(" "):
+            in_labels = False
+    if title is None or issue_number is None:
+        raise RuntimeError(f"{path}: missing title or issue_number in front matter")
+    return {"title": title, "issue_number": issue_number, "labels": labels}
+
+
+def gh_issue(issue_number: int):
+    proc = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "-R",
+            repo,
+            "--json",
+            "title,labels",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh issue view failed for #{issue_number}: {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    data = json.loads(proc.stdout)
+    return {
+        "title": data.get("title", "").strip(),
+        "labels": sorted(label["name"] for label in data.get("labels", [])),
+    }
+
+
+errors = []
+seen_issue_numbers = {}
+
+for prompt_path in sorted(body_dir.glob("issue-*.md")):
+    meta = parse_prompt(prompt_path)
+    issue_number = meta["issue_number"]
+    if issue_number in seen_issue_numbers:
+        errors.append(
+            f"duplicate canonical body prompts for issue #{issue_number}: "
+            f"{seen_issue_numbers[issue_number]} and {prompt_path.relative_to(root)}"
+        )
+        continue
+    seen_issue_numbers[issue_number] = prompt_path.relative_to(root)
+
+    github = gh_issue(issue_number)
+    if github["title"] != meta["title"]:
+        errors.append(
+            f"issue #{issue_number}: title mismatch: expected '{meta['title']}', got '{github['title']}'"
+        )
+
+    expected_labels = set(meta["labels"])
+    actual_labels = set(github["labels"])
+    missing = sorted(expected_labels - actual_labels)
+    if missing:
+        errors.append(
+            f"issue #{issue_number}: missing labels on GitHub: {', '.join(missing)}"
+        )
+    if f"version:{version}" not in actual_labels:
+        errors.append(
+            f"issue #{issue_number}: missing required version label version:{version}"
+        )
+
+for issue_number in sorted(seen_issue_numbers):
+    body_hits = sorted(
+        path.relative_to(root)
+        for path in adl_dir.glob(f"*/bodies/issue-{issue_number:04d}-*.md")
+    )
+    task_hits = sorted(
+        path.relative_to(root)
+        for path in adl_dir.glob(f"*/tasks/issue-{issue_number:04d}__*")
+    )
+    canonical_body = Path(seen_issue_numbers[issue_number])
+    canonical_task = Path(".adl") / version / "tasks" / canonical_body.stem.replace(
+        f"issue-{issue_number:04d}-", f"issue-{issue_number:04d}__"
+    )
+    extra_bodies = [str(path) for path in body_hits if path != canonical_body]
+    extra_tasks = [str(path) for path in task_hits if path != canonical_task]
+    if extra_bodies or extra_tasks:
+        joined = ", ".join(extra_bodies + extra_tasks)
+        errors.append(
+            f"issue #{issue_number}: duplicate local prompt/task identities detected: {joined}"
+        )
+
+if errors:
+    print("FAIL check_issue_metadata_parity", file=sys.stderr)
+    for err in errors:
+        print(f"- {err}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"PASS check_issue_metadata_parity {version}")
+PY

--- a/adl/tools/test_check_issue_metadata_parity.sh
+++ b/adl/tools/test_check_issue_metadata_parity.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REPO="$TMP/repo"
+mkdir -p "$REPO/.adl/v0.87.1/bodies" "$REPO/.adl/v0.87.1/tasks/issue-1153__v0-87-1-tools-metadata-parity"
+
+cat >"$REPO/.adl/v0.87.1/bodies/issue-1153-v0-87-1-tools-metadata-parity.md" <<'EOF'
+---
+issue_card_schema: adl.issue.v1
+wp: "tools"
+slug: "v0-87-1-tools-metadata-parity"
+title: "[v0.87.1][tools] Metadata parity"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.87.1"
+issue_number: 1153
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes: []
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-metadata-parity"
+---
+
+# [v0.87.1][tools] Metadata parity
+EOF
+
+cat >"$REPO/.adl/v0.87.1/tasks/issue-1153__v0-87-1-tools-metadata-parity/sor.md" <<'EOF'
+# placeholder
+EOF
+
+mkdir -p "$REPO/bin"
+cat >"$REPO/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+MODE="${GH_MODE:-fail}"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf 'owner/repo\n'
+  exit 0
+fi
+if [[ "$*" == *"issue view 1153 -R owner/repo --json title,labels"* ]]; then
+  if [[ "$MODE" == "pass" ]]; then
+    cat <<'JSON'
+{"title":"[v0.87.1][tools] Metadata parity","labels":[{"name":"track:roadmap"},{"name":"type:task"},{"name":"area:tools"},{"name":"version:v0.87.1"}]}
+JSON
+  else
+    cat <<'JSON'
+{"title":"[tools] Metadata parity","labels":[{"name":"track:roadmap"},{"name":"type:task"},{"name":"area:tools"}]}
+JSON
+  fi
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$REPO/bin/gh"
+
+PATH="$REPO/bin:$PATH" GH_MODE=fail bash "$ROOT/adl/tools/check_issue_metadata_parity.sh" --root "$REPO" --version v0.87.1 --repo owner/repo --help >/dev/null
+
+if PATH="$REPO/bin:$PATH" GH_MODE=fail bash "$ROOT/adl/tools/check_issue_metadata_parity.sh" --root "$REPO" --version v0.87.1 --repo owner/repo >/dev/null 2>&1; then
+  echo "expected drift check to fail when version metadata is missing" >&2
+  exit 1
+fi
+
+PATH="$REPO/bin:$PATH" GH_MODE=pass bash "$ROOT/adl/tools/check_issue_metadata_parity.sh" --root "$REPO" --version v0.87.1 --repo owner/repo >/dev/null
+
+echo "PASS test_check_issue_metadata_parity"


### PR DESCRIPTION
Closes #1607.

## Summary
- enforce version-prefixed title and version-label parity against canonical `.adl` issue prompts during `pr create`, `pr init`, and issue-mode `pr run`
- reject duplicate local prompt/task identities for the same issue number instead of silently picking one
- add a bounded metadata audit script plus regression coverage for GitHub drift detection

## Validation
- `cargo test --manifest-path adl/Cargo.toml normalize_issue_title_for_version_adds_or_replaces_prefix -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml ensure_no_duplicate_issue_identities_rejects_duplicate_prompt_or_task_bundle -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_init_repairs_missing_version_metadata_on_github_issue -- --nocapture`
- `bash adl/tools/test_check_issue_metadata_parity.sh`
- `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md`
- `git diff --check`
