### PR TITLE
[v0.89.1][WP-11] Demo scaffolding and proof entry points

### DIFF
--- a/adl/src/cli/identity_cmd/contracts.rs
+++ b/adl/src/cli/identity_cmd/contracts.rs
@@ -14,6 +14,7 @@ use ::adl::chronosense::{
 };
 use ::adl::continuous_verification_self_attack::ContinuousVerificationSelfAttackContract;
 use ::adl::delegation_refusal_coordination::DelegationRefusalCoordinationContract;
+use ::adl::demo_proof_entry_points::DemoProofEntryPointsContract;
 use ::adl::exploit_artifact_replay::ExploitArtifactReplayContract;
 use ::adl::operational_skills_substrate::OperationalSkillsSubstrateContract;
 use ::adl::provider_extension_packaging::ProviderExtensionPackagingContract;
@@ -203,6 +204,20 @@ pub(super) fn real_identity_provider_extension_packaging(
         "provider extension packaging",
         "PROVIDER_EXTENSION_PACKAGING_PATH",
         ProviderExtensionPackagingContract::v1(),
+    )
+}
+
+pub(super) fn real_identity_demo_proof_entry_points(
+    repo_root: &Path,
+    args: &[String],
+) -> Result<()> {
+    write_contract_json(
+        repo_root,
+        args,
+        "demo-proof-entry-points",
+        "demo proof entry points",
+        "DEMO_PROOF_ENTRY_POINTS_PATH",
+        DemoProofEntryPointsContract::v1(),
     )
 }
 

--- a/adl/src/cli/identity_cmd/dispatch.rs
+++ b/adl/src/cli/identity_cmd/dispatch.rs
@@ -5,10 +5,11 @@ use super::contracts::{
     real_identity_adversarial_runner, real_identity_adversarial_runtime, real_identity_causality,
     real_identity_commitments, real_identity_continuity, real_identity_continuous_verification,
     real_identity_cost, real_identity_delegation_refusal_coordination,
-    real_identity_exploit_replay, real_identity_foundation, real_identity_instinct,
-    real_identity_instinct_runtime, real_identity_operational_skills, real_identity_phi,
-    real_identity_provider_extension_packaging, real_identity_red_blue_architecture,
-    real_identity_retrieval, real_identity_schema, real_identity_skill_composition,
+    real_identity_demo_proof_entry_points, real_identity_exploit_replay, real_identity_foundation,
+    real_identity_instinct, real_identity_instinct_runtime, real_identity_operational_skills,
+    real_identity_phi, real_identity_provider_extension_packaging,
+    real_identity_red_blue_architecture, real_identity_retrieval, real_identity_schema,
+    real_identity_skill_composition,
 };
 use super::helpers::repo_root;
 use super::profile::{real_identity_init, real_identity_now, real_identity_show};
@@ -21,7 +22,7 @@ pub(crate) fn real_identity(args: &[String]) -> Result<()> {
 pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | provider-extension-packaging | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
+            "identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | provider-extension-packaging | demo-proof-entry-points | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime"
         ));
     };
 
@@ -43,6 +44,7 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
         "provider-extension-packaging" => {
             real_identity_provider_extension_packaging(repo_root, &args[1..])
         }
+        "demo-proof-entry-points" => real_identity_demo_proof_entry_points(repo_root, &args[1..]),
         "schema" => real_identity_schema(repo_root, &args[1..]),
         "continuity" => real_identity_continuity(repo_root, &args[1..]),
         "retrieval" => real_identity_retrieval(repo_root, &args[1..]),
@@ -57,7 +59,7 @@ pub(super) fn real_identity_in_repo(args: &[String], repo_root: &Path) -> Result
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | provider-extension-packaging | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
+            "unknown identity subcommand '{subcommand}' (expected init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | provider-extension-packaging | demo-proof-entry-points | schema | continuity | retrieval | commitments | causality | cost | phi | instinct | instinct-runtime)"
         )),
     }
 }

--- a/adl/src/cli/identity_cmd/tests.rs
+++ b/adl/src/cli/identity_cmd/tests.rs
@@ -164,7 +164,7 @@ fn identity_requires_subcommand_and_rejects_unknown_subcommand() {
     let err = real_identity_in_repo(&[], &repo).expect_err("missing subcommand should fail");
     assert!(err
         .to_string()
-        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | provider-extension-packaging | schema"));
+        .contains("identity requires a subcommand: init | show | now | foundation | adversarial-runtime | red-blue-architecture | adversarial-runner | exploit-replay | continuous-verification | operational-skills | skill-composition | delegation-refusal-coordination | provider-extension-packaging | demo-proof-entry-points | schema"));
     assert!(err.to_string().contains("continuity"));
 
     let err = real_identity_in_repo(&["nope".to_string()], &repo)
@@ -205,6 +205,11 @@ fn identity_top_level_help_and_subcommand_help_succeed() {
         &repo,
     )
     .expect("continuous-verification help");
+    real_identity_in_repo(
+        &["demo-proof-entry-points".to_string(), "--help".to_string()],
+        &repo,
+    )
+    .expect("demo-proof-entry-points help");
     real_identity_in_repo(
         &["operational-skills".to_string(), "--help".to_string()],
         &repo,
@@ -1080,6 +1085,77 @@ fn identity_provider_extension_packaging_validates_unknown_args_and_missing_out_
             "provider-extension-packaging".to_string(),
             "--out".to_string(),
         ],
+        &repo,
+    )
+    .expect_err("out flag without value should fail");
+    assert!(err.to_string().contains("--out requires a value"));
+}
+
+#[test]
+fn identity_demo_proof_entry_points_writes_contract_json() {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let repo = temp_repo("identity-demo-proof-entry-points");
+    let out_path = repo.join(".adl/state/demo_proof_entry_points_v1.json");
+
+    real_identity_in_repo(
+        &[
+            "demo-proof-entry-points".to_string(),
+            "--out".to_string(),
+            ".adl/state/demo_proof_entry_points_v1.json".to_string(),
+        ],
+        &repo,
+    )
+    .expect("identity demo-proof-entry-points");
+
+    let json: Value =
+        serde_json::from_slice(&fs::read(&out_path).expect("read out")).expect("parse json");
+    assert_eq!(json["schema_version"], "demo_proof_entry_points.v1");
+    assert_eq!(
+        json["proof_hook_output_path"],
+        ".adl/state/demo_proof_entry_points_v1.json"
+    );
+    assert!(json["owned_runtime_surfaces"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|value| value == "adl identity demo-proof-entry-points"));
+    assert!(
+        json["package"]["rows"]
+            .as_array()
+            .expect("rows")
+            .iter()
+            .any(|row| row["demo_id"] == "D1"
+                && row["entry_commands"]
+                    .as_array()
+                    .expect("entry commands")
+                    .iter()
+                    .any(|command| command
+                        == "adl identity adversarial-runtime --out .adl/state/adversarial_runtime_model_v1.json"))
+    );
+    assert!(json["package"]["deferred_surfaces"]
+        .as_array()
+        .expect("deferred")
+        .iter()
+        .any(|surface| surface["owner"] == "WP-13"));
+}
+
+#[test]
+fn identity_demo_proof_entry_points_validates_unknown_args_and_missing_out_value() {
+    let repo = temp_repo("identity-demo-proof-entry-points-errors");
+
+    let err = real_identity_in_repo(
+        &["demo-proof-entry-points".to_string(), "--bogus".to_string()],
+        &repo,
+    )
+    .expect_err("unknown arg should fail");
+    assert!(err
+        .to_string()
+        .contains("unknown arg for identity demo-proof-entry-points: --bogus"));
+
+    let err = real_identity_in_repo(
+        &["demo-proof-entry-points".to_string(), "--out".to_string()],
         &repo,
     )
     .expect_err("out flag without value should fail");

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -17,6 +17,7 @@ pub fn usage() -> &'static str {
   adl identity skill-composition [--out <path>]
   adl identity delegation-refusal-coordination [--out <path>]
   adl identity provider-extension-packaging [--out <path>]
+  adl identity demo-proof-entry-points [--out <path>]
   adl identity schema [--out <path>]
   adl identity continuity [--out <path>]
   adl identity retrieval [--out <path>]
@@ -83,6 +84,7 @@ Examples:
   adl identity skill-composition --out .adl/state/skill_composition_model_v1.json
   adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json
   adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json
+  adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json
   adl provider setup chatgpt
   adl provider setup claude
   adl provider setup anthropic --out ./.adl/provider-setup/anthropic

--- a/adl/src/demo_proof_entry_points.rs
+++ b/adl/src/demo_proof_entry_points.rs
@@ -1,0 +1,469 @@
+use serde::{Deserialize, Serialize};
+
+use crate::adversarial_execution_runner::ADVERSARIAL_EXECUTION_RUNNER_SCHEMA;
+use crate::adversarial_runtime::ADVERSARIAL_RUNTIME_MODEL_SCHEMA;
+use crate::continuous_verification_self_attack::CONTINUOUS_VERIFICATION_SELF_ATTACK_SCHEMA;
+use crate::delegation_refusal_coordination::DELEGATION_REFUSAL_COORDINATION_SCHEMA;
+use crate::exploit_artifact_replay::EXPLOIT_ARTIFACT_REPLAY_SCHEMA;
+use crate::operational_skills_substrate::OPERATIONAL_SKILLS_SUBSTRATE_SCHEMA;
+use crate::provider_extension_packaging::PROVIDER_EXTENSION_PACKAGING_SCHEMA;
+use crate::red_blue_agent_architecture::RED_BLUE_AGENT_ARCHITECTURE_SCHEMA;
+use crate::skill_composition_model::SKILL_COMPOSITION_MODEL_SCHEMA;
+
+pub const DEMO_PROOF_ENTRY_POINTS_SCHEMA: &str = "demo_proof_entry_points.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DemoProofEntryPointRow {
+    pub demo_id: String,
+    pub title: String,
+    pub work_packages: Vec<String>,
+    pub entry_commands: Vec<String>,
+    pub primary_proof_surfaces: Vec<String>,
+    pub proof_role: String,
+    pub status: String,
+    pub determinism_note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DemoProofRunbookStep {
+    pub step_id: String,
+    pub purpose: String,
+    pub command: String,
+    pub expected_output: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DemoProofDeferredSurface {
+    pub surface: String,
+    pub owner: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DemoProofPackage {
+    pub package_id: String,
+    pub milestone: String,
+    pub work_package: String,
+    pub package_role: String,
+    pub rows: Vec<DemoProofEntryPointRow>,
+    pub copy_paste_runbook: Vec<DemoProofRunbookStep>,
+    pub deferred_surfaces: Vec<DemoProofDeferredSurface>,
+    pub review_boundaries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DemoProofEntryPointsContract {
+    pub schema_version: String,
+    pub owned_runtime_surfaces: Vec<String>,
+    pub runtime_condition: String,
+    pub upstream_contracts: Vec<String>,
+    pub package: DemoProofPackage,
+    pub reviewer_questions: Vec<String>,
+    pub proof_fixture_hooks: Vec<String>,
+    pub proof_hook_command: String,
+    pub proof_hook_output_path: String,
+    pub scope_boundary: String,
+}
+
+impl DemoProofEntryPointsContract {
+    pub fn v1() -> Self {
+        Self {
+            schema_version: DEMO_PROOF_ENTRY_POINTS_SCHEMA.to_string(),
+            owned_runtime_surfaces: strings(&[
+                "adl::demo_proof_entry_points::DemoProofEntryPointsContract",
+                "adl::demo_proof_entry_points::DemoProofPackage",
+                "docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md",
+                "adl identity demo-proof-entry-points",
+            ]),
+            runtime_condition:
+                "v0.89.1 exposes reviewer-facing proof entry points for adversarial runtime, exploit replay, continuous verification, skill governance, and demo packets without absorbing later integration work."
+                    .to_string(),
+            upstream_contracts: strings(&[
+                ADVERSARIAL_RUNTIME_MODEL_SCHEMA,
+                RED_BLUE_AGENT_ARCHITECTURE_SCHEMA,
+                ADVERSARIAL_EXECUTION_RUNNER_SCHEMA,
+                EXPLOIT_ARTIFACT_REPLAY_SCHEMA,
+                CONTINUOUS_VERIFICATION_SELF_ATTACK_SCHEMA,
+                OPERATIONAL_SKILLS_SUBSTRATE_SCHEMA,
+                SKILL_COMPOSITION_MODEL_SCHEMA,
+                DELEGATION_REFUSAL_COORDINATION_SCHEMA,
+                PROVIDER_EXTENSION_PACKAGING_SCHEMA,
+            ]),
+            package: DemoProofPackage {
+                package_id: "v0.89.1.wp11.demo_proof_entry_points".to_string(),
+                milestone: "v0.89.1".to_string(),
+                work_package: "WP-11".to_string(),
+                package_role:
+                    "Copy/paste reviewer entry-point package for the milestone demo matrix."
+                        .to_string(),
+                rows: demo_rows(),
+                copy_paste_runbook: runbook_steps(),
+                deferred_surfaces: deferred_surfaces(),
+                review_boundaries: strings(&[
+                    "The package names commands and proof surfaces; it does not execute every heavyweight demo during normal identity-contract validation.",
+                    "D8 remains planned until the coordination/integration demo issue lands.",
+                    "WP-13 still owns broader integration and manuscript convergence packets.",
+                    "Provider-security attestation, trust scoring, sandbox policy, and external provider-security demos remain out of v0.89.1 scope unless later work explicitly promotes them.",
+                ]),
+            },
+            reviewer_questions: strings(&[
+                "Which command should a reviewer run for each v0.89.1 demo row?",
+                "Which rows are already landed, partial, ready, or still planned?",
+                "Which proof surfaces are deterministic contract packets versus heavyweight demo runs?",
+                "Which later integration surfaces are intentionally deferred?",
+            ]),
+            proof_fixture_hooks: strings(&[
+                "demo_proof_entry_points_exposes_copy_paste_runtime_and_replay_commands",
+                "demo_proof_entry_points_keeps_d8_and_wp13_deferred",
+                "identity_demo_proof_entry_points_writes_contract_json",
+            ]),
+            proof_hook_command:
+                "adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json"
+                    .to_string(),
+            proof_hook_output_path: ".adl/state/demo_proof_entry_points_v1.json".to_string(),
+            scope_boundary:
+                "This contract lands WP-11 demo scaffolding and proof entry points; it does not replace WP-12 review, WP-13 integration demos, or later release closeout."
+                    .to_string(),
+        }
+    }
+}
+
+fn demo_rows() -> Vec<DemoProofEntryPointRow> {
+    vec![
+        DemoProofEntryPointRow {
+            demo_id: "D1".to_string(),
+            title: "Adversarial runtime walkthrough".to_string(),
+            work_packages: strings(&["WP-02", "WP-03", "WP-04"]),
+            entry_commands: strings(&[
+                "adl identity adversarial-runtime --out .adl/state/adversarial_runtime_model_v1.json",
+                "adl identity red-blue-architecture --out .adl/state/red_blue_agent_architecture_v1.json",
+                "adl identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json",
+            ]),
+            primary_proof_surfaces: strings(&[
+                ".adl/state/adversarial_runtime_model_v1.json",
+                ".adl/state/red_blue_agent_architecture_v1.json",
+                ".adl/state/adversarial_execution_runner_v1.json",
+            ]),
+            proof_role:
+                "Shows contested runtime assumptions, red/blue/purple role boundaries, and bounded adversarial execution stages."
+                    .to_string(),
+            status: "LANDED".to_string(),
+            determinism_note:
+                "Identity contract packets are deterministic; runner execution semantics remain bounded by the contract."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D2".to_string(),
+            title: "Exploit artifact and replay proof".to_string(),
+            work_packages: strings(&["WP-05"]),
+            entry_commands: strings(&[
+                "adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json",
+            ]),
+            primary_proof_surfaces: strings(&[".adl/state/exploit_artifact_replay_v1.json"]),
+            proof_role:
+                "Shows exploit artifact family, replay preconditions, expected outcome, and deterministic or bounded-variance replay declaration."
+                    .to_string(),
+            status: "LANDED".to_string(),
+            determinism_note:
+                "Replay mode is declared in the contract packet rather than inferred from prose."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D3".to_string(),
+            title: "Continuous verification loop".to_string(),
+            work_packages: strings(&["WP-06"]),
+            entry_commands: strings(&[
+                "adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json",
+            ]),
+            primary_proof_surfaces: strings(&[
+                ".adl/state/continuous_verification_self_attack_v1.json",
+            ]),
+            proof_role:
+                "Shows repeated falsification pressure, exploit hypothesis generation, evidence capture, replay, mitigation, and promotion linkage."
+                    .to_string(),
+            status: "LANDED".to_string(),
+            determinism_note:
+                "Repeated bounded inputs preserve lifecycle shape and proof packet structure."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D4".to_string(),
+            title: "Self-attack scenario packet".to_string(),
+            work_packages: strings(&["WP-06"]),
+            entry_commands: strings(&[
+                "adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json",
+            ]),
+            primary_proof_surfaces: strings(&[
+                ".adl/state/continuous_verification_self_attack_v1.json",
+            ]),
+            proof_role:
+                "Shows bounded self-attack layer rules, target/posture scope, evidence requirements, replay linkage, and learning-promotion boundaries."
+                    .to_string(),
+            status: "LANDED".to_string(),
+            determinism_note:
+                "Scenario structure remains posture-bounded and replay-legible."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D5".to_string(),
+            title: "Flagship adversarial demo".to_string(),
+            work_packages: strings(&["WP-07"]),
+            entry_commands: strings(&[
+                "adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open",
+            ]),
+            primary_proof_surfaces: strings(&[
+                ".adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json",
+            ]),
+            proof_role:
+                "Shows exploit, replay, mitigation, post-fix replay, and regression-promotion in one safe local packet."
+                    .to_string(),
+            status: "LANDED".to_string(),
+            determinism_note:
+                "The flagship local demo compares the same bounded request before and after mitigation."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D6".to_string(),
+            title: "Operational skills substrate integration".to_string(),
+            work_packages: strings(&["WP-08", "WP-09"]),
+            entry_commands: strings(&[
+                "adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json",
+                "adl identity skill-composition --out .adl/state/skill_composition_model_v1.json",
+                "adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json",
+            ]),
+            primary_proof_surfaces: strings(&[
+                ".adl/state/operational_skills_substrate_v1.json",
+                ".adl/state/skill_composition_model_v1.json",
+                ".adl/state/delegation_refusal_coordination_v1.json",
+            ]),
+            proof_role:
+                "Shows explicit skill invocation, composition, refusal, approval-gate, and coordination governance surfaces."
+                    .to_string(),
+            status: "LANDED".to_string(),
+            determinism_note:
+                "Governance outcome taxonomy is deterministic even when future node outputs are stochastic."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D7".to_string(),
+            title: "Reviewer-facing security proof package".to_string(),
+            work_packages: strings(&["WP-10", "WP-11", "WP-12", "WP-13"]),
+            entry_commands: strings(&[
+                "adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json",
+                "adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json",
+            ]),
+            primary_proof_surfaces: strings(&[
+                ".adl/state/provider_extension_packaging_v1.json",
+                ".adl/state/demo_proof_entry_points_v1.json",
+            ]),
+            proof_role:
+                "Bundles milestone proof commands, carry-forward boundaries, and reviewer-facing package status into one machine-readable packet."
+                    .to_string(),
+            status: "PARTIAL".to_string(),
+            determinism_note:
+                "WP-11 package generation is deterministic; WP-13 integration packets remain later work."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D8".to_string(),
+            title: "Five-Agent Hey Jude MIDI demo".to_string(),
+            work_packages: strings(&["WP-08", "WP-09", "WP-10", "WP-13"]),
+            entry_commands: Vec::new(),
+            primary_proof_surfaces: strings(&["planned WP-13 coordination demo packet"]),
+            proof_role:
+                "Future high-delight coordination demo for one human plus four providers on one ADL runtime."
+                    .to_string(),
+            status: "PLANNED".to_string(),
+            determinism_note:
+                "Bounded score/input should preserve composition shape and MIDI event ordering once the demo lands."
+                    .to_string(),
+        },
+        DemoProofEntryPointRow {
+            demo_id: "D9".to_string(),
+            title: "ArXiv manuscript workflow packet".to_string(),
+            work_packages: strings(&["WP-08", "WP-13"]),
+            entry_commands: strings(&["bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh"]),
+            primary_proof_surfaces: strings(&[
+                "artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json",
+            ]),
+            proof_role:
+                "Shows bounded manuscript workflow scaffolding, source packets, review gates, and three-paper status packet shape."
+                    .to_string(),
+            status: "READY".to_string(),
+            determinism_note:
+                "Packet generation is deterministic; WP-13 owns final manuscript convergence."
+                    .to_string(),
+        },
+    ]
+}
+
+fn runbook_steps() -> Vec<DemoProofRunbookStep> {
+    vec![
+        DemoProofRunbookStep {
+            step_id: "runtime-and-roles".to_string(),
+            purpose: "Materialize D1 adversarial runtime, role architecture, and runner contract packets."
+                .to_string(),
+            command:
+                "adl identity adversarial-runtime --out .adl/state/adversarial_runtime_model_v1.json && adl identity red-blue-architecture --out .adl/state/red_blue_agent_architecture_v1.json && adl identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json"
+                    .to_string(),
+            expected_output:
+                ".adl/state/adversarial_runtime_model_v1.json, .adl/state/red_blue_agent_architecture_v1.json, .adl/state/adversarial_execution_runner_v1.json"
+                    .to_string(),
+        },
+        DemoProofRunbookStep {
+            step_id: "replay-contract".to_string(),
+            purpose: "Materialize D2 exploit replay proof packet.".to_string(),
+            command:
+                "adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json"
+                    .to_string(),
+            expected_output: ".adl/state/exploit_artifact_replay_v1.json".to_string(),
+        },
+        DemoProofRunbookStep {
+            step_id: "continuous-verification".to_string(),
+            purpose: "Materialize D3/D4 continuous verification and self-attack packet."
+                .to_string(),
+            command:
+                "adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json"
+                    .to_string(),
+            expected_output: ".adl/state/continuous_verification_self_attack_v1.json".to_string(),
+        },
+        DemoProofRunbookStep {
+            step_id: "flagship-demo".to_string(),
+            purpose: "Run D5 flagship adversarial proof demo when heavyweight demo execution is desired."
+                .to_string(),
+            command:
+                "adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open"
+                    .to_string(),
+            expected_output:
+                ".adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json"
+                    .to_string(),
+        },
+        DemoProofRunbookStep {
+            step_id: "skills-and-governance".to_string(),
+            purpose: "Materialize D6 operational skills, composition, and governance packets."
+                .to_string(),
+            command:
+                "adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json && adl identity skill-composition --out .adl/state/skill_composition_model_v1.json && adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json"
+                    .to_string(),
+            expected_output:
+                ".adl/state/operational_skills_substrate_v1.json, .adl/state/skill_composition_model_v1.json, .adl/state/delegation_refusal_coordination_v1.json"
+                    .to_string(),
+        },
+        DemoProofRunbookStep {
+            step_id: "reviewer-package".to_string(),
+            purpose: "Materialize D7 reviewer-facing package boundaries.".to_string(),
+            command:
+                "adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json && adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json"
+                    .to_string(),
+            expected_output:
+                ".adl/state/provider_extension_packaging_v1.json, .adl/state/demo_proof_entry_points_v1.json"
+                    .to_string(),
+        },
+    ]
+}
+
+fn deferred_surfaces() -> Vec<DemoProofDeferredSurface> {
+    vec![
+        DemoProofDeferredSurface {
+            surface: "D8 five-agent Hey Jude MIDI coordination demo".to_string(),
+            owner: "WP-13".to_string(),
+            reason:
+                "The coordination/integration demo requires later cross-provider demo packaging and should not be claimed by WP-11."
+                    .to_string(),
+        },
+        DemoProofDeferredSurface {
+            surface: "final three-paper manuscript convergence".to_string(),
+            owner: "WP-13".to_string(),
+            reason:
+                "WP-11 names the manuscript workflow entry point; WP-13 owns final manuscript status and integration follow-through."
+                    .to_string(),
+        },
+        DemoProofDeferredSurface {
+            surface: "formal release review and remediation outcomes".to_string(),
+            owner: "WP-14 through WP-20".to_string(),
+            reason:
+                "WP-11 provides demo scaffolding only; later closeout packages own quality gates, review, remediation, and release ceremony."
+                    .to_string(),
+        },
+    ]
+}
+
+fn strings(items: &[&str]) -> Vec<String> {
+    items.iter().map(|item| (*item).to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demo_proof_entry_points_exposes_copy_paste_runtime_and_replay_commands() {
+        let contract = DemoProofEntryPointsContract::v1();
+
+        let d1 = contract
+            .package
+            .rows
+            .iter()
+            .find(|row| row.demo_id == "D1")
+            .expect("D1 row");
+        assert_eq!(d1.status, "LANDED");
+        assert!(d1
+            .entry_commands
+            .iter()
+            .any(|command| command.contains("adl identity adversarial-runtime")));
+        assert!(d1
+            .entry_commands
+            .iter()
+            .any(|command| command.contains("adl identity adversarial-runner")));
+
+        let d2 = contract
+            .package
+            .rows
+            .iter()
+            .find(|row| row.demo_id == "D2")
+            .expect("D2 row");
+        assert_eq!(d2.status, "LANDED");
+        assert!(d2
+            .primary_proof_surfaces
+            .iter()
+            .any(|surface| surface == ".adl/state/exploit_artifact_replay_v1.json"));
+    }
+
+    #[test]
+    fn demo_proof_entry_points_keeps_d8_and_wp13_deferred() {
+        let contract = DemoProofEntryPointsContract::v1();
+
+        let d8 = contract
+            .package
+            .rows
+            .iter()
+            .find(|row| row.demo_id == "D8")
+            .expect("D8 row");
+        assert_eq!(d8.status, "PLANNED");
+        assert!(d8.entry_commands.is_empty());
+        assert!(contract
+            .package
+            .deferred_surfaces
+            .iter()
+            .any(|surface| surface.owner == "WP-13"));
+        assert!(contract.scope_boundary.contains("does not replace WP-12"));
+    }
+
+    #[test]
+    fn demo_proof_entry_points_binds_upstream_contract_schemas() {
+        let contract = DemoProofEntryPointsContract::v1();
+
+        assert!(contract
+            .upstream_contracts
+            .iter()
+            .any(|schema| schema == ADVERSARIAL_RUNTIME_MODEL_SCHEMA));
+        assert!(contract
+            .upstream_contracts
+            .iter()
+            .any(|schema| schema == EXPLOIT_ARTIFACT_REPLAY_SCHEMA));
+        assert_eq!(
+            contract.proof_hook_command,
+            "adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json"
+        );
+    }
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -22,6 +22,7 @@ pub mod control_plane;
 pub mod delegation_policy;
 pub mod delegation_refusal_coordination;
 pub mod demo;
+pub mod demo_proof_entry_points;
 pub mod execute;
 pub mod execution_plan;
 pub mod exploit_artifact_replay;

--- a/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
+++ b/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
@@ -69,15 +69,15 @@ Additional environment / fixture requirements:
 
 ## Demo Coverage Summary
 
-| Demo ID | Demo title | Milestone claim / WP proved | Planned entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
+| Demo ID | Demo title | Milestone claim / WP proved | Entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
 |---|---|---|---|---|---|---|---|
-| D1 | Adversarial runtime walkthrough | `WP-02` - `WP-04` contested runtime, role architecture, and execution runner | planned `WP-02` / `WP-04` adversarial runner entry point | adversarial runtime review packet + bounded trace bundle | reviewer can see posture, target, roles, and bounded execution stages end to end | same bounded target and posture should preserve stage order and role attribution | PLANNED |
-| D2 | Exploit artifact and replay proof | `WP-05` exploit artifact family and replay manifest | planned `WP-05` schema/replay validation surface | exploit artifact family + replay manifest packet | reviewer can inspect exploit hypothesis, evidence, replay mode, and expected outcome without narrative reconstruction | replay contract should declare deterministic, bounded-variance, or best-effort mode explicitly | PLANNED |
+| D1 | Adversarial runtime walkthrough | `WP-02` - `WP-04` contested runtime, role architecture, and execution runner | `adl identity adversarial-runtime --out .adl/state/adversarial_runtime_model_v1.json`, `adl identity red-blue-architecture --out .adl/state/red_blue_agent_architecture_v1.json`, and `adl identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json` | adversarial runtime, red/blue architecture, and runner contract packets under `.adl/state/` | reviewer can see posture, target, roles, and bounded execution stages end to end | contract packets are deterministic; runner execution stays bounded by the declared contract | LANDED |
+| D2 | Exploit artifact and replay proof | `WP-05` exploit artifact family and replay manifest | `adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json` | `.adl/state/exploit_artifact_replay_v1.json` | reviewer can inspect exploit hypothesis, evidence, replay mode, and expected outcome without narrative reconstruction | replay contract declares deterministic, bounded-variance, or best-effort mode explicitly | LANDED |
 | D3 | Continuous verification loop | `WP-06` continuous verification and exploit generation | `adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json` | continuous verification contract artifact with lifecycle, cadence, replay, mitigation, and promotion rules | reviewer can see repeated falsification pressure as a governed execution pattern rather than ad hoc red-teaming | repeated bounded inputs should preserve lifecycle shape and proof packet structure | LANDED |
 | D4 | Self-attack scenario packet | `WP-06` self-attacking systems as architecture rather than rhetoric | `adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json` | self-attack contract artifact with bounded layers, target/posture policy, and evidence/replay rules | reviewer can see the system's self-attack pattern before externalization and inspect the required evidence chain | scenario should remain posture-bounded and replay-legible | LANDED |
 | D5 | Flagship adversarial demo | `WP-07` full exploit -> replay -> mitigation -> promotion loop | `adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open` | `.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json` | reviewer can answer what was attacked, how it was reproduced, what mitigation was applied, and whether replay post-fix succeeded | deterministic local replay compares the same request before and after mitigation | LANDED |
 | D6 | Operational skills substrate integration | `WP-08` - `WP-09` operational skills, composition, and bounded governance follow-through | `adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json`, `adl identity skill-composition --out .adl/state/skill_composition_model_v1.json`, and `adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json` | substrate/composition/governance contract packets | reviewer can see that adversarial work runs through explicit skill/composition surfaces with bounded delegation, refusal, approval-gate, and coordination outcomes | orchestration structure and governance outcome taxonomy should be deterministic even if node outputs remain stochastic | LANDED |
-| D7 | Reviewer-facing security proof package | `WP-10` - `WP-13` packaging convergence, milestone convergence, and integration demos | `adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json` plus planned `WP-11` / `WP-13` review package | provider-extension packaging packet + reviewer-facing adversarial/replay/trust packet | reviewer can inspect milestone claims, carry-forward boundaries, and proof surfaces as one coherent package | `WP-10` proof packet is deterministic; later review package may remain artifact/document driven | PARTIAL |
+| D7 | Reviewer-facing security proof package | `WP-10` - `WP-13` packaging convergence, milestone convergence, and integration demos | `adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json` and `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json` | provider-extension packaging packet + demo proof entry-point packet | reviewer can inspect milestone claims, carry-forward boundaries, and proof surfaces as one coherent package | `WP-10` and `WP-11` proof packets are deterministic; `WP-13` integration demos remain later work | PARTIAL |
 | D8 | Five-Agent Hey Jude MIDI demo | `WP-08` - `WP-10`, `WP-13` cross-provider coordination, human-in-the-loop orchestration, and integration delight surface | planned `WP-08` / `WP-13` coordination demo entry point | Hey Jude coordination packet + MIDI control trace + provider participation summary | reviewer can see one human plus four providers coordinating on one ADL runtime with explicit orchestration boundaries | bounded score/input should preserve composition shape, participant roles, and MIDI event ordering where declared | PLANNED |
 | D9 | ArXiv manuscript workflow packet | `WP-08`, `WP-13` bounded `arxiv-paper-writer` skill plus the initial three-paper publication program | `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh` | `artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json` | reviewer can see the bounded manuscript workflow packet for What Is ADL?, Gödel Agents and ADL, and Cognitive Spacetime Manifold without losing claim discipline or hiding the WP-08/WP-13 boundary | packet generation is deterministic; bounded source packets preserve role order, section structure, and packet shape | READY |
 
@@ -115,19 +115,24 @@ Milestone claims / work packages covered:
 - `WP-03`
 - `WP-04`
 
-Planned entry point:
+Entry point:
 
 ```bash
-Defined when the official `WP-02` / `WP-04` issues land.
+adl identity adversarial-runtime --out .adl/state/adversarial_runtime_model_v1.json
+adl identity red-blue-architecture --out .adl/state/red_blue_agent_architecture_v1.json
+adl identity adversarial-runner --out .adl/state/adversarial_execution_runner_v1.json
 ```
 
 Expected artifacts:
-- adversarial runtime review packet
-- bounded adversarial execution trace bundle
-- posture declaration and role-attribution evidence
+- adversarial runtime contract packet
+- red / blue agent architecture contract packet
+- bounded adversarial execution runner contract packet
+- posture declaration and role-attribution evidence in the contract surfaces
 
 Primary proof surface:
-- reviewer-facing runtime packet centered on the adversarial execution runner
+- `.adl/state/adversarial_runtime_model_v1.json`
+- `.adl/state/red_blue_agent_architecture_v1.json`
+- `.adl/state/adversarial_execution_runner_v1.json`
 
 Expected success signals:
 - reviewer can see the declared target, posture, goal, and bounded limit
@@ -135,7 +140,7 @@ Expected success signals:
 - the execution loop is legible as architecture, not narrative
 
 Known limits / caveats:
-- this row is about runtime architecture and trace, not yet full mitigation or regression promotion
+- this row is about runtime architecture and runner contract scaffolding; full mitigation and regression promotion remain the flagship D5 demo path
 
 ---
 
@@ -148,10 +153,10 @@ Description:
 Milestone claims / work packages covered:
 - `WP-05`
 
-Planned entry point:
+Entry point:
 
 ```bash
-Defined when the official `WP-05` schema/replay issue lands.
+adl identity exploit-replay --out .adl/state/exploit_artifact_replay_v1.json
 ```
 
 Expected artifacts:
@@ -161,7 +166,7 @@ Expected artifacts:
 - adversarial replay manifest
 
 Primary proof surface:
-- exploit artifact family plus replay manifest packet
+- `.adl/state/exploit_artifact_replay_v1.json`
 
 Expected success signals:
 - reviewer can inspect exploit family, preconditions, unsafe outcome, replay mode, and success criteria directly
@@ -374,16 +379,18 @@ Entry point:
 
 ```bash
 adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json
+adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json
 ```
 
 Expected artifacts:
 - provider extension packaging contract packet
-- reviewer-facing adversarial/replay/trust packet
-- integration demo summary
+- demo proof entry-point packet
+- reviewer-facing adversarial/replay/trust packet index
 - milestone convergence and carry-forward note
 
 Primary proof surface:
-- provider extension packaging packet now; broader reviewer-facing security proof package remains `WP-11` / `WP-13`
+- `.adl/state/provider_extension_packaging_v1.json`
+- `.adl/state/demo_proof_entry_points_v1.json`
 
 Expected success signals:
 - reviewer can inspect the milestone as one coherent adversarial/runtime package
@@ -392,6 +399,7 @@ Expected success signals:
 
 Known limits / caveats:
 - this is a heavyweight proof package and should not be confused with a quick demo row
+- `WP-11` lands the proof entry-point package, while `WP-13` still owns broader integration demo convergence
 - `WP-10` does not implement provider attestation, trust scoring, network posture enforcement, secret lifecycle enforcement, provider sandboxing, or external provider-security demos
 
 ---

--- a/docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md
+++ b/docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md
@@ -56,6 +56,11 @@ WP-10 proof hook:
 
 WP-10 keeps the existing provider substrate capability metadata in the milestone as a bounded packaging/proof surface. It does not promote the broader provider-security extension into `v0.89.1`; provider attestation, trust-tier scoring, network posture enforcement, secret lifecycle enforcement, provider sandboxing, and external provider-security demos remain later security-extension work.
 
+WP-11 proof hook:
+- `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json`
+
+WP-11 makes the demo matrix copy/paste-ready by collecting the landed adversarial-runtime, replay, verification, skill-governance, provider-packaging, and flagship demo entry points into one reviewer-facing contract. It keeps the five-agent Hey Jude integration demo and final manuscript convergence owned by `WP-13`.
+
 ## Source Planning Corpus -> Implementation Home
 
 ### Core `v0.89.1` source docs

--- a/docs/milestones/v0.89.1/README.md
+++ b/docs/milestones/v0.89.1/README.md
@@ -125,6 +125,7 @@ Additional validation surfaces:
 - replayable exploit artifacts
 - adversarial runtime traces and reviewer-facing demo packets
 - provider extension packaging proof: `adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json`
+- demo proof entry-point package: `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json`
 - quality-gate and review issue outputs
 
 Success criteria:

--- a/docs/milestones/v0.89.1/SPRINT_v0.89.1.md
+++ b/docs/milestones/v0.89.1/SPRINT_v0.89.1.md
@@ -68,7 +68,7 @@ Land the exploit-proof and governed execution substrate that makes `v0.89.1` mor
 Close the milestone using the normal ADL pattern: demos, quality gate, docs/review, internal review, 3rd-party review, findings remediation, next-milestone planning, and release ceremony.
 
 ### Scope
-- demo scaffolding and proof entry points
+- demo scaffolding and proof entry points, including `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json`
 - milestone convergence and follow-on mapping
 - demo matrix and integration demos
 - the initial three-paper arXiv manuscript program

--- a/docs/milestones/v0.89.1/WBS_v0.89.1.md
+++ b/docs/milestones/v0.89.1/WBS_v0.89.1.md
@@ -60,7 +60,7 @@
 - WP-08 -> the skill substrate/composition layer is explicit enough for runtime implementation and includes a bounded `arxiv-paper-writer` skill surface
 - WP-09 -> governance/coordination supporting inputs are resolved enough to keep the milestone coherent
 - WP-10 -> bounded provider capability packaging has a proof hook and under-authored provider-security extension docs are explicitly kept out
-- WP-11 -> proof entry points exist for the main milestone claims
+- WP-11 -> proof entry points exist for the main milestone claims via `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json`
 - WP-12 -> the milestone package and issue graph are converged
 - WP-13 -> milestone claims have bounded demo/proof surfaces and the three-paper publication program has reviewer-legible manuscript outputs
 - WP-14 -> quality/coverage posture is truthful and reviewable


### PR DESCRIPTION
Closes #1932

## Summary
Implemented the `WP-11` demo proof entry-point package for `v0.89.1`. The work adds a deterministic `adl identity demo-proof-entry-points` contract that aggregates the landed adversarial-runtime, red/blue, adversarial-runner, exploit-replay, continuous-verification, flagship demo, operational-skills, governance, provider-packaging, and manuscript workflow proof surfaces while keeping the five-agent Hey Jude integration demo and final manuscript convergence deferred to later work.

## Artifacts
- `adl/src/demo_proof_entry_points.rs` defines `demo_proof_entry_points.v1`, the reviewer-facing row package, copy/paste runbook, deferred-surface list, and module tests.
- `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json` is wired through the identity CLI, usage text, and CLI tests.
- `docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md` now has concrete D1/D2 proof commands and the WP-11 D7 package hook.
- `docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md`, `README.md`, `WBS_v0.89.1.md`, and `SPRINT_v0.89.1.md` now reference the WP-11 proof hook.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --all -- --check` from `adl/` verified Rust formatting.
  - `cargo clippy --all-targets -- -D warnings` from `adl/` verified lint cleanliness across targets.
  - `cargo test` from `adl/` verified the full Rust test suite.
  - `cargo test --manifest-path adl/Cargo.toml demo_proof_entry_points --lib` verified the new contract module tests directly.
  - `cargo test --manifest-path adl/Cargo.toml identity_demo_proof_entry_points` verified the new identity CLI output and error-path tests.
  - `cargo test --manifest-path adl/Cargo.toml identity_requires_subcommand_and_rejects_unknown_subcommand` verified updated identity subcommand enumeration.
  - `cargo test --manifest-path adl/Cargo.toml identity_top_level_help_and_subcommand_help_succeed` verified the help path includes the new subcommand.
  - `cargo run --manifest-path adl/Cargo.toml -- identity demo-proof-entry-points --out target/wp-1932/demo_proof_entry_points_v1.json && test -s target/wp-1932/demo_proof_entry_points_v1.json` verified artifact emission.
  - `jq -r '.schema_version, .proof_hook_output_path, (.package.rows[] | select(.demo_id=="D8") | .status)' target/wp-1932/demo_proof_entry_points_v1.json` verified schema version, canonical proof output path, and D8 planned status.
  - `rg -n "/Users|/private|/var/folders|TOKEN|SECRET|PASSWORD|API_KEY" adl/src/demo_proof_entry_points.rs docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md docs/milestones/v0.89.1/README.md docs/milestones/v0.89.1/SPRINT_v0.89.1.md docs/milestones/v0.89.1/WBS_v0.89.1.md target/wp-1932/demo_proof_entry_points_v1.json -S` over changed source/docs plus the generated target artifact verified no host-path or obvious secret leakage in the committed surfaces or proof packet.
  - `bash tools/check_release_notes_commands.sh` from `adl/` verified documented release-note command references remain valid.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1932__v0-89-1-wp-11-demo-scaffolding-and-proof-entry-points/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1932__v0-89-1-wp-11-demo-scaffolding-and-proof-entry-points/sor.md
- Idempotency-Key: v0-89-1-wp-11-demo-scaffolding-and-proof-entry-points-adl-src-demo-proof-entry-points-rs-adl-src-lib-rs-adl-src-cli-identity-cmd-contracts-rs-adl-src-cli-identity-cmd-dispatch-rs-adl-src-cli-identity-cmd-tests-rs-adl-src-cli-usage-rs-docs-milestones-v0-89-1-demo-matrix-v0-89-1-md-docs-milestones-v0-89-1-feature-docs-v0-89-1-md-docs-milestones-v0-89-1-readme-md-docs-milestones-v0-89-1-sprint-v0-89-1-md-docs-milestones-v0-89-1-wbs-v0-89-1-md-adl-v0-89-1-tasks-issue-1932-v0-89-1-wp-11-demo-scaffolding-and-proof-entry-points-sip-md-adl-v0-89-1-tasks-issue-1932-v0-89-1-wp-11-demo-scaffolding-and-proof-entry-points-sor-md