### PR TITLE
[v0.88][tools] Add static milestone dashboard HTML

### DIFF
--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -43,6 +43,7 @@ Stable reviewer regression fixture:
 These docs describe the bounded editor and authoring surfaces used in the v0.85 authoring/control-plane work.
 
 - [Task Bundle Editor](editor/README.md)
+- [Milestone Dashboard](milestone-dashboard/README.md)
 - `editor/five_command_demo.md`
 - `editor/five_command_regression_suite.md`
 

--- a/docs/tooling/milestone-dashboard/README.md
+++ b/docs/tooling/milestone-dashboard/README.md
@@ -1,0 +1,32 @@
+# Milestone Dashboard
+
+This directory contains a reusable static HTML milestone dashboard.
+
+## Purpose
+
+The dashboard gives one operator-facing view of:
+- milestone status
+- sprint posture
+- work-package coverage
+- canonical source docs
+- issue map
+- immediate next actions and watchlist items
+
+## Current dataset
+
+The first bundled dataset is `v0.88`, drawn from:
+- `docs/milestones/v0.88/README.md`
+- `docs/milestones/v0.88/WBS_v0.88.md`
+- `docs/milestones/v0.88/SPRINT_v0.88.md`
+
+## Files
+
+- `index.html` — static dashboard shell
+- `style.css` — visual system and responsive layout
+- `dashboard.js` — milestone dataset and rendering logic
+
+## Usage
+
+Open `index.html` in a browser.
+
+To adapt it for another milestone, update the `milestoneData` object in `dashboard.js`.

--- a/docs/tooling/milestone-dashboard/dashboard.js
+++ b/docs/tooling/milestone-dashboard/dashboard.js
@@ -1,0 +1,308 @@
+const milestoneData = {
+  milestone: "v0.88",
+  version: "0.88",
+  owner: "Daniel Austin / Agent Logic",
+  updated: "2026-04-11",
+  status: "active",
+  statusLabel: "Planning package active; issue wave pending",
+  summary:
+    "v0.88 turns temporal / chronosense and instinct / bounded-agency planning into one coherent public execution package without letting later-band ideas leak into scope.",
+  bands: [
+    "Temporal / chronosense substrate",
+    "Instinct / bounded-agency substrate",
+  ],
+  nextActions: [
+    "Seed the real execution issue wave from WP-02 through WP-20.",
+    "Start Sprint 1 with temporal substrate work, not more scope reshaping.",
+    "Keep accepted pull-ins bounded to #1614 and #1618.",
+    "Preserve the normal v0.86 / v0.87 closeout pattern."
+  ],
+  watchlist: [
+    "Issue wave is still pending even though the planning package is now coherent.",
+    "Paper Sonata needs to stay bounded as the flagship demo, not become a catch-all.",
+    "Local planning notes must not silently become canonical milestone promises.",
+    "Sprint 3 should stay a closeout tail, not a second implementation sprint."
+  ],
+  sprints: [
+    {
+      id: "v0.88-s1",
+      title: "Sprint 1",
+      status: "active",
+      purpose: "Lock canonical milestone truth and execute the temporal substrate.",
+      wps: ["WP-01", "WP-02", "WP-03", "WP-04", "WP-05", "WP-06", "WP-07", "WP-08"]
+    },
+    {
+      id: "v0.88-s2",
+      title: "Sprint 2",
+      status: "planned",
+      purpose: "Execute PHI metrics, instinct / bounded agency, and the Paper Sonata flagship demo.",
+      wps: ["WP-09", "WP-10", "WP-11", "WP-12", "WP-13"]
+    },
+    {
+      id: "v0.88-s3",
+      title: "Sprint 3",
+      status: "planned",
+      purpose: "Converge demos, quality, reviews, remediation, next-milestone planning, and release ceremony.",
+      wps: ["WP-14", "WP-15", "WP-16", "WP-17", "WP-18", "WP-19", "WP-20"]
+    }
+  ],
+  docs: [
+    { label: "README", path: "../../milestones/v0.88/README.md", note: "Canonical milestone purpose, scope, and issue map." },
+    { label: "WBS", path: "../../milestones/v0.88/WBS_v0.88.md", note: "Twenty-work-package execution map with dependencies." },
+    { label: "Sprint plan", path: "../../milestones/v0.88/SPRINT_v0.88.md", note: "Three-sprint sequence and exit criteria." },
+    { label: "Design", path: "../../milestones/v0.88/DESIGN_v0.88.md", note: "Milestone design boundary and architectural story." },
+    { label: "Feature index", path: "../../milestones/v0.88/FEATURE_DOCS_v0.88.md", note: "Promoted feature package and non-promoted local planning boundaries." },
+    { label: "Milestone checklist", path: "../../milestones/v0.88/MILESTONE_CHECKLIST_v0.88.md", note: "Closeout gates and release-tail proof expectations." },
+    { label: "Release plan", path: "../../milestones/v0.88/RELEASE_PLAN_v0.88.md", note: "Release-tail sequence and package discipline." },
+    { label: "Demo matrix", path: "../../milestones/v0.88/DEMO_MATRIX_v0.88.md", note: "Primary proof surfaces and reviewer-facing demos." }
+  ],
+  issues: [
+    { label: "#1527", url: "https://github.com/danielbaustin/agent-design-language/issues/1527", kind: "tracked planning", note: "Initial v0.88 planning shell and milestone scaffolding." },
+    { label: "#1579", url: "https://github.com/danielbaustin/agent-design-language/issues/1579", kind: "tracked planning", note: "Promotion of the bounded tracked v0.88 feature-doc package." },
+    { label: "#1497", url: "https://github.com/danielbaustin/agent-design-language/issues/1497", kind: "tracked planning", note: "Canonical next-milestone planning reconciliation and scope closure." },
+    { label: "#1614", url: "https://github.com/danielbaustin/agent-design-language/issues/1614", kind: "accepted pull-in", note: "Bounded temporal/deadline pressure follow-on." },
+    { label: "#1618", url: "https://github.com/danielbaustin/agent-design-language/issues/1618", kind: "accepted pull-in", note: "Bounded comparative-demo / positioning follow-on." }
+  ],
+  workPackages: [
+    { id: "WP-01", title: "Canonical planning package", sprint: "v0.88-s1", status: "complete", issue: "#1527, #1579, #1497", deps: "none", desc: "Reconcile the tracked planning package, promoted feature index, and milestone structure.", deliverable: "Coherent milestone docs + promoted feature set" },
+    { id: "WP-02", title: "Chronosense foundation", sprint: "v0.88-s1", status: "pending", issue: "execution issue to be seeded", deps: "WP-01", desc: "Establish the conceptual chronosense substrate.", deliverable: "Runtime-facing chronosense definitions and one bounded proof hook" },
+    { id: "WP-03", title: "Temporal schema", sprint: "v0.88-s1", status: "pending", issue: "execution issue to be seeded", deps: "WP-01", desc: "Define temporal anchors, clocks, and execution-policy trace hooks.", deliverable: "Concrete schema fields and targeted tests" },
+    { id: "WP-04", title: "Continuity and identity semantics", sprint: "v0.88-s1", status: "pending", issue: "execution issue to be seeded", deps: "WP-02, WP-03", desc: "Ground continuity, interruption, resumption, and identity semantics in temporal structure.", deliverable: "Continuity artifact contract and proof fixture" },
+    { id: "WP-05", title: "Temporal query and retrieval", sprint: "v0.88-s1", status: "pending", issue: "execution issue to be seeded", deps: "WP-03", desc: "Make time-aware retrieval and staleness queryable.", deliverable: "Query surface and fixture-backed validation tests" },
+    { id: "WP-06", title: "Commitments and deadlines", sprint: "v0.88-s1", status: "pending", issue: "execution issue to be seeded; bounded pull-in #1614", deps: "WP-03, WP-05", desc: "Represent future obligations and missed commitments as first-class temporal records.", deliverable: "Commitment / deadline artifact model and proof fixtures" },
+    { id: "WP-07", title: "Temporal causality and explanation", sprint: "v0.88-s1", status: "pending", issue: "execution issue to be seeded", deps: "WP-03, WP-05", desc: "Define bounded causal and explanatory review surfaces.", deliverable: "Explanation artifact format and reviewer-facing examples" },
+    { id: "WP-08", title: "Execution policy and cost model", sprint: "v0.88-s1", status: "pending", issue: "execution issue to be seeded", deps: "WP-03", desc: "Tie execution mode and realized cost back to trace reviewability.", deliverable: "Execution-policy contract and cost proof path" },
+    { id: "WP-09", title: "PHI-style integration metrics", sprint: "v0.88-s2", status: "planned", issue: "execution issue to be seeded", deps: "WP-02 through WP-08", desc: "Define bounded engineering metrics for integration and adaptive depth.", deliverable: "Metric definitions and reviewable outputs" },
+    { id: "WP-10", title: "Instinct model", sprint: "v0.88-s2", status: "planned", issue: "execution issue to be seeded", deps: "WP-01", desc: "Define bounded instinct as an explicit cognitive substrate.", deliverable: "Runtime-facing instinct contract and acceptance tests" },
+    { id: "WP-11", title: "Instinct runtime surface and bounded agency hook", sprint: "v0.88-s2", status: "planned", issue: "execution issue to be seeded", deps: "WP-10", desc: "Make instinct visible in runtime declaration, routing, prioritization, trace, and demo proof.", deliverable: "Implementation slice and bounded-agency proof case" },
+    { id: "WP-12", title: "Paper Sonata flagship demo", sprint: "v0.88-s2", status: "planned", issue: "execution issue to be seeded", deps: "WP-02 through WP-11", desc: "Build a bounded multi-agent manuscript demo with durable artifacts and truthful runtime proof.", deliverable: "Runner, synthetic packet, artifact tree, and smoke path" },
+    { id: "WP-13", title: "Demo matrix + integration demos", sprint: "v0.88-s2", status: "planned", issue: "execution issue to be seeded; supporting pull-in #1618", deps: "WP-02 through WP-12", desc: "Define and implement the primary proof surfaces for temporal, PHI, instinct, and flagship demo bands.", deliverable: "Runnable demos and reviewer-facing matrix" },
+    { id: "WP-14", title: "Coverage / quality gate", sprint: "v0.88-s3", status: "closeout", issue: "closeout issue to be seeded", deps: "WP-13", desc: "Enforce milestone quality and coverage posture.", deliverable: "Green quality gate" },
+    { id: "WP-15", title: "Docs + review pass", sprint: "v0.88-s3", status: "closeout", issue: "closeout issue to be seeded", deps: "WP-13, WP-14", desc: "Converge reviewer-facing docs against delivered proof.", deliverable: "Reviewer-ready package" },
+    { id: "WP-16", title: "Internal review", sprint: "v0.88-s3", status: "closeout", issue: "closeout issue to be seeded", deps: "WP-15", desc: "Perform bounded internal review of milestone truth and proof surfaces.", deliverable: "Internal review record" },
+    { id: "WP-17", title: "3rd-party review", sprint: "v0.88-s3", status: "closeout", issue: "closeout issue to be seeded", deps: "WP-15, WP-16", desc: "Perform external review and capture findings.", deliverable: "3rd-party review record" },
+    { id: "WP-18", title: "Review findings remediation", sprint: "v0.88-s3", status: "closeout", issue: "closeout issue to be seeded", deps: "WP-16, WP-17", desc: "Resolve or explicitly defer accepted review findings.", deliverable: "Remediation record" },
+    { id: "WP-19", title: "Next milestone planning", sprint: "v0.88-s3", status: "closeout", issue: "closeout issue to be seeded", deps: "WP-18", desc: "Prepare the next milestone planning package before v0.88 closeout.", deliverable: "Next-milestone package" },
+    { id: "WP-20", title: "Release ceremony", sprint: "v0.88-s3", status: "closeout", issue: "closeout issue to be seeded", deps: "WP-18, WP-19", desc: "Do final validation, notes, tag, cleanup, and closeout record.", deliverable: "Release package" }
+  ]
+};
+
+const state = {
+  statusFilter: "all",
+  sprintFilter: "all"
+};
+
+function byId(id) {
+  return document.getElementById(id);
+}
+
+function humanStatus(status) {
+  return {
+    complete: "Complete",
+    active: "Active",
+    pending: "Pending issue wave",
+    planned: "Planned",
+    closeout: "Closeout tail",
+    ready: "Ready",
+    blocked: "Blocked"
+  }[status] || status;
+}
+
+function renderMeta() {
+  byId("milestone-chip").textContent = `${milestoneData.milestone} / ${milestoneData.version}`;
+  byId("headline").textContent = `${milestoneData.milestone} milestone dashboard`;
+  byId("lede").textContent = milestoneData.summary;
+
+  const badge = byId("status-badge");
+  badge.textContent = milestoneData.statusLabel;
+  badge.className = `status-badge status-${milestoneData.status}`;
+
+  const meta = [
+    ["Owner", milestoneData.owner],
+    ["Updated", milestoneData.updated],
+    ["Version", milestoneData.version],
+    ["Status", humanStatus(milestoneData.status)]
+  ];
+
+  byId("meta-list").innerHTML = meta
+    .map(([key, value]) => `<dt>${key}</dt><dd>${value}</dd>`)
+    .join("");
+
+  byId("bands-list").innerHTML = milestoneData.bands
+    .map((band) => `<li>${band}</li>`)
+    .join("");
+
+  byId("next-actions").innerHTML = milestoneData.nextActions
+    .map((item) => `<li>${item}</li>`)
+    .join("");
+
+  byId("watchlist").innerHTML = milestoneData.watchlist
+    .map((item) => `<li>${item}</li>`)
+    .join("");
+}
+
+function renderMetrics() {
+  const total = milestoneData.workPackages.length;
+  const complete = milestoneData.workPackages.filter((wp) => wp.status === "complete").length;
+  const active = milestoneData.workPackages.filter((wp) => wp.status === "active").length;
+  const pending = milestoneData.workPackages.filter((wp) => ["pending", "planned"].includes(wp.status)).length;
+  const closeout = milestoneData.workPackages.filter((wp) => wp.status === "closeout").length;
+  const percent = Math.round((complete / total) * 100);
+
+  const metrics = [
+    ["Completed", complete, "Work packages landed"],
+    ["Active", active, "Currently executing"],
+    ["Queued", pending, "Need issue-wave work"],
+    ["Closeout", closeout, "Review and release tail"]
+  ];
+
+  byId("metric-stack").innerHTML = metrics
+    .map(
+      ([label, value, note]) => `
+        <div class="metric">
+          <span class="metric-label">${label}</span>
+          <strong>${value}</strong>
+          <span>${note}</span>
+        </div>
+      `
+    )
+    .join("");
+
+  byId("progress-copy").textContent = `${percent}%`;
+  requestAnimationFrame(() => {
+    byId("progress-bar").style.width = `${percent}%`;
+  });
+}
+
+function renderSprints() {
+  byId("sprint-grid").innerHTML = milestoneData.sprints
+    .map((sprint) => {
+      const wpCount = milestoneData.workPackages.filter((wp) => wp.sprint === sprint.id).length;
+      return `
+        <article class="sprint-card">
+          <div class="sprint-topline">
+            <div>
+              <p class="section-kicker">${sprint.id}</p>
+              <h4>${sprint.title}</h4>
+            </div>
+            <span class="status-pill status-${sprint.status}">${humanStatus(sprint.status)}</span>
+          </div>
+          <p>${sprint.purpose}</p>
+          <ul>
+            <li>${wpCount} work packages in this sprint</li>
+            <li>${sprint.wps.join(", ")}</li>
+          </ul>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderFilters() {
+  const statusOptions = [
+    ["all", "All"],
+    ["complete", "Complete"],
+    ["active", "Active"],
+    ["pending", "Queued"],
+    ["closeout", "Closeout"]
+  ];
+
+  const sprintOptions = [
+    ["all", "All sprints"],
+    ...milestoneData.sprints.map((sprint) => [sprint.id, sprint.id])
+  ];
+
+  const renderChips = (options, activeValue) =>
+    options
+      .map(([value, label]) => `<button class="chip${value === activeValue ? " active" : ""}" data-value="${value}" type="button">${label}</button>`)
+      .join("");
+
+  byId("status-filters").innerHTML = renderChips(statusOptions, state.statusFilter);
+  byId("sprint-filters").innerHTML = renderChips(sprintOptions, state.sprintFilter);
+
+  byId("status-filters").querySelectorAll(".chip").forEach((chip) => {
+    chip.addEventListener("click", () => {
+      state.statusFilter = chip.dataset.value;
+      renderFilters();
+      renderWorkPackages();
+    });
+  });
+
+  byId("sprint-filters").querySelectorAll(".chip").forEach((chip) => {
+    chip.addEventListener("click", () => {
+      state.sprintFilter = chip.dataset.value;
+      renderFilters();
+      renderWorkPackages();
+    });
+  });
+}
+
+function renderWorkPackages() {
+  const filtered = milestoneData.workPackages.filter((wp) => {
+    const statusOk =
+      state.statusFilter === "all" ||
+      (state.statusFilter === "pending" && ["pending", "planned"].includes(wp.status)) ||
+      wp.status === state.statusFilter;
+    const sprintOk = state.sprintFilter === "all" || wp.sprint === state.sprintFilter;
+    return statusOk && sprintOk;
+  });
+
+  byId("wp-list").innerHTML = filtered
+    .map(
+      (wp) => `
+        <article class="wp-row">
+          <div class="wp-title-block">
+            <div class="wp-topline">
+              <strong class="wp-title">${wp.id} · ${wp.title}</strong>
+            </div>
+            <p class="wp-desc">${wp.desc}</p>
+            <p class="wp-meta">Deliverable: ${wp.deliverable}</p>
+          </div>
+          <div><span class="status-pill status-${wp.status}">${humanStatus(wp.status)}</span></div>
+          <div>${wp.sprint}</div>
+          <div>${wp.deps}</div>
+          <div>${wp.issue}</div>
+        </article>
+      `
+    )
+    .join("");
+}
+
+function renderDocs() {
+  byId("docs-list").innerHTML = milestoneData.docs
+    .map(
+      (doc) => `
+        <article class="doc-item">
+          <a href="${doc.path}">${doc.label}</a>
+          <span class="doc-meta">${doc.note}</span>
+        </article>
+      `
+    )
+    .join("");
+}
+
+function renderIssues() {
+  byId("issues-list").innerHTML = milestoneData.issues
+    .map(
+      (issue) => `
+        <article class="issue-item">
+          <a href="${issue.url}">${issue.label}</a>
+          <span class="doc-meta">${issue.kind}</span>
+          <span class="issue-copy">${issue.note}</span>
+        </article>
+      `
+    )
+    .join("");
+}
+
+function init() {
+  renderMeta();
+  renderMetrics();
+  renderSprints();
+  renderFilters();
+  renderWorkPackages();
+  renderDocs();
+  renderIssues();
+}
+
+init();

--- a/docs/tooling/milestone-dashboard/index.html
+++ b/docs/tooling/milestone-dashboard/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADL Milestone Dashboard</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="app-shell">
+    <aside class="rail">
+      <div class="rail-block rail-brand">
+        <p class="rail-kicker">ADL Tooling</p>
+        <h1>Milestone Dashboard</h1>
+        <p class="rail-copy">
+          A reusable project cockpit for milestone truth, sprint posture, work-package coverage, and next actions.
+        </p>
+      </div>
+
+      <div class="rail-block">
+        <p class="rail-label">Current milestone</p>
+        <div id="milestone-chip" class="milestone-chip"></div>
+        <dl class="meta-list" id="meta-list"></dl>
+      </div>
+
+      <div class="rail-block">
+        <p class="rail-label">Bands</p>
+        <ul id="bands-list" class="bands-list"></ul>
+      </div>
+
+      <div class="rail-block">
+        <p class="rail-label">Primary actions</p>
+        <ul id="next-actions" class="next-actions"></ul>
+      </div>
+    </aside>
+
+    <section class="workspace">
+      <header class="workspace-header">
+        <div>
+          <p class="section-kicker">Milestone posture</p>
+          <h2 id="headline"></h2>
+        </div>
+        <p id="lede" class="lede"></p>
+      </header>
+
+      <section class="hero-grid">
+        <article class="surface metric-surface">
+          <div class="surface-head">
+            <div>
+              <p class="section-kicker">Status</p>
+              <h3>Execution snapshot</h3>
+            </div>
+            <div id="status-badge" class="status-badge"></div>
+          </div>
+          <div class="metric-stack" id="metric-stack"></div>
+          <div class="progress-shell">
+            <div class="progress-label-row">
+              <span>Milestone coverage</span>
+              <strong id="progress-copy"></strong>
+            </div>
+            <div class="progress-track">
+              <div id="progress-bar" class="progress-bar"></div>
+            </div>
+          </div>
+        </article>
+
+        <article class="surface watch-surface">
+          <div class="surface-head">
+            <div>
+              <p class="section-kicker">Operator view</p>
+              <h3>Watchlist</h3>
+            </div>
+          </div>
+          <ul id="watchlist" class="watchlist"></ul>
+        </article>
+      </section>
+
+      <section class="surface">
+        <div class="surface-head">
+          <div>
+            <p class="section-kicker">Sprint model</p>
+            <h3>Three-sprint flow</h3>
+          </div>
+        </div>
+        <div id="sprint-grid" class="sprint-grid"></div>
+      </section>
+
+      <section class="surface">
+        <div class="surface-head">
+          <div>
+            <p class="section-kicker">Work packages</p>
+            <h3>Execution map</h3>
+          </div>
+          <div class="toolbar">
+            <div id="status-filters" class="chip-group"></div>
+            <div id="sprint-filters" class="chip-group"></div>
+          </div>
+        </div>
+        <div class="table-head">
+          <span>Work package</span>
+          <span>Status</span>
+          <span>Sprint</span>
+          <span>Dependencies</span>
+          <span>Issue</span>
+        </div>
+        <div id="wp-list" class="wp-list"></div>
+      </section>
+
+      <section class="detail-grid">
+        <article class="surface">
+          <div class="surface-head">
+            <div>
+              <p class="section-kicker">Source docs</p>
+              <h3>Canonical package</h3>
+            </div>
+          </div>
+          <div id="docs-list" class="docs-list"></div>
+        </article>
+
+        <article class="surface">
+          <div class="surface-head">
+            <div>
+              <p class="section-kicker">Issue map</p>
+              <h3>Tracked issues and pull-ins</h3>
+            </div>
+          </div>
+          <div id="issues-list" class="issues-list"></div>
+        </article>
+      </section>
+    </section>
+  </main>
+
+  <script src="./dashboard.js"></script>
+</body>
+</html>

--- a/docs/tooling/milestone-dashboard/style.css
+++ b/docs/tooling/milestone-dashboard/style.css
@@ -1,0 +1,562 @@
+:root {
+  --bg: #f3efe6;
+  --paper: rgba(255, 252, 246, 0.86);
+  --paper-strong: #fffaf0;
+  --ink: #1f2330;
+  --muted: #596074;
+  --line: rgba(31, 35, 48, 0.12);
+  --line-strong: rgba(31, 35, 48, 0.2);
+  --accent: #b44f2f;
+  --accent-soft: rgba(180, 79, 47, 0.12);
+  --cool: #2f5f85;
+  --cool-soft: rgba(47, 95, 133, 0.12);
+  --good: #25634f;
+  --good-soft: rgba(37, 99, 79, 0.12);
+  --warn: #8a5d13;
+  --warn-soft: rgba(138, 93, 19, 0.12);
+  --shadow: 0 24px 60px rgba(32, 30, 24, 0.08);
+  --radius-xl: 32px;
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --rail-width: 320px;
+  --sans: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  --serif: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: var(--sans);
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(180, 79, 47, 0.1), transparent 28%),
+    radial-gradient(circle at top right, rgba(47, 95, 133, 0.1), transparent 24%),
+    linear-gradient(180deg, #f7f2e8 0%, #efe8da 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(31, 35, 48, 0.03) 1px, transparent 1px);
+  background-size: 100% 34px;
+  opacity: 0.45;
+}
+
+.app-shell {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(280px, var(--rail-width)) minmax(0, 1fr);
+  gap: 20px;
+  padding: 22px;
+}
+
+.rail,
+.surface {
+  backdrop-filter: blur(18px);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+}
+
+.rail {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+  border-radius: var(--radius-xl);
+  min-height: calc(100svh - 44px);
+  position: sticky;
+  top: 22px;
+}
+
+.rail-block + .rail-block {
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+}
+
+.rail-kicker,
+.section-kicker,
+.rail-label {
+  margin: 0 0 10px;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.rail h1,
+.workspace-header h2,
+.surface h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+}
+
+.rail h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 0.96;
+  max-width: 9ch;
+}
+
+.rail-copy,
+.lede,
+.meta-list dd,
+.bands-list li,
+.next-actions li,
+.watchlist li,
+.sprint-card p,
+.doc-meta,
+.issue-copy,
+.wp-meta,
+.wp-desc {
+  color: var(--muted);
+}
+
+.milestone-chip,
+.status-badge,
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 0.88rem;
+  border: 1px solid var(--line-strong);
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.milestone-chip {
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.meta-list {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 8px 10px;
+  margin: 14px 0 0;
+}
+
+.meta-list dt {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.meta-list dd {
+  margin: 0;
+  font-size: 0.94rem;
+}
+
+.bands-list,
+.next-actions,
+.watchlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.bands-list li,
+.next-actions li,
+.watchlist li {
+  padding-left: 16px;
+  position: relative;
+  line-height: 1.45;
+}
+
+.bands-list li::before,
+.next-actions li::before,
+.watchlist li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.workspace {
+  display: grid;
+  gap: 20px;
+}
+
+.workspace-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  gap: 20px;
+  align-items: end;
+  padding: 10px 8px 0;
+  animation: rise 500ms ease;
+}
+
+.workspace-header h2 {
+  font-size: clamp(2.2rem, 4vw, 3.8rem);
+  line-height: 0.95;
+  max-width: 12ch;
+}
+
+.lede {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.6;
+}
+
+.surface {
+  border-radius: var(--radius-lg);
+  padding: 22px;
+  animation: rise 560ms ease both;
+}
+
+.hero-grid,
+.detail-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.hero-grid {
+  grid-template-columns: 1.1fr 0.9fr;
+}
+
+.detail-grid {
+  grid-template-columns: 1fr 1fr;
+}
+
+.surface-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
+.metric-stack {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 22px;
+}
+
+.metric {
+  padding: 14px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid var(--line);
+}
+
+.metric-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.metric strong {
+  font-size: 1.65rem;
+  letter-spacing: -0.04em;
+}
+
+.metric span:last-child {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+.progress-shell {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(47, 95, 133, 0.08), rgba(180, 79, 47, 0.08));
+  border: 1px solid var(--line);
+}
+
+.progress-label-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.progress-track {
+  overflow: hidden;
+  height: 13px;
+  border-radius: 999px;
+  background: rgba(31, 35, 48, 0.08);
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--cool), var(--accent));
+  transition: width 700ms ease;
+}
+
+.watchlist li::before {
+  background: var(--warn);
+}
+
+.sprint-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.sprint-card {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid var(--line);
+  display: grid;
+  gap: 12px;
+}
+
+.sprint-topline,
+.wp-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.sprint-card h4,
+.wp-title {
+  margin: 0;
+  font-size: 1.04rem;
+}
+
+.sprint-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+  gap: 8px 12px;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  cursor: pointer;
+  user-select: none;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.chip:hover {
+  transform: translateY(-1px);
+}
+
+.chip.active {
+  border-color: transparent;
+  background: var(--ink);
+  color: white;
+}
+
+.table-head,
+.wp-row {
+  display: grid;
+  grid-template-columns: minmax(260px, 1.4fr) 140px 120px minmax(150px, 0.9fr) minmax(150px, 0.9fr);
+  gap: 14px;
+}
+
+.table-head {
+  padding: 0 12px 12px;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.wp-list {
+  display: grid;
+  gap: 10px;
+}
+
+.wp-row {
+  padding: 16px 12px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid var(--line);
+  align-items: start;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.wp-row:hover {
+  transform: translateY(-2px);
+  border-color: var(--line-strong);
+  box-shadow: 0 16px 26px rgba(31, 35, 48, 0.07);
+}
+
+.wp-title-block {
+  display: grid;
+  gap: 6px;
+}
+
+.wp-desc,
+.wp-meta {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.status-pill {
+  display: inline-flex;
+  width: fit-content;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.status-complete,
+.status-ready {
+  background: var(--good-soft);
+  color: var(--good);
+}
+
+.status-active {
+  background: var(--cool-soft);
+  color: var(--cool);
+}
+
+.status-pending,
+.status-planned,
+.status-closeout {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+
+.status-blocked {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.docs-list,
+.issues-list {
+  display: grid;
+  gap: 12px;
+}
+
+.doc-item,
+.issue-item {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid var(--line);
+}
+
+.doc-item a,
+.issue-item a {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.doc-item a:hover,
+.issue-item a:hover {
+  color: var(--accent);
+}
+
+.status-badge.status-active {
+  background: var(--cool-soft);
+  color: var(--cool);
+}
+
+.status-badge.status-planned,
+.status-badge.status-pending {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+
+.status-badge.status-complete {
+  background: var(--good-soft);
+  color: var(--good);
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1120px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .rail {
+    position: relative;
+    top: 0;
+    min-height: auto;
+  }
+
+  .hero-grid,
+  .detail-grid,
+  .workspace-header,
+  .sprint-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-stack {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 860px) {
+  .table-head {
+    display: none;
+  }
+
+  .wp-row {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar {
+    justify-content: start;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 14px;
+  }
+
+  .rail,
+  .surface {
+    padding: 18px;
+    border-radius: 22px;
+  }
+
+  .metric-stack {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Closes #1673

## Summary
Create a bounded static HTML milestone dashboard that makes the canonical milestone package easy to inspect and use.

## Goal
Provide one calm operator-facing dashboard that shows milestone status, sprint posture, work-package coverage, issue map, canonical docs, and next actions without requiring the user to skim multiple planning files.

## Required Outcome
The repository has a reusable milestone dashboard bundle under `docs/tooling/` that opens directly in a browser, works well on desktop and mobile, and uses the tracked `v0.88` milestone package as its first real dataset.

## Deliverables
- a static HTML/CSS/JS milestone dashboard bundle
- a first populated `v0.88` dashboard dataset drawn from canonical milestone docs
- concise usage notes for adapting the dashboard to future milestones
- bounded proof that the page renders and the data surfaces line up with the tracked docs

## Acceptance Criteria
- the dashboard opens as a static HTML page with no build step
- it shows milestone metadata, sprint posture, work-package state, canonical docs, issue map, and next actions in one usable surface
- the visual design is intentional and responsive rather than a generic card grid
- the bundled `v0.88` data matches the tracked milestone docs used as source truth
- the implementation stays bounded to a dashboard surface and does not reshape milestone scope

## Repo Inputs
- `docs/milestones/v0.88/README.md`
- `docs/milestones/v0.88/WBS_v0.88.md`
- `docs/milestones/v0.88/SPRINT_v0.88.md`
- `docs/tooling/README.md`
- `docs/tooling/editor/` as the nearest existing static HTML tooling surface

## Dependencies
- no new runtime or build dependency is required

## Demo Expectations
- open the dashboard in a browser as the bounded proof surface
- no separate public demo runner is required

## Non-goals
- adding a full web framework
- introducing live data fetching or milestone mutation
- replacing the canonical markdown milestone docs

## Issue-Graph Notes
- This is a bounded test issue that is safe to use while rehearsing the workflow-conductor skill on a non-critical surface.

## Notes
- Prefer a reusable structure so later milestones can swap data with minimal edits.
- Keep the dashboard operator-facing and utility-first.

## Tooling Notes
- Use the dashboard as a safe conductor-skill rehearsal target, but keep the implementation itself independent of the conductor logic.
