### PR TITLE
[v0.89][demo] Build Gemini in the Loop bounded provider demo

### DIFF
--- a/adl/examples/packets/v0-89-gemini-in-the-loop-review-packet.md
+++ b/adl/examples/packets/v0-89-gemini-in-the-loop-review-packet.md
@@ -1,0 +1,24 @@
+# Gemini Review Packet
+
+Packet ID: `gemini_review_packet.v1`
+
+## Scope
+
+This is a bounded review packet for a future ADL provider-harmony demo.
+
+## Question
+
+How should ADL host Gemini as a welcomed participant without pretending it has unrestricted repo autonomy?
+
+## Evidence
+
+- Gemini should be treated as a first-class participant, not a compatibility guest.
+- ADL should package the bounded context.
+- The runtime, not Gemini, should own repo access, file selection, validation, and artifact writing.
+- The demo should emit a reviewer-friendly findings artifact plus runtime evidence.
+
+## Review Contract
+
+- Stay inside this packet.
+- Produce concise findings.
+- Prefer calm synthesis over competitive framing.

--- a/adl/examples/v0-89-gemini-in-the-loop.adl.yaml
+++ b/adl/examples/v0-89-gemini-in-the-loop.adl.yaml
@@ -1,0 +1,66 @@
+version: "0.5"
+
+providers:
+  gemini_loop:
+    profile: "http:gemini-2.0-flash"
+    config:
+      endpoint: "http://127.0.0.1:8789/complete"
+      auth:
+        type: bearer
+        env: GEMINI_API_KEY
+      headers:
+        X-Client: "adl-v0.89-gemini-loop"
+      timeout_secs: 15
+      model_ref: "reasoning/default"
+      provider_model_id: "gemini-2.0-flash"
+
+agents:
+  gemini_agent:
+    provider: "gemini_loop"
+    model: "reasoning/default"
+
+tasks:
+  review_packet:
+    prompt:
+      user: |
+        You are Gemini inside a bounded ADL review-packet demo.
+
+        Review packet:
+        {{packet}}
+
+        Return exactly one JSON object with this schema:
+        {
+          "schema_version": "adl.gemini.review.v1",
+          "packet_id": "string",
+          "provider_family": "gemini",
+          "execution_mode": "bounded_http_profile",
+          "verdict": "accept" | "revise",
+          "findings": [
+            {
+              "id": "F1",
+              "severity": "high" | "medium" | "low",
+              "title": "short title",
+              "detail": "one concise paragraph"
+            }
+          ],
+          "synthesis": "short bounded synthesis"
+        }
+
+        Rules:
+        - Preserve the packet_id exactly.
+        - Keep findings grounded in the provided packet only.
+        - Do not mention browsing the repo.
+        - Do not emit Markdown or commentary outside the JSON object.
+
+run:
+  name: "v0-89-gemini-in-the-loop"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "gemini.review.packet"
+        agent: "gemini_agent"
+        task: "review_packet"
+        inputs:
+          packet: "@file:packets/v0-89-gemini-in-the-loop-review-packet.md"
+        save_as: "gemini_review_output"
+        write_to: "review/01-gemini-review.json"

--- a/adl/tools/demo_v089_gemini_in_the_loop.sh
+++ b/adl/tools/demo_v089_gemini_in_the_loop.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v089/gemini_in_the_loop}"
+FIXTURE_DIR="$ROOT_DIR/demos/fixtures/gemini_in_the_loop"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-89-gemini-in-the-loop"
+EXAMPLE="adl/examples/v0-89-gemini-in-the-loop.adl.yaml"
+PACKET_DIR="$OUT_DIR/packet"
+REVIEW_DIR="$OUT_DIR/review_artifacts"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+PORT="${ADL_GEMINI_LOOP_PORT:-8789}"
+RESPONSE_FILE="${ADL_GEMINI_RESPONSE_FILE:-$FIXTURE_DIR/valid_response.json}"
+SERVER_LOG="$OUT_DIR/mock_server.log"
+TMP_PROVIDER_OUT="$OUT_DIR/provider_setup"
+
+sanitize_generated_artifacts() {
+  export ADL_SANITIZE_OUT_DIR="$OUT_DIR"
+  export ADL_SANITIZE_OUT_REAL
+  ADL_SANITIZE_OUT_REAL="$(cd "$OUT_DIR" && pwd -P)"
+  export ADL_SANITIZE_ROOT_DIR="$ROOT_DIR"
+  export ADL_SANITIZE_ROOT_REAL
+  ADL_SANITIZE_ROOT_REAL="$(cd "$ROOT_DIR" && pwd -P)"
+  find "$OUT_DIR" -type f \( -name '*.json' -o -name '*.md' -o -name '*.txt' -o -name '*.yaml' \) -print0 |
+    xargs -0 perl -0pi -e '
+      for my $name (qw(ADL_SANITIZE_OUT_REAL ADL_SANITIZE_OUT_DIR ADL_SANITIZE_ROOT_REAL ADL_SANITIZE_ROOT_DIR)) {
+        my $value = $ENV{$name} // "";
+        next if $value eq "";
+        my $replacement = $name =~ /ROOT/ ? "<repo_root>" : "<output_dir>";
+        s/\Q$value\E/$replacement/g;
+      }
+    '
+}
+
+require_fixture() {
+  local path="$1"
+  [[ -f "$path" ]] || {
+    echo "missing required Gemini fixture: $path" >&2
+    exit 1
+  }
+}
+
+validate_output() {
+  local input="$1"
+  local output="$2"
+  python3 - <<'PY' "$input" "$output"
+from pathlib import Path
+import json, sys
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "adl.gemini.review.v1":
+    raise SystemExit("unexpected schema_version")
+if payload.get("packet_id") != "gemini_review_packet.v1":
+    raise SystemExit("packet_id mismatch")
+if payload.get("provider_family") != "gemini":
+    raise SystemExit("provider_family mismatch")
+if payload.get("execution_mode") != "bounded_http_profile":
+    raise SystemExit("execution_mode mismatch")
+if payload.get("verdict") not in {"accept", "revise"}:
+    raise SystemExit("invalid verdict")
+findings = payload.get("findings")
+if not isinstance(findings, list) or not findings:
+    raise SystemExit("findings must be a non-empty list")
+for idx, finding in enumerate(findings, start=1):
+    if not isinstance(finding, dict):
+      raise SystemExit(f"finding {idx} must be an object")
+    for key in ("id", "severity", "title", "detail"):
+      if not isinstance(finding.get(key), str) or not finding[key]:
+        raise SystemExit(f"finding {idx} missing {key}")
+Path(sys.argv[2]).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+render_findings() {
+  local input="$1"
+  local output="$2"
+  python3 - <<'PY' "$input" "$output"
+from pathlib import Path
+import json, sys
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+lines = [
+    "# Gemini Findings",
+    "",
+    f"Packet ID: `{payload['packet_id']}`",
+    f"Verdict: `{payload['verdict']}`",
+    "",
+    "## Findings",
+]
+for finding in payload["findings"]:
+    lines.extend([
+        "",
+        f"### {finding['id']} - {finding['title']}",
+        f"- Severity: `{finding['severity']}`",
+        "",
+        finding["detail"],
+    ])
+lines.extend(["", "## Synthesis", "", payload["synthesis"], ""])
+Path(sys.argv[2]).write_text("\n".join(lines), encoding="utf-8")
+PY
+}
+
+require_fixture "$FIXTURE_DIR/review_packet.md"
+require_fixture "$RESPONSE_FILE"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$PACKET_DIR" "$REVIEW_DIR"
+cp "$FIXTURE_DIR/review_packet.md" "$PACKET_DIR/review_packet.md"
+
+export GEMINI_API_KEY="${GEMINI_API_KEY:-demo-gemini-token}"
+
+python3 "$ROOT_DIR/adl/tools/mock_gemini_http_provider.py" \
+  --port "$PORT" \
+  --response-file "$RESPONSE_FILE" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+cleanup() {
+  kill "$SERVER_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+sleep 1
+
+cd "$ROOT_DIR"
+mkdir -p "$TMP_PROVIDER_OUT"
+cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- provider setup gemini --out "$TMP_PROVIDER_OUT" --force >/dev/null
+
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+  cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+    "$EXAMPLE" \
+    --run \
+    --trace \
+    --allow-unsigned \
+    --out "$STEP_OUT" \
+    >"$OUT_DIR/run_log.txt" 2>&1
+
+validate_output "$STEP_OUT/review/01-gemini-review.json" "$REVIEW_DIR/validated_review.json"
+render_findings "$REVIEW_DIR/validated_review.json" "$REVIEW_DIR/findings.md"
+
+python3 - "$MANIFEST" "$RUN_ID" <<'PY'
+import json, sys
+from pathlib import Path
+manifest = {
+    "schema_version": "adl.gemini_in_the_loop_demo.v1",
+    "demo_id": "v0.89.gemini_in_the_loop",
+    "title": "Gemini in the Loop bounded provider demo",
+    "execution_mode": "bounded_http_profile",
+    "provider_family": "gemini",
+    "provider_profile": "http:gemini-2.0-flash",
+    "claim": "ADL can host Gemini as a first-class bounded participant by packaging a review packet, invoking Gemini through a provider-aware path, validating the output, and writing stable reviewer-facing artifacts.",
+    "artifacts": {
+        "packet": "packet/review_packet.md",
+        "provider_setup": "provider_setup/provider.adl.yaml",
+        "raw_output": "out/review/01-gemini-review.json",
+        "validated_output": "review_artifacts/validated_review.json",
+        "findings": "review_artifacts/findings.md",
+        "run_summary": f"runtime/runs/{sys.argv[2]}/run_summary.json",
+        "steps": f"runtime/runs/{sys.argv[2]}/steps.json",
+        "trace": f"runtime/runs/{sys.argv[2]}/logs/trace_v1.json"
+    }
+}
+Path(sys.argv[1]).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$README_OUT" <<EOF
+# v0.89 Demo - Gemini in the Loop
+
+Canonical command:
+
+\`\`\`bash
+bash adl/tools/demo_v089_gemini_in_the_loop.sh
+\`\`\`
+
+Primary proof surfaces:
+- \`demo_manifest.json\`
+- \`packet/review_packet.md\`
+- \`review_artifacts/validated_review.json\`
+- \`review_artifacts/findings.md\`
+- \`runtime/runs/$RUN_ID/run_summary.json\`
+- \`runtime/runs/$RUN_ID/logs/trace_v1.json\`
+
+What this proves:
+- ADL can package a bounded packet for Gemini
+- Gemini can contribute through a provider-aware HTTP profile path
+- output is validated before it is accepted as a review artifact
+- the runtime, not Gemini, stays responsible for packet construction and artifact writing
+EOF
+
+sanitize_generated_artifacts
+
+echo "Gemini in the Loop proof surface under the output directory:"
+echo "  demo_manifest.json"
+echo "  review_artifacts/findings.md"
+echo "  review_artifacts/validated_review.json"
+echo "  runtime/runs/$RUN_ID/run_summary.json"
+echo "  runtime/runs/$RUN_ID/logs/trace_v1.json"

--- a/adl/tools/mock_gemini_http_provider.py
+++ b/adl/tools/mock_gemini_http_provider.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+
+def load_output(response_path: Path) -> str:
+    payload = json.loads(response_path.read_text(encoding="utf-8"))
+    return json.dumps(payload, indent=2)
+
+
+class Handler(BaseHTTPRequestHandler):
+    response_text = ""
+
+    def do_POST(self) -> None:
+        if self.path != "/complete":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            self.send_error(400, "invalid json")
+            return
+        if "prompt" not in payload or not isinstance(payload["prompt"], str):
+            self.send_error(400, "missing prompt")
+            return
+        response = {"output": self.response_text}
+        encoded = json.dumps(response).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, fmt: str, *args) -> None:
+        return
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--response-file", type=Path, required=True)
+    args = parser.parse_args()
+    Handler.response_text = load_output(args.response_file)
+    server = HTTPServer(("127.0.0.1", args.port), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_demo_v089_gemini_in_the_loop.sh
+++ b/adl/tools/test_demo_v089_gemini_in_the_loop.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+RUN_ROOT="$OUT_DIR/runtime/runs/v0-89-gemini-in-the-loop"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v089_gemini_in_the_loop.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/README.md" \
+  "$OUT_DIR/packet/review_packet.md" \
+  "$OUT_DIR/provider_setup/provider.adl.yaml" \
+  "$OUT_DIR/provider_setup/.env.example" \
+  "$OUT_DIR/review_artifacts/validated_review.json" \
+  "$OUT_DIR/review_artifacts/findings.md" \
+  "$OUT_DIR/out/review/01-gemini-review.json" \
+  "$RUN_ROOT/run_summary.json" \
+  "$RUN_ROOT/steps.json" \
+  "$RUN_ROOT/logs/trace_v1.json" \
+  "$OUT_DIR/run_log.txt"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+python3 - "$OUT_DIR/demo_manifest.json" "$OUT_DIR/review_artifacts/validated_review.json" <<'PY'
+import json
+import sys
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+review = json.load(open(sys.argv[2], encoding="utf-8"))
+assert manifest["schema_version"] == "adl.gemini_in_the_loop_demo.v1"
+assert manifest["provider_family"] == "gemini"
+assert manifest["provider_profile"] == "http:gemini-2.0-flash"
+assert review["packet_id"] == "gemini_review_packet.v1"
+assert review["provider_family"] == "gemini"
+assert len(review["findings"]) >= 1
+PY
+
+grep -Fq 'profile: "http:gemini-2.0-flash"' "$OUT_DIR/provider_setup/provider.adl.yaml" || {
+  echo "assertion failed: provider setup missing gemini profile" >&2
+  exit 1
+}
+
+grep -Fq '# Gemini Findings' "$OUT_DIR/review_artifacts/findings.md" || {
+  echo "assertion failed: findings artifact missing heading" >&2
+  exit 1
+}
+
+if grep -R -E '/Users/|/private/tmp|/tmp/' "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: absolute path leaked into generated artifacts" >&2
+  exit 1
+fi
+
+echo "demo_v089_gemini_in_the_loop: ok"

--- a/demos/README.md
+++ b/demos/README.md
@@ -92,6 +92,10 @@ multi-agent runtime demo that keeps Claude and ChatGPT as two explicit named
 agents in a longer act-structured tea discussion and emits a transcript plus runtime proof
 artifacts.
 
+Use `v0.89/gemini_in_the_loop_demo.md` for a bounded provider-harmony demo that
+packages one review packet for Gemini, validates Gemini's structured response,
+and records a reviewer-facing findings artifact plus runtime proof.
+
 ### v0.89 bounded provider-participation demos
 
 - `v0.89/gemma4_issue_clerk_demo.md`

--- a/demos/fixtures/gemini_in_the_loop/invalid_response.json
+++ b/demos/fixtures/gemini_in_the_loop/invalid_response.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "adl.gemini.review.v1",
+  "packet_id": "WRONG_PACKET",
+  "provider_family": "gemini",
+  "execution_mode": "bounded_http_profile",
+  "verdict": "accept",
+  "findings": "not-a-list",
+  "synthesis": "broken"
+}

--- a/demos/fixtures/gemini_in_the_loop/review_packet.md
+++ b/demos/fixtures/gemini_in_the_loop/review_packet.md
@@ -1,0 +1,24 @@
+# Gemini Review Packet
+
+Packet ID: `gemini_review_packet.v1`
+
+## Scope
+
+This is a bounded review packet for a future ADL provider-harmony demo.
+
+## Question
+
+How should ADL host Gemini as a welcomed participant without pretending it has unrestricted repo autonomy?
+
+## Evidence
+
+- Gemini should be treated as a first-class participant, not a compatibility guest.
+- ADL should package the bounded context.
+- The runtime, not Gemini, should own repo access, file selection, validation, and artifact writing.
+- The demo should emit a reviewer-friendly findings artifact plus runtime evidence.
+
+## Review Contract
+
+- Stay inside this packet.
+- Produce concise findings.
+- Prefer calm synthesis over competitive framing.

--- a/demos/fixtures/gemini_in_the_loop/valid_response.json
+++ b/demos/fixtures/gemini_in_the_loop/valid_response.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "adl.gemini.review.v1",
+  "packet_id": "gemini_review_packet.v1",
+  "provider_family": "gemini",
+  "execution_mode": "bounded_http_profile",
+  "verdict": "accept",
+  "findings": [
+    {
+      "id": "F1",
+      "severity": "medium",
+      "title": "Keep runtime ownership explicit",
+      "detail": "The packet is strongest when ADL, not Gemini, stays visibly responsible for repo access, validation, and artifact writing."
+    },
+    {
+      "id": "F2",
+      "severity": "low",
+      "title": "Preserve the welcoming tone",
+      "detail": "The demo should frame Gemini as a welcomed participant and avoid benchmark-style comparison language."
+    }
+  ],
+  "synthesis": "Gemini contributes best here when ADL supplies the bounded packet, validates the output, and records a calm reviewer-facing artifact."
+}

--- a/demos/v0.89/gemini_in_the_loop_demo.md
+++ b/demos/v0.89/gemini_in_the_loop_demo.md
@@ -1,0 +1,34 @@
+# Gemini in the Loop
+
+This bounded `v0.89` demo presents Gemini as a welcomed ADL participant rather
+than a pretend repo-native operator.
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v089_gemini_in_the_loop.sh
+```
+
+What the demo does:
+
+- prepares one bounded review packet
+- generates a local Gemini provider-setup bundle
+- invokes a Gemini-profile HTTP provider path through ADL
+- validates the structured review output before accepting it
+- writes reviewer-facing findings plus runtime proof artifacts
+
+Primary proof surfaces:
+
+- `artifacts/v089/gemini_in_the_loop/demo_manifest.json`
+- `artifacts/v089/gemini_in_the_loop/packet/review_packet.md`
+- `artifacts/v089/gemini_in_the_loop/review_artifacts/validated_review.json`
+- `artifacts/v089/gemini_in_the_loop/review_artifacts/findings.md`
+- `artifacts/v089/gemini_in_the_loop/runtime/runs/v0-89-gemini-in-the-loop/run_summary.json`
+- `artifacts/v089/gemini_in_the_loop/runtime/runs/v0-89-gemini-in-the-loop/logs/trace_v1.json`
+
+Truth boundary:
+
+- this is a bounded packet demo
+- ADL owns packet construction, validation, and artifact writing
+- Gemini is not asked to browse the repo or claim tool autonomy
+- the provider path is explicit and reviewable


### PR DESCRIPTION
Closes #1812

## Summary
Built `Gemini in the Loop` as a bounded ADL-native provider demo. The demo prepares a fixed review packet, invokes a Gemini-profile HTTP provider path through ADL against a local deterministic completion server, validates the returned JSON review contract, and materializes reviewer-facing findings plus runtime evidence.

## Artifacts
- workflow example at `adl/examples/v0-89-gemini-in-the-loop.adl.yaml`
- canonical packet at `adl/examples/packets/v0-89-gemini-in-the-loop-review-packet.md`
- mock Gemini HTTP provider at `adl/tools/mock_gemini_http_provider.py`
- demo wrapper at `adl/tools/demo_v089_gemini_in_the_loop.sh`
- proof test at `adl/tools/test_demo_v089_gemini_in_the_loop.sh`
- fixtures at `demos/fixtures/gemini_in_the_loop/`
- demo doc at `demos/v0.89/gemini_in_the_loop_demo.md`
- demo index update at `demos/README.md`
- conductor routing proof at `.adl/reviews/workflow-conductor-1812-run-dispatch.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 1812 --slug build-gemini-in-the-loop-bounded-provider-demo --version v0.89 --mode full --json`
    - verified the issue was structurally ready before execution
  - `bash -n adl/tools/demo_v089_gemini_in_the_loop.sh adl/tools/test_demo_v089_gemini_in_the_loop.sh`
    - verified the wrapper and test are shell-valid
  - `python3 -m py_compile adl/tools/mock_gemini_http_provider.py`
    - verified the mock provider helper parses cleanly
  - `bash adl/tools/test_demo_v089_gemini_in_the_loop.sh`
    - verified the full bounded demo path: provider setup, mock Gemini completion, ADL workflow run, output validation, artifact materialization, and leakage checks
  - `git diff --check`
    - verified no whitespace or patch-format defects remain
- Results:
  - doctor passed
  - shell syntax passed
  - mock provider syntax passed
  - full Gemini demo proof test passed
  - diff hygiene is clean

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1812__build-gemini-in-the-loop-bounded-provider-demo/sip.md
- Output card: .adl/v0.89/tasks/issue-1812__build-gemini-in-the-loop-bounded-provider-demo/sor.md
- Idempotency-Key: v0-89-demo-build-gemini-in-the-loop-bounded-provider-demo-adl-v0-89-tasks-issue-1812-build-gemini-in-the-loop-bounded-provider-demo-sip-md-adl-v0-89-tasks-issue-1812-build-gemini-in-the-loop-bounded-provider-demo-sor-md