### PR TITLE
[v0.89][tools] Make bootstrap SORs validator-safe and make doctor fail on invalid root output cards

### DIFF
--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd_cards::validate_bootstrap_output_card;
 use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -282,6 +283,15 @@ pub(super) fn run_doctor_ready(
         )
         || root_input_body
             .contains("Do not assume a branch or worktree already exists before `pr run`.");
+    if root_indicates_pre_run {
+        validate_bootstrap_output_card(
+            repo_root,
+            issue_ref.issue_number(),
+            issue_ref.slug(),
+            &root_branch,
+            &root_bundle_output,
+        )?;
+    }
     if !worktree_path.is_dir() {
         if root_indicates_pre_run {
             return Ok(DoctorReadyResult {

--- a/adl/src/cli/pr_cmd_cards.rs
+++ b/adl/src/cli/pr_cmd_cards.rs
@@ -804,7 +804,7 @@ pub(crate) fn ensure_symlink(link_path: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
-fn validate_bootstrap_cards(
+pub(crate) fn validate_bootstrap_cards(
     repo_root: &Path,
     issue: u32,
     slug: &str,
@@ -836,7 +836,13 @@ fn validate_bootstrap_cards(
             "--input",
             path_str(output_path)?,
         ],
-    )?;
+    )
+    .with_context(|| {
+        format!(
+            "doctor: output card failed bootstrap validation: {}",
+            output_path.display()
+        )
+    })?;
     let expected = format!("issue-{:04}", issue);
     if field_line_value(input_path, "Task ID")? != expected {
         bail!("start: input card Task ID mismatch");
@@ -858,6 +864,42 @@ fn validate_bootstrap_cards(
     }
     if !output_card_title_matches_slug(output_path, slug)? {
         bail!("start: output card title mismatch");
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_bootstrap_output_card(
+    repo_root: &Path,
+    issue: u32,
+    slug: &str,
+    branch: &str,
+    output_path: &Path,
+) -> Result<()> {
+    let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
+    run_status(
+        "bash",
+        &[
+            path_str(&validator)?,
+            "--type",
+            "sor",
+            "--phase",
+            "bootstrap",
+            "--input",
+            path_str(output_path)?,
+        ],
+    )?;
+    let expected = format!("issue-{:04}", issue);
+    if field_line_value(output_path, "Task ID")? != expected {
+        bail!("doctor: output card Task ID mismatch");
+    }
+    if field_line_value(output_path, "Run ID")? != expected {
+        bail!("doctor: output card Run ID mismatch");
+    }
+    if field_line_value(output_path, "Branch")? != branch {
+        bail!("doctor: output card branch mismatch");
+    }
+    if !output_card_title_matches_slug(output_path, slug)? {
+        bail!("doctor: output card title mismatch");
     }
     Ok(())
 }

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -253,6 +253,147 @@ fn real_pr_doctor_full_accepts_pre_run_analysis_issue_with_partial_worktree_resi
 }
 
 #[test]
+fn real_pr_doctor_full_blocks_invalid_root_bootstrap_output_card() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-doctor-invalid-root-output");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "doctor invalid root output\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1186, "v0.86", "doctor-invalid-root-output").expect("issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Doctor invalid root output",
+    );
+    real_pr(&[
+        "init".to_string(),
+        "1186".to_string(),
+        "--slug".to_string(),
+        "doctor-invalid-root-output".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Doctor invalid root output".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let root_sip = issue_ref.task_bundle_input_path(&repo);
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    write_authored_sip(
+        &root_sip,
+        &issue_ref,
+        "[v0.86][tools] Doctor invalid root output",
+        "not bound yet",
+        &source_path,
+        &repo,
+    );
+
+    let root_sor = issue_ref.task_bundle_output_path(&repo);
+    let invalid_sor = fs::read_to_string(&root_sor)
+        .expect("read bootstrap sor")
+        .replace("Status: IN_PROGRESS", "Status: NOT_STARTED")
+        .replace("- Start Time:", "- Start Time: not started yet")
+        .replace("- End Time:", "- End Time: not started yet")
+        .replace(
+            "- Integration state: worktree_only",
+            "- Integration state: main_repo",
+        );
+    fs::write(&root_sor, invalid_sor).expect("write invalid sor");
+
+    let doctor = real_pr(&[
+        "doctor".to_string(),
+        "1186".to_string(),
+        "--slug".to_string(),
+        "doctor-invalid-root-output".to_string(),
+        "--mode".to_string(),
+        "full".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+        "--json".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    let err = doctor.expect_err("doctor should fail when root bootstrap sor is invalid");
+    let text = err.to_string();
+    assert!(
+        text.contains("bash failed"),
+        "unexpected doctor error: {text}"
+    );
+}
+
+#[test]
 fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-doctor-worktree-cwd");

--- a/adl/src/cli/tooling_cmd/tests.rs
+++ b/adl/src/cli/tooling_cmd/tests.rs
@@ -1026,6 +1026,19 @@ fn structured_prompt_sor_validator_accepts_not_bound_yet_only_in_bootstrap_phase
 }
 
 #[test]
+fn structured_prompt_bootstrap_sor_rejects_free_form_not_started_timestamps() {
+    let sor = valid_sor_text()
+        .replace("Branch: codex/1374-tooling-test", "Branch: not bound yet")
+        .replace("Status: DONE", "Status: NOT_STARTED")
+        .replace("2026-04-07T19:00:00Z", "not started yet")
+        .replace("2026-04-07T19:05:00Z", "not started yet");
+
+    let err = validate_sor_text(&sor, Some("bootstrap"))
+        .expect_err("bootstrap SOR should reject free-form timestamp placeholders");
+    assert!(err.to_string().contains("Execution.Start Time"));
+}
+
+#[test]
 fn structured_prompt_completed_sor_validator_accepts_closed_no_pr_retrospective_branch() {
     let sor = valid_sor_text()
         .replace(


### PR DESCRIPTION
Closes #1886

## Summary
- block doctor-ready on invalid root bootstrap output cards
- add targeted validator and doctor regressions for bootstrap SOR truth
- normalize the remaining local v0.89 bootstrap SOR wave to validator-safe pre-run placeholders

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all
- cargo test --manifest-path adl/Cargo.toml structured_prompt_bootstrap_sor_rejects_free_form_not_started_timestamps -- --nocapture
- cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_blocks_invalid_root_bootstrap_output_card -- --nocapture
- cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_reports_pre_run_ready_without_worktree -- --nocapture
- bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.89/tasks/issue-1798__v0-89-wp-11-demo-scaffolding-and-proof-entry-points/sor.md
- bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.89/tasks/issue-1807__v0-89-wp-20-release-ceremony-final-validation-tag-notes-cleanup/sor.md
- bash adl/tools/pr.sh doctor 1798 --slug v0-89-wp-11-demo-scaffolding-and-proof-entry-points --version v0.89 --mode full --json