### PR TITLE
[v0.88][tools] Refresh Rust module watch list for 2026-04-13 size scan

### DIFF
--- a/docs/tooling/rust_module_watch_list.md
+++ b/docs/tooling/rust_module_watch_list.md
@@ -53,18 +53,18 @@ The table below reflects the current branch state from
 
 | Path | Approx. LoC | Responsibility summary | Suggested future split boundaries | Watch level |
 |---|---:|---|---|---|
-| `adl/src/chronosense.rs` | 1935 | identity-profile loading, temporal-context synthesis, and chronosense output shaping | split profile/schema loading from temporal-derivation helpers and CLI/report formatting helpers | Rationale |
+| `adl/src/chronosense.rs` | 2072 | identity-profile loading, temporal-context synthesis, and chronosense output shaping | split profile/schema loading from temporal-derivation helpers and CLI/report formatting helpers | Rationale |
 | `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs` | 1677 | `pr finish` guardrail regression coverage after the inline finish split | split guardrail cases by concern (`branch state`, `review requirements`, `publication blockers`) and centralize shared fixtures | Rationale |
-| `adl/src/cli/identity_cmd.rs` | 1572 | identity command parsing, profile IO, and temporal-context output flows | split parsing/dispatch from profile persistence and output rendering helpers | Rationale |
+| `adl/src/cli/identity_cmd.rs` | 1639 | identity command parsing, profile IO, and temporal-context output flows | split parsing/dispatch from profile persistence and output rendering helpers | Rationale |
+| `adl/src/cli/run_artifacts/cognitive.rs` | 1391 | cognitive artifact assembly, shaping, and export helpers | split schema/model builders from export and report formatting helpers | Review |
+| `adl/src/cli/tests/artifact_builders/learning_runtime.rs` | 1363 | learning/runtime artifact-builder regression coverage | split learning-vs-runtime assertions and centralize shared fixture setup | Review |
+| `adl/src/cli/pr_cmd.rs` | 1360 | PR command façade and residual dispatch after the lifecycle/github/git-support extraction | keep the façade thin and avoid re-accumulating lifecycle/helper logic into this file | Review |
 | `adl/src/instrumentation.rs` | 1353 | instrumentation/event capture, shaping, and persistence/report helpers | split event/schema definitions from emitters, formatting, and persistence helpers | Review |
+| `adl/src/cli/run_artifacts/runtime.rs` | 1337 | runtime artifact assembly, trace export, and persistence/report shaping | split path/schema helpers from emit/export flows and separate persistence from presentation helpers | Review |
 | `adl/src/cli/tooling_cmd/tests.rs` | 1318 | tooling command regression coverage across review-surface and prompt-contract helpers | split tests by subcommand family and centralize shared CLI fixture builders | Review |
-| `adl/src/cli/run_artifacts/cognitive.rs` | 1297 | cognitive artifact assembly, shaping, and export helpers | split schema/model builders from export and report formatting helpers | Review |
-| `adl/src/cli/pr_cmd.rs` | 1294 | PR command façade and residual dispatch after the lifecycle/github/git-support extraction | keep the façade thin and avoid re-accumulating lifecycle/helper logic into this file | Review |
-| `adl/src/cli/run_artifacts/runtime.rs` | 1285 | runtime artifact assembly, trace export, and persistence/report shaping | split path/schema helpers from emit/export flows and separate persistence from presentation helpers | Review |
-| `adl/src/provider/http_family.rs` | 1184 | HTTP-family provider configuration and request-family normalization helpers | split family/profile normalization from request execution or shared HTTP transport helpers | Review |
+| `adl/src/provider/http_family.rs` | 1266 | HTTP-family provider configuration and request-family normalization helpers | split family/profile normalization from request execution or shared HTTP transport helpers | Review |
 | `adl/src/execute/state/runtime_control.rs` | 1165 | runtime control-state modeling and projection helpers | split state model/schema code from projection/serialization helpers if the file grows again | Review |
 | `adl/src/adl/tests.rs` | 1157 | ADL parser/validator regression coverage across many behaviors | split tests by behavior family and move shared builders into test helpers | Review |
-| `adl/src/cli/tests/artifact_builders/learning_runtime.rs` | 1107 | learning/runtime artifact-builder regression coverage | split learning-vs-runtime assertions and centralize shared fixture setup | Review |
 | `adl/src/trace.rs` | 1024 | trace model, persistence, and rendering/query helpers | split trace record/schema logic from output formatting and IO helpers | Review |
 | `adl/src/cli/tests/pr_cmd_inline/basics.rs` | 1017 | baseline `pr` workflow regression coverage across parsing and bootstrap helpers | split parser/argument cases from bootstrap/body-generation cases and keep shared fixtures centralized | Review |
 | `adl/src/remote_exec.rs` | 1014 | remote execution client/server orchestration after the transport/signing/security split | split remaining client/server orchestration from any future report/retrieval helpers only if new growth resumes | Review |
@@ -76,8 +76,10 @@ The table below reflects the current branch state from
 | `adl/src/godel/stage_loop.rs` | 916 | stage progression, orchestration, and artifact/report linkage for the Godel loop | split stage state transitions from artifact/report assembly and CLI-facing summaries | Watch |
 | `adl/src/cli/pr_cmd/lifecycle.rs` | 888 | extracted PR lifecycle helper module after the larger façade split | keep the extracted lifecycle surface bounded and avoid re-accumulating command-family logic | Watch |
 | `adl/src/sandbox.rs` | 887 | sandbox policy/configuration and execution boundary helpers | split policy/config parsing from sandbox command/runtime helpers | Watch |
-| `adl/src/demo.rs` | 855 | demo catalog façade, shared file/trace helpers, remaining Demo A/B/C fixtures, and tests | keep the façade thin and split further only if new growth resumes in dispatch or fixture surfaces | Watch |
 | `adl/src/cli/tests/pr_cmd_inline/finish/publication.rs` | 871 | publication-path regression coverage after the inline finish split | keep publication-path cases isolated and avoid merging them back into a larger omnibus finish test file | Watch |
+| `adl/src/demo.rs` | 855 | demo catalog façade, shared file/trace helpers, remaining Demo A/B/C fixtures, and tests | keep the façade thin and split further only if new growth resumes in dispatch or fixture surfaces | Watch |
+| `adl/src/cli/tests/artifact_builders/agency_execution.rs` | 821 | agency/execution artifact-builder regression coverage | split agency-vs-execution assertions and centralize shared artifact-builder fixtures | Watch |
+| `adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs` | 816 | lifecycle diagnosis regression coverage after the inline lifecycle split | keep doctor/diagnosis cases isolated and centralize shared lifecycle fixture setup | Watch |
 | `adl/src/cli/godel_cmd.rs` | 815 | CLI argument handling and command dispatch for Godel features | split command parsing/dispatch from artifact inspection/rendering helpers | Watch |
 
 ## v0.86 External Review Follow-up
@@ -88,7 +90,7 @@ partially discharged by the `v0.87.1` refactor wave:
 
 | Path | Current LoC | External review posture | Current disposition |
 |---|---:|---|---|
-| `adl/src/cli/pr_cmd.rs` | 1294 | non-blocking maintainability concern | materially reduced by `#1562`, but has regrown further within the `Review` band; prevent lifecycle/helper scope from drifting back into the façade |
+| `adl/src/cli/pr_cmd.rs` | 1360 | non-blocking maintainability concern | materially reduced by `#1562`, but has regrown further within the `Review` band; prevent lifecycle/helper scope from drifting back into the façade |
 | `adl/src/demo.rs` | 855 | non-blocking maintainability concern | materially reduced by `#1561`; keep on watch list at `Watch` while the new façade stabilizes |
 | `adl/src/remote_exec.rs` | 1014 | non-blocking maintainability concern | materially reduced by `#1560`; keep on watch list at `Review` because the remaining orchestration surface is still above 1k |
 
@@ -96,11 +98,13 @@ This document no longer treats those three surfaces as `Rationale`-band
 monoliths, but it keeps them visible until their new smaller boundaries prove
 stable over subsequent work.
 
-The 2026-04-13 scan also shows a new top-end shape:
+The current 2026-04-13 scan shows a sharper top-end shape:
 
-- `adl/src/chronosense.rs` and `adl/src/cli/identity_cmd.rs` have newly entered the `Rationale` band
+- `adl/src/chronosense.rs` has grown past 2k LoC and is now the largest tracked implementation file
+- `adl/src/cli/identity_cmd.rs` remains in the `Rationale` band and has continued to grow
 - the old `pr_cmd_inline` `finish.rs` / `lifecycle.rs` parent hotspots have been split into smaller child files
-- the new high-pressure test surface is now `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs`
+- the highest-pressure test surface remains `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs`
+- `adl/src/cli/tests/artifact_builders/learning_runtime.rs` and `adl/src/cli/run_artifacts/runtime.rs` are now upper-`Review` candidates that should not silently continue growing
 
 ## Completed From This Queue
 
@@ -111,10 +115,11 @@ The 2026-04-13 scan also shows a new top-end shape:
 ## Next Bounded Refactor Candidates
 
 - `adl/src/chronosense.rs`
-- `adl/src/cli/identity_cmd.rs`
 - `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs`
+- `adl/src/cli/identity_cmd.rs`
+- `adl/src/cli/run_artifacts/cognitive.rs`
+- `adl/src/cli/tests/artifact_builders/learning_runtime.rs`
 - `adl/src/cli/pr_cmd.rs`
-- `adl/src/provider.rs`
 - `adl/src/instrumentation.rs`
 
 ## Modules Removed From Immediate Watch Priority


### PR DESCRIPTION
Closes #1822

## Summary
- refresh `docs/tooling/rust_module_watch_list.md` from the current `./adl/tools/report_large_rust_modules.sh --format tsv` scan
- update the current hotspot table to match the live `adl/src` watch-band values
- tighten the bounded next-refactor queue around the newly emerged top-end surfaces

## Validation
- `./adl/tools/report_large_rust_modules.sh --format tsv`
