### PR TITLE
[v0.88][tools] Accept semver patch versions in release ceremony preflight

### DIFF
--- a/adl/tools/release_ceremony.sh
+++ b/adl/tools/release_ceremony.sh
@@ -109,10 +109,23 @@ assert_release_present() {
 
 check_cargo_version() {
   local expected="${VERSION#v}"
+  local expected_alt=""
   local actual
   actual="$(sed -n 's/^version = "\(.*\)"/\1/p' "$ROOT/adl/Cargo.toml" | head -n 1)"
   [[ -n "$actual" ]] || fail "could not read version from adl/Cargo.toml"
-  [[ "$actual" == "$expected" ]] || fail "adl/Cargo.toml version mismatch: expected $expected, found $actual"
+  if [[ "$expected" != *.*.* ]]; then
+    expected_alt="${expected}.0"
+  fi
+
+  if [[ "$actual" == "$expected" || ( -n "$expected_alt" && "$actual" == "$expected_alt" ) ]]; then
+    return 0
+  fi
+
+  if [[ -n "$expected_alt" ]]; then
+    fail "adl/Cargo.toml version mismatch: expected $expected or $expected_alt, found $actual"
+  fi
+
+  fail "adl/Cargo.toml version mismatch: expected $expected, found $actual"
 }
 
 check_sor_gate() {


### PR DESCRIPTION
Closes #1780

## Summary
- accept semver patch versions like `0.88.0` during `v0.88` release-ceremony preflight
- keep the mismatch guard intact for genuinely wrong milestone versions
- preserve the bounded release-tail tooling scope

## Validation
- `bash adl/tools/release_ceremony.sh --version v0.88 --allow-dirty --target-branch codex/1780-v0-88-tools-accept-semver-patch-versions-in-release-ceremony-preflight`
- `bash adl/tools/release_ceremony.sh --version v0.89 --allow-dirty --target-branch codex/1780-v0-88-tools-accept-semver-patch-versions-in-release-ceremony-preflight`
