### PR TITLE
[v0.89][tools] Make completed SOR validation accept truthful closed-no-PR records

### DIFF
--- a/adl/schemas/structured_output_record.contract.yaml
+++ b/adl/schemas/structured_output_record.contract.yaml
@@ -30,7 +30,7 @@ fields:
     required: false
   Main Repo Integration.Integration state:
     type: enum
-    values: [worktree_only, pr_open, merged]
+    values: [worktree_only, pr_open, merged, closed_no_pr]
     required: false
   Main Repo Integration.Verification scope:
     type: enum

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -502,9 +502,23 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         !markdown_field(text, "Title").unwrap_or_default().is_empty(),
         "missing required field: Title"
     );
+    let integration_state = markdown_block_field(
+        text,
+        "Main Repo Integration (REQUIRED)",
+        "Integration state",
+    )
+    .unwrap_or_default();
+    ensure!(
+        integration_state.is_empty()
+            || ["worktree_only", "pr_open", "merged", "closed_no_pr"]
+                .contains(&integration_state.as_str()),
+        "Main Repo Integration.Integration state must be one of: worktree_only, pr_open, merged, closed_no_pr"
+    );
     let branch = markdown_field(text, "Branch").unwrap_or_default();
     let branch_ok = if phase == Some("bootstrap") {
         valid_branch(&branch) || branch.eq_ignore_ascii_case("not bound yet")
+    } else if phase == Some("completed") && integration_state == "closed_no_pr" {
+        branch.eq_ignore_ascii_case("retrospective-no-branch")
     } else {
         valid_branch(&branch)
     };
@@ -513,6 +527,8 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
         "Branch must be a codex/ branch{}",
         if phase == Some("bootstrap") {
             " or `not bound yet` in bootstrap phase"
+        } else if phase == Some("completed") && integration_state == "closed_no_pr" {
+            " or `retrospective-no-branch` when completed-phase Integration state is `closed_no_pr`"
         } else {
             ""
         }
@@ -531,17 +547,6 @@ pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
     ensure!(
         end.is_empty() || valid_iso8601_datetime(&end),
         "Execution.End Time must be UTC ISO 8601 / RFC3339 with trailing Z (YYYY-MM-DDTHH:MM:SSZ)"
-    );
-    let integration_state = markdown_block_field(
-        text,
-        "Main Repo Integration (REQUIRED)",
-        "Integration state",
-    )
-    .unwrap_or_default();
-    ensure!(
-        integration_state.is_empty()
-            || ["worktree_only", "pr_open", "merged"].contains(&integration_state.as_str()),
-        "Main Repo Integration.Integration state must be one of: worktree_only, pr_open, merged"
     );
     let verification_scope = markdown_block_field(
         text,

--- a/adl/src/cli/tooling_cmd/tests.rs
+++ b/adl/src/cli/tooling_cmd/tests.rs
@@ -1026,6 +1026,36 @@ fn structured_prompt_sor_validator_accepts_not_bound_yet_only_in_bootstrap_phase
 }
 
 #[test]
+fn structured_prompt_completed_sor_validator_accepts_closed_no_pr_retrospective_branch() {
+    let sor = valid_sor_text()
+        .replace(
+            "Branch: codex/1374-tooling-test",
+            "Branch: retrospective-no-branch",
+        )
+        .replace(
+            "Integration state: merged",
+            "Integration state: closed_no_pr",
+        );
+
+    validate_sor_text(&sor, Some("completed"))
+        .expect("completed closed_no_pr SOR should accept retrospective-no-branch");
+}
+
+#[test]
+fn structured_prompt_completed_sor_closed_no_pr_still_rejects_non_retrospective_branch() {
+    let sor = valid_sor_text()
+        .replace("Branch: codex/1374-tooling-test", "Branch: not bound yet")
+        .replace(
+            "Integration state: merged",
+            "Integration state: closed_no_pr",
+        );
+
+    let err = validate_sor_text(&sor, Some("completed"))
+        .expect_err("closed_no_pr completed SOR should still reject invalid branch markers");
+    assert!(err.to_string().contains("retrospective-no-branch"));
+}
+
+#[test]
 fn review_commands_validate_and_render_expected_surfaces() {
     let repo = TempRepo::new("review");
     let input = repo.write_rel(

--- a/adl/tools/test_structured_prompt_validation.sh
+++ b/adl/tools/test_structured_prompt_validation.sh
@@ -731,6 +731,57 @@ EOF
 
 "$VALIDATOR" --type sor --phase completed --input "$tmpdir/sor_completed_worktree_only_valid.md" >/dev/null
 
+cat >"$tmpdir/sor_completed_closed_no_pr_valid.md" <<'EOF'
+# dependable-execution-fixture
+
+Task ID: issue-0899
+Run ID: issue-0899
+Version: v0.85
+Title: completed-closed-no-pr-valid-sor
+Branch: retrospective-no-branch
+Status: DONE
+
+Execution:
+- Actor: codex
+- Model: gpt-5-codex
+- Provider: codex desktop
+- Start Time: 2026-03-18T07:00:00Z
+- End Time: 2026-03-18T07:05:00Z
+
+## Summary
+Completed no-PR closeout record for truthful retrospective normalization.
+## Artifacts produced
+x
+## Actions taken
+x
+## Main Repo Integration (REQUIRED)
+- Main-repo paths updated:
+- Worktree-only paths remaining: none
+- Integration state: closed_no_pr
+- Verification scope: main_repo
+- Integration method used: direct write in main repo for local-only closeout surfaces
+- Verification performed:
+- Result: PASS
+## Validation
+x
+## Verification Summary
+x
+## Determinism Evidence
+x
+## Security / Privacy Checks
+x
+## Replay Artifacts
+x
+## Artifact Verification
+x
+## Decisions / Deviations
+x
+## Follow-ups / Deferred work
+x
+EOF
+
+"$VALIDATOR" --type sor --phase completed --input "$tmpdir/sor_completed_closed_no_pr_valid.md" >/dev/null
+
 cat >"$tmpdir/sor_absolute_path_invalid.md" <<'EOF'
 # dependable-execution-fixture
 


### PR DESCRIPTION
Closes #1885

## Summary
Accepted truthful completed `closed_no_pr` SOR records in the structured prompt validator and schema, kept malformed branch variants rejected for that integration mode, and backfilled shell and Rust coverage so the validation contract is now explicit and reproducible.

## Artifacts
- updated validator logic in `adl/src/cli/tooling_cmd/structured_prompt.rs`
- focused regression tests in `adl/src/cli/tooling_cmd/tests.rs`
- updated schema enum in `adl/schemas/structured_output_record.contract.yaml`
- shell harness coverage in `adl/tools/test_structured_prompt_validation.sh`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_completed_sor_validator_accepts_closed_no_pr_retrospective_branch -- --nocapture`
    Verified the validator accepts truthful completed `closed_no_pr` records that use the retrospective no-branch marker.
  - `cargo test --manifest-path adl/Cargo.toml structured_prompt_completed_sor_closed_no_pr_still_rejects_non_retrospective_branch -- --nocapture`
    Verified malformed completed `closed_no_pr` records still fail when they use a normal branch name.
  - `bash adl/tools/test_structured_prompt_validation.sh`
    Verified the shell-level prompt validation harness accepts the new closed-no-PR fixture and preserves existing prompt-validation behavior.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the Rust/schema/test edits remain formatting-clean.
  - `git diff --check`
    Verified there are no diff hygiene or whitespace errors in the tracked patch.
- Results:
  - both targeted Rust validator tests passed
  - the shell validation harness passed
  - formatting and diff-hygiene checks passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1885__v0-89-tools-make-completed-sor-validation-accept-truthful-closed-no-pr-records/sip.md
- Output card: .adl/v0.89/tasks/issue-1885__v0-89-tools-make-completed-sor-validation-accept-truthful-closed-no-pr-records/sor.md
- Idempotency-Key: v0-89-tools-make-completed-sor-validation-accept-truthful-closed-no-pr-records-adl-v0-89-tasks-issue-1885-v0-89-tools-make-completed-sor-validation-accept-truthful-closed-no-pr-records-sip-md-adl-v0-89-tasks-issue-1885-v0-89-tools-make-completed-sor-validation-accept-truthful-closed-no-pr-records-sor-md