### PR TITLE
test: deepen chronosense failure-path and semantic coverage

### DIFF
--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -1567,6 +1567,21 @@ fn format_offset(offset: FixedOffset) -> String {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use std::{
+        env,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        env::temp_dir().join(format!(
+            "chronosense-{label}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
 
     #[test]
     fn identity_profile_derives_local_birth_fields() {
@@ -1584,6 +1599,43 @@ mod tests {
         assert_eq!(profile.birth_weekday_local, "Monday");
         assert_eq!(profile.birth_timezone, "America/Los_Angeles");
         assert_eq!(profile.continuity_mode, "repo_local_persistent");
+    }
+
+    #[test]
+    fn identity_profile_rejects_invalid_birthday_timezone_and_empty_fields() {
+        let err = IdentityProfile::from_birthday(
+            "codex",
+            "Codex",
+            "not-a-date",
+            "America/Los_Angeles",
+            "daniel",
+        )
+        .expect_err("invalid RFC3339 should fail");
+        assert!(err
+            .to_string()
+            .contains("invalid RFC3339 datetime 'not-a-date'"));
+
+        let err = IdentityProfile::from_birthday(
+            "codex",
+            "Codex",
+            "2026-03-30T13:34:00-07:00",
+            "Mars/Olympus",
+            "daniel",
+        )
+        .expect_err("invalid timezone should fail");
+        assert!(err
+            .to_string()
+            .contains("unsupported timezone 'Mars/Olympus'"));
+
+        let err = IdentityProfile::from_birthday(
+            "  ",
+            "Codex",
+            "2026-03-30T13:34:00-07:00",
+            "America/Los_Angeles",
+            "daniel",
+        )
+        .expect_err("empty identity field should fail");
+        assert!(err.to_string().contains("agent_id must not be empty"));
     }
 
     #[test]
@@ -1610,12 +1662,97 @@ mod tests {
     }
 
     #[test]
+    fn temporal_context_rejects_identity_with_invalid_persisted_birthday() {
+        let profile = IdentityProfile {
+            schema_version: IDENTITY_PROFILE_SCHEMA.to_string(),
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            birthday_rfc3339: "bad-value".to_string(),
+            birth_date_local: "2026-03-30".to_string(),
+            birth_weekday_local: "Monday".to_string(),
+            birth_timezone: "America/Los_Angeles".to_string(),
+            created_by: "daniel".to_string(),
+            continuity_mode: "repo_local_persistent".to_string(),
+        };
+        let now_utc = Utc.with_ymd_and_hms(2026, 3, 31, 20, 0, 0).unwrap();
+
+        let err = TemporalContext::from_now(now_utc, "America/Los_Angeles", Some(&profile))
+            .expect_err("invalid persisted birthday should fail");
+        assert!(err
+            .to_string()
+            .contains("invalid RFC3339 datetime 'bad-value'"));
+    }
+
+    #[test]
     fn default_identity_profile_path_is_repo_relative() {
         let path = default_identity_profile_path(Path::new("/repo"));
         assert_eq!(
             path,
             PathBuf::from("/repo/adl/identity/identity_profile.v1.json")
         );
+    }
+
+    #[test]
+    fn write_identity_profile_creates_parent_dirs_and_load_round_trips() {
+        let root = unique_temp_path("identity-profile-roundtrip");
+        let path = root.join("adl/identity/identity_profile.v1.json");
+        let profile = IdentityProfile::from_birthday(
+            "codex",
+            "Codex",
+            "2026-03-30T13:34:00-07:00",
+            "America/Los_Angeles",
+            "daniel",
+        )
+        .expect("profile");
+
+        write_identity_profile(&path, &profile).expect("write identity profile");
+        let loaded = load_identity_profile(&path).expect("load identity profile");
+
+        assert_eq!(loaded.agent_id, "codex");
+        assert_eq!(loaded.birth_timezone, "America/Los_Angeles");
+        assert_eq!(loaded.birthday_rfc3339, "2026-03-30T13:34:00-07:00");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn load_identity_profile_rejects_malformed_json_and_unsupported_schema() {
+        let malformed_root = unique_temp_path("identity-profile-malformed");
+        let malformed_path = malformed_root.join("identity_profile.v1.json");
+        fs::create_dir_all(&malformed_root).expect("create malformed root");
+        fs::write(&malformed_path, b"{not json").expect("write malformed profile");
+
+        let err = load_identity_profile(&malformed_path).expect_err("malformed JSON should fail");
+        assert!(err.to_string().contains("failed to parse identity profile"));
+
+        let unsupported_root = unique_temp_path("identity-profile-unsupported");
+        let unsupported_path = unsupported_root.join("identity_profile.v1.json");
+        fs::create_dir_all(&unsupported_root).expect("create unsupported root");
+        fs::write(
+            &unsupported_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": "identity_profile.v0",
+                "agent_id": "codex",
+                "display_name": "Codex",
+                "birthday_rfc3339": "2026-03-30T20:34:00+00:00",
+                "birth_date_local": "2026-03-30",
+                "birth_weekday_local": "Monday",
+                "birth_timezone": "America/Los_Angeles",
+                "created_by": "daniel",
+                "continuity_mode": "repo_local_persistent"
+            }))
+            .expect("json bytes"),
+        )
+        .expect("write unsupported profile");
+
+        let err =
+            load_identity_profile(&unsupported_path).expect_err("unsupported schema should fail");
+        assert!(err
+            .to_string()
+            .contains("unsupported identity profile schema version 'identity_profile.v0'"));
+
+        let _ = fs::remove_dir_all(malformed_root);
+        let _ = fs::remove_dir_all(unsupported_root);
     }
 
     #[test]

--- a/adl/src/cli/identity_cmd.rs
+++ b/adl/src/cli/identity_cmd.rs
@@ -1153,6 +1153,15 @@ mod tests {
             json["proof_hook_output_path"],
             ".adl/state/temporal_schema_v01.json"
         );
+        assert_eq!(
+            json["primary_temporal_anchor"]["monotonic_order"],
+            "required strictly increasing order token"
+        );
+        assert!(json["reference_frames"]["internal_reasoning"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "monotonic"));
         assert!(json["execution_policy_trace_hooks"]
             .as_array()
             .expect("array")
@@ -1201,6 +1210,14 @@ mod tests {
             .expect("array")
             .iter()
             .any(|value| value == "resume_ready"));
+        assert!(json["resumption_rules"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|rule| {
+                rule["continuity_status"] == "continuity_refused"
+                    && rule["resume_permitted"] == Value::Bool(false)
+            }));
         assert_eq!(
             json["proof_hook_output_path"],
             ".adl/state/continuity_semantics_v1.json"
@@ -1294,6 +1311,16 @@ mod tests {
             json["proof_hook_output_path"],
             ".adl/state/commitment_deadline_semantics_v1.json"
         );
+        assert!(json["lifecycle"]["states"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "missed"));
+        assert!(json["deadline_semantics"]["supported_frames"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "continuity_relative"));
         assert!(json["owned_runtime_surfaces"]
             .as_array()
             .expect("array")
@@ -1341,6 +1368,15 @@ mod tests {
             json["proof_hook_output_path"],
             ".adl/state/temporal_causality_explanation_v1.json"
         );
+        assert_eq!(
+            json["causal_relations"]["sequence_boundary_rule"],
+            "sequence alone is insufficient evidence for causality"
+        );
+        assert!(json["causal_relations"]["relation_types"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "unknown_relation"));
         assert!(json["owned_runtime_surfaces"]
             .as_array()
             .expect("array")
@@ -1435,6 +1471,15 @@ mod tests {
             json["proof_hook_output_path"],
             ".adl/state/phi_integration_metrics_v1.json"
         );
+        assert_eq!(
+            json["comparison_profiles"].as_array().expect("array").len(),
+            3
+        );
+        assert!(json["review_surface"]["non_goals"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value == "formal IIT phi calculation"));
         assert!(json["owned_runtime_surfaces"]
             .as_array()
             .expect("array")
@@ -1482,6 +1527,19 @@ mod tests {
             json["proof_hook_output_path"],
             ".adl/state/instinct_model_v1.json"
         );
+        assert_eq!(json["instinct_set"].as_array().expect("array").len(), 4);
+        assert!(json["instinct_set"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|entry| {
+                entry["instinct_id"] == "integrity"
+                    && entry["subordinate_to"]
+                        .as_array()
+                        .expect("array")
+                        .iter()
+                        .any(|value| value == "policy")
+            }));
         assert!(json["owned_runtime_surfaces"]
             .as_array()
             .expect("array")
@@ -1529,6 +1587,15 @@ mod tests {
             json["proof_hook_output_path"],
             ".adl/state/instinct_runtime_surface_v1.json"
         );
+        assert!(json["proof_cases"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value["expected_candidate_id"] == "cand-fast-verify"));
+        assert!(json["review_surface"]["policy_override_rule"]
+            .as_str()
+            .expect("string")
+            .contains("high-risk slow-path review remains mandatory"));
         assert!(json["owned_runtime_surfaces"]
             .as_array()
             .expect("array")


### PR DESCRIPTION
Closes #1772

## Summary
Added direct chronosense failure-path coverage for invalid birthday strings, unsupported timezones, empty identity fields, malformed persisted profile JSON, unsupported schema versions, and invalid persisted birthday reuse in temporal-context construction. Strengthened representative `identity` contract tests so they assert deeper semantic content instead of only schema version and output path.

## Artifacts
- `adl/src/chronosense.rs`
- `adl/src/cli/identity_cmd.rs`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified Rust formatting stayed canonical
  - `cargo test --manifest-path adl/Cargo.toml chronosense::tests:: -- --nocapture` verified the expanded chronosense unit suite, including the new negative-path and persistence coverage
  - `cargo test --manifest-path adl/Cargo.toml identity_schema_writes_temporal_schema_contract_json -- --nocapture` verified deeper schema artifact assertions
  - `cargo test --manifest-path adl/Cargo.toml identity_continuity_writes_continuity_semantics_contract_json -- --nocapture` verified deeper continuity artifact assertions
  - `cargo test --manifest-path adl/Cargo.toml identity_commitments_writes_commitment_deadline_contract_json -- --nocapture` verified deeper commitments artifact assertions
  - `cargo test --manifest-path adl/Cargo.toml identity_causality_writes_temporal_causality_explanation_contract_json -- --nocapture` verified deeper causality artifact assertions
  - `cargo test --manifest-path adl/Cargo.toml identity_phi_writes_phi_integration_metrics_contract_json -- --nocapture` verified deeper PHI artifact assertions
  - `cargo test --manifest-path adl/Cargo.toml identity_instinct_writes_instinct_model_contract_json -- --nocapture` verified deeper instinct artifact assertions
  - `cargo test --manifest-path adl/Cargo.toml identity_instinct_runtime_writes_instinct_runtime_surface_contract_json -- --nocapture` verified deeper instinct-runtime artifact assertions
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1772__v0-88-tests-deepen-chronosense-failure-path-and-semantic-test-coverage/sip.md
- Output card: .adl/v0.88/tasks/issue-1772__v0-88-tests-deepen-chronosense-failure-path-and-semantic-test-coverage/sor.md
- Idempotency-Key: test-deepen-chronosense-failure-path-and-semantic-coverage-adl-src-chronosense-rs-adl-src-cli-identity-cmd-rs-adl-v0-88-tasks-issue-1772-v0-88-tests-deepen-chronosense-failure-path-and-semantic-test-coverage-sip-md-adl-v0-88-tasks-issue-1772-v0-88-tests-deepen-chronosense-failure-path-and-semantic-test-coverage-sor-md