### PR TITLE
[v0.88][WP-06] Commitments and deadlines

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -11,6 +11,7 @@ pub const CHRONOSENSE_FOUNDATION_SCHEMA: &str = "chronosense_foundation.v1";
 pub const TEMPORAL_SCHEMA_V01: &str = "temporal_schema.v0_1";
 pub const CONTINUITY_SEMANTICS_SCHEMA: &str = "continuity_semantics.v1";
 pub const TEMPORAL_QUERY_RETRIEVAL_SCHEMA: &str = "temporal_query_retrieval.v1";
+pub const COMMITMENT_DEADLINE_SCHEMA: &str = "commitment_deadline_semantics.v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdentityProfile {
@@ -172,6 +173,49 @@ pub struct TemporalQueryRetrievalContract {
     pub owned_runtime_surfaces: Vec<String>,
     pub query_primitives: TemporalQueryPrimitiveSet,
     pub retrieval_semantics: TemporalRetrievalSemantics,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommitmentLifecycleContract {
+    pub states: Vec<String>,
+    pub open_states: Vec<String>,
+    pub terminal_states: Vec<String>,
+    pub state_distinctions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommitmentRecordRequirements {
+    pub required_fields: Vec<String>,
+    pub history_requirements: Vec<String>,
+    pub persistence_expectations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeadlineSemanticsContract {
+    pub supported_frames: Vec<String>,
+    pub frame_rule: String,
+    pub explicitness_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MissedCommitmentDetectionContract {
+    pub detection_conditions: Vec<String>,
+    pub visibility_requirements: Vec<String>,
+    pub retrieval_surfaces: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommitmentDeadlineContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub lifecycle: CommitmentLifecycleContract,
+    pub record_requirements: CommitmentRecordRequirements,
+    pub deadline_semantics: DeadlineSemanticsContract,
+    pub missed_commitment_detection: MissedCommitmentDetectionContract,
     pub proof_fixture_hooks: Vec<String>,
     pub proof_hook_command: String,
     pub proof_hook_output_path: String,
@@ -535,7 +579,118 @@ impl TemporalQueryRetrievalContract {
                     .to_string(),
             proof_hook_output_path: ".adl/state/temporal_query_retrieval_v1.json".to_string(),
             scope_boundary:
-                "temporal query/retrieval semantics only; full temporal indexing, causality, commitments, and distributed temporal truth remain downstream work"
+                "temporal query/retrieval semantics only; full temporal indexing, causality, and distributed temporal truth remain downstream work"
+                    .to_string(),
+        }
+    }
+}
+
+impl CommitmentDeadlineContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: COMMITMENT_DEADLINE_SCHEMA.to_string(),
+            owned_runtime_surfaces: vec![
+                "adl::chronosense::CommitmentDeadlineContract".to_string(),
+                "adl::chronosense::CommitmentLifecycleContract".to_string(),
+                "adl::chronosense::DeadlineSemanticsContract".to_string(),
+                "adl::chronosense::MissedCommitmentDetectionContract".to_string(),
+                "adl::chronosense::TemporalQueryRetrievalContract".to_string(),
+                "adl identity commitments".to_string(),
+            ],
+            lifecycle: CommitmentLifecycleContract {
+                states: vec![
+                    "proposed".to_string(),
+                    "accepted".to_string(),
+                    "active".to_string(),
+                    "fulfilled".to_string(),
+                    "deferred".to_string(),
+                    "canceled".to_string(),
+                    "expired".to_string(),
+                    "missed".to_string(),
+                ],
+                open_states: vec![
+                    "accepted".to_string(),
+                    "active".to_string(),
+                    "deferred".to_string(),
+                ],
+                terminal_states: vec![
+                    "fulfilled".to_string(),
+                    "canceled".to_string(),
+                    "expired".to_string(),
+                    "missed".to_string(),
+                ],
+                state_distinctions: vec![
+                    "accepted_and_open_vs_not_yet_accepted".to_string(),
+                    "deferred_vs_silent_neglect".to_string(),
+                    "canceled_vs_fulfilled".to_string(),
+                    "expired_vs_missed".to_string(),
+                ],
+            },
+            record_requirements: CommitmentRecordRequirements {
+                required_fields: vec![
+                    "obligation_or_intended_action".to_string(),
+                    "accepted_by".to_string(),
+                    "applicable_office_or_authority".to_string(),
+                    "created_at".to_string(),
+                    "deadline_or_review_window".to_string(),
+                    "current_status".to_string(),
+                    "fulfillment_conditions".to_string(),
+                ],
+                history_requirements: vec![
+                    "what_changed".to_string(),
+                    "when_it_changed".to_string(),
+                    "why_it_changed".to_string(),
+                ],
+                persistence_expectations: vec![
+                    "remain_queryable_across_runs".to_string(),
+                    "survive_bounded_interruption".to_string(),
+                    "support_honest_resume_or_cancellation".to_string(),
+                ],
+            },
+            deadline_semantics: DeadlineSemanticsContract {
+                supported_frames: vec![
+                    "wall_clock".to_string(),
+                    "event_count".to_string(),
+                    "review_gate".to_string(),
+                    "continuity_relative".to_string(),
+                ],
+                frame_rule: "a deadline is meaningful only relative to an explicit temporal frame"
+                    .to_string(),
+                explicitness_requirements: vec![
+                    "deadline_frame_must_be_named".to_string(),
+                    "review_window_must_be_recorded_when_used".to_string(),
+                    "no_implicit_single_clock_assumption".to_string(),
+                ],
+            },
+            missed_commitment_detection: MissedCommitmentDetectionContract {
+                detection_conditions: vec![
+                    "overdue_active_commitment".to_string(),
+                    "fulfillment_conditions_not_met_before_deadline".to_string(),
+                    "commitment_invalidated_by_interruption_or_context_change".to_string(),
+                ],
+                visibility_requirements: vec![
+                    "missed_commitments_remain_visible_for_review".to_string(),
+                    "missed_commitments_remain_visible_for_accountability".to_string(),
+                    "missed_commitments_remain_visible_for_planning_correction".to_string(),
+                ],
+                retrieval_surfaces: vec![
+                    "open commitments".to_string(),
+                    "approaching deadlines".to_string(),
+                    "missed commitments in interval".to_string(),
+                ],
+            },
+            proof_fixture_hooks: vec![
+                "adl::chronosense::CommitmentDeadlineContract::v1".to_string(),
+                "adl identity commitments --out .adl/state/commitment_deadline_semantics_v1.json"
+                    .to_string(),
+            ],
+            proof_hook_command:
+                "adl identity commitments --out .adl/state/commitment_deadline_semantics_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/commitment_deadline_semantics_v1.json"
+                .to_string(),
+            scope_boundary:
+                "commitment and deadline semantics only; scheduling automation, negotiation, and calendar integration remain downstream work"
                     .to_string(),
         }
     }
@@ -754,5 +909,27 @@ mod tests {
         assert!(contract
             .proof_hook_output_path
             .contains("temporal_query_retrieval_v1.json"));
+    }
+
+    #[test]
+    fn commitment_deadline_contract_matches_runtime_and_review_surfaces() {
+        let contract = CommitmentDeadlineContract::v1();
+
+        assert_eq!(contract.schema_version, COMMITMENT_DEADLINE_SCHEMA);
+        assert!(contract
+            .owned_runtime_surfaces
+            .contains(&"adl identity commitments".to_string()));
+        assert!(contract.lifecycle.states.contains(&"missed".to_string()));
+        assert!(contract
+            .deadline_semantics
+            .supported_frames
+            .contains(&"continuity_relative".to_string()));
+        assert!(contract
+            .missed_commitment_detection
+            .retrieval_surfaces
+            .contains(&"approaching deadlines".to_string()));
+        assert!(contract
+            .proof_hook_output_path
+            .contains("commitment_deadline_semantics_v1.json"));
     }
 }

--- a/adl/src/cli/identity_cmd.rs
+++ b/adl/src/cli/identity_cmd.rs
@@ -7,8 +7,8 @@ use std::process::Command;
 
 use ::adl::chronosense::{
     default_identity_profile_path, load_identity_profile, write_identity_profile,
-    ChronosenseFoundation, ContinuitySemanticsContract, IdentityProfile, TemporalContext,
-    TemporalQueryRetrievalContract, TemporalSchemaContract,
+    ChronosenseFoundation, CommitmentDeadlineContract, ContinuitySemanticsContract,
+    IdentityProfile, TemporalContext, TemporalQueryRetrievalContract, TemporalSchemaContract,
 };
 
 pub(crate) fn real_identity(args: &[String]) -> Result<()> {
@@ -19,7 +19,7 @@ pub(crate) fn real_identity(args: &[String]) -> Result<()> {
 fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "identity requires a subcommand: init | show | now | foundation | schema | continuity | retrieval"
+            "identity requires a subcommand: init | show | now | foundation | schema | continuity | retrieval | commitments"
         ));
     };
 
@@ -31,12 +31,13 @@ fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
         "schema" => real_identity_schema(repo_root, &args[1..]),
         "continuity" => real_identity_continuity(repo_root, &args[1..]),
         "retrieval" => real_identity_retrieval(repo_root, &args[1..]),
+        "commitments" => real_identity_commitments(repo_root, &args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments)"
         )),
     }
 }
@@ -370,6 +371,55 @@ fn real_identity_retrieval(repo_root: &Path, args: &[String]) -> Result<()> {
             )
         })?;
         println!("TEMPORAL_QUERY_RETRIEVAL_PATH={}", resolved.display());
+    } else {
+        println!("{json}");
+    }
+
+    Ok(())
+}
+
+fn real_identity_commitments(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                out_path = Some(PathBuf::from(required_value(args, i, "--out")?));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => return Err(anyhow!("unknown arg for identity commitments: {other}")),
+        }
+        i += 1;
+    }
+
+    let contract = CommitmentDeadlineContract::v1();
+    let json = to_string_pretty(&contract)?;
+
+    if let Some(out) = out_path {
+        let resolved = if out.is_absolute() {
+            out
+        } else {
+            repo_root.join(out)
+        };
+        let Some(parent) = resolved.parent() else {
+            return Err(anyhow!(
+                "identity commitments --out path must have a parent directory"
+            ));
+        };
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+        fs::write(&resolved, json.as_bytes()).with_context(|| {
+            format!(
+                "failed to write commitment deadline artifact to {}",
+                resolved.display()
+            )
+        })?;
+        println!("COMMITMENT_DEADLINE_PATH={}", resolved.display());
     } else {
         println!("{json}");
     }
@@ -958,6 +1008,53 @@ mod tests {
             .contains("unknown arg for identity retrieval: --bogus"));
 
         let err = real_identity_in_repo(&["retrieval".to_string(), "--out".to_string()], &repo)
+            .expect_err("out flag without value should fail");
+        assert!(err.to_string().contains("--out requires a value"));
+    }
+
+    #[test]
+    fn identity_commitments_writes_commitment_deadline_contract_json() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let repo = temp_repo("identity-commitments");
+        let out_path = repo.join(".adl/state/commitment_deadline_semantics_v1.json");
+
+        real_identity_in_repo(
+            &[
+                "commitments".to_string(),
+                "--out".to_string(),
+                ".adl/state/commitment_deadline_semantics_v1.json".to_string(),
+            ],
+            &repo,
+        )
+        .expect("identity commitments");
+
+        let json: Value =
+            serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+        assert_eq!(json["schema_version"], "commitment_deadline_semantics.v1");
+        assert_eq!(
+            json["proof_hook_output_path"],
+            ".adl/state/commitment_deadline_semantics_v1.json"
+        );
+        assert!(json["owned_runtime_surfaces"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "adl identity commitments"));
+    }
+
+    #[test]
+    fn identity_commitments_validates_unknown_args_and_missing_out_value() {
+        let repo = temp_repo("identity-commitments-errors");
+
+        let err = real_identity_in_repo(&["commitments".to_string(), "--bogus".to_string()], &repo)
+            .expect_err("unknown arg should fail");
+        assert!(err
+            .to_string()
+            .contains("unknown arg for identity commitments: --bogus"));
+
+        let err = real_identity_in_repo(&["commitments".to_string(), "--out".to_string()], &repo)
             .expect_err("out flag without value should fail");
         assert!(err.to_string().contains("--out requires a value"));
     }

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -11,6 +11,7 @@ pub fn usage() -> &'static str {
   adl identity schema [--out <path>]
   adl identity continuity [--out <path>]
   adl identity retrieval [--out <path>]
+  adl identity commitments [--out <path>]
   adl provider setup <family> [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]

--- a/docs/milestones/v0.88/features/COMMITMENTS_AND_DEADLINES.md
+++ b/docs/milestones/v0.88/features/COMMITMENTS_AND_DEADLINES.md
@@ -212,6 +212,48 @@ This document does not define:
 
 ---
 
+## Runtime-facing Ownership
+
+For `v0.88`, this feature owns the bounded commitment/deadline contract and proof surface.
+
+Primary owned surfaces:
+- `adl::chronosense::CommitmentDeadlineContract`
+- `adl::chronosense::CommitmentLifecycleContract`
+- `adl::chronosense::DeadlineSemanticsContract`
+- `adl::chronosense::MissedCommitmentDetectionContract`
+- `adl identity commitments`
+
+This `v0.88` slice does not claim full scheduling or negotiation machinery.
+It makes commitment and deadline semantics explicit and reviewable against the temporal
+contracts already introduced in the earlier sprint work.
+
+---
+
+## Bounded Acceptance Criteria
+
+`WP-06` is complete for `v0.88` when:
+- the repo exposes a bounded, reviewable commitment/deadline contract
+- commitment lifecycle states, open/terminal distinctions, and missed-state visibility are explicit
+- deadline frames are named explicitly rather than implied as one universal clock
+- persistence/history requirements are visible in the contract
+- a proof hook emits the contract as a repo-local artifact
+- tests cover the contract and proof-hook surface
+
+This milestone does not require:
+- calendar integration
+- automation scheduling
+- social negotiation over commitments
+- full trust or reputation interpretation
+
+---
+
+## Proof Hook
+
+- Command: `adl identity commitments --out .adl/state/commitment_deadline_semantics_v1.json`
+- Output: `.adl/state/commitment_deadline_semantics_v1.json`
+
+---
+
 ## Summary
 
 Commitments and deadlines give ADL a way to represent the future as an inspectable


### PR DESCRIPTION
Closes #1651

## Summary
Added a bounded commitment/deadline semantics contract for `v0.88`, exposed it through a new
`adl identity commitments` proof hook, and tightened the feature doc so the tracked milestone
claim matches the runtime surface exactly.

## Artifacts
- `adl/src/chronosense.rs`
- `adl/src/cli/identity_cmd.rs`
- `adl/src/cli/usage.rs`
- `docs/milestones/v0.88/features/COMMITMENTS_AND_DEADLINES.md`
- `.adl/state/commitment_deadline_semantics_v1.json`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    - verified the Rust surfaces are formatted consistently.
  - `cargo test --manifest-path adl/Cargo.toml commitment_deadline_contract_matches_runtime_and_review_surfaces -- --nocapture`
    - verified the new commitment/deadline contract exposes the expected runtime and review surfaces.
  - `cargo test --manifest-path adl/Cargo.toml identity_commitments_writes_commitment_deadline_contract_json -- --nocapture`
    - verified the new CLI proof hook writes the commitment/deadline artifact with the expected schema and owned surfaces.
  - `cargo test --manifest-path adl/Cargo.toml identity_commitments_validates_unknown_args_and_missing_out_value -- --nocapture`
    - verified the new CLI surface rejects malformed invocation.
  - `cargo test --manifest-path adl/Cargo.toml temporal_query_retrieval_contract_matches_runtime_and_retrieval_surfaces -- --nocapture`
    - verified the adjacent retrieval contract remains valid after the scope-boundary update.
  - `cargo test --manifest-path adl/Cargo.toml identity_retrieval_writes_temporal_query_retrieval_contract_json -- --nocapture`
    - verified the existing retrieval proof hook still writes the expected artifact after the contract wording change.
  - `cargo run --manifest-path adl/Cargo.toml -- identity commitments --out .adl/state/commitment_deadline_semantics_v1.json`
    - verified the branch emits the new proof artifact at the documented path.
  - `git diff --check`
    - verified the final patch is free of diff hygiene errors.
- Results:
  - all listed commands passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1651__v0-88-wp-06-commitments-and-deadlines/sip.md
- Output card: .adl/v0.88/tasks/issue-1651__v0-88-wp-06-commitments-and-deadlines/sor.md
- Idempotency-Key: v0-88-wp-06-commitments-and-deadlines-adl-docs-adl-v0-88-tasks-issue-1651-v0-88-wp-06-commitments-and-deadlines-sip-md-adl-v0-88-tasks-issue-1651-v0-88-wp-06-commitments-and-deadlines-sor-md