### PR TITLE
[v0.88][tools] Make PR preflight queue-aware instead of globally blocking on any open PR

### DIFF
--- a/.adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/sip.md
+++ b/.adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1680
+Run ID: issue-1680
+Version: v0.88
+Title: [v0.88][tools] Make PR preflight queue-aware instead of globally blocking on any open PR
+Branch: codex/1680-v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1680
+- PR:
+- Source Issue Prompt: .adl/v0.88/bodies/issue-1680-v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/sor.md
+++ b/.adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/sor.md
@@ -1,0 +1,192 @@
+# v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1680
+Run ID: issue-1680
+Version: v0.88
+Title: [v0.88][tools] Make PR preflight queue-aware instead of globally blocking on any open PR
+Branch: codex/1680-v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: OpenAI Codex desktop
+- Start Time: 2026-04-12T19:20:00Z
+- End Time: 2026-04-12T19:50:31Z
+
+## Summary
+Implemented queue-aware milestone preflight for PR workflow execution. The control plane now resolves a target queue from canonical issue metadata or truthful inference, blocks only on same-queue open PRs, and reports the queue in doctor/preflight output and guard messages. Added queue metadata emission for generated issue prompts, plus regression coverage for same-queue blocking, cross-queue allow, and missing/uninferrable queue failure.
+
+## Artifacts produced
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd/doctor.rs`
+- `adl/src/cli/pr_cmd/github.rs`
+- `adl/src/cli/pr_cmd_cards.rs`
+- `adl/src/cli/pr_cmd_prompt.rs`
+- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
+- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
+- `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`
+- `adl/tools/pr.sh`
+- `adl/tools/test_pr_start_worktree_safe.sh`
+- updated local issue surfaces for `#1680` with explicit `queue: "tools"`
+
+## Actions taken
+- Added workflow-queue inference and prompt-resolution helpers in `pr_cmd_prompt.rs`.
+- Added `queue:` emission to generated and mirrored issue prompt front matter.
+- Changed `unresolved_milestone_pr_wave(...)` to filter open PR blockers by target queue instead of milestone-only breadth.
+- Extended doctor/preflight output to report `TARGET_QUEUE`, `TARGET_QUEUE_SOURCE`, and per-PR queue data.
+- Updated start/run guard messaging to describe same-queue blocking truthfully.
+- Added focused regression tests for queue inference, same-queue blocking, cross-queue allowance, and missing queue handling.
+- Dogfooded the new queue metadata in the `#1680` issue prompt/STP.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated:
+- `adl/src/cli/pr_cmd.rs`
+- `adl/src/cli/pr_cmd/doctor.rs`
+- `adl/src/cli/pr_cmd/github.rs`
+- `adl/src/cli/pr_cmd_cards.rs`
+- `adl/src/cli/pr_cmd_prompt.rs`
+- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
+- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
+- `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`
+- `adl/tools/pr.sh`
+- `adl/tools/test_pr_start_worktree_safe.sh`
+- `.adl/v0.88/bodies/issue-1680-v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr.md`
+- `.adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/stp.md`
+- Worktree-only paths remaining:
+  - none; all required changes exist in the issue branch worktree and are tracked for PR publication, but they are not yet on `main`
+- Integration state: worktree_only
+- Verification scope: worktree
+- Integration method used: direct edits in the issue worktree after `pr run` binding
+- Verification performed:
+  - `git status --short`
+  - `git diff --check`
+- Result: FAIL
+  Explanation: the worktree contains the full required artifact set and is ready for `pr-finish`, but nothing has been integrated into `main` yet, so main-repo integration is not complete at `pr-run` time
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo build --manifest-path adl/Cargo.toml --bin adl` to rebuild the CLI against the queue-aware guard changes
+  - `cargo test --manifest-path adl/Cargo.toml infer_workflow_queue_prefers_explicit_signals_and_tags -- --nocapture` to prove queue inference behavior
+  - `cargo test --manifest-path adl/Cargo.toml real_pr_preflight_allows_cross_queue_open_prs -- --nocapture` to prove cross-queue preflight allow behavior
+  - `cargo test --manifest-path adl/Cargo.toml resolve_issue_prompt_workflow_queue_rejects_missing_and_uninferrable_queue -- --nocapture` to prove truthful failure on missing/uninferrable queue metadata
+  - `bash adl/tools/test_pr_start_worktree_safe.sh` to prove the shell wrapper blocks same-queue work and allows cross-queue preflight
+  - `adl/tools/pr.sh doctor 1680 --version v0.88 --slug v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr` to inspect live queue-aware doctor output for the issue itself
+  - `git diff --check` to verify patch hygiene
+- Results:
+  - all listed validations passed
+  - live doctor output now reports the issue as `TARGET_QUEUE=tools` and only blocks on a same-queue open PR (`#1682`), which matches the intended policy
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo build --manifest-path adl/Cargo.toml --bin adl"
+      - "cargo test --manifest-path adl/Cargo.toml infer_workflow_queue_prefers_explicit_signals_and_tags -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml real_pr_preflight_allows_cross_queue_open_prs -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml resolve_issue_prompt_workflow_queue_rejects_missing_and_uninferrable_queue -- --nocapture"
+      - "bash adl/tools/test_pr_start_worktree_safe.sh"
+      - "adl/tools/pr.sh doctor 1680 --version v0.88 --slug v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: true
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: queue inference helper tests and doctor/preflight regression tests were rerun against stable fake `gh pr list` payloads.
+- Fixtures or scripts used: Rust inline lifecycle/repo-helper tests plus `adl/tools/test_pr_start_worktree_safe.sh`.
+- Replay verification (same inputs -> same artifacts/order): repeated fake-GitHub inputs produced stable same-queue block vs cross-queue pass outcomes and stable doctor text output.
+- Ordering guarantees (sorting / tie-break rules used): blocker selection still relies on deterministic `gh pr list` parsing plus explicit queue classification; no nondeterministic ordering logic was introduced.
+- Artifact stability notes: output now includes explicit queue fields, reducing ambiguity rather than adding hidden branching.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: review of changed command output and recorded card content; no secrets or tokens were introduced.
+- Prompt / tool argument redaction verified: the change only adds queue metadata and blocker explanations; no prompt/tool-arg surfaces were widened.
+- Absolute path leakage check: `git diff --check` passed, and recorded commands in this card use repository-relative paths.
+- Sandbox / policy invariants preserved: yes; the change stays within local control-plane logic and test fixtures.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this issue changes control-plane gating logic rather than ADL trace artifacts.
+- Run artifact root: not applicable.
+- Replay command used for verification: targeted Rust tests and the shell wrapper regression script listed in Validation.
+- Replay result: pass; deterministic fake-GitHub fixtures reproduced the expected queue-aware outcomes.
+
+## Artifact Verification
+- Primary proof surface: queue-aware doctor/start behavior in the Rust lifecycle tests and `adl/tools/test_pr_start_worktree_safe.sh`.
+- Required artifacts present: yes; code, tests, help text, and the issue-local queue metadata changes are present in the worktree.
+- Artifact schema/version checks: front matter now supports `queue:`; older prompts remain supported through truthful inference when `queue:` is absent.
+- Hash/byte-stability checks: not applicable beyond deterministic test expectations; no binary artifact contract changed.
+- Missing/optional artifacts and rationale: no standalone demo was required for this tools issue.
+
+## Decisions / Deviations
+- Proceeded with `pr run ... --allow-open-pr-wave` because the issue existed specifically to repair the overly coarse open-PR guard, and the old guard was self-blocking the fix.
+- Kept the first implementation intentionally narrow: same-queue blocking is solved; protected-surface overlap and release-tail stricter policy remain future follow-on work.
+- Target queue resolution is explicit when `queue:` exists and inferred when older prompts omit it; missing and uninferrable queue metadata now fails truthfully.
+
+## Follow-ups / Deferred work
+- `workflow-conductor` remains useful as a lightweight router, but today it still depends on a hand-built payload rather than collecting repo state itself. That is a separate follow-on from this queue-aware preflight change.
+- Queue-aware blocking does not yet include protected-surface conflict detection across different queues.
+- Release-tail stricter concurrency policy is still deferred to later control-plane work.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/stp.md
+++ b/.adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/stp.md
@@ -1,0 +1,80 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+queue: "tools"
+slug: "v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr"
+title: "[v0.88][tools] Make PR preflight queue-aware instead of globally blocking on any open PR"
+labels:
+  - "track:roadmap"
+  - "area:tools"
+  - "type:task"
+  - "version:v0.88"
+issue_number: 1680
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr"
+---
+
+## Summary
+Make PR preflight queue-aware instead of globally blocking whenever any milestone PR is open.
+
+## Goal
+Allow bounded parallel progress across unrelated issue lanes by blocking only on conflicting open PRs in the same queue, while keeping the current truthful preflight model for actually conflicting work.
+
+## Required Outcome
+The repository can assign a primary workflow queue to an issue, doctor/preflight reports queue-aware blocking decisions, and execution is allowed when only unrelated queue PRs are open.
+
+## Deliverables
+- a queue expression surface in the canonical issue/workflow metadata
+- preflight logic that blocks on same-queue open PRs instead of any open PR
+- tests covering same-queue blocking, cross-queue allow, and missing-or-invalid queue handling
+- tightened workflow docs describing the queue-aware rule
+
+## Acceptance Criteria
+- canonical issue/workflow metadata can express a queue such as `wp`, `tools`, `demo`, `docs`, `review`, or `release`
+- doctor/preflight no longer fails solely because an unrelated queue has an open PR
+- doctor/preflight still blocks when the target queue already has an open PR
+- missing or invalid queue metadata produces a truthful bounded result rather than silent fallback
+- repo docs or workflow notes explain the new queue-aware rule and its intended scope
+
+## Repo Inputs
+- `adl/tools/pr.sh`
+- `adl/src/cli/pr_cmd/`
+- canonical issue/task bundle metadata under `.adl/`
+- recent blocking behavior around `#1630`-`#1634` and `#1671`-`#1675`
+
+## Dependencies
+- builds on the current closing-linkage and workflow-conductor hardening work already landed in `v0.88`
+
+## Demo Expectations
+- no standalone demo required
+- proof should come from doctor/preflight behavior plus regression tests
+
+## Non-goals
+- shared-surface conflict detection beyond queue-aware blocking
+- late-release stricter policy overrides
+- broad workflow redesign outside preflight blocking
+
+## Issue-Graph Notes
+- This is the minimal first step toward multiple guarded work lanes instead of a single global PR lane.
+- Later work can add protected-surface overlap detection and release-tail strict mode if needed.
+
+## Notes
+- Prefer truthful blocking when queue data is missing instead of guessing.
+- Keep the first version narrow and auditable.
+
+## Tooling Notes
+- preflight should derive queue decisions from canonical local issue state rather than ad hoc branch naming alone
+- doctor output should explain both the target queue and the blocking queue when a conflict exists

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -20,11 +20,12 @@ use super::pr_cmd_cards::{
 #[cfg(test)]
 use super::pr_cmd_prompt::load_issue_prompt;
 use super::pr_cmd_prompt::{
-    ensure_no_duplicate_issue_identities, infer_required_outcome_type,
+    ensure_no_duplicate_issue_identities, infer_required_outcome_type, infer_workflow_queue,
     normalize_issue_title_for_version, normalize_labels_csv, parse_issue_number_from_url,
     render_generated_issue_body, resolve_issue_body, resolve_issue_prompt_path,
-    resolve_issue_scope_and_slug_from_local_state, validate_issue_prompt_exists,
-    version_from_labels_csv, version_from_title,
+    resolve_issue_prompt_workflow_queue, resolve_issue_scope_and_slug_from_local_state,
+    validate_issue_prompt_exists, version_from_labels_csv, version_from_title,
+    WorkflowQueueResolution,
 };
 use super::pr_cmd_validate::{
     validate_authored_prompt_surface, validate_milestone_doc_drift_for_finish, PromptSurfaceKind,
@@ -279,11 +280,29 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     }
     ensure_no_duplicate_issue_identities(&repo_root, &issue_ref)?;
     let branch = issue_ref.branch_name(&parsed.prefix);
-    let unresolved = unresolved_milestone_pr_wave(&repo, &version, Some(&branch))?;
+    let target_queue = if issue_ref.issue_prompt_path(&repo_root).is_file() {
+        resolve_issue_prompt_workflow_queue(&issue_ref.issue_prompt_path(&repo_root))?
+    } else {
+        WorkflowQueueResolution {
+            queue: infer_workflow_queue(&title, &normalized_labels, None)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "start: missing or invalid workflow queue for issue #{}; add a canonical queue such as wp/tools/demo/docs/review/release before execution",
+                        parsed.issue
+                    )
+                })?
+                .to_string(),
+            source: "inferred",
+        }
+    };
+    let unresolved =
+        unresolved_milestone_pr_wave(&repo, &version, &target_queue.queue, Some(&branch))?;
     if !parsed.allow_open_pr_wave && !unresolved.is_empty() {
         bail!(
-            "start: unresolved open PR wave detected for {}. Resolve or merge these PRs first, or rerun with --allow-open-pr-wave if you are deliberately overriding the guard:\n{}",
+            "start: unresolved open PR queue detected for {} [{}:{}]. Resolve or merge these PRs first, or rerun with --allow-open-pr-wave if you are deliberately overriding the guard:\n{}",
             version,
+            target_queue.queue,
+            target_queue.source,
             format_open_pr_wave(&unresolved)
         );
     }

--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -8,11 +8,14 @@ struct DoctorPreflightJsonPullRequest {
     number: u32,
     head_ref_name: String,
     state: &'static str,
+    queue: Option<String>,
     url: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DoctorPreflightResult {
+    target_queue: String,
+    target_queue_source: &'static str,
     open_pr_count: usize,
     open_prs: Vec<DoctorPreflightJsonPullRequest>,
     status: &'static str,
@@ -40,6 +43,8 @@ struct DoctorJsonOutput {
     slug: String,
     branch: String,
     mode: &'static str,
+    target_queue: String,
+    target_queue_source: &'static str,
     preflight_status: &'static str,
     open_pr_count: usize,
     open_prs: Vec<DoctorPreflightJsonPullRequest>,
@@ -63,7 +68,7 @@ pub(super) fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
     let issue_ref = IssueRef::new(parsed.issue, version.clone(), slug.clone())?;
     let branch = issue_ref.branch_name("codex");
 
-    let preflight = run_doctor_preflight(&repo, &version, &branch)?;
+    let preflight = run_doctor_preflight(&repo_root, &repo, &version, &issue_ref, &branch)?;
     let ready = match parsed.mode {
         DoctorMode::Preflight => None,
         DoctorMode::Ready | DoctorMode::Full => {
@@ -91,6 +96,8 @@ pub(super) fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
             slug,
             branch,
             mode,
+            target_queue: preflight.target_queue.clone(),
+            target_queue_source: preflight.target_queue_source,
             preflight_status: preflight.status,
             open_pr_count: preflight.open_pr_count,
             open_prs: preflight.open_prs,
@@ -111,6 +118,8 @@ pub(super) fn run_doctor(parsed: DoctorArgs, label: &str) -> Result<()> {
         println!("VERSION={version}");
         println!("SLUG={slug}");
         println!("BRANCH={branch}");
+        println!("TARGET_QUEUE={}", preflight.target_queue);
+        println!("TARGET_QUEUE_SOURCE={}", preflight.target_queue_source);
         print_doctor_preflight_text(&preflight);
         if let Some(ready) = &ready {
             print_doctor_ready_text(ready);
@@ -156,25 +165,39 @@ fn resolve_doctor_scope_and_slug(
     Ok((version, slug))
 }
 
-fn run_doctor_preflight(repo: &str, version: &str, branch: &str) -> Result<DoctorPreflightResult> {
-    let unresolved = unresolved_milestone_pr_wave(repo, version, Some(branch))?;
+fn run_doctor_preflight(
+    repo_root: &Path,
+    repo: &str,
+    version: &str,
+    issue_ref: &IssueRef,
+    branch: &str,
+) -> Result<DoctorPreflightResult> {
+    let source_path = resolve_issue_prompt_path(repo_root, issue_ref)?;
+    let target_queue = resolve_issue_prompt_workflow_queue(&source_path)?;
+    let unresolved =
+        unresolved_milestone_pr_wave(repo, version, &target_queue.queue, Some(branch))?;
     let open_prs = unresolved
         .iter()
         .map(|pr| DoctorPreflightJsonPullRequest {
             number: pr.number,
             head_ref_name: pr.head_ref_name.clone(),
             state: if pr.is_draft { "draft" } else { "ready" },
+            queue: pr.queue.clone(),
             url: pr.url.clone(),
         })
         .collect::<Vec<_>>();
     if open_prs.is_empty() {
         Ok(DoctorPreflightResult {
+            target_queue: target_queue.queue,
+            target_queue_source: target_queue.source,
             open_pr_count: 0,
             open_prs,
             status: "PASS",
         })
     } else {
         Ok(DoctorPreflightResult {
+            target_queue: target_queue.queue,
+            target_queue_source: target_queue.source,
             open_pr_count: open_prs.len(),
             open_prs,
             status: "BLOCK",
@@ -356,8 +379,12 @@ fn print_doctor_preflight_text(preflight: &DoctorPreflightResult) {
     println!("OPEN_PR_COUNT={}", preflight.open_pr_count);
     for pr in &preflight.open_prs {
         println!(
-            "OPEN_PR=#{}|{}|{}|{}",
-            pr.number, pr.head_ref_name, pr.state, pr.url
+            "OPEN_PR=#{}|{}|{}|{}|{}",
+            pr.number,
+            pr.head_ref_name,
+            pr.state,
+            pr.queue.as_deref().unwrap_or("unknown"),
+            pr.url
         );
     }
     println!("PREFLIGHT={}", preflight.status);

--- a/adl/src/cli/pr_cmd/github.rs
+++ b/adl/src/cli/pr_cmd/github.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd_prompt::infer_workflow_queue;
 use ::adl::control_plane::resolve_primary_checkout_root;
 use serde::Deserialize;
 use std::collections::BTreeSet;
@@ -16,6 +17,8 @@ pub(super) struct OpenPullRequest {
     pub(super) base_ref_name: String,
     #[serde(rename = "isDraft")]
     pub(super) is_draft: bool,
+    #[serde(skip)]
+    pub(super) queue: Option<String>,
 }
 
 pub(super) fn current_pr_url(repo: &str, branch: &str) -> Result<Option<String>> {
@@ -41,6 +44,7 @@ pub(super) fn current_pr_url(repo: &str, branch: &str) -> Result<Option<String>>
 pub(super) fn unresolved_milestone_pr_wave(
     repo: &str,
     version: &str,
+    target_queue: &str,
     exclude_branch: Option<&str>,
 ) -> Result<Vec<OpenPullRequest>> {
     let out = run_capture_allow_failure(
@@ -64,10 +68,19 @@ pub(super) fn unresolved_milestone_pr_wave(
         .into_iter()
         .filter(|pr| pr.base_ref_name == "main")
         .filter(|pr| pr.title.contains(&version_tag))
+        .map(|mut pr| {
+            pr.queue = infer_workflow_queue(&pr.title, "", None).map(str::to_string);
+            pr
+        })
         .filter(|pr| {
             exclude_branch
                 .map(|branch| pr.head_ref_name != branch)
                 .unwrap_or(true)
+        })
+        .filter(|pr| {
+            pr.queue
+                .as_deref()
+                .is_none_or(|queue| queue == target_queue)
         })
         .collect())
 }
@@ -79,7 +92,10 @@ pub(super) fn format_open_pr_wave(prs: &[OpenPullRequest]) -> String {
                 "- #{} [{}] {} ({})",
                 pr.number,
                 if pr.is_draft { "draft" } else { "ready" },
-                pr.title,
+                match pr.queue.as_deref() {
+                    Some(queue) => format!("[queue={queue}] {}", pr.title),
+                    None => format!("[queue=unknown] {}", pr.title),
+                },
                 pr.url
             )
         })

--- a/adl/src/cli/pr_cmd_cards.rs
+++ b/adl/src/cli/pr_cmd_cards.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::pr_cmd_prompt::{
-    infer_required_outcome_type, infer_wp_from_title, normalize_labels_csv,
+    infer_required_outcome_type, infer_workflow_queue, infer_wp_from_title, normalize_labels_csv,
     render_generated_issue_prompt,
 };
 use super::pr_cmd_validate::{
@@ -399,6 +399,7 @@ fn render_issue_prompt_from_body(
     }
 
     let wp = infer_wp_from_title(title);
+    let queue = infer_workflow_queue(title, labels_csv, Some(&wp)).unwrap_or("wp");
     let outcome_type = infer_required_outcome_type(labels_csv, title);
     let label_lines = labels_csv
         .split(',')
@@ -408,7 +409,7 @@ fn render_issue_prompt_from_body(
         .collect::<Vec<_>>()
         .join("\n");
     format!(
-        "---\nissue_card_schema: adl.issue.v1\nwp: \"{wp}\"\nslug: \"{slug}\"\ntitle: \"{title}\"\nlabels:\n{label_lines}\nissue_number: {issue}\nstatus: \"draft\"\naction: \"edit\"\ndepends_on: []\nmilestone_sprint: \"Pending sprint assignment\"\nrequired_outcome_type:\n  - \"{outcome_type}\"\nrepo_inputs: []\ncanonical_files: []\ndemo_required: false\ndemo_names: []\nissue_graph_notes:\n  - \"Mirrored from the authored GitHub issue body during bootstrap/init.\"\npr_start:\n  enabled: false\n  slug: \"{slug}\"\n---\n\n{body}\n"
+        "---\nissue_card_schema: adl.issue.v1\nwp: \"{wp}\"\nqueue: \"{queue}\"\nslug: \"{slug}\"\ntitle: \"{title}\"\nlabels:\n{label_lines}\nissue_number: {issue}\nstatus: \"draft\"\naction: \"edit\"\ndepends_on: []\nmilestone_sprint: \"Pending sprint assignment\"\nrequired_outcome_type:\n  - \"{outcome_type}\"\nrepo_inputs: []\ncanonical_files: []\ndemo_required: false\ndemo_names: []\nissue_graph_notes:\n  - \"Mirrored from the authored GitHub issue body during bootstrap/init.\"\npr_start:\n  enabled: false\n  slug: \"{slug}\"\n---\n\n{body}\n"
     )
 }
 

--- a/adl/src/cli/pr_cmd_prompt.rs
+++ b/adl/src/cli/pr_cmd_prompt.rs
@@ -15,6 +15,14 @@ pub(crate) struct IssuePromptFrontMatter {
     pub(crate) issue_number: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkflowQueueResolution {
+    pub(crate) queue: String,
+    pub(crate) source: &'static str,
+}
+
+const VALID_WORKFLOW_QUEUES: &[&str] = &["wp", "tools", "demo", "docs", "review", "release"];
+
 #[cfg(test)]
 #[derive(Debug)]
 pub(crate) struct IssuePromptDoc {
@@ -158,6 +166,7 @@ pub(crate) fn render_generated_issue_prompt(
     issue_url: &str,
 ) -> String {
     let wp = infer_wp_from_title(title);
+    let queue = infer_workflow_queue(title, labels_csv, Some(&wp)).unwrap_or("wp");
     let outcome_type = infer_required_outcome_type(labels_csv, title);
     let label_lines = labels_csv
         .split(',')
@@ -169,7 +178,7 @@ pub(crate) fn render_generated_issue_prompt(
     let body = render_generated_issue_body(title, outcome_type, Some(issue_url));
 
     format!(
-        "---\nissue_card_schema: adl.issue.v1\nwp: \"{wp}\"\nslug: \"{slug}\"\ntitle: \"{title}\"\nlabels:\n{label_lines}\nissue_number: {issue}\nstatus: \"draft\"\naction: \"edit\"\ndepends_on: []\nmilestone_sprint: \"Pending sprint assignment\"\nrequired_outcome_type:\n  - \"{outcome_type}\"\nrepo_inputs: []\ncanonical_files: []\ndemo_required: false\ndemo_names: []\nissue_graph_notes:\n  - \"Bootstrap-generated from GitHub issue metadata because no canonical local issue prompt existed yet.\"\npr_start:\n  enabled: false\n  slug: \"{slug}\"\n---\n\n{body}\n"
+        "---\nissue_card_schema: adl.issue.v1\nwp: \"{wp}\"\nqueue: \"{queue}\"\nslug: \"{slug}\"\ntitle: \"{title}\"\nlabels:\n{label_lines}\nissue_number: {issue}\nstatus: \"draft\"\naction: \"edit\"\ndepends_on: []\nmilestone_sprint: \"Pending sprint assignment\"\nrequired_outcome_type:\n  - \"{outcome_type}\"\nrepo_inputs: []\ncanonical_files: []\ndemo_required: false\ndemo_names: []\nissue_graph_notes:\n  - \"Bootstrap-generated from GitHub issue metadata because no canonical local issue prompt existed yet.\"\npr_start:\n  enabled: false\n  slug: \"{slug}\"\n---\n\n{body}\n"
     )
 }
 
@@ -227,6 +236,120 @@ pub(crate) fn infer_wp_from_title(title: &str) -> String {
         }
     }
     "unassigned".to_string()
+}
+
+fn normalize_workflow_queue(value: &str) -> Option<String> {
+    let lowered = value.trim().to_lowercase();
+    VALID_WORKFLOW_QUEUES
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == lowered)
+        .map(str::to_string)
+}
+
+pub(crate) fn infer_workflow_queue(
+    title: &str,
+    labels_csv: &str,
+    wp_hint: Option<&str>,
+) -> Option<&'static str> {
+    if title.to_lowercase().contains("[wp-") {
+        return Some("wp");
+    }
+    if let Some(wp) = wp_hint.and_then(normalize_workflow_queue) {
+        return VALID_WORKFLOW_QUEUES
+            .iter()
+            .copied()
+            .find(|candidate| *candidate == wp);
+    }
+    let lowered = format!("{} {}", labels_csv.to_lowercase(), title.to_lowercase());
+    if lowered.contains("area:tools") || lowered.contains("[tools]") {
+        return Some("tools");
+    }
+    if lowered.contains("area:demo") || lowered.contains("[demo]") {
+        return Some("demo");
+    }
+    if lowered.contains("area:docs")
+        || lowered.contains("type:docs")
+        || lowered.contains("[docs]")
+        || lowered.contains("type:design")
+    {
+        return Some("docs");
+    }
+    if lowered.contains("area:review") || lowered.contains("[review]") {
+        return Some("review");
+    }
+    if lowered.contains("area:release") || lowered.contains("[release]") {
+        return Some("release");
+    }
+    None
+}
+
+pub(crate) fn resolve_issue_prompt_workflow_queue(path: &Path) -> Result<WorkflowQueueResolution> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("queue: failed to read issue prompt: {}", path.display()))?;
+    let normalized = text.replace("\r\n", "\n");
+    let stripped = normalized.trim().strip_prefix("---\n").ok_or_else(|| {
+        anyhow!(
+            "queue: missing YAML front matter opener: {}",
+            path.display()
+        )
+    })?;
+    let (front_matter, _) = stripped.split_once("\n---\n").ok_or_else(|| {
+        anyhow!(
+            "queue: missing YAML front matter closer: {}",
+            path.display()
+        )
+    })?;
+    let value: serde_yaml::Value = serde_yaml::from_str(front_matter).with_context(|| {
+        format!(
+            "queue: failed to parse YAML front matter for issue prompt: {}",
+            path.display()
+        )
+    })?;
+    let mapping = value.as_mapping().ok_or_else(|| {
+        anyhow!(
+            "queue: issue prompt front matter is not a mapping: {}",
+            path.display()
+        )
+    })?;
+    let queue = mapping
+        .get(serde_yaml::Value::String("queue".to_string()))
+        .and_then(|value| value.as_str())
+        .and_then(normalize_workflow_queue);
+    if let Some(queue) = queue {
+        return Ok(WorkflowQueueResolution {
+            queue,
+            source: "explicit",
+        });
+    }
+    let title = mapping
+        .get(serde_yaml::Value::String("title".to_string()))
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| anyhow!("queue: missing title in issue prompt: {}", path.display()))?;
+    let wp = mapping
+        .get(serde_yaml::Value::String("wp".to_string()))
+        .and_then(|value| value.as_str());
+    let labels_csv = mapping
+        .get(serde_yaml::Value::String("labels".to_string()))
+        .and_then(|value| value.as_sequence())
+        .map(|labels| {
+            labels
+                .iter()
+                .filter_map(|value| value.as_str())
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .unwrap_or_default();
+    let inferred = infer_workflow_queue(title, &labels_csv, wp).ok_or_else(|| {
+        anyhow!(
+            "queue: missing or invalid workflow queue in {} and could not infer one from title/labels",
+            path.display()
+        )
+    })?;
+    Ok(WorkflowQueueResolution {
+        queue: inferred.to_string(),
+        source: "inferred",
+    })
 }
 
 pub(crate) fn infer_required_outcome_type(labels_csv: &str, title: &str) -> &'static str {

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -188,6 +188,31 @@ fn infer_wp_from_title_extracts_tag_or_defaults() {
 }
 
 #[test]
+fn infer_workflow_queue_prefers_explicit_signals_and_tags() {
+    assert_eq!(
+        infer_workflow_queue(
+            "[v0.86][WP-15] Implement local agent demo program",
+            "",
+            None
+        ),
+        Some("wp")
+    );
+    assert_eq!(
+        infer_workflow_queue("[v0.88][tools] Repair workflow conductor", "", None),
+        Some("tools")
+    );
+    assert_eq!(
+        infer_workflow_queue("[v0.88] Example", "track:roadmap,area:docs", None),
+        Some("docs")
+    );
+    assert_eq!(
+        infer_workflow_queue("[v0.88] Example", "", Some("review")),
+        Some("review")
+    );
+    assert_eq!(infer_workflow_queue("No queue signals", "", None), None);
+}
+
+#[test]
 fn infer_required_outcome_type_prefers_docs_tests_and_demo_signals() {
     assert_eq!(
         infer_required_outcome_type("track:roadmap,area:docs", "[v0.86][WP-01] Example"),

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle.rs
@@ -814,12 +814,19 @@ fn real_pr_preflight_reports_open_milestone_prs() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-preflight");
     init_git_repo(&repo);
+    let issue_ref = IssueRef::new(
+        1173,
+        "v0.86".to_string(),
+        "v0-86-tools-preflight".to_string(),
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Preflight");
     let bin_dir = repo.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_path = bin_dir.join("gh");
     write_executable(
             &gh_path,
-            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  cat <<'JSON'\n[{\"number\":1169,\"title\":\"[v0.86][runtime] Sprint 3A: Make WP-06 fast / slow paths drive real runtime behavior\",\"url\":\"https://example.test/pr/1169\",\"headRefName\":\"codex/1161-v0-86-runtime-sprint-3a-make-wp-06-fast-slow-paths-drive-real-runtime-behavior\",\"baseRefName\":\"main\",\"isDraft\":true}]\nJSON\n  exit 0\nfi\nexit 1\n",
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  cat <<'JSON'\n[{\"number\":1169,\"title\":\"[v0.86][tools] Keep tools queue busy\",\"url\":\"https://example.test/pr/1169\",\"headRefName\":\"codex/1161-v0-86-tools-keep-tools-queue-busy\",\"baseRefName\":\"main\",\"isDraft\":true}]\nJSON\n  exit 0\nfi\nexit 1\n",
         );
 
     let old_path = env::var("PATH").unwrap_or_default();
@@ -920,13 +927,20 @@ fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
         .status()
         .expect("git fetch")
         .success());
+    let issue_ref = IssueRef::new(
+        1173,
+        "v0.86".to_string(),
+        "v0-86-tools-preflight-guard".to_string(),
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Preflight guard");
 
     let bin_dir = repo.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let gh_path = bin_dir.join("gh");
     write_executable(
             &gh_path,
-            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  cat <<'JSON'\n[{\"number\":1169,\"title\":\"[v0.86][runtime] Sprint 3A: Make WP-06 fast / slow paths drive real runtime behavior\",\"url\":\"https://example.test/pr/1169\",\"headRefName\":\"codex/1161-v0-86-runtime-sprint-3a-make-wp-06-fast-slow-paths-drive-real-runtime-behavior\",\"baseRefName\":\"main\",\"isDraft\":true}]\nJSON\n  exit 0\nfi\nexit 1\n",
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  cat <<'JSON'\n[{\"number\":1169,\"title\":\"[v0.86][tools] Keep tools queue busy\",\"url\":\"https://example.test/pr/1169\",\"headRefName\":\"codex/1161-v0-86-tools-keep-tools-queue-busy\",\"baseRefName\":\"main\",\"isDraft\":true}]\nJSON\n  exit 0\nfi\nexit 1\n",
         );
 
     let old_path = env::var("PATH").unwrap_or_default();
@@ -947,7 +961,7 @@ fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
         "v0.86".to_string(),
         "--no-fetch-issue".to_string(),
     ])
-    .expect_err("start should block on open PR wave");
+    .expect_err("start should block on same-queue open PR");
 
     env::set_current_dir(prev_dir).expect("restore cwd");
     unsafe {
@@ -955,8 +969,121 @@ fn real_pr_start_blocks_when_open_milestone_pr_wave_exists() {
     }
     assert!(err
         .to_string()
-        .contains("start: unresolved open PR wave detected for v0.86"));
+        .contains("start: unresolved open PR queue detected for v0.86 [tools:inferred]"));
     assert!(err.to_string().contains("#1169 [draft]"));
+}
+
+#[test]
+fn real_pr_preflight_allows_cross_queue_open_prs() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-preflight-cross-queue-allow");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    fs::write(repo.join("README.md"), "# test\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+    let issue_ref = IssueRef::new(
+        1173,
+        "v0.86".to_string(),
+        "v0-86-tools-preflight-guard".to_string(),
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Preflight guard");
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2\" == \"pr list\" ]]; then\n  cat <<'JSON'\n[{\"number\":1169,\"title\":\"[v0.86][WP-06] Runtime demo lane\",\"url\":\"https://example.test/pr/1169\",\"headRefName\":\"codex/1161-v0-86-wp-06-runtime-demo-lane\",\"baseRefName\":\"main\",\"isDraft\":true}]\nJSON\n  exit 0\nfi\nexit 1\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    real_pr(&[
+        "preflight".to_string(),
+        "1173".to_string(),
+        "--slug".to_string(),
+        "v0-86-tools-preflight-guard".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+        "--no-fetch-issue".to_string(),
+    ])
+    .expect("preflight should allow cross-queue open pr");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -571,6 +571,22 @@ fn resolve_issue_prompt_path_accepts_legacy_issue_bodies_location() {
 }
 
 #[test]
+fn resolve_issue_prompt_workflow_queue_rejects_missing_and_uninferrable_queue() {
+    let repo = unique_temp_dir("adl-pr-missing-workflow-queue");
+    let prompt = repo.join("issue.md");
+    fs::write(
+        &prompt,
+        "---\nissue_card_schema: adl.issue.v1\nwp: \"unassigned\"\nslug: \"no-queue\"\ntitle: \"Plain issue title\"\nlabels:\n  - \"track:roadmap\"\n  - \"version:v0.88\"\nissue_number: 1\nstatus: \"draft\"\naction: \"edit\"\ndepends_on: []\nmilestone_sprint: \"Pending\"\nrequired_outcome_type:\n  - \"code\"\nrepo_inputs: []\ncanonical_files: []\ndemo_required: false\ndemo_names: []\nissue_graph_notes: []\npr_start:\n  enabled: false\n  slug: \"no-queue\"\n---\n\n# Plain issue title\n\n## Summary\nx\n## Goal\nx\n## Required Outcome\nx\n## Deliverables\nx\n## Acceptance Criteria\nx\n## Repo Inputs\nx\n## Dependencies\nx\n## Demo Expectations\nx\n## Non-goals\nx\n## Issue-Graph Notes\nx\n## Notes\nx\n## Tooling Notes\nx\n",
+    )
+    .expect("prompt");
+
+    let err = resolve_issue_prompt_workflow_queue(&prompt).expect_err("missing queue should fail");
+    assert!(err
+        .to_string()
+        .contains("missing or invalid workflow queue"));
+}
+
+#[test]
 fn real_pr_start_rejects_missing_slug_or_empty_sanitized_title_in_no_fetch_mode() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-start-preconditions");

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1809,7 +1809,7 @@ Flags:
   (card/run) --slug <slug>                     Use an explicit slug instead of fetching the issue title.
   (run)     --title "<title>"                  Optional; accepted for UX symmetry and used to derive slug when --slug is omitted.
   (run)     --version <v0.85|v0.87.1>          Override detected version when the caller already knows the intended milestone band.
-  (run)     --allow-open-pr-wave               Override the open milestone PR wave guard.
+  (run)     --allow-open-pr-wave               Override the same-queue open milestone PR guard.
 
 Notes:
 - `pr create` creates the GitHub issue and bootstraps the local root STP/SIP/SOR bundle for a new issue.
@@ -1885,7 +1885,7 @@ Notes:
 - Creates or reuses issue worktree at .worktrees/adl-wp-<issue> by default.
 - Leaves the primary checkout on its current branch.
 - `--version` overrides inferred issue version when the caller already knows the intended milestone band.
-- Refuses to start a later issue when an open PR wave already exists for the same milestone band unless `--allow-open-pr-wave` is passed.
+- Refuses to start a later issue when an open PR already exists in the same milestone queue unless `--allow-open-pr-wave` is passed.
 EOF
 }
 

--- a/adl/tools/test_pr_start_worktree_safe.sh
+++ b/adl/tools/test_pr_start_worktree_safe.sh
@@ -339,7 +339,7 @@ EOF
 set -euo pipefail
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
   cat <<'JSON'
-[{"number":1169,"title":"[v0.86][runtime] Sprint 3A: Make WP-06 fast / slow paths drive real runtime behavior","url":"https://example.test/pr/1169","headRefName":"codex/1161-v0-86-runtime-sprint-3a-make-wp-06-fast-slow-paths-drive-real-runtime-behavior","baseRefName":"main","isDraft":true}]
+[{"number":1169,"title":"[v0.86][tools] Keep tools queue busy","url":"https://example.test/pr/1169","headRefName":"codex/1161-v0-86-tools-keep-tools-queue-busy","baseRefName":"main","isDraft":true}]
 JSON
   exit 0
 fi
@@ -347,6 +347,7 @@ exit 1
 EOF
   chmod +x "$fakegh/gh"
 
+  seed_issue_prompt 990 blocked-wave
   preflight_out="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh preflight 990 --slug blocked-wave --version v0.86 --no-fetch-issue)"
   assert_contains "OPEN_PR_COUNT=1" "$preflight_out" "preflight detects open wave"
   assert_contains "PREFLIGHT=BLOCK" "$preflight_out" "preflight blocks"
@@ -359,12 +360,29 @@ EOF
     echo "assertion failed: expected start to block on unresolved open PR wave" >&2
     exit 1
   }
-  assert_contains "unresolved open PR wave detected for v0.86" "$blocked_start" "start guard message"
+  assert_contains "unresolved open PR queue detected for v0.86 [tools:inferred]" "$blocked_start" "start guard message"
   assert_contains "#1169 [draft]" "$blocked_start" "start guard lists open pr"
+  assert_contains "[queue=tools]" "$blocked_start" "start guard shows queue"
 
-  seed_issue_prompt 990 blocked-wave
   allowed_start="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh start 990 --slug blocked-wave --version v0.86 --no-fetch-issue --allow-open-pr-wave)"
   assert_contains "STATE  FULLY_STARTED" "$allowed_start" "override bypasses start guard"
+
+  cat >"$fakegh/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number":1169,"title":"[v0.86][WP-06] Runtime lane","url":"https://example.test/pr/1169","headRefName":"codex/1161-v0-86-wp-06-runtime-lane","baseRefName":"main","isDraft":true}]
+JSON
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$fakegh/gh"
+  cross_preflight="$(PATH="$fakegh:$PATH" "$BASH_BIN" adl/tools/pr.sh preflight 990 --slug blocked-wave --version v0.86 --no-fetch-issue)"
+  assert_contains "TARGET_QUEUE=tools" "$cross_preflight" "preflight reports target queue"
+  assert_contains "OPEN_PR_COUNT=0" "$cross_preflight" "cross-queue preflight does not block"
+  assert_contains "PREFLIGHT=PASS" "$cross_preflight" "cross-queue preflight passes"
 
   chmod 555 "$repo/.git" "$repo/.git/refs" "$repo/.git/refs/heads"
   set +e


### PR DESCRIPTION
Closes #1680

## Summary
Implemented queue-aware milestone preflight for PR workflow execution. The control plane now resolves a target queue from canonical issue metadata or truthful inference, blocks only on same-queue open PRs, and reports the queue in doctor/preflight output and guard messages. Added queue metadata emission for generated issue prompts, plus regression coverage for same-queue blocking, cross-queue allow, and missing/uninferrable queue failure.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/doctor.rs`
- `adl/src/cli/pr_cmd/github.rs`
- `adl/src/cli/pr_cmd_cards.rs`
- `adl/src/cli/pr_cmd_prompt.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
- `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`
- `adl/tools/pr.sh`
- `adl/tools/test_pr_start_worktree_safe.sh`
- updated local issue surfaces for `#1680` with explicit `queue: "tools"`

## Validation
- Validation commands and their purpose:
  - `cargo build --manifest-path adl/Cargo.toml --bin adl` to rebuild the CLI against the queue-aware guard changes
  - `cargo test --manifest-path adl/Cargo.toml infer_workflow_queue_prefers_explicit_signals_and_tags -- --nocapture` to prove queue inference behavior
  - `cargo test --manifest-path adl/Cargo.toml real_pr_preflight_allows_cross_queue_open_prs -- --nocapture` to prove cross-queue preflight allow behavior
  - `cargo test --manifest-path adl/Cargo.toml resolve_issue_prompt_workflow_queue_rejects_missing_and_uninferrable_queue -- --nocapture` to prove truthful failure on missing/uninferrable queue metadata
  - `bash adl/tools/test_pr_start_worktree_safe.sh` to prove the shell wrapper blocks same-queue work and allows cross-queue preflight
  - `adl/tools/pr.sh doctor 1680 --version v0.88 --slug v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr` to inspect live queue-aware doctor output for the issue itself
  - `git diff --check` to verify patch hygiene
- Results:
  - all listed validations passed
  - live doctor output now reports the issue as `TARGET_QUEUE=tools` and only blocks on a same-queue open PR (`#1682`), which matches the intended policy

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/sip.md
- Output card: .adl/v0.88/tasks/issue-1680__v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr/sor.md
- Idempotency-Key: v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr-adl-v0-88-tasks-issue-1680-v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr-sip-md-adl-v0-88-tasks-issue-1680-v0-88-tools-make-pr-preflight-queue-aware-instead-of-globally-blocking-on-any-open-pr-sor-md