### PR TITLE
[v0.88][WP-08] Execution policy and cost model

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -13,6 +13,7 @@ pub const CONTINUITY_SEMANTICS_SCHEMA: &str = "continuity_semantics.v1";
 pub const TEMPORAL_QUERY_RETRIEVAL_SCHEMA: &str = "temporal_query_retrieval.v1";
 pub const COMMITMENT_DEADLINE_SCHEMA: &str = "commitment_deadline_semantics.v1";
 pub const TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA: &str = "temporal_causality_explanation.v1";
+pub const EXECUTION_POLICY_COST_MODEL_SCHEMA: &str = "execution_policy_cost_model.v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdentityProfile {
@@ -253,6 +254,56 @@ pub struct TemporalCausalityExplanationContract {
     pub causal_relations: CausalRelationContract,
     pub explanation_surface: ExplanationSurfaceContract,
     pub explanation_fixtures: Vec<ExplanationFixture>,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CostPolicyContract {
+    pub requested_mode: String,
+    pub max_usd_per_run: String,
+    pub max_tokens: String,
+    pub max_duration_ms: String,
+    pub max_cognitive_units: String,
+    pub max_branches: String,
+    pub max_tool_calls: String,
+    pub preferred_models: String,
+    pub disallowed_models: String,
+    pub allow_parallel: String,
+    pub priority: String,
+    pub replay_strictness: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CostAnchorContract {
+    pub trace_event_id: String,
+    pub run_id: String,
+    pub agent_id: String,
+    pub observed_at_utc: String,
+    pub execution_policy: String,
+    pub duration_ms: String,
+    pub cost_vector: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CostReviewSurfaceContract {
+    pub required_questions: Vec<String>,
+    pub required_trace_hooks: Vec<String>,
+    pub comparison_rule: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionPolicyCostModelContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub execution_policy: ExecutionPolicySchema,
+    pub execution_realization: ExecutionRealizationSchema,
+    pub cost_vector: CostVectorSchema,
+    pub cost_policy: CostPolicyContract,
+    pub cost_anchor: CostAnchorContract,
+    pub review_surface: CostReviewSurfaceContract,
     pub proof_fixture_hooks: Vec<String>,
     pub proof_hook_command: String,
     pub proof_hook_output_path: String,
@@ -822,6 +873,98 @@ impl TemporalCausalityExplanationContract {
     }
 }
 
+impl ExecutionPolicyCostModelContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: EXECUTION_POLICY_COST_MODEL_SCHEMA.to_string(),
+            owned_runtime_surfaces: vec![
+                "adl::chronosense::ExecutionPolicyCostModelContract".to_string(),
+                "adl::chronosense::ExecutionPolicySchema".to_string(),
+                "adl::chronosense::ExecutionRealizationSchema".to_string(),
+                "adl::chronosense::CostVectorSchema".to_string(),
+                "adl::chronosense::CostPolicyContract".to_string(),
+                "adl::chronosense::CostAnchorContract".to_string(),
+                "adl identity cost".to_string(),
+            ],
+            execution_policy: ExecutionPolicySchema {
+                requested_mode: "required one of efficient|fast|deterministic|exploratory"
+                    .to_string(),
+                replay_strictness: "required one of strict|bounded|relaxed".to_string(),
+                max_tokens: "optional integer cap".to_string(),
+                max_duration_ms: "optional integer cap".to_string(),
+                max_branches: "optional integer cap".to_string(),
+                max_tool_calls: "optional integer cap".to_string(),
+            },
+            execution_realization: ExecutionRealizationSchema {
+                branch_count: "required realized branch count when branching is enabled"
+                    .to_string(),
+                tool_calls: "required realized tool-call count when tools are used".to_string(),
+                refinement_cycles: "optional realized refinement-cycle count".to_string(),
+                replay_variance: "required one of strict|bounded|high when recorded".to_string(),
+            },
+            cost_vector: CostVectorSchema {
+                time_ms: "required realized runtime in milliseconds".to_string(),
+                tokens_in: "optional input token count".to_string(),
+                tokens_out: "optional output token count".to_string(),
+                usd: "optional realized USD cost".to_string(),
+                cognitive_units: "optional bounded cognitive-cost unit".to_string(),
+            },
+            cost_policy: CostPolicyContract {
+                requested_mode: "required one of efficient|fast|deterministic|exploratory"
+                    .to_string(),
+                max_usd_per_run: "optional USD budget ceiling".to_string(),
+                max_tokens: "optional token ceiling".to_string(),
+                max_duration_ms: "optional runtime ceiling".to_string(),
+                max_cognitive_units: "optional cognitive-cost ceiling".to_string(),
+                max_branches: "optional branch ceiling".to_string(),
+                max_tool_calls: "optional tool-call ceiling".to_string(),
+                preferred_models: "optional ordered preferred-model list".to_string(),
+                disallowed_models: "optional disallowed-model list".to_string(),
+                allow_parallel: "required true|false policy flag".to_string(),
+                priority: "required one of cost|latency|quality".to_string(),
+                replay_strictness: "required one of strict|bounded|relaxed".to_string(),
+            },
+            cost_anchor: CostAnchorContract {
+                trace_event_id: "required canonical trace event id".to_string(),
+                run_id: "required canonical run id".to_string(),
+                agent_id: "required canonical agent id".to_string(),
+                observed_at_utc: "required RFC3339 UTC timestamp".to_string(),
+                execution_policy: "required execution policy reference".to_string(),
+                duration_ms: "required duration anchor for cost comparison".to_string(),
+                cost_vector: "required realized cost vector reference".to_string(),
+            },
+            review_surface: CostReviewSurfaceContract {
+                required_questions: vec![
+                    "what did this run cost".to_string(),
+                    "where was cost incurred".to_string(),
+                    "why was this execution posture chosen".to_string(),
+                ],
+                required_trace_hooks: vec![
+                    "run_state.v1.duration_ms".to_string(),
+                    "run_state.v1.scheduler_max_concurrency".to_string(),
+                    "run_summary.v1.policy".to_string(),
+                    "run_summary.v1.counts.provider_call_count".to_string(),
+                ],
+                comparison_rule:
+                    "reviewers must be able to compare requested execution posture against realized cost and execution behavior"
+                        .to_string(),
+            },
+            proof_fixture_hooks: vec![
+                "adl::chronosense::ExecutionPolicyCostModelContract::v1".to_string(),
+                "adl identity cost --out .adl/state/execution_policy_cost_model_v1.json"
+                    .to_string(),
+            ],
+            proof_hook_command:
+                "adl identity cost --out .adl/state/execution_policy_cost_model_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/execution_policy_cost_model_v1.json".to_string(),
+            scope_boundary:
+                "execution policy and cost reviewability only; enterprise pricing, instinct policy, and broader economics strategy remain downstream work"
+                    .to_string(),
+        }
+    }
+}
+
 pub fn default_identity_profile_path(repo_root: &Path) -> PathBuf {
     repo_root
         .join("adl")
@@ -1099,5 +1242,41 @@ mod tests {
         assert!(contract
             .proof_hook_output_path
             .contains("temporal_causality_explanation_v1.json"));
+    }
+
+    #[test]
+    fn execution_policy_cost_model_contract_is_trace_anchored_and_reviewable() {
+        let contract = ExecutionPolicyCostModelContract::v1();
+
+        assert_eq!(contract.schema_version, EXECUTION_POLICY_COST_MODEL_SCHEMA);
+        assert!(contract
+            .owned_runtime_surfaces
+            .contains(&"adl identity cost".to_string()));
+        assert_eq!(
+            contract.review_surface.comparison_rule,
+            "reviewers must be able to compare requested execution posture against realized cost and execution behavior"
+        );
+        assert!(contract
+            .review_surface
+            .required_trace_hooks
+            .contains(&"run_state.v1.duration_ms".to_string()));
+    }
+
+    #[test]
+    fn execution_policy_cost_model_contract_exposes_policy_and_cost_bounds() {
+        let contract = ExecutionPolicyCostModelContract::v1();
+
+        assert_eq!(
+            contract.cost_policy.priority,
+            "required one of cost|latency|quality"
+        );
+        assert_eq!(
+            contract.cost_anchor.trace_event_id,
+            "required canonical trace event id"
+        );
+        assert!(contract.proof_hook_command.contains("adl identity cost"));
+        assert!(contract
+            .proof_hook_output_path
+            .contains("execution_policy_cost_model_v1.json"));
     }
 }

--- a/adl/src/cli/identity_cmd.rs
+++ b/adl/src/cli/identity_cmd.rs
@@ -8,8 +8,8 @@ use std::process::Command;
 use ::adl::chronosense::{
     default_identity_profile_path, load_identity_profile, write_identity_profile,
     ChronosenseFoundation, CommitmentDeadlineContract, ContinuitySemanticsContract,
-    IdentityProfile, TemporalCausalityExplanationContract, TemporalContext,
-    TemporalQueryRetrievalContract, TemporalSchemaContract,
+    ExecutionPolicyCostModelContract, IdentityProfile, TemporalCausalityExplanationContract,
+    TemporalContext, TemporalQueryRetrievalContract, TemporalSchemaContract,
 };
 
 pub(crate) fn real_identity(args: &[String]) -> Result<()> {
@@ -34,12 +34,13 @@ fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
         "retrieval" => real_identity_retrieval(repo_root, &args[1..]),
         "commitments" => real_identity_commitments(repo_root, &args[1..]),
         "causality" => real_identity_causality(repo_root, &args[1..]),
+        "cost" => real_identity_cost(repo_root, &args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments | causality)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost)"
         )),
     }
 }
@@ -471,6 +472,55 @@ fn real_identity_causality(repo_root: &Path, args: &[String]) -> Result<()> {
             )
         })?;
         println!("TEMPORAL_CAUSALITY_EXPLANATION_PATH={}", resolved.display());
+    } else {
+        println!("{json}");
+    }
+
+    Ok(())
+}
+
+fn real_identity_cost(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                out_path = Some(PathBuf::from(required_value(args, i, "--out")?));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => return Err(anyhow!("unknown arg for identity cost: {other}")),
+        }
+        i += 1;
+    }
+
+    let contract = ExecutionPolicyCostModelContract::v1();
+    let json = to_string_pretty(&contract)?;
+
+    if let Some(out) = out_path {
+        let resolved = if out.is_absolute() {
+            out
+        } else {
+            repo_root.join(out)
+        };
+        let Some(parent) = resolved.parent() else {
+            return Err(anyhow!(
+                "identity cost --out path must have a parent directory"
+            ));
+        };
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+        fs::write(&resolved, json.as_bytes()).with_context(|| {
+            format!(
+                "failed to write execution policy cost artifact to {}",
+                resolved.display()
+            )
+        })?;
+        println!("EXECUTION_POLICY_COST_MODEL_PATH={}", resolved.display());
     } else {
         println!("{json}");
     }
@@ -1153,6 +1203,53 @@ mod tests {
             .contains("unknown arg for identity causality: --bogus"));
 
         let err = real_identity_in_repo(&["causality".to_string(), "--out".to_string()], &repo)
+            .expect_err("out flag without value should fail");
+        assert!(err.to_string().contains("--out requires a value"));
+    }
+
+    #[test]
+    fn identity_cost_writes_execution_policy_cost_model_contract_json() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let repo = temp_repo("identity-cost");
+        let out_path = repo.join(".adl/state/execution_policy_cost_model_v1.json");
+
+        real_identity_in_repo(
+            &[
+                "cost".to_string(),
+                "--out".to_string(),
+                ".adl/state/execution_policy_cost_model_v1.json".to_string(),
+            ],
+            &repo,
+        )
+        .expect("identity cost");
+
+        let json: Value =
+            serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+        assert_eq!(json["schema_version"], "execution_policy_cost_model.v1");
+        assert_eq!(
+            json["proof_hook_output_path"],
+            ".adl/state/execution_policy_cost_model_v1.json"
+        );
+        assert!(json["owned_runtime_surfaces"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "adl identity cost"));
+    }
+
+    #[test]
+    fn identity_cost_validates_unknown_args_and_missing_out_value() {
+        let repo = temp_repo("identity-cost-errors");
+
+        let err = real_identity_in_repo(&["cost".to_string(), "--bogus".to_string()], &repo)
+            .expect_err("unknown arg should fail");
+        assert!(err
+            .to_string()
+            .contains("unknown arg for identity cost: --bogus"));
+
+        let err = real_identity_in_repo(&["cost".to_string(), "--out".to_string()], &repo)
             .expect_err("out flag without value should fail");
         assert!(err.to_string().contains("--out requires a value"));
     }

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -13,6 +13,7 @@ pub fn usage() -> &'static str {
   adl identity retrieval [--out <path>]
   adl identity commitments [--out <path>]
   adl identity causality [--out <path>]
+  adl identity cost [--out <path>]
   adl provider setup <family> [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]

--- a/docs/milestones/v0.88/features/ADL_COST_MODEL.md
+++ b/docs/milestones/v0.88/features/ADL_COST_MODEL.md
@@ -4,7 +4,7 @@
 
 ## Metadata
 - Owner: `adl`
-- Status: `promoted milestone feature doc`
+- Status: `promoted milestone feature doc`; bounded runtime review surface implemented for `WP-08`
 - Target milestone: `v0.88`
 - Area: Runtime / Cognitive Architecture / Economics
 
@@ -213,6 +213,12 @@ ADL should record both:
 
 Without that split, a reviewer can see spend but not understand why the system spent it.
 
+For the current bounded `v0.88` implementation, the proof surface is:
+
+- `adl::chronosense::ExecutionPolicyCostModelContract`
+- `adl identity cost --out .adl/state/execution_policy_cost_model_v1.json`
+- `.adl/state/execution_policy_cost_model_v1.json`
+
 ---
 
 ## Cost Anchoring (Mandatory)
@@ -236,6 +242,8 @@ This ensures:
 - replay consistency
 - auditability
 - policy-aware reviewability
+
+The current bounded contract keeps these anchor fields explicit as reviewer-facing requirements rather than hidden runtime metadata.
 
 ---
 
@@ -275,6 +283,8 @@ execution_realization:
   refinement_cycles
   replay_variance: strict | bounded | high
 ```
+
+The current bounded runtime surface owns these reviewable structures directly instead of scattering them across unrelated docs or output fields.
 
 ---
 
@@ -375,6 +385,17 @@ A reviewer must be able to answer:
 
 Cost is part of truth, not metadata.
 
+For `WP-08`, the required reviewer comparison rule is:
+
+> reviewers must be able to compare requested execution posture against realized cost and execution behavior
+
+The current required trace hooks are:
+
+- `run_state.v1.duration_ms`
+- `run_state.v1.scheduler_max_concurrency`
+- `run_summary.v1.policy`
+- `run_summary.v1.counts.provider_call_count`
+
 ---
 
 ## Demo Surface
@@ -442,6 +463,8 @@ These policies operate alongside:
 ### Policy Structure
 
 ```
+
+The current `v0.88` contract records these policy fields as bounded review surfaces. It does not yet implement a full adaptive enforcement engine.
 cost_policy:
   requested_mode: efficient | fast | deterministic | exploratory
   max_usd_per_run
@@ -504,6 +527,32 @@ Trace should record:
 - any policy adjustments or violations
 - the realized execution envelope
 - the realized cost vector
+
+## Runtime Surface
+
+The current owned surface is:
+
+- `adl::chronosense::ExecutionPolicyCostModelContract`
+- `adl::chronosense::ExecutionPolicySchema`
+- `adl::chronosense::ExecutionRealizationSchema`
+- `adl::chronosense::CostVectorSchema`
+- `adl::chronosense::CostPolicyContract`
+- `adl::chronosense::CostAnchorContract`
+- `adl identity cost`
+
+This bounded surface is intentionally limited to:
+
+- requested execution posture
+- realized execution envelope
+- realized cost vector
+- trace-anchored attribution
+- reviewer-facing comparison rules
+
+It does not yet implement:
+
+- dynamic runtime policy enforcement
+- enterprise pricing catalogs
+- instinct/governance integration
 
 ---
 


### PR DESCRIPTION
Closes #1655

## Summary
- add a bounded execution-policy and cost-model contract for the v0.88 chronosense surface
- add the `adl identity cost` proof hook and JSON artifact emission path
- tighten the cost-model feature doc so it matches the owned runtime surface, trace anchors, and reviewer comparison rule

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all --check
- cargo test --manifest-path adl/Cargo.toml execution_policy_cost_model -- --nocapture
- cargo test --manifest-path adl/Cargo.toml identity_cost -- --nocapture
- cargo run --manifest-path adl/Cargo.toml -- identity cost --out .adl/state/execution_policy_cost_model_v1.json
- git diff --check