### PR TITLE
[codex] Refresh rust module watch list from 2026-04-12 scan

### DIFF
--- a/docs/tooling/rust_module_watch_list.md
+++ b/docs/tooling/rust_module_watch_list.md
@@ -53,14 +53,15 @@ The table below reflects the current branch state from
 
 | Path | Approx. LoC | Responsibility summary | Suggested future split boundaries | Watch level |
 |---|---:|---|---|---|
+| `adl/src/cli/tests/pr_cmd_inline/finish.rs` | 2254 | inline `pr finish` test matrix covering workflow closeout, publication, and edge conditions | split finish-path cases by concern (`validation`, `integration`, `publication`, `error paths`) and centralize shared fixtures | Rationale |
+| `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs` | 1547 | inline `pr` lifecycle regression coverage across doctor/init/finish control-flow edges | split lifecycle-path cases by command family and centralize shared fixtures | Rationale |
 | `adl/src/provider.rs` | 1399 | provider configuration, request assembly, and provider-facing orchestration | split provider model/schema code from request execution and normalization helpers | Review |
 | `adl/src/instrumentation.rs` | 1353 | instrumentation/event capture, shaping, and persistence/report helpers | split event/schema definitions from emitters, formatting, and persistence helpers | Review |
-| `adl/src/cli/tests/pr_cmd_inline/finish.rs` | 1319 | inline `pr finish` test matrix covering workflow closeout and edge conditions | split finish-path test cases by concern (`validation`, `integration`, `error paths`) and centralize shared fixtures | Review |
 | `adl/src/cli/tooling_cmd/tests.rs` | 1292 | tooling command regression coverage across review-surface and prompt-contract helpers | split tests by subcommand family and centralize shared CLI fixture builders | Review |
 | `adl/src/cli/run_artifacts/cognitive.rs` | 1287 | cognitive artifact assembly, shaping, and export helpers | split schema/model builders from export and report formatting helpers | Review |
 | `adl/src/cli/run_artifacts/runtime.rs` | 1285 | runtime artifact assembly, trace export, and persistence/report shaping | split path/schema helpers from emit/export flows and separate persistence from presentation helpers | Review |
-| `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs` | 1235 | inline `pr` lifecycle regression coverage across doctor/init/finish control-flow edges | split lifecycle-path test cases by command family and centralize shared fixtures | Review |
 | `adl/src/adl/tests.rs` | 1157 | ADL parser/validator regression coverage across many behaviors | split tests by behavior family and move shared builders into test helpers | Review |
+| `adl/src/cli/pr_cmd.rs` | 1127 | PR command façade and residual dispatch after the lifecycle/github/git-support extraction | keep the façade thin and avoid re-accumulating lifecycle/helper logic into this file | Review |
 | `adl/src/cli/tests/artifact_builders/learning_runtime.rs` | 1107 | learning/runtime artifact-builder regression coverage | split learning-vs-runtime assertions and centralize shared fixture setup | Review |
 | `adl/src/execute/state/runtime_control.rs` | 1059 | runtime control-state modeling and projection helpers | split state model/schema code from projection/serialization helpers if the file grows again | Review |
 | `adl/src/trace.rs` | 1024 | trace model, persistence, and rendering/query helpers | split trace record/schema logic from output formatting and IO helpers | Review |
@@ -69,11 +70,11 @@ The table below reflects the current branch state from
 | `adl/src/execute/tests.rs` | 975 | execution regression coverage across multiple behaviors | split tests by behavior family and move shared setup into helpers | Watch |
 | `adl/src/cli/pr_cmd_cards.rs` | 948 | PR card rendering and synchronization helpers | split output-card rendering from synchronization/update helpers if the file keeps growing | Watch |
 | `adl/src/signing.rs` | 929 | signing material handling, envelope creation, and verification helpers | split key/material utilities from signing/verification flows and report shaping | Watch |
+| `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs` | 916 | repo-helper regression coverage for PR workflow helpers | split helper families if new lifecycle/repo test growth accumulates here | Watch |
 | `adl/src/godel/stage_loop.rs` | 916 | stage progression, orchestration, and artifact/report linkage for the Godel loop | split stage state transitions from artifact/report assembly and CLI-facing summaries | Watch |
-| `adl/src/cli/pr_cmd.rs` | 889 | PR command façade and residual dispatch after the lifecycle/github/git-support extraction | keep the façade thin and avoid re-accumulating lifecycle/helper logic into this file | Watch |
 | `adl/src/sandbox.rs` | 887 | sandbox policy/configuration and execution boundary helpers | split policy/config parsing from sandbox command/runtime helpers | Watch |
+| `adl/src/cli/tests/pr_cmd_inline/basics.rs` | 855 | baseline `pr` workflow regression coverage across parsing and bootstrap helpers | split parser/argument cases from bootstrap/body-generation cases if growth continues | Watch |
 | `adl/src/demo.rs` | 855 | demo catalog façade, shared file/trace helpers, remaining Demo A/B/C fixtures, and tests | keep the façade thin and split further only if new growth resumes in dispatch or fixture surfaces | Watch |
-| `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs` | 838 | repo-helper regression coverage for PR workflow helpers | split helper families if new lifecycle/repo test growth accumulates here | Watch |
 | `adl/src/cli/godel_cmd.rs` | 815 | CLI argument handling and command dispatch for Godel features | split command parsing/dispatch from artifact inspection/rendering helpers | Watch |
 
 ## v0.86 External Review Follow-up
@@ -84,7 +85,7 @@ partially discharged by the `v0.87.1` refactor wave:
 
 | Path | Current LoC | External review posture | Current disposition |
 |---|---:|---|---|
-| `adl/src/cli/pr_cmd.rs` | 889 | non-blocking maintainability concern | materially reduced by `#1562`; keep on watch list at `Watch` to prevent scope regrowth |
+| `adl/src/cli/pr_cmd.rs` | 1127 | non-blocking maintainability concern | materially reduced by `#1562`, but has regrown into the `Review` band; prevent lifecycle/helper scope from drifting back into the façade |
 | `adl/src/demo.rs` | 855 | non-blocking maintainability concern | materially reduced by `#1561`; keep on watch list at `Watch` while the new façade stabilizes |
 | `adl/src/remote_exec.rs` | 1014 | non-blocking maintainability concern | materially reduced by `#1560`; keep on watch list at `Review` because the remaining orchestration surface is still above 1k |
 
@@ -100,9 +101,10 @@ stable over subsequent work.
 
 ## Next Bounded Refactor Candidates
 
+- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
+- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
 - `adl/src/provider.rs`
 - `adl/src/instrumentation.rs`
-- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
 - `adl/src/cli/tooling_cmd/tests.rs`
 - `adl/src/cli/run_artifacts/cognitive.rs`
 


### PR DESCRIPTION
## Summary
Refresh `docs/tooling/rust_module_watch_list.md` from the 2026-04-12 size scan.

## What changed
- Re-ranked the largest Rust modules and inline PR workflow test files based on the latest LoC scan.
- Moved `adl/src/cli/pr_cmd.rs` back into the `Review` band as it grew to 1127 LoC.
- Updated the bounded refactor candidate list to match the current hotspots.

## Why
Keep the watch list aligned with the current codebase so refactor planning tracks the files that have actually regrown since the last refresh.

## Impact
Developers have an up-to-date watch list for prioritizing the next Rust module split and follow-up maintainability work.

## Validation
- Reviewed the docs-only diff against `origin/main`.
- No tests run; this change only updates documentation.

Closes #1676