### PR TITLE
[v0.89][skills] Make operational skill schema references repo-portable

### DIFF
--- a/adl/tools/skills/demo-operator/adl-skill.yaml
+++ b/adl/tools/skills/demo-operator/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "demo_operator.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/DEMO_OPERATOR_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/DEMO_OPERATOR_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/medium-article-writer/adl-skill.yaml
+++ b/adl/tools/skills/medium-article-writer/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "medium_article_writer.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/pr-closeout/adl-skill.yaml
+++ b/adl/tools/skills/pr-closeout/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "pr_closeout.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/pr-finish/adl-skill.yaml
+++ b/adl/tools/skills/pr-finish/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "pr_finish.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/PR_FINISH_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/PR_FINISH_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/pr-init/adl-skill.yaml
+++ b/adl/tools/skills/pr-init/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "pr_init.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/PR_INIT_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/PR_INIT_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/pr-janitor/adl-skill.yaml
+++ b/adl/tools/skills/pr-janitor/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "pr_janitor.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/PR_JANITOR_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/PR_JANITOR_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/pr-ready/adl-skill.yaml
+++ b/adl/tools/skills/pr-ready/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "pr_ready.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/PR_READY_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/PR_READY_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/pr-run/adl-skill.yaml
+++ b/adl/tools/skills/pr-run/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "pr_run.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/PR_RUN_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/PR_RUN_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/repo-code-review/adl-skill.yaml
+++ b/adl/tools/skills/repo-code-review/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "repo_code_review.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/sip-editor/adl-skill.yaml
+++ b/adl/tools/skills/sip-editor/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "sip_editor.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/SIP_EDITOR_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/SIP_EDITOR_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/sor-editor/adl-skill.yaml
+++ b/adl/tools/skills/sor-editor/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "sor_editor.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/SOR_EDITOR_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/SOR_EDITOR_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/stp-editor/adl-skill.yaml
+++ b/adl/tools/skills/stp-editor/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "stp_editor.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/STP_EDITOR_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/STP_EDITOR_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/test-generator/adl-skill.yaml
+++ b/adl/tools/skills/test-generator/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "test_generator.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/TEST_GENERATOR_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/TEST_GENERATOR_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/skills/workflow-conductor/adl-skill.yaml
+++ b/adl/tools/skills/workflow-conductor/adl-skill.yaml
@@ -9,7 +9,7 @@ codex_compat:
 admission:
   input_schema:
     id: "workflow_conductor.v1"
-    reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
+    reference_doc: "../docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
     required_top_level_fields:
       - "skill_input_schema"
       - "mode"

--- a/adl/tools/test_demo_operator_skill_contracts.sh
+++ b/adl/tools/test_demo_operator_skill_contracts.sh
@@ -12,7 +12,7 @@ skills_root="${repo_root}/adl/tools/skills"
 [[ -f "${skills_root}/docs/DEMO_OPERATOR_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq 'id: "demo_operator.v1"' "${skills_root}/demo-operator/adl-skill.yaml"
-grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/DEMO_OPERATOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/demo-operator/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/DEMO_OPERATOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/demo-operator/adl-skill.yaml"
 grep -Fq "policy.classification_mode_must_be_explicit" "${skills_root}/demo-operator/adl-skill.yaml"
 grep -Fq "policy.validation_mode_must_be_explicit" "${skills_root}/demo-operator/adl-skill.yaml"
 grep -Fq "run one named demo" "${skills_root}/demo-operator/SKILL.md"

--- a/adl/tools/test_medium_article_writer_skill_contracts.sh
+++ b/adl/tools/test_medium_article_writer_skill_contracts.sh
@@ -11,7 +11,7 @@ skills_root="${repo_root}/adl/tools/skills"
 [[ -f "${skills_root}/medium-article-writer/references/output-contract.md" ]]
 
 grep -Fq 'id: "medium_article_writer.v1"' "${skills_root}/medium-article-writer/adl-skill.yaml"
-grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/medium-article-writer/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/medium-article-writer/adl-skill.yaml"
 grep -Fq "policy.writing_mode_must_be_explicit" "${skills_root}/medium-article-writer/adl-skill.yaml"
 grep -Fq "policy.stop_before_publish_must_be_true" "${skills_root}/medium-article-writer/adl-skill.yaml"
 grep -Fq "reviewer-friendly Medium article packet" "${skills_root}/medium-article-writer/SKILL.md"

--- a/adl/tools/test_pr_closeout_skill_contracts.sh
+++ b/adl/tools/test_pr_closeout_skill_contracts.sh
@@ -15,7 +15,7 @@ grep -Fq "post-merge and post-closure cleanup phase" "${skills_root}/pr-closeout
 grep -Fq "prune the local worktree safely" "${skills_root}/pr-closeout/SKILL.md"
 grep -Fq "record deferral, supersession, or duplicate links" "${skills_root}/pr-closeout/SKILL.md"
 grep -Fq 'id: "pr_closeout.v1"' "${skills_root}/pr-closeout/adl-skill.yaml"
-grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md"' "${skills_root}/pr-closeout/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md"' "${skills_root}/pr-closeout/adl-skill.yaml"
 grep -Fq "policy.closure_outcome_must_be_explicit" "${skills_root}/pr-closeout/adl-skill.yaml"
 grep -Fq "policy.closure_references_must_be_present_when_closure_outcome_is_superseded_or_duplicate" "${skills_root}/pr-closeout/adl-skill.yaml"
 grep -Fq "closeout_pr" "${skills_root}/docs/PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md"

--- a/adl/tools/test_repo_code_review_skill_contracts.sh
+++ b/adl/tools/test_repo_code_review_skill_contracts.sh
@@ -12,7 +12,7 @@ skills_root="${repo_root}/adl/tools/skills"
 [[ -f "${skills_root}/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq 'id: "repo_code_review.v1"' "${skills_root}/repo-code-review/adl-skill.yaml"
-grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"' "${skills_root}/repo-code-review/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"' "${skills_root}/repo-code-review/adl-skill.yaml"
 grep -Fq "policy.review_depth_must_be_explicit" "${skills_root}/repo-code-review/adl-skill.yaml"
 grep -Fq "policy.stop_after_review_must_be_true" "${skills_root}/repo-code-review/adl-skill.yaml"
 grep -Fq "mode: review_repository | review_path | review_branch | review_diff" "${skills_root}/docs/REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md"

--- a/adl/tools/test_test_generator_skill_contracts.sh
+++ b/adl/tools/test_test_generator_skill_contracts.sh
@@ -12,7 +12,7 @@ skills_root="${repo_root}/adl/tools/skills"
 [[ -f "${skills_root}/docs/TEST_GENERATOR_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq 'id: "test_generator.v1"' "${skills_root}/test-generator/adl-skill.yaml"
-grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/TEST_GENERATOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/test-generator/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/TEST_GENERATOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/test-generator/adl-skill.yaml"
 grep -Fq "policy.test_depth_must_be_explicit" "${skills_root}/test-generator/adl-skill.yaml"
 grep -Fq "policy.validation_mode_must_be_explicit" "${skills_root}/test-generator/adl-skill.yaml"
 grep -Fq "bounded regression-test authoring" "${skills_root}/test-generator/SKILL.md"

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -21,7 +21,7 @@ grep -Fq "writes one bounded routing artifact" "${skills_root}/docs/OPERATIONAL_
 grep -Fq "invoke one bounded downstream skill subtask" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq 'continue`, `ask_operator`, or `stop`' "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq 'id: "workflow_conductor.v1"' "${skills_root}/workflow-conductor/adl-skill.yaml"
-grep -Fq 'reference_doc: "/Users/daniel/git/agent-design-language/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/workflow-conductor/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/workflow-conductor/adl-skill.yaml"
 grep -Fq "policy.stop_after_routing_must_be_true" "${skills_root}/workflow-conductor/adl-skill.yaml"
 grep -Fq "python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input <validated-json>" "${skills_root}/workflow-conductor/adl-skill.yaml"
 grep -Fq "dispatch" "${skills_root}/workflow-conductor/references/output-contract.md"


### PR DESCRIPTION
## Summary
- replace machine-specific skill schema reference paths with sibling-relative docs references
- update the affected skill contract tests to enforce the portable form
- prove the change through targeted skill checks and an install round-trip

## Testing
- bash adl/tools/test_repo_code_review_skill_contracts.sh
- bash adl/tools/test_workflow_conductor_skill_contracts.sh
- bash adl/tools/test_medium_article_writer_skill_contracts.sh
- bash adl/tools/test_demo_operator_skill_contracts.sh
- bash adl/tools/test_pr_closeout_skill_contracts.sh
- bash adl/tools/test_test_generator_skill_contracts.sh
- bash adl/tools/test_install_adl_operational_skills.sh
- git diff --check

Closes #1904