### PR TITLE
[v0.89][WP-20] Bump ADL crate version to 0.89.0

### DIFF
--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.88.0"
+version = "0.89.0"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #1807

This is the final release-version bump required before the v0.89 closing ceremony can tag and publish from main.

The milestone closeout truth gate now passes locally, and the ceremony preflight is green. This PR only carries the crate version bump needed to make the release state truthful.
