### PR TITLE
[v0.88][tools] Enforce metadata parity across issue and local canonical surfaces

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -21,6 +21,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `adl tooling ...`: Rust-owned tooling surface for prompt/card/review validation helpers, with legacy wrapper scripts preserved at the historical `adl/tools/*` paths.
 - `burst_worktree.sh`, `burst_continue.sh`: burst lane/worktree helpers.
 - `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks, including the repo-code-review skill contract guard.
+- `check_issue_metadata_parity.sh`: canonical metadata parity audit for GitHub issue title/labels plus local `.adl` body/STP metadata identity.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
 - `report_large_rust_modules.sh`: non-blocking Rust implementation-module size report for maintainability review.
 - `open_artifact.sh`: convenience opener for cards/reports.
@@ -90,6 +91,9 @@ bash ./adl/tools/pr.sh run <issue_num> --slug <slug>
 
 # run standard checks
 ./adl/tools/batched_checks.sh
+
+# audit GitHub/local issue metadata parity for one milestone package
+./adl/tools/check_issue_metadata_parity.sh --version v0.88
 
 # enforce coverage thresholds from coverage-summary.json
 cd ./adl/ && bash tools/enforce_coverage_gates.sh coverage-summary.json

--- a/adl/tools/check_issue_metadata_parity.sh
+++ b/adl/tools/check_issue_metadata_parity.sh
@@ -17,6 +17,7 @@ Checks:
 - exact title parity with the canonical local issue prompt
 - presence of all prompt-declared labels on GitHub
 - presence of the matching version:<milestone> label on GitHub
+- local parity between the canonical issue prompt front matter and the canonical task-bundle STP front matter
 - duplicate local prompt/task-bundle identities for the same issue number
 EOF
 }
@@ -103,6 +104,38 @@ def parse_prompt(path: Path):
     return {"title": title, "issue_number": issue_number, "labels": labels}
 
 
+def parse_prompt_with_fields(path: Path):
+    text = path.read_text()
+    if not text.startswith("---\n"):
+        raise RuntimeError(f"{path}: missing front matter")
+    _, rest = text.split("---\n", 1)
+    fm_text, _ = rest.split("\n---\n", 1)
+    lines = fm_text.splitlines()
+    data = {"labels": []}
+    in_labels = False
+    for line in lines:
+        if line.startswith("title: "):
+            data["title"] = line.split(":", 1)[1].strip().strip('"')
+            in_labels = False
+        elif line.startswith("issue_number: "):
+            data["issue_number"] = int(line.split(":", 1)[1].strip())
+            in_labels = False
+        elif line.startswith("slug: "):
+            data["slug"] = line.split(":", 1)[1].strip().strip('"')
+            in_labels = False
+        elif line.startswith("wp: "):
+            data["wp"] = line.split(":", 1)[1].strip().strip('"')
+            in_labels = False
+        elif line.startswith("labels:"):
+            in_labels = True
+            data["labels"] = []
+        elif in_labels and line.startswith("  - "):
+            data["labels"].append(line.split("  - ", 1)[1].strip().strip('"'))
+        elif line and not line.startswith(" "):
+            in_labels = False
+    return data
+
+
 def gh_issue(issue_number: int):
     proc = subprocess.run(
         [
@@ -160,6 +193,44 @@ for prompt_path in sorted(body_dir.glob("issue-*.md")):
         errors.append(
             f"issue #{issue_number}: missing required version label version:{version}"
         )
+
+    body_meta = parse_prompt_with_fields(prompt_path)
+    canonical_task = root / ".adl" / version / "tasks" / prompt_path.stem.replace(
+        f"issue-{issue_number:04d}-", f"issue-{issue_number:04d}__"
+    )
+    stp_path = canonical_task / "stp.md"
+    if not stp_path.is_file():
+        errors.append(
+            f"issue #{issue_number}: missing canonical task-bundle STP: {stp_path.relative_to(root)}"
+        )
+    else:
+        stp_meta = parse_prompt_with_fields(stp_path)
+        for field in ("title", "issue_number", "slug", "wp"):
+            body_value = body_meta.get(field)
+            stp_value = stp_meta.get(field)
+            if body_value != stp_value:
+                errors.append(
+                    "issue #{}: local metadata mismatch for {} between {} and {}: expected {!r}, got {!r}".format(
+                        issue_number,
+                        field,
+                        prompt_path.relative_to(root),
+                        stp_path.relative_to(root),
+                        body_value,
+                        stp_value,
+                    )
+                )
+        body_labels = sorted(body_meta.get("labels", []))
+        stp_labels = sorted(stp_meta.get("labels", []))
+        if body_labels != stp_labels:
+            errors.append(
+                "issue #{}: local metadata mismatch for labels between {} and {}: expected {}, got {}".format(
+                    issue_number,
+                    prompt_path.relative_to(root),
+                    stp_path.relative_to(root),
+                    body_labels,
+                    stp_labels,
+                )
+            )
 
 for issue_number in sorted(seen_issue_numbers):
     body_hits = sorted(

--- a/adl/tools/test_check_issue_metadata_parity.sh
+++ b/adl/tools/test_check_issue_metadata_parity.sh
@@ -39,6 +39,37 @@ pr_start:
 # [v0.87.1][tools] Metadata parity
 EOF
 
+cat >"$REPO/.adl/v0.87.1/tasks/issue-1153__v0-87-1-tools-metadata-parity/stp.md" <<'EOF'
+---
+issue_card_schema: adl.issue.v1
+wp: "tools"
+slug: "v0-87-1-tools-metadata-parity"
+title: "[v0.87.1][tools] Metadata parity"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.87.1"
+issue_number: 1153
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Pending sprint assignment"
+required_outcome_type:
+  - "code"
+repo_inputs: []
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes: []
+pr_start:
+  enabled: false
+  slug: "v0-87-1-tools-metadata-parity"
+---
+
+# [v0.87.1][tools] Metadata parity
+EOF
+
 cat >"$REPO/.adl/v0.87.1/tasks/issue-1153__v0-87-1-tools-metadata-parity/sor.md" <<'EOF'
 # placeholder
 EOF
@@ -76,5 +107,20 @@ if PATH="$REPO/bin:$PATH" GH_MODE=fail bash "$ROOT/adl/tools/check_issue_metadat
 fi
 
 PATH="$REPO/bin:$PATH" GH_MODE=pass bash "$ROOT/adl/tools/check_issue_metadata_parity.sh" --root "$REPO" --version v0.87.1 --repo owner/repo >/dev/null
+
+python3 - "$REPO/.adl/v0.87.1/tasks/issue-1153__v0-87-1-tools-metadata-parity/stp.md" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+text = text.replace('wp: "tools"', 'wp: "docs"', 1)
+path.write_text(text)
+PY
+
+if PATH="$REPO/bin:$PATH" GH_MODE=pass bash "$ROOT/adl/tools/check_issue_metadata_parity.sh" --root "$REPO" --version v0.87.1 --repo owner/repo >/dev/null 2>&1; then
+  echo "expected drift check to fail when local STP metadata drifts from the canonical issue prompt" >&2
+  exit 1
+fi
 
 echo "PASS test_check_issue_metadata_parity"


### PR DESCRIPTION
Closes #1669

## Summary
Extended the issue-metadata parity audit so it now checks canonical local body/STP metadata alignment in addition to GitHub title/label parity and duplicate identity detection.

## Artifacts
- `adl/tools/check_issue_metadata_parity.sh`
- `adl/tools/test_check_issue_metadata_parity.sh`
- `adl/tools/README.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/check_issue_metadata_parity.sh adl/tools/test_check_issue_metadata_parity.sh` verified the updated parity audit and fixture harness are shell-valid.
  - `bash adl/tools/test_check_issue_metadata_parity.sh` verified the parity audit fails for missing GitHub metadata drift, passes for the aligned case, and fails again when the canonical STP drifts from the canonical issue prompt.
  - `git diff --check` verified there are no malformed patch artifacts or whitespace errors.
- Results: all listed validation commands passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1669__v0-88-tools-enforce-metadata-parity-across-issue-and-local-canonical-surfaces/sip.md
- Output card: .adl/v0.88/tasks/issue-1669__v0-88-tools-enforce-metadata-parity-across-issue-and-local-canonical-surfaces/sor.md
- Idempotency-Key: v0-88-tools-enforce-metadata-parity-across-issue-and-local-canonical-surfaces-adl-tools-check-issue-metadata-parity-sh-adl-tools-test-check-issue-metadata-parity-sh-adl-tools-readme-md-adl-v0-88-tasks-issue-1669-v0-88-tools-enforce-metadata-parity-across-issue-and-local-canonical-surfaces-sip-md-adl-v0-88-tasks-issue-1669-v0-88-tools-enforce-metadata-parity-across-issue-and-local-canonical-surfaces-sor-md