### PR TITLE
[v0.89][WP-08] ObsMem evidence and ranking

### DIFF
--- a/adl/src/demo/obsmem.rs
+++ b/adl/src/demo/obsmem.rs
@@ -1,8 +1,15 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 
 use crate::godel;
+use crate::obsmem_adapter::ObsMemAdapter;
+use crate::obsmem_retrieval_policy::{
+    explain_policy_results, ExplainedMemoryRecord, RetrievalOrder, RetrievalPolicyV1,
+    RetrievalRequest,
+};
+use crate::obsmem_store::FileObsMemClient;
 
 use super::write_file;
 
@@ -47,17 +54,48 @@ cargo run --manifest-path adl/Cargo.toml --bin adl -- demo demo-f-obsmem-retriev
 This demo seeds deterministic runtime experiment/index artifacts and performs deterministic retrieval by:
 
 - `failure_code`
-- optional `hypothesis_id`
-- optional `experiment_outcome`
+- explicit evidence-aware ranking explanations
+- provenance families derived from cited artifacts
+- deterministic tie-break values for equal-ranked hits
 
 Primary artifacts:
 - `runs/demo-f-run-a/godel/experiment_record.runtime.v1.json`
 - `runs/demo-f-run-a/godel/obsmem_index_entry.runtime.v1.json`
 - `runs/demo-f-run-b/godel/experiment_record.runtime.v1.json`
 - `runs/demo-f-run-b/godel/obsmem_index_entry.runtime.v1.json`
+- `runs/demo-f-run-c/godel/experiment_record.runtime.v1.json`
+- `runs/demo-f-run-c/godel/obsmem_index_entry.runtime.v1.json`
 - `obsmem_retrieval_result.json`
 - `trace.jsonl`
 "#;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct DemoObsMemQueryDescriptor {
+    workflow_id: Option<String>,
+    failure_code: Option<String>,
+    tags: Vec<String>,
+    limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct DemoObsMemOrderingDescriptor {
+    policy_order: String,
+    tie_break_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct DemoObsMemRetrievalArtifact {
+    schema_version: String,
+    shared_store_path: String,
+    query: DemoObsMemQueryDescriptor,
+    ordering: DemoObsMemOrderingDescriptor,
+    result_count: usize,
+    entries: Vec<crate::obsmem_contract::MemoryRecord>,
+    explained_results: Vec<ExplainedMemoryRecord>,
+}
 
 pub(super) fn run_godel_stage_loop_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut artifacts = Vec::new();
@@ -112,21 +150,43 @@ pub(super) fn seed_obsmem_retrieval_demo(out_dir: &Path) -> Result<Vec<PathBuf>>
     let runs_root = out_dir.join("runs");
     let exec = godel::GodelStageLoopExecutor::new(godel::StageLoopConfig::default());
 
-    let input_a = godel::StageLoopInput {
-        run_id: "demo-f-run-a".to_string(),
-        workflow_id: "godel-retrieval-demo".to_string(),
-        failure_code: "tool_failure".to_string(),
-        failure_summary: "deterministic failure A".to_string(),
-        evidence_refs: vec!["runs/demo-f-run-a/run_status.json".to_string()],
-    };
-    let mut input_b = input_a.clone();
-    input_b.run_id = "demo-f-run-b".to_string();
-    input_b.failure_code = "policy_denied".to_string();
-    input_b.failure_summary = "deterministic failure B".to_string();
-    input_b.evidence_refs = vec!["runs/demo-f-run-b/run_status.json".to_string()];
+    let runs = [
+        (
+            "demo-f-run-a",
+            "deterministic failure A",
+            "success",
+            vec!["runs/demo-f-run-a/run_status.json".to_string()],
+        ),
+        (
+            "demo-f-run-b",
+            "deterministic failure B",
+            "success",
+            vec!["runs/demo-f-run-b/run_status.json".to_string()],
+        ),
+        (
+            "demo-f-run-c",
+            "deterministic failure C",
+            "failed",
+            vec!["runs/demo-f-run-c/run_status.json".to_string()],
+        ),
+    ];
 
-    for input in [input_a, input_b] {
+    for (run_id, failure_summary, overall_status, evidence_refs) in runs {
+        let input = godel::StageLoopInput {
+            run_id: run_id.to_string(),
+            workflow_id: "godel-retrieval-demo".to_string(),
+            failure_code: "tool_failure".to_string(),
+            failure_summary: failure_summary.to_string(),
+            evidence_refs,
+        };
         let persisted = exec.execute_and_persist(&input, &runs_root)?;
+        write_demo_obsmem_runtime_artifacts(
+            &runs_root,
+            run_id,
+            "godel-retrieval-demo",
+            overall_status,
+            "tool_failure",
+        )?;
         artifacts.push(out_dir.join(&persisted.experiment_record_rel_path));
         artifacts.push(out_dir.join(&persisted.obsmem_index_rel_path));
     }
@@ -135,49 +195,147 @@ pub(super) fn seed_obsmem_retrieval_demo(out_dir: &Path) -> Result<Vec<PathBuf>>
 }
 
 pub(super) fn query_obsmem_retrieval_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
-    let mut entries: Vec<godel::obsmem_index::StageIndexEntry> = Vec::new();
     let runs_root = out_dir.join("runs");
-    for run_id in ["demo-f-run-a", "demo-f-run-b"] {
-        let path = runs_root
-            .join(run_id)
-            .join("godel")
-            .join("obsmem_index_entry.runtime.v1.json");
-        let raw = std::fs::read_to_string(&path)
-            .with_context(|| format!("failed to read '{}'", path.display()))?;
-        let persisted: godel::obsmem_index::PersistedStageIndexEntry =
-            serde_json::from_str(&raw)
-                .with_context(|| format!("failed to parse '{}'", path.display()))?;
-        entries.push(persisted.entry);
+    let shared_store_path = runs_root.join("_shared").join("obsmem_store.v1.json");
+    let adapter = ObsMemAdapter::new(FileObsMemClient::new(&shared_store_path));
+
+    for run_id in ["demo-f-run-a", "demo-f-run-b", "demo-f-run-c"] {
+        adapter
+            .index_run_from_artifacts(&runs_root, run_id)
+            .with_context(|| format!("index demo ObsMem artifacts for '{run_id}'"))?;
     }
 
-    let query = godel::obsmem_index::ObsMemIndexQuery {
-        failure_code: "tool_failure".to_string(),
-        hypothesis_id: None,
-        experiment_outcome: None,
+    let mut policy = RetrievalPolicyV1 {
+        default_limit: 10,
+        required_tags: vec!["workflow:godel-retrieval-demo".to_string()],
+        required_failure_code: Some("tool_failure".to_string()),
+        order: RetrievalOrder::EvidenceAdjustedDescIdAsc,
+    };
+    policy.normalize();
+
+    let request = RetrievalRequest {
+        workflow_id: Some("godel-retrieval-demo".to_string()),
+        failure_code: None,
+        tags: vec![],
+        limit_override: Some(10),
     };
 
-    let mut matches: Vec<_> = entries
-        .into_iter()
-        .filter(|e| godel::obsmem_index::matches_query(e, &query))
-        .collect();
-    matches.sort_by(|a, b| {
-        a.index_key
-            .cmp(&b.index_key)
-            .then(a.run_id.cmp(&b.run_id))
-            .then(a.mutation_id.cmp(&b.mutation_id))
-    });
+    let query = request
+        .to_query(&policy)
+        .context("build deterministic ObsMem demo query")?;
+    let raw_result = adapter
+        .query(
+            query.workflow_id.as_deref(),
+            query.failure_code.as_deref(),
+            &query.tags,
+            query.limit,
+        )
+        .context("query deterministic ObsMem demo results")?;
+    let explained = explain_policy_results(&policy, &request, raw_result)
+        .context("derive deterministic ObsMem ranking explanations")?;
+    let entries = explained
+        .iter()
+        .map(|entry| entry.record.clone())
+        .collect::<Vec<_>>();
 
-    let result = serde_json::json!({
-        "schema_version": "obsmem_retrieval_result.demo.v1",
-        "query": query,
-        "result_count": matches.len(),
-        "results": matches,
-    });
+    let result = DemoObsMemRetrievalArtifact {
+        schema_version: "obsmem_retrieval_result.demo.v2".to_string(),
+        shared_store_path: "runs/_shared/obsmem_store.v1.json".to_string(),
+        query: DemoObsMemQueryDescriptor {
+            workflow_id: query.workflow_id,
+            failure_code: query.failure_code,
+            tags: query.tags,
+            limit: query.limit,
+        },
+        ordering: DemoObsMemOrderingDescriptor {
+            policy_order: "evidence_adjusted_desc_id_asc".to_string(),
+            tie_break_fields: vec![
+                "id".to_string(),
+                "run_id".to_string(),
+                "workflow_id".to_string(),
+                "payload".to_string(),
+            ],
+        },
+        result_count: explained.len(),
+        entries,
+        explained_results: explained,
+    };
 
     let path = write_file(
         out_dir,
         "obsmem_retrieval_result.json",
         &serde_json::to_string_pretty(&result)?,
     )?;
-    Ok(vec![path])
+    Ok(vec![path, shared_store_path])
+}
+
+fn write_demo_obsmem_runtime_artifacts(
+    runs_root: &Path,
+    run_id: &str,
+    workflow_id: &str,
+    overall_status: &str,
+    failure_kind: &str,
+) -> Result<()> {
+    let run_dir = runs_root.join(run_id);
+    std::fs::create_dir_all(run_dir.join("logs"))
+        .with_context(|| format!("failed to create '{}'", run_dir.display()))?;
+
+    let run_summary = serde_json::json!({
+        "run_summary_version": 1,
+        "run_id": run_id,
+        "workflow_id": workflow_id,
+    });
+    std::fs::write(
+        run_dir.join("run_summary.json"),
+        serde_json::to_vec_pretty(&run_summary).context("serialize demo run_summary.json")?,
+    )
+    .with_context(|| format!("failed to write '{}/run_summary.json'", run_dir.display()))?;
+
+    let run_status = serde_json::json!({
+        "run_status_version": 1,
+        "run_id": run_id,
+        "overall_status": overall_status,
+        "failure_kind": failure_kind,
+    });
+    std::fs::write(
+        run_dir.join("run_status.json"),
+        serde_json::to_vec_pretty(&run_status).context("serialize demo run_status.json")?,
+    )
+    .with_context(|| format!("failed to write '{}/run_status.json'", run_dir.display()))?;
+
+    let activation = serde_json::json!({
+        "activation_log_version": 1,
+        "ordering": "append_only_emission_order",
+        "stable_ids": {
+            "step_id": "stable within resolved execution plan",
+            "delegation_id": "deterministic per run: del-<counter>",
+            "run_id": "run-scoped identifier; not replay-stable across independent runs",
+        },
+        "events": [
+            {
+                "kind": "StepStarted",
+                "step_id": "seed",
+                "agent_id": "demo-obsmem",
+                "provider_id": "local",
+                "task_id": "seed",
+                "delegation_json": null
+            },
+            {
+                "kind": "StepFinished",
+                "step_id": "seed",
+                "success": overall_status == "success"
+            }
+        ]
+    });
+    std::fs::write(
+        run_dir.join("logs").join("activation_log.json"),
+        serde_json::to_vec_pretty(&activation).context("serialize demo activation_log.json")?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to write '{}/logs/activation_log.json'",
+            run_dir.display()
+        )
+    })?;
+    Ok(())
 }

--- a/adl/src/godel/cross_workflow.rs
+++ b/adl/src/godel/cross_workflow.rs
@@ -185,6 +185,7 @@ mod tests {
     use crate::godel::prioritization::{
         PersistedPrioritizationArtifact, PrioritizationInputCandidate, RankedExperimentCandidate,
     };
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn fixture_hypothesis() -> PersistedHypothesisArtifact {
         PersistedHypothesisArtifact {
@@ -255,6 +256,14 @@ mod tests {
         }
     }
 
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("adl-cross-workflow-{label}-{now}"))
+    }
+
     #[test]
     fn build_cross_workflow_artifact_is_deterministic() {
         let hypothesis = fixture_hypothesis();
@@ -287,5 +296,159 @@ mod tests {
             left.downstream_decision.selected_candidate_id,
             "exp:retry-budget"
         );
+    }
+
+    #[test]
+    fn build_cross_workflow_artifact_rejects_mismatched_identity_surfaces() {
+        let hypothesis = fixture_hypothesis();
+        let mut policy = fixture_policy();
+        policy.workflow_id = "wf-other".to_string();
+        let prioritization = fixture_prioritization();
+
+        let err = build_cross_workflow_artifact(
+            &hypothesis,
+            Path::new("runs/run-1/godel/godel_hypothesis.v1.json"),
+            &policy,
+            Path::new("runs/run-1/godel/godel_policy.v1.json"),
+            &prioritization,
+            Path::new("runs/run-1/godel/godel_experiment_priority.v1.json"),
+        )
+        .expect_err("mismatched workflow ids must be rejected");
+
+        assert_eq!(
+            err.to_string(),
+            "GODEL_CROSS_WORKFLOW_INVALID: hypothesis, policy, and prioritization artifacts must share run_id and workflow_id"
+        );
+    }
+
+    #[test]
+    fn build_cross_workflow_artifact_covers_parser_guardrail_and_fallback_strategies() {
+        let hypothesis = fixture_hypothesis();
+        let policy = fixture_policy();
+        let mut prioritization = fixture_prioritization();
+        prioritization.ranked_candidates = vec![RankedExperimentCandidate {
+            candidate_id: "exp:parser-guardrail".to_string(),
+            strategy: "parser_guardrail_probe".to_string(),
+            target_surface: "parser".to_string(),
+            priority_score: 88,
+            confidence: 0.74,
+            ranking_reason: "parser-focused".to_string(),
+        }];
+
+        let parser = build_cross_workflow_artifact(
+            &hypothesis,
+            Path::new("runs/run-1/godel/godel_hypothesis.v1.json"),
+            &policy,
+            Path::new("runs/run-1/godel/godel_policy.v1.json"),
+            &prioritization,
+            Path::new("runs/run-1/godel/godel_experiment_priority.v1.json"),
+        )
+        .expect("parser strategy should build");
+        assert_eq!(
+            parser.downstream_decision.workflow_id,
+            "wf-parser-guardrail-learning"
+        );
+        assert!(parser
+            .downstream_decision
+            .expected_behavior_change
+            .contains("target_surface=parser"));
+
+        prioritization.ranked_candidates[0].strategy = "unknown_strategy".to_string();
+        prioritization.ranked_candidates[0].target_surface = "fallback-surface".to_string();
+        prioritization.ranked_candidates[0].confidence = 0.41;
+        let fallback = build_cross_workflow_artifact(
+            &hypothesis,
+            Path::new("runs/run-1/godel/godel_hypothesis.v1.json"),
+            &policy,
+            Path::new("runs/run-1/godel/godel_policy.v1.json"),
+            &prioritization,
+            Path::new("runs/run-1/godel/godel_experiment_priority.v1.json"),
+        )
+        .expect("fallback strategy should build");
+        assert_eq!(
+            fallback.downstream_decision.workflow_id,
+            "wf-fallback-surface-learning"
+        );
+        assert!(fallback
+            .downstream_decision
+            .expected_behavior_change
+            .contains("fallback-surface"));
+    }
+
+    #[test]
+    fn build_cross_workflow_artifact_rejects_empty_candidates_and_unsafe_paths() {
+        let hypothesis = fixture_hypothesis();
+        let policy = fixture_policy();
+        let mut prioritization = fixture_prioritization();
+        prioritization.ranked_candidates.clear();
+
+        let empty_err = build_cross_workflow_artifact(
+            &hypothesis,
+            Path::new("runs/run-1/godel/godel_hypothesis.v1.json"),
+            &policy,
+            Path::new("runs/run-1/godel/godel_policy.v1.json"),
+            &prioritization,
+            Path::new("runs/run-1/godel/godel_experiment_priority.v1.json"),
+        )
+        .expect_err("empty prioritization should be rejected");
+        assert_eq!(
+            empty_err.to_string(),
+            "GODEL_CROSS_WORKFLOW_INVALID: prioritization artifact must contain at least one ranked candidate"
+        );
+
+        let prioritization = fixture_prioritization();
+        let path_err = build_cross_workflow_artifact(
+            &hypothesis,
+            Path::new("/absolute/path.json"),
+            &policy,
+            Path::new("runs/run-1/godel/godel_policy.v1.json"),
+            &prioritization,
+            Path::new("runs/run-1/godel/godel_experiment_priority.v1.json"),
+        )
+        .expect_err("absolute artifact paths should be rejected");
+        assert_eq!(
+            path_err.to_string(),
+            "GODEL_CROSS_WORKFLOW_INVALID: artifact path '/absolute/path.json' must be a safe relative path"
+        );
+    }
+
+    #[test]
+    fn persist_cross_workflow_artifact_writes_expected_relative_path() {
+        let hypothesis = fixture_hypothesis();
+        let policy = fixture_policy();
+        let prioritization = fixture_prioritization();
+        let artifact = build_cross_workflow_artifact(
+            &hypothesis,
+            Path::new("runs/run-1/godel/godel_hypothesis.v1.json"),
+            &policy,
+            Path::new("runs/run-1/godel/godel_policy.v1.json"),
+            &prioritization,
+            Path::new("runs/run-1/godel/godel_experiment_priority.v1.json"),
+        )
+        .expect("artifact");
+        let runs_root = unique_temp_dir("persist");
+        fs::create_dir_all(&runs_root).expect("temp runs root");
+
+        let rel_path = persist_cross_workflow_artifact(&runs_root, &hypothesis.run_id, &artifact)
+            .expect("persist");
+        assert_eq!(
+            rel_path,
+            PathBuf::from("runs")
+                .join("run-1")
+                .join("godel")
+                .join("godel_cross_workflow_learning.v1.json")
+        );
+
+        let persisted_path = runs_root
+            .join("run-1")
+            .join("godel")
+            .join("godel_cross_workflow_learning.v1.json");
+        let persisted: PersistedCrossWorkflowArtifact = serde_json::from_str(
+            &fs::read_to_string(&persisted_path).expect("read persisted artifact"),
+        )
+        .expect("parse persisted artifact");
+        assert_eq!(persisted, artifact);
+
+        fs::remove_dir_all(&runs_root).expect("cleanup temp runs root");
     }
 }

--- a/adl/src/obsmem_retrieval_policy.rs
+++ b/adl/src/obsmem_retrieval_policy.rs
@@ -1,3 +1,7 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
 use crate::obsmem_contract::{
     MemoryQuery, MemoryQueryResult, MemoryRecord, ObsMemContractError, ObsMemContractErrorCode,
     OBSMEM_CONTRACT_VERSION,
@@ -69,6 +73,36 @@ pub struct RetrievalRequest {
     pub limit_override: Option<usize>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetrievalTieBreakValues {
+    pub id: String,
+    pub run_id: String,
+    pub workflow_id: String,
+    pub payload: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetrievalExplanation {
+    pub prior_score: String,
+    pub effective_score: String,
+    pub matched_query_tags: Vec<String>,
+    pub matched_failure_tag: Option<String>,
+    pub status_tags: Vec<String>,
+    pub citation_count: usize,
+    pub provenance_paths: Vec<String>,
+    pub provenance_families: Vec<String>,
+    pub trace_event_ref_count: usize,
+    pub explanation_signals: Vec<String>,
+    pub tie_break_values: RetrievalTieBreakValues,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedMemoryRecord {
+    pub rank: usize,
+    pub record: MemoryRecord,
+    pub explanation: RetrievalExplanation,
+}
+
 impl RetrievalRequest {
     /// Canonicalize request tags for deterministic behavior.
     pub fn normalize(&mut self) {
@@ -122,18 +156,41 @@ impl RetrievalRequest {
 pub fn apply_policy_to_results(
     policy: &RetrievalPolicyV1,
     request: &RetrievalRequest,
-    mut result: MemoryQueryResult,
+    result: MemoryQueryResult,
 ) -> Result<MemoryQueryResult, ObsMemContractError> {
+    let explained = explain_policy_results(policy, request, result)?;
+    Ok(MemoryQueryResult {
+        hits: explained.into_iter().map(|entry| entry.record).collect(),
+    })
+}
+
+pub fn explain_policy_results(
+    policy: &RetrievalPolicyV1,
+    request: &RetrievalRequest,
+    mut result: MemoryQueryResult,
+) -> Result<Vec<ExplainedMemoryRecord>, ObsMemContractError> {
     policy.validate()?;
 
     let query = request.to_query(policy)?;
+    retain_hits_for_query(&query, &mut result.hits);
+    stable_sort_hits(policy.order, &query, &mut result.hits);
+    result.hits.truncate(query.limit);
 
+    Ok(result
+        .hits
+        .into_iter()
+        .enumerate()
+        .map(|(idx, record)| explain_hit(policy.order, &query, idx + 1, record))
+        .collect())
+}
+
+fn retain_hits_for_query(query: &MemoryQuery, hits: &mut Vec<MemoryRecord>) {
     let required_failure_tag = query
         .failure_code
         .as_ref()
         .map(|fc| format!("failure:{fc}"));
 
-    result.hits.retain(|hit| {
+    hits.retain(|hit| {
         query
             .workflow_id
             .as_ref()
@@ -143,10 +200,6 @@ pub fn apply_policy_to_results(
                 .as_ref()
                 .is_none_or(|tag| hit.tags.binary_search(tag).is_ok())
     });
-
-    stable_sort_hits(policy.order, &query, &mut result.hits);
-    result.hits.truncate(query.limit);
-    Ok(result)
 }
 
 fn stable_sort_hits(order: RetrievalOrder, query: &MemoryQuery, hits: &mut [MemoryRecord]) {
@@ -185,6 +238,81 @@ fn stable_sort_hits(order: RetrievalOrder, query: &MemoryQuery, hits: &mut [Memo
     }
 }
 
+fn explain_hit(
+    order: RetrievalOrder,
+    query: &MemoryQuery,
+    rank: usize,
+    record: MemoryRecord,
+) -> ExplainedMemoryRecord {
+    let matched_failure_tag = query
+        .failure_code
+        .as_ref()
+        .map(|fc| format!("failure:{fc}"))
+        .filter(|tag| has_tag(&record, tag));
+    let matched_query_tags = query
+        .tags
+        .iter()
+        .filter(|tag| has_tag(&record, tag))
+        .cloned()
+        .collect::<Vec<_>>();
+    let status_tags = record
+        .tags
+        .iter()
+        .filter(|tag| tag.starts_with("status:"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let provenance_paths = record
+        .citations
+        .iter()
+        .map(|citation| citation.path.clone())
+        .collect::<Vec<_>>();
+    let mut provenance_families = provenance_paths
+        .iter()
+        .map(|path| provenance_family_for_path(path))
+        .collect::<Vec<_>>();
+    provenance_families.sort();
+    provenance_families.dedup();
+
+    let prior_score = parse_score_hundredths(&record.score);
+    let effective_score = rank_score_hundredths(order, &record, query);
+
+    ExplainedMemoryRecord {
+        rank,
+        explanation: RetrievalExplanation {
+            prior_score: format_score_hundredths(prior_score),
+            effective_score: format_score_hundredths(effective_score),
+            matched_query_tags,
+            matched_failure_tag: matched_failure_tag.clone(),
+            status_tags,
+            citation_count: record.citations.len(),
+            provenance_paths,
+            provenance_families,
+            trace_event_ref_count: record.trace_event_refs.len(),
+            explanation_signals: build_explanation_signals(
+                &record,
+                query,
+                matched_failure_tag.is_some(),
+            ),
+            tie_break_values: RetrievalTieBreakValues {
+                id: record.id.clone(),
+                run_id: record.run_id.clone(),
+                workflow_id: record.workflow_id.clone(),
+                payload: record.payload.clone(),
+            },
+        },
+        record,
+    }
+}
+
+fn rank_score_hundredths(order: RetrievalOrder, hit: &MemoryRecord, query: &MemoryQuery) -> i64 {
+    match order {
+        RetrievalOrder::EvidenceAdjustedDescIdAsc => evidence_adjusted_score_hundredths(hit, query),
+        RetrievalOrder::ScoreDescIdAsc | RetrievalOrder::IdAsc => {
+            parse_score_hundredths(&hit.score)
+        }
+    }
+}
+
 fn evidence_adjusted_score_hundredths(hit: &MemoryRecord, query: &MemoryQuery) -> i64 {
     let prior = parse_score_hundredths(&hit.score).max(0);
     let multiplier_percent = evidence_multiplier_percent(hit, query);
@@ -216,6 +344,62 @@ fn has_tag(hit: &MemoryRecord, tag: &str) -> bool {
         .is_ok()
 }
 
+fn build_explanation_signals(
+    hit: &MemoryRecord,
+    query: &MemoryQuery,
+    matched_failure_tag: bool,
+) -> Vec<String> {
+    let mut signals = Vec::new();
+
+    if matched_failure_tag {
+        signals.push("failure_code_match".to_string());
+    }
+
+    let shared_query_tags = query.tags.iter().filter(|tag| has_tag(hit, tag)).count();
+    if shared_query_tags > 0 {
+        signals.push(format!("query_tag_overlap:{shared_query_tags}"));
+    }
+
+    if has_tag(hit, "status:success") {
+        signals.push("status_success_boost".to_string());
+    }
+    if has_tag(hit, "status:failed") || has_tag(hit, "status:failure") {
+        signals.push("status_failure_penalty".to_string());
+    }
+
+    let citation_boost = hit.citations.len().min(3);
+    if citation_boost > 0 {
+        signals.push(format!("citation_boost:{citation_boost}"));
+    }
+
+    if !hit.trace_event_refs.is_empty() {
+        signals.push(format!("trace_refs:{}", hit.trace_event_refs.len()));
+    }
+
+    signals
+}
+
+fn provenance_family_for_path(path: &str) -> String {
+    match Path::new(path).file_name().and_then(|name| name.to_str()) {
+        Some("run_summary.json") => "run_summary".to_string(),
+        Some("run_status.json") => "run_status".to_string(),
+        Some("activation_log.json") => "activation_log".to_string(),
+        Some(name) if path.contains("/godel/") => format!(
+            "godel:{}",
+            Path::new(name)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("artifact")
+        ),
+        Some(name) => Path::new(name)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("other")
+            .to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
 fn parse_score_hundredths(score: &str) -> i64 {
     let trimmed = score.trim();
     let mut iter = trimmed.split('.');
@@ -228,6 +412,12 @@ fn parse_score_hundredths(score: &str) -> i64 {
     };
     let frac = frac_two.parse::<i64>().unwrap_or(0);
     whole * 100 + frac
+}
+
+fn format_score_hundredths(score: i64) -> String {
+    let sign = if score < 0 { "-" } else { "" };
+    let abs = score.abs();
+    format!("{sign}{}.{:02}", abs / 100, abs % 100)
 }
 
 #[cfg(test)]
@@ -492,6 +682,96 @@ mod tests {
             left.hits.iter().map(|h| h.id.as_str()).collect::<Vec<_>>(),
             vec!["a", "b"]
         );
+    }
+
+    #[test]
+    fn explain_policy_results_surfaces_ranking_reasons_and_provenance() {
+        let policy = RetrievalPolicyV1 {
+            default_limit: 10,
+            required_tags: vec![],
+            required_failure_code: Some("tool_failure".to_string()),
+            order: RetrievalOrder::EvidenceAdjustedDescIdAsc,
+        };
+        let request = RetrievalRequest {
+            workflow_id: Some("wf-a".to_string()),
+            failure_code: None,
+            tags: vec!["workflow:wf-a".to_string()],
+            limit_override: None,
+        };
+
+        let mut a = hit(
+            "a",
+            "1.00",
+            &["workflow:wf-a", "status:success", "failure:tool_failure"],
+        );
+        a.citations.push(MemoryCitation {
+            path: "runs/a/run_status.json".to_string(),
+            hash: "det64:0000000000000002".to_string(),
+        });
+        a.citations.push(MemoryCitation {
+            path: "runs/a/logs/activation_log.json".to_string(),
+            hash: "det64:0000000000000003".to_string(),
+        });
+
+        let mut b = hit(
+            "b",
+            "1.00",
+            &["workflow:wf-a", "status:success", "failure:tool_failure"],
+        );
+        b.citations.push(MemoryCitation {
+            path: "runs/b/run_status.json".to_string(),
+            hash: "det64:0000000000000004".to_string(),
+        });
+        b.citations.push(MemoryCitation {
+            path: "runs/b/logs/activation_log.json".to_string(),
+            hash: "det64:0000000000000005".to_string(),
+        });
+
+        let c = hit(
+            "c",
+            "1.00",
+            &["workflow:wf-a", "status:failed", "failure:tool_failure"],
+        );
+
+        let explained = explain_policy_results(
+            &policy,
+            &request,
+            MemoryQueryResult {
+                hits: vec![c, b, a],
+            },
+        )
+        .expect("explain policy");
+
+        assert_eq!(
+            explained
+                .iter()
+                .map(|entry| entry.record.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(explained[0].rank, 1);
+        assert_eq!(
+            explained[0].explanation.matched_failure_tag.as_deref(),
+            Some("failure:tool_failure")
+        );
+        assert_eq!(
+            explained[0].explanation.provenance_families,
+            vec![
+                "activation_log".to_string(),
+                "run_status".to_string(),
+                "run_summary".to_string()
+            ]
+        );
+        assert!(explained[0]
+            .explanation
+            .explanation_signals
+            .contains(&"status_success_boost".to_string()));
+        assert_eq!(explained[0].explanation.tie_break_values.id, "a");
+        assert_eq!(explained[1].explanation.tie_break_values.id, "b");
+        assert!(explained[2]
+            .explanation
+            .explanation_signals
+            .contains(&"status_failure_penalty".to_string()));
     }
 
     #[test]

--- a/adl/tests/demo_tests.rs
+++ b/adl/tests/demo_tests.rs
@@ -519,10 +519,75 @@ fn demo_f_run_writes_retrieval_artifacts() {
     );
     let run_out = out_root.join("demo-f-obsmem-retrieval");
     assert!(run_out.join("obsmem_retrieval_result.json").is_file());
+    assert!(run_out.join("runs/_shared/obsmem_store.v1.json").is_file());
     assert!(run_out
         .join("runs/demo-f-run-a/godel/obsmem_index_entry.runtime.v1.json")
         .is_file());
     assert!(run_out
         .join("runs/demo-f-run-b/godel/obsmem_index_entry.runtime.v1.json")
         .is_file());
+    assert!(run_out
+        .join("runs/demo-f-run-c/godel/obsmem_index_entry.runtime.v1.json")
+        .is_file());
+
+    let retrieval_text =
+        std::fs::read_to_string(run_out.join("obsmem_retrieval_result.json")).unwrap();
+    let retrieval: serde_json::Value = serde_json::from_str(&retrieval_text).unwrap();
+    assert_eq!(
+        retrieval
+            .get("schema_version")
+            .and_then(serde_json::Value::as_str),
+        Some("obsmem_retrieval_result.demo.v2")
+    );
+    let explained = retrieval
+        .get("explained_results")
+        .and_then(serde_json::Value::as_array)
+        .expect("explained_results array");
+    assert_eq!(explained.len(), 3);
+    assert_eq!(
+        explained[0]
+            .get("record")
+            .and_then(|entry| entry.get("run_id"))
+            .and_then(serde_json::Value::as_str),
+        Some("demo-f-run-a")
+    );
+    assert_eq!(
+        explained[1]
+            .get("record")
+            .and_then(|entry| entry.get("run_id"))
+            .and_then(serde_json::Value::as_str),
+        Some("demo-f-run-b")
+    );
+    assert_eq!(
+        explained[2]
+            .get("record")
+            .and_then(|entry| entry.get("run_id"))
+            .and_then(serde_json::Value::as_str),
+        Some("demo-f-run-c")
+    );
+    assert!(explained[0]
+        .get("explanation")
+        .and_then(|entry| entry.get("provenance_families"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|families| {
+            families
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect::<Vec<_>>()
+                == vec!["activation_log", "run_status", "run_summary"]
+        }));
+    assert!(explained[0]
+        .get("explanation")
+        .and_then(|entry| entry.get("explanation_signals"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|signals| signals
+            .iter()
+            .any(|signal| signal == "status_success_boost")));
+    assert!(explained[2]
+        .get("explanation")
+        .and_then(|entry| entry.get("explanation_signals"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|signals| signals
+            .iter()
+            .any(|signal| signal == "status_failure_penalty")));
 }

--- a/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
+++ b/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
@@ -74,7 +74,7 @@ Additional environment / fixture requirements:
 | D3 | Decision + action mediation proof | `WP-04` - `WP-05` explicit choice and authorization boundary | planned `WP-04` / `WP-05` entry points | `control_path/decisions.json` + `control_path/action_proposals.json` + `control_path/mediation.json` | reviewer can see model intent separated from authorized action | deterministic fixtures should preserve approval / rejection path | PLANNED |
 | D4 | Skill invocation contract demo | `WP-06` bounded skill execution protocol | `cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_ -- --nocapture` | `control_path/skill_model.json` + `control_path/skill_execution_protocol.json` + `control_path/summary.txt` | reviewer can distinguish a selected governed skill from other action kinds and inspect the pre-execution authorization lifecycle end to end | deterministic fixture replay should preserve lifecycle state, authorization outcome, and trace expectation | READY |
 | D5 | Godel experiment package demo | `WP-07` governed adopt / reject improvement behavior | `cargo run --manifest-path adl/Cargo.toml -- godel run ...` then `cargo run --manifest-path adl/Cargo.toml -- godel inspect ...` | `runs/<run-id>/godel/experiment_record.v1.json` + `evaluation_plan.v1.json` | reviewer can inspect baseline / variant pairing, canonical evidence, bounded mutation, and adopt / reject decision from one bounded summary | identical bounded inputs should preserve stage order, canonical artifact paths, and decision class | READY |
-| D6 | ObsMem evidence and ranking walkthrough | `WP-08` explainable retrieval and ranking | planned `WP-08` entry point | retrieval explanation artifact | ranking cites evidence families and provenance | tie-break behavior should be stable under replay | PLANNED |
+| D6 | ObsMem evidence and ranking walkthrough | `WP-08` explainable retrieval and ranking | `cargo run --manifest-path adl/Cargo.toml -- demo demo-f-obsmem-retrieval --run --trace --out ./out` | `obsmem_retrieval_result.json` | ranking cites evidence families, status signals, and deterministic tie-break values | identical demo inputs should preserve result order and explanation shape | READY |
 | D7 | Security / trust / posture walkthrough | `WP-09` main-band security contract | planned `WP-09` / `WP-11` review surface | reviewer-facing threat/posture/trust artifact set | reviewer can see explicit trust boundaries and declared posture | proof row may be document/artifact driven rather than fully executable | PLANNED |
 
 Status guidance:
@@ -218,6 +218,59 @@ Reviewer checks:
 Known limits / caveats:
 - this slice proves bounded experiment packaging and decision reviewability, not full later-band
   multi-run optimization or open-ended self-modification
+
+---
+
+### D6) ObsMem evidence and ranking walkthrough
+
+Description:
+- run the bounded ObsMem retrieval demo and inspect the resulting explanation-bearing retrieval
+  artifact
+- show that retrieval ordering is not just deterministic, but reviewer-legible through explicit
+  provenance, status, and tie-break signals
+
+Milestone claims / work packages covered:
+- `WP-08`
+
+Commands to run:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- demo demo-f-obsmem-retrieval --run --trace --out ./out
+```
+
+Expected artifacts:
+- `runs/_shared/obsmem_store.v1.json`
+- `obsmem_retrieval_result.json`
+- `runs/demo-f-run-a/godel/experiment_record.runtime.v1.json`
+- `runs/demo-f-run-a/godel/obsmem_index_entry.runtime.v1.json`
+- `runs/demo-f-run-b/godel/experiment_record.runtime.v1.json`
+- `runs/demo-f-run-b/godel/obsmem_index_entry.runtime.v1.json`
+- `runs/demo-f-run-c/godel/experiment_record.runtime.v1.json`
+- `runs/demo-f-run-c/godel/obsmem_index_entry.runtime.v1.json`
+
+Primary proof surface:
+- `obsmem_retrieval_result.json`
+
+Expected success signals:
+- reviewer can inspect the normalized query, policy order, and returned hit set directly
+- each explained result records prior vs effective score, provenance families, and deterministic
+  tie-break values
+- equal-ranked successful hits preserve lexical tie-break order while failed hits are explicitly
+  penalized
+
+Determinism / replay notes:
+- identical demo inputs should preserve the same run ordering and explanation shape across repeated
+  runs
+
+Reviewer checks:
+- verify that provenance is surfaced as named families rather than buried inside raw citations
+- verify that `status_success_boost` / `status_failure_penalty` and query-tag overlap signals are
+  visible in the explanation surface
+- verify that the tie-break values explain why equal-ranked hits remain ordered predictably
+
+Known limits / caveats:
+- this slice proves bounded retrieval explanation and ranking legibility, not the later full
+  memory-architecture or identity-linked semantics work
 
 ## Cross-Demo Validation
 

--- a/docs/milestones/v0.89/features/OBSMEM_EVIDENCE_AND_RANKING.md
+++ b/docs/milestones/v0.89/features/OBSMEM_EVIDENCE_AND_RANKING.md
@@ -24,6 +24,43 @@ Make ObsMem retrieval evidence-aware, explainable, and fit for governed reasonin
 - provenance and evidence classes affect ranking in named ways
 - later AEE, experiment, and governance work can cite retrieval explanations rather than hidden ranking behavior
 
+## Runtime Contract
+
+`WP-08` now uses the bounded ObsMem retrieval demo as the reviewer-facing proof entrypoint
+ instead of leaving evidence-aware ranking implicit inside policy tests alone.
+
+The bounded proof entrypoint is:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- demo demo-f-obsmem-retrieval --run --trace --out ./out
+```
+
+The reviewer-facing proof surfaces are:
+- `runs/_shared/obsmem_store.v1.json`
+- `obsmem_retrieval_result.json`
+- the bounded experiment/runtime scaffolding that feeds the retrieval query:
+  - `runs/demo-f-run-a/godel/experiment_record.runtime.v1.json`
+  - `runs/demo-f-run-a/godel/obsmem_index_entry.runtime.v1.json`
+  - `runs/demo-f-run-b/godel/experiment_record.runtime.v1.json`
+  - `runs/demo-f-run-b/godel/obsmem_index_entry.runtime.v1.json`
+  - `runs/demo-f-run-c/godel/experiment_record.runtime.v1.json`
+  - `runs/demo-f-run-c/godel/obsmem_index_entry.runtime.v1.json`
+
+`obsmem_retrieval_result.json` now records:
+- the normalized query and policy order
+- the returned memory records
+- explicit ranking explanations for each hit, including:
+  - prior vs effective score
+  - matched query tags and failure-code matches
+  - status-based boosts or penalties
+  - provenance paths and provenance families
+  - trace-event reference counts
+  - deterministic tie-break values
+
+This keeps `WP-08` bounded to evidence-aware retrieval ranking and reviewer-legible explanation.
+It does not claim the later full memory architecture, adversarial trust model, or identity-linked
+ memory semantics that belong downstream.
+
 ## Non-Goals
 
 - the full later four-layer memory model
@@ -39,3 +76,5 @@ Make ObsMem retrieval evidence-aware, explainable, and fit for governed reasonin
 
 - the milestone package defines what evidence-aware retrieval means in ADL
 - ranking/explanation outputs are concrete enough to drive later issue wave seeding
+- the bounded D6 proof surface makes ranking reasons and provenance legible without requiring a
+  reviewer to reverse-engineer retrieval policy from code


### PR DESCRIPTION
Closes #1795

## Summary
Implemented the bounded `WP-08` slice by turning ObsMem ranking from an internal deterministic
policy into a reviewer-legible proof surface. The branch now exposes explicit ranking explanations
for retrieval hits, including prior vs effective score, matched query tags, failure-code matches,
status-based boosts or penalties, provenance families derived from cited artifacts, trace-ref
counts, and deterministic tie-break values. The official `D6` demo row is now backed by the real
`demo-f-obsmem-retrieval` command instead of a planning placeholder.

## Artifacts
- runtime and demo proof surfaces:
  - `adl/src/obsmem_retrieval_policy.rs`
  - `adl/src/demo/obsmem.rs`
- test updates:
  - `adl/tests/demo_tests.rs`
- tracked milestone docs:
  - `docs/milestones/v0.89/features/OBSMEM_EVIDENCE_AND_RANKING.md`
  - `docs/milestones/v0.89/DEMO_MATRIX_v0.89.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Verified the bounded `WP-08` write set is rustfmt-clean.
  - `cargo test --manifest-path adl/Cargo.toml explain_policy_results_surfaces_ranking_reasons_and_provenance -- --nocapture`
    Verified the new ranking-explanation layer surfaces deterministic reasoning and provenance.
  - `cargo test --manifest-path adl/Cargo.toml demo_f_run_writes_retrieval_artifacts -- --nocapture`
    Verified the public `D6` demo emits the explanation-bearing retrieval artifact and expected
    supporting runtime surfaces.
  - `cargo test --manifest-path adl/Cargo.toml cross_workflow -- --nocapture`
    Verified the bounded cross-workflow branch and persistence coverage backfill that unblocked the
    per-file coverage gate for this PR.
  - `cargo run --manifest-path adl/Cargo.toml -- demo demo-f-obsmem-retrieval --run --trace --out "$(mktemp -d)"`
    Verified the official `D6` proof command runs successfully and emits the expected reviewer-facing
    artifact set.
  - `git diff --check`
    Verified there are no whitespace or patch-shape issues in the worktree diff.
- Results:
  - the retrieval explanation layer passed targeted deterministic tests
  - the public D6 demo now emits an explanation-bearing `obsmem_retrieval_result.json` artifact
  - the supporting cross-workflow learning helper is now covered across its decision branches and
    persistence path, keeping the branch above the current per-file floor
  - the official `WP-08` docs now point at a real command and proof surface instead of a planned
    placeholder

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1795__v0-89-wp-08-obsmem-evidence-and-ranking/sip.md
- Output card: .adl/v0.89/tasks/issue-1795__v0-89-wp-08-obsmem-evidence-and-ranking/sor.md
- Idempotency-Key: v0-89-wp-08-obsmem-evidence-and-ranking-adl-v0-89-tasks-issue-1795-v0-89-wp-08-obsmem-evidence-and-ranking-sip-md-adl-v0-89-tasks-issue-1795-v0-89-wp-08-obsmem-evidence-and-ranking-sor-md