### PR TITLE
[v0.89][docs] Update v0.89 feature-doc status metadata to match landed state

### DIFF
--- a/docs/milestones/v0.89/features/ACTION_MEDIATION_LAYER.md
+++ b/docs/milestones/v0.89/features/ACTION_MEDIATION_LAYER.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-05`
 

--- a/docs/milestones/v0.89/features/ACTION_PROPOSAL_SCHEMA.md
+++ b/docs/milestones/v0.89/features/ACTION_PROPOSAL_SCHEMA.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-05`
 

--- a/docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md
+++ b/docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-09`
 

--- a/docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md
+++ b/docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-09`
 

--- a/docs/milestones/v0.89/features/AEE_CONVERGENCE_MODEL.md
+++ b/docs/milestones/v0.89/features/AEE_CONVERGENCE_MODEL.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-02`
 

--- a/docs/milestones/v0.89/features/DECISION_SCHEMA.md
+++ b/docs/milestones/v0.89/features/DECISION_SCHEMA.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-04`
 

--- a/docs/milestones/v0.89/features/DECISION_SURFACES.md
+++ b/docs/milestones/v0.89/features/DECISION_SURFACES.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-04`
 

--- a/docs/milestones/v0.89/features/FREEDOM_GATE_V2.md
+++ b/docs/milestones/v0.89/features/FREEDOM_GATE_V2.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-03`
 

--- a/docs/milestones/v0.89/features/GODEL_EXPERIMENT_SYSTEM.md
+++ b/docs/milestones/v0.89/features/GODEL_EXPERIMENT_SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-07`
 

--- a/docs/milestones/v0.89/features/OBSMEM_EVIDENCE_AND_RANKING.md
+++ b/docs/milestones/v0.89/features/OBSMEM_EVIDENCE_AND_RANKING.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-08`
 

--- a/docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md
+++ b/docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-09`
 

--- a/docs/milestones/v0.89/features/SKILL_EXECUTION_PROTOCOL.md
+++ b/docs/milestones/v0.89/features/SKILL_EXECUTION_PROTOCOL.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-06`
 

--- a/docs/milestones/v0.89/features/SKILL_MODEL.md
+++ b/docs/milestones/v0.89/features/SKILL_MODEL.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Milestone: `v0.89`
-- Status: `Planned`
+- Status: `Landed`
 - Source planning input: local `v0.89` planning corpus
 - Milestone home: `WP-06`
 


### PR DESCRIPTION
Closes #1911

## Summary
Updated the promoted `v0.89` feature-doc package so the metadata status lines now match the milestone's landed state instead of still reading as planned-only surfaces.

## Artifacts
- updated `docs/milestones/v0.89/features/ACTION_MEDIATION_LAYER.md`
- updated `docs/milestones/v0.89/features/ACTION_PROPOSAL_SCHEMA.md`
- updated `docs/milestones/v0.89/features/ADL_SECURITY_POSTURE_MODEL.md`
- updated `docs/milestones/v0.89/features/ADL_TRUST_MODEL_UNDER_ADVERSARY.md`
- updated `docs/milestones/v0.89/features/AEE_CONVERGENCE_MODEL.md`
- updated `docs/milestones/v0.89/features/DECISION_SCHEMA.md`
- updated `docs/milestones/v0.89/features/DECISION_SURFACES.md`
- updated `docs/milestones/v0.89/features/FREEDOM_GATE_V2.md`
- updated `docs/milestones/v0.89/features/GODEL_EXPERIMENT_SYSTEM.md`
- updated `docs/milestones/v0.89/features/OBSMEM_EVIDENCE_AND_RANKING.md`
- updated `docs/milestones/v0.89/features/SECURITY_AND_THREAT_MODELING.md`
- updated `docs/milestones/v0.89/features/SKILL_EXECUTION_PROTOCOL.md`
- updated `docs/milestones/v0.89/features/SKILL_MODEL.md`

## Validation
- Validation commands and their purpose:
  - `rg -n '^- Status: ' docs/milestones/v0.89/features`
    - verified that all promoted `v0.89` feature docs now use the intended `Status: Landed` metadata line
  - `git diff --check -- docs/milestones/v0.89/features`
    - verified the bounded feature-doc sweep is whitespace-clean and diff-safe
  - `git diff --stat`
    - verified the issue remained bounded to the intended 13 feature-doc metadata edits
  - `bash adl/tools/pr.sh doctor 1911 --version v0.89 --no-fetch-issue`
    - verified the issue bundle remained structurally healthy in `run_bound` state after the docs sweep
- Results:
  - all validation checks passed

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1911__v0-89-docs-update-v0-89-feature-doc-status-metadata-to-match-landed-state/sip.md
- Output card: .adl/v0.89/tasks/issue-1911__v0-89-docs-update-v0-89-feature-doc-status-metadata-to-match-landed-state/sor.md
- Idempotency-Key: v0-89-docs-update-v0-89-feature-doc-status-metadata-to-match-landed-state-adl-v0-89-tasks-issue-1911-v0-89-docs-update-v0-89-feature-doc-status-metadata-to-match-landed-state-sip-md-adl-v0-89-tasks-issue-1911-v0-89-docs-update-v0-89-feature-doc-status-metadata-to-match-landed-state-sor-md