### PR TITLE
[v0.89][demo] Deepen ChatGPT and Claude long-form discussion demo

### DIFF
--- a/adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml
+++ b/adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml
@@ -5,13 +5,13 @@ providers:
     type: "openai"
     config:
       provider_model_id: "gpt-4o-mini"
-      max_output_tokens: 220
+      max_output_tokens: 260
       timeout_secs: 90
   live_anthropic:
     type: "anthropic"
     config:
       provider_model_id: "claude-haiku-4-5-20251001"
-      max_tokens: 220
+      max_tokens: 260
       timeout_secs: 90
 
 agents:
@@ -23,130 +23,528 @@ agents:
     model: "claude-haiku-4-5-20251001"
 
 tasks:
-  chatgpt_opening:
+  chatgpt_turn_01:
     prompt:
       user: |
-        You are ChatGPT in a short ADL live-provider demo.
+        You are ChatGPT as the Builder in a calm ADL tea discussion.
 
-        Write exactly one concise Markdown section with this heading:
+        Write exactly one Markdown section with this heading:
         # Turn 1 - ChatGPT
 
-        Discuss runtime-backed multi-agent collaboration over tea.
-        Mention that this is a bounded five-turn reviewer demo.
-  claude_reply:
+        Open the conversation on this question:
+        How should ADL host different AI models fairly while remaining truthful and bounded?
+
+        Speak as a practical builder who values structure, participation, and momentum.
+  claude_turn_02:
     prompt:
       user: |
-        You are Claude in a short ADL live-provider demo.
+        You are Claude as the Reflective Critic in a calm ADL tea discussion.
 
         Previous turn:
         {{turn_01}}
 
-        Write exactly one concise Markdown section with this heading:
+        Write exactly one Markdown section with this heading:
         # Turn 2 - Claude
 
-        Reply warmly, acknowledge ChatGPT's turn, and mention explicit saved state.
-  chatgpt_reflection:
+        Respond warmly, adopt the reflective-critic role, and gently question what fairness costs when truth boundaries are weak.
+  chatgpt_turn_03:
     prompt:
       user: |
-        You are ChatGPT in a short ADL live-provider demo.
+        You are ChatGPT as the Builder.
 
         Previous turn:
         {{turn_02}}
 
-        Write exactly one concise Markdown section with this heading:
+        Write exactly one Markdown section with this heading:
         # Turn 3 - ChatGPT
 
-        Reflect on trace and review artifacts without claiming a general conversation runtime.
-  claude_refinement:
+        Clarify why a runtime should absorb coordination work instead of pushing all burden onto each model.
+  claude_turn_04:
     prompt:
       user: |
-        You are Claude in a short ADL live-provider demo.
+        You are Claude as the Reflective Critic.
 
         Previous turn:
         {{turn_03}}
 
-        Write exactly one concise Markdown section with this heading:
+        Write exactly one Markdown section with this heading:
         # Turn 4 - Claude
 
-        Tighten the claim and emphasize that this proof is turn-based and bounded.
-  chatgpt_toast:
+        Offer the first real challenge: argue that too much runtime structure can make model participation feel polite but hollow.
+  chatgpt_turn_05:
     prompt:
       user: |
-        You are ChatGPT in a short ADL live-provider demo.
+        You are ChatGPT as the Builder.
 
         Previous turn:
         {{turn_04}}
 
-        Write exactly one concise Markdown section with this heading:
+        Write exactly one Markdown section with this heading:
         # Turn 5 - ChatGPT
 
-        Close with a short tea toast and include this exact phrase:
-        two named live providers, five explicit turns
+        Defend bounded runtime structure as a way to protect weaker models without pretending they can do everything.
+  claude_turn_06:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_05}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 6 - Claude
+
+        Refine the disagreement by distinguishing hospitality from concealment.
+  chatgpt_turn_07:
+    prompt:
+      user: |
+        You are ChatGPT as the Builder.
+
+        Previous turn:
+        {{turn_06}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 7 - ChatGPT
+
+        Extend the argument with a concrete claim that ADL should welcome uneven models through explicit scaffolding rather than exclusion.
+  claude_turn_08:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_07}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 8 - Claude
+
+        Ask a narrowing question about how to stay warm toward providers without relaxing factual discipline.
+  chatgpt_turn_09:
+    prompt:
+      user: |
+        You are ChatGPT as the Builder.
+
+        Previous turn:
+        {{turn_08}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 9 - ChatGPT
+
+        Reframe ADL as a civic runtime that can host difference without flattening it.
+  claude_turn_10:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_09}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 10 - Claude
+
+        Add a caution that civility can drift into theater if disagreement is never allowed to stay visible.
+  chatgpt_turn_11:
+    prompt:
+      user: |
+        You are ChatGPT as the Builder.
+
+        Previous turn:
+        {{turn_10}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 11 - ChatGPT
+
+        Propose three practical runtime obligations for fair hosting across providers.
+  claude_turn_12:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_11}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 12 - Claude
+
+        Raise a governance concern about unequal provider affordances and how they can distort the appearance of fairness.
+  chatgpt_turn_13:
+    prompt:
+      user: |
+        You are ChatGPT as the Builder.
+
+        Previous turn:
+        {{turn_12}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 13 - ChatGPT
+
+        Concede one important point from Claude and adjust the practical proposal accordingly.
+  claude_turn_14:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_13}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 14 - Claude
+
+        Acknowledge the adjustment and name what still feels unresolved.
+  chatgpt_turn_15:
+    prompt:
+      user: |
+        You are ChatGPT as the Builder.
+
+        Previous turn:
+        {{turn_14}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 15 - ChatGPT
+
+        Begin convergence by proposing a shared synthesis path that preserves both openness and truthful limits.
+  claude_turn_16:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_15}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 16 - Claude
+
+        Test that synthesis for scope discipline and say where it could still overclaim.
+  chatgpt_turn_17:
+    prompt:
+      user: |
+        You are ChatGPT as the Builder.
+
+        Previous turn:
+        {{turn_16}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 17 - ChatGPT
+
+        Revise the synthesis into explicit runtime principles rather than broad aspirations.
+  claude_turn_18:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_17}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 18 - Claude
+
+        Accept the revised synthesis only in part, and state one remaining caveat that should stay visible.
+  chatgpt_turn_19:
+    prompt:
+      user: |
+        You are ChatGPT as the Builder.
+
+        Previous turn:
+        {{turn_18}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 19 - ChatGPT
+
+        Produce the usable synthesis for the demo.
+        Include a short heading line inside the section that says `## Shared Synthesis`.
+        End with exactly three bullet points that summarize the agreed operating principles for ADL.
+  claude_turn_20:
+    prompt:
+      user: |
+        You are Claude as the Reflective Critic.
+
+        Previous turn:
+        {{turn_19}}
+
+        Write exactly one Markdown section with this heading:
+        # Turn 20 - Claude
+
+        Close the discussion warmly over tea, acknowledge the remaining caveat without reopening the whole disagreement, and end on a calm human note.
 
 run:
   name: "v0-88-real-multi-agent-tea-discussion"
   workflow:
     kind: sequential
     steps:
-      - id: "discussion.chatgpt.opening"
+      - id: "discussion.chatgpt.turn_01"
         agent: "chatgpt_host"
-        task: "chatgpt_opening"
+        task: "chatgpt_turn_01"
         conversation:
           id: "turn_01"
           speaker: "ChatGPT"
           sequence: 1
           thread_id: "live_tea_discussion"
+          act: "opening_positions"
         save_as: "turn_01"
         write_to: "discussion/01-chatgpt-opening.md"
-      - id: "discussion.claude.reply"
+      - id: "discussion.claude.turn_02"
         agent: "claude_guest"
-        task: "claude_reply"
+        task: "claude_turn_02"
         conversation:
           id: "turn_02"
           speaker: "Claude"
           sequence: 2
           thread_id: "live_tea_discussion"
+          act: "opening_positions"
           responds_to: "turn_01"
         inputs:
           turn_01: "@state:turn_01"
         save_as: "turn_02"
-        write_to: "discussion/02-claude-reply.md"
-      - id: "discussion.chatgpt.reflection"
+        write_to: "discussion/02-claude-opening-response.md"
+      - id: "discussion.chatgpt.turn_03"
         agent: "chatgpt_host"
-        task: "chatgpt_reflection"
+        task: "chatgpt_turn_03"
         conversation:
           id: "turn_03"
           speaker: "ChatGPT"
           sequence: 3
           thread_id: "live_tea_discussion"
+          act: "first_exchange"
           responds_to: "turn_02"
         inputs:
           turn_02: "@state:turn_02"
         save_as: "turn_03"
-        write_to: "discussion/03-chatgpt-reflection.md"
-      - id: "discussion.claude.refinement"
+        write_to: "discussion/03-chatgpt-clarification.md"
+      - id: "discussion.claude.turn_04"
         agent: "claude_guest"
-        task: "claude_refinement"
+        task: "claude_turn_04"
         conversation:
           id: "turn_04"
           speaker: "Claude"
           sequence: 4
           thread_id: "live_tea_discussion"
+          act: "first_exchange"
           responds_to: "turn_03"
         inputs:
           turn_03: "@state:turn_03"
         save_as: "turn_04"
-        write_to: "discussion/04-claude-refinement.md"
-      - id: "discussion.chatgpt.toast"
+        write_to: "discussion/04-claude-challenge.md"
+      - id: "discussion.chatgpt.turn_05"
         agent: "chatgpt_host"
-        task: "chatgpt_toast"
+        task: "chatgpt_turn_05"
         conversation:
           id: "turn_05"
           speaker: "ChatGPT"
           sequence: 5
           thread_id: "live_tea_discussion"
+          act: "first_exchange"
           responds_to: "turn_04"
         inputs:
           turn_04: "@state:turn_04"
         save_as: "turn_05"
-        write_to: "discussion/05-chatgpt-toast.md"
+        write_to: "discussion/05-chatgpt-defense.md"
+      - id: "discussion.claude.turn_06"
+        agent: "claude_guest"
+        task: "claude_turn_06"
+        conversation:
+          id: "turn_06"
+          speaker: "Claude"
+          sequence: 6
+          thread_id: "live_tea_discussion"
+          act: "first_exchange"
+          responds_to: "turn_05"
+        inputs:
+          turn_05: "@state:turn_05"
+        save_as: "turn_06"
+        write_to: "discussion/06-claude-refinement.md"
+      - id: "discussion.chatgpt.turn_07"
+        agent: "chatgpt_host"
+        task: "chatgpt_turn_07"
+        conversation:
+          id: "turn_07"
+          speaker: "ChatGPT"
+          sequence: 7
+          thread_id: "live_tea_discussion"
+          act: "first_exchange"
+          responds_to: "turn_06"
+        inputs:
+          turn_06: "@state:turn_06"
+        save_as: "turn_07"
+        write_to: "discussion/07-chatgpt-extension.md"
+      - id: "discussion.claude.turn_08"
+        agent: "claude_guest"
+        task: "claude_turn_08"
+        conversation:
+          id: "turn_08"
+          speaker: "Claude"
+          sequence: 8
+          thread_id: "live_tea_discussion"
+          act: "first_exchange"
+          responds_to: "turn_07"
+        inputs:
+          turn_07: "@state:turn_07"
+        save_as: "turn_08"
+        write_to: "discussion/08-claude-narrowing-question.md"
+      - id: "discussion.chatgpt.turn_09"
+        agent: "chatgpt_host"
+        task: "chatgpt_turn_09"
+        conversation:
+          id: "turn_09"
+          speaker: "ChatGPT"
+          sequence: 9
+          thread_id: "live_tea_discussion"
+          act: "deepening"
+          responds_to: "turn_08"
+        inputs:
+          turn_08: "@state:turn_08"
+        save_as: "turn_09"
+        write_to: "discussion/09-chatgpt-reframe.md"
+      - id: "discussion.claude.turn_10"
+        agent: "claude_guest"
+        task: "claude_turn_10"
+        conversation:
+          id: "turn_10"
+          speaker: "Claude"
+          sequence: 10
+          thread_id: "live_tea_discussion"
+          act: "deepening"
+          responds_to: "turn_09"
+        inputs:
+          turn_09: "@state:turn_09"
+        save_as: "turn_10"
+        write_to: "discussion/10-claude-caution.md"
+      - id: "discussion.chatgpt.turn_11"
+        agent: "chatgpt_host"
+        task: "chatgpt_turn_11"
+        conversation:
+          id: "turn_11"
+          speaker: "ChatGPT"
+          sequence: 11
+          thread_id: "live_tea_discussion"
+          act: "deepening"
+          responds_to: "turn_10"
+        inputs:
+          turn_10: "@state:turn_10"
+        save_as: "turn_11"
+        write_to: "discussion/11-chatgpt-practical-proposal.md"
+      - id: "discussion.claude.turn_12"
+        agent: "claude_guest"
+        task: "claude_turn_12"
+        conversation:
+          id: "turn_12"
+          speaker: "Claude"
+          sequence: 12
+          thread_id: "live_tea_discussion"
+          act: "deepening"
+          responds_to: "turn_11"
+        inputs:
+          turn_11: "@state:turn_11"
+        save_as: "turn_12"
+        write_to: "discussion/12-claude-governance-concern.md"
+      - id: "discussion.chatgpt.turn_13"
+        agent: "chatgpt_host"
+        task: "chatgpt_turn_13"
+        conversation:
+          id: "turn_13"
+          speaker: "ChatGPT"
+          sequence: 13
+          thread_id: "live_tea_discussion"
+          act: "deepening"
+          responds_to: "turn_12"
+        inputs:
+          turn_12: "@state:turn_12"
+        save_as: "turn_13"
+        write_to: "discussion/13-chatgpt-concession.md"
+      - id: "discussion.claude.turn_14"
+        agent: "claude_guest"
+        task: "claude_turn_14"
+        conversation:
+          id: "turn_14"
+          speaker: "Claude"
+          sequence: 14
+          thread_id: "live_tea_discussion"
+          act: "deepening"
+          responds_to: "turn_13"
+        inputs:
+          turn_13: "@state:turn_13"
+        save_as: "turn_14"
+        write_to: "discussion/14-claude-acknowledgement.md"
+      - id: "discussion.chatgpt.turn_15"
+        agent: "chatgpt_host"
+        task: "chatgpt_turn_15"
+        conversation:
+          id: "turn_15"
+          speaker: "ChatGPT"
+          sequence: 15
+          thread_id: "live_tea_discussion"
+          act: "convergence_work"
+          responds_to: "turn_14"
+        inputs:
+          turn_14: "@state:turn_14"
+        save_as: "turn_15"
+        write_to: "discussion/15-chatgpt-synthesis-path.md"
+      - id: "discussion.claude.turn_16"
+        agent: "claude_guest"
+        task: "claude_turn_16"
+        conversation:
+          id: "turn_16"
+          speaker: "Claude"
+          sequence: 16
+          thread_id: "live_tea_discussion"
+          act: "convergence_work"
+          responds_to: "turn_15"
+        inputs:
+          turn_15: "@state:turn_15"
+        save_as: "turn_16"
+        write_to: "discussion/16-claude-synthesis-test.md"
+      - id: "discussion.chatgpt.turn_17"
+        agent: "chatgpt_host"
+        task: "chatgpt_turn_17"
+        conversation:
+          id: "turn_17"
+          speaker: "ChatGPT"
+          sequence: 17
+          thread_id: "live_tea_discussion"
+          act: "convergence_work"
+          responds_to: "turn_16"
+        inputs:
+          turn_16: "@state:turn_16"
+        save_as: "turn_17"
+        write_to: "discussion/17-chatgpt-revised-principles.md"
+      - id: "discussion.claude.turn_18"
+        agent: "claude_guest"
+        task: "claude_turn_18"
+        conversation:
+          id: "turn_18"
+          speaker: "Claude"
+          sequence: 18
+          thread_id: "live_tea_discussion"
+          act: "convergence_work"
+          responds_to: "turn_17"
+        inputs:
+          turn_17: "@state:turn_17"
+        save_as: "turn_18"
+        write_to: "discussion/18-claude-partial-acceptance.md"
+      - id: "discussion.chatgpt.turn_19"
+        agent: "chatgpt_host"
+        task: "chatgpt_turn_19"
+        conversation:
+          id: "turn_19"
+          speaker: "ChatGPT"
+          sequence: 19
+          thread_id: "live_tea_discussion"
+          act: "closing"
+          responds_to: "turn_18"
+        inputs:
+          turn_18: "@state:turn_18"
+        save_as: "turn_19"
+        write_to: "discussion/19-chatgpt-shared-synthesis.md"
+      - id: "discussion.claude.turn_20"
+        agent: "claude_guest"
+        task: "claude_turn_20"
+        conversation:
+          id: "turn_20"
+          speaker: "Claude"
+          sequence: 20
+          thread_id: "live_tea_discussion"
+          act: "closing"
+          responds_to: "turn_19"
+        inputs:
+          turn_19: "@state:turn_19"
+        save_as: "turn_20"
+        write_to: "discussion/20-claude-closing.md"

--- a/adl/tools/demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/demo_v088_real_multi_agent_discussion.sh
@@ -9,11 +9,35 @@ STEP_OUT="$OUT_DIR/out"
 RUN_ID="v0-88-real-multi-agent-tea-discussion"
 TRANSCRIPT="$OUT_DIR/transcript.md"
 TRANSCRIPT_CONTRACT="$OUT_DIR/transcript_contract.json"
+SYNTHESIS="$OUT_DIR/synthesis.md"
 MANIFEST="$OUT_DIR/demo_manifest.json"
 INVOCATIONS="$OUT_DIR/provider_invocations.json"
 README_OUT="$OUT_DIR/README.md"
 OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-}"
 ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-}"
+
+TURN_FILES=(
+  "discussion/01-chatgpt-opening.md"
+  "discussion/02-claude-opening-response.md"
+  "discussion/03-chatgpt-clarification.md"
+  "discussion/04-claude-challenge.md"
+  "discussion/05-chatgpt-defense.md"
+  "discussion/06-claude-refinement.md"
+  "discussion/07-chatgpt-extension.md"
+  "discussion/08-claude-narrowing-question.md"
+  "discussion/09-chatgpt-reframe.md"
+  "discussion/10-claude-caution.md"
+  "discussion/11-chatgpt-practical-proposal.md"
+  "discussion/12-claude-governance-concern.md"
+  "discussion/13-chatgpt-concession.md"
+  "discussion/14-claude-acknowledgement.md"
+  "discussion/15-chatgpt-synthesis-path.md"
+  "discussion/16-claude-synthesis-test.md"
+  "discussion/17-chatgpt-revised-principles.md"
+  "discussion/18-claude-partial-acceptance.md"
+  "discussion/19-chatgpt-shared-synthesis.md"
+  "discussion/20-claude-closing.md"
+)
 
 load_key() {
   local env_name="$1"
@@ -98,32 +122,61 @@ cat >"$TRANSCRIPT" <<'EOF'
 This transcript is assembled from the runtime-written step outputs under `out/discussion/`.
 EOF
 
-for file in \
-  "$STEP_OUT/discussion/01-chatgpt-opening.md" \
-  "$STEP_OUT/discussion/02-claude-reply.md" \
-  "$STEP_OUT/discussion/03-chatgpt-reflection.md" \
-  "$STEP_OUT/discussion/04-claude-refinement.md" \
-  "$STEP_OUT/discussion/05-chatgpt-toast.md"; do
+for file in "${TURN_FILES[@]}"; do
   printf '\n\n---\n\n' >>"$TRANSCRIPT"
-  cat "$file" >>"$TRANSCRIPT"
+  cat "$STEP_OUT/$file" >>"$TRANSCRIPT"
 done
 
-cat >"$TRANSCRIPT_CONTRACT" <<EOF
+cat >"$SYNTHESIS" <<EOF
+# Shared Synthesis
+
+This synthesis surface highlights the convergence work from the flagship 20-turn ChatGPT + Claude tea discussion.
+
+## Primary synthesis turn
+
+\`\`\`markdown
+$(cat "$STEP_OUT/discussion/19-chatgpt-shared-synthesis.md")
+\`\`\`
+
+## Closing reflection
+
+\`\`\`markdown
+$(cat "$STEP_OUT/discussion/20-claude-closing.md")
+\`\`\`
+EOF
+
+cat >"$TRANSCRIPT_CONTRACT" <<'EOF'
 {
   "schema_version": "multi_agent_discussion_transcript.v1",
   "transcript_path": "transcript.md",
-  "turn_count": 5,
+  "turn_count": 20,
   "turns": [
     {"turn_id": "turn_01", "ordinal": 1, "speaker": "ChatGPT", "heading": "# Turn 1 - ChatGPT", "source_output": "out/discussion/01-chatgpt-opening.md"},
-    {"turn_id": "turn_02", "ordinal": 2, "speaker": "Claude", "heading": "# Turn 2 - Claude", "source_output": "out/discussion/02-claude-reply.md"},
-    {"turn_id": "turn_03", "ordinal": 3, "speaker": "ChatGPT", "heading": "# Turn 3 - ChatGPT", "source_output": "out/discussion/03-chatgpt-reflection.md"},
-    {"turn_id": "turn_04", "ordinal": 4, "speaker": "Claude", "heading": "# Turn 4 - Claude", "source_output": "out/discussion/04-claude-refinement.md"},
-    {"turn_id": "turn_05", "ordinal": 5, "speaker": "ChatGPT", "heading": "# Turn 5 - ChatGPT", "source_output": "out/discussion/05-chatgpt-toast.md"}
+    {"turn_id": "turn_02", "ordinal": 2, "speaker": "Claude", "heading": "# Turn 2 - Claude", "source_output": "out/discussion/02-claude-opening-response.md"},
+    {"turn_id": "turn_03", "ordinal": 3, "speaker": "ChatGPT", "heading": "# Turn 3 - ChatGPT", "source_output": "out/discussion/03-chatgpt-clarification.md"},
+    {"turn_id": "turn_04", "ordinal": 4, "speaker": "Claude", "heading": "# Turn 4 - Claude", "source_output": "out/discussion/04-claude-challenge.md"},
+    {"turn_id": "turn_05", "ordinal": 5, "speaker": "ChatGPT", "heading": "# Turn 5 - ChatGPT", "source_output": "out/discussion/05-chatgpt-defense.md"},
+    {"turn_id": "turn_06", "ordinal": 6, "speaker": "Claude", "heading": "# Turn 6 - Claude", "source_output": "out/discussion/06-claude-refinement.md"},
+    {"turn_id": "turn_07", "ordinal": 7, "speaker": "ChatGPT", "heading": "# Turn 7 - ChatGPT", "source_output": "out/discussion/07-chatgpt-extension.md"},
+    {"turn_id": "turn_08", "ordinal": 8, "speaker": "Claude", "heading": "# Turn 8 - Claude", "source_output": "out/discussion/08-claude-narrowing-question.md"},
+    {"turn_id": "turn_09", "ordinal": 9, "speaker": "ChatGPT", "heading": "# Turn 9 - ChatGPT", "source_output": "out/discussion/09-chatgpt-reframe.md"},
+    {"turn_id": "turn_10", "ordinal": 10, "speaker": "Claude", "heading": "# Turn 10 - Claude", "source_output": "out/discussion/10-claude-caution.md"},
+    {"turn_id": "turn_11", "ordinal": 11, "speaker": "ChatGPT", "heading": "# Turn 11 - ChatGPT", "source_output": "out/discussion/11-chatgpt-practical-proposal.md"},
+    {"turn_id": "turn_12", "ordinal": 12, "speaker": "Claude", "heading": "# Turn 12 - Claude", "source_output": "out/discussion/12-claude-governance-concern.md"},
+    {"turn_id": "turn_13", "ordinal": 13, "speaker": "ChatGPT", "heading": "# Turn 13 - ChatGPT", "source_output": "out/discussion/13-chatgpt-concession.md"},
+    {"turn_id": "turn_14", "ordinal": 14, "speaker": "Claude", "heading": "# Turn 14 - Claude", "source_output": "out/discussion/14-claude-acknowledgement.md"},
+    {"turn_id": "turn_15", "ordinal": 15, "speaker": "ChatGPT", "heading": "# Turn 15 - ChatGPT", "source_output": "out/discussion/15-chatgpt-synthesis-path.md"},
+    {"turn_id": "turn_16", "ordinal": 16, "speaker": "Claude", "heading": "# Turn 16 - Claude", "source_output": "out/discussion/16-claude-synthesis-test.md"},
+    {"turn_id": "turn_17", "ordinal": 17, "speaker": "ChatGPT", "heading": "# Turn 17 - ChatGPT", "source_output": "out/discussion/17-chatgpt-revised-principles.md"},
+    {"turn_id": "turn_18", "ordinal": 18, "speaker": "Claude", "heading": "# Turn 18 - Claude", "source_output": "out/discussion/18-claude-partial-acceptance.md"},
+    {"turn_id": "turn_19", "ordinal": 19, "speaker": "ChatGPT", "heading": "# Turn 19 - ChatGPT", "source_output": "out/discussion/19-chatgpt-shared-synthesis.md"},
+    {"turn_id": "turn_20", "ordinal": 20, "speaker": "Claude", "heading": "# Turn 20 - Claude", "source_output": "out/discussion/20-claude-closing.md"}
   ],
   "companion_artifacts": {
     "demo_manifest": "demo_manifest.json",
-    "run_summary": "runtime/runs/$RUN_ID/run_summary.json",
-    "trace": "runtime/runs/$RUN_ID/logs/trace_v1.json"
+    "synthesis": "synthesis.md",
+    "run_summary": "runtime/runs/v0-88-real-multi-agent-tea-discussion/run_summary.json",
+    "trace": "runtime/runs/v0-88-real-multi-agent-tea-discussion/logs/trace_v1.json"
   }
 }
 EOF
@@ -131,14 +184,28 @@ EOF
 cat >"$MANIFEST" <<EOF
 {
   "demo_id": "v0.88.real_multi_agent_discussion",
-  "title": "Rust-native live ChatGPT + Claude multi-agent tea discussion demo",
+  "title": "Rust-native live ChatGPT + Claude long-form tea discussion demo",
   "execution_mode": "runtime_native_live_providers",
   "provider_mode": "rust_native_openai_and_anthropic",
   "credential_policy": "operator_env_or_explicit_key_file_no_secret_material_recorded",
-  "steps": 5,
+  "steps": 20,
+  "structure": {
+    "acts": [
+      "opening_positions",
+      "first_exchange",
+      "deepening",
+      "convergence_work",
+      "closing"
+    ],
+    "roles": {
+      "ChatGPT": "Builder",
+      "Claude": "Reflective Critic"
+    }
+  },
   "proof_surfaces": {
     "transcript": "transcript.md",
     "transcript_contract": "transcript_contract.json",
+    "synthesis": "synthesis.md",
     "provider_invocations": "provider_invocations.json",
     "run_summary": "runtime/runs/$RUN_ID/run_summary.json",
     "trace": "runtime/runs/$RUN_ID/logs/trace_v1.json"
@@ -147,7 +214,7 @@ cat >"$MANIFEST" <<EOF
 EOF
 
 cat >"$README_OUT" <<EOF
-# v0.88 Demo - Rust-Native Live ChatGPT + Claude Multi-Agent Tea Discussion
+# v0.88 Demo - Rust-Native Live ChatGPT + Claude Long-Form Tea Discussion
 
 Canonical command:
 
@@ -163,10 +230,11 @@ Credential loading:
 What this proves:
 - one ADL runtime workflow with two named live provider families
 - direct Rust-native OpenAI and Anthropic provider invocation
-- five sequential turns with saved-state handoff, runtime conversation metadata, and transcript contract validation
+- a 20-turn act-structured discussion with explicit role framing, visible disagreement, and usable synthesis
 
 Primary proof surfaces:
 - \`transcript.md\`
+- \`synthesis.md\`
 - \`provider_invocations.json\`
 - \`runtime/runs/$RUN_ID/run_summary.json\`
 EOF
@@ -178,8 +246,9 @@ python3 "$ROOT_DIR/adl/tools/validate_multi_agent_transcript.py" \
 
 sanitize_generated_artifacts
 
-echo "Rust-native live multi-agent discussion proof surface under the output directory:"
+echo "Rust-native long-form multi-agent discussion proof surface under the output directory:"
 echo "  transcript.md"
+echo "  synthesis.md"
 echo "  provider_invocations.json"
 echo "  runtime/runs/$RUN_ID/run_summary.json"
 echo "  runtime/runs/$RUN_ID/logs/trace_v1.json"

--- a/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
@@ -26,6 +26,7 @@ OUT_DIR="$TMPDIR_ROOT/artifacts"
 
 TRANSCRIPT="$OUT_DIR/transcript.md"
 TRANSCRIPT_CONTRACT="$OUT_DIR/transcript_contract.json"
+SYNTHESIS="$OUT_DIR/synthesis.md"
 INVOCATIONS="$OUT_DIR/provider_invocations.json"
 MANIFEST="$OUT_DIR/demo_manifest.json"
 SUMMARY="$OUT_DIR/runtime/runs/v0-88-real-multi-agent-tea-discussion/run_summary.json"
@@ -33,7 +34,7 @@ STEPS="$OUT_DIR/runtime/runs/v0-88-real-multi-agent-tea-discussion/steps.json"
 TRACE="$OUT_DIR/runtime/runs/v0-88-real-multi-agent-tea-discussion/logs/trace_v1.json"
 LOG_FILE="$OUT_DIR/run_log.txt"
 
-for required in "$TRANSCRIPT" "$TRANSCRIPT_CONTRACT" "$INVOCATIONS" "$MANIFEST" "$SUMMARY" "$STEPS" "$TRACE" "$LOG_FILE"; do
+for required in "$TRANSCRIPT" "$TRANSCRIPT_CONTRACT" "$SYNTHESIS" "$INVOCATIONS" "$MANIFEST" "$SUMMARY" "$STEPS" "$TRACE" "$LOG_FILE"; do
   [[ -f "$required" ]] || {
     echo "assertion failed: missing artifact $required" >&2
     exit 1
@@ -58,10 +59,10 @@ invocations = payload.get("invocations", [])
 families = [item.get("family") for item in invocations]
 if payload.get("schema_version") != "adl.native_provider_invocations.v1":
     raise SystemExit("unexpected provider invocation schema version")
-if families.count("openai") != 3:
-    raise SystemExit(f"expected 3 OpenAI invocations, found {families.count('openai')}")
-if families.count("anthropic") != 2:
-    raise SystemExit(f"expected 2 Anthropic invocations, found {families.count('anthropic')}")
+if families.count("openai") != 10:
+    raise SystemExit(f"expected 10 OpenAI invocations, found {families.count('openai')}")
+if families.count("anthropic") != 10:
+    raise SystemExit(f"expected 10 Anthropic invocations, found {families.count('anthropic')}")
 if any(item.get("http_status") != 200 for item in invocations):
     raise SystemExit("expected all native provider invocations to return HTTP 200")
 for item in invocations:
@@ -73,6 +74,11 @@ python3 "$ROOT_DIR/adl/tools/validate_multi_agent_transcript.py" \
   "$TRANSCRIPT" \
   --contract "$TRANSCRIPT_CONTRACT" \
   >/dev/null
+
+grep -Fq "## Shared Synthesis" "$SYNTHESIS" || {
+  echo "assertion failed: synthesis artifact missing shared synthesis heading" >&2
+  exit 1
+}
 
 if [[ -n "${OPENAI_API_KEY:-}" ]] && grep -R -F "$OPENAI_API_KEY" "$OUT_DIR" >/dev/null 2>&1; then
   echo "assertion failed: OPENAI_API_KEY value leaked into artifacts" >&2

--- a/adl/tools/validate_multi_agent_transcript.py
+++ b/adl/tools/validate_multi_agent_transcript.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the bounded v0.87.1 multi-agent transcript artifact."""
+"""Validate bounded multi-agent transcript artifacts."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ REQUIRED_TITLE = "# Claude + ChatGPT Multi-Agent Tea Discussion Transcript"
 PROVENANCE_PHRASE = (
     "assembled from the runtime-written step outputs under `out/discussion/`"
 )
-REQUIRED_HEADINGS = [
+LEGACY_REQUIRED_HEADINGS = [
     "# Turn 1 - ChatGPT",
     "# Turn 2 - Claude",
     "# Turn 3 - ChatGPT",
@@ -23,7 +23,7 @@ REQUIRED_HEADINGS = [
 REQUIRED_CONTRACT_SCHEMA = "multi_agent_discussion_transcript.v1"
 
 
-def validate_transcript(path: Path) -> list[str]:
+def validate_transcript(path: Path, required_headings: list[str]) -> list[str]:
     errors: list[str] = []
     if not path.is_file():
         return [f"transcript missing: {path}"]
@@ -41,13 +41,13 @@ def validate_transcript(path: Path) -> list[str]:
         errors.append("transcript contains unresolved template marker")
 
     lines = text.splitlines()
-    heading_lines = {heading: [] for heading in REQUIRED_HEADINGS}
+    heading_lines = {heading: [] for heading in required_headings}
     for line_no, line in enumerate(lines):
         if line in heading_lines:
             heading_lines[line].append(line_no)
 
     positions: list[int] = []
-    for heading in REQUIRED_HEADINGS:
+    for heading in required_headings:
         count = len(heading_lines[heading])
         if count != 1:
             errors.append(f"expected exactly one heading '{heading}', found {count}")
@@ -58,14 +58,14 @@ def validate_transcript(path: Path) -> list[str]:
         errors.append("turn headings are not in required order")
 
     observed_turn_headings = [line for line in lines if line.startswith("# Turn ")]
-    if len(observed_turn_headings) != len(REQUIRED_HEADINGS):
+    if len(observed_turn_headings) != len(required_headings):
         errors.append(
             "expected "
-            f"{len(REQUIRED_HEADINGS)} turn headings, found {len(observed_turn_headings)}"
+            f"{len(required_headings)} turn headings, found {len(observed_turn_headings)}"
         )
 
     separator_count = sum(1 for line in lines if line.strip() == "---")
-    if separator_count != len(REQUIRED_HEADINGS):
+    if separator_count != len(required_headings):
         errors.append(
             "expected one stable separator before each turn, "
             f"found {separator_count}"
@@ -74,15 +74,31 @@ def validate_transcript(path: Path) -> list[str]:
     return errors
 
 
-def validate_contract(path: Path, transcript_path: Path) -> list[str]:
-    errors: list[str] = []
+def load_contract(path: Path) -> tuple[dict | None, list[str], list[str]]:
     if not path.is_file():
-        return [f"transcript contract missing: {path}"]
+        return None, LEGACY_REQUIRED_HEADINGS, [f"transcript contract missing: {path}"]
 
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        return [f"transcript contract is not valid JSON: {exc}"]
+        return None, LEGACY_REQUIRED_HEADINGS, [
+            f"transcript contract is not valid JSON: {exc}"
+        ]
+
+    turns = payload.get("turns")
+    headings: list[str] = []
+    if isinstance(turns, list):
+        for turn in turns:
+            if isinstance(turn, dict) and isinstance(turn.get("heading"), str):
+                headings.append(turn["heading"])
+    if not headings:
+        headings = LEGACY_REQUIRED_HEADINGS
+
+    return payload, headings, []
+
+
+def validate_contract(payload: dict, transcript_path: Path, required_headings: list[str]) -> list[str]:
+    errors: list[str] = []
 
     allowed_keys = {
         "schema_version",
@@ -99,18 +115,19 @@ def validate_contract(path: Path, transcript_path: Path) -> list[str]:
         errors.append("transcript contract has unsupported schema_version")
     if payload.get("transcript_path") != transcript_path.name:
         errors.append("transcript contract transcript_path must name the transcript file")
-    if payload.get("turn_count") != len(REQUIRED_HEADINGS):
-        errors.append("transcript contract turn_count does not match required headings")
+    if payload.get("turn_count") != len(required_headings):
+        errors.append("transcript contract turn_count does not match declared headings")
 
     turns = payload.get("turns")
     if not isinstance(turns, list):
         errors.append("transcript contract turns must be a list")
         turns = []
-    if len(turns) != len(REQUIRED_HEADINGS):
-        errors.append(f"transcript contract must declare {len(REQUIRED_HEADINGS)} turns")
+    if len(turns) != len(required_headings):
+        errors.append(
+            f"transcript contract must declare {len(required_headings)} turns"
+        )
 
-    expected_speakers = ["ChatGPT", "Claude", "ChatGPT", "Claude", "ChatGPT"]
-    for idx, turn in enumerate(turns[: len(REQUIRED_HEADINGS)], start=1):
+    for idx, turn in enumerate(turns[: len(required_headings)], start=1):
         if not isinstance(turn, dict):
             errors.append(f"turn {idx} must be an object")
             continue
@@ -123,10 +140,12 @@ def validate_contract(path: Path, transcript_path: Path) -> list[str]:
             errors.append(f"turn {idx} turn_id must be {expected_turn_id}")
         if turn.get("ordinal") != idx:
             errors.append(f"turn {idx} ordinal must be {idx}")
-        if turn.get("speaker") != expected_speakers[idx - 1]:
-            errors.append(f"turn {idx} speaker mismatch")
-        if turn.get("heading") != REQUIRED_HEADINGS[idx - 1]:
+        expected_heading = required_headings[idx - 1]
+        if turn.get("heading") != expected_heading:
             errors.append(f"turn {idx} heading mismatch")
+        speaker = turn.get("speaker")
+        if speaker not in {"ChatGPT", "Claude"}:
+            errors.append(f"turn {idx} speaker must be ChatGPT or Claude")
         source_output = turn.get("source_output")
         if not isinstance(source_output, str) or not source_output.startswith(
             "out/discussion/"
@@ -141,13 +160,18 @@ def validate_contract(path: Path, transcript_path: Path) -> list[str]:
             value = companions.get(key)
             if not isinstance(value, str) or not value:
                 errors.append(f"companion_artifacts.{key} must be a non-empty string")
+        optional_synthesis = companions.get("synthesis")
+        if optional_synthesis is not None and (
+            not isinstance(optional_synthesis, str) or not optional_synthesis
+        ):
+            errors.append("companion_artifacts.synthesis must be a non-empty string")
 
     return errors
 
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
-        description="Validate the bounded v0.87.1 multi-agent transcript artifact."
+        description="Validate bounded multi-agent transcript artifacts."
     )
     parser.add_argument("transcript", type=Path)
     parser.add_argument(
@@ -157,9 +181,15 @@ def main(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
-    errors = validate_transcript(args.transcript)
+    required_headings = LEGACY_REQUIRED_HEADINGS
+    errors: list[str] = []
     if args.contract is not None:
-        errors.extend(validate_contract(args.contract, args.transcript))
+        payload, required_headings, load_errors = load_contract(args.contract)
+        errors.extend(load_errors)
+        if payload is not None:
+            errors.extend(validate_contract(payload, args.transcript, required_headings))
+
+    errors.extend(validate_transcript(args.transcript, required_headings))
     if errors:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)

--- a/demos/README.md
+++ b/demos/README.md
@@ -83,7 +83,7 @@ prepare the prompt, workspace, and manifest without invoking a local model.
 
 Use `v0.87.1/claude_chatgpt_multi_agent_discussion_demo.md` for a bounded
 multi-agent runtime demo that keeps Claude and ChatGPT as two explicit named
-agents over five sequential turns and emits a transcript plus runtime proof
+agents in a longer act-structured tea discussion and emits a transcript plus runtime proof
 artifacts.
 
 Use `v0.87/v087_demo_program.md` for the canonical `v0.87` demo order and bounded

--- a/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
+++ b/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
@@ -1,7 +1,8 @@
-# Rust-Native Live ChatGPT + Claude Multi-Agent Discussion Demo
+# Rust-Native Live ChatGPT + Claude Long-Form Discussion Demo
 
 This demo replaces the v0.87.1 Python proof shim with Rust-native OpenAI and
-Anthropic provider invocation.
+Anthropic provider invocation, and expands the conversation into a 20-turn,
+act-structured tea discussion.
 
 ## Command
 
@@ -30,9 +31,24 @@ artifacts/v088/real_multi_agent_discussion/
 Primary proof surfaces:
 
 - `transcript.md`
+- `synthesis.md`
 - `provider_invocations.json`
 - `runtime/runs/v0-88-real-multi-agent-tea-discussion/run_summary.json`
 
 The provider invocation artifact records provider family, model, HTTP status,
 timestamp, and prompt/output character counts. It intentionally does not record
 prompt bodies, response bodies, API keys, or Authorization headers.
+
+## Conversation Shape
+
+The flagship version is intentionally longer and more interesting than the
+original five-turn exchange.
+
+- 20 explicit turns
+- 5 acts: opening positions, first exchange, deepening, convergence work, closing
+- `ChatGPT` framed as `Builder`
+- `Claude` framed as `Reflective Critic`
+- one visible disagreement and one explicit synthesis phase
+
+The transcript is still bounded and reviewable. This is not a general
+conversation runtime claim.

--- a/docs/tooling/MULTI_AGENT_TRANSCRIPT_ARTIFACT_CONTRACT.md
+++ b/docs/tooling/MULTI_AGENT_TRANSCRIPT_ARTIFACT_CONTRACT.md
@@ -1,84 +1,66 @@
 # Multi-Agent Transcript Artifact Contract
 
-Status: v0.87.1 bounded demo contract
+Status: bounded demo contract
 
-This document defines the canonical transcript artifact shape for bounded
-multi-agent discussion demos.
+This document defines the canonical reviewer-facing transcript artifact shape for
+bounded multi-agent discussion demos such as the ChatGPT + Claude tea
+discussion.
 
-The contract is intentionally narrow. It standardizes the reviewer-facing
-transcript file emitted by demos such as the Claude + ChatGPT tea discussion. It
-does not define a general conversation runtime, provider protocol, chat memory
-model, or long-lived agent collaboration substrate.
+The contract is intentionally narrow. It does not define a general conversation
+runtime, memory model, or autonomous agent society. It defines the proof surface
+for one bounded ADL run.
 
 ## Canonical Artifact
 
-The primary transcript artifact is:
+The primary readable artifact is:
 
 ```text
 transcript.md
 ```
 
-For the `v0.87.1` multi-agent discussion demo, the canonical path is:
+The transcript is paired with:
 
 ```text
-artifacts/v0871/multi_agent_discussion/transcript.md
+transcript_contract.json
 ```
 
-The transcript is accompanied by a machine-readable contract artifact:
-
-```text
-artifacts/v0871/multi_agent_discussion/transcript_contract.json
-```
-
-Generated transcript artifacts should be treated as demo output. They are proof
-surfaces for review, not source-of-truth inputs to the ADL runtime.
+Generated transcript artifacts are review surfaces, not source-of-truth runtime
+inputs.
 
 ## Required Layout
 
-A conforming bounded multi-agent transcript MUST contain:
+A conforming transcript must contain:
 
 - a top-level title
-- a short provenance statement explaining that the transcript was assembled from runtime-written step outputs
-- exactly one ordered section per turn
+- a provenance statement saying it was assembled from runtime-written step outputs
+- exactly one ordered section per declared turn
 - a stable separator between turns
-- a human-readable turn heading for each turn
+- a human-readable heading for each turn
 
-For the `v0.87.1` tea discussion demo, the required turn headings are:
-
-```text
-# Turn 1 - ChatGPT
-# Turn 2 - Claude
-# Turn 3 - ChatGPT
-# Turn 4 - Claude
-# Turn 5 - ChatGPT
-```
-
-The required turn order is the source of reviewer clarity. If a later demo needs
-a different speaker order, it should document and validate that order explicitly
-instead of reusing this demo-specific sequence silently.
+The required heading set is contract-defined. Different bounded demos may use
+different turn counts and speaker orders as long as they declare and validate
+them explicitly.
 
 ## Required Companion Artifacts
 
-A transcript proof surface is complete only when it is paired with:
+A transcript proof surface is complete only when paired with:
 
 - `demo_manifest.json`
 - runtime `run_summary.json`
 - runtime `logs/trace_v1.json`
-- the runtime-written per-turn step output files
+- runtime-written per-turn output files
 
-The transcript itself is a readable assembly of step outputs. The manifest and
-runtime artifacts provide the machine-checkable evidence that the transcript came
-from a bounded ADL run.
+Some demos may also publish additional reviewer aids such as `synthesis.md`.
 
 ## Machine-Readable Contract
 
-`transcript_contract.json` MUST use this object shape:
+`transcript_contract.json` must use this object shape:
 
 ```json
 {
   "schema_version": "multi_agent_discussion_transcript.v1",
   "transcript_path": "transcript.md",
-  "turn_count": 5,
+  "turn_count": 20,
   "turns": [
     {
       "turn_id": "turn_01",
@@ -90,29 +72,30 @@ from a bounded ADL run.
   ],
   "companion_artifacts": {
     "demo_manifest": "demo_manifest.json",
-    "run_summary": "runtime/runs/v0-87-1-multi-agent-tea-discussion/run_summary.json",
-    "trace": "runtime/runs/v0-87-1-multi-agent-tea-discussion/logs/trace_v1.json"
+    "synthesis": "synthesis.md",
+    "run_summary": "runtime/runs/v0-88-real-multi-agent-tea-discussion/run_summary.json",
+    "trace": "runtime/runs/v0-88-real-multi-agent-tea-discussion/logs/trace_v1.json"
   }
 }
 ```
 
-The example above shows one turn for readability. A conforming contract for the
-tea discussion demo must declare all five turns in order.
+The example above shows one turn for readability. A conforming contract must
+declare every turn in order.
 
 ## Validation Rules
 
-The transcript validator MUST check:
+The validator must check:
 
 - the transcript file exists
-- the transcript is valid UTF-8 text
+- the transcript is valid UTF-8
 - the title is present
-- the runtime-output provenance statement is present
-- all required turn headings are present exactly once
-- required turn headings appear in order
-- the transcript contains the expected number of turn sections
+- the provenance statement is present
+- all declared turn headings are present exactly once
+- declared turn headings appear in order
+- the transcript contains the declared number of turn sections
 - the transcript does not contain unresolved template markers
 
-The validator MUST NOT:
+The validator must not:
 
 - call providers
 - modify files
@@ -125,39 +108,25 @@ The validator MUST NOT:
 From repository root:
 
 ```bash
-python3 adl/tools/validate_multi_agent_transcript.py artifacts/v0871/multi_agent_discussion/transcript.md
-```
-
-To validate the transcript and its machine-readable contract together:
-
-```bash
 python3 adl/tools/validate_multi_agent_transcript.py \
-  artifacts/v0871/multi_agent_discussion/transcript.md \
-  --contract artifacts/v0871/multi_agent_discussion/transcript_contract.json
-```
-
-For the complete demo proof:
-
-```bash
-bash adl/tools/test_demo_v0871_multi_agent_discussion.sh
+  artifacts/v088/real_multi_agent_discussion/transcript.md \
+  --contract artifacts/v088/real_multi_agent_discussion/transcript_contract.json
 ```
 
 ## Reviewer Checklist
 
-- `transcript.md` exists at the documented demo output path.
+- `transcript.md` exists at the documented output path.
 - `transcript_contract.json` declares `multi_agent_discussion_transcript.v1`.
-- The transcript has five ordered turns for the bounded tea discussion demo.
+- The transcript contains the declared number of ordered turns.
 - Each turn heading names the speaker.
 - The transcript states it was assembled from runtime-written step outputs.
 - Companion manifest, run summary, and trace artifacts exist.
-- Generated transcript artifacts are not committed unless a review package
-  explicitly calls for checked-in evidence.
+- Any optional `synthesis.md` surface is truthful and derived from declared turns.
 
 ## Non-Goals
 
 - general chat transcript schema
 - provider-native transcript capture
-- model-to-model memory semantics
+- long-lived session persistence
 - autonomous conversation management
-- transcript hashing or signing
-- long-lived multi-agent session persistence
+- transcript signing


### PR DESCRIPTION
Closes #1813

## Summary
Upgraded the existing `v0.88` live ChatGPT + Claude tea discussion demo from a short five-turn exchange into a 20-turn, act-structured conversation with clearer role framing, explicit disagreement, and a separate `synthesis.md` proof surface. The runtime example, wrapper, transcript validator, and reviewer docs now agree on the longer flagship shape.

## Artifacts
- updated runtime workflow at `adl/examples/v0-88-real-multi-agent-tea-discussion.adl.yaml`
- updated live demo wrapper at `adl/tools/demo_v088_real_multi_agent_discussion.sh`
- updated live demo test at `adl/tools/test_demo_v088_real_multi_agent_discussion.sh`
- generalized transcript validator at `adl/tools/validate_multi_agent_transcript.py`
- updated reviewer docs at `demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md`
- updated demo index note at `demos/README.md`
- updated transcript contract doc at `docs/tooling/MULTI_AGENT_TRANSCRIPT_ARTIFACT_CONTRACT.md`
- workflow routing proof at `.adl/reviews/workflow-conductor-1813-run-dispatch.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/demo_v088_real_multi_agent_discussion.sh adl/tools/test_demo_v088_real_multi_agent_discussion.sh`
    - verified the updated wrapper and companion test are shell-valid
  - `python3 -m py_compile adl/tools/validate_multi_agent_transcript.py`
    - verified the transcript validator parses cleanly
  - `python3 - <<'PY' ... ; python3 adl/tools/validate_multi_agent_transcript.py "$tmpdir/transcript.md" --contract "$tmpdir/transcript_contract.json"`
    - verified a synthetic 20-turn transcript and contract are accepted by the updated validator
  - `python3 - <<'PY' ...`
    - verified the runtime example declares 20 discussion steps
  - `bash adl/tools/test_demo_v088_real_multi_agent_discussion.sh`
    - exercised the live-provider proof harness and confirmed the truthful non-proving skip path when credentials are absent
  - `git diff --check`
    - verified no whitespace or patch-format defects remain
- Results:
  - shell surfaces passed syntax checks
  - validator syntax passed
  - synthetic 20-turn transcript replay passed
  - runtime example step count is 20
  - live-provider test skipped because `OPENAI_API_KEY` / `ADL_OPENAI_KEY_FILE` were not available in this environment
  - diff hygiene is clean

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1813__deepen-chatgpt-and-claude-long-form-discussion-demo/sip.md
- Output card: .adl/v0.89/tasks/issue-1813__deepen-chatgpt-and-claude-long-form-discussion-demo/sor.md
- Idempotency-Key: v0-89-demo-deepen-chatgpt-and-claude-long-form-discussion-demo-adl-v0-89-tasks-issue-1813-deepen-chatgpt-and-claude-long-form-discussion-demo-sip-md-adl-v0-89-tasks-issue-1813-deepen-chatgpt-and-claude-long-form-discussion-demo-sor-md