### PR TITLE
[v0.88][WP-13] Demo matrix + integration demos

### DIFF
--- a/adl/tools/demo_v088_instinct_review_surface.sh
+++ b/adl/tools/demo_v088_instinct_review_surface.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v088/instinct_review_surface}"
+STATE_DIR="$OUT_DIR/state"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STATE_DIR"
+
+cd "$ROOT_DIR"
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity instinct --out "$STATE_DIR/instinct_model_v1.json" >/dev/null
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity instinct-runtime --out "$STATE_DIR/instinct_runtime_surface_v1.json" >/dev/null
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = {
+    "schema_version": "adl.v088.instinct_review_surface.v1",
+    "milestone": "v0.88",
+    "rows": [
+        {
+            "demo_id": "D6",
+            "focus": "instinct declaration and influence",
+            "command": "bash adl/tools/demo_v088_instinct_review_surface.sh",
+            "primary_proof_surface": "state/instinct_model_v1.json",
+            "secondary_proof_surfaces": ["state/instinct_runtime_surface_v1.json"],
+            "claim": "ADL exposes instinct explicitly as a bounded declared runtime input rather than hidden mood or persona drift."
+        },
+        {
+            "demo_id": "D7",
+            "focus": "bounded agency under instinct",
+            "command": "bash adl/tools/demo_v088_instinct_review_surface.sh",
+            "primary_proof_surface": "state/instinct_runtime_surface_v1.json",
+            "secondary_proof_surfaces": ["state/instinct_model_v1.json"],
+            "claim": "ADL can show a deterministic bounded case where instinct changes candidate selection without escaping risk and policy limits."
+        }
+    ]
+}
+Path(sys.argv[1]).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$README_OUT" <<'EOF'
+# v0.88 Demo Package - Instinct Review Surface
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v088_instinct_review_surface.sh
+```
+
+Primary proof surfaces:
+- `state/instinct_model_v1.json`
+- `state/instinct_runtime_surface_v1.json`
+EOF
+
+echo "Instinct review surface under the output directory:"
+echo "  demo_manifest.json"
+echo "  state/instinct_model_v1.json"
+echo "  state/instinct_runtime_surface_v1.json"

--- a/adl/tools/demo_v088_phi_review_surface.sh
+++ b/adl/tools/demo_v088_phi_review_surface.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v088/phi_review_surface}"
+STATE_DIR="$OUT_DIR/state"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STATE_DIR"
+
+cd "$ROOT_DIR"
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity phi --out "$STATE_DIR/phi_integration_metrics_v1.json" >/dev/null
+
+cat >"$MANIFEST" <<'EOF'
+{
+  "schema_version": "adl.v088.phi_review_surface.v1",
+  "demo_id": "D5",
+  "focus": "PHI-style integration metrics",
+  "command": "bash adl/tools/demo_v088_phi_review_surface.sh",
+  "primary_proof_surface": "state/phi_integration_metrics_v1.json",
+  "claim": "ADL can present low / medium / high integration profiles with explicit dimensions and no metaphysical overclaim."
+}
+EOF
+
+cat >"$README_OUT" <<'EOF'
+# v0.88 Demo Package - PHI Review Surface
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v088_phi_review_surface.sh
+```
+
+Primary proof surface:
+- `state/phi_integration_metrics_v1.json`
+EOF
+
+echo "PHI review surface under the output directory:"
+echo "  demo_manifest.json"
+echo "  state/phi_integration_metrics_v1.json"

--- a/adl/tools/demo_v088_review_surface.sh
+++ b/adl/tools/demo_v088_review_surface.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v088/review_surface}"
+TEMPORAL_ROOT="$OUT_DIR/temporal"
+PHI_ROOT="$OUT_DIR/phi"
+INSTINCT_ROOT="$OUT_DIR/instinct"
+PAPER_ROOT="$OUT_DIR/paper_sonata"
+COMPARATIVE_ROOT="$OUT_DIR/deep_agents_comparative"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+INDEX_OUT="$OUT_DIR/index.txt"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cd "$ROOT_DIR"
+
+bash adl/tools/demo_v088_temporal_review_surface.sh "$TEMPORAL_ROOT" >/dev/null
+bash adl/tools/demo_v088_phi_review_surface.sh "$PHI_ROOT" >/dev/null
+bash adl/tools/demo_v088_instinct_review_surface.sh "$INSTINCT_ROOT" >/dev/null
+bash adl/tools/demo_v088_paper_sonata.sh "$PAPER_ROOT" >/dev/null
+bash adl/tools/demo_v088_deep_agents_comparative_proof.sh "$COMPARATIVE_ROOT" >/dev/null
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = {
+    "schema_version": "adl.v088.review_surface.v1",
+    "milestone": "v0.88",
+    "title": "v0.88 integrated review surface",
+    "review_root": "artifacts/v088/review_surface",
+    "rows": [
+        {
+            "demo_id": "D1-D4",
+            "package": "temporal",
+            "command": "bash adl/tools/demo_v088_temporal_review_surface.sh",
+            "primary_proof_surface": "temporal/demo_manifest.json"
+        },
+        {
+            "demo_id": "D5",
+            "package": "phi",
+            "command": "bash adl/tools/demo_v088_phi_review_surface.sh",
+            "primary_proof_surface": "phi/state/phi_integration_metrics_v1.json"
+        },
+        {
+            "demo_id": "D6-D7",
+            "package": "instinct",
+            "command": "bash adl/tools/demo_v088_instinct_review_surface.sh",
+            "primary_proof_surface": "instinct/demo_manifest.json"
+        },
+        {
+            "demo_id": "D8",
+            "package": "paper_sonata",
+            "command": "bash adl/tools/demo_v088_paper_sonata.sh",
+            "primary_proof_surface": "paper_sonata/demo_manifest.json"
+        },
+        {
+            "demo_id": "D9",
+            "package": "deep_agents_comparative",
+            "command": "bash adl/tools/demo_v088_deep_agents_comparative_proof.sh",
+            "primary_proof_surface": "deep_agents_comparative/comparative_manifest.json"
+        }
+    ]
+}
+Path(sys.argv[1]).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$README_OUT" <<'EOF'
+# v0.88 Demo D10 - Integrated Review Surface
+
+Canonical review command:
+
+```bash
+bash adl/tools/demo_v088_review_surface.sh
+```
+
+Reviewer flow:
+- inspect `demo_manifest.json`
+- review the temporal package for D1-D4
+- review the PHI package for D5
+- review the instinct package for D6-D7
+- review the Paper Sonata flagship package for D8
+- review the comparative proof packet for D9
+EOF
+
+cat >"$INDEX_OUT" <<'EOF'
+D1-D4 temporal/demo_manifest.json
+D5 phi/state/phi_integration_metrics_v1.json
+D6-D7 instinct/demo_manifest.json
+D8 paper_sonata/demo_manifest.json
+D9 deep_agents_comparative/comparative_manifest.json
+EOF
+
+echo "v0.88 review surface:"
+echo "  artifacts/v088/review_surface/demo_manifest.json"
+echo "  artifacts/v088/review_surface/temporal/demo_manifest.json"
+echo "  artifacts/v088/review_surface/phi/state/phi_integration_metrics_v1.json"
+echo "  artifacts/v088/review_surface/instinct/demo_manifest.json"
+echo "  artifacts/v088/review_surface/paper_sonata/demo_manifest.json"
+echo "  artifacts/v088/review_surface/deep_agents_comparative/comparative_manifest.json"

--- a/adl/tools/demo_v088_temporal_review_surface.sh
+++ b/adl/tools/demo_v088_temporal_review_surface.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v088/temporal_review_surface}"
+STATE_DIR="$OUT_DIR/state"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STATE_DIR"
+
+cd "$ROOT_DIR"
+
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity foundation --out "$STATE_DIR/chronosense_foundation_v1.json" >/dev/null
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity schema --out "$STATE_DIR/temporal_schema_v1.json" >/dev/null
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity continuity --out "$STATE_DIR/continuity_semantics_v1.json" >/dev/null
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity retrieval --out "$STATE_DIR/temporal_query_retrieval_v1.json" >/dev/null
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity commitments --out "$STATE_DIR/commitment_deadline_semantics_v1.json" >/dev/null
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity causality --out "$STATE_DIR/temporal_causality_explanation_v1.json" >/dev/null
+cargo run --quiet --manifest-path adl/Cargo.toml -- identity cost --out "$STATE_DIR/execution_policy_cost_model_v1.json" >/dev/null
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+manifest = {
+    "schema_version": "adl.v088.temporal_review_surface.v1",
+    "demo_package_id": "temporal_review_surface",
+    "milestone": "v0.88",
+    "rows": [
+        {
+            "demo_id": "D1",
+            "focus": "temporal schema and anchors",
+            "command": "bash adl/tools/demo_v088_temporal_review_surface.sh",
+            "primary_proof_surface": "state/temporal_schema_v1.json",
+            "secondary_proof_surfaces": [
+                "state/chronosense_foundation_v1.json",
+            ],
+            "claim": "ADL exposes a reviewer-legible temporal schema and bounded chronosense foundation instead of hidden execution timing assumptions.",
+        },
+        {
+            "demo_id": "D2",
+            "focus": "continuity and identity",
+            "command": "bash adl/tools/demo_v088_temporal_review_surface.sh",
+            "primary_proof_surface": "state/continuity_semantics_v1.json",
+            "secondary_proof_surfaces": [
+                "state/chronosense_foundation_v1.json",
+            ],
+            "claim": "ADL surfaces continuity and interruption semantics explicitly enough for a reviewer to inspect state transitions and identity persistence.",
+        },
+        {
+            "demo_id": "D3",
+            "focus": "temporal retrieval and commitments",
+            "command": "bash adl/tools/demo_v088_temporal_review_surface.sh",
+            "primary_proof_surface": "state/temporal_query_retrieval_v1.json",
+            "secondary_proof_surfaces": [
+                "state/commitment_deadline_semantics_v1.json",
+            ],
+            "claim": "ADL exposes retrieval and commitment semantics as bounded reviewer artifacts rather than hidden internal bookkeeping.",
+        },
+        {
+            "demo_id": "D4",
+            "focus": "execution policy and cost",
+            "command": "bash adl/tools/demo_v088_temporal_review_surface.sh",
+            "primary_proof_surface": "state/execution_policy_cost_model_v1.json",
+            "secondary_proof_surfaces": [
+                "state/temporal_causality_explanation_v1.json",
+            ],
+            "claim": "ADL shows requested execution posture, realized cost, and temporal explanation as one explicit review surface.",
+        },
+    ],
+}
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$README_OUT" <<'EOF'
+# v0.88 Demo Package - Temporal Review Surface
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v088_temporal_review_surface.sh
+```
+
+This package proves the four temporal review rows:
+- D1 temporal schema and anchors
+- D2 continuity and identity
+- D3 temporal retrieval and commitments
+- D4 execution policy and cost
+
+Primary proof surfaces:
+- `state/temporal_schema_v1.json`
+- `state/continuity_semantics_v1.json`
+- `state/temporal_query_retrieval_v1.json`
+- `state/execution_policy_cost_model_v1.json`
+EOF
+
+echo "Temporal review surface under the output directory:"
+echo "  demo_manifest.json"
+echo "  state/temporal_schema_v1.json"
+echo "  state/continuity_semantics_v1.json"
+echo "  state/temporal_query_retrieval_v1.json"
+echo "  state/execution_policy_cost_model_v1.json"

--- a/adl/tools/test_demo_v088_instinct_review_surface.sh
+++ b/adl/tools/test_demo_v088_instinct_review_surface.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v088_instinct_review_surface.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/state/instinct_model_v1.json" \
+  "$OUT_DIR/state/instinct_runtime_surface_v1.json"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+grep -Fq '"demo_id": "D6"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest missing D6 row" >&2
+  exit 1
+}
+grep -Fq '"demo_id": "D7"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest missing D7 row" >&2
+  exit 1
+}
+
+echo "demo_v088_instinct_review_surface: ok"

--- a/adl/tools/test_demo_v088_phi_review_surface.sh
+++ b/adl/tools/test_demo_v088_phi_review_surface.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v088_phi_review_surface.sh "$OUT_DIR" >/dev/null
+)
+
+[[ -f "$OUT_DIR/demo_manifest.json" ]] || {
+  echo "assertion failed: missing manifest" >&2
+  exit 1
+}
+[[ -f "$OUT_DIR/state/phi_integration_metrics_v1.json" ]] || {
+  echo "assertion failed: missing phi state artifact" >&2
+  exit 1
+}
+grep -Fq '"demo_id": "D5"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest missing D5 row" >&2
+  exit 1
+}
+
+echo "demo_v088_phi_review_surface: ok"

--- a/adl/tools/test_demo_v088_review_surface.sh
+++ b/adl/tools/test_demo_v088_review_surface.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v088_review_surface.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/README.md" \
+  "$OUT_DIR/index.txt" \
+  "$OUT_DIR/temporal/demo_manifest.json" \
+  "$OUT_DIR/phi/state/phi_integration_metrics_v1.json" \
+  "$OUT_DIR/instinct/demo_manifest.json" \
+  "$OUT_DIR/paper_sonata/demo_manifest.json" \
+  "$OUT_DIR/deep_agents_comparative/comparative_manifest.json"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+grep -Fq '"schema_version": "adl.v088.review_surface.v1"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: integrated manifest schema mismatch" >&2
+  exit 1
+}
+grep -Fq 'D8 paper_sonata/demo_manifest.json' "$OUT_DIR/index.txt" || {
+  echo "assertion failed: index missing D8 row" >&2
+  exit 1
+}
+
+echo "demo_v088_review_surface: ok"

--- a/adl/tools/test_demo_v088_temporal_review_surface.sh
+++ b/adl/tools/test_demo_v088_temporal_review_surface.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v088_temporal_review_surface.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/README.md" \
+  "$OUT_DIR/state/chronosense_foundation_v1.json" \
+  "$OUT_DIR/state/temporal_schema_v1.json" \
+  "$OUT_DIR/state/continuity_semantics_v1.json" \
+  "$OUT_DIR/state/temporal_query_retrieval_v1.json" \
+  "$OUT_DIR/state/commitment_deadline_semantics_v1.json" \
+  "$OUT_DIR/state/temporal_causality_explanation_v1.json" \
+  "$OUT_DIR/state/execution_policy_cost_model_v1.json"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+grep -Fq '"demo_id": "D1"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest missing D1 row" >&2
+  exit 1
+}
+grep -Fq '"demo_id": "D4"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest missing D4 row" >&2
+  exit 1
+}
+
+echo "demo_v088_temporal_review_surface: ok"

--- a/docs/milestones/v0.88/DEMO_MATRIX_v0.88.md
+++ b/docs/milestones/v0.88/DEMO_MATRIX_v0.88.md
@@ -8,26 +8,30 @@
 
 ## Current State
 
-`v0.88` is still in planning / issue-seeding state, so this matrix records the concrete proof rows we expect to implement.
+`v0.88` now has a real reviewer package.
 
-Each row must eventually resolve to:
-- one obvious runner or command
-- one obvious artifact directory or manifest
-- one crisp reviewer claim the demo proves
+Primary integrated review command:
 
-## Planned Proof Rows
+```bash
+bash adl/tools/demo_v088_review_surface.sh
+```
 
-| Demo ID | Focus | Concrete output expectation | Planned artifact | Status |
-|---|---|---|---|---|
-| D1 | temporal schema and anchors | schema-aware trace output plus at least one fixture-backed assertion over anchors / clocks / execution posture | schema review artifact | planned |
-| D2 | continuity and identity | explicit continuity / interruption / resumption artifact with reviewer-legible state transitions | continuity proof artifact | planned |
-| D3 | temporal retrieval and commitments | queryable retrieval result plus commitment/deadline artifact showing open and resolved states | query / commitment artifact | planned |
-| D4 | execution policy and cost | run output that shows requested posture, realized cost, and their relationship in one review surface | cost / policy artifact | planned |
-| D5 | PHI-style integration metrics | bounded comparison across low / medium / high integration profiles with stable reported dimensions | PHI review artifact | planned |
-| D6 | instinct declaration and influence | explicit instinct configuration plus trace/artifact evidence that the setting materially influenced behavior | instinct runtime artifact | planned |
-| D7 | bounded agency under instinct | one deterministic proof case where instinct changes routing or prioritization without violating policy bounds | bounded-agency demo artifact | planned |
-| D8 | Paper Sonata flagship demo | bounded manuscript runner with stable artifact tree, intermediate role outputs, final draft package, and truthful runtime bundle | paper-sonata manifest, manuscript package, and trace bundle | planned |
-| D9 | deep-agents comparative proof | one comparative packet that shows the difference between visible-file multi-agent workflows and ADL's artifact-plus-trace proof surface | comparative proof note, manifest, transcript, provider invocations, and trace bundle | planned |
+Primary integrated review artifact:
+- `artifacts/v088/review_surface/demo_manifest.json`
+
+## Proof Rows
+
+| Demo ID | Focus | Command | Primary artifact | Reviewer claim | Status |
+|---|---|---|---|---|---|
+| D1 | temporal schema and anchors | `bash adl/tools/demo_v088_temporal_review_surface.sh` | `artifacts/v088/temporal_review_surface/state/temporal_schema_v1.json` | ADL exposes temporal schema and bounded chronosense anchors explicitly enough for direct reviewer inspection | implemented |
+| D2 | continuity and identity | `bash adl/tools/demo_v088_temporal_review_surface.sh` | `artifacts/v088/temporal_review_surface/state/continuity_semantics_v1.json` | ADL makes continuity and identity semantics reviewable rather than implicit | implemented |
+| D3 | temporal retrieval and commitments | `bash adl/tools/demo_v088_temporal_review_surface.sh` | `artifacts/v088/temporal_review_surface/state/temporal_query_retrieval_v1.json` | ADL exposes retrieval and commitment state through explicit reviewer artifacts | implemented |
+| D4 | execution policy and cost | `bash adl/tools/demo_v088_temporal_review_surface.sh` | `artifacts/v088/temporal_review_surface/state/execution_policy_cost_model_v1.json` | ADL shows policy posture, cost, and temporal explanation as one bounded review surface | implemented |
+| D5 | PHI-style integration metrics | `bash adl/tools/demo_v088_phi_review_surface.sh` | `artifacts/v088/phi_review_surface/state/phi_integration_metrics_v1.json` | ADL can compare low / medium / high integration profiles without metaphysical overclaim | implemented |
+| D6 | instinct declaration and influence | `bash adl/tools/demo_v088_instinct_review_surface.sh` | `artifacts/v088/instinct_review_surface/state/instinct_model_v1.json` | ADL declares instinct explicitly as a bounded runtime input | implemented |
+| D7 | bounded agency under instinct | `bash adl/tools/demo_v088_instinct_review_surface.sh` | `artifacts/v088/instinct_review_surface/state/instinct_runtime_surface_v1.json` | ADL can show a deterministic bounded case where instinct changes candidate selection without escaping policy limits | implemented |
+| D8 | Paper Sonata flagship demo | `bash adl/tools/demo_v088_paper_sonata.sh` | `artifacts/v088/paper_sonata/demo_manifest.json` | ADL can orchestrate a bounded manuscript workflow with durable role artifacts and truthful runtime evidence | implemented |
+| D9 | deep-agents comparative proof | `bash adl/tools/demo_v088_deep_agents_comparative_proof.sh` | `artifacts/v088/deep_agents_comparative_proof/comparative_manifest.json` | ADL turns a visible file-based deep-agent packet into a reviewer-auditable proof surface with provenance and reference mapping | implemented |
 
 ## Reviewer Rule
 


### PR DESCRIPTION
Closes #1657

## Summary
- add reviewer-friendly temporal, PHI, instinct, and integrated v0.88 review-surface demo wrappers
- turn the v0.88 demo matrix into a real command/artifact/claim table
- make the milestone demo package runnable and easy for reviewers to inspect