### PR TITLE
[v0.88][tools] Add lightweight workflow conductor skill

### DIFF
--- a/.adl/v0.88/bodies/issue-1647-add-lightweight-workflow-conductor-skill.md
+++ b/.adl/v0.88/bodies/issue-1647-add-lightweight-workflow-conductor-skill.md
@@ -1,0 +1,94 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "add-lightweight-workflow-conductor-skill"
+title: "[v0.88][tools] Add lightweight workflow conductor skill"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.88"
+issue_number: 1647
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "add-lightweight-workflow-conductor-skill"
+---
+
+# [v0.88][tools] Add lightweight workflow conductor skill
+
+## Summary
+
+Add a thin workflow conductor skill that routes into the existing ADL lifecycle and editor skills instead of replacing them. The conductor should reduce operator memory burden, enforce skill/subagent policy, and detect where a partially prepared issue should resume in the process.
+
+## Goal
+
+Make skill orchestration itself a first-class ADL workflow surface so operators can invoke one bounded conductor that chooses the right next skill and picks up from the correct lifecycle point.
+
+## Required Outcome
+
+The repository has a lightweight `workflow-conductor` skill that can inspect issue/workflow state, determine the correct next phase, route into the matching lifecycle or card-editor skill, and record workflow-compliance facts without duplicating the underlying skill logic.
+
+## Deliverables
+
+- a new `workflow-conductor` skill bundle under `adl/tools/skills/`
+- a structured input schema for conductor invocation
+- operator-facing docs in the operational skills guide
+- tests covering routing, editor-skill selection, subagent policy handling, and resume-from-partial-state behavior
+- bounded workflow-compliance output/recording guidance
+
+## Acceptance Criteria
+
+- The conductor can detect whether bootstrap, readiness, execution, finish, janitor, or closeout steps have already been completed and select the correct next skill.
+- The conductor routes STP/SIP/SOR work to the matching editor skill rather than silently editing cards ad hoc.
+- The conductor supports explicit skill/subagent execution policy and records workflow-compliance outcomes.
+- The conductor remains thin: it orchestrates existing skills rather than duplicating their implementation logic.
+- The conductor can resume from partially completed initial steps instead of assuming every issue always starts from bootstrap.
+- The skill bundle includes schema/docs/tests comparable to the other operational skills.
+
+## Repo Inputs
+
+- `adl/tools/skills/`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- `.adl/docs/TBD/ADL_EXECUTION_POLICY_FOR_SKILLS_AND_SUBAGENTS.md`
+- `.adl/docs/TBD/LIGHTWEIGHT_WORKFLOW_CONDUCTOR_SKILL.md`
+- existing `pr-*` and card-editor skills
+
+## Dependencies
+
+- Existing `pr-init`, `pr-ready`, `pr-run`, `pr-finish`, `pr-janitor`, `pr-closeout`, `stp-editor`, `sip-editor`, and `sor-editor` skills remain the authoritative implementations the conductor must call.
+
+## Demo Expectations
+
+No standalone public demo is required. Proof is the conductor skill contract, routing tests, and operator-facing usage examples.
+
+## Non-goals
+
+- replacing the existing lifecycle or editor skills
+- inventing a second hidden workflow engine
+- silently widening issue scope or bypassing editor skills
+- forcing every phase to use a subagent when policy does not require it
+
+## Issue-Graph Notes
+
+- This work should stay aligned with the planned v0.88 issue-preparation wave.
+- The conductor should make it easier to resume workflow from the right point rather than assuming every issue always starts from bootstrap.
+
+## Notes
+
+Use the normal ADL PR lifecycle for this issue. The implementation should prefer thin orchestration, explicit policy, and auditable routing over large new control-plane complexity.
+
+## Tooling Notes
+
+The conductor should be able to detect partially completed initial steps and choose the next appropriate lifecycle or editor skill rather than restarting the issue from the beginning.

--- a/.adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sip.md
+++ b/.adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1647
+Run ID: issue-1647
+Version: v0.88
+Title: [v0.88][tools] Add lightweight workflow conductor skill
+Branch: codex/1647-add-lightweight-workflow-conductor-skill
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1647
+- PR:
+- Source Issue Prompt: .adl/v0.88/bodies/issue-1647-add-lightweight-workflow-conductor-skill.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sor.md
+++ b/.adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sor.md
@@ -1,0 +1,162 @@
+# add-lightweight-workflow-conductor-skill
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1647
+Run ID: issue-1647
+Version: v0.88
+Title: [v0.88][tools] Add lightweight workflow conductor skill
+Branch: codex/1647-add-lightweight-workflow-conductor-skill
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: OpenAI Codex
+- Start Time: 2026-04-12T17:50:50Z
+- End Time: 2026-04-12T17:50:50Z
+
+## Summary
+
+Added a first-class `workflow-conductor` operational skill bundle that stays intentionally thin: it inspects one concrete issue/workflow target, selects the next appropriate lifecycle or editor skill, applies explicit skill/subagent policy, and stops after routing/compliance recording rather than reimplementing the underlying work. Added the matching input schema doc, output/playbook references, operator-guide coverage, contract tests, and install-surface expectations.
+
+## Artifacts produced
+- `adl/tools/skills/workflow-conductor/SKILL.md`
+- `adl/tools/skills/workflow-conductor/adl-skill.yaml`
+- `adl/tools/skills/workflow-conductor/agents/openai.yaml`
+- `adl/tools/skills/workflow-conductor/references/conductor-playbook.md`
+- `adl/tools/skills/workflow-conductor/references/output-contract.md`
+- `adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md`
+- updated `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- updated `adl/tools/test_install_adl_operational_skills.sh`
+- `adl/tools/test_workflow_conductor_skill_contracts.sh`
+
+## Actions taken
+- created the new `workflow-conductor` skill bundle under `adl/tools/skills/`
+- defined structured admission rules and policy fields for routing one concrete target at a time
+- documented the thin-conductor model, including resume-from-partial-state behavior and editor-skill routing
+- added an explicit input schema doc and operator-guide section so the skill is first-class alongside the existing operational skills
+- added a contract test for bundle/schema/guide parity and updated the install-surface test so the new skill is treated as part of the shipped operational set
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1664
+- Worktree-only paths remaining: none
+- Integration state: pr_open
+- Verification scope: pr_branch
+- Integration method used: managed issue worktree edits with manual git publication after repo-native `pr finish` was blocked by unrelated tracked legacy `.adl` residue on main
+- Verification performed:
+  - `gh pr view 1664 --json number,url,state,isDraft,headRefName,baseRefName` verified PR 1664 is open on the issue branch
+  - `git status --short` verified the branch is clean after publication
+  - `git diff --check` verified no patch-integrity or whitespace defects remain in the published branch state
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh` verified the bundle files, schema linkage, guide entry, and key policy phrases for the new skill
+  - `bash adl/tools/test_install_adl_operational_skills.sh` verified the new skill is included in copy/symlink operational-skill installation flows
+  - `bash adl/tools/validate_structured_prompt.sh --type stp --phase bootstrap --input .adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/stp.md` verified the rooted task plan remains structurally valid
+  - `bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input .adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sip.md` verified the pre-run input card remains structurally valid
+  - `bash adl/tools/pr.sh finish 1647 --title "[v0.88][tools] Add lightweight workflow conductor skill"` verified the normal finish path and surfaced the unrelated tracked-legacy-`.adl` residue blocker that required manual publication
+  - `git diff --check` verified there are no patch-integrity defects in the final worktree
+- Results: PASS
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "bash adl/tools/test_workflow_conductor_skill_contracts.sh"
+      - "bash adl/tools/test_install_adl_operational_skills.sh"
+      - "bash adl/tools/validate_structured_prompt.sh --type stp --phase bootstrap --input .adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/stp.md"
+      - "bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input .adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sip.md"
+      - "bash adl/tools/pr.sh finish 1647 --title \"[v0.88][tools] Add lightweight workflow conductor skill\""
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: true
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
+- Fixtures or scripts used: the bundle/schema/guide contract test plus the operational-skills install copy/symlink test
+- Replay verification (same inputs -> same artifacts/order): the contract test checks fixed bundle paths and fixed schema/guide strings, and the install test checks the same bundle names under both install modes
+- Ordering guarantees (sorting / tie-break rules used): install verification uses a fixed expected skill list including `workflow-conductor`, keeping bundle presence checks stable across runs
+- Artifact stability notes: the new bundle and docs are static tracked files with deterministic install and contract-check expectations
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of the new skill bundle, schema doc, and tests
+- Prompt / tool argument redaction verified: yes; the new skill bundle and docs describe policy and routing only and do not introduce secrets or operator-specific credentials
+- Absolute path leakage check: passed; recorded commands and artifact references in this output card are repository-relative
+- Sandbox / policy invariants preserved: yes; the conductor skill is explicitly route-only and does not widen into direct implementation work
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this issue adds skill/docs/test surfaces rather than runtime replay traces
+- Run artifact root: not applicable
+- Replay command used for verification: `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
+- Replay result: PASS
+
+## Artifact Verification
+- Primary proof surface: `adl/tools/test_workflow_conductor_skill_contracts.sh`
+- Required artifacts present: true
+- Artifact schema/version checks: the manifest references `workflow_conductor.v1` and the matching tracked schema doc
+- Hash/byte-stability checks: not applicable; deterministic proof is via fixed bundle-path and guide-contract verification
+- Missing/optional artifacts and rationale: no standalone demo is required because the acceptance surface is a normalized skill bundle plus docs/tests
+
+## Decisions / Deviations
+- kept `workflow-conductor` thin and route-only instead of inventing a second workflow engine
+- made resume-from-partial-state behavior explicit in docs instead of assuming every issue starts from bootstrap
+- relied on the existing install script auto-discovery rather than adding a special-case installer path for the new skill
+- published the branch manually after `pr finish` was blocked by unrelated tracked legacy `.adl` residue on main; the issue work itself remained complete and reviewable
+
+## Follow-ups / Deferred work
+- runtime-level enforcement of `workflow_compliance` recording beyond skill contracts remains future work
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/stp.md
+++ b/.adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/stp.md
@@ -1,0 +1,94 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "add-lightweight-workflow-conductor-skill"
+title: "[v0.88][tools] Add lightweight workflow conductor skill"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.88"
+issue_number: 1647
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "add-lightweight-workflow-conductor-skill"
+---
+
+# [v0.88][tools] Add lightweight workflow conductor skill
+
+## Summary
+
+Add a thin workflow conductor skill that routes into the existing ADL lifecycle and editor skills instead of replacing them. The conductor should reduce operator memory burden, enforce skill/subagent policy, and detect where a partially prepared issue should resume in the process.
+
+## Goal
+
+Make skill orchestration itself a first-class ADL workflow surface so operators can invoke one bounded conductor that chooses the right next skill and picks up from the correct lifecycle point.
+
+## Required Outcome
+
+The repository has a lightweight `workflow-conductor` skill that can inspect issue/workflow state, determine the correct next phase, route into the matching lifecycle or card-editor skill, and record workflow-compliance facts without duplicating the underlying skill logic.
+
+## Deliverables
+
+- a new `workflow-conductor` skill bundle under `adl/tools/skills/`
+- a structured input schema for conductor invocation
+- operator-facing docs in the operational skills guide
+- tests covering routing, editor-skill selection, subagent policy handling, and resume-from-partial-state behavior
+- bounded workflow-compliance output/recording guidance
+
+## Acceptance Criteria
+
+- The conductor can detect whether bootstrap, readiness, execution, finish, janitor, or closeout steps have already been completed and select the correct next skill.
+- The conductor routes STP/SIP/SOR work to the matching editor skill rather than silently editing cards ad hoc.
+- The conductor supports explicit skill/subagent execution policy and records workflow-compliance outcomes.
+- The conductor remains thin: it orchestrates existing skills rather than duplicating their implementation logic.
+- The conductor can resume from partially completed initial steps instead of assuming every issue always starts from bootstrap.
+- The skill bundle includes schema/docs/tests comparable to the other operational skills.
+
+## Repo Inputs
+
+- `adl/tools/skills/`
+- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- `.adl/docs/TBD/ADL_EXECUTION_POLICY_FOR_SKILLS_AND_SUBAGENTS.md`
+- `.adl/docs/TBD/LIGHTWEIGHT_WORKFLOW_CONDUCTOR_SKILL.md`
+- existing `pr-*` and card-editor skills
+
+## Dependencies
+
+- Existing `pr-init`, `pr-ready`, `pr-run`, `pr-finish`, `pr-janitor`, `pr-closeout`, `stp-editor`, `sip-editor`, and `sor-editor` skills remain the authoritative implementations the conductor must call.
+
+## Demo Expectations
+
+No standalone public demo is required. Proof is the conductor skill contract, routing tests, and operator-facing usage examples.
+
+## Non-goals
+
+- replacing the existing lifecycle or editor skills
+- inventing a second hidden workflow engine
+- silently widening issue scope or bypassing editor skills
+- forcing every phase to use a subagent when policy does not require it
+
+## Issue-Graph Notes
+
+- This work should stay aligned with the planned v0.88 issue-preparation wave.
+- The conductor should make it easier to resume workflow from the right point rather than assuming every issue always starts from bootstrap.
+
+## Notes
+
+Use the normal ADL PR lifecycle for this issue. The implementation should prefer thin orchestration, explicit policy, and auditable routing over large new control-plane complexity.
+
+## Tooling Notes
+
+The conductor should be able to detect partially completed initial steps and choose the next appropriate lifecycle or editor skill rather than restarting the issue from the beginning.

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -14,6 +14,7 @@ scratch.
 
 The tracked skill set is:
 
+- `workflow-conductor`
 - `pr-init`
 - `pr-ready`
 - `pr-run`
@@ -29,6 +30,7 @@ The tracked skill set is:
 
 The normal workflow is:
 
+0. `workflow-conductor` when the operator wants one bounded front door that chooses the next skill and resumes from current state
 1. `pr-init`
 2. qualitative card review
 3. `pr-ready`
@@ -39,6 +41,7 @@ The normal workflow is:
 7. `pr-closeout` after the PR outcome or explicit non-PR closure disposition is settled
 
 `repo-code-review` is cross-cutting rather than phase-specific.
+`workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 
 The three editor skills are helper skills:
 - `stp-editor` for bounded `stp.md` cleanup
@@ -86,6 +89,7 @@ For `pr-init`, the payload uses `issue:` instead of `target:`.
 
 The current automation model is:
 
+- `workflow-conductor` may inspect current issue/workflow state and route to the next correct lifecycle or editor skill without reimplementing that skill
 - `pr-init` creates or initializes the issue and root bundle
 - qualitative card review happens separately
 - `pr-ready` is the readiness phase
@@ -98,6 +102,93 @@ The current automation model is:
 - `pr-closeout` handles post-merge or post-closure local finalization
 - `pr-closeout` also covers truthful no-PR closure dispositions like superseded, duplicate, or docs-only-closed issues
 - editor skills may be called by lifecycle skills when the blocker is card-local rather than lifecycle-orchestration state
+
+The conductor should be especially useful when:
+- initial workflow steps are only partially complete
+- the operator wants one bounded entrypoint
+- skill/subagent policy should be applied explicitly instead of by memory
+
+## `workflow-conductor`
+
+### Purpose
+
+`workflow-conductor` is the lightweight front door for the operational skill family.
+
+It:
+
+- inspects the current issue/workflow state
+- selects the next correct lifecycle or editor skill
+- applies skill/editor/subagent policy
+- records workflow-compliance facts
+- stops before performing the selected skill's underlying work
+
+### When To Use It
+
+Use `workflow-conductor` when:
+
+- the next correct ADL skill is not obvious from the current state
+- the issue may need to resume from partially completed early steps
+- the operator wants one bounded entrypoint that still respects the modular skill family
+
+Do not use it for:
+
+- directly executing implementation work
+- replacing the lifecycle skills
+- bypassing editor skills
+- broad multi-issue orchestration
+
+### Required Inputs
+
+Minimum:
+
+- `repo_root`
+- one of:
+  - `target.issue_number`
+  - `target.task_bundle_path`
+  - `target.branch`
+  - `target.worktree_path`
+  - `target.pr_number`
+- explicit routing `mode`
+- explicit `policy`
+
+Structured schema:
+
+- `adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md`
+- schema id: `workflow_conductor.v1`
+
+### Example Invocation
+
+```yaml
+Use $workflow-conductor at /Users/daniel/git/agent-design-language/adl/tools/skills/workflow-conductor/SKILL.md with this validated input:
+
+skill_input_schema: workflow_conductor.v1
+mode: route_issue
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  issue_number: 1647
+  slug: add-lightweight-workflow-conductor-skill
+  version: v0.88
+  source_prompt_path: .adl/v0.88/bodies/issue-1647-add-lightweight-workflow-conductor-skill.md
+policy:
+  skills_required: true
+  card_editor_skills_required: true
+  subagent_requirement: required
+  bypass_without_explicit_blocker: false
+  allow_phase_inference: true
+  stop_after_routing: true
+```
+
+### Typical Uses
+
+- after issue bootstrap, when the operator wants the repo to detect whether `pr-ready`, `pr-run`, or an editor skill is next
+- when the issue should resume from partially completed early steps rather than restart from bootstrap
+- when explicit skill/subagent policy should be enforced consistently
+
+### Caller Notes
+
+- `workflow-conductor` is deliberately thin
+- it should route into `pr-*` or editor skills rather than reimplementing them
+- it is the best place to apply the execution-policy ideas for required skills, card editors, and subagents
 
 `ready` and `preflight` are compatibility aliases that may still exist in repo
 surfaces, but doctor JSON is the canonical structured automation surface.

--- a/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,118 @@
+# Workflow Conductor Skill Input Schema
+
+```yaml
+skill_input_schema: workflow_conductor.v1
+mode: route_issue | route_task_bundle | route_branch | route_worktree | route_pr
+repo_root: /absolute/path/to/repo
+target:
+  issue_number: <u32 optional, required for route_issue>
+  task_bundle_path: <repo-relative or absolute path optional, required for route_task_bundle>
+  branch: <branch optional, required for route_branch>
+  worktree_path: <absolute path optional, required for route_worktree>
+  pr_number: <u32 optional, required for route_pr>
+  slug: <string optional>
+  version: <milestone optional>
+  source_prompt_path: <path optional>
+  stp_path: <path optional>
+  sip_path: <path optional>
+  sor_path: <path optional>
+  doctor_result: <path_or_summary optional>
+  pr_state: <state optional>
+policy:
+  skills_required: true
+  card_editor_skills_required: true
+  subagent_requirement: required | recommended | optional | forbidden
+  bypass_without_explicit_blocker: false
+  allow_phase_inference: true
+  stop_after_routing: true
+```
+
+## Purpose
+
+Use this schema when one bounded conductor invocation should select the next correct ADL skill for one concrete target.
+
+The conductor should:
+- inspect the current state
+- select the next skill
+- apply workflow policy
+- stop after routing
+
+It should not perform the selected skill's implementation work.
+
+## Supported Modes
+
+- `route_issue`
+- `route_task_bundle`
+- `route_branch`
+- `route_worktree`
+- `route_pr`
+
+## Required Top-Level Fields
+
+- `skill_input_schema`
+- `mode`
+- `repo_root`
+- `target`
+- `policy`
+
+## Mode Requirements
+
+- `route_issue`
+  - requires `target.issue_number`
+- `route_task_bundle`
+  - requires `target.task_bundle_path`
+- `route_branch`
+  - requires `target.branch`
+- `route_worktree`
+  - requires `target.worktree_path`
+- `route_pr`
+  - requires `target.pr_number`
+
+Exactly one primary target should drive the mode.
+
+## Policy Requirements
+
+- `policy.subagent_requirement` must be explicit
+- `policy.allow_phase_inference` must be explicit
+- `policy.stop_after_routing` must be `true`
+
+If editor skills are required, the conductor should prefer:
+- `stp-editor`
+- `sip-editor`
+- `sor-editor`
+
+when the blocker is card-local.
+
+## Example Invocation
+
+```yaml
+Use $workflow-conductor at /Users/daniel/git/agent-design-language/adl/tools/skills/workflow-conductor/SKILL.md with this validated input:
+
+skill_input_schema: workflow_conductor.v1
+mode: route_issue
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  issue_number: 1647
+  slug: add-lightweight-workflow-conductor-skill
+  version: v0.88
+  source_prompt_path: .adl/v0.88/bodies/issue-1647-add-lightweight-workflow-conductor-skill.md
+policy:
+  skills_required: true
+  card_editor_skills_required: true
+  subagent_requirement: required
+  bypass_without_explicit_blocker: false
+  allow_phase_inference: true
+  stop_after_routing: true
+```
+
+## Stop Boundary
+
+The conductor must stop after:
+- phase/editor selection
+- policy application
+- workflow-compliance recording
+
+It must not:
+- silently execute the selected lifecycle skill
+- reimplement the selected skill's logic
+- widen into unrelated issue work

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: workflow-conductor
+description: Lightweight conductor for the ADL workflow skills. Use when the operator wants one bounded entrypoint that detects the current issue/workflow state, selects the correct next lifecycle or editor skill, enforces skill/subagent policy, and stops after routing/compliance recording rather than reimplementing the underlying work.
+---
+
+# Workflow Conductor
+
+This skill is a thin orchestrator over the existing ADL operational skills.
+
+Its job is to:
+- inspect current workflow state
+- choose the next appropriate lifecycle or editor skill
+- ensure card-local work is routed to the matching editor skill
+- apply explicit skill/subagent execution policy
+- record workflow-compliance outcomes and stop
+
+This skill must remain lightweight.
+
+It must not replace:
+- `pr-init`
+- `pr-ready`
+- `pr-run`
+- `pr-finish`
+- `pr-janitor`
+- `pr-closeout`
+- `stp-editor`
+- `sip-editor`
+- `sor-editor`
+
+It must stop after routing and compliance recording rather than reimplementing the selected skill's underlying work.
+
+## Design Basis
+
+This skill should track the repository's canonical operational skill family and
+the workflow-policy notes that motivated it.
+
+At the moment, the key repo references are:
+- `/Users/daniel/git/agent-design-language/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- `/Users/daniel/git/agent-design-language/.adl/docs/TBD/ADL_EXECUTION_POLICY_FOR_SKILLS_AND_SUBAGENTS.md`
+- `/Users/daniel/git/agent-design-language/.adl/docs/TBD/LIGHTWEIGHT_WORKFLOW_CONDUCTOR_SKILL.md`
+
+Within this bundle, the operational details live in:
+- `references/conductor-playbook.md`
+- `references/output-contract.md`
+
+If those docs move, prefer the moved tracked canonical copies over stale path references.
+
+## Entry Conditions
+
+Use this skill when all of the following are true:
+- there is one concrete issue/workflow target
+- the operator wants help choosing the next ADL skill
+- the operator wants policy-aware routing rather than manual phase selection
+
+Do not use this skill for:
+- directly doing the implementation work
+- bypassing editor skills
+- repo-wide orchestration across many unrelated issues
+- silently finishing or closing an issue
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `issue_number`
+  - `task_bundle_path`
+  - `branch`
+  - `worktree_path`
+  - `pr_number`
+- one explicit routing mode
+- one explicit policy block
+
+Useful additional inputs:
+- `slug`
+- `version`
+- `doctor_result`
+- `source_prompt_path`
+- `stp_path`
+- `sip_path`
+- `sor_path`
+- current `pr_state`
+- requested `stop_boundary`
+
+If there is no concrete target, stop and report `blocked`.
+
+## Quick Start
+
+1. Resolve the concrete issue/workflow target.
+2. Inspect the current workflow state using the strongest available evidence:
+   - doctor JSON
+   - task bundle paths
+   - branch/worktree state
+   - PR state
+3. Determine whether the next step is:
+   - lifecycle routing
+   - card-editor routing
+   - blocked/no-op reporting
+4. Apply the declared skill/subagent policy.
+5. Select the next skill.
+6. Record the workflow-compliance result.
+7. Stop before performing the selected skill's underlying work.
+
+## Routing Model
+
+Preferred next-skill mapping:
+- bootstrap missing -> `pr-init`
+- card-local STP issue -> `stp-editor`
+- card-local SIP issue -> `sip-editor`
+- card-local SOR issue -> `sor-editor`
+- structurally ready but not bound -> `pr-ready`
+- ready for execution bind -> `pr-run`
+- execution complete, needs publication -> `pr-finish`
+- PR in flight with checks/conflicts/review blockers -> `pr-janitor`
+- PR merged or intentionally closed -> `pr-closeout`
+
+Important rule:
+- treat partially completed early steps as normal state, not corruption
+- the conductor should resume from the next truthful step instead of restarting bootstrap by reflex
+
+## Policy Model
+
+This skill should enforce policy when supplied, including:
+- `skills_required`
+- `card_editor_skills_required`
+- `subagent_requirement`
+- `bypass_without_explicit_blocker`
+- `required_skill_by_phase`
+- `required_card_skill_by_type`
+
+If policy and repo reality conflict:
+- prefer truthful `blocked` output over hidden fallback
+
+## Stop Boundary
+
+This skill must stop after:
+- selecting the next skill
+- recording compliance and routing facts
+- surfacing any blocker that prevents safe routing
+
+It must not:
+- perform the selected skill's implementation work
+- silently invoke unrelated repo-wide cleanup
+- create an unrecorded fallback path
+
+## Output
+
+Return a concise structured result including:
+- selected phase
+- selected skill
+- selected card-editor skill if any
+- policy/compliance result
+- whether subagent assignment is required
+- whether the target should continue, stop, or ask for operator confirmation

--- a/adl/tools/skills/workflow-conductor/adl-skill.yaml
+++ b/adl/tools/skills/workflow-conductor/adl-skill.yaml
@@ -1,0 +1,120 @@
+version: "0.1"
+kind: "adl-skill"
+id: "workflow-conductor"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "workflow_conductor.v1"
+    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "route_issue"
+      - "route_task_bundle"
+      - "route_branch"
+      - "route_worktree"
+      - "route_pr"
+    policy_fields:
+      - "skills_required"
+      - "card_editor_skills_required"
+      - "subagent_requirement"
+      - "bypass_without_explicit_blocker"
+      - "allow_phase_inference"
+      - "stop_after_routing"
+    mode_requirements:
+      route_issue:
+        required_target_fields:
+          - "issue_number"
+      route_task_bundle:
+        required_target_fields:
+          - "task_bundle_path"
+      route_branch:
+        required_target_fields:
+          - "branch"
+      route_worktree:
+        required_target_fields:
+          - "worktree_path"
+      route_pr:
+        required_target_fields:
+          - "pr_number"
+  intent:
+    - "workflow_routing"
+    - "skill_orchestration"
+    - "policy_compliance"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "issue_number"
+    - "task_bundle_path"
+    - "branch"
+    - "worktree_path"
+    - "pr_number"
+    - "slug"
+    - "version"
+    - "doctor_result"
+    - "source_prompt_path"
+    - "stp_path"
+    - "sip_path"
+    - "sor_path"
+    - "pr_state"
+    - "stop_boundary"
+  stop_if_missing:
+    - "repo_root"
+  require_one_of:
+    - "issue_number"
+    - "task_bundle_path"
+    - "branch"
+    - "worktree_path"
+    - "pr_number"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_workflow_conductor.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "exactly_one_primary_target_should_drive_the_mode"
+    - "policy.stop_after_routing_must_be_true"
+    - "policy.subagent_requirement_must_be_explicit"
+    - "policy.allow_phase_inference_must_be_explicit"
+execution:
+  mode: "route_only"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: true
+  workflow_role: "conductor"
+  preferred_commands:
+    - "adl/tools/pr.sh doctor --json"
+    - "adl/tools/pr.sh run"
+    - "adl/tools/pr.sh finish"
+    - "adl/tools/pr.sh open"
+  preferred_path: "inspect_current_issue_state_then_route_to_one_existing_skill"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+    - "skill-routing review artifacts"
+  must_not_write:
+    - "implementation source files"
+    - "unrelated task bundles"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-workflow-conductor.md"
+  required_sections:
+    - "status"
+    - "target"
+    - "workflow_state"
+    - "selected_skill"
+    - "workflow_compliance"
+    - "handoff_state"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/workflow-conductor/agents/openai.yaml
+++ b/adl/tools/skills/workflow-conductor/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Workflow Conductor
+short_description: Route one issue or workflow target to the correct next ADL skill
+default_prompt: Help me determine the next correct ADL workflow skill for this issue and record the routing/compliance result.

--- a/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
@@ -1,0 +1,59 @@
+# Workflow Conductor Playbook
+
+## Purpose
+
+This playbook defines the lightweight routing behavior for `workflow-conductor`.
+
+The conductor should:
+- inspect the current issue/workflow state
+- choose the next appropriate ADL skill
+- apply skill/editor/subagent policy
+- stop after routing and compliance recording
+
+It should not perform the selected skill's underlying work.
+
+## Routing Order
+
+Prefer the strongest available state evidence in this order:
+
+1. explicit doctor JSON result
+2. concrete task bundle paths and card state
+3. explicit branch/worktree state
+4. explicit PR state
+5. bounded issue metadata
+
+## Preferred Skill Selection
+
+- missing bootstrap/root bundle -> `pr-init`
+- STP-only card defect -> `stp-editor`
+- SIP-only card defect -> `sip-editor`
+- SOR-only card defect -> `sor-editor`
+- issue structurally pre-run -> `pr-ready`
+- issue ready for execution or binding -> `pr-run`
+- execution done, publication needed -> `pr-finish`
+- PR in flight with checks/conflicts/review blockers -> `pr-janitor`
+- merged or intentionally closed issue/PR -> `pr-closeout`
+
+## Resume Rule
+
+If early workflow steps are already complete, do not restart them.
+
+Examples:
+- if bootstrap exists and doctor is the next truthful step, do not route back to `pr-init`
+- if cards are clean and execution is already bound, do not route back to `pr-ready`
+- if the PR exists and is failing CI, do not route to `pr-finish`; route to `pr-janitor`
+
+## Editor Rule
+
+If the blocker is card-local and the matching editor skill exists, route to the matching editor skill instead of allowing ad hoc card edits.
+
+## Policy Rule
+
+If policy requires:
+- skills
+- editor skills
+- subagents
+
+the conductor should record compliance or explicit blocker-driven bypass.
+
+Never silently downgrade a required policy to an optional one.

--- a/adl/tools/skills/workflow-conductor/references/output-contract.md
+++ b/adl/tools/skills/workflow-conductor/references/output-contract.md
@@ -1,0 +1,32 @@
+# Output Contract
+
+```yaml
+status: done | blocked | failed
+target:
+  issue_number: <u32 or null>
+  task_bundle_path: <path or null>
+  branch: <branch or null>
+  worktree_path: <path or null>
+  pr_number: <u32 or null>
+workflow_state:
+  detected_phase: bootstrap_missing | card_local_blocker | pre_run | run_bound | execution_done | pr_in_flight | closed_out | unknown
+  evidence_used:
+    - <doctor_json_or_path_or_state_surface>
+selected_skill:
+  phase: init | ready | run | finish | janitor | closeout | editor | blocked
+  skill_name: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none
+  editor_skill: stp-editor | sip-editor | sor-editor | none
+workflow_compliance:
+  skills_required: true | false
+  card_editor_skills_required: true | false
+  subagent_requirement: required | recommended | optional | forbidden
+  subagent_assigned: true | false | not_applicable
+  bypasses:
+    - component: <policy_component>
+      reason: <bounded_reason>
+  policy_result: PASS | PARTIAL | FAIL
+actions_taken:
+  - <routing or policy action>
+handoff_state:
+  next_phase: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | human_review | blocked
+```

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,10 +8,11 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
+  [[ -f "${root}/skills/workflow-conductor/SKILL.md" ]]
   [[ -f "${root}/skills/pr-init/SKILL.md" ]]
   [[ -f "${root}/skills/pr-ready/SKILL.md" ]]
   [[ -f "${root}/skills/pr-run/SKILL.md" ]]
@@ -23,6 +24,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]
 
+  grep -Fq "thin orchestrator" "${root}/skills/workflow-conductor/SKILL.md"
   grep -Fq "qualitative card review" "${root}/skills/pr-init/SKILL.md"
   grep -Fq "execution_readiness" "${root}/skills/pr-ready/references/output-contract.md"
   grep -Fq "perform the bounded implementation work" "${root}/skills/pr-run/SKILL.md"

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/workflow-conductor/SKILL.md" ]]
+[[ -f "${skills_root}/workflow-conductor/adl-skill.yaml" ]]
+[[ -f "${skills_root}/workflow-conductor/agents/openai.yaml" ]]
+[[ -f "${skills_root}/workflow-conductor/references/conductor-playbook.md" ]]
+[[ -f "${skills_root}/workflow-conductor/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq "thin orchestrator" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "stop after routing and compliance recording" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq 'id: "workflow_conductor.v1"' "${skills_root}/workflow-conductor/adl-skill.yaml"
+grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/workflow-conductor/adl-skill.yaml"
+grep -Fq "policy.stop_after_routing_must_be_true" "${skills_root}/workflow-conductor/adl-skill.yaml"
+grep -Fq "route_issue" "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
+grep -Fq "requires \`target.issue_number\`" "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
+grep -Fq "workflow-conductor" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "resume from partially completed early steps" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+
+echo "PASS test_workflow_conductor_skill_contracts"


### PR DESCRIPTION
## Summary
- add a thin workflow-conductor skill bundle as a first-class operational skill
- add schema/docs/tests/install-surface coverage for the conductor
- make the conductor explicitly resume from current workflow state rather than assuming bootstrap

## Validation
- bash adl/tools/test_workflow_conductor_skill_contracts.sh
- bash adl/tools/test_install_adl_operational_skills.sh
- bash adl/tools/validate_structured_prompt.sh --type stp --phase bootstrap --input .adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/stp.md
- bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input .adl/v0.88/tasks/issue-1647__add-lightweight-workflow-conductor-skill/sip.md
- git diff --check

Closes #1647