### PR TITLE
[v0.88][tools] Prune the first audited safe batch from .worktrees backlog

### DIFF
--- a/docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
+++ b/docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
@@ -1,0 +1,84 @@
+# Worktree Cleanup Wave 1
+
+This report records the first bounded cleanup wave against the repo-local
+`.worktrees/*` backlog. The scope is intentionally narrow: only repo-local
+managed worktrees that the cleanup tooling classified as `remove_merged_clean`
+were eligible.
+
+## Selection Summary
+
+- mode: apply
+- repo: repository root
+- managed_root: `.worktrees`
+- include_legacy_external: no
+- include_scratch: no
+- limit: 5
+- registered_removals_selected: 5
+- directory_removals_selected: 0
+- stale_registrations_present: no
+
+## Selected Registered Removals
+
+- `.worktrees/adl-wp-1348`
+- `.worktrees/adl-wp-1409`
+- `.worktrees/adl-wp-1411`
+- `.worktrees/adl-wp-1544`
+- `.worktrees/adl-wp-1550`
+
+## Commands Used
+
+Preview:
+
+```bash
+bash adl/tools/worktree_prune.sh --repo /Users/daniel/git/agent-design-language --limit 5 --report docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
+```
+
+Apply:
+
+```bash
+bash adl/tools/worktree_prune.sh --repo /Users/daniel/git/agent-design-language --limit 5 --apply --report docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md
+```
+
+Post-cleanup verification:
+
+```bash
+bash adl/tools/worktree_doctor.sh --repo /Users/daniel/git/agent-design-language --format tsv > /tmp/adl-worktree-doctor-post.tsv
+```
+
+## Executed Actions
+
+- `git worktree remove .worktrees/adl-wp-1348`
+- `git worktree remove .worktrees/adl-wp-1409`
+- `git worktree remove .worktrees/adl-wp-1411`
+- `git worktree remove .worktrees/adl-wp-1544`
+- `git worktree remove .worktrees/adl-wp-1550`
+
+## Verification
+
+Removed paths confirmed absent:
+
+- `.worktrees/adl-wp-1348`
+- `.worktrees/adl-wp-1409`
+- `.worktrees/adl-wp-1411`
+- `.worktrees/adl-wp-1544`
+- `.worktrees/adl-wp-1550`
+
+Remaining repo-local managed `remove_merged_clean` backlog after this wave: `9`
+
+Remaining candidates:
+
+- `.worktrees/adl-wp-1559`
+- `.worktrees/adl-wp-1658`
+- `.worktrees/adl-wp-1724`
+- `.worktrees/adl-wp-1731`
+- `.worktrees/adl-wp-1732`
+- `.worktrees/adl-wp-1733`
+- `.worktrees/adl-wp-1735`
+- `.worktrees/adl-wp-1739`
+- `.worktrees/adl-wp-1740`
+
+## Excluded By Default
+
+- legacy external worktrees outside `.worktrees/*`
+- Codex ephemeral worktrees
+- dirty or otherwise review-first repo-local worktrees


### PR DESCRIPTION
Closes #1763

## Summary
Pruned the first bounded batch of five repo-local managed worktrees from `.worktrees/*` using the hardened cleanup tooling, and recorded a tracked before/after cleanup report.

## Artifacts
- `docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md`
- `.adl/reviews/workflow-conductor-1763-prep.md`

## Validation
- Validation commands and their purpose:
  - `ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)" && bash adl/tools/worktree_prune.sh --repo "$ROOT" --limit 5 --report docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md` to preview the first bounded cleanup wave and write the tracked report
  - `ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)" && bash adl/tools/worktree_prune.sh --repo "$ROOT" --limit 5 --apply --report docs/tooling/worktree_cleanup/WORKTREE_CLEANUP_WAVE_1.md` to prune only the selected safe batch
  - `ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)" && bash adl/tools/worktree_doctor.sh --repo "$ROOT" --format tsv > .adl/reviews/worktree-doctor-post.tsv` to re-audit the remaining repo-local worktree backlog after apply
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.88/tasks/issue-1763__v0-88-tools-prune-the-first-audited-safe-batch-from-worktrees-backlog/sor.md` to validate the completed output record
  - `git diff --check` to ensure the tracked report change was whitespace-clean
- Results:
  - preview selected the expected five repo-local managed `remove_merged_clean` worktrees and no scratch or legacy external paths
  - apply removed those five selected worktrees successfully
  - post-cleanup audit reported `remaining_remove_merged_clean=9`
  - the completed SOR passed contract validation
  - `git diff --check` passed

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1763__v0-88-tools-prune-the-first-audited-safe-batch-from-worktrees-backlog/sip.md
- Output card: .adl/v0.88/tasks/issue-1763__v0-88-tools-prune-the-first-audited-safe-batch-from-worktrees-backlog/sor.md
- Idempotency-Key: v0-88-tools-prune-the-first-audited-safe-batch-from-worktrees-backlog-docs-tooling-worktree-cleanup-worktree-cleanup-wave-1-md-adl-v0-88-tasks-issue-1763-v0-88-tools-prune-the-first-audited-safe-batch-from-worktrees-backlog-sip-md-adl-v0-88-tasks-issue-1763-v0-88-tools-prune-the-first-audited-safe-batch-from-worktrees-backlog-sor-md