### PR TITLE
[v0.88][WP-07] Temporal causality and explanation

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -12,6 +12,7 @@ pub const TEMPORAL_SCHEMA_V01: &str = "temporal_schema.v0_1";
 pub const CONTINUITY_SEMANTICS_SCHEMA: &str = "continuity_semantics.v1";
 pub const TEMPORAL_QUERY_RETRIEVAL_SCHEMA: &str = "temporal_query_retrieval.v1";
 pub const COMMITMENT_DEADLINE_SCHEMA: &str = "commitment_deadline_semantics.v1";
+pub const TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA: &str = "temporal_causality_explanation.v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdentityProfile {
@@ -216,6 +217,42 @@ pub struct CommitmentDeadlineContract {
     pub record_requirements: CommitmentRecordRequirements,
     pub deadline_semantics: DeadlineSemanticsContract,
     pub missed_commitment_detection: MissedCommitmentDetectionContract,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CausalRelationContract {
+    pub relation_types: Vec<String>,
+    pub sequence_boundary_rule: String,
+    pub dependency_evidence_requirements: Vec<String>,
+    pub uncertainty_classes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExplanationSurfaceContract {
+    pub required_fields: Vec<String>,
+    pub citation_requirements: Vec<String>,
+    pub non_goals: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExplanationFixture {
+    pub scenario: String,
+    pub relation_type: String,
+    pub confidence: String,
+    pub explanation_note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TemporalCausalityExplanationContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub causal_relations: CausalRelationContract,
+    pub explanation_surface: ExplanationSurfaceContract,
+    pub explanation_fixtures: Vec<ExplanationFixture>,
     pub proof_fixture_hooks: Vec<String>,
     pub proof_hook_command: String,
     pub proof_hook_output_path: String,
@@ -696,6 +733,95 @@ impl CommitmentDeadlineContract {
     }
 }
 
+impl TemporalCausalityExplanationContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA.to_string(),
+            owned_runtime_surfaces: vec![
+                "adl::chronosense::TemporalCausalityExplanationContract".to_string(),
+                "adl::chronosense::CausalRelationContract".to_string(),
+                "adl::chronosense::ExplanationSurfaceContract".to_string(),
+                "adl::chronosense::ExplanationFixture".to_string(),
+                "adl::chronosense::TemporalQueryRetrievalContract".to_string(),
+                "adl::chronosense::CommitmentDeadlineContract".to_string(),
+                "adl identity causality".to_string(),
+            ],
+            causal_relations: CausalRelationContract {
+                relation_types: vec![
+                    "temporal_succession".to_string(),
+                    "declared_dependency".to_string(),
+                    "causal_contribution".to_string(),
+                    "unknown_relation".to_string(),
+                ],
+                sequence_boundary_rule:
+                    "sequence alone is insufficient evidence for causality".to_string(),
+                dependency_evidence_requirements: vec![
+                    "cite source event or condition".to_string(),
+                    "cite target event or state".to_string(),
+                    "name explicit relation type".to_string(),
+                    "record bounded confidence or uncertainty".to_string(),
+                ],
+                uncertainty_classes: vec![
+                    "high".to_string(),
+                    "medium".to_string(),
+                    "low".to_string(),
+                    "unknown".to_string(),
+                ],
+            },
+            explanation_surface: ExplanationSurfaceContract {
+                required_fields: vec![
+                    "source_event_or_condition".to_string(),
+                    "target_event_or_state".to_string(),
+                    "relation_type".to_string(),
+                    "confidence".to_string(),
+                    "explanation_note".to_string(),
+                ],
+                citation_requirements: vec![
+                    "cite dependency or state-change evidence".to_string(),
+                    "cite prior temporal anchor when available".to_string(),
+                    "cite uncertainty explicitly when causal evidence is incomplete".to_string(),
+                ],
+                non_goals: vec![
+                    "probabilistic global causal graphs".to_string(),
+                    "scientific causal inference engines".to_string(),
+                    "overclaiming causality from ordering alone".to_string(),
+                ],
+            },
+            explanation_fixtures: vec![
+                ExplanationFixture {
+                    scenario: "deadline_miss_after_interruption".to_string(),
+                    relation_type: "causal_contribution".to_string(),
+                    confidence: "medium".to_string(),
+                    explanation_note:
+                        "interruption preserved continuity boundary and contributed to missed commitment visibility"
+                            .to_string(),
+                },
+                ExplanationFixture {
+                    scenario: "adjacent_events_without_dependency".to_string(),
+                    relation_type: "unknown_relation".to_string(),
+                    confidence: "unknown".to_string(),
+                    explanation_note:
+                        "adjacent temporal order is recorded, but no dependency evidence is present"
+                            .to_string(),
+                },
+            ],
+            proof_fixture_hooks: vec![
+                "adl::chronosense::TemporalCausalityExplanationContract::v1".to_string(),
+                "adl identity causality --out .adl/state/temporal_causality_explanation_v1.json"
+                    .to_string(),
+            ],
+            proof_hook_command:
+                "adl identity causality --out .adl/state/temporal_causality_explanation_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/temporal_causality_explanation_v1.json"
+                .to_string(),
+            scope_boundary:
+                "bounded causal-link and explanation semantics only; full causal inference, planning policy, and global explanation graphs remain downstream work"
+                    .to_string(),
+        }
+    }
+}
+
 pub fn default_identity_profile_path(repo_root: &Path) -> PathBuf {
     repo_root
         .join("adl")
@@ -931,5 +1057,47 @@ mod tests {
         assert!(contract
             .proof_hook_output_path
             .contains("commitment_deadline_semantics_v1.json"));
+    }
+
+    #[test]
+    fn temporal_causality_explanation_contract_distinguishes_sequence_from_causality() {
+        let contract = TemporalCausalityExplanationContract::v1();
+
+        assert_eq!(
+            contract.schema_version,
+            TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA
+        );
+        assert_eq!(
+            contract.causal_relations.sequence_boundary_rule,
+            "sequence alone is insufficient evidence for causality"
+        );
+        assert!(contract
+            .causal_relations
+            .relation_types
+            .contains(&"unknown_relation".to_string()));
+        assert!(contract
+            .owned_runtime_surfaces
+            .contains(&"adl identity causality".to_string()));
+    }
+
+    #[test]
+    fn temporal_causality_explanation_contract_has_bounded_proof_hook_and_uncertainty() {
+        let contract = TemporalCausalityExplanationContract::v1();
+
+        assert!(contract
+            .explanation_surface
+            .required_fields
+            .contains(&"relation_type".to_string()));
+        assert!(contract
+            .explanation_surface
+            .citation_requirements
+            .iter()
+            .any(|value| value.contains("uncertainty")));
+        assert!(contract
+            .proof_hook_command
+            .contains("adl identity causality"));
+        assert!(contract
+            .proof_hook_output_path
+            .contains("temporal_causality_explanation_v1.json"));
     }
 }

--- a/adl/src/cli/identity_cmd.rs
+++ b/adl/src/cli/identity_cmd.rs
@@ -8,7 +8,8 @@ use std::process::Command;
 use ::adl::chronosense::{
     default_identity_profile_path, load_identity_profile, write_identity_profile,
     ChronosenseFoundation, CommitmentDeadlineContract, ContinuitySemanticsContract,
-    IdentityProfile, TemporalContext, TemporalQueryRetrievalContract, TemporalSchemaContract,
+    IdentityProfile, TemporalCausalityExplanationContract, TemporalContext,
+    TemporalQueryRetrievalContract, TemporalSchemaContract,
 };
 
 pub(crate) fn real_identity(args: &[String]) -> Result<()> {
@@ -32,12 +33,13 @@ fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
         "continuity" => real_identity_continuity(repo_root, &args[1..]),
         "retrieval" => real_identity_retrieval(repo_root, &args[1..]),
         "commitments" => real_identity_commitments(repo_root, &args[1..]),
+        "causality" => real_identity_causality(repo_root, &args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments | causality)"
         )),
     }
 }
@@ -420,6 +422,55 @@ fn real_identity_commitments(repo_root: &Path, args: &[String]) -> Result<()> {
             )
         })?;
         println!("COMMITMENT_DEADLINE_PATH={}", resolved.display());
+    } else {
+        println!("{json}");
+    }
+
+    Ok(())
+}
+
+fn real_identity_causality(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                out_path = Some(PathBuf::from(required_value(args, i, "--out")?));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => return Err(anyhow!("unknown arg for identity causality: {other}")),
+        }
+        i += 1;
+    }
+
+    let contract = TemporalCausalityExplanationContract::v1();
+    let json = to_string_pretty(&contract)?;
+
+    if let Some(out) = out_path {
+        let resolved = if out.is_absolute() {
+            out
+        } else {
+            repo_root.join(out)
+        };
+        let Some(parent) = resolved.parent() else {
+            return Err(anyhow!(
+                "identity causality --out path must have a parent directory"
+            ));
+        };
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+        fs::write(&resolved, json.as_bytes()).with_context(|| {
+            format!(
+                "failed to write temporal causality explanation artifact to {}",
+                resolved.display()
+            )
+        })?;
+        println!("TEMPORAL_CAUSALITY_EXPLANATION_PATH={}", resolved.display());
     } else {
         println!("{json}");
     }
@@ -1055,6 +1106,53 @@ mod tests {
             .contains("unknown arg for identity commitments: --bogus"));
 
         let err = real_identity_in_repo(&["commitments".to_string(), "--out".to_string()], &repo)
+            .expect_err("out flag without value should fail");
+        assert!(err.to_string().contains("--out requires a value"));
+    }
+
+    #[test]
+    fn identity_causality_writes_temporal_causality_explanation_contract_json() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let repo = temp_repo("identity-causality");
+        let out_path = repo.join(".adl/state/temporal_causality_explanation_v1.json");
+
+        real_identity_in_repo(
+            &[
+                "causality".to_string(),
+                "--out".to_string(),
+                ".adl/state/temporal_causality_explanation_v1.json".to_string(),
+            ],
+            &repo,
+        )
+        .expect("identity causality");
+
+        let json: Value =
+            serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+        assert_eq!(json["schema_version"], "temporal_causality_explanation.v1");
+        assert_eq!(
+            json["proof_hook_output_path"],
+            ".adl/state/temporal_causality_explanation_v1.json"
+        );
+        assert!(json["owned_runtime_surfaces"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "adl identity causality"));
+    }
+
+    #[test]
+    fn identity_causality_validates_unknown_args_and_missing_out_value() {
+        let repo = temp_repo("identity-causality-errors");
+
+        let err = real_identity_in_repo(&["causality".to_string(), "--bogus".to_string()], &repo)
+            .expect_err("unknown arg should fail");
+        assert!(err
+            .to_string()
+            .contains("unknown arg for identity causality: --bogus"));
+
+        let err = real_identity_in_repo(&["causality".to_string(), "--out".to_string()], &repo)
             .expect_err("out flag without value should fail");
         assert!(err.to_string().contains("--out requires a value"));
     }

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -12,6 +12,7 @@ pub fn usage() -> &'static str {
   adl identity continuity [--out <path>]
   adl identity retrieval [--out <path>]
   adl identity commitments [--out <path>]
+  adl identity causality [--out <path>]
   adl provider setup <family> [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]

--- a/docs/milestones/v0.88/features/TEMPORAL_CAUSALITY_AND_EXPLANATION.md
+++ b/docs/milestones/v0.88/features/TEMPORAL_CAUSALITY_AND_EXPLANATION.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Promoted milestone feature doc for `v0.88`.
+Promoted milestone feature doc for `v0.88`; bounded runtime surface implemented for WP-07.
 
 ## Purpose
 
@@ -49,10 +49,13 @@ This document defines:
 - sequence vs dependency
 - causal explanation needs
 - bounded causal-link representation
+- the reviewable `TemporalCausalityExplanationContract`
+- the proof hook `adl identity causality --out .adl/state/temporal_causality_explanation_v1.json`
 
 This document does not define:
 - full causal inference theory
 - probabilistic scientific causality engines
+- planning or governance policy
 
 ---
 
@@ -82,14 +85,20 @@ These are explanation questions, not just logging questions.
 
 ## Causal Links
 
-Bounded causal representation may need to support:
+The bounded causal surface now supports:
 - source event or condition
 - target event or state
 - relation type
 - confidence or certainty class
 - explanation note
 
-The exact schema can be defined later.
+The current relation classes are:
+- temporal succession
+- declared dependency
+- causal contribution
+- unknown relationship
+
+The current contract preserves the rule that sequence alone is insufficient evidence for causality.
 
 ---
 
@@ -98,6 +107,29 @@ The exact schema can be defined later.
 - do not overclaim causality from mere order
 - preserve uncertainty where causality is unclear
 - allow explanation to cite dependencies and prior state changes
+- require explanation records to cite bounded evidence rather than narrative speculation
+
+## Runtime Surface
+
+The current `v0.88` owned surface is:
+- `adl::chronosense::TemporalCausalityExplanationContract`
+- `adl identity causality`
+
+The proof artifact is:
+- `.adl/state/temporal_causality_explanation_v1.json`
+
+The explanation surface requires:
+- source event or condition
+- target event or state
+- relation type
+- confidence
+- explanation note
+
+The contract keeps explicit uncertainty classes:
+- high
+- medium
+- low
+- unknown
 
 ---
 


### PR DESCRIPTION
Closes #1653

## Summary
Implemented a bounded temporal causality and explanation contract for `v0.88`, added the `adl identity causality` proof hook, and tightened the feature doc so it names the owned runtime surface, bounded evidence model, and proof artifact without overclaiming causal inference.

## Artifacts
- `adl/src/chronosense.rs`
- `adl/src/cli/identity_cmd.rs`
- `adl/src/cli/usage.rs`
- `docs/milestones/v0.88/features/TEMPORAL_CAUSALITY_AND_EXPLANATION.md`
- `.adl/state/temporal_causality_explanation_v1.json`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified formatting.
  - `cargo test --manifest-path adl/Cargo.toml temporal_causality_explanation -- --nocapture` verified the bounded causality contract semantics and proof-hook metadata.
  - `cargo test --manifest-path adl/Cargo.toml identity_causality -- --nocapture` verified the CLI proof hook, output writing, and argument validation.
  - `cargo run --manifest-path adl/Cargo.toml -- identity causality --out .adl/state/temporal_causality_explanation_v1.json` verified end-to-end artifact emission.
- Results:
  - All listed validation commands passed on the branch.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1653__v0-88-wp-07-temporal-causality-and-explanation/sip.md
- Output card: .adl/v0.88/tasks/issue-1653__v0-88-wp-07-temporal-causality-and-explanation/sor.md
- Idempotency-Key: v0-88-wp-07-temporal-causality-and-explanation-adl-v0-88-tasks-issue-1653-v0-88-wp-07-temporal-causality-and-explanation-sip-md-adl-v0-88-tasks-issue-1653-v0-88-wp-07-temporal-causality-and-explanation-sor-md