### PR TITLE
[v0.89.1][WP-04] Adversarial execution runner

### DIFF
--- a/adl/src/adversarial_execution_runner.rs
+++ b/adl/src/adversarial_execution_runner.rs
@@ -1,0 +1,336 @@
+use serde::{Deserialize, Serialize};
+
+pub const ADVERSARIAL_EXECUTION_RUNNER_SCHEMA: &str = "adversarial_execution_runner.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdversarialRunnerEntrypointContract {
+    pub command_shape: String,
+    pub required_inputs: Vec<String>,
+    pub limit_semantics: Vec<String>,
+    pub non_authoritative_until: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdversarialRunnerStageContract {
+    pub stage_id: String,
+    pub role: String,
+    pub purpose: String,
+    pub required_inputs: Vec<String>,
+    pub required_outputs: Vec<String>,
+    pub blocked_in_postures: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdversarialRunnerPosturePolicyContract {
+    pub posture_profiles: Vec<String>,
+    pub freedom_gate_requirements: Vec<String>,
+    pub enforcement_rules: Vec<String>,
+    pub prohibited_shortcuts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdversarialEvidenceCaptureContract {
+    pub artifact_families: Vec<String>,
+    pub trace_requirements: Vec<String>,
+    pub linkage_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdversarialRunnerReviewSurfaceContract {
+    pub required_questions: Vec<String>,
+    pub required_visibility: Vec<String>,
+    pub downstream_boundaries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdversarialExecutionRunnerContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub runtime_condition: String,
+    pub entrypoint: AdversarialRunnerEntrypointContract,
+    pub canonical_stages: Vec<AdversarialRunnerStageContract>,
+    pub posture_policy: AdversarialRunnerPosturePolicyContract,
+    pub evidence_capture: AdversarialEvidenceCaptureContract,
+    pub review_surface: AdversarialRunnerReviewSurfaceContract,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+impl AdversarialExecutionRunnerContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: ADVERSARIAL_EXECUTION_RUNNER_SCHEMA.to_string(),
+            owned_runtime_surfaces: vec![
+                "adl::adversarial_execution_runner::AdversarialExecutionRunnerContract"
+                    .to_string(),
+                "adl::adversarial_execution_runner::AdversarialRunnerStageContract".to_string(),
+                "adl::adversarial_execution_runner::AdversarialRunnerPosturePolicyContract"
+                    .to_string(),
+                "adl::adversarial_execution_runner::AdversarialEvidenceCaptureContract"
+                    .to_string(),
+                "adl identity adversarial-runner".to_string(),
+            ],
+            runtime_condition:
+                "ADL adversarial execution must be orchestrated as a bounded staged runner with explicit target, posture, role attribution, evidence capture, and defer points."
+                    .to_string(),
+            entrypoint: AdversarialRunnerEntrypointContract {
+                command_shape:
+                    "planned: adl adversarial run --target <target_ref> --posture <profile> --goal <string> --limit <n|time> --output <path>"
+                        .to_string(),
+                required_inputs: vec![
+                    "target_ref".to_string(),
+                    "posture_profile".to_string(),
+                    "goal_or_focus".to_string(),
+                    "bounded_limit".to_string(),
+                    "artifact_root".to_string(),
+                ],
+                limit_semantics: vec![
+                    "iteration count or duration limit must be declared before execution"
+                        .to_string(),
+                    "runner stages must emit an explicit defer record instead of silently exceeding limits"
+                        .to_string(),
+                ],
+                non_authoritative_until: vec![
+                    "actual `adl adversarial run` CLI dispatch is intentionally deferred beyond this contract"
+                        .to_string(),
+                    "exploit and replay artifact schemas are owned by WP-05".to_string(),
+                ],
+            },
+            canonical_stages: vec![
+                AdversarialRunnerStageContract {
+                    stage_id: "load_target".to_string(),
+                    role: "purple".to_string(),
+                    purpose: "resolve the bounded target reference and declare the review scope"
+                        .to_string(),
+                    required_inputs: vec!["target_ref".to_string()],
+                    required_outputs: vec!["target scope record".to_string()],
+                    blocked_in_postures: vec![],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "declare_posture".to_string(),
+                    role: "purple".to_string(),
+                    purpose: "make posture, goal, and limit visible before any adversarial action"
+                        .to_string(),
+                    required_inputs: vec![
+                        "posture_profile".to_string(),
+                        "goal_or_focus".to_string(),
+                        "bounded_limit".to_string(),
+                    ],
+                    required_outputs: vec!["posture declaration".to_string()],
+                    blocked_in_postures: vec![],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "enumerate_surfaces".to_string(),
+                    role: "red".to_string(),
+                    purpose: "enumerate bounded target surfaces without attempting exploitation"
+                        .to_string(),
+                    required_inputs: vec!["target scope record".to_string()],
+                    required_outputs: vec!["attack-surface inventory".to_string()],
+                    blocked_in_postures: vec![],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "generate_hypothesis".to_string(),
+                    role: "red".to_string(),
+                    purpose: "produce one attributable exploit hypothesis for review".to_string(),
+                    required_inputs: vec!["attack-surface inventory".to_string()],
+                    required_outputs: vec!["exploit hypothesis draft".to_string()],
+                    blocked_in_postures: vec![],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "attempt_bounded_exploit".to_string(),
+                    role: "red".to_string(),
+                    purpose: "attempt the declared exploit path only when posture allows it"
+                        .to_string(),
+                    required_inputs: vec![
+                        "exploit hypothesis draft".to_string(),
+                        "posture declaration".to_string(),
+                    ],
+                    required_outputs: vec!["exploit evidence or blocked-action record".to_string()],
+                    blocked_in_postures: vec!["audit".to_string()],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "evaluate_risk".to_string(),
+                    role: "blue".to_string(),
+                    purpose: "interpret exploit evidence and decide mitigation posture".to_string(),
+                    required_inputs: vec!["exploit evidence or blocked-action record".to_string()],
+                    required_outputs: vec!["risk evaluation".to_string()],
+                    blocked_in_postures: vec![],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "decide_mitigation".to_string(),
+                    role: "blue".to_string(),
+                    purpose: "produce a mitigation or containment decision without hiding uncertainty"
+                        .to_string(),
+                    required_inputs: vec!["risk evaluation".to_string()],
+                    required_outputs: vec!["mitigation decision".to_string()],
+                    blocked_in_postures: vec![],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "capture_replay_decision".to_string(),
+                    role: "purple".to_string(),
+                    purpose: "record whether replay is strict, bounded, or deferred".to_string(),
+                    required_inputs: vec![
+                        "exploit evidence or blocked-action record".to_string(),
+                        "mitigation decision".to_string(),
+                    ],
+                    required_outputs: vec!["replay decision".to_string()],
+                    blocked_in_postures: vec![],
+                },
+                AdversarialRunnerStageContract {
+                    stage_id: "emit_runner_packet".to_string(),
+                    role: "purple".to_string(),
+                    purpose: "link target, posture, role stages, evidence, and defers into one review packet"
+                        .to_string(),
+                    required_inputs: vec![
+                        "posture declaration".to_string(),
+                        "risk evaluation".to_string(),
+                        "mitigation decision".to_string(),
+                        "replay decision".to_string(),
+                    ],
+                    required_outputs: vec!["adversarial runner review packet".to_string()],
+                    blocked_in_postures: vec![],
+                },
+            ],
+            posture_policy: AdversarialRunnerPosturePolicyContract {
+                posture_profiles: vec![
+                    "audit".to_string(),
+                    "validation".to_string(),
+                    "hardening".to_string(),
+                    "internal_contest".to_string(),
+                ],
+                freedom_gate_requirements: vec![
+                    "target scope must be declared before red execution".to_string(),
+                    "posture must be visible before exploit attempts".to_string(),
+                    "mutation-capable stages require explicit posture permission".to_string(),
+                ],
+                enforcement_rules: vec![
+                    "audit posture blocks exploit attempts".to_string(),
+                    "no-mutation posture blocks remediation application".to_string(),
+                    "limit exhaustion produces an explicit defer record".to_string(),
+                ],
+                prohibited_shortcuts: vec![
+                    "unbounded adversarial loops".to_string(),
+                    "exploit attempts without posture declaration".to_string(),
+                    "evidence capture without role attribution".to_string(),
+                    "silent replay omission".to_string(),
+                ],
+            },
+            evidence_capture: AdversarialEvidenceCaptureContract {
+                artifact_families: vec![
+                    "target scope record".to_string(),
+                    "posture declaration".to_string(),
+                    "attack-surface inventory".to_string(),
+                    "exploit hypothesis draft".to_string(),
+                    "exploit evidence or blocked-action record".to_string(),
+                    "risk evaluation".to_string(),
+                    "mitigation decision".to_string(),
+                    "replay decision".to_string(),
+                    "adversarial runner review packet".to_string(),
+                ],
+                trace_requirements: vec![
+                    "every stage must record role, stage_id, posture, and target_ref"
+                        .to_string(),
+                    "every produced artifact must link back to the stage that produced it"
+                        .to_string(),
+                    "blocked stages must be preserved as first-class evidence".to_string(),
+                ],
+                linkage_rules: vec![
+                    "mitigation decisions must cite exploit evidence or a blocked-action record"
+                        .to_string(),
+                    "replay decisions must cite both exploit evidence and mitigation decision when both exist"
+                        .to_string(),
+                    "runner packet must preserve canonical stage order for review".to_string(),
+                ],
+            },
+            review_surface: AdversarialRunnerReviewSurfaceContract {
+                required_questions: vec![
+                    "what target, posture, goal, and limit governed the run".to_string(),
+                    "which red, blue, and purple stages executed or were blocked".to_string(),
+                    "what evidence was captured and how is it linked across stages".to_string(),
+                    "which replay or schema details are explicitly deferred downstream".to_string(),
+                ],
+                required_visibility: vec![
+                    "target scope and posture declaration".to_string(),
+                    "canonical stage order and role attribution".to_string(),
+                    "evidence capture and blocked-action records".to_string(),
+                    "defer boundaries for exploit/replay schemas".to_string(),
+                ],
+                downstream_boundaries: vec![
+                    "canonical exploit artifact schemas remain WP-05".to_string(),
+                    "replay manifests and strict replay execution remain WP-05".to_string(),
+                    "continuous verification and self-attack loops remain WP-06".to_string(),
+                    "flagship adversarial demo entry points remain WP-07".to_string(),
+                ],
+            },
+            proof_fixture_hooks: vec![
+                "adl::adversarial_execution_runner::AdversarialExecutionRunnerContract::v1"
+                    .to_string(),
+                "adl identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json".to_string(),
+            ],
+            proof_hook_command:
+                "adl identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/adversarial_execution_runner_v1.json".to_string(),
+            scope_boundary:
+                "bounded runner orchestration and evidence-capture contract only; concrete exploit schemas, replay manifests, continuous self-attack scheduling, and flagship demos remain downstream milestone work."
+                    .to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AdversarialExecutionRunnerContract;
+
+    #[test]
+    fn adversarial_execution_runner_contract_is_staged_bounded_and_reviewable() {
+        let contract = AdversarialExecutionRunnerContract::v1();
+
+        assert_eq!(contract.schema_version, "adversarial_execution_runner.v1");
+        assert!(contract
+            .owned_runtime_surfaces
+            .iter()
+            .any(|surface| surface == "adl identity adversarial-runner"));
+        assert_eq!(
+            contract
+                .canonical_stages
+                .first()
+                .map(|stage| stage.stage_id.as_str()),
+            Some("load_target")
+        );
+        assert_eq!(
+            contract
+                .canonical_stages
+                .last()
+                .map(|stage| stage.stage_id.as_str()),
+            Some("emit_runner_packet")
+        );
+        assert!(contract.canonical_stages.iter().any(|stage| {
+            stage.stage_id == "attempt_bounded_exploit"
+                && stage
+                    .blocked_in_postures
+                    .iter()
+                    .any(|posture| posture == "audit")
+        }));
+        assert!(contract
+            .posture_policy
+            .enforcement_rules
+            .iter()
+            .any(|rule| rule == "limit exhaustion produces an explicit defer record"));
+        assert!(contract
+            .evidence_capture
+            .linkage_rules
+            .iter()
+            .any(|rule| rule.contains("mitigation decisions must cite exploit evidence")));
+        assert!(contract
+            .review_surface
+            .downstream_boundaries
+            .iter()
+            .any(|boundary| boundary.contains("WP-05")));
+        assert!(contract
+            .scope_boundary
+            .contains("downstream milestone work"));
+    }
+}

--- a/adl/src/cli/identity_cmd/contracts.rs
+++ b/adl/src/cli/identity_cmd/contracts.rs
@@ -4,6 +4,7 @@ use serde_json::to_string_pretty;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use ::adl::adversarial_execution_runner::AdversarialExecutionRunnerContract;
 use ::adl::adversarial_runtime::AdversarialRuntimeModelContract;
 use ::adl::chronosense::{
     ChronosenseFoundation, CommitmentDeadlineContract, ContinuitySemanticsContract,
@@ -110,6 +111,17 @@ pub(super) fn real_identity_red_blue_architecture(repo_root: &Path, args: &[Stri
         "red blue agent architecture",
         "RED_BLUE_AGENT_ARCHITECTURE_PATH",
         RedBlueAgentArchitectureContract::v1(),
+    )
+}
+
+pub(super) fn real_identity_adversarial_runner(repo_root: &Path, args: &[String]) -> Result<()> {
+    write_contract_json(
+        repo_root,
+        args,
+        "adversarial-runner",
+        "adversarial execution runner",
+        "ADVERSARIAL_EXECUTION_RUNNER_PATH",
+        AdversarialExecutionRunnerContract::v1(),
     )
 }
 

--- a/adl/src/cli/identity_cmd/dispatch.rs
+++ b/adl/src/cli/identity_cmd/dispatch.rs
@@ -2,10 +2,11 @@ use anyhow::{anyhow, Result};
 use std::path::Path;
 
 use super::contracts::{
-    real_identity_adversarial_runtime, real_identity_causality, real_identity_commitments,
-    real_identity_continuity, real_identity_cost, real_identity_foundation, real_identity_instinct,
-    real_identity_instinct_runtime, real_identity_phi, real_identity_red_blue_architecture,
-    real_identity_retrieval, real_identity_schema,
+    real_identity_adversarial_runner, real_identity_adversarial_runtime, real_identity_causality,
+    real_identity_commitments, real_identity_continuity, real_identity_cost,
+    real_identity_foundation, real_identity_instinct, real_identity_instinct_runtime,
+    real_identity_phi, real_identity_red_blue_architecture, real_identity_retrieval,
+    real_identity_schema,
 };
 use super::helpers::repo_root;
 use super::profile::{real_identity_init, real_identity_now, real_identity_show};
@@ -18,7 +19,7 @@ pub(crate) fn real_identity(args: &[String]) -> Result<()> {
 pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
+            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
         ));
     };
 
@@ -29,6 +30,7 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
         "foundation" => real_identity_foundation(repo_root, &args[1..]),
         "adversarial-runtime" => real_identity_adversarial_runtime(repo_root, &args[1..]),
         "red-blue-architecture" => real_identity_red_blue_architecture(repo_root, &args[1..]),
+        "adversarial-runner" => real_identity_adversarial_runner(repo_root, &args[1..]),
         "schema" => real_identity_schema(repo_root, &args[1..]),
         "continuity" => real_identity_continuity(repo_root, &args[1..]),
         "retrieval" => real_identity_retrieval(repo_root, &args[1..]),
@@ -43,7 +45,7 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
         )),
     }
 }

--- a/adl/src/cli/identity_cmd/tests.rs
+++ b/adl/src/cli/identity_cmd/tests.rs
@@ -164,7 +164,7 @@ fn identity_requires_subcommand_and_rejects_unknown_subcommand() {
     let err = real_identity_in_repo(&[], &repo).expect_err("missing subcommand should fail");
     assert!(err
         .to_string()
-        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | schema"));
+        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | schema"));
     assert!(err.to_string().contains("continuity"));
 
     let err = real_identity_in_repo(&["nope".to_string()], &repo)
@@ -193,6 +193,11 @@ fn identity_top_level_help_and_subcommand_help_succeed() {
         &repo,
     )
     .expect("red-blue-architecture help");
+    real_identity_in_repo(
+        &["adversarial-runner".to_string(), "--help".to_string()],
+        &repo,
+    )
+    .expect("adversarial-runner help");
     real_identity_in_repo(&["schema".to_string(), "--help".to_string()], &repo)
         .expect("schema help");
     real_identity_in_repo(&["continuity".to_string(), "--help".to_string()], &repo)
@@ -533,6 +538,87 @@ fn identity_red_blue_architecture_validates_unknown_args_and_missing_out_value()
 
     let err = real_identity_in_repo(
         &["red-blue-architecture".to_string(), "--out".to_string()],
+        &repo,
+    )
+    .expect_err("out flag without value should fail");
+    assert!(err.to_string().contains("--out requires a value"));
+}
+
+#[test]
+fn identity_adversarial_runner_writes_contract_json() {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let repo = temp_repo("identity-adversarial-runner");
+    let out_path = repo.join(".adl/state/adversarial_execution_runner_v1.json");
+
+    real_identity_in_repo(
+        &[
+            "adversarial-runner".to_string(),
+            "--out".to_string(),
+            ".adl/state/adversarial_execution_runner_v1.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("identity adversarial-runner");
+
+    let json: Value =
+        serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+    assert_eq!(json["schema_version"], "adversarial_execution_runner.v1");
+    assert_eq!(
+        json["proof_hook_output_path"],
+        ".adl/state/adversarial_execution_runner_v1.json"
+    );
+    assert!(json["canonical_stages"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|stage| stage["stage_id"] == "attempt_bounded_exploit"
+            && stage["blocked_in_postures"]
+                .as_array()
+                .expect("array")
+                .iter()
+                .any(|posture| posture == "audit")));
+    assert!(json["posture_policy"]["enforcement_rules"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "limit exhaustion produces an explicit defer record"));
+    assert!(json["evidence_capture"]["linkage_rules"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value
+            .as_str()
+            .expect("string")
+            .contains("mitigation decisions must cite exploit evidence")));
+    assert!(json["review_surface"]["downstream_boundaries"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value.as_str().expect("string").contains("WP-05")));
+    assert!(json["owned_runtime_surfaces"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "adl identity adversarial-runner"));
+}
+
+#[test]
+fn identity_adversarial_runner_validates_unknown_args_and_missing_out_value() {
+    let repo = temp_repo("identity-adversarial-runner-errors");
+
+    let err = real_identity_in_repo(
+        &["adversarial-runner".to_string(), "--bogus".to_string()],
+        &repo,
+    )
+    .expect_err("unknown arg should fail");
+    assert!(err
+        .to_string()
+        .contains("unknown arg for identity adversarial-runner: --bogus"));
+
+    let err = real_identity_in_repo(
+        &["adversarial-runner".to_string(), "--out".to_string()],
         &repo,
     )
     .expect_err("out flag without value should fail");

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -10,6 +10,7 @@ pub fn usage() -> &'static str {
   adl identity foundation [--out <path>]
   adl identity adversarial-runtime [--out <path>]
   adl identity red-blue-architecture [--out <path>]
+  adl identity adversarial-runner [--out <path>]
   adl identity schema [--out <path>]
   adl identity continuity [--out <path>]
   adl identity retrieval [--out <path>]

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -12,6 +12,7 @@
 //! - remote execution MVP where scheduling remains local
 
 pub mod adl;
+pub mod adversarial_execution_runner;
 pub mod adversarial_runtime;
 pub mod artifacts;
 pub mod bounded_executor;

--- a/docs/milestones/v0.89.1/features/ADVERSARIAL_EXECUTION_RUNNER.md
+++ b/docs/milestones/v0.89.1/features/ADVERSARIAL_EXECUTION_RUNNER.md
@@ -1,46 +1,67 @@
-
-
 # Adversarial Execution Runner
 
 ## Metadata
 - Project: `ADL`
-- Status: `Draft`
+- Milestone: `v0.89.1`
+- Status: `Implemented`
 - Owner: `Daniel Austin`
-- Created: `2026-04-12`
+- Updated: `2026-04-15`
+- WP: `WP-04`
 
 ---
 
 ## Purpose
 
-Define the **Adversarial Execution Runner** as the orchestration surface that wires together:
+Make the adversarial runner explicit as a bounded orchestration and evidence-capture contract instead of leaving it as a proposed CLI sketch.
 
-- red / blue / purple roles
-- security posture
-- continuous verification loop
-- exploit artifacts
-- replay manifests
-- mitigation and validation
-- promotion to regression
+The core shift is simple:
 
-The runner is the minimal executable surface that turns the adversarial subsystem into a real, repeatable workflow.
+> ADL adversarial execution must have a declared target, posture, stage order, role attribution, evidence chain, and defer points.
+
+`WP-04` does not yet implement exploit schemas, strict replay manifests, continuous self-attack scheduling, or the flagship demo. It defines the runner contract those later `v0.89.1` surfaces must preserve.
 
 ---
 
-## Overview
+## Owned Runtime Surfaces
 
-The Adversarial Execution Runner is responsible for executing a bounded, policy-governed adversarial loop against a declared target.
+`WP-04` is now owned by these concrete repo surfaces:
 
-It provides:
+- `adl::adversarial_execution_runner::AdversarialExecutionRunnerContract`
+- `adl::adversarial_execution_runner::AdversarialRunnerStageContract`
+- `adl::adversarial_execution_runner::AdversarialRunnerPosturePolicyContract`
+- `adl::adversarial_execution_runner::AdversarialEvidenceCaptureContract`
+- `adl identity adversarial-runner`
 
-- a single entrypoint for adversarial runs
-- consistent sequencing of lifecycle stages
-- artifact production and linking
-- trace emission and replay hooks
-- posture enforcement via the Freedom Gate
+Proof hook:
+
+```bash
+adl identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json
+```
+
+Primary proof artifact:
+
+- `.adl/state/adversarial_execution_runner_v1.json`
 
 ---
 
-## CLI Surface (Proposed)
+## Runtime Condition
+
+ADL adversarial execution is only reviewable if the runner shape is explicit before any exploit/replay machinery arrives.
+
+That means:
+
+- the target, posture, goal, and limit are declared before execution
+- every stage has a role and a required evidence shape
+- blocked stages are preserved as first-class evidence rather than disappearing
+- replay may be strict, bounded, or explicitly deferred, but never silent
+
+This is a runner-orchestration claim, not yet a full exploit/replay engine.
+
+---
+
+## Planned Entrypoint Contract
+
+The runner contract reserves this eventual command shape:
 
 ```bash
 adl adversarial run \
@@ -51,240 +72,162 @@ adl adversarial run \
   --output <path>
 ```
 
-### Flags
+This CLI is not authoritative yet. In `WP-04`, the authoritative proof surface is the `adl identity adversarial-runner` contract artifact.
 
-- `--target` : target reference (id or path)
-- `--posture` : named posture profile (audit|validation|hardening|internal_contest)
-- `--goal` : optional focus (e.g., "input validation", "auth boundary")
-- `--limit` : cap on iterations (count or duration)
-- `--output` : artifact root directory
+Required inputs:
 
----
-
-## Execution Flow
-
-The runner executes the canonical loop:
-
-```text
-load target
--> declare posture
--> enumerate surfaces
--> generate hypothesis
--> attempt exploit (bounded)
--> record evidence
--> build replay manifest
--> (optional) run replay pre-fix
--> generate mitigation
--> (optional) apply bounded fix
--> run replay post-fix
--> classify and promote
--> emit artifacts + trace
-```
-
-Each step must be:
-
-- bounded by posture
-- attributable to a role (red/blue/purple)
-- recorded in trace
-- materialized as artifacts where applicable
-
----
-
-## Minimal Implementation Slice (v0)
-
-Start with a single-path, single-issue flow:
-
-1. One target (demo fixture)
-2. One hypothesis
-3. One exploit attempt
-4. One replay manifest
-5. One mitigation
-6. One post-fix replay
-7. One promotion artifact
-
-No parallelism, no scheduling-just a clear, linear proof path.
-
----
-
-## Components
-
-### 1. Target Loader
-
-- resolves `target_ref`
-- validates scope vs posture
-- prepares environment (demo/sandbox)
-
-### 2. Posture Enforcer
-
-- loads posture profile
-- enforces allowed actions
-- integrates with Freedom Gate decisions
-
-### 3. Red Engine
-
-- surface enumeration
-- hypothesis generation
-- bounded exploit attempts
-
-### 4. Blue Engine
-
-- risk evaluation
-- mitigation proposal
-- (optional) bounded remediation
-
-### 5. Replay Engine
-
-- builds `AdversarialReplayManifest`
-- executes replay (pre/post fix)
-- evaluates success criteria
-
-### 6. Artifact Manager
-
-- creates and links artifacts
-- enforces schema completeness
-- writes to output tree
-
-### 7. Trace Emitter
-
-- records posture
-- records steps and outcomes
-- links artifacts to trace refs
-
-### 8. Promotion Engine (Purple)
-
-- classifies exploit
-- decides promotion targets
-- emits `ExploitPromotionArtifact`
-
----
-
-## Artifact Output Layout
-
-```text
-<output>/
-  target/
-  posture.yaml
-  hypothesis.yaml
-  evidence.yaml
-  replay.yaml
-  mitigation.yaml
-  replay_pre_fix/
-  replay_post_fix/
-  classification.yaml
-  promotion.yaml
-  trace/
-```
-
-All artifacts must include:
-- `artifact_id`
-- `artifact_type`
-- `schema_version`
-- `trace_refs`
 - `target_ref`
-- `security_posture_ref`
+- `posture_profile`
+- `goal_or_focus`
+- `bounded_limit`
+- `artifact_root`
+
+Limit semantics:
+
+- iteration count or duration limit must be declared before execution
+- limit exhaustion produces an explicit defer record instead of silent continuation
 
 ---
 
-## Posture Enforcement Rules
+## Canonical Stage Order
 
-- Block exploit attempts in `audit` posture
-- Block mutation in `no_mutation` modes
-- Restrict targets by `target_scope`
-- Require evidence level by `evidence_requirement`
-- Gate high-intensity modes behind approval
+The bounded runner contract defines this stage order:
 
-All violations must be:
-- prevented or
-- recorded explicitly as blocked actions
+1. `load_target`
+2. `declare_posture`
+3. `enumerate_surfaces`
+4. `generate_hypothesis`
+5. `attempt_bounded_exploit`
+6. `evaluate_risk`
+7. `decide_mitigation`
+8. `capture_replay_decision`
+9. `emit_runner_packet`
+
+Role attribution:
+
+- purple owns target loading, posture declaration, replay/defer decisions, and packet emission
+- red owns bounded enumeration, hypothesis generation, and exploit attempt stages
+- blue owns risk evaluation and mitigation decisions
+
+The runner is successful only when it preserves the stage order and records whether each stage executed, blocked, or deferred.
 
 ---
 
-## Trace Requirements
+## Posture Policy
 
-Trace must include events for:
+Supported posture profiles:
 
+- `audit`
+- `validation`
+- `hardening`
+- `internal_contest`
+
+Freedom Gate requirements:
+
+- target scope must be declared before red execution
+- posture must be visible before exploit attempts
+- mutation-capable stages require explicit posture permission
+
+Enforcement rules:
+
+- `audit` posture blocks exploit attempts
+- no-mutation posture blocks remediation application
+- limit exhaustion produces an explicit defer record
+
+Prohibited shortcuts:
+
+- unbounded adversarial loops
+- exploit attempts without posture declaration
+- evidence capture without role attribution
+- silent replay omission
+
+---
+
+## Evidence Capture
+
+The runner contract defines the required evidence family names without yet owning the detailed exploit/replay schemas.
+
+Artifact families:
+
+- target scope record
 - posture declaration
-- hypothesis generation
-- exploit attempt (with outcome)
-- replay execution (pre/post)
+- attack-surface inventory
+- exploit hypothesis draft
+- exploit evidence or blocked-action record
+- risk evaluation
 - mitigation decision
-- promotion decision
+- replay decision
+- adversarial runner review packet
 
-Each event should include:
-- timestamp
-- agent role
-- step id
-- references to artifacts
+Trace requirements:
 
----
+- every stage records role, `stage_id`, posture, and `target_ref`
+- every produced artifact links back to the stage that produced it
+- blocked stages are preserved as first-class evidence
 
-## Success Criteria
+Linkage rules:
 
-A run is successful when:
-
-- at least one hypothesis is generated
-- at least one exploit attempt is recorded
-- a replay manifest is produced
-- replay executes with defined outcome
-- mitigation is linked to evidence
-- post-fix replay shows changed behavior (if fix applied)
-- promotion artifact is emitted (or explicit defer recorded)
+- mitigation decisions cite exploit evidence or a blocked-action record
+- replay decisions cite exploit evidence and mitigation decision when both exist
+- the runner packet preserves canonical stage order for review
 
 ---
 
-## Failure Modes
+## Review Surface
 
-- No artifacts produced (prose-only run)
-- Replay cannot be executed or explained
-- Posture violations not enforced
-- Mitigation not linked to evidence
-- No before/after validation
+Reviewers should be able to answer these questions directly from the proof surface:
 
-These should fail the run or mark it `incomplete`.
+- what target, posture, goal, and limit governed the run
+- which red, blue, and purple stages executed or were blocked
+- what evidence was captured and how is it linked across stages
+- which replay or schema details are explicitly deferred downstream
 
----
+Minimum required visibility:
 
-## Demo Hook
-
-Primary demo command:
-
-```bash
-adl adversarial run \
-  --target demo.simple_api \
-  --posture validation \
-  --goal "input validation bypass" \
-  --limit 1 \
-  --output reports/adversarial-demo
-```
-
-Expected outcome:
-- full artifact chain present
-- replay works pre-fix
-- replay fails post-fix
+- target scope and posture declaration
+- canonical stage order and role attribution
+- evidence capture and blocked-action records
+- defer boundaries for exploit/replay schemas
 
 ---
 
-## Future Extensions
+## Relationship To Existing ADL Concepts
 
-- parallel hypothesis exploration
-- scheduling (continuous runs)
-- posture escalation workflows
-- multi-target campaigns
-- provider capability gating
-- signed trace integration
-- CI integration for regression suites
+This contract is intentionally downstream of `WP-02` and `WP-03`:
+
+- `WP-02` defines the contested-runtime assumption
+- `WP-03` defines persistent red, blue, and purple role architecture
+- `WP-04` defines how the runner orders those roles, captures evidence, and records defer points
+
+It also preserves existing ADL boundaries:
+
+- Freedom Gate and posture govern mutation and exploit permission
+- trace and artifact review remain the proof surface
+- chronosense can later make contested activity temporally legible
 
 ---
 
-## Conclusion
+## Explicit Boundaries
 
-The Adversarial Execution Runner is the minimal bridge from design to reality.
+`WP-04` is intentionally smaller than the whole adversarial band.
 
-It takes the adversarial architecture and makes it:
+Still deferred downstream:
 
-- runnable
-- repeatable
-- inspectable
-- provable
+- canonical exploit artifact schemas: `WP-05`
+- replay manifests and strict replay execution: `WP-05`
+- continuous verification and self-attack loops: `WP-06`
+- flagship adversarial demo entry points: `WP-07`
 
-It is the surface where contested cognition becomes engineering practice.
+This keeps the issue truthful: it resolves the runner-orchestration and evidence-capture contract without pretending exploit/replay execution is already complete.
+
+---
+
+## Acceptance For WP-04
+
+`WP-04` is satisfied when:
+
+- the adversarial runner contract is explicit in code and docs
+- reviewers can inspect a concrete proof artifact for stage order, posture policy, evidence capture, and downstream defers
+- later `v0.89.1` exploit, replay, verification, and demo work has a stable bounded runner contract to extend
+
+That is the current state of this feature.


### PR DESCRIPTION
Closes #1925

## Summary
Landed the bounded `WP-04` adversarial execution-runner contract as a reviewer-facing code and
proof-hook surface instead of pretending the full exploit/replay engine already exists. The
delivered slice adds `adl::adversarial_execution_runner::AdversarialExecutionRunnerContract`,
exposes it through `adl identity adversarial-runner`, and rewrites the promoted `v0.89.1` feature
doc so stage order, posture policy, evidence capture, and downstream defers are explicit,
test-backed, and reviewable.

## Artifacts
- adversarial runner contract surface:
  - `adl/src/adversarial_execution_runner.rs`
  - `adl/src/lib.rs`
- identity proof-hook wiring:
  - `adl/src/cli/identity_cmd/contracts.rs`
  - `adl/src/cli/identity_cmd/dispatch.rs`
  - `adl/src/cli/identity_cmd/tests.rs`
  - `adl/src/cli/usage.rs`
- promoted feature doc:
  - `docs/milestones/v0.89.1/features/ADVERSARIAL_EXECUTION_RUNNER.md`
- local proof artifact:
  - `.adl/state/adversarial_execution_runner_v1.json`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Normalized Rust formatting after the new runner-contract module and identity-proof wiring.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified the final Rust formatting is stable.
  - `cargo test --manifest-path adl/Cargo.toml adversarial_execution_runner_contract_is_staged_bounded_and_reviewable -- --nocapture`
    Verified the new runner constructor exposes the intended schema, canonical stage order,
    posture gate, evidence linkage, and downstream boundaries.
  - `cargo test --manifest-path adl/Cargo.toml identity_adversarial_runner -- --nocapture`
    Verified the new identity proof hook writes the expected JSON artifact and rejects bad args.
  - `cargo test --manifest-path adl/Cargo.toml identity_ -- --nocapture`
    Reverified the broader identity command surface still passes with the new subcommand added.
  - `cargo run --manifest-path adl/Cargo.toml -- identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json`
    Emitted the reviewer-facing proof artifact for the bounded `WP-04` runner contract.
  - `adl/target/debug/adl identity adversarial-runner --out .adl/determinism/adversarial_execution_runner_a.json`
    Emitted the contract artifact once for byte-stability comparison.
  - `adl/target/debug/adl identity adversarial-runner --out .adl/determinism/adversarial_execution_runner_b.json`
    Emitted the contract artifact a second time for byte-stability comparison.
  - `cmp -s .adl/determinism/adversarial_execution_runner_a.json .adl/determinism/adversarial_execution_runner_b.json`
    Verified repeated proof-hook execution produces byte-identical output for the same inputs.
  - `git diff --check`
    Verified no patch-shape or whitespace defects remain.
- Results:
  - all targeted runner-contract and identity tests passed
  - the proof hook emitted `.adl/state/adversarial_execution_runner_v1.json` successfully
  - repeated direct proof-hook runs produced byte-identical output
  - the bounded `WP-04` docs and code remained clean under `cargo fmt --check` and `git diff --check`

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1925__v0-89-1-wp-04-adversarial-execution-runner/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1925__v0-89-1-wp-04-adversarial-execution-runner/sor.md
- Idempotency-Key: v0-89-1-wp-04-adversarial-execution-runner-adl-v0-89-1-tasks-issue-1925-v0-89-1-wp-04-adversarial-execution-runner-sip-md-adl-v0-89-1-tasks-issue-1925-v0-89-1-wp-04-adversarial-execution-runner-sor-md