### PR TITLE
[v0.89.1][demo] Build deeper Gemini provider harmony and economics follow-on demo

### DIFF
--- a/adl/examples/v0-89-1-gemini-provider-harmony-roundtable.adl.yaml
+++ b/adl/examples/v0-89-1-gemini-provider-harmony-roundtable.adl.yaml
@@ -1,0 +1,160 @@
+version: "0.5"
+
+providers:
+  gemini_roundtable:
+    profile: "http:gemini-2.0-flash"
+    config:
+      endpoint: "http://127.0.0.1:8793/gemini"
+      auth:
+        type: bearer
+        env: GEMINI_API_KEY
+      timeout_secs: 20
+      model_ref: "reasoning/default"
+      provider_model_id: "gemini-2.0-flash"
+  chatgpt_roundtable:
+    profile: "http:gpt-4.1-mini"
+    config:
+      endpoint: "http://127.0.0.1:8793/chatgpt"
+      auth:
+        type: bearer
+        env: OPENAI_API_KEY
+      timeout_secs: 20
+      model_ref: "reasoning/default"
+      provider_model_id: "gpt-4.1-mini"
+  claude_roundtable:
+    profile: "http:claude-3-7-sonnet"
+    config:
+      endpoint: "http://127.0.0.1:8793/claude"
+      auth:
+        type: bearer
+        env: ANTHROPIC_API_KEY
+      timeout_secs: 20
+      model_ref: "reasoning/default"
+      provider_model_id: "claude-3-7-sonnet"
+  synthesis_roundtable:
+    profile: "http:gpt-4.1-mini"
+    config:
+      endpoint: "http://127.0.0.1:8793/synthesis"
+      auth:
+        type: bearer
+        env: OPENAI_API_KEY
+      timeout_secs: 20
+      model_ref: "reasoning/default"
+      provider_model_id: "gpt-4.1-mini"
+
+agents:
+  gemini_host:
+    provider: "gemini_roundtable"
+    model: "reasoning/default"
+  chatgpt_guest:
+    provider: "chatgpt_roundtable"
+    model: "reasoning/default"
+  claude_guest:
+    provider: "claude_roundtable"
+    model: "reasoning/default"
+  synthesis_host:
+    provider: "synthesis_roundtable"
+    model: "reasoning/default"
+
+tasks:
+  gemini_opening:
+    prompt:
+      user: |
+        ROLE: Gemini Opening
+        TOPIC: {{topic}}
+
+        Write exactly one Markdown section with this heading:
+        # Gemini Opening
+
+        Explain why Gemini is the right provider for this bounded packet without claiming it is universally best.
+        Keep the tone calm, specific, and reviewer-friendly.
+  chatgpt_response:
+    prompt:
+      user: |
+        ROLE: ChatGPT Response
+        TOPIC: {{topic}}
+
+        Previous turn:
+        {{gemini_turn}}
+
+        Write exactly one Markdown section with this heading:
+        # ChatGPT Response
+
+        Respond as a respectful peer. Name one reason the Gemini choice is sensible and one tradeoff that still matters.
+  claude_response:
+    prompt:
+      user: |
+        ROLE: Claude Response
+        TOPIC: {{topic}}
+
+        Previous turn:
+        {{chatgpt_turn}}
+
+        Write exactly one Markdown section with this heading:
+        # Claude Response
+
+        Add a governance or reviewability caution while staying fair to Gemini.
+  synthesis:
+    prompt:
+      user: |
+        ROLE: Synthesis
+        TOPIC: {{topic}}
+
+        Gemini opening:
+        {{gemini_turn}}
+
+        ChatGPT response:
+        {{chatgpt_turn}}
+
+        Claude response:
+        {{claude_turn}}
+
+        Write exactly one Markdown section with this heading:
+        # Gemini Roundtable Synthesis
+
+        Include these subheadings:
+        ## Findings
+        ## Why Gemini Fits This Packet
+        ## Tradeoffs That Remain Visible
+        ## Acknowledgement
+
+        Keep the synthesis grounded in the three prior turns only.
+
+run:
+  name: "v0-89-1-gemini-provider-harmony-roundtable"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "gemini.opening"
+        agent: "gemini_host"
+        task: "gemini_opening"
+        inputs:
+          topic: "@file:packets/v0-89-1-gemini-provider-roundtable-topic.md"
+        save_as: "gemini_turn"
+        write_to: "discussion/01-gemini-opening.md"
+      - id: "chatgpt.response"
+        agent: "chatgpt_guest"
+        task: "chatgpt_response"
+        inputs:
+          topic: "@file:packets/v0-89-1-gemini-provider-roundtable-topic.md"
+          gemini_turn: "{{gemini_turn}}"
+        save_as: "chatgpt_turn"
+        write_to: "discussion/02-chatgpt-response.md"
+      - id: "claude.response"
+        agent: "claude_guest"
+        task: "claude_response"
+        inputs:
+          topic: "@file:packets/v0-89-1-gemini-provider-roundtable-topic.md"
+          chatgpt_turn: "{{chatgpt_turn}}"
+        save_as: "claude_turn"
+        write_to: "discussion/03-claude-response.md"
+      - id: "roundtable.synthesis"
+        agent: "synthesis_host"
+        task: "synthesis"
+        inputs:
+          topic: "@file:packets/v0-89-1-gemini-provider-roundtable-topic.md"
+          gemini_turn: "{{gemini_turn}}"
+          chatgpt_turn: "{{chatgpt_turn}}"
+          claude_turn: "{{claude_turn}}"
+        save_as: "synthesis_turn"
+        write_to: "discussion/04-synthesis.md"

--- a/adl/tools/demo_v0891_gemini_provider_harmony_roundtable.sh
+++ b/adl/tools/demo_v0891_gemini_provider_harmony_roundtable.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/provider_demo_common.sh"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0891/gemini_provider_harmony_roundtable}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-89-1-gemini-provider-harmony-roundtable"
+PORT="${ADL_GEMINI_ROUNDTABLE_PORT:-0}"
+PORT_FILE="$OUT_DIR/provider_server.port"
+SERVER_LOG="$OUT_DIR/provider_server.log"
+EXAMPLE="adl/examples/v0-89-1-gemini-provider-harmony-roundtable.adl.yaml"
+GENERATED_EXAMPLE="$OUT_DIR/v0-89-1-gemini-provider-harmony-roundtable.runtime.adl.yaml"
+PACKET_DIR="$OUT_DIR/packet"
+PROVIDER_DIR="$OUT_DIR/provider_selection"
+ROUNDTABLE_DIR="$OUT_DIR/roundtable"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+TMP_PROVIDER_OUT="$OUT_DIR/provider_setup"
+
+sanitize_generated_artifacts() {
+  export ADL_SANITIZE_OUT_DIR="$OUT_DIR"
+  export ADL_SANITIZE_OUT_REAL
+  ADL_SANITIZE_OUT_REAL="$(cd "$OUT_DIR" && pwd -P)"
+  export ADL_SANITIZE_ROOT_DIR="$ROOT_DIR"
+  export ADL_SANITIZE_ROOT_REAL
+  ADL_SANITIZE_ROOT_REAL="$(cd "$ROOT_DIR" && pwd -P)"
+  find "$OUT_DIR" -type f \( -name '*.json' -o -name '*.md' -o -name '*.txt' -o -name '*.yaml' \) -print0 |
+    xargs -0 perl -0pi -e '
+      for my $name (qw(ADL_SANITIZE_OUT_REAL ADL_SANITIZE_OUT_DIR ADL_SANITIZE_ROOT_REAL ADL_SANITIZE_ROOT_DIR)) {
+        my $value = $ENV{$name} // "";
+        next if $value eq "";
+        my $replacement = $name =~ /ROOT/ ? "<repo_root>" : "<output_dir>";
+        s/\Q$value\E/$replacement/g;
+      }
+    '
+}
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STEP_OUT" "$PACKET_DIR" "$PROVIDER_DIR" "$ROUNDTABLE_DIR" "$TMP_PROVIDER_OUT"
+
+cat >"$PACKET_DIR/topic.md" <<'EOF'
+# Provider-fit question
+
+Why is Gemini the right participant for a bounded reviewer-facing packet, and
+what tradeoffs should still remain visible when ADL makes that choice?
+EOF
+
+cat >"$PACKET_DIR/packet_manifest.json" <<'EOF'
+{
+  "schema_version": "adl.provider_demo.packet_manifest.v1",
+  "packet_id": "gemini_provider_roundtable_packet.v1",
+  "task_class": "bounded_provider_fit_roundtable",
+  "reviewer_goal": "Inspect why Gemini was selected, how peer providers respond, and whether the final rationale remains calm and legible.",
+  "inputs": [
+    "topic.md"
+  ]
+}
+EOF
+
+cat >"$PROVIDER_DIR/candidate_providers.json" <<'EOF'
+{
+  "schema_version": "adl.provider_candidates.v1",
+  "candidates": [
+    {
+      "provider_family": "gemini",
+      "fit_for_packet": "high",
+      "cost_class": "economical",
+      "reviewability": "high",
+      "strength": "bounded structured synthesis"
+    },
+    {
+      "provider_family": "chatgpt",
+      "fit_for_packet": "high",
+      "cost_class": "premium",
+      "reviewability": "high",
+      "strength": "broader exploratory depth"
+    },
+    {
+      "provider_family": "claude",
+      "fit_for_packet": "high",
+      "cost_class": "premium",
+      "reviewability": "high",
+      "strength": "careful critique and governance caution"
+    }
+  ]
+}
+EOF
+
+cat >"$PROVIDER_DIR/provider_selection_manifest.json" <<'EOF'
+{
+  "schema_version": "adl.provider_selection_manifest.v1",
+  "demo_id": "v0.89.1.gemini_provider_harmony_roundtable",
+  "packet_id": "gemini_provider_roundtable_packet.v1",
+  "selected_provider_family": "gemini",
+  "selection_dimensions": [
+    "capability_fit",
+    "cost_class",
+    "reviewability",
+    "provider_harmony",
+    "bounded_scope_match"
+  ],
+  "selection_result": "Gemini is selected as the best-fit participant for this bounded reviewer-facing packet while peer provider tradeoffs remain visible."
+}
+EOF
+
+cat >"$PROVIDER_DIR/capability_and_cost_reasoning.md" <<'EOF'
+# Capability And Cost Reasoning
+
+This follow-on is not a benchmark contest.
+
+It is a bounded provider-fit packet where Gemini is selected because:
+
+- the task is reviewer-facing and structurally bounded
+- the expected artifact is synthesis-heavy rather than autonomy-heavy
+- the cost-class can honestly be described as economical rather than premium
+- the runtime can still preserve peer commentary and visible tradeoffs afterward
+
+ChatGPT and Claude remain respected alternatives.
+The value of this packet is that ADL can explain the selection calmly instead of
+smuggling it in as mere preference.
+EOF
+
+cat >"$PROVIDER_DIR/provider_fit_scorecard.json" <<'EOF'
+{
+  "schema_version": "adl.provider_fit_scorecard.v1",
+  "packet_id": "gemini_provider_roundtable_packet.v1",
+  "rows": [
+    {"provider_family": "gemini", "capability_fit": "high", "cost_class": "economical", "reviewability": "high", "selected": true},
+    {"provider_family": "chatgpt", "capability_fit": "high", "cost_class": "premium", "reviewability": "high", "selected": false},
+    {"provider_family": "claude", "capability_fit": "high", "cost_class": "premium", "reviewability": "high", "selected": false}
+  ]
+}
+EOF
+
+python3 "$ROOT_DIR/adl/tools/mock_gemini_provider_roundtable.py" \
+  "$PORT" \
+  --port-file "$PORT_FILE" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+cleanup() {
+  if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+
+python3 - "$EXAMPLE" "$GENERATED_EXAMPLE" "$PORT" "$PACKET_DIR/topic.md" <<'PY'
+import sys
+from pathlib import Path
+
+source, target, port, topic = sys.argv[1:5]
+text = Path(source).read_text(encoding="utf-8")
+text = text.replace("http://127.0.0.1:8793/gemini", f"http://127.0.0.1:{port}/gemini")
+text = text.replace("http://127.0.0.1:8793/chatgpt", f"http://127.0.0.1:{port}/chatgpt")
+text = text.replace("http://127.0.0.1:8793/claude", f"http://127.0.0.1:{port}/claude")
+text = text.replace("http://127.0.0.1:8793/synthesis", f"http://127.0.0.1:{port}/synthesis")
+text = text.replace("@file:packets/v0-89-1-gemini-provider-roundtable-topic.md", f"@file:{topic}")
+Path(target).write_text(text, encoding="utf-8")
+PY
+
+export GEMINI_API_KEY="${GEMINI_API_KEY:-demo-gemini-token}"
+export OPENAI_API_KEY="${OPENAI_API_KEY:-demo-openai-token}"
+export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-demo-anthropic-token}"
+
+cd "$ROOT_DIR"
+cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- provider setup gemini --out "$TMP_PROVIDER_OUT" --force >/dev/null
+
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+  cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+    "$GENERATED_EXAMPLE" \
+    --run \
+    --trace \
+    --allow-unsigned \
+    --out "$STEP_OUT" \
+    >"$OUT_DIR/run_log.txt" 2>&1
+
+cp "$STEP_OUT/discussion/01-gemini-opening.md" "$ROUNDTABLE_DIR/01-gemini-opening.md"
+cp "$STEP_OUT/discussion/02-chatgpt-response.md" "$ROUNDTABLE_DIR/02-chatgpt-response.md"
+cp "$STEP_OUT/discussion/03-claude-response.md" "$ROUNDTABLE_DIR/03-claude-response.md"
+cp "$STEP_OUT/discussion/04-synthesis.md" "$ROUNDTABLE_DIR/synthesis.md"
+
+cat >"$ROUNDTABLE_DIR/provider_participation_summary.json" <<'EOF'
+{
+  "schema_version": "adl.provider_participation_summary.v1",
+  "participants": [
+    {"provider_family": "gemini", "role": "selected primary participant"},
+    {"provider_family": "chatgpt", "role": "peer response"},
+    {"provider_family": "claude", "role": "governance caution"},
+    {"provider_family": "adl", "role": "selection and synthesis host"}
+  ]
+}
+EOF
+
+python3 - "$MANIFEST" "$RUN_ID" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = {
+    "schema_version": "adl.gemini_provider_harmony_follow_on_demo.v1",
+    "demo_id": "v0.89.1.gemini_provider_harmony_roundtable",
+    "title": "v0.89.1 Gemini provider harmony roundtable",
+    "execution_mode": "runtime_http_roundtable_demo",
+    "selected_provider_family": "gemini",
+    "claim": "ADL can host Gemini as a first-class bounded participant while recording a calm provider-fit and cost-class rationale plus visible peer tradeoffs.",
+    "artifacts": {
+        "topic": "packet/topic.md",
+        "packet_manifest": "packet/packet_manifest.json",
+        "candidate_providers": "provider_selection/candidate_providers.json",
+        "selection_manifest": "provider_selection/provider_selection_manifest.json",
+        "scorecard": "provider_selection/provider_fit_scorecard.json",
+        "reasoning": "provider_selection/capability_and_cost_reasoning.md",
+        "gemini_opening": "roundtable/01-gemini-opening.md",
+        "chatgpt_response": "roundtable/02-chatgpt-response.md",
+        "claude_response": "roundtable/03-claude-response.md",
+        "synthesis": "roundtable/synthesis.md",
+        "participation_summary": "roundtable/provider_participation_summary.json",
+        "provider_setup": "provider_setup/provider.adl.yaml",
+        "run_summary": f"runtime/runs/{sys.argv[2]}/run_summary.json",
+        "steps": f"runtime/runs/{sys.argv[2]}/steps.json",
+        "trace": f"runtime/runs/{sys.argv[2]}/logs/trace_v1.json"
+    }
+}
+Path(sys.argv[1]).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$README_OUT" <<EOF
+# v0.89.1 Demo - Gemini Provider Harmony Roundtable
+
+Canonical command:
+
+\`\`\`bash
+bash adl/tools/demo_v0891_gemini_provider_harmony_roundtable.sh
+\`\`\`
+
+What this proves:
+- ADL can explain why Gemini was selected for one bounded packet
+- Gemini can participate as a first-class participant without benchmark-war framing
+- ChatGPT and Claude can remain visible as peer voices instead of disappearing behind the routing choice
+
+Primary proof surfaces:
+- \`provider_selection/provider_selection_manifest.json\`
+- \`provider_selection/capability_and_cost_reasoning.md\`
+- \`roundtable/synthesis.md\`
+- \`roundtable/provider_participation_summary.json\`
+- \`runtime/runs/$RUN_ID/run_summary.json\`
+EOF
+
+sanitize_generated_artifacts
+
+echo "Gemini provider harmony roundtable proof surface under the output directory:"
+echo "  provider_selection/provider_selection_manifest.json"
+echo "  provider_selection/capability_and_cost_reasoning.md"
+echo "  roundtable/synthesis.md"
+echo "  roundtable/provider_participation_summary.json"
+echo "  runtime/runs/$RUN_ID/run_summary.json"
+echo "  runtime/runs/$RUN_ID/logs/trace_v1.json"

--- a/adl/tools/mock_gemini_provider_roundtable.py
+++ b/adl/tools/mock_gemini_provider_roundtable.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+def _collapse(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _extract_between(prompt: str, label: str) -> str:
+    marker = f"{label}:"
+    if marker not in prompt:
+        return ""
+    return _collapse(prompt.split(marker, 1)[1].strip())
+
+
+def build_output(route: str, prompt: str) -> str:
+    topic = _extract_between(prompt, "TOPIC")
+    if route == "gemini":
+        return (
+            "# Gemini Opening\n\n"
+            "Gemini argues that this packet fits it well because the task is bounded, "
+            "reviewer-facing, and synthesis-heavy rather than repo-autonomy-heavy. "
+            "It explicitly avoids claiming a universal win and frames itself as the "
+            f"right participant for this question: {topic}"
+        )
+    if route == "chatgpt":
+        return (
+            "# ChatGPT Response\n\n"
+            "ChatGPT agrees that Gemini is a sensible choice for a bounded, legible "
+            "packet and says the selection rationale is already clearer than simple "
+            "provider preference. It keeps one tradeoff visible: premium models may "
+            "still be the better fit when the task demands broader exploratory depth."
+        )
+    if route == "claude":
+        return (
+            "# Claude Response\n\n"
+            "Claude adds a governance caution: a calm provider-fit story only works if "
+            "the runtime keeps the boundaries visible and does not use hospitality to "
+            "conceal missing affordances. That caution strengthens, rather than weakens, "
+            "the case for explicit Gemini selection artifacts."
+        )
+    if route == "synthesis":
+        return (
+            "# Gemini Roundtable Synthesis\n\n"
+            "## Findings\n"
+            "- Gemini fits this packet because it is bounded, structured, and reviewer-facing.\n"
+            "- ChatGPT keeps the capability-depth tradeoff visible instead of flattening it.\n"
+            "- Claude adds the governance warning that makes the provider-choice story honest.\n\n"
+            "## Why Gemini Fits This Packet\n"
+            "Gemini is selected here because the packet rewards bounded synthesis, legibility, "
+            "and an economical cost-class rather than maximal open-ended reasoning.\n\n"
+            "## Tradeoffs That Remain Visible\n"
+            "ADL should still say plainly that premium providers may remain the better fit for "
+            "broader exploratory work, and that provider hospitality is not a license to blur "
+            "real capability differences.\n\n"
+            "## Acknowledgement\n"
+            "This packet builds on earlier bounded Gemini and provider-harmony work instead of "
+            "pretending to discover the framing from scratch."
+        )
+    return "# Unknown\n\nUnsupported route."
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self._json(200, {"ok": True})
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        route = self.path.lstrip("/")
+        if route not in {"gemini", "chatgpt", "claude", "synthesis"}:
+            self._json(404, {"error": "unknown route"})
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        prompt = payload.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            self._json(400, {"error": "prompt must be a non-empty string"})
+            return
+        self._json(200, {"output": build_output(route, prompt)})
+
+    def log_message(self, fmt: str, *args) -> None:
+        return
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("port", nargs="?", type=int, default=8793)
+    parser.add_argument("--port-file", type=Path)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    if args.port_file:
+        args.port_file.parent.mkdir(parents=True, exist_ok=True)
+        args.port_file.write_text(f"{server.server_address[1]}\n", encoding="utf-8")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_demo_v0891_gemini_provider_harmony_roundtable.sh
+++ b/adl/tools/test_demo_v0891_gemini_provider_harmony_roundtable.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+RUN_ROOT="$OUT_DIR/runtime/runs/v0-89-1-gemini-provider-harmony-roundtable"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0891_gemini_provider_harmony_roundtable.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/README.md" \
+  "$OUT_DIR/packet/topic.md" \
+  "$OUT_DIR/packet/packet_manifest.json" \
+  "$OUT_DIR/provider_selection/candidate_providers.json" \
+  "$OUT_DIR/provider_selection/provider_selection_manifest.json" \
+  "$OUT_DIR/provider_selection/provider_fit_scorecard.json" \
+  "$OUT_DIR/provider_selection/capability_and_cost_reasoning.md" \
+  "$OUT_DIR/roundtable/01-gemini-opening.md" \
+  "$OUT_DIR/roundtable/02-chatgpt-response.md" \
+  "$OUT_DIR/roundtable/03-claude-response.md" \
+  "$OUT_DIR/roundtable/synthesis.md" \
+  "$OUT_DIR/roundtable/provider_participation_summary.json" \
+  "$OUT_DIR/provider_setup/provider.adl.yaml" \
+  "$RUN_ROOT/run_summary.json" \
+  "$RUN_ROOT/steps.json" \
+  "$RUN_ROOT/logs/trace_v1.json"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+python3 - "$OUT_DIR/demo_manifest.json" "$OUT_DIR/provider_selection/provider_selection_manifest.json" "$OUT_DIR/provider_selection/provider_fit_scorecard.json" <<'PY'
+import json
+import sys
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+selection = json.load(open(sys.argv[2], encoding="utf-8"))
+scorecard = json.load(open(sys.argv[3], encoding="utf-8"))
+assert manifest["schema_version"] == "adl.gemini_provider_harmony_follow_on_demo.v1"
+assert manifest["selected_provider_family"] == "gemini"
+assert selection["selected_provider_family"] == "gemini"
+selected_rows = [row for row in scorecard["rows"] if row["selected"]]
+assert len(selected_rows) == 1 and selected_rows[0]["provider_family"] == "gemini"
+PY
+
+grep -Fq 'economical' "$OUT_DIR/provider_selection/candidate_providers.json" || {
+  echo "assertion failed: candidate providers missing cost-class rationale" >&2
+  exit 1
+}
+
+grep -Fq '## Acknowledgement' "$OUT_DIR/roundtable/synthesis.md" || {
+  echo "assertion failed: synthesis missing acknowledgement section" >&2
+  exit 1
+}
+
+grep -Fq 'first-class' "$OUT_DIR/README.md" || {
+  echo "assertion failed: README missing expected participant framing" >&2
+  exit 1
+}
+
+if grep -R -E '/Users/|/private/tmp|/tmp/' "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: absolute path leaked into generated artifacts" >&2
+  exit 1
+fi
+
+echo "demo_v0891_gemini_provider_harmony_roundtable: ok"

--- a/demos/v0.89.1/gemini_provider_harmony_roundtable_demo.md
+++ b/demos/v0.89.1/gemini_provider_harmony_roundtable_demo.md
@@ -1,0 +1,46 @@
+# Gemini Provider Harmony Roundtable Demo
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v0891_gemini_provider_harmony_roundtable.sh
+```
+
+## What It Does
+
+This `v0.89.1` follow-on deepens the earlier bounded Gemini demo into a calmer
+provider-harmony roundtable packet.
+
+ADL:
+
+- prepares one bounded provider-fit question
+- records why Gemini is selected for that packet
+- keeps ChatGPT and Claude visible as peer voices
+- writes one synthesis artifact that keeps the tradeoffs legible
+
+## Why It Matters
+
+The earlier `v0.89` Gemini slice proved that Gemini could participate in a
+bounded workflow.
+
+This follow-on proves something richer:
+
+- provider choice can be explained instead of hand-waved
+- Gemini can be treated as a welcomed first-class participant
+- peer-provider tradeoffs can stay visible without collapsing into benchmark war
+
+## Primary Proof Surfaces
+
+- `provider_selection/provider_selection_manifest.json`
+- `provider_selection/provider_fit_scorecard.json`
+- `provider_selection/capability_and_cost_reasoning.md`
+- `roundtable/synthesis.md`
+- `roundtable/provider_participation_summary.json`
+- `runtime/runs/v0-89-1-gemini-provider-harmony-roundtable/run_summary.json`
+
+## Notes
+
+- This demo explicitly builds on the earlier bounded Gemini and provider-harmony
+  groundwork.
+- It is still a bounded packet, not a general economics or provider market
+  system.


### PR DESCRIPTION
Closes #1948

## Summary
Implemented a deeper `v0.89.1` Gemini provider-harmony follow-on demo that turns
provider choice into a reviewer-facing roundtable packet instead of a flat
single-provider proof. The new surface keeps Gemini as the selected lead
participant while making ChatGPT and Claude visible as bounded peers, and it
emits artifact surfaces that explain capability, reviewability, and cost-class
reasoning without drifting into benchmark theater.

## Artifacts
- `adl/examples/v0-89-1-gemini-provider-harmony-roundtable.adl.yaml`
- `adl/tools/mock_gemini_provider_roundtable.py`
- `adl/tools/demo_v0891_gemini_provider_harmony_roundtable.sh`
- `adl/tools/test_demo_v0891_gemini_provider_harmony_roundtable.sh`
- `demos/v0.89.1/gemini_provider_harmony_roundtable_demo.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/demo_v0891_gemini_provider_harmony_roundtable.sh adl/tools/test_demo_v0891_gemini_provider_harmony_roundtable.sh` verified shell syntax for the new demo and proving test
  - `python3 -m py_compile adl/tools/mock_gemini_provider_roundtable.py` verified the mock provider helper is syntactically valid
  - `bash adl/tools/test_demo_v0891_gemini_provider_harmony_roundtable.sh` ran the full bounded demo and validated the artifact packet
  - `git diff --check` verified the tracked patch is whitespace-clean
- Results: PASS; the new demo runs end to end against the deterministic mock provider and emits the required reviewer-facing artifacts

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1948__v0-89-1-demo-build-deeper-gemini-provider-harmony-and-economics-follow-on-demo/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1948__v0-89-1-demo-build-deeper-gemini-provider-harmony-and-economics-follow-on-demo/sor.md
- Idempotency-Key: v0-89-1-demo-build-deeper-gemini-provider-harmony-and-economics-follow-on-demo-adl-v0-89-1-tasks-issue-1948-v0-89-1-demo-build-deeper-gemini-provider-harmony-and-economics-follow-on-demo-sip-md-adl-v0-89-1-tasks-issue-1948-v0-89-1-demo-build-deeper-gemini-provider-harmony-and-economics-follow-on-demo-sor-md