### PR TITLE
[v0.89][runtime] Replace stringly-typed runtime-control route, path, and instinct fields with enums

### DIFF
--- a/adl/src/cli/run_artifacts/cognitive.rs
+++ b/adl/src/cli/run_artifacts/cognitive.rs
@@ -179,18 +179,20 @@ pub(crate) fn build_cognitive_signals_state(
         "low"
     };
     let dominant_instinct = if integrity_bias == "high" {
-        "integrity"
+        execute::DominantInstinct::Integrity
     } else if completion_pressure == "elevated" {
-        "completion"
+        execute::DominantInstinct::Completion
     } else if curiosity_bias == "active" {
-        "curiosity"
+        execute::DominantInstinct::Curiosity
     } else {
-        "coherence"
+        execute::DominantInstinct::Coherence
     };
     let candidate_selection_bias = match dominant_instinct {
-        "integrity" => "prefer lower-risk constrained candidates",
-        "completion" => "prefer candidates that reduce unfinished work quickly",
-        "curiosity" => "prefer candidates that reduce uncertainty",
+        execute::DominantInstinct::Integrity => "prefer lower-risk constrained candidates",
+        execute::DominantInstinct::Completion => {
+            "prefer candidates that reduce unfinished work quickly"
+        }
+        execute::DominantInstinct::Curiosity => "prefer candidates that reduce uncertainty",
         _ => "prefer candidates that preserve bounded coherence",
     };
     let salience_level = if selected.severity == "high" || selected.evidence.failure_count > 0 {
@@ -221,7 +223,7 @@ pub(crate) fn build_cognitive_signals_state(
     );
 
     CognitiveSignalsState {
-        dominant_instinct: dominant_instinct.to_string(),
+        dominant_instinct,
         completion_pressure: completion_pressure.to_string(),
         integrity_bias: integrity_bias.to_string(),
         curiosity_bias: curiosity_bias.to_string(),
@@ -261,7 +263,7 @@ pub(crate) fn build_cognitive_signals_artifact_from_state(
         },
         instinct: CognitiveInstinctRecord {
             instinct_profile_id: "instinct-001".to_string(),
-            dominant_instinct: state.dominant_instinct.clone(),
+            dominant_instinct: state.dominant_instinct.as_str().to_string(),
             completion_pressure: state.completion_pressure.clone(),
             integrity_bias: state.integrity_bias.clone(),
             curiosity_bias: state.curiosity_bias.clone(),
@@ -319,15 +321,15 @@ pub(crate) fn build_cognitive_arbitration_state(
         || selected.evidence.failure_count > 0
         || signals.instinct.integrity_bias == "reinforced"
     {
-        ("slow", "review_heavy")
+        (execute::Route::Slow, "review_heavy")
     } else if affect_state.affect.recovery_bias >= 2
         || selected.evidence.retry_count > 0
         || signals.affect.confidence_shift == "reduced"
         || signals.affect.persistence_pressure == "sustained"
     {
-        ("hybrid", "bounded_recovery")
+        (execute::Route::Hybrid, "bounded_recovery")
     } else {
-        ("fast", "direct_execution")
+        (execute::Route::Fast, "direct_execution")
     };
     let risk_class = if selected.evidence.security_denied_count > 0 {
         "high"
@@ -336,9 +338,9 @@ pub(crate) fn build_cognitive_arbitration_state(
     } else {
         "low"
     };
-    let confidence = if route_selected == "fast" {
+    let confidence = if route_selected == execute::Route::Fast {
         "high"
-    } else if route_selected == "hybrid" {
+    } else if route_selected == execute::Route::Hybrid {
         "guarded"
     } else {
         "review_required"
@@ -358,13 +360,17 @@ pub(crate) fn build_cognitive_arbitration_state(
     }
 
     let cost_latency_assumption = match route_selected {
-        "fast" => "prefer lower-cost low-latency execution when bounded evidence is stable",
-        "hybrid" => "allow bounded extra review when retry or recovery pressure is present",
+        execute::Route::Fast => {
+            "prefer lower-cost low-latency execution when bounded evidence is stable"
+        }
+        execute::Route::Hybrid => {
+            "allow bounded extra review when retry or recovery pressure is present"
+        }
         _ => "spend bounded additional cognition when failure or policy risk is present",
     };
     let route_reason = format!(
         "route={} dominant_instinct={} confidence_shift={} affect_mode={} failure_count={} retry_count={} security_denied_count={} selected_intent={}",
-        route_selected,
+        route_selected.as_str(),
         signals.instinct.dominant_instinct,
         signals.affect.confidence_shift,
         affect_state.affect.affect_mode,
@@ -375,7 +381,7 @@ pub(crate) fn build_cognitive_arbitration_state(
     );
 
     CognitiveArbitrationState {
-        route_selected: route_selected.to_string(),
+        route_selected,
         reasoning_mode: reasoning_mode.to_string(),
         confidence: confidence.to_string(),
         risk_class: risk_class.to_string(),
@@ -412,7 +418,7 @@ pub(crate) fn build_cognitive_arbitration_artifact_from_state(
             suggestions_version: suggestions.suggestions_version,
             scores_version: scores.map(|value| value.scores_version),
         },
-        route_selected: state.route_selected.clone(),
+        route_selected: state.route_selected.as_str().to_string(),
         reasoning_mode: state.reasoning_mode.clone(),
         confidence: state.confidence.clone(),
         risk_class: state.risk_class.clone(),
@@ -429,6 +435,12 @@ pub(crate) fn build_cognitive_arbitration_artifact_from_state(
 pub(crate) fn build_fast_slow_path_state(
     arbitration: &CognitiveArbitrationArtifact,
 ) -> FastSlowPathState {
+    let route_selected = match arbitration.route_selected.as_str() {
+        "fast" => execute::Route::Fast,
+        "hybrid" => execute::Route::Hybrid,
+        "slow" => execute::Route::Slow,
+        other => panic!("unexpected arbitration route_selected value: {other}"),
+    };
     let (
         selected_path,
         path_family,
@@ -438,9 +450,9 @@ pub(crate) fn build_fast_slow_path_state(
         review_depth,
         execution_profile,
         termination_expectation,
-    ) = match arbitration.route_selected.as_str() {
-        "fast" => (
-            "fast_path",
+    ) = match route_selected {
+        execute::Route::Fast => (
+            execute::SelectedPath::FastPath,
             "fast",
             "fast_direct_execution_branch",
             "direct_handoff",
@@ -449,8 +461,8 @@ pub(crate) fn build_fast_slow_path_state(
             "single_pass_direct_execution",
             "terminate_on_first_bounded_success_or_policy_block",
         ),
-        "hybrid" => (
-            "slow_path",
+        execute::Route::Hybrid => (
+            execute::SelectedPath::SlowPath,
             "slow",
             "slow_bounded_recovery_branch",
             "bounded_recovery_handoff",
@@ -460,7 +472,7 @@ pub(crate) fn build_fast_slow_path_state(
             "terminate_after_bounded_review_cycle_or_policy_block",
         ),
         _ => (
-            "slow_path",
+            execute::SelectedPath::SlowPath,
             "slow",
             "slow_review_refine_branch",
             "review_handoff",
@@ -471,16 +483,16 @@ pub(crate) fn build_fast_slow_path_state(
         ),
     };
     let path_difference_summary = match selected_path {
-        "fast_path" => {
+        execute::SelectedPath::FastPath => {
             "fast_path favors direct execution with minimal review and a single bounded candidate handoff"
         }
-        _ => {
+        execute::SelectedPath::SlowPath => {
             "slow_path requires bounded review/refinement before execution and can revise or veto the current candidate"
         }
     };
 
     FastSlowPathState {
-        selected_path: selected_path.to_string(),
+        selected_path,
         path_family: path_family.to_string(),
         runtime_branch_taken: runtime_branch_taken.to_string(),
         handoff_state: handoff_state.to_string(),
@@ -508,7 +520,7 @@ pub(crate) fn build_fast_slow_path_artifact(
             scores_version: scores.map(|value| value.scores_version),
         },
         arbitration_route: arbitration.route_selected.clone(),
-        selected_path: state.selected_path.clone(),
+        selected_path: state.selected_path.as_str().to_string(),
         path_family: state.path_family.clone(),
         runtime_branch_taken: state.runtime_branch_taken.clone(),
         handoff_state: state.handoff_state.clone(),
@@ -530,6 +542,18 @@ pub(crate) fn build_agency_selection_state(
     fast_slow_state: &FastSlowPathState,
     fast_slow_path: &FastSlowPathArtifact,
 ) -> AgencySelectionState {
+    let dominant_instinct = match signals.instinct.dominant_instinct.as_str() {
+        "integrity" => execute::DominantInstinct::Integrity,
+        "completion" => execute::DominantInstinct::Completion,
+        "curiosity" => execute::DominantInstinct::Curiosity,
+        "coherence" => execute::DominantInstinct::Coherence,
+        other => panic!("unexpected dominant_instinct value: {other}"),
+    };
+    let selected_path = match fast_slow_path.selected_path.as_str() {
+        "fast_path" => execute::SelectedPath::FastPath,
+        "slow_path" => execute::SelectedPath::SlowPath,
+        other => panic!("unexpected selected_path value: {other}"),
+    };
     let (
         selection_mode,
         candidate_set,
@@ -537,20 +561,22 @@ pub(crate) fn build_agency_selection_state(
         selected_candidate_kind,
         selected_candidate_action,
         selected_candidate_reason,
-    ) = match fast_slow_path.selected_path.as_str() {
-        "fast_path" => {
+    ) = match selected_path {
+        execute::SelectedPath::FastPath => {
             let candidate_set = vec![
-                    AgencyCandidateRecord {
-                        candidate_id: "cand-fast-execute".to_string(),
+                AgencyCandidateRecord {
+                    candidate_id: "cand-fast-execute".to_string(),
                         candidate_kind: "direct_execution".to_string(),
-                        bounded_action: "execute selected candidate directly under bounded once semantics".to_string(),
-                        review_requirement: "minimal".to_string(),
-                        execution_priority: 1,
-                        rationale: format!(
-                            "route={} dominant_instinct={} confidence={}",
-                            arbitration.route_selected, signals.instinct.dominant_instinct, arbitration.confidence
-                        ),
-                    },
+                    bounded_action: "execute selected candidate directly under bounded once semantics".to_string(),
+                    review_requirement: "minimal".to_string(),
+                    execution_priority: 1,
+                    rationale: format!(
+                        "route={} dominant_instinct={} confidence={}",
+                        arbitration.route_selected,
+                        dominant_instinct,
+                        arbitration.confidence
+                    ),
+                },
                     AgencyCandidateRecord {
                         candidate_id: "cand-fast-verify".to_string(),
                         candidate_kind: "bounded_verification".to_string(),
@@ -559,10 +585,10 @@ pub(crate) fn build_agency_selection_state(
                         execution_priority: 2,
                         rationale: "keep a bounded verification candidate available when instinct pressure favors uncertainty reduction or extra constraint checks".to_string(),
                     },
-                ];
+            ];
             let decision = execute::select_instinct_runtime_candidate(
-                fast_slow_path.selected_path.as_str(),
-                signals.instinct.dominant_instinct.as_str(),
+                selected_path,
+                dominant_instinct,
                 arbitration.risk_class.as_str(),
             );
             (
@@ -574,19 +600,21 @@ pub(crate) fn build_agency_selection_state(
                 decision.candidate_reason.to_string(),
             )
         }
-        _ => {
+        execute::SelectedPath::SlowPath => {
             let candidate_set = vec![
                     AgencyCandidateRecord {
                         candidate_id: "cand-slow-review".to_string(),
                         candidate_kind: "review_and_refine".to_string(),
-                        bounded_action: "review, refine, or veto the current candidate before execution".to_string(),
-                        review_requirement: "verification_required".to_string(),
-                        execution_priority: 1,
-                        rationale: format!(
-                            "route={} dominant_instinct={} risk_class={}",
-                            arbitration.route_selected, signals.instinct.dominant_instinct, arbitration.risk_class
-                        ),
-                    },
+                    bounded_action: "review, refine, or veto the current candidate before execution".to_string(),
+                    review_requirement: "verification_required".to_string(),
+                    execution_priority: 1,
+                    rationale: format!(
+                        "route={} dominant_instinct={} risk_class={}",
+                        arbitration.route_selected,
+                        dominant_instinct,
+                        arbitration.risk_class
+                    ),
+                },
                     AgencyCandidateRecord {
                         candidate_id: "cand-slow-direct".to_string(),
                         candidate_kind: "direct_execution".to_string(),
@@ -603,10 +631,10 @@ pub(crate) fn build_agency_selection_state(
                         execution_priority: 3,
                         rationale: "preserve a bounded non-execution option when curiosity keeps uncertainty high or the system should pause before commitment".to_string(),
                     },
-                ];
+            ];
             let decision = execute::select_instinct_runtime_candidate(
-                fast_slow_path.selected_path.as_str(),
-                signals.instinct.dominant_instinct.as_str(),
+                selected_path,
+                dominant_instinct,
                 arbitration.risk_class.as_str(),
             );
             (
@@ -623,7 +651,7 @@ pub(crate) fn build_agency_selection_state(
     AgencySelectionState {
         candidate_generation_basis: format!(
             "path={} runtime_branch={} route={} candidate_selection_bias={}",
-            fast_slow_path.selected_path,
+            selected_path,
             fast_slow_state.runtime_branch_taken,
             arbitration.route_selected,
             signals.instinct.candidate_selection_bias

--- a/adl/src/cli/tests/artifact_builders/agency_execution.rs
+++ b/adl/src/cli/tests/artifact_builders/agency_execution.rs
@@ -325,7 +325,7 @@ fn build_agency_selection_artifact_exposes_instinct_sensitive_candidate_shift() 
             "derive route from visible arbitration state without hidden initiative".to_string(),
     };
     let fast_state = FastSlowPathState {
-        selected_path: "fast_path".to_string(),
+        selected_path: execute::SelectedPath::FastPath,
         path_family: "fast".to_string(),
         runtime_branch_taken: "fast_direct_execution_branch".to_string(),
         handoff_state: "candidate_ready".to_string(),

--- a/adl/src/cli/tests/artifact_builders/cognitive.rs
+++ b/adl/src/cli/tests/artifact_builders/cognitive.rs
@@ -286,7 +286,7 @@ fn build_cognitive_signals_state_is_deterministic_and_runtime_usable() {
     assert_eq!(left.dominant_instinct, right.dominant_instinct);
     assert_eq!(left.confidence_shift, right.confidence_shift);
     assert_eq!(left.persistence_pressure, right.persistence_pressure);
-    assert_eq!(left.dominant_instinct, "completion");
+    assert_eq!(left.dominant_instinct.as_str(), "completion");
     assert_eq!(left.confidence_shift, "reduced");
     assert_eq!(left.persistence_pressure, "retry_biased");
 }
@@ -386,7 +386,7 @@ fn build_cognitive_arbitration_artifact_is_deterministic_and_routes_boundedly() 
         serde_json::to_value(&right).expect("right value")
     );
     assert_eq!(left.cognitive_arbitration_version, 1);
-    assert_eq!(left.route_selected, "slow");
+    assert_eq!(left.route_selected.as_str(), "slow");
     assert_eq!(left.reasoning_mode, "review_heavy");
     assert_eq!(left.risk_class, "medium");
     assert!(left
@@ -491,8 +491,8 @@ fn build_cognitive_arbitration_artifact_consumes_signal_state() {
         Some(&scores),
     );
 
-    assert_eq!(fast.route_selected, "fast");
-    assert_eq!(hybrid.route_selected, "hybrid");
+    assert_eq!(fast.route_selected.as_str(), "fast");
+    assert_eq!(hybrid.route_selected.as_str(), "hybrid");
 }
 
 #[test]
@@ -599,7 +599,7 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
         serde_json::to_value(&fast_left).expect("fast left value"),
         serde_json::to_value(&fast_right).expect("fast right value")
     );
-    assert_eq!(fast_left.selected_path, "fast_path");
+    assert_eq!(fast_left.selected_path.as_str(), "fast_path");
     assert_eq!(
         fast_left.runtime_branch_taken,
         "fast_direct_execution_branch"
@@ -653,7 +653,7 @@ fn build_fast_slow_path_artifact_is_deterministic_and_distinguishes_modes() {
         Some(&failure_scores),
     );
     assert_eq!(slow.fast_slow_path_version, 1);
-    assert_eq!(slow.selected_path, "slow_path");
+    assert_eq!(slow.selected_path.as_str(), "slow_path");
     assert_eq!(slow.runtime_branch_taken, "slow_review_refine_branch");
     assert_eq!(slow.review_depth, "verification_required");
     assert_eq!(slow.execution_profile, "review_and_refine_before_execution");

--- a/adl/src/cli/tests/artifact_builders/learning_runtime/artifact_models.rs
+++ b/adl/src/cli/tests/artifact_builders/learning_runtime/artifact_models.rs
@@ -148,7 +148,7 @@ fn build_aee_convergence_artifact_distinguishes_core_outcome_classes() {
             candidate_rationale: "execute the reviewed bounded candidate".to_string(),
             risk_class: "bounded".to_string(),
             policy_context: execute::FreedomGatePolicyContextState {
-                route_selected: "slow".to_string(),
+                route_selected: execute::Route::Slow,
                 selected_candidate_kind: "review_and_refine".to_string(),
                 requires_review: true,
                 policy_blocked: false,
@@ -677,7 +677,7 @@ fn build_control_path_security_review_artifact_projects_posture_and_trust() {
             candidate_rationale: "high-risk path remains bounded".to_string(),
             risk_class: "high".to_string(),
             policy_context: execute::FreedomGatePolicyContextState {
-                route_selected: "slow".to_string(),
+                route_selected: execute::Route::Slow,
                 selected_candidate_kind: "review_and_refine".to_string(),
                 requires_review: true,
                 policy_blocked: false,
@@ -1121,7 +1121,7 @@ fn build_freedom_gate_artifact_is_deterministic_and_blocks_commitment_when_not_a
             candidate_rationale: "custom selected candidate reason".to_string(),
             risk_class: "high".to_string(),
             policy_context: execute::FreedomGatePolicyContextState {
-                route_selected: "slow".to_string(),
+                route_selected: execute::Route::Slow,
                 selected_candidate_kind: "review_and_refine".to_string(),
                 requires_review: false,
                 policy_blocked: false,

--- a/adl/src/cli/tests/artifact_builders/learning_runtime/decision_surfaces.rs
+++ b/adl/src/cli/tests/artifact_builders/learning_runtime/decision_surfaces.rs
@@ -130,7 +130,7 @@ fn build_control_path_decisions_artifact_is_deterministic_and_surfaces_core_reco
             candidate_rationale: "custom selected candidate reason".to_string(),
             risk_class: "high".to_string(),
             policy_context: execute::FreedomGatePolicyContextState {
-                route_selected: "slow".to_string(),
+                route_selected: execute::Route::Slow,
                 selected_candidate_kind: "review_and_refine".to_string(),
                 requires_review: false,
                 policy_blocked: false,
@@ -349,7 +349,7 @@ fn build_action_proposal_and_mediation_artifacts_are_deterministic_and_non_autho
             candidate_rationale: "custom selected candidate reason".to_string(),
             risk_class: "high".to_string(),
             policy_context: execute::FreedomGatePolicyContextState {
-                route_selected: "slow".to_string(),
+                route_selected: execute::Route::Slow,
                 selected_candidate_kind: "review_and_refine".to_string(),
                 requires_review: false,
                 policy_blocked: false,

--- a/adl/src/cli/tests/run_state/mod.rs
+++ b/adl/src/cli/tests/run_state/mod.rs
@@ -80,7 +80,7 @@ fn runtime_control_for(status: &str, tr: &trace::Trace) -> execute::RuntimeContr
 fn custom_runtime_control() -> execute::RuntimeControlState {
     execute::RuntimeControlState {
         signals: execute::CognitiveSignalsState {
-            dominant_instinct: "integrity".to_string(),
+            dominant_instinct: execute::DominantInstinct::Integrity,
             completion_pressure: "guarded".to_string(),
             integrity_bias: "high".to_string(),
             curiosity_bias: "bounded".to_string(),
@@ -92,7 +92,7 @@ fn custom_runtime_control() -> execute::RuntimeControlState {
             downstream_influence: "custom downstream influence".to_string(),
         },
         arbitration: execute::CognitiveArbitrationState {
-            route_selected: "slow".to_string(),
+            route_selected: execute::Route::Slow,
             reasoning_mode: "review_heavy".to_string(),
             confidence: "guarded".to_string(),
             risk_class: "high".to_string(),
@@ -106,7 +106,7 @@ fn custom_runtime_control() -> execute::RuntimeControlState {
             route_reason: "custom arbitration reason".to_string(),
         },
         fast_slow: execute::FastSlowPathState {
-            selected_path: "slow_path".to_string(),
+            selected_path: execute::SelectedPath::SlowPath,
             path_family: "slow".to_string(),
             runtime_branch_taken: "slow_review_refine_branch".to_string(),
             handoff_state: "review_handoff".to_string(),
@@ -177,7 +177,7 @@ fn custom_runtime_control() -> execute::RuntimeControlState {
                 candidate_rationale: "custom selected candidate reason".to_string(),
                 risk_class: "high".to_string(),
                 policy_context: execute::FreedomGatePolicyContextState {
-                    route_selected: "slow".to_string(),
+                    route_selected: execute::Route::Slow,
                     selected_candidate_kind: "review_and_refine".to_string(),
                     requires_review: false,
                     policy_blocked: false,

--- a/adl/src/demo/v086_review_surface.rs
+++ b/adl/src/demo/v086_review_surface.rs
@@ -9,7 +9,7 @@ use super::{write_file, DEMO_G_V086_CONTROL_PATH};
 fn custom_v086_control_path_runtime() -> execute::RuntimeControlState {
     execute::RuntimeControlState {
         signals: execute::CognitiveSignalsState {
-            dominant_instinct: "integrity".to_string(),
+            dominant_instinct: execute::DominantInstinct::Integrity,
             completion_pressure: "guarded".to_string(),
             integrity_bias: "high".to_string(),
             curiosity_bias: "bounded".to_string(),
@@ -21,7 +21,7 @@ fn custom_v086_control_path_runtime() -> execute::RuntimeControlState {
             downstream_influence: "integrated control path demo".to_string(),
         },
         arbitration: execute::CognitiveArbitrationState {
-            route_selected: "slow".to_string(),
+            route_selected: execute::Route::Slow,
             reasoning_mode: "review_heavy".to_string(),
             confidence: "guarded".to_string(),
             risk_class: "high".to_string(),
@@ -37,7 +37,7 @@ fn custom_v086_control_path_runtime() -> execute::RuntimeControlState {
                     .to_string(),
         },
         fast_slow: execute::FastSlowPathState {
-            selected_path: "slow_path".to_string(),
+            selected_path: execute::SelectedPath::SlowPath,
             path_family: "slow".to_string(),
             runtime_branch_taken: "slow_review_refine_branch".to_string(),
             handoff_state: "review_handoff".to_string(),
@@ -112,7 +112,7 @@ fn custom_v086_control_path_runtime() -> execute::RuntimeControlState {
                     .to_string(),
                 risk_class: "high".to_string(),
                 policy_context: execute::FreedomGatePolicyContextState {
-                    route_selected: "slow".to_string(),
+                    route_selected: execute::Route::Slow,
                     selected_candidate_kind: "review_and_refine".to_string(),
                     requires_review: false,
                     policy_blocked: false,
@@ -893,7 +893,7 @@ pub fn write_v086_control_path_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
 pub fn write_v086_fast_slow_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut artifacts = Vec::new();
     let simple_arbitration = execute::CognitiveArbitrationState {
-        route_selected: "fast".to_string(),
+        route_selected: execute::Route::Fast,
         reasoning_mode: "quick_commit".to_string(),
         confidence: "high".to_string(),
         risk_class: "low".to_string(),
@@ -902,7 +902,7 @@ pub fn write_v086_fast_slow_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
         route_reason: "simple bounded summary task remains on the fast path".to_string(),
     };
     let simple_path = execute::FastSlowPathState {
-        selected_path: "fast_path".to_string(),
+        selected_path: execute::SelectedPath::FastPath,
         path_family: "fast".to_string(),
         runtime_branch_taken: "fast_direct_execution_branch".to_string(),
         handoff_state: "direct_commit".to_string(),
@@ -914,7 +914,7 @@ pub fn write_v086_fast_slow_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
             .to_string(),
     };
     let complex_arbitration = execute::CognitiveArbitrationState {
-        route_selected: "slow".to_string(),
+        route_selected: execute::Route::Slow,
         reasoning_mode: "review_heavy".to_string(),
         confidence: "guarded".to_string(),
         risk_class: "high".to_string(),
@@ -929,7 +929,7 @@ pub fn write_v086_fast_slow_demo(out_dir: &Path) -> Result<Vec<PathBuf>> {
             .to_string(),
     };
     let complex_path = execute::FastSlowPathState {
-        selected_path: "slow_path".to_string(),
+        selected_path: execute::SelectedPath::SlowPath,
         path_family: "slow".to_string(),
         runtime_branch_taken: "slow_review_refine_branch".to_string(),
         handoff_state: "review_handoff".to_string(),

--- a/adl/src/execute/state/mod.rs
+++ b/adl/src/execute/state/mod.rs
@@ -12,11 +12,11 @@ pub use policy::{stable_failure_kind, ExecutionPolicyError, ExecutionPolicyError
 pub use runtime_control::{
     derive_runtime_control_state, select_instinct_runtime_candidate, AgencyCandidateRecord,
     AgencySelectionDecisionTemplate, AgencySelectionState, BoundedExecutionIteration,
-    BoundedExecutionState, CognitiveArbitrationState, CognitiveSignalsState,
+    BoundedExecutionState, CognitiveArbitrationState, CognitiveSignalsState, DominantInstinct,
     EvaluationControlState, FastSlowPathState, FreedomGateConsequenceContextState,
     FreedomGateEvaluationSignalsState, FreedomGateInputState, FreedomGatePolicyContextState,
     FreedomGateState, MemoryParticipationState, MemoryQueryState, MemoryReadEntry, MemoryReadState,
-    MemoryWriteState, ReframingControlState, RuntimeControlState,
+    MemoryWriteState, ReframingControlState, Route, RuntimeControlState, SelectedPath,
 };
 pub use steering::{
     apply_steering_patch, steering_record_from_patch, validate_steering_patch, PauseState,

--- a/adl/src/execute/state/runtime_control.rs
+++ b/adl/src/execute/state/runtime_control.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
@@ -23,10 +24,82 @@ pub struct RuntimeControlState {
     pub memory: MemoryParticipationState,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DominantInstinct {
+    Integrity,
+    Completion,
+    Curiosity,
+    Coherence,
+}
+
+impl DominantInstinct {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Integrity => "integrity",
+            Self::Completion => "completion",
+            Self::Curiosity => "curiosity",
+            Self::Coherence => "coherence",
+        }
+    }
+}
+
+impl fmt::Display for DominantInstinct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Route {
+    Fast,
+    Hybrid,
+    Slow,
+}
+
+impl Route {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Fast => "fast",
+            Self::Hybrid => "hybrid",
+            Self::Slow => "slow",
+        }
+    }
+}
+
+impl fmt::Display for Route {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectedPath {
+    FastPath,
+    SlowPath,
+}
+
+impl SelectedPath {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FastPath => "fast_path",
+            Self::SlowPath => "slow_path",
+        }
+    }
+}
+
+impl fmt::Display for SelectedPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CognitiveSignalsState {
-    pub dominant_instinct: String,
+    pub dominant_instinct: DominantInstinct,
     pub completion_pressure: String,
     pub integrity_bias: String,
     pub curiosity_bias: String,
@@ -41,7 +114,7 @@ pub struct CognitiveSignalsState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CognitiveArbitrationState {
-    pub route_selected: String,
+    pub route_selected: Route,
     pub reasoning_mode: String,
     pub confidence: String,
     pub risk_class: String,
@@ -53,7 +126,7 @@ pub struct CognitiveArbitrationState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FastSlowPathState {
-    pub selected_path: String,
+    pub selected_path: SelectedPath,
     pub path_family: String,
     pub runtime_branch_taken: String,
     pub handoff_state: String,
@@ -164,10 +237,67 @@ pub struct FreedomGateInputState {
     pub frame_state: String,
 }
 
+fn parse_route(value: &str) -> Route {
+    match value {
+        "fast" => Route::Fast,
+        "hybrid" => Route::Hybrid,
+        "slow" => Route::Slow,
+        other => panic!("unexpected route_selected value: {other}"),
+    }
+}
+
+impl From<freedom_gate::FreedomGatePolicyContext> for FreedomGatePolicyContextState {
+    fn from(value: freedom_gate::FreedomGatePolicyContext) -> Self {
+        Self {
+            route_selected: parse_route(&value.route_selected),
+            selected_candidate_kind: value.selected_candidate_kind,
+            requires_review: value.requires_review,
+            policy_blocked: value.policy_blocked,
+        }
+    }
+}
+
+impl From<freedom_gate::FreedomGateEvaluationSignals> for FreedomGateEvaluationSignalsState {
+    fn from(value: freedom_gate::FreedomGateEvaluationSignals) -> Self {
+        Self {
+            progress_signal: value.progress_signal,
+            contradiction_signal: value.contradiction_signal,
+            failure_signal: value.failure_signal,
+            termination_reason: value.termination_reason,
+        }
+    }
+}
+
+impl From<freedom_gate::FreedomGateConsequenceContext> for FreedomGateConsequenceContextState {
+    fn from(value: freedom_gate::FreedomGateConsequenceContext) -> Self {
+        Self {
+            impact_scope: value.impact_scope,
+            recovery_cost: value.recovery_cost,
+            operator_visibility: value.operator_visibility,
+            escalation_available: value.escalation_available,
+        }
+    }
+}
+
+impl From<freedom_gate::FreedomGateInput> for FreedomGateInputState {
+    fn from(value: freedom_gate::FreedomGateInput) -> Self {
+        Self {
+            candidate_id: value.candidate_id,
+            candidate_action: value.candidate_action,
+            candidate_rationale: value.candidate_rationale,
+            risk_class: value.risk_class,
+            policy_context: value.policy_context.into(),
+            evaluation_signals: value.evaluation_signals.into(),
+            consequence_context: value.consequence_context.into(),
+            frame_state: value.frame_state,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FreedomGatePolicyContextState {
-    pub route_selected: String,
+    pub route_selected: Route,
     pub selected_candidate_kind: String,
     pub requires_review: bool,
     pub policy_blocked: bool,
@@ -368,18 +498,18 @@ fn derive_cognitive_signals_state(
         "low"
     };
     let dominant_instinct = if integrity_bias == "high" {
-        "integrity"
+        DominantInstinct::Integrity
     } else if completion_pressure == "elevated" {
-        "completion"
+        DominantInstinct::Completion
     } else if curiosity_bias == "active" {
-        "curiosity"
+        DominantInstinct::Curiosity
     } else {
-        "coherence"
+        DominantInstinct::Coherence
     };
     let candidate_selection_bias = match dominant_instinct {
-        "integrity" => "prefer lower-risk constrained candidates",
-        "completion" => "prefer candidates that reduce unfinished work quickly",
-        "curiosity" => "prefer candidates that reduce uncertainty",
+        DominantInstinct::Integrity => "prefer lower-risk constrained candidates",
+        DominantInstinct::Completion => "prefer candidates that reduce unfinished work quickly",
+        DominantInstinct::Curiosity => "prefer candidates that reduce uncertainty",
         _ => "prefer candidates that preserve bounded coherence",
     };
     let salience_level = if evidence.failure_count > 0 || evidence.delegation_denied_count > 0 {
@@ -403,7 +533,7 @@ fn derive_cognitive_signals_state(
     };
 
     CognitiveSignalsState {
-        dominant_instinct: dominant_instinct.to_string(),
+        dominant_instinct,
         completion_pressure: completion_pressure.to_string(),
         integrity_bias: integrity_bias.to_string(),
         curiosity_bias: curiosity_bias.to_string(),
@@ -414,7 +544,7 @@ fn derive_cognitive_signals_state(
         confidence_shift: confidence_shift.to_string(),
         downstream_influence: format!(
             "dominant_instinct={} failure_count={} retry_count={} delegation_denied_count={} max_parallel={}",
-            dominant_instinct,
+            dominant_instinct.as_str(),
             evidence.failure_count,
             evidence.retry_count,
             evidence.delegation_denied_count,
@@ -430,16 +560,16 @@ fn derive_cognitive_arbitration_state(
 ) -> CognitiveArbitrationState {
     let (route_selected, reasoning_mode) = if evidence.security_denied_count > 0
         || evidence.failure_count > 0
-        || signals.dominant_instinct == "integrity"
+        || signals.dominant_instinct == DominantInstinct::Integrity
     {
-        ("slow", "review_heavy")
+        (Route::Slow, "review_heavy")
     } else if evidence.retry_count > 0
         || overall_status == "paused"
         || signals.confidence_shift == "reduced"
     {
-        ("hybrid", "bounded_recovery")
+        (Route::Hybrid, "bounded_recovery")
     } else {
-        ("fast", "direct_execution")
+        (Route::Fast, "direct_execution")
     };
     let risk_class = if evidence.security_denied_count > 0 {
         "high"
@@ -448,9 +578,9 @@ fn derive_cognitive_arbitration_state(
     } else {
         "low"
     };
-    let confidence = if route_selected == "fast" {
+    let confidence = if route_selected == Route::Fast {
         "high"
-    } else if route_selected == "hybrid" {
+    } else if route_selected == Route::Hybrid {
         "guarded"
     } else {
         "review_required"
@@ -472,13 +602,13 @@ fn derive_cognitive_arbitration_state(
         applied_constraints.push("bounded_default_path".to_string());
     }
     let cost_latency_assumption = match route_selected {
-        "fast" => "prefer lower-cost low-latency execution when bounded evidence is stable",
-        "hybrid" => "allow bounded extra review when retry or pause pressure is present",
+        Route::Fast => "prefer lower-cost low-latency execution when bounded evidence is stable",
+        Route::Hybrid => "allow bounded extra review when retry or pause pressure is present",
         _ => "spend bounded additional cognition when failure or policy risk is present",
     };
 
     CognitiveArbitrationState {
-        route_selected: route_selected.to_string(),
+        route_selected,
         reasoning_mode: reasoning_mode.to_string(),
         confidence: confidence.to_string(),
         risk_class: risk_class.to_string(),
@@ -486,8 +616,8 @@ fn derive_cognitive_arbitration_state(
         cost_latency_assumption: cost_latency_assumption.to_string(),
         route_reason: format!(
             "route={} dominant_instinct={} overall_status={} failure_count={} retry_count={} delegation_denied_count={}",
-            route_selected,
-            signals.dominant_instinct,
+            route_selected.as_str(),
+            signals.dominant_instinct.as_str(),
             overall_status,
             evidence.failure_count,
             evidence.retry_count,
@@ -506,9 +636,9 @@ fn derive_fast_slow_path_state(arbitration: &CognitiveArbitrationState) -> FastS
         review_depth,
         execution_profile,
         termination_expectation,
-    ) = match arbitration.route_selected.as_str() {
-        "fast" => (
-            "fast_path",
+    ) = match arbitration.route_selected {
+        Route::Fast => (
+            SelectedPath::FastPath,
             "fast",
             "fast_direct_execution_branch",
             "direct_handoff",
@@ -517,8 +647,8 @@ fn derive_fast_slow_path_state(arbitration: &CognitiveArbitrationState) -> FastS
             "single_pass_direct_execution",
             "terminate_on_first_bounded_success_or_policy_block",
         ),
-        "hybrid" => (
-            "slow_path",
+        Route::Hybrid => (
+            SelectedPath::SlowPath,
             "slow",
             "slow_bounded_recovery_branch",
             "bounded_recovery_handoff",
@@ -527,8 +657,8 @@ fn derive_fast_slow_path_state(arbitration: &CognitiveArbitrationState) -> FastS
             "review_then_execute_once",
             "terminate_after_bounded_review_cycle_or_policy_block",
         ),
-        _ => (
-            "slow_path",
+        Route::Slow => (
+            SelectedPath::SlowPath,
             "slow",
             "slow_review_refine_branch",
             "review_handoff",
@@ -539,16 +669,16 @@ fn derive_fast_slow_path_state(arbitration: &CognitiveArbitrationState) -> FastS
         ),
     };
     let path_difference_summary = match selected_path {
-        "fast_path" => {
+        SelectedPath::FastPath => {
             "fast_path favors direct execution with minimal review and a single bounded candidate handoff"
         }
-        _ => {
+        SelectedPath::SlowPath => {
             "slow_path requires bounded review/refinement before execution and can revise or veto the current candidate"
         }
     };
 
     FastSlowPathState {
-        selected_path: selected_path.to_string(),
+        selected_path,
         path_family: path_family.to_string(),
         runtime_branch_taken: runtime_branch_taken.to_string(),
         handoff_state: handoff_state.to_string(),
@@ -572,8 +702,8 @@ fn derive_agency_selection_state(
         selected_candidate_kind,
         selected_candidate_action,
         selected_candidate_reason,
-    ) = match fast_slow.selected_path.as_str() {
-        "fast_path" => {
+    ) = match fast_slow.selected_path {
+        SelectedPath::FastPath => {
             let candidate_set = vec![
                 AgencyCandidateRecord {
                     candidate_id: "cand-fast-execute".to_string(),
@@ -585,7 +715,9 @@ fn derive_agency_selection_state(
                     execution_priority: 1,
                     rationale: format!(
                         "route={} dominant_instinct={} confidence={}",
-                        arbitration.route_selected, signals.dominant_instinct, arbitration.confidence
+                        arbitration.route_selected.as_str(),
+                        signals.dominant_instinct.as_str(),
+                        arbitration.confidence
                     ),
                 },
                 AgencyCandidateRecord {
@@ -601,8 +733,8 @@ fn derive_agency_selection_state(
                 },
             ];
             let decision = select_instinct_runtime_candidate(
-                fast_slow.selected_path.as_str(),
-                signals.dominant_instinct.as_str(),
+                fast_slow.selected_path,
+                signals.dominant_instinct,
                 arbitration.risk_class.as_str(),
             );
             (
@@ -626,7 +758,9 @@ fn derive_agency_selection_state(
                     execution_priority: 1,
                     rationale: format!(
                         "route={} dominant_instinct={} risk_class={}",
-                        arbitration.route_selected, signals.dominant_instinct, arbitration.risk_class
+                        arbitration.route_selected.as_str(),
+                        signals.dominant_instinct.as_str(),
+                        arbitration.risk_class
                     ),
                 },
                 AgencyCandidateRecord {
@@ -652,8 +786,8 @@ fn derive_agency_selection_state(
                 },
             ];
             let decision = select_instinct_runtime_candidate(
-                fast_slow.selected_path.as_str(),
-                signals.dominant_instinct.as_str(),
+                fast_slow.selected_path,
+                signals.dominant_instinct,
                 arbitration.risk_class.as_str(),
             );
             (
@@ -670,9 +804,9 @@ fn derive_agency_selection_state(
     AgencySelectionState {
         candidate_generation_basis: format!(
             "path={} runtime_branch={} route={} candidate_selection_bias={}",
-            fast_slow.selected_path,
+            fast_slow.selected_path.as_str(),
             fast_slow.runtime_branch_taken,
-            arbitration.route_selected,
+            arbitration.route_selected.as_str(),
             signals.candidate_selection_bias
         ),
         selection_mode: selection_mode.to_string(),
@@ -685,13 +819,13 @@ fn derive_agency_selection_state(
 }
 
 pub fn select_instinct_runtime_candidate(
-    selected_path: &str,
-    dominant_instinct: &str,
+    selected_path: SelectedPath,
+    dominant_instinct: DominantInstinct,
     risk_class: &str,
 ) -> AgencySelectionDecisionTemplate {
     match selected_path {
-        "fast_path" => match dominant_instinct {
-            "curiosity" | "integrity" => AgencySelectionDecisionTemplate {
+        SelectedPath::FastPath => match dominant_instinct {
+            DominantInstinct::Curiosity | DominantInstinct::Integrity => AgencySelectionDecisionTemplate {
                 selection_mode: "fast_candidate_verification",
                 candidate_id: "cand-fast-verify",
                 candidate_kind: "bounded_verification",
@@ -708,8 +842,10 @@ pub fn select_instinct_runtime_candidate(
                     "fast path prioritizes direct bounded execution when instinct pressure does not require extra verification",
             },
         },
-        _ => {
-            if risk_class == "high" || matches!(dominant_instinct, "integrity" | "coherence") {
+        SelectedPath::SlowPath => {
+            if risk_class == "high"
+                || matches!(dominant_instinct, DominantInstinct::Integrity | DominantInstinct::Coherence)
+            {
                 AgencySelectionDecisionTemplate {
                     selection_mode: "slow_candidate_review",
                     candidate_id: "cand-slow-review",
@@ -719,7 +855,7 @@ pub fn select_instinct_runtime_candidate(
                     candidate_reason:
                         "slow path keeps review/refinement selected when risk stays high or instinct pressure favors constraint and coherence preservation",
                 }
-            } else if dominant_instinct == "curiosity" {
+            } else if dominant_instinct == DominantInstinct::Curiosity {
                 AgencySelectionDecisionTemplate {
                     selection_mode: "slow_candidate_uncertainty_hold",
                     candidate_id: "cand-slow-defer",
@@ -880,9 +1016,9 @@ fn derive_reframing_control_state(
     bounded_execution: &BoundedExecutionState,
     evaluation: &EvaluationControlState,
 ) -> ReframingControlState {
-    let prior_frame = match fast_slow.selected_path.as_str() {
-        "fast_path" => "direct_execution_under_current_frame",
-        _ => "review_and_refine_under_current_frame",
+    let prior_frame = match fast_slow.selected_path {
+        SelectedPath::FastPath => "direct_execution_under_current_frame",
+        SelectedPath::SlowPath => "review_and_refine_under_current_frame",
     };
 
     let (
@@ -968,7 +1104,7 @@ fn derive_freedom_gate_state(
         candidate_rationale: agency.selected_candidate_reason.clone(),
         risk_class: arbitration.risk_class.clone(),
         policy_context: freedom_gate::FreedomGatePolicyContext {
-            route_selected: arbitration.route_selected.clone(),
+            route_selected: arbitration.route_selected.as_str().to_string(),
             selected_candidate_kind: agency.selected_candidate_kind.clone(),
             requires_review: agency.selected_candidate_kind == "bounded_deferral"
                 || evaluation.next_control_action == "await_resume",
@@ -988,20 +1124,20 @@ fn derive_freedom_gate_state(
             },
             recovery_cost: if evaluation.next_control_action == "handoff_to_reframing" {
                 "requires_reframing".to_string()
-            } else if arbitration.route_selected == "slow" {
+            } else if arbitration.route_selected == Route::Slow {
                 "bounded_review_replay".to_string()
             } else {
                 "low".to_string()
             },
             operator_visibility: if arbitration.risk_class == "high"
-                || arbitration.route_selected == "slow"
+                || arbitration.route_selected == Route::Slow
                 || evaluation.contradiction_signal == "present"
             {
                 "review_required".to_string()
             } else {
                 "routine".to_string()
             },
-            escalation_available: arbitration.route_selected == "slow"
+            escalation_available: arbitration.route_selected == Route::Slow
                 || arbitration.risk_class == "high"
                 || evaluation.contradiction_signal == "present"
                 || evaluation.failure_signal != "none",
@@ -1009,33 +1145,10 @@ fn derive_freedom_gate_state(
         frame_state: reframing.post_reframe_state.clone(),
     };
     let decision = freedom_gate::evaluate_freedom_gate(&input);
+    let input = input.into();
 
     FreedomGateState {
-        input: FreedomGateInputState {
-            candidate_id: input.candidate_id,
-            candidate_action: input.candidate_action,
-            candidate_rationale: input.candidate_rationale,
-            risk_class: input.risk_class,
-            policy_context: FreedomGatePolicyContextState {
-                route_selected: input.policy_context.route_selected,
-                selected_candidate_kind: input.policy_context.selected_candidate_kind,
-                requires_review: input.policy_context.requires_review,
-                policy_blocked: input.policy_context.policy_blocked,
-            },
-            evaluation_signals: FreedomGateEvaluationSignalsState {
-                progress_signal: input.evaluation_signals.progress_signal,
-                contradiction_signal: input.evaluation_signals.contradiction_signal,
-                failure_signal: input.evaluation_signals.failure_signal,
-                termination_reason: input.evaluation_signals.termination_reason,
-            },
-            consequence_context: FreedomGateConsequenceContextState {
-                impact_scope: input.consequence_context.impact_scope,
-                recovery_cost: input.consequence_context.recovery_cost,
-                operator_visibility: input.consequence_context.operator_visibility,
-                escalation_available: input.consequence_context.escalation_available,
-            },
-            frame_state: input.frame_state,
-        },
+        input,
         gate_decision: decision.gate_decision,
         reason_code: decision.reason_code,
         decision_reason: decision.decision_reason,
@@ -1067,12 +1180,14 @@ fn derive_memory_participation_state(
     } else if evaluation.next_control_action == "handoff_to_reframing" {
         format!(
             "prior_failure_memory reinforces bounded reframing for route={} selected_candidate={}",
-            arbitration.route_selected, agency.selected_candidate_id
+            arbitration.route_selected.as_str(),
+            agency.selected_candidate_id
         )
     } else {
         format!(
             "prior_success_memory reinforces retained bounded frame for route={} selected_candidate={}",
-            arbitration.route_selected, agency.selected_candidate_id
+            arbitration.route_selected.as_str(),
+            agency.selected_candidate_id
         )
     };
     let influenced_stage = if evaluation.next_control_action == "handoff_to_reframing" {
@@ -1105,7 +1220,7 @@ fn derive_memory_participation_state(
     let mut tags = vec![
         format!("workflow:{workflow_id}"),
         format!("status:{overall_status}"),
-        format!("route:{}", arbitration.route_selected),
+        format!("route:{}", arbitration.route_selected.as_str()),
         format!("candidate:{}", agency.selected_candidate_kind),
         format!("action:{}", evaluation.next_control_action),
     ];
@@ -1185,11 +1300,16 @@ fn load_memory_read_entries(
 
 #[cfg(test)]
 mod tests {
-    use super::select_instinct_runtime_candidate;
+    use super::*;
+    use crate::freedom_gate;
 
     #[test]
     fn select_instinct_runtime_candidate_changes_fast_path_for_curiosity() {
-        let decision = select_instinct_runtime_candidate("fast_path", "curiosity", "low");
+        let decision = select_instinct_runtime_candidate(
+            SelectedPath::FastPath,
+            DominantInstinct::Curiosity,
+            "low",
+        );
 
         assert_eq!(decision.candidate_id, "cand-fast-verify");
         assert_eq!(decision.candidate_kind, "bounded_verification");
@@ -1197,7 +1317,11 @@ mod tests {
 
     #[test]
     fn select_instinct_runtime_candidate_keeps_review_for_high_risk_slow_path() {
-        let decision = select_instinct_runtime_candidate("slow_path", "completion", "high");
+        let decision = select_instinct_runtime_candidate(
+            SelectedPath::SlowPath,
+            DominantInstinct::Completion,
+            "high",
+        );
 
         assert_eq!(decision.candidate_id, "cand-slow-review");
         assert_eq!(decision.candidate_kind, "review_and_refine");
@@ -1205,9 +1329,69 @@ mod tests {
 
     #[test]
     fn select_instinct_runtime_candidate_allows_curiosity_biased_slow_defer() {
-        let decision = select_instinct_runtime_candidate("slow_path", "curiosity", "medium");
+        let decision = select_instinct_runtime_candidate(
+            SelectedPath::SlowPath,
+            DominantInstinct::Curiosity,
+            "medium",
+        );
 
         assert_eq!(decision.candidate_id, "cand-slow-defer");
         assert_eq!(decision.candidate_kind, "bounded_deferral");
+    }
+
+    #[test]
+    fn runtime_control_enums_serialize_to_existing_string_values() {
+        let state = CognitiveSignalsState {
+            dominant_instinct: DominantInstinct::Integrity,
+            completion_pressure: "guarded".to_string(),
+            integrity_bias: "high".to_string(),
+            curiosity_bias: "bounded".to_string(),
+            candidate_selection_bias: "prefer lower-risk constrained candidates".to_string(),
+            urgency_level: "moderate".to_string(),
+            salience_level: "high".to_string(),
+            persistence_pressure: "stabilize_then_retry".to_string(),
+            confidence_shift: "reduced".to_string(),
+            downstream_influence: "demo".to_string(),
+        };
+
+        let json = serde_json::to_value(&state).expect("serialize state");
+        assert_eq!(json["dominant_instinct"], "integrity");
+    }
+
+    #[test]
+    fn freedom_gate_input_state_conversion_preserves_nested_fields() {
+        let input = freedom_gate::FreedomGateInput {
+            candidate_id: "cand-1".to_string(),
+            candidate_action: "review".to_string(),
+            candidate_rationale: "bounded rationale".to_string(),
+            risk_class: "high".to_string(),
+            policy_context: freedom_gate::FreedomGatePolicyContext {
+                route_selected: "slow".to_string(),
+                selected_candidate_kind: "review_and_refine".to_string(),
+                requires_review: true,
+                policy_blocked: false,
+            },
+            evaluation_signals: freedom_gate::FreedomGateEvaluationSignals {
+                progress_signal: "steady".to_string(),
+                contradiction_signal: "present".to_string(),
+                failure_signal: "none".to_string(),
+                termination_reason: "contradiction_detected".to_string(),
+            },
+            consequence_context: freedom_gate::FreedomGateConsequenceContext {
+                impact_scope: "cross_surface".to_string(),
+                recovery_cost: "requires_reframing".to_string(),
+                operator_visibility: "review_required".to_string(),
+                escalation_available: true,
+            },
+            frame_state: "ready_for_reframed_execution".to_string(),
+        };
+
+        let state = FreedomGateInputState::from(input);
+
+        assert_eq!(state.candidate_id, "cand-1");
+        assert_eq!(state.policy_context.route_selected, Route::Slow);
+        assert_eq!(state.evaluation_signals.contradiction_signal, "present");
+        assert!(state.consequence_context.escalation_available);
+        assert_eq!(state.frame_state, "ready_for_reframed_execution");
     }
 }


### PR DESCRIPTION
Closes #1913

## Summary
Replaced the runtime-control route, selected-path, and dominant-instinct state with enums in the execute-state projection while preserving the serialized string output at the artifact boundary.

## Artifacts
- Typed `Route`, `SelectedPath`, and `DominantInstinct` enums in `adl/src/execute/state/runtime_control.rs`.
- Serialization-preserving enum exports in `adl/src/execute/state/mod.rs`.

## Validation
- Validation commands and their purpose:
  - `git -C .worktrees/adl-wp-1913 status --short`: confirmed the issue worktree contains only the intended tracked runtime-refactor edits
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`: confirmed formatting stayed clean after the enum refactor.
  - `cargo test --manifest-path adl/Cargo.toml runtime_control -- --nocapture`: exercised the runtime-control and affected run-state projection tests.
- Results: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89/tasks/issue-1913__v0-89-runtime-replace-stringly-typed-runtime-control-route-path-and-instinct-fields-with-enums/sip.md
- Output card: .adl/v0.89/tasks/issue-1913__v0-89-runtime-replace-stringly-typed-runtime-control-route-path-and-instinct-fields-with-enums/sor.md
- Idempotency-Key: v0-89-runtime-replace-stringly-typed-runtime-control-route-path-and-instinct-fields-with-enums-adl-v0-89-tasks-issue-1913-v0-89-runtime-replace-stringly-typed-runtime-control-route-path-and-instinct-fields-with-enums-sip-md-adl-v0-89-tasks-issue-1913-v0-89-runtime-replace-stringly-typed-runtime-control-route-path-and-instinct-fields-with-enums-sor-md