### PR TITLE
[v0.88][tools] Harden repo-local worktree cleanup tooling for audited safe batches

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -70,8 +70,14 @@ bash ./adl/tools/pr.sh run <issue_num> --slug <slug>
 # inspect worktree status/fate across managed, stale, orphan, and Codex-ephemeral namespaces
 ./adl/tools/worktree_doctor.sh
 
-# dry-run safe cleanup of merged clean worktrees + stale registrations
+# dry-run safe repo-local cleanup of merged clean worktrees + stale registrations
 ./adl/tools/worktree_prune.sh
+
+# write a reviewable report for a bounded first batch without deleting anything
+./adl/tools/worktree_prune.sh --limit 10 --report docs/tooling/worktree_cleanup/first_batch.md
+
+# apply the same bounded batch after review
+./adl/tools/worktree_prune.sh --limit 10 --report docs/tooling/worktree_cleanup/first_batch.md --apply
 
 # inventory local run artifacts without deleting or moving the source data
 ./adl/tools/archive_run_artifacts.sh --include-worktrees

--- a/adl/tools/test_worktree_prune.sh
+++ b/adl/tools/test_worktree_prune.sh
@@ -45,24 +45,44 @@ assert_path_missing() {
 }
 
 managed_root="$(cd "$managed_root" && pwd -P)"
+report_path="$tmpdir/report.md"
 
 (
   cd "$repo"
   git branch codex/900-merged >/dev/null 2>&1 || true
   git worktree add -q "$managed_root/adl-wp-900" codex/900-merged
+  git branch codex/901-merged >/dev/null 2>&1 || true
+  git worktree add -q "$managed_root/adl-wp-901" codex/901-merged
 
-  out="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --apply)"
+  dry_limited="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --limit 1)"
+  assert_contains "Registered clean merged worktrees removable: 1" "$dry_limited" "limit constrains selected registered removals"
+
+  out="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --limit 1 --report "$report_path" --apply)"
   assert_contains "Registered clean merged worktrees removable: 1" "$out" "empty remove_dirs apply run"
   assert_contains "Directory removals eligible: 0" "$out" "empty remove_dirs apply run"
   assert_contains "Applying cleanup" "$out" "empty remove_dirs apply run"
+  assert_contains "Report: $report_path" "$out" "report path printed"
   assert_path_missing "$managed_root/adl-wp-900" "registered worktree removed"
+  assert_contains "# Worktree Cleanup Report" "$(cat "$report_path")" "report written"
+  assert_contains "$managed_root/adl-wp-900" "$(cat "$report_path")" "report lists selected removal"
+  [[ -d "$managed_root/adl-wp-901" ]] || {
+    echo "assertion failed (limit retained second merged worktree): expected path to remain: $managed_root/adl-wp-901" >&2
+    exit 1
+  }
 
   mkdir -p "$managed_root/rogue-clean"
   out2="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --apply)"
-  assert_contains "Registered clean merged worktrees removable: 0" "$out2" "non-empty remove_dirs apply run"
-  assert_contains "Directory removals eligible: 1" "$out2" "non-empty remove_dirs apply run"
+  assert_contains "Registered clean merged worktrees removable: 1" "$out2" "remaining merged worktree still removable"
+  assert_contains "Directory removals eligible: 0" "$out2" "non-empty remove_dirs apply run"
   assert_contains "Applying cleanup" "$out2" "non-empty remove_dirs apply run"
-  assert_path_missing "$managed_root/rogue-clean" "managed scratch removed"
+  [[ -d "$managed_root/rogue-clean" ]] || {
+    echo "assertion failed (managed scratch retained by default): expected path to remain: $managed_root/rogue-clean" >&2
+    exit 1
+  }
+
+  out3="$("$BASH_BIN" adl/tools/worktree_prune.sh --repo "$repo" --managed-root "$managed_root" --include-scratch --apply)"
+  assert_contains "Directory removals eligible: 1" "$out3" "explicit scratch inclusion"
+  assert_path_missing "$managed_root/rogue-clean" "managed scratch removed when explicitly included"
 )
 
 echo "worktree prune apply regression: ok"

--- a/adl/tools/worktree_prune.sh
+++ b/adl/tools/worktree_prune.sh
@@ -4,15 +4,14 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  adl/tools/worktree_prune.sh [--repo <path>] [--managed-root <path>] [--codex-root <path>] [--apply]
+  adl/tools/worktree_prune.sh [--repo <path>] [--managed-root <path>] [--codex-root <path>] [--limit <n>] [--report <path>] [--include-legacy-external] [--include-scratch] [--apply]
 
 Dry-run by default. Removes only clearly safe cases:
 - stale git worktree registrations (via `git worktree prune`)
-- clean repo-local managed clones whose branch is already merged into main
-- clean legacy external clones that already have repo-local replacements
-- clean repo-local scratch directories
+- clean repo-local managed worktrees whose branch is already merged into main
 
-Everything else remains report-only.
+Legacy external clones and repo-local scratch directories remain report-only unless
+explicitly included.
 EOF
 }
 
@@ -22,12 +21,20 @@ repo=""
 managed_root=""
 codex_root=""
 mode="dry-run"
+limit=""
+report_path=""
+include_legacy_external="no"
+include_scratch="no"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo) repo="${2-}"; shift 2 ;;
     --managed-root) managed_root="${2-}"; shift 2 ;;
     --codex-root) codex_root="${2-}"; shift 2 ;;
+    --limit) limit="${2-}"; shift 2 ;;
+    --report) report_path="${2-}"; shift 2 ;;
+    --include-legacy-external) include_legacy_external="yes"; shift ;;
+    --include-scratch) include_scratch="yes"; shift ;;
     --apply) mode="apply"; shift ;;
     --help|-h) usage; exit 0 ;;
     *) die "unknown argument: $1" ;;
@@ -40,6 +47,9 @@ doctor="$script_dir/worktree_doctor.sh"
 
 [[ -z "$repo" ]] && repo="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [[ -n "$repo" ]] || die "unable to determine repo root; use --repo <path>"
+if [[ -n "$limit" ]]; then
+  [[ "$limit" =~ ^[0-9]+$ ]] || die "--limit must be a non-negative integer"
+fi
 
 args=(--repo "$repo" --format tsv)
 [[ -n "$managed_root" ]] && args+=(--managed-root "$managed_root")
@@ -52,51 +62,191 @@ done < <("$doctor" "${args[@]}")
 
 declare -a remove_registered remove_dirs
 prune_needed="no"
+declare -a selected_rows report_rows skipped_rows
 
 for row in "${rows[@]}"; do
   IFS='|' read -r kind fate path branch clean merged prunable notes <<<"$row"
+  report_rows+=("$row")
   case "$fate" in
     prune_now)
       prune_needed="yes"
+      selected_rows+=("$row")
       ;;
     remove_merged_clean)
       if [[ "$kind" == "managed_registered" ]]; then
         remove_registered+=("$path")
+        selected_rows+=("$row")
       else
-        remove_dirs+=("$path")
+        skipped_rows+=("$row|excluded_by_default")
       fi
       ;;
     remove_legacy_replaced|remove_scratch_clean)
       if [[ "$kind" == "legacy_external_registered" ]]; then
-        remove_registered+=("$path")
+        if [[ "$include_legacy_external" == "yes" ]]; then
+          remove_registered+=("$path")
+          selected_rows+=("$row")
+        else
+          skipped_rows+=("$row|excluded_by_default")
+        fi
       else
-        remove_dirs+=("$path")
+        if [[ "$include_scratch" == "yes" ]]; then
+          remove_dirs+=("$path")
+          selected_rows+=("$row")
+        else
+          skipped_rows+=("$row|excluded_by_default")
+        fi
       fi
       ;;
   esac
 done
 
+limit_array() {
+  local max="$1"
+  shift
+  local count=0
+  local item
+  for item in "$@"; do
+    if [[ -n "$max" ]] && (( count >= max )); then
+      break
+    fi
+    printf '%s\n' "$item"
+    count=$((count + 1))
+  done
+}
+
+declare -a trimmed_registered
+trimmed_registered=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && trimmed_registered+=("$line")
+done < <(limit_array "$limit" "${remove_registered[@]-}")
+remove_registered=()
+if (( ${#trimmed_registered[@]} > 0 )); then
+  remove_registered=("${trimmed_registered[@]}")
+fi
+
+remaining_slots=""
+if [[ -n "$limit" ]]; then
+  remaining_slots=$(( limit - ${#remove_registered[@]} ))
+  if (( remaining_slots < 0 )); then
+    remaining_slots=0
+  fi
+fi
+if [[ -n "$limit" ]]; then
+  declare -a trimmed_dirs
+  trimmed_dirs=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && trimmed_dirs+=("$line")
+  done < <(limit_array "$remaining_slots" "${remove_dirs[@]-}")
+  remove_dirs=()
+  if (( ${#trimmed_dirs[@]} > 0 )); then
+    remove_dirs=("${trimmed_dirs[@]}")
+  fi
+fi
+
+selected_registered_count=0
+selected_dir_count=0
+for _path in "${remove_registered[@]+"${remove_registered[@]}"}"; do
+  selected_registered_count=$((selected_registered_count + 1))
+done
+for _path in "${remove_dirs[@]+"${remove_dirs[@]}"}"; do
+  selected_dir_count=$((selected_dir_count + 1))
+done
+
+write_report() {
+  local report="$1"
+  mkdir -p "$(dirname "$report")"
+  {
+    echo "# Worktree Cleanup Report"
+    echo
+    echo "- mode: $mode"
+    echo "- repo: $repo"
+    echo "- managed_root: ${managed_root:-$repo/.worktrees}"
+    echo "- include_legacy_external: $include_legacy_external"
+    echo "- include_scratch: $include_scratch"
+    echo "- limit: ${limit:-all}"
+    echo "- registered_removals_selected: $selected_registered_count"
+    echo "- directory_removals_selected: $selected_dir_count"
+    echo "- stale_registrations_present: $prune_needed"
+    echo
+    echo "## Selected Registered Removals"
+    if (( selected_registered_count == 0 )); then
+      echo "- none"
+    else
+      for path in "${remove_registered[@]+"${remove_registered[@]}"}"; do
+        echo "- $path"
+      done
+    fi
+    echo
+    echo "## Selected Directory Removals"
+    if (( selected_dir_count == 0 )); then
+      echo "- none"
+    else
+      for path in "${remove_dirs[@]+"${remove_dirs[@]}"}"; do
+        echo "- $path"
+      done
+    fi
+    echo
+    echo "## Selected Actions"
+    if (( selected_registered_count == 0 && selected_dir_count == 0 )) && [[ "$prune_needed" != "yes" ]]; then
+      echo "- none"
+    else
+      for path in "${remove_registered[@]+"${remove_registered[@]}"}"; do
+        echo "- git worktree remove $path"
+      done
+      for path in "${remove_dirs[@]+"${remove_dirs[@]}"}"; do
+        echo "- rm -rf $path"
+      done
+      if [[ "$prune_needed" == "yes" ]]; then
+        echo "- git worktree prune --verbose"
+      fi
+    fi
+    echo
+    echo "## Excluded By Default"
+    if (( ${#skipped_rows[@]} == 0 )); then
+      echo "- none"
+    else
+      for row in "${skipped_rows[@]}"; do
+        IFS='|' read -r kind fate path branch clean merged prunable notes reason <<<"$row"
+        echo "- $path ($fate; $reason)"
+      done
+    fi
+  } >"$report"
+}
+
 echo "Mode: $mode"
 echo "Repo: $repo"
-echo "Registered clean merged worktrees removable: ${#remove_registered[@]}"
-echo "Directory removals eligible: ${#remove_dirs[@]}"
+echo "Legacy external included: $include_legacy_external"
+echo "Scratch included: $include_scratch"
+echo "Limit: ${limit:-all}"
+echo "Registered clean merged worktrees removable: $selected_registered_count"
+echo "Directory removals eligible: $selected_dir_count"
 echo "Stale/prunable registrations present: $prune_needed"
 echo
 
-if [[ ${#remove_registered[@]} -gt 0 ]]; then
+if (( selected_registered_count > 0 )); then
   echo "Registered removals:"
-  printf '  %s\n' "${remove_registered[@]}"
+  for path in "${remove_registered[@]+"${remove_registered[@]}"}"; do
+    printf '  %s\n' "$path"
+  done
   echo
 fi
 
-if [[ ${#remove_dirs[@]} -gt 0 ]]; then
+if (( selected_dir_count > 0 )); then
   echo "Directory removals:"
-  printf '  %s\n' "${remove_dirs[@]}"
+  for path in "${remove_dirs[@]+"${remove_dirs[@]}"}"; do
+    printf '  %s\n' "$path"
+  done
   echo
 fi
 
 if [[ "$prune_needed" == "yes" ]]; then
   echo "Stale registrations will be cleaned by: git worktree prune --verbose"
+  echo
+fi
+
+if [[ -n "$report_path" ]]; then
+  write_report "$report_path"
+  echo "Report: $report_path"
   echo
 fi
 
@@ -107,15 +257,15 @@ fi
 
 echo "Applying cleanup..."
 
-if (( ${#remove_registered[@]} > 0 )); then
-  for path in "${remove_registered[@]}"; do
+if (( selected_registered_count > 0 )); then
+  for path in "${remove_registered[@]+"${remove_registered[@]}"}"; do
     echo "git -C $repo worktree remove $path"
     git -C "$repo" worktree remove "$path"
   done
 fi
 
-if (( ${#remove_dirs[@]} > 0 )); then
-  for path in "${remove_dirs[@]}"; do
+if (( selected_dir_count > 0 )); then
+  for path in "${remove_dirs[@]+"${remove_dirs[@]}"}"; do
     echo "rm -rf $path"
     rm -rf "$path"
   done

--- a/docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
+++ b/docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
@@ -1,0 +1,84 @@
+# Worktree Cleanup Wave 1
+
+This report records the first bounded cleanup wave against the repo-local
+`.worktrees/*` backlog. The scope is intentionally narrow: only repo-local
+managed worktrees that the cleanup tooling classified as `remove_merged_clean`
+were eligible.
+
+## Selection Summary
+
+- mode: apply
+- repo: repository root
+- managed_root: `.worktrees`
+- include_legacy_external: no
+- include_scratch: no
+- limit: 5
+- registered_removals_selected: 5
+- directory_removals_selected: 0
+- stale_registrations_present: no
+
+## Selected Registered Removals
+
+- `.worktrees/adl-wp-1348`
+- `.worktrees/adl-wp-1409`
+- `.worktrees/adl-wp-1411`
+- `.worktrees/adl-wp-1544`
+- `.worktrees/adl-wp-1550`
+
+## Commands Used
+
+Preview:
+
+```bash
+bash adl/tools/worktree_prune.sh --repo /Users/daniel/git/agent-design-language --limit 5 --report docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
+```
+
+Apply:
+
+```bash
+bash adl/tools/worktree_prune.sh --repo /Users/daniel/git/agent-design-language --limit 5 --apply --report docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
+```
+
+Post-cleanup verification:
+
+```bash
+bash adl/tools/worktree_doctor.sh --repo /Users/daniel/git/agent-design-language --format tsv > /tmp/adl-worktree-doctor-post.tsv
+```
+
+## Executed Actions
+
+- `git worktree remove .worktrees/adl-wp-1348`
+- `git worktree remove .worktrees/adl-wp-1409`
+- `git worktree remove .worktrees/adl-wp-1411`
+- `git worktree remove .worktrees/adl-wp-1544`
+- `git worktree remove .worktrees/adl-wp-1550`
+
+## Verification
+
+Removed paths confirmed absent:
+
+- `.worktrees/adl-wp-1348`
+- `.worktrees/adl-wp-1409`
+- `.worktrees/adl-wp-1411`
+- `.worktrees/adl-wp-1544`
+- `.worktrees/adl-wp-1550`
+
+Remaining repo-local managed `remove_merged_clean` backlog after this wave: `9`
+
+Remaining candidates:
+
+- `.worktrees/adl-wp-1559`
+- `.worktrees/adl-wp-1658`
+- `.worktrees/adl-wp-1724`
+- `.worktrees/adl-wp-1731`
+- `.worktrees/adl-wp-1732`
+- `.worktrees/adl-wp-1733`
+- `.worktrees/adl-wp-1735`
+- `.worktrees/adl-wp-1739`
+- `.worktrees/adl-wp-1740`
+
+## Excluded By Default
+
+- legacy external worktrees outside `.worktrees/*`
+- Codex ephemeral worktrees
+- dirty or otherwise review-first repo-local worktrees

--- a/docs/tooling/worktree_governance.md
+++ b/docs/tooling/worktree_governance.md
@@ -77,18 +77,21 @@ Use the tracked tooling rather than ad hoc shell commands:
 # inspect current worktree status and recommended fate
 ./adl/tools/worktree_doctor.sh
 
-# see what safe cleanup would happen
+# see what safe repo-local cleanup would happen
 ./adl/tools/worktree_prune.sh
 
-# apply only the clearly safe cleanup set
-./adl/tools/worktree_prune.sh --apply
+# write a reviewable first-batch report before deletion
+./adl/tools/worktree_prune.sh --limit 10 --report docs/tooling/worktree_cleanup/first_batch.md
+
+# apply only the clearly safe repo-local batch after review
+./adl/tools/worktree_prune.sh --limit 10 --report docs/tooling/worktree_cleanup/first_batch.md --apply
 ```
 
 The pruning flow is intentionally conservative:
 
 - it removes only clean managed worktrees whose branch is already merged into `main`
 - it prunes stale git worktree registrations
-- it does not silently delete orphan directories, dirty worktrees, or Codex-ephemeral worktrees
+- it does not silently delete orphan directories, dirty worktrees, Codex-ephemeral worktrees, legacy external clones, or repo-local scratch directories unless those broader scopes are explicitly requested
 
 ## Interaction with `pr.sh`
 


### PR DESCRIPTION
Closes #1764

## Summary
Hardened the repo-local worktree cleanup tooling so operators can preview and apply a bounded `.worktrees/*` cleanup batch with a tracked report, while keeping legacy external clones and scratch directories out of scope unless they are explicitly requested.

## Artifacts
- `adl/tools/worktree_prune.sh`
- `adl/tools/test_worktree_prune.sh`
- `adl/tools/README.md`
- `docs/tooling/worktree_governance.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_worktree_doctor.sh` to verify worktree classification behavior remained stable
  - `bash adl/tools/test_worktree_prune.sh` to verify bounded prune selection, report writing, and explicit scratch inclusion behavior
  - `ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)" && bash adl/tools/worktree_prune.sh --repo "$ROOT" --limit 5 --report "$ROOT/.adl/reviews/worktree-prune-preview.md"` to verify the live repo can produce a bounded preview report against the primary checkout without deleting anything
  - `git diff --check` to verify the branch diff is clean
- Results:
  - both worktree tool regression scripts passed
  - the live repo dry-run preview produced a bounded five-path report at `.adl/reviews/worktree-prune-preview.md`
  - `git diff --check` passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1764__v0-88-tools-harden-repo-local-worktree-cleanup-tooling-for-audited-safe-batches/sip.md
- Output card: .adl/v0.88/tasks/issue-1764__v0-88-tools-harden-repo-local-worktree-cleanup-tooling-for-audited-safe-batches/sor.md
- Idempotency-Key: v0-88-tools-harden-repo-local-worktree-cleanup-tooling-for-audited-safe-batches-adl-tools-worktree-prune-sh-adl-tools-test-worktree-prune-sh-adl-tools-readme-md-docs-tooling-worktree-governance-md-adl-v0-88-tasks-issue-1764-v0-88-tools-harden-repo-local-worktree-cleanup-tooling-for-audited-safe-batches-sip-md-adl-v0-88-tasks-issue-1764-v0-88-tools-harden-repo-local-worktree-cleanup-tooling-for-audited-safe-batches-sor-md