### PR TITLE
[v0.87.1][WP-18A] Remediate 3rd-party review findings

### DIFF
--- a/adl/tools/demo_v0871_multi_agent_discussion.sh
+++ b/adl/tools/demo_v0871_multi_agent_discussion.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/provider_demo_common.sh"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT_DIR="${1:-$ROOT_DIR/artifacts/v0871/multi_agent_discussion}"
 RUNTIME_ROOT="$OUT_DIR/runtime"
 RUNS_ROOT="$RUNTIME_ROOT/runs"
 STEP_OUT="$OUT_DIR/out"
 RUN_ID="v0-87-1-multi-agent-tea-discussion"
-PORT=8791
+PORT="${ADL_MULTI_AGENT_PORT:-0}"
+PORT_FILE="$OUT_DIR/provider_server.port"
 SERVER_LOG="$OUT_DIR/provider_server.log"
 TRANSCRIPT="$OUT_DIR/transcript.md"
 TRANSCRIPT_CONTRACT="$OUT_DIR/transcript_contract.json"
 MANIFEST="$OUT_DIR/demo_manifest.json"
 README_OUT="$OUT_DIR/README.md"
+EXAMPLE="adl/examples/v0-87-1-multi-agent-tea-discussion.adl.yaml"
+GENERATED_EXAMPLE="$OUT_DIR/v0-87-1-multi-agent-tea-discussion.runtime.adl.yaml"
 
 rm -rf "$OUT_DIR"
 mkdir -p "$STEP_OUT"
 
-python3 "$ROOT_DIR/adl/tools/mock_multi_agent_discussion_provider.py" "$PORT" >"$SERVER_LOG" 2>&1 &
+python3 "$ROOT_DIR/adl/tools/mock_multi_agent_discussion_provider.py" \
+  "$PORT" \
+  --port-file "$PORT_FILE" \
+  >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 cleanup() {
   if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
@@ -26,6 +34,19 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+
+python3 - "$EXAMPLE" "$GENERATED_EXAMPLE" "$PORT" <<'PY'
+import sys
+
+source, target, port = sys.argv[1:4]
+text = open(source, encoding="utf-8").read()
+text = text.replace("http://127.0.0.1:8791/chatgpt", f"http://127.0.0.1:{port}/chatgpt")
+text = text.replace("http://127.0.0.1:8791/claude", f"http://127.0.0.1:{port}/claude")
+with open(target, "w", encoding="utf-8") as fh:
+    fh.write(text)
+PY
 
 python3 - "$PORT" <<'PY'
 import json
@@ -53,7 +74,7 @@ cd "$ROOT_DIR"
 
 ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
 ADL_RUNS_ROOT="$RUNS_ROOT" \
-  bash adl/tools/pr.sh run adl/examples/v0-87-1-multi-agent-tea-discussion.adl.yaml \
+  bash adl/tools/pr.sh run "$GENERATED_EXAMPLE" \
     --trace \
     --allow-unsigned \
     --out "$STEP_OUT" \
@@ -183,6 +204,7 @@ Secondary proof surfaces:
 - \`$OUT_DIR/run_log.txt\`
 - \`$MANIFEST\`
 - \`$SERVER_LOG\`
+- \`$PORT_FILE\`
 
 Scope note:
 - This is a bounded demo, not a general conversation-native runtime.

--- a/adl/tools/demo_v0871_real_multi_agent_discussion.sh
+++ b/adl/tools/demo_v0871_real_multi_agent_discussion.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/provider_demo_common.sh"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT_DIR="${1:-$ROOT_DIR/artifacts/v0871/real_multi_agent_discussion}"
 RUNTIME_ROOT="$OUT_DIR/runtime"
 RUNS_ROOT="$RUNTIME_ROOT/runs"
 STEP_OUT="$OUT_DIR/out"
 RUN_ID="v0-87-1-real-multi-agent-tea-discussion"
-PORT="${ADL_LIVE_MULTI_AGENT_PORT:-8792}"
+PORT="${ADL_LIVE_MULTI_AGENT_PORT:-0}"
+PORT_FILE="$OUT_DIR/provider_adapter.port"
 SERVER_LOG="$OUT_DIR/provider_adapter.log"
 INVOCATIONS="$OUT_DIR/provider_invocations.json"
 TRANSCRIPT="$OUT_DIR/transcript.md"
 TRANSCRIPT_CONTRACT="$OUT_DIR/transcript_contract.json"
 MANIFEST="$OUT_DIR/demo_manifest.json"
 README_OUT="$OUT_DIR/README.md"
+EXAMPLE="adl/examples/v0-87-1-real-multi-agent-tea-discussion.adl.yaml"
+GENERATED_EXAMPLE="$OUT_DIR/v0-87-1-real-multi-agent-tea-discussion.runtime.adl.yaml"
 OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
 ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
 
@@ -60,6 +65,7 @@ mkdir -p "$STEP_OUT"
 
 python3 "$ROOT_DIR/adl/tools/real_multi_agent_provider_adapter.py" \
   --port "$PORT" \
+  --port-file "$PORT_FILE" \
   --metadata "$INVOCATIONS" \
   >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
@@ -70,6 +76,19 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+
+python3 - "$EXAMPLE" "$GENERATED_EXAMPLE" "$PORT" <<'PY'
+import sys
+
+source, target, port = sys.argv[1:4]
+text = open(source, encoding="utf-8").read()
+text = text.replace("http://127.0.0.1:8792/openai", f"http://127.0.0.1:{port}/openai")
+text = text.replace("http://127.0.0.1:8792/anthropic", f"http://127.0.0.1:{port}/anthropic")
+with open(target, "w", encoding="utf-8") as fh:
+    fh.write(text)
+PY
 
 python3 - "$PORT" <<'PY'
 import json
@@ -97,7 +116,7 @@ cd "$ROOT_DIR"
 
 ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
 ADL_RUNS_ROOT="$RUNS_ROOT" \
-  bash adl/tools/pr.sh run adl/examples/v0-87-1-real-multi-agent-tea-discussion.adl.yaml \
+  bash adl/tools/pr.sh run "$GENERATED_EXAMPLE" \
     --trace \
     --allow-unsigned \
     --out "$STEP_OUT" \
@@ -238,6 +257,7 @@ Secondary proof surfaces:
 - \`$TRANSCRIPT_CONTRACT\`
 - \`$OUT_DIR/run_log.txt\`
 - \`$MANIFEST\`
+- \`$PORT_FILE\`
 
 Scope note:
 - This is a live provider demo, not a CI-required deterministic test.

--- a/adl/tools/mock_multi_agent_discussion_provider.py
+++ b/adl/tools/mock_multi_agent_discussion_provider.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
+import argparse
 import json
 import re
 import sys
+from pathlib import Path
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
@@ -108,10 +110,17 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main() -> int:
-    port = 8791
-    if len(sys.argv) > 1:
-        port = int(sys.argv[1])
-    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    parser = argparse.ArgumentParser(
+        description="Run the bounded local compatibility provider for the multi-agent discussion demo."
+    )
+    parser.add_argument("port", nargs="?", type=int, default=8791)
+    parser.add_argument("--port-file", type=Path)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    if args.port_file:
+        args.port_file.parent.mkdir(parents=True, exist_ok=True)
+        args.port_file.write_text(f"{server.server_address[1]}\n", encoding="utf-8")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/adl/tools/real_multi_agent_provider_adapter.py
+++ b/adl/tools/real_multi_agent_provider_adapter.py
@@ -254,6 +254,7 @@ def main() -> int:
         description="Run a local ADL completion adapter backed by live model APIs."
     )
     parser.add_argument("--port", type=int, default=8792)
+    parser.add_argument("--port-file", type=Path)
     parser.add_argument("--metadata", type=Path, required=True)
     parser.add_argument("--openai-model", default=os.getenv("ADL_LIVE_OPENAI_MODEL", DEFAULT_OPENAI_MODEL))
     parser.add_argument(
@@ -276,6 +277,9 @@ def main() -> int:
     adapter.write_metadata()
     handler = make_handler(adapter)
     server = http.server.ThreadingHTTPServer(("127.0.0.1", args.port), handler)
+    if args.port_file:
+        args.port_file.parent.mkdir(parents=True, exist_ok=True)
+        args.port_file.write_text(f"{server.server_address[1]}\n", encoding="utf-8")
     server.serve_forever()
     return 0
 

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -133,7 +133,7 @@ Use this table as the fast review surface for milestone coverage.
 | D9 | Integrated Runtime Path | `WP-02` through `WP-08` integrated runtime completion | `bash adl/tools/demo_v0871_integrated_runtime.sh` | `artifacts/v0871/integrated_runtime/demo_manifest.json` | One run demonstrates the authoritative bounded runtime path from D1 through D8 end-to-end | Replay is judged by package ordering and proof-surface shape stability across the integrated manifest | READY |
 | D10 | Docs-To-Runtime Consistency Check | `WP-09`, `WP-15` docs/review convergence | `bash adl/tools/demo_v0871_docs_review.sh` | `artifacts/v0871/docs_review/docs_review_manifest.json` | Reviewer can move from promoted runtime docs to integrated proof surfaces without contradiction | Navigation and proof mapping remain stable for the bounded docs-to-proof map | READY |
 | D11 | Quality Gate Walkthrough | `WP-14` quality gate | `bash adl/tools/demo_v0871_quality_gate.sh` | `artifacts/v0871/quality_gate/quality_gate_record.json` | Tests, validators, and bounded demo checks are reviewable in one place with per-check logs | Same repo state should preserve gate outcome and log inventory | READY |
-| D12 | Release Review Package | `WP-16` through `WP-20` review/remediation/planning/release tail | `bash adl/tools/demo_v0871_release_review_package.sh` | `artifacts/v0871/release_review_package/release_review_package_manifest.json` | Review, remediation, planning, and release artifacts are coherent and navigable from one package root | Package layout and key entrypoints remain stable for the bounded release-review surface | READY |
+| D12 | Release Review Package | `WP-16` through `WP-20` release-tail review package / navigation surface | `bash adl/tools/demo_v0871_release_review_package.sh` | `artifacts/v0871/release_review_package/release_review_package_manifest.json` | Review, remediation, planning, and release-tail artifacts are coherent and navigable from one package root without implying final ceremony closure | Package layout and key entrypoints remain stable for the bounded release-review surface | READY |
 | D13 | Claude + ChatGPT Tea Discussion | bounded multi-agent runtime discussion proof (`#1490`, `#1491`, `#1501`, `#1502`) | `bash adl/tools/demo_v0871_multi_agent_discussion.sh` | `artifacts/v0871/multi_agent_discussion/transcript.md` | Reviewer can inspect five explicit turns, two named agents, runtime turn metadata, the transcript contract, and the paired runtime trace/summaries | Fixed shim outputs should preserve transcript shape and turn ordering | READY |
 | D13L | Live Claude + ChatGPT Tea Discussion | live-provider companion proof for D13 (`#1500`, `#1501`, `#1502`, `#1533`) | `bash adl/tools/demo_v0871_real_multi_agent_discussion.sh` | `artifacts/v0871/real_multi_agent_discussion/provider_invocations.json` plus `transcript.md` | Reviewer can inspect real OpenAI and Anthropic invocation metadata, five explicit turns, runtime turn metadata, and transcript contract proof without secret leakage when valid operator credentials and provider account credit are available; a no-credential test skip is a bounded non-proving disposition, not live-provider proof | Live model text is non-deterministic; runtime artifact shape, turn ordering, accepted contract shape, and non-secret invocation metadata remain stable | READY_WITH_OPERATOR_CREDENTIALS |
 
@@ -168,7 +168,7 @@ Status guidance:
 - `D9` -> all promoted `v0.87.1` runtime feature docs
 - `D10` -> `FEATURE_DOCS_v0.87.1.md` and all promoted `v0.87.1` runtime feature docs
 - `D11` -> milestone review and validation surfaces derived from the promoted runtime feature set
-- `D12` -> review, remediation, planning, and release surfaces for the runtime milestone
+- `D12` -> release-tail review, remediation, planning, and ceremony entry surfaces for the runtime milestone
 - `D13` -> bounded multi-agent runtime demo evidence for later conversation/runtime follow-on work (`#1490`, `#1491`, `#1501`, `#1502`)
 - `D13L` -> live provider evidence that the bounded D13 shape can call real OpenAI and Anthropic models through the current ADL HTTP completion boundary (`#1533`)
 
@@ -279,7 +279,7 @@ Failure policy:
 ## Determinism Evidence
 
 Evidence directory / run root:
-- runtime demo artifact roots will be defined per demo as implementation lands
+- runtime demo artifact roots are defined per demo in the coverage table and detail sections below
 - the canonical runtime root and runs root are established by `adl::runtime_environment::RuntimeEnvironment`
 
 Repeatability approach:

--- a/docs/milestones/v0.87.1/README.md
+++ b/docs/milestones/v0.87.1/README.md
@@ -31,7 +31,7 @@ This milestone focuses on:
 Key outcomes:
 - a real runtime-completion implementation surface with many thousands of lines of code
 - canonical milestone documents that truthfully describe the runtime
-- a runnable demo program and review package proving the runtime is real
+- a runnable demo program and review package providing bounded proof surfaces for the implemented runtime
 - a stable public surface for later chronosense and bounded-agency work
 - one authoritative runtime-environment bring-up/configuration contract:
   - `adl::runtime_environment::RuntimeEnvironment`

--- a/docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md
+++ b/docs/milestones/v0.87.1/RELEASE_NOTES_v0.87.1.md
@@ -15,7 +15,7 @@
 # `ADL` `v0.87.1` Release Notes
 
 ## Summary
-`v0.87.1` is the release vehicle for ADL's first full runtime milestone. It turns the seeded execution substrate from `v0.87` into a coherent runtime system with explicit lifecycle boundaries, trace-aligned execution, local resilience, operator surfaces, review surfaces, and a substantial demo-backed proof program; final release wording remains pending until the open milestone gates are complete or explicitly deferred.
+`v0.87.1` is the release vehicle for ADL's first full runtime milestone. The milestone work has turned the seeded execution substrate from `v0.87` into a coherent runtime system with explicit lifecycle boundaries, trace-aligned execution, local resilience, operator surfaces, review surfaces, and a substantial bounded proof program; final release wording remains pending until the open milestone gates are complete or explicitly deferred.
 
 ## Highlights
 - Runtime environment and lifecycle completion surfaces landed for `v0.87.1`


### PR DESCRIPTION
Closes #1628

## Summary
- tighten v0.87.1 release and demo-matrix wording so the review package stays truthful about open release-tail work
- remove fixed-port assumptions from the bounded and live multi-agent demo wrappers by materializing runtime-local loopback endpoints
- keep the live-provider skip path explicitly non-proving while preserving the bounded demo acceptance surface

## Validation
- bash adl/tools/test_demo_v0871_multi_agent_discussion.sh
- ADL_OPENAI_KEY_FILE=.adl/nonexistent-openai.key ADL_ANTHROPIC_KEY_FILE=.adl/nonexistent-anthropic.key bash adl/tools/test_demo_v0871_real_multi_agent_discussion.sh
- git diff --check

## Notes
- repo-native pr finish is currently blocked by a preexisting tracked legacy .adl issue-record residue guard unrelated to this patch, so this PR was published manually after the issue SOR was updated truthfully