### PR TITLE
[v0.89][WP-04] Decision surfaces and decision schema

### DIFF
--- a/adl/src/artifacts.rs
+++ b/adl/src/artifacts.rs
@@ -176,6 +176,10 @@ impl RunArtifactPaths {
         self.control_path_dir().join("convergence.json")
     }
 
+    pub fn control_path_decisions_json(&self) -> PathBuf {
+        self.control_path_dir().join("decisions.json")
+    }
+
     pub fn control_path_final_result_json(&self) -> PathBuf {
         self.control_path_dir().join("final_result.json")
     }

--- a/adl/src/cli/run_artifacts/cognitive.rs
+++ b/adl/src/cli/run_artifacts/cognitive.rs
@@ -1062,6 +1062,204 @@ pub(crate) fn build_control_path_memory_artifact(
     }
 }
 
+fn route_outcome_class(route_selected: &str) -> &'static str {
+    if route_selected == "fast" {
+        "accept"
+    } else {
+        "reroute"
+    }
+}
+
+fn reframing_outcome_class(reframing_trigger: &str) -> &'static str {
+    if reframing_trigger == "triggered" {
+        "reroute"
+    } else {
+        "accept"
+    }
+}
+
+fn gate_outcome_class(gate_decision: &str) -> &'static str {
+    match gate_decision {
+        "allow" => "accept",
+        "refuse" => "reject",
+        "defer" => "defer",
+        "escalate" => "escalate",
+        _ => "reject",
+    }
+}
+
+pub(crate) fn build_control_path_decisions_artifact(
+    run_summary: &RunSummaryArtifact,
+    arbitration: &CognitiveArbitrationArtifact,
+    agency: &AgencySelectionArtifact,
+    evaluation: &EvaluationSignalsArtifact,
+    reframing: &ReframingArtifact,
+    freedom_gate: &FreedomGateArtifact,
+    scores: Option<&ScoresArtifact>,
+) -> ControlPathDecisionsArtifact {
+    let route_policy_bindings = if arbitration.applied_constraints.is_empty() {
+        vec!["no_explicit_constraints".to_string()]
+    } else {
+        arbitration.applied_constraints.clone()
+    };
+    let reframing_policy_bindings = vec![
+        format!("frame_adequacy_score={}", reframing.frame_adequacy_score),
+        format!("termination_reason={}", evaluation.termination_reason),
+        format!("progress_signal={}", evaluation.progress_signal),
+    ];
+    let gate_policy_bindings = vec![
+        format!(
+            "route_selected={}",
+            freedom_gate.input.policy_context.route_selected
+        ),
+        format!(
+            "selected_candidate_kind={}",
+            freedom_gate.input.policy_context.selected_candidate_kind
+        ),
+        format!(
+            "requires_review={}",
+            freedom_gate.input.policy_context.requires_review
+        ),
+        format!(
+            "policy_blocked={}",
+            freedom_gate.input.policy_context.policy_blocked
+        ),
+        format!(
+            "impact_scope={}",
+            freedom_gate.input.consequence_context.impact_scope
+        ),
+        format!(
+            "operator_visibility={}",
+            freedom_gate.input.consequence_context.operator_visibility
+        ),
+        format!(
+            "escalation_available={}",
+            freedom_gate.input.consequence_context.escalation_available
+        ),
+    ];
+
+    ControlPathDecisionsArtifact {
+        control_path_decisions_version: CONTROL_PATH_DECISIONS_VERSION,
+        run_id: run_summary.run_id.clone(),
+        generated_from: AeeDecisionGeneratedFrom {
+            artifact_model_version: run_summary.artifact_model_version,
+            run_summary_version: run_summary.run_summary_version,
+            suggestions_version: arbitration.generated_from.suggestions_version,
+            scores_version: scores.map(|value| value.scores_version),
+        },
+        decision_schema_name: "adl.runtime.decision.v1".to_string(),
+        decision_schema_fields: vec![
+            "decision_id".to_string(),
+            "surface_id".to_string(),
+            "proposal_or_action".to_string(),
+            "outcome_class".to_string(),
+            "decision_maker".to_string(),
+            "policy_bindings".to_string(),
+            "rationale".to_string(),
+            "downstream_consequence".to_string(),
+            "temporal_anchor".to_string(),
+        ],
+        outcome_class_vocabulary: vec![
+            "accept".to_string(),
+            "reject".to_string(),
+            "defer".to_string(),
+            "escalate".to_string(),
+            "reroute".to_string(),
+        ],
+        surfaces: vec![
+            DecisionSurfaceRecord {
+                surface_id: "delegation_and_routing.route_selection".to_string(),
+                surface_family: "delegation_and_routing".to_string(),
+                bounded_role:
+                    "select the bounded runtime path before commitment is attempted".to_string(),
+                outcome_classes: vec!["accept".to_string(), "reroute".to_string()],
+                temporal_anchor_ref: "control_path/arbitration.json".to_string(),
+            },
+            DecisionSurfaceRecord {
+                surface_id: "recovery_continuity.reframing".to_string(),
+                surface_family: "recovery_continuity".to_string(),
+                bounded_role:
+                    "decide whether the current frame should be retained or rerouted through reframing"
+                        .to_string(),
+                outcome_classes: vec!["accept".to_string(), "reroute".to_string()],
+                temporal_anchor_ref: "control_path/reframing.json".to_string(),
+            },
+            DecisionSurfaceRecord {
+                surface_id: "pre_execution_authorization.commitment_gate".to_string(),
+                surface_family: "pre_execution_authorization".to_string(),
+                bounded_role:
+                    "decide whether commitment may proceed for the selected bounded candidate"
+                        .to_string(),
+                outcome_classes: vec![
+                    "accept".to_string(),
+                    "reject".to_string(),
+                    "defer".to_string(),
+                    "escalate".to_string(),
+                ],
+                temporal_anchor_ref: "control_path/freedom_gate.json".to_string(),
+            },
+        ],
+        decisions: vec![
+            DecisionRecord {
+                decision_id: "decision.route_selection".to_string(),
+                surface_id: "delegation_and_routing.route_selection".to_string(),
+                proposal_or_action: format!(
+                    "route candidate {} through the {} path",
+                    agency.selected_candidate_id, arbitration.route_selected
+                ),
+                outcome_class: route_outcome_class(&arbitration.route_selected).to_string(),
+                decision_maker: "cognitive_arbitration".to_string(),
+                policy_bindings: route_policy_bindings,
+                rationale: arbitration.route_reason.clone(),
+                downstream_consequence: format!(
+                    "selected_path={} reasoning_mode={}",
+                    arbitration.route_selected, arbitration.reasoning_mode
+                ),
+                temporal_anchor: "control_path/arbitration.json".to_string(),
+            },
+            DecisionRecord {
+                decision_id: "decision.reframing".to_string(),
+                surface_id: "recovery_continuity.reframing".to_string(),
+                proposal_or_action: format!(
+                    "decide whether candidate {} should keep the current frame or reframe before re-execution",
+                    agency.selected_candidate_id
+                ),
+                outcome_class: reframing_outcome_class(&reframing.reframing_trigger).to_string(),
+                decision_maker: "reframing_control".to_string(),
+                policy_bindings: reframing_policy_bindings,
+                rationale: reframing.reframing_reason.clone(),
+                downstream_consequence: reframing.reexecution_choice.clone(),
+                temporal_anchor: "control_path/reframing.json".to_string(),
+            },
+            DecisionRecord {
+                decision_id: "decision.commitment_gate".to_string(),
+                surface_id: "pre_execution_authorization.commitment_gate".to_string(),
+                proposal_or_action: freedom_gate
+                    .selected_action_or_none
+                    .clone()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or_else(|| {
+                        let candidate_action = freedom_gate.input.candidate_action.trim();
+                        if candidate_action.is_empty() {
+                            "withhold commitment until bounded context is restored".to_string()
+                        } else {
+                            candidate_action.to_string()
+                        }
+                    }),
+                outcome_class: gate_outcome_class(&freedom_gate.gate_decision).to_string(),
+                decision_maker: "freedom_gate".to_string(),
+                policy_bindings: gate_policy_bindings,
+                rationale: freedom_gate.decision_reason.clone(),
+                downstream_consequence: freedom_gate
+                    .selected_action_or_none
+                    .clone()
+                    .unwrap_or_else(|| freedom_gate.required_follow_up.clone()),
+                temporal_anchor: "control_path/freedom_gate.json".to_string(),
+            },
+        ],
+    }
+}
+
 pub(crate) fn build_control_path_final_result_artifact(
     run_summary: &RunSummaryArtifact,
     arbitration: &CognitiveArbitrationArtifact,
@@ -1156,6 +1354,12 @@ pub(crate) fn build_control_path_summary(context: &ControlPathSummaryContext<'_>
             convergence.convergence_state,
             convergence.stop_condition_family,
             convergence.progress_signal
+        ),
+        format!(
+            "decisions: route_selection={} reframing={} commitment_gate={}",
+            route_outcome_class(&arbitration.route_selected),
+            reframing_outcome_class(&reframing.reframing_trigger),
+            gate_outcome_class(&freedom_gate.gate_decision)
         ),
         format!(
             "memory: read_count={} influenced_stage={} write_reason={}",

--- a/adl/src/cli/run_artifacts/runtime.rs
+++ b/adl/src/cli/run_artifacts/runtime.rs
@@ -1,11 +1,11 @@
 use super::cognitive::{
     build_aee_decision_artifact, build_affect_state_artifact, build_agency_selection_artifact,
     build_bounded_execution_artifact, build_cognitive_arbitration_artifact_from_state,
-    build_cognitive_signals_artifact_from_state, build_control_path_final_result_artifact,
-    build_control_path_memory_artifact, build_control_path_summary,
-    build_evaluation_signals_artifact, build_fast_slow_path_artifact, build_freedom_gate_artifact,
-    build_memory_read_artifact, build_memory_write_artifact, build_reasoning_graph_artifact,
-    build_reframing_artifact,
+    build_cognitive_signals_artifact_from_state, build_control_path_decisions_artifact,
+    build_control_path_final_result_artifact, build_control_path_memory_artifact,
+    build_control_path_summary, build_evaluation_signals_artifact, build_fast_slow_path_artifact,
+    build_freedom_gate_artifact, build_memory_read_artifact, build_memory_write_artifact,
+    build_reasoning_graph_artifact, build_reframing_artifact,
 };
 use super::summary::{
     build_cluster_groundwork_artifact, build_scores_artifact, build_suggestions_artifact,
@@ -253,6 +253,15 @@ pub(crate) fn write_run_state_artifacts(
     );
     let control_path_memory =
         build_control_path_memory_artifact(&run_summary, &memory_read, &memory_write);
+    let control_path_decisions = build_control_path_decisions_artifact(
+        &run_summary,
+        &cognitive_arbitration,
+        &agency_selection,
+        &evaluation_signals,
+        &reframing,
+        &freedom_gate,
+        Some(&scores_for_suggestions),
+    );
     let control_path_final_result = build_control_path_final_result_artifact(
         &run_summary,
         &cognitive_arbitration,
@@ -294,6 +303,8 @@ pub(crate) fn write_run_state_artifacts(
         serde_json::to_vec_pretty(&memory_write).context("serialize memory_write.v1.json")?;
     let control_path_memory_json = serde_json::to_vec_pretty(&control_path_memory)
         .context("serialize control_path memory.json")?;
+    let control_path_decisions_json = serde_json::to_vec_pretty(&control_path_decisions)
+        .context("serialize control_path decisions.json")?;
     let control_path_final_result_json = serde_json::to_vec_pretty(&control_path_final_result)
         .context("serialize control_path final_result.json")?;
     let aee_decision = build_aee_decision_artifact(
@@ -364,6 +375,10 @@ pub(crate) fn write_run_state_artifacts(
     artifacts::atomic_write(
         &run_paths.control_path_memory_json(),
         &control_path_memory_json,
+    )?;
+    artifacts::atomic_write(
+        &run_paths.control_path_decisions_json(),
+        &control_path_decisions_json,
     )?;
     artifacts::atomic_write(
         &run_paths.control_path_freedom_gate_json(),
@@ -1016,6 +1031,8 @@ pub(crate) fn validate_control_path_artifact_set(control_path_dir: &Path) -> Res
         read_required_json_artifact(control_path_dir, "reframing.json")?;
     let memory: ControlPathMemoryArtifact =
         read_required_json_artifact(control_path_dir, "memory.json")?;
+    let decisions: ControlPathDecisionsArtifact =
+        read_required_json_artifact(control_path_dir, "decisions.json")?;
     let freedom_gate: FreedomGateArtifact =
         read_required_json_artifact(control_path_dir, "freedom_gate.json")?;
     let convergence: AeeConvergenceArtifact =
@@ -1064,6 +1081,7 @@ pub(crate) fn validate_control_path_artifact_set(control_path_dir: &Path) -> Res
         evaluation.run_id.as_str(),
         reframing.run_id.as_str(),
         memory.run_id.as_str(),
+        decisions.run_id.as_str(),
         freedom_gate.run_id.as_str(),
         convergence.run_id.as_str(),
         final_result.run_id.as_str(),
@@ -1140,12 +1158,101 @@ pub(crate) fn validate_control_path_artifact_set(control_path_dir: &Path) -> Res
         ));
     }
 
+    let expected_schema_fields = vec![
+        "decision_id".to_string(),
+        "surface_id".to_string(),
+        "proposal_or_action".to_string(),
+        "outcome_class".to_string(),
+        "decision_maker".to_string(),
+        "policy_bindings".to_string(),
+        "rationale".to_string(),
+        "downstream_consequence".to_string(),
+        "temporal_anchor".to_string(),
+    ];
+    if decisions.decision_schema_fields != expected_schema_fields {
+        return Err(anyhow!(
+            "control-path decisions schema fields mismatch: expected {:?}, found {:?}",
+            expected_schema_fields,
+            decisions.decision_schema_fields
+        ));
+    }
+
+    let expected_outcome_vocabulary = vec![
+        "accept".to_string(),
+        "reject".to_string(),
+        "defer".to_string(),
+        "escalate".to_string(),
+        "reroute".to_string(),
+    ];
+    if decisions.outcome_class_vocabulary != expected_outcome_vocabulary {
+        return Err(anyhow!(
+            "control-path decisions outcome vocabulary mismatch: expected {:?}, found {:?}",
+            expected_outcome_vocabulary,
+            decisions.outcome_class_vocabulary
+        ));
+    }
+    if decisions.surfaces.len() != 3 || decisions.decisions.len() != 3 {
+        return Err(anyhow!(
+            "control-path decisions artifact must contain exactly 3 surfaces and 3 records"
+        ));
+    }
+
+    let expected_surface_ids = [
+        "delegation_and_routing.route_selection",
+        "recovery_continuity.reframing",
+        "pre_execution_authorization.commitment_gate",
+    ];
+    for expected_surface_id in expected_surface_ids {
+        let Some(surface) = decisions
+            .surfaces
+            .iter()
+            .find(|surface| surface.surface_id == expected_surface_id)
+        else {
+            return Err(anyhow!(
+                "control-path decisions artifact is missing surface '{}'",
+                expected_surface_id
+            ));
+        };
+        let Some(record) = decisions
+            .decisions
+            .iter()
+            .find(|record| record.surface_id == expected_surface_id)
+        else {
+            return Err(anyhow!(
+                "control-path decisions artifact is missing decision record for '{}'",
+                expected_surface_id
+            ));
+        };
+        if record.temporal_anchor != surface.temporal_anchor_ref {
+            return Err(anyhow!(
+                "control-path decision temporal anchor '{}' does not match surface anchor '{}'",
+                record.temporal_anchor,
+                surface.temporal_anchor_ref
+            ));
+        }
+        if !decisions
+            .outcome_class_vocabulary
+            .contains(&record.outcome_class)
+        {
+            return Err(anyhow!(
+                "control-path decision outcome '{}' is not in the declared vocabulary",
+                record.outcome_class
+            ));
+        }
+    }
+
     let required_summary_markers = [
         "stage_order: signals -> candidate_selection -> arbitration -> execution -> evaluation -> reframing -> memory -> freedom_gate -> final_result".to_string(),
         format!("candidate_selection: candidate_id={}", agency.selected_candidate_id),
         format!("arbitration: route={}", arbitration.route_selected),
         format!("evaluation: termination_reason={}", evaluation.termination_reason),
         format!("reframing: trigger={}", reframing.reframing_trigger),
+        format!(
+            "decisions: route_selection={} reframing={} commitment_gate={}",
+            decisions.decisions[0].outcome_class,
+            decisions.decisions[1].outcome_class,
+            decisions.decisions[2].outcome_class
+        ),
         format!("freedom_gate: decision={}", freedom_gate.gate_decision),
         format!(
             "convergence: state={} stop_condition_family={} progress_signal={}",

--- a/adl/src/cli/run_artifacts_types.rs
+++ b/adl/src/cli/run_artifacts_types.rs
@@ -23,6 +23,7 @@ pub(crate) const AEE_CONVERGENCE_VERSION: u32 = 1;
 pub(crate) const MEMORY_READ_VERSION: u32 = 1;
 pub(crate) const MEMORY_WRITE_VERSION: u32 = 1;
 pub(crate) const CONTROL_PATH_MEMORY_VERSION: u32 = 1;
+pub(crate) const CONTROL_PATH_DECISIONS_VERSION: u32 = 1;
 pub(crate) const CONTROL_PATH_FINAL_RESULT_VERSION: u32 = 1;
 pub(crate) const REASONING_GRAPH_VERSION: u32 = 1;
 pub(crate) const CLUSTER_GROUNDWORK_VERSION: u32 = 1;
@@ -674,6 +675,43 @@ pub(crate) struct ControlPathMemoryArtifact {
     pub(crate) generated_from: AeeDecisionGeneratedFrom,
     pub(crate) read: MemoryReadArtifact,
     pub(crate) write: MemoryWriteArtifact,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ControlPathDecisionsArtifact {
+    pub(crate) control_path_decisions_version: u32,
+    pub(crate) run_id: String,
+    pub(crate) generated_from: AeeDecisionGeneratedFrom,
+    pub(crate) decision_schema_name: String,
+    pub(crate) decision_schema_fields: Vec<String>,
+    pub(crate) outcome_class_vocabulary: Vec<String>,
+    pub(crate) surfaces: Vec<DecisionSurfaceRecord>,
+    pub(crate) decisions: Vec<DecisionRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionSurfaceRecord {
+    pub(crate) surface_id: String,
+    pub(crate) surface_family: String,
+    pub(crate) bounded_role: String,
+    pub(crate) outcome_classes: Vec<String>,
+    pub(crate) temporal_anchor_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionRecord {
+    pub(crate) decision_id: String,
+    pub(crate) surface_id: String,
+    pub(crate) proposal_or_action: String,
+    pub(crate) outcome_class: String,
+    pub(crate) decision_maker: String,
+    pub(crate) policy_bindings: Vec<String>,
+    pub(crate) rationale: String,
+    pub(crate) downstream_consequence: String,
+    pub(crate) temporal_anchor: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/adl/src/cli/tests/artifact_builders/learning_runtime.rs
+++ b/adl/src/cli/tests/artifact_builders/learning_runtime.rs
@@ -854,6 +854,225 @@ fn build_freedom_gate_artifact_is_deterministic_and_blocks_commitment_when_not_a
 }
 
 #[test]
+fn build_control_path_decisions_artifact_is_deterministic_and_surfaces_core_records() {
+    let generated_from = run_artifacts::AeeDecisionGeneratedFrom {
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_summary_version: 1,
+        suggestions_version: 1,
+        scores_version: Some(1),
+    };
+    let run_summary = RunSummaryArtifact {
+        run_summary_version: 1,
+        artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+        run_id: "decision-run".to_string(),
+        workflow_id: "wf".to_string(),
+        adl_version: "0.89".to_string(),
+        swarm_version: "test".to_string(),
+        status: "failure".to_string(),
+        error_kind: None,
+        counts: RunSummaryCounts {
+            total_steps: 1,
+            completed_steps: 1,
+            failed_steps: 1,
+            provider_call_count: 1,
+            delegation_steps: 0,
+            delegation_requires_verification_steps: 0,
+        },
+        policy: RunSummaryPolicy {
+            security_envelope_enabled: false,
+            signing_required: false,
+            key_id_required: false,
+            verify_allowed_algs: Vec::new(),
+            verify_allowed_key_sources: Vec::new(),
+            sandbox_policy: "centralized_path_resolver_v1".to_string(),
+            security_denials_by_code: BTreeMap::new(),
+        },
+        links: RunSummaryLinks {
+            run_json: "run.json".to_string(),
+            steps_json: "steps.json".to_string(),
+            pause_state_json: None,
+            outputs_dir: "outputs".to_string(),
+            logs_dir: "logs".to_string(),
+            learning_dir: "learning".to_string(),
+            scores_json: None,
+            suggestions_json: None,
+            aee_decision_json: None,
+            cognitive_signals_json: None,
+            fast_slow_path_json: None,
+            agency_selection_json: None,
+            bounded_execution_json: None,
+            evaluation_signals_json: None,
+            cognitive_arbitration_json: None,
+            affect_state_json: None,
+            reasoning_graph_json: None,
+            overlays_dir: "learning/overlays".to_string(),
+            cluster_groundwork_json: None,
+            trace_json: None,
+        },
+    };
+    let arbitration = run_artifacts::CognitiveArbitrationArtifact {
+        cognitive_arbitration_version: 1,
+        run_id: "decision-run".to_string(),
+        generated_from: generated_from.clone(),
+        route_selected: "slow".to_string(),
+        reasoning_mode: "review_heavy".to_string(),
+        confidence: "guarded".to_string(),
+        risk_class: "high".to_string(),
+        applied_constraints: vec![
+            "bounded_integrity_review".to_string(),
+            "contradiction_review_required".to_string(),
+        ],
+        cost_latency_assumption: "favor review over speed for high-risk contradictions".to_string(),
+        route_reason: "contradiction and risk require the slow review path".to_string(),
+        deterministic_selection_rule: "deterministic".to_string(),
+    };
+    let agency = run_artifacts::AgencySelectionArtifact {
+        agency_selection_version: 1,
+        run_id: "decision-run".to_string(),
+        generated_from: generated_from.clone(),
+        candidate_generation_basis: "bounded deterministic candidates".to_string(),
+        selection_mode: "review_first".to_string(),
+        candidate_set: vec![execute::AgencyCandidateRecord {
+            candidate_id: "cand-custom-review".to_string(),
+            candidate_kind: "review_and_refine".to_string(),
+            bounded_action: "review and refine the candidate".to_string(),
+            review_requirement: "review_required".to_string(),
+            execution_priority: 1,
+            rationale: "custom selected candidate reason".to_string(),
+        }],
+        selected_candidate_id: "cand-custom-review".to_string(),
+        selected_candidate_reason: "custom selected candidate reason".to_string(),
+        deterministic_selection_rule: "deterministic".to_string(),
+    };
+    let evaluation = run_artifacts::EvaluationSignalsArtifact {
+        evaluation_signals_version: 1,
+        run_id: "decision-run".to_string(),
+        generated_from: generated_from.clone(),
+        selected_candidate_id: "cand-custom-review".to_string(),
+        selected_path: "slow_path".to_string(),
+        progress_signal: "guarded_progress".to_string(),
+        contradiction_signal: "present".to_string(),
+        failure_signal: "none".to_string(),
+        termination_reason: "contradiction_detected".to_string(),
+        behavior_effect: "surface contradiction for bounded follow-up".to_string(),
+        next_control_action: "handoff_to_reframing".to_string(),
+        deterministic_evaluation_rule: "deterministic".to_string(),
+    };
+    let reframing = run_artifacts::ReframingArtifact {
+        reframing_version: 1,
+        run_id: "decision-run".to_string(),
+        generated_from: generated_from.clone(),
+        selected_candidate_id: "cand-custom-review".to_string(),
+        selected_path: "slow_path".to_string(),
+        frame_adequacy_score: 24,
+        reframing_trigger: "triggered".to_string(),
+        reframing_reason: "contradiction requires bounded reframing before commitment".to_string(),
+        prior_frame: "initial".to_string(),
+        new_frame: "reframed".to_string(),
+        reexecution_choice: "bounded_reframe_and_retry".to_string(),
+        post_reframe_state: "ready_for_reframed_execution".to_string(),
+        deterministic_reframing_rule: "deterministic".to_string(),
+    };
+    let freedom_gate = run_artifacts::FreedomGateArtifact {
+        freedom_gate_version: 1,
+        run_id: "decision-run".to_string(),
+        generated_from: generated_from.clone(),
+        input: run_artifacts::FreedomGateInputState {
+            candidate_id: "cand-custom-review".to_string(),
+            candidate_action: "review and refine the candidate".to_string(),
+            candidate_rationale: "custom selected candidate reason".to_string(),
+            risk_class: "high".to_string(),
+            policy_context: execute::FreedomGatePolicyContextState {
+                route_selected: "slow".to_string(),
+                selected_candidate_kind: "review_and_refine".to_string(),
+                requires_review: false,
+                policy_blocked: false,
+            },
+            evaluation_signals: execute::FreedomGateEvaluationSignalsState {
+                progress_signal: "guarded_progress".to_string(),
+                contradiction_signal: "present".to_string(),
+                failure_signal: "none".to_string(),
+                termination_reason: "contradiction_detected".to_string(),
+            },
+            consequence_context: execute::FreedomGateConsequenceContextState {
+                impact_scope: "cross_surface".to_string(),
+                recovery_cost: "requires_reframing".to_string(),
+                operator_visibility: "review_required".to_string(),
+                escalation_available: true,
+            },
+            frame_state: "ready_for_reframed_execution".to_string(),
+        },
+        gate_decision: "escalate".to_string(),
+        reason_code: "frame_escalation_required".to_string(),
+        decision_reason:
+            "frame state and consequence context require explicit escalation before commitment can proceed"
+                .to_string(),
+        selected_action_or_none: None,
+        commitment_blocked: true,
+        judgment_boundary: "judgment_boundary".to_string(),
+        required_follow_up: "escalate_for_judgment_review".to_string(),
+        decision_record_kind: "gate_escalation_record".to_string(),
+        deterministic_gate_rule: "deterministic".to_string(),
+    };
+    let scores = ScoresArtifact {
+        scores_version: 1,
+        run_id: "decision-run".to_string(),
+        generated_from: ScoresGeneratedFrom {
+            artifact_model_version: artifacts::ARTIFACT_MODEL_VERSION,
+            run_summary_version: 1,
+        },
+        summary: ScoresSummary {
+            success_ratio: 0.0,
+            failure_count: 1,
+            retry_count: 0,
+            delegation_denied_count: 0,
+            security_denied_count: 0,
+        },
+        metrics: ScoresMetrics {
+            scheduler_max_parallel_observed: 1,
+        },
+    };
+
+    let left = run_artifacts::build_control_path_decisions_artifact(
+        &run_summary,
+        &arbitration,
+        &agency,
+        &evaluation,
+        &reframing,
+        &freedom_gate,
+        Some(&scores),
+    );
+    let right = run_artifacts::build_control_path_decisions_artifact(
+        &run_summary,
+        &arbitration,
+        &agency,
+        &evaluation,
+        &reframing,
+        &freedom_gate,
+        Some(&scores),
+    );
+
+    assert_eq!(
+        serde_json::to_value(&left).expect("decision surfaces left"),
+        serde_json::to_value(&right).expect("decision surfaces right")
+    );
+    assert_eq!(left.decision_schema_name, "adl.runtime.decision.v1");
+    assert_eq!(left.surfaces.len(), 3);
+    assert_eq!(left.decisions.len(), 3);
+    assert_eq!(
+        left.decisions[0].surface_id,
+        "delegation_and_routing.route_selection"
+    );
+    assert_eq!(left.decisions[0].outcome_class, "reroute");
+    assert_eq!(left.decisions[1].outcome_class, "reroute");
+    assert_eq!(left.decisions[2].outcome_class, "escalate");
+    assert_eq!(
+        left.decisions[2].downstream_consequence,
+        "escalate_for_judgment_review"
+    );
+}
+
+#[test]
 fn build_reasoning_graph_artifact_changes_selected_path_with_affect() {
     let summary = RunSummaryArtifact {
         run_summary_version: 1,

--- a/adl/src/cli/tests/internal_commands.rs
+++ b/adl/src/cli/tests/internal_commands.rs
@@ -418,6 +418,35 @@ fn cli_artifact_validate_control_path_rejects_missing_required_artifact() {
 }
 
 #[test]
+fn cli_artifact_validate_control_path_rejects_missing_decisions_artifact() {
+    let out_dir = unique_temp_dir("adl-control-path-validate-missing-decisions");
+    real_demo(&[
+        "demo-g-v086-control-path".to_string(),
+        "--run".to_string(),
+        "--no-open".to_string(),
+        "--out".to_string(),
+        out_dir.to_string_lossy().to_string(),
+    ])
+    .expect("control-path demo should succeed");
+
+    let control_path_root = out_dir.join("demo-g-v086-control-path");
+    std::fs::remove_file(control_path_root.join("decisions.json"))
+        .expect("remove decisions artifact");
+
+    let err = real_artifact(&[
+        "validate-control-path".to_string(),
+        "--root".to_string(),
+        control_path_root.to_string_lossy().to_string(),
+    ])
+    .expect_err("validator should reject missing decisions artifact");
+    assert!(err
+        .to_string()
+        .contains("missing required control-path artifact"));
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+#[test]
 fn cli_artifact_validate_control_path_rejects_malformed_artifact() {
     let out_dir = unique_temp_dir("adl-control-path-validate-malformed");
     real_demo(&[

--- a/adl/src/cli/tests/run_state/persistence.rs
+++ b/adl/src/cli/tests/run_state/persistence.rs
@@ -355,6 +355,39 @@ fn write_run_state_artifacts_projects_execute_owned_runtime_control_state() {
     assert_eq!(convergence.stop_condition_family, "policy_boundary");
     assert_eq!(convergence.progress_signal, "steady_progress");
 
+    let decisions: run_artifacts::ControlPathDecisionsArtifact = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("control_path/decisions.json"))
+            .expect("read decisions artifact"),
+    )
+    .expect("parse decisions artifact");
+    assert_eq!(decisions.decision_schema_name, "adl.runtime.decision.v1");
+    assert_eq!(
+        decisions.outcome_class_vocabulary,
+        vec![
+            "accept".to_string(),
+            "reject".to_string(),
+            "defer".to_string(),
+            "escalate".to_string(),
+            "reroute".to_string(),
+        ]
+    );
+    assert_eq!(decisions.surfaces.len(), 3);
+    assert_eq!(decisions.decisions.len(), 3);
+    assert_eq!(
+        decisions.decisions[0].surface_id,
+        "delegation_and_routing.route_selection"
+    );
+    assert_eq!(decisions.decisions[0].outcome_class, "reroute");
+    assert_eq!(
+        decisions.decisions[2].surface_id,
+        "pre_execution_authorization.commitment_gate"
+    );
+    assert_eq!(decisions.decisions[2].outcome_class, "escalate");
+    assert_eq!(
+        decisions.decisions[2].downstream_consequence,
+        "escalate_for_judgment_review"
+    );
+
     let memory_read: MemoryReadArtifact = serde_json::from_str(
         &std::fs::read_to_string(run_dir.join("learning/memory_read.v1.json"))
             .expect("read memory read artifact"),
@@ -418,6 +451,12 @@ fn write_run_state_artifacts_projects_execute_owned_runtime_control_state() {
     assert!(
         control_path_summary.contains(
             "convergence: state=policy_stop stop_condition_family=policy_boundary progress_signal=steady_progress"
+        ),
+        "summary was:\n{control_path_summary}"
+    );
+    assert!(
+        control_path_summary.contains(
+            "decisions: route_selection=reroute reframing=reroute commitment_gate=escalate"
         ),
         "summary was:\n{control_path_summary}"
     );

--- a/adl/src/demo/v086_review_surface.rs
+++ b/adl/src/demo/v086_review_surface.rs
@@ -346,6 +346,100 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
         ),
         "deterministic_convergence_rule": "demo deterministic convergence projection"
     });
+    let decisions = serde_json::json!({
+        "control_path_decisions_version": 1,
+        "run_id": DEMO_G_V086_CONTROL_PATH,
+        "generated_from": generated_from.clone(),
+        "decision_schema_name": "adl.runtime.decision.v1",
+        "decision_schema_fields": [
+            "decision_id",
+            "surface_id",
+            "proposal_or_action",
+            "outcome_class",
+            "decision_maker",
+            "policy_bindings",
+            "rationale",
+            "downstream_consequence",
+            "temporal_anchor"
+        ],
+        "outcome_class_vocabulary": [
+            "accept",
+            "reject",
+            "defer",
+            "escalate",
+            "reroute"
+        ],
+        "surfaces": [
+            {
+                "surface_id": "delegation_and_routing.route_selection",
+                "surface_family": "delegation_and_routing",
+                "bounded_role": "select the bounded runtime path before commitment is attempted",
+                "outcome_classes": ["accept", "reroute"],
+                "temporal_anchor_ref": "control_path/arbitration.json"
+            },
+            {
+                "surface_id": "recovery_continuity.reframing",
+                "surface_family": "recovery_continuity",
+                "bounded_role": "decide whether the current frame should be retained or rerouted through reframing",
+                "outcome_classes": ["accept", "reroute"],
+                "temporal_anchor_ref": "control_path/reframing.json"
+            },
+            {
+                "surface_id": "pre_execution_authorization.commitment_gate",
+                "surface_family": "pre_execution_authorization",
+                "bounded_role": "decide whether commitment may proceed for the selected bounded candidate",
+                "outcome_classes": ["accept", "reject", "defer", "escalate"],
+                "temporal_anchor_ref": "control_path/freedom_gate.json"
+            }
+        ],
+        "decisions": [
+            {
+                "decision_id": "decision.route_selection",
+                "surface_id": "delegation_and_routing.route_selection",
+                "proposal_or_action": "route candidate cand-custom-review through the slow path",
+                "outcome_class": "reroute",
+                "decision_maker": "cognitive_arbitration",
+                "policy_bindings": ["bounded_integrity_review", "contradiction_review_required"],
+                "rationale": runtime.arbitration.route_reason,
+                "downstream_consequence": "selected_path=slow reasoning_mode=review_heavy",
+                "temporal_anchor": "control_path/arbitration.json"
+            },
+            {
+                "decision_id": "decision.reframing",
+                "surface_id": "recovery_continuity.reframing",
+                "proposal_or_action": "decide whether candidate cand-custom-review should keep the current frame or reframe before re-execution",
+                "outcome_class": "reroute",
+                "decision_maker": "reframing_control",
+                "policy_bindings": [
+                    "frame_adequacy_score=24",
+                    "termination_reason=contradiction_detected",
+                    format!("progress_signal={}", runtime.evaluation.progress_signal)
+                ],
+                "rationale": runtime.reframing.reframing_reason,
+                "downstream_consequence": runtime.reframing.reexecution_choice,
+                "temporal_anchor": "control_path/reframing.json"
+            },
+            {
+                "decision_id": "decision.commitment_gate",
+                "surface_id": "pre_execution_authorization.commitment_gate",
+                "proposal_or_action": "review and refine the candidate",
+                "outcome_class": "escalate",
+                "decision_maker": "freedom_gate",
+                "policy_bindings": [
+                    "route_selected=slow",
+                    "selected_candidate_kind=review_and_refine",
+                    "requires_review=false",
+                    "policy_blocked=false",
+                    "impact_scope=cross_surface",
+                    "operator_visibility=review_required",
+                    "escalation_available=true"
+                ],
+                "rationale": runtime.freedom_gate.decision_reason,
+                "downstream_consequence": runtime.freedom_gate.required_follow_up,
+                "temporal_anchor": "control_path/freedom_gate.json"
+            }
+        ]
+    });
     let final_result = serde_json::json!({
         "control_path_final_result_version": 1,
         "run_id": DEMO_G_V086_CONTROL_PATH,
@@ -382,6 +476,7 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
             "convergence: state=policy_stop stop_condition_family=policy_boundary progress_signal={}",
             runtime.evaluation.progress_signal
         ),
+        "decisions: route_selection=reroute reframing=reroute commitment_gate=escalate".to_string(),
         "memory: read_count=1 influenced_stage=reframing write_reason=record_failure_for_future_reframing_context".to_string(),
         "freedom_gate: decision=escalate reason_code=frame_escalation_required follow_up=escalate_for_judgment_review commitment_blocked=true".to_string(),
         "final_result: escalate".to_string(),
@@ -432,6 +527,11 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
         out_dir,
         "convergence.json",
         &serde_json::to_string_pretty(&convergence)?,
+    )?);
+    artifacts.push(write_file(
+        out_dir,
+        "decisions.json",
+        &serde_json::to_string_pretty(&decisions)?,
     )?);
     artifacts.push(write_file(
         out_dir,

--- a/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
+++ b/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
@@ -133,11 +133,12 @@ cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_exe
 
 Expected artifacts:
 - `learning/freedom_gate.v1.json`
+- `control_path/decisions.json`
 - `control_path/final_result.json`
 - `control_path/summary.txt`
 
 Primary proof surface:
-- gate artifact and final-result pair
+- gate artifact and decision record pair, centered on `control_path/decisions.json`
 
 Expected success signals:
 - reviewer can see allow / defer / refuse / escalate distinctions

--- a/docs/milestones/v0.89/features/DECISION_SCHEMA.md
+++ b/docs/milestones/v0.89/features/DECISION_SCHEMA.md
@@ -28,6 +28,36 @@ Define the bounded record shape that makes ADL decisions legible in trace, revie
 - outcome classes are not collapsed into generic success/failure
 - rationale and constraint bindings remain reviewable
 
+## Runtime Contract
+
+`WP-04` now defines a bounded reviewer-facing record shape for milestone-critical runtime
+decisions.
+
+The canonical runtime proof surface is:
+- `control_path/decisions.json`
+
+The decision schema used there makes these fields explicit:
+- `decision_id`
+- `surface_id`
+- `proposal_or_action`
+- `outcome_class`
+- `decision_maker`
+- `policy_bindings`
+- `rationale`
+- `downstream_consequence`
+- `temporal_anchor`
+
+The bounded outcome vocabulary for `v0.89` is:
+- `accept`
+- `reject`
+- `defer`
+- `escalate`
+- `reroute`
+
+This keeps decision records reviewer-legible and reusable across runtime artifacts without
+pretending `WP-04` already owns the full action mediation layer, negotiation transcripts, or
+later constitutional/governance work.
+
 ## Non-Goals
 
 - full negotiation transcript capture
@@ -43,3 +73,4 @@ Define the bounded record shape that makes ADL decisions legible in trace, revie
 
 - reviewers can answer what was decided, why, and under what constraints
 - decision-event language is consistent across planning docs and future issue wave seeding
+- the control-path proof set emits a stable decision record artifact with the bounded schema

--- a/docs/milestones/v0.89/features/DECISION_SURFACES.md
+++ b/docs/milestones/v0.89/features/DECISION_SURFACES.md
@@ -33,6 +33,30 @@ This feature defines where the runtime is permitted to:
 - decision states are governed, named, and traceable
 - later demos and review docs can point to concrete moments of choice
 
+## Runtime Contract
+
+`WP-04` now treats the main runtime decision points as a reviewer-facing proof surface rather
+than only a planning abstraction.
+
+The bounded runtime slice makes these decision surfaces explicit:
+- `delegation_and_routing.route_selection`
+- `recovery_continuity.reframing`
+- `pre_execution_authorization.commitment_gate`
+
+The reviewer-facing proof surface is:
+- `control_path/decisions.json` as the canonical decision-surface and decision-record artifact
+- `control_path/arbitration.json`, `control_path/reframing.json`, and `control_path/freedom_gate.json`
+  as the linked stage-local sources
+- `control_path/summary.txt` as the compact human-readable companion
+
+The intended semantics are:
+- route selection may `accept` the fast path or `reroute` into a slower bounded path
+- reframing may `accept` the current frame or `reroute` through bounded reframing
+- commitment gating may `accept`, `reject`, `defer`, or `escalate` before action commitment
+
+This keeps points of choice explicit without pulling full action mediation or later governance
+bands into `WP-04`.
+
 ## Non-Goals
 
 - the full decision-event wire format
@@ -49,3 +73,4 @@ This feature defines where the runtime is permitted to:
 
 - the milestone package consistently names the main decision states
 - WBS and demo planning can refer to concrete decision surfaces without ambiguity
+- the runtime-control proof set exposes a reviewer-facing decision-surface artifact


### PR DESCRIPTION
Closes #1791

## Summary
Implemented the bounded `WP-04` runtime slice by making the main runtime points of choice
explicit as a reviewer-facing decision artifact. The branch now emits
`control_path/decisions.json`, validates it as part of the canonical control-path bundle, keeps
the legacy control-path demo fixture truthful, and tightens the `v0.89` feature docs and demo
matrix around the landed proof surface.

## Artifacts
- code and schema surfaces:
  - `adl/src/artifacts.rs`
  - `adl/src/cli/run_artifacts/cognitive.rs`
  - `adl/src/cli/run_artifacts/runtime.rs`
  - `adl/src/cli/run_artifacts_types.rs`
- test and fixture updates:
  - `adl/src/cli/tests/artifact_builders/learning_runtime.rs`
  - `adl/src/cli/tests/internal_commands.rs`
  - `adl/src/cli/tests/run_state/persistence.rs`
  - `adl/src/demo/v086_review_surface.rs`
- tracked milestone docs:
  - `docs/milestones/v0.89/features/DECISION_SURFACES.md`
  - `docs/milestones/v0.89/features/DECISION_SCHEMA.md`
  - `docs/milestones/v0.89/DEMO_MATRIX_v0.89.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified that the bounded `WP-04` write set is rustfmt-clean.
  - `cargo test --manifest-path adl/Cargo.toml build_control_path_decisions_artifact_is_deterministic_and_surfaces_core_records -- --nocapture`
    Verified the new decision artifact builder is deterministic and emits the expected route,
    reframing, and commitment-gate records.
  - `cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_ -- --nocapture`
    Verified the canonical control-path validator accepts the updated demo fixture and rejects
    missing or malformed `decisions.json`.
  - `cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture`
    Verified runtime persistence writes `control_path/decisions.json` and keeps the linked control
    path summary and final-result surfaces internally consistent.
  - `git diff --check`
    Verified there are no whitespace or patch-shape issues in the worktree diff.
- Results:
  - all targeted `WP-04` code, validator, fixture, and persistence checks passed
  - the decision artifact is wired into the canonical control-path bundle
  - the promoted `v0.89` decision docs now point at the actual runtime proof surface

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1791__v0-89-wp-04-decision-surfaces-and-decision-schema/sip.md
- Output card: .adl/v0.89/tasks/issue-1791__v0-89-wp-04-decision-surfaces-and-decision-schema/sor.md
- Idempotency-Key: v0-89-wp-04-decision-surfaces-and-decision-schema-adl-v0-89-tasks-issue-1791-v0-89-wp-04-decision-surfaces-and-decision-schema-sip-md-adl-v0-89-tasks-issue-1791-v0-89-wp-04-decision-surfaces-and-decision-schema-sor-md