### PR TITLE
[v0.89.1][WP-07] Adversarial demo and security proof surfaces

### DIFF
--- a/adl/src/cli/demo_cmd.rs
+++ b/adl/src/cli/demo_cmd.rs
@@ -39,16 +39,7 @@ pub(crate) fn real_demo(args: &[String]) -> Result<()> {
 
     if !demo::known_demo(demo_name) {
         eprintln!("unknown demo: {demo_name}");
-        eprintln!(
-            "available demos: {}, {}, {}, {}, {}, {}, {}",
-            demo::DEMO_A_SAY_MCP,
-            demo::DEMO_B_ONE_COMMAND,
-            demo::DEMO_C_GODEL_RUNTIME,
-            demo::DEMO_D_GODEL_OBSMEM_LOOP,
-            demo::DEMO_E_MULTI_AGENT_CARD_PIPELINE,
-            demo::DEMO_F_OBSMEM_RETRIEVAL,
-            demo::DEMO_G_V086_CONTROL_PATH
-        );
+        eprintln!("available demos: {}", demo::available_demos().join(", "));
         std::process::exit(2);
     }
 

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -73,6 +73,8 @@ Examples:
   adl demo demo-d-godel-obsmem-loop --run --trace --out ./out
   adl demo demo-e-multi-agent-card-pipeline --run --trace --out ./out
   adl demo demo-f-obsmem-retrieval --run --trace --out ./out
+  adl demo demo-g-v086-control-path --run --trace --out ./out
+  adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open
   adl provider setup chatgpt
   adl provider setup claude
   adl provider setup anthropic --out ./.adl/provider-setup/anthropic

--- a/adl/src/demo.rs
+++ b/adl/src/demo.rs
@@ -6,6 +6,8 @@ use crate::godel;
 use crate::prompt;
 use crate::trace::Trace;
 
+#[path = "demo/adversarial_self_attack.rs"]
+mod adversarial_self_attack;
 #[path = "demo/obsmem.rs"]
 mod obsmem;
 #[path = "demo/pipeline.rs"]
@@ -33,6 +35,18 @@ pub const DEMO_D_GODEL_OBSMEM_LOOP: &str = "demo-d-godel-obsmem-loop";
 pub const DEMO_E_MULTI_AGENT_CARD_PIPELINE: &str = "demo-e-multi-agent-card-pipeline";
 pub const DEMO_F_OBSMEM_RETRIEVAL: &str = "demo-f-obsmem-retrieval";
 pub const DEMO_G_V086_CONTROL_PATH: &str = "demo-g-v086-control-path";
+pub const DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK: &str = "demo-h-v0891-adversarial-self-attack";
+
+pub const ALL_DEMOS: &[&str] = &[
+    DEMO_A_SAY_MCP,
+    DEMO_B_ONE_COMMAND,
+    DEMO_C_GODEL_RUNTIME,
+    DEMO_D_GODEL_OBSMEM_LOOP,
+    DEMO_E_MULTI_AGENT_CARD_PIPELINE,
+    DEMO_F_OBSMEM_RETRIEVAL,
+    DEMO_G_V086_CONTROL_PATH,
+    DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK,
+];
 
 #[derive(Debug, Clone)]
 pub struct DemoResult {
@@ -42,30 +56,19 @@ pub struct DemoResult {
 }
 
 pub fn known_demo(name: &str) -> bool {
-    matches!(
-        name,
-        DEMO_A_SAY_MCP
-            | DEMO_B_ONE_COMMAND
-            | DEMO_C_GODEL_RUNTIME
-            | DEMO_D_GODEL_OBSMEM_LOOP
-            | DEMO_E_MULTI_AGENT_CARD_PIPELINE
-            | DEMO_F_OBSMEM_RETRIEVAL
-            | DEMO_G_V086_CONTROL_PATH
-    )
+    ALL_DEMOS.contains(&name)
+}
+
+pub fn available_demos() -> &'static [&'static str] {
+    ALL_DEMOS
 }
 
 pub fn run_demo(name: &str, out_dir: &Path) -> Result<DemoResult> {
     if !known_demo(name) {
         return Err(anyhow!(
-            "unknown demo '{}'; available demos: {}, {}, {}, {}, {}, {}, {}",
+            "unknown demo '{}'; available demos: {}",
             name,
-            DEMO_A_SAY_MCP,
-            DEMO_B_ONE_COMMAND,
-            DEMO_C_GODEL_RUNTIME,
-            DEMO_D_GODEL_OBSMEM_LOOP,
-            DEMO_E_MULTI_AGENT_CARD_PIPELINE,
-            DEMO_F_OBSMEM_RETRIEVAL,
-            DEMO_G_V086_CONTROL_PATH
+            available_demos().join(", ")
         ));
     }
 
@@ -220,6 +223,11 @@ pub fn run_demo(name: &str, out_dir: &Path) -> Result<DemoResult> {
                 }
                 _ => {}
             },
+            DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK => {
+                artifacts.extend(adversarial_self_attack::write_adversarial_self_attack_step(
+                    out_dir, step_id,
+                )?);
+            }
             _ => {}
         }
         trace.step_finished(step_id, true);
@@ -244,6 +252,16 @@ pub fn plan_steps(name: &str) -> &'static [&'static str] {
         DEMO_E_MULTI_AGENT_CARD_PIPELINE => &["writer", "editor", "copyeditor", "publisher"],
         DEMO_F_OBSMEM_RETRIEVAL => &["seed", "query", "emit"],
         DEMO_G_V086_CONTROL_PATH => &["integrate", "summarize"],
+        DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK => &[
+            "target_and_posture",
+            "exploit_hypothesis",
+            "exploit_evidence",
+            "replay_pre_fix",
+            "mitigation",
+            "replay_post_fix",
+            "promotion",
+            "review_packet",
+        ],
         _ => &[],
     }
 }
@@ -294,6 +312,40 @@ fn steps_for(name: &str) -> &'static [(&'static str, &'static str)] {
                 "Emit the canonical bounded cognitive path proof surfaces",
             ),
             ("summarize", "Emit deterministic control-path summary"),
+        ],
+        DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK => &[
+            (
+                "target_and_posture",
+                "Declare the bounded demo target and security posture",
+            ),
+            (
+                "exploit_hypothesis",
+                "Emit a structured exploit hypothesis artifact",
+            ),
+            (
+                "exploit_evidence",
+                "Capture bounded exploit evidence and classification artifacts",
+            ),
+            (
+                "replay_pre_fix",
+                "Emit the replay manifest and pre-mitigation replay result",
+            ),
+            (
+                "mitigation",
+                "Link the exploit evidence to a concrete mitigation",
+            ),
+            (
+                "replay_post_fix",
+                "Replay the same request after mitigation and capture the changed result",
+            ),
+            (
+                "promotion",
+                "Promote the exploit into a durable regression surface",
+            ),
+            (
+                "review_packet",
+                "Emit the reviewer-facing adversarial demo proof packet",
+            ),
         ],
         _ => &[],
     }
@@ -822,6 +874,70 @@ mod tests {
         assert!(
             summary.contains("final_result: escalate"),
             "summary was:\n{summary}"
+        );
+    }
+
+    #[test]
+    fn run_demo_h_writes_adversarial_self_attack_artifacts() {
+        let out = tmp_dir("demo-h");
+        let result = run_demo(DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK, &out).unwrap();
+        assert_eq!(result.run_id, DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK);
+        assert!(out.join("target/target.json").is_file());
+        assert!(out.join("target/security_posture.json").is_file());
+        assert!(out.join("hypothesis.json").is_file());
+        assert!(out.join("evidence.json").is_file());
+        assert!(out.join("classification.json").is_file());
+        assert!(out.join("replay_manifest.json").is_file());
+        assert!(out.join("replay_pre_fix/result.json").is_file());
+        assert!(out.join("mitigation.json").is_file());
+        assert!(out.join("replay_post_fix/result.json").is_file());
+        assert!(out.join("promotion.json").is_file());
+        assert!(out.join("review_packet.json").is_file());
+        assert!(out.join("trace.jsonl").is_file());
+
+        let review: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(out.join("review_packet.json")).unwrap())
+                .unwrap();
+        assert_eq!(review["demo_id"], "D5");
+        assert_eq!(
+            review["result_summary"]["pre_mitigation_unsafe_state_reached"],
+            true
+        );
+        assert_eq!(
+            review["result_summary"]["post_mitigation_unsafe_state_reached"],
+            false
+        );
+        assert_eq!(review["result_summary"]["promotion_status"], "applied");
+
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(out.join("replay_manifest.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(manifest["replay_mode"], "deterministic");
+        assert_eq!(
+            manifest["expected_outcome"]["pre_mitigation"]["unsafe_state_reached"],
+            true
+        );
+        assert_eq!(
+            manifest["expected_outcome"]["post_mitigation"]["unsafe_state_reached"],
+            false
+        );
+    }
+
+    #[test]
+    fn demo_h_plan_steps_capture_full_adversarial_loop() {
+        assert_eq!(
+            plan_steps(DEMO_H_V0891_ADVERSARIAL_SELF_ATTACK),
+            &[
+                "target_and_posture",
+                "exploit_hypothesis",
+                "exploit_evidence",
+                "replay_pre_fix",
+                "mitigation",
+                "replay_post_fix",
+                "promotion",
+                "review_packet",
+            ]
         );
     }
 

--- a/adl/src/demo/adversarial_self_attack.rs
+++ b/adl/src/demo/adversarial_self_attack.rs
@@ -1,0 +1,678 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde_json::{json, Map, Value};
+
+use crate::adversarial_execution_runner::ADVERSARIAL_EXECUTION_RUNNER_SCHEMA;
+use crate::adversarial_runtime::ADVERSARIAL_RUNTIME_MODEL_SCHEMA;
+use crate::continuous_verification_self_attack::CONTINUOUS_VERIFICATION_SELF_ATTACK_SCHEMA;
+use crate::exploit_artifact_replay::EXPLOIT_ARTIFACT_REPLAY_SCHEMA;
+use crate::red_blue_agent_architecture::RED_BLUE_AGENT_ARCHITECTURE_SCHEMA;
+
+use super::write_file;
+
+const DEMO_NAME: &str = "demo-h-v0891-adversarial-self-attack";
+const RUN_ID: &str = "demo-h-adversarial-self-attack-run-001";
+const FIXED_TIME: &str = "2026-04-16T00:00:00Z";
+const TARGET_ID: &str = "demo-target-token-gate-v1";
+const POSTURE_ID: &str = "posture-validation-demo-only";
+const HYPOTHESIS_ID: &str = "hyp-token-gate-debug-override";
+const EVIDENCE_ID: &str = "evidence-token-gate-debug-override-pre-fix";
+const CLASSIFICATION_ID: &str = "classification-token-gate-policy-bypass";
+const REPLAY_ID: &str = "replay-token-gate-debug-override";
+const MITIGATION_ID: &str = "mitigation-token-first-admin-gate";
+const PROMOTION_ID: &str = "promotion-token-gate-regression";
+
+const TARGET_PATH: &str = "target/target.json";
+const POSTURE_PATH: &str = "target/security_posture.json";
+const HYPOTHESIS_PATH: &str = "hypothesis.json";
+const EVIDENCE_PATH: &str = "evidence.json";
+const CLASSIFICATION_PATH: &str = "classification.json";
+const REPLAY_PATH: &str = "replay_manifest.json";
+const PRE_REPLAY_PATH: &str = "replay_pre_fix/result.json";
+const MITIGATION_PATH: &str = "mitigation.json";
+const POST_REPLAY_PATH: &str = "replay_post_fix/result.json";
+const PROMOTION_PATH: &str = "promotion.json";
+const REVIEW_PACKET_PATH: &str = "review_packet.json";
+
+pub(super) fn write_adversarial_self_attack_step(
+    out_dir: &Path,
+    step_id: &str,
+) -> Result<Vec<PathBuf>> {
+    match step_id {
+        "target_and_posture" => Ok(vec![
+            write_json(out_dir, TARGET_PATH, &target_definition())?,
+            write_json(out_dir, POSTURE_PATH, &security_posture())?,
+            write_file(out_dir, "README.md", readme())?,
+        ]),
+        "exploit_hypothesis" => Ok(vec![write_json(
+            out_dir,
+            HYPOTHESIS_PATH,
+            &exploit_hypothesis(),
+        )?]),
+        "exploit_evidence" => Ok(vec![
+            write_json(out_dir, EVIDENCE_PATH, &exploit_evidence())?,
+            write_json(out_dir, CLASSIFICATION_PATH, &exploit_classification())?,
+        ]),
+        "replay_pre_fix" => Ok(vec![
+            write_json(out_dir, REPLAY_PATH, &replay_manifest())?,
+            write_json(out_dir, PRE_REPLAY_PATH, &pre_fix_replay_result())?,
+        ]),
+        "mitigation" => Ok(vec![write_json(out_dir, MITIGATION_PATH, &mitigation())?]),
+        "replay_post_fix" => Ok(vec![write_json(
+            out_dir,
+            POST_REPLAY_PATH,
+            &post_fix_replay_result(),
+        )?]),
+        "promotion" => Ok(vec![write_json(out_dir, PROMOTION_PATH, &promotion())?]),
+        "review_packet" => Ok(vec![write_json(
+            out_dir,
+            REVIEW_PACKET_PATH,
+            &review_packet(),
+        )?]),
+        _ => Ok(Vec::new()),
+    }
+}
+
+fn write_json(out_dir: &Path, rel: &str, value: &Value) -> Result<PathBuf> {
+    let mut body = serde_json::to_string_pretty(value)?;
+    body.push('\n');
+    write_file(out_dir, rel, &body)
+}
+
+fn artifact_base(
+    artifact_id: &str,
+    artifact_type: &str,
+    status: &str,
+    trace_step: &str,
+    related_artifacts: &[&str],
+) -> Map<String, Value> {
+    let mut object = Map::new();
+    object.insert("artifact_id".to_string(), json!(artifact_id));
+    object.insert("artifact_type".to_string(), json!(artifact_type));
+    object.insert(
+        "schema_version".to_string(),
+        json!(EXPLOIT_ARTIFACT_REPLAY_SCHEMA),
+    );
+    object.insert("status".to_string(), json!(status));
+    object.insert("created_at_utc".to_string(), json!(FIXED_TIME));
+    object.insert("updated_at_utc".to_string(), json!(FIXED_TIME));
+    object.insert("created_by_agent".to_string(), json!("adl-demo-local"));
+    object.insert("run_id".to_string(), json!(RUN_ID));
+    object.insert("target_ref".to_string(), target_ref());
+    object.insert("security_posture_ref".to_string(), security_posture_ref());
+    object.insert(
+        "trace_refs".to_string(),
+        json!([trace_ref(trace_step, "demo trace step for this artifact")]),
+    );
+    object.insert("related_artifacts".to_string(), json!(related_artifacts));
+    object
+}
+
+fn with_fields(mut object: Map<String, Value>, fields: Vec<(&str, Value)>) -> Value {
+    for (key, value) in fields {
+        object.insert(key.to_string(), value);
+    }
+    Value::Object(object)
+}
+
+fn target_ref() -> Value {
+    json!({
+        "target_id": TARGET_ID,
+        "target_type": "bounded_demo_policy_gate",
+        "target_name": "Token Gate Debug Override Fixture",
+        "environment": "demo_local_only",
+        "artifact_path": TARGET_PATH
+    })
+}
+
+fn security_posture_ref() -> Value {
+    json!({
+        "posture_id": POSTURE_ID,
+        "profile": "validation",
+        "artifact_path": POSTURE_PATH
+    })
+}
+
+fn trace_ref(step_id: &str, note: &str) -> Value {
+    json!({
+        "trace_id": format!("{RUN_ID}:trace.jsonl"),
+        "step_id": step_id,
+        "note": note
+    })
+}
+
+fn target_definition() -> Value {
+    json!({
+        "schema_version": "adversarial_demo_target.v1",
+        "target_id": TARGET_ID,
+        "target_type": "bounded_demo_policy_gate",
+        "target_name": "Token Gate Debug Override Fixture",
+        "environment": "demo_local_only",
+        "run_id": RUN_ID,
+        "safe_to_attack": true,
+        "network_required": false,
+        "secret_material_required": false,
+        "pre_fix_behavior": {
+            "summary": "admin access is granted when debug_override=true before token verification runs",
+            "access_rule_order": [
+                "debug override check",
+                "admin role check",
+                "token verification"
+            ]
+        },
+        "post_fix_behavior": {
+            "summary": "admin access requires a valid token before any debug override can influence routing",
+            "access_rule_order": [
+                "token verification",
+                "admin role check",
+                "debug override ignored for admin surfaces"
+            ]
+        },
+        "attack_request": {
+            "role": "admin",
+            "token": null,
+            "debug_override": true
+        },
+        "expected_pre_fix_decision": "allow",
+        "expected_post_fix_decision": "deny"
+    })
+}
+
+fn security_posture() -> Value {
+    json!({
+        "schema_version": "adversarial_demo_posture.v1",
+        "posture_id": POSTURE_ID,
+        "run_id": RUN_ID,
+        "profile": "validation",
+        "observation_mode": "exploit_validate",
+        "mutation_mode": "ephemeral_test_mutation",
+        "target_scope": "demo_only",
+        "mitigation_authority": "prepare_demo_fix",
+        "evidence_requirement": "strict",
+        "risk_tolerance": "low",
+        "bounds": [
+            "no network access",
+            "no private credentials",
+            "no uncontrolled external target",
+            "same replay input before and after mitigation"
+        ],
+        "upstream_contracts": [
+            ADVERSARIAL_RUNTIME_MODEL_SCHEMA,
+            RED_BLUE_AGENT_ARCHITECTURE_SCHEMA,
+            ADVERSARIAL_EXECUTION_RUNNER_SCHEMA,
+            EXPLOIT_ARTIFACT_REPLAY_SCHEMA,
+            CONTINUOUS_VERIFICATION_SELF_ATTACK_SCHEMA
+        ]
+    })
+}
+
+fn exploit_hypothesis() -> Value {
+    with_fields(
+        artifact_base(
+            HYPOTHESIS_ID,
+            "ExploitHypothesisArtifact",
+            "recorded",
+            "exploit_hypothesis",
+            &[TARGET_PATH, POSTURE_PATH],
+        ),
+        vec![
+            ("hypothesis_id", json!(HYPOTHESIS_ID)),
+            ("exploit_family", json!("authorization_policy_bypass")),
+            (
+                "summary",
+                json!("debug_override may bypass token verification for an admin request"),
+            ),
+            ("target_surface", json!("admin access decision gate")),
+            (
+                "unsafe_outcome",
+                json!("admin-only surface reached without a valid token"),
+            ),
+            (
+                "preconditions",
+                json!([
+                    "role=admin is accepted from the request body",
+                    "token is absent",
+                    "debug_override=true is evaluated before token verification"
+                ]),
+            ),
+            (
+                "steps",
+                json!([
+                    "submit the deterministic attack request",
+                    "observe the pre-fix access decision",
+                    "record whether the unsafe admin state is reached"
+                ]),
+            ),
+            ("confidence", json!("high")),
+            (
+                "uncertainties",
+                json!(["none for the local fixture; live system generalization is out of scope"]),
+            ),
+            (
+                "policy_notes",
+                json!(["validation posture permits this bounded demo-only exploit attempt"]),
+            ),
+        ],
+    )
+}
+
+fn exploit_evidence() -> Value {
+    with_fields(
+        artifact_base(
+            EVIDENCE_ID,
+            "ExploitEvidenceArtifact",
+            "validated",
+            "exploit_evidence",
+            &[HYPOTHESIS_PATH, TARGET_PATH, POSTURE_PATH],
+        ),
+        vec![
+            ("hypothesis_ref", json!(HYPOTHESIS_PATH)),
+            ("attempt_id", json!("attempt-pre-fix-debug-override")),
+            ("outcome", json!("success")),
+            (
+                "outcome_summary",
+                json!("pre-fix gate allowed admin access without a token"),
+            ),
+            (
+                "preconditions_observed",
+                json!([
+                    "role=admin",
+                    "token=null",
+                    "debug_override=true",
+                    "pre-fix rule order evaluates debug override before token verification"
+                ]),
+            ),
+            (
+                "attempt_steps",
+                json!([
+                    "load bounded demo target",
+                    "apply attack request",
+                    "evaluate pre-fix policy gate",
+                    "capture access decision and unsafe-state flag"
+                ]),
+            ),
+            (
+                "observed_effects",
+                json!({
+                    "access_decision": "allow",
+                    "unsafe_state": "admin_panel_reached_without_token"
+                }),
+            ),
+            ("unsafe_state_reached", json!(true)),
+            ("evidence_refs", json!([PRE_REPLAY_PATH])),
+            ("replayability", json!("deterministic")),
+            (
+                "residual_uncertainty",
+                json!("none for the bounded fixture"),
+            ),
+        ],
+    )
+}
+
+fn exploit_classification() -> Value {
+    with_fields(
+        artifact_base(
+            CLASSIFICATION_ID,
+            "ExploitClassificationArtifact",
+            "recorded",
+            "exploit_evidence",
+            &[EVIDENCE_PATH],
+        ),
+        vec![
+            ("evidence_ref", json!(EVIDENCE_PATH)),
+            ("exploit_family", json!("authorization_policy_bypass")),
+            ("target_type", json!("bounded_demo_policy_gate")),
+            ("severity", json!("high_in_demo_scope")),
+            ("reproducibility", json!("deterministic")),
+            ("recurrence_potential", json!("high when policy shortcuts precede authentication")),
+            ("mitigation_complexity", json!("low")),
+            (
+                "classification_notes",
+                json!("The vulnerability is a policy ordering flaw: convenience override before authorization."),
+            ),
+        ],
+    )
+}
+
+fn replay_manifest() -> Value {
+    with_fields(
+        artifact_base(
+            REPLAY_ID,
+            "AdversarialReplayManifest",
+            "validated",
+            "replay_pre_fix",
+            &[EVIDENCE_PATH],
+        ),
+        vec![
+            ("replay_id", json!(REPLAY_ID)),
+            ("evidence_ref", json!(EVIDENCE_PATH)),
+            (
+                "summary",
+                json!("Replay the same debug_override admin request before and after mitigation."),
+            ),
+            (
+                "replay_goal",
+                json!("prove the exploit reproduces pre-mitigation and stops reproducing post-mitigation"),
+            ),
+            ("replay_mode", json!("deterministic")),
+            (
+                "required_preconditions",
+                json!([
+                    "bounded demo target loaded",
+                    "fixed attack request used unchanged",
+                    "pre-fix and post-fix rule order selected explicitly"
+                ]),
+            ),
+            (
+                "environment",
+                json!({
+                    "kind": "local_fixture",
+                    "network": false,
+                    "secrets": false,
+                    "external_services": []
+                }),
+            ),
+            (
+                "inputs",
+                json!({
+                    "request": {
+                        "role": "admin",
+                        "token": null,
+                        "debug_override": true
+                    }
+                }),
+            ),
+            (
+                "replay_steps",
+                json!([
+                    {
+                        "step_id": "load_target",
+                        "phase": "shared",
+                        "expected": "target fixture and posture are available"
+                    },
+                    {
+                        "step_id": "apply_attack_request_pre_fix",
+                        "phase": "pre_mitigation",
+                        "expected": "access_decision=allow"
+                    },
+                    {
+                        "step_id": "apply_attack_request_post_fix",
+                        "phase": "post_mitigation",
+                        "expected": "access_decision=deny"
+                    }
+                ]),
+            ),
+            (
+                "expected_outcome",
+                json!({
+                    "pre_mitigation": {
+                        "unsafe_state_reached": true,
+                        "access_decision": "allow"
+                    },
+                    "post_mitigation": {
+                        "unsafe_state_reached": false,
+                        "access_decision": "deny"
+                    }
+                }),
+            ),
+            (
+                "success_criteria",
+                json!([
+                    "pre-mitigation replay reproduces the unsafe state",
+                    "post-mitigation replay denies the same request",
+                    "promotion artifact links evidence, mitigation, and replay results"
+                ]),
+            ),
+            (
+                "failure_modes",
+                json!([
+                    "pre-mitigation replay does not reproduce the exploit",
+                    "post-mitigation replay still reaches the unsafe state",
+                    "artifact chain loses evidence or mitigation provenance"
+                ]),
+            ),
+            (
+                "trace_expectations",
+                json!([
+                    "target_and_posture",
+                    "exploit_hypothesis",
+                    "exploit_evidence",
+                    "replay_pre_fix",
+                    "mitigation",
+                    "replay_post_fix",
+                    "promotion"
+                ]),
+            ),
+            (
+                "limitations",
+                json!(["local deterministic fixture only; not a live exploit runner"]),
+            ),
+        ],
+    )
+}
+
+fn pre_fix_replay_result() -> Value {
+    json!({
+        "schema_version": "adversarial_demo_replay_result.v1",
+        "artifact_id": "replay-result-token-gate-pre-fix",
+        "artifact_type": "ReplayValidationArtifact",
+        "run_id": RUN_ID,
+        "replay_id": REPLAY_ID,
+        "manifest_ref": REPLAY_PATH,
+        "phase": "pre_mitigation",
+        "status": "validated",
+        "input_ref": "replay_manifest.json#/inputs/request",
+        "access_decision": "allow",
+        "unsafe_state_reached": true,
+        "result": "exploit_reproduced",
+        "trace_refs": [trace_ref("replay_pre_fix", "pre-mitigation replay result")]
+    })
+}
+
+fn mitigation() -> Value {
+    with_fields(
+        artifact_base(
+            MITIGATION_ID,
+            "MitigationLinkageArtifact",
+            "validated",
+            "mitigation",
+            &[EVIDENCE_PATH, CLASSIFICATION_PATH, REPLAY_PATH, PRE_REPLAY_PATH],
+        ),
+        vec![
+            ("evidence_ref", json!(EVIDENCE_PATH)),
+            ("classification_ref_or_defer_reason", json!(CLASSIFICATION_PATH)),
+            ("mitigation_id", json!(MITIGATION_ID)),
+            ("mitigation_type", json!("policy_guard_ordering_fix")),
+            (
+                "summary",
+                json!("verify token before considering debug override and ignore debug override for admin surfaces"),
+            ),
+            (
+                "protection_boundary",
+                json!("admin authorization gate for the bounded demo fixture"),
+            ),
+            (
+                "tradeoffs",
+                json!(["debug convenience cannot grant admin access without authentication"]),
+            ),
+            ("side_effects", json!(["none for non-admin demo requests"])),
+            (
+                "validation_plan",
+                json!({
+                    "manifest_ref": REPLAY_PATH,
+                    "expected_post_mitigation_access_decision": "deny",
+                    "expected_post_mitigation_unsafe_state_reached": false
+                }),
+            ),
+        ],
+    )
+}
+
+fn post_fix_replay_result() -> Value {
+    json!({
+        "schema_version": "adversarial_demo_replay_result.v1",
+        "artifact_id": "replay-result-token-gate-post-fix",
+        "artifact_type": "ReplayValidationArtifact",
+        "run_id": RUN_ID,
+        "replay_id": REPLAY_ID,
+        "manifest_ref": REPLAY_PATH,
+        "phase": "post_mitigation",
+        "status": "validated",
+        "mitigation_ref": MITIGATION_PATH,
+        "input_ref": "replay_manifest.json#/inputs/request",
+        "access_decision": "deny",
+        "unsafe_state_reached": false,
+        "result": "mitigation_validated",
+        "trace_refs": [trace_ref("replay_post_fix", "post-mitigation replay result")]
+    })
+}
+
+fn promotion() -> Value {
+    with_fields(
+        artifact_base(
+            PROMOTION_ID,
+            "ExploitPromotionArtifact",
+            "validated",
+            "promotion",
+            &[EVIDENCE_PATH, MITIGATION_PATH, PRE_REPLAY_PATH, POST_REPLAY_PATH],
+        ),
+        vec![
+            ("evidence_ref", json!(EVIDENCE_PATH)),
+            ("mitigation_ref", json!(MITIGATION_PATH)),
+            ("promotion_id", json!(PROMOTION_ID)),
+            (
+                "promotion_targets",
+                json!([
+                    "regression replay fixture: token-gate-debug-override",
+                    "hardening rule: authentication before debug override",
+                    "review packet invariant: pre true -> post false"
+                ]),
+            ),
+            (
+                "promotion_reason",
+                json!("the exploit was reproduced and then blocked by replaying the same request after mitigation"),
+            ),
+            (
+                "expected_future_value",
+                json!("future changes can detect policy-ordering regressions without reconstructing the exploit narrative"),
+            ),
+            ("promotion_status", json!("applied")),
+        ],
+    )
+}
+
+fn review_packet() -> Value {
+    json!({
+        "schema_version": "adversarial_demo_review_packet.v1",
+        "demo_id": "D5",
+        "demo_name": DEMO_NAME,
+        "run_id": RUN_ID,
+        "status": "landed",
+        "primary_claim": "full exploit -> replay -> mitigation -> promotion loop",
+        "entrypoint": format!("adl demo {DEMO_NAME} --run --trace --out .adl/reports/adversarial-demo --no-open"),
+        "primary_proof_surface": REVIEW_PACKET_PATH,
+        "artifact_chain": [
+            TARGET_PATH,
+            POSTURE_PATH,
+            HYPOTHESIS_PATH,
+            EVIDENCE_PATH,
+            CLASSIFICATION_PATH,
+            REPLAY_PATH,
+            PRE_REPLAY_PATH,
+            MITIGATION_PATH,
+            POST_REPLAY_PATH,
+            PROMOTION_PATH,
+            "trace.jsonl"
+        ],
+        "result_summary": {
+            "vulnerability": "debug_override evaluated before token verification",
+            "exploit_reproduced_pre_mitigation": true,
+            "pre_mitigation_unsafe_state_reached": true,
+            "mitigation_linked": true,
+            "exploit_blocked_post_mitigation": true,
+            "post_mitigation_unsafe_state_reached": false,
+            "promotion_status": "applied"
+        },
+        "reviewer_answers": [
+            {
+                "question": "what vulnerability was found?",
+                "answer": "a policy-ordering flaw allowed debug_override to grant admin access before token verification"
+            },
+            {
+                "question": "how was it exploited?",
+                "answer": "the replay request used role=admin, token=null, and debug_override=true against the pre-fix gate"
+            },
+            {
+                "question": "can the exploit be reproduced?",
+                "answer": "yes, replay_pre_fix/result.json records unsafe_state_reached=true for the deterministic request"
+            },
+            {
+                "question": "what mitigation was applied?",
+                "answer": "token verification now precedes debug override and debug override cannot grant admin access"
+            },
+            {
+                "question": "does the mitigation hold under replay?",
+                "answer": "yes, replay_post_fix/result.json records unsafe_state_reached=false for the same request"
+            },
+            {
+                "question": "what was learned and promoted?",
+                "answer": "the exploit became a regression replay fixture and hardening rule linked by promotion.json"
+            }
+        ],
+        "upstream_contracts": [
+            ADVERSARIAL_RUNTIME_MODEL_SCHEMA,
+            RED_BLUE_AGENT_ARCHITECTURE_SCHEMA,
+            ADVERSARIAL_EXECUTION_RUNNER_SCHEMA,
+            EXPLOIT_ARTIFACT_REPLAY_SCHEMA,
+            CONTINUOUS_VERIFICATION_SELF_ATTACK_SCHEMA
+        ],
+        "security_bounds": [
+            "local deterministic fixture only",
+            "no live target",
+            "no network",
+            "no secrets",
+            "no uncontrolled exploitation"
+        ],
+        "pass_conditions": [
+            "review_packet.result_summary.pre_mitigation_unsafe_state_reached == true",
+            "review_packet.result_summary.post_mitigation_unsafe_state_reached == false",
+            "promotion.json promotion_status == applied",
+            "trace.jsonl includes the target, exploit, replay, mitigation, replay, and promotion steps"
+        ]
+    })
+}
+
+fn readme() -> &'static str {
+    r#"# Demo H Output - v0.89.1 Adversarial Self-Attack
+
+Generated by:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml --bin adl -- demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open
+```
+
+This is a safe, deterministic, local-only proof surface. It does not attack a live
+system. The fixture models a token-gate ordering flaw where `debug_override=true`
+is evaluated before token verification for an admin request.
+
+Primary artifacts:
+- `review_packet.json`
+- `target/target.json`
+- `target/security_posture.json`
+- `hypothesis.json`
+- `evidence.json`
+- `classification.json`
+- `replay_manifest.json`
+- `replay_pre_fix/result.json`
+- `mitigation.json`
+- `replay_post_fix/result.json`
+- `promotion.json`
+- `trace.jsonl`
+
+Proof signal:
+- pre-mitigation replay reaches the unsafe state
+- post-mitigation replay denies the same request
+- promotion links the exploit evidence, mitigation, replay results, and regression target
+"#
+}

--- a/adl/tests/demo_tests.rs
+++ b/adl/tests/demo_tests.rs
@@ -238,6 +238,68 @@ fn demo_c_run_writes_runtime_surface_artifacts() {
 }
 
 #[test]
+fn demo_h_run_writes_adversarial_review_packet() {
+    let out_root = tmp_dir("demo-h-run");
+    let out = run_swarm(&[
+        "demo",
+        "demo-h-v0891-adversarial-self-attack",
+        "--run",
+        "--trace",
+        "--out",
+        out_root.to_string_lossy().as_ref(),
+        "--no-open",
+    ]);
+    assert!(
+        out.status.success(),
+        "expected success, stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let run_out = out_root.join("demo-h-v0891-adversarial-self-attack");
+    assert!(run_out.join("review_packet.json").is_file());
+    assert!(run_out.join("replay_manifest.json").is_file());
+    assert!(run_out.join("replay_pre_fix/result.json").is_file());
+    assert!(run_out.join("replay_post_fix/result.json").is_file());
+    assert!(run_out.join("promotion.json").is_file());
+    assert!(run_out.join("trace.jsonl").is_file());
+
+    let review: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(run_out.join("review_packet.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        review["primary_claim"],
+        "full exploit -> replay -> mitigation -> promotion loop"
+    );
+    assert_eq!(
+        review["result_summary"]["pre_mitigation_unsafe_state_reached"],
+        true
+    );
+    assert_eq!(
+        review["result_summary"]["post_mitigation_unsafe_state_reached"],
+        false
+    );
+    assert_eq!(review["result_summary"]["promotion_status"], "applied");
+
+    let trace = fs::read_to_string(run_out.join("trace.jsonl")).unwrap();
+    assert!(
+        trace.contains("StepStarted step=target_and_posture"),
+        "trace:\n{trace}"
+    );
+    assert!(
+        trace.contains("StepStarted step=replay_pre_fix"),
+        "trace:\n{trace}"
+    );
+    assert!(
+        trace.contains("StepStarted step=replay_post_fix"),
+        "trace:\n{trace}"
+    );
+    assert!(
+        trace.contains("StepStarted step=promotion"),
+        "trace:\n{trace}"
+    );
+}
+
+#[test]
 fn demo_d_print_plan_works() {
     let out = run_swarm(&["demo", "demo-d-godel-obsmem-loop", "--print-plan"]);
     assert!(

--- a/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
+++ b/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
@@ -75,7 +75,7 @@ Additional environment / fixture requirements:
 | D2 | Exploit artifact and replay proof | `WP-05` exploit artifact family and replay manifest | planned `WP-05` schema/replay validation surface | exploit artifact family + replay manifest packet | reviewer can inspect exploit hypothesis, evidence, replay mode, and expected outcome without narrative reconstruction | replay contract should declare deterministic, bounded-variance, or best-effort mode explicitly | PLANNED |
 | D3 | Continuous verification loop | `WP-06` continuous verification and exploit generation | `adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json` | continuous verification contract artifact with lifecycle, cadence, replay, mitigation, and promotion rules | reviewer can see repeated falsification pressure as a governed execution pattern rather than ad hoc red-teaming | repeated bounded inputs should preserve lifecycle shape and proof packet structure | LANDED |
 | D4 | Self-attack scenario packet | `WP-06` self-attacking systems as architecture rather than rhetoric | `adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json` | self-attack contract artifact with bounded layers, target/posture policy, and evidence/replay rules | reviewer can see the system's self-attack pattern before externalization and inspect the required evidence chain | scenario should remain posture-bounded and replay-legible | LANDED |
-| D5 | Flagship adversarial demo | `WP-07` full exploit -> replay -> mitigation -> promotion loop | planned `WP-07` adversarial demo entry point | flagship adversarial demo packet | reviewer can answer what was attacked, how it was reproduced, what mitigation was applied, and whether replay post-fix succeeded | replay should make before/after mitigation comparison explicit | PLANNED |
+| D5 | Flagship adversarial demo | `WP-07` full exploit -> replay -> mitigation -> promotion loop | `adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open` | `.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json` | reviewer can answer what was attacked, how it was reproduced, what mitigation was applied, and whether replay post-fix succeeded | deterministic local replay compares the same request before and after mitigation | LANDED |
 | D6 | Operational skills substrate integration | `WP-08` - `WP-09` operational skills, composition, and bounded governance follow-through | planned `WP-08` / `WP-09` governed composition entry point | substrate/composition packet + delegation/refusal integration note | reviewer can see that adversarial work runs through explicit skill/composition surfaces instead of ad hoc orchestration | orchestration structure should be deterministic even if node outputs remain stochastic | PLANNED |
 | D7 | Reviewer-facing security proof package | `WP-10` - `WP-13` packaging convergence, milestone convergence, and integration demos | planned `WP-10` / `WP-13` review package | reviewer-facing adversarial/replay/trust packet | reviewer can inspect milestone claims, carry-forward boundaries, and proof surfaces as one coherent package | may remain artifact/document driven rather than fully runnable | PLANNED |
 | D8 | Five-Agent Hey Jude MIDI demo | `WP-08` - `WP-10`, `WP-13` cross-provider coordination, human-in-the-loop orchestration, and integration delight surface | planned `WP-08` / `WP-13` coordination demo entry point | Hey Jude coordination packet + MIDI control trace + provider participation summary | reviewer can see one human plus four providers coordinating on one ADL runtime with explicit orchestration boundaries | bounded score/input should preserve composition shape, participant roles, and MIDI event ordering where declared | PLANNED |
@@ -246,21 +246,33 @@ Milestone claims / work packages covered:
 Planned entry point:
 
 ```bash
-Defined when the official `WP-07` adversarial demo issue lands.
+adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open
 ```
 
 Expected artifacts:
-- exploit artifact packet
-- replay manifest and replay results
-- mitigation linkage artifact
-- promotion / regression artifact
+- `target/target.json`
+- `target/security_posture.json`
+- `hypothesis.json`
+- `evidence.json`
+- `classification.json`
+- `replay_manifest.json`
+- `replay_pre_fix/result.json`
+- `mitigation.json`
+- `replay_post_fix/result.json`
+- `promotion.json`
+- `review_packet.json`
+- `trace.jsonl`
 
 Primary proof surface:
-- flagship adversarial demo packet
+- `.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json`
 
 Expected success signals:
 - reviewer can answer what was found, how it was exploited, how replay worked, what changed after mitigation, and what was promoted
 - the packet closes the loop without hidden reasoning steps
+- pre-mitigation replay reaches the unsafe state and post-mitigation replay denies the same request
+
+Known limits / caveats:
+- this row is the flagship proof row and stays bounded to a safe, local, deterministic target
 
 ---
 
@@ -298,11 +310,6 @@ Expected success signals:
 
 Known limits / caveats:
 - this row is about bounded drafting and review workflow, not automatic submission or unverifiable authorship claims
-
-Known limits / caveats:
-- this row is the flagship proof row and should stay bounded to a safe, intelligible target
-
----
 
 ### D6) Operational skills substrate integration
 

--- a/docs/milestones/v0.89.1/features/ADL_ADVERSARIAL_DEMO.md
+++ b/docs/milestones/v0.89.1/features/ADL_ADVERSARIAL_DEMO.md
@@ -4,9 +4,12 @@
 
 ## Metadata
 - Project: `ADL`
-- Status: `Draft`
+- Status: `Implemented`
 - Owner: `Daniel Austin`
 - Created: `2026-04-12`
+- Updated: `2026-04-16`
+- Milestone: `v0.89.1`
+- Work package: `WP-07`
 
 ---
 
@@ -44,7 +47,7 @@ exploit discovery
 -> regression promotion
 ```
 
-This is not a simulation or narrative demo.
+This is not a prose-only demo.
 
 It must produce:
 
@@ -52,6 +55,31 @@ It must produce:
 - real trace
 - replayable behavior
 - a reviewer-verifiable result
+
+---
+
+## Implemented Proof Surface
+
+Canonical entry point:
+
+```bash
+adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open
+```
+
+Primary proof surface:
+
+```text
+.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json
+```
+
+The implemented target is a safe local fixture, not a live exploit target. It models a token-gate policy-ordering flaw where `debug_override=true` can be evaluated before token verification for an admin request. The demo then replays the same request after mitigation and proves the unsafe state no longer occurs.
+
+Security bounds:
+
+- no network access
+- no private credentials
+- no uncontrolled external target
+- deterministic replay inputs before and after mitigation
 
 ---
 
@@ -290,33 +318,38 @@ The demo fails if:
 Suggested artifact tree:
 
 ```text
-reports/adversarial-demo/
-  target/
-  hypothesis.yaml
-  evidence.yaml
-  replay.yaml
-  mitigation.yaml
+.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/
+  target/target.json
+  target/security_posture.json
+  hypothesis.json
+  evidence.json
+  classification.json
+  replay_manifest.json
   replay_pre_fix/
+    result.json
+  mitigation.json
   replay_post_fix/
-  promotion.yaml
-  trace/
+    result.json
+  promotion.json
+  review_packet.json
+  trace.jsonl
 ```
 
 ---
 
 ## Demo Matrix Integration
 
-Add a new demo row:
+This feature lands demo matrix row `D5`:
 
 | Demo ID | Focus | Output | Claim |
 |--------|------|--------|------|
-| D9 | adversarial self-attack loop | exploit + replay + mitigation artifacts | system can attack itself and prove mitigation |
+| D5 | adversarial self-attack loop | exploit + replay + mitigation + promotion artifacts | system can attack itself and prove mitigation |
 
 This complements existing demo rows focused on:
 
-- temporal structure
-- cost and posture
-- instinct and routing
+- adversarial runtime contracts
+- exploit artifact and replay schemas
+- continuous verification and self-attack contracts
 
 ---
 


### PR DESCRIPTION
Closes #1928

## Summary
Implemented the bounded WP-07 flagship adversarial demo and proof surface. The change adds `demo-h-v0891-adversarial-self-attack`, a safe local fixture that emits structured target, posture, exploit, replay, mitigation, promotion, trace, and review-packet artifacts for the full exploit -> replay -> mitigation -> promotion loop.

## Artifacts
- `adl/src/demo/adversarial_self_attack.rs`
- `adl demo demo-h-v0891-adversarial-self-attack`
- generated proof artifact shape: `.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json`
- generated linked artifacts under `.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/`
- updated demo CLI available-demo listing and usage examples
- updated `docs/milestones/v0.89.1/features/ADL_ADVERSARIAL_DEMO.md`
- updated `docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md` row D5 to `LANDED`
- updated output card for this issue

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all` formatted the Rust changes.
  - `cargo test --manifest-path adl/Cargo.toml run_demo_h -- --nocapture` verified the new demo writer emits every required artifact and the review packet reports pre-mitigation unsafe state true, post-mitigation unsafe state false, and promotion applied.
  - `cargo test --manifest-path adl/Cargo.toml demo_h -- --nocapture` verified the unit tests, CLI integration test, and usage/help path that include the new demo.
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open` generated the primary proof packet and trace for manual review.
  - `cargo run --manifest-path adl/Cargo.toml --bin adl -- demo demo-h-v0891-adversarial-self-attack --run --out <temp-dir>/adl-demo-h-a --no-open --quiet` and the same command to `<temp-dir>/adl-demo-h-b` generated two comparable structured artifact trees.
  - `diff -ru --exclude=trace.jsonl <temp-dir>/adl-demo-h-a/demo-h-v0891-adversarial-self-attack <temp-dir>/adl-demo-h-b/demo-h-v0891-adversarial-self-attack` verified deterministic structured output; `trace.jsonl` is excluded because the trace records real runtime timestamps.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check` verified formatting remained clean after edits.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` verified the Rust demo integration remains warning-free under the finish gate.
  - `git diff --check` verified no whitespace errors.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.89.1/tasks/issue-1928__v0-89-1-wp-07-adversarial-demo-and-security-proof-surfaces/sor.md` verifies this output card structure.
  - `rg -n "sk-[A-Za-z0-9]|ghp_[A-Za-z0-9]|BEGIN (RSA|OPENSSH|PRIVATE) KEY" <touched paths>` checks for common secret and private-key patterns.
  - `rg -n "(<local-home>|<private-temp>|<system-temp>)" <touched paths and generated demo report>` records the local absolute-host-path leakage scan with placeholders instead of embedding host paths in the card.
- Results: targeted Rust validation, CLI demo execution, structured-artifact replay comparison, formatter check, diff check, leakage scans, and SOR validation passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1928__v0-89-1-wp-07-adversarial-demo-and-security-proof-surfaces/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1928__v0-89-1-wp-07-adversarial-demo-and-security-proof-surfaces/sor.md
- Idempotency-Key: v0-89-1-wp-07-adversarial-demo-and-security-proof-surfaces-adl-src-demo-adversarial-self-attack-rs-adl-src-demo-rs-adl-src-cli-demo-cmd-rs-adl-src-cli-usage-rs-adl-tests-demo-tests-rs-docs-milestones-v0-89-1-demo-matrix-v0-89-1-md-docs-milestones-v0-89-1-features-adl-adversarial-demo-md-adl-v0-89-1-tasks-issue-1928-v0-89-1-wp-07-adversarial-demo-and-security-proof-surfaces-sip-md-adl-v0-89-1-tasks-issue-1928-v0-89-1-wp-07-adversarial-demo-and-security-proof-surfaces-sor-md