### PR TITLE
release: make Cargo.toml version policy reviewer-proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Summary:
 - Internal review has completed a full repo code-review pass, and the one concrete implementation finding from that pass was remediated before 3rd-party review
 
 Version note:
-- the active milestone is `v0.88`, but the crate version on `main` remains `0.87.1` until the `v0.88` release ceremony/version bump
+- the active milestone is `v0.88`, and the crate version on `main` has already been bumped to `0.88.0`; the remaining release ceremony owns tagging and release publication rather than the version-number transition
 
 References:
 - `docs/milestones/v0.88/README.md`

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Other useful entrypoints:
 ## Current Status
 
 - Active milestone: **v0.88**
-- Current crate version on `main`: **0.87.1**
-- Version note: **the `v0.88` milestone is active, but the crate version remains `0.87.1` until the `v0.88` release ceremony/version bump**
+- Current crate version on `main`: **0.88.0**
+- Version note: **the crate version was bumped to `0.88.0` during the `v0.88` review/remediation tail so reviewers do not need a separate oral explanation for the milestone/version match; the final release ceremony still owns tagging and release publication**
 - Most recently completed milestone package: **v0.87.1**
 - Previous completed milestone: **v0.87**
 - Project changelog: `CHANGELOG.md`

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.87.1"
+version = "0.88.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.87.1"
+version = "0.88.0"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -49,7 +49,7 @@ can survive code review, ops review, and postmortem analysis.
 
 The current repo truth is:
 - active milestone: `v0.88`
-- current crate version on `main`: `0.87.1`
+- current crate version on `main`: `0.88.0`
 - most recently completed runtime-completion milestone package: `v0.87.1`
 - most recently completed substrate milestone package: `v0.87`
 


### PR DESCRIPTION
Closes #1770

## Summary
Bumped the crate version to `0.88.0` and aligned the main reviewer-facing version-story surfaces so `v0.88` no longer reads like a milestone/version mismatch that requires oral explanation.

## Artifacts
- `adl/Cargo.toml`
- `adl/Cargo.lock`
- `README.md`
- `CHANGELOG.md`
- `docs/planning/ADL_FEATURE_LIST.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml identity_schema_writes_temporal_schema_contract_json -- --nocapture` verified the manifest version bump still builds and runs a representative CLI contract test cleanly
  - `git diff --check` verified the final patch has no whitespace or merge-artifact drift
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1770__v0-88-release-make-cargo-toml-version-policy-reviewer-proof/sip.md
- Output card: .adl/v0.88/tasks/issue-1770__v0-88-release-make-cargo-toml-version-policy-reviewer-proof/sor.md
- Idempotency-Key: release-make-cargo-toml-version-policy-reviewer-proof-adl-cargo-toml-adl-cargo-lock-readme-md-changelog-md-docs-planning-adl-feature-list-md-adl-v0-88-tasks-issue-1770-v0-88-release-make-cargo-toml-version-policy-reviewer-proof-sip-md-adl-v0-88-tasks-issue-1770-v0-88-release-make-cargo-toml-version-policy-reviewer-proof-sor-md