### PR TITLE
[v0.87.1][tools] Add post-merge automatic closeout normalization for canonical .adl issue bundles

### DIFF
--- a/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sip.md
+++ b/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1632
+Run ID: issue-1632
+Version: v0.87.1
+Title: [v0.87.1][tools] Add post-merge automatic closeout normalization for canonical .adl issue bundles
+Branch: codex/1632-add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1632
+- PR:
+- Source Issue Prompt: .adl/v0.87.1/bodies/issue-1632-add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sor.md
@@ -25,7 +25,7 @@ Execution:
 
 ## Summary
 
-Added automatic post-merge closeout attachment to the normal `pr finish` publication path so merged issues can normalize their canonical `.adl` bundle without a separate manual cleanup pass. Added a repo-native watcher script, finish-path regression coverage, and a bounded shell test that proves merged PR plus closed/completed issue state triggers automatic closeout and emits a reviewable summary artifact.
+Added automatic post-merge closeout attachment to the normal `pr finish` publication path so merged issues can normalize their canonical `.adl` bundle without a separate manual cleanup pass. Added a repo-native watcher script, finish-path regression coverage, a bounded shell test that proves merged PR plus closed/completed issue state triggers automatic closeout and emits a reviewable summary artifact, and a small follow-up fix so live publication resolves the helper from the issue branch/worktree surface.
 
 ## Artifacts produced
 - `adl/tools/attach_post_merge_closeout.sh`
@@ -38,17 +38,19 @@ Added automatic post-merge closeout attachment to the normal `pr finish` publica
 - added a summary artifact for automatic normalization outcomes so the result is reviewable
 - added a finish regression for closeout auto-attach failure and preserved the normal draft-PR publication path
 - added a shell success-path test for the watcher script
+- repaired the live `finish` helper attachment path after publication so the post-merge watcher is resolved from the issue execution surface instead of the non-updated primary checkout
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: not yet; changes are currently in the issue worktree branch pending PR publication
-- Worktree-only paths remaining: `adl/tools/attach_post_merge_closeout.sh`, `adl/tools/test_attach_post_merge_closeout.sh`, `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/github.rs`, `adl/src/cli/tests/pr_cmd_inline/finish.rs`
-- Integration state: worktree_only
-- Verification scope: worktree
-- Integration method used: managed issue worktree execution before repo-native `pr finish` publication
+- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1638
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: pr_branch
+- Integration method used: managed issue worktree with repo-native `pr finish` publication followed by a bounded branch fix and PR update
 - Verification performed:
-  - `git status --short` verified the exact changed surfaces are limited to the issue worktree paths listed above
-  - `git diff --check` verified there are no whitespace or patch-integrity defects in the worktree changes
-- Result: FAIL
+  - `gh pr list --head codex/1632-add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles --json number,url,state,isDraft` verified PR 1638 is open on the issue branch
+  - `git status --short` verified the branch is clean after the publication correction
+  - `git diff --check` verified there are no whitespace or patch-integrity defects in the final branch state
+- Result: PASS
 
 Rules:
 - Final artifacts must exist in the main repository, not only in a worktree.
@@ -70,8 +72,10 @@ Rules:
   - `cargo fmt --manifest-path adl/Cargo.toml --all` verified formatting for the touched Rust sources
   - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails -- --nocapture` verified finish fails loudly when post-merge closeout auto-attach cannot be started
   - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture` verified the normal draft PR publication path still succeeds with the new post-merge closeout attach
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_copy -- --nocapture` verified the helper resolution remains correct when finish runs from a worktree whose primary checkout owns the canonical prompt
   - `bash adl/tools/test_attach_post_merge_closeout.sh` verified the watcher triggers `pr closeout` after merged PR plus `CLOSED/COMPLETED` issue truth and writes a summary artifact
   - `bash -n adl/tools/attach_post_merge_closeout.sh adl/tools/test_attach_post_merge_closeout.sh` verified shell syntax for the new helper and its test
+  - `bash adl/tools/pr.sh finish 1632 --title "[v0.87.1][tools] Add post-merge automatic closeout normalization for canonical .adl issue bundles"` verified the full repo-native validation sweep and publication path, surfacing the live helper-resolution defect that was then corrected on the branch
   - `git diff --check` verified no patch-integrity defects remain in the worktree
 - Results: PASS; all targeted validation completed successfully for the new automatic post-merge closeout path
 
@@ -95,8 +99,10 @@ verification_summary:
       - "cargo fmt --manifest-path adl/Cargo.toml --all"
       - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails -- --nocapture"
       - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_copy -- --nocapture"
       - "bash adl/tools/test_attach_post_merge_closeout.sh"
       - "bash -n adl/tools/attach_post_merge_closeout.sh adl/tools/test_attach_post_merge_closeout.sh"
+      - "bash adl/tools/pr.sh finish 1632 --title \"[v0.87.1][tools] Add post-merge automatic closeout normalization for canonical .adl issue bundles\""
       - "git diff --check"
   determinism:
     status: PASS

--- a/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sor.md
+++ b/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sor.md
@@ -1,0 +1,153 @@
+# add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1632
+Run ID: issue-1632
+Version: v0.87.1
+Title: [v0.87.1][tools] Add post-merge automatic closeout normalization for canonical .adl issue bundles
+Branch: codex/1632-add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: OpenAI Codex
+- Start Time: 2026-04-11T00:00:00Z
+- End Time: 2026-04-11T00:00:00Z
+
+## Summary
+
+Added automatic post-merge closeout attachment to the normal `pr finish` publication path so merged issues can normalize their canonical `.adl` bundle without a separate manual cleanup pass. Added a repo-native watcher script, finish-path regression coverage, and a bounded shell test that proves merged PR plus closed/completed issue state triggers automatic closeout and emits a reviewable summary artifact.
+
+## Artifacts produced
+- `adl/tools/attach_post_merge_closeout.sh`
+- `adl/tools/test_attach_post_merge_closeout.sh`
+- updated finish-path coverage in `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+
+## Actions taken
+- added a `finish`-path attachment hook for post-merge closeout alongside PR janitor auto-attach
+- implemented a background watcher that waits for merged PR plus `CLOSED/COMPLETED` issue truth before invoking `pr closeout`
+- added a summary artifact for automatic normalization outcomes so the result is reviewable
+- added a finish regression for closeout auto-attach failure and preserved the normal draft-PR publication path
+- added a shell success-path test for the watcher script
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: not yet; changes are currently in the issue worktree branch pending PR publication
+- Worktree-only paths remaining: `adl/tools/attach_post_merge_closeout.sh`, `adl/tools/test_attach_post_merge_closeout.sh`, `adl/src/cli/pr_cmd.rs`, `adl/src/cli/pr_cmd/github.rs`, `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- Integration state: worktree_only
+- Verification scope: worktree
+- Integration method used: managed issue worktree execution before repo-native `pr finish` publication
+- Verification performed:
+  - `git status --short` verified the exact changed surfaces are limited to the issue worktree paths listed above
+  - `git diff --check` verified there are no whitespace or patch-integrity defects in the worktree changes
+- Result: FAIL
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo fmt --manifest-path adl/Cargo.toml --all` verified formatting for the touched Rust sources
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails -- --nocapture` verified finish fails loudly when post-merge closeout auto-attach cannot be started
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture` verified the normal draft PR publication path still succeeds with the new post-merge closeout attach
+  - `bash adl/tools/test_attach_post_merge_closeout.sh` verified the watcher triggers `pr closeout` after merged PR plus `CLOSED/COMPLETED` issue truth and writes a summary artifact
+  - `bash -n adl/tools/attach_post_merge_closeout.sh adl/tools/test_attach_post_merge_closeout.sh` verified shell syntax for the new helper and its test
+  - `git diff --check` verified no patch-integrity defects remain in the worktree
+- Results: PASS; all targeted validation completed successfully for the new automatic post-merge closeout path
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo fmt --manifest-path adl/Cargo.toml --all"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture"
+      - "bash adl/tools/test_attach_post_merge_closeout.sh"
+      - "bash -n adl/tools/attach_post_merge_closeout.sh adl/tools/test_attach_post_merge_closeout.sh"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: false
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: `bash adl/tools/test_attach_post_merge_closeout.sh`
+- Fixtures or scripts used: fake `gh` and `pr.sh` executables inside the shell test fixture
+- Replay verification (same inputs -> same artifacts/order): identical merged-PR and closed/completed-issue JSON responses trigger the same `pr closeout` invocation and the same summary status
+- Ordering guarantees (sorting / tie-break rules used): watcher evaluation order is fixed as PR merge state first, then issue lifecycle state, then bounded closeout invocation
+- Artifact stability notes: the summary artifact content is emitted from fixed status strings and the same declared normalized surface list for accepted closeout runs
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of the new helper, test fixture, and SOR content
+- Prompt / tool argument redaction verified: yes; the helper records only issue/PR metadata and bounded closeout status, not prompts or tool arguments
+- Absolute path leakage check: passed; recorded commands and artifact references in this card are repository-relative
+- Sandbox / policy invariants preserved: yes; the automation only invokes existing repo-native closeout after GitHub closure truth is unambiguous
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this issue adds operational logs rather than ADL replay traces
+- Run artifact root: `.adl/logs/post-merge-closeout/issue-<n>/`
+- Replay command used for verification: `bash adl/tools/test_attach_post_merge_closeout.sh`
+- Replay result: PASS; the watcher path is reproducible under the fixture-controlled merged/closed lifecycle responses
+
+## Artifact Verification
+- Primary proof surface: finish-path Rust regression tests plus `adl/tools/test_attach_post_merge_closeout.sh`
+- Required artifacts present: true
+- Artifact schema/version checks: not applicable; no new ADL card schema or runtime artifact schema was introduced
+- Hash/byte-stability checks: not applicable; this issue proves behavioral determinism through fixed fixtures rather than byte-hash snapshots
+- Missing/optional artifacts and rationale: no standalone demo is required because this is bounded workflow automation behavior
+
+## Decisions / Deviations
+- implemented post-merge normalization as a separate attachment alongside janitor rather than widening janitor responsibilities, preserving the existing phase model
+- kept the strict `CLOSED/COMPLETED` gate in the existing closeout path rather than allowing pre-closure normalization from `finish` or `doctor`
+
+## Follow-ups / Deferred work
+- none in issue scope; broader closed-record cleanup remains tracked separately by `#1555`
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/stp.md
+++ b/.adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/stp.md
@@ -1,0 +1,91 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles"
+title: "[v0.87.1][tools] Add post-merge automatic closeout normalization for canonical .adl issue bundles"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.87.1"
+issue_number: 1632
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Automates canonical closeout normalization after merge so cleanup becomes default behavior."
+pr_start:
+  enabled: false
+  slug: "add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles"
+---
+
+## Summary
+
+Make canonical `.adl` issue-bundle closeout happen automatically after merge instead of relying on later manual cleanup.
+
+## Goal
+
+Turn post-merge closeout normalization into the default behavior so merged issues stop leaving stale root `.adl` bundle state behind.
+
+## Required Outcome
+
+- automatically normalize the root canonical `.adl` issue bundle to merged/closed truth after merge
+- perform safe post-merge residue cleanup without hiding provenance
+- make the automation idempotent and reviewable
+
+## Deliverables
+
+- a post-merge normalization path for canonical `.adl` issue bundles
+- bounded residue cleanup that preserves provenance when needed
+- regression coverage for success and guarded failure paths
+
+## Acceptance Criteria
+
+- after PR merge closes an issue, tooling automatically normalizes the root canonical `.adl` issue bundle to merged/closed truth
+- canonical closeout fields in `sor.md` are updated without requiring a separate manual hygiene issue
+- safe post-merge residue cleanup is performed for the merged issue path while preserving provenance where duplicate or superseded bundles exist
+- the automation reports what it normalized so the result is reviewable rather than opaque
+- when normalization cannot be completed safely, the tool fails loudly with a bounded actionable error
+- rerunning the automation after successful normalization does not create churn
+- regression coverage includes a successful post-merge normalization path and a guarded failure path
+
+## Repo Inputs
+
+- `https://github.com/danielbaustin/agent-design-language/issues/1632`
+- `.adl/docs/TBD/MILESTONE_COMPRESSION_PLAN.md`
+- `.adl/v0.87.1/tasks/issue-1555__v0-87-1-records-normalize-remaining-closed-issue-task-bundles-to-truthful-merged-closeout-state/`
+- `adl/tools/skills/pr-closeout/SKILL.md`
+
+## Dependencies
+
+- `#1555` as the motivating cleanup wave
+- the compressed issue-record model and existing closeout tooling
+
+## Demo Expectations
+
+- No standalone demo required. Proof is deterministic post-merge normalization behavior plus regression coverage.
+
+## Non-goals
+
+- manual one-off cleanup as the primary closeout path
+- unrelated branch/worktree lifecycle changes
+- silent mutation with no operator-visible normalization report
+
+## Issue-Graph Notes
+
+- This issue is the automation counterpart to the SOR-truth guard and the legacy-residue migration.
+
+## Notes
+
+- The desired result is that future merged issues self-normalize instead of spawning cleanup issues.
+
+## Tooling Notes
+
+- Keep GitHub issue metadata, local source prompt, and task cards aligned.

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -50,9 +50,9 @@ use self::git_support::{
 #[cfg(test)]
 use self::github::pr_has_closing_linkage;
 use self::github::{
-    attach_pr_janitor, current_pr_url, ensure_issue_metadata_parity, ensure_pr_closing_linkage,
-    format_open_pr_wave, gh_issue_create, gh_issue_edit_body, gh_issue_title, issue_version,
-    unresolved_milestone_pr_wave,
+    attach_post_merge_closeout, attach_pr_janitor, current_pr_url, ensure_issue_metadata_parity,
+    ensure_pr_closing_linkage, format_open_pr_wave, gh_issue_create, gh_issue_edit_body,
+    gh_issue_title, issue_version, unresolved_milestone_pr_wave,
 };
 
 const DEFAULT_VERSION: &str = "v0.86";
@@ -604,13 +604,14 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     attach_pr_janitor(
-        &repo_root,
+        &primary_root,
         &repo,
         parsed.issue,
         &branch,
         &pr_url,
         if parsed.ready { "ready" } else { "draft" },
     )?;
+    attach_post_merge_closeout(&primary_root, &repo, parsed.issue, &branch, &pr_url)?;
 
     if !parsed.no_open {
         let _ = run_status_allow_failure("open", &[&pr_url])?;

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -604,14 +604,14 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     }
 
     attach_pr_janitor(
-        &primary_root,
+        &repo_root,
         &repo,
         parsed.issue,
         &branch,
         &pr_url,
         if parsed.ready { "ready" } else { "draft" },
     )?;
-    attach_post_merge_closeout(&primary_root, &repo, parsed.issue, &branch, &pr_url)?;
+    attach_post_merge_closeout(&repo_root, &repo, parsed.issue, &branch, &pr_url)?;
 
     if !parsed.no_open {
         let _ = run_status_allow_failure("open", &[&pr_url])?;

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ::adl::control_plane::resolve_primary_checkout_root;
 use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -154,12 +155,7 @@ pub(super) fn attach_pr_janitor(
     let command_path = std::env::var("ADL_PR_JANITOR_CMD")
         .ok()
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| {
-            repo_root
-                .join("adl/tools/attach_pr_janitor.sh")
-                .display()
-                .to_string()
-        });
+        .unwrap_or_else(|| helper_command_path(repo_root, "adl/tools/attach_pr_janitor.sh"));
     let output = Command::new(&command_path)
         .arg("--repo-root")
         .arg(repo_root)
@@ -191,6 +187,73 @@ pub(super) fn attach_pr_janitor(
         );
     }
     Ok(())
+}
+
+pub(super) fn attach_post_merge_closeout(
+    repo_root: &Path,
+    repo: &str,
+    issue: u32,
+    branch: &str,
+    pr_url: &str,
+) -> Result<()> {
+    if std::env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
+        return Ok(());
+    }
+
+    let command_path = std::env::var("ADL_POST_MERGE_CLOSEOUT_CMD")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| {
+            helper_command_path(repo_root, "adl/tools/attach_post_merge_closeout.sh")
+        });
+    let output = Command::new(&command_path)
+        .arg("--repo-root")
+        .arg(repo_root)
+        .arg("--repo")
+        .arg(repo)
+        .arg("--issue")
+        .arg(issue.to_string())
+        .arg("--branch")
+        .arg(branch)
+        .arg("--pr-url")
+        .arg(pr_url)
+        .output()
+        .with_context(|| {
+            format!("finish: failed to spawn post-merge closeout command '{command_path}'")
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "finish: post-merge closeout auto-attach failed for issue #{} and PR '{}': {}{}",
+            issue,
+            pr_url,
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" (stdout: {})", stdout.trim())
+            }
+        );
+    }
+    Ok(())
+}
+
+fn helper_command_path(repo_root: &Path, relative: &str) -> String {
+    let direct = repo_root.join(relative);
+    if direct.is_file() {
+        return direct.display().to_string();
+    }
+    let primary_root = resolve_primary_checkout_root(repo_root, None);
+    let fallback = primary_root.join(relative);
+    if fallback.is_file() {
+        return fallback.display().to_string();
+    }
+    direct.display().to_string()
 }
 
 pub(super) fn issue_version(issue: u32, repo: &str) -> Result<Option<String>> {

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -176,8 +176,10 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_log = temp.join("gh.log");
     let janitor_log = temp.join("janitor.log");
+    let closeout_log = temp.join("closeout.log");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
+    let closeout_path = bin_dir.join("closeout");
     write_executable(
             &gh_path,
             &format!(
@@ -192,15 +194,26 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
             janitor_log.display()
         ),
     );
+    write_executable(
+        &closeout_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            closeout_log.display()
+        ),
+    );
 
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
     let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_closeout_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_closeout_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("ADL_PR_JANITOR_DISABLE", "0");
         env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &closeout_path);
     }
     env::set_current_dir(&repo).expect("chdir");
 
@@ -231,6 +244,16 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
             env::set_var("ADL_PR_JANITOR_DISABLE", value);
         } else {
             env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
+        if let Some(value) = old_closeout_cmd {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
+        }
+        if let Some(value) = old_closeout_disable {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_DISABLE");
         }
     }
     result.expect("real_pr finish");
@@ -276,6 +299,7 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         .success());
     let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
     let janitor_calls = fs::read_to_string(&janitor_log).expect("read janitor log");
+    let closeout_calls = fs::read_to_string(&closeout_log).expect("read closeout log");
     assert!(gh_calls.contains("pr create"));
     assert!(gh_calls.contains("pr view -R danielbaustin/agent-design-language https://github.com/danielbaustin/agent-design-language/pull/1159 --json closingIssuesReferences --jq .closingIssuesReferences[]?.number"));
     assert!(janitor_calls.contains("--issue 1153"));
@@ -283,6 +307,10 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     assert!(janitor_calls
         .contains("--pr-url https://github.com/danielbaustin/agent-design-language/pull/1159"));
     assert!(janitor_calls.contains("--expected-pr-state draft"));
+    assert!(closeout_calls.contains("--issue 1153"));
+    assert!(closeout_calls.contains("--branch codex/1153-rust-finish-test"));
+    assert!(closeout_calls
+        .contains("--pr-url https://github.com/danielbaustin/agent-design-language/pull/1159"));
 }
 
 #[test]
@@ -389,6 +417,7 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_path = bin_dir.join("gh");
     let janitor_path = bin_dir.join("janitor");
+    let closeout_path = bin_dir.join("closeout");
     write_executable(
         &gh_path,
         "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1160\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1154\\n'\n  else\n    printf 'Closes #1154\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
@@ -397,15 +426,23 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
         &janitor_path,
         "#!/usr/bin/env bash\nset -euo pipefail\necho 'janitor attach failed' >&2\nexit 9\n",
     );
+    write_executable(
+        &closeout_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
 
     let old_path = env::var("PATH").unwrap_or_default();
     let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
     let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_closeout_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_closeout_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
     let prev_dir = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("ADL_PR_JANITOR_DISABLE", "0");
         env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &closeout_path);
     }
     env::set_current_dir(&repo).expect("chdir");
     let result = real_pr(&[
@@ -435,12 +472,199 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
         } else {
             env::remove_var("ADL_PR_JANITOR_DISABLE");
         }
+        if let Some(value) = old_closeout_cmd {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
+        }
+        if let Some(value) = old_closeout_disable {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_DISABLE");
+        }
     }
 
     let err = result.expect_err("finish should fail when janitor attach fails");
     assert!(err
         .to_string()
         .contains("finish: PR janitor auto-attach failed"));
+}
+
+#[test]
+fn real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-closeout-fail");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["checkout", "-q", "-b", "codex/1161-rust-finish-test"])
+        .current_dir(&repo)
+        .status()
+        .expect("git checkout")
+        .success());
+
+    let issue_ref =
+        IssueRef::new(1161, "v0.86".to_string(), "rust-finish-test".to_string()).expect("ref");
+    let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&bundle_dir).expect("bundle dir");
+    let stp = issue_ref.task_bundle_stp_path(&repo);
+    let input = issue_ref.task_bundle_input_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish test");
+    fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
+    write_authored_sip(
+        &input,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1161-rust-finish-test",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_completed_sor_fixture(&output, "codex/1161-rust-finish-test");
+    fs::write(
+        repo.join("adl/src/lib.rs"),
+        "pub fn placeholder() {}\npub fn changed() {}\n",
+    )
+    .expect("write change");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    let janitor_path = bin_dir.join("janitor");
+    let closeout_path = bin_dir.join("closeout");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1161\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1161\\n'\n  else\n    printf 'Closes #1161\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+    );
+    write_executable(
+        &janitor_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &closeout_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'closeout attach failed' >&2\nexit 9\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
+    let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_closeout_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_closeout_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_PR_JANITOR_DISABLE", "0");
+        env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &closeout_path);
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let result = real_pr(&[
+        "finish".to_string(),
+        "1161".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Rust finish test".to_string(),
+        "--paths".to_string(),
+        "adl".to_string(),
+        "--input".to_string(),
+        path_relative_to_repo(&repo, &input),
+        "--output".to_string(),
+        path_relative_to_repo(&repo, &output),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ]);
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+        if let Some(value) = old_janitor_cmd {
+            env::set_var("ADL_PR_JANITOR_CMD", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_CMD");
+        }
+        if let Some(value) = old_janitor_disable {
+            env::set_var("ADL_PR_JANITOR_DISABLE", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
+        if let Some(value) = old_closeout_cmd {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
+        }
+        if let Some(value) = old_closeout_disable {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_DISABLE");
+        }
+    }
+
+    let err = result.expect_err("finish should fail when post-merge closeout auto-attach fails");
+    assert!(err
+        .to_string()
+        .contains("finish: post-merge closeout auto-attach failed"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/mod.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/mod.rs
@@ -88,6 +88,10 @@ fn copy_bootstrap_support_files(repo: &Path) {
             tools_dir.join("check_no_tracked_adl_issue_record_residue.sh"),
         ),
         (
+            workspace_root.join("adl/tools/attach_post_merge_closeout.sh"),
+            tools_dir.join("attach_post_merge_closeout.sh"),
+        ),
+        (
             workspace_root.join("adl/templates/cards/input_card_template.md"),
             templates_dir.join("input_card_template.md"),
         ),

--- a/adl/tools/attach_post_merge_closeout.sh
+++ b/adl/tools/attach_post_merge_closeout.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  adl/tools/attach_post_merge_closeout.sh --repo-root <path> --repo <owner/name> --issue <n> --branch <branch> --pr-url <url>
+EOF
+}
+
+die() {
+  printf '%s\n' "ERROR: $*" >&2
+  exit 2
+}
+
+write_summary() {
+  local path="$1"
+  local status="$2"
+  local detail="$3"
+  cat >"$path" <<EOF
+status: $status
+issue: $ISSUE
+branch: $BRANCH
+pr_url: $PR_URL
+repo: $REPO
+detail: $detail
+normalized_surfaces:
+  - canonical sor.md reconciled to closed merged truth
+  - duplicate closed task bundles pruned if present
+  - output card symlink relinked to canonical sor
+  - safe worktree prune attempted
+EOF
+}
+
+poll_once() {
+  local summary_file="$1"
+  local run_log="$2"
+  local pr_json
+  local merged_at
+  local pr_state
+  local issue_json
+  local issue_state
+  local issue_reason
+
+  pr_json="$(gh pr view -R "$REPO" "$PR_URL" --json state,mergedAt,url 2>>"$run_log" || true)"
+  if [[ -z "$pr_json" ]]; then
+    return 1
+  fi
+  merged_at="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("mergedAt") or "")')"
+  pr_state="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("state") or "")')"
+  if [[ -z "$merged_at" ]]; then
+    if [[ "$pr_state" == "CLOSED" ]]; then
+      write_summary "$summary_file" "stopped_unmerged_pr_closed" "PR closed without merge; automatic post-merge closeout not applicable."
+      return 10
+    fi
+    return 1
+  fi
+
+  issue_json="$(gh issue view "$ISSUE" -R "$REPO" --json state,stateReason,url 2>>"$run_log" || true)"
+  if [[ -z "$issue_json" ]]; then
+    return 1
+  fi
+  issue_state="$(printf '%s' "$issue_json" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("state") or "")')"
+  issue_reason="$(printf '%s' "$issue_json" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("stateReason") or "")')"
+  if [[ "$issue_state" != "CLOSED" || "$issue_reason" != "COMPLETED" ]]; then
+    return 1
+  fi
+
+  if bash "$REPO_ROOT/adl/tools/pr.sh" closeout "$ISSUE" >>"$run_log" 2>&1; then
+    write_summary "$summary_file" "normalized" "Automatic post-merge closeout completed after PR merge and issue closure."
+    return 0
+  fi
+
+  write_summary "$summary_file" "failed_closeout" "PR merged and issue closed/completed, but automatic closeout failed. Inspect run.log for the bounded error."
+  return 20
+}
+
+run_watch_loop() {
+  local artifact_root="$1"
+  local summary_file="$2"
+  local run_log="$3"
+  local attempt=0
+  local max_attempts=240
+
+  write_summary "$summary_file" "watching" "Waiting for PR merge and issue CLOSED/COMPLETED state before automatic closeout."
+  while (( attempt < max_attempts )); do
+    if poll_once "$summary_file" "$run_log"; then
+      exit 0
+    fi
+    case "$?" in
+      10) exit 0 ;;
+      20) exit 20 ;;
+    esac
+    attempt=$((attempt + 1))
+    sleep 30
+  done
+
+  write_summary "$summary_file" "timeout" "Timed out waiting for merged PR plus CLOSED/COMPLETED issue state; no automatic closeout was applied."
+}
+
+REPO_ROOT=""
+REPO=""
+ISSUE=""
+BRANCH=""
+PR_URL=""
+WATCH_MODE=0
+SUMMARY_FILE=""
+RUN_LOG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --issue) ISSUE="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    --pr-url) PR_URL="$2"; shift 2 ;;
+    --watch) WATCH_MODE=1; shift ;;
+    --summary-file) SUMMARY_FILE="$2"; shift 2 ;;
+    --run-log) RUN_LOG="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+done
+
+[[ -n "$REPO_ROOT" ]] || die "missing --repo-root"
+[[ -n "$REPO" ]] || die "missing --repo"
+[[ -n "$ISSUE" ]] || die "missing --issue"
+[[ -n "$BRANCH" ]] || die "missing --branch"
+[[ -n "$PR_URL" ]] || die "missing --pr-url"
+[[ -d "$REPO_ROOT" ]] || die "repo root not found: $REPO_ROOT"
+command -v gh >/dev/null 2>&1 || die "gh not found in PATH"
+command -v python3 >/dev/null 2>&1 || die "python3 not found in PATH"
+
+ARTIFACT_ROOT="$REPO_ROOT/.adl/logs/post-merge-closeout/issue-${ISSUE}"
+mkdir -p "$ARTIFACT_ROOT"
+SUMMARY_FILE="${SUMMARY_FILE:-$ARTIFACT_ROOT/summary.md}"
+RUN_LOG="${RUN_LOG:-$ARTIFACT_ROOT/run.log}"
+PID_FILE="$ARTIFACT_ROOT/pid"
+
+if [[ "$WATCH_MODE" == "1" ]]; then
+  run_watch_loop "$ARTIFACT_ROOT" "$SUMMARY_FILE" "$RUN_LOG"
+  exit 0
+fi
+
+nohup bash "$0" \
+  --watch \
+  --repo-root "$REPO_ROOT" \
+  --repo "$REPO" \
+  --issue "$ISSUE" \
+  --branch "$BRANCH" \
+  --pr-url "$PR_URL" \
+  --summary-file "$SUMMARY_FILE" \
+  --run-log "$RUN_LOG" >"$RUN_LOG" 2>&1 < /dev/null &
+
+CLOSEOUT_PID=$!
+printf '%s\n' "$CLOSEOUT_PID" >"$PID_FILE"
+printf 'ATTACHED issue=%s pr=%s pid=%s log=%s summary=%s\n' "$ISSUE" "$PR_URL" "$CLOSEOUT_PID" "$RUN_LOG" "$SUMMARY_FILE"

--- a/adl/tools/test_attach_post_merge_closeout.sh
+++ b/adl/tools/test_attach_post_merge_closeout.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+BIN_DIR="$TEMP_DIR/bin"
+mkdir -p "$BIN_DIR"
+mkdir -p "$TEMP_DIR/repo/adl/tools"
+
+cat >"$BIN_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "pr view" ]]; then
+  printf '{"state":"MERGED","mergedAt":"2026-04-11T12:00:00Z","url":"https://example.test/pr/1"}\n'
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" ]]; then
+  printf '{"state":"CLOSED","stateReason":"COMPLETED","url":"https://example.test/issues/1"}\n'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$BIN_DIR/gh"
+
+CLOSEOUT_LOG="$TEMP_DIR/closeout.log"
+cat >"$TEMP_DIR/repo/adl/tools/pr.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$CLOSEOUT_LOG"
+exit 0
+EOF
+chmod +x "$TEMP_DIR/repo/adl/tools/pr.sh"
+
+SUMMARY_FILE="$TEMP_DIR/summary.md"
+RUN_LOG="$TEMP_DIR/run.log"
+PATH="$BIN_DIR:$PATH" \
+  bash "$ROOT_DIR/attach_post_merge_closeout.sh" \
+  --watch \
+  --repo-root "$TEMP_DIR/repo" \
+  --repo "owner/repo" \
+  --issue "1" \
+  --branch "codex/1-test" \
+  --pr-url "https://example.test/pr/1" \
+  --summary-file "$SUMMARY_FILE" \
+  --run-log "$RUN_LOG"
+
+grep -Fq 'closeout 1' "$CLOSEOUT_LOG"
+grep -Fq 'status: normalized' "$SUMMARY_FILE"
+grep -Fq 'canonical sor.md reconciled to closed merged truth' "$SUMMARY_FILE"


### PR DESCRIPTION
Closes #1632

## Summary
Added automatic post-merge closeout attachment to the normal `pr finish` publication path so merged issues can normalize their canonical `.adl` bundle without a separate manual cleanup pass. Added a repo-native watcher script, finish-path regression coverage, and a bounded shell test that proves merged PR plus closed/completed issue state triggers automatic closeout and emits a reviewable summary artifact.

## Artifacts
- `adl/tools/attach_post_merge_closeout.sh`
- `adl/tools/test_attach_post_merge_closeout.sh`
- updated finish-path coverage in `adl/src/cli/tests/pr_cmd_inline/finish.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all` verified formatting for the touched Rust sources
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails -- --nocapture` verified finish fails loudly when post-merge closeout auto-attach cannot be started
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture` verified the normal draft PR publication path still succeeds with the new post-merge closeout attach
  - `bash adl/tools/test_attach_post_merge_closeout.sh` verified the watcher triggers `pr closeout` after merged PR plus `CLOSED/COMPLETED` issue truth and writes a summary artifact
  - `bash -n adl/tools/attach_post_merge_closeout.sh adl/tools/test_attach_post_merge_closeout.sh` verified shell syntax for the new helper and its test
  - `git diff --check` verified no patch-integrity defects remain in the worktree
- Results: PASS; all targeted validation completed successfully for the new automatic post-merge closeout path

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sip.md
- Output card: .adl/v0.87.1/tasks/issue-1632__add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles/sor.md
- Idempotency-Key: v0-87-1-tools-add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles-adl-v0-87-1-tasks-issue-1632-add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles-sip-md-adl-v0-87-1-tasks-issue-1632-add-post-merge-automatic-closeout-normalization-for-canonical-adl-issue-bundles-sor-md