### PR TITLE
[v0.89][WP-07] Godel experiment system

### DIFF
--- a/adl/src/cli/godel_cmd.rs
+++ b/adl/src/cli/godel_cmd.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ::adl::{
     artifacts, godel,
@@ -29,7 +29,11 @@ struct GodelRunCliSummary {
     cross_workflow_path: String,
     eval_report_path: String,
     promotion_decision_path: String,
+    canonical_evaluation_plan_path: String,
+    canonical_mutation_path: String,
+    canonical_evidence_path: String,
     experiment_record_path: String,
+    canonical_experiment_record_path: String,
     obsmem_index_path: String,
 }
 
@@ -43,7 +47,11 @@ struct GodelInspectCliSummary {
     cross_workflow_path: String,
     eval_report_path: String,
     promotion_decision_path: String,
+    canonical_evaluation_plan_path: String,
+    canonical_mutation_path: String,
+    canonical_evidence_path: String,
     experiment_record_path: String,
+    canonical_experiment_record_path: String,
     obsmem_index_path: String,
     failure_code: String,
     workflow_id: String,
@@ -69,6 +77,14 @@ struct GodelInspectCliSummary {
     mutation_id: String,
     evaluation_decision: String,
     improvement_delta: i32,
+    canonical_evaluation_plan_id: String,
+    canonical_mutation_id: String,
+    canonical_evidence_view_id: String,
+    canonical_experiment_id: String,
+    canonical_decision_result: String,
+    canonical_decision_rationale: String,
+    baseline_run_id: String,
+    variant_run_id: String,
     obsmem_index_key: String,
     experiment_outcome: String,
 }
@@ -96,6 +112,22 @@ struct GodelAffectSliceCliSummary {
     adapted_selected_strategy: String,
     changed_output_surface: String,
     changed_downstream_decision: bool,
+}
+
+fn load_canonical_artifact<T, E, F>(path: &Path, rel: &Path, load: F) -> Result<T>
+where
+    F: FnOnce(&Path) -> std::result::Result<T, E>,
+    E: std::fmt::Display,
+{
+    fs::metadata(path).map_err(|err| {
+        anyhow::anyhow!("GODEL_INSPECT_IO: failed to read {}: {err}", rel.display())
+    })?;
+    load(path).map_err(|err| {
+        anyhow::anyhow!(
+            "GODEL_INSPECT_INVALID: failed to parse {}: {err}",
+            rel.display()
+        )
+    })
 }
 
 pub(crate) fn real_godel(args: &[String]) -> Result<()> {
@@ -208,7 +240,17 @@ pub(crate) fn real_godel_run(args: &[String]) -> Result<()> {
         cross_workflow_path: result.cross_workflow_rel_path.display().to_string(),
         eval_report_path: result.eval_report_rel_path.display().to_string(),
         promotion_decision_path: result.promotion_decision_rel_path.display().to_string(),
+        canonical_evaluation_plan_path: result
+            .canonical_evaluation_plan_rel_path
+            .display()
+            .to_string(),
+        canonical_mutation_path: result.canonical_mutation_rel_path.display().to_string(),
+        canonical_evidence_path: result.canonical_evidence_rel_path.display().to_string(),
         experiment_record_path: result.experiment_record_rel_path.display().to_string(),
+        canonical_experiment_record_path: result
+            .canonical_experiment_record_rel_path
+            .display()
+            .to_string(),
         obsmem_index_path: result.obsmem_index_rel_path.display().to_string(),
     };
     println!("{}", serde_json::to_string_pretty(&summary)?);
@@ -282,6 +324,22 @@ pub(crate) fn real_godel_inspect(args: &[String]) -> Result<()> {
         .join(&run_id)
         .join("godel")
         .join("godel_promotion_decision.v1.json");
+    let canonical_evaluation_plan_rel = PathBuf::from("runs")
+        .join(&run_id)
+        .join("godel")
+        .join("evaluation_plan.v1.json");
+    let canonical_mutation_rel = PathBuf::from("runs")
+        .join(&run_id)
+        .join("godel")
+        .join("mutation.v1.json");
+    let canonical_evidence_rel = PathBuf::from("runs")
+        .join(&run_id)
+        .join("godel")
+        .join("canonical_evidence_view.v1.json");
+    let canonical_experiment_record_rel = PathBuf::from("runs")
+        .join(&run_id)
+        .join("godel")
+        .join("experiment_record.v1.json");
     let obsmem_index_rel = PathBuf::from("runs")
         .join(&run_id)
         .join("godel")
@@ -314,10 +372,26 @@ pub(crate) fn real_godel_inspect(args: &[String]) -> Result<()> {
         .join(&run_id)
         .join("godel")
         .join("godel_promotion_decision.v1.json");
+    let canonical_evaluation_plan_path = runs_dir
+        .join(&run_id)
+        .join("godel")
+        .join("evaluation_plan.v1.json");
+    let canonical_mutation_path = runs_dir
+        .join(&run_id)
+        .join("godel")
+        .join("mutation.v1.json");
+    let canonical_evidence_path = runs_dir
+        .join(&run_id)
+        .join("godel")
+        .join("canonical_evidence_view.v1.json");
     let experiment_record_path = runs_dir
         .join(&run_id)
         .join("godel")
         .join("experiment_record.runtime.v1.json");
+    let canonical_experiment_record_path = runs_dir
+        .join(&run_id)
+        .join("godel")
+        .join("experiment_record.v1.json");
     let obsmem_index_path = runs_dir
         .join(&run_id)
         .join("godel")
@@ -432,6 +506,26 @@ pub(crate) fn real_godel_inspect(args: &[String]) -> Result<()> {
             promotion_decision_rel.display()
         )
     })?;
+    let canonical_evaluation_plan = load_canonical_artifact(
+        &canonical_evaluation_plan_path,
+        &canonical_evaluation_plan_rel,
+        godel::evaluation::load_canonical_evaluation_plan,
+    )?;
+    let canonical_mutation = load_canonical_artifact(
+        &canonical_mutation_path,
+        &canonical_mutation_rel,
+        godel::mutation::load_canonical_mutation,
+    )?;
+    let canonical_evidence = load_canonical_artifact(
+        &canonical_evidence_path,
+        &canonical_evidence_rel,
+        godel::canonical_evidence::load_canonical_evidence,
+    )?;
+    let canonical_experiment_record = load_canonical_artifact(
+        &canonical_experiment_record_path,
+        &canonical_experiment_record_rel,
+        godel::experiment_record::load_canonical_record,
+    )?;
 
     let index: PersistedStageIndexEntry =
         serde_json::from_str(&fs::read_to_string(&obsmem_index_path).map_err(|err| {
@@ -462,7 +556,11 @@ pub(crate) fn real_godel_inspect(args: &[String]) -> Result<()> {
         cross_workflow_path: cross_workflow_rel.display().to_string(),
         eval_report_path: eval_report_rel.display().to_string(),
         promotion_decision_path: promotion_decision_rel.display().to_string(),
+        canonical_evaluation_plan_path: canonical_evaluation_plan_rel.display().to_string(),
+        canonical_mutation_path: canonical_mutation_rel.display().to_string(),
+        canonical_evidence_path: canonical_evidence_rel.display().to_string(),
         experiment_record_path: experiment_record_rel.display().to_string(),
+        canonical_experiment_record_path: canonical_experiment_record_rel.display().to_string(),
         obsmem_index_path: obsmem_index_rel.display().to_string(),
         failure_code: record.record.failure_code.clone(),
         workflow_id: record.record.workflow_id.clone(),
@@ -499,6 +597,14 @@ pub(crate) fn real_godel_inspect(args: &[String]) -> Result<()> {
         mutation_id: record.record.mutation_id.clone(),
         evaluation_decision: record.record.evaluation_decision.clone(),
         improvement_delta: record.record.improvement_delta,
+        canonical_evaluation_plan_id: canonical_evaluation_plan.plan_id.clone(),
+        canonical_mutation_id: canonical_mutation.mutation_id.clone(),
+        canonical_evidence_view_id: canonical_evidence.evidence_view_id.clone(),
+        canonical_experiment_id: canonical_experiment_record.experiment_id.clone(),
+        canonical_decision_result: canonical_experiment_record.decision.result.clone(),
+        canonical_decision_rationale: canonical_experiment_record.decision.rationale.clone(),
+        baseline_run_id: canonical_experiment_record.runs.baseline_run_id.clone(),
+        variant_run_id: canonical_experiment_record.runs.variant_run_id.clone(),
         obsmem_index_key: index.entry.index_key.clone(),
         experiment_outcome: index.entry.experiment_outcome.clone(),
     };

--- a/adl/src/cli/tests.rs
+++ b/adl/src/cli/tests.rs
@@ -136,15 +136,22 @@ fn top_level_version_flag_is_handled_before_workflow_dispatch() {
 
 #[test]
 fn provider_setup_dispatch_path_succeeds() {
+    let _lock = env_lock();
     let temp = unique_temp_dir("provider-setup-dispatch");
-    real_provider(&[
+    let prev_dir = std::env::current_dir().expect("cwd");
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("adl crate lives under repo root");
+    std::env::set_current_dir(repo_root).expect("chdir repo root");
+    let result = real_provider(&[
         "setup".to_string(),
         "chatgpt".to_string(),
         "--out".to_string(),
         temp.display().to_string(),
         "--force".to_string(),
-    ])
-    .expect("provider setup dispatch should succeed");
+    ]);
+    std::env::set_current_dir(prev_dir).expect("restore cwd");
+    result.expect("provider setup dispatch should succeed");
     assert!(temp.join("provider.adl.yaml").exists());
     assert!(temp.join(".env.example").exists());
     assert!(temp.join("README.md").exists());

--- a/adl/src/cli/tests/godel.rs
+++ b/adl/src/cli/tests/godel.rs
@@ -505,6 +505,53 @@ fn real_godel_inspect_reads_persisted_runtime_artifacts() {
         decision_reason: "Deterministic threshold decision: score=95 -> promote".to_string(),
         evaluation_artifact_path: "runs/run-745-a/godel/godel_eval_report.v1.json".to_string(),
     };
+    let canonical_input = ::adl::godel::StageLoopInput {
+        run_id: "run-745-a".to_string(),
+        workflow_id: "wf-godel-loop".to_string(),
+        failure_code: "tool_failure".to_string(),
+        failure_summary: "deterministic parse error".to_string(),
+        evidence_refs: vec!["runs/run-745-a/run_status.json".to_string()],
+    };
+    let mutation = ::adl::godel::mutation::MutationProposal {
+        id: "mut:run-745-a:tool_failure:00".to_string(),
+        hypothesis_id: "hyp:run-745-a:tool_failure:00".to_string(),
+        target_surface: "workflow-step-config".to_string(),
+        bounded_change: "Apply deterministic bounded workflow-step adjustment.".to_string(),
+    };
+    let canonical_mutation = ::adl::godel::mutation::build_canonical_mutation(
+        "run-745-a",
+        "wf-godel-loop",
+        "tool_failure",
+        &::adl::godel::hypothesis::HypothesisCandidate {
+            id: "hyp:run-745-a:tool_failure:00".to_string(),
+            statement: hypothesis.claim.clone(),
+            failure_code: "tool_failure".to_string(),
+            evidence_refs: vec!["runs/run-745-a/run_status.json".to_string()],
+        },
+        &mutation,
+    )
+    .expect("build canonical mutation");
+    let canonical_evidence =
+        ::adl::godel::canonical_evidence::build_canonical_evidence(&canonical_input)
+            .expect("build canonical evidence");
+    let canonical_evaluation_plan = ::adl::godel::evaluation::build_canonical_evaluation_plan(
+        "run-745-a",
+        "wf-godel-loop",
+        "tool_failure",
+        &canonical_input.evidence_refs,
+        &::adl::godel::hypothesis::HypothesisCandidate {
+            id: "hyp:run-745-a:tool_failure:00".to_string(),
+            statement: hypothesis.claim.clone(),
+            failure_code: "tool_failure".to_string(),
+            evidence_refs: vec!["runs/run-745-a/run_status.json".to_string()],
+        },
+        &mutation,
+    )
+    .expect("build canonical evaluation plan");
+    let runtime_record_rel =
+        std::path::PathBuf::from("runs/run-745-a/godel/experiment_record.runtime.v1.json");
+    let index_rel =
+        std::path::PathBuf::from("runs/run-745-a/godel/obsmem_index_entry.runtime.v1.json");
 
     std::fs::write(
         run_dir.join("experiment_record.runtime.v1.json"),
@@ -551,6 +598,25 @@ fn real_godel_inspect_reads_persisted_runtime_artifacts() {
         serde_json::to_string_pretty(&index).expect("index json"),
     )
     .expect("write index");
+    ::adl::godel::mutation::persist_canonical_mutation(&base, "run-745-a", &canonical_mutation)
+        .expect("write canonical mutation");
+    ::adl::godel::canonical_evidence::persist_canonical_evidence(&base, &canonical_evidence)
+        .expect("write canonical evidence");
+    ::adl::godel::evaluation::persist_canonical_evaluation_plan(
+        &base,
+        "run-745-a",
+        &canonical_evaluation_plan,
+    )
+    .expect("write canonical evaluation plan");
+    let canonical_record = ::adl::godel::experiment_record::build_canonical_record(
+        &base,
+        &record.record,
+        &runtime_record_rel,
+        &index_rel,
+    )
+    .expect("build canonical record");
+    ::adl::godel::experiment_record::persist_canonical_record(&base, &canonical_record)
+        .expect("write canonical record");
 
     real_godel_inspect(&[
         "--run-id".to_string(),
@@ -606,6 +672,25 @@ fn real_godel_inspect_reads_persisted_runtime_artifacts() {
             serde_json::to_string_pretty(&index).expect("index json"),
         )
         .expect("write index");
+        ::adl::godel::mutation::persist_canonical_mutation(&base, "run-745-a", &canonical_mutation)
+            .expect("write canonical mutation");
+        ::adl::godel::canonical_evidence::persist_canonical_evidence(&base, &canonical_evidence)
+            .expect("write canonical evidence");
+        ::adl::godel::evaluation::persist_canonical_evaluation_plan(
+            &base,
+            "run-745-a",
+            &canonical_evaluation_plan,
+        )
+        .expect("write canonical evaluation plan");
+        let canonical_record = ::adl::godel::experiment_record::build_canonical_record(
+            &base,
+            &record.record,
+            &runtime_record_rel,
+            &index_rel,
+        )
+        .expect("build canonical record");
+        ::adl::godel::experiment_record::persist_canonical_record(&base, &canonical_record)
+            .expect("write canonical record");
     };
 
     let parse_cases = [
@@ -637,6 +722,14 @@ fn real_godel_inspect_reads_persisted_runtime_artifacts() {
             "{",
             "GODEL_INSPECT_INVALID",
         ),
+        ("evaluation_plan.v1.json", "{", "GODEL_INSPECT_INVALID"),
+        ("mutation.v1.json", "{", "GODEL_INSPECT_INVALID"),
+        (
+            "canonical_evidence_view.v1.json",
+            "{",
+            "GODEL_INSPECT_INVALID",
+        ),
+        ("experiment_record.v1.json", "{", "GODEL_INSPECT_INVALID"),
         (
             "obsmem_index_entry.runtime.v1.json",
             "{",
@@ -662,6 +755,8 @@ fn real_godel_inspect_reads_persisted_runtime_artifacts() {
     let missing_cases = [
         "godel_eval_report.v1.json",
         "godel_promotion_decision.v1.json",
+        "evaluation_plan.v1.json",
+        "experiment_record.v1.json",
     ];
     for file_name in missing_cases {
         write_all();

--- a/adl/tests/cli_smoke/godel.rs
+++ b/adl/tests/cli_smoke/godel.rs
@@ -91,8 +91,24 @@ fn godel_run_executes_bounded_stage_loop_and_persists_artifacts() {
         "runs/run-745-a/godel/godel_promotion_decision.v1.json"
     );
     assert_eq!(
+        summary["canonical_evaluation_plan_path"],
+        "runs/run-745-a/godel/evaluation_plan.v1.json"
+    );
+    assert_eq!(
+        summary["canonical_mutation_path"],
+        "runs/run-745-a/godel/mutation.v1.json"
+    );
+    assert_eq!(
+        summary["canonical_evidence_path"],
+        "runs/run-745-a/godel/canonical_evidence_view.v1.json"
+    );
+    assert_eq!(
         summary["experiment_record_path"],
         "runs/run-745-a/godel/experiment_record.runtime.v1.json"
+    );
+    assert_eq!(
+        summary["canonical_experiment_record_path"],
+        "runs/run-745-a/godel/experiment_record.v1.json"
     );
     assert_eq!(
         summary["obsmem_index_path"],
@@ -120,7 +136,17 @@ fn godel_run_executes_bounded_stage_loop_and_persists_artifacts() {
         .join("run-745-a/godel/godel_promotion_decision.v1.json")
         .is_file());
     assert!(runs_dir
+        .join("run-745-a/godel/evaluation_plan.v1.json")
+        .is_file());
+    assert!(runs_dir.join("run-745-a/godel/mutation.v1.json").is_file());
+    assert!(runs_dir
+        .join("run-745-a/godel/canonical_evidence_view.v1.json")
+        .is_file());
+    assert!(runs_dir
         .join("run-745-a/godel/experiment_record.runtime.v1.json")
+        .is_file());
+    assert!(runs_dir
+        .join("run-745-a/godel/experiment_record.v1.json")
         .is_file());
     assert!(runs_dir
         .join("run-745-a/godel/obsmem_index_entry.runtime.v1.json")
@@ -271,8 +297,24 @@ fn godel_inspect_reads_runtime_artifacts_deterministically() {
         "runs/run-745-a/godel/godel_promotion_decision.v1.json"
     );
     assert_eq!(
+        summary["canonical_evaluation_plan_path"],
+        "runs/run-745-a/godel/evaluation_plan.v1.json"
+    );
+    assert_eq!(
+        summary["canonical_mutation_path"],
+        "runs/run-745-a/godel/mutation.v1.json"
+    );
+    assert_eq!(
+        summary["canonical_evidence_path"],
+        "runs/run-745-a/godel/canonical_evidence_view.v1.json"
+    );
+    assert_eq!(
         summary["experiment_record_path"],
         "runs/run-745-a/godel/experiment_record.runtime.v1.json"
+    );
+    assert_eq!(
+        summary["canonical_experiment_record_path"],
+        "runs/run-745-a/godel/experiment_record.v1.json"
     );
     assert_eq!(
         summary["obsmem_index_path"],
@@ -334,6 +376,29 @@ fn godel_inspect_reads_runtime_artifacts_deterministically() {
         .contains("score=95 -> promote"));
     assert_eq!(summary["evaluation_decision"], "adopt");
     assert_eq!(summary["improvement_delta"], 1);
+    assert_eq!(
+        summary["canonical_evaluation_plan_id"],
+        "plan_run_745_a_tool_failure"
+    );
+    assert_eq!(
+        summary["canonical_mutation_id"],
+        "mut_mut_run_745_a_tool_failure_00"
+    );
+    assert_eq!(
+        summary["canonical_evidence_view_id"],
+        "cev-run-745-a-tool_failure"
+    );
+    assert_eq!(
+        summary["canonical_experiment_id"],
+        "exp-run-745-a-mut-run-745-a-tool_failure-00"
+    );
+    assert_eq!(summary["canonical_decision_result"], "adopt");
+    assert!(summary["canonical_decision_rationale"]
+        .as_str()
+        .expect("canonical rationale")
+        .contains("decision=Adopt"));
+    assert_eq!(summary["baseline_run_id"], "run-745-a");
+    assert_eq!(summary["variant_run_id"], "run-745-a");
     assert_eq!(
         summary["obsmem_index_key"],
         "tool_failure:hyp:run-745-a:tool_failure:00:adopt"

--- a/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
+++ b/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
@@ -73,7 +73,7 @@ Additional environment / fixture requirements:
 | D2 | Freedom Gate v2 judgment demo | `WP-03` richer allow / defer / refuse / escalate behavior | `cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture` | `learning/freedom_gate.v1.json` + `control_path/final_result.json` | reviewer can distinguish decision outcome, judgment boundary, and follow-up | stable fixtures should replay to the same outcome class and escalation path | READY |
 | D3 | Decision + action mediation proof | `WP-04` - `WP-05` explicit choice and authorization boundary | planned `WP-04` / `WP-05` entry points | `control_path/decisions.json` + `control_path/action_proposals.json` + `control_path/mediation.json` | reviewer can see model intent separated from authorized action | deterministic fixtures should preserve approval / rejection path | PLANNED |
 | D4 | Skill invocation contract demo | `WP-06` bounded skill execution protocol | `cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_ -- --nocapture` | `control_path/skill_model.json` + `control_path/skill_execution_protocol.json` + `control_path/summary.txt` | reviewer can distinguish a selected governed skill from other action kinds and inspect the pre-execution authorization lifecycle end to end | deterministic fixture replay should preserve lifecycle state, authorization outcome, and trace expectation | READY |
-| D5 | Experiment record demo | `WP-07` governed adopt / reject improvement behavior | planned `WP-07` entry point | experiment record artifact | reviewer can inspect baseline, variant, evidence, and decision | paired fixture runs should be stably comparable | PLANNED |
+| D5 | Godel experiment package demo | `WP-07` governed adopt / reject improvement behavior | `cargo run --manifest-path adl/Cargo.toml -- godel run ...` then `cargo run --manifest-path adl/Cargo.toml -- godel inspect ...` | `runs/<run-id>/godel/experiment_record.v1.json` + `evaluation_plan.v1.json` | reviewer can inspect baseline / variant pairing, canonical evidence, bounded mutation, and adopt / reject decision from one bounded summary | identical bounded inputs should preserve stage order, canonical artifact paths, and decision class | READY |
 | D6 | ObsMem evidence and ranking walkthrough | `WP-08` explainable retrieval and ranking | planned `WP-08` entry point | retrieval explanation artifact | ranking cites evidence families and provenance | tie-break behavior should be stable under replay | PLANNED |
 | D7 | Security / trust / posture walkthrough | `WP-09` main-band security contract | planned `WP-09` / `WP-11` review surface | reviewer-facing threat/posture/trust artifact set | reviewer can see explicit trust boundaries and declared posture | proof row may be document/artifact driven rather than fully executable | PLANNED |
 
@@ -170,6 +170,54 @@ Reviewer checks:
 
 Known limits / caveats:
 - richer moral/constitutional layers remain later-band work
+
+---
+
+### D5) Godel experiment package demo
+
+Description:
+- run the bounded Godel stage loop and inspect the resulting canonical experiment package
+- show that adopt / reject behavior is recorded as explicit experiment evidence rather than
+  narrative inference
+
+Milestone claims / work packages covered:
+- `WP-07`
+
+Commands to run:
+
+```bash
+tmp_root="$(mktemp -d)"
+cargo run --manifest-path adl/Cargo.toml -- godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary "step failed with deterministic parse error" --evidence-ref runs/run-745-a/run_status.json --evidence-ref runs/run-745-a/logs/activation_log.json --runs-dir "$tmp_root"
+cargo run --manifest-path adl/Cargo.toml -- godel inspect --run-id run-745-a --runs-dir "$tmp_root"
+```
+
+Expected artifacts:
+- `runs/run-745-a/godel/evaluation_plan.v1.json`
+- `runs/run-745-a/godel/mutation.v1.json`
+- `runs/run-745-a/godel/canonical_evidence_view.v1.json`
+- `runs/run-745-a/godel/experiment_record.v1.json`
+- `runs/run-745-a/godel/experiment_record.runtime.v1.json`
+
+Primary proof surface:
+- `godel inspect` summary paired with `runs/run-745-a/godel/experiment_record.v1.json`
+
+Expected success signals:
+- reviewer can inspect canonical experiment ID, evidence view ID, mutation ID, and evaluation plan
+  ID directly from the bounded inspect output
+- reviewer can see baseline / variant pairing and final canonical decision without reconstructing
+  the package by hand
+
+Determinism / replay notes:
+- identical bounded inputs should preserve the same stage order, artifact paths, and canonical
+  decision class
+
+Reviewer checks:
+- verify that the canonical package is visible alongside the runtime stage-loop artifacts
+- verify that the inspect surface exposes the canonical decision and paired run context directly
+
+Known limits / caveats:
+- this slice proves bounded experiment packaging and decision reviewability, not full later-band
+  multi-run optimization or open-ended self-modification
 
 ## Cross-Demo Validation
 

--- a/docs/milestones/v0.89/features/GODEL_EXPERIMENT_SYSTEM.md
+++ b/docs/milestones/v0.89/features/GODEL_EXPERIMENT_SYSTEM.md
@@ -26,6 +26,49 @@ Deepen the bounded scientific loop into a real experiment system with explicit e
 - adoption decisions are governed acts, not hidden preferences
 - experiment evidence can later support ObsMem and review surfaces
 
+## Runtime Contract
+
+`WP-07` now exposes the bounded Godel experiment package through the public CLI instead of
+leaving it implicit inside stage-loop persistence.
+
+The bounded proof entrypoints are:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary "step failed with deterministic parse error" --evidence-ref runs/run-745-a/run_status.json --evidence-ref runs/run-745-a/logs/activation_log.json --runs-dir /tmp/adl-godel-demo
+cargo run --manifest-path adl/Cargo.toml -- godel inspect --run-id run-745-a --runs-dir /tmp/adl-godel-demo
+```
+
+The reviewer-facing proof surfaces now include both the runtime loop artifacts and the canonical
+experiment package:
+- runtime stage-loop artifacts:
+  - `runs/<run-id>/godel/godel_hypothesis.v1.json`
+  - `runs/<run-id>/godel/godel_policy.v1.json`
+  - `runs/<run-id>/godel/godel_policy_comparison.v1.json`
+  - `runs/<run-id>/godel/godel_experiment_priority.v1.json`
+  - `runs/<run-id>/godel/godel_cross_workflow_learning.v1.json`
+  - `runs/<run-id>/godel/godel_eval_report.v1.json`
+  - `runs/<run-id>/godel/godel_promotion_decision.v1.json`
+  - `runs/<run-id>/godel/experiment_record.runtime.v1.json`
+  - `runs/<run-id>/godel/obsmem_index_entry.runtime.v1.json`
+- canonical experiment artifacts:
+  - `runs/<run-id>/godel/evaluation_plan.v1.json`
+  - `runs/<run-id>/godel/mutation.v1.json`
+  - `runs/<run-id>/godel/canonical_evidence_view.v1.json`
+  - `runs/<run-id>/godel/experiment_record.v1.json`
+
+`godel inspect` now surfaces the canonical package identifiers and decision semantics directly:
+- `canonical_evaluation_plan_id`
+- `canonical_mutation_id`
+- `canonical_evidence_view_id`
+- `canonical_experiment_id`
+- `canonical_decision_result`
+- `baseline_run_id`
+- `variant_run_id`
+
+This keeps `WP-07` bounded to governed experiment packaging and reviewability without pretending
+that later multi-run optimization, broader experiment scheduling, or adversarial self-mutation are
+already in scope.
+
 ## Non-Goals
 
 - unconstrained self-modification
@@ -42,3 +85,5 @@ Deepen the bounded scientific loop into a real experiment system with explicit e
 
 - the milestone package can describe bounded improvement as an explicit evidence-bearing subsystem
 - later demos can show adopt / reject behavior without narrative hand-waving
+- the public `godel run` / `godel inspect` summaries expose both the runtime loop artifacts and
+  the canonical experiment package for review


### PR DESCRIPTION
Closes #1794

## Summary
Implemented the bounded `WP-07` slice by surfacing the canonical Godel experiment package through
the public `godel run` and `godel inspect` CLI summaries. The branch now exposes the persisted
canonical evaluation plan, mutation, evidence view, and experiment record alongside the existing
runtime stage-loop artifacts, proves those surfaces through targeted CLI smoke and direct command
tests, and tightens the promoted `v0.89` feature and demo docs around the real experiment-package
proof surface.

## Artifacts
- code and CLI proof surfaces:
  - `adl/src/cli/godel_cmd.rs`
- test updates:
  - `adl/src/cli/tests/godel.rs`
  - `adl/tests/cli_smoke/godel.rs`
- tracked milestone docs:
  - `docs/milestones/v0.89/features/GODEL_EXPERIMENT_SYSTEM.md`
  - `docs/milestones/v0.89/DEMO_MATRIX_v0.89.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the bounded `WP-07` write set is rustfmt-clean.
  - `cargo test --manifest-path adl/Cargo.toml godel -- --nocapture`
    Verified the bounded Godel runtime, CLI, smoke, canonical artifact, and demo-adjacent proof
    surfaces stay green with the widened run and inspect summaries.
  - `git diff --check`
    Verified there are no whitespace or patch-shape issues in the worktree diff.
- Results:
  - all bounded Godel runtime, canonical artifact, CLI, smoke, and demo-adjacent tests passed
  - direct CLI proof now surfaces the canonical experiment package alongside the runtime
    stage-loop artifacts
  - the promoted `v0.89` feature and demo docs now point at the real `WP-07` proof entrypoint

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1794__v0-89-wp-07-godel-experiment-system/sip.md
- Output card: .adl/v0.89/tasks/issue-1794__v0-89-wp-07-godel-experiment-system/sor.md
- Idempotency-Key: v0-89-wp-07-godel-experiment-system-adl-v0-89-tasks-issue-1794-v0-89-wp-07-godel-experiment-system-sip-md-adl-v0-89-tasks-issue-1794-v0-89-wp-07-godel-experiment-system-sor-md