### PR TITLE
[v0.86][runtime] Implement first-class remote Ollama provider transport

### DIFF
--- a/adl-spec/examples/hello-contract.yaml
+++ b/adl-spec/examples/hello-contract.yaml
@@ -13,8 +13,7 @@ version: "0.1"
 
 providers:
   ollama_local:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     config:
       model: "gemma3:latest"
       temperature: 0.2

--- a/adl/examples/adl-0.1.yaml
+++ b/adl/examples/adl-0.1.yaml
@@ -2,8 +2,7 @@ version: "0.1"
 
 providers:
   ollama_local:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/failure-missing-file.adl.yaml
+++ b/adl/examples/failure-missing-file.adl.yaml
@@ -2,8 +2,7 @@ version: "0.1"
 
 providers:
   ollama_local:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/override-precedence.adl.yaml
+++ b/adl/examples/override-precedence.adl.yaml
@@ -2,8 +2,7 @@ version: "0.1"
 
 providers:
   ollama_local:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-2-coordinator-agents-sdk.adl.yaml
+++ b/adl/examples/v0-2-coordinator-agents-sdk.adl.yaml
@@ -2,8 +2,7 @@ version: "0.2"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-2-failure-unknown-field.adl.yaml
+++ b/adl/examples/v0-2-failure-unknown-field.adl.yaml
@@ -2,8 +2,7 @@ version: "0.2"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
     modell: "typo-should-fail"
 

--- a/adl/examples/v0-2-failure-unknown-state-ref.adl.yaml
+++ b/adl/examples/v0-2-failure-unknown-state-ref.adl.yaml
@@ -2,8 +2,7 @@ version: "0.2"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-2-multi-step-basic.adl.yaml
+++ b/adl/examples/v0-2-multi-step-basic.adl.yaml
@@ -2,8 +2,7 @@ version: "0.2"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-2-multi-step-file-input.adl.yaml
+++ b/adl/examples/v0-2-multi-step-file-input.adl.yaml
@@ -2,8 +2,7 @@ version: "0.2"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-3-concurrency-fork-join.adl.yaml
+++ b/adl/examples/v0-3-concurrency-fork-join.adl.yaml
@@ -2,8 +2,7 @@ version: "0.3"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-3-demo-a-say-mcp.adl.yaml
+++ b/adl/examples/v0-3-demo-a-say-mcp.adl.yaml
@@ -2,8 +2,7 @@ version: "0.3"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-3-fork-join-seq-run.adl.yaml
+++ b/adl/examples/v0-3-fork-join-seq-run.adl.yaml
@@ -2,8 +2,7 @@ version: "0.3"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/examples/v0-3-scheduler-max-concurrency.adl.yaml
+++ b/adl/examples/v0-3-scheduler-max-concurrency.adl.yaml
@@ -2,8 +2,7 @@ version: "0.3"
 
 providers:
   local_ollama:
-    type: "ollama"
-    base_url: "http://localhost:11434"
+    type: "local_ollama"
     default_model: "gemma3:latest"
 
 agents:

--- a/adl/src/adl/validation.rs
+++ b/adl/src/adl/validation.rs
@@ -302,7 +302,35 @@ pub(super) fn validate_provider(provider_id: &str, provider: &ProviderSpec) -> R
     }
 
     match provider.kind.as_str() {
-        "ollama" | "local_ollama" | "mock" | "openai" | "anthropic" => Ok(()),
+        "ollama" => {
+            let endpoint = provider
+                .base_url
+                .as_deref()
+                .or_else(|| provider.config.get("endpoint").and_then(|v| v.as_str()));
+            if let Some(endpoint) = endpoint {
+                if !crate::provider::is_allowed_ollama_endpoint(endpoint) {
+                    return Err(anyhow!(
+                        "providers.{provider_id} kind 'ollama' requires an http:// or https:// base_url/config.endpoint when remote transport is configured"
+                    ));
+                }
+            }
+            Ok(())
+        }
+        "local_ollama" => {
+            if provider.base_url.is_some()
+                || provider
+                    .config
+                    .get("endpoint")
+                    .and_then(|v| v.as_str())
+                    .is_some()
+            {
+                return Err(anyhow!(
+                    "providers.{provider_id} kind 'local_ollama' is CLI-backed and must not set base_url or config.endpoint; use kind 'ollama' for remote HTTP transport"
+                ));
+            }
+            Ok(())
+        }
+        "mock" | "openai" | "anthropic" => Ok(()),
         "http" | "http_remote" => {
             let endpoint = provider
                 .base_url

--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -1,4 +1,5 @@
 use super::*;
+use reqwest::Url;
 use std::thread;
 use std::time::Duration;
 
@@ -96,6 +97,38 @@ fn vendor_endpoint(
         }
     }
     Ok(endpoint)
+}
+
+fn ollama_generate_endpoint(spec: &adl::ProviderSpec) -> Result<String> {
+    let explicit_endpoint = cfg_str(&spec.config, "endpoint").map(ToString::to_string);
+    let base_url = spec.base_url.clone();
+    let source = explicit_endpoint.or(base_url).ok_or_else(|| {
+        invalid_config(
+            "ollama",
+            "remote Ollama transport requires base_url or config.endpoint",
+        )
+    })?;
+    if !is_allowed_ollama_endpoint(&source) {
+        return Err(invalid_config(
+            "ollama",
+            "remote Ollama endpoint must use http:// or https://",
+        ));
+    }
+
+    let mut url = Url::parse(&source)
+        .map_err(|err| invalid_config("ollama", format!("invalid Ollama endpoint: {err}")))?;
+    let path = url.path().trim_end_matches('/');
+    let explicit_path = !path.is_empty() && path != "/";
+
+    if path.ends_with("/api/generate") {
+        return Ok(url.to_string());
+    }
+
+    if spec.base_url.is_some() || !explicit_path {
+        url.set_path("/api/generate");
+    }
+
+    Ok(url.to_string())
 }
 
 fn truncate_provider_body(text: &str) -> &str {
@@ -409,6 +442,67 @@ pub struct HttpProvider {
     auth: Option<HttpAuth>,
     headers: HashMap<String, String>,
     timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OllamaHttpProvider {
+    endpoint: String,
+    model: String,
+    temperature: Option<f32>,
+    timeout_secs: Option<u64>,
+}
+
+impl OllamaHttpProvider {
+    pub fn from_target(
+        spec: &adl::ProviderSpec,
+        target: &ProviderInvocationTargetV1,
+    ) -> Result<Self> {
+        Ok(Self {
+            endpoint: ollama_generate_endpoint(spec)?,
+            model: target.provider_model_id.clone(),
+            temperature: super::local::cfg_f32(&spec.config, "temperature"),
+            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+        })
+    }
+}
+
+impl Provider for OllamaHttpProvider {
+    fn complete(&self, prompt: &str) -> Result<String> {
+        let mut client_builder = reqwest::blocking::Client::builder();
+        if let Some(secs) = self.timeout_secs {
+            client_builder = client_builder.timeout(Duration::from_secs(secs));
+        }
+        let client = client_builder
+            .build()
+            .context("failed to build ollama http client")
+            .map_err(|err| runtime_error("ollama", err.to_string()))?;
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "prompt": prompt,
+            "stream": false,
+        });
+        if let Some(temperature) = self.temperature {
+            body["options"] = serde_json::json!({ "temperature": temperature });
+        }
+
+        let req = client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .json(&body);
+        let (json, http_status) = provider_http_json("ollama", req)?;
+        let output = json
+            .get("response")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| {
+                runtime_error_non_retryable("ollama", "response missing 'response' text field")
+            })?
+            .to_string();
+        write_native_invocation_record("ollama", &self.model, prompt, &output, http_status)?;
+        Ok(output)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -742,6 +836,17 @@ mod tests {
         }
     }
 
+    fn ollama_provider_spec_with_base_url(base_url: &str) -> adl::ProviderSpec {
+        adl::ProviderSpec {
+            id: Some("ollama_primary".to_string()),
+            profile: None,
+            kind: "ollama".to_string(),
+            base_url: Some(base_url.to_string()),
+            default_model: Some("phi4-mini".to_string()),
+            config: HashMap::new(),
+        }
+    }
+
     fn provider_spec(
         kind: &str,
         endpoint: &str,
@@ -832,6 +937,53 @@ mod tests {
             Some(v) => env::set_var("OPENAI_API_KEY", v),
             None => env::remove_var("OPENAI_API_KEY"),
         }
+
+        let _ = handle.join();
+    }
+
+    #[test]
+    fn ollama_http_provider_complete_posts_to_generate_endpoint() {
+        let _guard = env_lock();
+        let Some((endpoint, captured, handle)) =
+            spawn_json_server(200, r#"{"response":"ollama ok","done":true}"#)
+        else {
+            return;
+        };
+
+        let spec = ollama_provider_spec_with_base_url(&endpoint);
+        let target = provider_target("ollama", endpoint.clone(), "phi4-mini");
+        let provider = OllamaHttpProvider::from_target(&spec, &target).expect("provider");
+
+        let output = provider.complete("hello ollama").expect("completion");
+        assert_eq!(output, "ollama ok");
+
+        let captured = captured.lock().expect("capture").clone().expect("request");
+        assert_eq!(captured.url, "/api/generate");
+        assert!(captured.body.contains(r#""model":"phi4-mini""#));
+        assert!(captured.body.contains(r#""prompt":"hello ollama""#));
+        assert!(captured.body.contains(r#""stream":false"#));
+
+        let _ = handle.join();
+    }
+
+    #[test]
+    fn ollama_http_provider_rejects_missing_response_text() {
+        let _guard = env_lock();
+        let Some((endpoint, _captured, handle)) = spawn_json_server(200, r#"{"done":true}"#) else {
+            return;
+        };
+
+        let spec = ollama_provider_spec_with_base_url(&endpoint);
+        let target = provider_target("ollama", endpoint, "phi4-mini");
+        let provider = OllamaHttpProvider::from_target(&spec, &target).expect("provider");
+        let err = provider
+            .complete("hello ollama")
+            .expect_err("missing response should fail");
+        assert!(
+            err.to_string()
+                .contains("response missing 'response' text field"),
+            "{err:#}"
+        );
 
         let _ = handle.join();
     }

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -19,13 +19,13 @@ mod http_family;
 mod local;
 mod profiles;
 
-pub use http_family::{AnthropicProvider, HttpProvider, OpenAiProvider};
+pub use http_family::{AnthropicProvider, HttpProvider, OllamaHttpProvider, OpenAiProvider};
 pub use local::{MockProvider, OllamaProvider};
 pub use profiles::{expand_provider_profiles, provider_profile_names};
 
 pub(crate) use profiles::{
-    is_allowed_remote_endpoint, ANTHROPIC_MESSAGES_ENDPOINT, ANTHROPIC_VERSION,
-    OPENAI_RESPONSES_ENDPOINT,
+    is_allowed_ollama_endpoint, is_allowed_remote_endpoint, ANTHROPIC_MESSAGES_ENDPOINT,
+    ANTHROPIC_VERSION, OPENAI_RESPONSES_ENDPOINT,
 };
 
 /// A minimal blocking provider interface for v0.1.
@@ -235,6 +235,7 @@ pub fn build_provider_for_id(
     match target.transport {
         provider_substrate::ProviderTransportV1::Http => match target.provider_kind.as_str() {
             "http" | "http_remote" => Ok(Box::new(HttpProvider::from_target(spec, &target)?)),
+            "ollama" => Ok(Box::new(OllamaHttpProvider::from_target(spec, &target)?)),
             "openai" => Ok(Box::new(OpenAiProvider::from_target(spec, &target)?)),
             "anthropic" => Ok(Box::new(AnthropicProvider::from_target(spec, &target)?)),
             other => Err(unknown_kind(other)),

--- a/adl/src/provider/profiles.rs
+++ b/adl/src/provider/profiles.rs
@@ -42,6 +42,11 @@ pub(crate) fn is_allowed_remote_endpoint(endpoint: &str) -> bool {
         || normalized.starts_with("http://[::1]")
 }
 
+pub(crate) fn is_allowed_ollama_endpoint(endpoint: &str) -> bool {
+    let normalized = endpoint.trim().to_ascii_lowercase();
+    normalized.starts_with("https://") || normalized.starts_with("http://")
+}
+
 pub(crate) const OPENAI_RESPONSES_ENDPOINT: &str = "https://api.openai.com/v1/responses";
 pub(crate) const ANTHROPIC_MESSAGES_ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
 pub(crate) const ANTHROPIC_VERSION: &str = "2023-06-01";

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -166,8 +166,15 @@ fn infer_vendor(spec: &adl::ProviderSpec) -> String {
 
 fn infer_transport(spec: &adl::ProviderSpec) -> Result<ProviderTransportV1> {
     match spec.kind.trim() {
+        "ollama" => {
+            if spec.base_url.is_some() || cfg_str(&spec.config, "endpoint").is_some() {
+                Ok(ProviderTransportV1::Http)
+            } else {
+                Ok(ProviderTransportV1::LocalCli)
+            }
+        }
         "http" | "http_remote" | "openai" | "anthropic" => Ok(ProviderTransportV1::Http),
-        "ollama" | "local_ollama" => Ok(ProviderTransportV1::LocalCli),
+        "local_ollama" => Ok(ProviderTransportV1::LocalCli),
         "mock" => Ok(ProviderTransportV1::InProcess),
         other => Err(anyhow!(
             "unsupported provider kind '{other}' for provider substrate v1"
@@ -181,6 +188,42 @@ fn infer_capability_defaults(
     model_ref: Option<&str>,
 ) -> ProviderCapabilitiesV1 {
     let model = model_ref.unwrap_or("").trim().to_lowercase();
+    if vendor == "ollama" {
+        let native_supported = model.contains("gpt-oss")
+            || model.contains("qwen3-coder")
+            || model.contains("qwen2.5-coder");
+        let tool_calling = if native_supported {
+            CapabilitySupportV1 {
+                supported: true,
+                mode: CapabilityModeV1::Native,
+            }
+        } else {
+            CapabilitySupportV1 {
+                supported: false,
+                mode: CapabilityModeV1::None,
+            }
+        };
+        let structured_json = if tool_calling.supported {
+            CapabilitySupportV1 {
+                supported: true,
+                mode: CapabilityModeV1::Native,
+            }
+        } else {
+            CapabilitySupportV1 {
+                supported: true,
+                mode: CapabilityModeV1::PromptBased,
+            }
+        };
+        return ProviderCapabilitiesV1 {
+            tool_calling,
+            structured_json,
+            semantic_tool_fallback: CapabilitySupportV1 {
+                supported: true,
+                mode: CapabilityModeV1::SemanticFallback,
+            },
+        };
+    }
+
     let native_tool_calling = match transport {
         ProviderTransportV1::Http | ProviderTransportV1::InProcess => CapabilitySupportV1 {
             supported: true,
@@ -458,6 +501,32 @@ mod tests {
         assert_eq!(target.transport, ProviderTransportV1::LocalCli);
         assert_eq!(target.model_ref, "phi4-mini");
         assert_eq!(target.provider_model_id, "phi4-mini-provider-native");
+    }
+
+    #[test]
+    fn provider_substrate_uses_http_transport_for_ollama_with_endpoint() {
+        let mut spec = provider_spec("ollama");
+        spec.base_url = Some("http://192.168.68.73:11434".to_string());
+        spec.default_model = Some("phi4-mini".to_string());
+
+        let substrate = provider_substrate_v1("remote_ollama", &spec).expect("substrate");
+        assert_eq!(substrate.vendor, "ollama");
+        assert_eq!(substrate.transport, ProviderTransportV1::Http);
+        assert!(substrate.capabilities.semantic_tool_fallback.supported);
+        assert_eq!(
+            substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::PromptBased
+        );
+    }
+
+    #[test]
+    fn provider_substrate_keeps_local_ollama_cli_transport() {
+        let mut spec = provider_spec("local_ollama");
+        spec.default_model = Some("phi4-mini".to_string());
+
+        let substrate = provider_substrate_v1("local_ollama", &spec).expect("substrate");
+        assert_eq!(substrate.vendor, "ollama");
+        assert_eq!(substrate.transport, ProviderTransportV1::LocalCli);
     }
 
     #[test]

--- a/adl/tests/remote_ollama_provider_tests.rs
+++ b/adl/tests/remote_ollama_provider_tests.rs
@@ -1,0 +1,111 @@
+use ::adl::adl::AdlDoc;
+use ::adl::provider::build_provider;
+use tiny_http::{Header, Response, Server};
+
+mod helpers;
+use helpers::unique_test_temp_dir;
+
+fn reserve_local_port() -> Option<u16> {
+    let listener = match std::net::TcpListener::bind("127.0.0.1:0") {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(err) => panic!("bind ephemeral port: {err}"),
+    };
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    Some(port)
+}
+
+#[test]
+fn build_provider_accepts_remote_ollama_http_transport() {
+    let _temp_dir = unique_test_temp_dir("remote-ollama-provider");
+    let Some(port) = reserve_local_port() else {
+        return;
+    };
+    let bind_addr = format!("127.0.0.1:{port}");
+    let server = Server::http(&bind_addr).expect("bind tiny_http server");
+    let handle = std::thread::spawn(move || {
+        if let Some(request) = server.incoming_requests().next() {
+            let mut response = Response::from_string(
+                r#"{"response":"REMOTE_OLLAMA_PROVIDER_TEST_OK","done":true}"#,
+            )
+            .with_status_code(200);
+            if let Ok(header) = Header::from_bytes("Content-Type", "application/json") {
+                response = response.with_header(header);
+            }
+            let _ = request.respond(response);
+        }
+    });
+
+    let endpoint = format!("http://{bind_addr}");
+    let doc: AdlDoc = serde_yaml::from_str(&format!(
+        r#"
+version: "0.5"
+providers:
+  remote:
+    type: ollama
+    base_url: "{endpoint}"
+    default_model: phi4-mini
+agents:
+  a1:
+    provider: remote
+    model: phi4-mini
+tasks:
+  t1:
+    prompt:
+      user: hello
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: a1
+        task: t1
+"#
+    ))
+    .expect("parse doc");
+    doc.validate().expect("remote ollama validation");
+    let provider = build_provider(&doc.providers["remote"], Some("phi4-mini"))
+        .expect("build_provider should accept remote ollama");
+    let output = provider
+        .complete("REMOTE_OLLAMA_PROVIDER_TEST_OK")
+        .expect("remote ollama provider should complete over http");
+    assert_eq!(output, "REMOTE_OLLAMA_PROVIDER_TEST_OK");
+
+    let _ = handle.join();
+}
+
+#[test]
+fn validate_rejects_endpoint_on_local_ollama_kind() {
+    let doc: AdlDoc = serde_yaml::from_str(
+        r#"
+version: "0.5"
+providers:
+  local:
+    type: local_ollama
+    base_url: "http://127.0.0.1:11434"
+agents:
+  a1:
+    provider: local
+    model: phi4-mini
+tasks:
+  t1:
+    prompt:
+      user: hello
+run:
+  workflow:
+    kind: sequential
+    steps:
+      - agent: a1
+        task: t1
+"#,
+    )
+    .expect("parse doc");
+    let err = doc
+        .validate()
+        .expect_err("local_ollama with endpoint must fail");
+    assert!(
+        err.to_string()
+            .contains("kind 'local_ollama' is CLI-backed"),
+        "{err:#}"
+    );
+}

--- a/adl/tests/resolve_tests.rs
+++ b/adl/tests/resolve_tests.rs
@@ -38,8 +38,7 @@ tasks:
       user: "task user"
 providers:
   ollama_local:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     config:
       model: "llama3.1:8b"
 "#,
@@ -84,8 +83,7 @@ tasks:
       user: "task user"
 providers:
   ollama_local:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     config:
       model: "llama3.1:8b"
 "#,
@@ -133,8 +131,7 @@ tasks:
       user: "task user"
 providers:
   p1:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     config:
       model: "llama3.1:8b"
 "#,
@@ -180,8 +177,7 @@ tasks:
       user: "task user"
 providers:
   p1:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     config:
       model: "llama3.1:8b"
 "#,
@@ -341,8 +337,7 @@ tasks:
       user: "task user"
 providers:
   p1:
-    type: ollama
-    base_url: "http://localhost:11434"
+    type: local_ollama
     config:
       model: "llama3.1:8b"
 "#,

--- a/docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md
+++ b/docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md
@@ -82,6 +82,11 @@ Key capabilities:
 - provide a configuration surface that lets agents target vendors and models without brittle string coupling
 - integrate cleanly with declared, observed, and effective capability envelopes
 
+Current runtime clarification:
+- `local_ollama` is the explicit local CLI-backed Ollama surface
+- `ollama` may resolve to either local CLI compatibility mode or first-class HTTP transport when `base_url` or `config.endpoint` is configured
+- remote Ollama intentionally permits explicit `http://` endpoints because native Ollama deployments commonly run on loopback or LAN-local plaintext HTTP
+
 ## Design
 
 ### Core Concepts


### PR DESCRIPTION
Closes #1882

## Summary
- add first-class remote Ollama HTTP transport for runtime providers
- keep `local_ollama` as the explicit CLI-backed surface
- add focused runtime, validation, and architecture coverage for the transport split