### PR TITLE
[v0.89][tools] Make pr finish use bounded validation for docs-only and review-only publication

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -511,8 +511,9 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
         })?;
     }
 
+    let finish_validation_mode = select_finish_validation_mode(&parsed.paths)?;
     if !parsed.no_checks {
-        run_batched_checks_rust(&repo_root)?;
+        run_finish_validation_rust(&repo_root, finish_validation_mode)?;
     }
 
     stage_selected_paths_rust(&repo_root, &parsed.paths)?;
@@ -537,6 +538,11 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
     } else {
         Some(format!("Closes #{}", parsed.issue))
     };
+    let default_validation = if parsed.no_checks {
+        None
+    } else {
+        Some(render_default_finish_validation(finish_validation_mode))
+    };
     let fingerprint = finish_inputs_fingerprint(
         &parsed.title,
         &parsed.paths,
@@ -548,7 +554,7 @@ fn real_pr_finish(args: &[String]) -> Result<()> {
         &input_path,
         &output_path,
         parsed.extra_body.as_deref(),
-        parsed.no_checks,
+        default_validation.as_deref(),
         &fingerprint,
         &repo_root,
     )?;
@@ -945,11 +951,56 @@ fn validate_completed_sor(repo_root: &Path, output_path: &Path) -> Result<()> {
     })
 }
 
-fn run_batched_checks_rust(repo_root: &Path) -> Result<()> {
-    let manifest = repo_root.join("adl/Cargo.toml");
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FinishValidationMode {
+    DocsOnly,
+    FullRust,
+}
+
+fn finish_validation_guard(repo_root: &Path) -> Result<()> {
     let tracked_residue_guard =
         repo_root.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh");
-    run_status("bash", &[path_str(&tracked_residue_guard)?])?;
+    run_status("bash", &[path_str(&tracked_residue_guard)?])
+}
+
+fn select_finish_validation_mode(paths_csv: &str) -> Result<FinishValidationMode> {
+    let paths = paths_csv
+        .split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>();
+    if paths.is_empty() {
+        bail!("finish: --paths resolved to empty");
+    }
+    if paths.iter().all(|path| finish_path_is_docs_only(path)) {
+        return Ok(FinishValidationMode::DocsOnly);
+    }
+    Ok(FinishValidationMode::FullRust)
+}
+
+fn finish_path_is_docs_only(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed == "docs" || trimmed.starts_with("docs/") {
+        return true;
+    }
+    !trimmed.contains('/')
+        && Path::new(trimmed)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+}
+
+fn run_finish_validation_rust(repo_root: &Path, mode: FinishValidationMode) -> Result<()> {
+    finish_validation_guard(repo_root)?;
+    if mode == FinishValidationMode::DocsOnly {
+        run_status("git", &["-C", path_str(repo_root)?, "diff", "--check"])?;
+        return Ok(());
+    }
+
+    let manifest = repo_root.join("adl/Cargo.toml");
     run_status(
         "cargo",
         &[
@@ -974,6 +1025,23 @@ fn run_batched_checks_rust(repo_root: &Path) -> Result<()> {
     )?;
     run_status("cargo", &["test", "--manifest-path", path_str(&manifest)?])?;
     Ok(())
+}
+
+fn render_default_finish_validation(mode: FinishValidationMode) -> String {
+    match mode {
+        FinishValidationMode::DocsOnly => [
+            "- bash adl/tools/check_no_tracked_adl_issue_record_residue.sh",
+            "- git diff --check",
+        ]
+        .join("\n"),
+        FinishValidationMode::FullRust => [
+            "- bash adl/tools/check_no_tracked_adl_issue_record_residue.sh",
+            "- cargo fmt",
+            "- cargo clippy --all-targets -- -D warnings",
+            "- cargo test",
+        ]
+        .join("\n"),
+    }
 }
 
 fn ensure_issue_surfaces_are_local_only(
@@ -1171,7 +1239,7 @@ fn render_pr_body(
     input_path: &Path,
     output_path: &Path,
     extra_body: Option<&str>,
-    no_checks: bool,
+    default_validation: Option<&str>,
     fingerprint: &str,
     repo_root: &Path,
 ) -> Result<String> {
@@ -1206,11 +1274,9 @@ fn render_pr_body(
         parts.push("## Validation".to_string());
         parts.push(validation);
         parts.push(String::new());
-    } else if !no_checks {
+    } else if let Some(default_validation) = default_validation {
         parts.push("## Validation".to_string());
-        parts.push("- cargo fmt".to_string());
-        parts.push("- cargo clippy --all-targets -- -D warnings".to_string());
-        parts.push("- cargo test".to_string());
+        parts.push(default_validation.to_string());
         parts.push(String::new());
     }
     if let Some(extra) = extra_body {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -44,7 +44,9 @@ fn render_pr_body_uses_output_sections_and_rejects_issue_template_text() {
         &input,
         &output,
         Some("extra notes"),
-        false,
+        Some(&render_default_finish_validation(
+            FinishValidationMode::FullRust,
+        )),
         "fp-123",
         &temp,
     )
@@ -63,12 +65,46 @@ fn render_pr_body_uses_output_sections_and_rejects_issue_template_text() {
         &input,
         &output,
         Some("issue_card_schema: adl.issue.v1"),
-        false,
+        Some(&render_default_finish_validation(
+            FinishValidationMode::FullRust,
+        )),
         "fp-123",
         &temp,
     )
     .expect_err("issue template text should be rejected");
     assert!(err.to_string().contains("issue-template/prompt text"));
+}
+
+#[test]
+fn render_pr_body_defaults_docs_only_validation_when_needed() {
+    let temp = unique_temp_dir("adl-pr-render-body-docs-only");
+    fs::create_dir_all(&temp).expect("temp dir");
+    let input = temp.join("input.md");
+    let output = temp.join("output.md");
+    fs::write(&input, "# input\n").expect("write input");
+    fs::write(
+        &output,
+        "# rust-finish-test\n\n## Summary\nsummary text\n\n## Artifacts produced\n- docs/milestones/v0.89/README.md\n",
+    )
+    .expect("write output");
+
+    let body = render_pr_body(
+        Some("Closes #1153"),
+        &input,
+        &output,
+        None,
+        Some(&render_default_finish_validation(
+            FinishValidationMode::DocsOnly,
+        )),
+        "fp-123",
+        &temp,
+    )
+    .expect("render body");
+
+    assert!(body.contains("bash adl/tools/check_no_tracked_adl_issue_record_residue.sh"));
+    assert!(body.contains("git diff --check"));
+    assert!(!body.contains("cargo clippy --all-targets -- -D warnings"));
+    assert!(!body.contains("cargo test"));
 }
 
 #[test]
@@ -149,7 +185,7 @@ fn finish_helper_paths_cover_nonempty_and_staged_checks() {
 }
 
 #[test]
-fn finish_helper_paths_cover_ahead_count_and_batch_checks() {
+fn finish_helper_paths_cover_ahead_count_and_validation_modes() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-batch-checks");
     let origin = temp.join("origin.git");
@@ -256,7 +292,22 @@ fn finish_helper_paths_cover_ahead_count_and_batch_checks() {
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
     }
-    run_batched_checks_rust(&repo).expect("batch checks");
+    assert_eq!(
+        select_finish_validation_mode("docs,README.md").expect("docs-only mode"),
+        FinishValidationMode::DocsOnly
+    );
+    run_finish_validation_rust(&repo, FinishValidationMode::DocsOnly)
+        .expect("docs-only validation");
+    assert!(
+        !cargo_log.exists(),
+        "docs-only validation should not invoke cargo"
+    );
+
+    assert_eq!(
+        select_finish_validation_mode("adl,docs").expect("full-rust mode"),
+        FinishValidationMode::FullRust
+    );
+    run_finish_validation_rust(&repo, FinishValidationMode::FullRust).expect("full validation");
     unsafe {
         env::set_var("PATH", old_path);
     }


### PR DESCRIPTION
Closes #1817

## Summary
Made `pr finish` choose a bounded docs-only validation path instead of always running the full Rust `fmt` + `clippy` + `test` stack, and kept the PR body fallback validation text truthful for docs/review publication.

## Artifacts
- Code:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- Generated runtime artifacts: not_applicable for this tooling change

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Verified the finish policy change and tests remain formatted.
  - `cargo test --manifest-path adl/Cargo.toml --bin adl 'cli::pr_cmd::tests::finish::arg_render'`
    Verified the finish arg-render helper surface, including the new docs-only validation behavior, passes end to end.
  - `git diff --check`
    Verified no whitespace or patch-format regressions remain in the worktree diff.
- Results:
  - all listed commands passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1817__make-pr-finish-use-bounded-validation-for-docs-only-and-review-only-publication/sip.md
- Output card: .adl/v0.89/tasks/issue-1817__make-pr-finish-use-bounded-validation-for-docs-only-and-review-only-publication/sor.md
- Idempotency-Key: v0-89-tools-make-pr-finish-use-bounded-validation-for-docs-only-and-review-only-publication-adl-adl-v0-89-tasks-issue-1817-make-pr-finish-use-bounded-validation-for-docs-only-and-review-only-publication-sip-md-adl-v0-89-tasks-issue-1817-make-pr-finish-use-bounded-validation-for-docs-only-and-review-only-publication-sor-md