### PR TITLE
[v0.88][docs] Align root release surfaces and version story for 3rd-party review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
+## v0.88 (Temporal / Chronosense + Instinct Review Tail In Progress)
+
+Status: Implementation wave completed through `WP-13`; docs/review/remediation/release tail in progress.
+
+Summary:
+- ADL now has a real `v0.88` milestone on `main`, centered on two bounded substrate bands:
+  `temporal / chronosense -> instinct / bounded agency`
+- The promoted `v0.88` feature-doc package now covers temporal schema, continuity/identity semantics, temporal retrieval, commitments/deadlines, bounded temporal causality, PHI-style integration metrics, instinct, and instinct runtime influence
+- The bounded `v0.88` proof package now exists through `demo_v088_temporal_review_surface.sh`, `demo_v088_phi_review_surface.sh`, `demo_v088_instinct_review_surface.sh`, `demo_v088_paper_sonata.sh`, `demo_v088_deep_agents_comparative_proof.sh`, and `demo_v088_review_surface.sh`
+- Paper Sonata now serves as the flagship bounded public-facing `v0.88` demo, with the deep-agents comparative proof as a supporting reviewer-facing row
+- Internal review has completed a full repo code-review pass, and the one concrete implementation finding from that pass was remediated before 3rd-party review
+
+Version note:
+- the active milestone is `v0.88`, but the crate version on `main` remains `0.87.1` until the `v0.88` release ceremony/version bump
+
+References:
+- `docs/milestones/v0.88/README.md`
+- `docs/milestones/v0.88/WBS_v0.88.md`
+- `docs/milestones/v0.88/SPRINT_v0.88.md`
+- `docs/milestones/v0.88/DEMO_MATRIX_v0.88.md`
+- `docs/milestones/v0.88/FEATURE_DOCS_v0.88.md`
+- `docs/milestones/v0.88/MILESTONE_CHECKLIST_v0.88.md`
+- `docs/milestones/v0.88/RELEASE_PLAN_v0.88.md`
+- `docs/milestones/v0.88/RELEASE_NOTES_v0.88.md`
+
+Not yet claimed in v0.88:
+- final 3rd-party review completion and accepted-findings remediation closeout
+- release ceremony completion and version/tag publication
+- later-band governance, economics, aptitude, or broader social-agency systems beyond the bounded `v0.88` slice
+
 ## v0.87.1 (Runtime Completion Review Tail In Progress)
 
 Status: Runtime implementation and bounded demo program landed; docs/review/quality/release tail in progress.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Those artifacts are schema-validated, compiled into a deterministic execution pl
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.87.1%20active-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.88%20active-blue)
 
 ## Why ADL
 
@@ -60,6 +60,12 @@ cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-87-1-mi
 If you want the current milestone proof package:
 
 ```bash
+bash adl/tools/demo_v088_review_surface.sh
+```
+
+If you want the previous runtime-completion milestone proof suite:
+
+```bash
 bash adl/tools/demo_v0871_suite.sh
 ```
 
@@ -83,19 +89,31 @@ bash adl/tools/demo_v0871_multi_agent_discussion.sh
 
 ## Current Status
 
-- Active milestone: **v0.87.1**
+- Active milestone: **v0.88**
 - Current crate version on `main`: **0.87.1**
-- Most recently completed milestone: **v0.87**
-- Previous completed milestone: **v0.86**
+- Version note: **the `v0.88` milestone is active, but the crate version remains `0.87.1` until the `v0.88` release ceremony/version bump**
+- Most recently completed milestone package: **v0.87.1**
+- Previous completed milestone: **v0.87**
 - Project changelog: `CHANGELOG.md`
 
 ADL is in active development. This repository contains both implemented runtime surfaces and milestone/spec/planning documents. Read the milestone docs as bounded engineering records: they distinguish what has shipped, what is under active review or closeout, what is demoable, and what is still planned.
 
 ## Recent Milestones
 
+### v0.88 - Temporal / Chronosense + Instinct Review-Tail Milestone
+
+v0.88 is the current active milestone. The implementation wave is complete through `WP-13`, and the repository is now in the docs, review, remediation, next-milestone planning, and release tail.
+
+Key features:
+- promoted temporal / chronosense and instinct / bounded-agency feature-doc package
+- bounded proof surfaces for temporal review, PHI metrics, instinct review, and the integrated `v0.88` review surface
+- Paper Sonata as the flagship bounded public-facing demo
+- deep-agents comparative proof as a supporting reviewer-facing proof row
+- active handoff into internal review, 3rd-party review, remediation, next-milestone planning, and release ceremony
+
 ### v0.87.1 - Runtime Completion and Reviewer-Facing Proof Package
 
-v0.87.1 is the current active milestone. The implementation and bounded demo program are in place, and the remaining work is the docs, review, quality, and release tail that makes the runtime package reviewable without oral reconstruction.
+v0.87.1 is the previous runtime-completion milestone. The implementation and bounded demo program landed on `main`, and it now serves as the prior runtime proof package that `v0.88` builds on.
 
 Key features:
 - runtime environment, lifecycle, execution-boundary, and resilience surfaces promoted into one canonical milestone package
@@ -113,7 +131,7 @@ Key features:
 - promoted feature docs and milestone docs reconciled against the real implementation and issue sequence
 - bounded demo and reviewer proof surfaces for trace, provider portability, shared ObsMem, skills, and control-plane behavior
 - completed Sprint 3 release-tail work for documentation convergence, review, quality gate, and release closeout
-- explicit handoff into `v0.87.1` for the runtime-completion milestone now moving through review and release closeout
+- explicit handoff into `v0.87.1` for the runtime-completion milestone that set up the current `v0.88` follow-on
 
 ### v0.86 - Bounded Cognitive System and Reviewable Proof Surfaces
 
@@ -173,6 +191,7 @@ Important supporting demo/readiness docs:
 - `docs/tooling/editor/five_command_regression_suite.md`
 
 For milestone-specific context:
+- `docs/milestones/v0.88/DEMO_MATRIX_v0.88.md`
 - `docs/milestones/v0.87/DEMO_MATRIX_v0.87.md`
 - `docs/milestones/v0.86/DEMO_MATRIX_v0.86.md`
 - `docs/milestones/v0.7/DEMOS_v0.7.md`

--- a/docs/milestones/v0.88/MILESTONE_CHECKLIST_v0.88.md
+++ b/docs/milestones/v0.88/MILESTONE_CHECKLIST_v0.88.md
@@ -55,7 +55,7 @@ This milestone must prove a real temporal / PHI / instinct package with runnable
 - [ ] Paper Sonata is strong enough to function as a flagship public-facing demo
 
 ## Quality Gates
-- [ ] canonical quality gate defined (`docs/milestones/v0.88/QUALITY_GATE_v0.88.md`)
+- [x] canonical quality gate defined (`docs/milestones/v0.88/QUALITY_GATE_v0.88.md`)
 - [ ] formatting / lint gates pass
 - [ ] test and CI gates pass
 - [ ] coverage signal is acceptable or exceptions are documented


### PR DESCRIPTION
Closes #1739

## Summary
- align root reviewer-facing release surfaces with the active v0.88 milestone
- add an explicit pre-ceremony crate-version note instead of prematurely bumping Cargo.toml
- mark the v0.88 checklist quality-gate definition truthfully

## Validation
- rg -n 'milestone-v0\.87\.1%20active|Active milestone: \*\*v0\.87\.1|v0\.87\.1 is the current active milestone' README.md CHANGELOG.md -S
- git diff --check
