### PR TITLE
[v0.88][tools] Make workflow conductor detect already-satisfied issues from merged sibling work

### DIFF
--- a/adl/tools/skills/workflow-conductor/references/output-contract.md
+++ b/adl/tools/skills/workflow-conductor/references/output-contract.md
@@ -10,7 +10,7 @@ target:
   pr_number: <u32 or null>
 workflow_state:
   detected_phase: bootstrap_missing | card_local_blocker | pre_run | run_bound | execution_done | pr_in_flight | closed_out | already_satisfied | tracker_in_flight | unknown
-  blocker_class: none | open_pr_wave_only | doctor_failed_or_inconclusive | review_changes_requested | merge_conflict | checks_failed | merge_blocked | healthy_pr_waiting | satisfied_by_child_issue_wave | active_child_issue_wave
+  blocker_class: none | open_pr_wave_only | doctor_failed_or_inconclusive | review_changes_requested | merge_conflict | checks_failed | merge_blocked | healthy_pr_waiting | satisfied_by_child_issue_wave | satisfied_by_related_issue_refs | satisfied_by_sibling_issue_artifact | active_child_issue_wave | related_issue_ref_active | tracked_adl_residue | open_linkage_only
   evidence_used:
     - <doctor_json_or_path_or_state_surface>
 selected_skill:
@@ -31,7 +31,7 @@ actions_taken:
 handoff_state:
   next_phase: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | human_review | blocked
   continuation: continue | ask_operator | stop
-  escalation_reason: none | operator_override_required | ambiguous_live_state | healthy_pr_waiting | manual_review_required | policy_block | child_issue_wave_satisfied | child_issue_wave_active
+  escalation_reason: none | operator_override_required | ambiguous_live_state | healthy_pr_waiting | manual_review_required | policy_block | child_issue_wave_satisfied | related_issue_ref_satisfied | sibling_issue_artifact_satisfied | child_issue_wave_active | related_issue_ref_active | repo_policy_residue
 artifact:
   path: <path or null>
 ```

--- a/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
+++ b/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
@@ -254,6 +254,52 @@ def related_issue_reference_state(texts, issue_index):
     return "related_issue_ref_active"
 
 
+def first_parent_issue_ref(texts):
+    for text in texts:
+        lower = text.lower()
+        match = re.search(r"child of #(\d+)", lower)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def mentions_machine_readable_wp_dependency(texts):
+    lowered = "\n".join(text.lower() for text in texts if text)
+    needles = (
+        "machine-readable wp dependency",
+        "machine-readable wp dependency surface",
+        "machine-readable dependency surface",
+        "wp dependency surface",
+    )
+    return any(needle in lowered for needle in needles)
+
+
+def sibling_issue_artifact_state(repo_root: Path, texts, issue_number: int, version: str, issue_index):
+    if not version or not mentions_machine_readable_wp_dependency(texts):
+        return "none"
+    parent_issue = first_parent_issue_ref(texts)
+    if parent_issue is None:
+        return "none"
+
+    artifact = repo_root / "docs" / "milestones" / version / f"WP_ISSUE_WAVE_{version}.yaml"
+    if not artifact.exists():
+        return "none"
+
+    sibling_needle = f"child of #{parent_issue}"
+    for sibling_issue in issue_index.values():
+        sibling_number = int(sibling_issue.get("number", 0) or 0)
+        if sibling_number == issue_number or sibling_issue.get("state") != "CLOSED":
+            continue
+        sibling_body = sibling_issue.get("body") or ""
+        if sibling_needle not in sibling_body.lower():
+            continue
+        sibling_title = (sibling_issue.get("title") or "").lower()
+        sibling_text = f"{sibling_title}\n{sibling_body.lower()}"
+        if "issue wave" in sibling_text and ("generate" in sibling_text or "generator" in sibling_text):
+            return "satisfied_by_sibling_issue_artifact"
+    return "none"
+
+
 def detect_tracked_adl_residue(repo_root: Path):
     guard = repo_root / "adl" / "tools" / "check_no_tracked_adl_issue_record_residue.sh"
     if not guard.exists():
@@ -385,6 +431,7 @@ def collect_route_issue(repo_root: Path, payload):
         workflow["evidence_used"].append("missing_root_bundle")
         return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
+    issue_index = gh_issue_index(repo_root)
     tracker_state = issue_tracker_state(repo_root, bundle, source_prompt, issue_number)
     if tracker_state == "satisfied_by_child_issue_wave":
         workflow["blocker_class"] = "satisfied_by_child_issue_wave"
@@ -395,7 +442,7 @@ def collect_route_issue(repo_root: Path, payload):
 
     related_state = related_issue_reference_state(
         [read_text(source_prompt), read_text(bundle / "stp.md") if bundle else ""],
-        gh_issue_index(repo_root),
+        issue_index,
     )
     if workflow["blocker_class"] == "none" and related_state == "satisfied_by_related_issue_refs":
         workflow["blocker_class"] = "satisfied_by_related_issue_refs"
@@ -403,6 +450,17 @@ def collect_route_issue(repo_root: Path, payload):
     elif workflow["blocker_class"] == "none" and related_state == "related_issue_ref_active":
         workflow["blocker_class"] = "related_issue_ref_active"
         workflow["evidence_used"].append("related_issue_refs")
+
+    sibling_artifact_state = sibling_issue_artifact_state(
+        repo_root,
+        [read_text(source_prompt), read_text(bundle / "stp.md") if bundle else ""],
+        issue_number,
+        resolved_target.get("version"),
+        issue_index,
+    )
+    if workflow["blocker_class"] == "none" and sibling_artifact_state == "satisfied_by_sibling_issue_artifact":
+        workflow["blocker_class"] = "satisfied_by_sibling_issue_artifact"
+        workflow["evidence_used"].append("sibling_issue_artifact")
 
     doctor = doctor_snapshot(
         repo_root,

--- a/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
+++ b/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
@@ -88,6 +88,12 @@ def evaluate(payload):
         skill_name = "none"
         continuation = "ask_operator"
         escalation_reason = "related_issue_ref_satisfied"
+    elif blocker_class == "satisfied_by_sibling_issue_artifact":
+        detected_phase = "already_satisfied"
+        selected_phase = "blocked"
+        skill_name = "none"
+        continuation = "ask_operator"
+        escalation_reason = "sibling_issue_artifact_satisfied"
     elif blocker_class == "active_child_issue_wave":
         detected_phase = "tracker_in_flight"
         selected_phase = "blocked"

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -29,6 +29,7 @@ grep -Fq "classify known blocker families" "${skills_root}/docs/WORKFLOW_CONDUCT
 grep -Fq "workflow-conductor" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq "resume from partially completed early steps" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq "child issue wave already appears to cover the acceptance surface" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "satisfied_by_sibling_issue_artifact" "${skills_root}/workflow-conductor/references/output-contract.md"
 
 cat >"${tmpdir}/bootstrap_missing.json" <<'EOF'
 {
@@ -170,12 +171,21 @@ PY
 
 fixture_repo="${tmpdir}/fixture-repo"
 mkdir -p "${fixture_repo}/adl/tools" "${fixture_repo}/.adl/v0.88/bodies" "${fixture_repo}/.adl/v0.88/tasks"
+mkdir -p "${fixture_repo}/docs/milestones/v0.88"
 git -C "${fixture_repo}" init -q
 git -C "${fixture_repo}" config user.email "codex@example.test"
 git -C "${fixture_repo}" config user.name "Codex"
 git -C "${fixture_repo}" commit --allow-empty -qm "init"
 cat >"${fixture_repo}/.gitignore" <<'EOF'
 .adl/
+EOF
+
+cat >"${fixture_repo}/docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml" <<'EOF'
+version: v0.88
+entries:
+  - wp: WP-02
+    dependencies:
+      - WP-01
 EOF
 
 cat >"${fixture_repo}/adl/tools/pr.sh" <<'EOF'
@@ -211,6 +221,21 @@ JSON
   2009)
     cat <<'JSON'
 {"schema":"adl.pr.doctor.v1","issue":2009,"version":"v0.88","slug":"route-residue-finish","branch":"codex/2009-route-residue-finish","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"execution_done","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2009-route-residue-finish.md","root_stp":".adl/v0.88/tasks/issue-2009__route-residue-finish/stp.md","root_input":".adl/v0.88/tasks/issue-2009__route-residue-finish/sip.md","root_output":".adl/v0.88/tasks/issue-2009__route-residue-finish/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"doctor_status":"PASS"}
+JSON
+    ;;
+  2015)
+    cat <<'JSON'
+{"schema":"adl.pr.doctor.v1","issue":2015,"version":"v0.88","slug":"route-sibling-satisfied","branch":"codex/2015-route-sibling-satisfied","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"pre_run","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2015-route-sibling-satisfied.md","root_stp":".adl/v0.88/tasks/issue-2015__route-sibling-satisfied/stp.md","root_input":".adl/v0.88/tasks/issue-2015__route-sibling-satisfied/sip.md","root_output":".adl/v0.88/tasks/issue-2015__route-sibling-satisfied/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"doctor_status":"PASS"}
+JSON
+    ;;
+  2016)
+    cat <<'JSON'
+{"schema":"adl.pr.doctor.v1","issue":2016,"version":"v0.88","slug":"route-sibling-no-artifact","branch":"codex/2016-route-sibling-no-artifact","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"pre_run","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2016-route-sibling-no-artifact.md","root_stp":".adl/v0.88/tasks/issue-2016__route-sibling-no-artifact/stp.md","root_input":".adl/v0.88/tasks/issue-2016__route-sibling-no-artifact/sip.md","root_output":".adl/v0.88/tasks/issue-2016__route-sibling-no-artifact/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"doctor_status":"PASS"}
+JSON
+    ;;
+  2017)
+    cat <<'JSON'
+{"schema":"adl.pr.doctor.v1","issue":2017,"version":"v0.88","slug":"route-sibling-unrelated","branch":"codex/2017-route-sibling-unrelated","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"pre_run","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2017-route-sibling-unrelated.md","root_stp":".adl/v0.88/tasks/issue-2017__route-sibling-unrelated/stp.md","root_input":".adl/v0.88/tasks/issue-2017__route-sibling-unrelated/sip.md","root_output":".adl/v0.88/tasks/issue-2017__route-sibling-unrelated/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"doctor_status":"PASS"}
 JSON
     ;;
   *)
@@ -270,6 +295,45 @@ touch "${fixture_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/stp.md"
 touch "${fixture_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/sip.md"
 touch "${fixture_repo}/.adl/v0.88/tasks/issue-2009__route-residue-finish/sor.md"
 touch "${fixture_repo}/.adl/v0.88/bodies/issue-2009-route-residue-finish.md"
+
+mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-2015__route-sibling-satisfied"
+cat >"${fixture_repo}/.adl/v0.88/tasks/issue-2015__route-sibling-satisfied/stp.md" <<'EOF'
+## Summary
+
+Add a machine-readable WP dependency surface for the milestone package.
+
+## Issue-Graph Notes
+- child of #2020
+EOF
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2015__route-sibling-satisfied/sip.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2015__route-sibling-satisfied/sor.md"
+touch "${fixture_repo}/.adl/v0.88/bodies/issue-2015-route-sibling-satisfied.md"
+
+mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-2016__route-sibling-no-artifact"
+cat >"${fixture_repo}/.adl/v0.88/tasks/issue-2016__route-sibling-no-artifact/stp.md" <<'EOF'
+## Summary
+
+Add a machine-readable WP dependency surface for the milestone package.
+
+## Issue-Graph Notes
+- child of #2021
+EOF
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2016__route-sibling-no-artifact/sip.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2016__route-sibling-no-artifact/sor.md"
+touch "${fixture_repo}/.adl/v0.88/bodies/issue-2016-route-sibling-no-artifact.md"
+
+mkdir -p "${fixture_repo}/.adl/v0.88/tasks/issue-2017__route-sibling-unrelated"
+cat >"${fixture_repo}/.adl/v0.88/tasks/issue-2017__route-sibling-unrelated/stp.md" <<'EOF'
+## Summary
+
+Add a machine-readable WP dependency surface for the milestone package.
+
+## Issue-Graph Notes
+- child of #2022
+EOF
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2017__route-sibling-unrelated/sip.md"
+touch "${fixture_repo}/.adl/v0.88/tasks/issue-2017__route-sibling-unrelated/sor.md"
+touch "${fixture_repo}/.adl/v0.88/bodies/issue-2017-route-sibling-unrelated.md"
 
 mkdir -p "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2005__route-worktree-finish"
 touch "${fixture_repo}/.worktrees/adl-wp-2005/.adl/v0.88/tasks/issue-2005__route-worktree-finish/stp.md"
@@ -472,6 +536,72 @@ cat >"${tmpdir}/route_related_satisfied.json" <<EOF
 }
 EOF
 
+cat >"${tmpdir}/route_sibling_satisfied.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_issue",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "issue_number": 2015
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
+cat >"${tmpdir}/route_sibling_no_artifact.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_issue",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "issue_number": 2016
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
+cat >"${tmpdir}/route_sibling_unrelated.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_issue",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "issue_number": 2017
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
 mock_bin="${tmpdir}/mock-bin"
 mkdir -p "${mock_bin}"
 cat >"${mock_bin}/gh" <<'EOF'
@@ -489,7 +619,10 @@ if [[ "$1" == "issue" && "$2" == "list" ]]; then
   {"number":2011,"state":"CLOSED","title":"child-a","body":"## Issue-Graph Notes\n- child of #2006"},
   {"number":2012,"state":"CLOSED","title":"child-b","body":"## Issue-Graph Notes\n- child of #2006"},
   {"number":2013,"state":"CLOSED","title":"covered-fix","body":"Resolved by prior child issue"},
-  {"number":2014,"state":"OPEN","title":"active-follow-on","body":"Still in progress"}
+  {"number":2014,"state":"OPEN","title":"active-follow-on","body":"Still in progress"},
+  {"number":2016,"state":"CLOSED","title":"Generate WP issue waves from canonical WBS surfaces","body":"## Issue-Graph Notes\n- child of #2020"},
+  {"number":2017,"state":"CLOSED","title":"Generate WP issue waves from canonical WBS surfaces","body":"## Issue-Graph Notes\n- child of #2021"},
+  {"number":2018,"state":"CLOSED","title":"Unrelated closed sibling","body":"## Issue-Graph Notes\n- child of #2022"}
 ]
 JSON
   exit 0
@@ -666,6 +799,10 @@ python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "$
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_tracker_satisfied.json" --artifact-path ".adl/reviews/route-tracker-satisfied.md" >"${tmpdir}/route_tracker_satisfied.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_issue_finish_from_worktree.json" --artifact-path ".adl/reviews/route-issue-finish-from-worktree.md" >"${tmpdir}/route_issue_finish_from_worktree.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_related_satisfied.json" --artifact-path ".adl/reviews/route-related-satisfied.md" >"${tmpdir}/route_related_satisfied.out.json"
+PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_sibling_satisfied.json" --artifact-path ".adl/reviews/route-sibling-satisfied.md" >"${tmpdir}/route_sibling_satisfied.out.json"
+PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_sibling_unrelated.json" --artifact-path ".adl/reviews/route-sibling-unrelated.md" >"${tmpdir}/route_sibling_unrelated.out.json"
+rm -f "${fixture_repo}/docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml"
+PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_sibling_no_artifact.json" --artifact-path ".adl/reviews/route-sibling-no-artifact.md" >"${tmpdir}/route_sibling_no_artifact.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_pr_blocked.json" --artifact-path ".adl/reviews/route-pr-blocked.md" >"${tmpdir}/route_pr_blocked.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_pr_merged.json" --artifact-path ".adl/reviews/route-pr-merged.md" >"${tmpdir}/route_pr_merged.out.json"
 PATH="${mock_bin}:$PATH" python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_pr_clean.json" --artifact-path ".adl/reviews/route-pr-clean.md" >"${tmpdir}/route_pr_clean.out.json"
@@ -719,6 +856,21 @@ assert route_related_satisfied["workflow_state"]["blocker_class"] == "satisfied_
 assert route_related_satisfied["handoff_state"]["next_phase"] == "human_review"
 assert route_related_satisfied["handoff_state"]["continuation"] == "ask_operator"
 assert route_related_satisfied["handoff_state"]["escalation_reason"] == "related_issue_ref_satisfied"
+
+route_sibling_satisfied = load("route_sibling_satisfied.out.json")
+assert route_sibling_satisfied["selected_skill"]["skill_name"] == "none"
+assert route_sibling_satisfied["workflow_state"]["blocker_class"] == "satisfied_by_sibling_issue_artifact"
+assert route_sibling_satisfied["handoff_state"]["next_phase"] == "human_review"
+assert route_sibling_satisfied["handoff_state"]["continuation"] == "ask_operator"
+assert route_sibling_satisfied["handoff_state"]["escalation_reason"] == "sibling_issue_artifact_satisfied"
+
+route_sibling_no_artifact = load("route_sibling_no_artifact.out.json")
+assert route_sibling_no_artifact["selected_skill"]["skill_name"] == "pr-run"
+assert route_sibling_no_artifact["workflow_state"]["blocker_class"] == "none"
+
+route_sibling_unrelated = load("route_sibling_unrelated.out.json")
+assert route_sibling_unrelated["selected_skill"]["skill_name"] == "pr-run"
+assert route_sibling_unrelated["workflow_state"]["blocker_class"] == "none"
 
 route_worktree_finish = load("route_worktree_finish.out.json")
 assert route_worktree_finish["selected_skill"]["skill_name"] == "pr-finish"


### PR DESCRIPTION
Closes #1713

## Summary
Improved the workflow conductor so it can conservatively stop on already-satisfied issues when merged sibling issue-wave work and the canonical milestone artifact already cover the requested machine-readable WP dependency surface.

## Artifacts
- `adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
- `adl/tools/skills/workflow-conductor/scripts/select_next_skill.py`
- `adl/tools/skills/workflow-conductor/references/output-contract.md`
- `adl/tools/test_workflow_conductor_skill_contracts.sh`
- `.adl/reviews/workflow-conductor-1713-init.md`
- `.adl/reviews/workflow-conductor-1713-post.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/workflow-conductor/scripts/route_workflow.py adl/tools/skills/workflow-conductor/scripts/select_next_skill.py` verified the updated conductor helpers remain syntactically valid Python.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh` verified the new positive and negative sibling-satisfaction routing cases along with the preexisting conductor contract surface.
  - `python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <temporary validated conductor input> --artifact-path .adl/reviews/workflow-conductor-1713-post.md` verified the live finished worktree now routes to `pr-finish`.
  - `git diff --check` verified there are no malformed patch artifacts or whitespace errors.
- Results: all listed validation commands passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1713__v0-88-tools-make-workflow-conductor-detect-already-satisfied-issues-from-merged-sibling-work/sip.md
- Output card: .adl/v0.88/tasks/issue-1713__v0-88-tools-make-workflow-conductor-detect-already-satisfied-issues-from-merged-sibling-work/sor.md
- Idempotency-Key: v0-88-tools-make-workflow-conductor-detect-already-satisfied-issues-from-merged-sibling-work-adl-tools-skills-workflow-conductor-scripts-route-workflow-py-adl-tools-skills-workflow-conductor-scripts-select-next-skill-py-adl-tools-skills-workflow-conductor-references-output-contract-md-adl-tools-test-workflow-conductor-skill-contracts-sh-adl-v0-88-tasks-issue-1713-v0-88-tools-make-workflow-conductor-detect-already-satisfied-issues-from-merged-sibling-work-sip-md-adl-v0-88-tasks-issue-1713-v0-88-tools-make-workflow-conductor-detect-already-satisfied-issues-from-merged-sibling-work-sor-md