### PR TITLE
[v0.88][tools] Add a closed-issue truth gate for local-only bundles

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -23,6 +23,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks, including the repo-code-review skill contract guard.
 - `check_issue_metadata_parity.sh`: canonical metadata parity audit for GitHub issue title/labels plus local `.adl` body/STP metadata identity.
 - `closeout_completed_issue_wave.sh`: bounded local catch-up helper that runs `pr closeout` across closed/completed issue bundles for a milestone version so local-only `.adl` truth can converge after merge or main sync.
+- `check_milestone_closed_issue_sor_truth.sh`: milestone closed-issue bundle truth gate for local-only `.adl` task bundles; verifies canonical `stp.md`, `sip.md`, and final `sor.md` truth for closed/completed issues.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
 - `report_large_rust_modules.sh`: non-blocking Rust implementation-module size report for maintainability review.
 - `open_artifact.sh`: convenience opener for cards/reports.

--- a/adl/tools/check_milestone_closed_issue_sor_truth.sh
+++ b/adl/tools/check_milestone_closed_issue_sor_truth.sh
@@ -144,9 +144,9 @@ for issue in issues:
         )
 
     if state_reason == "COMPLETED":
-        if integration_state != "merged":
+        if integration_state not in ("merged", "closed_no_pr"):
             errors.append(
-                f"{sor.relative_to(root)}: Integration state for CLOSED/COMPLETED issue #{number} expected 'merged' but found {integration_state!r}"
+                f"{sor.relative_to(root)}: Integration state for CLOSED/COMPLETED issue #{number} expected 'merged' or 'closed_no_pr' but found {integration_state!r}"
             )
         if verification_scope != "main_repo":
             errors.append(

--- a/adl/tools/check_milestone_closed_issue_sor_truth.sh
+++ b/adl/tools/check_milestone_closed_issue_sor_truth.sh
@@ -1,17 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+resolve_primary_root() {
+  local top
+  top="$(git -C "$SCRIPT_ROOT" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$SCRIPT_ROOT")"
+  case "$top" in
+    */.worktrees/*)
+      printf '%s\n' "${top%%/.worktrees/*}"
+      ;;
+    *)
+      printf '%s\n' "$top"
+      ;;
+  esac
+}
+ROOT="$(resolve_primary_root)"
 VERSION=""
 REPO=""
 
 usage() {
   cat <<'EOF'
 Usage:
-  check_milestone_closed_issue_sor_truth.sh --version <v0.87.1> [--repo <owner/name>]
+  check_milestone_closed_issue_sor_truth.sh --version <v0.88> [--repo <owner/name>]
 
 Scans closed GitHub issues for the target milestone label and verifies the
-canonical local `.adl/<version>/tasks/issue-*__*/sor.md` records are not stale.
+canonical local `.adl/<version>/tasks/issue-*__*/` bundle surfaces are present
+and the final `sor.md` truth is not stale.
 EOF
 }
 
@@ -83,49 +97,64 @@ def extract(text: str, prefix: str):
             return line[len(prefix):].strip()
     return None
 
+def nonempty(path: Path) -> bool:
+    return path.is_file() and path.read_text().strip() != ""
+
 for issue in issues:
     number = issue["number"]
     state_reason = (issue.get("stateReason") or "").strip()
-    matches = sorted((root / ".adl" / version / "tasks").glob(f"issue-{number}__*/sor.md"))
-    if not matches:
-        errors.append(f"issue #{number}: missing canonical sor.md under .adl/{version}/tasks/issue-{number}__*/sor.md")
+    bundle_matches = sorted((root / ".adl" / version / "tasks").glob(f"issue-{number}__*/"))
+    if not bundle_matches:
+        errors.append(f"issue #{number}: missing canonical task bundle under .adl/{version}/tasks/issue-{number}__*/")
         continue
-    if len(matches) > 1:
-        for path in matches:
+    if len(bundle_matches) > 1:
+        for path in bundle_matches:
             errors.append(f"{path.relative_to(root)}: duplicate task bundle for closed issue #{number}")
         continue
 
     checked += 1
-    path = matches[0]
-    text = path.read_text()
+    bundle = bundle_matches[0]
+    stp = bundle / "stp.md"
+    sip = bundle / "sip.md"
+    sor = bundle / "sor.md"
+
+    if not nonempty(stp):
+        errors.append(f"{stp.relative_to(root)}: missing or empty canonical stp.md for closed issue #{number}")
+    if not nonempty(sip):
+        errors.append(f"{sip.relative_to(root)}: missing or empty canonical sip.md for closed issue #{number}")
+    if not nonempty(sor):
+        errors.append(f"{sor.relative_to(root)}: missing or empty canonical sor.md for closed issue #{number}")
+        continue
+
+    text = sor.read_text()
     status = extract(text, "Status:")
     integration_state = extract(text, "- Integration state:")
     verification_scope = extract(text, "- Verification scope:")
     worktree_paths = extract(text, "- Worktree-only paths remaining:")
 
     if status != "DONE":
-        errors.append(f"{path.relative_to(root)}: Status expected 'DONE' for closed issue #{number} but found {status!r}")
+        errors.append(f"{sor.relative_to(root)}: Status expected 'DONE' for closed issue #{number} but found {status!r}")
     if integration_state in (None, "worktree_only", "pr_open"):
         errors.append(
-            f"{path.relative_to(root)}: Integration state for closed issue #{number} must not be worktree_only/pr_open; found {integration_state!r}"
+            f"{sor.relative_to(root)}: Integration state for closed issue #{number} must not be worktree_only/pr_open; found {integration_state!r}"
         )
     if worktree_paths != "none":
         errors.append(
-            f"{path.relative_to(root)}: Worktree-only paths remaining for closed issue #{number} expected 'none' but found {worktree_paths!r}"
+            f"{sor.relative_to(root)}: Worktree-only paths remaining for closed issue #{number} expected 'none' but found {worktree_paths!r}"
         )
 
     if state_reason == "COMPLETED":
         if integration_state != "merged":
             errors.append(
-                f"{path.relative_to(root)}: Integration state for CLOSED/COMPLETED issue #{number} expected 'merged' but found {integration_state!r}"
+                f"{sor.relative_to(root)}: Integration state for CLOSED/COMPLETED issue #{number} expected 'merged' but found {integration_state!r}"
             )
         if verification_scope != "main_repo":
             errors.append(
-                f"{path.relative_to(root)}: Verification scope for CLOSED/COMPLETED issue #{number} expected 'main_repo' but found {verification_scope!r}"
+                f"{sor.relative_to(root)}: Verification scope for CLOSED/COMPLETED issue #{number} expected 'main_repo' but found {verification_scope!r}"
             )
 
 if errors:
-    print(f"ERROR: stale closed-issue SOR truth detected for version {version}", file=sys.stderr)
+    print(f"ERROR: stale closed-issue bundle truth detected for version {version}", file=sys.stderr)
     for error in errors:
         print(error, file=sys.stderr)
     raise SystemExit(1)

--- a/adl/tools/release_ceremony.sh
+++ b/adl/tools/release_ceremony.sh
@@ -36,7 +36,7 @@ Other options:
   --tag <tag>             Override tag name (default: same as --version)
   --target-branch <name>  Branch required for ceremony mutations (default: main)
   --allow-dirty           Skip the clean-worktree check
-  --skip-sor-gate         Skip adl/tools/check_milestone_closed_issue_sor_truth.sh
+  --skip-sor-gate         Skip adl/tools/check_milestone_closed_issue_sor_truth.sh (closed-issue bundle truth gate)
   -h, --help              Show this help
 
 Examples:
@@ -117,17 +117,17 @@ check_cargo_version() {
 
 check_sor_gate() {
   if [[ "$SKIP_SOR_GATE" == "1" ]]; then
-    info "skipping closed-issue SOR truth gate by request"
+    info "skipping closed-issue bundle truth gate by request"
     return 0
   fi
 
   local checker="$ROOT/adl/tools/check_milestone_closed_issue_sor_truth.sh"
   [[ -x "$checker" || -f "$checker" ]] || {
-    info "closed-issue SOR truth gate not present; skipping"
+    info "closed-issue bundle truth gate not present; skipping"
     return 0
   }
 
-  info "running closed-issue SOR truth gate for $VERSION"
+  info "running closed-issue bundle truth gate for $VERSION"
   bash "$checker" --version "$VERSION"
 }
 

--- a/adl/tools/test_check_milestone_closed_issue_sor_truth.sh
+++ b/adl/tools/test_check_milestone_closed_issue_sor_truth.sh
@@ -64,6 +64,25 @@ chmod +x "$PASS_REPO/.worktrees/adl-wp-1546/adl/tools/check_milestone_closed_iss
   PATH="$PASS_REPO/bin:$PATH" bash ./adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1 --repo example/repo >/dev/null
 )
 
+mkdir -p "$PASS_REPO/.adl/v0.87.1/tasks/issue-1548__sample"
+cat >"$PASS_REPO/.adl/v0.87.1/tasks/issue-1548__sample/stp.md" <<'EOF'
+title: sample
+EOF
+cat >"$PASS_REPO/.adl/v0.87.1/tasks/issue-1548__sample/sip.md" <<'EOF'
+Title: sample
+EOF
+cat >"$PASS_REPO/.adl/v0.87.1/tasks/issue-1548__sample/sor.md" <<'EOF'
+Status: DONE
+- Integration state: closed_no_pr
+- Verification scope: main_repo
+- Worktree-only paths remaining: none
+EOF
+write_fake_gh "$PASS_REPO/bin" '[{"number":1546,"stateReason":"COMPLETED","title":"sample"},{"number":1548,"stateReason":"COMPLETED","title":"sample"}]'
+(
+  cd "$PASS_REPO"
+  PATH="$PASS_REPO/bin:$PATH" bash ./adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1 --repo example/repo >/dev/null
+)
+
 FAIL_REPO="$TMP/fail"
 mkdir -p "$FAIL_REPO"
 init_repo "$FAIL_REPO"

--- a/adl/tools/test_check_milestone_closed_issue_sor_truth.sh
+++ b/adl/tools/test_check_milestone_closed_issue_sor_truth.sh
@@ -38,6 +38,12 @@ PASS_REPO="$TMP/pass"
 mkdir -p "$PASS_REPO"
 init_repo "$PASS_REPO"
 mkdir -p "$PASS_REPO/.adl/v0.87.1/tasks/issue-1546__sample"
+cat >"$PASS_REPO/.adl/v0.87.1/tasks/issue-1546__sample/stp.md" <<'EOF'
+title: sample
+EOF
+cat >"$PASS_REPO/.adl/v0.87.1/tasks/issue-1546__sample/sip.md" <<'EOF'
+Title: sample
+EOF
 cat >"$PASS_REPO/.adl/v0.87.1/tasks/issue-1546__sample/sor.md" <<'EOF'
 Status: DONE
 - Integration state: merged
@@ -50,10 +56,21 @@ write_fake_gh "$PASS_REPO/bin" '[{"number":1546,"stateReason":"COMPLETED","title
   PATH="$PASS_REPO/bin:$PATH" bash ./adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1 --repo example/repo >/dev/null
 )
 
+mkdir -p "$PASS_REPO/.worktrees/adl-wp-1546/adl/tools"
+cp "$ROOT/adl/tools/check_milestone_closed_issue_sor_truth.sh" "$PASS_REPO/.worktrees/adl-wp-1546/adl/tools/check_milestone_closed_issue_sor_truth.sh"
+chmod +x "$PASS_REPO/.worktrees/adl-wp-1546/adl/tools/check_milestone_closed_issue_sor_truth.sh"
+(
+  cd "$PASS_REPO/.worktrees/adl-wp-1546"
+  PATH="$PASS_REPO/bin:$PATH" bash ./adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.87.1 --repo example/repo >/dev/null
+)
+
 FAIL_REPO="$TMP/fail"
 mkdir -p "$FAIL_REPO"
 init_repo "$FAIL_REPO"
 mkdir -p "$FAIL_REPO/.adl/v0.87.1/tasks/issue-1547__sample"
+cat >"$FAIL_REPO/.adl/v0.87.1/tasks/issue-1547__sample/stp.md" <<'EOF'
+title: sample
+EOF
 cat >"$FAIL_REPO/.adl/v0.87.1/tasks/issue-1547__sample/sor.md" <<'EOF'
 Status: IN_PROGRESS
 - Integration state: pr_open


### PR DESCRIPTION
Closes #1732

## Summary
Strengthened the closed-issue bundle truth gate so it validates canonical `stp.md`, `sip.md`, and final `sor.md` presence and content, resolves back to the primary checkout when invoked from issue worktrees, and is wired clearly into release-ceremony documentation.

## Artifacts
- `adl/tools/check_milestone_closed_issue_sor_truth.sh`
- `adl/tools/test_check_milestone_closed_issue_sor_truth.sh`
- `adl/tools/release_ceremony.sh`
- `adl/tools/README.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/check_milestone_closed_issue_sor_truth.sh adl/tools/test_check_milestone_closed_issue_sor_truth.sh adl/tools/release_ceremony.sh` verified shell syntax after the root-resolution and wording updates.
  - `bash adl/tools/test_check_milestone_closed_issue_sor_truth.sh` verified the new bundle-presence checks and worktree-to-primary-root resolution behavior.
  - `bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.88` verified the gate now surfaces the actual cleanup worklist for closed v0.88 bundles.
- Results: all listed validations passed in the bound worktree before PR publication.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1732__v0-88-tools-add-a-closed-issue-truth-gate-for-local-only-bundles/sip.md
- Output card: .adl/v0.88/tasks/issue-1732__v0-88-tools-add-a-closed-issue-truth-gate-for-local-only-bundles/sor.md
- Idempotency-Key: v0-88-tools-add-a-closed-issue-truth-gate-for-local-only-bundles-adl-tools-adl-v0-88-tasks-issue-1732-v0-88-tools-add-a-closed-issue-truth-gate-for-local-only-bundles-sip-md-adl-v0-88-tasks-issue-1732-v0-88-tools-add-a-closed-issue-truth-gate-for-local-only-bundles-sor-md