### PR TITLE
[v0.88][WP-15] Docs + review pass

### DIFF
--- a/adl/src/cli/tooling_cmd/wp_issue_wave.rs
+++ b/adl/src/cli/tooling_cmd/wp_issue_wave.rs
@@ -159,7 +159,7 @@ fn generate_wave_doc(
     let sprint_map = parse_sprint_overview(sprint_text)?;
     let entries = parse_wbs_rows(wbs_text)?
         .into_iter()
-        .filter(|row| row.issue_column.contains("to be seeded"))
+        .filter(|row| row.wp != "WP-01" && issue_column_is_trackable(&row.issue_column))
         .map(|row| build_entry(version, &row, &sprint_map))
         .collect::<Result<Vec<_>>>()?;
 
@@ -182,7 +182,8 @@ fn build_entry(
     let Some((sprint_id, sprint_label)) = sprint_map.get(&row.wp) else {
         bail!("no sprint mapping found for {}", row.wp);
     };
-    let area = infer_area(&row.work_package, &row.issue_column);
+    let is_closeout = is_closeout_row(&row.work_package, &row.issue_column);
+    let area = infer_area(&row.work_package, is_closeout);
     let slug = format!(
         "{}-{}-{}",
         slugify(version),
@@ -191,7 +192,7 @@ fn build_entry(
     );
     Ok(WaveEntry {
         wp: row.wp.clone(),
-        issue_kind: if row.issue_column.contains("closeout issue to be seeded") {
+        issue_kind: if is_closeout {
             "closeout".to_string()
         } else {
             "execution".to_string()
@@ -216,9 +217,28 @@ fn build_entry(
     })
 }
 
-fn infer_area(work_package: &str, issue_column: &str) -> &'static str {
-    let lowered = work_package.to_lowercase();
+fn issue_column_is_trackable(issue_column: &str) -> bool {
+    issue_column.contains("to be seeded") || issue_column.contains('#')
+}
+
+fn is_closeout_row(work_package: &str, issue_column: &str) -> bool {
     if issue_column.contains("closeout issue to be seeded") {
+        return true;
+    }
+    let lowered = work_package.to_lowercase();
+    lowered.contains("quality")
+        || lowered.contains("coverage")
+        || lowered.contains("docs + review")
+        || lowered == "internal review"
+        || lowered.contains("3rd-party review")
+        || lowered.contains("review findings remediation")
+        || lowered.contains("next milestone planning")
+        || lowered.contains("release ceremony")
+}
+
+fn infer_area(work_package: &str, is_closeout: bool) -> &'static str {
+    let lowered = work_package.to_lowercase();
+    if is_closeout {
         if lowered.contains("release") {
             "release"
         } else if lowered.contains("docs") || lowered.contains("next milestone planning") {

--- a/docs/milestones/v0.88/DESIGN_v0.88.md
+++ b/docs/milestones/v0.88/DESIGN_v0.88.md
@@ -209,7 +209,7 @@ The expected milestone flow is:
 - milestone planning docs no longer contradict the promoted package or the intended closeout pattern
 - tracked docs clearly separate canonical feature docs from local-only planning notes
 - eventual implementation issues and demo issues can be derived directly from the WBS without additional scope rewrites
-- the issue map distinguishes completed planning/package issues from the still-pending execution and closeout issue wave
+- the issue map distinguishes completed planning/package issues, completed implementation work, and the still-open closeout issue wave
 - the planning package explicitly states that scope closure has been reached
 
 ## Exit Criteria

--- a/docs/milestones/v0.88/MILESTONE_CHECKLIST_v0.88.md
+++ b/docs/milestones/v0.88/MILESTONE_CHECKLIST_v0.88.md
@@ -20,10 +20,10 @@ This milestone must prove a real temporal / PHI / instinct package with runnable
 - [x] Sprint state recorded truthfully (`docs/milestones/v0.88/SPRINT_v0.88.md`)
 
 ## Execution Readiness
-- [ ] Core implementation issue wave created
-- [ ] Each implementation issue promises concrete code, tests, artifacts, or demos rather than doc-only alignment
-- [ ] Demo / proof plan populated with runnable commands
-- [ ] Review-tail issues created and linked
+- [x] Core implementation issue wave created
+- [x] Each implementation issue promises concrete code, tests, artifacts, or demos rather than doc-only alignment
+- [x] Demo / proof plan populated with runnable commands
+- [x] Review-tail issues created and linked
 
 ## Functional / System Proof (v0.88-specific)
 
@@ -62,8 +62,8 @@ This milestone must prove a real temporal / PHI / instinct package with runnable
 
 ## Documentation Integrity
 - [x] DESIGN, README, WBS, SPRINT, and feature-doc inventory agree on the milestone boundary
-- [ ] demo matrix matches the actual runnable proof surface
-- [ ] docs match implementation truthfully once the issue wave lands
+- [x] demo matrix matches the actual runnable proof surface
+- [ ] docs match implementation truthfully once the review-tail reconciliation pass is complete
 
 ## Review
 - [ ] internal review completed and findings recorded

--- a/docs/milestones/v0.88/README.md
+++ b/docs/milestones/v0.88/README.md
@@ -98,6 +98,7 @@ Tracked planning/package issues already reflected in this milestone:
 - `#1527` initial `v0.88` planning shell and milestone scaffolding
 - `#1579` promotion of the bounded tracked `v0.88` feature-doc package
 - `#1497` canonical next-milestone planning reconciliation and scope closure
+- `#1643` seeding of the `v0.88` work-package issue wave
 
 Accepted supporting backlog pull-ins:
 - `#1614` bounded temporal/deadline pressure follow-on
@@ -117,17 +118,41 @@ The milestone should not invent an extra process sprint beyond that established 
 
 ## Status
 
-Current status: **tracked planning package reconciled; scope closed; execution issue wave pending**
+Current status: **implementation wave seeded and largely complete; `v0.88` is in late docs/review closeout**
 
-- Planning package: active
-- Promoted feature package: present
-- Scope shape: closed for `v0.88`; only accepted backlog pull-ins are the `#1614` temporal/deadline slice and `#1618` bounded comparative-demo direction
-- Issue wave: substantive `WP-02` through `WP-20` work-package issues still need to be created from this package, and they must promise real code, tests, artifacts, or demos rather than more scope-shaping work
-- Demo/review/release surfaces: seeded and aligned to the normal milestone pattern, but not yet populated with implementation evidence
+- Planning package: reconciled and stable
+- Promoted feature package: present and implemented across the main temporal / PHI / instinct bands
+- Scope shape: closed for `v0.88`; the only accepted bounded pull-ins were `#1614` and `#1618`, both completed
+- Issue wave: `WP-02` through `WP-13` are complete, and `WP-14` through `WP-20` are now the active closeout / review / release tail
+- Demo/review/release surfaces: present, runnable, and in active truth-tightening rather than pre-seeding
+
+### Active Work-Package State
+
+- Closed implementation wave:
+  - `WP-02` `#1644`
+  - `WP-03` `#1646`
+  - `WP-04` `#1648`
+  - `WP-05` `#1650`
+  - `WP-06` `#1651` plus bounded supporting slice `#1614`
+  - `WP-07` `#1653`
+  - `WP-08` `#1655`
+  - `WP-09` `#1645`
+  - `WP-10` `#1649`
+  - `WP-11` `#1654`
+  - `WP-12` `#1656`
+  - `WP-13` `#1657` plus bounded supporting proof `#1618`
+- Open closeout tail:
+  - `WP-14` `#1652`
+  - `WP-15` `#1658`
+  - `WP-16` `#1659`
+  - `WP-17` `#1660`
+  - `WP-18` `#1661`
+  - `WP-19` `#1662`
+  - `WP-20` `#1663`
 
 ## Exit Criteria
 
 - canonical `v0.88` milestone docs are internally consistent
 - tracked feature docs match the intended bounded milestone scope
 - local-only exploratory docs are not silently treated as canonical milestone promises
-- the `v0.88` issue wave can be seeded from this package without re-litigating milestone scope
+- the reviewer can distinguish completed implementation work from the still-open closeout tail without consulting local-only planning surfaces

--- a/docs/milestones/v0.88/RELEASE_NOTES_v0.88.md
+++ b/docs/milestones/v0.88/RELEASE_NOTES_v0.88.md
@@ -2,15 +2,39 @@
 
 ## Status
 
-Pre-release planning state.
+Pre-release closeout state.
 
-`v0.88` now has an established tracked planning package and promoted feature-doc package, but it does not yet have implementation-complete release notes.
-The eventual release must be based on delivered code, tests, demos, and artifacts, not on planning alignment alone.
+`v0.88` now has a completed implementation wave through `WP-13` plus an active closeout tail through `WP-20`.
+These release notes are still provisional because the milestone is in docs / review / release convergence, but they are no longer planning-only.
 
 Planning/package issues already represented:
 - `#1527`
 - `#1579`
 - `#1497`
+- `#1643`
+
+Completed implementation issues already represented:
+- `#1644`
+- `#1646`
+- `#1648`
+- `#1650`
+- `#1651`
+- `#1653`
+- `#1655`
+- `#1645`
+- `#1649`
+- `#1654`
+- `#1656`
+- `#1657`
+
+Active closeout issues:
+- `#1652`
+- `#1658`
+- `#1659`
+- `#1660`
+- `#1661`
+- `#1662`
+- `#1663`
 
 ## Current Public Package
 - chronosense / substance-of-time foundation
@@ -31,4 +55,4 @@ Planning/package issues already represented:
 - The only accepted supporting backlog pull-ins are `#1614` and `#1618`.
 - protected local follow-on planning remains for deepening `Paper Sonata`
   beyond the bounded `v0.88` slice.
-- The actual `WP-02` through `WP-20` implementation and closeout issue wave still needs to be created from the canonical planning package.
+- The implementation and closeout issue wave exists; the remaining work is reviewer-truth convergence, review execution, remediation, and ceremony.

--- a/docs/milestones/v0.88/RELEASE_PLAN_v0.88.md
+++ b/docs/milestones/v0.88/RELEASE_PLAN_v0.88.md
@@ -7,13 +7,12 @@
 
 ## Current State
 
-`v0.88` is not in release-tail execution yet.
+`v0.88` is in release-tail execution now.
 
 The current tracked work for `v0.88` is:
-- canonical milestone reconciliation
-- promoted temporal / chronosense feature package
-- promoted instinct / bounded-agency feature package
-- milestone closeout structure aligned to the standard ADL pattern
+- completed implementation wave through `WP-13`
+- active quality / docs / review / release tail through `WP-14` to `WP-20`
+- next-milestone planning already underway under `#1662`
 
 ## Purpose
 
@@ -28,7 +27,7 @@ This is not just a reminder that a release will happen later. When the milestone
 All of the following must be true before ceremony:
 
 - [ ] milestone checklist is fully updated and honest
-- [ ] implementation issue wave for `WP-02` through `WP-13` is complete or explicitly deferred
+- [x] implementation issue wave for `WP-02` through `WP-13` is complete or explicitly deferred
 - [ ] each completed implementation WP produced concrete code, tests, artifacts, demos, or an explicit defer record
 - [ ] demo matrix rows map to real runnable commands and proof artifacts
 - [ ] docs, WBS, demos, and implementation agree on the same bounded milestone
@@ -59,8 +58,7 @@ If any answer is NO, do not release.
 
 ## Intended Closeout Sequence
 
-When implementation begins, `v0.88` should close using the same bounded sequence used in `v0.86` and `v0.87`:
-- demos
+`v0.88` is currently traversing the same bounded closeout sequence used in `v0.86` and `v0.87`:
 - quality gate
 - docs + review pass
 - internal review

--- a/docs/milestones/v0.88/SPRINT_v0.88.md
+++ b/docs/milestones/v0.88/SPRINT_v0.88.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Milestone: `v0.88`
 - Sprint sequence: `v0.88-s1`, `v0.88-s2`, `v0.88-s3`
-- Start date: `TBD (execution not started)`
+- Start date: `2026-04-11`
 - End date: `TBD`
 - Owner: `Daniel Austin`
 
@@ -20,9 +20,9 @@ This keeps the closeout flow consistent with `v0.86` and `v0.87`.
 
 | Sprint | Purpose | WPs | Current status |
 |---|---|---|---|
-| `v0.88-s1` | lock canonical milestone truth and execute the temporal substrate | `WP-01` through `WP-08` | `WP-01` complete; execution issues pending for the rest |
-| `v0.88-s2` | execute PHI metrics, instinct / bounded-agency work, and the Paper Sonata flagship demo | `WP-09`, `WP-10`, `WP-11`, `WP-12`, `WP-13` | not started; issue seeding next |
-| `v0.88-s3` | converge docs, quality, review, release, and next-milestone planning | `WP-14` through `WP-20` | not started; follows implementation and demo proof |
+| `v0.88-s1` | lock canonical milestone truth and execute the temporal substrate | `WP-01` through `WP-08` | complete |
+| `v0.88-s2` | execute PHI metrics, instinct / bounded-agency work, and the Paper Sonata flagship demo | `WP-09`, `WP-10`, `WP-11`, `WP-12`, `WP-13` | complete |
+| `v0.88-s3` | converge docs, quality, review, release, and next-milestone planning | `WP-14` through `WP-20` | active; closeout tail in progress |
 
 ## Sprint 1
 
@@ -43,6 +43,7 @@ Establish the canonical `v0.88` package and land the temporal / chronosense subs
 - the tracked `v0.88` package is internally coherent
 - the full temporal band is represented in both docs and WBS
 - no placeholder-only planning-package language remains
+- the temporal execution wave is closed with concrete issue records from `#1644` through `#1655`
 
 ## Sprint 2
 
@@ -62,14 +63,14 @@ Execute the PHI metrics and instinct / bounded-agency bands and land the Paper S
 - instinct is a tracked, explicit, inspectable milestone surface
 - Paper Sonata is strong enough to function as a reviewer-facing and investor-facing milestone demo
 - at least one planned proof path shows how instinct affects routing or prioritization without escaping policy bounds
+- the implementation/demo wave is closed through `#1657`, with `#1618` providing the bounded comparative proof row
 
 ## Sprint 3
 
 ### Goal
-Close the milestone using the normal ADL pattern: demos, quality gate, docs/review, internal review, 3rd-party review, remediation, next-milestone planning, and release ceremony.
+Close the milestone using the normal ADL pattern: quality gate, docs/review, internal review, 3rd-party review, remediation, next-milestone planning, and release ceremony.
 
 ### Scope
-- demo matrix + integration demos
 - coverage / quality gate
 - docs + review pass
 - internal review
@@ -77,6 +78,15 @@ Close the milestone using the normal ADL pattern: demos, quality gate, docs/revi
 - review findings remediation
 - next milestone planning
 - release ceremony
+
+Current issue map:
+- `WP-14` `#1652`
+- `WP-15` `#1658`
+- `WP-16` `#1659`
+- `WP-17` `#1660`
+- `WP-18` `#1661`
+- `WP-19` `#1662`
+- `WP-20` `#1663`
 
 ### Exit Criteria
 - reviewer-facing docs match delivered proof surfaces

--- a/docs/milestones/v0.88/WBS_v0.88.md
+++ b/docs/milestones/v0.88/WBS_v0.88.md
@@ -19,33 +19,33 @@ After those feature bands, the milestone follows the same demo / quality / revie
 | ID | Work Package | Description | Deliverable | Dependencies | Issue |
 |---|---|---|---|---|---|
 | WP-01 | Canonical planning package | reconcile the tracked `v0.88` planning package, promoted feature index, and milestone structure so issue seeding can start from one truthful public surface | coherent milestone docs + promoted feature set | none | `#1527`, `#1579`, `#1497` |
-| WP-02 | Chronosense foundation | establish the conceptual chronosense substrate | runtime-facing chronosense definitions, acceptance criteria, and at least one bounded proof hook | `WP-01` | execution issue to be seeded |
-| WP-03 | Temporal schema | define temporal anchors, clocks, and execution-policy trace hooks | concrete schema fields, runtime serialization surface, and targeted tests | `WP-01` | execution issue to be seeded |
-| WP-04 | Continuity and identity semantics | ground continuity, interruption, resumption, and identity semantics in temporal structure | continuity artifact contract, implementation slice, and at least one proof fixture | `WP-02`, `WP-03` | execution issue to be seeded |
-| WP-05 | Temporal query and retrieval | make time-aware retrieval and staleness queryable | query surface, fixture-backed examples, and validation tests | `WP-03` | execution issue to be seeded |
-| WP-06 | Commitments and deadlines | represent future obligations and missed commitments as first-class temporal records | commitment/deadline artifact model, bounded runtime path, and proof fixtures | `WP-03`, `WP-05` | execution issue to be seeded; bounded pull-in `#1614` |
-| WP-07 | Temporal causality and explanation | define bounded causal / explanatory review surfaces | explanation artifact format, bounded evaluation path, and reviewer-facing examples | `WP-03`, `WP-05` | execution issue to be seeded |
-| WP-08 | Execution policy and cost model | tie execution mode and realized cost back to trace reviewability | execution-policy contract, cost fields/artifacts, and comparison proof path | `WP-03` | execution issue to be seeded |
-| WP-09 | PHI-style integration metrics | define bounded engineering metrics for integration, irreducibility, coupling, and adaptive depth in ADL systems | metric definitions, comparison runner or fixture set, and reviewable outputs | `WP-02` through `WP-08` | execution issue to be seeded |
-| WP-10 | Instinct model | define bounded instinct as an explicit cognitive substrate | runtime-facing instinct contract, bounded semantics, and acceptance tests | `WP-01` | execution issue to be seeded |
-| WP-11 | Instinct runtime surface and bounded agency hook | make instinct visible in runtime declaration, routing, prioritization, trace, and demo proof | implementation slice, trace/artifact evidence, and bounded-agency proof case | `WP-10` | execution issue to be seeded |
-| WP-12 | Paper Sonata flagship demo | implement a bounded investor-/reviewer-facing multi-agent manuscript demo with durable artifacts and truthful runtime proof | bounded runner, synthetic fixture packet, stable artifact tree, and smoke/validation path | `WP-02` through `WP-11` | execution issue to be seeded; protected local follow-on planning retained |
-| WP-13 | Demo matrix + integration demos | define and implement the primary proof surfaces for temporal, PHI, instinct, and Paper Sonata bands | runnable demo entrypoints, validated artifacts, and reviewer-facing demo matrix | `WP-02` through `WP-12` | execution issue to be seeded; supporting pull-in `#1618` |
-| WP-14 | Coverage / quality gate | enforce milestone quality and coverage posture | green quality gate | `WP-13` | closeout issue to be seeded |
-| WP-15 | Docs + review pass | converge reviewer-facing docs against delivered proof | reviewer-ready package | `WP-13`, `WP-14` | closeout issue to be seeded |
-| WP-16 | Internal review | perform bounded internal review of milestone truth and proof surfaces | internal review record | `WP-15` | closeout issue to be seeded |
-| WP-17 | 3rd-party review | perform external review of the milestone package and capture findings | 3rd-party review record | `WP-15`, `WP-16` | closeout issue to be seeded |
-| WP-18 | Review findings remediation | resolve or explicitly defer accepted review findings | remediation record | `WP-16`, `WP-17` | closeout issue to be seeded |
-| WP-19 | Next milestone planning | prepare the next milestone planning package before `v0.88` closeout | next-milestone package | `WP-18` | closeout issue to be seeded |
-| WP-20 | Release ceremony | final validation, notes, tag, cleanup, and closeout record | release package | `WP-18`, `WP-19` | closeout issue to be seeded |
+| WP-02 | Chronosense foundation | establish the conceptual chronosense substrate | runtime-facing chronosense definitions, acceptance criteria, and at least one bounded proof hook | `WP-01` | `#1644` closed |
+| WP-03 | Temporal schema | define temporal anchors, clocks, and execution-policy trace hooks | concrete schema fields, runtime serialization surface, and targeted tests | `WP-01` | `#1646` closed |
+| WP-04 | Continuity and identity semantics | ground continuity, interruption, resumption, and identity semantics in temporal structure | continuity artifact contract, implementation slice, and at least one proof fixture | `WP-02`, `WP-03` | `#1648` closed |
+| WP-05 | Temporal query and retrieval | make time-aware retrieval and staleness queryable | query surface, fixture-backed examples, and validation tests | `WP-03` | `#1650` closed |
+| WP-06 | Commitments and deadlines | represent future obligations and missed commitments as first-class temporal records | commitment/deadline artifact model, bounded runtime path, and proof fixtures | `WP-03`, `WP-05` | `#1651` closed; bounded supporting slice `#1614` closed |
+| WP-07 | Temporal causality and explanation | define bounded causal / explanatory review surfaces | explanation artifact format, bounded evaluation path, and reviewer-facing examples | `WP-03`, `WP-05` | `#1653` closed |
+| WP-08 | Execution policy and cost model | tie execution mode and realized cost back to trace reviewability | execution-policy contract, cost fields/artifacts, and comparison proof path | `WP-03` | `#1655` closed |
+| WP-09 | PHI-style integration metrics | define bounded engineering metrics for integration, irreducibility, coupling, and adaptive depth in ADL systems | metric definitions, comparison runner or fixture set, and reviewable outputs | `WP-02` through `WP-08` | `#1645` closed |
+| WP-10 | Instinct model | define bounded instinct as an explicit cognitive substrate | runtime-facing instinct contract, bounded semantics, and acceptance tests | `WP-01` | `#1649` closed |
+| WP-11 | Instinct runtime surface and bounded agency hook | make instinct visible in runtime declaration, routing, prioritization, trace, and demo proof | implementation slice, trace/artifact evidence, and bounded-agency proof case | `WP-10` | `#1654` closed |
+| WP-12 | Paper Sonata flagship demo | implement a bounded investor-/reviewer-facing multi-agent manuscript demo with durable artifacts and truthful runtime proof | bounded runner, synthetic fixture packet, stable artifact tree, and smoke/validation path | `WP-02` through `WP-11` | `#1656` closed; protected local follow-on planning retained |
+| WP-13 | Demo matrix + integration demos | define and implement the primary proof surfaces for temporal, PHI, instinct, and Paper Sonata bands | runnable demo entrypoints, validated artifacts, and reviewer-facing demo matrix | `WP-02` through `WP-12` | `#1657` closed; bounded supporting proof `#1618` closed |
+| WP-14 | Coverage / quality gate | enforce milestone quality and coverage posture | green quality gate | `WP-13` | `#1652` open |
+| WP-15 | Docs + review pass | converge reviewer-facing docs against delivered proof | reviewer-ready package | `WP-13`, `WP-14` | `#1658` open |
+| WP-16 | Internal review | perform bounded internal review of milestone truth and proof surfaces | internal review record | `WP-15` | `#1659` open |
+| WP-17 | 3rd-party review | perform external review of the milestone package and capture findings | 3rd-party review record | `WP-15`, `WP-16` | `#1660` open |
+| WP-18 | Review findings remediation | resolve or explicitly defer accepted review findings | remediation record | `WP-16`, `WP-17` | `#1661` open |
+| WP-19 | Next milestone planning | prepare the next milestone planning package before `v0.88` closeout | next-milestone package | `WP-18` | `#1662` open |
+| WP-20 | Release ceremony | final validation, notes, tag, cleanup, and closeout record | release package | `WP-18`, `WP-19` | `#1663` open |
 
 Issue-column note:
 - `WP-01` is already represented by tracked planning/package issues.
-- `WP-02` through `WP-20` intentionally await the real execution and closeout issue wave.
-- `#1614` and `#1618` are supporting backlog items, not substitutes for the milestone's main work-package issues.
+- `WP-02` through `WP-20` are now represented by the seeded `v0.88` work-package issue wave.
+- `#1614` and `#1618` are bounded supporting pull-ins, not replacements for the main work-package issues.
 
 ## Exit Criteria
 - every tracked `v0.88` feature doc maps to at least one WBS item
 - the instinct / bounded-agency band is no longer missing from tracked milestone truth
 - the release tail uses the normal `v0.86` / `v0.87` pattern with no extra invented steps
-- the planning package is strong enough to seed the real issue wave without another structural rewrite
+- the WBS tells the truth about both completed implementation work and the still-open closeout tail

--- a/docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml
+++ b/docs/milestones/v0.88/WP_ISSUE_WAVE_v0.88.yaml
@@ -22,7 +22,7 @@ entries:
   work_package: Chronosense foundation
   summary: establish the conceptual chronosense substrate
   deliverable: runtime-facing chronosense definitions, acceptance criteria, and at least one bounded proof hook
-  issue_column: execution issue to be seeded
+  issue_column: '#1644 closed'
 - wp: WP-03
   issue_kind: execution
   title: '[v0.88][WP-03] Temporal schema'
@@ -41,7 +41,7 @@ entries:
   work_package: Temporal schema
   summary: define temporal anchors, clocks, and execution-policy trace hooks
   deliverable: concrete schema fields, runtime serialization surface, and targeted tests
-  issue_column: execution issue to be seeded
+  issue_column: '#1646 closed'
 - wp: WP-04
   issue_kind: execution
   title: '[v0.88][WP-04] Continuity and identity semantics'
@@ -61,7 +61,7 @@ entries:
   work_package: Continuity and identity semantics
   summary: ground continuity, interruption, resumption, and identity semantics in temporal structure
   deliverable: continuity artifact contract, implementation slice, and at least one proof fixture
-  issue_column: execution issue to be seeded
+  issue_column: '#1648 closed'
 - wp: WP-05
   issue_kind: execution
   title: '[v0.88][WP-05] Temporal query and retrieval'
@@ -80,7 +80,7 @@ entries:
   work_package: Temporal query and retrieval
   summary: make time-aware retrieval and staleness queryable
   deliverable: query surface, fixture-backed examples, and validation tests
-  issue_column: execution issue to be seeded
+  issue_column: '#1650 closed'
 - wp: WP-06
   issue_kind: execution
   title: '[v0.88][WP-06] Commitments and deadlines'
@@ -100,7 +100,7 @@ entries:
   work_package: Commitments and deadlines
   summary: represent future obligations and missed commitments as first-class temporal records
   deliverable: commitment/deadline artifact model, bounded runtime path, and proof fixtures
-  issue_column: execution issue to be seeded; bounded pull-in `#1614`
+  issue_column: '#1651 closed; bounded supporting slice #1614 closed'
 - wp: WP-07
   issue_kind: execution
   title: '[v0.88][WP-07] Temporal causality and explanation'
@@ -120,7 +120,7 @@ entries:
   work_package: Temporal causality and explanation
   summary: define bounded causal / explanatory review surfaces
   deliverable: explanation artifact format, bounded evaluation path, and reviewer-facing examples
-  issue_column: execution issue to be seeded
+  issue_column: '#1653 closed'
 - wp: WP-08
   issue_kind: execution
   title: '[v0.88][WP-08] Execution policy and cost model'
@@ -139,7 +139,7 @@ entries:
   work_package: Execution policy and cost model
   summary: tie execution mode and realized cost back to trace reviewability
   deliverable: execution-policy contract, cost fields/artifacts, and comparison proof path
-  issue_column: execution issue to be seeded
+  issue_column: '#1655 closed'
 - wp: WP-09
   issue_kind: execution
   title: '[v0.88][WP-09] PHI-style integration metrics'
@@ -164,7 +164,7 @@ entries:
   work_package: PHI-style integration metrics
   summary: define bounded engineering metrics for integration, irreducibility, coupling, and adaptive depth in ADL systems
   deliverable: metric definitions, comparison runner or fixture set, and reviewable outputs
-  issue_column: execution issue to be seeded
+  issue_column: '#1645 closed'
 - wp: WP-10
   issue_kind: execution
   title: '[v0.88][WP-10] Instinct model'
@@ -183,7 +183,7 @@ entries:
   work_package: Instinct model
   summary: define bounded instinct as an explicit cognitive substrate
   deliverable: runtime-facing instinct contract, bounded semantics, and acceptance tests
-  issue_column: execution issue to be seeded
+  issue_column: '#1649 closed'
 - wp: WP-11
   issue_kind: execution
   title: '[v0.88][WP-11] Instinct runtime surface and bounded agency hook'
@@ -202,7 +202,7 @@ entries:
   work_package: Instinct runtime surface and bounded agency hook
   summary: make instinct visible in runtime declaration, routing, prioritization, trace, and demo proof
   deliverable: implementation slice, trace/artifact evidence, and bounded-agency proof case
-  issue_column: execution issue to be seeded
+  issue_column: '#1654 closed'
 - wp: WP-12
   issue_kind: execution
   title: '[v0.88][WP-12] Paper Sonata flagship demo'
@@ -230,7 +230,7 @@ entries:
   work_package: Paper Sonata flagship demo
   summary: implement a bounded investor-/reviewer-facing multi-agent manuscript demo with durable artifacts and truthful runtime proof
   deliverable: bounded runner, synthetic fixture packet, stable artifact tree, and smoke/validation path
-  issue_column: execution issue to be seeded; protected local follow-on planning retained
+  issue_column: '#1656 closed; protected local follow-on planning retained'
 - wp: WP-13
   issue_kind: execution
   title: '[v0.88][WP-13] Demo matrix + integration demos'
@@ -259,7 +259,7 @@ entries:
   work_package: Demo matrix + integration demos
   summary: define and implement the primary proof surfaces for temporal, PHI, instinct, and Paper Sonata bands
   deliverable: runnable demo entrypoints, validated artifacts, and reviewer-facing demo matrix
-  issue_column: execution issue to be seeded; supporting pull-in `#1618`
+  issue_column: '#1657 closed; bounded supporting proof #1618 closed'
 - wp: WP-14
   issue_kind: closeout
   title: '[v0.88][WP-14] Coverage / quality gate'
@@ -278,7 +278,7 @@ entries:
   work_package: Coverage / quality gate
   summary: enforce milestone quality and coverage posture
   deliverable: green quality gate
-  issue_column: closeout issue to be seeded
+  issue_column: '#1652 open'
 - wp: WP-15
   issue_kind: closeout
   title: '[v0.88][WP-15] Docs + review pass'
@@ -298,7 +298,7 @@ entries:
   work_package: Docs + review pass
   summary: converge reviewer-facing docs against delivered proof
   deliverable: reviewer-ready package
-  issue_column: closeout issue to be seeded
+  issue_column: '#1658 open'
 - wp: WP-16
   issue_kind: closeout
   title: '[v0.88][WP-16] Internal review'
@@ -317,7 +317,7 @@ entries:
   work_package: Internal review
   summary: perform bounded internal review of milestone truth and proof surfaces
   deliverable: internal review record
-  issue_column: closeout issue to be seeded
+  issue_column: '#1659 open'
 - wp: WP-17
   issue_kind: closeout
   title: '[v0.88][WP-17] 3rd-party review'
@@ -337,7 +337,7 @@ entries:
   work_package: 3rd-party review
   summary: perform external review of the milestone package and capture findings
   deliverable: 3rd-party review record
-  issue_column: closeout issue to be seeded
+  issue_column: '#1660 open'
 - wp: WP-18
   issue_kind: closeout
   title: '[v0.88][WP-18] Review findings remediation'
@@ -357,7 +357,7 @@ entries:
   work_package: Review findings remediation
   summary: resolve or explicitly defer accepted review findings
   deliverable: remediation record
-  issue_column: closeout issue to be seeded
+  issue_column: '#1661 open'
 - wp: WP-19
   issue_kind: closeout
   title: '[v0.88][WP-19] Next milestone planning'
@@ -376,7 +376,7 @@ entries:
   work_package: Next milestone planning
   summary: prepare the next milestone planning package before `v0.88` closeout
   deliverable: next-milestone package
-  issue_column: closeout issue to be seeded
+  issue_column: '#1662 open'
 - wp: WP-20
   issue_kind: closeout
   title: '[v0.88][WP-20] Release ceremony'
@@ -396,4 +396,4 @@ entries:
   work_package: Release ceremony
   summary: final validation, notes, tag, cleanup, and closeout record
   deliverable: release package
-  issue_column: closeout issue to be seeded
+  issue_column: '#1663 open'


### PR DESCRIPTION
Closes #1658

## Summary
- reconcile the tracked v0.88 reviewer-facing package with the real work-package issue wave
- replace stale pre-seeding and planning-only language with truthful implementation/closeout state
- align the machine-readable WP issue wave with the human-facing milestone docs

## Validation
- gh issue list --state all --search "repo:danielbaustin/agent-design-language label:v0.88" --limit 200
- rg -n "execution issue to be seeded|closeout issue to be seeded|execution issue wave pending|not in release-tail execution yet|Pre-release planning state|issue seeding next|not started; issue seeding next|execution not started|still needs to be created" docs/milestones/v0.88
- git diff --check -- docs/milestones/v0.88
- bash adl/tools/pr.sh doctor 1658