### PR TITLE
[v0.87.1][tools] Add milestone closeout stale-record gate

### DIFF
--- a/.github/workflows/v0871_milestone_closeout_gate.yaml
+++ b/.github/workflows/v0871_milestone_closeout_gate.yaml
@@ -1,0 +1,20 @@
+name: v0.87.1 Milestone Closeout Gate
+
+on:
+  workflow_dispatch:
+
+jobs:
+  closed-issue-sor-truth:
+    name: Closed Issue SOR Truth
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run v0.87.1 closed-issue SOR truth gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1

--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -38,7 +38,6 @@ echo "Skipping codex_pr sanity check (no --paths configured)."
 sh "$ROOT/adl/tools/codexw.sh" --help >/dev/null 2>&1
 run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_review_skill_contracts.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
-
 echo "• Running adl checks (batched)…"
 (
   cd "$ROOT/adl"

--- a/adl/tools/check_milestone_closed_issue_sor_truth.sh
+++ b/adl/tools/check_milestone_closed_issue_sor_truth.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSION=""
+REPO=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  check_milestone_closed_issue_sor_truth.sh --version <v0.87.1> [--repo <owner/name>]
+
+Scans closed GitHub issues for the target milestone label and verifies the
+canonical local `.adl/<version>/tasks/issue-*__*/sor.md` records are not stale.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || {
+  echo "ERROR: --version is required" >&2
+  exit 2
+}
+
+if [[ -z "$REPO" ]]; then
+  remote_url="$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)"
+  if [[ "$remote_url" =~ github.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+    REPO="${BASH_REMATCH[1]}"
+  else
+    echo "ERROR: could not infer GitHub repo from origin remote; pass --repo <owner/name>" >&2
+    exit 1
+  fi
+fi
+
+command -v gh >/dev/null 2>&1 || {
+  echo "ERROR: gh is required" >&2
+  exit 1
+}
+command -v python3 >/dev/null 2>&1 || {
+  echo "ERROR: python3 is required" >&2
+  exit 1
+}
+
+issues_json="$(gh issue list -R "$REPO" --state closed --label "version:$VERSION" --limit 200 --json number,stateReason,title)"
+
+ISSUES_JSON="$issues_json" python3 - "$ROOT" "$VERSION" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+version = sys.argv[2]
+issues = json.loads(os.environ.get("ISSUES_JSON", "[]") or "[]")
+issues.sort(key=lambda item: item["number"])
+
+errors = []
+checked = 0
+
+def extract(text: str, prefix: str):
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix):].strip()
+    return None
+
+for issue in issues:
+    number = issue["number"]
+    state_reason = (issue.get("stateReason") or "").strip()
+    matches = sorted((root / ".adl" / version / "tasks").glob(f"issue-{number}__*/sor.md"))
+    if not matches:
+        errors.append(f"issue #{number}: missing canonical sor.md under .adl/{version}/tasks/issue-{number}__*/sor.md")
+        continue
+    if len(matches) > 1:
+        for path in matches:
+            errors.append(f"{path.relative_to(root)}: duplicate task bundle for closed issue #{number}")
+        continue
+
+    checked += 1
+    path = matches[0]
+    text = path.read_text()
+    status = extract(text, "Status:")
+    integration_state = extract(text, "- Integration state:")
+    verification_scope = extract(text, "- Verification scope:")
+    worktree_paths = extract(text, "- Worktree-only paths remaining:")
+
+    if status != "DONE":
+        errors.append(f"{path.relative_to(root)}: Status expected 'DONE' for closed issue #{number} but found {status!r}")
+    if integration_state in (None, "worktree_only", "pr_open"):
+        errors.append(
+            f"{path.relative_to(root)}: Integration state for closed issue #{number} must not be worktree_only/pr_open; found {integration_state!r}"
+        )
+    if worktree_paths != "none":
+        errors.append(
+            f"{path.relative_to(root)}: Worktree-only paths remaining for closed issue #{number} expected 'none' but found {worktree_paths!r}"
+        )
+
+    if state_reason == "COMPLETED":
+        if integration_state != "merged":
+            errors.append(
+                f"{path.relative_to(root)}: Integration state for CLOSED/COMPLETED issue #{number} expected 'merged' but found {integration_state!r}"
+            )
+        if verification_scope != "main_repo":
+            errors.append(
+                f"{path.relative_to(root)}: Verification scope for CLOSED/COMPLETED issue #{number} expected 'main_repo' but found {verification_scope!r}"
+            )
+
+if errors:
+    print(f"ERROR: stale closed-issue SOR truth detected for version {version}", file=sys.stderr)
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"PASS check_milestone_closed_issue_sor_truth version={version} checked={checked}")
+PY

--- a/adl/tools/test_check_milestone_closed_issue_sor_truth.sh
+++ b/adl/tools/test_check_milestone_closed_issue_sor_truth.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+init_repo() {
+  local repo="$1"
+  git init -q "$repo"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" remote add origin https://github.com/example/repo.git
+  mkdir -p "$repo/adl/tools" "$repo/.adl/v0.87.1/tasks"
+  cp "$ROOT/adl/tools/check_milestone_closed_issue_sor_truth.sh" "$repo/adl/tools/check_milestone_closed_issue_sor_truth.sh"
+  chmod +x "$repo/adl/tools/check_milestone_closed_issue_sor_truth.sh"
+}
+
+write_fake_gh() {
+  local bin_dir="$1"
+  local payload="$2"
+  mkdir -p "$bin_dir"
+  cat >"$bin_dir/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\$1 \$2" == "issue list" ]]; then
+  cat <<'JSON'
+$payload
+JSON
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$bin_dir/gh"
+}
+
+PASS_REPO="$TMP/pass"
+mkdir -p "$PASS_REPO"
+init_repo "$PASS_REPO"
+mkdir -p "$PASS_REPO/.adl/v0.87.1/tasks/issue-1546__sample"
+cat >"$PASS_REPO/.adl/v0.87.1/tasks/issue-1546__sample/sor.md" <<'EOF'
+Status: DONE
+- Integration state: merged
+- Verification scope: main_repo
+- Worktree-only paths remaining: none
+EOF
+write_fake_gh "$PASS_REPO/bin" '[{"number":1546,"stateReason":"COMPLETED","title":"sample"}]'
+(
+  cd "$PASS_REPO"
+  PATH="$PASS_REPO/bin:$PATH" bash ./adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1 --repo example/repo >/dev/null
+)
+
+FAIL_REPO="$TMP/fail"
+mkdir -p "$FAIL_REPO"
+init_repo "$FAIL_REPO"
+mkdir -p "$FAIL_REPO/.adl/v0.87.1/tasks/issue-1547__sample"
+cat >"$FAIL_REPO/.adl/v0.87.1/tasks/issue-1547__sample/sor.md" <<'EOF'
+Status: IN_PROGRESS
+- Integration state: pr_open
+- Verification scope: worktree
+- Worktree-only paths remaining: adl/src/foo.rs
+EOF
+write_fake_gh "$FAIL_REPO/bin" '[{"number":1547,"stateReason":"COMPLETED","title":"sample"}]'
+if (
+  cd "$FAIL_REPO"
+  PATH="$FAIL_REPO/bin:$PATH" bash ./adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1 --repo example/repo >/dev/null 2>&1
+); then
+  echo "expected closed-issue stale-record check to fail" >&2
+  exit 1
+fi
+
+echo "PASS test_check_milestone_closed_issue_sor_truth"

--- a/docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md
+++ b/docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md
@@ -57,6 +57,7 @@ Ship/no-ship gate for the milestone. Check items only when evidence exists.
 
 ## Release Packaging
 - [ ] Release readiness reviewed in the order documented by `docs/milestones/v0.87.1/RELEASE_PLAN_v0.87.1.md`
+- [ ] Closed-issue SOR truth gate passes for `v0.87.1` before ceremony/closure (`bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1` or the `v0.87.1 Milestone Closeout Gate` workflow)
 - [ ] Release notes finalized (`docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md`)
 - [ ] Tag verified: `v0.87.1`
 - [ ] GitHub Release drafted (GitHub Releases UI)

--- a/docs/milestones/v0.87.1/RELEASE_PLAN_v0.87.1.md
+++ b/docs/milestones/v0.87.1/RELEASE_PLAN_v0.87.1.md
@@ -18,6 +18,7 @@
 
 ## 1) Release Readiness
 - [ ] Canonical quality gate reviewed and aligned with CI / docs / demo posture (`docs/milestones/v0.87.1/QUALITY_GATE_v0.87.1.md`)
+- [ ] Closed-issue SOR truth gate passes for `v0.87.1` (`bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1` locally or the `v0.87.1 Milestone Closeout Gate` workflow)
 - [ ] Milestone checklist complete (`docs/milestones/v0.87.1/MILESTONE_CHECKLIST_v0.87.1.md`)
 - [ ] WBS acceptance mapping reviewed against demo, quality, review, and release-tail evidence (`docs/milestones/v0.87.1/WBS_v0.87.1.md`)
 - [ ] Sprint sequencing and handoff gates reviewed against the release-tail issue order (`docs/milestones/v0.87.1/SPRINT_v0.87.1.md`)


### PR DESCRIPTION
## Summary
- add a deterministic milestone closeout gate for stale closed-issue SOR truth
- add passing/failing fixture coverage for the gate
- wire the gate into v0.87.1 release-closeout docs and a dedicated manual GitHub Actions workflow

## Validation
- bash -n adl/tools/check_milestone_closed_issue_sor_truth.sh adl/tools/test_check_milestone_closed_issue_sor_truth.sh
- bash adl/tools/test_check_milestone_closed_issue_sor_truth.sh
- bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1
- git diff --check

Closes #1633