### PR TITLE
[v0.89][maintainability] Clarify or expand the Rust large-module watch surface

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -26,7 +26,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `closeout_completed_issue_wave.sh`: bounded local catch-up helper that runs `pr closeout` across closed/completed issue bundles for a milestone version so local-only `.adl` truth can converge after merge or main sync.
 - `check_milestone_closed_issue_sor_truth.sh`: milestone closed-issue bundle truth gate for local-only `.adl` task bundles; verifies canonical `stp.md`, `sip.md`, and final `sor.md` truth for closed/completed issues.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
-- `report_large_rust_modules.sh`: non-blocking Rust implementation-module size report for maintainability review.
+- `report_large_rust_modules.sh`: non-blocking Rust source-and-test module size report for maintainability review.
 - `open_artifact.sh`: convenience opener for cards/reports.
 - `update_reports_index.sh`, `update_latest_reports.sh`: report index maintenance.
 
@@ -110,7 +110,7 @@ bash adl/tools/demo_v089_quality_gate.sh
 # enforce coverage thresholds from coverage-summary.json
 cd ./adl/ && bash tools/enforce_coverage_gates.sh coverage-summary.json
 
-# report large Rust implementation modules without failing the build
+# report large Rust source and test modules without failing the build
 ./adl/tools/report_large_rust_modules.sh
 
 # generate deterministic execution prompt from an input card

--- a/adl/tools/report_large_rust_modules.sh
+++ b/adl/tools/report_large_rust_modules.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="adl/src"
+ROOTS=("adl/src" "adl/tests")
 THRESHOLD_WATCH=800
 THRESHOLD_REVIEW=1000
 THRESHOLD_RATIONALE=1500
@@ -14,7 +14,7 @@ Usage: adl/tools/report_large_rust_modules.sh [options]
 Report large Rust implementation modules without failing the build.
 
 Options:
-  --root <path>                Root to scan (default: adl/src)
+  --root <path>                Root to scan; repeatable (default: adl/src and adl/tests)
   --threshold-watch <n>        Watch threshold in lines (default: 800)
   --threshold-review <n>       Review threshold in lines (default: 1000)
   --threshold-rationale <n>    Rationale threshold in lines (default: 1500)
@@ -28,7 +28,10 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --root)
-      ROOT="$2"
+      if [[ "${ROOTS[*]}" == "adl/src adl/tests" ]]; then
+        ROOTS=()
+      fi
+      ROOTS+=("$2")
       shift 2
       ;;
     --threshold-watch)
@@ -59,39 +62,46 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ ! -d "$ROOT" ]]; then
-  echo "Scan root does not exist: $ROOT" >&2
-  exit 2
-fi
+for root in "${ROOTS[@]}"; do
+  if [[ ! -d "$root" ]]; then
+    echo "Scan root does not exist: $root" >&2
+    exit 2
+  fi
+done
 
 if [[ "$FORMAT" != "table" && "$FORMAT" != "tsv" ]]; then
   echo "Unsupported format: $FORMAT" >&2
   exit 2
 fi
 
-python3 - "$ROOT" "$THRESHOLD_WATCH" "$THRESHOLD_REVIEW" "$THRESHOLD_RATIONALE" "$FORMAT" <<'PY'
+python3 - "$THRESHOLD_WATCH" "$THRESHOLD_REVIEW" "$THRESHOLD_RATIONALE" "$FORMAT" "${ROOTS[@]}" <<'PY'
 import sys
 from pathlib import Path
 
-root = Path(sys.argv[1])
-watch = int(sys.argv[2])
-review = int(sys.argv[3])
-rationale = int(sys.argv[4])
-fmt = sys.argv[5]
+watch = int(sys.argv[1])
+review = int(sys.argv[2])
+rationale = int(sys.argv[3])
+fmt = sys.argv[4]
+roots = [Path(arg) for arg in sys.argv[5:]]
 
 rows = []
-for path in sorted(root.rglob("*.rs")):
-    with path.open("r", encoding="utf-8") as handle:
-        loc = sum(1 for _ in handle)
-    if loc < watch:
-        continue
-    if loc >= rationale:
-        level = "RATIONALE"
-    elif loc >= review:
-        level = "REVIEW"
-    else:
-        level = "WATCH"
-    rows.append((str(path), loc, level))
+seen = set()
+for root in roots:
+    for path in sorted(root.rglob("*.rs")):
+        if path in seen:
+            continue
+        seen.add(path)
+        with path.open("r", encoding="utf-8") as handle:
+            loc = sum(1 for _ in handle)
+        if loc < watch:
+            continue
+        if loc >= rationale:
+            level = "RATIONALE"
+        elif loc >= review:
+            level = "REVIEW"
+        else:
+            level = "WATCH"
+        rows.append((str(path), loc, level))
 
 rows.sort(key=lambda row: (-row[1], row[0]))
 
@@ -102,7 +112,7 @@ if fmt == "tsv":
     sys.exit(0)
 
 print("Rust module size watch report")
-print(f"scan root: {root}")
+print(f"scan roots: {', '.join(str(root) for root in roots)}")
 print(f"thresholds: watch>={watch}, review>={review}, rationale>={rationale}")
 print("")
 

--- a/docs/milestones/v0.89/QUALITY_GATE_v0.89.md
+++ b/docs/milestones/v0.89/QUALITY_GATE_v0.89.md
@@ -186,6 +186,8 @@ For `v0.89`, the watch-list posture is:
 
 - treat the current report as a local operational snapshot rather than a tracked
   governance file
+- let the default report cover both `adl/src` and `adl/tests` so the largest
+  Rust implementation and integration-test surfaces stay visible together
 - use the report during review and quality-gate walkthroughs
 - keep the report script green-by-default
 - require explicit deferral rationale in output cards only when a PR materially

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -73,7 +73,7 @@ Important repo-local tooling surfaces include:
 - `bash adl/tools/demo_v0871_operator_surface.sh` — canonical `v0.87.1` operator-surface demo for runtime bring-up and proof-surface inspection
 - `bash adl/tools/demo_v0871_review_surface.sh` — canonical `v0.87.1` reviewer walkthrough package across operator and runtime-state proof roots
 - `adl/tools/*.sh` wrappers remain available as compatibility entrypoints over the Rust-owned commands
-- `adl/tools/report_large_rust_modules.sh` — non-blocking Rust implementation-module size report; write current snapshots to `.adl/reports/manual/` instead of tracked repo docs
+- `adl/tools/report_large_rust_modules.sh` — non-blocking Rust source-and-test module size report; by default it scans both `adl/src` and `adl/tests`, and current snapshots should live under `.adl/reports/manual/` instead of tracked repo docs
 - `adl/tools/sync_task_bundle_prompts.sh` — refresh canonical local task-bundle prompt layout from compatibility paths
 
 Deprecated compatibility aliases such as `pr ready`, `pr preflight`, and


### PR DESCRIPTION
Closes #1902

## Summary
- expand the large Rust module watch script so it covers both `adl/src` and `adl/tests` by default
- update tooling docs and the v0.89 quality gate notes to reflect the broader maintainability surface
- keep repeatable `--root` overrides available for narrower scans

## Testing
- bash adl/tools/report_large_rust_modules.sh --format tsv | sed -n 1,40p
- bash adl/tools/report_large_rust_modules.sh --format tsv --root adl/src | sed -n 1,20p
- bash adl/tools/report_large_rust_modules.sh --format tsv | rg 'adl/tests/(execute_tests/delegation_resume.rs|provider_tests.rs|adl_tests.rs)'
- git diff --check
