### PR TITLE
[v0.87.1][records] Normalize final tracked closed-issue SOR residue

### DIFF
--- a/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sor.md
@@ -40,30 +40,19 @@ Normalized the `repo-code-review` skill to the same typed-input standard as the 
 - Added and ran a dedicated contract test to keep the manifest, schema doc, and guide aligned over time.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: none yet; execution changes currently exist only on the issue branch/worktree prior to `pr finish`
-- Worktree-only paths remaining: `adl/tools/skills/repo-code-review/adl-skill.yaml`, `adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md`, `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`, and `adl/tools/test_repo_code_review_skill_contracts.sh`
-- Integration state: worktree_only
-- Verification scope: worktree
-- Integration method used: issue branch/worktree edits staged for `pr finish`; main-repo tracked copy not updated yet
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sor.md`
+- Worktree-only paths remaining: none
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1590`
 - Verification performed:
-  - `git status --short`
-  - `git diff --check`
+  - `gh issue view 1589 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1590 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1589__v0-87-1-skills-normalize-repo-code-review-skill-input-schema-and-docs/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:

--- a/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sor.md
@@ -37,30 +37,19 @@ Fixed the Rust `pr finish` publication path so it stages the current issue's can
 - Added regression tests for both the mixed tracked-plus-ignored case and the ignored-bundle-only case.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: none yet; execution changes currently exist only on the issue branch/worktree prior to `pr finish`
-- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs` and `adl/src/cli/tests/pr_cmd_inline/finish.rs`
-- Integration state: worktree_only
-- Verification scope: worktree
-- Integration method used: issue branch/worktree edits staged for `pr finish`; main-repo tracked copy not updated yet
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sor.md`
+- Worktree-only paths remaining: none
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1599`
 - Verification performed:
-  - `git status --short`
-  - `git diff --check`
+  - `gh issue view 1592 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1599 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1592__v0-87-1-tools-make-pr-finish-stage-canonical-ignored-adl-issue-bundles-during-publication/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:

--- a/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sor.md
@@ -38,30 +38,19 @@ Clarified the `pr finish` contract so `--allow-gitignore` only covers staged ign
 - Opened PR `#1606` stacked on PR `#1599` so the contract cleanup is reviewed against the runtime fix it describes.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1606
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sor.md`
 - Worktree-only paths remaining: none
-- Integration state: pr_open
-- Verification scope: worktree
-- Integration method used: committed on the issue branch, pushed to origin, and opened as stacked PR `#1606`
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1606`
 - Verification performed:
-  - `git status --short` to confirm the branch was clean after the publish commit
-  - `git ls-files adl/src/cli/pr_cmd.rs adl/src/cli/tests/pr_cmd_inline/finish.rs adl/tools/pr.sh` to verify the tracked proof surface is present on the issue branch
+  - `gh issue view 1593 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1606 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1593__v0-87-1-tools-make-allow-gitignore-truthful-for-pr-finish-publication/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:

--- a/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sor.md
@@ -38,30 +38,19 @@ Wired the repo-code-review contract test into both GitHub CI and the local batch
 - Opened PR `#1605` with the enforcement wiring and operator-facing note.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1605
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sor.md`
 - Worktree-only paths remaining: none
-- Integration state: pr_open
-- Verification scope: worktree
-- Integration method used: committed on the issue branch, pushed to origin, and opened as PR `#1605`
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1605`
 - Verification performed:
-  - `git status --short` to confirm the branch was clean after the publish commit
-  - `git ls-files .github/workflows/ci.yaml adl/tools/batched_checks.sh adl/tools/README.md` to verify the tracked proof surface is present on the issue branch
+  - `gh issue view 1594 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1605 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1594__v0-87-1-skills-enforce-repo-code-review-contract-checks-in-ci-and-batched-checks/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:

--- a/.adl/v0.87.1/tasks/issue-1595__v0-87-1-tools-auto-attach-pr-janitor-on-pr-open/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1595__v0-87-1-tools-auto-attach-pr-janitor-on-pr-open/sor.md
@@ -42,32 +42,19 @@ Added a repo-native janitor auto-attach hook to the finish path so a concrete `p
 - Updated the finish/janitor docs to reflect that repo-native finish now auto-attaches the in-flight PR janitor hook.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: none yet; branch-local tracked edits are prepared for PR publication only
-- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/github.rs`, `adl/src/cli/tests/pr_cmd_inline/finish.rs`, `adl/src/cli/tests/pr_cmd_inline/mod.rs`, `adl/tools/attach_pr_janitor.sh`, `adl/tools/skills/pr-finish/SKILL.md`, `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
-- Integration state: pr_open
-- Verification scope: worktree
-- Integration method used: branch-local tracked edits validated in the issue worktree and prepared for `pr finish`
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1595__v0-87-1-tools-auto-attach-pr-janitor-on-pr-open/sor.md`
+- Worktree-only paths remaining: none
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1603`
 - Verification performed:
-  - `git status --short`
-    - verified the bounded tracked change set that will be staged for publication.
-  - `git diff --check`
-    - verified there are no whitespace or malformed patch artifacts in the final branch diff.
+  - `gh issue view 1595 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1603 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1595__v0-87-1-tools-auto-attach-pr-janitor-on-pr-open/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:

--- a/.adl/v0.87.1/tasks/issue-1596__v0-87-1-tools-make-closeout-automatic-after-merge-closure/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1596__v0-87-1-tools-make-closeout-automatic-after-merge-closure/sor.md
@@ -45,32 +45,19 @@ Added a real Rust-owned `adl pr closeout` surface, reused the same closeout life
 - Taught `adl/tools/pr.sh` and the operator docs about the new `closeout` command and the automatic control-plane-triggered closeout behavior.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: none yet; branch-local tracked edits are prepared for PR publication only
-- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/doctor.rs`, `adl/src/cli/pr_cmd/lifecycle.rs`, `adl/src/cli/pr_cmd_args.rs`, `adl/src/cli/tests/pr_cmd_inline/basics.rs`, `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`, `adl/src/cli/usage.rs`, `adl/tools/pr.sh`, `adl/tools/skills/pr-closeout/SKILL.md`, `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
-- Integration state: pr_open
-- Verification scope: worktree
-- Integration method used: branch-local tracked edits validated in the issue worktree and prepared for `pr finish`
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1596__v0-87-1-tools-make-closeout-automatic-after-merge-closure/sor.md`
+- Worktree-only paths remaining: none
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1601`
 - Verification performed:
-  - `git status --short`
-    - verified the bounded closeout-related tracked paths on the issue branch.
-  - `git diff --check`
-    - verified the final diff is clean and publication-safe.
+  - `gh issue view 1596 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1601 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1596__v0-87-1-tools-make-closeout-automatic-after-merge-closure/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:

--- a/.adl/v0.87.1/tasks/issue-1597__tools-add-milestone-doc-drift-checks-to-pr-finish/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1597__tools-add-milestone-doc-drift-checks-to-pr-finish/sor.md
@@ -36,32 +36,19 @@ Added a bounded finish-time milestone-doc drift guard so `pr finish` blocks publ
 - Added validator-level tests for a coherent package pass case and a missing feature-doc failure case.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: none yet; branch-local tracked edits are prepared for PR publication only
-- Worktree-only paths remaining: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd_validate.rs`
-- Integration state: pr_open
-- Verification scope: worktree
-- Integration method used: branch-local tracked edits validated in the issue worktree and prepared for `pr finish`
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1597__tools-add-milestone-doc-drift-checks-to-pr-finish/sor.md`
+- Worktree-only paths remaining: none
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1602`
 - Verification performed:
-  - `git status --short`
-    - verified the bounded finish-path validation change set on the issue branch.
-  - `git diff --check`
-    - verified the final diff is clean and publication-safe.
+  - `gh issue view 1597 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1602 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1597__tools-add-milestone-doc-drift-checks-to-pr-finish/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:

--- a/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md
@@ -44,32 +44,19 @@ Enforced GitHub issue metadata parity in the PR control plane by normalizing ver
 - Added regression coverage for title normalization, duplicate local identities, and init-time repair of missing GitHub version metadata.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1620
+- Main-repo paths updated: `.adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md`
 - Worktree-only paths remaining: none
-- Integration state: pr_open
-- Verification scope: worktree
-- Integration method used: managed issue worktree with committed branch push and open pull request; canonical `.adl` issue bundle was force-staged for publication
+- Integration state: merged
+- Verification scope: main_repo
+- Integration method used: normalized the canonical root SOR directly on `main` after verifying the issue is already closed and linked to merged PR `#1620`
 - Verification performed:
-  - `git status --short`
-    - verifies the branch contains only the intended tracked changes before publication.
-  - `rg --files .adl/v0.87.1/bodies .adl/v0.87.1/tasks adl/src/cli adl/tools | rg '1607|check_issue_metadata_parity|pr_cmd.rs$|pr_cmd_prompt.rs$|github.rs$|repo_helpers.rs$|basics.rs$'`
-    - verifies the expected proof surfaces exist in the worktree.
+  - `gh issue view 1607 --json title,url,state,stateReason,closedByPullRequestsReferences`
+    - verified the issue is closed and captured the final closure metadata used for this normalization pass
+  - `gh pr view 1620 --json state,url`
+    - verified the linked closing PR remains available as the final publication surface
+  - `ls .adl/v0.87.1/tasks/issue-1607__v0-87-1-tools-enforce-github-issue-metadata-parity-with-canonical-adl-v0-87-1-issue-prompts/sor.md`
+    - verified the canonical root SOR path exists on the main repository path
 - Result: PASS
-
-Rules:
-- Final artifacts must exist in the main repository, not only in a worktree.
-- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
-- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
-- If artifacts exist only in the worktree, the task is NOT complete.
-- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
-- `Verification scope` describes where the verification commands were run.
-- `worktree_only` means at least one required path still exists only outside the main repository path.
-- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
-- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
-- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
-- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
-- Completed output records must not leave `Status` as `NOT_STARTED`.
-- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
 
 ## Validation
 - Validation commands and their purpose:


### PR DESCRIPTION
Closes #1555

## Summary
- normalize the final tracked legacy `.adl` SOR subset that was still stale after the local v0.87.1 records-hygiene pass
- align eight tracked closed-issue SORs with their final closed/merged GitHub truth
- preserve the local `.adl` corpus cleanup while publishing the remaining repo-tracked residue through a normal PR

## Validation
- `python3 - <<'PY'` closed-issue stale-state scan over `.worktrees/adl-wp-1555/.adl/v0.87.1/tasks/`
- `git diff --cached --check`
