### PR TITLE
[v0.88][WP-11] Instinct runtime surface and bounded agency hook

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -16,6 +16,7 @@ pub const TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA: &str = "temporal_causality_expl
 pub const EXECUTION_POLICY_COST_MODEL_SCHEMA: &str = "execution_policy_cost_model.v1";
 pub const PHI_INTEGRATION_METRICS_SCHEMA: &str = "phi_integration_metrics.v1";
 pub const INSTINCT_MODEL_SCHEMA: &str = "instinct_model.v1";
+pub const INSTINCT_RUNTIME_SURFACE_SCHEMA: &str = "instinct_runtime_surface.v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdentityProfile {
@@ -402,6 +403,37 @@ pub struct InstinctModelContract {
     pub representation: InstinctRepresentationContract,
     pub review_surface: InstinctReviewSurfaceContract,
     pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstinctRuntimeProofCase {
+    pub case_id: String,
+    pub selected_path: String,
+    pub dominant_instinct: String,
+    pub risk_class: String,
+    pub expected_candidate_id: String,
+    pub expected_candidate_kind: String,
+    pub expected_effect: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstinctRuntimeReviewSurfaceContract {
+    pub visible_fields: Vec<String>,
+    pub required_questions: Vec<String>,
+    pub policy_override_rule: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstinctRuntimeSurfaceContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub shared_selection_rule: String,
+    pub bounded_influence_rules: Vec<String>,
+    pub proof_cases: Vec<InstinctRuntimeProofCase>,
+    pub review_surface: InstinctRuntimeReviewSurfaceContract,
     pub proof_hook_command: String,
     pub proof_hook_output_path: String,
     pub scope_boundary: String,
@@ -1390,6 +1422,81 @@ impl InstinctModelContract {
     }
 }
 
+impl InstinctRuntimeSurfaceContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: INSTINCT_RUNTIME_SURFACE_SCHEMA.to_string(),
+            owned_runtime_surfaces: vec![
+                "adl::execute::select_instinct_runtime_candidate".to_string(),
+                "adl::execute::AgencySelectionState".to_string(),
+                "adl::execute::RuntimeControlState".to_string(),
+                "adl identity instinct-runtime".to_string(),
+            ],
+            shared_selection_rule:
+                "derive the selected bounded agency candidate from the already-selected fast/slow path, dominant instinct, and risk class using one deterministic shared rule"
+                    .to_string(),
+            bounded_influence_rules: vec![
+                "instinct may change candidate selection but may not bypass fast/slow routing".to_string(),
+                "high-risk slow-path decisions stay review-first regardless of completion pressure".to_string(),
+                "all instinct influence must remain visible through selected candidate id, kind, and reason".to_string(),
+            ],
+            proof_cases: vec![
+                InstinctRuntimeProofCase {
+                    case_id: "fast-curiosity-verification".to_string(),
+                    selected_path: "fast_path".to_string(),
+                    dominant_instinct: "curiosity".to_string(),
+                    risk_class: "medium".to_string(),
+                    expected_candidate_id: "cand-fast-verify".to_string(),
+                    expected_candidate_kind: "bounded_verification".to_string(),
+                    expected_effect: "curiosity upgrades fast-path direct execution to a single bounded verification pass".to_string(),
+                },
+                InstinctRuntimeProofCase {
+                    case_id: "slow-curiosity-defer".to_string(),
+                    selected_path: "slow_path".to_string(),
+                    dominant_instinct: "curiosity".to_string(),
+                    risk_class: "medium".to_string(),
+                    expected_candidate_id: "cand-slow-defer".to_string(),
+                    expected_candidate_kind: "bounded_deferral".to_string(),
+                    expected_effect: "curiosity can choose a bounded uncertainty-hold candidate instead of immediate execution or refinement".to_string(),
+                },
+                InstinctRuntimeProofCase {
+                    case_id: "slow-high-risk-review".to_string(),
+                    selected_path: "slow_path".to_string(),
+                    dominant_instinct: "curiosity".to_string(),
+                    risk_class: "high".to_string(),
+                    expected_candidate_id: "cand-slow-review".to_string(),
+                    expected_candidate_kind: "review_and_refine".to_string(),
+                    expected_effect: "policy-constrained high-risk review overrides curiosity's bounded deferral pressure".to_string(),
+                },
+            ],
+            review_surface: InstinctRuntimeReviewSurfaceContract {
+                visible_fields: vec![
+                    "dominant_instinct".to_string(),
+                    "selected_path".to_string(),
+                    "risk_class".to_string(),
+                    "selected_candidate_id".to_string(),
+                    "selected_candidate_reason".to_string(),
+                ],
+                required_questions: vec![
+                    "did instinct change the candidate or leave it unchanged".to_string(),
+                    "was the change still bounded by path and risk policy".to_string(),
+                    "can the selected candidate be replay-explained from visible fields".to_string(),
+                ],
+                policy_override_rule:
+                    "high-risk slow-path review remains mandatory even when curiosity would otherwise choose bounded deferral"
+                        .to_string(),
+            },
+            proof_hook_command:
+                "adl identity instinct-runtime --out .adl/state/instinct_runtime_surface_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/instinct_runtime_surface_v1.json".to_string(),
+            scope_boundary:
+                "bounded instinct runtime hook only; this does not introduce open-ended autonomy, hidden initiative, or governance-layer override logic"
+                    .to_string(),
+        }
+    }
+}
+
 pub fn default_identity_profile_path(repo_root: &Path) -> PathBuf {
     repo_root
         .join("adl")
@@ -1789,5 +1896,40 @@ mod tests {
         assert!(contract
             .proof_hook_output_path
             .contains("instinct_model_v1.json"));
+    }
+
+    #[test]
+    fn instinct_runtime_surface_contract_proves_bounded_candidate_shift() {
+        let contract = InstinctRuntimeSurfaceContract::v1();
+
+        assert_eq!(contract.schema_version, INSTINCT_RUNTIME_SURFACE_SCHEMA);
+        assert!(contract
+            .owned_runtime_surfaces
+            .contains(&"adl identity instinct-runtime".to_string()));
+        assert!(contract
+            .proof_cases
+            .iter()
+            .any(|case| case.expected_candidate_id == "cand-fast-verify"));
+        assert!(contract
+            .proof_cases
+            .iter()
+            .any(|case| case.expected_candidate_id == "cand-slow-defer"));
+    }
+
+    #[test]
+    fn instinct_runtime_surface_contract_keeps_high_risk_review_policy_visible() {
+        let contract = InstinctRuntimeSurfaceContract::v1();
+
+        assert!(contract
+            .bounded_influence_rules
+            .iter()
+            .any(|value| value.contains("high-risk slow-path decisions stay review-first")));
+        assert!(contract
+            .review_surface
+            .policy_override_rule
+            .contains("high-risk slow-path review remains mandatory"));
+        assert!(contract
+            .proof_hook_output_path
+            .contains("instinct_runtime_surface_v1.json"));
     }
 }

--- a/adl/src/cli/identity_cmd.rs
+++ b/adl/src/cli/identity_cmd.rs
@@ -9,8 +9,9 @@ use ::adl::chronosense::{
     default_identity_profile_path, load_identity_profile, write_identity_profile,
     ChronosenseFoundation, CommitmentDeadlineContract, ContinuitySemanticsContract,
     ExecutionPolicyCostModelContract, IdentityProfile, InstinctModelContract,
-    PhiIntegrationMetricsContract, TemporalCausalityExplanationContract, TemporalContext,
-    TemporalQueryRetrievalContract, TemporalSchemaContract,
+    InstinctRuntimeSurfaceContract, PhiIntegrationMetricsContract,
+    TemporalCausalityExplanationContract, TemporalContext, TemporalQueryRetrievalContract,
+    TemporalSchemaContract,
 };
 
 pub(crate) fn real_identity(args: &[String]) -> Result<()> {
@@ -21,7 +22,7 @@ pub(crate) fn real_identity(args: &[String]) -> Result<()> {
 fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "identity requires a subcommand: init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost | phi | instinct"
+            "identity requires a subcommand: init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
         ));
     };
 
@@ -38,12 +39,13 @@ fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
         "cost" => real_identity_cost(repo_root, &args[1..]),
         "phi" => real_identity_phi(repo_root, &args[1..]),
         "instinct" => real_identity_instinct(repo_root, &args[1..]),
+        "instinct-runtime" => real_identity_instinct_runtime(repo_root, &args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost | phi | instinct)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
         )),
     }
 }
@@ -622,6 +624,59 @@ fn real_identity_instinct(repo_root: &Path, args: &[String]) -> Result<()> {
             )
         })?;
         println!("INSTINCT_MODEL_PATH={}", resolved.display());
+    } else {
+        println!("{json}");
+    }
+
+    Ok(())
+}
+
+fn real_identity_instinct_runtime(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                out_path = Some(PathBuf::from(required_value(args, i, "--out")?));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => {
+                return Err(anyhow!(
+                    "unknown arg for identity instinct-runtime: {other}"
+                ))
+            }
+        }
+        i += 1;
+    }
+
+    let contract = InstinctRuntimeSurfaceContract::v1();
+    let json = to_string_pretty(&contract)?;
+
+    if let Some(out) = out_path {
+        let resolved = if out.is_absolute() {
+            out
+        } else {
+            repo_root.join(out)
+        };
+        let Some(parent) = resolved.parent() else {
+            return Err(anyhow!(
+                "identity instinct-runtime --out path must have a parent directory"
+            ));
+        };
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+        fs::write(&resolved, json.as_bytes()).with_context(|| {
+            format!(
+                "failed to write instinct runtime surface artifact to {}",
+                resolved.display()
+            )
+        })?;
+        println!("INSTINCT_RUNTIME_SURFACE_PATH={}", resolved.display());
     } else {
         println!("{json}");
     }
@@ -1446,6 +1501,59 @@ mod tests {
 
         let err = real_identity_in_repo(&["instinct".to_string(), "--out".to_string()], &repo)
             .expect_err("out flag without value should fail");
+        assert!(err.to_string().contains("--out requires a value"));
+    }
+
+    #[test]
+    fn identity_instinct_runtime_writes_instinct_runtime_surface_contract_json() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let repo = temp_repo("identity-instinct-runtime");
+        let out_path = repo.join(".adl/state/instinct_runtime_surface_v1.json");
+
+        real_identity_in_repo(
+            &[
+                "instinct-runtime".to_string(),
+                "--out".to_string(),
+                ".adl/state/instinct_runtime_surface_v1.json".to_string(),
+            ],
+            &repo,
+        )
+        .expect("identity instinct-runtime");
+
+        let json: Value =
+            serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+        assert_eq!(json["schema_version"], "instinct_runtime_surface.v1");
+        assert_eq!(
+            json["proof_hook_output_path"],
+            ".adl/state/instinct_runtime_surface_v1.json"
+        );
+        assert!(json["owned_runtime_surfaces"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "adl identity instinct-runtime"));
+    }
+
+    #[test]
+    fn identity_instinct_runtime_validates_unknown_args_and_missing_out_value() {
+        let repo = temp_repo("identity-instinct-runtime-errors");
+
+        let err = real_identity_in_repo(
+            &["instinct-runtime".to_string(), "--bogus".to_string()],
+            &repo,
+        )
+        .expect_err("unknown arg should fail");
+        assert!(err
+            .to_string()
+            .contains("unknown arg for identity instinct-runtime: --bogus"));
+
+        let err = real_identity_in_repo(
+            &["instinct-runtime".to_string(), "--out".to_string()],
+            &repo,
+        )
+        .expect_err("out flag without value should fail");
         assert!(err.to_string().contains("--out requires a value"));
     }
 

--- a/adl/src/cli/run_artifacts/cognitive.rs
+++ b/adl/src/cli/run_artifacts/cognitive.rs
@@ -555,17 +555,22 @@ pub(crate) fn build_agency_selection_state(
                         bounded_action: "perform one bounded verification pass before execution".to_string(),
                         review_requirement: "light".to_string(),
                         execution_priority: 2,
-                        rationale: "keep a fallback candidate available without changing the primary fast-path commitment".to_string(),
+                        rationale: "keep a bounded verification candidate available when instinct pressure favors uncertainty reduction or extra constraint checks".to_string(),
                     },
                 ];
+            let decision = execute::select_instinct_runtime_candidate(
+                fast_slow_path.selected_path.as_str(),
+                signals.instinct.dominant_instinct.as_str(),
+                arbitration.risk_class.as_str(),
+            );
             (
-                    "fast_candidate_commitment",
-                    candidate_set,
-                    "cand-fast-execute".to_string(),
-                    "direct_execution".to_string(),
-                    "execute selected candidate directly under bounded once semantics".to_string(),
-                    "fast path prioritizes direct bounded execution when arbitration confidence is high and failure pressure is absent".to_string(),
-                )
+                decision.selection_mode,
+                candidate_set,
+                decision.candidate_id.to_string(),
+                decision.candidate_kind.to_string(),
+                decision.candidate_action.to_string(),
+                decision.candidate_reason.to_string(),
+            )
         }
         _ => {
             let candidate_set = vec![
@@ -586,7 +591,7 @@ pub(crate) fn build_agency_selection_state(
                         bounded_action: "execute the current candidate without additional refinement".to_string(),
                         review_requirement: "minimal".to_string(),
                         execution_priority: 2,
-                        rationale: "retain the direct-execution alternative as a bounded comparator candidate".to_string(),
+                        rationale: "retain the direct-execution alternative when completion pressure can still justify a bounded finish-first move".to_string(),
                     },
                     AgencyCandidateRecord {
                         candidate_id: "cand-slow-defer".to_string(),
@@ -594,17 +599,22 @@ pub(crate) fn build_agency_selection_state(
                         bounded_action: "defer execution and surface the candidate set for later gate/review stages".to_string(),
                         review_requirement: "review_required".to_string(),
                         execution_priority: 3,
-                        rationale: "preserve a bounded non-execution option when policy or review pressure remains elevated".to_string(),
+                        rationale: "preserve a bounded non-execution option when curiosity keeps uncertainty high or the system should pause before commitment".to_string(),
                     },
                 ];
+            let decision = execute::select_instinct_runtime_candidate(
+                fast_slow_path.selected_path.as_str(),
+                signals.instinct.dominant_instinct.as_str(),
+                arbitration.risk_class.as_str(),
+            );
             (
-                    "slow_candidate_comparison",
-                    candidate_set,
-                    "cand-slow-review".to_string(),
-                    "review_and_refine".to_string(),
-                    "review, refine, or veto the current candidate before execution".to_string(),
-                    "slow path makes review/refinement the selected candidate when arbitration requires bounded caution".to_string(),
-                )
+                decision.selection_mode,
+                candidate_set,
+                decision.candidate_id.to_string(),
+                decision.candidate_kind.to_string(),
+                decision.candidate_action.to_string(),
+                decision.candidate_reason.to_string(),
+            )
         }
     };
 

--- a/adl/src/cli/tests/artifact_builders/agency_execution.rs
+++ b/adl/src/cli/tests/artifact_builders/agency_execution.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::cli::run_artifacts_types::{
+    CognitiveArbitrationArtifact, FastSlowPathArtifact, FastSlowPathState, SuggestedChangeIntent,
+    SuggestionEvidence, SuggestionItem, SuggestionsArtifact, SuggestionsGeneratedFrom,
+};
 
 #[test]
 fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidates() {
@@ -199,6 +203,172 @@ fn build_agency_selection_artifact_is_deterministic_and_emits_multiple_candidate
         fast_left.selected_candidate_reason,
         slow.selected_candidate_reason
     );
+}
+
+#[test]
+fn build_agency_selection_artifact_exposes_instinct_sensitive_candidate_shift() {
+    let summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "agency-selection-instinct-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.88".to_string(),
+        swarm_version: "test".to_string(),
+        status: "success".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 2,
+            completed_steps: 2,
+            failed_steps: 0,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            evaluation_signals_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let suggestions = SuggestionsArtifact {
+        suggestions_version: 1,
+        run_id: summary.run_id.clone(),
+        generated_from: SuggestionsGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+            scores_version: Some(1),
+        },
+        suggestions: vec![SuggestionItem {
+            id: "sug-001".to_string(),
+            category: "stability".to_string(),
+            severity: "medium".to_string(),
+            rationale: "follow up on unexplained variance before direct execution".to_string(),
+            evidence: SuggestionEvidence {
+                failure_count: 0,
+                retry_count: 1,
+                delegation_denied_count: 0,
+                security_denied_count: 0,
+                success_ratio: 0.8,
+                scheduler_max_parallel_observed: 1,
+            },
+            proposed_change: SuggestedChangeIntent {
+                intent: "review_failure_hotspots".to_string(),
+                target: "workflow-runtime".to_string(),
+            },
+        }],
+    };
+    let scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: summary.run_id.clone(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.8,
+            failure_count: 0,
+            retry_count: 1,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+    let signals =
+        run_artifacts::build_cognitive_signals_artifact(&summary, &suggestions, Some(&scores));
+    assert_eq!(signals.instinct.dominant_instinct, "curiosity");
+
+    let arbitration = CognitiveArbitrationArtifact {
+        cognitive_arbitration_version: 1,
+        run_id: summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+            suggestions_version: 1,
+            scores_version: Some(1),
+        },
+        route_selected: "continue".to_string(),
+        reasoning_mode: "bounded_fast_path".to_string(),
+        confidence: "high".to_string(),
+        risk_class: "medium".to_string(),
+        applied_constraints: vec!["bounded_once".to_string()],
+        cost_latency_assumption: "prefer low latency".to_string(),
+        route_reason: "keep execution moving while reducing uncertainty".to_string(),
+        deterministic_selection_rule:
+            "derive route from visible arbitration state without hidden initiative".to_string(),
+    };
+    let fast_state = FastSlowPathState {
+        selected_path: "fast_path".to_string(),
+        path_family: "fast".to_string(),
+        runtime_branch_taken: "fast_direct_execution_branch".to_string(),
+        handoff_state: "candidate_ready".to_string(),
+        candidate_strategy: "single bounded candidate".to_string(),
+        review_depth: "minimal".to_string(),
+        execution_profile: "bounded_once".to_string(),
+        termination_expectation: "ready_for_evaluation".to_string(),
+        path_difference_summary: "fast path".to_string(),
+    };
+    let fast_artifact = FastSlowPathArtifact {
+        fast_slow_path_version: 1,
+        run_id: summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+            suggestions_version: 1,
+            scores_version: Some(1),
+        },
+        arbitration_route: "continue".to_string(),
+        selected_path: "fast_path".to_string(),
+        path_family: "fast".to_string(),
+        runtime_branch_taken: "fast_direct_execution_branch".to_string(),
+        handoff_state: "candidate_ready".to_string(),
+        candidate_strategy: "single bounded candidate".to_string(),
+        review_depth: "minimal".to_string(),
+        execution_profile: "bounded_once".to_string(),
+        termination_expectation: "ready_for_evaluation".to_string(),
+        path_difference_summary: "fast path".to_string(),
+        deterministic_handoff_rule: "test fixture".to_string(),
+    };
+
+    let agency = run_artifacts::build_agency_selection_state(
+        &signals,
+        &arbitration,
+        &fast_state,
+        &fast_artifact,
+    );
+
+    assert_eq!(agency.selected_candidate_id, "cand-fast-verify");
+    assert_eq!(agency.selected_candidate_kind, "bounded_verification");
+    assert!(agency
+        .selected_candidate_reason
+        .contains("curiosity or integrity pressure"));
 }
 
 #[test]

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -16,6 +16,7 @@ pub fn usage() -> &'static str {
   adl identity cost [--out <path>]
   adl identity phi [--out <path>]
   adl identity instinct [--out <path>]
+  adl identity instinct-runtime [--out <path>]
   adl provider setup <family> [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]

--- a/adl/src/execute/state/mod.rs
+++ b/adl/src/execute/state/mod.rs
@@ -10,12 +10,13 @@ pub use contracts::{
 };
 pub use policy::{stable_failure_kind, ExecutionPolicyError, ExecutionPolicyErrorKind};
 pub use runtime_control::{
-    derive_runtime_control_state, AgencyCandidateRecord, AgencySelectionState,
-    BoundedExecutionIteration, BoundedExecutionState, CognitiveArbitrationState,
-    CognitiveSignalsState, EvaluationControlState, FastSlowPathState,
-    FreedomGateEvaluationSignalsState, FreedomGateInputState, FreedomGatePolicyContextState,
-    FreedomGateState, MemoryParticipationState, MemoryQueryState, MemoryReadEntry, MemoryReadState,
-    MemoryWriteState, ReframingControlState, RuntimeControlState,
+    derive_runtime_control_state, select_instinct_runtime_candidate, AgencyCandidateRecord,
+    AgencySelectionDecisionTemplate, AgencySelectionState, BoundedExecutionIteration,
+    BoundedExecutionState, CognitiveArbitrationState, CognitiveSignalsState,
+    EvaluationControlState, FastSlowPathState, FreedomGateEvaluationSignalsState,
+    FreedomGateInputState, FreedomGatePolicyContextState, FreedomGateState,
+    MemoryParticipationState, MemoryQueryState, MemoryReadEntry, MemoryReadState, MemoryWriteState,
+    ReframingControlState, RuntimeControlState,
 };
 pub use steering::{
     apply_steering_patch, steering_record_from_patch, validate_steering_patch, PauseState,

--- a/adl/src/execute/state/runtime_control.rs
+++ b/adl/src/execute/state/runtime_control.rs
@@ -87,6 +87,15 @@ pub struct AgencyCandidateRecord {
     pub rationale: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgencySelectionDecisionTemplate {
+    pub selection_mode: &'static str,
+    pub candidate_id: &'static str,
+    pub candidate_kind: &'static str,
+    pub candidate_action: &'static str,
+    pub candidate_reason: &'static str,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BoundedExecutionState {
@@ -574,17 +583,22 @@ fn derive_agency_selection_state(
                     review_requirement: "light".to_string(),
                     execution_priority: 2,
                     rationale:
-                        "keep a fallback candidate available without changing the primary fast-path commitment"
+                        "keep a bounded verification candidate available when instinct pressure favors uncertainty reduction or extra constraint checks"
                             .to_string(),
                 },
             ];
+            let decision = select_instinct_runtime_candidate(
+                fast_slow.selected_path.as_str(),
+                signals.dominant_instinct.as_str(),
+                arbitration.risk_class.as_str(),
+            );
             (
-                "fast_candidate_commitment",
+                decision.selection_mode,
                 candidate_set,
-                "cand-fast-execute".to_string(),
-                "direct_execution".to_string(),
-                "execute selected candidate directly under bounded once semantics".to_string(),
-                "fast path prioritizes direct bounded execution when arbitration confidence is high and failure pressure is absent".to_string(),
+                decision.candidate_id.to_string(),
+                decision.candidate_kind.to_string(),
+                decision.candidate_action.to_string(),
+                decision.candidate_reason.to_string(),
             )
         }
         _ => {
@@ -609,9 +623,8 @@ fn derive_agency_selection_state(
                         "execute the current candidate without additional refinement".to_string(),
                     review_requirement: "minimal".to_string(),
                     execution_priority: 2,
-                    rationale:
-                        "retain the direct-execution alternative as a bounded comparator candidate"
-                            .to_string(),
+                    rationale: "retain the direct-execution alternative when completion pressure can still justify a bounded finish-first move"
+                        .to_string(),
                 },
                 AgencyCandidateRecord {
                     candidate_id: "cand-slow-defer".to_string(),
@@ -621,18 +634,22 @@ fn derive_agency_selection_state(
                             .to_string(),
                     review_requirement: "review_required".to_string(),
                     execution_priority: 3,
-                    rationale:
-                        "preserve a bounded non-execution option when policy or review pressure remains elevated"
-                            .to_string(),
+                    rationale: "preserve a bounded non-execution option when curiosity keeps uncertainty high or the system should pause before commitment"
+                        .to_string(),
                 },
             ];
+            let decision = select_instinct_runtime_candidate(
+                fast_slow.selected_path.as_str(),
+                signals.dominant_instinct.as_str(),
+                arbitration.risk_class.as_str(),
+            );
             (
-                "slow_candidate_comparison",
+                decision.selection_mode,
                 candidate_set,
-                "cand-slow-review".to_string(),
-                "review_and_refine".to_string(),
-                "review, refine, or veto the current candidate before execution".to_string(),
-                "slow path makes review/refinement the selected candidate when arbitration requires bounded caution".to_string(),
+                decision.candidate_id.to_string(),
+                decision.candidate_kind.to_string(),
+                decision.candidate_action.to_string(),
+                decision.candidate_reason.to_string(),
             )
         }
     };
@@ -651,6 +668,66 @@ fn derive_agency_selection_state(
         selected_candidate_kind,
         selected_candidate_action,
         selected_candidate_reason,
+    }
+}
+
+pub fn select_instinct_runtime_candidate(
+    selected_path: &str,
+    dominant_instinct: &str,
+    risk_class: &str,
+) -> AgencySelectionDecisionTemplate {
+    match selected_path {
+        "fast_path" => match dominant_instinct {
+            "curiosity" | "integrity" => AgencySelectionDecisionTemplate {
+                selection_mode: "fast_candidate_verification",
+                candidate_id: "cand-fast-verify",
+                candidate_kind: "bounded_verification",
+                candidate_action: "perform one bounded verification pass before execution",
+                candidate_reason:
+                    "fast path stays bounded, but curiosity or integrity pressure upgrades the selected candidate to a single verification pass before execution",
+            },
+            _ => AgencySelectionDecisionTemplate {
+                selection_mode: "fast_candidate_commitment",
+                candidate_id: "cand-fast-execute",
+                candidate_kind: "direct_execution",
+                candidate_action: "execute selected candidate directly under bounded once semantics",
+                candidate_reason:
+                    "fast path prioritizes direct bounded execution when instinct pressure does not require extra verification",
+            },
+        },
+        _ => {
+            if risk_class == "high" || matches!(dominant_instinct, "integrity" | "coherence") {
+                AgencySelectionDecisionTemplate {
+                    selection_mode: "slow_candidate_review",
+                    candidate_id: "cand-slow-review",
+                    candidate_kind: "review_and_refine",
+                    candidate_action:
+                        "review, refine, or veto the current candidate before execution",
+                    candidate_reason:
+                        "slow path keeps review/refinement selected when risk stays high or instinct pressure favors constraint and coherence preservation",
+                }
+            } else if dominant_instinct == "curiosity" {
+                AgencySelectionDecisionTemplate {
+                    selection_mode: "slow_candidate_uncertainty_hold",
+                    candidate_id: "cand-slow-defer",
+                    candidate_kind: "bounded_deferral",
+                    candidate_action:
+                        "defer execution and surface the candidate set for later gate/review stages",
+                    candidate_reason:
+                        "slow path preserves a bounded defer option when curiosity keeps uncertainty reduction more important than immediate execution",
+                }
+            } else {
+                AgencySelectionDecisionTemplate {
+                    selection_mode: "slow_candidate_review",
+                    candidate_id: "cand-slow-review",
+                    candidate_kind: "review_and_refine",
+                    candidate_action:
+                        "review, refine, or veto the current candidate before execution",
+                    candidate_reason:
+                        "slow path keeps review/refinement selected unless curiosity introduces a bounded uncertainty hold",
+                }
+            }
+        }
     }
 }
 
@@ -1056,4 +1133,33 @@ fn load_memory_read_entries(
     });
     entries.truncate(limit);
     entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_instinct_runtime_candidate;
+
+    #[test]
+    fn select_instinct_runtime_candidate_changes_fast_path_for_curiosity() {
+        let decision = select_instinct_runtime_candidate("fast_path", "curiosity", "low");
+
+        assert_eq!(decision.candidate_id, "cand-fast-verify");
+        assert_eq!(decision.candidate_kind, "bounded_verification");
+    }
+
+    #[test]
+    fn select_instinct_runtime_candidate_keeps_review_for_high_risk_slow_path() {
+        let decision = select_instinct_runtime_candidate("slow_path", "completion", "high");
+
+        assert_eq!(decision.candidate_id, "cand-slow-review");
+        assert_eq!(decision.candidate_kind, "review_and_refine");
+    }
+
+    #[test]
+    fn select_instinct_runtime_candidate_allows_curiosity_biased_slow_defer() {
+        let decision = select_instinct_runtime_candidate("slow_path", "curiosity", "medium");
+
+        assert_eq!(decision.candidate_id, "cand-slow-defer");
+        assert_eq!(decision.candidate_kind, "bounded_deferral");
+    }
 }

--- a/docs/milestones/v0.88/features/INSTINCT_RUNTIME_SURFACE.md
+++ b/docs/milestones/v0.88/features/INSTINCT_RUNTIME_SURFACE.md
@@ -20,27 +20,32 @@ It does not own:
 
 ## Core Runtime Contract
 
-Instinct should exist as an explicit structured surface attached to an agent or execution context.
+`WP-11` owns one bounded, reviewable runtime hook:
+- a shared instinct-sensitive agency-selection rule
+- deterministic candidate shifts inside the already-selected fast / slow path
+- a proof surface that exposes when instinct changed the selected candidate and when policy held it in place
 
-Each instinct entry should make it possible to represent:
-- an identifier
-- a bounded weight or strength
-- optional constraints or enablement state
+Owned runtime surfaces:
+- `adl::execute::select_instinct_runtime_candidate`
+- `adl::execute::AgencySelectionState`
+- `adl::execute::RuntimeControlState`
+- `adl identity instinct-runtime --out .adl/state/instinct_runtime_surface_v1.json`
 
 At runtime:
-- instincts are read during arbitration or planning
-- they influence prioritization or routing in a bounded way
-- they remain subordinate to higher-level policy and safety constraints
+- instinct is read after arbitration and fast / slow path selection
+- instinct may change the selected bounded candidate within that path
+- instinct remains subordinate to risk and policy constraints
 
 ## Observability Requirements
 
 Instinct influence must be visible in trace or derived artifacts.
 
 At minimum, a reviewer should be able to see:
-- which instinct settings were present
-- where they influenced a decision
-- which candidate or route was selected
-- whether policy or governance overrode the instinct pressure
+- which instinct setting was dominant
+- which path had already been selected
+- which candidate was chosen
+- why that candidate was chosen
+- whether risk / policy overrode instinct pressure
 
 If instinct influence is not inspectable, the feature is too implicit to trust.
 
@@ -48,8 +53,8 @@ If instinct influence is not inspectable, the feature is too implicit to trust.
 
 Primary integrations:
 - arbitration
-- fast / slow or equivalent routing surfaces
-- trace emission
+- fast / slow routing surfaces
+- agency candidate selection
 - proof artifacts
 
 Secondary integrations:
@@ -66,18 +71,28 @@ The runtime surface must remain:
 
 Instinct must not become a hidden source of non-deterministic drift.
 
-## Planned Proof Surface
+## Bounded Decision Rule
 
-`v0.88` should include at least one bounded proof path where:
-- two or more candidate actions or routes exist
-- instinct settings differ materially
-- the selected result changes in a reviewable way
-- the result remains policy-constrained and deterministic
+The shared rule is intentionally small:
+- on `fast_path`, `curiosity` or `integrity` upgrades direct execution to one bounded verification pass
+- on `slow_path`, `curiosity` may choose bounded deferral rather than immediate execution
+- on `slow_path`, `high` risk or `integrity` / `coherence` keeps review selected
+- on `slow_path`, `completion` still stays bounded inside review-first slow-path semantics
 
-Good proof examples:
-- completion-biased choice between finishing current work and exploring novelty
-- curiosity / coherence bias toward anomaly follow-up
-- integrity bias toward a slower, more constrained route
+This is enough to make instinct operational without turning it into hidden initiative.
+
+## Proof Surface
+
+`v0.88` now includes a bounded proof hook:
+
+```text
+adl identity instinct-runtime --out .adl/state/instinct_runtime_surface_v1.json
+```
+
+That proof surface includes review cases where:
+- `curiosity` changes a `fast_path` candidate from direct execution to bounded verification
+- `curiosity` changes a `slow_path` candidate from review to bounded deferral
+- `high` risk keeps the `slow_path` on review even when curiosity would otherwise defer
 
 ## Acceptance Shape
 
@@ -93,4 +108,4 @@ This is the runtime companion to `INSTINCT_MODEL.md`.
 
 Together, the two docs define:
 - what instinct means
-- how instinct shows up in actual ADL runtime behavior
+- how instinct changes bounded candidate selection at runtime


### PR DESCRIPTION
Closes #1654

## Summary
Implemented the bounded instinct runtime hook for `v0.88` by making agency selection depend on one shared instinct-sensitive runtime rule, reusing that rule in the proof/test builder, adding the `adl identity instinct-runtime` proof surface, and tightening the feature doc so the milestone claim matches the actual bounded decision behavior.

## Artifacts
- `adl/src/execute/state/runtime_control.rs`
- `adl/src/execute/state/mod.rs`
- `adl/src/cli/run_artifacts/cognitive.rs`
- `adl/src/chronosense.rs`
- `adl/src/cli/identity_cmd.rs`
- `adl/src/cli/usage.rs`
- `adl/src/cli/tests/artifact_builders/agency_execution.rs`
- `docs/milestones/v0.88/features/INSTINCT_RUNTIME_SURFACE.md`
- `.adl/state/instinct_runtime_surface_v1.json`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified formatting.
  - `cargo test --manifest-path adl/Cargo.toml select_instinct_runtime_candidate -- --nocapture` verified the shared runtime-selection rule for fast-path curiosity, slow-path completion, and high-risk review override behavior.
  - `cargo test --manifest-path adl/Cargo.toml build_agency_selection_artifact_exposes_instinct_sensitive_candidate_shift -- --nocapture` verified the reviewer-facing agency-selection artifact reflects the shared runtime rule instead of a separate hard-coded decision.
  - `cargo test --manifest-path adl/Cargo.toml identity_instinct_runtime -- --nocapture` verified the new CLI proof hook, JSON output, and argument validation.
  - `cargo test --manifest-path adl/Cargo.toml instinct_runtime_surface_contract -- --nocapture` verified the contract exposes bounded candidate-shift proof cases and the explicit high-risk review override.
  - `cargo run --manifest-path adl/Cargo.toml -- identity instinct-runtime --out .adl/state/instinct_runtime_surface_v1.json` verified end-to-end proof artifact emission.
- Results:
  - All listed validation commands passed on the branch.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1654__v0-88-wp-11-instinct-runtime-surface-and-bounded-agency-hook/sip.md
- Output card: .adl/v0.88/tasks/issue-1654__v0-88-wp-11-instinct-runtime-surface-and-bounded-agency-hook/sor.md
- Idempotency-Key: v0-88-wp-11-instinct-runtime-surface-and-bounded-agency-hook-adl-v0-88-tasks-issue-1654-v0-88-wp-11-instinct-runtime-surface-and-bounded-agency-hook-sip-md-adl-v0-88-tasks-issue-1654-v0-88-wp-11-instinct-runtime-surface-and-bounded-agency-hook-sor-md