### PR TITLE
[v0.89][demo] Move live demo OpenAI key-file defaults to openai2.key

### DIFF
--- a/adl/tools/demo_v0871_real_multi_agent_discussion.sh
+++ b/adl/tools/demo_v0871_real_multi_agent_discussion.sh
@@ -19,7 +19,7 @@ MANIFEST="$OUT_DIR/demo_manifest.json"
 README_OUT="$OUT_DIR/README.md"
 EXAMPLE="adl/examples/v0-87-1-real-multi-agent-tea-discussion.adl.yaml"
 GENERATED_EXAMPLE="$OUT_DIR/v0-87-1-real-multi-agent-tea-discussion.runtime.adl.yaml"
-OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai2.key}"
 ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
 
 load_key() {
@@ -235,7 +235,7 @@ bash adl/tools/demo_v0871_real_multi_agent_discussion.sh
 
 Credential loading:
 - Uses \`OPENAI_API_KEY\` and \`ANTHROPIC_API_KEY\` when already set.
-- Otherwise reads local operator-managed keys from \`\\\$HOME/keys/openai.key\` and \`\\\$HOME/keys/claude.key\`.
+- Otherwise reads local operator-managed keys from \`\\\$HOME/keys/openai2.key\` and \`\\\$HOME/keys/claude.key\`.
 - Secret values and raw Authorization headers are not written to generated artifacts.
 
 What this proves:

--- a/adl/tools/demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/demo_v088_real_multi_agent_discussion.sh
@@ -13,7 +13,7 @@ SYNTHESIS="$OUT_DIR/synthesis.md"
 MANIFEST="$OUT_DIR/demo_manifest.json"
 INVOCATIONS="$OUT_DIR/provider_invocations.json"
 README_OUT="$OUT_DIR/README.md"
-OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-}"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai2.key}"
 ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-}"
 
 TURN_FILES=(
@@ -224,7 +224,7 @@ bash adl/tools/demo_v088_real_multi_agent_discussion.sh
 
 Credential loading:
 - Uses \`OPENAI_API_KEY\` and \`ANTHROPIC_API_KEY\` when already set.
-- Otherwise reads operator-selected key files only when \`ADL_OPENAI_KEY_FILE\` and \`ADL_ANTHROPIC_KEY_FILE\` are set.
+- Otherwise defaults to \`\\\$HOME/keys/openai2.key\` for OpenAI and \`\\\$HOME/keys/claude.key\` for Anthropic, unless \`ADL_OPENAI_KEY_FILE\` or \`ADL_ANTHROPIC_KEY_FILE\` overrides are set explicitly.
 - Secret values, key-file paths, and raw Authorization headers are not written to generated artifacts.
 
 What this proves:

--- a/adl/tools/test_demo_v0871_real_multi_agent_discussion.sh
+++ b/adl/tools/test_demo_v0871_real_multi_agent_discussion.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai.key}"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai2.key}"
 ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
 
 emit_disposition() {

--- a/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
+++ b/adl/tools/test_demo_v088_real_multi_agent_discussion.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-}"
-ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-}"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai2.key}"
+ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
 
-if [[ -z "${OPENAI_API_KEY:-}" && ( -z "$OPENAI_KEY_FILE" || ! -s "$OPENAI_KEY_FILE" ) ]]; then
-  echo "SKIP: missing OPENAI_API_KEY or ADL_OPENAI_KEY_FILE" >&2
+if [[ -z "${OPENAI_API_KEY:-}" && ! -s "$OPENAI_KEY_FILE" ]]; then
+  echo "SKIP: missing OPENAI_API_KEY and $OPENAI_KEY_FILE" >&2
   exit 0
 fi
-if [[ -z "${ANTHROPIC_API_KEY:-}" && ( -z "$ANTHROPIC_KEY_FILE" || ! -s "$ANTHROPIC_KEY_FILE" ) ]]; then
-  echo "SKIP: missing ANTHROPIC_API_KEY or ADL_ANTHROPIC_KEY_FILE" >&2
+if [[ -z "${ANTHROPIC_API_KEY:-}" && ! -s "$ANTHROPIC_KEY_FILE" ]]; then
+  echo "SKIP: missing ANTHROPIC_API_KEY and $ANTHROPIC_KEY_FILE" >&2
   exit 0
 fi
 

--- a/demos/v0.87.1/real_chatgpt_claude_multi_agent_discussion_demo.md
+++ b/demos/v0.87.1/real_chatgpt_claude_multi_agent_discussion_demo.md
@@ -25,7 +25,7 @@ bash adl/tools/demo_v0871_real_multi_agent_discussion.sh
 
 The demo uses operator-managed credentials only:
 
-- `OPENAI_API_KEY` if already set, otherwise `$HOME/keys/openai.key`
+- `OPENAI_API_KEY` if already set, otherwise `$HOME/keys/openai2.key`
 - `ANTHROPIC_API_KEY` if already set, otherwise `$HOME/keys/claude.key`
 
 The scripts must not print, persist, or commit secret values. Generated proof

--- a/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
+++ b/demos/v0.88/real_chatgpt_claude_multi_agent_discussion_demo.md
@@ -15,7 +15,8 @@ bash adl/tools/demo_v088_real_multi_agent_discussion.sh
 The demo uses operator-managed credentials only:
 
 - `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` when already set
-- explicit `ADL_OPENAI_KEY_FILE` and `ADL_ANTHROPIC_KEY_FILE` overrides when the operator chooses key-file loading
+- otherwise `$HOME/keys/openai2.key` for OpenAI and `$HOME/keys/claude.key` for Anthropic
+- explicit `ADL_OPENAI_KEY_FILE` and `ADL_ANTHROPIC_KEY_FILE` overrides when the operator chooses different key-file paths
 
 Secret values, key-file paths, and raw credential headers must not be printed
 or written to generated artifacts.


### PR DESCRIPTION
## Summary
- move the tracked live ChatGPT/Claude demo surfaces to the new default OpenAI key-file path
- keep the existing override behavior and leave Anthropic on its current key-file path
- recover the mistaken tracked edit on main by publishing the bounded fix from issue #1909's worktree

Closes #1909