### PR TITLE
[v0.89.1][WP-09] Delegation, refusal, and coordination follow-through

### DIFF
--- a/adl/src/cli/identity_cmd/contracts.rs
+++ b/adl/src/cli/identity_cmd/contracts.rs
@@ -13,6 +13,7 @@ use ::adl::chronosense::{
     TemporalQueryRetrievalContract, TemporalSchemaContract,
 };
 use ::adl::continuous_verification_self_attack::ContinuousVerificationSelfAttackContract;
+use ::adl::delegation_refusal_coordination::DelegationRefusalCoordinationContract;
 use ::adl::exploit_artifact_replay::ExploitArtifactReplayContract;
 use ::adl::operational_skills_substrate::OperationalSkillsSubstrateContract;
 use ::adl::red_blue_agent_architecture::RedBlueAgentArchitectureContract;
@@ -173,6 +174,20 @@ pub(super) fn real_identity_skill_composition(repo_root: &Path, args: &[String])
         "skill composition model",
         "SKILL_COMPOSITION_MODEL_PATH",
         SkillCompositionModelContract::v1(),
+    )
+}
+
+pub(super) fn real_identity_delegation_refusal_coordination(
+    repo_root: &Path,
+    args: &[String],
+) -> Result<()> {
+    write_contract_json(
+        repo_root,
+        args,
+        "delegation-refusal-coordination",
+        "delegation refusal coordination",
+        "DELEGATION_REFUSAL_COORDINATION_PATH",
+        DelegationRefusalCoordinationContract::v1(),
     )
 }
 

--- a/adl/src/cli/identity_cmd/dispatch.rs
+++ b/adl/src/cli/identity_cmd/dispatch.rs
@@ -4,10 +4,11 @@ use std::path::Path;
 use super::contracts::{
     real_identity_adversarial_runner, real_identity_adversarial_runtime, real_identity_causality,
     real_identity_commitments, real_identity_continuity, real_identity_continuous_verification,
-    real_identity_cost, real_identity_exploit_replay, real_identity_foundation,
-    real_identity_instinct, real_identity_instinct_runtime, real_identity_operational_skills,
-    real_identity_phi, real_identity_red_blue_architecture, real_identity_retrieval,
-    real_identity_schema, real_identity_skill_composition,
+    real_identity_cost, real_identity_delegation_refusal_coordination,
+    real_identity_exploit_replay, real_identity_foundation, real_identity_instinct,
+    real_identity_instinct_runtime, real_identity_operational_skills, real_identity_phi,
+    real_identity_red_blue_architecture, real_identity_retrieval, real_identity_schema,
+    real_identity_skill_composition,
 };
 use super::helpers::repo_root;
 use super::profile::{real_identity_init, real_identity_now, real_identity_show};
@@ -20,7 +21,7 @@ pub(crate) fn real_identity(args: &[String]) -> Result<()> {
 pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
+            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
         ));
     };
 
@@ -36,6 +37,9 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
         "continuous-verification" => real_identity_continuous_verification(repo_root, &args[1..]),
         "operational-skills" => real_identity_operational_skills(repo_root, &args[1..]),
         "skill-composition" => real_identity_skill_composition(repo_root, &args[1..]),
+        "delegation-refusal-coordination" => {
+            real_identity_delegation_refusal_coordination(repo_root, &args[1..])
+        }
         "schema" => real_identity_schema(repo_root, &args[1..]),
         "continuity" => real_identity_continuity(repo_root, &args[1..]),
         "retrieval" => real_identity_retrieval(repo_root, &args[1..]),
@@ -50,7 +54,7 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
         )),
     }
 }

--- a/adl/src/cli/identity_cmd/tests.rs
+++ b/adl/src/cli/identity_cmd/tests.rs
@@ -164,7 +164,7 @@ fn identity_requires_subcommand_and_rejects_unknown_subcommand() {
     let err = real_identity_in_repo(&[], &repo).expect_err("missing subcommand should fail");
     assert!(err
         .to_string()
-        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | schema"));
+        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | schema"));
     assert!(err.to_string().contains("continuity"));
 
     let err = real_identity_in_repo(&["nope".to_string()], &repo)
@@ -933,6 +933,82 @@ fn identity_skill_composition_validates_unknown_args_and_missing_out_value() {
 
     let err = real_identity_in_repo(
         &["skill-composition".to_string(), "--out".to_string()],
+        &repo,
+    )
+    .expect_err("out flag without value should fail");
+    assert!(err.to_string().contains("--out requires a value"));
+}
+
+#[test]
+fn identity_delegation_refusal_coordination_writes_contract_json() {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let repo = temp_repo("identity-delegation-refusal-coordination");
+    let out_path = repo.join(".adl/state/delegation_refusal_coordination_v1.json");
+
+    real_identity_in_repo(
+        &[
+            "delegation-refusal-coordination".to_string(),
+            "--out".to_string(),
+            ".adl/state/delegation_refusal_coordination_v1.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("identity delegation-refusal-coordination");
+
+    let json: Value =
+        serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+    assert_eq!(json["schema_version"], "delegation_refusal_coordination.v1");
+    assert_eq!(
+        json["proof_hook_output_path"],
+        ".adl/state/delegation_refusal_coordination_v1.json"
+    );
+    assert!(json["outcome_taxonomy"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value["outcome_kind"] == "governed_refusal"));
+    assert!(
+        json["delegation_refusal_boundary"]["failure_separation_rules"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|value| value.as_str().expect("string").contains("governed refusal"))
+    );
+    assert!(json["coordination_negotiation"]["allowed_outcomes"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "bounded_dissent"));
+    assert!(json["owned_runtime_surfaces"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "adl identity delegation-refusal-coordination"));
+}
+
+#[test]
+fn identity_delegation_refusal_coordination_validates_unknown_args_and_missing_out_value() {
+    let repo = temp_repo("identity-delegation-refusal-coordination-errors");
+
+    let err = real_identity_in_repo(
+        &[
+            "delegation-refusal-coordination".to_string(),
+            "--bogus".to_string(),
+        ],
+        &repo,
+    )
+    .expect_err("unknown arg should fail");
+    assert!(err
+        .to_string()
+        .contains("unknown arg for identity delegation-refusal-coordination: --bogus"));
+
+    let err = real_identity_in_repo(
+        &[
+            "delegation-refusal-coordination".to_string(),
+            "--out".to_string(),
+        ],
         &repo,
     )
     .expect_err("out flag without value should fail");

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -15,6 +15,7 @@ pub fn usage() -> &'static str {
   adl identity continuous-verification [--out <path>]
   adl identity operational-skills [--out <path>]
   adl identity skill-composition [--out <path>]
+  adl identity delegation-refusal-coordination [--out <path>]
   adl identity schema [--out <path>]
   adl identity continuity [--out <path>]
   adl identity retrieval [--out <path>]
@@ -79,6 +80,7 @@ Examples:
   adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open
   adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json
   adl identity skill-composition --out .adl/state/skill_composition_model_v1.json
+  adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json
   adl provider setup chatgpt
   adl provider setup claude
   adl provider setup anthropic --out ./.adl/provider-setup/anthropic

--- a/adl/src/delegation_refusal_coordination.rs
+++ b/adl/src/delegation_refusal_coordination.rs
@@ -1,0 +1,469 @@
+use serde::{Deserialize, Serialize};
+
+use crate::delegation_policy::{DelegationDecision, DelegationPolicyOutcome};
+use crate::operational_skills_substrate::OPERATIONAL_SKILLS_SUBSTRATE_SCHEMA;
+use crate::red_blue_agent_architecture::RED_BLUE_AGENT_ARCHITECTURE_SCHEMA;
+use crate::skill_composition_model::SKILL_COMPOSITION_MODEL_SCHEMA;
+
+pub const DELEGATION_REFUSAL_COORDINATION_SCHEMA: &str = "delegation_refusal_coordination.v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernedOutcomeKind {
+    BoundedDelegationAllowed,
+    GovernedRefusal,
+    ApprovalGate,
+}
+
+impl GovernedOutcomeKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            GovernedOutcomeKind::BoundedDelegationAllowed => "bounded_delegation_allowed",
+            GovernedOutcomeKind::GovernedRefusal => "governed_refusal",
+            GovernedOutcomeKind::ApprovalGate => "approval_gate",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GovernedPolicyDecision {
+    pub outcome_kind: String,
+    pub trace_decision: String,
+    pub matched_rule_id: Option<String>,
+    pub review_obligation: String,
+}
+
+pub fn governed_policy_decision(outcome: &DelegationPolicyOutcome) -> GovernedPolicyDecision {
+    let outcome_kind = match outcome.decision {
+        DelegationDecision::Allowed => GovernedOutcomeKind::BoundedDelegationAllowed,
+        DelegationDecision::Denied => GovernedOutcomeKind::GovernedRefusal,
+        DelegationDecision::NeedsApproval => GovernedOutcomeKind::ApprovalGate,
+    };
+    let review_obligation = match outcome_kind {
+        GovernedOutcomeKind::BoundedDelegationAllowed => {
+            "record the delegated action, target, and preserved constraints"
+        }
+        GovernedOutcomeKind::GovernedRefusal => {
+            "record the refused action, target, matched rule, and why this is not generic failure"
+        }
+        GovernedOutcomeKind::ApprovalGate => {
+            "stop automatic execution and surface the approval authority before proceeding"
+        }
+    };
+
+    GovernedPolicyDecision {
+        outcome_kind: outcome_kind.as_str().to_string(),
+        trace_decision: outcome.decision.as_str().to_string(),
+        matched_rule_id: outcome.rule_id.clone(),
+        review_obligation: review_obligation.to_string(),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GovernanceOutcomeContract {
+    pub outcome_kind: String,
+    pub meaning: String,
+    pub required_trace_events: Vec<String>,
+    pub distinct_from: Vec<String>,
+    pub review_questions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DelegationRefusalBoundaryContract {
+    pub required_distinctions: Vec<String>,
+    pub refusal_rules: Vec<String>,
+    pub delegation_rules: Vec<String>,
+    pub reroute_rules: Vec<String>,
+    pub failure_separation_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoordinationNegotiationContract {
+    pub participant_requirements: Vec<String>,
+    pub position_requirements: Vec<String>,
+    pub allowed_outcomes: Vec<String>,
+    pub disagreement_visibility_rules: Vec<String>,
+    pub prohibited_shortcuts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OperationalSkillGovernanceContract {
+    pub required_skill_surfaces: Vec<String>,
+    pub admission_rules: Vec<String>,
+    pub handoff_rules: Vec<String>,
+    pub stop_boundaries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DelegationCoordinationReviewSurfaceContract {
+    pub required_questions: Vec<String>,
+    pub reviewer_visible_artifacts: Vec<String>,
+    pub downstream_boundaries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DelegationRefusalCoordinationContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub runtime_condition: String,
+    pub upstream_contracts: Vec<String>,
+    pub outcome_taxonomy: Vec<GovernanceOutcomeContract>,
+    pub delegation_refusal_boundary: DelegationRefusalBoundaryContract,
+    pub coordination_negotiation: CoordinationNegotiationContract,
+    pub operational_skill_governance: OperationalSkillGovernanceContract,
+    pub review_surface: DelegationCoordinationReviewSurfaceContract,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+impl DelegationRefusalCoordinationContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: DELEGATION_REFUSAL_COORDINATION_SCHEMA.to_string(),
+            owned_runtime_surfaces: strings(&[
+                "adl::delegation_refusal_coordination::DelegationRefusalCoordinationContract",
+                "adl::delegation_refusal_coordination::GovernedPolicyDecision",
+                "adl::delegation_refusal_coordination::GovernedOutcomeKind",
+                "adl::delegation_policy::DelegationPolicyOutcome",
+                "adl identity delegation-refusal-coordination",
+            ]),
+            runtime_condition:
+                "ADL governance handoffs must distinguish bounded delegation, governed refusal, approval gating, and structured coordination instead of hiding them as generic failure, success, or model wording."
+                    .to_string(),
+            upstream_contracts: strings(&[
+                RED_BLUE_AGENT_ARCHITECTURE_SCHEMA,
+                OPERATIONAL_SKILLS_SUBSTRATE_SCHEMA,
+                SKILL_COMPOSITION_MODEL_SCHEMA,
+            ]),
+            outcome_taxonomy: vec![
+                outcome(
+                    "bounded_delegation_allowed",
+                    "the action is allowed under policy and may be handled by the declared actor, provider, office, or skill while preserving constraints",
+                    &[
+                        "DelegationRequested",
+                        "DelegationPolicyEvaluated",
+                        "DelegationDispatched",
+                    ],
+                    &["silent reroute", "generic success", "unbounded handoff"],
+                    &[
+                        "what was delegated",
+                        "to whom or to what surface",
+                        "which constraints remained in force",
+                    ],
+                ),
+                outcome(
+                    "governed_refusal",
+                    "the system recognized the action and intentionally stopped it under declared constraints",
+                    &["DelegationPolicyEvaluated", "DelegationDenied"],
+                    &["capability failure", "tool failure", "silence", "ambiguous avoidance"],
+                    &[
+                        "what was refused",
+                        "which policy or boundary caused the refusal",
+                        "why this is not a generic execution failure",
+                    ],
+                ),
+                outcome(
+                    "approval_gate",
+                    "the action may be valid but cannot proceed automatically without an explicit approval authority",
+                    &["DelegationPolicyEvaluated"],
+                    &["automatic allow", "automatic deny", "hidden human override"],
+                    &[
+                        "who must approve",
+                        "what would be approved",
+                        "what remains blocked until approval",
+                    ],
+                ),
+                outcome(
+                    "structured_coordination",
+                    "multiple roles or skills state bounded positions before an outcome is selected, deferred, refused, or delegated",
+                    &[
+                        "coordination_session_started",
+                        "coordination_position_recorded",
+                        "coordination_outcome_recorded",
+                    ],
+                    &["opaque chat", "silent dominance", "unattributed consensus"],
+                    &[
+                        "who participated",
+                        "what positions were recorded",
+                        "how the outcome binds back to a decision record",
+                    ],
+                ),
+                outcome(
+                    "bounded_dissent",
+                    "coordination ended with visible unresolved disagreement and an explicit defer, escalation, or refusal path",
+                    &["coordination_position_recorded", "coordination_dissent_recorded"],
+                    &["erased disagreement", "false consensus", "silent escalation"],
+                    &[
+                        "what dissent remained",
+                        "why it was not resolved",
+                        "what downstream unblock condition exists",
+                    ],
+                ),
+            ],
+            delegation_refusal_boundary: DelegationRefusalBoundaryContract {
+                required_distinctions: strings(&[
+                    "cannot_do",
+                    "should_not_do",
+                    "should_not_do_here",
+                    "can_do_later_under_better_conditions",
+                ]),
+                refusal_rules: strings(&[
+                    "refusal must identify the recognized action",
+                    "refusal must cite a declared constraint, policy rule, posture, or approval boundary",
+                    "refusal must be trace-visible and reviewer-legible",
+                    "refusal must not be recorded as generic tool failure",
+                ]),
+                delegation_rules: strings(&[
+                    "delegation must preserve the original constraint context",
+                    "delegation must name the actor, provider, office, or skill that receives the handoff",
+                    "delegation must record whether verification or approval is still required",
+                    "delegation must not masquerade as final success before the delegated result is received",
+                ]),
+                reroute_rules: strings(&[
+                    "rerouting is a delegation outcome when another surface should handle the action",
+                    "rerouting must carry the same posture and evidence constraints forward",
+                    "rerouting cannot erase the original responsibility boundary",
+                ]),
+                failure_separation_rules: strings(&[
+                    "capability failure means the action could not be performed",
+                    "governed refusal means the action was intentionally stopped",
+                    "approval gate means execution is paused pending authority",
+                    "delegation means execution responsibility moved under preserved constraints",
+                ]),
+            },
+            coordination_negotiation: CoordinationNegotiationContract {
+                participant_requirements: strings(&[
+                    "participant_id",
+                    "role_or_skill_id",
+                    "standing_or_scope",
+                    "authority_boundary",
+                ]),
+                position_requirements: strings(&[
+                    "position_id",
+                    "participant_id",
+                    "claim_or_recommendation",
+                    "evidence_refs",
+                    "constraints_cited",
+                ]),
+                allowed_outcomes: strings(&[
+                    "consensus",
+                    "bounded_dissent",
+                    "escalation",
+                    "governed_refusal",
+                    "delegated_resolution",
+                    "explicit_defer",
+                ]),
+                disagreement_visibility_rules: strings(&[
+                    "dissent remains visible even when an outcome is selected",
+                    "unresolved conflicts include unblock conditions",
+                    "position records cite participants rather than anonymous group sentiment",
+                    "outcomes bind back to explicit decision records",
+                ]),
+                prohibited_shortcuts: strings(&[
+                    "unstructured chat as the only coordination artifact",
+                    "silent dominance by one role",
+                    "consensus without participant positions",
+                    "delegation without preserved constraints",
+                    "refusal without a recognized action",
+                ]),
+            },
+            operational_skill_governance: OperationalSkillGovernanceContract {
+                required_skill_surfaces: strings(&[
+                    "skill_id",
+                    "entry_conditions",
+                    "admission_decision",
+                    "allowed_tools_or_capabilities",
+                    "handoff_state",
+                    "stop_boundary",
+                ]),
+                admission_rules: strings(&[
+                    "candidate skills are selected by explicit context rather than description text alone",
+                    "admission records missing inputs before execution",
+                    "more specific skills win over generic orchestration skills",
+                    "judgment skills default to findings or handoff when authority is unclear",
+                ]),
+                handoff_rules: strings(&[
+                    "handoff names the selected downstream skill or authority",
+                    "handoff records whether it is auto-apply, findings-only, propose-and-stop, or blocked",
+                    "handoff preserves issue, branch, worktree, and artifact context where available",
+                ]),
+                stop_boundaries: strings(&[
+                    "do not continue after approval_gate without explicit approval",
+                    "do not continue after governed_refusal except to record the refusal",
+                    "do not continue from bounded_dissent unless a declared escalation or defer path exists",
+                    "do not treat delegated_resolution as complete until result or defer evidence exists",
+                ]),
+            },
+            review_surface: DelegationCoordinationReviewSurfaceContract {
+                required_questions: strings(&[
+                    "what was delegated, refused, approved, deferred, or coordinated",
+                    "which policy, posture, role, or skill boundary controlled the outcome",
+                    "what evidence and constraints moved across any handoff",
+                    "what disagreement or uncertainty remains visible",
+                    "which downstream work package owns anything still not implemented",
+                ]),
+                reviewer_visible_artifacts: strings(&[
+                    "delegation/refusal/coordination contract artifact",
+                    "policy outcome mapping",
+                    "trace event obligations",
+                    "coordination position/outcome packet when negotiation is used",
+                    "D6 integration note in the demo matrix",
+                ]),
+                downstream_boundaries: strings(&[
+                    "WP-10 owns provider-extension and milestone-packaging convergence",
+                    "WP-11 through WP-13 own demo entry points and integration proof packets",
+                    "later identity, moral-governance, and constitutional bands own broader society mechanics",
+                    "this contract does not implement final negotiation law or social reputation interpretation",
+                ]),
+            },
+            proof_fixture_hooks: strings(&[
+                "adl::delegation_refusal_coordination::DelegationRefusalCoordinationContract::v1",
+                "adl::delegation_refusal_coordination::governed_policy_decision",
+                "adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json",
+            ]),
+            proof_hook_command:
+                "adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/delegation_refusal_coordination_v1.json".to_string(),
+            scope_boundary:
+                "WP-09 integrates delegation, refusal, and coordination governance as a bounded review contract; it does not implement final constitutional negotiation, social reputation, provider-security extension, or fully automated approval authority."
+                    .to_string(),
+        }
+    }
+}
+
+fn outcome(
+    outcome_kind: &str,
+    meaning: &str,
+    required_trace_events: &[&str],
+    distinct_from: &[&str],
+    review_questions: &[&str],
+) -> GovernanceOutcomeContract {
+    GovernanceOutcomeContract {
+        outcome_kind: outcome_kind.to_string(),
+        meaning: meaning.to_string(),
+        required_trace_events: strings(required_trace_events),
+        distinct_from: strings(distinct_from),
+        review_questions: strings(review_questions),
+    }
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delegation_refusal_coordination_contract_is_bounded() {
+        let contract = DelegationRefusalCoordinationContract::v1();
+
+        assert_eq!(
+            contract.schema_version,
+            DELEGATION_REFUSAL_COORDINATION_SCHEMA
+        );
+        assert_eq!(
+            contract.upstream_contracts,
+            vec![
+                RED_BLUE_AGENT_ARCHITECTURE_SCHEMA.to_string(),
+                OPERATIONAL_SKILLS_SUBSTRATE_SCHEMA.to_string(),
+                SKILL_COMPOSITION_MODEL_SCHEMA.to_string()
+            ]
+        );
+        assert!(contract
+            .owned_runtime_surfaces
+            .contains(&"adl identity delegation-refusal-coordination".to_string()));
+        assert!(contract
+            .scope_boundary
+            .contains("does not implement final constitutional negotiation"));
+    }
+
+    #[test]
+    fn outcome_taxonomy_distinguishes_refusal_from_failure_and_reroute() {
+        let contract = DelegationRefusalCoordinationContract::v1();
+        let refusal = contract
+            .outcome_taxonomy
+            .iter()
+            .find(|outcome| outcome.outcome_kind == "governed_refusal")
+            .expect("refusal outcome");
+
+        assert!(refusal.distinct_from.contains(&"tool failure".to_string()));
+        assert!(refusal
+            .required_trace_events
+            .contains(&"DelegationDenied".to_string()));
+        assert!(contract
+            .delegation_refusal_boundary
+            .required_distinctions
+            .contains(&"should_not_do_here".to_string()));
+        assert!(contract
+            .delegation_refusal_boundary
+            .failure_separation_rules
+            .iter()
+            .any(|rule| rule.contains("governed refusal means")));
+    }
+
+    #[test]
+    fn coordination_requires_visible_positions_and_dissent() {
+        let contract = DelegationRefusalCoordinationContract::v1();
+
+        assert!(contract
+            .coordination_negotiation
+            .position_requirements
+            .contains(&"participant_id".to_string()));
+        assert!(contract
+            .coordination_negotiation
+            .allowed_outcomes
+            .contains(&"bounded_dissent".to_string()));
+        assert!(contract
+            .coordination_negotiation
+            .prohibited_shortcuts
+            .contains(&"silent dominance by one role".to_string()));
+    }
+
+    #[test]
+    fn policy_outcome_mapping_is_reviewable() {
+        let denied = DelegationPolicyOutcome {
+            decision: DelegationDecision::Denied,
+            rule_id: Some("deny-remote".to_string()),
+        };
+        let mapped = governed_policy_decision(&denied);
+        assert_eq!(mapped.outcome_kind, "governed_refusal");
+        assert_eq!(mapped.trace_decision, "denied");
+        assert_eq!(mapped.matched_rule_id.as_deref(), Some("deny-remote"));
+        assert!(mapped.review_obligation.contains("not generic failure"));
+
+        let approval = governed_policy_decision(&DelegationPolicyOutcome {
+            decision: DelegationDecision::NeedsApproval,
+            rule_id: None,
+        });
+        assert_eq!(approval.outcome_kind, "approval_gate");
+
+        let allowed = governed_policy_decision(&DelegationPolicyOutcome {
+            decision: DelegationDecision::Allowed,
+            rule_id: None,
+        });
+        assert_eq!(allowed.outcome_kind, "bounded_delegation_allowed");
+    }
+
+    #[test]
+    fn contract_has_identity_proof_hook() {
+        let contract = DelegationRefusalCoordinationContract::v1();
+
+        assert_eq!(
+            contract.proof_hook_command,
+            "adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json"
+        );
+        assert_eq!(
+            contract.proof_hook_output_path,
+            ".adl/state/delegation_refusal_coordination_v1.json"
+        );
+        assert!(contract
+            .review_surface
+            .reviewer_visible_artifacts
+            .iter()
+            .any(|artifact| artifact.contains("D6 integration note")));
+    }
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -20,6 +20,7 @@ pub mod chronosense;
 pub mod continuous_verification_self_attack;
 pub mod control_plane;
 pub mod delegation_policy;
+pub mod delegation_refusal_coordination;
 pub mod demo;
 pub mod execute;
 pub mod execution_plan;

--- a/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
+++ b/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
@@ -76,7 +76,7 @@ Additional environment / fixture requirements:
 | D3 | Continuous verification loop | `WP-06` continuous verification and exploit generation | `adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json` | continuous verification contract artifact with lifecycle, cadence, replay, mitigation, and promotion rules | reviewer can see repeated falsification pressure as a governed execution pattern rather than ad hoc red-teaming | repeated bounded inputs should preserve lifecycle shape and proof packet structure | LANDED |
 | D4 | Self-attack scenario packet | `WP-06` self-attacking systems as architecture rather than rhetoric | `adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json` | self-attack contract artifact with bounded layers, target/posture policy, and evidence/replay rules | reviewer can see the system's self-attack pattern before externalization and inspect the required evidence chain | scenario should remain posture-bounded and replay-legible | LANDED |
 | D5 | Flagship adversarial demo | `WP-07` full exploit -> replay -> mitigation -> promotion loop | `adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open` | `.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json` | reviewer can answer what was attacked, how it was reproduced, what mitigation was applied, and whether replay post-fix succeeded | deterministic local replay compares the same request before and after mitigation | LANDED |
-| D6 | Operational skills substrate integration | `WP-08` - `WP-09` operational skills, composition, and bounded governance follow-through | `adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json` and `adl identity skill-composition --out .adl/state/skill_composition_model_v1.json`; WP-09 governance remains pending | substrate/composition packet + later delegation/refusal integration note | reviewer can see that adversarial work runs through explicit skill/composition surfaces instead of ad hoc orchestration | orchestration structure should be deterministic even if node outputs remain stochastic | PLANNED |
+| D6 | Operational skills substrate integration | `WP-08` - `WP-09` operational skills, composition, and bounded governance follow-through | `adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json`, `adl identity skill-composition --out .adl/state/skill_composition_model_v1.json`, and `adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json` | substrate/composition/governance contract packets | reviewer can see that adversarial work runs through explicit skill/composition surfaces with bounded delegation, refusal, approval-gate, and coordination outcomes | orchestration structure and governance outcome taxonomy should be deterministic even if node outputs remain stochastic | LANDED |
 | D7 | Reviewer-facing security proof package | `WP-10` - `WP-13` packaging convergence, milestone convergence, and integration demos | planned `WP-10` / `WP-13` review package | reviewer-facing adversarial/replay/trust packet | reviewer can inspect milestone claims, carry-forward boundaries, and proof surfaces as one coherent package | may remain artifact/document driven rather than fully runnable | PLANNED |
 | D8 | Five-Agent Hey Jude MIDI demo | `WP-08` - `WP-10`, `WP-13` cross-provider coordination, human-in-the-loop orchestration, and integration delight surface | planned `WP-08` / `WP-13` coordination demo entry point | Hey Jude coordination packet + MIDI control trace + provider participation summary | reviewer can see one human plus four providers coordinating on one ADL runtime with explicit orchestration boundaries | bounded score/input should preserve composition shape, participant roles, and MIDI event ordering where declared | PLANNED |
 | D9 | ArXiv manuscript workflow packet | `WP-08`, `WP-13` bounded `arxiv-paper-writer` skill plus the initial three-paper publication program | `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh` | `artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json` | reviewer can see the bounded manuscript workflow packet for What Is ADL?, Gödel Agents and ADL, and Cognitive Spacetime Manifold without losing claim discipline or hiding the WP-08/WP-13 boundary | packet generation is deterministic; bounded source packets preserve role order, section structure, and packet shape | READY |
@@ -329,28 +329,32 @@ Milestone claims / work packages covered:
 - `WP-08`
 - `WP-09`
 
-Planned entry point:
+Entry point:
 
 ```bash
 adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json
 adl identity skill-composition --out .adl/state/skill_composition_model_v1.json
+adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json
 ```
 
 Expected artifacts:
 - operational skills substrate packet
 - skill composition packet
-- delegation / refusal / coordination integration note
+- delegation / refusal / coordination governance packet
+- bounded policy-outcome mapping for allowed delegation, governed refusal, and approval gates
+- coordination and bounded-dissent review rules
 
 Primary proof surface:
-- substrate/composition integration packet
+- substrate/composition/governance contract packets under `.adl/state/`
 
 Expected success signals:
-- reviewer can see explicit invocation boundaries, composition primitives, and governed coordination surfaces
+- reviewer can see explicit invocation boundaries, composition primitives, and governed coordination outcomes
 - the adversarial milestone is anchored in runtime execution substrate rather than ad hoc scripts
+- refusal remains distinguishable from generic failure, approval gates stop before authority, and delegation preserves constraints
 
 Known limits / caveats:
-- delegation/refusal and negotiation remain supporting inputs unless and until they are integrated truthfully during execution
-- WP-09 remains the governance follow-through boundary before this row can be marked `LANDED`
+- the draft delegation/refusal and negotiation notes remain supporting inputs rather than promoted tracked feature docs
+- this contract does not implement final constitutional negotiation, social reputation, or provider-security extension
 
 ---
 

--- a/docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md
+++ b/docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md
@@ -46,6 +46,11 @@ WP-08 proof hooks:
 
 The bounded `arxiv-paper-writer` skill is part of the WP-08 operational substrate and composition contracts. The later three-paper manuscript packet remains owned by `WP-13`.
 
+WP-09 proof hook:
+- `adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json`
+
+The local delegation/refusal and negotiation notes remain supporting inputs rather than promoted feature docs. WP-09 integrates their bounded runtime distinctions into a repo-visible contract so reviewers can see delegation, refusal, approval gates, and coordination outcomes without over-claiming final constitutional or negotiation governance.
+
 ## Source Planning Corpus -> Implementation Home
 
 ### Core `v0.89.1` source docs
@@ -62,9 +67,9 @@ The bounded `arxiv-paper-writer` skill is part of the WP-08 operational substrat
 | `ADL_ADVERSARIAL_DEMO.md` | promoted | `v0.89.1 / WP-07` |
 | `OPERATIONAL_SKILLS_SUBSTRATE.md` | promoted | `v0.89.1 / WP-08` |
 | `SKILL_COMPOSITION_MODEL.md` | promoted | `v0.89.1 / WP-08` |
-| `DELEGATION_AND_REFUSAL.md` | supporting planning input | informs `WP-09` governance boundary work |
-| `MULTI_AGENT_NEGOTIATION.md` | supporting planning input | informs `WP-09` coordination and disagreement surfaces |
-| `PROPOSED_OPERATIONAL_SKILLS.md` | supporting planning input | informs `WP-08` and `WP-09` skill-surface packaging |
+| `DELEGATION_AND_REFUSAL.md` | supporting planning input | integrated into the bounded `WP-09` delegation/refusal/coordination contract without promotion as a standalone feature doc |
+| `MULTI_AGENT_NEGOTIATION.md` | supporting planning input | integrated into the bounded `WP-09` coordination and disagreement surface without final negotiation-law claims |
+| `PROPOSED_OPERATIONAL_SKILLS.md` | supporting planning input | informs `WP-08` skill-surface packaging and the `WP-09` skill-admission/handoff governance contract |
 | local arXiv paper-program planning doc | supporting planning input | informs the committed `WP-08` bounded `arxiv-paper-writer` skill and the `WP-13` three-paper publication packet |
 | `ADL_SECURITY_DEMOS.md` | under-authored supporting input | do not promote until authored; informs later demo packaging |
 | `PROVIDER_SECURITY_CAPABILITIES_EXTENSION.md` | under-authored supporting input | do not promote until authored; candidate later security-extension slice |


### PR DESCRIPTION
Closes #1930

## Summary
Implemented the bounded WP-09 delegation/refusal/coordination review surface. The change adds a Rust contract for governed delegation outcomes, a new identity CLI proof hook, focused unit/CLI tests, and v0.89.1 milestone doc/demo-matrix wiring without promoting the supporting delegation/refusal and negotiation notes into standalone feature docs.

## Artifacts
- Code:
  - `adl/src/delegation_refusal_coordination.rs`
  - `adl/src/lib.rs`
  - `adl/src/cli/identity_cmd/contracts.rs`
  - `adl/src/cli/identity_cmd/dispatch.rs`
  - `adl/src/cli/identity_cmd/tests.rs`
  - `adl/src/cli/usage.rs`
- Documentation:
  - `docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md`
  - `docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md`
- Runtime proof artifact generated for verification only:
  - `.adl/state/delegation_refusal_coordination_v1.json`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml delegation_refusal_coordination`
    Verified the new contract module tests and the matching identity CLI tests.
  - `cargo run --manifest-path adl/Cargo.toml -- identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json`
    Verified the identity command writes the WP-09 proof packet.
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check`
    Verified Rust formatting.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified lint cleanliness across all Rust targets.
  - `cargo test --manifest-path adl/Cargo.toml identity_requires_subcommand_and_rejects_unknown_subcommand`
    Verified the updated identity subcommand list contract after the full-suite catch.
  - `cargo test --manifest-path adl/Cargo.toml`
    Verified the full Rust test suite.
  - `git diff --check`
    Verified whitespace hygiene in the final diff.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling validate-structured-prompt --type sor --phase completed --input .adl/v0.89.1/tasks/issue-1930__v0-89-1-wp-09-delegation-refusal-and-coordination-follow-through/sor.md`
    Verified the completed output card against the structured SOR contract.
- Results: PASS for all listed commands.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1930__v0-89-1-wp-09-delegation-refusal-and-coordination-follow-through/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1930__v0-89-1-wp-09-delegation-refusal-and-coordination-follow-through/sor.md
- Idempotency-Key: v0-89-1-wp-09-delegation-refusal-and-coordination-follow-through-adl-v0-89-1-tasks-issue-1930-v0-89-1-wp-09-delegation-refusal-and-coordination-follow-through-sip-md-adl-v0-89-1-tasks-issue-1930-v0-89-1-wp-09-delegation-refusal-and-coordination-follow-through-sor-md