### PR TITLE
[v0.90][backlog][skills] Add bounded arXiv paper writer skill

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,10 @@ jobs:
         run: bash adl/tools/test_demo_operator_skill_contracts.sh
         working-directory: .
 
+      - name: arxiv-paper-writer contract check
+        run: bash adl/tools/test_arxiv_paper_writer_skill_contracts.sh
+        working-directory: .
+
       - name: fmt
         run: cargo fmt --all -- --check
 

--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -40,6 +40,7 @@ run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"
+run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_paper_writer_skill_contracts.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
 echo "• Running adl checks (batched)…"
 (

--- a/adl/tools/skills/arxiv-paper-writer/SKILL.md
+++ b/adl/tools/skills/arxiv-paper-writer/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: arxiv-paper-writer
+description: Turn one bounded scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, inventing citations, or adding unsupported claims. Use when the user wants arXiv paper drafting, manuscript section drafting, citation-gap review, claim-boundary review, or a pre-submission review packet that must stop before publication.
+---
+
+# arXiv Paper Writer
+
+Draft or revise one arXiv-style manuscript packet from a bounded source packet.
+
+This skill exists to make scholarly drafting reviewable. It does not perform
+literature search, invent citations, submit to arXiv, or claim publication.
+
+This skill is allowed to:
+- inspect one concrete source packet
+- draft title, abstract, outline, sections, reviewer notes, and revision notes
+- produce citation-gap and claim-boundary reports
+- mark unsupported claims instead of laundering them into the draft
+- write one bounded manuscript or review artifact
+
+It is not allowed to:
+- submit to arXiv or any publication platform
+- invent citations, author lists, affiliations, acknowledgements, or results
+- treat model-written prose as final author-approved text
+- broaden into an unbounded research or literature-review task
+- claim novelty, correctness, benchmark wins, or peer acceptance without source support
+
+## Quick Start
+
+1. Confirm the concrete source packet.
+2. Identify the intended manuscript mode and target artifact.
+3. Read `references/arxiv-writing-playbook.md` when drafting or revising text.
+4. Read `references/output-contract.md` when writing a review packet.
+5. Build a source-backed claim map before drafting.
+6. Produce the bounded manuscript packet.
+7. Stop before submission or publication.
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `target.source_packet_path`
+  - `target.source_packet_text`
+  - `target.demo_doc_path`
+
+Useful additional inputs:
+- `artifact_root`
+- `paper_title`
+- `paper_domain`
+- `target_sections`
+- `known_citations`
+- `forbidden_claims`
+- `author_approval_state`
+- `validation_mode`
+
+If there is no concrete source packet, stop and report `blocked`.
+
+## Workflow
+
+### 1. Resolve The Source Packet
+
+Prefer:
+1. explicit source packet path
+2. explicit source packet text
+3. demo document plus a declared source packet
+
+The source packet should name the facts, results, citations, examples, and
+scope boundaries that the manuscript may use.
+
+If the packet is vague, ask for a source packet rather than creating an
+unsourced paper.
+
+### 2. Build The Evidence Map
+
+Before drafting, identify:
+- supported claims
+- claims that need citations
+- claims that need experimental evidence
+- claims that must be weakened or removed
+- citation gaps and missing bibliographic details
+- author or affiliation fields that require human confirmation
+
+Treat gaps as review notes, not as permission to invent.
+
+### 3. Draft Or Revise The Packet
+
+Depending on the mode, produce one bounded artifact:
+- manuscript outline
+- title and abstract options
+- section draft
+- full manuscript packet
+- citation-gap report
+- claim-boundary report
+- reviewer response or revision packet
+
+Prefer clear technical prose, explicit limitations, and source-backed claims
+over grand framing.
+
+### 4. Apply Publication Gates
+
+Before returning the result, check:
+- no arXiv submission was attempted
+- no citation was invented
+- unsupported claims are listed as gaps
+- human authorship and approval are required before publication
+- any web or live citation research is explicitly out of scope unless a future
+  issue adds that step
+
+### 5. Stop Boundary
+
+Stop after:
+- one bounded manuscript or review packet
+- one explicit citation-gap and claim-boundary status
+- one note that submission/publication is out of scope
+
+Do not:
+- publish, submit, schedule, or upload anything
+- claim peer review, acceptance, or arXiv availability
+- silently create unrelated issues, demos, or lifecycle artifacts
+
+## Output Expectations
+
+Default output should include:
+- target source packet
+- intended manuscript mode
+- packet contents produced
+- source-backed claim status
+- citation-gap status
+- submission boundary
+- recommended next review step
+
+When ADL expects a structured artifact, follow `references/output-contract.md`.
+
+## Design Basis
+
+Within this skill bundle, the operational details live in:
+- `references/arxiv-writing-playbook.md`
+- `references/output-contract.md`
+
+The operator-facing invocation contract lives in:
+- `/Users/daniel/git/agent-design-language/adl/tools/skills/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md`
+
+Prefer the tracked repo copies of these docs over memory when the bundle evolves.

--- a/adl/tools/skills/arxiv-paper-writer/adl-skill.yaml
+++ b/adl/tools/skills/arxiv-paper-writer/adl-skill.yaml
@@ -1,0 +1,118 @@
+version: "0.1"
+kind: "adl-skill"
+id: "arxiv-paper-writer"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "arxiv_paper_writer.v1"
+    reference_doc: "../docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "draft_from_source_packet"
+      - "draft_section"
+      - "review_claims_and_citations"
+      - "revise_from_review_notes"
+    policy_fields:
+      - "citation_policy"
+      - "claim_policy"
+      - "validation_mode"
+      - "stop_before_submission"
+    mode_requirements:
+      draft_from_source_packet:
+        required_target_fields:
+          - "source_packet_path"
+      draft_section:
+        required_target_fields:
+          - "source_packet_path"
+          - "target_sections"
+      review_claims_and_citations:
+        required_target_fields:
+          - "source_packet_path"
+      revise_from_review_notes:
+        required_target_fields:
+          - "source_packet_path"
+          - "review_notes_path"
+  intent:
+    - "arxiv_manuscript_drafting"
+    - "citation_gap_review"
+    - "claim_boundary_review"
+    - "bounded_scholarly_writing_support"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "source_packet_path"
+    - "source_packet_text"
+    - "demo_doc_path"
+    - "review_notes_path"
+    - "artifact_root"
+    - "paper_title"
+    - "paper_domain"
+    - "target_sections"
+    - "known_citations"
+    - "forbidden_claims"
+    - "author_approval_state"
+    - "validation_mode"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_arxiv_paper_writer.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "draft_from_source_packet_requires_target.source_packet_path"
+    - "draft_section_requires_target.source_packet_path_and_target.target_sections"
+    - "review_claims_and_citations_requires_target.source_packet_path"
+    - "revise_from_review_notes_requires_target.source_packet_path_and_target.review_notes_path"
+    - "policy.citation_policy_must_be_explicit"
+    - "policy.claim_policy_must_be_explicit"
+    - "policy.validation_mode_must_be_explicit"
+    - "policy.stop_before_submission_must_be_true"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: true
+  preferred_read_order:
+    - "source_packet"
+    - "review_notes"
+    - "arxiv_demo_doc"
+    - "arxiv_writing_playbook"
+  preferred_commands:
+    - "rg --files"
+    - "rg -n"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+    - "manuscript packet artifacts"
+    - "bounded review manifests"
+  must_not_write:
+    - "publication platforms"
+    - "arxiv submission state"
+    - "unrelated issue bundles"
+    - "unrelated worktrees"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-arxiv-paper-writer.md"
+  required_sections:
+    - "status"
+    - "target"
+    - "packet"
+    - "claim_boundary_report"
+    - "citation_gap_report"
+    - "submission_boundary"
+    - "follow_up"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/arxiv-paper-writer/agents/openai.yaml
+++ b/adl/tools/skills/arxiv-paper-writer/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: arXiv Paper Writer
+short_description: Draft bounded arXiv-style manuscript packets without submitting or inventing citations
+default_prompt: Turn one concrete source packet into a reviewer-friendly arXiv-style manuscript packet, surface citation and claim gaps, and stop before submission or publication.

--- a/adl/tools/skills/arxiv-paper-writer/references/arxiv-writing-playbook.md
+++ b/adl/tools/skills/arxiv-paper-writer/references/arxiv-writing-playbook.md
@@ -1,0 +1,89 @@
+# arXiv Writing Playbook
+
+Use this file after the main skill triggers and the source packet is concrete.
+
+## Priorities
+
+Prefer this order:
+1. preserve source-packet truth
+2. state the contribution clearly and narrowly
+3. separate evidence-backed claims from hypotheses or motivation
+4. surface citation gaps instead of filling them from memory
+5. keep limitations visible
+6. leave submission decisions to human authors
+
+## Source Packet Checklist
+
+Before drafting, identify:
+- core problem statement
+- contribution claim
+- method or system description
+- evaluation evidence
+- limitations and failure modes
+- known citations and missing citations
+- author-approved terminology
+- claims that are explicitly forbidden or not yet proven
+
+## Manuscript Guidance
+
+Bias toward:
+- concise, testable contribution language
+- clear abstract structure: problem, method, evidence, result, limitation
+- section headings that reveal the argument
+- related-work language that says what is known, unknown, or deferred
+- limitations that reviewers can verify
+- explicit TODO markers for author-owned facts
+
+Avoid:
+- inflated novelty claims
+- invented comparisons to prior work
+- fabricated benchmark results
+- placeholder citations that look real
+- claims that imply peer review, acceptance, or arXiv availability
+- author, affiliation, funding, or acknowledgement details not present in the packet
+
+## Claim Boundary Rules
+
+Use these labels when reviewing claims:
+- `SUPPORTED`: directly supported by the source packet
+- `NEEDS_CITATION`: plausible but missing citation support
+- `NEEDS_EVIDENCE`: requires experiment, proof, or repo-visible result
+- `AUTHOR_DECISION`: requires human author confirmation
+- `REMOVE_OR_WEAKEN`: too broad, unsupported, or misleading
+
+Unsupported claims should appear in the review packet, not silently in the draft.
+
+## Citation Rules
+
+Allowed:
+- cite works explicitly listed in the source packet
+- preserve incomplete citation placeholders as gaps when clearly marked
+- ask for missing bibliographic details
+
+Not allowed:
+- invent title, author, venue, DOI, arXiv id, or year
+- claim a citation supports a statement without source-packet evidence
+- run live web research unless the operator explicitly supplies a separate
+  sourced research step
+
+## Packet Guidance
+
+A strong bounded packet usually includes:
+- title options
+- abstract draft
+- section outline
+- selected section drafts or full manuscript draft
+- claim-boundary table
+- citation-gap table
+- reviewer notes
+- explicit submission caveat
+
+## Stop Rule
+
+This skill stops at a reviewable manuscript packet.
+
+It does not:
+- submit to arXiv
+- claim author approval
+- claim peer review or acceptance
+- fill citation gaps from memory

--- a/adl/tools/skills/arxiv-paper-writer/references/output-contract.md
+++ b/adl/tools/skills/arxiv-paper-writer/references/output-contract.md
@@ -1,0 +1,54 @@
+# Output Contract
+
+The default `arxiv-paper-writer` artifact is markdown with these sections in this order:
+
+```md
+## Metadata
+- Skill: arxiv-paper-writer
+- Subject: <source packet target>
+- Date: <UTC timestamp or calendar date>
+- Output Location: <path or none>
+
+## Target
+- Mode: draft_from_source_packet | draft_section | review_claims_and_citations | revise_from_review_notes
+- Source Packet: <path, doc, or inline target>
+- Paper Domain: <explicit domain or unknown>
+- Target Sections: <sections or none>
+
+## Packet
+- Produced Sections:
+  - <title options / abstract / outline / draft sections / reviewer notes>
+- Primary Draft Surface: <path or explicit none>
+- Result: PASS | FAIL | PARTIAL | NOT_RUN
+
+## Claim Boundary Report
+- Unsupported Claims Present: true | false
+- Claim Labels Used:
+  - SUPPORTED
+  - NEEDS_CITATION
+  - NEEDS_EVIDENCE
+  - AUTHOR_DECISION
+  - REMOVE_OR_WEAKEN
+- Notes: <bounded summary>
+
+## Citation Gap Report
+- Citations Invented: true | false
+- Citation Gaps Present: true | false
+- Missing Bibliographic Details: <bounded list or none>
+
+## Submission Boundary
+- Submission Attempted: true | false
+- Publication Claimed: true | false
+- Human Author Approval Required: true | false
+- Reason: <must explain why submit/publish is out of scope>
+
+## Follow-up
+- Recommended Next Step: <one bounded next action or explicit none>
+```
+
+## Rules
+
+- Do not claim arXiv submission or publication.
+- Do not invent citations, authors, affiliations, acknowledgements, or results.
+- Do not hide unsupported claims; mark them in the claim-boundary report.
+- Do not emit raw secrets, raw prompts, raw tool arguments, or unjustified absolute host paths.

--- a/adl/tools/skills/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,144 @@
+# arXiv Paper Writer Skill Input Schema
+
+Schema id: `arxiv_paper_writer.v1`
+
+## Purpose
+
+Provide one structured invocation shape for the bounded `arxiv-paper-writer`
+skill.
+
+The skill should turn one concrete scholarly source packet into a
+reviewer-friendly arXiv-style manuscript packet while stopping before
+submission or publication.
+
+## Supported Modes
+
+- `draft_from_source_packet`
+- `draft_section`
+- `review_claims_and_citations`
+- `revise_from_review_notes`
+
+## Top-Level Shape
+
+```yaml
+skill_input_schema: arxiv_paper_writer.v1
+mode: draft_from_source_packet | draft_section | review_claims_and_citations | revise_from_review_notes
+repo_root: /absolute/path
+target:
+  source_packet_path: <path or null>
+  source_packet_text: <string or null>
+  demo_doc_path: <path or null>
+  review_notes_path: <path or null>
+  artifact_root: <path or null>
+  paper_title: <string or null>
+  paper_domain: <string or null>
+  target_sections:
+    - <section name>
+  known_citations:
+    - <citation supplied by the source packet>
+  forbidden_claims:
+    - <string>
+  author_approval_state: unknown | draft_reviewed | approved_for_submission
+policy:
+  citation_policy: source_packet_only | mark_gaps
+  claim_policy: strict_source_bound | mark_unsupported
+  validation_mode: artifact_only | demo_aligned | none
+  stop_before_submission: true
+```
+
+## Mode Requirements
+
+### `draft_from_source_packet`
+
+Requires:
+
+- `target.source_packet_path`
+
+Use when:
+
+- the operator wants a bounded manuscript packet from a concrete local source packet
+
+### `draft_section`
+
+Requires:
+
+- `target.source_packet_path`
+- `target.target_sections`
+
+Use when:
+
+- only selected manuscript sections should be drafted or revised
+
+### `review_claims_and_citations`
+
+Requires:
+
+- `target.source_packet_path`
+
+Use when:
+
+- the operator wants a citation-gap or unsupported-claim review before drafting
+
+### `revise_from_review_notes`
+
+Requires:
+
+- `target.source_packet_path`
+- `target.review_notes_path`
+
+Use when:
+
+- an existing manuscript packet should be revised against bounded review notes
+
+## Policy Fields
+
+- `citation_policy`
+  - required
+  - one of `source_packet_only` or `mark_gaps`
+- `claim_policy`
+  - required
+  - one of `strict_source_bound` or `mark_unsupported`
+- `validation_mode`
+  - required
+  - one of `artifact_only`, `demo_aligned`, or `none`
+- `stop_before_submission`
+  - must be `true`
+
+## Example Invocation
+
+```yaml
+Use $arxiv-paper-writer at /Users/daniel/git/agent-design-language/adl/tools/skills/arxiv-paper-writer/SKILL.md with this validated input:
+
+skill_input_schema: arxiv_paper_writer.v1
+mode: draft_from_source_packet
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  source_packet_path: demos/v0.89.1/arxiv_manuscript_workflow_demo.md
+  source_packet_text: null
+  demo_doc_path: demos/v0.89.1/arxiv_manuscript_workflow_demo.md
+  review_notes_path: null
+  artifact_root: null
+  paper_title: Agent Design Language manuscript packet
+  paper_domain: agentic software engineering
+  target_sections:
+    - abstract
+    - introduction
+    - limitations
+  known_citations: []
+  forbidden_claims:
+    - peer reviewed
+    - submitted to arXiv
+    - benchmark superiority without evidence
+  author_approval_state: unknown
+policy:
+  citation_policy: mark_gaps
+  claim_policy: mark_unsupported
+  validation_mode: artifact_only
+  stop_before_submission: true
+```
+
+## Notes
+
+- prefer a smaller source-backed draft over a polished but unsupported paper
+- keep arXiv submission outside the skill boundary
+- use citation gaps and claim-boundary labels as first-class review output

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -25,6 +25,7 @@ The tracked skill set is:
 - `test-generator`
 - `demo-operator`
 - `medium-article-writer`
+- `arxiv-paper-writer`
 - `stp-editor`
 - `sip-editor`
 - `sor-editor`
@@ -47,6 +48,7 @@ The normal workflow is:
 `test-generator` is a bounded helper skill for focused tests for a concrete issue, diff, file, or worktree.
 `demo-operator` is a bounded helper skill for running one named demo and classifying the proof result consistently.
 `medium-article-writer` is a bounded helper skill for turning one concrete article brief into a reviewer-friendly Medium packet without publishing.
+`arxiv-paper-writer` is a bounded helper skill for turning one concrete scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, or inventing citations.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 
 The three editor skills are helper skills:
@@ -1511,6 +1513,129 @@ policy:
 Run the named demo in a bounded way, classify the result, and stop.
 ```
 
+## `arxiv-paper-writer`
+
+### Purpose
+
+`arxiv-paper-writer` drafts or reviews one arXiv-style manuscript packet from a
+bounded scholarly source packet.
+
+It is a bounded helper skill, not a publication or literature-search workflow.
+
+### When To Use It
+
+Use it when:
+
+- a concrete source packet should become a manuscript outline, abstract, section
+  draft, full packet, citation-gap report, or claim-boundary report
+- the operator wants source-backed scholarly drafting with explicit citation and
+  claim guardrails
+- the output should stop before arXiv submission or publication
+
+Do not use it for:
+
+- arXiv submission
+- live literature search or citation harvesting
+- inventing citations, author details, benchmark results, or novelty claims
+- broad research planning without a concrete source packet
+
+### Required Inputs
+
+Minimum:
+
+- `repo_root`
+- structured invocation should use `skill_input_schema: arxiv_paper_writer.v1`
+- one of:
+  - `target.source_packet_path`
+  - `target.source_packet_text`
+  - `target.demo_doc_path`
+
+### Input Schema
+
+Canonical schema:
+
+- `adl/tools/skills/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md`
+
+Schema id:
+
+- `arxiv_paper_writer.v1`
+
+Structured invocation shape:
+
+```yaml
+skill_input_schema: arxiv_paper_writer.v1
+mode: draft_from_source_packet | draft_section | review_claims_and_citations | revise_from_review_notes
+repo_root: /absolute/path
+target:
+  source_packet_path: <path or null>
+  source_packet_text: <string or null>
+  demo_doc_path: <path or null>
+  review_notes_path: <path or null>
+  artifact_root: <path or null>
+  paper_title: <string or null>
+  paper_domain: <string or null>
+  target_sections:
+    - <section name>
+  known_citations:
+    - <citation supplied by the source packet>
+  forbidden_claims:
+    - <string>
+  author_approval_state: unknown | draft_reviewed | approved_for_submission
+policy:
+  citation_policy: source_packet_only | mark_gaps
+  claim_policy: strict_source_bound | mark_unsupported
+  validation_mode: artifact_only | demo_aligned | none
+  stop_before_submission: true
+```
+
+### Output And Stop Boundary
+
+Expected output includes:
+
+- target source packet
+- manuscript packet contents
+- claim-boundary report
+- citation-gap report
+- submission boundary
+- follow-up recommendation
+
+The skill may write one bounded manuscript or review artifact.
+It must stop before submission, publication, author approval claims, or
+unbounded research.
+
+### Example Invocation
+
+```yaml
+Use $arxiv-paper-writer at /Users/daniel/git/agent-design-language/adl/tools/skills/arxiv-paper-writer/SKILL.md with:
+skill_input_schema: arxiv_paper_writer.v1
+mode: draft_from_source_packet
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  source_packet_path: demos/v0.89.1/arxiv_manuscript_workflow_demo.md
+  source_packet_text: null
+  demo_doc_path: demos/v0.89.1/arxiv_manuscript_workflow_demo.md
+  review_notes_path: null
+  artifact_root: null
+  paper_title: Agent Design Language manuscript packet
+  paper_domain: agentic software engineering
+  target_sections:
+    - abstract
+    - introduction
+    - limitations
+  known_citations: []
+  forbidden_claims:
+    - submitted to arXiv
+    - peer reviewed
+    - benchmark superiority without evidence
+  author_approval_state: unknown
+policy:
+  citation_policy: mark_gaps
+  claim_policy: mark_unsupported
+  validation_mode: artifact_only
+  stop_before_submission: true
+Draft the bounded packet, surface citation and claim gaps, and stop before submission.
+```
+
 ## Choosing The Right Skill
 
 Use this quick selector:
@@ -1533,6 +1658,8 @@ Use this quick selector:
   - `pr-closeout`
 - need a broad findings-first code review:
   - `repo-code-review`
+- need source-backed arXiv-style manuscript drafting or citation-gap review:
+  - `arxiv-paper-writer`
 
 ## Common Failure Modes
 

--- a/adl/tools/test_arxiv_paper_writer_skill_contracts.sh
+++ b/adl/tools/test_arxiv_paper_writer_skill_contracts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/arxiv-paper-writer/SKILL.md" ]]
+[[ -f "${skills_root}/arxiv-paper-writer/adl-skill.yaml" ]]
+[[ -f "${skills_root}/arxiv-paper-writer/agents/openai.yaml" ]]
+[[ -f "${skills_root}/arxiv-paper-writer/references/arxiv-writing-playbook.md" ]]
+[[ -f "${skills_root}/arxiv-paper-writer/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "arxiv_paper_writer.v1"' "${skills_root}/arxiv-paper-writer/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/arxiv-paper-writer/adl-skill.yaml"
+grep -Fq "policy.citation_policy_must_be_explicit" "${skills_root}/arxiv-paper-writer/adl-skill.yaml"
+grep -Fq "policy.stop_before_submission_must_be_true" "${skills_root}/arxiv-paper-writer/adl-skill.yaml"
+grep -Fq "without submitting, publishing, inventing citations" "${skills_root}/arxiv-paper-writer/SKILL.md"
+grep -Fq "no arXiv submission was attempted" "${skills_root}/arxiv-paper-writer/SKILL.md"
+grep -Fq "This skill stops at a reviewable manuscript packet." "${skills_root}/arxiv-paper-writer/references/arxiv-writing-playbook.md"
+grep -Fq "Submission Attempted: true | false" "${skills_root}/arxiv-paper-writer/references/output-contract.md"
+grep -Fq 'Schema id: `arxiv_paper_writer.v1`' "${skills_root}/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md"
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/arxiv-paper-writer/SKILL.md"
+
+echo "PASS test_arxiv_paper_writer_skill_contracts"

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review test-generator demo-operator medium-article-writer stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review test-generator demo-operator medium-article-writer arxiv-paper-writer stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -23,6 +23,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
+  [[ -f "${root}/skills/arxiv-paper-writer/SKILL.md" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]
@@ -38,6 +39,7 @@ assert_skill_bundle() {
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
+  grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
   grep -Fq "truthful execution and integration state" "${root}/skills/sor-editor/SKILL.md"
@@ -54,6 +56,7 @@ assert_skill_bundle() {
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
+    "${root}/skills/arxiv-paper-writer/SKILL.md" \
     "${root}/skills/stp-editor/SKILL.md" \
     "${root}/skills/sip-editor/SKILL.md" \
     "${root}/skills/sor-editor/SKILL.md"
@@ -69,6 +72,7 @@ ADL_OPERATIONAL_SKILLS_INSTALL_MODE=symlink bash "${repo_root}/adl/tools/install
 assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/pr-init" ]]
 [[ -L "${CODEX_HOME}/skills/pr-ready" ]]
+[[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]
 
 malformed_root="${tmpdir}/malformed-skills"


### PR DESCRIPTION
Closes #1975

## Summary
Implemented the bounded `arxiv-paper-writer` operational skill. The change adds the repo-owned skill bundle, ADL invocation contract, UI metadata, source-backed drafting playbook, output contract, input-schema documentation, install/sync coverage, focused contract tests, and CI/batched-check wiring.

## Artifacts
- Skill bundle:
  - `adl/tools/skills/arxiv-paper-writer/SKILL.md`
  - `adl/tools/skills/arxiv-paper-writer/adl-skill.yaml`
  - `adl/tools/skills/arxiv-paper-writer/agents/openai.yaml`
  - `adl/tools/skills/arxiv-paper-writer/references/arxiv-writing-playbook.md`
  - `adl/tools/skills/arxiv-paper-writer/references/output-contract.md`
- Documentation:
  - `adl/tools/skills/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md`
  - `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- Tests and check wiring:
  - `adl/tools/test_arxiv_paper_writer_skill_contracts.sh`
  - `adl/tools/test_install_adl_operational_skills.sh`
  - `adl/tools/batched_checks.sh`
  - `.github/workflows/ci.yaml`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_arxiv_paper_writer_skill_contracts.sh`
    Verified the new skill bundle, schema doc, guardrail wording, output contract, and frontmatter.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Verified operational skill installation includes `arxiv-paper-writer` in copy and symlink modes.
  - `bash -n adl/tools/*.sh`
    Verified shell syntax for the new and touched tooling scripts.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/arxiv-paper-writer/SKILL.md`
    Verified the new skill frontmatter parses cleanly.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.90/tasks/issue-1975__backlog-skills-add-bounded-arxiv-paper-writer-skill/sor.md`
    Verified the completed output record.
  - `git diff --check`
    Verified whitespace hygiene in the final diff.
- Results: PASS for all listed commands.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-1975__backlog-skills-add-bounded-arxiv-paper-writer-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-1975__backlog-skills-add-bounded-arxiv-paper-writer-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-bounded-arxiv-paper-writer-skill-adl-v0-90-tasks-issue-1975-backlog-skills-add-bounded-arxiv-paper-writer-skill-sip-md-adl-v0-90-tasks-issue-1975-backlog-skills-add-bounded-arxiv-paper-writer-skill-sor-md