### PR TITLE
[v0.88][tools] Generate WP issue waves from canonical WBS surfaces

### DIFF
--- a/.adl/v0.88/bodies/issue-1667-v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces.md
+++ b/.adl/v0.88/bodies/issue-1667-v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces.md
@@ -1,0 +1,86 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces"
+title: "[v0.88][tools] Generate WP issue waves from canonical WBS surfaces"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.88"
+issue_number: 1667
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces"
+---
+
+## Summary
+
+Create a deterministic WBS-to-issue-wave generator so milestone work packages can be seeded from canonical planning docs without manual re-entry.
+
+## Goal
+
+Generate the main milestone issue wave from the tracked WBS/sprint package so issue creation becomes a reproducible control-plane action instead of a hand-built pass.
+
+## Required Outcome
+
+- the control plane can derive a milestone issue wave from canonical planning inputs
+- generated issues preserve WP ordering, titles, dependency notes, and version/label metadata
+- the generator stops at readiness/bootstrap rather than silently executing work
+
+## Deliverables
+
+- WBS-to-issue-wave generation surface
+- tests covering deterministic generation and metadata parity
+- docs describing the generation contract
+
+## Acceptance Criteria
+
+- a canonical milestone package can produce the expected WP issue wave without hand-copying each issue definition
+- the output is deterministic for identical planning inputs
+- generated issues still stop before branch/worktree creation
+
+## Repo Inputs
+
+- docs/milestones/v0.88/WBS_v0.88.md
+- docs/milestones/v0.88/SPRINT_v0.88.md
+- .adl/docs/TBD/V0_88_WP_READINESS_QUEUE.md
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- no demo required
+
+## Non-goals
+
+- executing generated issues
+- inventing milestone structure outside the tracked package
+
+## Issue-Graph Notes
+
+- child of #1665
+- this issue is the direct control-plane follow-on to the manual v0.88 readiness-wave pass
+
+## Notes
+
+- prefer canonical planning inputs over freeform inference
+
+## Tooling Notes
+
+- bootstrap only in this pass; no execution context creation
+

--- a/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/sip.md
+++ b/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/sip.md
@@ -1,0 +1,174 @@
+# ADL Input Card
+
+Task ID: issue-1667
+Run ID: issue-1667
+Version: v0.88
+Title: [v0.88][tools] Generate WP issue waves from canonical WBS surfaces
+Branch: codex/1667-v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces
+
+Context:
+- Issue: https://github.com/danielbaustin/agent-design-language/issues/1667
+- PR:
+- Source Issue Prompt: .adl/v0.88/bodies/issue-1667-v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces.md
+- Docs: none
+- Other: none
+
+## Agent Execution Rules
+- Do not run `pr start`; the branch and worktree already exist.
+- Do not delete or recreate cards.
+- Do not switch branches unless explicitly instructed.
+- Do not work on `main`.
+- Only modify files required for the issue.
+- Use repository-relative paths; avoid absolute host paths.
+- Write the output record to the paired local task bundle `sor.md` path.
+- If repository state is unexpected, stop and ask before attempting repository repair.
+
+## Prompt Spec
+```yaml
+prompt_schema: adl.v1
+actor:
+  role: execution_agent
+  name: codex
+model:
+  id: gpt-5-codex
+  determinism_mode: stable
+inputs:
+  sections:
+    - goal
+    - required_outcome
+    - acceptance_criteria
+    - inputs
+    - target_files_surfaces
+    - validation_plan
+    - demo_proof_requirements
+    - constraints_policies
+    - system_invariants
+    - reviewer_checklist
+    - non_goals_out_of_scope
+    - notes_risks
+    - instructions_to_agent
+outputs:
+  output_card: .adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/sor.md
+  summary_style: concise_structured
+constraints:
+  include_system_invariants: true
+  include_reviewer_checklist: true
+  disallow_secrets: true
+  disallow_absolute_host_paths: true
+automation_hints:
+  source_issue_prompt_required: true
+  target_files_surfaces_recommended: true
+  validation_plan_required: true
+  required_outcome_type_supported: true
+review_surfaces:
+  - card_review_checklist.v1
+  - card_review_output.v1
+  - card_reviewer_gpt.v1.1
+```
+
+Reviewer protocol IDs are versioned and order-sensitive:
+1. checklist contract
+2. output artifact contract
+3. reviewer behavior contract
+
+Prompt Spec contract notes:
+- Supported section IDs and machine-readable field semantics are defined in `docs/tooling/prompt-spec.md`.
+- Missing required Prompt Spec keys or required boolean `automation_hints` fields should fail lint.
+- Prompt generation must preserve declared section order rather than heuristic extraction.
+
+Execution:
+- Agent:
+- Provider:
+- Tools allowed:
+- Sandbox / approvals:
+- Source issue-prompt slug:
+- Required outcome type:
+- Demo required:
+
+## Goal
+
+Execute the linked issue prompt in this started worktree without rerunning bootstrap commands.
+
+## Required Outcome
+
+- Ship the required outcome type recorded in the linked source issue prompt.
+- Keep the linked issue prompt, repository changes, and output record aligned.
+
+## Acceptance Criteria
+
+- The implementation satisfies the linked source issue prompt.
+- Validation and proof surfaces named below are completed or explicitly marked not applicable.
+
+## Inputs
+- linked source issue prompt
+- root and worktree task bundle cards
+- current repository state for this branch
+
+## Target Files / Surfaces
+- files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt
+
+## Validation Plan
+- Commands to run: derive the exact command set from the linked issue prompt and repo state; record what actually ran in the output card.
+- Tests to run: execute the smallest proving test set for the required outcome.
+- Artifacts or traces: produce or update the proof surfaces required by the linked issue prompt.
+- Reviewer checks: capture any manual review or demo checks in the output card.
+
+## Demo / Proof Requirements
+- Demo set: follow the linked issue prompt.
+- Proof surfaces: use the proof surfaces named by the linked issue prompt and output card.
+- No-demo rationale: if no demo is required, explain why in the output card.
+
+## Constraints / Policies
+- Determinism: keep behavior stable for identical inputs unless the issue explicitly changes semantics.
+- Security and privacy: do not introduce secrets, tokens, prompts, tool arguments, or absolute host paths.
+- Resource limits: prefer the smallest command and test surface that proves the issue is complete.
+
+## System Invariants (must remain true)
+- Deterministic execution for identical inputs.
+- No hidden state or undeclared side effects.
+- Artifacts remain replay-compatible with the replay runner.
+- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.
+- Artifact schema changes are explicit and approved.
+
+## Reviewer Checklist (machine-readable hints)
+```yaml
+determinism_required: true
+network_allowed: false
+artifact_schema_change: false
+replay_required: true
+security_sensitive: true
+ci_validation_required: true
+```
+
+## Card Automation Hooks (prompt generation)
+- Prompt source fields:
+  - Goal
+  - Required Outcome
+  - Acceptance Criteria
+  - Inputs
+  - Target Files / Surfaces
+  - Validation Plan
+  - Demo / Proof Requirements
+  - Constraints / Policies
+  - System Invariants
+  - Reviewer Checklist
+- Generation requirements:
+  - Deterministic output for identical input card content
+  - No secrets, tokens, or absolute host paths in generated prompt text
+  - Preserve traceability back to the source issue prompt
+  - Preserve explicit required-outcome and demo/proof requirements
+
+## Non-goals / Out of scope
+
+- unrelated repository repair
+- changing the source issue prompt without recording it explicitly
+
+## Notes / Risks
+
+- Refine this card if the linked source issue prompt changes materially before implementation begins.
+
+## Instructions to the Agent
+- Read this file.
+- Read the linked source issue prompt before starting work.
+- Do the work described above.
+- Write results to the paired output card file.

--- a/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/sor.md
+++ b/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/sor.md
@@ -24,7 +24,7 @@ Execution:
 - End Time: 2026-04-13T00:33:05Z
 
 ## Summary
-Added a deterministic `adl tooling generate-wp-issue-wave` control-plane generator that derives a stable WP issue-wave plan from the canonical milestone WBS and sprint docs, along with a checked-in `v0.88` proof artifact and operator documentation. The command is intentionally bounded: it emits planning/bootstrap metadata only and does not create issues, branches, or worktrees.
+Added a deterministic `adl tooling generate-wp-issue-wave` control-plane generator that derives a stable WP issue-wave plan from the canonical milestone WBS and sprint docs, along with a checked-in `v0.88` proof artifact and operator documentation. The command is intentionally bounded: it emits planning/bootstrap metadata only and does not create issues, branches, or worktrees. Published for review in PR `#1697`.
 
 ## Artifacts produced
 - `adl/src/cli/tooling_cmd/wp_issue_wave.rs`
@@ -43,14 +43,17 @@ Added a deterministic `adl tooling generate-wp-issue-wave` control-plane generat
 - Verified the conductor twice around this issue: once before execution, where it correctly routed `pre_run -> pr-run`, and once after implementation, where it still classified the issue as `run_bound` and asked for operator escalation instead of routing to `pr-finish`.
 
 ## Main Repo Integration (REQUIRED)
-- Main-repo paths updated: none yet
-- Worktree-only paths remaining: `adl/src/cli/tooling_cmd/wp_issue_wave.rs`, `adl/src/cli/tooling_cmd.rs`, `adl/src/cli/tooling_cmd/tests.rs`, `docs/tooling/WP_ISSUE_WAVE_GENERATION.md`, `docs/tooling/README.md`, `docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml`
-- Integration state: worktree_only
+- Main-repo paths updated: tracked repository paths are updated on the issue branch via PR 1697
+- Worktree-only paths remaining: none
+- Integration state: pr_open
 - Verification scope: worktree
-- Integration method used: direct edits in the bound issue worktree before publication
+- Integration method used: `pr finish` validation followed by manual commit + push + PR creation because ignored local `.adl` issue-bundle paths and unrelated tracked legacy `.adl` residue on `main` blocked the publication guard
 - Verification performed:
-  - `git status --short` verified the intended tracked changes are limited to the issue-scoped code/docs/artifact surfaces.
-  - `ls docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml` / equivalent path checks verified the generated proof artifact exists in the issue worktree.
+  - `bash adl/tools/pr.sh finish 1667 --title "[v0.88][tools] Generate WP issue waves from canonical WBS surfaces" --paths "adl/src/cli/tooling_cmd.rs,adl/src/cli/tooling_cmd/tests.rs,adl/src/cli/tooling_cmd/wp_issue_wave.rs,docs/tooling/README.md,docs/tooling/WP_ISSUE_WAVE_GENERATION.md,docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml"` validated the issue bundle and publication inputs before stopping on ignored local `.adl` issue-bundle paths plus unrelated tracked legacy `.adl` residue on `main`.
+  - `git add ... && git add -f .adl/v0.88/.../issue-1667... && git commit` recorded the intended tracked changes plus the canonical issue bundle on the issue branch.
+  - `git push -u origin codex/1667-v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces` published the issue branch.
+  - `gh pr create --base main --head codex/1667-v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces --title "[v0.88][tools] Generate WP issue waves from canonical WBS surfaces"` opened PR `#1697` with closing linkage for issue `#1667`.
+  - `git status --short` verified the branch was clean before the publication-record correction commit.
 - Result: PASS
 
 Rules:

--- a/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/sor.md
+++ b/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/sor.md
@@ -1,0 +1,169 @@
+# v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces
+
+Canonical Template Source: `adl/templates/cards/output_card_template.md`
+Consumed by: `adl/tools/pr.sh` (`OUTPUT_TEMPLATE`) with legacy fallback support for `.adl/templates/output_card_template.md`.
+
+Execution Record Requirements:
+- The output card is a machine-auditable execution record.
+- All sections must be fully populated. Empty sections, placeholders, or implicit claims are not allowed.
+- Every command listed must include both what was run and what it verified.
+- If something is not applicable, include a one-line justification.
+
+Task ID: issue-1667
+Run ID: issue-1667
+Version: v0.88
+Title: [v0.88][tools] Generate WP issue waves from canonical WBS surfaces
+Branch: codex/1667-v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces
+Status: DONE
+
+Execution:
+- Actor: Codex
+- Model: gpt-5-codex
+- Provider: OpenAI
+- Start Time: 2026-04-12T23:55:00Z
+- End Time: 2026-04-13T00:33:05Z
+
+## Summary
+Added a deterministic `adl tooling generate-wp-issue-wave` control-plane generator that derives a stable WP issue-wave plan from the canonical milestone WBS and sprint docs, along with a checked-in `v0.88` proof artifact and operator documentation. The command is intentionally bounded: it emits planning/bootstrap metadata only and does not create issues, branches, or worktrees.
+
+## Artifacts produced
+- `adl/src/cli/tooling_cmd/wp_issue_wave.rs`
+- `adl/src/cli/tooling_cmd.rs`
+- `adl/src/cli/tooling_cmd/tests.rs`
+- `docs/tooling/WP_ISSUE_WAVE_GENERATION.md`
+- `docs/tooling/README.md`
+- `docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml`
+
+## Actions taken
+- Added a new public tooling command, `adl tooling generate-wp-issue-wave`, with explicit `--version`, `--wbs`, `--sprint`, and `--out` handling.
+- Implemented deterministic parsing of the canonical WBS work-package table and the sprint-overview table, including support for `WP-02 through WP-08` range expansion.
+- Derived stable issue-wave metadata for all WBS rows whose Issue column still says the issue is to be seeded, including title, slug, labels, sprint assignment, dependency notes, and execution-vs-closeout classification.
+- Checked in a generated `docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml` proof artifact produced from the live `v0.88` milestone package.
+- Added operator-facing documentation describing the command contract, truth boundary, and deterministic behavior.
+- Verified the conductor twice around this issue: once before execution, where it correctly routed `pre_run -> pr-run`, and once after implementation, where it still classified the issue as `run_bound` and asked for operator escalation instead of routing to `pr-finish`.
+
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated: none yet
+- Worktree-only paths remaining: `adl/src/cli/tooling_cmd/wp_issue_wave.rs`, `adl/src/cli/tooling_cmd.rs`, `adl/src/cli/tooling_cmd/tests.rs`, `docs/tooling/WP_ISSUE_WAVE_GENERATION.md`, `docs/tooling/README.md`, `docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml`
+- Integration state: worktree_only
+- Verification scope: worktree
+- Integration method used: direct edits in the bound issue worktree before publication
+- Verification performed:
+  - `git status --short` verified the intended tracked changes are limited to the issue-scoped code/docs/artifact surfaces.
+  - `ls docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml` / equivalent path checks verified the generated proof artifact exists in the issue worktree.
+- Result: PASS
+
+Rules:
+- Final artifacts must exist in the main repository, not only in a worktree.
+- Do not leave docs, code, or generated artifacts only under a `adl-wp-*` worktree.
+- Prefer git-aware transfer into the main repo (`git checkout <branch> -- <path>` or commit + cherry-pick).
+- If artifacts exist only in the worktree, the task is NOT complete.
+- `Integration state` describes lifecycle state of the integrated artifact set, not where verification happened.
+- `Verification scope` describes where the verification commands were run.
+- `worktree_only` means at least one required path still exists only outside the main repository path.
+- `pr_open` should pair with truthful `Worktree-only paths remaining` content; list those paths when they still exist only in the worktree or say `none` only when the branch contents are fully represented in the main repository path.
+- If `Integration state` is `pr_open`, verify the actual proof artifacts rather than only the containing directory or card path.
+- If `Integration method used` is `direct write in main repo`, `Verification scope` should normally be `main_repo` unless the deviation is explained.
+- If `Verification scope` and `Integration method used` differ in a non-obvious way, explain the difference in one line.
+- Completed output records must not leave `Status` as `NOT_STARTED`.
+- By `pr finish`, `Status` should normally be `DONE` (or `FAILED` if the run failed and the record is documenting that failure).
+
+## Validation
+- Validation commands and their purpose:
+  - `cargo test --manifest-path adl/Cargo.toml generate_wave_doc_from_v088_surfaces_is_deterministic_and_complete -- --nocapture` verified the generator deterministically derives the full `v0.88` wave from the live canonical WBS and sprint docs.
+  - `cargo test --manifest-path adl/Cargo.toml tooling_dispatch_and_help_paths_cover_public_entrypoint -- --nocapture` verified the new command is reachable through the public `adl tooling` dispatch surface.
+  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` verified the Rust changes are formatted canonically.
+  - `cargo run --manifest-path adl/Cargo.toml -- tooling generate-wp-issue-wave --version v0.88 --out <tmp>` followed by `diff -u <tmp> docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml` verified the checked-in `v0.88` wave artifact matches a fresh deterministic regeneration.
+  - `python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <tmp-input.json> --artifact-path .adl/reviews/workflow-conductor-1667-post-implementation.md` verified the conductor can still route the live issue through its canonical schema-driven entrypoint, and surfaced the current post-implementation classification gap.
+  - `git diff --check` verified there are no whitespace or malformed patch artifacts in the tracked changes.
+- Results: all listed validation commands passed.
+
+Validation command/path rules:
+- Prefer repository-relative paths in recorded commands and artifact references.
+- Do not record absolute host paths in output records unless they are explicitly required and justified.
+- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
+- Do not list commands without describing their effect.
+
+## Verification Summary
+
+Rules:
+- Replace the example values below with one actual final value per field.
+- Do not leave pipe-delimited enum menus or placeholder text in a finished record.
+
+```yaml
+verification_summary:
+  validation:
+    status: PASS
+    checks_run:
+      - "cargo test --manifest-path adl/Cargo.toml generate_wave_doc_from_v088_surfaces_is_deterministic_and_complete -- --nocapture"
+      - "cargo test --manifest-path adl/Cargo.toml tooling_dispatch_and_help_paths_cover_public_entrypoint -- --nocapture"
+      - "cargo fmt --manifest-path adl/Cargo.toml --all -- --check"
+      - "cargo run --manifest-path adl/Cargo.toml -- tooling generate-wp-issue-wave --version v0.88 --out <tmp> && diff -u <tmp> docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml"
+      - "python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <tmp-input.json> --artifact-path .adl/reviews/workflow-conductor-1667-post-implementation.md"
+      - "git diff --check"
+  determinism:
+    status: PASS
+    replay_verified: true
+    ordering_guarantees_verified: true
+  security_privacy:
+    status: PASS
+    secrets_leakage_detected: false
+    prompt_or_tool_arg_leakage_detected: false
+    absolute_path_leakage_detected: false
+  artifacts:
+    status: PASS
+    required_artifacts_present: true
+    schema_changes:
+      present: true
+      approved: not_applicable
+```
+
+## Determinism Evidence
+- Determinism tests executed: reran the generator-specific Rust test and regenerated the checked-in `v0.88` wave artifact into a temporary path before diffing it against the committed YAML.
+- Fixtures or scripts used: `cargo test --manifest-path adl/Cargo.toml generate_wave_doc_from_v088_surfaces_is_deterministic_and_complete -- --nocapture`, `cargo run --manifest-path adl/Cargo.toml -- tooling generate-wp-issue-wave --version v0.88 --out <tmp>`, and `diff -u`.
+- Replay verification (same inputs -> same artifacts/order): identical WBS and sprint inputs produce the same ordered wave entries and the same emitted YAML content for `docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml`.
+- Ordering guarantees (sorting / tie-break rules used): WBS rows preserve canonical WBS order, sprint mapping expands range notation deterministically, and range-derived dependency refs are emitted in ascending WP order.
+- Artifact stability notes: the command does not read GitHub or timestamps, so the output is controlled entirely by the tracked WBS and sprint docs.
+
+Rules:
+- If deterministic fixtures or scripts are used, describe them as determinism evidence rather than merely listing them.
+- State what guarantee is being proven (for example byte-for-byte equality, stable ordering, or stable emitted record content).
+- If a script or fixture can be rerun to reproduce the same result, that counts as replay and should be described that way.
+
+## Security / Privacy Checks
+- Secret leakage scan performed: manual review of the new tooling module, generated YAML, and docs for credentials or tokens; none were introduced.
+- Prompt / tool argument redaction verified: yes; the generated wave artifact records only milestone planning metadata and does not persist prompts, secrets, or arbitrary tool arguments.
+- Absolute path leakage check: `git diff --check` passed, and the tracked docs/artifact use repository-relative paths only.
+- Sandbox / policy invariants preserved: yes; the generator remains planning-only and does not create issues, bind worktrees, or mutate GitHub state.
+
+Rules:
+- State what was checked and how it was checked.
+- Do not leave any field blank; if a check truly does not apply, give a one-line reason.
+
+## Replay Artifacts
+- Trace bundle path(s): not applicable; this tooling issue does not produce a runtime trace bundle.
+- Run artifact root: `docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml`
+- Replay command used for verification: `cargo run --manifest-path adl/Cargo.toml -- tooling generate-wp-issue-wave --version v0.88 --out <tmp>` followed by `diff -u <tmp> docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml`
+- Replay result: pass; the checked-in artifact matched a fresh regeneration byte-for-byte.
+
+## Artifact Verification
+- Primary proof surface: `docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml`
+- Required artifacts present: yes; the new tooling module, dispatch/docs updates, and the generated `v0.88` wave artifact are present in the issue worktree.
+- Artifact schema/version checks: the generated artifact declares `schema: adl.wp_issue_wave.v1`, and the public docs describe the bounded input/output contract.
+- Hash/byte-stability checks: no separate hash file was added; deterministic regeneration and `diff -u` were used as the byte-stability check.
+- Missing/optional artifacts and rationale: no GitHub-created issue bundle is expected here because issue creation/init enforcement belongs to follow-on control-plane issues in the same tranche.
+
+## Decisions / Deviations
+- Kept the new generator under the existing `adl tooling` public surface rather than embedding it into the conductor or `pr.sh`, so the output remains a bounded planning artifact instead of a hidden execution engine.
+- Emitted only rows whose WBS Issue column still says they are to be seeded, which keeps the wave artifact focused on the still-pending canonical work-package issues.
+- Preserved the existing `v0.88` public issue wave as repo truth instead of trying to retroactively mutate GitHub from this issue.
+- The source issue prompt still references `.adl/docs/TBD/V0_88_WP_READINESS_QUEUE.md`, but that file does not exist in current repo state; the implementation used the live WBS and sprint docs directly and records that stale input reference here as a repo-process note.
+- The conductor remained helpful before execution, but after implementation it still classified the live issue as `run_bound` with `open_pr_wave_only` and routed to `pr-run`/`ask_operator` instead of `pr-finish`; that maturity gap is recorded rather than widened into another conductor refactor here.
+
+## Follow-ups / Deferred work
+- Create/init enforcement that consumes the generated wave and turns it into ready bootstrap issue surfaces remains owned by follow-on issues in the `#1665` control-plane tranche.
+- The conductor still needs stronger post-implementation/publication-state detection so completed issues route to `pr-finish` more reliably without operator-shaped payloads.
+
+Global rule:
+- No section header may be left empty.
+- If a field is included, it must contain either concrete content or a one-line justification for why it does not apply.

--- a/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/stp.md
+++ b/.adl/v0.88/tasks/issue-1667__v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces/stp.md
@@ -1,0 +1,86 @@
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+slug: "v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces"
+title: "[v0.88][tools] Generate WP issue waves from canonical WBS surfaces"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.88"
+issue_number: 1667
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Mirrored from the authored GitHub issue body during bootstrap/init."
+pr_start:
+  enabled: false
+  slug: "v0-88-tools-generate-wp-issue-waves-from-canonical-wbs-surfaces"
+---
+
+## Summary
+
+Create a deterministic WBS-to-issue-wave generator so milestone work packages can be seeded from canonical planning docs without manual re-entry.
+
+## Goal
+
+Generate the main milestone issue wave from the tracked WBS/sprint package so issue creation becomes a reproducible control-plane action instead of a hand-built pass.
+
+## Required Outcome
+
+- the control plane can derive a milestone issue wave from canonical planning inputs
+- generated issues preserve WP ordering, titles, dependency notes, and version/label metadata
+- the generator stops at readiness/bootstrap rather than silently executing work
+
+## Deliverables
+
+- WBS-to-issue-wave generation surface
+- tests covering deterministic generation and metadata parity
+- docs describing the generation contract
+
+## Acceptance Criteria
+
+- a canonical milestone package can produce the expected WP issue wave without hand-copying each issue definition
+- the output is deterministic for identical planning inputs
+- generated issues still stop before branch/worktree creation
+
+## Repo Inputs
+
+- docs/milestones/v0.88/WBS_v0.88.md
+- docs/milestones/v0.88/SPRINT_v0.88.md
+- .adl/docs/TBD/V0_88_WP_READINESS_QUEUE.md
+
+## Dependencies
+
+- none
+
+## Demo Expectations
+
+- no demo required
+
+## Non-goals
+
+- executing generated issues
+- inventing milestone structure outside the tracked package
+
+## Issue-Graph Notes
+
+- child of #1665
+- this issue is the direct control-plane follow-on to the manual v0.88 readiness-wave pass
+
+## Notes
+
+- prefer canonical planning inputs over freeform inference
+
+## Tooling Notes
+
+- bootstrap only in this pass; no execution context creation
+

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -12,11 +12,14 @@ mod review_contract;
 mod review_surface;
 #[path = "tooling_cmd/structured_prompt.rs"]
 mod structured_prompt;
+#[path = "tooling_cmd/wp_issue_wave.rs"]
+mod wp_issue_wave;
 
 use card_prompt::real_card_prompt;
 use review_contract::{real_verify_repo_review_contract, real_verify_review_output_provenance};
 use review_surface::{real_review_card_surface, real_review_runtime_surface};
 use structured_prompt::{real_lint_prompt_spec, real_validate_structured_prompt};
+use wp_issue_wave::real_generate_wp_issue_wave;
 
 #[cfg(test)]
 use common::{
@@ -42,12 +45,13 @@ use structured_prompt::{
 pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "tooling requires a subcommand: card-prompt | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract"
+            "tooling requires a subcommand: card-prompt | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
         ));
     };
 
     match subcommand {
         "card-prompt" => real_card_prompt(&args[1..]),
+        "generate-wp-issue-wave" => real_generate_wp_issue_wave(&args[1..]),
         "lint-prompt-spec" => real_lint_prompt_spec(&args[1..]),
         "validate-structured-prompt" => real_validate_structured_prompt(&args[1..]),
         "review-card-surface" => real_review_card_surface(&args[1..]),
@@ -59,7 +63,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown tooling subcommand '{subcommand}' (expected card-prompt | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract)"
+            "unknown tooling subcommand '{subcommand}' (expected card-prompt | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave)"
         )),
     }
 }
@@ -67,6 +71,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
 fn tooling_usage() -> &'static str {
     "adl tooling card-prompt --issue <number> [--out <path>]\n\
 adl tooling card-prompt --input <path> [--out <path>]\n\
+adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\
 adl tooling lint-prompt-spec --issue <number>\n\
 adl tooling lint-prompt-spec --input <path>\n\
 adl tooling validate-structured-prompt --type <stp|sip|sor> --input <path> [--phase <phase>]\n\

--- a/adl/src/cli/tooling_cmd/tests.rs
+++ b/adl/src/cli/tooling_cmd/tests.rs
@@ -855,6 +855,32 @@ fn tooling_dispatch_and_help_paths_cover_public_entrypoint() {
     .expect("card-prompt dispatch should succeed");
     assert!(prompt_out.is_file());
 
+    let wbs = repo.write_rel(
+        ".tmp/tooling_cmd_tests/wbs.md",
+        "# Work Breakdown Structure (WBS) - v0.88\n\n## Work Packages\n\n| ID | Work Package | Description | Deliverable | Dependencies | Issue |\n|---|---|---|---|---|---|\n| WP-01 | Canonical planning package | docs | docs | none | `#1` |\n| WP-02 | Chronosense foundation | chrono | proof hook | `WP-01` | execution issue to be seeded |\n| WP-14 | Coverage / quality gate | quality | green gate | `WP-13` | closeout issue to be seeded |\n",
+    );
+    let sprint = repo.write_rel(
+        ".tmp/tooling_cmd_tests/sprint.md",
+        "# Sprint Plan - v0.88\n\n## Sprint Overview\n\n| Sprint | Purpose | WPs | Current status |\n|---|---|---|---|\n| `v0.88-s1` | temporal | `WP-01` through `WP-08` | active |\n| `v0.88-s3` | closeout | `WP-14` through `WP-20` | not started |\n",
+    );
+    let wave_out = repo.path().join("wave.yaml");
+    real_tooling(&[
+        "generate-wp-issue-wave".to_string(),
+        "--version".to_string(),
+        "v0.88".to_string(),
+        "--wbs".to_string(),
+        wbs.to_string_lossy().to_string(),
+        "--sprint".to_string(),
+        sprint.to_string_lossy().to_string(),
+        "--out".to_string(),
+        wave_out.to_string_lossy().to_string(),
+    ])
+    .expect("wave generation dispatch should succeed");
+    let wave_text = fs::read_to_string(&wave_out).expect("wave output");
+    assert!(wave_text.contains("schema: adl.wp_issue_wave.v1"));
+    assert!(wave_text.contains("title: '[v0.88][WP-02] Chronosense foundation'"));
+    assert!(wave_text.contains("area:quality"));
+
     real_tooling(&[
         "lint-prompt-spec".to_string(),
         "--input".to_string(),

--- a/adl/src/cli/tooling_cmd/wp_issue_wave.rs
+++ b/adl/src/cli/tooling_cmd/wp_issue_wave.rs
@@ -1,0 +1,446 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::common::{repo_relative_display, repo_root};
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct WaveDoc {
+    schema: &'static str,
+    version: String,
+    sources: WaveSources,
+    entries: Vec<WaveEntry>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct WaveSources {
+    wbs: String,
+    sprint: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct WaveEntry {
+    wp: String,
+    issue_kind: String,
+    title: String,
+    slug: String,
+    queue: String,
+    labels: Vec<String>,
+    milestone_sprint: String,
+    sprint_id: String,
+    dependencies: Vec<String>,
+    dependency_notes: String,
+    work_package: String,
+    summary: String,
+    deliverable: String,
+    issue_column: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WbsRow {
+    wp: String,
+    work_package: String,
+    description: String,
+    deliverable: String,
+    dependencies: Vec<String>,
+    dependency_notes: String,
+    issue_column: String,
+}
+
+pub(crate) fn real_generate_wp_issue_wave(args: &[String]) -> Result<()> {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+    {
+        println!(
+            "adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]"
+        );
+        return Ok(());
+    }
+
+    let parsed = parse_args(args)?;
+    let repo = repo_root()?;
+    let default_wbs = repo.join(format!("docs/milestones/{0}/WBS_{0}.md", parsed.version));
+    let default_sprint = repo.join(format!("docs/milestones/{0}/SPRINT_{0}.md", parsed.version));
+    let wbs_path = absolutize_from_repo(&repo, parsed.wbs.unwrap_or(default_wbs));
+    let sprint_path = absolutize_from_repo(&repo, parsed.sprint.unwrap_or(default_sprint));
+
+    let wbs_text = fs::read_to_string(&wbs_path)
+        .with_context(|| format!("read WBS file: {}", wbs_path.display()))?;
+    let sprint_text = fs::read_to_string(&sprint_path)
+        .with_context(|| format!("read sprint file: {}", sprint_path.display()))?;
+
+    let wave = generate_wave_doc(
+        &parsed.version,
+        &wbs_text,
+        &sprint_text,
+        &repo_relative_display(&repo, &wbs_path)?,
+        &repo_relative_display(&repo, &sprint_path)?,
+    )?;
+    let rendered = serde_yaml::to_string(&wave)?;
+
+    if let Some(out) = parsed.out {
+        let out = absolutize_from_repo(&repo, out);
+        if let Some(parent) = out.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&out, rendered)?;
+    } else {
+        print!("{rendered}");
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct GenerateArgs {
+    version: String,
+    wbs: Option<PathBuf>,
+    sprint: Option<PathBuf>,
+    out: Option<PathBuf>,
+}
+
+fn parse_args(args: &[String]) -> Result<GenerateArgs> {
+    let mut parsed = GenerateArgs::default();
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--version" => {
+                parsed.version = require_value(args, i, "--version")?;
+                i += 1;
+            }
+            "--wbs" => {
+                parsed.wbs = Some(PathBuf::from(require_value(args, i, "--wbs")?));
+                i += 1;
+            }
+            "--sprint" => {
+                parsed.sprint = Some(PathBuf::from(require_value(args, i, "--sprint")?));
+                i += 1;
+            }
+            "--out" => {
+                parsed.out = Some(PathBuf::from(require_value(args, i, "--out")?));
+                i += 1;
+            }
+            other => bail!("generate-wp-issue-wave: unknown arg: {other}"),
+        }
+        i += 1;
+    }
+
+    if parsed.version.trim().is_empty() {
+        bail!("generate-wp-issue-wave: --version is required");
+    }
+
+    Ok(parsed)
+}
+
+fn require_value(args: &[String], index: usize, flag: &str) -> Result<String> {
+    args.get(index + 1)
+        .cloned()
+        .ok_or_else(|| anyhow!("generate-wp-issue-wave: missing value for {flag}"))
+}
+
+fn absolutize_from_repo(repo_root: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        repo_root.join(path)
+    }
+}
+
+fn generate_wave_doc(
+    version: &str,
+    wbs_text: &str,
+    sprint_text: &str,
+    wbs_rel: &str,
+    sprint_rel: &str,
+) -> Result<WaveDoc> {
+    let sprint_map = parse_sprint_overview(sprint_text)?;
+    let entries = parse_wbs_rows(wbs_text)?
+        .into_iter()
+        .filter(|row| row.issue_column.contains("to be seeded"))
+        .map(|row| build_entry(version, &row, &sprint_map))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(WaveDoc {
+        schema: "adl.wp_issue_wave.v1",
+        version: version.to_string(),
+        sources: WaveSources {
+            wbs: wbs_rel.to_string(),
+            sprint: sprint_rel.to_string(),
+        },
+        entries,
+    })
+}
+
+fn build_entry(
+    version: &str,
+    row: &WbsRow,
+    sprint_map: &BTreeMap<String, (String, String)>,
+) -> Result<WaveEntry> {
+    let Some((sprint_id, sprint_label)) = sprint_map.get(&row.wp) else {
+        bail!("no sprint mapping found for {}", row.wp);
+    };
+    let area = infer_area(&row.work_package, &row.issue_column);
+    let slug = format!(
+        "{}-{}-{}",
+        slugify(version),
+        slugify(&row.wp),
+        slugify(&row.work_package)
+    );
+    Ok(WaveEntry {
+        wp: row.wp.clone(),
+        issue_kind: if row.issue_column.contains("closeout issue to be seeded") {
+            "closeout".to_string()
+        } else {
+            "execution".to_string()
+        },
+        title: format!("[{version}][{}] {}", row.wp, row.work_package),
+        slug,
+        queue: "wp".to_string(),
+        labels: vec![
+            "track:roadmap".to_string(),
+            "type:task".to_string(),
+            format!("area:{area}"),
+            format!("version:{version}"),
+        ],
+        milestone_sprint: sprint_label.clone(),
+        sprint_id: sprint_id.clone(),
+        dependencies: row.dependencies.clone(),
+        dependency_notes: row.dependency_notes.clone(),
+        work_package: row.work_package.clone(),
+        summary: row.description.clone(),
+        deliverable: row.deliverable.clone(),
+        issue_column: row.issue_column.clone(),
+    })
+}
+
+fn infer_area(work_package: &str, issue_column: &str) -> &'static str {
+    let lowered = work_package.to_lowercase();
+    if issue_column.contains("closeout issue to be seeded") {
+        if lowered.contains("release") {
+            "release"
+        } else if lowered.contains("docs") || lowered.contains("next milestone planning") {
+            "docs"
+        } else if lowered.contains("quality") || lowered.contains("coverage") {
+            "quality"
+        } else {
+            "review"
+        }
+    } else if lowered.contains("demo") || lowered.contains("paper sonata") {
+        "demo"
+    } else {
+        "runtime"
+    }
+}
+
+fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
+    let mut rows = Vec::new();
+    let table = extract_markdown_table(text, "## Work Packages")?;
+    for line in table.into_iter().skip(2) {
+        let cols = split_markdown_row(&line);
+        if cols.len() != 6 {
+            bail!(
+                "unexpected WBS table shape: expected 6 columns, got {}",
+                cols.len()
+            );
+        }
+        rows.push(WbsRow {
+            wp: cols[0].to_string(),
+            work_package: cols[1].to_string(),
+            description: cols[2].to_string(),
+            deliverable: cols[3].to_string(),
+            dependencies: extract_wp_refs(cols[4]),
+            dependency_notes: cols[4].to_string(),
+            issue_column: cols[5].to_string(),
+        });
+    }
+    Ok(rows)
+}
+
+fn parse_sprint_overview(text: &str) -> Result<BTreeMap<String, (String, String)>> {
+    let table = extract_markdown_table(text, "## Sprint Overview")?;
+    let mut mapping = BTreeMap::new();
+    for line in table.into_iter().skip(2) {
+        let cols = split_markdown_row(&line);
+        if cols.len() != 4 {
+            bail!(
+                "unexpected sprint overview table shape: expected 4 columns, got {}",
+                cols.len()
+            );
+        }
+        let sprint_id = cols[0].trim_matches('`').to_string();
+        let sprint_label = sprint_display_label(&sprint_id);
+        for wp in extract_wp_refs(cols[2]) {
+            mapping.insert(wp, (sprint_id.clone(), sprint_label.clone()));
+        }
+    }
+    Ok(mapping)
+}
+
+fn sprint_display_label(sprint_id: &str) -> String {
+    if let Some((_, suffix)) = sprint_id.rsplit_once("-s") {
+        if suffix.chars().all(|ch| ch.is_ascii_digit()) {
+            return format!("Sprint {suffix}");
+        }
+    }
+    sprint_id.to_string()
+}
+
+fn extract_markdown_table(text: &str, heading: &str) -> Result<Vec<String>> {
+    let mut in_section = false;
+    let mut rows = Vec::new();
+    for raw_line in text.lines() {
+        let line = raw_line.trim_end();
+        if line.trim() == heading {
+            in_section = true;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if line.starts_with("## ") && !rows.is_empty() {
+            break;
+        }
+        if line.trim_start().starts_with('|') {
+            rows.push(line.trim().to_string());
+        } else if !rows.is_empty() && !line.trim().is_empty() {
+            break;
+        }
+    }
+
+    if rows.len() < 3 {
+        bail!("unable to find markdown table under heading '{heading}'");
+    }
+
+    Ok(rows)
+}
+
+fn split_markdown_row(line: &str) -> Vec<&str> {
+    line.trim()
+        .trim_matches('|')
+        .split('|')
+        .map(|part| part.trim())
+        .collect()
+}
+
+fn extract_wp_refs(text: &str) -> Vec<String> {
+    let bytes = text.as_bytes();
+    let mut refs = Vec::new();
+    let mut idx = 0usize;
+    while idx + 5 <= bytes.len() {
+        if &bytes[idx..idx + 3] == b"WP-" {
+            let mut end = idx + 3;
+            while end < bytes.len() && bytes[end].is_ascii_digit() {
+                end += 1;
+            }
+            if end > idx + 3 {
+                refs.push(text[idx..end].to_string());
+                idx = end;
+                continue;
+            }
+        }
+        idx += 1;
+    }
+    if text.contains("through") && refs.len() == 2 {
+        if let (Some(start), Some(end)) = (parse_wp_number(&refs[0]), parse_wp_number(&refs[1])) {
+            if start <= end {
+                return (start..=end)
+                    .map(|value| format!("WP-{value:02}"))
+                    .collect();
+            }
+        }
+    }
+    refs
+}
+
+fn parse_wp_number(value: &str) -> Option<u32> {
+    value.strip_prefix("WP-")?.parse::<u32>().ok()
+}
+
+fn slugify(value: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = false;
+    for ch in value.chars() {
+        let mapped = match ch {
+            'A'..='Z' => ch.to_ascii_lowercase(),
+            'a'..='z' | '0'..='9' => ch,
+            _ => '-',
+        };
+        if mapped == '-' {
+            if !out.is_empty() && !prev_dash {
+                out.push('-');
+            }
+            prev_dash = true;
+        } else {
+            out.push(mapped);
+            prev_dash = false;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_wp_refs_handles_lists_and_ranges() {
+        assert_eq!(
+            extract_wp_refs("`WP-02` through `WP-08`"),
+            vec!["WP-02", "WP-08"]
+        );
+        assert_eq!(
+            extract_wp_refs("`WP-09`, `WP-10`, `WP-11`"),
+            vec!["WP-09", "WP-10", "WP-11"]
+        );
+    }
+
+    #[test]
+    fn generate_wave_doc_from_v088_surfaces_is_deterministic_and_complete() {
+        let wbs = include_str!("../../../../docs/milestones/v0.88/WBS_v0.88.md");
+        let sprint = include_str!("../../../../docs/milestones/v0.88/SPRINT_v0.88.md");
+
+        let first = generate_wave_doc(
+            "v0.88",
+            wbs,
+            sprint,
+            "docs/milestones/v0.88/WBS_v0.88.md",
+            "docs/milestones/v0.88/SPRINT_v0.88.md",
+        )
+        .expect("generate first");
+        let second = generate_wave_doc(
+            "v0.88",
+            wbs,
+            sprint,
+            "docs/milestones/v0.88/WBS_v0.88.md",
+            "docs/milestones/v0.88/SPRINT_v0.88.md",
+        )
+        .expect("generate second");
+
+        assert_eq!(first, second);
+        assert_eq!(first.entries.len(), 19);
+        assert_eq!(first.entries.first().unwrap().wp, "WP-02");
+        assert_eq!(
+            first.entries.first().unwrap().title,
+            "[v0.88][WP-02] Chronosense foundation"
+        );
+        assert_eq!(
+            first.entries.first().unwrap().labels,
+            vec![
+                "track:roadmap",
+                "type:task",
+                "area:runtime",
+                "version:v0.88"
+            ]
+        );
+        assert_eq!(first.entries.first().unwrap().milestone_sprint, "Sprint 1");
+        assert_eq!(first.entries.first().unwrap().dependencies, vec!["WP-01"]);
+        assert_eq!(first.entries[10].wp, "WP-12");
+        assert_eq!(first.entries[10].labels[2], "area:demo");
+        assert_eq!(first.entries.last().unwrap().wp, "WP-20");
+        assert_eq!(first.entries.last().unwrap().issue_kind, "closeout");
+        assert_eq!(first.entries.last().unwrap().labels[2], "area:release");
+    }
+}

--- a/adl/src/cli/tooling_cmd/wp_issue_wave.rs
+++ b/adl/src/cli/tooling_cmd/wp_issue_wave.rs
@@ -389,7 +389,7 @@ mod tests {
     fn extract_wp_refs_handles_lists_and_ranges() {
         assert_eq!(
             extract_wp_refs("`WP-02` through `WP-08`"),
-            vec!["WP-02", "WP-08"]
+            vec!["WP-02", "WP-03", "WP-04", "WP-05", "WP-06", "WP-07", "WP-08"]
         );
         assert_eq!(
             extract_wp_refs("`WP-09`, `WP-10`, `WP-11`"),

--- a/docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml
+++ b/docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml
@@ -1,0 +1,399 @@
+schema: adl.wp_issue_wave.v1
+version: v0.88
+sources:
+  wbs: docs/milestones/v0.88/WBS_v0.88.md
+  sprint: docs/milestones/v0.88/SPRINT_v0.88.md
+entries:
+- wp: WP-02
+  issue_kind: execution
+  title: '[v0.88][WP-02] Chronosense foundation'
+  slug: v0-88-wp-02-chronosense-foundation
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 1
+  sprint_id: v0.88-s1
+  dependencies:
+  - WP-01
+  dependency_notes: '`WP-01`'
+  work_package: Chronosense foundation
+  summary: establish the conceptual chronosense substrate
+  deliverable: runtime-facing chronosense definitions, acceptance criteria, and at least one bounded proof hook
+  issue_column: execution issue to be seeded
+- wp: WP-03
+  issue_kind: execution
+  title: '[v0.88][WP-03] Temporal schema'
+  slug: v0-88-wp-03-temporal-schema
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 1
+  sprint_id: v0.88-s1
+  dependencies:
+  - WP-01
+  dependency_notes: '`WP-01`'
+  work_package: Temporal schema
+  summary: define temporal anchors, clocks, and execution-policy trace hooks
+  deliverable: concrete schema fields, runtime serialization surface, and targeted tests
+  issue_column: execution issue to be seeded
+- wp: WP-04
+  issue_kind: execution
+  title: '[v0.88][WP-04] Continuity and identity semantics'
+  slug: v0-88-wp-04-continuity-and-identity-semantics
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 1
+  sprint_id: v0.88-s1
+  dependencies:
+  - WP-02
+  - WP-03
+  dependency_notes: '`WP-02`, `WP-03`'
+  work_package: Continuity and identity semantics
+  summary: ground continuity, interruption, resumption, and identity semantics in temporal structure
+  deliverable: continuity artifact contract, implementation slice, and at least one proof fixture
+  issue_column: execution issue to be seeded
+- wp: WP-05
+  issue_kind: execution
+  title: '[v0.88][WP-05] Temporal query and retrieval'
+  slug: v0-88-wp-05-temporal-query-and-retrieval
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 1
+  sprint_id: v0.88-s1
+  dependencies:
+  - WP-03
+  dependency_notes: '`WP-03`'
+  work_package: Temporal query and retrieval
+  summary: make time-aware retrieval and staleness queryable
+  deliverable: query surface, fixture-backed examples, and validation tests
+  issue_column: execution issue to be seeded
+- wp: WP-06
+  issue_kind: execution
+  title: '[v0.88][WP-06] Commitments and deadlines'
+  slug: v0-88-wp-06-commitments-and-deadlines
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 1
+  sprint_id: v0.88-s1
+  dependencies:
+  - WP-03
+  - WP-05
+  dependency_notes: '`WP-03`, `WP-05`'
+  work_package: Commitments and deadlines
+  summary: represent future obligations and missed commitments as first-class temporal records
+  deliverable: commitment/deadline artifact model, bounded runtime path, and proof fixtures
+  issue_column: execution issue to be seeded; bounded pull-in `#1614`
+- wp: WP-07
+  issue_kind: execution
+  title: '[v0.88][WP-07] Temporal causality and explanation'
+  slug: v0-88-wp-07-temporal-causality-and-explanation
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 1
+  sprint_id: v0.88-s1
+  dependencies:
+  - WP-03
+  - WP-05
+  dependency_notes: '`WP-03`, `WP-05`'
+  work_package: Temporal causality and explanation
+  summary: define bounded causal / explanatory review surfaces
+  deliverable: explanation artifact format, bounded evaluation path, and reviewer-facing examples
+  issue_column: execution issue to be seeded
+- wp: WP-08
+  issue_kind: execution
+  title: '[v0.88][WP-08] Execution policy and cost model'
+  slug: v0-88-wp-08-execution-policy-and-cost-model
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 1
+  sprint_id: v0.88-s1
+  dependencies:
+  - WP-03
+  dependency_notes: '`WP-03`'
+  work_package: Execution policy and cost model
+  summary: tie execution mode and realized cost back to trace reviewability
+  deliverable: execution-policy contract, cost fields/artifacts, and comparison proof path
+  issue_column: execution issue to be seeded
+- wp: WP-09
+  issue_kind: execution
+  title: '[v0.88][WP-09] PHI-style integration metrics'
+  slug: v0-88-wp-09-phi-style-integration-metrics
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 2
+  sprint_id: v0.88-s2
+  dependencies:
+  - WP-02
+  - WP-03
+  - WP-04
+  - WP-05
+  - WP-06
+  - WP-07
+  - WP-08
+  dependency_notes: '`WP-02` through `WP-08`'
+  work_package: PHI-style integration metrics
+  summary: define bounded engineering metrics for integration, irreducibility, coupling, and adaptive depth in ADL systems
+  deliverable: metric definitions, comparison runner or fixture set, and reviewable outputs
+  issue_column: execution issue to be seeded
+- wp: WP-10
+  issue_kind: execution
+  title: '[v0.88][WP-10] Instinct model'
+  slug: v0-88-wp-10-instinct-model
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 2
+  sprint_id: v0.88-s2
+  dependencies:
+  - WP-01
+  dependency_notes: '`WP-01`'
+  work_package: Instinct model
+  summary: define bounded instinct as an explicit cognitive substrate
+  deliverable: runtime-facing instinct contract, bounded semantics, and acceptance tests
+  issue_column: execution issue to be seeded
+- wp: WP-11
+  issue_kind: execution
+  title: '[v0.88][WP-11] Instinct runtime surface and bounded agency hook'
+  slug: v0-88-wp-11-instinct-runtime-surface-and-bounded-agency-hook
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:runtime
+  - version:v0.88
+  milestone_sprint: Sprint 2
+  sprint_id: v0.88-s2
+  dependencies:
+  - WP-10
+  dependency_notes: '`WP-10`'
+  work_package: Instinct runtime surface and bounded agency hook
+  summary: make instinct visible in runtime declaration, routing, prioritization, trace, and demo proof
+  deliverable: implementation slice, trace/artifact evidence, and bounded-agency proof case
+  issue_column: execution issue to be seeded
+- wp: WP-12
+  issue_kind: execution
+  title: '[v0.88][WP-12] Paper Sonata flagship demo'
+  slug: v0-88-wp-12-paper-sonata-flagship-demo
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:demo
+  - version:v0.88
+  milestone_sprint: Sprint 2
+  sprint_id: v0.88-s2
+  dependencies:
+  - WP-02
+  - WP-03
+  - WP-04
+  - WP-05
+  - WP-06
+  - WP-07
+  - WP-08
+  - WP-09
+  - WP-10
+  - WP-11
+  dependency_notes: '`WP-02` through `WP-11`'
+  work_package: Paper Sonata flagship demo
+  summary: implement a bounded investor-/reviewer-facing multi-agent manuscript demo with durable artifacts and truthful runtime proof
+  deliverable: bounded runner, synthetic fixture packet, stable artifact tree, and smoke/validation path
+  issue_column: execution issue to be seeded; protected local follow-on planning retained
+- wp: WP-13
+  issue_kind: execution
+  title: '[v0.88][WP-13] Demo matrix + integration demos'
+  slug: v0-88-wp-13-demo-matrix-integration-demos
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:demo
+  - version:v0.88
+  milestone_sprint: Sprint 2
+  sprint_id: v0.88-s2
+  dependencies:
+  - WP-02
+  - WP-03
+  - WP-04
+  - WP-05
+  - WP-06
+  - WP-07
+  - WP-08
+  - WP-09
+  - WP-10
+  - WP-11
+  - WP-12
+  dependency_notes: '`WP-02` through `WP-12`'
+  work_package: Demo matrix + integration demos
+  summary: define and implement the primary proof surfaces for temporal, PHI, instinct, and Paper Sonata bands
+  deliverable: runnable demo entrypoints, validated artifacts, and reviewer-facing demo matrix
+  issue_column: execution issue to be seeded; supporting pull-in `#1618`
+- wp: WP-14
+  issue_kind: closeout
+  title: '[v0.88][WP-14] Coverage / quality gate'
+  slug: v0-88-wp-14-coverage-quality-gate
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:quality
+  - version:v0.88
+  milestone_sprint: Sprint 3
+  sprint_id: v0.88-s3
+  dependencies:
+  - WP-13
+  dependency_notes: '`WP-13`'
+  work_package: Coverage / quality gate
+  summary: enforce milestone quality and coverage posture
+  deliverable: green quality gate
+  issue_column: closeout issue to be seeded
+- wp: WP-15
+  issue_kind: closeout
+  title: '[v0.88][WP-15] Docs + review pass'
+  slug: v0-88-wp-15-docs-review-pass
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:docs
+  - version:v0.88
+  milestone_sprint: Sprint 3
+  sprint_id: v0.88-s3
+  dependencies:
+  - WP-13
+  - WP-14
+  dependency_notes: '`WP-13`, `WP-14`'
+  work_package: Docs + review pass
+  summary: converge reviewer-facing docs against delivered proof
+  deliverable: reviewer-ready package
+  issue_column: closeout issue to be seeded
+- wp: WP-16
+  issue_kind: closeout
+  title: '[v0.88][WP-16] Internal review'
+  slug: v0-88-wp-16-internal-review
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:review
+  - version:v0.88
+  milestone_sprint: Sprint 3
+  sprint_id: v0.88-s3
+  dependencies:
+  - WP-15
+  dependency_notes: '`WP-15`'
+  work_package: Internal review
+  summary: perform bounded internal review of milestone truth and proof surfaces
+  deliverable: internal review record
+  issue_column: closeout issue to be seeded
+- wp: WP-17
+  issue_kind: closeout
+  title: '[v0.88][WP-17] 3rd-party review'
+  slug: v0-88-wp-17-3rd-party-review
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:review
+  - version:v0.88
+  milestone_sprint: Sprint 3
+  sprint_id: v0.88-s3
+  dependencies:
+  - WP-15
+  - WP-16
+  dependency_notes: '`WP-15`, `WP-16`'
+  work_package: 3rd-party review
+  summary: perform external review of the milestone package and capture findings
+  deliverable: 3rd-party review record
+  issue_column: closeout issue to be seeded
+- wp: WP-18
+  issue_kind: closeout
+  title: '[v0.88][WP-18] Review findings remediation'
+  slug: v0-88-wp-18-review-findings-remediation
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:review
+  - version:v0.88
+  milestone_sprint: Sprint 3
+  sprint_id: v0.88-s3
+  dependencies:
+  - WP-16
+  - WP-17
+  dependency_notes: '`WP-16`, `WP-17`'
+  work_package: Review findings remediation
+  summary: resolve or explicitly defer accepted review findings
+  deliverable: remediation record
+  issue_column: closeout issue to be seeded
+- wp: WP-19
+  issue_kind: closeout
+  title: '[v0.88][WP-19] Next milestone planning'
+  slug: v0-88-wp-19-next-milestone-planning
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:docs
+  - version:v0.88
+  milestone_sprint: Sprint 3
+  sprint_id: v0.88-s3
+  dependencies:
+  - WP-18
+  dependency_notes: '`WP-18`'
+  work_package: Next milestone planning
+  summary: prepare the next milestone planning package before `v0.88` closeout
+  deliverable: next-milestone package
+  issue_column: closeout issue to be seeded
+- wp: WP-20
+  issue_kind: closeout
+  title: '[v0.88][WP-20] Release ceremony'
+  slug: v0-88-wp-20-release-ceremony
+  queue: wp
+  labels:
+  - track:roadmap
+  - type:task
+  - area:release
+  - version:v0.88
+  milestone_sprint: Sprint 3
+  sprint_id: v0.88-s3
+  dependencies:
+  - WP-18
+  - WP-19
+  dependency_notes: '`WP-18`, `WP-19`'
+  work_package: Release ceremony
+  summary: final validation, notes, tag, cleanup, and closeout record
+  deliverable: release package
+  issue_column: closeout issue to be seeded

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -53,6 +53,7 @@ These docs describe worktree governance, large-module tracking, and related main
 
 - [Worktree Governance](worktree_governance.md)
 - [Rust Module Watch List](rust_module_watch_list.md)
+- [WP Issue-Wave Generation](WP_ISSUE_WAVE_GENERATION.md)
 - [Historical Public Task Records](../records/README.md)
 
 ## Tooling Scripts and Utilities
@@ -65,6 +66,7 @@ Important repo-local tooling surfaces include:
 - `adl tooling lint-prompt-spec` — Prompt Spec lint and validation
 - `adl tooling card-prompt` — deterministic prompt generation from cards
 - `adl tooling validate-structured-prompt` — structured prompt contract validation
+- `adl tooling generate-wp-issue-wave` — deterministic WBS/sprint-to-issue-wave planning generator
 - `adl tooling verify-review-output-provenance` — provenance verification for review-output artifacts
 - `adl tooling review-card-surface` — bounded deterministic review helper
 - `adl tooling review-runtime-surface` — deterministic validator for the `v0.87.1` runtime review package

--- a/docs/tooling/WP_ISSUE_WAVE_GENERATION.md
+++ b/docs/tooling/WP_ISSUE_WAVE_GENERATION.md
@@ -1,0 +1,64 @@
+# WP Issue-Wave Generation
+
+## Purpose
+
+`adl tooling generate-wp-issue-wave` derives a deterministic milestone work-package issue-wave plan from the canonical milestone WBS and sprint surfaces.
+
+This command is intentionally bounded:
+
+- it reads tracked planning inputs
+- it emits a stable issue-wave definition
+- it stops before branch/worktree creation and does not execute any generated issue
+
+## Inputs
+
+- `docs/milestones/<version>/WBS_<version>.md`
+- `docs/milestones/<version>/SPRINT_<version>.md`
+
+You can override either path explicitly, but the default contract is milestone-package driven generation.
+
+## Output
+
+The command emits YAML with:
+
+- milestone version
+- source paths
+- one entry per WBS row whose Issue column says the issue is still "to be seeded"
+- deterministic metadata for each planned issue:
+  - `wp`
+  - `issue_kind`
+  - `title`
+  - `slug`
+  - `queue`
+  - `labels`
+  - `milestone_sprint`
+  - `sprint_id`
+  - `dependencies`
+  - `dependency_notes`
+  - `work_package`
+  - `summary`
+  - `deliverable`
+  - `issue_column`
+
+## Usage
+
+```bash
+adl tooling generate-wp-issue-wave --version v0.88
+adl tooling generate-wp-issue-wave --version v0.88 --out docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml
+```
+
+## Truth Boundary
+
+This generator does not:
+
+- create GitHub issues
+- bootstrap worktrees or branches
+- infer milestone structure outside the tracked WBS and sprint docs
+
+It is a control-plane planning surface. Follow-on create/init/doctor enforcement can consume the generated wave, but that work stays outside this command.
+
+## Determinism
+
+For identical WBS and sprint inputs, the emitted YAML is identical.
+
+There are no timestamps, random IDs, or ambient GitHub reads in this command path.


### PR DESCRIPTION
## Summary
- add a deterministic `adl tooling generate-wp-issue-wave` control-plane command
- generate and check in the canonical `v0.88` wave artifact from the live WBS/sprint package
- document the bounded generation contract and keep issue-wave creation separate from execution

## Validation
- cargo test --manifest-path adl/Cargo.toml generate_wave_doc_from_v088_surfaces_is_deterministic_and_complete -- --nocapture
- cargo test --manifest-path adl/Cargo.toml tooling_dispatch_and_help_paths_cover_public_entrypoint -- --nocapture
- cargo fmt --manifest-path adl/Cargo.toml --all -- --check
- cargo run --manifest-path adl/Cargo.toml -- tooling generate-wp-issue-wave --version v0.88 --out <tmp> && diff -u <tmp> docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml
- git diff --check

Closes #1667
