### PR TITLE
[v0.88][tools] Automate pr-closeout after merge for local-only .adl records

### DIFF
--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
@@ -314,17 +315,20 @@ fn ensure_canonical_output_is_local_only(
         return Ok(());
     };
     let repo_relative = repo_relative.to_string_lossy().into_owned();
-    if run_status_allow_failure(
-        "git",
-        &[
+    let status = Command::new("git")
+        .args([
             "-C",
             path_str(repo_root)?,
             "ls-files",
             "--error-unmatch",
             "--",
             &repo_relative,
-        ],
-    )? {
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to spawn 'git'")?;
+    if status.success() {
         bail!(
             "{context}: '{}' is still tracked in git. Untrack canonical .adl issue surfaces before lifecycle normalization.",
             repo_relative

--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -22,6 +22,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `burst_worktree.sh`, `burst_continue.sh`: burst lane/worktree helpers.
 - `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks, including the repo-code-review skill contract guard.
 - `check_issue_metadata_parity.sh`: canonical metadata parity audit for GitHub issue title/labels plus local `.adl` body/STP metadata identity.
+- `closeout_completed_issue_wave.sh`: bounded local catch-up helper that runs `pr closeout` across closed/completed issue bundles for a milestone version so local-only `.adl` truth can converge after merge or main sync.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
 - `report_large_rust_modules.sh`: non-blocking Rust implementation-module size report for maintainability review.
 - `open_artifact.sh`: convenience opener for cards/reports.

--- a/adl/tools/attach_post_merge_closeout.sh
+++ b/adl/tools/attach_post_merge_closeout.sh
@@ -83,7 +83,8 @@ run_watch_loop() {
   local summary_file="$2"
   local run_log="$3"
   local attempt=0
-  local max_attempts=240
+  local max_attempts="${ADL_POST_MERGE_CLOSEOUT_MAX_ATTEMPTS:-240}"
+  local sleep_secs="${ADL_POST_MERGE_CLOSEOUT_SLEEP_SECS:-30}"
 
   write_summary "$summary_file" "watching" "Waiting for PR merge and issue CLOSED/COMPLETED state before automatic closeout."
   while (( attempt < max_attempts )); do
@@ -95,10 +96,11 @@ run_watch_loop() {
       20) exit 20 ;;
     esac
     attempt=$((attempt + 1))
-    sleep 30
+    sleep "$sleep_secs"
   done
 
   write_summary "$summary_file" "timeout" "Timed out waiting for merged PR plus CLOSED/COMPLETED issue state; no automatic closeout was applied."
+  exit 30
 }
 
 REPO_ROOT=""

--- a/adl/tools/closeout_completed_issue_wave.sh
+++ b/adl/tools/closeout_completed_issue_wave.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSION=""
+REPO=""
+REPORT_PATH=""
+ISSUES_CSV=""
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  closeout_completed_issue_wave.sh --version <v0.88> [--repo <owner/name>] [--issues <csv>] [--report <path>] [--dry-run]
+
+Scans the local `.adl/<version>/tasks/` bundle set, finds GitHub issues that are
+already CLOSED/COMPLETED for that version, and runs `adl/tools/pr.sh closeout`
+for the matching local issue bundles.
+EOF
+}
+
+die() {
+  echo "closeout-wave: $*" >&2
+  exit 1
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+infer_repo() {
+  local remote_url
+  remote_url="$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)"
+  if [[ "$remote_url" =~ github.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+collect_local_issues() {
+  local version="$1"
+  local tasks_root="$ROOT/.adl/$version/tasks"
+  [[ -d "$tasks_root" ]] || return 0
+  find "$tasks_root" -mindepth 1 -maxdepth 1 -type d | \
+    while IFS= read -r dir; do
+      local base
+      base="$(basename "$dir")"
+      if [[ "$base" =~ ^issue-([0-9]+)__ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+      fi
+    done | sort -n | uniq
+}
+
+write_report() {
+  local path="$1"
+  local mode="$2"
+  local eligible_count="$3"
+  local normalized_count="$4"
+  local failed_count="$5"
+  local normalized_list="$6"
+  local failed_list="$7"
+  mkdir -p "$(dirname "$path")"
+  {
+    echo "version: $VERSION"
+    echo "repo: $REPO"
+    echo "mode: $mode"
+    echo "eligible_issues: $eligible_count"
+    echo "normalized_issues: $normalized_count"
+    echo "failed_issues: $failed_count"
+    echo "normalized:"
+    if [[ -n "$normalized_list" ]]; then
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && echo "  - $line"
+      done <<< "$normalized_list"
+    else
+      echo "  - none"
+    fi
+    echo "failures:"
+    if [[ -n "$failed_list" ]]; then
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && echo "  - $line"
+      done <<< "$failed_list"
+    else
+      echo "  - none"
+    fi
+  } >"$path"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --issues) ISSUES_CSV="${2:-}"; shift 2 ;;
+    --report) REPORT_PATH="${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || die "missing --version"
+command -v gh >/dev/null 2>&1 || die "gh is required"
+command -v python3 >/dev/null 2>&1 || die "python3 is required"
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(infer_repo)" || die "could not infer GitHub repo from origin remote; pass --repo"
+fi
+
+if [[ -z "$REPORT_PATH" ]]; then
+  REPORT_PATH="$ROOT/.adl/reports/closeout/closeout-wave-${VERSION}.md"
+fi
+
+local_issues="$(collect_local_issues "$VERSION")"
+if [[ -z "$local_issues" ]]; then
+  write_report "$REPORT_PATH" "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" 0 0 0 "" ""
+  echo "PASS closeout_completed_issue_wave version=$VERSION eligible=0"
+  exit 0
+fi
+
+closed_json="$(gh issue list -R "$REPO" --state closed --label "version:$VERSION" --limit 200 --json number,stateReason)"
+
+eligible_issues="$(
+  LOCAL_ISSUES="$local_issues" CLOSED_JSON="$closed_json" ISSUES_CSV="$ISSUES_CSV" python3 - <<'PY'
+import json, os
+local_issues = {int(v) for v in os.environ.get("LOCAL_ISSUES", "").splitlines() if v.strip()}
+closed = json.loads(os.environ.get("CLOSED_JSON", "[]") or "[]")
+issue_filter = {
+    int(v.strip()) for v in os.environ.get("ISSUES_CSV", "").split(",") if v.strip()
+}
+eligible = []
+for item in closed:
+    number = int(item["number"])
+    if number not in local_issues:
+        continue
+    if issue_filter and number not in issue_filter:
+        continue
+    if (item.get("stateReason") or "").strip() != "COMPLETED":
+        continue
+    eligible.append(number)
+for number in sorted(set(eligible)):
+    print(number)
+PY
+)"
+
+if [[ -z "$eligible_issues" ]]; then
+  write_report "$REPORT_PATH" "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" 0 0 0 "" ""
+  echo "PASS closeout_completed_issue_wave version=$VERSION eligible=0"
+  exit 0
+fi
+
+normalized_list=""
+failed_list=""
+normalized_count=0
+failed_count=0
+report_log="$(mktemp)"
+trap 'rm -f "$report_log"' EXIT
+
+while IFS= read -r issue; do
+  [[ -n "$issue" ]] || continue
+  if [[ "$DRY_RUN" == "1" ]]; then
+    normalized_list+="${issue}"$'\n'
+    normalized_count=$((normalized_count + 1))
+    continue
+  fi
+  if bash "$ROOT/adl/tools/pr.sh" closeout "$issue" --version "$VERSION" --no-fetch-issue >>"$report_log" 2>&1; then
+    normalized_list+="${issue}"$'\n'
+    normalized_count=$((normalized_count + 1))
+  else
+    failed_count=$((failed_count + 1))
+    last_error="$(tail -n 1 "$report_log" | tr '\n' ' ')"
+    failed_list+="#${issue}: $(trim "$last_error")"$'\n'
+  fi
+done <<< "$eligible_issues"
+
+write_report \
+  "$REPORT_PATH" \
+  "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" \
+  "$(printf '%s\n' "$eligible_issues" | sed '/^$/d' | wc -l | tr -d ' ')" \
+  "$normalized_count" \
+  "$failed_count" \
+  "$normalized_list" \
+  "$failed_list"
+
+if [[ "$failed_count" != "0" ]]; then
+  die "failed to normalize $failed_count closed issue bundle(s); see $REPORT_PATH"
+fi
+
+echo "PASS closeout_completed_issue_wave version=$VERSION normalized=$normalized_count"

--- a/adl/tools/fix_git_main_sync.sh
+++ b/adl/tools/fix_git_main_sync.sh
@@ -60,6 +60,42 @@ restore_missing_local_adl_cards() {
   done <"$preserve_list"
 }
 
+latest_local_adl_version() {
+  local version_root="$repo_root/.adl"
+  [[ -d "$version_root" ]] || return 0
+  find "$version_root" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | \
+    sort -V | tail -n 1
+}
+
+run_closeout_catchup() {
+  [[ "${ADL_MAIN_SYNC_CLOSEOUT_DISABLE:-0}" == "1" ]] && return 0
+  command -v gh >/dev/null 2>&1 || {
+    echo "fix-git: gh not found; skipping closeout catch-up" >&2
+    return 0
+  }
+
+  local versions_csv="${ADL_MAIN_SYNC_CLOSEOUT_VERSIONS:-}"
+  local closeout_repo="${ADL_MAIN_SYNC_CLOSEOUT_REPO:-}"
+  if [[ -z "$versions_csv" ]]; then
+    versions_csv="$(latest_local_adl_version || true)"
+  fi
+  [[ -n "$versions_csv" ]] || return 0
+
+  local version
+  OLDIFS="$IFS"
+  IFS=','
+  for version in $versions_csv; do
+    version="$(echo "$version" | xargs)"
+    [[ -n "$version" ]] || continue
+    if [[ -n "$closeout_repo" ]]; then
+      bash "$repo_root/adl/tools/closeout_completed_issue_wave.sh" --version "$version" --repo "$closeout_repo"
+    else
+      bash "$repo_root/adl/tools/closeout_completed_issue_wave.sh" --version "$version"
+    fi
+  done
+  IFS="$OLDIFS"
+}
+
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" ||
   die "not inside a git checkout"
 
@@ -86,3 +122,4 @@ capture_local_adl_cards
 git -C "$repo_root" fetch origin main
 git -C "$repo_root" merge --ff-only origin/main
 restore_missing_local_adl_cards
+run_closeout_catchup

--- a/adl/tools/test_attach_post_merge_closeout.sh
+++ b/adl/tools/test_attach_post_merge_closeout.sh
@@ -52,3 +52,39 @@ PATH="$BIN_DIR:$PATH" \
 grep -Fq 'closeout 1' "$CLOSEOUT_LOG"
 grep -Fq 'status: normalized' "$SUMMARY_FILE"
 grep -Fq 'canonical sor.md reconciled to closed merged truth' "$SUMMARY_FILE"
+
+cat >"$BIN_DIR/gh-open" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "pr view" ]]; then
+  printf '{"state":"OPEN","mergedAt":"","url":"https://example.test/pr/2"}\n'
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" ]]; then
+  printf '{"state":"OPEN","stateReason":"","url":"https://example.test/issues/2"}\n'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$BIN_DIR/gh-open"
+
+if PATH="$BIN_DIR:$PATH" GH="$BIN_DIR/gh-open" ADL_POST_MERGE_CLOSEOUT_MAX_ATTEMPTS=1 ADL_POST_MERGE_CLOSEOUT_SLEEP_SECS=0 bash -c '
+  function gh(){ "$GH" "$@"; }
+  export -f gh
+  bash "'"$ROOT_DIR"'/attach_post_merge_closeout.sh" \
+    --watch \
+    --repo-root "'"$TEMP_DIR"'/repo" \
+    --repo "owner/repo" \
+    --issue "2" \
+    --branch "codex/2-test" \
+    --pr-url "https://example.test/pr/2" \
+    --summary-file "'"$TEMP_DIR"'/timeout-summary.md" \
+    --run-log "'"$TEMP_DIR"'/timeout.log"
+'; then
+  echo "expected timeout watcher to fail non-zero" >&2
+  exit 1
+fi
+
+grep -Fq 'status: timeout' "$TEMP_DIR/timeout-summary.md"
+
+echo "PASS test_attach_post_merge_closeout"

--- a/adl/tools/test_closeout_completed_issue_wave.sh
+++ b/adl/tools/test_closeout_completed_issue_wave.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REPO="$TMP/repo"
+mkdir -p "$REPO/adl/tools"
+mkdir -p "$REPO/.git"
+
+mkdir -p "$REPO/.adl/v0.88/tasks/issue-100__demo"
+cat >"$REPO/.adl/v0.88/tasks/issue-100__demo/sor.md" <<'EOF'
+Status: DONE
+- Integration state: pr_open
+- Verification scope: pr_branch
+- Worktree-only paths remaining: worktree/path
+EOF
+
+cat >"$REPO/.git/config" <<'EOF'
+[remote "origin"]
+	url = git@github.com:danielbaustin/agent-design-language.git
+EOF
+
+cp "$ROOT/adl/tools/closeout_completed_issue_wave.sh" "$REPO/adl/tools/closeout_completed_issue_wave.sh"
+chmod +x "$REPO/adl/tools/closeout_completed_issue_wave.sh"
+
+CLOSEOUT_LOG="$TMP/closeout.log"
+cat >"$REPO/adl/tools/pr.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$CLOSEOUT_LOG"
+exit 0
+EOF
+chmod +x "$REPO/adl/tools/pr.sh"
+
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+cat >"$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "issue list" ]]; then
+  printf '[{"number":100,"stateReason":"COMPLETED"},{"number":101,"stateReason":"COMPLETED"}]\n'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$BIN/gh"
+
+REPORT="$TMP/report.md"
+(cd "$REPO" && PATH="$BIN:$PATH" bash ./adl/tools/closeout_completed_issue_wave.sh --version v0.88 --repo danielbaustin/agent-design-language --report "$REPORT")
+
+grep -Fq 'closeout 100 --version v0.88 --no-fetch-issue' "$CLOSEOUT_LOG"
+grep -Fq 'normalized_issues: 1' "$REPORT"
+grep -Fq 'failed_issues: 0' "$REPORT"
+
+echo "PASS test_closeout_completed_issue_wave"

--- a/adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh
+++ b/adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh
@@ -18,11 +18,20 @@ git -C "$SEED" config user.name "Test User"
 git -C "$SEED" config user.email "test@example.com"
 mkdir -p "$SEED/adl/tools"
 cp "$ROOT/adl/tools/fix_git_main_sync.sh" "$SEED/adl/tools/fix_git_main_sync.sh"
+cp "$ROOT/adl/tools/closeout_completed_issue_wave.sh" "$SEED/adl/tools/closeout_completed_issue_wave.sh"
 chmod +x "$SEED/adl/tools/fix_git_main_sync.sh"
+chmod +x "$SEED/adl/tools/closeout_completed_issue_wave.sh"
 printf '.adl/\n' >"$SEED/.gitignore"
+cat >"$SEED/adl/tools/pr.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$TEST_CLOSEOUT_LOG"
+exit 0
+EOF
+chmod +x "$SEED/adl/tools/pr.sh"
 mkdir -p "$SEED/$(dirname "$CARD_PATH")"
 printf 'tracked residue\n' >"$SEED/$CARD_PATH"
-git -C "$SEED" add -f .gitignore adl/tools/fix_git_main_sync.sh "$CARD_PATH"
+git -C "$SEED" add -f .gitignore adl/tools/fix_git_main_sync.sh adl/tools/closeout_completed_issue_wave.sh adl/tools/pr.sh "$CARD_PATH"
 git -C "$SEED" commit -q -m "seed tracked residue"
 git -C "$SEED" push -q -u origin main
 
@@ -35,7 +44,22 @@ git -C "$SEED" rm -q "$CARD_PATH"
 git -C "$SEED" commit -q -m "remove tracked residue"
 git -C "$SEED" push -q
 
-(cd "$LOCAL" && bash ./adl/tools/fix_git_main_sync.sh >/dev/null)
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+cat >"$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "issue list" ]]; then
+  printf '[{"number":1650,"stateReason":"COMPLETED"}]\n'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$BIN/gh"
+
+export TEST_CLOSEOUT_LOG="$TMP/closeout.log"
+
+(cd "$LOCAL" && PATH="$BIN:$PATH" ADL_MAIN_SYNC_CLOSEOUT_VERSIONS=v0.88 ADL_MAIN_SYNC_CLOSEOUT_REPO=danielbaustin/agent-design-language bash ./adl/tools/fix_git_main_sync.sh >/dev/null)
 
 if [[ ! -f "$LOCAL/$CARD_PATH" ]]; then
   echo "expected local card to be restored after fast-forward sync" >&2
@@ -47,5 +71,7 @@ if [[ -n "$(git -C "$LOCAL" status --porcelain)" ]]; then
   git -C "$LOCAL" status --short >&2
   exit 1
 fi
+
+grep -Fq 'closeout 1650 --version v0.88 --no-fetch-issue' "$TEST_CLOSEOUT_LOG"
 
 echo "PASS test_fix_git_main_sync_preserves_local_adl_cards"


### PR DESCRIPTION
Closes #1731

## Summary
Strengthened the existing post-merge closeout path for local-only `.adl` bundles, added a reusable closed-issue closeout wave helper, and wired main fast-forward sync to run a local closeout catch-up pass for the current milestone.

## Artifacts
- `adl/tools/closeout_completed_issue_wave.sh`
- `adl/tools/attach_post_merge_closeout.sh`
- `adl/tools/fix_git_main_sync.sh`
- `adl/tools/test_closeout_completed_issue_wave.sh`
- `adl/tools/test_attach_post_merge_closeout.sh`
- `adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh`
- `adl/src/cli/pr_cmd/lifecycle.rs`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/attach_post_merge_closeout.sh adl/tools/closeout_completed_issue_wave.sh adl/tools/fix_git_main_sync.sh adl/tools/test_attach_post_merge_closeout.sh adl/tools/test_closeout_completed_issue_wave.sh adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh` verified shell syntax across the new helper path and updated tests.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check` verified Rust formatting for the lifecycle change.
  - `bash adl/tools/test_attach_post_merge_closeout.sh` verified both normalized and timeout watcher paths.
  - `bash adl/tools/test_closeout_completed_issue_wave.sh` verified the new closeout-wave helper.
  - `bash adl/tools/test_fix_git_main_sync_preserves_local_adl_cards.sh` verified sync preservation plus post-sync catch-up.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_closeout_reconciles_closed_completed_issue_bundle -- --nocapture` verified the Rust closeout reconciliation path.
- Results: all listed validations passed in the bound worktree before PR publication.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1731__v0-88-tools-automate-pr-closeout-after-merge-for-local-only-adl-records/sip.md
- Output card: .adl/v0.88/tasks/issue-1731__v0-88-tools-automate-pr-closeout-after-merge-for-local-only-adl-records/sor.md
- Idempotency-Key: v0-88-tools-automate-pr-closeout-after-merge-for-local-only-adl-records-adl-tools-adl-src-cli-adl-v0-88-tasks-issue-1731-v0-88-tools-automate-pr-closeout-after-merge-for-local-only-adl-records-sip-md-adl-v0-88-tasks-issue-1731-v0-88-tools-automate-pr-closeout-after-merge-for-local-only-adl-records-sor-md