### PR TITLE
[v0.89][docs] Rename the explicit follow-on band from v0.89.2 to v0.89.1

### DIFF
--- a/docs/milestones/v0.85/features/ROAD_TO_v0.95.md
+++ b/docs/milestones/v0.85/features/ROAD_TO_v0.95.md
@@ -318,7 +318,7 @@ Sub-milestones:
   explicit convergence signals, bounded stop conditions, and inspectable
   convergence state
 
-- `v0.89.2`:
+- `v0.89.1`:
   retry/adaptation loop + Freedom Gate v2
   visible adaptation behavior within bounded retries using the stabilized trace
   and shared-memory substrate, plus a stronger Freedom Gate with richer

--- a/docs/milestones/v0.89/DECISIONS_v0.89.md
+++ b/docs/milestones/v0.89/DECISIONS_v0.89.md
@@ -16,12 +16,12 @@ Capture milestone-critical scope and packaging decisions for `v0.89`.
 |---|---|---|---|---|---|---|
 | D-01 | Treat `v0.89` as the main governed-adaptation band rather than a placeholder roadmap shell. | accepted | The source-planning corpus is already large and mature enough that leaving the milestone as templates would preserve drift. | Keep only a thin README/WBS shell for now. | Enables direct issue-wave seeding from the milestone package. | `#1662` |
 | D-02 | Promote the convergence / gate / decision / action / skill / experiment / ObsMem / security core docs into tracked `v0.89` feature docs. | accepted | These are the main surfaces that need stable tracked contracts before execution starts. | Leave them as local-only planning docs. | Gives the milestone a real canonical feature package. | `FEATURE_DOCS_v0.89.md` |
-| D-03 | Keep the adversarial runtime and exploit/replay package in explicit `v0.89.2` carry-forward rather than in the main `v0.89` core band. | accepted | The adversarial package is real and important, but it would muddy the core milestone if silently absorbed now. | Pull the full package into `v0.89`. | Preserves milestone discipline and clear handoff. | `FEATURE_DOCS_v0.89.md` |
+| D-03 | Keep the adversarial runtime and exploit/replay package in explicit `v0.89.1` carry-forward rather than in the main `v0.89` core band. | accepted | The adversarial package is real and important, but it would muddy the core milestone if silently absorbed now. | Pull the full package into `v0.89`. | Preserves milestone discipline and clear handoff. | `FEATURE_DOCS_v0.89.md` |
 | D-04 | Keep reasonableness, constitution, and cluster-map docs as supporting planning inputs rather than promoted tracked feature commitments in this milestone package. | accepted | They matter architecturally, but promoting them all now would overstate near-term implementation scope. | Promote every governance concept doc into tracked `v0.89` features. | Keeps the core package bounded while preserving the ideas locally. | `FEATURE_DOCS_v0.89.md` |
 
 ## Open Questions
 
-- How much of the security posture / trust package lands as code and tests inside `v0.89` versus remaining design-contract work for `v0.89.2`? (Owner: Daniel Austin) (Issue: `#1796` / `WP-09`)
+- How much of the security posture / trust package lands as code and tests inside `v0.89` versus remaining design-contract work for `v0.89.1`? (Owner: Daniel Austin) (Issue: `#1796` / `WP-09`)
 - Which demo shapes are enough to count as `v0.89` proof surfaces before the heavier adversarial runtime band begins? (Owner: Daniel Austin) (Issue: `#1798` - `#1800` / `WP-11` - `WP-13`)
 
 ## Exit Criteria

--- a/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
+++ b/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
@@ -22,7 +22,7 @@ In scope for `v0.89`:
 - security / trust / posture walkthroughs
 
 Out of scope for `v0.89`:
-- the full `v0.89.2` adversarial runtime/demo package
+- the full `v0.89.1` adversarial runtime/demo package
 - later signed-trace and reasoning-graph proof surfaces
 
 ## Runtime Preconditions
@@ -161,7 +161,7 @@ Defined by `WP-11` through `WP-13` as the demo and integration surfaces land.
 Cross-demo checks:
 - convergence claims use the same stop-state vocabulary as the feature docs and WBS
 - gate / decision / action demos agree on outcome classes and authority boundaries
-- security/trust/posture proof rows do not overclaim adversarial runtime work that belongs to `v0.89.2`
+- security/trust/posture proof rows do not overclaim adversarial runtime work that belongs to `v0.89.1`
 
 Failure policy:
 - If one demo is blocked, record the blocker and say whether milestone review can proceed with an alternate proof surface.
@@ -203,7 +203,7 @@ Review status:
 
 ## Notes
 - this matrix is specific enough to seed demo issues without pretending the demos already exist
-- `v0.89.2` adversarial runtime demos should not be silently folded into this matrix without an explicit scope decision
+- `v0.89.1` adversarial runtime demos should not be silently folded into this matrix without an explicit scope decision
 
 ## Exit Criteria
 - The milestone’s major claims are mapped to bounded demos or explicit alternate proof surfaces.

--- a/docs/milestones/v0.89/DESIGN_v0.89.md
+++ b/docs/milestones/v0.89/DESIGN_v0.89.md
@@ -29,7 +29,7 @@ Without a real `v0.89` package, later milestones would inherit drift instead of 
 - seed a WBS that is strong enough to drive the official issue wave without reconstructing milestone intent by hand
 
 ## Non-Goals
-- fully implement the `v0.89.2` adversarial runtime and exploit package inside the main `v0.89` core band
+- fully implement the `v0.89.1` adversarial runtime and exploit package inside the main `v0.89` core band
 - pull later identity, capability, or full governance work forward into this milestone
 
 ## Scope
@@ -49,7 +49,7 @@ Without a real `v0.89` package, later milestones would inherit drift instead of 
 
 ### Functional
 - the milestone must have a real feature index and promoted feature docs
-- the main planning docs must agree on what belongs to `v0.89` versus `v0.89.2`
+- the main planning docs must agree on what belongs to `v0.89` versus `v0.89.1`
 - every feature-planning source doc must have an explicit implementation home
 
 ### Non-functional
@@ -69,7 +69,7 @@ The `v0.89` package is organized as one main milestone band plus one explicit ca
   - skill execution contracts
   - experiment and evidence surfaces
   - security / trust / posture package
-- `v0.89.2` carry-forward band:
+- `v0.89.1` carry-forward band:
   - adversarial runtime
   - exploit / replay / red-blue package
   - security demos and self-attack surfaces
@@ -94,7 +94,7 @@ The milestone package therefore prefers strong surface contracts first, then off
 
 ## Risks and Mitigations
 
-- Risk: `v0.89` scope sprawls into `v0.89.2` adversarial runtime work.
+- Risk: `v0.89` scope sprawls into `v0.89.1` adversarial runtime work.
   - Mitigation: keep the carry-forward package explicit in `FEATURE_DOCS_v0.89.md`, `WBS_v0.89.md`, and `DECISIONS_v0.89.md`.
 - Risk: the milestone package remains conceptually strong but execution-weak.
   - Mitigation: map every promoted feature doc to a WBS row and an opened official issue-wave slot.
@@ -116,4 +116,4 @@ The milestone package therefore prefers strong surface contracts first, then off
 
 - goals/non-goals and scope boundaries are explicit
 - the promoted feature package is coherent and complete enough to seed implementation
-- major open questions are either tracked in the decisions log or explicitly carried to `v0.89.2`
+- major open questions are either tracked in the decisions log or explicitly carried to `v0.89.1`

--- a/docs/milestones/v0.89/FEATURE_DOCS_v0.89.md
+++ b/docs/milestones/v0.89/FEATURE_DOCS_v0.89.md
@@ -13,7 +13,7 @@ Provide the canonical feature index for `v0.89`.
 This page defines:
 - which `v0.89` feature docs are promoted into the tracked milestone package now
 - which local planning docs remain supporting inputs but are not yet promoted
-- which security-heavy or adversarial runtime docs are intentionally carried into `v0.89.2`
+- which security-heavy or adversarial runtime docs are intentionally carried into `v0.89.1`
 
 The goal is to eliminate floating feature notes. Every source planning doc should have an explicit implementation home or reserved later-band home.
 
@@ -30,7 +30,7 @@ The core tracked feature band is:
 - evidence-aware ObsMem retrieval
 - security, trust, and posture as explicit runtime planning surfaces
 
-This package intentionally does not absorb the full adversarial runtime and exploit package into the main `v0.89` core. That package is planned in the explicit `v0.89.2` follow-on band.
+This package intentionally does not absorb the full adversarial runtime and exploit package into the main `v0.89` core. That package is planned in the explicit `v0.89.1` follow-on band.
 
 ## Promoted Tracked Feature Docs
 
@@ -80,25 +80,25 @@ This package intentionally does not absorb the full adversarial runtime and expl
 | `.adl/docs/v0.89planning/LEARNING_AND_SKILLS_CLUSTER_MAP.md` | local planning map | stays local until broader learning/skills promotion |
 | `.adl/docs/v0.89planning/REASONING_PATTERNS_CATALOG.md` | supporting planning input | later reasoning band `v0.90` |
 
-### `v0.89.2` carry-forward package
+### `v0.89.1` carry-forward package
 
 | Local source doc | Disposition | Implementation home |
 |---|---|---|
-| `.adl/docs/v0.89.2planning/ADL_ADVERSARIAL_RUNTIME_MODEL.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/ADL_ADVERSARIAL_DEMO.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/ADL_SECURITY_DEMOS.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/ADVERSARIAL_EXECUTION_RUNNER.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/ADVERSARIAL_REPLAY_MANIFEST.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/CONTINUOUS_VERIFICATION_AND_EXPLOIT_GENERATION.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/EXPLOIT_ARTIFACT_SCHEMA.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/PROVIDER_SECURITY_CAPABILITIES_EXTENSION.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/RED_BLUE_AGENT_ARCHITECTURE.md` | carry forward | `v0.89.2` |
-| `.adl/docs/v0.89.2planning/SELF_ATTACKING_SYSTEMS.md` | carry forward | `v0.89.2` |
+| `.adl/docs/v0.89.1planning/ADL_ADVERSARIAL_RUNTIME_MODEL.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/ADL_ADVERSARIAL_DEMO.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/ADL_SECURITY_DEMOS.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/ADVERSARIAL_EXECUTION_RUNNER.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/ADVERSARIAL_REPLAY_MANIFEST.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/CONTINUOUS_VERIFICATION_AND_EXPLOIT_GENERATION.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/EXPLOIT_ARTIFACT_SCHEMA.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/PROVIDER_SECURITY_CAPABILITIES_EXTENSION.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/RED_BLUE_AGENT_ARCHITECTURE.md` | carry forward | `v0.89.1` |
+| `.adl/docs/v0.89.1planning/SELF_ATTACKING_SYSTEMS.md` | carry forward | `v0.89.1` |
 
 ## Review Guidance
 
 - Treat `README.md`, `VISION_v0.89.md`, `DESIGN_v0.89.md`, `WBS_v0.89.md`, and `SPRINT_v0.89.md` as the canonical milestone planning package.
 - Treat the files in `features/` as the promoted tracked feature commitments for the main `v0.89` band.
-- Treat the remaining `.adl/docs/v0.89planning/*` and `.adl/docs/v0.89.2planning/*` docs as local planning inputs, not already-shipped promises.
+- Treat the remaining `.adl/docs/v0.89planning/*` and `.adl/docs/v0.89.1planning/*` docs as local planning inputs, not already-shipped promises.
 - Treat contradictions between the planning package, promoted feature docs, and carry-forward mapping as defects.
 - Treat every promoted feature doc as an engineering commitment that must resolve to code, tests, artifacts, demos, or explicit defer records.

--- a/docs/milestones/v0.89/MILESTONE_CHECKLIST_v0.89.md
+++ b/docs/milestones/v0.89/MILESTONE_CHECKLIST_v0.89.md
@@ -23,7 +23,7 @@ Ship/no-ship gate for `v0.89`. Check items only when evidence exists.
 - [ ] Each issue has truthful input/output cards under `.adl/`
 - [ ] Draft PR opened for each tracked issue before merge where applicable
 - [ ] Queue and closeout discipline followed consistently
-- [ ] Carry-forward to `v0.89.2` remains explicit rather than implicit
+- [ ] Carry-forward to `v0.89.1` remains explicit rather than implicit
 - [ ] Green-only merge policy followed
 
 ## Quality Gates

--- a/docs/milestones/v0.89/README.md
+++ b/docs/milestones/v0.89/README.md
@@ -31,7 +31,7 @@ This milestone focuses on:
 Key outcomes:
 - a real tracked feature package for the `v0.89` core band
 - a coherent WBS and sprint plan that map feature docs to executable work
-- explicit carry-forward of adversarial runtime proof work into `v0.89.2`
+- explicit carry-forward of adversarial runtime proof work into `v0.89.1`
 
 ## Scope Summary
 
@@ -76,14 +76,14 @@ Tracked feature docs:
 
 Supporting local planning inputs:
 - `.adl/docs/v0.89planning/*`
-- `.adl/docs/v0.89.2planning/*`
+- `.adl/docs/v0.89.1planning/*`
 
 ## Execution Model
 
 This milestone is designed to execute as a sequence of work packages once the official `v0.89` kickoff occurs:
 - `WP-01`: milestone design pass and canonical package completion
 - `WP-02` - `WP-09`: core feature band
-- `WP-10` - `WP-12`: demoability, milestone convergence, and `v0.89.2` handoff
+- `WP-10` - `WP-12`: demoability, milestone convergence, and `v0.89.1` handoff
 - `WP-13`: demo matrix + integration demos
 - `WP-14`: quality gate
 - `WP-15`: docs + review convergence
@@ -94,7 +94,7 @@ This milestone is designed to execute as a sequence of work packages once the of
 Execution expectations after kickoff:
 - each substantive WP gets a bounded issue and PR
 - promoted feature docs resolve to implementation, proofs, or explicit defer records
-- carry-forward to `v0.89.2` is explicit rather than implied
+- carry-forward to `v0.89.1` is explicit rather than implied
 
 ## Demo and Validation Surface
 
@@ -125,12 +125,12 @@ Evidence locations:
 ## Risks and Open Questions
 
 Known risks:
-- `v0.89` can blur together too many governance, security, and reasoning concepts if the scope boundary against `v0.89.2` is not maintained
+- `v0.89` can blur together too many governance, security, and reasoning concepts if the scope boundary against `v0.89.1` is not maintained
 - the feature band is conceptually strong but still early in implementation, so issue-wave discipline matters
 
 Open questions:
 - how much of the security posture / trust package lands in `v0.89` code versus remaining design-contract work
-- which proof surfaces are enough for `v0.89` itself versus intentionally deferred to `v0.89.2`
+- which proof surfaces are enough for `v0.89` itself versus intentionally deferred to `v0.89.1`
 
 ## Status
 

--- a/docs/milestones/v0.89/RELEASE_NOTES_v0.89.md
+++ b/docs/milestones/v0.89/RELEASE_NOTES_v0.89.md
@@ -42,14 +42,14 @@
 
 ## Known Limitations
 - this document is pre-release and should not be treated as a shipped-claims document yet
-- the adversarial runtime/demo package is intentionally deferred to `v0.89.2`
+- the adversarial runtime/demo package is intentionally deferred to `v0.89.1`
 
 ## Validation Notes
 - final release notes must be updated from shipped proof surfaces only
 - demo/review package and quality-gate outputs should be cited before release
 
 ## What's Next
-- `v0.89.2` adversarial runtime and exploit/replay package
+- `v0.89.1` adversarial runtime and exploit/replay package
 - later reasoning/signature/identity/governance bands continue after this milestone
 
 ## Exit Criteria

--- a/docs/milestones/v0.89/SPRINT_v0.89.md
+++ b/docs/milestones/v0.89/SPRINT_v0.89.md
@@ -11,7 +11,7 @@
 
 `v0.89` is a three-sprint execution plan:
 - Sprint 1: open the official issue wave and land the convergence / judgment / action core
-- Sprint 2: land the skill / experiment / memory / security package and the explicit `v0.89.2` handoff
+- Sprint 2: land the skill / experiment / memory / security package and the explicit `v0.89.1` handoff
 - Sprint 3: converge demos, quality, review, remediation, next-milestone planning, and release closure
 
 This keeps the execution model aligned with the recent milestone pattern while preserving a clean boundary between the main governed-adaptation band and the follow-on adversarial-runtime band.
@@ -21,7 +21,7 @@ This keeps the execution model aligned with the recent milestone pattern while p
 | Sprint | Purpose | WPs | Current status |
 |---|---|---|---|
 | `v0.89-s1` | open the official issue wave and execute the convergence / gate / action core | `WP-01` (`#1662`), `WP-02` - `WP-05` (`#1789` - `#1792`) | issue wave open |
-| `v0.89-s2` | execute the skill / experiment / memory / security package plus explicit `v0.89.2` handoff planning | `WP-06` - `WP-10` (`#1793` - `#1797`) | issue wave open |
+| `v0.89-s2` | execute the skill / experiment / memory / security package plus explicit `v0.89.1` handoff planning | `WP-06` - `WP-10` (`#1793` - `#1797`) | issue wave open |
 | `v0.89-s3` | converge demos, quality, review, remediation, next-milestone planning, and release ceremony | `WP-11` - `WP-20` (`#1798` - `#1807`) | issue wave open |
 
 ## Sprint 1
@@ -58,7 +58,7 @@ Land the governed execution substrate that makes `v0.89` useful beyond judgment 
 - Godel experiment system
 - ObsMem evidence and ranking
 - security, trust, and posture package
-- explicit `v0.89.2` handoff planning
+- explicit `v0.89.1` handoff planning
 
 Current issue map:
 - `WP-06` `#1793`
@@ -70,7 +70,7 @@ Current issue map:
 ### Exit Criteria
 - `WP-06` through `WP-10` are opened and tracked in the milestone package with their real issue numbers
 - the main `v0.89` feature band is fully represented in the active execution package
-- `v0.89.2` carry-forward is explicit and bounded
+- `v0.89.1` carry-forward is explicit and bounded
 
 ## Sprint 3
 

--- a/docs/milestones/v0.89/VISION_v0.89.md
+++ b/docs/milestones/v0.89/VISION_v0.89.md
@@ -137,7 +137,7 @@ Important targets include:
 - explicit threat boundaries
 - declared security posture
 - explicit trust assumptions under adversary
-- carry-forward clarity into `v0.89.2`
+- carry-forward clarity into `v0.89.1`
 
 This milestone is not the entire adversarial runtime band. It is the point where the system gets a serious enough security and trust contract that later adversarial proof work has a coherent foundation.
 

--- a/docs/milestones/v0.89/WBS_v0.89.md
+++ b/docs/milestones/v0.89/WBS_v0.89.md
@@ -19,7 +19,7 @@
 - then land the core convergence / gate / action / skill / experiment / memory / security band
 - then package demos, quality, docs/review, and release closure
 
-The adversarial runtime/proof package is intentionally planned as the `v0.89.2` carry-forward band rather than silently swelling the main `v0.89` milestone.
+The adversarial runtime/proof package is intentionally planned as the `v0.89.1` carry-forward band rather than silently swelling the main `v0.89` milestone.
 
 ## Work Packages
 | ID | Work Package | Description | Deliverable | Dependencies | Issue |
@@ -33,7 +33,7 @@ The adversarial runtime/proof package is intentionally planned as the `v0.89.2` 
 | WP-07 | Godel experiment system | Deepen bounded scientific-loop behavior into explicit experiments and adopt/reject records. | experiment record and evaluation package | `WP-02`, `WP-04`, `WP-06` | `#1794` |
 | WP-08 | ObsMem evidence and ranking | Make retrieval evidence-aware, provenance-sensitive, and reviewer-legible. | ranking/explanation package | `WP-02`, `WP-07` | `#1795` |
 | WP-09 | Security, trust, and posture package | Land the main `v0.89` security contract: threat model, posture model, and trust-under-adversary framing. | security/trust/posture package | `WP-04`, `WP-05`, `WP-06` | `#1796` |
-| WP-10 | `v0.89.2` handoff planning | Convert adversarial-runtime carry-forward into an explicit `v0.89.2` package with no ambiguity. | follow-on planning package for `v0.89.2` | `WP-01`, `WP-09` | `#1797` |
+| WP-10 | `v0.89.1` handoff planning | Convert adversarial-runtime carry-forward into an explicit `v0.89.1` package with no ambiguity. | follow-on planning package for `v0.89.1` | `WP-01`, `WP-09` | `#1797` |
 | WP-11 | Demo scaffolding and proof entry points | Define and land the bounded demo entry points for convergence, gate behavior, experiment evidence, and security review surfaces. | runnable or reviewer-legible demo surfaces | `WP-02` - `WP-09` | `#1798` |
 | WP-12 | Milestone convergence and follow-on mapping | Reconcile issue graph, carry-forward, and proof surfaces before the release tail starts. | converged issue graph and milestone status surfaces | `WP-02` - `WP-11` | `#1799` |
 | WP-13 | Demo matrix + integration demos | Validate the milestone claims through bounded demos and integration review. | canonical demo matrix and demo artifacts | `WP-02` - `WP-12` | `#1800` |
@@ -47,7 +47,7 @@ The adversarial runtime/proof package is intentionally planned as the `v0.89.2` 
 
 ## Sequencing
 - Phase 1: establish the canonical package and the seedable issue-wave plan (`WP-01`)
-- Phase 2: land the core feature band plus the explicit `v0.89.2` handoff (`WP-02` - `WP-10`)
+- Phase 2: land the core feature band plus the explicit `v0.89.1` handoff (`WP-02` - `WP-10`)
 - Phase 3: package demos, quality, review, remediation, next-milestone handoff, and release closure (`WP-11` - `WP-20`)
 
 ## Acceptance Mapping
@@ -60,7 +60,7 @@ The adversarial runtime/proof package is intentionally planned as the `v0.89.2` 
 - WP-07 -> experiment records and governed adopt/reject behavior are explicit
 - WP-08 -> ObsMem retrieval becomes evidence-aware and explainable
 - WP-09 -> trust boundaries, posture, and threats are explicit enough to drive implementation and review
-- WP-10 -> the `v0.89.2` adversarial package is clear rather than implicit
+- WP-10 -> the `v0.89.1` adversarial package is clear rather than implicit
 - WP-11 -> demo/proof entry points exist for the main milestone claims
 - WP-12 -> the milestone package and issue graph are converged
 - WP-13 (Demos) -> milestone claims have bounded proof surfaces

--- a/docs/milestones/v0.89/WP_ISSUE_WAVE_v0.89.yaml
+++ b/docs/milestones/v0.89/WP_ISSUE_WAVE_v0.89.yaml
@@ -168,8 +168,8 @@ entries:
   issue_column: '#1796'
 - wp: WP-10
   issue_kind: execution
-  title: '[v0.89][WP-10] `v0.89.2` handoff planning'
-  slug: v0-89-wp-10-v0-89-2-handoff-planning
+  title: '[v0.89][WP-10] `v0.89.1` handoff planning'
+  slug: v0-89-wp-10-v0-89-1-handoff-planning
   queue: wp
   labels:
   - track:roadmap
@@ -182,9 +182,9 @@ entries:
   - WP-01
   - WP-09
   dependency_notes: '`WP-01`, `WP-09`'
-  work_package: '`v0.89.2` handoff planning'
-  summary: Convert adversarial-runtime carry-forward into an explicit `v0.89.2` package with no ambiguity.
-  deliverable: follow-on planning package for `v0.89.2`
+  work_package: '`v0.89.1` handoff planning'
+  summary: Convert adversarial-runtime carry-forward into an explicit `v0.89.1` package with no ambiguity.
+  deliverable: follow-on planning package for `v0.89.1`
   issue_column: '#1797'
 - wp: WP-11
   issue_kind: execution

--- a/docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md
+++ b/docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md
@@ -33,7 +33,7 @@ Define declared security posture as a first-class execution contract in ADL.
 
 - Security and Threat Modeling
 - Trust model under adversary
-- later `v0.89.2` adversarial execution work
+- later `v0.89.1` adversarial execution work
 
 ## Exit Criteria
 

--- a/docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md
+++ b/docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md
@@ -22,7 +22,7 @@ Define how trust assumptions change when the system is operating under adversari
 
 - trust under adversary is explicit rather than implied by normal-path assumptions
 - the system can distinguish ordinary runtime confidence from contested confidence
-- later `v0.89.2` adversarial work inherits a coherent trust story
+- later `v0.89.1` adversarial work inherits a coherent trust story
 
 ## Non-Goals
 

--- a/docs/milestones/v0.89/features/FREEDOM_GATE_V2.md
+++ b/docs/milestones/v0.89/features/FREEDOM_GATE_V2.md
@@ -31,7 +31,7 @@ Deepen the existing bounded Freedom Gate into a richer judgment surface that sti
 
 - a complete moral philosophy engine
 - full later constitutional/governance band completion
-- adversarial red/blue runtime implementation, which belongs to `v0.89.2`
+- adversarial red/blue runtime implementation, which belongs to `v0.89.1`
 
 ## Dependencies
 

--- a/docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md
+++ b/docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md
@@ -23,7 +23,7 @@ Turn ADL security from intuition into an explicit trust-boundary and threat-mode
 
 - security claims become tied to actual runtime surfaces
 - trust boundaries are described in a way that can drive implementation and demos
-- the main band stays focused on governance and threat-model clarity, while heavier adversarial runtime proof work moves to `v0.89.2`
+- the main band stays focused on governance and threat-model clarity, while heavier adversarial runtime proof work moves to `v0.89.1`
 
 ## Non-Goals
 

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -111,7 +111,7 @@ ADL already provides a serious platform baseline:
 | AEE 1.0 convergence | Partially implemented | bounded recovery/AEE proof surfaces and planning docs | `v0.89` |
 | Freedom Gate v2 | Planned | baseline Freedom Gate plus `v0.89` planning docs | `v0.89` |
 | Decision, action, and skill-governance surfaces | Planned | `v0.89` planning package | `v0.89` |
-| Security, posture, and trust-under-adversary package | Planned | `v0.89` planning package | `v0.89` / `v0.89.2` |
+| Security, posture, and trust-under-adversary package | Planned | `v0.89` planning package | `v0.89` / `v0.89.1` |
 | Reasoning graph baseline | Planned | planning/schema/proof surfaces | `v0.90` |
 | Signed trace and trace query | Planned | roadmap and planning docs | `v0.90` |
 | Affect, kindness, moral cognition, humor | Planned | `v0.91` planning docs | `v0.91` |


### PR DESCRIPTION
Closes #1821

## Summary
Renamed the active follow-on adversarial/security band from `v0.89.2` to `v0.89.1` across the tracked `v0.89` milestone package, the planning feature list, and the current local planning/issue surfaces that govern the active wave.

## Artifacts
- updated tracked milestone docs under `docs/milestones/v0.89/`
- updated tracked planning surface `docs/planning/ADL_FEATURE_LIST.md`
- updated tracked roadmap surface `docs/milestones/v0.85/features/ROAD_TO_v0.95.md`
- renamed local planning directory `.adl/docs/v0.89.1planning/`
- renamed current local `WP-10` handoff bundle to the `v0.89.1` form

## Validation
- Validation commands and their purpose:
  - `rg -n "v0\\.89\\.2|v0\\.89\\.2planning|v0-89-2" docs/planning docs/milestones/v0.89 docs/milestones/v0.85/features/ROAD_TO_v0.95.md -S`
    - verified no stale tracked `v0.89.2` references remain in the active milestone/planning package
  - `git diff --check -- docs/planning/ADL_FEATURE_LIST.md docs/milestones/v0.85/features/ROAD_TO_v0.95.md docs/milestones/v0.89`
    - verified the tracked rename patch is whitespace-clean
  - `bash adl/tools/pr.sh doctor 1821 --version v0.89 --slug rename-the-explicit-follow-on-band-from-v0-89-2-to-v0-89-1 --json`
    - verified the corrected local issue bundle is structurally ready after the rename and card-normalization pass
- Results:
  - stale tracked `v0.89.2` references: none
  - diff hygiene: PASS
  - doctor: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1821__rename-the-explicit-follow-on-band-from-v0-89-2-to-v0-89-1/sip.md
- Output card: .adl/v0.89/tasks/issue-1821__rename-the-explicit-follow-on-band-from-v0-89-2-to-v0-89-1/sor.md
- Idempotency-Key: v0-89-docs-rename-the-explicit-follow-on-band-from-v0-89-2-to-v0-89-1-docs-adl-v0-89-tasks-issue-1821-rename-the-explicit-follow-on-band-from-v0-89-2-to-v0-89-1-sip-md-adl-v0-89-tasks-issue-1821-rename-the-explicit-follow-on-band-from-v0-89-2-to-v0-89-1-sor-md