### PR TITLE
[v0.90][backlog][tools] Harden workflow skills for worktree-first execution

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -65,10 +65,10 @@ use self::git_support::commits_ahead_of_origin_main;
 #[cfg(test)]
 use self::git_support::{branch_checked_out_worktree_path, infer_repo_from_remote};
 use self::git_support::{
-    default_repo, ensure_git_metadata_writable, ensure_local_branch_exists,
+    current_branch, default_repo, ensure_git_metadata_writable, ensure_local_branch_exists,
     ensure_worktree_for_branch, fetch_origin_main_with_fallback, has_uncommitted_changes,
     issue_create_repo, path_str, primary_checkout_root, repo_root, run_capture,
-    run_capture_allow_failure, run_status,
+    run_capture_allow_failure, run_status, tracked_changes_status,
 };
 #[cfg(test)]
 use self::github::ensure_pr_closing_linkage;
@@ -321,6 +321,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
             bail!("start: title produced empty slug after normalization");
         }
     }
+    ensure_issue_run_primary_checkout_safe(&repo_root)?;
     let fetched_labels = if parsed.no_fetch_issue {
         String::new()
     } else {
@@ -442,6 +443,35 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     println!("  STATE  FULLY_STARTED");
     eprintln!("• Done.");
     Ok(())
+}
+
+fn ensure_issue_run_primary_checkout_safe(repo_root: &Path) -> Result<()> {
+    let primary_root = primary_checkout_root()?;
+    if !same_checkout_root(repo_root, &primary_root)? {
+        return Ok(());
+    }
+    if current_branch(repo_root)? != "main" {
+        return Ok(());
+    }
+    let tracked_status = tracked_changes_status(repo_root)?;
+    if tracked_status.trim().is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "run: unsafe_root_checkout_execution: the primary checkout is on main with tracked changes. Issue-mode run may bind or reuse an issue worktree only from a tracked-clean main checkout. Move tracked edits into the issue worktree or clear them before rerunning; ignored local .adl notes may remain.\n{}",
+        tracked_status.trim()
+    );
+}
+
+fn same_checkout_root(left: &Path, right: &Path) -> Result<bool> {
+    if left == right {
+        return Ok(true);
+    }
+    let left = fs::canonicalize(left)
+        .with_context(|| format!("failed to canonicalize checkout path '{}'", left.display()))?;
+    let right = fs::canonicalize(right)
+        .with_context(|| format!("failed to canonicalize checkout path '{}'", right.display()))?;
+    Ok(left == right)
 }
 
 fn real_pr_ready(args: &[String]) -> Result<()> {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -4,9 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::git_support::{
-    commits_ahead_of_origin_main, current_branch, default_repo, ensure_not_on_main_branch,
-    has_uncommitted_changes, path_str, primary_checkout_root, repo_root, run_capture, run_status,
-    run_status_allow_failure,
+    branch_checked_out_worktree_path, commits_ahead_of_origin_main, current_branch, default_repo,
+    ensure_not_on_main_branch, has_uncommitted_changes, path_str, primary_checkout_root, repo_root,
+    run_capture, run_status, run_status_allow_failure,
 };
 use super::github::{
     attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
@@ -31,6 +31,16 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     let primary_root = primary_checkout_root()?;
     let repo = default_repo(&repo_root)?;
 
+    let _ = run_status_allow_failure("git", &["fetch", "origin"]);
+
+    let inferred = resolve_issue_scope_and_slug_from_local_state(&primary_root, parsed.issue)?
+        .unwrap_or((
+            DEFAULT_VERSION.to_string(),
+            format!("issue-{}", parsed.issue),
+        ));
+    let issue_ref = IssueRef::new(parsed.issue, inferred.0.clone(), inferred.1.clone())?;
+    let expected_branch = issue_ref.branch_name("codex");
+    ensure_finish_uses_bound_checkout(&repo_root, &expected_branch)?;
     ensure_not_on_main_branch(&repo_root)?;
 
     let branch = current_branch(&repo_root)?;
@@ -43,14 +53,6 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         );
     }
 
-    let _ = run_status_allow_failure("git", &["fetch", "origin"]);
-
-    let inferred = resolve_issue_scope_and_slug_from_local_state(&repo_root, parsed.issue)?
-        .unwrap_or((
-            DEFAULT_VERSION.to_string(),
-            format!("issue-{}", parsed.issue),
-        ));
-    let issue_ref = IssueRef::new(parsed.issue, inferred.0.clone(), inferred.1.clone())?;
     let source_path = resolve_issue_prompt_path(&primary_root, &issue_ref)?;
     let stp_path = issue_ref.task_bundle_stp_path(&repo_root);
 
@@ -261,6 +263,40 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
 
     println!("{pr_url}");
     Ok(())
+}
+
+fn ensure_finish_uses_bound_checkout(repo_root: &Path, branch: &str) -> Result<()> {
+    let Some(bound_worktree) = branch_checked_out_worktree_path(branch)? else {
+        return Ok(());
+    };
+    if same_checkout_root(repo_root, &bound_worktree)? {
+        return Ok(());
+    }
+    bail!(
+        "finish: mismatched_publication_surface: branch '{}' is bound to worktree '{}', but finish is running from '{}'. Rerun finish from the bound issue worktree instead of publishing from the primary checkout or another checkout.",
+        branch,
+        bound_worktree.display(),
+        repo_root.display()
+    );
+}
+
+fn same_checkout_root(left: &Path, right: &Path) -> Result<bool> {
+    if left == right {
+        return Ok(true);
+    }
+    let left = fs::canonicalize(left).with_context(|| {
+        format!(
+            "finish: failed to canonicalize checkout '{}'",
+            left.display()
+        )
+    })?;
+    let right = fs::canonicalize(right).with_context(|| {
+        format!(
+            "finish: failed to canonicalize checkout '{}'",
+            right.display()
+        )
+    })?;
+    Ok(left == right)
 }
 
 pub(super) fn finish_changed_paths(repo_root: &Path, has_uncommitted: bool) -> Result<Vec<String>> {

--- a/adl/src/cli/pr_cmd/git_support.rs
+++ b/adl/src/cli/pr_cmd/git_support.rs
@@ -125,6 +125,19 @@ pub(super) fn has_uncommitted_changes(repo_root: &Path) -> Result<bool> {
     Ok(!(unstaged && staged))
 }
 
+pub(super) fn tracked_changes_status(repo_root: &Path) -> Result<String> {
+    run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(repo_root)?,
+            "status",
+            "--porcelain",
+            "--untracked-files=no",
+        ],
+    )
+}
+
 pub(super) fn commits_ahead_of_origin_main(repo_root: &Path) -> Result<usize> {
     let local_origin_main = run_status_allow_failure(
         "git",

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
@@ -1,6 +1,91 @@
 use super::*;
 
 #[test]
+fn real_pr_finish_rejects_primary_checkout_when_issue_branch_is_bound_elsewhere() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-bound-worktree-guard");
+    let worktree = temp.join("issue-worktree");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("seed gitignore");
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    assert!(Command::new("git")
+        .args(["add", ".gitignore", "adl/src/lib.rs"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "codex/1153-rust-finish-bound",
+            path_str(&worktree).expect("worktree path"),
+            "HEAD",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git worktree add")
+        .success());
+
+    let issue_ref = IssueRef::new(1153, "v0.86", "rust-finish-bound").expect("issue ref");
+    let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
+    fs::create_dir_all(&bundle_dir).expect("bundle dir");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish bound");
+    fs::copy(
+        issue_ref.issue_prompt_path(&repo),
+        issue_ref.task_bundle_stp_path(&repo),
+    )
+    .expect("seed stp");
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let err = real_pr(&[
+        "finish".to_string(),
+        "1153".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Rust finish bound".to_string(),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ])
+    .expect_err("finish should refuse the wrong checkout when branch is bound elsewhere");
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    let err = err.to_string();
+    assert!(err.contains("mismatched_publication_surface"));
+    assert!(err.contains("codex/1153-rust-finish-bound"));
+    assert!(err.contains(&worktree.display().to_string()));
+}
+
+#[test]
 fn real_pr_finish_rejects_main_and_reports_no_pr_when_only_local_bundle_sync_changes_exist() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-errors");

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -1,6 +1,73 @@
 use super::*;
 
 #[test]
+fn real_pr_start_rejects_tracked_dirty_primary_main_before_binding_worktree() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-dirty-main-guard");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("gitignore");
+    fs::write(repo.join("README.md"), "clean main\n").expect("readme");
+    assert!(Command::new("git")
+        .args(["add", ".gitignore", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+
+    fs::create_dir_all(repo.join(".adl/local-notes")).expect("local notes dir");
+    fs::write(repo.join(".adl/local-notes/ignored.md"), "local only\n").expect("ignored adl");
+    fs::write(repo.join("README.md"), "tracked drift on main\n").expect("dirty readme");
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let err = real_pr(&[
+        "start".to_string(),
+        "1777".to_string(),
+        "--slug".to_string(),
+        "dirty-main-guard".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Dirty main guard".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("tracked dirty primary main should block issue-mode run");
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    let err = err.to_string();
+    assert!(err.contains("unsafe_root_checkout_execution"));
+    assert!(err.contains("README.md"));
+    assert!(!err.contains("ignored.md"));
+}
+
+#[test]
 fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-ready");

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -114,6 +114,23 @@ The conductor should be especially useful when:
 - the operator wants one bounded entrypoint
 - skill/subagent policy should be applied explicitly instead of by memory
 
+## Worktree-First Invariant
+
+The ADL workflow uses one primary checkout and issue-scoped worktrees.
+
+- The primary checkout stays on clean main and is used for root-level inspection, issue bootstrap, and issue-mode binding commands.
+- Tracked implementation, validation fixes, finish staging, and janitor repairs happen in the issue worktree after the issue is bound.
+- A bound worktree path reported by doctor or conductor evidence is first-class lifecycle state and must be preserved in follow-on handoffs.
+- `pr-run` may bind or reuse a worktree from the primary checkout only when main has no tracked changes.
+- Ignored local `.adl` planning, review, and routing notes may remain local-only in the primary checkout, but that exception does not permit tracked edits on main.
+- `pr-finish` must publish from the bound issue worktree when the issue branch is checked out there.
+- `pr-janitor` repairs the existing PR branch/worktree; it must not recreate work from primary main.
+
+Canonical blocker names:
+- `unsafe_root_checkout_execution`
+- `mismatched_publication_surface`
+- `rebind_to_issue_worktree_required`
+
 ## `workflow-conductor`
 
 ### Purpose

--- a/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -53,6 +53,7 @@ The conductor should:
 - apply workflow policy
 - write one bounded routing artifact
 - classify known blocker families from doctor, PR, explicit related-issue references, or repo-policy residue when safe
+- preserve bound worktree identity from doctor/git evidence and classify unsafe root checkout or mismatched publication surfaces explicitly
 - optionally dispatch one bounded downstream skill subtask
 - stop at that routing/dispatch boundary
 

--- a/adl/tools/skills/pr-finish/SKILL.md
+++ b/adl/tools/skills/pr-finish/SKILL.md
@@ -76,6 +76,7 @@ If multiple surfaces disagree materially, report `blocked`.
 
 Before closeout:
 - confirm the issue work actually exists on the branch/worktree
+- confirm finish is running from the bound issue worktree when the issue branch is checked out in a worktree
 - confirm the output record exists and is not still a bootstrap stub
 - confirm the output record is finalized before any PR create/update action
 - confirm the intended staged paths are explicit or deterministically derived
@@ -91,9 +92,15 @@ This skill may:
 - create or update the reviewable draft PR
 
 This skill must not:
+- publish from the primary checkout or another checkout when the issue branch is bound elsewhere
 - silently widen scope
 - silently merge
 - silently close the issue
+
+If the repo control plane reports `mismatched_publication_surface`, stop and
+rerun finish from the bound issue worktree. If it reports
+`rebind_to_issue_worktree_required`, re-establish the issue worktree through the
+repo-native lifecycle before attempting publication.
 
 ### 4. Stop Boundary
 

--- a/adl/tools/skills/pr-janitor/SKILL.md
+++ b/adl/tools/skills/pr-janitor/SKILL.md
@@ -133,11 +133,12 @@ Distinguish among:
 Allowed bounded interventions may include:
 - rerunning or re-verifying the smallest relevant local checks
 - preparing a focused fix for a clear CI failure
-- refreshing branch state or conflict remediation when the intended resolution is unambiguous
+- refreshing branch state or conflict remediation when the intended resolution is unambiguous and the fix is applied from the existing PR branch/worktree
 - refreshing PR metadata or the PR event when a linkage-only guardrail failure is caused by stale GitHub payload state
 - updating truthful PR progress notes or result output
 
 Do not auto-apply if the intervention would:
+- recreate the PR branch from primary main instead of repairing the existing PR branch/worktree
 - widen issue scope materially
 - rewrite large areas without a clear blocker-driven reason
 - override substantive reviewer judgment silently

--- a/adl/tools/skills/pr-ready/SKILL.md
+++ b/adl/tools/skills/pr-ready/SKILL.md
@@ -111,8 +111,9 @@ If there is no concrete target, stop and report `blocked` with the missing targe
    - `blocked`
 7. Report preflight or scheduling gates separately from execution readiness when the issue structure itself is sound.
 8. Treat missing worktree before `pr-run` as expected pre-run state when the root bundle is authored and execution has not yet been bound.
-9. Apply only clearly safe bounded repairs if permitted.
-10. Emit a structured readiness result and stop.
+9. If the issue is already bound, report the exact worktree path and branch as readiness evidence.
+10. Apply only clearly safe bounded repairs if permitted.
+11. Emit a structured readiness result and stop.
 
 ## Workflow
 
@@ -138,6 +139,7 @@ At minimum, inspect where applicable:
 - worktree-local STP/SIP/SOR if execution has already been bound
 - branch naming and branch-to-issue traceability
 - worktree presence and worktree branch match
+- whether the reported worktree is the checkout that follow-on run or finish work must use
 - milestone/open-PR blocking state when a preflight-style check is relevant
 
 ### 3. Validate Core Readiness

--- a/adl/tools/skills/pr-run/SKILL.md
+++ b/adl/tools/skills/pr-run/SKILL.md
@@ -53,6 +53,9 @@ Important lifecycle rule:
 - branch and worktree creation are intentionally deferred until just before execution
 - do not create or expect a bound issue worktree earlier in the lifecycle unless the repo is still carrying compatibility state
 - late binding is preferred because it reduces unnecessary rebasing and branch drift across prepared-but-not-started issues
+- the primary checkout may be used to invoke the repo-native issue-mode run/bind command only while it is tracked-clean on main
+- after binding, all tracked implementation edits happen in the issue worktree, not in the primary checkout
+- ignored local `.adl` planning or review notes may remain local-only, but that exception must not widen into tracked repo edits on main
 
 ## Entry Conditions
 
@@ -148,6 +151,8 @@ Preferred behavior:
 - if the issue already has the correct bound branch/worktree because of compatibility or prior execution, reuse it
 - if binding is needed, use repo-native run commands rather than manual git surgery
 - keep branch/worktree naming traceable to the issue id and slug
+- if the primary checkout has tracked changes while on main, stop with `unsafe_root_checkout_execution` and move the work into the issue worktree before continuing
+- if an issue is already bound, run implementation reads/writes from the bound worktree path reported by doctor/conductor evidence
 
 This skill may create or confirm:
 - the issue execution branch

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -13,6 +13,7 @@ Its job is to:
 - ensure card-local work is routed to the matching editor skill
 - apply explicit skill/subagent execution policy
 - record workflow-compliance outcomes
+- preserve bound issue worktree identity as first-class routing evidence
 - emit a bounded routing artifact
 - when explicitly enabled, dispatch one bounded downstream skill subtask and stop at that boundary
 
@@ -123,6 +124,8 @@ Preferred next-skill mapping:
 Important rule:
 - treat partially completed early steps as normal state, not corruption
 - the conductor should resume from the next truthful step instead of restarting bootstrap by reflex
+- when doctor or worktree evidence reports a bound issue worktree, carry that path into the selected target and downstream handoff instead of treating the primary checkout as the execution surface
+- classify unsafe primary-checkout execution, publication from the wrong checkout, and required rebind-to-worktree cases as explicit blockers rather than improvising a root-checkout workflow
 - healthy open PRs should normally hand off to human review/waiting state rather than janitor unless there is an actual blocker
 - explicit `covered by #<n>` / `satisfied by #<n>` style references should block fresh execution when the referenced issue is already closed
 - repo-policy residue such as tracked legacy `.adl` issue records should escalate as a mechanical blocker rather than being mistaken for issue-local implementation work

--- a/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
@@ -26,6 +26,11 @@ Prefer the strongest available state evidence in this order:
 5. bounded issue metadata
 6. explicit observed operator state such as subagent assignment
 
+When doctor or git worktree evidence identifies a bound issue worktree, preserve
+that path in the target and route follow-on implementation or publication from
+that checkout. Do not collapse the execution surface back onto the primary
+checkout just because the primary checkout is where the conductor was invoked.
+
 ## Preferred Skill Selection
 
 - missing bootstrap/root bundle -> `pr-init`
@@ -76,6 +81,11 @@ Known cases that should normally produce `ask_operator`:
 - healthy open PRs that are waiting for review rather than janitor work
 - doctor output that is missing or too inconsistent to support confident routing
 - tracker or WP issues whose acceptance already appears satisfied by a closed child-issue wave
+
+Known cases that should normally produce `stop`:
+- `unsafe_root_checkout_execution`
+- `mismatched_publication_surface`
+- `rebind_to_issue_worktree_required`
 
 ## Deterministic Helper
 

--- a/adl/tools/skills/workflow-conductor/references/output-contract.md
+++ b/adl/tools/skills/workflow-conductor/references/output-contract.md
@@ -10,7 +10,7 @@ target:
   pr_number: <u32 or null>
 workflow_state:
   detected_phase: bootstrap_missing | card_local_blocker | pre_run | run_bound | execution_done | pr_in_flight | closed_out | already_satisfied | tracker_in_flight | unknown
-  blocker_class: none | open_pr_wave_only | doctor_failed_or_inconclusive | review_changes_requested | merge_conflict | checks_failed | merge_blocked | healthy_pr_waiting | satisfied_by_child_issue_wave | satisfied_by_related_issue_refs | satisfied_by_sibling_issue_artifact | active_child_issue_wave | related_issue_ref_active | tracked_adl_residue | open_linkage_only
+  blocker_class: none | open_pr_wave_only | doctor_failed_or_inconclusive | review_changes_requested | merge_conflict | checks_failed | merge_blocked | healthy_pr_waiting | satisfied_by_child_issue_wave | satisfied_by_related_issue_refs | satisfied_by_sibling_issue_artifact | active_child_issue_wave | related_issue_ref_active | tracked_adl_residue | unsafe_root_checkout_execution | mismatched_publication_surface | rebind_to_issue_worktree_required | open_linkage_only
   evidence_used:
     - <doctor_json_or_path_or_state_surface>
 selected_skill:
@@ -31,7 +31,7 @@ actions_taken:
 handoff_state:
   next_phase: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | human_review | blocked
   continuation: continue | ask_operator | stop
-  escalation_reason: none | operator_override_required | ambiguous_live_state | healthy_pr_waiting | manual_review_required | policy_block | child_issue_wave_satisfied | related_issue_ref_satisfied | sibling_issue_artifact_satisfied | child_issue_wave_active | related_issue_ref_active | repo_policy_residue
+  escalation_reason: none | operator_override_required | ambiguous_live_state | healthy_pr_waiting | manual_review_required | policy_block | child_issue_wave_satisfied | related_issue_ref_satisfied | sibling_issue_artifact_satisfied | child_issue_wave_active | related_issue_ref_active | repo_policy_residue | unsafe_root_checkout_execution | mismatched_publication_surface | rebind_to_issue_worktree_required
 dispatch:
   mode: route_only | plan_subtask | invoke_subtask
   selected_skill: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none

--- a/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
+++ b/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
@@ -383,6 +383,22 @@ def detect_tracked_adl_residue(repo_root: Path):
     return result.returncode != 0
 
 
+def primary_main_has_tracked_changes(repo_root: Path):
+    branch = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo_root)
+    if branch.returncode != 0 or branch.stdout.strip() != "main":
+        return False
+    status = run_command(["git", "status", "--porcelain", "--untracked-files=no"], repo_root)
+    return status.returncode == 0 and bool(status.stdout.strip())
+
+
+def apply_root_execution_guard(repo_root: Path, workflow):
+    if workflow.get("blocker_class") != "none":
+        return
+    if primary_main_has_tracked_changes(repo_root):
+        workflow["blocker_class"] = "unsafe_root_checkout_execution"
+        workflow["evidence_used"].append("tracked_primary_main_status")
+
+
 def worktree_execution_done(repo_root: Path, issue_number: int, slug: str, version: str, worktree_hint):
     if not worktree_hint:
         return False
@@ -569,6 +585,7 @@ def collect_route_issue(repo_root: Path, payload):
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
         workflow["blocker_class"] = "tracked_adl_residue"
         workflow["evidence_used"].append("tracked_adl_residue_guard")
+    apply_root_execution_guard(repo_root, workflow)
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -608,6 +625,7 @@ def collect_route_task_bundle(repo_root: Path, payload):
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
         workflow["blocker_class"] = "tracked_adl_residue"
         workflow["evidence_used"].append("tracked_adl_residue_guard")
+    apply_root_execution_guard(repo_root, workflow)
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -652,6 +670,7 @@ def collect_route_branch(repo_root: Path, payload):
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
         workflow["blocker_class"] = "tracked_adl_residue"
         workflow["evidence_used"].append("tracked_adl_residue_guard")
+    apply_root_execution_guard(repo_root, workflow)
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -726,6 +745,7 @@ def collect_route_worktree(repo_root: Path, payload):
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
         workflow["blocker_class"] = "tracked_adl_residue"
         workflow["evidence_used"].append("tracked_adl_residue_guard")
+    apply_root_execution_guard(repo_root, workflow)
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 
@@ -785,6 +805,7 @@ def collect_route_pr(repo_root: Path, payload):
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
         workflow["blocker_class"] = "tracked_adl_residue"
         workflow["evidence_used"].append("tracked_adl_residue_guard")
+    apply_root_execution_guard(repo_root, workflow)
     return {"target": resolved_target, "workflow_state": workflow, "policy": payload.get("policy", {})}
 
 

--- a/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
+++ b/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
@@ -112,6 +112,15 @@ def evaluate(payload):
         skill_name = "none"
         continuation = "ask_operator"
         escalation_reason = "related_issue_ref_active"
+    elif blocker_class in (
+        "unsafe_root_checkout_execution",
+        "mismatched_publication_surface",
+        "rebind_to_issue_worktree_required",
+    ):
+        selected_phase = "blocked"
+        skill_name = "none"
+        continuation = "stop"
+        escalation_reason = blocker_class
     elif lifecycle_state == "execution_done":
         selected_phase = "finish"
         skill_name = "pr-finish"
@@ -183,6 +192,8 @@ def evaluate(payload):
 
     next_phase = skill_name if skill_name != "none" else "human_review"
     status = "done" if skill_name != "none" else "blocked"
+    if selected_phase == "blocked" and continuation == "stop":
+        next_phase = "blocked"
     if blocked_by_policy and not policy.get("bypass_without_explicit_blocker", False):
         status = "blocked"
         next_phase = "blocked"

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -32,6 +32,10 @@ grep -Fq "workflow-conductor" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq "resume from partially completed early steps" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq "child issue wave already appears to cover the acceptance surface" "${skills_root}/workflow-conductor/SKILL.md"
 grep -Fq "satisfied_by_sibling_issue_artifact" "${skills_root}/workflow-conductor/references/output-contract.md"
+grep -Fq "preserve bound issue worktree identity" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "unsafe_root_checkout_execution" "${skills_root}/workflow-conductor/references/output-contract.md"
+grep -Fq "mismatched_publication_surface" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "rebind_to_issue_worktree_required" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 
 cat >"${tmpdir}/bootstrap_missing.json" <<'EOF'
 {
@@ -129,11 +133,32 @@ cat >"${tmpdir}/required_subagent_missing.json" <<'EOF'
 }
 EOF
 
+cat >"${tmpdir}/unsafe_root_checkout.json" <<'EOF'
+{
+  "target": {"issue_number": 1647},
+  "workflow_state": {
+    "bootstrap_present": true,
+    "lifecycle_state": "pre_run",
+    "ready_state": "pass",
+    "pr_state": "none",
+    "blocker_class": "unsafe_root_checkout_execution",
+    "subagent_assigned": true,
+    "evidence_used": ["tracked_primary_main_status"]
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional"
+  }
+}
+EOF
+
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/bootstrap_missing.json" >"${tmpdir}/bootstrap_missing.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/stp_blocker.json" >"${tmpdir}/stp_blocker.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/resume_to_run.json" >"${tmpdir}/resume_to_run.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/pr_in_flight.json" >"${tmpdir}/pr_in_flight.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/required_subagent_missing.json" >"${tmpdir}/required_subagent_missing.out.json"
+python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/unsafe_root_checkout.json" >"${tmpdir}/unsafe_root_checkout.out.json"
 
 python3 - "$tmpdir" <<'PY'
 import json
@@ -169,6 +194,13 @@ assert required_missing["status"] == "blocked"
 assert required_missing["handoff_state"]["next_phase"] == "blocked"
 assert required_missing["handoff_state"]["continuation"] == "stop"
 assert required_missing["handoff_state"]["escalation_reason"] == "policy_block"
+
+unsafe_root = load("unsafe_root_checkout.out.json")
+assert unsafe_root["status"] == "blocked"
+assert unsafe_root["selected_skill"]["skill_name"] == "none"
+assert unsafe_root["handoff_state"]["next_phase"] == "blocked"
+assert unsafe_root["handoff_state"]["continuation"] == "stop"
+assert unsafe_root["handoff_state"]["escalation_reason"] == "unsafe_root_checkout_execution"
 PY
 
 fixture_repo="${tmpdir}/fixture-repo"
@@ -1004,6 +1036,7 @@ assert route_tracker_satisfied["handoff_state"]["escalation_reason"] == "child_i
 route_issue_finish_from_worktree = load("route_issue_finish_from_worktree.out.json")
 assert route_issue_finish_from_worktree["selected_skill"]["skill_name"] == "pr-finish"
 assert route_issue_finish_from_worktree["workflow_state"]["blocker_class"] == "open_pr_wave_only"
+assert route_issue_finish_from_worktree["target"]["worktree_path"] == ".worktrees/adl-wp-2007"
 assert route_issue_finish_from_worktree["handoff_state"]["continuation"] == "ask_operator"
 assert route_issue_finish_from_worktree["handoff_state"]["escalation_reason"] == "operator_override_required"
 


### PR DESCRIPTION
Closes #1978

## Summary
Implemented LB-034 as a worktree-first workflow hardening pass. The Rust control plane now blocks issue-mode run from a tracked-dirty primary main checkout while still allowing ignored local `.adl` notes, and finish now refuses publication from the wrong checkout when the issue branch is already bound to a worktree. The workflow-conductor, lifecycle skills, operator guide, and conductor contracts now name the same invariant and blocker classes explicitly.

## Artifacts
- Code:
  - `adl/src/cli/pr_cmd.rs`
  - `adl/src/cli/pr_cmd/finish_support.rs`
  - `adl/src/cli/pr_cmd/git_support.rs`
- Tests:
  - `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs`
  - `adl/tools/test_workflow_conductor_skill_contracts.sh`
- Skill and operator docs:
  - `adl/tools/skills/workflow-conductor/SKILL.md`
  - `adl/tools/skills/workflow-conductor/references/conductor-playbook.md`
  - `adl/tools/skills/workflow-conductor/references/output-contract.md`
  - `adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
  - `adl/tools/skills/workflow-conductor/scripts/select_next_skill.py`
  - `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
  - `adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md`
  - `adl/tools/skills/pr-ready/SKILL.md`
  - `adl/tools/skills/pr-run/SKILL.md`
  - `adl/tools/skills/pr-finish/SKILL.md`
  - `adl/tools/skills/pr-janitor/SKILL.md`
- Generated runtime artifacts: not applicable for this tooling/skill hardening issue.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Ensured Rust source formatting remained canonical.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Exercised conductor policy, routing, blocker, and dispatch contracts.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_rejects_tracked_dirty_primary_main_before_binding_worktree -- --nocapture`
    Exercised the new unsafe-root-checkout run blocker.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_rejects_primary_checkout_when_issue_branch_is_bound_elsewhere -- --nocapture`
    Exercised the new mismatched-publication-surface finish blocker.
  - `bash adl/tools/test_pr_run_issue_mode.sh`
    Confirmed the public issue-mode run shell delegation still works.
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd`
    Re-ran the broad PR-command regression surface.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.90/tasks/issue-1978__backlog-tools-harden-workflow-skills-for-worktree-first-execution/sor.md`
    Validated the output card.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-1978__backlog-tools-harden-workflow-skills-for-worktree-first-execution/sip.md
- Output card: .adl/v0.90/tasks/issue-1978__backlog-tools-harden-workflow-skills-for-worktree-first-execution/sor.md
- Idempotency-Key: v0-90-backlog-tools-harden-workflow-skills-for-worktree-first-execution-adl-v0-90-tasks-issue-1978-backlog-tools-harden-workflow-skills-for-worktree-first-execution-sip-md-adl-v0-90-tasks-issue-1978-backlog-tools-harden-workflow-skills-for-worktree-first-execution-sor-md