### PR TITLE
[v0.89][tools] Harden repo-review demo validator against general host-path leakage

### DIFF
--- a/adl/tools/test_demo_v089_multi_agent_repo_code_review.sh
+++ b/adl/tools/test_demo_v089_multi_agent_repo_code_review.sh
@@ -44,4 +44,18 @@ grep -Fq '[P3] Workflow conductor routing remains concentrated in one large disp
   exit 1
 }
 
+for leaked_path in \
+  "/Users/alice/private.txt" \
+  "/home/bob/private.txt" \
+  "/private/tmp/demo-leak.txt"; do
+  LEAK_DIR="$TMPDIR_ROOT/leak-check"
+  rm -rf "$LEAK_DIR"
+  cp -R "$OUT_DIR" "$LEAK_DIR"
+  printf '\nInjected leak: %s\n' "$leaked_path" >> "$LEAK_DIR/reviewers/code_review.md"
+  if python3 "$ROOT_DIR/adl/tools/validate_multi_agent_repo_review_demo.py" "$LEAK_DIR" >/dev/null 2>&1; then
+    echo "assertion failed: validator accepted leaked path $leaked_path" >&2
+    exit 1
+  fi
+done
+
 echo "demo_v089_multi_agent_repo_code_review: ok"

--- a/adl/tools/validate_multi_agent_repo_review_demo.py
+++ b/adl/tools/validate_multi_agent_repo_review_demo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -14,6 +15,12 @@ REQUIRED_REVIEW_SECTIONS = [
     "## Follow-ups / Deferred Work",
     "## Final Assessment",
 ]
+
+ABSOLUTE_HOST_PATH_RE = re.compile(
+    r"(?:(?<![A-Za-z0-9._-])/(?:Users|home)/[^/\s`]+(?:/[^\s`]+)*)|"
+    r"(?:(?<![A-Za-z0-9._-])/(?:private|var|tmp|etc|opt|srv|root)/[^\s`]+)|"
+    r"(?:[A-Za-z]:\\\\[^\s`]+)"
+)
 
 
 def require(condition: bool, message: str) -> None:
@@ -28,6 +35,13 @@ def ordered_sections(text: str, sections: list[str], label: str) -> None:
         require(idx >= 0, f"{label}: missing section {section}")
         require(idx > last, f"{label}: section out of order for {section}")
         last = idx
+
+
+def absolute_host_path_match(text: str) -> str | None:
+    match = ABSOLUTE_HOST_PATH_RE.search(text)
+    if not match:
+        return None
+    return match.group(0)
 
 
 def main() -> int:
@@ -82,7 +96,8 @@ def main() -> int:
     require("Lower-Priority Observations:" in synthesis_text, "synthesis missing lower-priority observations classification")
 
     root_text = "\n".join(path.read_text(encoding="utf-8") for path in [selected_paths_path, synthesis_path, *reviewer_paths])
-    require("/Users/daniel/" not in root_text, "artifact leakage: absolute host path found")
+    leaked_path = absolute_host_path_match(root_text)
+    require(leaked_path is None, f"artifact leakage: absolute host path found: {leaked_path}")
 
     print("validate_multi_agent_repo_review_demo: ok")
     return 0

--- a/docs/tooling/MULTI_AGENT_REPO_CODE_REVIEW_DEMO_CONTRACT.md
+++ b/docs/tooling/MULTI_AGENT_REPO_CODE_REVIEW_DEMO_CONTRACT.md
@@ -75,7 +75,7 @@ Each specialist reviewer artifact should:
 - follow the repo review surface format
 - stay findings-first
 - state what was and was not reviewed
-- avoid secrets, absolute host paths, and raw prompts
+- avoid secrets, machine-specific absolute host paths, and raw prompts
 
 The final synthesis artifact must:
 


### PR DESCRIPTION
## Summary
- broaden the repo-review demo validator beyond one developer-specific path check
- add regression coverage for representative host-path leakage families
- keep the reviewer-facing contract wording aligned with the actual validator policy

## Testing
- bash adl/tools/test_demo_v089_multi_agent_repo_code_review.sh
- git diff --check

Closes #1903