### PR TITLE
[v0.88][tools] Make workflow-conductor dispatch selected lifecycle/editor skills as bounded subtasks

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -121,7 +121,8 @@ It:
 - applies skill/editor/subagent policy
 - records workflow-compliance facts
 - writes one bounded routing artifact
-- stops before performing the selected skill's underlying work
+- may invoke one bounded downstream skill subtask when explicit dispatch mode is enabled
+- stops without absorbing the selected skill's underlying work
 
 ### When To Use It
 
@@ -195,7 +196,7 @@ observed_state:
 - it should route into `pr-*` or editor skills rather than reimplementing them
 - it is the best place to apply the execution-policy ideas for required skills, card editors, and subagents
 - it should return explicit `continue`, `ask_operator`, or `stop` handoff intent rather than leaving escalation implicit
-- the preferred route-only entrypoint is `python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <validated-json>`
+- the preferred route/dispatch entrypoint is `python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <validated-json>`
 
 `ready` and `preflight` are compatibility aliases that may still exist in repo
 surfaces, but doctor JSON is the canonical structured automation surface.

--- a/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -27,6 +27,20 @@ policy:
   stop_after_routing: true
 observed_state:
   subagent_assigned: true | false
+dispatch:
+  mode: route_only | plan_subtask | invoke_subtask
+  allow_builtin_dispatch: true | false
+  timeout_secs: <positive integer optional>
+  command_overrides:
+    pr-init: [<argv token>, ...] optional
+    pr-ready: [<argv token>, ...] optional
+    pr-run: [<argv token>, ...] optional
+    pr-finish: [<argv token>, ...] optional
+    pr-janitor: [<argv token>, ...] optional
+    pr-closeout: [<argv token>, ...] optional
+    stp-editor: [<argv token>, ...] optional
+    sip-editor: [<argv token>, ...] optional
+    sor-editor: [<argv token>, ...] optional
 ```
 
 ## Purpose
@@ -39,9 +53,10 @@ The conductor should:
 - apply workflow policy
 - write one bounded routing artifact
 - classify known blocker families from doctor, PR, explicit related-issue references, or repo-policy residue when safe
-- stop after routing
+- optionally dispatch one bounded downstream skill subtask
+- stop at that routing/dispatch boundary
 
-It should not perform the selected skill's implementation work.
+It should not absorb the selected skill's implementation work into the conductor itself.
 
 ## Supported Modes
 
@@ -122,8 +137,9 @@ The conductor must stop after:
 - policy application
 - routing-artifact emission
 - workflow-compliance recording
+- optional single-subtask dispatch result capture
 
 It must not:
-- silently execute the selected lifecycle skill
+- silently chain several downstream skills
 - reimplement the selected skill's logic
 - widen into unrelated issue work

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: workflow-conductor
 description: Lightweight conductor for the ADL workflow skills. Use when the operator wants one bounded entrypoint that detects the current issue/workflow state, selects the correct next lifecycle or editor skill, enforces skill/subagent policy, and stops after routing/compliance recording rather than reimplementing the underlying work.
+description: Lightweight conductor for the ADL workflow skills. Use when the operator wants one bounded entrypoint that detects the current issue/workflow state, selects the correct next lifecycle or editor skill, enforces skill/subagent policy, and either stops after routing or dispatches one bounded downstream skill subtask without reimplementing the underlying work.
 ---
 
 # Workflow Conductor
@@ -12,7 +13,9 @@ Its job is to:
 - choose the next appropriate lifecycle or editor skill
 - ensure card-local work is routed to the matching editor skill
 - apply explicit skill/subagent execution policy
-- record workflow-compliance outcomes, emit a bounded routing artifact, and stop
+- record workflow-compliance outcomes
+- emit a bounded routing artifact
+- when explicitly enabled, dispatch one bounded downstream skill subtask and stop at that boundary
 
 This skill must remain lightweight.
 
@@ -27,7 +30,7 @@ It must not replace:
 - `sip-editor`
 - `sor-editor`
 
-It must stop after routing and compliance recording rather than reimplementing the selected skill's underlying work.
+It must stop at the routing/dispatch boundary rather than reimplementing the selected skill's underlying work.
 
 The bundle may include small deterministic helpers for routing evaluation and test fixtures, but those helpers exist to support the stop-boundary contract, not to silently turn the conductor into a second execution engine.
 
@@ -102,7 +105,8 @@ If there is no concrete target, stop and report `blocked`.
 4. Apply the declared skill/subagent policy.
 5. Select the next skill.
 6. Record the workflow-compliance result and write the routing artifact.
-7. Stop before performing the selected skill's underlying work.
+7. When explicit dispatch mode is enabled, dispatch one bounded downstream skill subtask.
+8. Stop without absorbing the selected skill's logic.
 
 ## Routing Model
 
@@ -145,12 +149,25 @@ This skill must stop after:
 - selecting the next skill
 - recording compliance and routing facts
 - writing the bounded routing artifact
+- optionally dispatching one bounded downstream skill subtask
 - surfacing any blocker that prevents safe routing
 
 It must not:
-- perform the selected skill's implementation work
+- perform the selected skill's implementation work itself
 - silently invoke unrelated repo-wide cleanup
 - create an unrecorded fallback path
+
+## Dispatch Boundary
+
+When explicit dispatch mode is enabled, the conductor may:
+- call one supported downstream lifecycle skill through the repo-native command it already wraps
+- call one editor or special-case skill through an explicit operator-provided command override
+- record the selected skill, command source, command shape, and bounded result
+
+It must not:
+- inline the downstream skill's behavior into the conductor
+- chain multiple downstream skills in one silent rollout
+- continue past the first dispatched subtask as if it owned the downstream lifecycle
 
 ## Output
 

--- a/adl/tools/skills/workflow-conductor/adl-skill.yaml
+++ b/adl/tools/skills/workflow-conductor/adl-skill.yaml
@@ -67,6 +67,7 @@ admission:
     - "sor_path"
     - "pr_state"
     - "stop_boundary"
+    - "dispatch"
   stop_if_missing:
     - "repo_root"
   require_one_of:
@@ -84,7 +85,7 @@ admission:
     - "policy.subagent_requirement_must_be_explicit"
     - "policy.allow_phase_inference_must_be_explicit"
 execution:
-  mode: "route_only"
+  mode: "route_and_dispatch_bounded_subtasks"
   allow_code_edits: false
   allow_network: true
   allow_subagents: true
@@ -93,7 +94,7 @@ execution:
     - "python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <validated-json>"
     - "python3 adl/tools/skills/workflow-conductor/scripts/select_next_skill.py"
     - "adl/tools/open_artifact.sh"
-  preferred_path: "inspect_state_then_route_without_executing_the_selected_skill"
+  preferred_path: "inspect_state_then_route_and_optionally_dispatch_one_bounded_downstream_skill"
   invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
 boundaries:
   writes_limited_to:
@@ -114,6 +115,7 @@ outputs:
     - "selected_skill"
     - "workflow_compliance"
     - "handoff_state"
+    - "dispatch"
 security:
   trusted_root_required: true
   deny_symlink_escape: true

--- a/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
@@ -10,9 +10,10 @@ The conductor should:
 - apply skill/editor/subagent policy
 - classify known blocker families when doctor or PR evidence makes them clear
 - write one bounded routing artifact
-- stop after routing and compliance recording
+- optionally invoke one bounded downstream skill subtask
+- stop at that routing/dispatch boundary
 
-It should not perform the selected skill's underlying work.
+It should not perform the selected skill's underlying work itself.
 
 ## Routing Order
 
@@ -84,7 +85,13 @@ synthetic or real state snapshots. That helper must:
 - never perform the selected skill's underlying work
 - remain bounded to routing/compliance facts
 
-The bundle may also use a route-only collection entrypoint to derive those
+The bundle may also use a state-collection entrypoint to derive those
 state snapshots from a real issue, task bundle, branch, worktree, or PR.
 That collector must remain read-mostly, except for writing the declared routing
 artifact.
+
+When explicit dispatch mode is enabled, the conductor may call the selected
+downstream skill through one bounded subtask command. That dispatch must:
+- preserve the modular skill boundary
+- record the selected skill and downstream result
+- stop after the first downstream subtask instead of chaining more work

--- a/adl/tools/skills/workflow-conductor/references/output-contract.md
+++ b/adl/tools/skills/workflow-conductor/references/output-contract.md
@@ -32,6 +32,17 @@ handoff_state:
   next_phase: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | human_review | blocked
   continuation: continue | ask_operator | stop
   escalation_reason: none | operator_override_required | ambiguous_live_state | healthy_pr_waiting | manual_review_required | policy_block | child_issue_wave_satisfied | related_issue_ref_satisfied | sibling_issue_artifact_satisfied | child_issue_wave_active | related_issue_ref_active | repo_policy_residue
+dispatch:
+  mode: route_only | plan_subtask | invoke_subtask
+  selected_skill: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none
+  skill_file: <absolute skill path or null>
+  command_source: none | builtin | override
+  command: <argv array or null>
+  status: not_requested | planned | invoked | failed | unsupported | blocked
+  result: not_applicable | planned | success | failure | timeout | dispatch_unsupported_for_selected_skill | missing_dispatch_placeholders | no_selected_skill
+  exit_code: <int or null>
+  stdout: <bounded text summary>
+  stderr: <bounded text summary>
 artifact:
   path: <path or null>
 ```

--- a/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
+++ b/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
@@ -18,6 +18,63 @@ PRIMARY_TARGET_FIELDS = {
     "route_pr": "pr_number",
 }
 
+SKILL_FILES = {
+    "pr-init": "adl/tools/skills/pr-init/SKILL.md",
+    "pr-ready": "adl/tools/skills/pr-ready/SKILL.md",
+    "pr-run": "adl/tools/skills/pr-run/SKILL.md",
+    "pr-finish": "adl/tools/skills/pr-finish/SKILL.md",
+    "pr-janitor": "adl/tools/skills/pr-janitor/SKILL.md",
+    "pr-closeout": "adl/tools/skills/pr-closeout/SKILL.md",
+    "stp-editor": "adl/tools/skills/stp-editor/SKILL.md",
+    "sip-editor": "adl/tools/skills/sip-editor/SKILL.md",
+    "sor-editor": "adl/tools/skills/sor-editor/SKILL.md",
+}
+
+BUILTIN_DISPATCH_COMMANDS = {
+    "pr-init": [
+        "bash",
+        "adl/tools/pr.sh",
+        "init",
+        "{issue_number}",
+        "--slug",
+        "{slug}",
+        "--version",
+        "{version}",
+    ],
+    "pr-ready": [
+        "bash",
+        "adl/tools/pr.sh",
+        "doctor",
+        "{issue_number}",
+        "--slug",
+        "{slug}",
+        "--version",
+        "{version}",
+        "--mode",
+        "full",
+        "--json",
+    ],
+    "pr-run": [
+        "bash",
+        "adl/tools/pr.sh",
+        "run",
+        "{issue_number}",
+        "--slug",
+        "{slug}",
+        "--version",
+        "{version}",
+    ],
+    "pr-closeout": [
+        "bash",
+        "adl/tools/pr.sh",
+        "closeout",
+        "{issue_number}",
+        "--version",
+        "{version}",
+        "--no-fetch-issue",
+    ],
+}
+
 
 def load_payload(path: str):
     return json.loads(Path(path).read_text(encoding="utf-8"))
@@ -36,6 +93,24 @@ def run_command(args, cwd: Path):
         text=True,
         check=False,
     )
+
+
+def run_command_with_timeout(args, cwd: Path, timeout_secs=None):
+    try:
+        return subprocess.run(
+            args,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_secs,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "timed_out": True,
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+        }
 
 
 def read_text(path: Path):
@@ -749,6 +824,7 @@ def render_markdown(result):
     selected = result["selected_skill"]
     compliance = result["workflow_compliance"]
     handoff = result["handoff_state"]
+    dispatch = result.get("dispatch", {})
     lines = [
         "# Workflow Conductor Review",
         "",
@@ -783,6 +859,16 @@ def render_markdown(result):
         f"- continuation: {handoff.get('continuation')}",
         f"- escalation_reason: {handoff.get('escalation_reason')}",
         "",
+        "## dispatch",
+        f"- mode: {dispatch.get('mode')}",
+        f"- selected_skill: {dispatch.get('selected_skill')}",
+        f"- skill_file: {dispatch.get('skill_file')}",
+        f"- command_source: {dispatch.get('command_source')}",
+        f"- command: {json.dumps(dispatch.get('command'))}",
+        f"- status: {dispatch.get('status')}",
+        f"- result: {dispatch.get('result')}",
+        f"- exit_code: {dispatch.get('exit_code')}",
+        "",
     ]
     return "\n".join(lines)
 
@@ -790,6 +876,114 @@ def render_markdown(result):
 def default_artifact_path(repo_root: Path):
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     return repo_root / ".adl" / "reviews" / f"{stamp}-workflow-conductor.md"
+
+
+def dispatch_placeholders(repo_root: Path, result):
+    target = result.get("target", {})
+    artifact = result.get("artifact", {})
+    values = {
+        "repo_root": str(repo_root),
+        "issue_number": "" if target.get("issue_number") is None else str(target.get("issue_number")),
+        "task_bundle_path": target.get("task_bundle_path") or "",
+        "branch": target.get("branch") or "",
+        "worktree_path": target.get("worktree_path") or "",
+        "pr_number": "" if target.get("pr_number") is None else str(target.get("pr_number")),
+        "slug": target.get("slug") or "",
+        "version": target.get("version") or "",
+        "source_prompt_path": target.get("source_prompt_path") or "",
+        "artifact_path": artifact.get("path") or "",
+    }
+    return values
+
+
+def render_command_template(template, placeholders):
+    rendered = []
+    missing = []
+    for token in template:
+        try:
+            value = token.format(**placeholders)
+        except KeyError as exc:
+            missing.append(str(exc))
+            continue
+        if value == "":
+            missing.append(token)
+            continue
+        rendered.append(value)
+    if missing:
+        return None, sorted(set(missing))
+    return rendered, []
+
+
+def dispatch_plan(repo_root: Path, payload, result):
+    dispatch = payload.get("dispatch", {})
+    mode = dispatch.get("mode", "route_only")
+    selected_skill = result.get("selected_skill", {}).get("skill_name", "none")
+    plan = {
+        "mode": mode,
+        "selected_skill": selected_skill,
+        "skill_file": None,
+        "command_source": "none",
+        "command": None,
+        "status": "not_requested",
+        "result": "not_applicable",
+        "exit_code": None,
+        "stdout": "",
+        "stderr": "",
+    }
+    if selected_skill in SKILL_FILES:
+        plan["skill_file"] = str((repo_root / SKILL_FILES[selected_skill]).resolve())
+    if mode == "route_only":
+        return plan
+    if selected_skill in (None, "none"):
+        plan["status"] = "blocked"
+        plan["result"] = "no_selected_skill"
+        return plan
+
+    overrides = dispatch.get("command_overrides", {}) or {}
+    command_template = overrides.get(selected_skill)
+    if command_template:
+        plan["command_source"] = "override"
+    elif dispatch.get("allow_builtin_dispatch", True):
+        command_template = BUILTIN_DISPATCH_COMMANDS.get(selected_skill)
+        if command_template:
+            plan["command_source"] = "builtin"
+    if not command_template:
+        plan["status"] = "unsupported"
+        plan["result"] = "dispatch_unsupported_for_selected_skill"
+        return plan
+
+    command, missing = render_command_template(command_template, dispatch_placeholders(repo_root, result))
+    if not command:
+        plan["status"] = "blocked"
+        plan["result"] = "missing_dispatch_placeholders"
+        plan["stderr"] = f"missing placeholders: {', '.join(missing)}"
+        return plan
+
+    plan["command"] = command
+    plan["status"] = "planned"
+    plan["result"] = "planned"
+
+    if mode != "invoke_subtask":
+        return plan
+
+    executed = run_command_with_timeout(command, repo_root, dispatch.get("timeout_secs"))
+    if isinstance(executed, dict) and executed.get("timed_out"):
+        plan["status"] = "failed"
+        plan["result"] = "timeout"
+        plan["stderr"] = (executed.get("stderr") or "").strip()
+        plan["stdout"] = (executed.get("stdout") or "").strip()
+        return plan
+
+    plan["exit_code"] = executed.returncode
+    plan["stdout"] = executed.stdout.strip()
+    plan["stderr"] = executed.stderr.strip()
+    if executed.returncode == 0:
+        plan["status"] = "invoked"
+        plan["result"] = "success"
+    else:
+        plan["status"] = "failed"
+        plan["result"] = "failure"
+    return plan
 
 
 def main():
@@ -802,6 +996,10 @@ def main():
     payload = load_payload(args.input)
     snapshot = collect_state(payload)
     result = evaluate(snapshot)
+    result_target = result.setdefault("target", {})
+    for key in ("slug", "version", "source_prompt_path"):
+        if snapshot.get("target", {}).get(key) not in (None, ""):
+            result_target[key] = snapshot["target"][key]
     result["artifact"] = {"path": None}
 
     if not args.no_artifact:
@@ -810,9 +1008,22 @@ def main():
         if not artifact_path.is_absolute():
             artifact_path = repo_root / artifact_path
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
-        artifact_path.write_text(render_markdown(result), encoding="utf-8")
         result["artifact"]["path"] = str(artifact_path)
         result.setdefault("actions_taken", []).append(f"wrote routing artifact to {artifact_path}")
+
+    result["dispatch"] = dispatch_plan(Path(payload["repo_root"]).resolve(), payload, result)
+    if result["dispatch"]["status"] in {"invoked", "failed", "unsupported", "blocked"}:
+        result.setdefault("actions_taken", []).append(
+            f"dispatch {result['dispatch']['result']} for {result['dispatch']['selected_skill']}"
+        )
+    elif result["dispatch"]["status"] == "planned":
+        result.setdefault("actions_taken", []).append(
+            f"planned dispatch for {result['dispatch']['selected_skill']}"
+        )
+
+    if not args.no_artifact:
+        artifact_path = Path(result["artifact"]["path"])
+        artifact_path.write_text(render_markdown(result), encoding="utf-8")
 
     print(json.dumps(result, indent=2))
 

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -16,13 +16,15 @@ trap 'rm -rf "${tmpdir}"' EXIT
 [[ -f "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq "thin orchestrator" "${skills_root}/workflow-conductor/SKILL.md"
-grep -Fq "stop after routing and compliance recording" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "dispatch one bounded downstream skill subtask" "${skills_root}/workflow-conductor/SKILL.md"
 grep -Fq "writes one bounded routing artifact" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "invoke one bounded downstream skill subtask" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq 'continue`, `ask_operator`, or `stop`' "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq 'id: "workflow_conductor.v1"' "${skills_root}/workflow-conductor/adl-skill.yaml"
 grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/workflow-conductor/adl-skill.yaml"
 grep -Fq "policy.stop_after_routing_must_be_true" "${skills_root}/workflow-conductor/adl-skill.yaml"
 grep -Fq "python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <validated-json>" "${skills_root}/workflow-conductor/adl-skill.yaml"
+grep -Fq "dispatch" "${skills_root}/workflow-conductor/references/output-contract.md"
 grep -Fq "route_issue" "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
 grep -Fq "requires \`target.issue_number\`" "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
 grep -Fq "classify known blocker families" "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
@@ -191,7 +193,15 @@ EOF
 cat >"${fixture_repo}/adl/tools/pr.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-issue="$2"
+cmd="${1:-}"
+issue="${2:-}"
+if [[ "$cmd" == "run" ]]; then
+  echo "RUN:${issue}" >>"${ADL_DISPATCH_LOG}"
+  exit 0
+fi
+if [[ "$cmd" != "doctor" ]]; then
+  exit 1
+fi
 case "$issue" in
   2001)
     cat <<'JSON'
@@ -378,6 +388,33 @@ cat >"${tmpdir}/route_issue.json" <<EOF
 }
 EOF
 
+cat >"${tmpdir}/route_issue_dispatch.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_issue",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "issue_number": 2001
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "required",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true
+  },
+  "dispatch": {
+    "mode": "invoke_subtask",
+    "allow_builtin_dispatch": true,
+    "timeout_secs": 5
+  },
+  "observed_state": {
+    "subagent_assigned": true
+  }
+}
+EOF
+
 cat >"${tmpdir}/route_task_bundle.json" <<EOF
 {
   "skill_input_schema": "workflow_conductor.v1",
@@ -395,6 +432,43 @@ cat >"${tmpdir}/route_task_bundle.json" <<EOF
     "stop_after_routing": true,
     "required_card_skill_by_type": {
       "sip": "sip-editor"
+    }
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
+cat >"${tmpdir}/route_task_bundle_dispatch.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_task_bundle",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "task_bundle_path": ".adl/v0.88/tasks/issue-2003__route-editor"
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true,
+    "required_card_skill_by_type": {
+      "sip": "sip-editor"
+    }
+  },
+  "dispatch": {
+    "mode": "invoke_subtask",
+    "allow_builtin_dispatch": false,
+    "timeout_secs": 5,
+    "command_overrides": {
+      "sip-editor": [
+        "bash",
+        "-lc",
+        "printf 'EDITOR:%s\\n' \"{issue_number}\" >> \"${tmpdir}/editor-dispatch.log\""
+      ]
     }
   },
   "observed_state": {
@@ -791,8 +865,13 @@ cat >"${tmpdir}/route_residue_finish.json" <<EOF
 }
 EOF
 
+dispatch_log="${tmpdir}/dispatch.log"
+export ADL_DISPATCH_LOG="${dispatch_log}"
+
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_issue.json" --artifact-path ".adl/reviews/route-issue.md" >"${tmpdir}/route_issue.out.json"
+python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_issue_dispatch.json" --artifact-path ".adl/reviews/route-issue-dispatch.md" >"${tmpdir}/route_issue_dispatch.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_task_bundle.json" --artifact-path ".adl/reviews/route-task-bundle.md" >"${tmpdir}/route_task_bundle.out.json"
+python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_task_bundle_dispatch.json" --artifact-path ".adl/reviews/route-task-bundle-dispatch.md" >"${tmpdir}/route_task_bundle_dispatch.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_finish.json" --artifact-path ".adl/reviews/route-finish.md" >"${tmpdir}/route_finish.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_worktree_finish.json" --artifact-path ".adl/reviews/route-worktree-finish.md" >"${tmpdir}/route_worktree_finish.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_worktree_disambiguated.json" --artifact-path ".adl/reviews/route-worktree-disambiguated.md" >"${tmpdir}/route_worktree_disambiguated.out.json"
@@ -826,10 +905,25 @@ assert route_issue["artifact"]["path"].endswith(".adl/reviews/route-issue.md")
 assert "wrote routing artifact to" in route_issue["actions_taken"][-1]
 assert (repo / ".adl/reviews/route-issue.md").exists()
 
+route_issue_dispatch = load("route_issue_dispatch.out.json")
+assert route_issue_dispatch["selected_skill"]["skill_name"] == "pr-run"
+assert route_issue_dispatch["dispatch"]["command_source"] == "builtin"
+assert route_issue_dispatch["dispatch"]["status"] == "invoked"
+assert route_issue_dispatch["dispatch"]["result"] == "success"
+assert route_issue_dispatch["dispatch"]["command"][0:4] == ["bash", "adl/tools/pr.sh", "run", "2001"]
+assert (tmp / "dispatch.log").read_text().strip() == "RUN:2001"
+
 route_editor = load("route_task_bundle.out.json")
 assert route_editor["selected_skill"]["skill_name"] == "sip-editor"
 assert route_editor["status"] == "done"
 assert (repo / ".adl/reviews/route-task-bundle.md").exists()
+
+route_editor_dispatch = load("route_task_bundle_dispatch.out.json")
+assert route_editor_dispatch["selected_skill"]["skill_name"] == "sip-editor"
+assert route_editor_dispatch["dispatch"]["command_source"] == "override"
+assert route_editor_dispatch["dispatch"]["status"] == "invoked"
+assert route_editor_dispatch["dispatch"]["result"] == "success"
+assert (tmp / "editor-dispatch.log").read_text().strip() == "EDITOR:2003"
 
 route_finish = load("route_finish.out.json")
 assert route_finish["selected_skill"]["skill_name"] == "pr-finish"


### PR DESCRIPTION
Closes #1740

## Summary
Extended the workflow-conductor so it can dispatch the selected lifecycle or editor skill as one bounded downstream subtask command, while preserving the thin-conductor boundary and recording dispatch outcome in the routing artifact.

## Artifacts
- `adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
- `adl/tools/test_workflow_conductor_skill_contracts.sh`
- `adl/tools/skills/workflow-conductor/SKILL.md`
- `adl/tools/skills/workflow-conductor/adl-skill.yaml`
- `adl/tools/skills/workflow-conductor/references/conductor-playbook.md`
- `adl/tools/skills/workflow-conductor/references/output-contract.md`
- `adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/workflow-conductor/scripts/route_workflow.py adl/tools/skills/workflow-conductor/scripts/select_next_skill.py` to verify the conductor helper scripts remain syntactically valid after the dispatch changes
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh` to verify routing, bounded dispatch invocation, contract docs, and output-shape expectations all pass together
  - `git diff --check` to verify the edited patch is free of whitespace and merge-marker defects
- Results:
  - Python compilation passed
  - `test_workflow_conductor_skill_contracts` passed
  - `git diff --check` passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1740__v0-88-tools-make-workflow-conductor-dispatch-selected-lifecycle-editor-skills-as-bounded-subtasks/sip.md
- Output card: .adl/v0.88/tasks/issue-1740__v0-88-tools-make-workflow-conductor-dispatch-selected-lifecycle-editor-skills-as-bounded-subtasks/sor.md
- Idempotency-Key: v0-88-tools-make-workflow-conductor-dispatch-selected-lifecycle-editor-skills-as-bounded-subtasks-adl-tools-skills-workflow-conductor-adl-tools-test-workflow-conductor-skill-contracts-sh-adl-tools-skills-docs-workflow-conductor-skill-input-schema-md-adl-tools-skills-docs-operational-skills-guide-md-adl-v0-88-tasks-issue-1740-v0-88-tools-make-workflow-conductor-dispatch-selected-lifecycle-editor-skills-as-bounded-subtasks-sip-md-adl-v0-88-tasks-issue-1740-v0-88-tools-make-workflow-conductor-dispatch-selected-lifecycle-editor-skills-as-bounded-subtasks-sor-md