### PR TITLE
[v0.88][tools] Make PR publication own closing linkage and stale-event recovery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
         working-directory: .
 
       - name: guardrail (issue PR closing linkage)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: bash adl/tools/check_pr_closing_linkage.sh
         working-directory: .
 

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -48,10 +48,12 @@ use self::git_support::{
     run_status_allow_failure,
 };
 #[cfg(test)]
+use self::github::ensure_pr_closing_linkage;
+#[cfg(test)]
 use self::github::pr_has_closing_linkage;
 use self::github::{
     attach_post_merge_closeout, attach_pr_janitor, current_pr_url, ensure_issue_metadata_parity,
-    ensure_pr_closing_linkage, format_open_pr_wave, gh_issue_create, gh_issue_edit_body,
+    ensure_or_repair_pr_closing_linkage, format_open_pr_wave, gh_issue_create, gh_issue_edit_body,
     gh_issue_title, issue_version, unresolved_milestone_pr_wave,
 };
 
@@ -570,7 +572,13 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
         created.trim().to_string()
     };
 
-    ensure_pr_closing_linkage(&repo, &pr_url, parsed.issue, parsed.no_close)?;
+    let _closing_linkage_repaired = ensure_or_repair_pr_closing_linkage(
+        &repo,
+        &pr_url,
+        parsed.issue,
+        parsed.no_close,
+        &pr_body_file,
+    )?;
 
     if parsed.merge_mode {
         if parsed.ready {

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -140,6 +140,35 @@ pub(super) fn ensure_pr_closing_linkage(
     Ok(())
 }
 
+pub(super) fn ensure_or_repair_pr_closing_linkage(
+    repo: &str,
+    pr_ref: &str,
+    issue: u32,
+    no_close: bool,
+    desired_body_file: &Path,
+) -> Result<bool> {
+    if no_close {
+        return Ok(false);
+    }
+    if pr_has_closing_linkage(repo, pr_ref, issue)? {
+        return Ok(false);
+    }
+    run_status(
+        "gh",
+        &[
+            "pr",
+            "edit",
+            "-R",
+            repo,
+            pr_ref,
+            "--body-file",
+            path_str(desired_body_file)?,
+        ],
+    )?;
+    ensure_pr_closing_linkage(repo, pr_ref, issue, no_close)?;
+    Ok(true)
+}
+
 pub(super) fn attach_pr_janitor(
     repo_root: &Path,
     repo: &str,

--- a/adl/src/cli/tests/pr_cmd_inline/finish.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish.rs
@@ -1808,6 +1808,57 @@ fn real_pr_finish_rejects_main_and_does_not_report_no_pr_when_bundle_sync_change
 }
 
 #[test]
+fn ensure_or_repair_pr_closing_linkage_repairs_live_pr_body() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-repair-linkage");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    let state_body = temp.join("pr_body.txt");
+    fs::write(&state_body, "Refs #1153\n").expect("seed body");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    if grep -q 'Closes #1153' '{}'; then\n      printf '1153\\n'\n    fi\n    exit 0\n  fi\n  if printf '%s ' \"$@\" | grep -q ' --json body '; then\n    cat '{}'\n    exit 0\n  fi\nfi\nif [ \"$1 $2\" = 'pr edit' ]; then\n  body_file=''\n  while [ $# -gt 0 ]; do\n    if [ \"$1\" = '--body-file' ]; then\n      body_file=\"$2\"\n      shift 2\n    else\n      shift\n    fi\n  done\n  cp \"$body_file\" '{}'\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            state_body.display(),
+            state_body.display(),
+            state_body.display()
+        ),
+    );
+
+    let body_file = temp.join("desired.md");
+    fs::write(&body_file, "Closes #1153\n\n## Summary\nrepaired\n").expect("desired body");
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_entries = env::split_paths(&old_path).collect::<Vec<_>>();
+    let mut new_entries = vec![bin_dir.clone()];
+    new_entries.extend(old_entries);
+    unsafe {
+        env::set_var("PATH", env::join_paths(new_entries).expect("join PATH"));
+    }
+
+    ensure_or_repair_pr_closing_linkage(
+        "danielbaustin/agent-design-language",
+        "https://github.com/danielbaustin/agent-design-language/pull/1159",
+        1153,
+        false,
+        &body_file,
+    )
+    .expect("repair should succeed");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let repaired = fs::read_to_string(&state_body).expect("read repaired body");
+    assert!(repaired.contains("Closes #1153"));
+    let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
+    assert!(gh_calls.contains("pr edit -R danielbaustin/agent-design-language https://github.com/danielbaustin/agent-design-language/pull/1159 --body-file"));
+}
+
+#[test]
 fn real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-gitignore-guard");

--- a/adl/tools/attach_pr_janitor.sh
+++ b/adl/tools/attach_pr_janitor.sh
@@ -78,6 +78,7 @@ policy:
   monitor_checks: true
   monitor_conflicts: true
   monitor_review_state: true
+  monitor_linkage_guardrail: true
   stop_after_janitor_pass: true
 EOF
 
@@ -88,7 +89,7 @@ Use \$pr-janitor at $REPO_ROOT/adl/tools/skills/pr-janitor/SKILL.md with this va
 $(cat "$INPUT_FILE")
 \`\`\`
 
-Run one bounded janitor pass for this newly opened PR. Stop after the janitor pass and write a concise status summary.
+Run one bounded janitor pass for this newly opened PR. If the only failing signal is the issue-closing-linkage guardrail, verify live PR metadata first and treat stale event payloads as metadata-refresh work rather than product-code work. Stop after the janitor pass and write a concise status summary.
 EOF
 
 nohup codex exec \

--- a/adl/tools/check_pr_closing_linkage.sh
+++ b/adl/tools/check_pr_closing_linkage.sh
@@ -5,6 +5,21 @@ EVENT_NAME="${GITHUB_EVENT_NAME:-}"
 EVENT_PATH="${GITHUB_EVENT_PATH:-}"
 HEAD_REF="${GITHUB_HEAD_REF:-}"
 
+body_has_linkage() {
+  local issue="$1"
+  python3 -c '
+import re
+import sys
+
+issue = sys.argv[1]
+body = sys.stdin.read()
+pattern = re.compile(rf"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#?{re.escape(issue)}\b", re.IGNORECASE)
+if pattern.search(body):
+    raise SystemExit(0)
+raise SystemExit(1)
+' "$issue"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --event-name)
@@ -71,19 +86,48 @@ print(body)
 PY
 )"
 
-if python3 -c '
-import re
-import sys
-
-issue = sys.argv[1]
-body = sys.stdin.read()
-pattern = re.compile(rf"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#?{re.escape(issue)}\b", re.IGNORECASE)
-if pattern.search(body):
-    raise SystemExit(0)
-raise SystemExit(1)
-' "$ISSUE_NUMBER" <<<"$PR_BODY"; then
+if body_has_linkage "$ISSUE_NUMBER" <<<"$PR_BODY"; then
   echo "closing linkage OK for issue #$ISSUE_NUMBER"
   exit 0
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  LIVE_REPO="$(
+    python3 - "$EVENT_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+repo = data.get("repository", {}).get("full_name") or ""
+print(repo)
+PY
+  )"
+  LIVE_PR="$(
+    python3 - "$EVENT_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+pr = data.get("pull_request", {}).get("number") or ""
+print(pr)
+PY
+  )"
+  if [[ -n "$LIVE_REPO" && -n "$LIVE_PR" ]]; then
+    LIVE_LINKED="$(
+      gh pr view "$LIVE_PR" -R "$LIVE_REPO" --json closingIssuesReferences --jq '.closingIssuesReferences[]?.number' 2>/dev/null || true
+    )"
+    if grep -Fxq "$ISSUE_NUMBER" <<<"$LIVE_LINKED"; then
+      echo "closing linkage OK for issue #$ISSUE_NUMBER via live PR truth"
+      exit 0
+    fi
+    LIVE_BODY="$(gh pr view "$LIVE_PR" -R "$LIVE_REPO" --json body --jq '.body' 2>/dev/null || true)"
+    if [[ -n "$LIVE_BODY" ]] && body_has_linkage "$ISSUE_NUMBER" <<<"$LIVE_BODY"; then
+      echo "closing linkage OK for issue #$ISSUE_NUMBER via live PR body"
+      exit 0
+    fi
+  fi
 fi
 
 echo "ERROR: PR body for branch '$HEAD_REF' is missing closing linkage for issue #$ISSUE_NUMBER" >&2

--- a/adl/tools/skills/pr-janitor/SKILL.md
+++ b/adl/tools/skills/pr-janitor/SKILL.md
@@ -134,6 +134,7 @@ Allowed bounded interventions may include:
 - rerunning or re-verifying the smallest relevant local checks
 - preparing a focused fix for a clear CI failure
 - refreshing branch state or conflict remediation when the intended resolution is unambiguous
+- refreshing PR metadata or the PR event when a linkage-only guardrail failure is caused by stale GitHub payload state
 - updating truthful PR progress notes or result output
 
 Do not auto-apply if the intervention would:
@@ -203,6 +204,7 @@ Default result should make these explicit:
 Common failure modes:
 - wrong PR targeted
 - stale or incomplete check interpretation
+- stale GitHub pull_request payloads that disagree with the live PR body
 - merge conflict diagnosis without clear safe resolution
 - silently treating substantive review feedback as mechanical
 - over-fixing beyond the actual blocker

--- a/adl/tools/skills/pr-janitor/references/janitor-playbook.md
+++ b/adl/tools/skills/pr-janitor/references/janitor-playbook.md
@@ -62,6 +62,7 @@ Allowed:
 - rerun or locally reproduce the smallest relevant failing check
 - prepare a focused blocker-driven fix
 - resolve an unambiguous conflict when the intended resolution is clear
+- repair or refresh PR metadata when the only failure is a linkage-style guardrail and live PR truth already looks correct
 - record truthful PR progress output
 
 Not allowed:
@@ -87,3 +88,10 @@ If the process fails or remains blocked:
 - record whether no repair was attempted, a repair was attempted and succeeded, or a repair was attempted and did not resolve the blocker
 - report the exact next handoff needed
 - stop without widening scope
+
+## Linkage Guardrail Special Case
+
+If the only failing check is the issue-closing-linkage guardrail:
+1. inspect the live PR body and closing-issue metadata first
+2. if live PR truth is still wrong, repair the PR metadata in-bounds
+3. if live PR truth is already correct, treat the failure as stale-event recovery and use the smallest refresh path rather than changing product code

--- a/adl/tools/test_pr_closing_linkage.sh
+++ b/adl/tools/test_pr_closing_linkage.sh
@@ -5,18 +5,45 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/adl/tools/check_pr_closing_linkage.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+ORIG_PATH="$PATH"
+
+mkdir -p "$TMPDIR/bin"
+cat >"$TMPDIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ " $* " == *" --json closingIssuesReferences "* ]]; then
+    printf '%s\n' "${MOCK_GH_CLOSING_ISSUES:-}"
+    exit 0
+  fi
+  if [[ " $* " == *" --json body "* ]]; then
+    printf '%s\n' "${MOCK_GH_PR_BODY:-}"
+    exit 0
+  fi
+fi
+exit 1
+EOF
+chmod +x "$TMPDIR/bin/gh"
+PATH="$TMPDIR/bin:$PATH"
 
 make_event() {
   local path="$1"
   local body="$2"
-  python3 - "$path" "$body" <<'PY'
+  local repo="${3:-example/repo}"
+  local pr_number="${4:-77}"
+  python3 - "$path" "$body" "$repo" "$pr_number" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
 body = sys.argv[2]
-path.write_text(json.dumps({"pull_request": {"body": body}}))
+repo = sys.argv[3]
+pr_number = int(sys.argv[4])
+path.write_text(json.dumps({
+    "repository": {"full_name": repo},
+    "pull_request": {"body": body, "number": pr_number}
+}))
 PY
 }
 
@@ -34,6 +61,12 @@ if bash "$SCRIPT" --event-name pull_request --event-path "$event_bad" --head-ref
   echo "expected failure for missing closing linkage" >&2
   exit 1
 fi
+
+event_stale="$TMPDIR/stale.json"
+make_event "$event_stale" "Refs #1414" "example/repo" "88"
+export MOCK_GH_CLOSING_ISSUES=""
+export MOCK_GH_PR_BODY="Closes #1414"
+bash "$SCRIPT" --event-name pull_request --event-path "$event_stale" --head-ref "codex/1414-remediation"
 
 event_other="$TMPDIR/other.json"
 make_event "$event_other" "Refs #1414"


### PR DESCRIPTION
Closes #1675

## Summary
Make the ADL PR publication path own GitHub closing linkage and stale-event recovery so mechanical PR metadata drift does not keep failing CI after publish.

## Goal
Ensure `pr finish` always creates or repairs live PR closing linkage for the bound issue, and ensure the workflow has a deterministic recovery path when GitHub Actions evaluates a stale pull_request payload after a body-only fix.

## Required Outcome
The repository's PR publication and janitor workflow automatically handles closing-linkage generation, live verification, repair, and stale-event refresh for issue-bound PRs, so operators do not need to hand-edit PR bodies or push sync commits to recover from this failure family.

## Deliverables
- bounded implementation changes in the PR publication / janitor path for closing-linkage ownership
- tests covering missing-linkage repair and stale-event recovery triggers
- operator-facing truth that documents the automatic behavior where needed
- a clean proof pass showing current failing PRs can be recovered through the owned process

## Acceptance Criteria
- `pr finish` creates or repairs the live PR body so it contains valid closing linkage for the bound issue
- publication verifies the live GitHub PR body after create/update instead of trusting only the local template
- the janitor path can recognize a linkage-only stale-event CI failure and trigger the smallest refresh path
- regression tests cover both missing-linkage publication and stale-event recovery behavior
- operators no longer need to remember or hand-apply `Closes #<issue>` for normal issue-bound PR publication

## Repo Inputs
- `adl/tools/pr.sh`
- `adl/tools/check_pr_closing_linkage.sh`
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
- recent failing PRs `#1672` and `#1674`

## Dependencies
- existing issue-bound PR workflow and closing-linkage guardrail are already in place; this issue repairs ownership gaps in publication and recovery.

## Demo Expectations
- no standalone public demo is required
- proof is the repaired workflow plus successful recovery of the live failing PRs

## Non-goals
- redesigning the entire PR workflow
- changing unrelated closeout or issue-card semantics
- relaxing the closing-linkage guardrail

## Issue-Graph Notes
- This issue should close the remaining tail from the earlier PR-linkage work by moving from detection to full publication ownership.

## Notes
- Treat the current failures on `#1672` and `#1674` as proving fixtures, not one-off manual exceptions.

## Tooling Notes
- The workflow-conductor should be able to route this issue through doctor, execution, and janitor recovery without ad hoc operator memory.
