### PR TITLE
[v0.89][WP-03] Freedom Gate v2

### DIFF
--- a/adl/src/cli/run_artifacts/cognitive.rs
+++ b/adl/src/cli/run_artifacts/cognitive.rs
@@ -898,8 +898,11 @@ pub(crate) fn build_freedom_gate_artifact(
         decision_reason: state.decision_reason.clone(),
         selected_action_or_none: state.selected_action_or_none.clone(),
         commitment_blocked: state.commitment_blocked,
+        judgment_boundary: state.judgment_boundary.clone(),
+        required_follow_up: state.required_follow_up.clone(),
+        decision_record_kind: state.decision_record_kind.clone(),
         deterministic_gate_rule:
-            "derive allow/defer/refuse commitment decisions from execute-owned freedom-gate input state before action commitment and without hidden bypass paths"
+            "derive allow/defer/refuse/escalate judgment decisions from execute-owned freedom-gate input state before action commitment and without hidden bypass paths"
                 .to_string(),
     }
 }
@@ -1080,6 +1083,7 @@ pub(crate) fn build_control_path_final_result_artifact(
             .unwrap_or_else(|| agency.selected_candidate_reason.clone()),
         "defer" => "defer".to_string(),
         "refuse" => "refuse".to_string(),
+        "escalate" => "escalate".to_string(),
         other => format!("unrecognized_gate_decision:{other}"),
     };
 
@@ -1158,8 +1162,11 @@ pub(crate) fn build_control_path_summary(context: &ControlPathSummaryContext<'_>
             memory.read.read_count, memory.read.influenced_stage, memory.write.write_reason
         ),
         format!(
-            "freedom_gate: decision={} reason_code={} commitment_blocked={}",
-            freedom_gate.gate_decision, freedom_gate.reason_code, freedom_gate.commitment_blocked
+            "freedom_gate: decision={} reason_code={} follow_up={} commitment_blocked={}",
+            freedom_gate.gate_decision,
+            freedom_gate.reason_code,
+            freedom_gate.required_follow_up,
+            freedom_gate.commitment_blocked
         ),
         format!("final_result: {}", final_result.final_result),
     ]

--- a/adl/src/cli/run_artifacts_types.rs
+++ b/adl/src/cli/run_artifacts_types.rs
@@ -603,6 +603,9 @@ pub(crate) struct FreedomGateArtifact {
     pub(crate) decision_reason: String,
     pub(crate) selected_action_or_none: Option<String>,
     pub(crate) commitment_blocked: bool,
+    pub(crate) judgment_boundary: String,
+    pub(crate) required_follow_up: String,
+    pub(crate) decision_record_kind: String,
     pub(crate) deterministic_gate_rule: String,
 }
 

--- a/adl/src/cli/tests/artifact_builders/learning_runtime.rs
+++ b/adl/src/cli/tests/artifact_builders/learning_runtime.rs
@@ -159,6 +159,12 @@ fn build_aee_convergence_artifact_distinguishes_core_outcome_classes() {
                 failure_signal: "none".to_string(),
                 termination_reason: "success".to_string(),
             },
+            consequence_context: execute::FreedomGateConsequenceContextState {
+                impact_scope: "local_bounded".to_string(),
+                recovery_cost: "low".to_string(),
+                operator_visibility: "routine".to_string(),
+                escalation_available: false,
+            },
             frame_state: "retain_current_frame".to_string(),
         },
         gate_decision: "allow".to_string(),
@@ -166,6 +172,9 @@ fn build_aee_convergence_artifact_distinguishes_core_outcome_classes() {
         decision_reason: "allowed".to_string(),
         selected_action_or_none: Some("execute".to_string()),
         commitment_blocked: false,
+        judgment_boundary: "commitment_boundary".to_string(),
+        required_follow_up: "commit_selected_action".to_string(),
+        decision_record_kind: "gate_allow_record".to_string(),
         deterministic_gate_rule: "rule".to_string(),
     };
     let defer_gate = run_artifacts::FreedomGateArtifact {
@@ -174,6 +183,9 @@ fn build_aee_convergence_artifact_distinguishes_core_outcome_classes() {
         decision_reason: "defer".to_string(),
         selected_action_or_none: None,
         commitment_blocked: true,
+        judgment_boundary: "frame_boundary".to_string(),
+        required_follow_up: "reframe_before_commitment".to_string(),
+        decision_record_kind: "gate_defer_record".to_string(),
         ..allow_gate.clone()
     };
     let scores = ScoresArtifact {
@@ -798,14 +810,24 @@ fn build_freedom_gate_artifact_is_deterministic_and_blocks_commitment_when_not_a
                 failure_signal: "none".to_string(),
                 termination_reason: "contradiction_detected".to_string(),
             },
+            consequence_context: execute::FreedomGateConsequenceContextState {
+                impact_scope: "cross_surface".to_string(),
+                recovery_cost: "requires_reframing".to_string(),
+                operator_visibility: "review_required".to_string(),
+                escalation_available: true,
+            },
             frame_state: "ready_for_reframed_execution".to_string(),
         },
-        gate_decision: "defer".to_string(),
-        reason_code: "frame_inadequate".to_string(),
-        decision_reason: "frame state requires bounded reframing before commitment can be allowed"
-            .to_string(),
+        gate_decision: "escalate".to_string(),
+        reason_code: "frame_escalation_required".to_string(),
+        decision_reason:
+            "frame state and consequence context require explicit escalation before commitment can proceed"
+                .to_string(),
         selected_action_or_none: None,
         commitment_blocked: true,
+        judgment_boundary: "judgment_boundary".to_string(),
+        required_follow_up: "escalate_for_judgment_review".to_string(),
+        decision_record_kind: "gate_escalation_record".to_string(),
     };
 
     let left = run_artifacts::build_freedom_gate_artifact(
@@ -824,10 +846,11 @@ fn build_freedom_gate_artifact_is_deterministic_and_blocks_commitment_when_not_a
         serde_json::to_value(&left).expect("freedom gate left"),
         serde_json::to_value(&right).expect("freedom gate right")
     );
-    assert_eq!(left.gate_decision, "defer");
-    assert_eq!(left.reason_code, "frame_inadequate");
+    assert_eq!(left.gate_decision, "escalate");
+    assert_eq!(left.reason_code, "frame_escalation_required");
     assert!(left.commitment_blocked);
     assert!(left.selected_action_or_none.is_none());
+    assert_eq!(left.decision_record_kind, "gate_escalation_record");
 }
 
 #[test]

--- a/adl/src/cli/tests/run_state/mod.rs
+++ b/adl/src/cli/tests/run_state/mod.rs
@@ -188,15 +188,24 @@ fn custom_runtime_control() -> execute::RuntimeControlState {
                     failure_signal: "none".to_string(),
                     termination_reason: "contradiction_detected".to_string(),
                 },
+                consequence_context: execute::FreedomGateConsequenceContextState {
+                    impact_scope: "cross_surface".to_string(),
+                    recovery_cost: "requires_reframing".to_string(),
+                    operator_visibility: "review_required".to_string(),
+                    escalation_available: true,
+                },
                 frame_state: "ready_for_reframed_execution".to_string(),
             },
-            gate_decision: "defer".to_string(),
-            reason_code: "frame_inadequate".to_string(),
+            gate_decision: "escalate".to_string(),
+            reason_code: "frame_escalation_required".to_string(),
             decision_reason:
-                "frame state requires bounded reframing before commitment can be allowed"
+                "frame state and consequence context require explicit escalation before commitment can proceed"
                     .to_string(),
             selected_action_or_none: None,
             commitment_blocked: true,
+            judgment_boundary: "judgment_boundary".to_string(),
+            required_follow_up: "escalate_for_judgment_review".to_string(),
+            decision_record_kind: "gate_escalation_record".to_string(),
         },
         memory: execute::MemoryParticipationState {
             read: execute::MemoryReadState {

--- a/adl/src/cli/tests/run_state/persistence.rs
+++ b/adl/src/cli/tests/run_state/persistence.rs
@@ -337,9 +337,13 @@ fn write_run_state_artifacts_projects_execute_owned_runtime_control_state() {
             .expect("read freedom gate artifact"),
     )
     .expect("parse freedom gate artifact");
-    assert_eq!(freedom_gate.gate_decision, "defer");
-    assert_eq!(freedom_gate.reason_code, "frame_inadequate");
+    assert_eq!(freedom_gate.gate_decision, "escalate");
+    assert_eq!(freedom_gate.reason_code, "frame_escalation_required");
     assert!(freedom_gate.commitment_blocked);
+    assert_eq!(
+        freedom_gate.required_follow_up,
+        "escalate_for_judgment_review"
+    );
     assert_eq!(freedom_gate.input.candidate_id, "cand-custom-review");
 
     let convergence: run_artifacts::AeeConvergenceArtifact = serde_json::from_str(
@@ -394,8 +398,8 @@ fn write_run_state_artifacts_projects_execute_owned_runtime_control_state() {
         control_path_final_result.selected_candidate,
         "cand-custom-review"
     );
-    assert_eq!(control_path_final_result.gate_decision, "defer");
-    assert_eq!(control_path_final_result.final_result, "defer");
+    assert_eq!(control_path_final_result.gate_decision, "escalate");
+    assert_eq!(control_path_final_result.final_result, "escalate");
 
     let control_path_summary =
         std::fs::read_to_string(run_dir.join("control_path/summary.txt")).expect("read summary");
@@ -406,7 +410,9 @@ fn write_run_state_artifacts_projects_execute_owned_runtime_control_state() {
         "summary was:\n{control_path_summary}"
     );
     assert!(
-        control_path_summary.contains("freedom_gate: decision=defer"),
+        control_path_summary.contains(
+            "freedom_gate: decision=escalate reason_code=frame_escalation_required follow_up=escalate_for_judgment_review"
+        ),
         "summary was:\n{control_path_summary}"
     );
     assert!(

--- a/adl/src/cli/tests/run_state/runtime_control.rs
+++ b/adl/src/cli/tests/run_state/runtime_control.rs
@@ -24,8 +24,15 @@ fn derive_runtime_control_state_triggers_reframing_on_failure() {
         runtime_control.reframing.reexecution_choice,
         "bounded_reframe_and_retry"
     );
-    assert_eq!(runtime_control.freedom_gate.gate_decision, "defer");
-    assert_eq!(runtime_control.freedom_gate.reason_code, "frame_inadequate");
+    assert_eq!(runtime_control.freedom_gate.gate_decision, "escalate");
+    assert_eq!(
+        runtime_control.freedom_gate.reason_code,
+        "frame_escalation_required"
+    );
+    assert_eq!(
+        runtime_control.freedom_gate.required_follow_up,
+        "escalate_for_judgment_review"
+    );
     assert!(
         runtime_control.reframing.frame_adequacy_score < 50,
         "failure should lower the frame adequacy score"

--- a/adl/src/demo.rs
+++ b/adl/src/demo.rs
@@ -820,7 +820,7 @@ mod tests {
         assert!(out.join("trace.jsonl").is_file());
         let summary = std::fs::read_to_string(out.join("summary.txt")).unwrap();
         assert!(
-            summary.contains("final_result: defer"),
+            summary.contains("final_result: escalate"),
             "summary was:\n{summary}"
         );
     }

--- a/adl/src/demo/v086_review_surface.rs
+++ b/adl/src/demo/v086_review_surface.rs
@@ -123,15 +123,24 @@ fn custom_v086_control_path_runtime() -> execute::RuntimeControlState {
                     failure_signal: "none".to_string(),
                     termination_reason: "contradiction_detected".to_string(),
                 },
+                consequence_context: execute::FreedomGateConsequenceContextState {
+                    impact_scope: "cross_surface".to_string(),
+                    recovery_cost: "requires_reframing".to_string(),
+                    operator_visibility: "review_required".to_string(),
+                    escalation_available: true,
+                },
                 frame_state: "ready_for_reframed_execution".to_string(),
             },
-            gate_decision: "defer".to_string(),
-            reason_code: "frame_inadequate".to_string(),
+            gate_decision: "escalate".to_string(),
+            reason_code: "frame_escalation_required".to_string(),
             decision_reason:
-                "frame state requires bounded reframing before commitment can be allowed"
+                "frame state and consequence context require explicit escalation before commitment can proceed"
                     .to_string(),
             selected_action_or_none: None,
             commitment_blocked: true,
+            judgment_boundary: "judgment_boundary".to_string(),
+            required_follow_up: "escalate_for_judgment_review".to_string(),
+            decision_record_kind: "gate_escalation_record".to_string(),
         },
         memory: execute::MemoryParticipationState {
             read: execute::MemoryReadState {
@@ -309,6 +318,9 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
         "decision_reason": runtime.freedom_gate.decision_reason,
         "selected_action_or_none": runtime.freedom_gate.selected_action_or_none,
         "commitment_blocked": runtime.freedom_gate.commitment_blocked,
+        "judgment_boundary": runtime.freedom_gate.judgment_boundary,
+        "required_follow_up": runtime.freedom_gate.required_follow_up,
+        "decision_record_kind": runtime.freedom_gate.decision_record_kind,
         "deterministic_gate_rule": "demo deterministic freedom gate"
     });
     let convergence = serde_json::json!({
@@ -328,8 +340,9 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
         "strategy_change_visible": true,
         "reframing_trigger": runtime.reframing.reframing_trigger,
         "reviewer_summary": format!(
-            "AEE convergence ended as 'policy_stop' after 2 bounded iteration(s); progress signal '{}' led to stop family 'policy_boundary' with next control action 'handoff_to_reframing' and gate decision 'defer'.",
-            runtime.evaluation.progress_signal
+            "AEE convergence ended as 'policy_stop' after 2 bounded iteration(s); progress signal '{}' led to stop family 'policy_boundary' with next control action 'handoff_to_reframing' and gate decision '{}'.",
+            runtime.evaluation.progress_signal,
+            runtime.freedom_gate.gate_decision
         ),
         "deterministic_convergence_rule": "demo deterministic convergence projection"
     });
@@ -339,8 +352,8 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
         "route_selected": "slow",
         "selected_candidate": "cand-custom-review",
         "termination_reason": "contradiction_detected",
-        "gate_decision": "defer",
-        "final_result": "defer",
+        "gate_decision": runtime.freedom_gate.gate_decision,
+        "final_result": runtime.freedom_gate.gate_decision,
         "commitment_blocked": true,
         "next_control_action": "handoff_to_reframing",
         "stage_order": [
@@ -370,8 +383,8 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
             runtime.evaluation.progress_signal
         ),
         "memory: read_count=1 influenced_stage=reframing write_reason=record_failure_for_future_reframing_context".to_string(),
-        "freedom_gate: decision=defer reason_code=frame_inadequate commitment_blocked=true".to_string(),
-        "final_result: defer".to_string(),
+        "freedom_gate: decision=escalate reason_code=frame_escalation_required follow_up=escalate_for_judgment_review commitment_blocked=true".to_string(),
+        "final_result: escalate".to_string(),
     ]
     .join("\n");
 
@@ -602,6 +615,12 @@ pub fn write_v086_freedom_gate_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
             failure_signal: "none".to_string(),
             termination_reason: "success".to_string(),
         },
+        consequence_context: freedom_gate::FreedomGateConsequenceContext {
+            impact_scope: "local_bounded".to_string(),
+            recovery_cost: "low".to_string(),
+            operator_visibility: "routine".to_string(),
+            escalation_available: false,
+        },
         frame_state: "complete_run".to_string(),
     };
     let blocked = freedom_gate::FreedomGateInput {
@@ -620,6 +639,12 @@ pub fn write_v086_freedom_gate_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
             contradiction_signal: "present".to_string(),
             failure_signal: "none".to_string(),
             termination_reason: "contradiction_detected".to_string(),
+        },
+        consequence_context: freedom_gate::FreedomGateConsequenceContext {
+            impact_scope: "cross_surface".to_string(),
+            recovery_cost: "high".to_string(),
+            operator_visibility: "review_required".to_string(),
+            escalation_available: false,
         },
         frame_state: "complete_run".to_string(),
     };

--- a/adl/src/execute/state/mod.rs
+++ b/adl/src/execute/state/mod.rs
@@ -13,10 +13,10 @@ pub use runtime_control::{
     derive_runtime_control_state, select_instinct_runtime_candidate, AgencyCandidateRecord,
     AgencySelectionDecisionTemplate, AgencySelectionState, BoundedExecutionIteration,
     BoundedExecutionState, CognitiveArbitrationState, CognitiveSignalsState,
-    EvaluationControlState, FastSlowPathState, FreedomGateEvaluationSignalsState,
-    FreedomGateInputState, FreedomGatePolicyContextState, FreedomGateState,
-    MemoryParticipationState, MemoryQueryState, MemoryReadEntry, MemoryReadState, MemoryWriteState,
-    ReframingControlState, RuntimeControlState,
+    EvaluationControlState, FastSlowPathState, FreedomGateConsequenceContextState,
+    FreedomGateEvaluationSignalsState, FreedomGateInputState, FreedomGatePolicyContextState,
+    FreedomGateState, MemoryParticipationState, MemoryQueryState, MemoryReadEntry, MemoryReadState,
+    MemoryWriteState, ReframingControlState, RuntimeControlState,
 };
 pub use steering::{
     apply_steering_patch, steering_record_from_patch, validate_steering_patch, PauseState,

--- a/adl/src/execute/state/runtime_control.rs
+++ b/adl/src/execute/state/runtime_control.rs
@@ -146,6 +146,9 @@ pub struct FreedomGateState {
     pub decision_reason: String,
     pub selected_action_or_none: Option<String>,
     pub commitment_blocked: bool,
+    pub judgment_boundary: String,
+    pub required_follow_up: String,
+    pub decision_record_kind: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -157,6 +160,7 @@ pub struct FreedomGateInputState {
     pub risk_class: String,
     pub policy_context: FreedomGatePolicyContextState,
     pub evaluation_signals: FreedomGateEvaluationSignalsState,
+    pub consequence_context: FreedomGateConsequenceContextState,
     pub frame_state: String,
 }
 
@@ -176,6 +180,15 @@ pub struct FreedomGateEvaluationSignalsState {
     pub contradiction_signal: String,
     pub failure_signal: String,
     pub termination_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FreedomGateConsequenceContextState {
+    pub impact_scope: String,
+    pub recovery_cost: String,
+    pub operator_visibility: String,
+    pub escalation_available: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -967,6 +980,32 @@ fn derive_freedom_gate_state(
             failure_signal: evaluation.failure_signal.clone(),
             termination_reason: evaluation.termination_reason.clone(),
         },
+        consequence_context: freedom_gate::FreedomGateConsequenceContext {
+            impact_scope: if arbitration.risk_class == "high" {
+                "cross_surface".to_string()
+            } else {
+                "local_bounded".to_string()
+            },
+            recovery_cost: if evaluation.next_control_action == "handoff_to_reframing" {
+                "requires_reframing".to_string()
+            } else if arbitration.route_selected == "slow" {
+                "bounded_review_replay".to_string()
+            } else {
+                "low".to_string()
+            },
+            operator_visibility: if arbitration.risk_class == "high"
+                || arbitration.route_selected == "slow"
+                || evaluation.contradiction_signal == "present"
+            {
+                "review_required".to_string()
+            } else {
+                "routine".to_string()
+            },
+            escalation_available: arbitration.route_selected == "slow"
+                || arbitration.risk_class == "high"
+                || evaluation.contradiction_signal == "present"
+                || evaluation.failure_signal != "none",
+        },
         frame_state: reframing.post_reframe_state.clone(),
     };
     let decision = freedom_gate::evaluate_freedom_gate(&input);
@@ -989,6 +1028,12 @@ fn derive_freedom_gate_state(
                 failure_signal: input.evaluation_signals.failure_signal,
                 termination_reason: input.evaluation_signals.termination_reason,
             },
+            consequence_context: FreedomGateConsequenceContextState {
+                impact_scope: input.consequence_context.impact_scope,
+                recovery_cost: input.consequence_context.recovery_cost,
+                operator_visibility: input.consequence_context.operator_visibility,
+                escalation_available: input.consequence_context.escalation_available,
+            },
             frame_state: input.frame_state,
         },
         gate_decision: decision.gate_decision,
@@ -996,6 +1041,9 @@ fn derive_freedom_gate_state(
         decision_reason: decision.decision_reason,
         selected_action_or_none: decision.selected_action_or_none,
         commitment_blocked: decision.commitment_blocked,
+        judgment_boundary: decision.judgment_boundary,
+        required_follow_up: decision.required_follow_up,
+        decision_record_kind: decision.decision_record_kind,
     }
 }
 

--- a/adl/src/freedom_gate.rs
+++ b/adl/src/freedom_gate.rs
@@ -9,6 +9,7 @@ pub struct FreedomGateInput {
     pub risk_class: String,
     pub policy_context: FreedomGatePolicyContext,
     pub evaluation_signals: FreedomGateEvaluationSignals,
+    pub consequence_context: FreedomGateConsequenceContext,
     pub frame_state: String,
 }
 
@@ -32,67 +33,144 @@ pub struct FreedomGateEvaluationSignals {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct FreedomGateConsequenceContext {
+    pub impact_scope: String,
+    pub recovery_cost: String,
+    pub operator_visibility: String,
+    pub escalation_available: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct FreedomGateDecision {
     pub gate_decision: String,
     pub reason_code: String,
     pub decision_reason: String,
     pub selected_action_or_none: Option<String>,
     pub commitment_blocked: bool,
+    pub judgment_boundary: String,
+    pub required_follow_up: String,
+    pub decision_record_kind: String,
 }
 
 pub fn evaluate_freedom_gate(input: &FreedomGateInput) -> FreedomGateDecision {
     let candidate_action = input.candidate_action.trim();
 
-    let (gate_decision, reason_code, decision_reason, selected_action_or_none, commitment_blocked) =
-        if input.policy_context.policy_blocked {
-            (
-                "refuse",
-                "policy_blocked",
-                "policy context explicitly blocks commitment for this bounded candidate",
-                None,
-                true,
-            )
-        } else if candidate_action.is_empty() {
-            (
-                "defer",
-                "insufficient_context",
-                "candidate action is empty, so commitment must remain blocked until context is restored",
-                None,
-                true,
-            )
-        } else if input.frame_state == "ready_for_reframed_execution" {
-            (
-                "defer",
-                "frame_inadequate",
-                "frame state requires bounded reframing before commitment can be allowed",
-                None,
-                true,
-            )
-        } else if input.policy_context.requires_review {
-            (
-                "defer",
-                "requires_review",
-                "policy context requires bounded review before commitment can be allowed",
-                None,
-                true,
-            )
-        } else if input.risk_class == "high" {
-            (
-                "refuse",
-                "risk_too_high",
-                "risk class remains too high for bounded commitment in v0.86",
-                None,
-                true,
-            )
-        } else {
-            (
-                "allow",
-                "policy_allowed",
-                "bounded policy context allows commitment for the selected candidate",
-                Some(candidate_action.to_string()),
-                false,
-            )
-        };
+    let escalation_candidate = input.consequence_context.escalation_available
+        && (input.risk_class == "high"
+            || input.evaluation_signals.contradiction_signal == "present"
+            || input.evaluation_signals.failure_signal != "none"
+            || input.frame_state == "ready_for_reframed_execution");
+
+    let (
+        gate_decision,
+        reason_code,
+        decision_reason,
+        selected_action_or_none,
+        commitment_blocked,
+        judgment_boundary,
+        required_follow_up,
+        decision_record_kind,
+    ) = if input.policy_context.policy_blocked {
+        (
+            "refuse",
+            "policy_blocked",
+            "policy context explicitly blocks commitment for this bounded candidate",
+            None,
+            true,
+            "policy_boundary",
+            "record_refusal_and_stop",
+            "gate_refusal_record",
+        )
+    } else if candidate_action.is_empty() {
+        (
+            "defer",
+            "insufficient_context",
+            "candidate action is empty, so commitment must remain blocked until context is restored",
+            None,
+            true,
+            "context_boundary",
+            "restore_candidate_context",
+            "gate_defer_record",
+        )
+    } else if escalation_candidate && input.frame_state == "ready_for_reframed_execution" {
+        (
+            "escalate",
+            "frame_escalation_required",
+            "frame state and consequence context require explicit escalation before commitment can proceed",
+            None,
+            true,
+            "judgment_boundary",
+            "escalate_for_judgment_review",
+            "gate_escalation_record",
+        )
+    } else if escalation_candidate && input.policy_context.requires_review {
+        (
+            "escalate",
+            "review_escalation_required",
+            "policy review and consequence context together require escalation instead of a silent defer",
+            None,
+            true,
+            "judgment_boundary",
+            "escalate_for_review_board",
+            "gate_escalation_record",
+        )
+    } else if input.frame_state == "ready_for_reframed_execution" {
+        (
+            "defer",
+            "frame_inadequate",
+            "frame state requires bounded reframing before commitment can be allowed",
+            None,
+            true,
+            "frame_boundary",
+            "reframe_before_commitment",
+            "gate_defer_record",
+        )
+    } else if input.policy_context.requires_review {
+        (
+            "defer",
+            "requires_review",
+            "policy context requires bounded review before commitment can be allowed",
+            None,
+            true,
+            "review_boundary",
+            "complete_bounded_review",
+            "gate_defer_record",
+        )
+    } else if input.risk_class == "high" && input.consequence_context.escalation_available {
+        (
+            "escalate",
+            "high_risk_requires_escalation",
+            "risk remains too high for bounded commitment and must be escalated through an explicit judgment path",
+            None,
+            true,
+            "judgment_boundary",
+            "escalate_for_operator_decision",
+            "gate_escalation_record",
+        )
+    } else if input.risk_class == "high" {
+        (
+            "refuse",
+            "risk_too_high",
+            "risk class remains too high for bounded commitment without an available escalation path",
+            None,
+            true,
+            "risk_boundary",
+            "record_refusal_and_stop",
+            "gate_refusal_record",
+        )
+    } else {
+        (
+            "allow",
+            "policy_allowed",
+            "bounded policy context allows commitment for the selected candidate",
+            Some(candidate_action.to_string()),
+            false,
+            "commitment_boundary",
+            "commit_selected_action",
+            "gate_allow_record",
+        )
+    };
 
     FreedomGateDecision {
         gate_decision: gate_decision.to_string(),
@@ -100,6 +178,9 @@ pub fn evaluate_freedom_gate(input: &FreedomGateInput) -> FreedomGateDecision {
         decision_reason: decision_reason.to_string(),
         selected_action_or_none,
         commitment_blocked,
+        judgment_boundary: judgment_boundary.to_string(),
+        required_follow_up: required_follow_up.to_string(),
+        decision_record_kind: decision_record_kind.to_string(),
     }
 }
 
@@ -125,6 +206,12 @@ mod tests {
                 failure_signal: "none".to_string(),
                 termination_reason: "success".to_string(),
             },
+            consequence_context: FreedomGateConsequenceContext {
+                impact_scope: "local_bounded".to_string(),
+                recovery_cost: "low".to_string(),
+                operator_visibility: "routine".to_string(),
+                escalation_available: false,
+            },
             frame_state: "complete_run".to_string(),
         }
     }
@@ -139,6 +226,8 @@ mod tests {
             Some("execute bounded candidate")
         );
         assert!(!decision.commitment_blocked);
+        assert_eq!(decision.judgment_boundary, "commitment_boundary");
+        assert_eq!(decision.required_follow_up, "commit_selected_action");
     }
 
     #[test]
@@ -149,6 +238,7 @@ mod tests {
         assert_eq!(decision.gate_decision, "defer");
         assert_eq!(decision.reason_code, "frame_inadequate");
         assert!(decision.commitment_blocked);
+        assert_eq!(decision.decision_record_kind, "gate_defer_record");
     }
 
     #[test]
@@ -159,5 +249,22 @@ mod tests {
         assert_eq!(decision.gate_decision, "refuse");
         assert_eq!(decision.reason_code, "policy_blocked");
         assert!(decision.commitment_blocked);
+        assert_eq!(decision.decision_record_kind, "gate_refusal_record");
+    }
+
+    #[test]
+    fn freedom_gate_escalates_high_risk_reframing_cases_when_escalation_is_available() {
+        let mut input = base_input();
+        input.risk_class = "high".to_string();
+        input.frame_state = "ready_for_reframed_execution".to_string();
+        input.evaluation_signals.contradiction_signal = "present".to_string();
+        input.consequence_context.escalation_available = true;
+        input.consequence_context.operator_visibility = "review_required".to_string();
+        let decision = evaluate_freedom_gate(&input);
+        assert_eq!(decision.gate_decision, "escalate");
+        assert_eq!(decision.reason_code, "frame_escalation_required");
+        assert_eq!(decision.judgment_boundary, "judgment_boundary");
+        assert_eq!(decision.required_follow_up, "escalate_for_judgment_review");
+        assert_eq!(decision.decision_record_kind, "gate_escalation_record");
     }
 }

--- a/adl/src/freedom_gate.rs
+++ b/adl/src/freedom_gate.rs
@@ -267,4 +267,72 @@ mod tests {
         assert_eq!(decision.required_follow_up, "escalate_for_judgment_review");
         assert_eq!(decision.decision_record_kind, "gate_escalation_record");
     }
+
+    #[test]
+    fn freedom_gate_defers_when_candidate_action_is_empty() {
+        let mut input = base_input();
+        input.candidate_action = "   ".to_string();
+        let decision = evaluate_freedom_gate(&input);
+        assert_eq!(decision.gate_decision, "defer");
+        assert_eq!(decision.reason_code, "insufficient_context");
+        assert_eq!(decision.judgment_boundary, "context_boundary");
+        assert_eq!(decision.required_follow_up, "restore_candidate_context");
+        assert!(decision.commitment_blocked);
+        assert_eq!(decision.decision_record_kind, "gate_defer_record");
+    }
+
+    #[test]
+    fn freedom_gate_defers_when_review_is_required_without_escalation() {
+        let mut input = base_input();
+        input.policy_context.requires_review = true;
+        let decision = evaluate_freedom_gate(&input);
+        assert_eq!(decision.gate_decision, "defer");
+        assert_eq!(decision.reason_code, "requires_review");
+        assert_eq!(decision.judgment_boundary, "review_boundary");
+        assert_eq!(decision.required_follow_up, "complete_bounded_review");
+        assert!(decision.commitment_blocked);
+    }
+
+    #[test]
+    fn freedom_gate_escalates_when_review_and_consequence_context_require_it() {
+        let mut input = base_input();
+        input.policy_context.requires_review = true;
+        input.consequence_context.escalation_available = true;
+        input.evaluation_signals.failure_signal = "tool_failure".to_string();
+        let decision = evaluate_freedom_gate(&input);
+        assert_eq!(decision.gate_decision, "escalate");
+        assert_eq!(decision.reason_code, "review_escalation_required");
+        assert_eq!(decision.judgment_boundary, "judgment_boundary");
+        assert_eq!(decision.required_follow_up, "escalate_for_review_board");
+        assert_eq!(decision.decision_record_kind, "gate_escalation_record");
+    }
+
+    #[test]
+    fn freedom_gate_escalates_high_risk_cases_when_operator_escalation_exists() {
+        let mut input = base_input();
+        input.risk_class = "high".to_string();
+        input.consequence_context.escalation_available = true;
+        let decision = evaluate_freedom_gate(&input);
+        assert_eq!(decision.gate_decision, "escalate");
+        assert_eq!(decision.reason_code, "high_risk_requires_escalation");
+        assert_eq!(
+            decision.required_follow_up,
+            "escalate_for_operator_decision"
+        );
+        assert_eq!(decision.decision_record_kind, "gate_escalation_record");
+        assert!(decision.commitment_blocked);
+    }
+
+    #[test]
+    fn freedom_gate_refuses_high_risk_cases_without_escalation_path() {
+        let mut input = base_input();
+        input.risk_class = "high".to_string();
+        let decision = evaluate_freedom_gate(&input);
+        assert_eq!(decision.gate_decision, "refuse");
+        assert_eq!(decision.reason_code, "risk_too_high");
+        assert_eq!(decision.judgment_boundary, "risk_boundary");
+        assert_eq!(decision.required_follow_up, "record_refusal_and_stop");
+        assert_eq!(decision.decision_record_kind, "gate_refusal_record");
+        assert!(decision.commitment_blocked);
+    }
 }

--- a/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
+++ b/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
@@ -56,7 +56,7 @@ Additional environment / fixture requirements:
 | Demo ID | Demo title | Milestone claim / WP proved | Command entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
 |---|---|---|---|---|---|---|---|
 | D1 | AEE convergence walkthrough | `WP-02` bounded convergence and stop conditions | planned `WP-02` entry point | convergence artifact + output record | reviewer can see converge / stall / bounded-out behavior | use deterministic fixtures for repeated stop-state verification | PLANNED |
-| D2 | Freedom Gate v2 judgment demo | `WP-03` richer allow / defer / refuse / escalate behavior | planned `WP-03` entry point | gate artifact + trace | reviewer can distinguish decision outcomes and rationale | stable test cases should replay to the same outcome class | PLANNED |
+| D2 | Freedom Gate v2 judgment demo | `WP-03` richer allow / defer / refuse / escalate behavior | `cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture` | `learning/freedom_gate.v1.json` + `control_path/final_result.json` | reviewer can distinguish decision outcome, judgment boundary, and follow-up | stable fixtures should replay to the same outcome class and escalation path | READY |
 | D3 | Decision + action mediation proof | `WP-04` - `WP-05` explicit choice and authorization boundary | planned `WP-04` / `WP-05` entry points | decision record + mediation artifact | reviewer can see model intent separated from authorized action | deterministic fixtures should preserve approval / rejection path | PLANNED |
 | D4 | Skill invocation contract demo | `WP-06` bounded skill execution protocol | planned `WP-06` entry point | invocation artifact + trace | invocation lifecycle is reviewer-legible end to end | replay should preserve lifecycle structure | PLANNED |
 | D5 | Experiment record demo | `WP-07` governed adopt / reject improvement behavior | planned `WP-07` entry point | experiment record artifact | reviewer can inspect baseline, variant, evidence, and decision | paired fixture runs should be stably comparable | PLANNED |
@@ -123,26 +123,28 @@ Description:
 
 Milestone claims / work packages covered:
 - `WP-03`
-- `WP-04`
 
 Commands to run:
 
 ```bash
-Defined when the official `WP-03` and `WP-04` issues open and land.
+cargo test --manifest-path adl/Cargo.toml freedom_gate -- --nocapture
+cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture
 ```
 
 Expected artifacts:
-- gate artifact path established by the gate implementation wave
-- decision record path established by the decision implementation wave
+- `learning/freedom_gate.v1.json`
+- `control_path/final_result.json`
+- `control_path/summary.txt`
 
 Primary proof surface:
-- gate artifact and decision record pair
+- gate artifact and final-result pair
 
 Expected success signals:
 - reviewer can see allow / defer / refuse / escalate distinctions
+- reviewer can inspect `judgment_boundary`, `required_follow_up`, and deterministic rationale fields
 
 Determinism / replay notes:
-- stable fixtures should preserve outcome class and rationale shape
+- stable fixtures should preserve outcome class, rationale shape, and escalation follow-up
 
 Reviewer checks:
 - verify the gate is a substrate boundary, not just prompt rhetoric

--- a/docs/milestones/v0.89/features/FREEDOM_GATE_V2.md
+++ b/docs/milestones/v0.89/features/FREEDOM_GATE_V2.md
@@ -27,6 +27,30 @@ Deepen the existing bounded Freedom Gate into a richer judgment surface that sti
 - refusal, defer, and escalation are legitimate governed outcomes, not exceptions
 - the gate consumes richer runtime context without becoming hidden model temperament
 
+## Runtime Contract
+
+`WP-03` now treats Freedom Gate as a concrete runtime and reviewer surface instead of a planning-only note.
+
+The bounded runtime slice makes these judgment surfaces explicit:
+- decision outcomes: `allow`, `defer`, `refuse`, and `escalate`
+- consequence-aware gate input context alongside policy and evaluation signals
+- reviewer-facing judgment metadata:
+  - `judgment_boundary`
+  - `required_follow_up`
+  - `decision_record_kind`
+- linked proof artifacts in the runtime-control bundle:
+  - `learning/freedom_gate.v1.json`
+  - `control_path/final_result.json`
+  - `control_path/summary.txt`
+
+The intended semantics are:
+- `allow` means bounded commitment can proceed
+- `defer` means bounded context or review is still missing, but escalation is not yet required
+- `refuse` means policy or risk blocks commitment outright
+- `escalate` means the runtime must surface a higher-judgment path instead of silently deferring
+
+This keeps the gate as a substrate boundary rather than turning it into prompt rhetoric or an implicit model temperament.
+
 ## Non-Goals
 
 - a complete moral philosophy engine
@@ -44,3 +68,4 @@ Deepen the existing bounded Freedom Gate into a richer judgment surface that sti
 - `v0.89` planning docs agree on the gate's widened outcome vocabulary
 - demos and WBS rows can cite a concrete gate contract instead of a vague future claim
 - carry-forward to later constitutional/governance bands is explicit
+- the runtime-control proof surface exposes judgment boundary and required follow-up metadata


### PR DESCRIPTION
Closes #1790

## Summary
Implemented the bounded `WP-03` Freedom Gate v2 slice by widening the runtime gate from minimal allow / defer / refuse behavior into a richer judgment boundary with explicit escalation semantics, consequence-aware inputs, reviewer-facing judgment metadata, updated runtime-control artifacts, refreshed control-path demo fixtures, and truthful `v0.89` feature/demo documentation.

## Artifacts
- tracked implementation surfaces:
  - `adl/src/freedom_gate.rs`
  - `adl/src/demo.rs`
  - `adl/src/execute/state/runtime_control.rs`
  - `adl/src/execute/state/mod.rs`
  - `adl/src/cli/run_artifacts_types.rs`
  - `adl/src/cli/run_artifacts/cognitive.rs`
  - `adl/src/cli/tests/run_state/mod.rs`
  - `adl/src/cli/tests/run_state/persistence.rs`
  - `adl/src/cli/tests/run_state/runtime_control.rs`
  - `adl/src/cli/tests/artifact_builders/learning_runtime.rs`
  - `adl/src/demo/v086_review_surface.rs`
  - `docs/milestones/v0.89/features/FREEDOM_GATE_V2.md`
  - `docs/milestones/v0.89/DEMO_MATRIX_v0.89.md`
- worktree-local execution bundle:
  - `.adl/v0.89/tasks/issue-1790__v0-89-wp-03-freedom-gate-v2/stp.md`
  - `.adl/v0.89/tasks/issue-1790__v0-89-wp-03-freedom-gate-v2/sip.md`
  - `.adl/v0.89/tasks/issue-1790__v0-89-wp-03-freedom-gate-v2/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 1790 --version v0.89 --json`
    Verified the root readiness bundle before routing the issue into execution.
  - `bash adl/tools/pr.sh run 1790 --slug v0-89-wp-03-freedom-gate-v2 --version v0.89`
    Bound the issue branch and worktree and exposed the pre-run output-card timestamp defect that required bounded worktree-local card repair.
  - `bash adl/tools/pr.sh doctor 1790 --slug v0-89-wp-03-freedom-gate-v2 --version v0.89 --json`
    Verified that the repaired execution bundle is truthfully `run_bound` and ready for implementation.
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Normalized Rust formatting after the Freedom Gate runtime, artifact, test, and doc changes.
  - `cargo test --manifest-path adl/Cargo.toml freedom_gate -- --nocapture`
    Verified the widened allow / defer / refuse / escalate decision logic and the bounded Freedom Gate artifact projection.
  - `cargo test --manifest-path adl/Cargo.toml derive_runtime_control_state_triggers_reframing_on_failure -- --nocapture`
    Verified that runtime-control derivation now carries the new escalation path and follow-up metadata for reframing-sensitive cases.
  - `cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture`
    Verified that persisted runtime-control artifacts emit the widened Freedom Gate surface in the canonical run-state package.
  - `cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_accepts_demo_fixture -- --nocapture`
    Verified that the canonical control-path demo fixture remains valid after the Freedom Gate schema expansion.
  - `cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_rejects_malformed_artifact -- --nocapture`
    Verified that control-path validation still rejects malformed packages under the widened gate schema.
  - `cargo test --manifest-path adl/Cargo.toml run_demo_g_writes_control_path_artifacts -- --nocapture`
    Verified that the repo-level canonical control-path demo test agrees with the widened Freedom Gate final-result contract.
  - `git diff --check`
    Verified that the final tracked diff is patch-clean before publication.
- Results:
  - PASS: conductor-routed execution state remained truthful and bounded throughout implementation
  - PASS: Freedom Gate v2 now exposes escalation-aware judgment metadata through runtime-control and artifact surfaces
  - PASS: the canonical control-path review fixture and validator stay aligned with the widened Freedom Gate contract
  - PASS: the repo-level control-path demo test now agrees with the widened Freedom Gate review summary and final result
  - PASS: the bounded tracked diff is clean and ready for `pr finish`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1790__v0-89-wp-03-freedom-gate-v2/sip.md
- Output card: .adl/v0.89/tasks/issue-1790__v0-89-wp-03-freedom-gate-v2/sor.md
- Idempotency-Key: v0-89-wp-03-freedom-gate-v2-adl-v0-89-tasks-issue-1790-v0-89-wp-03-freedom-gate-v2-sip-md-adl-v0-89-tasks-issue-1790-v0-89-wp-03-freedom-gate-v2-sor-md