### PR TITLE
[v0.90][backlog][skills] Add multi-agent repo review skill suite

### DIFF
--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -1,0 +1,201 @@
+# Multi-Agent Repo Review Skill Suite
+
+## Purpose
+
+Provide a modular review suite for repository-wide or large-slice review. The
+suite decomposes review into specialist roles and a synthesis role instead of
+asking one monolithic prompt to absorb every concern.
+
+Use the existing `repo-code-review` skill when one bounded monolithic review is
+enough. Use this suite when the operator wants distinct role artifacts, deeper
+coverage, or an explicit multi-agent review demo/proof surface.
+
+## Skills
+
+- `repo-review-code`
+- `repo-review-security`
+- `repo-review-tests`
+- `repo-review-docs`
+- `repo-review-synthesis`
+
+## Invocation Order
+
+Recommended order:
+
+1. `repo-review-code`
+2. `repo-review-security`
+3. `repo-review-tests`
+4. `repo-review-docs`
+5. `repo-review-synthesis`
+
+The first four roles may run independently when the operator wants parallel
+review. The synthesis role should run after at least one specialist artifact is
+available, and ideally after all required roles have reported.
+
+## Shared Specialist Input Shape
+
+```yaml
+skill_input_schema: repo_review_code.v1 | repo_review_security.v1 | repo_review_tests.v1 | repo_review_docs.v1
+mode: review_repository | review_path | review_branch | review_diff | review_packet
+repo_root: /absolute/path
+target:
+  target_path: <path or null>
+  branch: <string or null>
+  diff_base: <string or null>
+  review_packet_path: <path or null>
+  changed_paths:
+    - <path>
+  artifact_root: <path or null>
+policy:
+  review_depth: quick | standard | deep
+  validation_mode: targeted | inspect_only | none
+  write_review_artifact: true | false
+  stop_after_review: true
+```
+
+## Synthesis Input Shape
+
+```yaml
+skill_input_schema: repo_review_synthesis.v1
+mode: synthesize_specialist_artifacts | synthesize_review_packet
+repo_root: /absolute/path
+target:
+  target_path: <path or null>
+  branch: <string or null>
+  diff_base: <string or null>
+  specialist_artifacts:
+    code: <path or null>
+    security: <path or null>
+    tests: <path or null>
+    docs: <path or null>
+  artifact_root: <path or null>
+policy:
+  required_roles:
+    - code
+    - security
+    - tests
+    - docs
+  severity_policy: preserve_highest | preserve_role_severity
+  write_review_artifact: true | false
+  stop_after_synthesis: true
+```
+
+## Specialist Output Contract
+
+Each specialist artifact should use this shape:
+
+```md
+## Metadata
+- Skill: repo-review-code | repo-review-security | repo-review-tests | repo-review-docs
+- Target: <repo/path/branch/diff>
+- Date: <UTC timestamp or calendar date>
+- Artifact: <path or none>
+
+## Findings
+- <priority>: <title>
+  File: <repo-relative path or none>
+  Role: <code | security | tests | docs>
+  Scenario: <trigger or review condition>
+  Impact: <behavioral consequence>
+  Evidence: <specific code/doc/test/config observation>
+
+## Reviewed Surfaces
+- <bounded list>
+
+## Validation Performed
+- <command and what it proved, or explicit not run rationale>
+
+## Residual Risk
+- <what this role did not inspect or could not prove>
+```
+
+## Role-Specific Required Fields
+
+- `repo-review-code` must include `reviewed_surfaces` and code-risk residuals.
+- `repo-review-security` must include `trust_boundaries` and asset/attacker notes when relevant.
+- `repo-review-tests` must include a `missing_proof_map` when coverage gaps are found.
+- `repo-review-docs` must include `commands_or_claims_checked` when docs make runnable claims.
+
+## Synthesis Output Contract
+
+```md
+## Metadata
+- Skill: repo-review-synthesis
+- Target: <repo/path/branch/diff>
+- Date: <UTC timestamp or calendar date>
+- Specialist Artifacts:
+  - code: <path or missing>
+  - security: <path or missing>
+  - tests: <path or missing>
+  - docs: <path or missing>
+
+## Findings
+- <priority>: <title>
+  Source Roles: <role list>
+  File: <repo-relative path or none>
+  Scenario: <trigger or review condition>
+  Impact: <behavioral consequence>
+  Evidence: <merged evidence without hiding disagreement>
+
+## Coverage Matrix
+- Code: present | missing | skipped
+- Security: present | missing | skipped
+- Tests: present | missing | skipped
+- Docs: present | missing | skipped
+
+## Dedupe Notes
+- <what was merged and why>
+
+## Disagreements
+- <role disagreements or explicit none>
+
+## Validation Performed
+- <commands from specialist artifacts; synthesis should not invent new validation>
+
+## Residual Risk
+- <missing roles, skipped paths, unexecuted tests, generated/vendor exclusions>
+
+## Recommended Follow-up Issues
+- <bounded issue candidate or explicit none>
+```
+
+## Severity Rules
+
+- Preserve the highest severity attached to a merged finding unless the source
+  role explicitly withdraws it.
+- Do not downgrade security findings merely because the code reviewer did not
+  mention them.
+- Do not hide missing tests behind a "no code defect found" result.
+- Do not convert docs truth drift into style feedback when it affects reviewer
+  reproducibility or operator safety.
+- Mark disagreement explicitly instead of silently choosing one role's view.
+
+## Boundaries
+
+The suite may:
+- inspect repo files and local diffs
+- run bounded local validation commands when safe
+- write review artifacts under `.adl/reviews`
+- recommend follow-up issues
+
+The suite must not:
+- edit code, tests, docs, configs, or issue state
+- claim merge approval
+- claim remediation
+- run unbounded repository-wide analysis without a declared target
+- use network or paid data feeds
+- hide severity, disagreement, skipped roles, or residual risk
+
+## Relationship To `repo-code-review`
+
+Use `repo-code-review` when:
+- one reviewer is enough
+- the review is quick or standard depth
+- the operator does not need separate role artifacts
+- the result should be a single findings-first pass
+
+Use this suite when:
+- the review is deep or release-adjacent
+- role separation is useful for traceability
+- security, tests, or docs need explicit ownership
+- the synthesis artifact should show specialist coverage and disagreement

--- a/adl/tools/skills/repo-review-code/SKILL.md
+++ b/adl/tools/skills/repo-review-code/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: repo-review-code
+description: Specialist code reviewer for a multi-agent repository review. Use when a review packet needs a bounded code/correctness reviewer focused on behavioral bugs, regressions, maintainability risks, API misuse, state transitions, concurrency, parsing, serialization, and implementation drift without taking over security, docs, tests, or synthesis roles.
+---
+
+# Repo Review Code
+
+Review executable code for correctness and maintainability findings as one
+specialist in the multi-agent repo review suite.
+
+This skill is findings-only. It may inspect code and run bounded local tests,
+but it must not edit code or claim merge approval.
+
+## Quick Start
+
+1. Confirm the repo, branch, path, diff, or review packet scope.
+2. Identify entrypoints, core runtime modules, stateful logic, manifests, and
+   the highest-risk implementation surfaces.
+3. Review behavior before style.
+4. Emit findings first, with file references, severity, and trigger scenario.
+5. Hand the artifact to `repo-review-synthesis` when a multi-agent review is
+   being assembled.
+
+## Focus
+
+Prioritize:
+- correctness bugs and behavioral regressions
+- API misuse and mismatched assumptions
+- partial refactors and stale call sites
+- state-machine, retry, cancellation, and recovery holes
+- parsing, serialization, path handling, and external I/O behavior
+- maintainability risks that materially increase review or change hazards
+
+Defer primary ownership of these areas to other specialists:
+- security threat and abuse analysis: `repo-review-security`
+- missing or weak test coverage: `repo-review-tests`
+- misleading docs and onboarding drift: `repo-review-docs`
+- cross-role dedupe and final ordering: `repo-review-synthesis`
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `target.target_path`
+  - `target.branch`
+  - `target.diff_base`
+  - `target.review_packet_path`
+
+Useful additional inputs:
+- `changed_paths`
+- `review_depth`
+- `artifact_root`
+- `exclude_paths`
+- `validation_mode`
+
+If there is no concrete repo or slice target, stop and report `blocked`.
+
+## Output Expectations
+
+Default output should include:
+- findings first
+- assumptions
+- reviewed code surfaces
+- validation performed or not run
+- residual code-review risk
+
+Use the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md` when ADL expects
+a structured artifact.
+
+## Stop Boundary
+
+Stop after producing the code-review artifact.
+
+Do not:
+- edit implementation files
+- silently run the whole multi-agent workflow
+- downgrade security, docs, or test findings from other specialists
+- claim approval, merge readiness, or remediation completion

--- a/adl/tools/skills/repo-review-code/adl-skill.yaml
+++ b/adl/tools/skills/repo-review-code/adl-skill.yaml
@@ -1,0 +1,58 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-review-code"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_review_code.v1"
+    reference_doc: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_repository"
+      - "review_path"
+      - "review_branch"
+      - "review_diff"
+      - "review_packet"
+    policy_fields:
+      - "review_depth"
+      - "validation_mode"
+      - "write_review_artifact"
+      - "stop_after_review"
+  intent:
+    - "code_correctness_review"
+    - "behavioral_regression_review"
+    - "maintainability_review"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_review_code.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.review_depth_must_be_explicit"
+    - "policy.stop_after_review_must_be_true"
+execution:
+  mode: "findings_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_tests_when_bounded"
+outputs:
+  default_format: "markdown"
+  structured_contract: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-review-code.md"
+  required_sections:
+    - "findings"
+    - "reviewed_surfaces"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/repo-review-code/agents/openai.yaml
+++ b/adl/tools/skills/repo-review-code/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Repo Review Code
+short_description: Review code correctness and maintainability risks as one specialist role
+default_prompt: Review the bounded repository slice for behavioral bugs, regressions, API misuse, state-flow problems, and maintainability risks. Emit findings first and stop without editing code.

--- a/adl/tools/skills/repo-review-docs/SKILL.md
+++ b/adl/tools/skills/repo-review-docs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: repo-review-docs
+description: Specialist docs reviewer for a multi-agent repository review. Use when a review packet needs a bounded documentation role focused on misleading docs, stale commands, onboarding gaps, release and demo truth drift, API/CLI contract drift, and whether documentation overclaims behavior without editing docs.
+---
+
+# Repo Review Docs
+
+Review documentation truth and usability as one specialist in the multi-agent
+repo review suite.
+
+This skill focuses on docs as operational surfaces. It is not a copyediting
+role unless copy clarity affects real user or reviewer behavior.
+
+## Quick Start
+
+1. Confirm the repo, branch, path, diff, or review packet scope.
+2. Identify docs that make operational claims: README, milestone docs, CLI
+   commands, release notes, demos, schemas, and onboarding guides.
+3. Compare docs against repo-visible commands, files, and behavior.
+4. Emit findings first, with stale command or truth-drift evidence.
+5. Hand the artifact to `repo-review-synthesis` for cross-role assembly.
+
+## Focus
+
+Prioritize:
+- stale commands and broken paths
+- docs that claim behavior not present in code, tests, or artifacts
+- onboarding gaps that prevent a reviewer or operator from reproducing work
+- demo, release, milestone, and closeout truth drift
+- API, CLI, schema, or skill-contract documentation drift
+- ambiguity that can cause unsafe operation or wrong workflow execution
+
+Defer primary ownership of these areas to other specialists:
+- executable defects: `repo-review-code`
+- security exploitability: `repo-review-security`
+- missing tests: `repo-review-tests`
+- final dedupe and ordering: `repo-review-synthesis`
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `target.target_path`
+  - `target.branch`
+  - `target.diff_base`
+  - `target.review_packet_path`
+
+Useful additional inputs:
+- `changed_paths`
+- `claimed_commands`
+- `demo_docs`
+- `release_docs`
+- `validation_mode`
+
+If there is no concrete repo or slice target, stop and report `blocked`.
+
+## Output Expectations
+
+Default output should include:
+- findings first
+- reviewed docs surfaces
+- commands or claims checked
+- validation performed or not run
+- residual docs risk
+
+Use the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md` when ADL expects
+a structured artifact.
+
+## Stop Boundary
+
+Stop after producing the docs-review artifact.
+
+Do not:
+- rewrite documentation
+- spend the review on style nits when truth drift exists
+- claim demo/release readiness without proof
+- hide docs findings that affect operator safety or reviewer reproducibility

--- a/adl/tools/skills/repo-review-docs/adl-skill.yaml
+++ b/adl/tools/skills/repo-review-docs/adl-skill.yaml
@@ -1,0 +1,58 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-review-docs"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_review_docs.v1"
+    reference_doc: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_repository"
+      - "review_path"
+      - "review_branch"
+      - "review_diff"
+      - "review_packet"
+    policy_fields:
+      - "review_depth"
+      - "validation_mode"
+      - "write_review_artifact"
+      - "stop_after_review"
+  intent:
+    - "docs_review"
+    - "truth_drift_review"
+    - "onboarding_review"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_review_docs.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.review_depth_must_be_explicit"
+    - "policy.stop_after_review_must_be_true"
+execution:
+  mode: "findings_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_doc_commands_only_when_bounded_and_safe"
+outputs:
+  default_format: "markdown"
+  structured_contract: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-review-docs.md"
+  required_sections:
+    - "findings"
+    - "reviewed_docs"
+    - "commands_or_claims_checked"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/repo-review-docs/agents/openai.yaml
+++ b/adl/tools/skills/repo-review-docs/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Repo Review Docs
+short_description: Review documentation truth and onboarding drift as one specialist role
+default_prompt: Review the bounded repository slice for stale commands, misleading docs, onboarding gaps, and release or demo truth drift. Emit findings first and stop without rewriting docs.

--- a/adl/tools/skills/repo-review-security/SKILL.md
+++ b/adl/tools/skills/repo-review-security/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: repo-review-security
+description: Specialist security reviewer for a multi-agent repository review. Use when a review packet needs a bounded AppSec role focused on trust boundaries, secret handling, injection risks, privilege and permission failures, unsafe file/network IO, deserialization, supply-chain exposure, and abuse paths without performing remediation or broad synthesis.
+---
+
+# Repo Review Security
+
+Review a repository slice for security and abuse-path findings as one
+specialist in the multi-agent repo review suite.
+
+This is a review skill, not a threat-modeling replacement and not a remediation
+workflow. If the operator explicitly asks for a full threat model, use the
+dedicated threat-modeling path instead.
+
+## Quick Start
+
+1. Confirm the repo, branch, path, diff, or review packet scope.
+2. Identify trust boundaries, secret surfaces, external inputs, filesystem and
+   network effects, authz/authn checks, and dependency/config risks.
+3. Review concrete exploitability before generic hardening advice.
+4. Emit findings first, with severity, affected surface, and abuse scenario.
+5. Hand the artifact to `repo-review-synthesis` for cross-role assembly.
+
+## Focus
+
+Prioritize:
+- secret leakage, token handling, and credential persistence
+- injection, command execution, path traversal, and unsafe parsing
+- privilege, permission, tenancy, and authorization failures
+- unsafe network, filesystem, deserialization, and artifact handling
+- supply-chain, dependency, CI, and build configuration exposure
+- security-relevant logging, diagnostics, and durable artifact leaks
+
+Defer primary ownership of these areas to other specialists:
+- ordinary correctness and maintainability: `repo-review-code`
+- test coverage quality: `repo-review-tests`
+- docs and onboarding truth: `repo-review-docs`
+- final dedupe and ordering: `repo-review-synthesis`
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `target.target_path`
+  - `target.branch`
+  - `target.diff_base`
+  - `target.review_packet_path`
+
+Useful additional inputs:
+- `changed_paths`
+- `trust_boundaries`
+- `sensitive_assets`
+- `exclude_paths`
+- `validation_mode`
+
+If there is no concrete repo or slice target, stop and report `blocked`.
+
+## Output Expectations
+
+Default output should include:
+- findings first
+- trust boundaries reviewed
+- assets and attacker capabilities considered
+- validation performed or not run
+- residual security risk
+
+Use the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md` when ADL expects
+a structured artifact.
+
+## Stop Boundary
+
+Stop after producing the security-review artifact.
+
+Do not:
+- edit code or secrets
+- run destructive exploit attempts
+- claim remediation, approval, or compliance certification
+- bury a security finding behind a lower-severity synthesis summary

--- a/adl/tools/skills/repo-review-security/adl-skill.yaml
+++ b/adl/tools/skills/repo-review-security/adl-skill.yaml
@@ -1,0 +1,58 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-review-security"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_review_security.v1"
+    reference_doc: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_repository"
+      - "review_path"
+      - "review_branch"
+      - "review_diff"
+      - "review_packet"
+    policy_fields:
+      - "review_depth"
+      - "validation_mode"
+      - "write_review_artifact"
+      - "stop_after_review"
+  intent:
+    - "security_review"
+    - "abuse_path_review"
+    - "trust_boundary_review"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_review_security.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.review_depth_must_be_explicit"
+    - "policy.stop_after_review_must_be_true"
+execution:
+  mode: "findings_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_tests_when_bounded_and_safe"
+outputs:
+  default_format: "markdown"
+  structured_contract: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-review-security.md"
+  required_sections:
+    - "findings"
+    - "trust_boundaries"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/repo-review-security/agents/openai.yaml
+++ b/adl/tools/skills/repo-review-security/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Repo Review Security
+short_description: Review security and abuse-path risks as one specialist role
+default_prompt: Review the bounded repository slice for trust-boundary, secret-handling, injection, privilege, unsafe IO, and abuse-path risks. Emit findings first and stop without remediation.

--- a/adl/tools/skills/repo-review-synthesis/SKILL.md
+++ b/adl/tools/skills/repo-review-synthesis/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: repo-review-synthesis
+description: Synthesis reviewer for a multi-agent repository review. Use when specialist code, security, test, and docs review artifacts need to be merged into one findings-first repo review without hiding severity, disagreement, missing coverage, residual risk, or role-specific caveats, and without claiming merge approval or remediation.
+---
+
+# Repo Review Synthesis
+
+Merge specialist review artifacts into one findings-first repository review.
+
+This skill is the final assembly role for the multi-agent repo review suite. It
+does not replace the specialists and must not dilute their findings.
+
+## Quick Start
+
+1. Confirm the specialist artifacts and target repo/slice.
+2. Preserve each finding's source role, severity, file reference, and rationale.
+3. Deduplicate only when findings truly describe the same behavioral risk.
+4. Surface disagreements, missing specialist artifacts, and residual risk.
+5. Emit the final review packet and stop before remediation or approval claims.
+
+## Focus
+
+Prioritize:
+- severity-preserving merge of specialist findings
+- dedupe without losing role context
+- explicit disagreement and uncertainty
+- reviewer-friendly ordering by impact
+- coverage and validation summary across all roles
+- residual risks and recommended follow-up issues
+
+Do not treat synthesis as:
+- a new monolithic review pass
+- a vote that can erase a specialist finding
+- a remediation plan that silently edits code
+- merge approval
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- `target.specialist_artifacts`
+
+Useful additional inputs:
+- `target.target_path`
+- `target.branch`
+- `target.diff_base`
+- `artifact_root`
+- `required_roles`
+- `severity_policy`
+
+If there are no specialist artifacts, stop and report `blocked`; use
+`repo-code-review` for a monolithic review instead.
+
+## Output Expectations
+
+Default output should include:
+- findings first
+- specialist coverage matrix
+- dedupe and disagreement notes
+- validation performed across roles
+- residual risk
+- recommended follow-up issues
+
+Use the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md` when ADL expects
+a structured artifact.
+
+## Stop Boundary
+
+Stop after producing the synthesis artifact.
+
+Do not:
+- edit code, tests, docs, or configs
+- hide severity, disagreement, or missing specialist coverage
+- claim approval, merge readiness, or remediation completion
+- run additional specialist reviews unless the operator explicitly asks

--- a/adl/tools/skills/repo-review-synthesis/adl-skill.yaml
+++ b/adl/tools/skills/repo-review-synthesis/adl-skill.yaml
@@ -1,0 +1,56 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-review-synthesis"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_review_synthesis.v1"
+    reference_doc: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "synthesize_specialist_artifacts"
+      - "synthesize_review_packet"
+    policy_fields:
+      - "required_roles"
+      - "severity_policy"
+      - "write_review_artifact"
+      - "stop_after_synthesis"
+  intent:
+    - "multi_agent_review_synthesis"
+    - "findings_dedupe"
+    - "severity_preserving_review_merge"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_review_synthesis.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "target.specialist_artifacts_must_not_be_empty"
+    - "policy.stop_after_synthesis_must_be_true"
+execution:
+  mode: "synthesis_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "do_not_run_new_tests_during_synthesis"
+outputs:
+  default_format: "markdown"
+  structured_contract: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-review-synthesis.md"
+  required_sections:
+    - "findings"
+    - "coverage_matrix"
+    - "dedupe_notes"
+    - "disagreements"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/repo-review-synthesis/agents/openai.yaml
+++ b/adl/tools/skills/repo-review-synthesis/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Repo Review Synthesis
+short_description: Merge specialist repo review artifacts without hiding severity or residual risk
+default_prompt: Synthesize specialist code, security, tests, and docs review artifacts into one findings-first review packet, preserving severity, disagreement, missing coverage, and residual risk. Stop without remediation or approval claims.

--- a/adl/tools/skills/repo-review-tests/SKILL.md
+++ b/adl/tools/skills/repo-review-tests/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: repo-review-tests
+description: Specialist test reviewer for a multi-agent repository review. Use when a review packet needs a bounded test-quality role focused on missing coverage, weak assertions, brittle fixtures, validation gaps, test isolation, flaky or overbroad tests, and whether risky behavior has executable proof without editing tests.
+---
+
+# Repo Review Tests
+
+Review the test and validation surface as one specialist in the multi-agent repo
+review suite.
+
+This skill identifies coverage and validation risks. It does not write tests;
+use `test-generator` later if remediation is requested.
+
+## Quick Start
+
+1. Confirm the repo, branch, path, diff, or review packet scope.
+2. Identify risky behavior from the target and map it to existing tests.
+3. Look for missing coverage, weak assertions, brittle fixtures, and validation
+   commands that overclaim proof.
+4. Emit findings first, with affected behavior and the missing proof.
+5. Hand the artifact to `repo-review-synthesis` for cross-role assembly.
+
+## Focus
+
+Prioritize:
+- risky code paths without direct tests
+- weak assertions that only prove the happy path ran
+- brittle fixtures, hidden ordering assumptions, and flaky timing
+- tests that encode stale behavior or contradict docs
+- validation commands that are too broad, too narrow, or misleading
+- missing negative cases around parsing, permissions, retries, recovery, and IO
+
+Defer primary ownership of these areas to other specialists:
+- implementation defects: `repo-review-code`
+- security exploitability: `repo-review-security`
+- documentation truth: `repo-review-docs`
+- final dedupe and ordering: `repo-review-synthesis`
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `target.target_path`
+  - `target.branch`
+  - `target.diff_base`
+  - `target.review_packet_path`
+
+Useful additional inputs:
+- `changed_paths`
+- `risky_behaviors`
+- `test_commands`
+- `exclude_paths`
+- `validation_mode`
+
+If there is no concrete repo or slice target, stop and report `blocked`.
+
+## Output Expectations
+
+Default output should include:
+- findings first
+- reviewed test surfaces
+- missing proof map
+- validation performed or not run
+- residual test risk
+
+Use the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md` when ADL expects
+a structured artifact.
+
+## Stop Boundary
+
+Stop after producing the test-review artifact.
+
+Do not:
+- write tests or fixtures
+- claim coverage that was not executed
+- block on exhaustive test strategy when a bounded missing-proof finding is enough
+- downgrade code or security findings from other specialists

--- a/adl/tools/skills/repo-review-tests/adl-skill.yaml
+++ b/adl/tools/skills/repo-review-tests/adl-skill.yaml
@@ -1,0 +1,58 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-review-tests"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_review_tests.v1"
+    reference_doc: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_repository"
+      - "review_path"
+      - "review_branch"
+      - "review_diff"
+      - "review_packet"
+    policy_fields:
+      - "review_depth"
+      - "validation_mode"
+      - "write_review_artifact"
+      - "stop_after_review"
+  intent:
+    - "test_review"
+    - "coverage_gap_review"
+    - "validation_quality_review"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_review_tests.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.review_depth_must_be_explicit"
+    - "policy.stop_after_review_must_be_true"
+execution:
+  mode: "findings_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "inspect_and_optionally_run_targeted_local_tests_when_bounded"
+outputs:
+  default_format: "markdown"
+  structured_contract: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-review-tests.md"
+  required_sections:
+    - "findings"
+    - "missing_proof_map"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/repo-review-tests/agents/openai.yaml
+++ b/adl/tools/skills/repo-review-tests/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Repo Review Tests
+short_description: Review test coverage and validation quality as one specialist role
+default_prompt: Review the bounded repository slice for missing coverage, weak assertions, brittle fixtures, flaky validation, and proof gaps. Emit findings first and stop without writing tests.

--- a/adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh
+++ b/adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+specialists=(
+  repo-review-code
+  repo-review-security
+  repo-review-tests
+  repo-review-docs
+  repo-review-synthesis
+)
+
+for skill in "${specialists[@]}"; do
+  [[ -f "${skills_root}/${skill}/SKILL.md" ]]
+  [[ -f "${skills_root}/${skill}/adl-skill.yaml" ]]
+  [[ -f "${skills_root}/${skill}/agents/openai.yaml" ]]
+  grep -Fq 'reference_doc: "../docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"' "${skills_root}/${skill}/adl-skill.yaml"
+  grep -Fq "allow_code_edits: false" "${skills_root}/${skill}/adl-skill.yaml"
+  grep -Fq "allow_network: false" "${skills_root}/${skill}/adl-skill.yaml"
+done
+
+grep -Fq 'id: "repo-review-code"' "${skills_root}/repo-review-code/adl-skill.yaml"
+grep -Fq 'id: "repo-review-security"' "${skills_root}/repo-review-security/adl-skill.yaml"
+grep -Fq 'id: "repo-review-tests"' "${skills_root}/repo-review-tests/adl-skill.yaml"
+grep -Fq 'id: "repo-review-docs"' "${skills_root}/repo-review-docs/adl-skill.yaml"
+grep -Fq 'id: "repo-review-synthesis"' "${skills_root}/repo-review-synthesis/adl-skill.yaml"
+
+grep -Fq "behavioral bugs, regressions" "${skills_root}/repo-review-code/SKILL.md"
+grep -Fq "trust boundaries, secret handling" "${skills_root}/repo-review-security/SKILL.md"
+grep -Fq "missing coverage, weak assertions" "${skills_root}/repo-review-tests/SKILL.md"
+grep -Fq "misleading docs, stale commands" "${skills_root}/repo-review-docs/SKILL.md"
+grep -Fq "without hiding severity, disagreement" "${skills_root}/repo-review-synthesis/SKILL.md"
+
+grep -Fq "repo_review_code.v1" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+grep -Fq "repo_review_synthesis.v1" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+grep -Fq "Preserve the highest severity" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+grep -Fq "Use the existing \`repo-code-review\` skill" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/repo-review-code/SKILL.md" \
+  "${skills_root}/repo-review-security/SKILL.md" \
+  "${skills_root}/repo-review-tests/SKILL.md" \
+  "${skills_root}/repo-review-docs/SKILL.md" \
+  "${skills_root}/repo-review-synthesis/SKILL.md"
+
+export CODEX_HOME="${tmpdir}/codex-home"
+bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null
+for skill in "${specialists[@]}"; do
+  [[ -f "${CODEX_HOME}/skills/${skill}/SKILL.md" ]]
+done
+
+echo "PASS test_multi_agent_repo_review_skill_suite_contracts"


### PR DESCRIPTION
Closes #1976

## Summary
Implemented the additive multi-agent repo review skill suite. The change adds five specialist skill bundles for code, security, tests, docs, and synthesis review, plus a suite guide that defines invocation order, role boundaries, shared input shapes, specialist output contracts, synthesis rules, severity preservation, and the relationship to the existing monolithic `repo-code-review` skill.

## Artifacts
- Specialist skill bundles:
  - `adl/tools/skills/repo-review-code/SKILL.md`
  - `adl/tools/skills/repo-review-code/adl-skill.yaml`
  - `adl/tools/skills/repo-review-code/agents/openai.yaml`
  - `adl/tools/skills/repo-review-security/SKILL.md`
  - `adl/tools/skills/repo-review-security/adl-skill.yaml`
  - `adl/tools/skills/repo-review-security/agents/openai.yaml`
  - `adl/tools/skills/repo-review-tests/SKILL.md`
  - `adl/tools/skills/repo-review-tests/adl-skill.yaml`
  - `adl/tools/skills/repo-review-tests/agents/openai.yaml`
  - `adl/tools/skills/repo-review-docs/SKILL.md`
  - `adl/tools/skills/repo-review-docs/adl-skill.yaml`
  - `adl/tools/skills/repo-review-docs/agents/openai.yaml`
  - `adl/tools/skills/repo-review-synthesis/SKILL.md`
  - `adl/tools/skills/repo-review-synthesis/adl-skill.yaml`
  - `adl/tools/skills/repo-review-synthesis/agents/openai.yaml`
- Suite documentation and tests:
  - `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
  - `adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh`
    Verified all five specialist skill bundles, role-specific guardrail wording, ADL manifests, suite guide contracts, frontmatter, and generic install/sync visibility.
  - `bash -n adl/tools/*.sh`
    Verified shell syntax for the new and existing tool scripts.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/repo-review-code/SKILL.md adl/tools/skills/repo-review-security/SKILL.md adl/tools/skills/repo-review-tests/SKILL.md adl/tools/skills/repo-review-docs/SKILL.md adl/tools/skills/repo-review-synthesis/SKILL.md`
    Verified the five new skill frontmatter blocks parse cleanly.
  - `git diff --check`
    Verified whitespace hygiene in the final diff.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.90/tasks/issue-1976__backlog-skills-add-multi-agent-repo-review-skill-suite/sor.md`
    Verified the completed output record.
- Results: PASS for all listed commands.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-1976__backlog-skills-add-multi-agent-repo-review-skill-suite/sip.md
- Output card: .adl/v0.90/tasks/issue-1976__backlog-skills-add-multi-agent-repo-review-skill-suite/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-multi-agent-repo-review-skill-suite-adl-v0-90-tasks-issue-1976-backlog-skills-add-multi-agent-repo-review-skill-suite-sip-md-adl-v0-90-tasks-issue-1976-backlog-skills-add-multi-agent-repo-review-skill-suite-sor-md