### PR TITLE
[v0.89][process] Reclassify heavyweight proof and release surfaces separately from ordinary demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,16 +208,21 @@ Key features:
 
 ## Demos and Proof Surfaces
 
-ADL includes both user-facing demos and milestone-specific proof surfaces.
+ADL includes both ordinary demos and heavyweight reviewer or release proof packages.
 
 Start here:
-- current milestone reviewer package: `bash adl/tools/demo_v088_review_surface.sh`
 - canonical user-facing demo index: `demos/README.md`
+- current milestone reviewer package: `bash adl/tools/demo_v088_review_surface.sh`
 
 Important supporting demo/readiness docs:
 - `docs/tooling/editor/README.md`
 - `docs/tooling/editor/five_command_demo.md`
 - `docs/tooling/editor/five_command_regression_suite.md`
+
+Use this split when choosing an entrypoint:
+- ordinary demos are bounded runnable proofs intended for demo sweeps and first-run exploration
+- reviewer packages combine multiple proof rows into one heavier review surface
+- quality-gate and release-review packages are heavyweight release-tail proofs, not ordinary demos
 
 For milestone-specific context:
 - `docs/milestones/v0.88/DEMO_MATRIX_v0.88.md`

--- a/demos/README.md
+++ b/demos/README.md
@@ -22,7 +22,7 @@ If you want the historical `v0.8` flagship demo surface:
 cargo run --manifest-path demos/transpiler_demo/Cargo.toml --quiet
 ```
 
-If you want the current `v0.87.1` milestone demo-suite proof package:
+If you want the current `v0.87.1` reviewer proof suite:
 
 ```bash
 bash adl/tools/demo_v0871_suite.sh
@@ -59,6 +59,25 @@ bash adl/tools/demo_v089_gemma4_issue_clerk.sh --dry-run
 - Milestone runbooks and reviewer docs live here in `demos/`.
 - Spec-only example artifacts live in `adl-spec/examples/` and are not the main starting point for runnable demos.
 
+## Demo Taxonomy
+
+Use these categories consistently:
+
+- Ordinary demos:
+  bounded runnable surfaces intended for normal demo sweeps, milestone proof rows, or public-facing walkthroughs.
+- Reviewer packages:
+  heavier integrated review surfaces that bundle multiple proof rows for milestone or reviewer use.
+- Release and quality proof packages:
+  heavyweight validation or release-tail surfaces that are useful for review and ceremony work, but should not be treated as ordinary quick demos.
+
+Current heavyweight proof-package examples:
+- `bash adl/tools/demo_v0871_suite.sh`
+- `bash adl/tools/demo_v0871_quality_gate.sh`
+- `bash adl/tools/demo_v0871_release_review_package.sh`
+- `bash adl/tools/demo_v088_review_surface.sh`
+
+When planning a demo sweep, do not assume every proof-package command above belongs in the ordinary demo lane.
+
 ## Recommended Paths
 
 ### v0.87 demo program
@@ -76,8 +95,9 @@ entrypoint. It runs the currently implemented `v0.87.1` proof surfaces and
 writes a suite manifest at `artifacts/v0871/suite/demo_manifest.json`.
 
 Treat that suite as the current reviewer starting point for the milestone.
-It is the default bounded proof package. The live-provider D13L companion proof
-remains explicit and credential-gated rather than part of the default suite.
+It is a heavyweight reviewer proof package, not an ordinary quick demo.
+The live-provider D13L companion proof remains explicit and credential-gated
+rather than part of the default suite.
 
 Use `v0.87.1/codex_ollama_operational_skills_demo.md` for a bounded demo that
 installs the tracked skills into a demo-local `CODEX_HOME`, points Codex CLI at

--- a/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
+++ b/docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md
@@ -146,6 +146,10 @@ Status guidance:
 - `BLOCKED` = known dependency or missing proof surface
 - `LANDED` = milestone evidence exists and is ready for review
 
+Heavyweight proof-row note:
+- `D11` and `D12` are reviewer/release proof packages, not ordinary quick demos.
+- they belong in review and release-tail sweeps, even though they remain in the matrix as canonical proof rows.
+
 ## Coverage Rules
 - Every major milestone claim should map to a runnable demo or an explicit alternate proof surface.
 - Demo coverage should be reviewed against the WBS Acceptance Mapping before internal review.
@@ -182,6 +186,7 @@ Description:
 - Provides the canonical WP-13 entrypoint for the bounded `v0.87.1` proof surfaces.
 - Runs the bounded runtime rows D1-D5 and D9-D12, the provider-family demos, the runtime review walkthrough, and the bounded multi-agent discussion demo.
 - Deliberately excludes the live D13L provider demo from the default suite because it depends on operator-managed OpenAI and Anthropic credentials.
+- Includes heavyweight reviewer and release-tail proof rows alongside ordinary demos; do not treat the whole suite as a quick demo sweep.
 
 Commands to run:
 

--- a/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
+++ b/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
@@ -25,6 +25,20 @@ Out of scope for `v0.89`:
 - the full `v0.89.1` adversarial runtime/demo package
 - later signed-trace and reasoning-graph proof surfaces
 
+## Demo Taxonomy
+
+Use these categories consistently during `v0.89`:
+
+- Ordinary demos:
+  bounded runnable proof rows intended for milestone demo sweeps.
+- Heavyweight proof packages:
+  integrated reviewer, quality-gate, or release-tail surfaces that may still be canonical proof, but should not be treated like quick demos.
+
+For `v0.89`, rows `D1` through `D6` are expected to behave like ordinary demo rows.
+Row `D7` is a heavier reviewer-facing proof row and may remain artifact or document driven even when it is complete.
+
+Future quality-gate or release-review packages for `v0.89` should be classified as heavyweight proof packages, not ordinary demos.
+
 ## Runtime Preconditions
 
 Working directory:
@@ -68,6 +82,10 @@ Status guidance:
 - `READY` = runnable and locally validated
 - `BLOCKED` = known dependency or missing proof surface
 - `LANDED` = milestone evidence exists and is ready for review
+
+Heavyweight proof-package rule:
+- if a proof surface mainly exists to bundle review, release, or quality-gate evidence, classify it as a heavyweight proof package even if it is script-driven
+- do not silently fold heavyweight proof packages into ordinary demo sweeps without saying so explicitly
 
 ## Coverage Rules
 - every major milestone claim should map to a runnable demo or an explicit alternate proof surface
@@ -162,6 +180,7 @@ Cross-demo checks:
 - convergence claims use the same stop-state vocabulary as the feature docs and WBS
 - gate / decision / action demos agree on outcome classes and authority boundaries
 - security/trust/posture proof rows do not overclaim adversarial runtime work that belongs to `v0.89.1`
+- heavyweight proof packages remain clearly separated from ordinary demos in milestone guidance and review notes
 
 Failure policy:
 - If one demo is blocked, record the blocker and say whether milestone review can proceed with an alternate proof surface.


### PR DESCRIPTION
Closes #1830

## Summary
Reclassified heavyweight reviewer, quality-gate, and release-proof surfaces so the repo no longer presents them as ordinary demos. The public demo index, top-level README, `v0.87.1` demo matrix, and `v0.89` demo matrix now distinguish ordinary demos from heavier review and release packages, and the local closeout checklist records the same rule for future milestone tails.

## Artifacts
- updated tracked guidance in `README.md`
- updated tracked guidance in `demos/README.md`
- updated tracked classification notes in `docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md`
- updated tracked taxonomy and review-note guidance in `docs/milestones/v0.89/DEMO_MATRIX_v0.89.md`
- updated local checklist note in `.adl/docs/TBD/MILESTONE_CLOSEOUT_CHECKLIST.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    verifies the tracked doc edits are whitespace-clean and patch-safe
  - `git diff -- demos/README.md README.md docs/milestones/v0.87.1/DEMO_MATRIX_v0.87.1.md docs/milestones/v0.89/DEMO_MATRIX_v0.89.md`
    verifies the tracked wording changes match the intended demo/proof split
  - `git diff -- .adl/docs/TBD/MILESTONE_CLOSEOUT_CHECKLIST.md`
    verifies the local checklist captured the same closeout rule
- Results:
  - all validation checks passed
  - no formatter or test suite was needed because this issue only changes doc/process wording

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1830__v0-89-process-reclassify-heavyweight-proof-and-release-surfaces-separately-from-ordinary-demos/sip.md
- Output card: .adl/v0.89/tasks/issue-1830__v0-89-process-reclassify-heavyweight-proof-and-release-surfaces-separately-from-ordinary-demos/sor.md
- Idempotency-Key: v0-89-process-reclassify-heavyweight-proof-and-release-surfaces-separately-from-ordinary-demos-adl-v0-89-tasks-issue-1830-v0-89-process-reclassify-heavyweight-proof-and-release-surfaces-separately-from-ordinary-demos-sip-md-adl-v0-89-tasks-issue-1830-v0-89-process-reclassify-heavyweight-proof-and-release-surfaces-separately-from-ordinary-demos-sor-md