### PR TITLE
[v0.89][WP-11] Demo scaffolding and proof entry points

### DIFF
--- a/adl/tools/demo_v089_proof_entrypoints.sh
+++ b/adl/tools/demo_v089_proof_entrypoints.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v089/proof_entrypoints}"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+INDEX_OUT="$OUT_DIR/index.txt"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = {
+    "schema_version": "adl.v089.proof_entrypoints.v1",
+    "milestone": "v0.89",
+    "title": "v0.89 demo scaffolding and proof entrypoints",
+    "review_root": "artifacts/v089/proof_entrypoints",
+    "rows": [
+        {
+            "demo_id": "D1",
+            "title": "AEE convergence walkthrough",
+            "command": "cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture",
+            "primary_proof_surface": "control_path/convergence.json",
+            "secondary_surfaces": [
+                "control_path/summary.txt",
+                "learning/freedom_gate.v1.json"
+            ],
+            "status": "READY",
+            "notes": "Shares the bounded runtime-control proof run with D2 and D3."
+        },
+        {
+            "demo_id": "D2",
+            "title": "Freedom Gate v2 judgment demo",
+            "command": "cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture",
+            "primary_proof_surface": "learning/freedom_gate.v1.json",
+            "secondary_surfaces": [
+                "control_path/final_result.json",
+                "control_path/summary.txt"
+            ],
+            "status": "READY",
+            "notes": "Use the same runtime-control artifact bundle as D1 and D3."
+        },
+        {
+            "demo_id": "D3",
+            "title": "Decision + action mediation proof",
+            "command": "cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture",
+            "primary_proof_surface": "control_path/decisions.json",
+            "secondary_surfaces": [
+                "control_path/action_proposals.json",
+                "control_path/mediation.json",
+                "control_path/summary.txt"
+            ],
+            "status": "READY",
+            "notes": "This row proves route-selection, reframing, and commitment-gate visibility from one bounded runtime-control run."
+        },
+        {
+            "demo_id": "D4",
+            "title": "Skill invocation contract demo",
+            "command": "cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_ -- --nocapture",
+            "primary_proof_surface": "control_path/skill_model.json",
+            "secondary_surfaces": [
+                "control_path/skill_execution_protocol.json",
+                "control_path/summary.txt"
+            ],
+            "status": "READY",
+            "notes": "The validator path is the bounded proof surface here, not a hidden runtime shortcut."
+        },
+        {
+            "demo_id": "D5",
+            "title": "Godel experiment package demo",
+            "command": "cargo run --manifest-path adl/Cargo.toml -- godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary \"step failed with deterministic parse error\" --evidence-ref runs/run-745-a/run_status.json --evidence-ref runs/run-745-a/logs/activation_log.json --runs-dir \"$tmp_root\" && cargo run --manifest-path adl/Cargo.toml -- godel inspect --run-id run-745-a --runs-dir \"$tmp_root\"",
+            "primary_proof_surface": "runs/<run-id>/godel/experiment_record.v1.json",
+            "secondary_surfaces": [
+                "runs/<run-id>/godel/evaluation_plan.v1.json",
+                "runs/<run-id>/godel/canonical_evidence_view.v1.json"
+            ],
+            "status": "READY",
+            "notes": "Review the inspect summary alongside the canonical package."
+        },
+        {
+            "demo_id": "D6",
+            "title": "ObsMem evidence and ranking walkthrough",
+            "command": "cargo run --manifest-path adl/Cargo.toml -- demo demo-f-obsmem-retrieval --run --trace --out ./out",
+            "primary_proof_surface": "obsmem_retrieval_result.json",
+            "secondary_surfaces": [
+                "runs/_shared/obsmem_store.v1.json"
+            ],
+            "status": "READY",
+            "notes": "Reviewer focus is explanation-bearing ordering, not just successful execution."
+        },
+        {
+            "demo_id": "D7",
+            "title": "Security / trust / posture walkthrough",
+            "command": "Review docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md, docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md, and docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md together",
+            "primary_proof_surface": "docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md",
+            "secondary_surfaces": [
+                "docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md",
+                "docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md"
+            ],
+            "status": "READY",
+            "notes": "This is intentionally a reviewer-legible document proof row for v0.89, not the later adversarial runtime demo band."
+        }
+    ]
+}
+
+Path(sys.argv[1]).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$README_OUT" <<'EOF'
+# v0.89 Demo Scaffolding And Proof Entrypoints
+
+Canonical review command:
+
+```bash
+bash adl/tools/demo_v089_proof_entrypoints.sh
+```
+
+Reviewer flow:
+- inspect `demo_manifest.json` first
+- start with D1-D3 if you want the bounded runtime-control story in one place
+- use D4 for the explicit skill invocation contract validation path
+- use D5 and D6 for the experiment and retrieval proof rows
+- treat D7 as a bounded document walkthrough, not as the `v0.89.1` adversarial runtime band
+
+Important boundary:
+- D1, D2, and D3 intentionally share one bounded runtime-control proof run
+- D7 is reviewer-legible by design and should not be overclaimed as a live adversarial demo
+EOF
+
+cat >"$INDEX_OUT" <<'EOF'
+D1 control_path/convergence.json
+D2 learning/freedom_gate.v1.json
+D3 control_path/decisions.json
+D4 control_path/skill_model.json
+D5 runs/<run-id>/godel/experiment_record.v1.json
+D6 obsmem_retrieval_result.json
+D7 docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md
+EOF
+
+echo "v0.89 proof entrypoints:"
+echo "  artifacts/v089/proof_entrypoints/demo_manifest.json"
+echo "  artifacts/v089/proof_entrypoints/README.md"
+echo "  artifacts/v089/proof_entrypoints/index.txt"

--- a/adl/tools/test_demo_v089_proof_entrypoints.sh
+++ b/adl/tools/test_demo_v089_proof_entrypoints.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v089_proof_entrypoints.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/README.md" \
+  "$OUT_DIR/index.txt"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+grep -Fq '"schema_version": "adl.v089.proof_entrypoints.v1"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest schema mismatch" >&2
+  exit 1
+}
+grep -Fq '"demo_id": "D1"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest missing D1 row" >&2
+  exit 1
+}
+grep -Fq '"demo_id": "D7"' "$OUT_DIR/demo_manifest.json" || {
+  echo "assertion failed: manifest missing D7 row" >&2
+  exit 1
+}
+grep -Fq 'D7 docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md' "$OUT_DIR/index.txt" || {
+  echo "assertion failed: index missing D7 row" >&2
+  exit 1
+}
+grep -Fq 'D1, D2, and D3 intentionally share one bounded runtime-control proof run' "$OUT_DIR/README.md" || {
+  echo "assertion failed: README missing shared-proof guidance" >&2
+  exit 1
+}
+
+echo "demo_v089_proof_entrypoints: ok"

--- a/demos/README.md
+++ b/demos/README.md
@@ -130,12 +130,26 @@ and records a reviewer-facing findings artifact plus runtime proof.
 
 ### v0.89 bounded provider-participation demos
 
+- `v0.89/v089_demo_program.md`
 - `v0.89/deep_agents_comparative_wave_demo.md`
 - `v0.89/medium_article_writing_demo.md`
 - `v0.89/gemini_provider_harmony_and_economics_demo.md`
 - `v0.89/gemma4_issue_clerk_demo.md`
 - `v0.89/paper_sonata_demo_refresh.md`
 - `v0.89/multi_agent_repo_code_review_demo.md`
+
+Use `v0.89/v089_demo_program.md` for the canonical `v0.89` proof-row entrypoint
+guide. It ties D1 through D7 to one reviewer flow and points at the bounded
+proof-entrypoint manifest produced by:
+
+```bash
+bash adl/tools/demo_v089_proof_entrypoints.sh
+```
+
+That command writes a lightweight review packet at:
+- `artifacts/v089/proof_entrypoints/demo_manifest.json`
+- `artifacts/v089/proof_entrypoints/README.md`
+- `artifacts/v089/proof_entrypoints/index.txt`
 
 Use `v0.89/deep_agents_comparative_wave_demo.md` for a richer comparative demo
 where ChatGPT, Claude, and Gemini contribute bounded positions and ADL emits a

--- a/demos/v0.89/v089_demo_program.md
+++ b/demos/v0.89/v089_demo_program.md
@@ -1,0 +1,148 @@
+# v0.89 Demo Program
+
+`v0.89` uses a mixed proof model:
+- bounded runnable proof rows where the runtime already exposes stable entrypoints
+- reviewer-legible document rows where the milestone claim is deliberately design-contract work
+
+The canonical scaffolding command is:
+
+```bash
+bash adl/tools/demo_v089_proof_entrypoints.sh
+```
+
+That command writes:
+- `artifacts/v089/proof_entrypoints/demo_manifest.json`
+- `artifacts/v089/proof_entrypoints/README.md`
+- `artifacts/v089/proof_entrypoints/index.txt`
+
+Use those artifacts as the reviewer entry surface for D1 through D7.
+
+## Demo Order
+
+### D1) AEE convergence walkthrough
+
+Command:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture
+```
+
+Primary proof:
+- `control_path/convergence.json`
+
+Focus:
+- named convergence state
+- stop-condition family
+- progress signal
+
+### D2) Freedom Gate v2 judgment demo
+
+Command:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture
+```
+
+Primary proof:
+- `learning/freedom_gate.v1.json`
+
+Focus:
+- allow / defer / refuse / escalate boundary
+- required follow-up and blocked commitment semantics
+
+### D3) Decision + action mediation proof
+
+Command:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture
+```
+
+Primary proof:
+- `control_path/decisions.json`
+
+Supporting proofs:
+- `control_path/action_proposals.json`
+- `control_path/mediation.json`
+
+Focus:
+- route selection
+- reframing
+- commitment gate
+- model-proposes/runtime-decides boundary
+
+### D4) Skill invocation contract demo
+
+Command:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_ -- --nocapture
+```
+
+Primary proof:
+- `control_path/skill_model.json`
+
+Supporting proofs:
+- `control_path/skill_execution_protocol.json`
+
+Focus:
+- selected skill identity
+- lifecycle state before execution
+- authorization and trace expectations
+
+### D5) Godel experiment package demo
+
+Command shape:
+
+```bash
+tmp_root="$(mktemp -d)"
+cargo run --manifest-path adl/Cargo.toml -- godel run --run-id run-745-a --workflow-id wf-godel-loop --failure-code tool_failure --failure-summary "step failed with deterministic parse error" --evidence-ref runs/run-745-a/run_status.json --evidence-ref runs/run-745-a/logs/activation_log.json --runs-dir "$tmp_root"
+cargo run --manifest-path adl/Cargo.toml -- godel inspect --run-id run-745-a --runs-dir "$tmp_root"
+```
+
+Primary proof:
+- `runs/<run-id>/godel/experiment_record.v1.json`
+
+Focus:
+- canonical experiment record
+- baseline / variant pairing
+- explicit adopt / reject decision semantics
+
+### D6) ObsMem evidence and ranking walkthrough
+
+Command:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- demo demo-f-obsmem-retrieval --run --trace --out ./out
+```
+
+Primary proof:
+- `obsmem_retrieval_result.json`
+
+Focus:
+- explicit ranking explanation
+- provenance families
+- deterministic tie-break behavior
+
+### D7) Security / trust / posture walkthrough
+
+Review surfaces:
+- `docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md`
+- `docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md`
+- `docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md`
+
+Focus:
+- threat boundaries
+- declared posture classes
+- trust assumptions under contest
+
+Important boundary:
+- D7 is a bounded reviewer-facing documentation proof row for `v0.89`
+- it is not the live adversarial runtime/demo package planned for `v0.89.1`
+
+## Reviewer Notes
+
+- D1, D2, and D3 intentionally share one bounded runtime-control artifact set.
+- D4 validates the skill-contract layer on top of that control-path family.
+- D5 and D6 are the main runnable reviewer rows for experiment evidence and retrieval explanation.
+- D7 is the correct stop point for the main-band security story before `v0.89.1`.

--- a/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
+++ b/docs/milestones/v0.89/DEMO_MATRIX_v0.89.md
@@ -69,13 +69,13 @@ Additional environment / fixture requirements:
 
 | Demo ID | Demo title | Milestone claim / WP proved | Command entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
 |---|---|---|---|---|---|---|---|
-| D1 | AEE convergence walkthrough | `WP-02` bounded convergence and stop conditions | planned `WP-02` entry point | convergence artifact + output record | reviewer can see converge / stall / bounded-out behavior | use deterministic fixtures for repeated stop-state verification | PLANNED |
+| D1 | AEE convergence walkthrough | `WP-02` bounded convergence and stop conditions | `cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture` | `control_path/convergence.json` + `control_path/summary.txt` | reviewer can see converge / stall / bounded-out behavior and named stop-family reasoning | use deterministic runtime-control fixtures; D1 shares the bounded runtime-control proof run with D2 and D3 | READY |
 | D2 | Freedom Gate v2 judgment demo | `WP-03` richer allow / defer / refuse / escalate behavior | `cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture` | `learning/freedom_gate.v1.json` + `control_path/final_result.json` | reviewer can distinguish decision outcome, judgment boundary, and follow-up | stable fixtures should replay to the same outcome class and escalation path | READY |
-| D3 | Decision + action mediation proof | `WP-04` - `WP-05` explicit choice and authorization boundary | planned `WP-04` / `WP-05` entry points | `control_path/decisions.json` + `control_path/action_proposals.json` + `control_path/mediation.json` | reviewer can see model intent separated from authorized action | deterministic fixtures should preserve approval / rejection path | PLANNED |
+| D3 | Decision + action mediation proof | `WP-04` - `WP-05` explicit choice and authorization boundary | `cargo test --manifest-path adl/Cargo.toml write_run_state_artifacts_projects_execute_owned_runtime_control_state -- --nocapture` | `control_path/decisions.json` + `control_path/action_proposals.json` + `control_path/mediation.json` | reviewer can see route selection, reframing, and commitment-gate outcomes separated from authorized runtime action | deterministic fixtures should preserve outcome classes and mediation follow-up from the shared runtime-control proof run | READY |
 | D4 | Skill invocation contract demo | `WP-06` bounded skill execution protocol | `cargo test --manifest-path adl/Cargo.toml cli_artifact_validate_control_path_ -- --nocapture` | `control_path/skill_model.json` + `control_path/skill_execution_protocol.json` + `control_path/summary.txt` | reviewer can distinguish a selected governed skill from other action kinds and inspect the pre-execution authorization lifecycle end to end | deterministic fixture replay should preserve lifecycle state, authorization outcome, and trace expectation | READY |
 | D5 | Godel experiment package demo | `WP-07` governed adopt / reject improvement behavior | `cargo run --manifest-path adl/Cargo.toml -- godel run ...` then `cargo run --manifest-path adl/Cargo.toml -- godel inspect ...` | `runs/<run-id>/godel/experiment_record.v1.json` + `evaluation_plan.v1.json` | reviewer can inspect baseline / variant pairing, canonical evidence, bounded mutation, and adopt / reject decision from one bounded summary | identical bounded inputs should preserve stage order, canonical artifact paths, and decision class | READY |
 | D6 | ObsMem evidence and ranking walkthrough | `WP-08` explainable retrieval and ranking | `cargo run --manifest-path adl/Cargo.toml -- demo demo-f-obsmem-retrieval --run --trace --out ./out` | `obsmem_retrieval_result.json` | ranking cites evidence families, status signals, and deterministic tie-break values | identical demo inputs should preserve result order and explanation shape | READY |
-| D7 | Security / trust / posture walkthrough | `WP-09` main-band security contract | planned `WP-09` / `WP-11` review surface | reviewer-facing threat/posture/trust artifact set | reviewer can see explicit trust boundaries and declared posture | proof row may be document/artifact driven rather than fully executable | PLANNED |
+| D7 | Security / trust / posture walkthrough | `WP-09` main-band security contract | review `docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md`, `docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md`, and `docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md` together | reviewer-facing threat/posture/trust document set | reviewer can see explicit trust boundaries, declared posture, and contested-operation trust assumptions without overclaiming `v0.89.1` adversarial runtime work | proof row is intentionally document/artifact driven in the main `v0.89` band | READY |
 
 Status guidance:
 - `PLANNED` = intended but not yet validated
@@ -277,7 +277,9 @@ Known limits / caveats:
 Required baseline validation:
 
 ```bash
-Defined by `WP-11` through `WP-13` as the demo and integration surfaces land.
+Use `bash adl/tools/demo_v089_proof_entrypoints.sh` for the lightweight reviewer
+entrypoint manifest, then run the row-specific commands named above for D1-D6
+or review the D7 document set directly.
 ```
 
 Cross-demo checks:


### PR DESCRIPTION
Closes #1798

## Summary
- add a bounded v0.89 proof-entrypoint manifest and test surface for D1 through D7
- add a canonical v0.89 demo-program guide for reviewers
- make the demo matrix concrete for D1, D3, and D7 and wire the new guide into demos/README