### PR TITLE
[v0.89.1][demo] Build arXiv manuscript workflow demo

### DIFF
--- a/adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
+++ b/adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0891/arxiv_manuscript_workflow}"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+python3 - "$OUT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+out_dir = Path(sys.argv[1])
+writer_dir = out_dir / "writer_skill_packet"
+source_dir = out_dir / "source_packets"
+status_dir = out_dir / "manuscript_status"
+review_dir = out_dir / "review"
+
+for path in (writer_dir, source_dir, status_dir, review_dir):
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+
+
+paper_specs = [
+    {
+        "id": "what_is_adl",
+        "title": "What Is ADL?",
+        "working_claim": "ADL is a contract-first language and runtime for making agent work inspectable, replayable, and governable.",
+        "audience": "technical readers who need a crisp system overview",
+        "source_refs": [
+            "README.md",
+            "docs/planning/ADL_FEATURE_LIST.md",
+            "docs/milestones/v0.89.1/README.md",
+            "docs/architecture/TRACE_SYSTEM_ARCHITECTURE.md",
+        ],
+        "section_order": [
+            "problem",
+            "design principles",
+            "runtime and trace model",
+            "workflow examples",
+            "current limits",
+            "future work",
+        ],
+        "known_gaps": [
+            "needs final terminology pass after v0.89.1 release truth settles",
+            "must keep current-feature claims separated from roadmap claims",
+        ],
+    },
+    {
+        "id": "godel_agents_and_adl",
+        "title": "Gödel Agents and ADL",
+        "working_claim": "ADL provides bounded experiment, evidence, and replay surfaces for self-improvement loops without granting unchecked autonomy.",
+        "audience": "agent researchers interested in recursive improvement under governance",
+        "source_refs": [
+            "docs/adr/0008-godel-stage-loop-v08.md",
+            "demos/v0.85/adaptive_godel_loop_demo.md",
+            "demos/v0.85/godel_hypothesis_engine_demo.md",
+            "adl/src/godel/mod.rs",
+        ],
+        "section_order": [
+            "motivation",
+            "bounded self-improvement",
+            "experiment records",
+            "promotion and replay",
+            "safety boundaries",
+            "open research questions",
+        ],
+        "known_gaps": [
+            "needs updated examples from the latest convergence artifacts",
+            "must avoid claiming autonomous recursive self-modification",
+        ],
+    },
+    {
+        "id": "cognitive_spacetime_manifold",
+        "title": "Cognitive Spacetime Manifold",
+        "working_claim": "ADL's trace, memory, time, and identity-planning surfaces can be described as an inspectable manifold for agent cognition.",
+        "audience": "readers interested in higher-level ADL theory and cognitive architecture",
+        "source_refs": [
+            "docs/architecture/TRACE_SYSTEM_ARCHITECTURE.md",
+            "docs/adr/0010-chronosense-substrate.md",
+            "docs/milestones/v0.88/features/ADL_COST_MODEL.md",
+            "docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md",
+        ],
+        "section_order": [
+            "conceptual frame",
+            "trace as spacetime substrate",
+            "memory and temporal anchors",
+            "cost, attention, and action",
+            "identity boundary",
+            "research agenda",
+        ],
+        "known_gaps": [
+            "must clearly mark speculative theory versus shipped runtime behavior",
+            "should defer full identity claims to the later identity substrate milestone",
+        ],
+    },
+]
+
+role_order = [
+    {
+        "order": 1,
+        "role": "source_curator",
+        "responsibility": "select bounded repository sources and reject private notes or hidden chat state",
+    },
+    {
+        "order": 2,
+        "role": "outline_architect",
+        "responsibility": "map each paper to a stable section order and review path",
+    },
+    {
+        "order": 3,
+        "role": "manuscript_drafter",
+        "responsibility": "prepare review-ready manuscript packets after the writer skill lands",
+    },
+    {
+        "order": 4,
+        "role": "claim_auditor",
+        "responsibility": "separate repo-supported claims from roadmap, theory, and future work",
+    },
+    {
+        "order": 5,
+        "role": "review_coordinator",
+        "responsibility": "record gates, known gaps, and post-milestone submission cleanup",
+    },
+]
+
+writer_status = {
+    "schema_version": "adl.v0891.arxiv_manuscript_workflow.writer_skill_status.v1",
+    "skill_name": "arxiv-paper-writer",
+    "dependency_issue": "#1929",
+    "skill_status": "packet_only_dependency_open",
+    "runnable_in_this_demo": False,
+    "execution_truth": "WP-08 issue #1929 remains open, so D9 demonstrates the bounded manuscript workflow packet without claiming a runnable arxiv-paper-writer skill.",
+    "allowed_claim": "The packet proves role order, source packet shape, claim discipline, and three-paper status tracking.",
+    "forbidden_claims": [
+        "final arXiv submission happened",
+        "the three papers are submission-ready",
+        "a private writer transcript is required to inspect the result",
+        "the arxiv-paper-writer skill is complete while #1929 remains open",
+    ],
+    "role_order": role_order,
+}
+write_json(writer_dir / "writer_skill_status.json", writer_status)
+
+workflow_contract = """# Bounded arXiv Paper Writer Workflow Contract
+
+This packet records the D9 manuscript workflow boundary for v0.89.1.
+
+## Dependency Truth
+
+The bounded `arxiv-paper-writer` skill is owned by #1929. Because #1929 is
+still open for this execution slice, this demo is packet-only. It does not
+pretend the writer skill ran.
+
+## Role Order
+
+1. source_curator
+2. outline_architect
+3. manuscript_drafter
+4. claim_auditor
+5. review_coordinator
+
+## Review Gates
+
+- source packet exists for each paper
+- section order is declared before drafting
+- claim boundaries are explicit
+- review-ready packet is distinguished from final arXiv submission
+- post-milestone cleanup is recorded rather than hidden
+
+## Handoff To WP-08
+
+When #1929 lands, the runnable writer skill should consume the source packets
+and manuscript status records from this packet without changing the claim
+discipline or review gates.
+"""
+write_text(writer_dir / "workflow_contract.md", workflow_contract)
+
+source_manifest = {
+    "schema_version": "adl.v0891.arxiv_manuscript_workflow.source_packet_manifest.v1",
+    "packet_count": len(paper_specs),
+    "privacy_boundary": "repository_relative_public_sources_only",
+    "packets": [
+        {
+            "paper_id": paper["id"],
+            "title": paper["title"],
+            "packet_ref": f"source_packets/{paper['id']}_source_packet.md",
+            "source_refs": paper["source_refs"],
+        }
+        for paper in paper_specs
+    ],
+}
+write_json(source_dir / "source_packet_manifest.json", source_manifest)
+
+for paper in paper_specs:
+    source_lines = [
+        f"# Source Packet: {paper['title']}",
+        "",
+        "## Working Claim",
+        "",
+        paper["working_claim"],
+        "",
+        "## Audience",
+        "",
+        paper["audience"],
+        "",
+        "## Repository Sources",
+        "",
+    ]
+    source_lines.extend(f"- `{source}`" for source in paper["source_refs"])
+    source_lines.extend(
+        [
+            "",
+            "## Section Order",
+            "",
+        ]
+    )
+    source_lines.extend(f"{idx}. {section}" for idx, section in enumerate(paper["section_order"], start=1))
+    source_lines.extend(
+        [
+            "",
+            "## Known Gaps",
+            "",
+        ]
+    )
+    source_lines.extend(f"- {gap}" for gap in paper["known_gaps"])
+    source_lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "This source packet is review input. It is not a final manuscript and does not represent arXiv submission.",
+        ]
+    )
+    write_text(source_dir / f"{paper['id']}_source_packet.md", "\n".join(source_lines))
+
+status_payload = {
+    "schema_version": "adl.v0891.arxiv_manuscript_workflow.three_paper_status.v1",
+    "demo_id": "D9",
+    "writer_skill_status": "packet_only_dependency_open",
+    "submission_status": "not_submitted",
+    "review_ready_meaning": "source and status packets are ready for reviewer inspection; manuscripts are not final arXiv submissions",
+    "papers": [
+        {
+            "paper_id": paper["id"],
+            "title": paper["title"],
+            "packet_status": "review_packet_ready",
+            "draft_status": "not_started_until_writer_skill_lands",
+            "source_packet_ref": f"source_packets/{paper['id']}_source_packet.md",
+            "manuscript_status_ref": f"manuscript_status/{paper['id']}_status.md",
+            "known_gaps": paper["known_gaps"],
+        }
+        for paper in paper_specs
+    ],
+}
+write_json(status_dir / "three_paper_status.json", status_payload)
+
+for paper in paper_specs:
+    status_lines = [
+        f"# Manuscript Status: {paper['title']}",
+        "",
+        "## Current State",
+        "",
+        "- Packet status: review_packet_ready",
+        "- Draft status: not_started_until_writer_skill_lands",
+        "- Submission status: not_submitted",
+        "- Dependency: #1929 arxiv-paper-writer skill",
+        "",
+        "## Review-Ready Inputs",
+        "",
+        f"- Source packet: `source_packets/{paper['id']}_source_packet.md`",
+        "- Section order declared before drafting",
+        "- Claim boundary documented",
+        "",
+        "## Known Gaps",
+        "",
+    ]
+    status_lines.extend(f"- {gap}" for gap in paper["known_gaps"])
+    status_lines.extend(
+        [
+            "",
+            "## Next Step",
+            "",
+            "Run the bounded writer skill from #1929 against this source packet once WP-08 lands.",
+        ]
+    )
+    write_text(status_dir / f"{paper['id']}_status.md", "\n".join(status_lines))
+
+review_gates = {
+    "schema_version": "adl.v0891.arxiv_manuscript_workflow.review_gates.v1",
+    "gates": [
+        {"gate_id": "source_packets_complete", "status": "pass", "evidence": "source_packets/source_packet_manifest.json"},
+        {"gate_id": "role_order_declared", "status": "pass", "evidence": "writer_skill_packet/writer_skill_status.json"},
+        {"gate_id": "claim_boundaries_declared", "status": "pass", "evidence": "review/claim_boundaries.md"},
+        {"gate_id": "writer_skill_runnable", "status": "blocked_by_dependency", "evidence": "#1929 remains open"},
+        {"gate_id": "arxiv_submission", "status": "not_in_scope", "evidence": "review-ready packets are not final arXiv submissions"},
+    ],
+}
+write_json(review_dir / "review_gates.json", review_gates)
+
+claim_boundaries = """# Claim Boundaries
+
+## Supported In This Packet
+
+- D9 has a visible, reviewer-legible proof surface.
+- The three-paper slate has bounded source packets.
+- The workflow role order and review gates are explicit.
+- Review-ready manuscript packets are not final arXiv submissions.
+- The WP-08 writer skill dependency is recorded instead of hidden.
+
+## Not Claimed
+
+- Final arXiv submission.
+- Submission-ready manuscripts.
+- Private credentials or hidden chat state.
+- Completion of the `arxiv-paper-writer` skill before #1929 lands.
+- Full automation of scholarly authorship or peer review.
+"""
+write_text(review_dir / "claim_boundaries.md", claim_boundaries)
+
+reviewer_brief = """# Reviewer Brief: D9 ArXiv Manuscript Workflow Packet
+
+Review this packet in the following order:
+
+1. `demo_manifest.json`
+2. `writer_skill_packet/writer_skill_status.json`
+3. `writer_skill_packet/workflow_contract.md`
+4. `source_packets/source_packet_manifest.json`
+5. `manuscript_status/three_paper_status.json`
+6. `review/review_gates.json`
+7. `review/claim_boundaries.md`
+
+The packet is intentionally honest about dependency state. It demonstrates the
+bounded manuscript workflow shape and three-paper review packet without claiming
+that final papers have been submitted to arXiv or that #1929 has completed the
+writer skill.
+"""
+write_text(review_dir / "reviewer_brief.md", reviewer_brief)
+
+manifest = {
+    "schema_version": "adl.v0891.arxiv_manuscript_workflow_demo.v1",
+    "demo_id": "D9",
+    "title": "ArXiv manuscript workflow packet",
+    "disposition": "proving_packet_only",
+    "command": "bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh",
+    "dependency_truth": {
+        "wp_08_issue": "#1929",
+        "writer_skill_status": "packet_only_dependency_open",
+        "wp_13_issue": "#1934",
+    },
+    "proof_surfaces": {
+        "writer_skill_packet": "writer_skill_packet/writer_skill_status.json",
+        "workflow_contract": "writer_skill_packet/workflow_contract.md",
+        "source_packet_manifest": "source_packets/source_packet_manifest.json",
+        "three_paper_status": "manuscript_status/three_paper_status.json",
+        "review_gates": "review/review_gates.json",
+        "claim_boundaries": "review/claim_boundaries.md",
+        "reviewer_brief": "review/reviewer_brief.md",
+    },
+    "papers": [{"paper_id": paper["id"], "title": paper["title"]} for paper in paper_specs],
+    "security_privacy": {
+        "requires_private_credentials": False,
+        "requires_hidden_chat_state": False,
+        "publishes_local_control_plane_paths": False,
+        "submits_to_arxiv": False,
+    },
+}
+write_json(out_dir / "demo_manifest.json", manifest)
+
+readme = """# v0.89.1 Demo D9 - ArXiv Manuscript Workflow Packet
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
+```
+
+Primary proof surfaces:
+
+- `demo_manifest.json`
+- `writer_skill_packet/writer_skill_status.json`
+- `writer_skill_packet/workflow_contract.md`
+- `source_packets/source_packet_manifest.json`
+- `manuscript_status/three_paper_status.json`
+- `review/review_gates.json`
+- `review/claim_boundaries.md`
+- `review/reviewer_brief.md`
+
+This packet is a bounded publication workflow proof. It does not submit to
+arXiv, does not require credentials, and does not claim the WP-08 writer skill
+has landed while #1929 remains open.
+"""
+write_text(out_dir / "README.md", readme)
+
+print(f"arxiv_manuscript_workflow: wrote {out_dir}")
+PY
+
+echo "ArXiv manuscript workflow proof surface under the output directory:"
+echo "  demo_manifest.json"
+echo "  writer_skill_packet/writer_skill_status.json"
+echo "  source_packets/source_packet_manifest.json"
+echo "  manuscript_status/three_paper_status.json"
+echo "  review/review_gates.json"
+echo "  review/claim_boundaries.md"

--- a/adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh
+++ b/adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/demo_manifest.json" \
+  "$OUT_DIR/README.md" \
+  "$OUT_DIR/writer_skill_packet/writer_skill_status.json" \
+  "$OUT_DIR/writer_skill_packet/workflow_contract.md" \
+  "$OUT_DIR/source_packets/source_packet_manifest.json" \
+  "$OUT_DIR/source_packets/what_is_adl_source_packet.md" \
+  "$OUT_DIR/source_packets/godel_agents_and_adl_source_packet.md" \
+  "$OUT_DIR/source_packets/cognitive_spacetime_manifold_source_packet.md" \
+  "$OUT_DIR/manuscript_status/three_paper_status.json" \
+  "$OUT_DIR/manuscript_status/what_is_adl_status.md" \
+  "$OUT_DIR/manuscript_status/godel_agents_and_adl_status.md" \
+  "$OUT_DIR/manuscript_status/cognitive_spacetime_manifold_status.md" \
+  "$OUT_DIR/review/review_gates.json" \
+  "$OUT_DIR/review/claim_boundaries.md" \
+  "$OUT_DIR/review/reviewer_brief.md"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+python3 - "$ROOT_DIR" "$OUT_DIR/demo_manifest.json" "$OUT_DIR/writer_skill_packet/writer_skill_status.json" "$OUT_DIR/source_packets/source_packet_manifest.json" "$OUT_DIR/manuscript_status/three_paper_status.json" "$OUT_DIR/review/review_gates.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+manifest = json.load(open(sys.argv[2], encoding="utf-8"))
+writer = json.load(open(sys.argv[3], encoding="utf-8"))
+sources = json.load(open(sys.argv[4], encoding="utf-8"))
+status = json.load(open(sys.argv[5], encoding="utf-8"))
+gates = json.load(open(sys.argv[6], encoding="utf-8"))
+
+assert manifest["schema_version"] == "adl.v0891.arxiv_manuscript_workflow_demo.v1"
+assert manifest["demo_id"] == "D9"
+assert manifest["disposition"] == "proving_packet_only"
+assert manifest["dependency_truth"]["writer_skill_status"] == "packet_only_dependency_open"
+assert manifest["security_privacy"]["submits_to_arxiv"] is False
+assert writer["skill_status"] == "packet_only_dependency_open"
+assert writer["runnable_in_this_demo"] is False
+assert [role["order"] for role in writer["role_order"]] == [1, 2, 3, 4, 5]
+assert sources["packet_count"] == 3
+for packet in sources["packets"]:
+    for source_ref in packet["source_refs"]:
+        assert (repo_root / source_ref).exists(), source_ref
+assert len(status["papers"]) == 3
+assert {paper["title"] for paper in status["papers"]} == {
+    "What Is ADL?",
+    "Gödel Agents and ADL",
+    "Cognitive Spacetime Manifold",
+}
+assert any(
+    gate["gate_id"] == "writer_skill_runnable" and gate["status"] == "blocked_by_dependency"
+    for gate in gates["gates"]
+)
+PY
+
+grep -Fq "Review this packet in the following order" "$OUT_DIR/review/reviewer_brief.md" || {
+  echo "assertion failed: reviewer brief missing review order" >&2
+  exit 1
+}
+
+grep -Fq "Review-ready manuscript packets are not final arXiv submissions" "$OUT_DIR/review/claim_boundaries.md" || {
+  echo "assertion failed: claim boundary missing submission distinction" >&2
+  exit 1
+}
+
+if grep -R -E '/Users/|/private/tmp|/tmp/|Bearer |OPENAI_API_KEY|ANTHROPIC_API_KEY|\.adl/' "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: private path, control-plane path, or secret-like token leaked into generated artifacts" >&2
+  exit 1
+fi
+
+echo "demo_v0891_arxiv_manuscript_workflow: ok"

--- a/demos/v0.89.1/arxiv_manuscript_workflow_demo.md
+++ b/demos/v0.89.1/arxiv_manuscript_workflow_demo.md
@@ -1,0 +1,55 @@
+# ArXiv Manuscript Workflow Packet
+
+This `v0.89.1` D9 demo creates a bounded reviewer-facing packet for the initial
+three-paper ADL publication program:
+
+- What Is ADL?
+- Gödel Agents and ADL
+- Cognitive Spacetime Manifold
+
+The packet is intentionally honest about dependency state. The bounded
+`arxiv-paper-writer` skill belongs to WP-08 issue `#1929`, which is still open
+for this execution slice. This demo therefore proves the source packet,
+role/order, review-gate, and manuscript-status shape without pretending final
+arXiv submission or a completed writer skill.
+
+## Command
+
+```bash
+bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
+```
+
+Default artifact root:
+
+```text
+artifacts/v0891/arxiv_manuscript_workflow/
+```
+
+## Primary Proof Surfaces
+
+- `demo_manifest.json`
+- `writer_skill_packet/writer_skill_status.json`
+- `writer_skill_packet/workflow_contract.md`
+- `source_packets/source_packet_manifest.json`
+- `manuscript_status/three_paper_status.json`
+- `review/review_gates.json`
+- `review/claim_boundaries.md`
+- `review/reviewer_brief.md`
+
+## What It Proves
+
+- D9 is a visible, runnable packet demo rather than a hidden planning note.
+- The three-paper slate has stable source packets and manuscript status records.
+- The workflow role order is explicit before any future drafting step.
+- Claim boundaries are reviewable and separate repo-supported claims from future
+  work.
+- The WP-08 dependency is recorded truthfully instead of faking a runnable
+  `arxiv-paper-writer` skill.
+
+## What It Does Not Claim
+
+- It does not submit anything to arXiv.
+- It does not claim submission-ready manuscripts.
+- It does not require private credentials, hidden chat transcripts, or local
+  control-plane notes.
+- It does not complete the WP-08 writer skill.

--- a/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
+++ b/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
@@ -79,7 +79,7 @@ Additional environment / fixture requirements:
 | D6 | Operational skills substrate integration | `WP-08` - `WP-09` operational skills, composition, and bounded governance follow-through | planned `WP-08` / `WP-09` governed composition entry point | substrate/composition packet + delegation/refusal integration note | reviewer can see that adversarial work runs through explicit skill/composition surfaces instead of ad hoc orchestration | orchestration structure should be deterministic even if node outputs remain stochastic | PLANNED |
 | D7 | Reviewer-facing security proof package | `WP-10` - `WP-13` packaging convergence, milestone convergence, and integration demos | planned `WP-10` / `WP-13` review package | reviewer-facing adversarial/replay/trust packet | reviewer can inspect milestone claims, carry-forward boundaries, and proof surfaces as one coherent package | may remain artifact/document driven rather than fully runnable | PLANNED |
 | D8 | Five-Agent Hey Jude MIDI demo | `WP-08` - `WP-10`, `WP-13` cross-provider coordination, human-in-the-loop orchestration, and integration delight surface | planned `WP-08` / `WP-13` coordination demo entry point | Hey Jude coordination packet + MIDI control trace + provider participation summary | reviewer can see one human plus four providers coordinating on one ADL runtime with explicit orchestration boundaries | bounded score/input should preserve composition shape, participant roles, and MIDI event ordering where declared | PLANNED |
-| D9 | ArXiv manuscript workflow packet | `WP-08`, `WP-13` bounded `arxiv-paper-writer` skill plus the initial three-paper publication program | planned `WP-08` / `WP-13` manuscript workflow entry point | writer-skill packet + source packet bundle + three-paper manuscript status packet | reviewer can see ADL use a bounded manuscript workflow to draft and review What Is ADL?, Gödel Agents and ADL, and Cognitive Spacetime Manifold without losing claim discipline | bounded source packets should preserve role order, section structure, and packet shape where declared | PLANNED |
+| D9 | ArXiv manuscript workflow packet | `WP-08`, `WP-13` bounded `arxiv-paper-writer` skill plus the initial three-paper publication program | `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh` | `artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json` | reviewer can see the bounded manuscript workflow packet for What Is ADL?, Gödel Agents and ADL, and Cognitive Spacetime Manifold without losing claim discipline or hiding the open WP-08 writer-skill dependency | packet generation is deterministic; bounded source packets preserve role order, section structure, and packet shape | READY |
 
 Status guidance:
 - `PLANNED` = intended but not yet validated
@@ -286,22 +286,27 @@ Milestone claims / work packages covered:
 - `WP-08`
 - `WP-13`
 
-Planned entry point:
+Entry point:
 
 ```bash
-Defined when the official `WP-08` / `WP-13` publication-skill issues land.
+bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
 ```
 
 Expected artifacts:
-- bounded `arxiv-paper-writer` skill packet
-- shared paper-source packet bundle
-- manuscript status packets for:
+- `artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json`
+- `artifacts/v0891/arxiv_manuscript_workflow/writer_skill_packet/writer_skill_status.json`
+- `artifacts/v0891/arxiv_manuscript_workflow/writer_skill_packet/workflow_contract.md`
+- `artifacts/v0891/arxiv_manuscript_workflow/source_packets/source_packet_manifest.json`
+- `artifacts/v0891/arxiv_manuscript_workflow/manuscript_status/three_paper_status.json`
+- `artifacts/v0891/arxiv_manuscript_workflow/review/review_gates.json`
+- `artifacts/v0891/arxiv_manuscript_workflow/review/claim_boundaries.md`
+- source and status packets for:
   - What Is ADL?
   - Gödel Agents and ADL
   - Cognitive Spacetime Manifold
 
 Primary proof surface:
-- reviewer-facing manuscript workflow packet plus three-paper status bundle
+- reviewer-facing manuscript workflow packet plus three-paper status bundle under `artifacts/v0891/arxiv_manuscript_workflow/`
 
 Expected success signals:
 - reviewer can see the role mapping, source packet, section structure, and review packet shape directly
@@ -310,6 +315,9 @@ Expected success signals:
 
 Known limits / caveats:
 - this row is about bounded drafting and review workflow, not automatic submission or unverifiable authorship claims
+- `#1929` remains the WP-08 owner for the runnable `arxiv-paper-writer` skill; this D9 packet records that dependency truthfully instead of faking a completed writer-skill run
+
+---
 
 ### D6) Operational skills substrate integration
 


### PR DESCRIPTION
Closes #1971

## Summary
Implemented the D9 ArXiv manuscript workflow packet as a bounded, reviewer-legible v0.89.1 demo. The result is intentionally packet-only because WP-08 issue #1929, which owns the runnable `arxiv-paper-writer` skill, remains open. The demo now records the dependency truth, preserves the three-paper source/status packet shape, and avoids claiming final arXiv submission.

## Artifacts
- `adl/tools/demo_v0891_arxiv_manuscript_workflow.sh`
- `adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh`
- `demos/v0.89.1/arxiv_manuscript_workflow_demo.md`
- `docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md`
- Generated local proof packet: `artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json`
- Generated local writer-skill status: `artifacts/v0891/arxiv_manuscript_workflow/writer_skill_packet/writer_skill_status.json`
- Generated local source packet manifest: `artifacts/v0891/arxiv_manuscript_workflow/source_packets/source_packet_manifest.json`
- Generated local three-paper status: `artifacts/v0891/arxiv_manuscript_workflow/manuscript_status/three_paper_status.json`
- Generated local review gates and claim boundaries under `artifacts/v0891/arxiv_manuscript_workflow/review/`

## Validation
- Validation commands and their purpose:
  - `python3 adl/tools/skills/workflow-conductor/scripts/route_workflow.py --input .adl/reviews/workflow-conductor-1971-run-input.json --artifact-path .adl/reviews/workflow-conductor-1971-run-dispatch.md` routed issue #1971 through `workflow-conductor` and dispatched `pr-run`.
  - `bash -n adl/tools/demo_v0891_arxiv_manuscript_workflow.sh adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh` checked shell syntax for both new scripts.
  - `bash adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh` generated the packet in a temporary directory and asserted schema, artifact presence, three-paper titles, role order, dependency truth, source-reference existence, and sanitization.
  - `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh` generated the canonical local reviewer packet under `artifacts/v0891/arxiv_manuscript_workflow/`.
  - `jq -r '.packets[].source_refs[]' artifacts/v0891/arxiv_manuscript_workflow/source_packets/source_packet_manifest.json | while IFS= read -r p; do test -f "$p" || { echo "missing $p"; exit 1; }; done` verified the generated source packet manifest points only at existing tracked repository-relative files.
  - `git diff --check` verified no whitespace errors in tracked changes.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1971__v0-89-1-demo-build-arxiv-manuscript-workflow-demo/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1971__v0-89-1-demo-build-arxiv-manuscript-workflow-demo/sor.md
- Idempotency-Key: v0-89-1-demo-build-arxiv-manuscript-workflow-demo-adl-v0-89-1-tasks-issue-1971-v0-89-1-demo-build-arxiv-manuscript-workflow-demo-sip-md-adl-v0-89-1-tasks-issue-1971-v0-89-1-demo-build-arxiv-manuscript-workflow-demo-sor-md