### PR TITLE
[v0.88][tools] Improve workflow-conductor routing precedence and satisfaction detection

### DIFF
--- a/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -38,7 +38,7 @@ The conductor should:
 - select the next skill
 - apply workflow policy
 - write one bounded routing artifact
-- classify known blocker families from doctor or PR state when safe
+- classify known blocker families from doctor, PR, explicit related-issue references, or repo-policy residue when safe
 - stop after routing
 
 It should not perform the selected skill's implementation work.

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -121,6 +121,9 @@ Important rule:
 - treat partially completed early steps as normal state, not corruption
 - the conductor should resume from the next truthful step instead of restarting bootstrap by reflex
 - healthy open PRs should normally hand off to human review/waiting state rather than janitor unless there is an actual blocker
+- explicit `covered by #<n>` / `satisfied by #<n>` style references should block fresh execution when the referenced issue is already closed
+- repo-policy residue such as tracked legacy `.adl` issue records should escalate as a mechanical blocker rather than being mistaken for issue-local implementation work
+- linkage-only PR failures should route as a bounded janitor case rather than a generic merge-blocked state
 
 ## Policy Model
 

--- a/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
+++ b/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
@@ -219,6 +219,59 @@ def gh_child_issue_wave_state(repo_root: Path, parent_issue_number: int):
     return "active_child_issue_wave"
 
 
+def gh_issue_index(repo_root: Path):
+    result = run_command(
+        ["gh", "issue", "list", "--state", "all", "--limit", "200", "--json", "number,state,body,title"],
+        repo_root,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return {}
+    try:
+        issues = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+    return {int(issue.get("number")): issue for issue in issues if issue.get("number") is not None}
+
+
+def related_issue_reference_state(texts, issue_index):
+    refs = set()
+    patterns = [
+        r"(?:covered by|satisfied by|folded into|superseded by)\s+#(\d+)",
+        r"(?:duplicate of|resolved by)\s+#(\d+)",
+    ]
+    for text in texts:
+        lower = text.lower()
+        for pattern in patterns:
+            refs.update(int(match) for match in re.findall(pattern, lower))
+    if not refs:
+        return "none"
+    referenced = [issue_index.get(number) for number in sorted(refs)]
+    referenced = [issue for issue in referenced if issue]
+    if not referenced:
+        return "none"
+    if all(issue.get("state") == "CLOSED" for issue in referenced):
+        return "satisfied_by_related_issue_refs"
+    return "related_issue_ref_active"
+
+
+def detect_tracked_adl_residue(repo_root: Path):
+    guard = repo_root / "adl" / "tools" / "check_no_tracked_adl_issue_record_residue.sh"
+    if not guard.exists():
+        return False
+    result = run_command(["bash", str(guard)], repo_root)
+    return result.returncode != 0
+
+
+def worktree_execution_done(repo_root: Path, issue_number: int, slug: str, version: str, worktree_hint):
+    if not worktree_hint:
+        return False
+    worktree = Path(worktree_hint)
+    if not worktree.is_absolute():
+        worktree = repo_root / worktree
+    bundle = worktree / ".adl" / version / "tasks" / f"issue-{issue_number}__{slug}"
+    return read_output_status(bundle) == "DONE"
+
+
 def classify_pr_state(pr):
     state = pr.get("state")
     review = pr.get("reviewDecision")
@@ -240,6 +293,9 @@ def classify_pr_state(pr):
     elif checks == "blocked":
         pr_state = "open_checks_failed"
         blocker_class = "checks_failed"
+    elif merge_state == "BLOCKED" and checks == "pass":
+        pr_state = "open_linkage_only"
+        blocker_class = "open_linkage_only"
     elif merge_state == "BLOCKED":
         pr_state = "open_with_blockers"
         blocker_class = "merge_blocked"
@@ -337,6 +393,17 @@ def collect_route_issue(repo_root: Path, payload):
         workflow["blocker_class"] = "active_child_issue_wave"
         workflow["evidence_used"].append("child_issue_wave")
 
+    related_state = related_issue_reference_state(
+        [read_text(source_prompt), read_text(bundle / "stp.md") if bundle else ""],
+        gh_issue_index(repo_root),
+    )
+    if workflow["blocker_class"] == "none" and related_state == "satisfied_by_related_issue_refs":
+        workflow["blocker_class"] = "satisfied_by_related_issue_refs"
+        workflow["evidence_used"].append("related_issue_refs")
+    elif workflow["blocker_class"] == "none" and related_state == "related_issue_ref_active":
+        workflow["blocker_class"] = "related_issue_ref_active"
+        workflow["evidence_used"].append("related_issue_refs")
+
     doctor = doctor_snapshot(
         repo_root,
         issue_number,
@@ -352,11 +419,23 @@ def collect_route_issue(repo_root: Path, payload):
         workflow["evidence_used"].append("doctor_json")
         if doctor.get("worktree"):
             resolved_target.setdefault("worktree_path", doctor["worktree"])
+            if worktree_execution_done(
+                repo_root,
+                issue_number,
+                resolved_target.get("slug"),
+                resolved_target.get("version"),
+                doctor.get("worktree"),
+            ):
+                workflow["lifecycle_state"] = "execution_done"
+                workflow["evidence_used"].append("worktree_output_card")
         if doctor.get("branch"):
             resolved_target.setdefault("branch", doctor["branch"])
     else:
         workflow["lifecycle_state"] = "pre_run"
         workflow["evidence_used"].append("bundle_paths")
+    if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
+        workflow["blocker_class"] = "tracked_adl_residue"
+        workflow["evidence_used"].append("tracked_adl_residue_guard")
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -393,6 +472,9 @@ def collect_route_task_bundle(repo_root: Path, payload):
     resolved_target["task_bundle_path"] = str(bundle)
     if source_prompt:
         resolved_target.setdefault("source_prompt_path", str(source_prompt))
+    if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
+        workflow["blocker_class"] = "tracked_adl_residue"
+        workflow["evidence_used"].append("tracked_adl_residue_guard")
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -434,6 +516,9 @@ def collect_route_branch(repo_root: Path, payload):
         workflow["ready_state"] = doctor.get("ready_status", "unknown").lower()
         workflow["blocker_class"] = classify_doctor_state(doctor)
         workflow["evidence_used"].append("doctor_json")
+    if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
+        workflow["blocker_class"] = "tracked_adl_residue"
+        workflow["evidence_used"].append("tracked_adl_residue_guard")
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -505,6 +590,9 @@ def collect_route_worktree(repo_root: Path, payload):
         workflow["ready_state"] = doctor.get("ready_status", "unknown").lower()
         workflow["blocker_class"] = classify_doctor_state(doctor)
         workflow["evidence_used"].append("doctor_json")
+    if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
+        workflow["blocker_class"] = "tracked_adl_residue"
+        workflow["evidence_used"].append("tracked_adl_residue_guard")
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -561,6 +649,9 @@ def collect_route_pr(repo_root: Path, payload):
         "evidence_used": ["gh_pr"],
     }
     workflow["pr_state"], workflow["blocker_class"] = classify_pr_state(pr)
+    if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
+        workflow["blocker_class"] = "tracked_adl_residue"
+        workflow["evidence_used"].append("tracked_adl_residue_guard")
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 

--- a/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
+++ b/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
@@ -82,12 +82,24 @@ def evaluate(payload):
         skill_name = "none"
         continuation = "ask_operator"
         escalation_reason = "child_issue_wave_satisfied"
+    elif blocker_class == "satisfied_by_related_issue_refs":
+        detected_phase = "already_satisfied"
+        selected_phase = "blocked"
+        skill_name = "none"
+        continuation = "ask_operator"
+        escalation_reason = "related_issue_ref_satisfied"
     elif blocker_class == "active_child_issue_wave":
         detected_phase = "tracker_in_flight"
         selected_phase = "blocked"
         skill_name = "none"
         continuation = "ask_operator"
         escalation_reason = "child_issue_wave_active"
+    elif blocker_class == "related_issue_ref_active":
+        detected_phase = "tracker_in_flight"
+        selected_phase = "blocked"
+        skill_name = "none"
+        continuation = "ask_operator"
+        escalation_reason = "related_issue_ref_active"
     elif lifecycle_state == "execution_done":
         selected_phase = "finish"
         skill_name = "pr-finish"
@@ -110,12 +122,14 @@ def evaluate(payload):
             continuation = "continue"
             escalation_reason = "none"
 
-    if blocker_class in ("open_pr_wave_only", "doctor_failed_or_inconclusive"):
+    if blocker_class in ("open_pr_wave_only", "doctor_failed_or_inconclusive", "tracked_adl_residue"):
         continuation = "ask_operator"
         if blocker_class == "open_pr_wave_only" and skill_name in ("pr-run", "pr-finish"):
             escalation_reason = "operator_override_required"
         elif blocker_class == "doctor_failed_or_inconclusive":
             escalation_reason = "ambiguous_live_state"
+        elif blocker_class == "tracked_adl_residue":
+            escalation_reason = "repo_policy_residue"
 
     bypasses = []
     policy_result = "PASS"

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -174,6 +174,9 @@ git -C "${fixture_repo}" init -q
 git -C "${fixture_repo}" config user.email "codex@example.test"
 git -C "${fixture_repo}" config user.name "Codex"
 git -C "${fixture_repo}" commit --allow-empty -qm "init"
+cat >"${fixture_repo}/.gitignore" <<'EOF'
+.adl/
+EOF
 
 cat >"${fixture_repo}/adl/tools/pr.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -195,12 +198,29 @@ JSON
 {"schema":"adl.pr.doctor.v1","issue":2006,"version":"v0.88","slug":"route-tracker-stop","branch":"codex/2006-route-tracker-stop","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"pre_run","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2006-route-tracker-stop.md","root_stp":".adl/v0.88/tasks/issue-2006__route-tracker-stop/stp.md","root_input":".adl/v0.88/tasks/issue-2006__route-tracker-stop/sip.md","root_output":".adl/v0.88/tasks/issue-2006__route-tracker-stop/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"doctor_status":"PASS"}
 JSON
     ;;
+  2007)
+    cat <<'JSON'
+{"schema":"adl.pr.doctor.v1","issue":2007,"version":"v0.88","slug":"route-issue-finish-from-worktree","branch":"codex/2007-route-issue-finish-from-worktree","mode":"full","preflight_status":"BLOCK","open_pr_count":1,"open_prs":[{"number":9998,"head_ref_name":"codex/other-open-wave","state":"ready","url":"https://example.test/pr/9998"}],"lifecycle_state":"run_bound","ready_status":"PASS","worktree":".worktrees/adl-wp-2007","source":".adl/v0.88/bodies/issue-2007-route-issue-finish-from-worktree.md","root_stp":".adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/stp.md","root_input":".adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sip.md","root_output":".adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sor.md","wt_stp":".worktrees/adl-wp-2007/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/stp.md","wt_input":".worktrees/adl-wp-2007/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sip.md","wt_output":".worktrees/adl-wp-2007/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sor.md","doctor_status":"BLOCK"}
+JSON
+    ;;
+  2008)
+    cat <<'JSON'
+{"schema":"adl.pr.doctor.v1","issue":2008,"version":"v0.88","slug":"route-related-satisfied","branch":"codex/2008-route-related-satisfied","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"pre_run","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2008-route-related-satisfied.md","root_stp":".adl/v0.88/tasks/issue-2008__route-related-satisfied/stp.md","root_input":".adl/v0.88/tasks/issue-2008__route-related-satisfied/sip.md","root_output":".adl/v0.88/tasks/issue-2008__route-related-satisfied/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"doctor_status":"PASS"}
+JSON
+    ;;
+  2009)
+    cat <<'JSON'
+{"schema":"adl.pr.doctor.v1","issue":2009,"version":"v0.88","slug":"route-residue-finish","branch":"codex/2009-route-residue-finish","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"execution_done","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2009-route-residue-finish.md","root_stp":".adl/v0.88/tasks/issue-2009__route-residue-finish/stp.md","root_input":".adl/v0.88/tasks/issue-2009__route-residue-finish/sip.md","root_output":".adl/v0.88/tasks/issue-2009__route-residue-finish/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"doctor_status":"PASS"}
+JSON
+    ;;
   *)
     exit 1
     ;;
 esac
 EOF
 chmod +x "${fixture_repo}/adl/tools/pr.sh"
+cp "${repo_root}/adl/tools/check_no_tracked_adl_issue_record_residue.sh" "${fixture_repo}/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
+chmod +x "${fixture_repo}/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
 
 mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-2001__route-run"
 touch "${fixture_repo}/.adl/v0.88/tasks/issue-2001__route-run/stp.md"
@@ -230,6 +250,27 @@ touch "${fixture_repo}/.adl/v0.88/tasks/issue-2006__route-tracker-stop/sip.md"
 touch "${fixture_repo}/.adl/v0.88/tasks/issue-2006__route-tracker-stop/sor.md"
 touch "${fixture_repo}/.adl/v0.88/bodies/issue-2006-route-tracker-stop.md"
 
+mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/stp.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sip.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sor.md"
+touch "${fixture_repo}/.adl/v0.88/bodies/issue-2007-route-issue-finish-from-worktree.md"
+
+mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-2008__route-related-satisfied"
+cat >"${fixture_repo}/.adl/v0.88/tasks/issue-2008__route-related-satisfied/stp.md" <<'EOF'
+## Issue-Graph Notes
+- covered by #2013
+EOF
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2008__route-related-satisfied/sip.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2008__route-related-satisfied/sor.md"
+touch "${fixture_repo}/.adl/v0.88/bodies/issue-2008-route-related-satisfied.md"
+
+mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/stp.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/sip.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/sor.md"
+touch "${fixture_repo}/.adl/v0.88/bodies/issue-2009-route-residue-finish.md"
+
 mkdir -p "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2005__route-worktree-finish"
 touch "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2005__route-worktree-finish/stp.md"
 touch "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2005__route-worktree-finish/sip.md"
@@ -242,6 +283,14 @@ mkdir -p "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2999__ex
 touch "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2999__extra-worktree-bundle/stp.md"
 touch "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2999__extra-worktree-bundle/sip.md"
 touch "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2999__extra-worktree-bundle/sor.md"
+
+mkdir -p "${fixture_repo}/.worktrees/adl-wp-2007/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree"
+touch "${fixture_repo}/.worktrees/adl-wp-2007/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/stp.md"
+touch "${fixture_repo}/.worktrees/adl-wp-2007/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sip.md"
+cat >"${fixture_repo}/.worktrees/adl-wp-2007/.adl/v0.88/tasks/issue-2007__route-issue-finish-from-worktree/sor.md" <<'EOF'
+Task ID: issue-2007
+Status: DONE
+EOF
 
 cat >"${tmpdir}/route_issue.json" <<EOF
 {
@@ -379,6 +428,50 @@ cat >"${tmpdir}/route_tracker_satisfied.json" <<EOF
 }
 EOF
 
+cat >"${tmpdir}/route_issue_finish_from_worktree.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_issue",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "issue_number": 2007
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
+cat >"${tmpdir}/route_related_satisfied.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_issue",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "issue_number": 2008
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
 mock_bin="${tmpdir}/mock-bin"
 mkdir -p "${mock_bin}"
 cat >"${mock_bin}/gh" <<'EOF'
@@ -394,7 +487,9 @@ if [[ "$1" == "issue" && "$2" == "list" ]]; then
   cat <<'JSON'
 [
   {"number":2011,"state":"CLOSED","title":"child-a","body":"## Issue-Graph Notes\n- child of #2006"},
-  {"number":2012,"state":"CLOSED","title":"child-b","body":"## Issue-Graph Notes\n- child of #2006"}
+  {"number":2012,"state":"CLOSED","title":"child-b","body":"## Issue-Graph Notes\n- child of #2006"},
+  {"number":2013,"state":"CLOSED","title":"covered-fix","body":"Resolved by prior child issue"},
+  {"number":2014,"state":"OPEN","title":"active-follow-on","body":"Still in progress"}
 ]
 JSON
   exit 0
@@ -517,16 +612,65 @@ cat >"${tmpdir}/route_pr_linkage_only.json" <<EOF
 }
 EOF
 
+residue_repo="${tmpdir}/residue-repo"
+mkdir -p "${residue_repo}/adl/tools" "${residue_repo}/.adl/v0.88/bodies" "${residue_repo}/.adl/v0.88/tasks"
+git -C "${residue_repo}" init -q
+git -C "${residue_repo}" config user.email "codex@example.test"
+git -C "${residue_repo}" config user.name "Codex"
+cat >"${residue_repo}/.gitignore" <<'EOF'
+.adl/
+EOF
+cp "${repo_root}/adl/tools/check_no_tracked_adl_issue_record_residue.sh" "${residue_repo}/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
+cp "${fixture_repo}/adl/tools/pr.sh" "${residue_repo}/adl/tools/pr.sh"
+chmod +x "${residue_repo}/adl/tools/check_no_tracked_adl_issue_record_residue.sh" "${residue_repo}/adl/tools/pr.sh"
+mkdir -p "${residue_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish"
+touch "${residue_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/stp.md"
+touch "${residue_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/sip.md"
+touch "${residue_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/sor.md"
+touch "${residue_repo}/.adl/v0.88/bodies/issue-2009-route-residue-finish.md"
+mkdir -p "${residue_repo}/.adl/v0.88/tasks/issue-2998__tracked-residue"
+cat >"${residue_repo}/.adl/v0.88/tasks/issue-2998__tracked-residue/sor.md" <<'EOF'
+Status: DONE
+EOF
+git -C "${residue_repo}" add .gitignore adl/tools/check_no_tracked_adl_issue_record_residue.sh adl/tools/pr.sh
+git -C "${residue_repo}" add -f .adl/v0.88/tasks/issue-2998__tracked-residue/sor.md
+git -C "${residue_repo}" commit -qm "seed tracked residue fixture"
+
+cat >"${tmpdir}/route_residue_finish.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_issue",
+  "repo_root": "${residue_repo}",
+  "target": {
+    "issue_number": 2009
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_issue.json" --artifact-path ".adl/reviews/route-issue.md" >"${tmpdir}/route_issue.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_task_bundle.json" --artifact-path ".adl/reviews/route-task-bundle.md" >"${tmpdir}/route_task_bundle.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_finish.json" --artifact-path ".adl/reviews/route-finish.md" >"${tmpdir}/route_finish.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_worktree_finish.json" --artifact-path ".adl/reviews/route-worktree-finish.md" >"${tmpdir}/route_worktree_finish.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_worktree_disambiguated.json" --artifact-path ".adl/reviews/route-worktree-disambiguated.md" >"${tmpdir}/route_worktree_disambiguated.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_tracker_satisfied.json" --artifact-path ".adl/reviews/route-tracker-satisfied.md" >"${tmpdir}/route_tracker_satisfied.out.json"
+PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_issue_finish_from_worktree.json" --artifact-path ".adl/reviews/route-issue-finish-from-worktree.md" >"${tmpdir}/route_issue_finish_from_worktree.out.json"
+PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_related_satisfied.json" --artifact-path ".adl/reviews/route-related-satisfied.md" >"${tmpdir}/route_related_satisfied.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_pr_blocked.json" --artifact-path ".adl/reviews/route-pr-blocked.md" >"${tmpdir}/route_pr_blocked.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_pr_merged.json" --artifact-path ".adl/reviews/route-pr-merged.md" >"${tmpdir}/route_pr_merged.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_pr_clean.json" --artifact-path ".adl/reviews/route-pr-clean.md" >"${tmpdir}/route_pr_clean.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_pr_linkage_only.json" --artifact-path ".adl/reviews/route-pr-linkage-only.md" >"${tmpdir}/route_pr_linkage_only.out.json"
+PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_residue_finish.json" --artifact-path ".adl/reviews/route-residue-finish.md" >"${tmpdir}/route_residue_finish.out.json"
 
 python3 - "$tmpdir" "$fixture_repo" <<'PY'
 import json
@@ -563,6 +707,19 @@ assert route_tracker_satisfied["handoff_state"]["next_phase"] == "human_review"
 assert route_tracker_satisfied["handoff_state"]["continuation"] == "ask_operator"
 assert route_tracker_satisfied["handoff_state"]["escalation_reason"] == "child_issue_wave_satisfied"
 
+route_issue_finish_from_worktree = load("route_issue_finish_from_worktree.out.json")
+assert route_issue_finish_from_worktree["selected_skill"]["skill_name"] == "pr-finish"
+assert route_issue_finish_from_worktree["workflow_state"]["blocker_class"] == "open_pr_wave_only"
+assert route_issue_finish_from_worktree["handoff_state"]["continuation"] == "ask_operator"
+assert route_issue_finish_from_worktree["handoff_state"]["escalation_reason"] == "operator_override_required"
+
+route_related_satisfied = load("route_related_satisfied.out.json")
+assert route_related_satisfied["selected_skill"]["skill_name"] == "none"
+assert route_related_satisfied["workflow_state"]["blocker_class"] == "satisfied_by_related_issue_refs"
+assert route_related_satisfied["handoff_state"]["next_phase"] == "human_review"
+assert route_related_satisfied["handoff_state"]["continuation"] == "ask_operator"
+assert route_related_satisfied["handoff_state"]["escalation_reason"] == "related_issue_ref_satisfied"
+
 route_worktree_finish = load("route_worktree_finish.out.json")
 assert route_worktree_finish["selected_skill"]["skill_name"] == "pr-finish"
 
@@ -586,7 +743,13 @@ assert route_pr_clean["handoff_state"]["escalation_reason"] == "healthy_pr_waiti
 
 route_pr_linkage_only = load("route_pr_linkage_only.out.json")
 assert route_pr_linkage_only["selected_skill"]["skill_name"] == "pr-janitor"
-assert route_pr_linkage_only["workflow_state"]["blocker_class"] == "merge_blocked"
+assert route_pr_linkage_only["workflow_state"]["blocker_class"] == "open_linkage_only"
+
+route_residue_finish = load("route_residue_finish.out.json")
+assert route_residue_finish["selected_skill"]["skill_name"] == "pr-finish"
+assert route_residue_finish["workflow_state"]["blocker_class"] == "tracked_adl_residue"
+assert route_residue_finish["handoff_state"]["continuation"] == "ask_operator"
+assert route_residue_finish["handoff_state"]["escalation_reason"] == "repo_policy_residue"
 PY
 
 echo "PASS test_workflow_conductor_skill_contracts"


### PR DESCRIPTION
Closes #1706

## Summary
Improved the workflow-conductor so it stays thin but routes more truthfully: finished worktree output can now override stale `run_bound` doctor state, explicit `covered by #<n>` style references can stop redundant execution, tracked legacy `.adl` residue is classified as repo-policy blockage, and linkage-only PR failures are distinguished from generic merge blockers.

## Artifacts
- `adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
- `adl/tools/skills/workflow-conductor/scripts/select_next_skill.py`
- `adl/tools/skills/workflow-conductor/SKILL.md`
- `adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_workflow_conductor_skill_contracts.sh`
- `.adl/reviews/workflow-conductor-1706-post.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/workflow-conductor/scripts/route_workflow.py adl/tools/skills/workflow-conductor/scripts/select_next_skill.py` verified the conductor Python entrypoints parse cleanly after the routing changes.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh` verified deterministic routing for finished worktrees, related-issue satisfaction, tracked `.adl` residue escalation, linkage-only PR handling, tracker child-wave satisfaction, policy blocking, and worktree disambiguation.
  - `python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <tmp-input> --artifact-path .adl/reviews/workflow-conductor-1706-post-done.md` verified the live `#1706` worktree now routes to `pr-finish` once the worktree SOR is marked `DONE`.
  - `git diff --check` verified there are no malformed patch artifacts or whitespace errors in the tracked changes.
- Results: all listed validation commands passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1706__v0-88-tools-improve-workflow-conductor-routing-precedence-and-satisfaction-detection/sip.md
- Output card: .adl/v0.88/tasks/issue-1706__v0-88-tools-improve-workflow-conductor-routing-precedence-and-satisfaction-detection/sor.md
- Idempotency-Key: v0-88-tools-improve-workflow-conductor-routing-precedence-and-satisfaction-detection-adl-tools-skills-workflow-conductor-scripts-route-workflow-py-adl-tools-skills-workflow-conductor-scripts-select-next-skill-py-adl-tools-skills-workflow-conductor-skill-md-adl-tools-skills-docs-workflow-conductor-skill-input-schema-md-adl-tools-test-workflow-conductor-skill-contracts-sh-adl-v0-88-tasks-issue-1706-v0-88-tools-improve-workflow-conductor-routing-precedence-and-satisfaction-detection-sip-md-adl-v0-88-tasks-issue-1706-v0-88-tools-improve-workflow-conductor-routing-precedence-and-satisfaction-detection-sor-md