### PR TITLE
[v0.88][tools] Repair local Codex skill install validation and sync

### DIFF
--- a/adl/tools/install_adl_operational_skills.sh
+++ b/adl/tools/install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ if [[ -z "${repo_root}" ]]; then
 fi
 
 codex_home="${CODEX_HOME:-$HOME/.codex}"
-source_root="${repo_root}/adl/tools/skills"
+source_root="${ADL_OPERATIONAL_SKILLS_SOURCE_ROOT:-${repo_root}/adl/tools/skills}"
 dest_root="${codex_home}/skills"
 install_mode="${ADL_OPERATIONAL_SKILLS_INSTALL_MODE:-copy}"
 
@@ -35,6 +35,8 @@ for source_dir in "${source_root}"/*; do
   skill_name="$(basename "${source_dir}")"
   dest_dir="${dest_root}/${skill_name}"
 
+  bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" "${source_dir}/SKILL.md"
+
   rm -rf "${dest_dir}"
   case "${install_mode}" in
     copy)
@@ -44,6 +46,7 @@ for source_dir in "${source_root}"/*; do
         echo "install_adl_operational_skills.sh: install verification failed for ${dest_dir}" >&2
         exit 1
       fi
+      bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" "${dest_dir}/SKILL.md"
       ;;
     symlink)
       ln -s "${source_dir}" "${dest_dir}"
@@ -55,6 +58,7 @@ for source_dir in "${source_root}"/*; do
         echo "install_adl_operational_skills.sh: symlink verification failed for ${dest_dir}" >&2
         exit 1
       fi
+      bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" "${dest_dir}/SKILL.md"
       ;;
   esac
 

--- a/adl/tools/install_adl_pr_cycle_skill.sh
+++ b/adl/tools/install_adl_pr_cycle_skill.sh
@@ -8,7 +8,7 @@ if [[ -z "${repo_root}" ]]; then
 fi
 
 codex_home="${CODEX_HOME:-$HOME/.codex}"
-source_path="${repo_root}/docs/tooling/adl_pr_cycle_skill.md"
+source_path="${ADL_PR_CYCLE_SOURCE_PATH:-${repo_root}/docs/tooling/adl_pr_cycle_skill.md}"
 dest_dir="${codex_home}/skills/adl_pr_cycle"
 dest_path="${dest_dir}/SKILL.md"
 
@@ -17,6 +17,8 @@ if [[ ! -f "${source_path}" ]]; then
   exit 1
 fi
 
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" "${source_path}"
+
 mkdir -p "${dest_dir}"
 cp "${source_path}" "${dest_path}"
 
@@ -24,5 +26,7 @@ if ! cmp -s "${source_path}" "${dest_path}"; then
   echo "install_adl_pr_cycle_skill.sh: install verification failed for ${dest_path}" >&2
   exit 1
 fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" "${dest_path}"
 
 echo "INSTALLED ${dest_path}"

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: workflow-conductor
-description: Lightweight conductor for the ADL workflow skills. Use when the operator wants one bounded entrypoint that detects the current issue/workflow state, selects the correct next lifecycle or editor skill, enforces skill/subagent policy, and stops after routing/compliance recording rather than reimplementing the underlying work.
 description: Lightweight conductor for the ADL workflow skills. Use when the operator wants one bounded entrypoint that detects the current issue/workflow state, selects the correct next lifecycle or editor skill, enforces skill/subagent policy, and either stops after routing or dispatches one bounded downstream skill subtask without reimplementing the underlying work.
 ---
 

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -37,6 +37,20 @@ assert_skill_bundle() {
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
   grep -Fq "truthful execution and integration state" "${root}/skills/sor-editor/SKILL.md"
+
+  bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+    "${root}/skills/workflow-conductor/SKILL.md" \
+    "${root}/skills/pr-init/SKILL.md" \
+    "${root}/skills/pr-ready/SKILL.md" \
+    "${root}/skills/pr-run/SKILL.md" \
+    "${root}/skills/pr-finish/SKILL.md" \
+    "${root}/skills/pr-janitor/SKILL.md" \
+    "${root}/skills/pr-closeout/SKILL.md" \
+    "${root}/skills/repo-code-review/SKILL.md" \
+    "${root}/skills/test-generator/SKILL.md" \
+    "${root}/skills/stp-editor/SKILL.md" \
+    "${root}/skills/sip-editor/SKILL.md" \
+    "${root}/skills/sor-editor/SKILL.md"
 }
 
 export CODEX_HOME="${tmpdir}/codex-home-copy"
@@ -50,6 +64,21 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/pr-init" ]]
 [[ -L "${CODEX_HOME}/skills/pr-ready" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]
+
+malformed_root="${tmpdir}/malformed-skills"
+cp -R "${repo_root}/adl/tools/skills" "${malformed_root}"
+cat >"${malformed_root}/workflow-conductor/SKILL.md" <<'EOF'
+---
+name: broken
+description: first
+description: second
+---
+EOF
+if ADL_OPERATIONAL_SKILLS_SOURCE_ROOT="${malformed_root}" \
+  bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null 2>&1; then
+  echo "expected malformed operational skill source to fail" >&2
+  exit 1
+fi
 
 if ADL_OPERATIONAL_SKILLS_INSTALL_MODE=bogus bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null 2>&1; then
   echo "expected invalid install mode to fail" >&2

--- a/adl/tools/test_install_adl_pr_cycle_skill.sh
+++ b/adl/tools/test_install_adl_pr_cycle_skill.sh
@@ -14,9 +14,23 @@ source_path="${repo_root}/docs/tooling/adl_pr_cycle_skill.md"
 
 [[ -f "${installed}" ]]
 cmp -s "${source_path}" "${installed}"
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" "${installed}"
 grep -Fq 'preflight -> issue_ready -> init -> start -> codex -> run_if_required -> finish -> report' "${installed}"
 grep -Fq '.worktrees/adl-wp-<issue_num>' "${installed}"
 grep -Fq 'bash ./adl/tools/pr.sh init <issue_num> --slug <slug> [--version <version>]' "${installed}"
 grep -Fq 'bash adl/tools/test_five_command_regression_suite.sh' "${installed}"
+
+malformed_source="${tmpdir}/bad_adl_pr_cycle_skill.md"
+cat >"${malformed_source}" <<'EOF'
+---
+name: adl_pr_cycle
+description: broken: yaml
+---
+EOF
+
+if ADL_PR_CYCLE_SOURCE_PATH="${malformed_source}" bash "${repo_root}/adl/tools/install_adl_pr_cycle_skill.sh" >/dev/null 2>&1; then
+  echo "expected malformed adl_pr_cycle source to fail" >&2
+  exit 1
+fi
 
 echo "PASS test_install_adl_pr_cycle_skill"

--- a/adl/tools/validate_skill_frontmatter.sh
+++ b/adl/tools/validate_skill_frontmatter.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+  echo "usage: validate_skill_frontmatter.sh <SKILL.md> [<SKILL.md> ...]" >&2
+  exit 1
+fi
+
+ruby - "$@" <<'RUBY'
+require "yaml"
+require "psych"
+
+def extract_frontmatter(path)
+  text = File.read(path)
+  match = text.match(/\A---\n(.*?)\n---\n/m)
+  raise "#{path}: missing YAML frontmatter block" unless match
+  match[1]
+end
+
+def check_duplicate_keys(node, path)
+  return unless node.is_a?(Psych::Nodes::Node)
+
+  if node.is_a?(Psych::Nodes::Mapping)
+    seen = {}
+    node.children.each_slice(2) do |key_node, value_node|
+      key = if key_node.respond_to?(:value)
+        key_node.value
+      else
+        key_node.to_s
+      end
+      raise "#{path}: duplicate frontmatter key #{key.inspect}" if seen[key]
+      seen[key] = true
+      check_duplicate_keys(value_node, path)
+    end
+  elsif node.respond_to?(:children) && node.children
+    node.children.each do |child|
+      check_duplicate_keys(child, path)
+    end
+  end
+end
+
+ARGV.each do |path|
+  begin
+    frontmatter = extract_frontmatter(path)
+    ast = Psych.parse(frontmatter)
+    raise "#{path}: invalid YAML frontmatter" if ast.nil?
+    check_duplicate_keys(ast, path)
+    YAML.safe_load(frontmatter)
+  rescue StandardError => e
+    warn "validate_skill_frontmatter.sh: #{path}: #{e.message}"
+    exit 1
+  end
+end
+RUBY

--- a/docs/tooling/adl_pr_cycle_skill.md
+++ b/docs/tooling/adl_pr_cycle_skill.md
@@ -1,6 +1,6 @@
 ---
 name: adl_pr_cycle
-description: Deterministic Codex.app workflow for the real ADL authoring control plane: pr init, pr start, pr run, and pr finish, with bounded editor-adapter truth and required reporting.
+description: "Deterministic Codex.app workflow for the real ADL authoring control plane: pr init, pr start, pr run, and pr finish, with bounded editor-adapter truth and required reporting."
 ---
 
 # adl_pr_cycle


### PR DESCRIPTION
Closes #1808

## Summary
Repaired the local Codex skill install/sync path by adding explicit `SKILL.md` frontmatter validation, fixing malformed tracked skill frontmatter, resyncing the installed local skills under `$CODEX_HOME/skills`, and proving `codex exec` no longer fails on malformed local skill YAML during startup.

## Artifacts
- `adl/tools/validate_skill_frontmatter.sh`
- updated installers:
  - `adl/tools/install_adl_operational_skills.sh`
  - `adl/tools/install_adl_pr_cycle_skill.sh`
- updated installer tests:
  - `adl/tools/test_install_adl_operational_skills.sh`
  - `adl/tools/test_install_adl_pr_cycle_skill.sh`
- repaired tracked skill contracts:
  - `adl/tools/skills/workflow-conductor/SKILL.md`
  - `docs/tooling/adl_pr_cycle_skill.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_install_adl_operational_skills.sh` to prove operational skill installs succeed for copy and symlink modes and fail on malformed source frontmatter
  - `bash adl/tools/test_install_adl_pr_cycle_skill.sh` to prove `adl_pr_cycle` installs cleanly and fails on malformed source frontmatter
  - `bash adl/tools/install_adl_operational_skills.sh` to resync the local installed operational skills under `$CODEX_HOME/skills`
  - `bash adl/tools/install_adl_pr_cycle_skill.sh` to resync the local installed `adl_pr_cycle` skill
  - `bash adl/tools/validate_skill_frontmatter.sh "$CODEX_HOME"/skills/*/SKILL.md` to confirm all installed local skills are syntactically valid after resync
  - `CODEX_HOME=<temp-codex-home> codex exec --skip-git-repo-check --json 'Reply with exactly: OK'` to prove a clean installed skill set allows Codex CLI startup under a temporary home
  - `codex exec --skip-git-repo-check --json 'Reply with exactly: OK'` to verify the default local `CODEX_HOME` no longer emits malformed local skill YAML errors on startup
- Results:
  - PASS: both installer tests passed
  - PASS: tracked skill contracts validated cleanly
  - PASS: installed local skills under `$CODEX_HOME/skills` validated cleanly after resync
  - PASS: both `codex exec` smoke checks returned `OK`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.88/tasks/issue-1808__repair-local-codex-skill-install-validation-and-sync/sip.md
- Output card: .adl/v0.88/tasks/issue-1808__repair-local-codex-skill-install-validation-and-sync/sor.md
- Idempotency-Key: v0-88-tools-repair-local-codex-skill-install-validation-and-sync-adl-v0-88-tasks-issue-1808-repair-local-codex-skill-install-validation-and-sync-sip-md-adl-v0-88-tasks-issue-1808-repair-local-codex-skill-install-validation-and-sync-sor-md