### PR TITLE
[v0.88][WP-09] PHI-style integration metrics

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -14,6 +14,7 @@ pub const TEMPORAL_QUERY_RETRIEVAL_SCHEMA: &str = "temporal_query_retrieval.v1";
 pub const COMMITMENT_DEADLINE_SCHEMA: &str = "commitment_deadline_semantics.v1";
 pub const TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA: &str = "temporal_causality_explanation.v1";
 pub const EXECUTION_POLICY_COST_MODEL_SCHEMA: &str = "execution_policy_cost_model.v1";
+pub const PHI_INTEGRATION_METRICS_SCHEMA: &str = "phi_integration_metrics.v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdentityProfile {
@@ -304,6 +305,56 @@ pub struct ExecutionPolicyCostModelContract {
     pub cost_policy: CostPolicyContract,
     pub cost_anchor: CostAnchorContract,
     pub review_surface: CostReviewSurfaceContract,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhiMetricDimension {
+    pub name: String,
+    pub interpretation: String,
+    pub low_signal: String,
+    pub medium_signal: String,
+    pub high_signal: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhiComparisonProfile {
+    pub profile_name: String,
+    pub integration_band: String,
+    pub expected_runtime_surfaces: Vec<String>,
+    pub why_it_matters: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhiComparisonFixture {
+    pub profile_name: String,
+    pub structural_coupling: String,
+    pub memory_coupling: String,
+    pub feedback_depth: String,
+    pub policy_continuity: String,
+    pub instinct_coupling: String,
+    pub graph_irreducibility: String,
+    pub adaptive_depth: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhiReviewSurfaceContract {
+    pub required_questions: Vec<String>,
+    pub comparison_rule: String,
+    pub non_goals: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhiIntegrationMetricsContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub dimensions: Vec<PhiMetricDimension>,
+    pub comparison_profiles: Vec<PhiComparisonProfile>,
+    pub comparison_fixtures: Vec<PhiComparisonFixture>,
+    pub review_surface: PhiReviewSurfaceContract,
     pub proof_fixture_hooks: Vec<String>,
     pub proof_hook_command: String,
     pub proof_hook_output_path: String,
@@ -965,6 +1016,202 @@ impl ExecutionPolicyCostModelContract {
     }
 }
 
+impl PhiIntegrationMetricsContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: PHI_INTEGRATION_METRICS_SCHEMA.to_string(),
+            owned_runtime_surfaces: vec![
+                "adl::chronosense::PhiIntegrationMetricsContract".to_string(),
+                "adl::chronosense::PhiMetricDimension".to_string(),
+                "adl::chronosense::PhiComparisonProfile".to_string(),
+                "adl::chronosense::PhiComparisonFixture".to_string(),
+                "adl::chronosense::TemporalQueryRetrievalContract".to_string(),
+                "adl::chronosense::CommitmentDeadlineContract".to_string(),
+                "adl::chronosense::ExecutionPolicyCostModelContract".to_string(),
+                "adl identity phi".to_string(),
+            ],
+            dimensions: vec![
+                PhiMetricDimension {
+                    name: "structural_coupling".to_string(),
+                    interpretation:
+                        "how many runtime surfaces must remain coordinated for the path to work"
+                            .to_string(),
+                    low_signal: "mostly isolated steps with minimal cross-surface dependency"
+                        .to_string(),
+                    medium_signal:
+                        "some shared state or review surfaces must remain aligned".to_string(),
+                    high_signal:
+                        "behavior depends on multiple tightly coupled runtime surfaces".to_string(),
+                },
+                PhiMetricDimension {
+                    name: "memory_coupling".to_string(),
+                    interpretation:
+                        "how much the path relies on retrieval state or continuity-preserved records"
+                            .to_string(),
+                    low_signal: "little or no retrieval dependence".to_string(),
+                    medium_signal: "retrieval helps but is not the sole determinant".to_string(),
+                    high_signal:
+                        "retrieval or preserved state materially shapes behavior".to_string(),
+                },
+                PhiMetricDimension {
+                    name: "feedback_depth".to_string(),
+                    interpretation:
+                        "how much iterative review, adaptation, or reflexive correction is required"
+                            .to_string(),
+                    low_signal: "single-pass execution with little feedback".to_string(),
+                    medium_signal: "bounded refinement or review loops".to_string(),
+                    high_signal: "multi-step feedback materially changes the resulting path"
+                        .to_string(),
+                },
+                PhiMetricDimension {
+                    name: "policy_continuity".to_string(),
+                    interpretation:
+                        "how much stable policy and execution posture must persist across the path"
+                            .to_string(),
+                    low_signal: "policy can vary without changing the main outcome".to_string(),
+                    medium_signal: "policy consistency improves comparability and trust"
+                        .to_string(),
+                    high_signal:
+                        "policy continuity is necessary for meaningful comparison or replay"
+                            .to_string(),
+                },
+                PhiMetricDimension {
+                    name: "instinct_coupling".to_string(),
+                    interpretation:
+                        "how much instinct or bounded-priority posture must couple to execution"
+                            .to_string(),
+                    low_signal: "no instinct-sensitive routing involved".to_string(),
+                    medium_signal:
+                        "priority posture influences comparison but is still bounded".to_string(),
+                    high_signal:
+                        "instinct-sensitive posture materially changes execution shape"
+                            .to_string(),
+                },
+                PhiMetricDimension {
+                    name: "graph_irreducibility".to_string(),
+                    interpretation:
+                        "how much explanatory power is lost if the path is split into independent parts"
+                            .to_string(),
+                    low_signal: "the path stays understandable when decomposed".to_string(),
+                    medium_signal:
+                        "some explanatory loss appears when the path is decomposed".to_string(),
+                    high_signal:
+                        "decomposition hides important cross-surface behavior".to_string(),
+                },
+                PhiMetricDimension {
+                    name: "adaptive_depth".to_string(),
+                    interpretation:
+                        "how much bounded adaptation or runtime re-weighting is present"
+                            .to_string(),
+                    low_signal: "fixed execution with no meaningful adaptation".to_string(),
+                    medium_signal: "bounded adaptation within an explicit review surface"
+                        .to_string(),
+                    high_signal:
+                        "adaptation materially changes path selection or integration profile"
+                            .to_string(),
+                },
+            ],
+            comparison_profiles: vec![
+                PhiComparisonProfile {
+                    profile_name: "low_integration_path".to_string(),
+                    integration_band: "low".to_string(),
+                    expected_runtime_surfaces: vec![
+                        "adl identity foundation".to_string(),
+                        "adl identity schema".to_string(),
+                    ],
+                    why_it_matters:
+                        "establishes the baseline for bounded, mostly decomposable execution"
+                            .to_string(),
+                },
+                PhiComparisonProfile {
+                    profile_name: "medium_integration_path".to_string(),
+                    integration_band: "medium".to_string(),
+                    expected_runtime_surfaces: vec![
+                        "adl identity retrieval".to_string(),
+                        "adl identity commitments".to_string(),
+                        "adl identity cost".to_string(),
+                    ],
+                    why_it_matters:
+                        "shows when memory, commitment, and cost surfaces begin to couple"
+                            .to_string(),
+                },
+                PhiComparisonProfile {
+                    profile_name: "high_integration_path".to_string(),
+                    integration_band: "high".to_string(),
+                    expected_runtime_surfaces: vec![
+                        "adl identity continuity".to_string(),
+                        "adl identity causality".to_string(),
+                        "instinct runtime surface".to_string(),
+                    ],
+                    why_it_matters:
+                        "gives reviewers a bounded model for tightly coupled adaptive runtime behavior"
+                            .to_string(),
+                },
+            ],
+            comparison_fixtures: vec![
+                PhiComparisonFixture {
+                    profile_name: "low_integration_path".to_string(),
+                    structural_coupling: "low".to_string(),
+                    memory_coupling: "low".to_string(),
+                    feedback_depth: "low".to_string(),
+                    policy_continuity: "low".to_string(),
+                    instinct_coupling: "low".to_string(),
+                    graph_irreducibility: "low".to_string(),
+                    adaptive_depth: "low".to_string(),
+                },
+                PhiComparisonFixture {
+                    profile_name: "medium_integration_path".to_string(),
+                    structural_coupling: "medium".to_string(),
+                    memory_coupling: "medium".to_string(),
+                    feedback_depth: "medium".to_string(),
+                    policy_continuity: "medium".to_string(),
+                    instinct_coupling: "low".to_string(),
+                    graph_irreducibility: "medium".to_string(),
+                    adaptive_depth: "medium".to_string(),
+                },
+                PhiComparisonFixture {
+                    profile_name: "high_integration_path".to_string(),
+                    structural_coupling: "high".to_string(),
+                    memory_coupling: "high".to_string(),
+                    feedback_depth: "high".to_string(),
+                    policy_continuity: "high".to_string(),
+                    instinct_coupling: "medium".to_string(),
+                    graph_irreducibility: "high".to_string(),
+                    adaptive_depth: "high".to_string(),
+                },
+            ],
+            review_surface: PhiReviewSurfaceContract {
+                required_questions: vec![
+                    "which integration dimensions changed across low, medium, and high paths"
+                        .to_string(),
+                    "which runtime surfaces explain those differences".to_string(),
+                    "why the comparison matters for ADL execution behavior".to_string(),
+                ],
+                comparison_rule:
+                    "reviewers must be able to compare low, medium, and high integration profiles without collapsing them into a single metaphysical scalar"
+                        .to_string(),
+                non_goals: vec![
+                    "formal IIT phi calculation".to_string(),
+                    "consciousness or sentience claims".to_string(),
+                    "one-number replacement for cost, time, or routing".to_string(),
+                ],
+            },
+            proof_fixture_hooks: vec![
+                "adl::chronosense::PhiIntegrationMetricsContract::v1".to_string(),
+                "adl identity phi --out .adl/state/phi_integration_metrics_v1.json"
+                    .to_string(),
+            ],
+            proof_hook_command:
+                "adl identity phi --out .adl/state/phi_integration_metrics_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/phi_integration_metrics_v1.json".to_string(),
+            scope_boundary:
+                "bounded engineering comparison surface only; no formal IIT, no consciousness claims, and no replacement of cost or temporal review surfaces"
+                    .to_string(),
+        }
+    }
+}
+
 pub fn default_identity_profile_path(repo_root: &Path) -> PathBuf {
     repo_root
         .join("adl")
@@ -1278,5 +1525,49 @@ mod tests {
         assert!(contract
             .proof_hook_output_path
             .contains("execution_policy_cost_model_v1.json"));
+    }
+
+    #[test]
+    fn phi_integration_metrics_contract_has_low_medium_high_comparison_profiles() {
+        let contract = PhiIntegrationMetricsContract::v1();
+
+        assert_eq!(contract.schema_version, PHI_INTEGRATION_METRICS_SCHEMA);
+        assert!(contract
+            .owned_runtime_surfaces
+            .contains(&"adl identity phi".to_string()));
+        assert_eq!(contract.comparison_profiles.len(), 3);
+        assert!(contract
+            .comparison_profiles
+            .iter()
+            .any(|profile| profile.integration_band == "low"));
+        assert!(contract
+            .comparison_profiles
+            .iter()
+            .any(|profile| profile.integration_band == "medium"));
+        assert!(contract
+            .comparison_profiles
+            .iter()
+            .any(|profile| profile.integration_band == "high"));
+    }
+
+    #[test]
+    fn phi_integration_metrics_contract_is_engineering_facing_not_metaphysical() {
+        let contract = PhiIntegrationMetricsContract::v1();
+
+        assert!(contract
+            .dimensions
+            .iter()
+            .any(|dimension| dimension.name == "graph_irreducibility"));
+        assert!(contract
+            .review_surface
+            .non_goals
+            .contains(&"formal IIT phi calculation".to_string()));
+        assert!(contract
+            .review_surface
+            .comparison_rule
+            .contains("without collapsing them into a single metaphysical scalar"));
+        assert!(contract
+            .proof_hook_output_path
+            .contains("phi_integration_metrics_v1.json"));
     }
 }

--- a/adl/src/cli/identity_cmd.rs
+++ b/adl/src/cli/identity_cmd.rs
@@ -8,8 +8,9 @@ use std::process::Command;
 use ::adl::chronosense::{
     default_identity_profile_path, load_identity_profile, write_identity_profile,
     ChronosenseFoundation, CommitmentDeadlineContract, ContinuitySemanticsContract,
-    ExecutionPolicyCostModelContract, IdentityProfile, TemporalCausalityExplanationContract,
-    TemporalContext, TemporalQueryRetrievalContract, TemporalSchemaContract,
+    ExecutionPolicyCostModelContract, IdentityProfile, PhiIntegrationMetricsContract,
+    TemporalCausalityExplanationContract, TemporalContext, TemporalQueryRetrievalContract,
+    TemporalSchemaContract,
 };
 
 pub(crate) fn real_identity(args: &[String]) -> Result<()> {
@@ -20,7 +21,7 @@ pub(crate) fn real_identity(args: &[String]) -> Result<()> {
 fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "identity requires a subcommand: init | show | now | foundation | schema | continuity | retrieval | commitments"
+            "identity requires a subcommand: init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost | phi"
         ));
     };
 
@@ -35,12 +36,13 @@ fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
         "commitments" => real_identity_commitments(repo_root, &args[1..]),
         "causality" => real_identity_causality(repo_root, &args[1..]),
         "cost" => real_identity_cost(repo_root, &args[1..]),
+        "phi" => real_identity_phi(repo_root, &args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost | phi)"
         )),
     }
 }
@@ -521,6 +523,55 @@ fn real_identity_cost(repo_root: &Path, args: &[String]) -> Result<()> {
             )
         })?;
         println!("EXECUTION_POLICY_COST_MODEL_PATH={}", resolved.display());
+    } else {
+        println!("{json}");
+    }
+
+    Ok(())
+}
+
+fn real_identity_phi(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                out_path = Some(PathBuf::from(required_value(args, i, "--out")?));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => return Err(anyhow!("unknown arg for identity phi: {other}")),
+        }
+        i += 1;
+    }
+
+    let contract = PhiIntegrationMetricsContract::v1();
+    let json = to_string_pretty(&contract)?;
+
+    if let Some(out) = out_path {
+        let resolved = if out.is_absolute() {
+            out
+        } else {
+            repo_root.join(out)
+        };
+        let Some(parent) = resolved.parent() else {
+            return Err(anyhow!(
+                "identity phi --out path must have a parent directory"
+            ));
+        };
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+        fs::write(&resolved, json.as_bytes()).with_context(|| {
+            format!(
+                "failed to write phi integration metrics artifact to {}",
+                resolved.display()
+            )
+        })?;
+        println!("PHI_INTEGRATION_METRICS_PATH={}", resolved.display());
     } else {
         println!("{json}");
     }
@@ -1250,6 +1301,53 @@ mod tests {
             .contains("unknown arg for identity cost: --bogus"));
 
         let err = real_identity_in_repo(&["cost".to_string(), "--out".to_string()], &repo)
+            .expect_err("out flag without value should fail");
+        assert!(err.to_string().contains("--out requires a value"));
+    }
+
+    #[test]
+    fn identity_phi_writes_phi_integration_metrics_contract_json() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let repo = temp_repo("identity-phi");
+        let out_path = repo.join(".adl/state/phi_integration_metrics_v1.json");
+
+        real_identity_in_repo(
+            &[
+                "phi".to_string(),
+                "--out".to_string(),
+                ".adl/state/phi_integration_metrics_v1.json".to_string(),
+            ],
+            &repo,
+        )
+        .expect("identity phi");
+
+        let json: Value =
+            serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+        assert_eq!(json["schema_version"], "phi_integration_metrics.v1");
+        assert_eq!(
+            json["proof_hook_output_path"],
+            ".adl/state/phi_integration_metrics_v1.json"
+        );
+        assert!(json["owned_runtime_surfaces"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "adl identity phi"));
+    }
+
+    #[test]
+    fn identity_phi_validates_unknown_args_and_missing_out_value() {
+        let repo = temp_repo("identity-phi-errors");
+
+        let err = real_identity_in_repo(&["phi".to_string(), "--bogus".to_string()], &repo)
+            .expect_err("unknown arg should fail");
+        assert!(err
+            .to_string()
+            .contains("unknown arg for identity phi: --bogus"));
+
+        let err = real_identity_in_repo(&["phi".to_string(), "--out".to_string()], &repo)
             .expect_err("out flag without value should fail");
         assert!(err.to_string().contains("--out requires a value"));
     }

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -14,6 +14,7 @@ pub fn usage() -> &'static str {
   adl identity commitments [--out <path>]
   adl identity causality [--out <path>]
   adl identity cost [--out <path>]
+  adl identity phi [--out <path>]
   adl provider setup <family> [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]

--- a/docs/milestones/v0.88/features/PHI_METRICS_FOR_ADL.md
+++ b/docs/milestones/v0.88/features/PHI_METRICS_FOR_ADL.md
@@ -73,3 +73,69 @@ This makes cognitive routing partly a coupling-allocation problem, not just a sp
 This is a bounded metric-family feature for `v0.88`.
 
 The milestone should use it to learn something real about integration and coupling in ADL systems without overclaiming a final formal theory.
+
+## Runtime Surface
+
+`WP-09` owns one bounded engineering review surface:
+
+- `adl::chronosense::PhiIntegrationMetricsContract`
+- `adl identity phi --out .adl/state/phi_integration_metrics_v1.json`
+
+The contract must stay reviewer-facing and comparison-oriented:
+
+- explicit dimensions rather than one magic score
+- low / medium / high integration profiles
+- fixture-backed comparison output that names what changed
+- non-goals that explicitly rule out metaphysical or sentience claims
+
+## Required Dimensions
+
+The current bounded `v0.88` dimensions are:
+
+- structural coupling
+- memory coupling
+- feedback depth
+- policy continuity
+- instinct coupling
+- graph irreducibility
+- adaptive depth
+
+These dimensions are not final theory.
+They are a reviewer-readable engineering profile for comparing execution paths.
+
+## Comparison Model
+
+`v0.88` should support one bounded comparison across three integration bands:
+
+- low integration path
+- medium integration path
+- high integration path
+
+The comparison is successful when a reviewer can see:
+
+- which dimensions moved across the three profiles
+- which runtime surfaces explain the movement
+- why that matters for ADL runtime behavior
+
+## Proof Hook
+
+Current proof hook:
+
+```bash
+adl identity phi --out .adl/state/phi_integration_metrics_v1.json
+```
+
+Expected proof artifact:
+
+- `.adl/state/phi_integration_metrics_v1.json`
+
+This artifact should remain suitable for later `WP-13` demo-matrix integration.
+
+## Explicit Non-Goals
+
+This surface must not:
+
+- compute formal IIT `Φ`
+- make consciousness or sentience claims
+- collapse integration into one scalar that replaces cost, time, or routing review
+- pull later-band governance or social cognition claims into `v0.88`


### PR DESCRIPTION
## Summary
- add a bounded PHI-style integration metrics contract with explicit low / medium / high comparison fixtures
- add the reviewer-facing proof hook `adl identity phi`
- tighten the tracked feature doc so the milestone claim matches the real runtime surface

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all --check
- cargo test --manifest-path adl/Cargo.toml phi_integration_metrics -- --nocapture
- cargo test --manifest-path adl/Cargo.toml identity_phi -- --nocapture
- cargo run --manifest-path adl/Cargo.toml -- identity phi --out .adl/state/phi_integration_metrics_v1.json
- git diff --check

Closes #1645