### PR TITLE
[v0.87.1][tools] Enforce canonical closed-issue SOR truth at pr finish and closeout

### DIFF
--- a/.adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/sip.md
+++ b/.adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1630
+Run ID: issue-1630
+Version: v0.87.1
+Title: [v0.87.1][tools] Enforce canonical closed-issue SOR truth at pr finish and closeout
+Branch: codex/1630-enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1630
+- PR:
+- Source Issue Prompt: .adl/v0.87.1/bodies/issue-1630-enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/sor.md
@@ -1,0 +1,167 @@
+# enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1630
+Run ID: issue-1630
+Version: v0.87.1
+Title: [v0.87.1][tools] Enforce canonical closed-issue SOR truth at pr finish and closeout
+Branch: codex/1630-enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: OpenAI Codex desktop
+- Start Time: 2026-04-11T22:52:00Z
+- End Time: 2026-04-11T23:15:38Z
+
+## Summary
+
+Added a canonical closed-issue SOR truth gate in the Rust lifecycle layer so `pr finish` refuses to publish already-closed issues whose root canonical `sor.md` still reports stale lifecycle truth, while `closeout` now proves that its post-normalization result is truthful before pruning worktree residue.
+
+## Artifacts produced
+- Updated `adl/src/cli/pr_cmd.rs` to enforce the closed-issue SOR truth gate during `pr finish` after canonical output sync and before publication proceeds.
+- Updated `adl/src/cli/pr_cmd/lifecycle.rs` with a reusable canonical closed-issue SOR truth verifier plus post-closeout proof enforcement.
+- Updated `adl/src/cli/tests/pr_cmd_inline/finish.rs` with a regression proving `pr finish` rejects stale closed-issue canonical SOR truth before any PR publication attempt.
+
+## Actions taken
+- Reviewed the existing `finish`, `closeout`, and lifecycle reconciliation paths to find the smallest enforcement seam that would not accidentally break doctor's self-healing close-bundle behavior.
+- Added `ensure_closed_completed_issue_bundle_truth(...)` in the lifecycle module to verify the canonical root `sor.md` for closed issues reports `Status: DONE`, `Integration state: merged`, `Verification scope: main_repo`, `Worktree-only paths remaining: none`, and no duplicate task-bundle residue.
+- Wired the new truth check into `pr finish` only when GitHub reports the issue is already `CLOSED` with `COMPLETED` state, so open-issue publication behavior is unchanged.
+- Wired the same truth check into `closeout` after reconciliation so closeout now proves its own normalized result instead of assuming it.
+- Added focused regression coverage for stale closed-issue rejection and normalized lifecycle truth acceptance.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1636
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: worktree
+- Integration method used: managed issue worktree with repo-native `pr finish` publication to branch push and open pull request
+- Verification performed:
+  - `git status --short`
+    - verified the branch contains only the intended 1630 code and test changes before publication.
+  - `git diff --check`
+    - verified the patch is whitespace-clean before publication.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml ensure_closed_completed_issue_bundle_truth_rejects_stale_fields_and_duplicates -- --nocapture`
+    - verified the new lifecycle truth checker rejects duplicate bundle residue plus stale closed-issue SOR lifecycle fields.
+  - `cargo test --manifest-path adl/Cargo.toml ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle -- --nocapture`
+    - verified the lifecycle truth checker accepts an already normalized canonical closed-issue bundle.
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth -- --nocapture`
+    - verified `pr finish` fails before PR publication when GitHub reports the issue as closed/completed but the canonical root SOR still reports stale truth.
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_closeout_reconciles_closed_completed_issue_bundle -- --nocapture`
+    - verified `closeout` still normalizes and prunes successfully, with the new post-normalization truth check passing.
+  - `cargo fmt --manifest-path adl/Cargo.toml --all`
+    - normalized formatting for the touched Rust files.
+  - `git diff --check`
+    - verified the final patch is whitespace-clean.
+- Results: PASS
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml ensure_closed_completed_issue_bundle_truth_rejects_stale_fields_and_duplicates -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_closeout_reconciles_closed_completed_issue_bundle -- --nocapture"
+      - "cargo fmt --manifest-path adl/Cargo.toml --all"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: targeted lifecycle truth-check unit tests and finish/closeout regression tests.
+- Fixtures or scripts used: Rust lifecycle and inline `pr_cmd` fixture tests under `adl/src/cli/pr_cmd/lifecycle.rs` and `adl/src/cli/tests/pr_cmd_inline/finish.rs`.
+- Replay verification (same inputs -> same artifacts/order): rerunning the same stale closed-issue fixtures yields the same bounded finish failure, while rerunning the normalized lifecycle fixture yields the same closeout success behavior.
+- Ordering guarantees (sorting / tie-break rules used): duplicate bundle residue is surfaced from the sorted task-bundle match list, so the reported duplicate paths remain stable for identical repository state.
+- Artifact stability notes: the tests prove stable failure/success behavior for identical canonical SOR fixture content; temporary fixture roots vary by test run as expected, but the user-facing gating outcome remains stable.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review only; the added gate reads canonical repository-local issue bundle files and does not widen any credential or secret-handling path.
+- Prompt / tool argument redaction verified: the new diagnostics reference issue numbers, repository-relative artifact classes, and canonical SOR field names only.
+- Absolute path leakage check: committed code and recorded validation commands remain repository-relative; temporary fixture paths appear only in transient local test output, not in tracked artifacts.
+- Sandbox / policy invariants preserved: the change stays inside the existing Rust lifecycle/tooling boundary and does not broaden network scope beyond the already-authorized GitHub issue-state lookup.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not_applicable; this tooling issue is proven by repository-local Rust regression tests rather than a runtime trace bundle.
+- Run artifact root: temporary Rust fixture repositories created by the targeted lifecycle and finish tests.
+- Replay command used for verification: `cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth -- --nocapture`
+- Replay result: PASS
+
+## Artifact Verification
+- Primary proof surface: `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/lifecycle.rs`, and `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- Required artifacts present: yes; the lifecycle gate, finish wiring, and regression coverage are all present in the worktree branch.
+- Artifact schema/version checks: no schema changes; existing completed-phase SOR schema remains unchanged.
+- Hash/byte-stability checks: not_applicable; proof is behavioral Rust test coverage, not a byte-stable generated artifact.
+- Missing/optional artifacts and rationale: no separate demo artifact is required for this tooling guardrail issue.
+
+## Decisions / Deviations
+- Kept doctor's existing reconciliation behavior untouched for this issue so the new hard gate only affects `pr finish` on already-closed issues and post-normalization `closeout` proof.
+- Used the existing older non-versioned local 1630 slug instead of regenerating the bundle, because the issue already had a coherent canonical local prompt/task bundle and generating another one would have added more residue.
+
+## Follow-ups / Deferred work
+- `#1632` remains the follow-on for automatic post-merge normalization so this guardrail failure becomes rare in day-to-day use rather than only explicit and actionable.
+- `#1631` remains the separate residue-cleanup issue for legacy tracked/local record duplication patterns that predate this guardrail.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/stp.md
+++ b/.adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/stp.md
@@ -1,0 +1,95 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout"
+title: "[v0.87.1][tools] Enforce canonical closed-issue SOR truth at pr finish and closeout"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.87.1"
+issue_number: 1630
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Hardens the compressed issue-record model after #1555 exposed stale closed-issue SOR drift."
+pr_start:
+  enabled: false
+  slug: "enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout"
+---
+
+## Summary
+
+Add a hard guard so closed issues cannot publish or close out while their canonical root `sor.md` still reports stale lifecycle truth.
+
+## Goal
+
+Finish the missing enforcement step in the milestone-compression program by making stale closed-issue output records impossible to ignore.
+
+## Required Outcome
+
+- fail `pr finish` and/or closeout when a closed issue's canonical `sor.md` is stale
+- validate the root canonical `.adl/<scope>/tasks/.../sor.md`, not only the active worktree copy
+- surface exact mismatch details so the failure is actionable
+- add regression coverage for failure and success paths
+
+## Deliverables
+
+- control-plane enforcement in the finish or closeout path
+- actionable drift diagnostics for stale closed-issue SOR state
+- regression coverage proving stale closed records are rejected and truthful closed records pass
+
+## Acceptance Criteria
+
+- `pr finish` and/or closeout fails when a closed issue's canonical `sor.md` still reports stale lifecycle state
+- the check validates the root canonical `.adl/<scope>/tasks/.../sor.md`, not just the active worktree copy
+- the failure message identifies the exact issue bundle path and the mismatched fields that require normalization
+- tooling distinguishes open-issue execution state from closed-issue closeout truth and only enforces the gate for issues that should be merged or closed
+- duplicate or superseded issue-bundle residue is surfaced as actionable drift instead of being silently ignored
+- a passing path exists where truthful merged/closed SOR state allows `pr finish` / closeout to continue without manual cleanup
+- regression coverage includes at least one stale-SOR failure case and one normalized-success case
+
+## Repo Inputs
+
+- `https://github.com/danielbaustin/agent-design-language/issues/1630`
+- `.adl/docs/TBD/MILESTONE_COMPRESSION_PLAN.md`
+- `.adl/v0.87.1/tasks/issue-1555__v0-87-1-records-normalize-remaining-closed-issue-task-bundles-to-truthful-merged-closeout-state/`
+- `adl/tools/skills/pr-finish/SKILL.md`
+- `adl/tools/skills/pr-closeout/SKILL.md`
+
+## Dependencies
+
+- `#1555` as the motivating cleanup wave
+- the compressed issue-record model introduced by the v0.87/v0.87.1 tooling work
+
+## Demo Expectations
+
+- No standalone demo required. Proof is deterministic failing and passing tooling behavior plus regression coverage.
+
+## Non-goals
+
+- broad milestone closeout redesign unrelated to stale closed-issue records
+- manual one-off cleanup without a durable guardrail
+- changing the canonical issue-record model again instead of enforcing the current one
+
+## Issue-Graph Notes
+
+- This issue turns the compressed-model closeout rules into an enforced guardrail.
+- It should reduce the chance of future `#1555`-style hygiene waves.
+
+## Notes
+
+- This is the enforcement counterpart to the earlier model simplification work.
+
+## Tooling Notes
+
+- Keep GitHub issue metadata, local source prompt, and task cards aligned.
+- Prefer bounded failure messages that tell the operator exactly what to normalize.

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -444,7 +444,25 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     validate_authored_prompt_surface("finish", &stp_path, PromptSurfaceKind::Stp)?;
     validate_authored_prompt_surface("finish", &input_path, PromptSurfaceKind::Sip)?;
     validate_completed_sor(&repo_root, &output_path)?;
-    lifecycle::sync_completed_output_surfaces(&repo_root, &primary_root, &issue_ref, &output_path)?;
+    let canonical_output = lifecycle::sync_completed_output_surfaces(
+        &repo_root,
+        &primary_root,
+        &issue_ref,
+        &output_path,
+    )?;
+    if lifecycle::issue_is_closed_and_completed(parsed.issue, &repo)? {
+        lifecycle::ensure_closed_completed_issue_bundle_truth(
+            &primary_root,
+            &issue_ref,
+            &canonical_output,
+        )
+        .with_context(|| {
+            format!(
+                "finish: closed issue #{} has stale canonical sor truth; run closeout normalization before publication",
+                parsed.issue
+            )
+        })?;
+    }
 
     if !parsed.no_checks {
         run_batched_checks_rust(&repo_root)?;

--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -151,7 +151,93 @@ pub(super) fn closeout_closed_completed_issue_bundle(
     canonical_output: &Path,
 ) -> Result<()> {
     reconcile_closed_completed_issue_bundle(primary_root, issue_ref, canonical_output)?;
+    ensure_closed_completed_issue_bundle_truth(primary_root, issue_ref, canonical_output)
+        .with_context(|| {
+            format!(
+                "closeout: canonical closed-issue sor truth drift remains for issue #{}",
+                issue_ref.issue_number()
+            )
+        })?;
     prune_issue_worktree(repo_root, primary_root, issue_ref)
+}
+
+pub(super) fn ensure_closed_completed_issue_bundle_truth(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    canonical_output: &Path,
+) -> Result<()> {
+    let bundle_dir = issue_ref.task_bundle_dir_path(repo_root);
+    let duplicates = matching_task_bundle_dirs(repo_root, issue_ref)?;
+    let duplicate_paths = duplicates
+        .iter()
+        .filter(|path| **path != bundle_dir)
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
+
+    let mut mismatches = Vec::new();
+    if !duplicate_paths.is_empty() {
+        mismatches.push(format!(
+            "duplicate or superseded task bundles present: {}",
+            duplicate_paths.join(", ")
+        ));
+    }
+    if !ensure_nonempty_file_path(canonical_output)? {
+        mismatches.push("missing canonical sor.md".to_string());
+    } else {
+        let text = fs::read_to_string(canonical_output)?;
+        check_required_field(&text, "Status:", "DONE", "Status", &mut mismatches);
+        check_required_field(
+            &text,
+            "- Integration state:",
+            "merged",
+            "Integration state",
+            &mut mismatches,
+        );
+        check_required_field(
+            &text,
+            "- Verification scope:",
+            "main_repo",
+            "Verification scope",
+            &mut mismatches,
+        );
+        check_required_field(
+            &text,
+            "- Worktree-only paths remaining:",
+            "none",
+            "Worktree-only paths remaining",
+            &mut mismatches,
+        );
+    }
+
+    if !mismatches.is_empty() {
+        bail!(
+            "canonical closed-issue sor truth drift at {}: {}",
+            canonical_output.display(),
+            mismatches.join("; ")
+        );
+    }
+    Ok(())
+}
+
+fn check_required_field(
+    text: &str,
+    prefix: &str,
+    expected: &str,
+    label: &str,
+    mismatches: &mut Vec<String>,
+) {
+    match text
+        .lines()
+        .find(|line| line.starts_with(prefix))
+        .map(|line| line[prefix.len()..].trim().to_string())
+    {
+        Some(actual) if actual == expected => {}
+        Some(actual) => mismatches.push(format!(
+            "{} expected '{}' but found '{}'",
+            label, expected, actual
+        )),
+        None => mismatches.push(format!("{} is missing", label)),
+    }
 }
 
 fn matching_task_bundle_dirs(repo_root: &Path, issue_ref: &IssueRef) -> Result<Vec<PathBuf>> {
@@ -597,6 +683,54 @@ mod tests {
         assert!(text.contains("- Integration state: merged"));
         assert!(text.contains("- Verification scope: main_repo"));
         assert!(text.contains("- Worktree-only paths remaining: none"));
+    }
+
+    #[test]
+    fn ensure_closed_completed_issue_bundle_truth_rejects_stale_fields_and_duplicates() {
+        let temp = temp_dir("adl-pr-lifecycle-truth-drift");
+        let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+        let canonical_dir = issue_ref.task_bundle_dir_path(&temp);
+        let duplicate_dir = temp
+            .join(".adl")
+            .join("v0.87")
+            .join("tasks")
+            .join("issue-1410__legacy-slug");
+        fs::create_dir_all(&canonical_dir).expect("canonical dir");
+        fs::create_dir_all(&duplicate_dir).expect("duplicate dir");
+        let output = canonical_dir.join("sor.md");
+        fs::write(
+            &output,
+            "Status: IN_PROGRESS\n- Integration state: pr_open\n- Verification scope: worktree\n- Worktree-only paths remaining: adl/src/foo.rs\n",
+        )
+        .expect("write stale output");
+
+        let err = ensure_closed_completed_issue_bundle_truth(&temp, &issue_ref, &output)
+            .expect_err("stale truth should fail");
+        let rendered = err.to_string();
+        assert!(rendered.contains("canonical closed-issue sor truth drift"));
+        assert!(rendered.contains("duplicate or superseded task bundles present"));
+        assert!(rendered.contains("Status expected 'DONE' but found 'IN_PROGRESS'"));
+        assert!(rendered.contains("Integration state expected 'merged' but found 'pr_open'"));
+        assert!(rendered.contains("Verification scope expected 'main_repo' but found 'worktree'"));
+        assert!(rendered
+            .contains("Worktree-only paths remaining expected 'none' but found 'adl/src/foo.rs'"));
+    }
+
+    #[test]
+    fn ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle() {
+        let temp = temp_dir("adl-pr-lifecycle-truth-clean");
+        let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+        let canonical_dir = issue_ref.task_bundle_dir_path(&temp);
+        fs::create_dir_all(&canonical_dir).expect("canonical dir");
+        let output = canonical_dir.join("sor.md");
+        fs::write(
+            &output,
+            "Status: DONE\n- Integration state: merged\n- Verification scope: main_repo\n- Worktree-only paths remaining: none\n",
+        )
+        .expect("write normalized output");
+
+        ensure_closed_completed_issue_bundle_truth(&temp, &issue_ref, &output)
+            .expect("normalized truth should pass");
     }
 
     #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -1873,3 +1873,154 @@ Status: NOT_STARTED
         "finish should fail before any PR publication call"
     );
 }
+
+#[test]
+fn real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-closed-stale-sor");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "checkout",
+            "-q",
+            "-b",
+            "codex/1158-rust-finish-closed-stale"
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git checkout")
+        .success());
+
+    let issue_ref = IssueRef::new(
+        1158,
+        "v0.86".to_string(),
+        "rust-finish-closed-stale".to_string(),
+    )
+    .expect("ref");
+    let stp = issue_ref.task_bundle_stp_path(&repo);
+    let input = issue_ref.task_bundle_input_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish closed stale");
+    if let Some(parent) = stp.parent() {
+        fs::create_dir_all(parent).expect("bundle dir");
+    }
+    fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
+    write_authored_sip(
+        &input,
+        &issue_ref,
+        "[v0.86][tools] Rust finish closed stale",
+        "codex/1158-rust-finish-closed-stale",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_completed_sor_fixture(&output, "codex/1158-rust-finish-closed-stale");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [[ \"$1 $2 $3 $4\" == \"issue view 1158 -R\" ]]; then\n  printf '{{\"state\":\"CLOSED\",\"stateReason\":\"COMPLETED\"}}\\n'\n  exit 0\nfi\nexit 1\n",
+            gh_log.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "finish".to_string(),
+        "1158".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Rust finish closed stale".to_string(),
+        "--input".to_string(),
+        path_relative_to_repo(&repo, &input),
+        "--output".to_string(),
+        path_relative_to_repo(&repo, &output),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ])
+    .expect_err("finish should reject stale closed issue sor truth");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let rendered = err.to_string();
+    assert!(rendered.contains("finish: closed issue #1158 has stale canonical sor truth"));
+    let gh_calls = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(
+        !gh_calls.contains("pr create") && !gh_calls.contains("pr edit"),
+        "finish should fail before any PR publication call"
+    );
+}


### PR DESCRIPTION
Closes #1630

## Summary
Added a canonical closed-issue SOR truth gate in the Rust lifecycle layer so `pr finish` refuses to publish already-closed issues whose root canonical `sor.md` still reports stale lifecycle truth, while `closeout` now proves that its post-normalization result is truthful before pruning worktree residue.

## Artifacts
- Updated `adl/src/cli/pr_cmd.rs` to enforce the closed-issue SOR truth gate during `pr finish` after canonical output sync and before publication proceeds.
- Updated `adl/src/cli/pr_cmd/lifecycle.rs` with a reusable canonical closed-issue SOR truth verifier plus post-closeout proof enforcement.
- Updated `adl/src/cli/tests/pr_cmd_inline/finish.rs` with a regression proving `pr finish` rejects stale closed-issue canonical SOR truth before any PR publication attempt.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml ensure_closed_completed_issue_bundle_truth_rejects_stale_fields_and_duplicates -- --nocapture`
    - verified the new lifecycle truth checker rejects duplicate bundle residue plus stale closed-issue SOR lifecycle fields.
  - `cargo test --manifest-path adl/Cargo.toml ensure_closed_completed_issue_bundle_truth_accepts_normalized_bundle -- --nocapture`
    - verified the lifecycle truth checker accepts an already normalized canonical closed-issue bundle.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth -- --nocapture`
    - verified `pr finish` fails before PR publication when GitHub reports the issue as closed/completed but the canonical root SOR still reports stale truth.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_closeout_reconciles_closed_completed_issue_bundle -- --nocapture`
    - verified `closeout` still normalizes and prunes successfully, with the new post-normalization truth check passing.
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    - normalized formatting for the touched Rust files.
  - `git diff --check`
    - verified the final patch is whitespace-clean.
- Results: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1630__enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout/sor.md
- Idempotency-Key: v0-87-1-tools-enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout-adl-v0-87-1-tasks-issue-1630-enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout-sip-md-adl-v0-87-1-tasks-issue-1630-enforce-canonical-closed-issue-sor-truth-at-pr-finish-and-closeout-sor-md