### PR TITLE
[v0.88][tools] Preserve local .adl cards across main fast-forward syncs

### DIFF
--- a/adl/tools/fix_git_main_sync.sh
+++ b/adl/tools/fix_git_main_sync.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+snapshot_dir=""
+
+die() {
+  echo "fix-git: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$snapshot_dir" && -d "$snapshot_dir" ]]; then
+    rm -rf "$snapshot_dir"
+  fi
+}
+
+trap cleanup EXIT HUP INT TERM
+
+capture_local_adl_cards() {
+  local cards_root="$repo_root/.adl"
+  if [[ ! -d "$cards_root" ]]; then
+    return 0
+  fi
+
+  snapshot_dir="$(mktemp -d "${TMPDIR:-/tmp}/adl-fix-git.XXXXXX")"
+  local preserve_list="$snapshot_dir/preserve.list"
+  : >"$preserve_list"
+
+  while IFS= read -r source_path; do
+    [[ -n "$source_path" ]] || continue
+    local relative_path="${source_path#$repo_root/}"
+    local snapshot_path="$snapshot_dir/$relative_path"
+    mkdir -p "$(dirname "$snapshot_path")"
+    cp "$source_path" "$snapshot_path"
+    printf '%s\n' "$relative_path" >>"$preserve_list"
+  done < <(
+    find "$cards_root" -type f \
+      \( -path "$cards_root/*/bodies/*.md" \
+      -o -path "$cards_root/*/tasks/*/stp.md" \
+      -o -path "$cards_root/*/tasks/*/sip.md" \
+      -o -path "$cards_root/*/tasks/*/sor.md" \) |
+      sort
+  )
+}
+
+restore_missing_local_adl_cards() {
+  local preserve_list="$snapshot_dir/preserve.list"
+  if [[ ! -f "$preserve_list" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r relative_path; do
+    [[ -n "$relative_path" ]] || continue
+    local target_path="$repo_root/$relative_path"
+    local snapshot_path="$snapshot_dir/$relative_path"
+    if [[ ! -e "$target_path" && -f "$snapshot_path" ]]; then
+      mkdir -p "$(dirname "$target_path")"
+      cp "$snapshot_path" "$target_path"
+    fi
+  done <"$preserve_list"
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" ||
+  die "not inside a git checkout"
+
+branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
+if [[ "$branch" != "main" ]]; then
+  die "refusing to switch from '$branch' to main; run this only from an already-clean main checkout"
+fi
+
+if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+  die "refusing to pull with local changes in $repo_root"
+fi
+
+main_worktree="$(git -C "$repo_root" worktree list --porcelain |
+  awk '
+    /^worktree / { path = substr($0, 10) }
+    /^branch refs\/heads\/main$/ { print path }
+  ')"
+
+if [[ -n "$main_worktree" && "$main_worktree" != "$repo_root" ]]; then
+  die "main is checked out at $main_worktree; pull from that worktree or remove it intentionally"
+fi
+
+capture_local_adl_cards
+git -C "$repo_root" fetch origin main
+git -C "$repo_root" merge --ff-only origin/main
+restore_missing_local_adl_cards

--- a/adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh
+++ b/adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+ORIGIN="$TMP/origin.git"
+SEED="$TMP/seed"
+LOCAL="$TMP/local"
+CARD_PATH=".adl/v0.88/tasks/issue-1650__v0-88-wp-05-temporal-query-and-retrieval/sor.md"
+
+git init --bare -q "$ORIGIN"
+
+git clone -q "$ORIGIN" "$SEED"
+git -C "$SEED" checkout -q -b main
+git -C "$SEED" config user.name "Test User"
+git -C "$SEED" config user.email "test@example.com"
+mkdir -p "$SEED/adl/tools"
+cp "$ROOT/adl/tools/fix_git_main_sync.sh" "$SEED/adl/tools/fix_git_main_sync.sh"
+chmod +x "$SEED/adl/tools/fix_git_main_sync.sh"
+printf '.adl/\n' >"$SEED/.gitignore"
+mkdir -p "$SEED/$(dirname "$CARD_PATH")"
+printf 'tracked residue\n' >"$SEED/$CARD_PATH"
+git -C "$SEED" add -f .gitignore adl/tools/fix_git_main_sync.sh "$CARD_PATH"
+git -C "$SEED" commit -q -m "seed tracked residue"
+git -C "$SEED" push -q -u origin main
+
+git clone -q "$ORIGIN" "$LOCAL"
+git -C "$LOCAL" checkout -q main
+git -C "$LOCAL" config user.name "Test User"
+git -C "$LOCAL" config user.email "test@example.com"
+
+git -C "$SEED" rm -q "$CARD_PATH"
+git -C "$SEED" commit -q -m "remove tracked residue"
+git -C "$SEED" push -q
+
+(cd "$LOCAL" && bash ./adl/tools/fix_git_main_sync.sh >/dev/null)
+
+if [[ ! -f "$LOCAL/$CARD_PATH" ]]; then
+  echo "expected local card to be restored after fast-forward sync" >&2
+  exit 1
+fi
+
+if [[ -n "$(git -C "$LOCAL" status --porcelain)" ]]; then
+  echo "expected local checkout to remain clean after sync" >&2
+  git -C "$LOCAL" status --short >&2
+  exit 1
+fi
+
+echo "PASS test_fix_git_main_sync_preserves_local_adl_cards"


### PR DESCRIPTION
Closes #1699

## Summary
- add a tracked main-sync helper that snapshots canonical local `.adl` cards before a fast-forward and restores only missing ones afterward
- add a temp-repo regression proving local cards survive when upstream removes previously tracked `.adl` residue
- apply the same preservation logic to the local ignored `adl/.local/fix-git.sh` wrapper so the operational path is fixed immediately

## Validation
- bash adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh
- bash -n adl/tools/fix_git_main_sync.sh adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh
- bash -n adl/.local/fix-git.sh
- git diff --check