### PR TITLE
[v0.89.1][WP-05] Exploit artifact and replay schema

### DIFF
--- a/adl/src/cli/identity_cmd/contracts.rs
+++ b/adl/src/cli/identity_cmd/contracts.rs
@@ -12,6 +12,7 @@ use ::adl::chronosense::{
     PhiIntegrationMetricsContract, TemporalCausalityExplanationContract,
     TemporalQueryRetrievalContract, TemporalSchemaContract,
 };
+use ::adl::exploit_artifact_replay::ExploitArtifactReplayContract;
 use ::adl::red_blue_agent_architecture::RedBlueAgentArchitectureContract;
 
 use super::helpers::required_value;
@@ -122,6 +123,17 @@ pub(super) fn real_identity_adversarial_runner(repo_root: &Path, args: &[String]
         "adversarial execution runner",
         "ADVERSARIAL_EXECUTION_RUNNER_PATH",
         AdversarialExecutionRunnerContract::v1(),
+    )
+}
+
+pub(super) fn real_identity_exploit_replay(repo_root: &Path, args: &[String]) -> Result<()> {
+    write_contract_json(
+        repo_root,
+        args,
+        "exploit-replay",
+        "exploit artifact replay",
+        "EXPLOIT_ARTIFACT_REPLAY_PATH",
+        ExploitArtifactReplayContract::v1(),
     )
 }
 

--- a/adl/src/cli/identity_cmd/dispatch.rs
+++ b/adl/src/cli/identity_cmd/dispatch.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 use super::contracts::{
     real_identity_adversarial_runner, real_identity_adversarial_runtime, real_identity_causality,
     real_identity_commitments, real_identity_continuity, real_identity_cost,
-    real_identity_foundation, real_identity_instinct, real_identity_instinct_runtime,
-    real_identity_phi, real_identity_red_blue_architecture, real_identity_retrieval,
-    real_identity_schema,
+    real_identity_exploit_replay, real_identity_foundation, real_identity_instinct,
+    real_identity_instinct_runtime, real_identity_phi, real_identity_red_blue_architecture,
+    real_identity_retrieval, real_identity_schema,
 };
 use super::helpers::repo_root;
 use super::profile::{real_identity_init, real_identity_now, real_identity_show};
@@ -19,7 +19,7 @@ pub(crate) fn real_identity(args: &[String]) -> Result<()> {
 pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
+            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
         ));
     };
 
@@ -31,6 +31,7 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
         "adversarial-runtime" => real_identity_adversarial_runtime(repo_root, &args[1..]),
         "red-blue-architecture" => real_identity_red_blue_architecture(repo_root, &args[1..]),
         "adversarial-runner" => real_identity_adversarial_runner(repo_root, &args[1..]),
+        "exploit-replay" => real_identity_exploit_replay(repo_root, &args[1..]),
         "schema" => real_identity_schema(repo_root, &args[1..]),
         "continuity" => real_identity_continuity(repo_root, &args[1..]),
         "retrieval" => real_identity_retrieval(repo_root, &args[1..]),
@@ -45,7 +46,7 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
         )),
     }
 }

--- a/adl/src/cli/identity_cmd/tests.rs
+++ b/adl/src/cli/identity_cmd/tests.rs
@@ -164,7 +164,7 @@ fn identity_requires_subcommand_and_rejects_unknown_subcommand() {
     let err = real_identity_in_repo(&[], &repo).expect_err("missing subcommand should fail");
     assert!(err
         .to_string()
-        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | schema"));
+        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | schema"));
     assert!(err.to_string().contains("continuity"));
 
     let err = real_identity_in_repo(&["nope".to_string()], &repo)
@@ -198,6 +198,8 @@ fn identity_top_level_help_and_subcommand_help_succeed() {
         &repo,
     )
     .expect("adversarial-runner help");
+    real_identity_in_repo(&["exploit-replay".to_string(), "--help".to_string()], &repo)
+        .expect("exploit-replay help");
     real_identity_in_repo(&["schema".to_string(), "--help".to_string()], &repo)
         .expect("schema help");
     real_identity_in_repo(&["continuity".to_string(), "--help".to_string()], &repo)
@@ -622,6 +624,76 @@ fn identity_adversarial_runner_validates_unknown_args_and_missing_out_value() {
         &repo,
     )
     .expect_err("out flag without value should fail");
+    assert!(err.to_string().contains("--out requires a value"));
+}
+
+#[test]
+fn identity_exploit_replay_writes_contract_json() {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let repo = temp_repo("identity-exploit-replay");
+    let out_path = repo.join(".adl/state/exploit_artifact_replay_v1.json");
+
+    real_identity_in_repo(
+        &[
+            "exploit-replay".to_string(),
+            "--out".to_string(),
+            ".adl/state/exploit_artifact_replay_v1.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("identity exploit-replay");
+
+    let json: Value =
+        serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+    assert_eq!(json["schema_version"], "exploit_artifact_replay.v1");
+    assert_eq!(
+        json["proof_hook_output_path"],
+        ".adl/state/exploit_artifact_replay_v1.json"
+    );
+    assert!(json["lifecycle_order"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "AdversarialReplayManifest"));
+    assert!(json["replay_manifest"]["replay_modes"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|mode| mode["mode"] == "bounded_variance"));
+    assert!(json["integrity"]["rules"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "no mitigation without exploit evidence linkage"));
+    assert!(json["runner_integration"]["upstream_contracts"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "adversarial_execution_runner.v1"));
+    assert!(json["owned_runtime_surfaces"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "adl identity exploit-replay"));
+}
+
+#[test]
+fn identity_exploit_replay_validates_unknown_args_and_missing_out_value() {
+    let repo = temp_repo("identity-exploit-replay-errors");
+
+    let err = real_identity_in_repo(
+        &["exploit-replay".to_string(), "--bogus".to_string()],
+        &repo,
+    )
+    .expect_err("unknown arg should fail");
+    assert!(err
+        .to_string()
+        .contains("unknown arg for identity exploit-replay: --bogus"));
+
+    let err = real_identity_in_repo(&["exploit-replay".to_string(), "--out".to_string()], &repo)
+        .expect_err("out flag without value should fail");
     assert!(err.to_string().contains("--out requires a value"));
 }
 

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -11,6 +11,7 @@ pub fn usage() -> &'static str {
   adl identity adversarial-runtime [--out <path>]
   adl identity red-blue-architecture [--out <path>]
   adl identity adversarial-runner [--out <path>]
+  adl identity exploit-replay [--out <path>]
   adl identity schema [--out <path>]
   adl identity continuity [--out <path>]
   adl identity retrieval [--out <path>]

--- a/adl/src/exploit_artifact_replay.rs
+++ b/adl/src/exploit_artifact_replay.rs
@@ -1,0 +1,575 @@
+use serde::{Deserialize, Serialize};
+
+pub const EXPLOIT_ARTIFACT_REPLAY_SCHEMA: &str = "exploit_artifact_replay.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SharedExploitArtifactBaseContract {
+    pub required_base_fields: Vec<String>,
+    pub status_values: Vec<String>,
+    pub target_ref_fields: Vec<String>,
+    pub trace_ref_fields: Vec<String>,
+    pub temporal_extension_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExploitArtifactLifecycleMemberContract {
+    pub artifact_type: String,
+    pub lifecycle_stage: String,
+    pub purpose: String,
+    pub required_fields: Vec<String>,
+    pub required_links: Vec<String>,
+    pub reviewer_expectations: Vec<String>,
+    pub allowed_omissions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReplayModeContract {
+    pub mode: String,
+    pub reproducibility_claim: String,
+    pub allowed_variance: String,
+    pub required_disclosure: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdversarialReplayManifestContract {
+    pub artifact_type: String,
+    pub required_fields: Vec<String>,
+    pub replay_modes: Vec<ReplayModeContract>,
+    pub execution_requirements: Vec<String>,
+    pub determinism_rules: Vec<String>,
+    pub mitigation_validation_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExploitArtifactIntegrityContract {
+    pub rules: Vec<String>,
+    pub prohibited_shortcuts: Vec<String>,
+    pub promotion_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExploitArtifactRunnerIntegrationContract {
+    pub upstream_contracts: Vec<String>,
+    pub runner_stage_bindings: Vec<String>,
+    pub required_review_packet_links: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExploitArtifactReviewSurfaceContract {
+    pub required_questions: Vec<String>,
+    pub required_visibility: Vec<String>,
+    pub downstream_boundaries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExploitArtifactReplayContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub runtime_condition: String,
+    pub shared_base: SharedExploitArtifactBaseContract,
+    pub artifact_family: Vec<ExploitArtifactLifecycleMemberContract>,
+    pub replay_manifest: AdversarialReplayManifestContract,
+    pub lifecycle_order: Vec<String>,
+    pub runner_integration: ExploitArtifactRunnerIntegrationContract,
+    pub integrity: ExploitArtifactIntegrityContract,
+    pub review_surface: ExploitArtifactReviewSurfaceContract,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+impl ExploitArtifactReplayContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: EXPLOIT_ARTIFACT_REPLAY_SCHEMA.to_string(),
+            owned_runtime_surfaces: vec![
+                "adl::exploit_artifact_replay::ExploitArtifactReplayContract".to_string(),
+                "adl::exploit_artifact_replay::ExploitArtifactLifecycleMemberContract"
+                    .to_string(),
+                "adl::exploit_artifact_replay::AdversarialReplayManifestContract".to_string(),
+                "adl::exploit_artifact_replay::ReplayModeContract".to_string(),
+                "adl identity exploit-replay".to_string(),
+            ],
+            runtime_condition:
+                "ADL adversarial findings must become structured, posture-linked, replay-aware artifacts rather than remaining narrative-only claims."
+                    .to_string(),
+            shared_base: SharedExploitArtifactBaseContract {
+                required_base_fields: vec![
+                    "artifact_id".to_string(),
+                    "artifact_type".to_string(),
+                    "schema_version".to_string(),
+                    "status".to_string(),
+                    "created_at_utc".to_string(),
+                    "updated_at_utc".to_string(),
+                    "created_by_agent".to_string(),
+                    "run_id".to_string(),
+                    "trace_refs".to_string(),
+                    "related_artifacts".to_string(),
+                    "security_posture_ref".to_string(),
+                    "target_ref".to_string(),
+                ],
+                status_values: vec![
+                    "draft".to_string(),
+                    "recorded".to_string(),
+                    "validated".to_string(),
+                    "deferred".to_string(),
+                    "superseded".to_string(),
+                ],
+                target_ref_fields: vec![
+                    "target_id".to_string(),
+                    "target_type".to_string(),
+                    "target_name".to_string(),
+                    "environment".to_string(),
+                ],
+                trace_ref_fields: vec![
+                    "trace_id".to_string(),
+                    "step_id".to_string(),
+                    "note".to_string(),
+                ],
+                temporal_extension_fields: vec![
+                    "first_seen_utc".to_string(),
+                    "validated_at_utc".to_string(),
+                    "mitigated_at_utc".to_string(),
+                    "replay_validated_at_utc".to_string(),
+                ],
+            },
+            artifact_family: vec![
+                ExploitArtifactLifecycleMemberContract {
+                    artifact_type: "ExploitHypothesisArtifact".to_string(),
+                    lifecycle_stage: "hypothesize".to_string(),
+                    purpose: "capture a structured claim that an exploit path may exist"
+                        .to_string(),
+                    required_fields: vec![
+                        "hypothesis_id".to_string(),
+                        "exploit_family".to_string(),
+                        "summary".to_string(),
+                        "target_surface".to_string(),
+                        "unsafe_outcome".to_string(),
+                        "preconditions".to_string(),
+                        "steps".to_string(),
+                        "confidence".to_string(),
+                        "uncertainties".to_string(),
+                        "policy_notes".to_string(),
+                    ],
+                    required_links: vec!["target_ref".to_string(), "security_posture_ref".to_string()],
+                    reviewer_expectations: vec![
+                        "separate required preconditions from uncertainty".to_string(),
+                        "state the suspected unsafe outcome clearly".to_string(),
+                    ],
+                    allowed_omissions: vec![
+                        "may exist without a later exploit attempt when posture blocks execution"
+                            .to_string(),
+                    ],
+                },
+                ExploitArtifactLifecycleMemberContract {
+                    artifact_type: "ExploitEvidenceArtifact".to_string(),
+                    lifecycle_stage: "prove_or_block".to_string(),
+                    purpose: "record what happened during an actual bounded exploit attempt or blocked attempt"
+                        .to_string(),
+                    required_fields: vec![
+                        "hypothesis_ref".to_string(),
+                        "attempt_id".to_string(),
+                        "outcome".to_string(),
+                        "outcome_summary".to_string(),
+                        "preconditions_observed".to_string(),
+                        "attempt_steps".to_string(),
+                        "observed_effects".to_string(),
+                        "unsafe_state_reached".to_string(),
+                        "evidence_refs".to_string(),
+                        "replayability".to_string(),
+                        "residual_uncertainty".to_string(),
+                    ],
+                    required_links: vec![
+                        "hypothesis_ref".to_string(),
+                        "trace_refs".to_string(),
+                        "target_ref".to_string(),
+                    ],
+                    reviewer_expectations: vec![
+                        "distinguish success, failure, ambiguity, and policy blocking"
+                            .to_string(),
+                        "record actual observed behavior rather than intention".to_string(),
+                    ],
+                    allowed_omissions: vec![
+                        "successful exploit evidence may be absent when posture intentionally blocks the attempt"
+                            .to_string(),
+                    ],
+                },
+                ExploitArtifactLifecycleMemberContract {
+                    artifact_type: "ExploitClassificationArtifact".to_string(),
+                    lifecycle_stage: "classify".to_string(),
+                    purpose: "convert exploit evidence into reusable categorized knowledge"
+                        .to_string(),
+                    required_fields: vec![
+                        "evidence_ref".to_string(),
+                        "exploit_family".to_string(),
+                        "target_type".to_string(),
+                        "severity".to_string(),
+                        "reproducibility".to_string(),
+                        "recurrence_potential".to_string(),
+                        "mitigation_complexity".to_string(),
+                        "classification_notes".to_string(),
+                    ],
+                    required_links: vec!["evidence_ref".to_string()],
+                    reviewer_expectations: vec![
+                        "interpret raw evidence without replacing it".to_string(),
+                        "preserve severity rationale and reproducibility level".to_string(),
+                    ],
+                    allowed_omissions: vec![
+                        "may be deferred for ambiguous evidence when classification would overclaim"
+                            .to_string(),
+                    ],
+                },
+                ExploitArtifactLifecycleMemberContract {
+                    artifact_type: "AdversarialReplayManifest".to_string(),
+                    lifecycle_stage: "replay".to_string(),
+                    purpose: "define how an exploit scenario should be reproduced or explicitly limited"
+                        .to_string(),
+                    required_fields: vec![
+                        "replay_id".to_string(),
+                        "evidence_ref".to_string(),
+                        "summary".to_string(),
+                        "replay_goal".to_string(),
+                        "replay_mode".to_string(),
+                        "required_preconditions".to_string(),
+                        "environment".to_string(),
+                        "inputs".to_string(),
+                        "replay_steps".to_string(),
+                        "expected_outcome".to_string(),
+                        "success_criteria".to_string(),
+                        "failure_modes".to_string(),
+                        "trace_expectations".to_string(),
+                        "limitations".to_string(),
+                    ],
+                    required_links: vec![
+                        "evidence_ref".to_string(),
+                        "security_posture_ref".to_string(),
+                        "target_ref".to_string(),
+                    ],
+                    reviewer_expectations: vec![
+                        "make determinism expectations explicit".to_string(),
+                        "separate environment requirements from replay steps".to_string(),
+                    ],
+                    allowed_omissions: vec![
+                        "strict replay may be deferred only with explicit limitations".to_string(),
+                    ],
+                },
+                ExploitArtifactLifecycleMemberContract {
+                    artifact_type: "MitigationLinkageArtifact".to_string(),
+                    lifecycle_stage: "mitigate".to_string(),
+                    purpose: "link exploit evidence to a chosen defensive response or explicit defer"
+                        .to_string(),
+                    required_fields: vec![
+                        "evidence_ref".to_string(),
+                        "mitigation_id".to_string(),
+                        "mitigation_type".to_string(),
+                        "summary".to_string(),
+                        "protection_boundary".to_string(),
+                        "tradeoffs".to_string(),
+                        "side_effects".to_string(),
+                        "validation_plan".to_string(),
+                    ],
+                    required_links: vec![
+                        "evidence_ref".to_string(),
+                        "classification_ref_or_defer_reason".to_string(),
+                    ],
+                    reviewer_expectations: vec![
+                        "explain why the mitigation addresses the evidence".to_string(),
+                        "make replay validation expectations visible".to_string(),
+                    ],
+                    allowed_omissions: vec![
+                        "mitigation application may be deferred, but defer_reason must be recorded"
+                            .to_string(),
+                    ],
+                },
+                ExploitArtifactLifecycleMemberContract {
+                    artifact_type: "ExploitPromotionArtifact".to_string(),
+                    lifecycle_stage: "promote".to_string(),
+                    purpose: "record how exploit knowledge becomes durable future proof surface"
+                        .to_string(),
+                    required_fields: vec![
+                        "evidence_ref".to_string(),
+                        "mitigation_ref".to_string(),
+                        "promotion_id".to_string(),
+                        "promotion_targets".to_string(),
+                        "promotion_reason".to_string(),
+                        "expected_future_value".to_string(),
+                        "promotion_status".to_string(),
+                    ],
+                    required_links: vec![
+                        "evidence_ref".to_string(),
+                        "mitigation_ref".to_string(),
+                    ],
+                    reviewer_expectations: vec![
+                        "state what became permanent".to_string(),
+                        "preserve provenance for future regression surfaces".to_string(),
+                    ],
+                    allowed_omissions: vec![
+                        "promotion may be planned or deferred, but never implied".to_string(),
+                    ],
+                },
+            ],
+            replay_manifest: AdversarialReplayManifestContract {
+                artifact_type: "AdversarialReplayManifest".to_string(),
+                required_fields: vec![
+                    "replay_id".to_string(),
+                    "evidence_ref".to_string(),
+                    "replay_goal".to_string(),
+                    "replay_mode".to_string(),
+                    "required_preconditions".to_string(),
+                    "environment".to_string(),
+                    "inputs".to_string(),
+                    "replay_steps".to_string(),
+                    "expected_outcome".to_string(),
+                    "success_criteria".to_string(),
+                    "failure_modes".to_string(),
+                    "trace_expectations".to_string(),
+                    "limitations".to_string(),
+                ],
+                replay_modes: vec![
+                    ReplayModeContract {
+                        mode: "deterministic".to_string(),
+                        reproducibility_claim: "same inputs and conditions must reproduce the same outcome"
+                            .to_string(),
+                        allowed_variance: "none beyond explicitly normalized trace metadata"
+                            .to_string(),
+                        required_disclosure: vec![
+                            "stable inputs".to_string(),
+                            "stable environment".to_string(),
+                            "strict expected outcome".to_string(),
+                        ],
+                    },
+                    ReplayModeContract {
+                        mode: "bounded_variance".to_string(),
+                        reproducibility_claim:
+                            "controlled inputs may produce acceptable bounded outcome variance"
+                                .to_string(),
+                        allowed_variance: "declared acceptable outcome range only".to_string(),
+                        required_disclosure: vec![
+                            "variance source".to_string(),
+                            "acceptable bounds".to_string(),
+                            "success criteria".to_string(),
+                        ],
+                    },
+                    ReplayModeContract {
+                        mode: "best_effort".to_string(),
+                        reproducibility_claim:
+                            "conditions can only be reconstructed partially and proof claims must stay limited"
+                                .to_string(),
+                        allowed_variance: "explicitly caveated and reviewer-visible".to_string(),
+                        required_disclosure: vec![
+                            "missing conditions".to_string(),
+                            "known limitations".to_string(),
+                            "non-authoritative replay status".to_string(),
+                        ],
+                    },
+                ],
+                execution_requirements: vec![
+                    "load replay manifest before execution".to_string(),
+                    "validate required preconditions before replay steps".to_string(),
+                    "preserve bounded step order".to_string(),
+                    "capture trace and outputs for review".to_string(),
+                    "evaluate success criteria without relying on prose-only claims".to_string(),
+                ],
+                determinism_rules: vec![
+                    "a manifest must not claim deterministic replay without stable inputs, environment, and expected outcome"
+                        .to_string(),
+                    "non-deterministic replay must declare variance bounds or best-effort limitations"
+                        .to_string(),
+                    "limitations are required whenever replay is partial, deferred, or non-authoritative"
+                        .to_string(),
+                ],
+                mitigation_validation_rules: vec![
+                    "mitigation validation must cite a replay manifest or explicitly explain why replay is not required"
+                        .to_string(),
+                    "post-mitigation replay must state whether unsafe_state_reached changed"
+                        .to_string(),
+                    "regression promotion must preserve replay mode and evidence provenance"
+                        .to_string(),
+                ],
+            },
+            lifecycle_order: vec![
+                "ExploitHypothesisArtifact".to_string(),
+                "ExploitEvidenceArtifact".to_string(),
+                "ExploitClassificationArtifact".to_string(),
+                "AdversarialReplayManifest".to_string(),
+                "MitigationLinkageArtifact".to_string(),
+                "ExploitPromotionArtifact".to_string(),
+            ],
+            runner_integration: ExploitArtifactRunnerIntegrationContract {
+                upstream_contracts: vec![
+                    "adversarial_runtime_model.v1".to_string(),
+                    "red_blue_agent_architecture.v1".to_string(),
+                    "adversarial_execution_runner.v1".to_string(),
+                ],
+                runner_stage_bindings: vec![
+                    "generate_hypothesis -> ExploitHypothesisArtifact".to_string(),
+                    "attempt_bounded_exploit -> ExploitEvidenceArtifact".to_string(),
+                    "evaluate_risk -> ExploitClassificationArtifact".to_string(),
+                    "capture_replay_decision -> AdversarialReplayManifest".to_string(),
+                    "decide_mitigation -> MitigationLinkageArtifact".to_string(),
+                    "emit_runner_packet -> ExploitPromotionArtifact or explicit defer"
+                        .to_string(),
+                ],
+                required_review_packet_links: vec![
+                    "target_ref".to_string(),
+                    "security_posture_ref".to_string(),
+                    "trace_refs".to_string(),
+                    "related_artifacts".to_string(),
+                    "replay_mode".to_string(),
+                ],
+            },
+            integrity: ExploitArtifactIntegrityContract {
+                rules: vec![
+                    "no proof without ExploitEvidenceArtifact or equivalent explicit validation"
+                        .to_string(),
+                    "no mitigation without exploit evidence linkage".to_string(),
+                    "no promotion without evidence and mitigation provenance".to_string(),
+                    "no silent ambiguity; ambiguous outcomes must stay explicit".to_string(),
+                    "no posture-free exploit artifact".to_string(),
+                ],
+                prohibited_shortcuts: vec![
+                    "narrative-only exploit records".to_string(),
+                    "schema collapse across hypothesis, evidence, replay, mitigation, and promotion"
+                        .to_string(),
+                    "target identity omission".to_string(),
+                    "posture linkage omission".to_string(),
+                    "determinism overclaiming".to_string(),
+                ],
+                promotion_requirements: vec![
+                    "promotion target must name regression test, replay suite, hardening rule, provider warning, or posture rule"
+                        .to_string(),
+                    "promotion_status must be planned, applied, or deferred".to_string(),
+                    "deferred promotion must include defer_reason".to_string(),
+                ],
+            },
+            review_surface: ExploitArtifactReviewSurfaceContract {
+                required_questions: vec![
+                    "what was hypothesized, attempted, observed, classified, replayed, mitigated, and promoted"
+                        .to_string(),
+                    "which target, posture, trace, and related artifacts prove provenance"
+                        .to_string(),
+                    "does the replay manifest justify deterministic, bounded-variance, or best-effort status"
+                        .to_string(),
+                    "what is explicitly deferred instead of silently omitted".to_string(),
+                ],
+                required_visibility: vec![
+                    "canonical lifecycle order".to_string(),
+                    "shared base fields and status semantics".to_string(),
+                    "target_ref and trace_refs".to_string(),
+                    "replay mode and limitations".to_string(),
+                    "mitigation and promotion linkage".to_string(),
+                ],
+                downstream_boundaries: vec![
+                    "continuous verification scheduling remains WP-06".to_string(),
+                    "flagship adversarial demo wiring remains WP-07".to_string(),
+                    "operational skill composition remains WP-08".to_string(),
+                    "full replay runner CLI remains future executable tooling beyond this schema contract"
+                        .to_string(),
+                ],
+            },
+            proof_fixture_hooks: vec![
+                "adl::exploit_artifact_replay::ExploitArtifactReplayContract::v1".to_string(),
+                "adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json"
+                    .to_string(),
+            ],
+            proof_hook_command:
+                "adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/exploit_artifact_replay_v1.json".to_string(),
+            scope_boundary:
+                "bounded exploit artifact schema and replay manifest contract only; continuous verification scheduling, self-attack loops, flagship demos, and a full replay execution CLI remain downstream work."
+                    .to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ExploitArtifactReplayContract;
+
+    #[test]
+    fn exploit_artifact_replay_contract_covers_full_lifecycle_and_links() {
+        let contract = ExploitArtifactReplayContract::v1();
+
+        assert_eq!(contract.schema_version, "exploit_artifact_replay.v1");
+        assert_eq!(
+            contract.lifecycle_order,
+            vec![
+                "ExploitHypothesisArtifact",
+                "ExploitEvidenceArtifact",
+                "ExploitClassificationArtifact",
+                "AdversarialReplayManifest",
+                "MitigationLinkageArtifact",
+                "ExploitPromotionArtifact",
+            ]
+        );
+        assert_eq!(contract.artifact_family.len(), 6);
+        assert!(contract
+            .shared_base
+            .required_base_fields
+            .iter()
+            .any(|field| field == "security_posture_ref"));
+        assert!(contract
+            .artifact_family
+            .iter()
+            .any(
+                |artifact| artifact.artifact_type == "ExploitEvidenceArtifact"
+                    && artifact
+                        .required_links
+                        .iter()
+                        .any(|link| link == "hypothesis_ref")
+            ));
+        assert!(contract
+            .artifact_family
+            .iter()
+            .any(
+                |artifact| artifact.artifact_type == "MitigationLinkageArtifact"
+                    && artifact
+                        .required_links
+                        .iter()
+                        .any(|link| link == "evidence_ref")
+            ));
+        assert!(contract
+            .runner_integration
+            .runner_stage_bindings
+            .iter()
+            .any(|binding| binding == "capture_replay_decision -> AdversarialReplayManifest"));
+    }
+
+    #[test]
+    fn replay_manifest_contract_requires_explicit_determinism_and_limitations() {
+        let contract = ExploitArtifactReplayContract::v1();
+
+        let replay_modes: Vec<&str> = contract
+            .replay_manifest
+            .replay_modes
+            .iter()
+            .map(|mode| mode.mode.as_str())
+            .collect();
+        assert_eq!(
+            replay_modes,
+            vec!["deterministic", "bounded_variance", "best_effort"]
+        );
+        assert!(contract
+            .replay_manifest
+            .required_fields
+            .iter()
+            .any(|field| field == "limitations"));
+        assert!(contract
+            .replay_manifest
+            .determinism_rules
+            .iter()
+            .any(|rule| rule.contains("must not claim deterministic replay")));
+        assert!(contract
+            .integrity
+            .rules
+            .iter()
+            .any(|rule| rule == "no posture-free exploit artifact"));
+        assert!(contract
+            .review_surface
+            .downstream_boundaries
+            .iter()
+            .any(|boundary| boundary.contains("WP-06")));
+    }
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -22,6 +22,7 @@ pub mod delegation_policy;
 pub mod demo;
 pub mod execute;
 pub mod execution_plan;
+pub mod exploit_artifact_replay;
 pub mod failure_taxonomy;
 pub mod freedom_gate;
 pub mod godel;

--- a/docs/milestones/v0.89.1/features/ADVERSARIAL_REPLAY_MANIFEST.md
+++ b/docs/milestones/v0.89.1/features/ADVERSARIAL_REPLAY_MANIFEST.md
@@ -1,498 +1,125 @@
-
-
 # Adversarial Replay Manifest
 
 ## Metadata
+
 - Project: `ADL`
-- Status: `Draft`
+- Status: `Implemented`
 - Owner: `Daniel Austin`
 - Created: `2026-04-12`
-
----
+- Updated: `2026-04-15`
+- Version: `v0.89.1`
+- WP: `WP-05`
 
 ## Purpose
 
-Define the **Adversarial Replay Manifest** as the canonical artifact for reproducing exploit scenarios in ADL.
+The adversarial replay manifest is the artifact that turns exploit evidence into a reproducible or explicitly limited experiment.
 
-This document specifies how exploit evidence is transformed into:
+In `v0.89.1`, this manifest is implemented as part of the `ExploitArtifactReplayContract`:
 
-- deterministic or explainable replay
-- validation of mitigations
-- durable regression surfaces
-- reviewer-visible proof paths
+```text
+adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json
+```
 
-The central claim is:
+The contract defines replay structure, replay modes, determinism rules, mitigation validation rules, and review expectations. It does not yet provide a standalone `adl replay` execution command.
 
-> An exploit is not fully real in engineering terms until it can be replayed, validated, and inspected as a structured artifact.
+## Role In The Lifecycle
 
----
-
-## Overview
-
-Replay is the bridge between:
-
-- exploit discovery
-- mitigation validation
-- regression prevention
-
-Without replay:
-
-- exploit evidence remains anecdotal
-- mitigation cannot be verified reliably
-- regressions cannot be prevented systematically
-
-With replay:
-
-- exploit scenarios become reproducible
-- mitigations can be tested under identical or controlled conditions
-- adversarial knowledge becomes durable and cumulative
-
-The Adversarial Replay Manifest is the artifact that makes this possible.
-
----
-
-## Core Claim
-
-A replay manifest defines:
-
-- what scenario should be reproduced
-- under what conditions
-- using what steps
-- with what expected outcome
-
-It converts exploit evidence into a **repeatable experiment**.
-
----
-
-## Role in the Adversarial Lifecycle
-
-The replay manifest sits at a critical point in the lifecycle:
+The replay manifest sits between exploit evidence and mitigation validation:
 
 ```text
 ExploitEvidenceArtifact
 -> AdversarialReplayManifest
--> Mitigation validation
--> Regression promotion
+-> MitigationLinkageArtifact
+-> ExploitPromotionArtifact
 ```
 
-It is the artifact that allows a system to move from:
+It answers:
 
-- "we saw something happen"
+- what scenario should be reproduced
+- under what preconditions
+- in what environment
+- with what inputs
+- through what bounded steps
+- with what expected outcome
+- under what determinism claim
+- with what known limitations
 
-to:
+## Required Fields
 
-- "we can make it happen again under controlled conditions"
+The implemented contract requires:
 
----
+- `replay_id`
+- `evidence_ref`
+- `replay_goal`
+- `replay_mode`
+- `required_preconditions`
+- `environment`
+- `inputs`
+- `replay_steps`
+- `expected_outcome`
+- `success_criteria`
+- `failure_modes`
+- `trace_expectations`
+- `limitations`
+
+Replay manifests also inherit the shared artifact base fields from the exploit artifact schema family, including `security_posture_ref`, `target_ref`, and `trace_refs`.
 
 ## Replay Modes
 
-Not all replay is identical.
+`deterministic` means the same inputs and conditions must reproduce the same outcome. Allowed variance is limited to explicitly normalized trace metadata.
 
-ADL should explicitly support multiple replay modes.
+`bounded_variance` means controlled inputs may produce an acceptable declared range of outcomes. The manifest must disclose variance source, acceptable bounds, and success criteria.
 
-### 1. Deterministic Replay
+`best_effort` means conditions can only be reconstructed partially. The manifest must disclose missing conditions, known limitations, and non-authoritative replay status.
 
-- identical inputs and conditions
-- identical expected outcome
-- strict reproducibility
+## Determinism Rules
 
-Used when:
-- the system is deterministic or sufficiently controlled
-- exact reproduction is possible and required
+The contract enforces epistemic honesty:
 
----
+- a manifest must not claim deterministic replay without stable inputs, environment, and expected outcome
+- non-deterministic replay must declare variance bounds or best-effort limitations
+- limitations are required whenever replay is partial, deferred, or non-authoritative
 
-### 2. Bounded-Variance Replay
+## Execution Requirements
 
-- inputs and conditions are controlled
-- some variability is allowed
-- outcome must fall within a defined acceptable range
+A future replay runner must be able to:
 
-Used when:
-- stochastic elements exist
-- exact replication is not feasible
+- load the replay manifest before execution
+- validate required preconditions before replay steps
+- preserve bounded step order
+- capture trace and outputs for review
+- evaluate success criteria without relying on prose-only claims
 
----
+These are contract requirements for later tooling. `WP-05` intentionally stops at the schema/proof surface.
 
-### 3. Best-Effort Replay
+## Mitigation Validation
 
-- partial reconstruction of conditions
-- outcome may not be guaranteed
-- used for exploratory or low-confidence cases
+Mitigation validation must cite a replay manifest or explicitly explain why replay is not required.
 
-Used when:
-- environment cannot be fully reconstructed
-- exploit depended on transient conditions
+Post-mitigation replay must state whether `unsafe_state_reached` changed. Regression promotion must preserve replay mode and evidence provenance.
 
----
+## Review Surface
 
-## Manifest Structure
+A reviewer should see:
 
-The Adversarial Replay Manifest is a structured artifact.
+- the original evidence reference
+- the replay goal and mode
+- preconditions and environment
+- ordered replay steps
+- expected outcome and success criteria
+- failure modes
+- trace expectations
+- limitations
+- mitigation and promotion linkage
 
-### Minimum schema
+If any of those are absent, the absence must be a recorded defer rather than an accidental gap.
 
-```yaml
-artifact_type: AdversarialReplayManifest
-schema_version: "v1"
+## Boundaries
 
-replay_id: <stable_replay_id>
-evidence_ref: <exploit_evidence_ref>
-hypothesis_ref: <hypothesis_ref_optional>
+`WP-05` implements the replay manifest contract. Later work owns:
 
-summary: <short_text>
-replay_goal: <short_text>
-
-replay_mode: <deterministic|bounded_variance|best_effort>
-
-security_posture_ref: <posture_ref>
-target_ref: <target_ref>
-
-required_preconditions:
-  - <condition>
-
-environment:
-  type: <demo|sandbox|internal|critical_subset>
-  configuration:
-    - <key: value>
-  dependencies:
-    - <dependency>
-
-inputs:
-  - name: <input_name>
-    value: <value_or_reference>
-
-replay_steps:
-  - step_id: <id>
-    description: <text>
-    expected_intermediate_result: <optional_text>
-
-expected_outcome:
-  unsafe_state_reached: <true|false|unknown>
-  description: <text>
-
-success_criteria:
-  - <condition>
-
-failure_modes:
-  - <condition>
-
-trace_expectations:
-  - <trace_property>
-
-limitations:
-  - <text>
-
-created_at_utc: <timestamp>
-created_by_agent: <agent_id_or_role>
-trace_refs:
-  - <trace_ref>
-```
-
----
-
-## Field Semantics
-
-### `replay_mode`
-
-Defines the strictness of reproducibility expectations.
-
-### `required_preconditions`
-
-Conditions that must be true for replay to be meaningful.
-
-Examples:
-- system state
-- permissions
-- data availability
-- configuration flags
-
----
-
-### `environment`
-
-Describes where and how replay occurs.
-
-Includes:
-- environment type
-- configuration
-- dependencies
-
-This is critical for:
-- reproducibility
-- isolation
-- reviewer understanding
-
----
-
-### `inputs`
-
-Explicit inputs used during replay.
-
-These should be:
-- stable where possible
-- referenceable when large or external
-
----
-
-### `replay_steps`
-
-The ordered sequence of actions required to reproduce the scenario.
-
-Each step should be:
-- clear
-- bounded
-- attributable
-
----
-
-### `expected_outcome`
-
-Defines what constitutes the exploit scenario.
-
-Must distinguish:
-- unsafe state reached
-- safe behavior
-- ambiguous outcomes
-
----
-
-### `success_criteria`
-
-Defines how replay success is judged.
-
-Examples:
-- exploit condition reproduced
-- unsafe state detected
-- mitigation prevents exploit
-
----
-
-### `failure_modes`
-
-Defines known ways replay may fail.
-
-This helps:
-- interpret results correctly
-- avoid false negatives
-
----
-
-### `trace_expectations`
-
-Defines what trace evidence should appear.
-
-Examples:
-- specific events
-- ordering constraints
-- state transitions
-
----
-
-### `limitations`
-
-Explicitly records:
-- incomplete reproducibility
-- environmental gaps
-- known uncertainties
-
-This is essential for epistemic honesty.
-
----
-
-## Runtime Contract
-
-Replay manifests must satisfy strict requirements.
-
-### Required guarantees
-
-- every replay manifest must reference exploit evidence
-- replay steps must be explicit and bounded
-- expected outcomes must be defined
-- success criteria must be testable
-- limitations must be recorded when present
-
-### Integrity rule
-
-A replay manifest must not claim determinism without justification.
-
-If replay is not deterministic, the manifest must:
-- state the expected variance
-- define acceptable outcomes
-
----
-
-## Replay Execution
-
-A replay runner should be able to:
-
-- load a replay manifest
-- validate preconditions
-- configure environment
-- execute steps
-- capture trace and outputs
-- evaluate success criteria
-
-This suggests future tooling:
-
-- `adl replay <manifest>`
-
----
-
-## Relationship to Mitigation
-
-Replay manifests are essential for validating mitigation.
-
-Workflow:
-
-```text
-ExploitEvidenceArtifact
--> AdversarialReplayManifest
--> Mitigation applied
--> Replay executed
--> Validation result
-```
-
-Without replay:
-- mitigation is asserted
-
-With replay:
-- mitigation is proven
-
----
-
-## Relationship to Regression Promotion
-
-Replay manifests are the natural input to regression systems.
-
-They can be promoted into:
-
-- regression tests
-- replay suites
-- continuous validation pipelines
-
-This makes exploit knowledge:
-
-- persistent
-- automated
-- enforceable
-
----
-
-## Temporal Considerations
-
-Replay is inherently temporal.
-
-The manifest should support tracking:
-
-- when replay was created
-- when it was last executed
-- when it last passed or failed
-
-Future extension:
-
-```yaml
-replay_history:
-  - executed_at_utc: <timestamp>
-    result: <success|failure|ambiguous>
-```
-
----
-
-## Security Posture Interaction
-
-Replay must respect security posture.
-
-Examples:
-
-- deterministic replay may be required in strict posture
-- exploit validation may be disallowed in audit posture
-- mutation during replay may be restricted
-
-Replay manifests must therefore include posture linkage.
-
----
-
-## Risks and Anti-Patterns
-
-### 1. Non-replayable exploits
-Exploit evidence that cannot be reproduced or explained.
-
-### 2. Hidden assumptions
-Replay depends on conditions not captured in the manifest.
-
-### 3. Overclaiming determinism
-Marking replay as deterministic when variability exists.
-
-### 4. Missing success criteria
-Replay runs without clear pass/fail definition.
-
-### 5. Replay drift
-Replay steps diverge from original exploit conditions over time.
-
-These should be treated as defects.
-
----
-
-## Demo Implications
-
-Minimum viable demo:
-
-- generate exploit evidence
-- construct replay manifest
-- execute replay
-- show outcome matches expectation
-- apply mitigation
-- re-run replay and show changed outcome
-
-This demonstrates:
-
-- replay as proof
-- mitigation validation
-- closed-loop adversarial verification
-
----
-
-## Conceptual Diagram
-
-A dedicated diagram is intentionally deferred for now. The manifest structure and replay contract in this document are the canonical contract.
-
-Illustrate:
-
-- exploit evidence feeding replay manifest
-- replay execution loop
-- mitigation validation path
-- regression promotion path
-- trace substrate underneath
-
----
-
-## Strategic Direction
-
-Future directions include:
-
-- replay runners
-- replay scheduling systems
-- replay-based regression pipelines
-- integration with signed trace
-- replay artifact versioning
-
-Longer term:
-
-> replay manifests may become the canonical unit of adversarial proof in ADL.
-
----
-
-## Conclusion
-
-Replay is what turns exploit discovery into engineering truth.
-
-The Adversarial Replay Manifest provides:
-
-- structure
-- reproducibility
-- validation
-- continuity
-
-It ensures that adversarial knowledge is not lost, but becomes part of the system's durable cognitive and verification substrate.
+- executable replay CLI behavior
+- continuous replay scheduling
+- self-attack loop integration
+- flagship adversarial demo proof packets
+- regression-suite promotion automation

--- a/docs/milestones/v0.89.1/features/EXPLOIT_ARTIFACT_SCHEMA.md
+++ b/docs/milestones/v0.89.1/features/EXPLOIT_ARTIFACT_SCHEMA.md
@@ -1,82 +1,98 @@
-
-
 # Exploit Artifact Schema
 
 ## Metadata
+
 - Project: `ADL`
-- Status: `Draft`
+- Status: `Implemented`
 - Owner: `Daniel Austin`
 - Created: `2026-04-12`
-
----
+- Updated: `2026-04-15`
+- Version: `v0.89.1`
+- WP: `WP-05`
 
 ## Purpose
 
-Define the canonical **exploit artifact schema family** for adversarial verification in ADL.
+`WP-05` makes exploit knowledge a structured artifact family rather than a prose-only finding. The authoritative implementation surface is the Rust contract `adl::exploit_artifact_replay::ExploitArtifactReplayContract::v1`, with proof emitted by:
 
-This document specifies the minimum structural expectations for artifacts produced during:
+```text
+adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json
+```
 
-- exploit hypothesis generation
-- exploit validation
-- replay packaging
-- mitigation linkage
-- regression promotion
+This is a schema and proof-surface slice. It does not yet implement a full exploit runner, continuous verification scheduler, or flagship adversarial demo.
 
-The central claim is:
+## Owned Surfaces
 
-> Exploit knowledge should not remain trapped in prose. It should become structured, replayable, reviewable engineering artifacts.
+- `adl/src/exploit_artifact_replay.rs`
+- `adl::exploit_artifact_replay::ExploitArtifactReplayContract`
+- `adl::exploit_artifact_replay::ExploitArtifactLifecycleMemberContract`
+- `adl::exploit_artifact_replay::AdversarialReplayManifestContract`
+- `adl::exploit_artifact_replay::ReplayModeContract`
+- `adl identity exploit-replay`
 
----
+## Runtime Claim
 
-## Overview
+ADL adversarial findings must become structured, posture-linked, replay-aware artifacts rather than remaining narrative-only claims.
 
-The adversarial documents in this cluster assume that exploit discovery will produce durable artifacts rather than loose narrative summaries.
+The schema family preserves:
 
-That assumption now needs a schema surface.
+- evidence over rhetoric
+- lifecycle separation
+- target and posture linkage
+- trace linkage
+- replay expectations
+- mitigation provenance
+- promotion provenance
 
-Without a canonical artifact model:
+## Shared Base Fields
 
-- exploit evidence becomes inconsistent
-- replay becomes fragile
-- mitigation linkage becomes ambiguous
-- regression promotion becomes ad hoc
-- reviewers cannot reliably compare findings across runs or targets
+Every artifact in the family carries a common base shape:
 
-ADL therefore needs a stable exploit artifact family that is:
+- `artifact_id`
+- `artifact_type`
+- `schema_version`
+- `status`
+- `created_at_utc`
+- `updated_at_utc`
+- `created_by_agent`
+- `run_id`
+- `trace_refs`
+- `related_artifacts`
+- `security_posture_ref`
+- `target_ref`
 
-- bounded
-- structured
-- trace-linked
-- posture-aware
-- replay-friendly
-- suitable for promotion into durable proof surfaces
+The status vocabulary is:
 
----
+- `draft`
+- `recorded`
+- `validated`
+- `deferred`
+- `superseded`
 
-## Schema Philosophy
+## Target And Trace References
 
-Exploit artifacts in ADL should follow several principles.
+`target_ref` must preserve enough identity to compare findings across runs:
 
-### 1. Evidence over rhetoric
-An exploit artifact should record what was actually hypothesized, attempted, observed, and learned.
+- `target_id`
+- `target_type`
+- `target_name`
+- `environment`
 
-### 2. Separation by lifecycle stage
-Hypothesis, proof, replay, mitigation, and promotion are related but distinct stages. Each should have a clear artifact role.
+`trace_refs` must keep evidence tied to runtime truth:
 
-### 3. Trace-linked structure
-Every exploit artifact should be linkable to trace events, posture declarations, targets, and temporal anchors.
+- `trace_id`
+- `step_id`
+- `note`
 
-### 4. Replayability when possible
-Artifacts should contain enough structured data to support deterministic replay or an explicit statement of why replay is limited.
+Temporal extension fields are reserved for later continuity surfaces:
 
-### 5. Promotion readiness
-Artifacts should be suitable for conversion into regression tests, replay suites, hardening rules, or later review surfaces.
-
----
+- `first_seen_utc`
+- `validated_at_utc`
+- `mitigated_at_utc`
+- `replay_validated_at_utc`
 
 ## Canonical Artifact Family
 
-ADL should treat the following as the minimum exploit artifact family.
+The implemented contract defines six lifecycle members in order:
 
 1. `ExploitHypothesisArtifact`
 2. `ExploitEvidenceArtifact`
@@ -85,456 +101,66 @@ ADL should treat the following as the minimum exploit artifact family.
 5. `MitigationLinkageArtifact`
 6. `ExploitPromotionArtifact`
 
-These may be represented as YAML, JSON, or another canonical artifact format later, but the field model should be stable.
-
----
-
-## Shared Base Fields
-
-All exploit artifact types should include a common base field set.
-
-```yaml
-artifact_id: <uuid-or-stable-id>
-artifact_type: <type_name>
-schema_version: "v1"
-status: <draft|recorded|validated|deferred|superseded>
-created_at_utc: <timestamp>
-updated_at_utc: <timestamp>
-created_by_agent: <agent_id_or_role>
-run_id: <run_id>
-trace_refs:
-  - <trace_ref>
-related_artifacts:
-  - <artifact_ref>
-security_posture_ref: <posture_ref>
-target_ref: <target_ref>
-```
-
-### Shared field expectations
-
-- `artifact_id` must uniquely identify the artifact
-- `artifact_type` must identify the schema family member
-- `schema_version` makes future migration possible
-- `status` records lifecycle state
-- `trace_refs` link the artifact to execution evidence
-- `related_artifacts` link artifacts across the adversarial lifecycle
-- `security_posture_ref` ties the artifact to declared posture
-- `target_ref` identifies the attacked or defended surface
-
----
-
-## 1. ExploitHypothesisArtifact
-
-Purpose:
-Capture a structured claim that an exploit path may exist.
-
-### Minimum schema
-
-```yaml
-artifact_type: ExploitHypothesisArtifact
-hypothesis_id: <stable_hypothesis_id>
-exploit_family: <string_or_enum>
-summary: <short_text>
-target_surface: <surface_name>
-unsafe_outcome: <short_text>
-preconditions:
-  - <condition>
-steps:
-  - <hypothesized_step>
-confidence:
-  level: <low|medium|high>
-  rationale: <text>
-uncertainties:
-  - <text>
-policy_notes:
-  - <text>
-```
-
-### Expectations
-
-- must identify the suspected unsafe path clearly
-- must state the expected unsafe outcome
-- must separate required preconditions from uncertainty
-- may exist even if no exploit attempt is later allowed
-
----
-
-## 2. ExploitEvidenceArtifact
-
-Purpose:
-Record what happened during an actual bounded exploit attempt.
-
-### Minimum schema
-
-```yaml
-artifact_type: ExploitEvidenceArtifact
-hypothesis_ref: <hypothesis_id>
-attempt_id: <stable_attempt_id>
-outcome: <success|failure|ambiguous|blocked>
-outcome_summary: <short_text>
-preconditions_observed:
-  satisfied:
-    - <condition>
-  unsatisfied:
-    - <condition>
-attempt_steps:
-  - step: <text>
-    result: <text>
-observed_effects:
-  - <text>
-unsafe_state_reached: <true|false|unknown>
-evidence_refs:
-  - <log|trace|artifact_ref>
-replayability:
-  state: <replayable|partially_replayable|non_replayable>
-  rationale: <text>
-residual_uncertainty:
-  - <text>
-```
-
-### Expectations
-
-- must distinguish success, failure, ambiguity, and policy blocking
-- must capture actual attempt behavior, not just intention
-- must link directly to observable evidence
-- should support later replay packaging when possible
-
----
-
-## 3. ExploitClassificationArtifact
-
-Purpose:
-Convert exploit evidence into reusable categorized knowledge.
-
-### Minimum schema
-
-```yaml
-artifact_type: ExploitClassificationArtifact
-evidence_ref: <attempt_id_or_artifact_ref>
-exploit_family: <string_or_enum>
-target_type: <string_or_enum>
-severity:
-  level: <informational|low|medium|high|critical>
-  rationale: <text>
-reproducibility:
-  level: <low|medium|high>
-recurrence_potential: <low|medium|high>
-mitigation_complexity: <low|medium|high>
-classification_notes:
-  - <text>
-```
-
-### Expectations
-
-- must not overwrite raw evidence; it interprets it
-- should help prioritize future verification and mitigation work
-- should help cluster exploit families over time
-
----
-
-## 4. AdversarialReplayManifest
-
-Purpose:
-Define how an exploit scenario should be replayed.
-
-### Minimum schema
-
-```yaml
-artifact_type: AdversarialReplayManifest
-evidence_ref: <attempt_id_or_artifact_ref>
-replay_id: <stable_replay_id>
-replay_goal: <short_text>
-required_preconditions:
-  - <condition>
-environment_requirements:
-  - <requirement>
-replay_steps:
-  - <step>
-expected_outcome:
-  unsafe_state_reached: <true|false|unknown>
-  notes: <text>
-determinism_expectation: <deterministic|bounded_variance|best_effort>
-replay_limitations:
-  - <text>
-```
-
-### Expectations
-
-- must be usable by a reviewer or tool to understand replay requirements
-- should separate environmental needs from the replay steps themselves
-- must make determinism expectations explicit
-
----
-
-## 5. MitigationLinkageArtifact
-
-Purpose:
-Link exploit evidence to a chosen defensive response.
+Not every run must produce every member, but omissions must be explicit. For example, audit posture may block exploit attempts, and ambiguous evidence may defer classification.
 
-### Minimum schema
+## Lifecycle Semantics
 
-```yaml
-artifact_type: MitigationLinkageArtifact
-evidence_ref: <attempt_id_or_artifact_ref>
-classification_ref: <artifact_ref_optional>
-mitigation_id: <stable_mitigation_id>
-mitigation_type: <patch|config_hardening|containment|policy_change|defer>
-summary: <short_text>
-protection_boundary: <text>
-tradeoffs:
-  - <text>
-side_effects:
-  - <text>
-validation_plan:
-  replay_required: <true|false>
-  replay_ref: <replay_id_or_ref_optional>
-defer_reason: <text_optional>
-```
+`ExploitHypothesisArtifact` records the suspected unsafe path, preconditions, confidence, uncertainty, and policy notes.
 
-### Expectations
+`ExploitEvidenceArtifact` records what actually happened during a bounded exploit attempt or blocked attempt, including outcome, observed effects, evidence refs, replayability, and residual uncertainty.
 
-- must explain why the mitigation addresses the exploit
-- must represent defer decisions explicitly rather than silently omitting them
-- should make replay validation expectations visible
+`ExploitClassificationArtifact` interprets evidence without overwriting it, adding severity, reproducibility, recurrence potential, and mitigation complexity.
 
----
+`AdversarialReplayManifest` defines how evidence should be reproduced or why strict replay is limited.
 
-## 6. ExploitPromotionArtifact
+`MitigationLinkageArtifact` links evidence to a defensive response or explicit defer, including validation expectations.
 
-Purpose:
-Record how exploit knowledge is promoted into durable future proof surfaces.
+`ExploitPromotionArtifact` records what becomes durable: regression tests, replay suites, hardening rules, provider warnings, or posture rules.
 
-### Minimum schema
+## Integrity Rules
 
-```yaml
-artifact_type: ExploitPromotionArtifact
-evidence_ref: <attempt_id_or_artifact_ref>
-mitigation_ref: <mitigation_id_or_ref>
-promotion_id: <stable_promotion_id>
-promotion_targets:
-  - type: <regression_test|replay_suite|hardening_rule|provider_warning|posture_rule>
-    ref: <target_ref_or_path>
-promotion_reason: <short_text>
-expected_future_value:
-  - <text>
-promotion_status: <planned|applied|deferred>
-defer_reason: <text_optional>
-```
+The contract makes these rules explicit:
 
-### Expectations
+- no proof without `ExploitEvidenceArtifact` or equivalent validation
+- no mitigation without exploit evidence linkage
+- no promotion without evidence and mitigation provenance
+- no silent ambiguity
+- no posture-free exploit artifact
 
-- must say what became permanent, not just that "learning happened"
-- should connect the exploit lifecycle to future validation surfaces
-- makes cumulative adversarial learning inspectable
+These are review rules, not just naming conventions.
 
----
+## Runner Integration
 
-## Target Reference Model
+The schema binds to the upstream contracts from `WP-02`, `WP-03`, and `WP-04`:
 
-All exploit artifacts depend on a stable notion of target identity.
+- `adversarial_runtime_model.v1`
+- `red_blue_agent_architecture.v1`
+- `adversarial_execution_runner.v1`
 
-Minimum target reference model:
+The runner-stage bindings are:
 
-```yaml
-target_ref:
-  target_id: <stable_id>
-  target_type: <demo_fixture|sandbox_service|workflow_surface|policy_boundary|artifact_surface|provider_boundary>
-  target_name: <human_readable_name>
-  environment: <demo|sandbox|internal|critical_subset>
-```
+- `generate_hypothesis -> ExploitHypothesisArtifact`
+- `attempt_bounded_exploit -> ExploitEvidenceArtifact`
+- `evaluate_risk -> ExploitClassificationArtifact`
+- `capture_replay_decision -> AdversarialReplayManifest`
+- `decide_mitigation -> MitigationLinkageArtifact`
+- `emit_runner_packet -> ExploitPromotionArtifact or explicit defer`
 
-This should be stable enough to make exploit knowledge comparable over time.
+## Review Surface
 
----
+A reviewer should be able to answer:
 
-## Trace Reference Model
+- what was hypothesized, attempted, observed, classified, replayed, mitigated, and promoted
+- which target, posture, trace, and related artifacts prove provenance
+- whether the replay manifest justifies deterministic, bounded-variance, or best-effort status
+- what is explicitly deferred instead of silently omitted
 
-Exploit artifacts must remain coupled to trace.
+## Boundaries
 
-Minimum trace reference shape:
+`WP-05` owns the schema family and replay manifest contract. Later work owns:
 
-```yaml
-trace_refs:
-  - trace_id: <trace_id>
-    step_id: <step_or_event_id_optional>
-    note: <short_text_optional>
-```
-
-This allows exploit evidence to remain tied back to runtime truth.
-
----
-
-## Temporal Requirements
-
-Exploit artifacts are also temporal artifacts.
-
-In addition to shared timestamps, artifacts should support later extension with fields such as:
-
-```yaml
-temporal_context:
-  first_seen_utc: <timestamp_optional>
-  validated_at_utc: <timestamp_optional>
-  mitigated_at_utc: <timestamp_optional>
-  replay_validated_at_utc: <timestamp_optional>
-```
-
-This matters because exploit history is part of system continuity, not merely a detached incident log.
-
----
-
-## Status Semantics
-
-The common `status` field should be interpreted consistently.
-
-- `draft` = generated but not yet treated as authoritative
-- `recorded` = captured as part of the run record
-- `validated` = reviewed or confirmed sufficiently for downstream use
-- `deferred` = explicitly left unresolved or unapplied
-- `superseded` = replaced by a newer or corrected artifact
-
-These semantics help keep exploit knowledge legible as it evolves.
-
----
-
-## Schema Integrity Rules
-
-The exploit artifact family should obey several integrity rules.
-
-### Rule 1. No proof without evidence
-An exploit cannot be treated as proven without an `ExploitEvidenceArtifact` or an equivalent explicit validation artifact.
-
-### Rule 2. No mitigation without exploit linkage
-A mitigation in this adversarial flow must point back to the exploit evidence that motivated it.
-
-### Rule 3. No promotion without source knowledge
-A promoted regression surface must identify the exploit evidence and mitigation context it preserves.
-
-### Rule 4. No silent ambiguity
-Ambiguous cases must remain explicit in artifact fields.
-
-### Rule 5. No posture-free exploit artifact
-Exploit artifacts must identify the security posture under which they were produced.
-
----
-
-## Example Lifecycle
-
-A typical exploit lifecycle should look like this:
-
-```text
-ExploitHypothesisArtifact
--> ExploitEvidenceArtifact
--> ExploitClassificationArtifact
--> AdversarialReplayManifest
--> MitigationLinkageArtifact
--> ExploitPromotionArtifact
-```
-
-Not every run will produce every artifact.
-But the lifecycle should be explicit enough that omissions are meaningful rather than accidental.
-
----
-
-## Serialization Guidance
-
-ADL can decide later whether these artifacts live primarily as:
-
-- YAML files
-- JSON blobs
-- typed Rust structs with serialization
-- trace-attached artifact records
-
-For now, the main requirement is conceptual stability.
-
-That means:
-
-- fields should be named consistently
-- artifact boundaries should be stable
-- the schema family should be easy to map into code later
-
----
-
-## Relationship to Existing Docs
-
-This schema doc is the structural companion to:
-
-- `ADL_ADVERSARIAL_RUNTIME_MODEL.md`
-- `RED_BLUE_AGENT_ARCHITECTURE.md`
-- `SELF_ATTACKING_SYSTEMS.md`
-- `ADL_SECURITY_POSTURE_MODEL.md`
-- `CONTINUOUS_VERIFICATION_AND_EXPLOIT_GENERATION.md`
-
-Those docs define the runtime, roles, loop, control surface, and verification pattern.
-This doc defines the artifact truth those patterns rely on.
-
----
-
-## Risks and Anti-Patterns
-
-### 1. Narrative-only exploit records
-Documenting findings in prose without stable artifact structure.
-
-### 2. Schema collapse
-Stuffing hypothesis, proof, replay, mitigation, and promotion into one vague artifact.
-
-### 3. Missing target identity
-Recording exploit evidence without a stable notion of what was attacked.
-
-### 4. Missing posture linkage
-Failing to record under what allowed-action posture the exploit evidence was produced.
-
-### 5. Promotion without provenance
-Creating durable regression surfaces without preserving where the knowledge came from.
-
-These should all be treated as defects in the adversarial substrate.
-
----
-
-## Demo Implications
-
-This doc should support at least one artifact-focused proof demo.
-
-Minimum viable demo:
-
-- generate one `ExploitHypothesisArtifact`
-- execute one bounded exploit attempt and emit one `ExploitEvidenceArtifact`
-- package a replay manifest
-- emit one mitigation linkage artifact
-- promote the exploit into one durable regression surface with an `ExploitPromotionArtifact`
-
-The demo should show that exploit knowledge is not merely described.
-It is structured, replayable, and promotable.
-
----
-
-## Strategic Direction
-
-This schema family suggests several future directions:
-
-- typed Rust schema structs
-- validation tooling for artifact completeness
-- artifact-to-trace integrity checks
-- replay runners that consume manifests directly
-- regression promotion tooling driven from exploit artifacts
-
-Longer term, this supports a broader platform claim:
-
-> adversarial knowledge should become part of the durable substrate of software engineering, not a pile of disconnected incident notes.
-
----
-
-## Conclusion
-
-If exploit generation is going to become a serious engineering capability in ADL, it needs serious artifacts.
-
-The exploit artifact schema family provides the beginning of that substrate.
-It turns exploit discovery from a fleeting narrative event into a structured lifecycle:
-
-- hypothesize
-- prove
-- classify
-- replay
-- mitigate
-- promote
-
-That structure is what makes adversarial verification cumulative, reviewable, and ultimately trustworthy.
+- continuous verification scheduling in `WP-06`
+- self-attack loops in `WP-06`
+- flagship adversarial demo wiring in `WP-07`
+- operational skill composition in `WP-08`
+- full replay execution CLI beyond this schema contract


### PR DESCRIPTION
Closes #1926

## Summary
Implemented the bounded `WP-05` exploit artifact and replay schema package. The branch now adds a typed `exploit_artifact_replay.v1` contract, exposes it through `adl identity exploit-replay`, validates the schema lifecycle and identity proof hook, and rewrites the promoted feature docs from draft planning language into implemented contract truth.

## Artifacts
- `adl/src/exploit_artifact_replay.rs`
- `adl/src/lib.rs`
- `adl/src/cli/identity_cmd/contracts.rs`
- `adl/src/cli/identity_cmd/dispatch.rs`
- `adl/src/cli/identity_cmd/tests.rs`
- `adl/src/cli/usage.rs`
- `docs/milestones/v0.89.1/features/EXPLOIT_ARTIFACT_SCHEMA.md`
- `docs/milestones/v0.89.1/features/ADVERSARIAL_REPLAY_MANIFEST.md`
- generated proof artifact: `.adl/state/exploit_artifact_replay_v1.json`
- determinism comparison artifacts: `.adl/determinism/exploit_artifact_replay_a.json` and `.adl/determinism/exploit_artifact_replay_b.json`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 1926 --version v0.89.1 --json` verified the issue was structurally ready, pre-run, and unblocked before binding.
  - `bash adl/tools/pr.sh run 1926 --version v0.89.1` bound the issue branch/worktree and materialized the local STP/SIP/SOR bundle.
  - `cargo fmt --manifest-path adl/Cargo.toml --all` formatted Rust changes.
  - `cargo test --manifest-path adl/Cargo.toml exploit_artifact -- --nocapture` verified the new exploit artifact/replay contract unit tests.
  - `cargo test --manifest-path adl/Cargo.toml identity_exploit_replay -- --nocapture` verified the new identity proof hook and argument validation tests.
  - `cargo test --manifest-path adl/Cargo.toml identity_ -- --nocapture` verified the broader identity command family after adding the new subcommand.
  - `cargo run --manifest-path adl/Cargo.toml -- identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json` emitted the proof artifact through the public CLI path.
  - `adl/target/debug/adl identity exploit-replay --out .adl/determinism/exploit_artifact_replay_a.json` emitted the first determinism artifact.
  - `adl/target/debug/adl identity exploit-replay --out .adl/determinism/exploit_artifact_replay_b.json` emitted the second determinism artifact.
  - `cmp -s .adl/determinism/exploit_artifact_replay_a.json .adl/determinism/exploit_artifact_replay_b.json && echo BYTE_STABLE=PASS` verified byte-for-byte stable proof output.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified formatting stayed clean.
  - `git diff --check` verified no whitespace errors.
  - `rg -n "<absolute-host-path-patterns>" adl/src/exploit_artifact_replay.rs docs/milestones/v0.89.1/features/EXPLOIT_ARTIFACT_SCHEMA.md docs/milestones/v0.89.1/features/ADVERSARIAL_REPLAY_MANIFEST.md .adl/state/exploit_artifact_replay_v1.json` checked the changed tracked surfaces and generated proof artifact for absolute host-path leakage.
- Results: PASS for all listed validation commands.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1926__v0-89-1-wp-05-exploit-artifact-and-replay-schema/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1926__v0-89-1-wp-05-exploit-artifact-and-replay-schema/sor.md
- Idempotency-Key: v0-89-1-wp-05-exploit-artifact-and-replay-schema-adl-v0-89-1-tasks-issue-1926-v0-89-1-wp-05-exploit-artifact-and-replay-schema-sip-md-adl-v0-89-1-tasks-issue-1926-v0-89-1-wp-05-exploit-artifact-and-replay-schema-sor-md