### PR TITLE
[codex] Refresh rust module watch list for 2026-04-13

### DIFF
--- a/docs/tooling/rust_module_watch_list.md
+++ b/docs/tooling/rust_module_watch_list.md
@@ -53,28 +53,31 @@ The table below reflects the current branch state from
 
 | Path | Approx. LoC | Responsibility summary | Suggested future split boundaries | Watch level |
 |---|---:|---|---|---|
-| `adl/src/cli/tests/pr_cmd_inline/finish.rs` | 2254 | inline `pr finish` test matrix covering workflow closeout, publication, and edge conditions | split finish-path cases by concern (`validation`, `integration`, `publication`, `error paths`) and centralize shared fixtures | Rationale |
-| `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs` | 1547 | inline `pr` lifecycle regression coverage across doctor/init/finish control-flow edges | split lifecycle-path cases by command family and centralize shared fixtures | Rationale |
-| `adl/src/provider.rs` | 1399 | provider configuration, request assembly, and provider-facing orchestration | split provider model/schema code from request execution and normalization helpers | Review |
+| `adl/src/chronosense.rs` | 1935 | identity-profile loading, temporal-context synthesis, and chronosense output shaping | split profile/schema loading from temporal-derivation helpers and CLI/report formatting helpers | Rationale |
+| `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs` | 1677 | `pr finish` guardrail regression coverage after the inline finish split | split guardrail cases by concern (`branch state`, `review requirements`, `publication blockers`) and centralize shared fixtures | Rationale |
+| `adl/src/cli/identity_cmd.rs` | 1572 | identity command parsing, profile IO, and temporal-context output flows | split parsing/dispatch from profile persistence and output rendering helpers | Rationale |
 | `adl/src/instrumentation.rs` | 1353 | instrumentation/event capture, shaping, and persistence/report helpers | split event/schema definitions from emitters, formatting, and persistence helpers | Review |
-| `adl/src/cli/tooling_cmd/tests.rs` | 1292 | tooling command regression coverage across review-surface and prompt-contract helpers | split tests by subcommand family and centralize shared CLI fixture builders | Review |
-| `adl/src/cli/run_artifacts/cognitive.rs` | 1287 | cognitive artifact assembly, shaping, and export helpers | split schema/model builders from export and report formatting helpers | Review |
+| `adl/src/cli/tooling_cmd/tests.rs` | 1318 | tooling command regression coverage across review-surface and prompt-contract helpers | split tests by subcommand family and centralize shared CLI fixture builders | Review |
+| `adl/src/cli/run_artifacts/cognitive.rs` | 1297 | cognitive artifact assembly, shaping, and export helpers | split schema/model builders from export and report formatting helpers | Review |
+| `adl/src/cli/pr_cmd.rs` | 1294 | PR command façade and residual dispatch after the lifecycle/github/git-support extraction | keep the façade thin and avoid re-accumulating lifecycle/helper logic into this file | Review |
 | `adl/src/cli/run_artifacts/runtime.rs` | 1285 | runtime artifact assembly, trace export, and persistence/report shaping | split path/schema helpers from emit/export flows and separate persistence from presentation helpers | Review |
+| `adl/src/provider/http_family.rs` | 1184 | HTTP-family provider configuration and request-family normalization helpers | split family/profile normalization from request execution or shared HTTP transport helpers | Review |
+| `adl/src/execute/state/runtime_control.rs` | 1165 | runtime control-state modeling and projection helpers | split state model/schema code from projection/serialization helpers if the file grows again | Review |
 | `adl/src/adl/tests.rs` | 1157 | ADL parser/validator regression coverage across many behaviors | split tests by behavior family and move shared builders into test helpers | Review |
-| `adl/src/cli/pr_cmd.rs` | 1127 | PR command façade and residual dispatch after the lifecycle/github/git-support extraction | keep the façade thin and avoid re-accumulating lifecycle/helper logic into this file | Review |
 | `adl/src/cli/tests/artifact_builders/learning_runtime.rs` | 1107 | learning/runtime artifact-builder regression coverage | split learning-vs-runtime assertions and centralize shared fixture setup | Review |
-| `adl/src/execute/state/runtime_control.rs` | 1059 | runtime control-state modeling and projection helpers | split state model/schema code from projection/serialization helpers if the file grows again | Review |
 | `adl/src/trace.rs` | 1024 | trace model, persistence, and rendering/query helpers | split trace record/schema logic from output formatting and IO helpers | Review |
+| `adl/src/cli/tests/pr_cmd_inline/basics.rs` | 1017 | baseline `pr` workflow regression coverage across parsing and bootstrap helpers | split parser/argument cases from bootstrap/body-generation cases and keep shared fixtures centralized | Review |
 | `adl/src/remote_exec.rs` | 1014 | remote execution client/server orchestration after the transport/signing/security split | split remaining client/server orchestration from any future report/retrieval helpers only if new growth resumes | Review |
 | `adl/src/execute/runner.rs` | 1011 | execution runner orchestration, scheduling, and policy handling | split policy/scheduler helpers from runner lifecycle and error/report shaping | Review |
 | `adl/src/execute/tests.rs` | 975 | execution regression coverage across multiple behaviors | split tests by behavior family and move shared setup into helpers | Watch |
-| `adl/src/cli/pr_cmd_cards.rs` | 948 | PR card rendering and synchronization helpers | split output-card rendering from synchronization/update helpers if the file keeps growing | Watch |
+| `adl/src/cli/pr_cmd_cards.rs` | 959 | PR card rendering and synchronization helpers | split output-card rendering from synchronization/update helpers if the file keeps growing | Watch |
+| `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs` | 932 | repo-helper regression coverage for PR workflow helpers | split helper families if new lifecycle/repo test growth accumulates here | Watch |
 | `adl/src/signing.rs` | 929 | signing material handling, envelope creation, and verification helpers | split key/material utilities from signing/verification flows and report shaping | Watch |
-| `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs` | 916 | repo-helper regression coverage for PR workflow helpers | split helper families if new lifecycle/repo test growth accumulates here | Watch |
 | `adl/src/godel/stage_loop.rs` | 916 | stage progression, orchestration, and artifact/report linkage for the Godel loop | split stage state transitions from artifact/report assembly and CLI-facing summaries | Watch |
+| `adl/src/cli/pr_cmd/lifecycle.rs` | 888 | extracted PR lifecycle helper module after the larger façade split | keep the extracted lifecycle surface bounded and avoid re-accumulating command-family logic | Watch |
 | `adl/src/sandbox.rs` | 887 | sandbox policy/configuration and execution boundary helpers | split policy/config parsing from sandbox command/runtime helpers | Watch |
-| `adl/src/cli/tests/pr_cmd_inline/basics.rs` | 855 | baseline `pr` workflow regression coverage across parsing and bootstrap helpers | split parser/argument cases from bootstrap/body-generation cases if growth continues | Watch |
 | `adl/src/demo.rs` | 855 | demo catalog façade, shared file/trace helpers, remaining Demo A/B/C fixtures, and tests | keep the façade thin and split further only if new growth resumes in dispatch or fixture surfaces | Watch |
+| `adl/src/cli/tests/pr_cmd_inline/finish/publication.rs` | 871 | publication-path regression coverage after the inline finish split | keep publication-path cases isolated and avoid merging them back into a larger omnibus finish test file | Watch |
 | `adl/src/cli/godel_cmd.rs` | 815 | CLI argument handling and command dispatch for Godel features | split command parsing/dispatch from artifact inspection/rendering helpers | Watch |
 
 ## v0.86 External Review Follow-up
@@ -85,13 +88,19 @@ partially discharged by the `v0.87.1` refactor wave:
 
 | Path | Current LoC | External review posture | Current disposition |
 |---|---:|---|---|
-| `adl/src/cli/pr_cmd.rs` | 1127 | non-blocking maintainability concern | materially reduced by `#1562`, but has regrown into the `Review` band; prevent lifecycle/helper scope from drifting back into the façade |
+| `adl/src/cli/pr_cmd.rs` | 1294 | non-blocking maintainability concern | materially reduced by `#1562`, but has regrown further within the `Review` band; prevent lifecycle/helper scope from drifting back into the façade |
 | `adl/src/demo.rs` | 855 | non-blocking maintainability concern | materially reduced by `#1561`; keep on watch list at `Watch` while the new façade stabilizes |
 | `adl/src/remote_exec.rs` | 1014 | non-blocking maintainability concern | materially reduced by `#1560`; keep on watch list at `Review` because the remaining orchestration surface is still above 1k |
 
 This document no longer treats those three surfaces as `Rationale`-band
 monoliths, but it keeps them visible until their new smaller boundaries prove
 stable over subsequent work.
+
+The 2026-04-13 scan also shows a new top-end shape:
+
+- `adl/src/chronosense.rs` and `adl/src/cli/identity_cmd.rs` have newly entered the `Rationale` band
+- the old `pr_cmd_inline` `finish.rs` / `lifecycle.rs` parent hotspots have been split into smaller child files
+- the new high-pressure test surface is now `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs`
 
 ## Completed From This Queue
 
@@ -101,12 +110,12 @@ stable over subsequent work.
 
 ## Next Bounded Refactor Candidates
 
-- `adl/src/cli/tests/pr_cmd_inline/finish.rs`
-- `adl/src/cli/tests/pr_cmd_inline/lifecycle.rs`
+- `adl/src/chronosense.rs`
+- `adl/src/cli/identity_cmd.rs`
+- `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs`
+- `adl/src/cli/pr_cmd.rs`
 - `adl/src/provider.rs`
 - `adl/src/instrumentation.rs`
-- `adl/src/cli/tooling_cmd/tests.rs`
-- `adl/src/cli/run_artifacts/cognitive.rs`
 
 ## Modules Removed From Immediate Watch Priority
 


### PR DESCRIPTION
## Summary
- refresh `docs/tooling/rust_module_watch_list.md` for the 2026-04-13 size scan
- add new `Rationale` entries for `adl/src/chronosense.rs` and `adl/src/cli/identity_cmd.rs`
- record the shift from the old parent `finish.rs` / `lifecycle.rs` hotspots to smaller child hotspots, led by `finish/guardrails.rs`

## Why
This keeps the Rust module watch list aligned with the current branch shape so the next bounded refactor targets match the real highest-pressure files.

## Validation
- docs-only change; no checks run

Closes #1735
