### PR TITLE
[v0.89.1][demo] Build deeper deep-agents comparative wave follow-on demo

### DIFF
--- a/adl/examples/v0-89-1-deep-agents-comparative-governance-wave.adl.yaml
+++ b/adl/examples/v0-89-1-deep-agents-comparative-governance-wave.adl.yaml
@@ -1,0 +1,138 @@
+version: "0.5"
+
+providers:
+  chatgpt_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8794/chatgpt"
+      timeout_secs: 10
+  claude_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8794/claude"
+      timeout_secs: 10
+  gemini_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8794/gemini"
+      timeout_secs: 10
+  synthesis_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8794/synthesis"
+      timeout_secs: 10
+
+agents:
+  chatgpt_builder:
+    provider: "chatgpt_local"
+    model: "gpt-5.4-demo"
+  claude_critic:
+    provider: "claude_local"
+    model: "claude-haiku-demo"
+  gemini_analyst:
+    provider: "gemini_local"
+    model: "gemini-2.0-flash-demo"
+  synthesis_editor:
+    provider: "synthesis_local"
+    model: "adl-synthesis-demo"
+
+tasks:
+  chatgpt_position:
+    prompt:
+      user: |
+        DEMO_ID: v0-89-1-deep-agents-comparative-governance-wave
+        TURN_ID: 01
+        SPEAKER: ChatGPT
+        ROLE: Runtime Builder
+        TOPIC: Compare ADL's reviewer-facing runtime surfaces with looser filesystem-first deep-agent demos.
+        INSTRUCTIONS: Make the strongest bounded case for ADL's reviewability and trace legibility without claiming universal superiority.
+  claude_position:
+    prompt:
+      user: |
+        DEMO_ID: v0-89-1-deep-agents-comparative-governance-wave
+        TURN_ID: 02
+        SPEAKER: Claude
+        ROLE: Governance Critic
+        TOPIC: Compare ADL's reviewer-facing runtime surfaces with looser filesystem-first deep-agent demos.
+        PREVIOUS_TURN_START
+        {{turn_01}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Add one real caution about coordination cost or over-ceremonial process and keep the disagreement visible.
+  gemini_position:
+    prompt:
+      user: |
+        DEMO_ID: v0-89-1-deep-agents-comparative-governance-wave
+        TURN_ID: 03
+        SPEAKER: Gemini
+        ROLE: Comparative Analyst
+        TOPIC: Compare ADL's reviewer-facing runtime surfaces with looser filesystem-first deep-agent demos.
+        PREVIOUS_TURN_START
+        {{turn_02}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Name where ADL is clearly stronger on governance or review surfaces and where looser packet demos still feel faster or more playful.
+  synthesis_packet:
+    prompt:
+      user: |
+        DEMO_ID: v0-89-1-deep-agents-comparative-governance-wave
+        TURN_ID: 04
+        SPEAKER: ADL
+        ROLE: Comparative Editor
+        PREVIOUS_TURN_START
+        {{turn_01}}
+
+        {{turn_02}}
+
+        {{turn_03}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Produce a findings-first synthesis with explicit sections for Findings, Agreement, Disagreement, Governance Delta, Operator Visibility, and Positioning Takeaway.
+
+run:
+  name: "v0-89-1-deep-agents-comparative-governance-wave"
+  workflow:
+    kind: "sequential"
+    steps:
+      - id: "deep_agents.chatgpt.position"
+        agent: "chatgpt_builder"
+        task: "chatgpt_position"
+        conversation:
+          id: "turn_01"
+          speaker: "ChatGPT"
+          sequence: 1
+          thread_id: "deep_agents_governance_wave"
+        save_as: "turn_01"
+        write_to: "discussion/01-chatgpt-position.md"
+      - id: "deep_agents.claude.position"
+        agent: "claude_critic"
+        task: "claude_position"
+        conversation:
+          id: "turn_02"
+          speaker: "Claude"
+          sequence: 2
+          thread_id: "deep_agents_governance_wave"
+          responds_to: "turn_01"
+        inputs:
+          turn_01: "@state:turn_01"
+        save_as: "turn_02"
+        write_to: "discussion/02-claude-position.md"
+      - id: "deep_agents.gemini.position"
+        agent: "gemini_analyst"
+        task: "gemini_position"
+        conversation:
+          id: "turn_03"
+          speaker: "Gemini"
+          sequence: 3
+          thread_id: "deep_agents_governance_wave"
+          responds_to: "turn_02"
+        inputs:
+          turn_02: "@state:turn_02"
+        save_as: "turn_03"
+        write_to: "discussion/03-gemini-position.md"
+      - id: "deep_agents.synthesis"
+        agent: "synthesis_editor"
+        task: "synthesis_packet"
+        inputs:
+          turn_01: "@state:turn_01"
+          turn_02: "@state:turn_02"
+          turn_03: "@state:turn_03"
+        save_as: "comparative_synthesis"
+        write_to: "discussion/04-synthesis.md"

--- a/adl/tools/demo_v0891_deep_agents_comparative_wave.sh
+++ b/adl/tools/demo_v0891_deep_agents_comparative_wave.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/provider_demo_common.sh"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0891/deep_agents_comparative_wave}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-89-1-deep-agents-comparative-governance-wave"
+PORT="${ADL_DEEP_AGENTS_FOLLOW_ON_PORT:-0}"
+PORT_FILE="$OUT_DIR/provider_server.port"
+SERVER_LOG="$OUT_DIR/provider_server.log"
+EXAMPLE="adl/examples/v0-89-1-deep-agents-comparative-governance-wave.adl.yaml"
+GENERATED_EXAMPLE="$OUT_DIR/v0-89-1-deep-agents-comparative-governance-wave.runtime.adl.yaml"
+WAVE_DIR="$OUT_DIR/comparative_wave"
+POSITIONS_DIR="$WAVE_DIR/positions"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+README_OUT="$OUT_DIR/README.md"
+
+sanitize_generated_artifacts() {
+  export ADL_SANITIZE_OUT_DIR="$OUT_DIR"
+  export ADL_SANITIZE_OUT_REAL
+  ADL_SANITIZE_OUT_REAL="$(cd "$OUT_DIR" && pwd -P)"
+  export ADL_SANITIZE_ROOT_DIR="$ROOT_DIR"
+  export ADL_SANITIZE_ROOT_REAL
+  ADL_SANITIZE_ROOT_REAL="$(cd "$ROOT_DIR" && pwd -P)"
+  find "$OUT_DIR" -type f \( -name '*.json' -o -name '*.md' -o -name '*.txt' -o -name '*.yaml' \) -print0 |
+    xargs -0 perl -0pi -e '
+      for my $name (qw(ADL_SANITIZE_OUT_REAL ADL_SANITIZE_OUT_DIR ADL_SANITIZE_ROOT_REAL ADL_SANITIZE_ROOT_DIR)) {
+        my $value = $ENV{$name} // "";
+        next if $value eq "";
+        my $replacement = $name =~ /ROOT/ ? "<repo_root>" : "<output_dir>";
+        s/\Q$value\E/$replacement/g;
+      }
+    '
+}
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STEP_OUT" "$WAVE_DIR" "$POSITIONS_DIR"
+
+python3 "$ROOT_DIR/adl/tools/mock_deep_agents_follow_on_provider.py" \
+  "$PORT" \
+  --port-file "$PORT_FILE" \
+  >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+cleanup() {
+  if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+
+python3 - "$EXAMPLE" "$GENERATED_EXAMPLE" "$PORT" <<'PY'
+import sys
+from pathlib import Path
+
+source, target, port = sys.argv[1:4]
+text = Path(source).read_text(encoding="utf-8")
+text = text.replace("http://127.0.0.1:8794/chatgpt", f"http://127.0.0.1:{port}/chatgpt")
+text = text.replace("http://127.0.0.1:8794/claude", f"http://127.0.0.1:{port}/claude")
+text = text.replace("http://127.0.0.1:8794/gemini", f"http://127.0.0.1:{port}/gemini")
+text = text.replace("http://127.0.0.1:8794/synthesis", f"http://127.0.0.1:{port}/synthesis")
+Path(target).write_text(text, encoding="utf-8")
+PY
+
+python3 - "$PORT" <<'PY'
+import json
+import sys
+import time
+import urllib.request
+
+port = int(sys.argv[1])
+url = f"http://127.0.0.1:{port}/health"
+deadline = time.time() + 10.0
+last_error = None
+while time.time() < deadline:
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as resp:
+            payload = json.load(resp)
+        if payload.get("ok") is True:
+            raise SystemExit(0)
+    except Exception as exc:
+        last_error = exc
+        time.sleep(0.1)
+raise SystemExit(f"provider shim failed health check: {last_error}")
+PY
+
+cd "$ROOT_DIR"
+
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+  cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+    "$GENERATED_EXAMPLE" \
+    --run \
+    --trace \
+    --allow-unsigned \
+    --out "$STEP_OUT" \
+    >"$OUT_DIR/run_log.txt" 2>&1
+
+cp "$STEP_OUT/discussion/01-chatgpt-position.md" "$POSITIONS_DIR/chatgpt.md"
+cp "$STEP_OUT/discussion/02-claude-position.md" "$POSITIONS_DIR/claude.md"
+cp "$STEP_OUT/discussion/03-gemini-position.md" "$POSITIONS_DIR/gemini.md"
+cp "$STEP_OUT/discussion/04-synthesis.md" "$WAVE_DIR/synthesis.md"
+
+cat >"$WAVE_DIR/comparison_claims.md" <<'EOF'
+# Comparison Claims
+
+This packet deepens the bounded `v0.88` comparative proof rather than replacing it.
+
+The comparative claim is intentionally narrow:
+
+- ADL makes multi-agent behavior more reviewable and governable
+- ADL gives the reviewer clearer packet, trace, and operator surfaces
+- the filesystem-first style still retains some appeal for fast exploratory work
+
+This is not a benchmark ladder or winner/loser packet.
+EOF
+
+cat >"$WAVE_DIR/reviewer_checklist.md" <<'EOF'
+# Reviewer Checklist
+
+Review this packet in order:
+
+1. `comparative_wave/comparison_claims.md`
+2. `comparative_wave/adl_surface_map.json`
+3. `comparative_wave/filesystem_surface_map.json`
+4. `comparative_wave/positions/chatgpt.md`
+5. `comparative_wave/positions/claude.md`
+6. `comparative_wave/positions/gemini.md`
+7. `comparative_wave/synthesis.md`
+8. `comparative_wave/public_positioning_summary.md`
+9. `runtime/runs/v0-89-1-deep-agents-comparative-governance-wave/run_summary.json`
+
+What to verify:
+
+- the claim is comparative, bounded, and respectful
+- governance and review surfaces are visible rather than implied
+- operator visibility is explicit enough to explain accountability quickly
+EOF
+
+cat >"$WAVE_DIR/adl_surface_map.json" <<'EOF'
+{
+  "schema_version": "adl.deep_agents_surface_map.v1",
+  "surface_kind": "adl_runtime_reviewable",
+  "surfaces": [
+    "packet manifest and comparison claims",
+    "explicit reviewer checklist",
+    "position-by-position provider outputs",
+    "runtime trace and run summary",
+    "operator visibility and governance summary"
+  ]
+}
+EOF
+
+cat >"$WAVE_DIR/filesystem_surface_map.json" <<'EOF'
+{
+  "schema_version": "adl.deep_agents_surface_map.v1",
+  "surface_kind": "filesystem_first_reference",
+  "surfaces": [
+    "visible files and role outputs",
+    "lighter-weight packet structure",
+    "weaker reviewer guidance",
+    "less explicit provenance and governance surfacing"
+  ]
+}
+EOF
+
+cat >"$WAVE_DIR/operator_visibility.md" <<'EOF'
+# Operator Visibility
+
+In this comparative packet, the operator role is legible because ADL makes the
+review surface explicit:
+
+- the packet has a declared comparative claim
+- the reviewer checklist states what should be verified
+- the runtime emits trace and run-summary artifacts
+- the synthesis names governance and coordination cost directly
+
+That is the difference this packet is trying to show. The operator is not just
+the person who ran the demo; the operator is part of a visible review contract.
+EOF
+
+cat >"$WAVE_DIR/governance_snapshot.json" <<'EOF'
+{
+  "schema_version": "adl.deep_agents_governance_snapshot.v1",
+  "claims": [
+    "review surfaces are explicit",
+    "operator obligations are visible",
+    "trace-backed packet lineage exists",
+    "comparative language remains bounded"
+  ],
+  "non_goals": [
+    "benchmark ranking",
+    "winner-loser scorecard",
+    "claiming universal superiority"
+  ]
+}
+EOF
+
+cat >"$WAVE_DIR/public_positioning_summary.md" <<'EOF'
+# Public Positioning Summary
+
+The right public story is not that ADL makes louder deep-agent demos.
+
+The right public story is that ADL makes multi-agent behavior easier to inspect:
+
+- stronger reviewer orientation
+- clearer governance and packet boundaries
+- more explicit operator role visibility
+- more legible lineage from packet to trace
+
+That is a calmer and more defensible claim than "our agents are smarter."
+EOF
+
+python3 - "$MANIFEST" "$RUN_ID" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = {
+    "schema_version": "adl.deep_agents_comparative_wave_follow_on_demo.v1",
+    "demo_id": "v0.89.1.deep_agents_comparative_governance_wave",
+    "title": "v0.89.1 deep-agents comparative governance wave demo",
+    "execution_mode": "runtime_http_compatibility_demo",
+    "claim": "ADL can host a bounded comparative wave whose runtime, governance, and operator surfaces make the review difference legible in minutes.",
+    "artifacts": {
+        "comparison_claims": "comparative_wave/comparison_claims.md",
+        "reviewer_checklist": "comparative_wave/reviewer_checklist.md",
+        "adl_surface_map": "comparative_wave/adl_surface_map.json",
+        "filesystem_surface_map": "comparative_wave/filesystem_surface_map.json",
+        "operator_visibility": "comparative_wave/operator_visibility.md",
+        "governance_snapshot": "comparative_wave/governance_snapshot.json",
+        "public_positioning_summary": "comparative_wave/public_positioning_summary.md",
+        "chatgpt_position": "comparative_wave/positions/chatgpt.md",
+        "claude_position": "comparative_wave/positions/claude.md",
+        "gemini_position": "comparative_wave/positions/gemini.md",
+        "synthesis": "comparative_wave/synthesis.md",
+        "run_summary": f"runtime/runs/{sys.argv[2]}/run_summary.json",
+        "steps": f"runtime/runs/{sys.argv[2]}/steps.json",
+        "trace": f"runtime/runs/{sys.argv[2]}/logs/trace_v1.json"
+    }
+}
+Path(sys.argv[1]).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$README_OUT" <<EOF
+# v0.89.1 Demo - Deep-Agents Comparative Governance Wave
+
+Canonical command:
+
+\`\`\`bash
+bash adl/tools/demo_v0891_deep_agents_comparative_wave.sh
+\`\`\`
+
+Primary proof surfaces:
+- \`comparative_wave/comparison_claims.md\`
+- \`comparative_wave/reviewer_checklist.md\`
+- \`comparative_wave/adl_surface_map.json\`
+- \`comparative_wave/filesystem_surface_map.json\`
+- \`comparative_wave/operator_visibility.md\`
+- \`comparative_wave/public_positioning_summary.md\`
+- \`comparative_wave/synthesis.md\`
+- \`runtime/runs/$RUN_ID/run_summary.json\`
+
+What this proves:
+- ADL can deepen the earlier bounded comparative row without turning into a benchmark stunt
+- the difference is expressed through governance, reviewer, and operator surfaces
+- the final packet stays calm, evidence-first, and publicly usable
+EOF
+
+sanitize_generated_artifacts
+
+echo "Deep-agents comparative governance proof surface under the output directory:"
+echo "  comparative_wave/comparison_claims.md"
+echo "  comparative_wave/reviewer_checklist.md"
+echo "  comparative_wave/adl_surface_map.json"
+echo "  comparative_wave/filesystem_surface_map.json"
+echo "  comparative_wave/operator_visibility.md"
+echo "  comparative_wave/public_positioning_summary.md"
+echo "  comparative_wave/synthesis.md"
+echo "  runtime/runs/$RUN_ID/run_summary.json"

--- a/adl/tools/mock_deep_agents_follow_on_provider.py
+++ b/adl/tools/mock_deep_agents_follow_on_provider.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def build_output(agent: str) -> str:
+    if agent == "chatgpt":
+        return (
+            "# Turn 1 - ChatGPT\n\n"
+            "ADL's comparative strength is not that it makes more dramatic files. "
+            "It makes the same multi-agent packet easier to inspect because the "
+            "review surface, trace, and packet structure stay explicit. That is a "
+            "better story for a serious reviewer than a folder full of outputs with "
+            "implied orchestration."
+        )
+    if agent == "claude":
+        return (
+            "# Turn 2 - Claude\n\n"
+            "That strength is real, but ADL should admit the cost. Additional "
+            "review surfaces and governance signals can make the flow feel more "
+            "ceremonial. A filesystem-first deep-agent demo can still feel faster "
+            "and more exploratory when the audience values improvisation over audit."
+        )
+    if agent == "gemini":
+        return (
+            "# Turn 3 - Gemini\n\n"
+            "The comparison gets sharper when framed around operator trust. ADL is "
+            "clearly stronger when the reviewer needs stop conditions, provenance, "
+            "and role visibility. The looser packet style still has appeal for quick "
+            "creative iteration, but it gives the reviewer fewer structured handles."
+        )
+    if agent == "synthesis":
+        return (
+            "# Deep-Agents Comparative Governance Wave\n\n"
+            "## Findings\n"
+            "- ADL makes multi-agent behavior easier to inspect because the packet, trace, and review surfaces stay linked.\n"
+            "- Filesystem-first demos remain attractive when speed and improvisation matter more than auditability.\n"
+            "- The honest comparative claim is about governance and reviewability, not who wins a benchmark.\n\n"
+            "## Agreement\n"
+            "- visible intermediate artifacts help reviewers\n"
+            "- bounded claims are stronger than theatrical claims\n\n"
+            "## Disagreement\n"
+            "- whether stronger governance is worth the added coordination surface\n\n"
+            "## Governance Delta\n"
+            "ADL exposes packet shape, reviewer checkpoints, and trace lineage as explicit review surfaces rather than leaving them implicit.\n\n"
+            "## Operator Visibility\n"
+            "The operator role is easier to describe because ADL makes packet boundaries and review obligations visible instead of burying them inside the process.\n\n"
+            "## Positioning Takeaway\n"
+            "ADL should present itself as the calm, inspectable runtime for serious multi-agent review work, not as the loudest deep-agent theater."
+        )
+    return "# Unknown\n\nUnsupported route."
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self._json(200, {"ok": True})
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        agent = self.path.lstrip("/")
+        if agent not in {"chatgpt", "claude", "gemini", "synthesis"}:
+            self._json(404, {"error": "unknown route"})
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        prompt = payload.get("prompt", "")
+        if not isinstance(prompt, str) or not prompt.strip():
+            self._json(400, {"error": "prompt must be a non-empty string"})
+            return
+        self._json(200, {"output": build_output(agent)})
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("port", nargs="?", type=int, default=8794)
+    parser.add_argument("--port-file", type=Path)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    if args.port_file:
+        args.port_file.parent.mkdir(parents=True, exist_ok=True)
+        args.port_file.write_text(f"{server.server_address[1]}\n", encoding="utf-8")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_demo_v0891_deep_agents_comparative_wave.sh
+++ b/adl/tools/test_demo_v0891_deep_agents_comparative_wave.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+RUN_ROOT="$OUT_DIR/runtime/runs/v0-89-1-deep-agents-comparative-governance-wave"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0891_deep_agents_comparative_wave.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/README.md" \
+  "$OUT_DIR/comparative_wave/comparison_claims.md" \
+  "$OUT_DIR/comparative_wave/reviewer_checklist.md" \
+  "$OUT_DIR/comparative_wave/adl_surface_map.json" \
+  "$OUT_DIR/comparative_wave/filesystem_surface_map.json" \
+  "$OUT_DIR/comparative_wave/operator_visibility.md" \
+  "$OUT_DIR/comparative_wave/governance_snapshot.json" \
+  "$OUT_DIR/comparative_wave/public_positioning_summary.md" \
+  "$OUT_DIR/comparative_wave/positions/chatgpt.md" \
+  "$OUT_DIR/comparative_wave/positions/claude.md" \
+  "$OUT_DIR/comparative_wave/positions/gemini.md" \
+  "$OUT_DIR/comparative_wave/synthesis.md" \
+  "$RUN_ROOT/run_summary.json" \
+  "$RUN_ROOT/steps.json" \
+  "$RUN_ROOT/logs/trace_v1.json"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+python3 - "$OUT_DIR/demo_manifest.json" "$OUT_DIR/comparative_wave/adl_surface_map.json" "$OUT_DIR/comparative_wave/filesystem_surface_map.json" "$OUT_DIR/comparative_wave/governance_snapshot.json" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+adl_map = json.load(open(sys.argv[2], encoding="utf-8"))
+filesystem_map = json.load(open(sys.argv[3], encoding="utf-8"))
+governance = json.load(open(sys.argv[4], encoding="utf-8"))
+
+assert manifest["schema_version"] == "adl.deep_agents_comparative_wave_follow_on_demo.v1"
+assert manifest["demo_id"] == "v0.89.1.deep_agents_comparative_governance_wave"
+assert adl_map["schema_version"] == "adl.deep_agents_surface_map.v1"
+assert filesystem_map["schema_version"] == "adl.deep_agents_surface_map.v1"
+assert governance["schema_version"] == "adl.deep_agents_governance_snapshot.v1"
+assert "review surfaces are explicit" in governance["claims"]
+PY
+
+grep -Fq 'bounded `v0.88` comparative proof' "$OUT_DIR/comparative_wave/comparison_claims.md" || {
+  echo "assertion failed: comparison claims missing predecessor acknowledgement" >&2
+  exit 1
+}
+
+grep -Fq '## Governance Delta' "$OUT_DIR/comparative_wave/synthesis.md" || {
+  echo "assertion failed: synthesis missing governance delta section" >&2
+  exit 1
+}
+
+grep -Fq 'operator is part of a visible review contract' "$OUT_DIR/comparative_wave/operator_visibility.md" || {
+  echo "assertion failed: operator visibility surface missing core claim" >&2
+  exit 1
+}
+
+if grep -R -E '/Users/|/private/tmp|/tmp/' "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: absolute path leaked into generated artifacts" >&2
+  exit 1
+fi
+
+echo "demo_v0891_deep_agents_comparative_wave: ok"

--- a/demos/v0.89.1/deep_agents_comparative_wave_follow_on_demo.md
+++ b/demos/v0.89.1/deep_agents_comparative_wave_follow_on_demo.md
@@ -1,0 +1,45 @@
+# Deep-Agents Comparative Governance Wave Demo
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v0891_deep_agents_comparative_wave.sh
+```
+
+## What It Does
+
+This `v0.89.1` follow-on deepens the earlier bounded comparative row into a
+clearer public-positioning and reviewer packet.
+
+ADL:
+
+- keeps ChatGPT, Claude, and Gemini as explicit comparative voices
+- preserves one real disagreement about governance cost
+- emits review maps instead of a generic scorecard
+- makes the operator role and governance delta visible in the final packet
+
+## Why It Matters
+
+The `v0.88` comparative row proved a careful bounded claim.
+
+This follow-on proves a stronger one:
+
+- the ADL difference is legible through review and governance surfaces
+- the operator role is visible enough to explain accountability
+- the comparative packet stays respectful and evidence-first
+
+## Primary Proof Surfaces
+
+- `comparative_wave/comparison_claims.md`
+- `comparative_wave/reviewer_checklist.md`
+- `comparative_wave/adl_surface_map.json`
+- `comparative_wave/filesystem_surface_map.json`
+- `comparative_wave/operator_visibility.md`
+- `comparative_wave/public_positioning_summary.md`
+- `comparative_wave/synthesis.md`
+- `runtime/runs/v0-89-1-deep-agents-comparative-governance-wave/run_summary.json`
+
+## Notes
+
+- This demo explicitly builds on the bounded `v0.88` comparative proof row.
+- It is not a benchmark contest or winner-loser packet.


### PR DESCRIPTION
Closes #1949

## Summary
Implemented a deeper `v0.89.1` deep-agents comparative follow-on demo that
keeps the calmer bounded comparative claim from `v0.88` but adds stronger
governance, operator-visibility, and reviewer-surface artifacts. The new packet
stays respectful and evidence-first while making the ADL difference legible in
minutes through surface maps, a reviewer checklist, and a findings-first
synthesis.

## Artifacts
- `adl/examples/v0-89-1-deep-agents-comparative-governance-wave.adl.yaml`
- `adl/tools/mock_deep_agents_follow_on_provider.py`
- `adl/tools/demo_v0891_deep_agents_comparative_wave.sh`
- `adl/tools/test_demo_v0891_deep_agents_comparative_wave.sh`
- `demos/v0.89.1/deep_agents_comparative_wave_follow_on_demo.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/demo_v0891_deep_agents_comparative_wave.sh adl/tools/test_demo_v0891_deep_agents_comparative_wave.sh` verified shell syntax for the new follow-on demo and proving test
  - `python3 -m py_compile adl/tools/mock_deep_agents_follow_on_provider.py` verified the mock provider helper is syntactically valid
  - `bash adl/tools/test_demo_v0891_deep_agents_comparative_wave.sh` ran the full bounded demo and validated the richer comparative packet
  - `git diff --check` verified the tracked patch is whitespace-clean
- Results: PASS; the new comparative governance wave runs end to end and emits the required reviewer-facing artifact set

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1949__v0-89-1-demo-build-deeper-deep-agents-comparative-wave-follow-on-demo/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1949__v0-89-1-demo-build-deeper-deep-agents-comparative-wave-follow-on-demo/sor.md
- Idempotency-Key: v0-89-1-demo-build-deeper-deep-agents-comparative-wave-follow-on-demo-adl-v0-89-1-tasks-issue-1949-v0-89-1-demo-build-deeper-deep-agents-comparative-wave-follow-on-demo-sip-md-adl-v0-89-1-tasks-issue-1949-v0-89-1-demo-build-deeper-deep-agents-comparative-wave-follow-on-demo-sor-md