### PR TITLE
[v0.89][docs] Canonicalize v0.89 issue-wave source paths

### DIFF
--- a/docs/milestones/v0.89/WP_ISSUE_WAVE_v0.89.yaml
+++ b/docs/milestones/v0.89/WP_ISSUE_WAVE_v0.89.yaml
@@ -1,8 +1,8 @@
 schema: adl.wp_issue_wave.v1
 version: v0.89
 sources:
-  wbs: .worktrees/adl-wp-1662/docs/milestones/v0.89/WBS_v0.89.md
-  sprint: .worktrees/adl-wp-1662/docs/milestones/v0.89/SPRINT_v0.89.md
+  wbs: docs/milestones/v0.89/WBS_v0.89.md
+  sprint: docs/milestones/v0.89/SPRINT_v0.89.md
 entries:
 - wp: WP-02
   issue_kind: execution


### PR DESCRIPTION
Closes #1783

## Summary
Canonicalized the tracked `v0.89` issue-wave YAML so its source references now point at the tracked milestone docs on `main` rather than the obsolete `adl-wp-1662` worktree paths.

## Artifacts
- `docs/milestones/v0.89/WP_ISSUE_WAVE_v0.89.yaml`

## Validation
- Validation commands and their purpose:
- `bash adl/tools/pr.sh run 1783 --slug v0-89-docs-canonicalize-v0-89-issue-wave-source-paths --version v0.89` to bind the issue branch/worktree through the repo control plane
- `git -C .worktrees/adl-wp-1783 diff --check` to verify no formatting/patch defects
- `git -C .worktrees/adl-wp-1783 diff -- docs/milestones/v0.89/WP_ISSUE_WAVE_v0.89.yaml` to verify only the intended YAML source-path lines changed
- Results:
  - issue binding succeeded and created the expected branch/worktree
  - patch cleanliness check passed
  - diff inspection confirmed a bounded two-line canonicalization change

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1783__v0-89-docs-canonicalize-v0-89-issue-wave-source-paths/sip.md
- Output card: .adl/v0.89/tasks/issue-1783__v0-89-docs-canonicalize-v0-89-issue-wave-source-paths/sor.md
- Idempotency-Key: v0-89-docs-canonicalize-v0-89-issue-wave-source-paths-docs-milestones-v0-89-wp-issue-wave-v0-89-yaml-adl-v0-89-tasks-issue-1783-v0-89-docs-canonicalize-v0-89-issue-wave-source-paths-sip-md-adl-v0-89-tasks-issue-1783-v0-89-docs-canonicalize-v0-89-issue-wave-source-paths-sor-md