### PR TITLE
[v0.89][tools] Add bounded Medium article writer skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -39,6 +39,7 @@ sh "$ROOT/adl/tools/codexw.sh" --help >/dev/null 2>&1
 run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_review_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
+run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
 echo "• Running adl checks (batched)…"
 (

--- a/adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,123 @@
+# Medium Article Writer Skill Input Schema
+
+Schema id: `medium_article_writer.v1`
+
+## Purpose
+
+Provide one structured invocation shape for the bounded `medium-article-writer`
+skill.
+
+The skill should turn one concrete article brief into a reviewer-friendly
+Medium-style article packet while stopping before publication.
+
+## Supported Modes
+
+- `draft_from_brief_path`
+- `draft_from_brief_text`
+- `draft_from_demo_doc`
+
+## Top-Level Shape
+
+```yaml
+skill_input_schema: medium_article_writer.v1
+mode: draft_from_brief_path | draft_from_brief_text | draft_from_demo_doc
+repo_root: /absolute/path
+target:
+  article_brief_path: <path or null>
+  article_brief_text: <string or null>
+  demo_doc_path: <path or null>
+  artifact_root: <path or null>
+  audience: <string or null>
+  house_style: <string or null>
+  forbidden_claims:
+    - <string>
+  expected_sections:
+    - <string>
+policy:
+  writing_mode: standard | sharp | conservative
+  headline_style: clear | curious | essay
+  validation_mode: demo_aligned | artifact_only | none
+  stop_before_publish: true
+```
+
+## Mode Requirements
+
+### `draft_from_brief_path`
+
+Requires:
+
+- `target.article_brief_path`
+
+Use when:
+
+- the brief already exists as a local file
+
+### `draft_from_brief_text`
+
+Requires:
+
+- `target.article_brief_text`
+
+Use when:
+
+- the operator wants to provide the brief inline
+
+### `draft_from_demo_doc`
+
+Requires:
+
+- `target.demo_doc_path`
+
+Use when:
+
+- the skill should start from the existing Medium-writing demo surface and its documented packet shape
+
+## Policy Fields
+
+- `writing_mode`
+  - required
+  - one of `standard`, `sharp`, or `conservative`
+- `headline_style`
+  - required
+  - one of `clear`, `curious`, or `essay`
+- `validation_mode`
+  - required
+  - one of `demo_aligned`, `artifact_only`, or `none`
+- `stop_before_publish`
+  - must be `true`
+
+## Example Invocation
+
+```yaml
+Use $medium-article-writer at /Users/daniel/git/agent-design-language/adl/tools/skills/medium-article-writer/SKILL.md with this validated input:
+
+skill_input_schema: medium_article_writer.v1
+mode: draft_from_brief_path
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  article_brief_path: demos/fixtures/medium_article_writing/v0-89-medium-article-brief.md
+  article_brief_text: null
+  demo_doc_path: demos/v0.89/medium_article_writing_demo.md
+  artifact_root: null
+  audience: ADL reviewers
+  house_style: thoughtful technical essay
+  forbidden_claims:
+    - guaranteed virality
+    - autonomous publishing
+  expected_sections:
+    - title_options
+    - outline
+    - draft
+    - editorial_notes
+policy:
+  writing_mode: sharp
+  headline_style: clear
+  validation_mode: demo_aligned
+  stop_before_publish: true
+```
+
+## Notes
+
+- prefer concrete drafts over vague content strategy language
+- keep publication outside the skill boundary
+- use the existing bounded Medium article writing demo as the truthful baseline when relevant

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -24,6 +24,7 @@ The tracked skill set is:
 - `repo-code-review`
 - `test-generator`
 - `demo-operator`
+- `medium-article-writer`
 - `stp-editor`
 - `sip-editor`
 - `sor-editor`
@@ -45,6 +46,7 @@ The normal workflow is:
 `repo-code-review` is cross-cutting rather than phase-specific.
 `test-generator` is a bounded helper skill for focused tests for a concrete issue, diff, file, or worktree.
 `demo-operator` is a bounded helper skill for running one named demo and classifying the proof result consistently.
+`medium-article-writer` is a bounded helper skill for turning one concrete article brief into a reviewer-friendly Medium packet without publishing.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 
 The three editor skills are helper skills:

--- a/adl/tools/skills/medium-article-writer/SKILL.md
+++ b/adl/tools/skills/medium-article-writer/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: medium-article-writer
+description: Turn one concrete article brief into a reviewer-friendly Medium article packet without directly publishing. Use when the user wants bounded Medium-style drafting that enforces title quality, strong lead, section clarity, readability, and editorial notes while stopping before publication, platform posting, or scheduling.
+---
+
+# Medium Article Writer
+
+Write one Medium-style article packet with a bounded editorial mindset.
+
+This skill exists to turn one concrete article brief into a reviewable article
+packet, not to run a publication program or publish to Medium.
+
+This skill is allowed to:
+- inspect one concrete article brief
+- reuse the existing bounded Medium article writing demo surface
+- draft one article packet with title options, outline, article draft, and editorial notes
+- enforce Medium-oriented writing rules and reviewer-facing checks
+- write one bounded review artifact
+
+It is not allowed to:
+- publish directly to Medium
+- schedule posts or manage an editorial calendar
+- silently widen into a content strategy project
+- claim guaranteed reach, virality, or business outcomes
+
+## Quick Start
+
+1. Confirm the concrete article brief.
+2. Read the existing Medium-writing demo surface first.
+3. Identify the audience, claim, and reviewer expectations.
+4. Produce one bounded article packet.
+5. Record what was written and stop before publication.
+
+## When To Use It
+
+Use this skill when:
+- one concrete article brief should become a reviewer-friendly Medium packet
+- the operator wants Medium-style writing rules enforced consistently
+- the output should be draft-oriented rather than publish-oriented
+
+Do not use it when:
+- there is no concrete brief
+- the user wants direct platform publishing
+- the task is a broad content program or editorial calendar
+- the real task is just running the existing demo without creating a reusable skill
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `target.article_brief_path`
+  - `target.article_brief_text`
+  - `target.demo_doc_path`
+
+Useful additional inputs:
+- `artifact_root`
+- `audience`
+- `house_style`
+- `forbidden_claims`
+- `expected_sections`
+- `validation_mode`
+- `reviewer_mode`
+
+If there is no concrete article brief, stop and report `blocked`.
+
+## Workflow
+
+### 1. Resolve The Writing Target
+
+Prefer:
+1. explicit brief path
+2. explicit brief text
+3. documented demo packet plus explicit brief override
+
+If the brief is vague, stop rather than inventing a strategy document.
+
+### 2. Inspect The Existing Writing Surface
+
+Read:
+- the Medium article writing demo doc
+- the Medium article writing demo entrypoint
+- the concrete brief
+
+The skill should understand:
+- who the article is for
+- what claim the article makes
+- what proof or examples the article should contain
+- what would make the packet reviewable
+
+### 3. Enforce Medium-Oriented Writing Rules
+
+Bias toward:
+- one sharp headline family, not many weak options
+- a strong opening that earns the reader's attention quickly
+- section clarity and readable pacing
+- concrete examples over abstract filler
+- editorial notes that call out risks, not just polish
+
+Avoid:
+- clickbait certainty
+- vague “thought leadership” padding
+- corporate boilerplate
+- fake certainty about performance or audience reaction
+
+### 4. Produce The Packet
+
+The packet should normally include:
+- article premise or angle
+- title and subtitle options
+- section outline
+- article draft
+- editorial notes
+- publication caveats or reviewer notes
+
+Prefer reusing the existing demo's bounded packet shape rather than inventing a
+different hidden workflow engine.
+
+### 5. Stop Boundary
+
+Stop after:
+- one bounded article packet
+- one review artifact
+- one explicit note that publication is out of scope
+
+Do not:
+- publish to Medium
+- schedule the article
+- claim the article is final without reviewer approval
+
+## Output Expectations
+
+Default output should include:
+- target brief
+- intended audience and angle
+- packet contents produced
+- Medium-rule checks applied
+- publication boundary
+- follow-up recommendation
+
+When ADL expects a structured artifact, follow `references/output-contract.md`.
+
+## Design Basis
+
+Within this skill bundle, the operational details live in:
+- `references/medium-writing-playbook.md`
+- `references/output-contract.md`
+
+The operator-facing invocation contract lives in:
+- `/Users/daniel/git/agent-design-language/adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md`
+
+Prefer the tracked repo copies of these docs over memory when the bundle evolves.

--- a/adl/tools/skills/medium-article-writer/adl-skill.yaml
+++ b/adl/tools/skills/medium-article-writer/adl-skill.yaml
@@ -1,0 +1,108 @@
+version: "0.1"
+kind: "adl-skill"
+id: "medium-article-writer"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "medium_article_writer.v1"
+    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "draft_from_brief_path"
+      - "draft_from_brief_text"
+      - "draft_from_demo_doc"
+    policy_fields:
+      - "writing_mode"
+      - "headline_style"
+      - "validation_mode"
+      - "stop_before_publish"
+    mode_requirements:
+      draft_from_brief_path:
+        required_target_fields:
+          - "article_brief_path"
+      draft_from_brief_text:
+        required_target_fields:
+          - "article_brief_text"
+      draft_from_demo_doc:
+        required_target_fields:
+          - "demo_doc_path"
+  intent:
+    - "medium_article_drafting"
+    - "editorial_packet_generation"
+    - "bounded_writing_support"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "article_brief_path"
+    - "article_brief_text"
+    - "demo_doc_path"
+    - "artifact_root"
+    - "audience"
+    - "house_style"
+    - "forbidden_claims"
+    - "expected_sections"
+    - "validation_mode"
+    - "reviewer_mode"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_medium_article_writer.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "draft_from_brief_path_requires_target.article_brief_path"
+    - "draft_from_brief_text_requires_target.article_brief_text"
+    - "draft_from_demo_doc_requires_target.demo_doc_path"
+    - "policy.writing_mode_must_be_explicit"
+    - "policy.validation_mode_must_be_explicit"
+    - "policy.stop_before_publish_must_be_true"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: true
+  preferred_read_order:
+    - "brief"
+    - "medium_demo_doc"
+    - "medium_demo_entrypoint"
+    - "writing_playbook"
+  preferred_commands:
+    - "rg --files"
+    - "rg -n"
+    - "bash adl/tools/demo_v089_medium_article_writing.sh"
+    - "bash adl/tools/test_demo_v089_medium_article_writing.sh"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+    - "article packet artifacts"
+    - "bounded review manifests"
+  must_not_write:
+    - "publication platforms"
+    - "editorial calendar state"
+    - "unrelated issue bundles"
+    - "unrelated worktrees"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-medium-article-writer.md"
+  required_sections:
+    - "status"
+    - "target"
+    - "packet"
+    - "medium_rules_applied"
+    - "publication_boundary"
+    - "follow_up"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/medium-article-writer/agents/openai.yaml
+++ b/adl/tools/skills/medium-article-writer/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Medium Article Writer
+short_description: Draft one reviewer-friendly Medium article packet without publishing
+default_prompt: Turn one concrete article brief into a bounded Medium-style article packet with strong title options, a readable draft, and editorial notes, then stop before publication.

--- a/adl/tools/skills/medium-article-writer/references/medium-writing-playbook.md
+++ b/adl/tools/skills/medium-article-writer/references/medium-writing-playbook.md
@@ -1,0 +1,57 @@
+# Medium Writing Playbook
+
+Use this file after the main skill triggers and the article target is already concrete.
+
+## Priorities
+
+Prefer this order:
+1. identify the article's promise
+2. make the opening earn attention quickly
+3. keep the structure readable and concrete
+4. preserve one clear through-line
+5. leave the packet easy for a human editor to review
+
+## High-Value Questions
+
+Ask:
+- What is the one idea this article earns?
+- Why would a reader keep going after the first paragraph?
+- Where does the draft become vague or inflated?
+- Which claims need examples, qualification, or proof?
+- What should remain a reviewer decision instead of being “auto-published”?
+
+## Medium-Oriented Guidance
+
+Bias toward:
+- titles with specificity and curiosity, not hype
+- a lead that orients the reader fast
+- short, purposeful sections
+- concrete examples, scenes, or observations
+- editorial notes that mention risk, weak spots, and likely cuts
+
+Avoid:
+- generic “in today’s world” openings
+- empty thought-leadership phrasing
+- overlong intros
+- inflated certainty
+- fake claims about virality or audience response
+
+## Packet Guidance
+
+A strong bounded packet usually includes:
+- angle / premise
+- 3-5 title options
+- optional subtitle options
+- outline
+- full draft
+- editorial notes
+- explicit publication caveat
+
+## Stop Rule
+
+This skill stops at a reviewable draft packet.
+
+It does not:
+- publish to Medium
+- claim editorial approval
+- commit to a posting schedule

--- a/adl/tools/skills/medium-article-writer/references/output-contract.md
+++ b/adl/tools/skills/medium-article-writer/references/output-contract.md
@@ -1,0 +1,43 @@
+# Output Contract
+
+The default `medium-article-writer` artifact is markdown with these sections in this order:
+
+```md
+## Metadata
+- Skill: medium-article-writer
+- Subject: <article brief target>
+- Date: <UTC timestamp or calendar date>
+- Output Location: <path or none>
+
+## Target
+- Mode: draft_from_brief_path | draft_from_brief_text | draft_from_demo_doc
+- Brief Surface: <path, doc, or inline target>
+- Audience: <explicit audience or unknown>
+- Intended Angle: <one concise angle>
+
+## Packet
+- Produced Sections:
+  - <outline / titles / draft / editorial notes / reviewer summary>
+- Primary Draft Surface: <path or explicit none>
+- Result: PASS | FAIL | PARTIAL | NOT_RUN
+
+## Medium Rules Applied
+- Title Quality: <what was enforced>
+- Lead Quality: <what was enforced>
+- Structure and Readability: <what was enforced>
+- Editorial Notes: <what was surfaced>
+
+## Publication Boundary
+- Publication Attempted: true | false
+- Reason: <must explain why publish is out of scope>
+
+## Follow-up
+- Recommended Next Step: <one bounded next action or explicit none>
+```
+
+## Rules
+
+- Do not claim publication or platform posting.
+- Do not claim audience or performance outcomes as facts.
+- Keep the output reviewable and bounded.
+- Do not emit raw secrets, raw prompts, raw tool arguments, or unjustified absolute host paths.

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review test-generator demo-operator stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review test-generator demo-operator medium-article-writer stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -22,6 +22,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/repo-code-review/SKILL.md" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
+  [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]
@@ -36,6 +37,7 @@ assert_skill_bundle() {
   grep -Fq "findings-first" "${root}/skills/repo-code-review/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
+  grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
   grep -Fq "truthful execution and integration state" "${root}/skills/sor-editor/SKILL.md"
@@ -51,6 +53,7 @@ assert_skill_bundle() {
     "${root}/skills/repo-code-review/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
+    "${root}/skills/medium-article-writer/SKILL.md" \
     "${root}/skills/stp-editor/SKILL.md" \
     "${root}/skills/sip-editor/SKILL.md" \
     "${root}/skills/sor-editor/SKILL.md"

--- a/adl/tools/test_medium_article_writer_skill_contracts.sh
+++ b/adl/tools/test_medium_article_writer_skill_contracts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/medium-article-writer/SKILL.md" ]]
+[[ -f "${skills_root}/medium-article-writer/adl-skill.yaml" ]]
+[[ -f "${skills_root}/medium-article-writer/agents/openai.yaml" ]]
+[[ -f "${skills_root}/medium-article-writer/references/medium-writing-playbook.md" ]]
+[[ -f "${skills_root}/medium-article-writer/references/output-contract.md" ]]
+
+grep -Fq 'id: "medium_article_writer.v1"' "${skills_root}/medium-article-writer/adl-skill.yaml"
+grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/medium-article-writer/adl-skill.yaml"
+grep -Fq "policy.writing_mode_must_be_explicit" "${skills_root}/medium-article-writer/adl-skill.yaml"
+grep -Fq "policy.stop_before_publish_must_be_true" "${skills_root}/medium-article-writer/adl-skill.yaml"
+grep -Fq "reviewer-friendly Medium article packet" "${skills_root}/medium-article-writer/SKILL.md"
+grep -Fq "stopping before publication" "${skills_root}/medium-article-writer/SKILL.md"
+grep -Fq "This skill stops at a reviewable draft packet." "${skills_root}/medium-article-writer/references/medium-writing-playbook.md"
+grep -Fq "Publication Attempted: true | false" "${skills_root}/medium-article-writer/references/output-contract.md"
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/medium-article-writer/SKILL.md"
+
+echo "PASS test_medium_article_writer_skill_contracts"


### PR DESCRIPTION
Closes #1890

## Summary
- add the bounded `medium-article-writer` skill bundle and schema docs
- wire the new skill into installer coverage, batched checks, and the operational skills guide
- add focused contract coverage proving the skill stops before publication