### PR TITLE
[v0.89][tools] Make issue bootstrap refuse bogus version inference and require truthful local bundle placement

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -69,6 +69,55 @@ use self::github::{
 
 const DEFAULT_VERSION: &str = "v0.86";
 const DEFAULT_NEW_LABELS: &str = "track:roadmap,type:task,area:tools";
+
+fn resolve_version_for_create(
+    explicit_version: Option<String>,
+    labels_csv: Option<&str>,
+    raw_title: &str,
+) -> Result<String> {
+    if let Some(version) = explicit_version {
+        return Ok(version);
+    }
+
+    version_from_labels_csv(labels_csv.unwrap_or_default())
+        .or_else(|| version_from_title(raw_title))
+        .ok_or_else(|| {
+            anyhow!(
+                "create: could not infer version from title or labels; pass --version or include a version:vX.Y label / [vX.Y] title prefix"
+            )
+        })
+}
+
+fn resolve_version_for_existing_issue(
+    repo_root: &Path,
+    repo: &str,
+    issue: u32,
+    explicit_version: Option<String>,
+    no_fetch_issue: bool,
+    command: &str,
+) -> Result<String> {
+    if let Some(version) = explicit_version {
+        return Ok(version);
+    }
+
+    if no_fetch_issue {
+        if let Some((version, _slug)) =
+            resolve_issue_scope_and_slug_from_local_state(repo_root, issue)?
+        {
+            return Ok(version);
+        }
+        bail!(
+            "{command}: --version is required when --no-fetch-issue is set and no canonical local bundle exists to infer the milestone band"
+        );
+    }
+
+    issue_version(issue, repo)?.ok_or_else(|| {
+        anyhow!(
+            "{command}: could not infer version for issue #{issue}; pass --version or add a version:vX.Y label / [vX.Y] title prefix"
+        )
+    })
+}
+
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
@@ -105,16 +154,8 @@ fn real_pr_create(args: &[String]) -> Result<()> {
         bail!("create: slug is empty after sanitization");
     }
 
-    let version = if let Some(version) = parsed.version.clone() {
-        version
-    } else {
-        parsed
-            .labels
-            .as_deref()
-            .and_then(version_from_labels_csv)
-            .or_else(|| version_from_title(&raw_title))
-            .unwrap_or_else(|| DEFAULT_VERSION.to_string())
-    };
+    let version =
+        resolve_version_for_create(parsed.version.clone(), parsed.labels.as_deref(), &raw_title)?;
     let title = normalize_issue_title_for_version(&raw_title, &version);
     if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
         slug = sanitize_slug(&title);
@@ -251,13 +292,14 @@ fn real_pr_start(args: &[String]) -> Result<()> {
         title = slug.clone();
     }
 
-    let version = if let Some(version) = parsed.version.clone() {
-        version
-    } else if parsed.no_fetch_issue {
-        DEFAULT_VERSION.to_string()
-    } else {
-        issue_version(parsed.issue, &repo)?.unwrap_or_else(|| DEFAULT_VERSION.to_string())
-    };
+    let version = resolve_version_for_existing_issue(
+        &repo_root,
+        &repo,
+        parsed.issue,
+        parsed.version.clone(),
+        parsed.no_fetch_issue,
+        "start",
+    )?;
     title = normalize_issue_title_for_version(&title, &version);
     if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
         slug = sanitize_slug(&title);
@@ -780,13 +822,14 @@ fn real_pr_init(args: &[String]) -> Result<()> {
         title = slug.clone();
     }
 
-    let version = if let Some(version) = parsed.version.clone() {
-        version
-    } else if parsed.no_fetch_issue {
-        DEFAULT_VERSION.to_string()
-    } else {
-        issue_version(issue, &repo)?.unwrap_or_else(|| DEFAULT_VERSION.to_string())
-    };
+    let version = resolve_version_for_existing_issue(
+        &repo_root,
+        &repo,
+        issue,
+        parsed.version.clone(),
+        parsed.no_fetch_issue,
+        "init",
+    )?;
     title = normalize_issue_title_for_version(&title, &version);
     if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
         slug = sanitize_slug(&title);

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -276,6 +276,7 @@ fn repo_root() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::tests::env_lock;
     use std::env;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -497,7 +498,13 @@ mod tests {
 
     #[test]
     fn real_provider_uses_repo_root_for_default_output() {
-        let repo_root = repo_root().expect("repo root should resolve");
+        let _guard = env_lock();
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("adl crate lives under repo root")
+            .to_path_buf();
+        let prev_dir = env::current_dir().expect("cwd");
+        env::set_current_dir(&repo_root).expect("switch to repo root");
         let out = repo_root.join(".adl/provider-setup/deepseek");
         if out.exists() {
             fs::remove_dir_all(&out).expect("remove stale output");
@@ -511,5 +518,6 @@ mod tests {
         assert!(out.join("README.md").exists());
 
         fs::remove_dir_all(out).expect("cleanup generated output");
+        env::set_current_dir(prev_dir).expect("restore cwd");
     }
 }

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -957,6 +957,60 @@ fn real_pr_create_rejects_bootstrap_stub_issue_body_with_authored_body_guidance(
 }
 
 #[test]
+fn real_pr_create_requires_explicit_or_inferable_version() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-real-create-missing-version");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/example/repo.git",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    write_executable(
+        &bin_dir.join("gh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 99\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "create".to_string(),
+        "--title".to_string(),
+        "[runtime] Missing version signals".to_string(),
+        "--slug".to_string(),
+        "runtime-missing-version-signals".to_string(),
+        "--labels".to_string(),
+        "track:roadmap,type:task,area:runtime".to_string(),
+    ])
+    .expect_err("missing version signals should fail before issue creation");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(err
+        .to_string()
+        .contains("create: could not infer version from title or labels"));
+    assert!(!repo.join(".adl").join("v0.86").exists());
+}
+
+#[test]
 fn real_pr_create_rejects_missing_origin_before_spawning_gh_issue_create() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-create-no-origin");

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -444,6 +444,97 @@ fn real_pr_init_repairs_missing_version_metadata_on_github_issue() {
 }
 
 #[test]
+fn real_pr_init_requires_explicit_or_inferable_version_for_issue() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-init-missing-version");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+
+    let bin_dir = repo.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    write_executable(
+        &bin_dir.join("gh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json title -q .title\"* ]]; then\n  printf '[runtime] Missing version metadata\\n'\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json labels -q .labels[].name\"* ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:runtime\\n'\n  exit 0\nfi\nexit 1\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "init".to_string(),
+        "1153".to_string(),
+        "--slug".to_string(),
+        "runtime-missing-version-metadata".to_string(),
+    ])
+    .expect_err("missing version metadata should fail init");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(err
+        .to_string()
+        .contains("init: could not infer version for issue #1153"));
+}
+
+#[test]
+fn real_pr_start_requires_explicit_version_when_no_fetch_issue_has_no_local_bundle() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-start-no-fetch-missing-version");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "start".to_string(),
+        "1153".to_string(),
+        "--slug".to_string(),
+        "runtime-missing-version-no-fetch".to_string(),
+        "--no-fetch-issue".to_string(),
+    ])
+    .expect_err("no-fetch start without local bundle or explicit version should fail");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(err.to_string().contains(
+        "start: --version is required when --no-fetch-issue is set and no canonical local bundle exists to infer the milestone band"
+    ));
+}
+
+#[test]
 fn current_pr_url_filters_empty_and_null_results() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-current-url");

--- a/adl/tools/test_pr_issue_version_inference.sh
+++ b/adl/tools/test_pr_issue_version_inference.sh
@@ -43,26 +43,69 @@ cat >"$bindir/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 LOG_FILE="${GH_LOG_FILE:?}"
+STATE_DIR="$(dirname "$LOG_FILE")"
+TITLE_976_FILE="$STATE_DIR/issue-976.title"
+LABELS_976_FILE="$STATE_DIR/issue-976.labels"
 printf '%s\n' "$*" >>"$LOG_FILE"
+read_labels() {
+  local issue="$1"
+  if [[ "$issue" == "975" ]]; then
+    printf 'track:roadmap\ntype:task\narea:tools\nversion:v0.85\n'
+    return 0
+  fi
+  if [[ "$issue" == "976" ]]; then
+    if [[ -f "$LABELS_976_FILE" ]]; then
+      cat "$LABELS_976_FILE"
+    fi
+    return 0
+  fi
+  return 1
+}
+read_title() {
+  local issue="$1"
+  if [[ "$issue" == "975" ]]; then
+    printf '[v0.85][process] Infer current milestone card version from issue title when labels are missing\n'
+    return 0
+  fi
+  if [[ "$issue" == "976" ]]; then
+    if [[ -f "$TITLE_976_FILE" ]]; then
+      cat "$TITLE_976_FILE"
+    else
+      printf '[v0.87.1][process] Infer dot suffixed milestone card version from issue title when labels are missing\n'
+    fi
+    return 0
+  fi
+  return 1
+}
 if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
   issue="${3:-}"
   shift 3
   if [[ "$issue" != "975" && "$issue" != "976" ]]; then
     exit 1
   fi
-  if [[ "$issue" == "975" && "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
-    echo "version:v0.85"
+  if [[ "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
+    read_labels "$issue"
     exit 0
   fi
-  if [[ "$issue" == "976" && "$*" == *"--json labels"* && "$*" == *"-q .labels[].name"* ]]; then
+  if [[ "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
+    read_title "$issue"
     exit 0
   fi
-  if [[ "$issue" == "975" && "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
-    echo "[v0.85][process] Infer current milestone card version from issue title when labels are missing"
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+  issue="${3:-}"
+  shift 3
+  if [[ "$issue" == "976" && "$*" == *"--add-label"* ]]; then
+    cat <<'LABELS' >"$LABELS_976_FILE"
+track:roadmap
+type:task
+area:tools
+version:v0.87.1
+LABELS
     exit 0
   fi
-  if [[ "$issue" == "976" && "$*" == *"--json title"* && "$*" == *"-q .title"* ]]; then
-    echo "[v0.87.1][process] Infer dot suffixed milestone card version from issue title when labels are missing"
+  if [[ "$issue" == "976" && "$*" == *"--title"* ]]; then
+    printf '%s\n' '[v0.87.1][process] Infer dot suffixed milestone card version from issue title when labels are missing' >"$TITLE_976_FILE"
     exit 0
   fi
 fi
@@ -107,10 +150,12 @@ write_authored_source_prompt() {
 ---
 issue_card_schema: adl.issue.v1
 wp: "process"
+queue: "tools"
 slug: "$slug"
 title: "$title"
 labels:
   - "track:roadmap"
+  - "area:tools"
   - "version:$version"
 issue_number: $issue
 status: "draft"


### PR DESCRIPTION
Closes #1883

## Summary
Hardened the bootstrap/version-inference control plane so `create`, `init`, and `start` no longer
silently fall back to the stale default milestone band when neither explicit version metadata nor
inferable issue metadata is present. The branch now fails fast with actionable guidance, prefers
local canonical bundle state when `--no-fetch-issue` is used, and keeps the repo's version
inference shell proof fixture truthful under the newer queue-aware metadata rules.

## Artifacts
- control-plane implementation updates:
  - `adl/src/cli/pr_cmd.rs`
- focused regression coverage:
  - `adl/src/cli/tests/pr_cmd_inline/basics.rs`
  - `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`
  - `adl/tools/test_pr_issue_version_inference.sh`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_requires_explicit_or_inferable_version -- --nocapture`
    Verified `create` fails fast instead of silently inferring the wrong milestone band.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_init_requires_explicit_or_inferable_version_for_issue -- --nocapture`
    Verified `init` rejects issues whose GitHub metadata still lacks an inferable version.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_requires_explicit_version_when_no_fetch_issue_has_no_local_bundle -- --nocapture`
    Verified `start --no-fetch-issue` now requires explicit version information or canonical local
    bundle state.
  - `cargo test --manifest-path adl/Cargo.toml issue_version_prefers_labels_and_falls_back_to_title -- --nocapture`
    Verified label-first, title-fallback issue version inference still works for valid metadata.
  - `bash adl/tools/test_pr_issue_version_inference.sh`
    Verified the repo-native init/start shell proof still writes version-correct bundle paths for
    both plain and dot-suffixed milestone bands.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the Rust write set is formatter-clean.
  - `git diff --check`
    Verified the final patch has no whitespace or malformed-diff defects.
- Results:
  - missing-version bootstrap paths now fail with explicit remediation guidance instead of falling
    back to `v0.86`
  - `--no-fetch-issue` bootstrap paths now reuse truthful local bundle placement when available
  - the repo shell proof fixture now remains green under queue-aware metadata repair behavior
  - the final bounded write set is formatter-clean and diff-clean

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1883__v0-89-tools-make-issue-bootstrap-refuse-bogus-version-inference-and-require-truthful-local-bundle-placement/sip.md
- Output card: .adl/v0.89/tasks/issue-1883__v0-89-tools-make-issue-bootstrap-refuse-bogus-version-inference-and-require-truthful-local-bundle-placement/sor.md
- Idempotency-Key: v0-89-tools-make-issue-bootstrap-refuse-bogus-version-inference-and-require-truthful-local-bundle-placement-adl-v0-89-tasks-issue-1883-v0-89-tools-make-issue-bootstrap-refuse-bogus-version-inference-and-require-truthful-local-bundle-placement-sip-md-adl-v0-89-tasks-issue-1883-v0-89-tools-make-issue-bootstrap-refuse-bogus-version-inference-and-require-truthful-local-bundle-placement-sor-md