### PR TITLE
[v0.89.1][WP-13] Demo matrix and integration demos

### DIFF
--- a/adl/src/cli/identity_cmd/tests.rs
+++ b/adl/src/cli/identity_cmd/tests.rs
@@ -1134,11 +1134,29 @@ fn identity_demo_proof_entry_points_writes_contract_json() {
                     .any(|command| command
                         == "adl identity adversarial-runtime --out .adl/state/adversarial_runtime_model_v1.json"))
     );
-    assert!(json["package"]["deferred_surfaces"]
+    assert!(json["package"]["rows"]
         .as_array()
-        .expect("deferred")
+        .expect("rows")
         .iter()
-        .any(|surface| surface["owner"] == "WP-13"));
+        .any(|row| row["demo_id"] == "D8"
+            && row["status"] == "LANDED"
+            && row["entry_commands"]
+                .as_array()
+                .expect("entry commands")
+                .iter()
+                .any(|command| command == "bash adl/tools/demo_v0891_five_agent_hey_jude.sh")));
+    assert!(json["package"]["rows"]
+        .as_array()
+        .expect("rows")
+        .iter()
+        .any(|row| row["demo_id"] == "D9"
+            && row["status"] == "LANDED"
+            && row["primary_proof_surfaces"]
+                .as_array()
+                .expect("proof surfaces")
+                .iter()
+                .any(|surface| surface
+                    == "artifacts/v0891/arxiv_manuscript_workflow/manuscript_status/three_paper_status.json")));
 }
 
 #[test]

--- a/adl/src/cli/run_artifacts/summary.rs
+++ b/adl/src/cli/run_artifacts/summary.rs
@@ -496,12 +496,11 @@ pub(crate) fn build_scores_artifact(
         .counts
         .completed_steps
         .saturating_sub(run_summary.counts.failed_steps);
-    let success_ratio = if run_summary.counts.total_steps == 0 {
-        1.0
-    } else {
-        let permille = (success_steps * 1000) / run_summary.counts.total_steps;
-        (permille as f64) / 1000.0
-    };
+    let success_ratio = success_steps
+        .saturating_mul(1000)
+        .checked_div(run_summary.counts.total_steps)
+        .map(|permille| (permille as f64) / 1000.0)
+        .unwrap_or(1.0);
     let security_denied_count: usize = run_summary.policy.security_denials_by_code.values().sum();
     let delegation_denied_count: usize = run_summary
         .policy
@@ -562,12 +561,11 @@ pub(crate) fn build_suggestions_artifact(
             .counts
             .completed_steps
             .saturating_sub(failed_steps);
-        let success_ratio = if run_summary.counts.total_steps == 0 {
-            1.0
-        } else {
-            let permille = (success_steps * 1000) / run_summary.counts.total_steps;
-            (permille as f64) / 1000.0
-        };
+        let success_ratio = success_steps
+            .saturating_mul(1000)
+            .checked_div(run_summary.counts.total_steps)
+            .map(|permille| (permille as f64) / 1000.0)
+            .unwrap_or(1.0);
         let security_denied_count: usize =
             run_summary.policy.security_denials_by_code.values().sum();
         let delegation_denied_count: usize = run_summary

--- a/adl/src/demo_proof_entry_points.rs
+++ b/adl/src/demo_proof_entry_points.rs
@@ -76,7 +76,7 @@ impl DemoProofEntryPointsContract {
                 "adl identity demo-proof-entry-points",
             ]),
             runtime_condition:
-                "v0.89.1 exposes reviewer-facing proof entry points for adversarial runtime, exploit replay, continuous verification, skill governance, and demo packets without absorbing later integration work."
+                "v0.89.1 exposes reviewer-facing proof entry points for adversarial runtime, exploit replay, continuous verification, skill governance, and bounded integration demo packets."
                     .to_string(),
             upstream_contracts: strings(&[
                 ADVERSARIAL_RUNTIME_MODEL_SCHEMA,
@@ -92,17 +92,17 @@ impl DemoProofEntryPointsContract {
             package: DemoProofPackage {
                 package_id: "v0.89.1.wp11.demo_proof_entry_points".to_string(),
                 milestone: "v0.89.1".to_string(),
-                work_package: "WP-11".to_string(),
+                work_package: "WP-11 / WP-13".to_string(),
                 package_role:
-                    "Copy/paste reviewer entry-point package for the milestone demo matrix."
+                    "Copy/paste reviewer entry-point package for the milestone demo matrix and WP-13 integration packet."
                         .to_string(),
                 rows: demo_rows(),
                 copy_paste_runbook: runbook_steps(),
                 deferred_surfaces: deferred_surfaces(),
                 review_boundaries: strings(&[
                     "The package names commands and proof surfaces; it does not execute every heavyweight demo during normal identity-contract validation.",
-                    "D8 remains planned until the coordination/integration demo issue lands.",
-                    "WP-13 still owns broader integration and manuscript convergence packets.",
+                    "D8 is landed as a bounded integration demo with a fixture-backed validation command.",
+                    "D9 is landed as a bounded manuscript workflow packet without claiming final arXiv submission.",
                     "Provider-security attestation, trust scoring, sandbox policy, and external provider-security demos remain out of v0.89.1 scope unless later work explicitly promotes them.",
                 ]),
             },
@@ -110,11 +110,11 @@ impl DemoProofEntryPointsContract {
                 "Which command should a reviewer run for each v0.89.1 demo row?",
                 "Which rows are already landed, partial, ready, or still planned?",
                 "Which proof surfaces are deterministic contract packets versus heavyweight demo runs?",
-                "Which later integration surfaces are intentionally deferred?",
+                "Which later release or provider-security surfaces are intentionally deferred?",
             ]),
             proof_fixture_hooks: strings(&[
                 "demo_proof_entry_points_exposes_copy_paste_runtime_and_replay_commands",
-                "demo_proof_entry_points_keeps_d8_and_wp13_deferred",
+                "demo_proof_entry_points_exposes_wp13_integration_demos",
                 "identity_demo_proof_entry_points_writes_contract_json",
             ]),
             proof_hook_command:
@@ -122,7 +122,7 @@ impl DemoProofEntryPointsContract {
                     .to_string(),
             proof_hook_output_path: ".adl/state/demo_proof_entry_points_v1.json".to_string(),
             scope_boundary:
-                "This contract lands WP-11 demo scaffolding and proof entry points; it does not replace WP-12 review, WP-13 integration demos, or later release closeout."
+                "This contract lands WP-11 demo scaffolding plus WP-13 integration rows; it does not replace WP-12 review, later quality gates, release review, or release closeout."
                     .to_string(),
         }
     }
@@ -255,27 +255,33 @@ fn demo_rows() -> Vec<DemoProofEntryPointRow> {
             primary_proof_surfaces: strings(&[
                 ".adl/state/provider_extension_packaging_v1.json",
                 ".adl/state/demo_proof_entry_points_v1.json",
+                "artifacts/v0891/wp13_demo_integration/integration_manifest.json",
             ]),
             proof_role:
-                "Bundles milestone proof commands, carry-forward boundaries, and reviewer-facing package status into one machine-readable packet."
+                "Bundles milestone proof commands, carry-forward boundaries, D8 delight demo, and D9 manuscript workflow packet into one machine-readable reviewer package."
                     .to_string(),
-            status: "PARTIAL".to_string(),
+            status: "LANDED".to_string(),
             determinism_note:
-                "WP-11 package generation is deterministic; WP-13 integration packets remain later work."
+                "WP-11 identity packets and the WP-13 integration packet are deterministic; heavyweight child demos remain replayable through their own test commands."
                     .to_string(),
         },
         DemoProofEntryPointRow {
             demo_id: "D8".to_string(),
             title: "Five-Agent Hey Jude MIDI demo".to_string(),
             work_packages: strings(&["WP-08", "WP-09", "WP-10", "WP-13"]),
-            entry_commands: Vec::new(),
-            primary_proof_surfaces: strings(&["planned WP-13 coordination demo packet"]),
+            entry_commands: strings(&["bash adl/tools/demo_v0891_five_agent_hey_jude.sh"]),
+            primary_proof_surfaces: strings(&[
+                "artifacts/v0891/five_agent_hey_jude/performance_manifest.json",
+                "artifacts/v0891/five_agent_hey_jude/midi_event_log.json",
+                "artifacts/v0891/five_agent_hey_jude/provider_participation_summary.json",
+                "artifacts/v0891/five_agent_hey_jude/runtime/runs/v0-89-1-five-agent-hey-jude-midi-demo/run_summary.json",
+            ]),
             proof_role:
-                "Future high-delight coordination demo for one human plus four providers on one ADL runtime."
+                "Shows one human Layer 8 participant plus four provider voices coordinating through one bounded ADL runtime packet and MIDI cue layer."
                     .to_string(),
-            status: "PLANNED".to_string(),
+            status: "LANDED".to_string(),
             determinism_note:
-                "Bounded score/input should preserve composition shape and MIDI event ordering once the demo lands."
+                "The fixture-backed MVAVE Chocolate event stream preserves cue order and validates the same artifact schema on each run."
                     .to_string(),
         },
         DemoProofEntryPointRow {
@@ -285,13 +291,16 @@ fn demo_rows() -> Vec<DemoProofEntryPointRow> {
             entry_commands: strings(&["bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh"]),
             primary_proof_surfaces: strings(&[
                 "artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json",
+                "artifacts/v0891/arxiv_manuscript_workflow/source_packets/source_packet_manifest.json",
+                "artifacts/v0891/arxiv_manuscript_workflow/manuscript_status/three_paper_status.json",
+                "artifacts/v0891/arxiv_manuscript_workflow/review/review_gates.json",
             ]),
             proof_role:
                 "Shows bounded manuscript workflow scaffolding, source packets, review gates, and three-paper status packet shape."
                     .to_string(),
-            status: "READY".to_string(),
+            status: "LANDED".to_string(),
             determinism_note:
-                "Packet generation is deterministic; WP-13 owns final manuscript convergence."
+                "Packet generation is deterministic and WP-13 preserves the no-submission boundary while making the three-paper status packet reviewable."
                     .to_string(),
         },
     ]
@@ -359,25 +368,33 @@ fn runbook_steps() -> Vec<DemoProofRunbookStep> {
                 ".adl/state/provider_extension_packaging_v1.json, .adl/state/demo_proof_entry_points_v1.json"
                     .to_string(),
         },
+        DemoProofRunbookStep {
+            step_id: "wp13-integration-packet".to_string(),
+            purpose: "Materialize the WP-13 integration package for D7, D8, and D9.".to_string(),
+            command: "bash adl/tools/demo_v0891_wp13_demo_integration.sh".to_string(),
+            expected_output: "artifacts/v0891/wp13_demo_integration/integration_manifest.json"
+                .to_string(),
+        },
+        DemoProofRunbookStep {
+            step_id: "five-agent-midi-demo".to_string(),
+            purpose: "Run D8 five-agent Hey Jude MIDI demo when integration demo execution is desired."
+                .to_string(),
+            command: "bash adl/tools/demo_v0891_five_agent_hey_jude.sh".to_string(),
+            expected_output:
+                "artifacts/v0891/five_agent_hey_jude/performance_manifest.json".to_string(),
+        },
+        DemoProofRunbookStep {
+            step_id: "arxiv-manuscript-workflow".to_string(),
+            purpose: "Run D9 bounded three-paper manuscript workflow packet.".to_string(),
+            command: "bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh".to_string(),
+            expected_output:
+                "artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json".to_string(),
+        },
     ]
 }
 
 fn deferred_surfaces() -> Vec<DemoProofDeferredSurface> {
     vec![
-        DemoProofDeferredSurface {
-            surface: "D8 five-agent Hey Jude MIDI coordination demo".to_string(),
-            owner: "WP-13".to_string(),
-            reason:
-                "The coordination/integration demo requires later cross-provider demo packaging and should not be claimed by WP-11."
-                    .to_string(),
-        },
-        DemoProofDeferredSurface {
-            surface: "final three-paper manuscript convergence".to_string(),
-            owner: "WP-13".to_string(),
-            reason:
-                "WP-11 names the manuscript workflow entry point; WP-13 owns final manuscript status and integration follow-through."
-                    .to_string(),
-        },
         DemoProofDeferredSurface {
             surface: "formal release review and remediation outcomes".to_string(),
             owner: "WP-14 through WP-20".to_string(),
@@ -430,8 +447,21 @@ mod tests {
     }
 
     #[test]
-    fn demo_proof_entry_points_keeps_d8_and_wp13_deferred() {
+    fn demo_proof_entry_points_exposes_wp13_integration_demos() {
         let contract = DemoProofEntryPointsContract::v1();
+
+        let d7 = contract
+            .package
+            .rows
+            .iter()
+            .find(|row| row.demo_id == "D7")
+            .expect("D7 row");
+        assert_eq!(d7.status, "LANDED");
+        assert!(d7
+            .primary_proof_surfaces
+            .iter()
+            .any(|surface| surface
+                == "artifacts/v0891/wp13_demo_integration/integration_manifest.json"));
 
         let d8 = contract
             .package
@@ -439,13 +469,32 @@ mod tests {
             .iter()
             .find(|row| row.demo_id == "D8")
             .expect("D8 row");
-        assert_eq!(d8.status, "PLANNED");
-        assert!(d8.entry_commands.is_empty());
+        assert_eq!(d8.status, "LANDED");
+        assert!(d8
+            .entry_commands
+            .iter()
+            .any(|command| command == "bash adl/tools/demo_v0891_five_agent_hey_jude.sh"));
+        assert!(d8
+            .primary_proof_surfaces
+            .iter()
+            .any(|surface| surface.ends_with("performance_manifest.json")));
+
+        let d9 = contract
+            .package
+            .rows
+            .iter()
+            .find(|row| row.demo_id == "D9")
+            .expect("D9 row");
+        assert_eq!(d9.status, "LANDED");
+        assert!(d9
+            .primary_proof_surfaces
+            .iter()
+            .any(|surface| surface.ends_with("three_paper_status.json")));
         assert!(contract
             .package
-            .deferred_surfaces
+            .copy_paste_runbook
             .iter()
-            .any(|surface| surface.owner == "WP-13"));
+            .any(|step| step.step_id == "wp13-integration-packet"));
         assert!(contract.scope_boundary.contains("does not replace WP-12"));
     }
 

--- a/adl/src/execute/state/runtime_control.rs
+++ b/adl/src/execute/state/runtime_control.rs
@@ -89,15 +89,10 @@ fn collect_runtime_signal_evidence(
         .filter(|event| matches!(event, trace::TraceEvent::DelegationDenied { .. }))
         .count();
     let security_denied_count = delegation_denied_count;
-    let success_ratio_permille = if total_steps == 0 {
-        if overall_status == "success" {
-            1000
-        } else {
-            0
-        }
-    } else {
-        (success_count * 1000) / total_steps
-    };
+    let success_ratio_permille = success_count
+        .saturating_mul(1000)
+        .checked_div(total_steps)
+        .unwrap_or(if overall_status == "success" { 1000 } else { 0 });
     let scheduler_max_parallel_observed = compute_max_parallel_observed_from_trace(tr);
 
     RuntimeSignalEvidence {

--- a/adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
+++ b/adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
@@ -139,7 +139,7 @@ writer_status = {
     "dependency_issue": "#1929",
     "skill_status": "wp08_contract_defined_packet_only",
     "runnable_in_this_demo": False,
-    "execution_truth": "WP-08 issue #1929 defines the bounded arxiv-paper-writer contract; D9 demonstrates the manuscript workflow packet without claiming final writer execution or arXiv submission.",
+    "execution_truth": "WP-08 issue #1929 defines the bounded arxiv-paper-writer contract; D9 demonstrates the WP-13 manuscript workflow packet without claiming final arXiv submission.",
     "allowed_claim": "The packet proves role order, source packet shape, claim discipline, WP-08 contract alignment, and three-paper status tracking.",
     "forbidden_claims": [
         "final arXiv submission happened",
@@ -177,10 +177,10 @@ publication follow-through separate from the writer-skill contract.
 - review-ready packet is distinguished from final arXiv submission
 - post-milestone cleanup is recorded rather than hidden
 
-## Handoff To WP-13
+## WP-13 Integration
 
-WP-13 should consume the source packets and manuscript status records from this
-packet without changing the claim discipline, human review gates, or
+WP-13 consumes the source packets and manuscript status records from this
+packet while preserving claim discipline, human review gates, and the
 no-submission boundary.
 """
 write_text(writer_dir / "workflow_contract.md", workflow_contract)
@@ -248,13 +248,13 @@ status_payload = {
     "demo_id": "D9",
     "writer_skill_status": "wp08_contract_defined_packet_only",
     "submission_status": "not_submitted",
-    "review_ready_meaning": "source and status packets are ready for reviewer inspection; manuscripts are not final arXiv submissions",
+    "review_ready_meaning": "source and status packets are ready for reviewer inspection; final arXiv submission remains out of scope",
     "papers": [
         {
             "paper_id": paper["id"],
             "title": paper["title"],
             "packet_status": "review_packet_ready",
-            "draft_status": "not_finalized_until_wp13_manuscript_follow_through",
+            "draft_status": "review_packet_ready_submission_deferred",
             "source_packet_ref": f"source_packets/{paper['id']}_source_packet.md",
             "manuscript_status_ref": f"manuscript_status/{paper['id']}_status.md",
             "known_gaps": paper["known_gaps"],
@@ -271,7 +271,7 @@ for paper in paper_specs:
         "## Current State",
         "",
         "- Packet status: review_packet_ready",
-        "- Draft status: not_finalized_until_wp13_manuscript_follow_through",
+        "- Draft status: review_packet_ready_submission_deferred",
         "- Submission status: not_submitted",
         "- Dependency: #1929 WP-08 writer-skill contract plus #1934 WP-13 manuscript follow-through",
         "",
@@ -290,7 +290,7 @@ for paper in paper_specs:
             "",
             "## Next Step",
             "",
-            "Use the bounded writer contract from #1929 in the WP-13 manuscript follow-through while preserving the human review gates.",
+            "Use this packet as the WP-13 manuscript workflow proof surface while preserving human review gates before any future submission step.",
         ]
     )
     write_text(status_dir / f"{paper['id']}_status.md", "\n".join(status_lines))
@@ -302,7 +302,7 @@ review_gates = {
         {"gate_id": "role_order_declared", "status": "pass", "evidence": "writer_skill_packet/writer_skill_status.json"},
         {"gate_id": "claim_boundaries_declared", "status": "pass", "evidence": "review/claim_boundaries.md"},
         {"gate_id": "wp08_writer_contract_defined", "status": "pass", "evidence": "writer_skill_packet/workflow_contract.md"},
-        {"gate_id": "wp13_manuscript_follow_through", "status": "not_in_scope", "evidence": "#1934 owns final manuscript packet follow-through"},
+        {"gate_id": "wp13_manuscript_packet", "status": "pass", "evidence": "manuscript_status/three_paper_status.json"},
         {"gate_id": "arxiv_submission", "status": "not_in_scope", "evidence": "review-ready packets are not final arXiv submissions"},
     ],
 }
@@ -320,10 +320,9 @@ claim_boundaries = """# Claim Boundaries
 
 ## Not Claimed
 
-- Final arXiv submission.
 - Submission-ready manuscripts.
 - Private credentials or hidden chat state.
-- Completion of WP-13 manuscript follow-through.
+- Final arXiv submission or publication.
 - A full manuscript drafting run inside this D9 packet.
 - Full automation of scholarly authorship or peer review.
 """
@@ -343,8 +342,7 @@ Review this packet in the following order:
 
 The packet is intentionally honest about scope. It demonstrates the bounded
 manuscript workflow shape and three-paper review packet without claiming that
-final papers have been submitted to arXiv or that WP-13 manuscript
-follow-through is complete.
+final papers have been submitted to arXiv.
 """
 write_text(review_dir / "reviewer_brief.md", reviewer_brief)
 
@@ -398,8 +396,8 @@ Primary proof surfaces:
 - `review/reviewer_brief.md`
 
 This packet is a bounded publication workflow proof. It does not submit to
-arXiv, does not require credentials, and does not claim WP-13 manuscript
-follow-through is complete.
+arXiv, does not require credentials, and preserves future human review before
+any submission step.
 """
 write_text(out_dir / "README.md", readme)
 

--- a/adl/tools/demo_v0891_wp13_demo_integration.sh
+++ b/adl/tools/demo_v0891_wp13_demo_integration.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0891/wp13_demo_integration}"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+python3 - "$OUT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+out_dir = Path(sys.argv[1])
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+
+
+demo_rows = [
+    {
+        "demo_id": "D7",
+        "title": "Reviewer-facing security proof package",
+        "status": "LANDED",
+        "work_packages": ["WP-10", "WP-11", "WP-12", "WP-13"],
+        "entry_commands": [
+            "adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json",
+            "adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json",
+            "bash adl/tools/demo_v0891_wp13_demo_integration.sh",
+        ],
+        "primary_proof_surfaces": [
+            ".adl/state/provider_extension_packaging_v1.json",
+            ".adl/state/demo_proof_entry_points_v1.json",
+            "artifacts/v0891/wp13_demo_integration/integration_manifest.json",
+        ],
+        "proof_role": "Bundles the milestone proof commands, carry-forward boundaries, D8 delight demo, and D9 manuscript workflow packet into one reviewer-facing integration surface.",
+        "determinism_note": "Identity packets and the WP-13 integration packet are deterministic; heavyweight child demos remain replayable through their own test commands.",
+    },
+    {
+        "demo_id": "D8",
+        "title": "Five-Agent Hey Jude MIDI demo",
+        "status": "LANDED",
+        "work_packages": ["WP-08", "WP-09", "WP-10", "WP-13"],
+        "entry_commands": ["bash adl/tools/demo_v0891_five_agent_hey_jude.sh"],
+        "test_commands": ["bash adl/tools/test_demo_v0891_five_agent_hey_jude.sh"],
+        "primary_proof_surfaces": [
+            "artifacts/v0891/five_agent_hey_jude/performance_manifest.json",
+            "artifacts/v0891/five_agent_hey_jude/midi_event_log.json",
+            "artifacts/v0891/five_agent_hey_jude/provider_participation_summary.json",
+            "artifacts/v0891/five_agent_hey_jude/runtime/runs/v0-89-1-five-agent-hey-jude-midi-demo/run_summary.json",
+        ],
+        "tracked_repo_paths": [
+            "adl/tools/demo_v0891_five_agent_hey_jude.sh",
+            "adl/tools/test_demo_v0891_five_agent_hey_jude.sh",
+            "adl/tools/validate_five_agent_music_demo.py",
+            "demos/v0.89.1/five_agent_hey_jude_midi_demo.md",
+        ],
+        "proof_role": "Shows one human Layer 8 participant plus four provider voices coordinating through one bounded ADL runtime packet and MIDI cue layer.",
+        "determinism_note": "The fixture-backed MVAVE Chocolate event stream preserves cue order and validates the same artifact schema on each run.",
+    },
+    {
+        "demo_id": "D9",
+        "title": "ArXiv manuscript workflow packet",
+        "status": "LANDED",
+        "work_packages": ["WP-08", "WP-13"],
+        "entry_commands": ["bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh"],
+        "test_commands": ["bash adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh"],
+        "primary_proof_surfaces": [
+            "artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json",
+            "artifacts/v0891/arxiv_manuscript_workflow/source_packets/source_packet_manifest.json",
+            "artifacts/v0891/arxiv_manuscript_workflow/manuscript_status/three_paper_status.json",
+            "artifacts/v0891/arxiv_manuscript_workflow/review/review_gates.json",
+        ],
+        "tracked_repo_paths": [
+            "adl/tools/demo_v0891_arxiv_manuscript_workflow.sh",
+            "adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh",
+            "demos/v0.89.1/arxiv_manuscript_workflow_demo.md",
+        ],
+        "proof_role": "Shows the bounded three-paper manuscript workflow packet, source packets, review gates, and no-submission boundary.",
+        "determinism_note": "Packet generation is deterministic and preserves paper order, role order, source references, and claim-boundary wording.",
+    },
+]
+
+manifest = {
+    "schema_version": "adl.v0891.wp13_demo_integration.v1",
+    "milestone": "v0.89.1",
+    "work_package": "WP-13",
+    "issue": "#1934",
+    "title": "Demo matrix and integration demos",
+    "disposition": "bounded_integration_packet",
+    "dependency_truth": {
+        "wp12_issue": "#1933",
+        "wp12_state": "merged_before_wp13_publication",
+        "integration_record": "WP-13 consumes the merged WP-12 convergence surface and does not close or replace WP-12.",
+    },
+    "demo_rows": demo_rows,
+    "validation_commands": [
+        {
+            "command": "bash adl/tools/test_demo_v0891_wp13_demo_integration.sh",
+            "verifies": "WP-13 integration packet schema, row status, tracked path existence, and leakage checks.",
+        },
+        {
+            "command": "bash adl/tools/test_demo_v0891_five_agent_hey_jude.sh",
+            "verifies": "D8 five-agent MIDI demo artifacts and copyright-safe transcript boundary.",
+        },
+        {
+            "command": "bash adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh",
+            "verifies": "D9 manuscript workflow packet, source packets, review gates, and no-submission boundary.",
+        },
+        {
+            "command": "cargo test --manifest-path adl/Cargo.toml demo_proof_entry_points --quiet",
+            "verifies": "CLI proof-entry contract status for the updated D7/D8/D9 integration rows.",
+        },
+    ],
+    "review_boundaries": [
+        "The integration packet names and validates demo proof surfaces; it does not submit papers to arXiv.",
+        "D8 is a bounded delight/integration demo and not a replacement for the adversarial D5 exploit-replay proof.",
+        "Provider-security attestation, trust scoring, sandbox policy, and external provider-security demos remain out of v0.89.1 scope.",
+        "WP-13 consumes the merged WP-12 convergence surface instead of reopening or replacing it.",
+    ],
+}
+
+write_json(out_dir / "integration_manifest.json", manifest)
+write_json(out_dir / "demo_rows.json", {"schema_version": "adl.v0891.wp13_demo_rows.v1", "rows": demo_rows})
+
+reviewer_brief = """# WP-13 Demo Integration Reviewer Brief
+
+Review this packet in the following order:
+
+1. `integration_manifest.json`
+2. `demo_rows.json`
+3. `dependency_and_scope.md`
+4. `validation_plan.json`
+
+Then run or inspect the child demo commands:
+
+- `bash adl/tools/test_demo_v0891_five_agent_hey_jude.sh`
+- `bash adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh`
+
+This packet makes D7, D8, and D9 reviewer-legible together. It does not claim
+arXiv submission, final provider-security extension work, or closure of WP-12.
+"""
+write_text(out_dir / "reviewer_brief.md", reviewer_brief)
+
+dependency_scope = """# Dependency And Scope Notes
+
+## Dependency Truth
+
+WP-13 depends on WP-12 in the planning package. Issue #1933 has landed before
+WP-13 publication, so this packet consumes the merged WP-12 convergence surface
+rather than closing or replacing it.
+
+## What WP-13 Lands
+
+- D7 integration package status moves from partial to landed.
+- D8 five-agent Hey Jude MIDI demo has a runnable command, validation command,
+  and reviewer-facing proof surfaces.
+- D9 arXiv manuscript workflow packet has a runnable command, validation
+  command, three-paper status packet, and no-submission boundary.
+
+## What WP-13 Does Not Land
+
+- release quality gates or release ceremony
+- arXiv submission
+- full provider-security extension
+- replacement of WP-12 issue #1933
+"""
+write_text(out_dir / "dependency_and_scope.md", dependency_scope)
+
+validation_plan = {
+    "schema_version": "adl.v0891.wp13_demo_integration.validation_plan.v1",
+    "required_commands": manifest["validation_commands"],
+    "leakage_guards": [
+        "no absolute host paths in generated WP-13 integration artifacts",
+        "no secret-like environment variable names or bearer tokens",
+        "no hidden claim that arXiv submission occurred",
+    ],
+}
+write_json(out_dir / "validation_plan.json", validation_plan)
+
+readme = """# v0.89.1 WP-13 Demo Integration Packet
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v0891_wp13_demo_integration.sh
+```
+
+Primary proof surfaces:
+
+- `integration_manifest.json`
+- `demo_rows.json`
+- `reviewer_brief.md`
+- `dependency_and_scope.md`
+- `validation_plan.json`
+
+This packet integrates the landed D8 and D9 demo work with the D7 reviewer
+package without claiming final release closeout or arXiv submission.
+"""
+write_text(out_dir / "README.md", readme)
+
+print(f"wp13_demo_integration: wrote {out_dir}")
+PY
+
+echo "WP-13 demo integration proof surface under the output directory:"
+echo "  integration_manifest.json"
+echo "  demo_rows.json"
+echo "  reviewer_brief.md"
+echo "  dependency_and_scope.md"
+echo "  validation_plan.json"

--- a/adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh
+++ b/adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh
@@ -68,7 +68,7 @@ assert any(
     for gate in gates["gates"]
 )
 assert any(
-    gate["gate_id"] == "wp13_manuscript_follow_through" and gate["status"] == "not_in_scope"
+    gate["gate_id"] == "wp13_manuscript_packet" and gate["status"] == "pass"
     for gate in gates["gates"]
 )
 PY

--- a/adl/tools/test_demo_v0891_wp13_demo_integration.sh
+++ b/adl/tools/test_demo_v0891_wp13_demo_integration.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v0891_wp13_demo_integration.sh "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/integration_manifest.json" \
+  "$OUT_DIR/demo_rows.json" \
+  "$OUT_DIR/reviewer_brief.md" \
+  "$OUT_DIR/dependency_and_scope.md" \
+  "$OUT_DIR/validation_plan.json" \
+  "$OUT_DIR/README.md"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+python3 - "$ROOT_DIR" "$OUT_DIR/integration_manifest.json" "$OUT_DIR/demo_rows.json" "$OUT_DIR/validation_plan.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+manifest = json.load(open(sys.argv[2], encoding="utf-8"))
+rows = json.load(open(sys.argv[3], encoding="utf-8"))
+validation = json.load(open(sys.argv[4], encoding="utf-8"))
+
+assert manifest["schema_version"] == "adl.v0891.wp13_demo_integration.v1"
+assert manifest["work_package"] == "WP-13"
+assert manifest["issue"] == "#1934"
+assert manifest["dependency_truth"]["wp12_issue"] == "#1933"
+assert manifest["dependency_truth"]["wp12_state"] == "merged_before_wp13_publication"
+
+by_id = {row["demo_id"]: row for row in manifest["demo_rows"]}
+assert {demo_id for demo_id in by_id} == {"D7", "D8", "D9"}
+assert by_id["D7"]["status"] == "LANDED"
+assert by_id["D8"]["status"] == "LANDED"
+assert by_id["D9"]["status"] == "LANDED"
+assert any(command == "bash adl/tools/demo_v0891_five_agent_hey_jude.sh" for command in by_id["D8"]["entry_commands"])
+assert any(command == "bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh" for command in by_id["D9"]["entry_commands"])
+assert any(surface.endswith("performance_manifest.json") for surface in by_id["D8"]["primary_proof_surfaces"])
+assert any(surface.endswith("three_paper_status.json") for surface in by_id["D9"]["primary_proof_surfaces"])
+
+for row in (by_id["D8"], by_id["D9"]):
+    for tracked_path in row["tracked_repo_paths"]:
+        assert (repo_root / tracked_path).exists(), tracked_path
+
+validation_commands = [item["command"] for item in validation["required_commands"]]
+assert "bash adl/tools/test_demo_v0891_wp13_demo_integration.sh" in validation_commands
+assert "bash adl/tools/test_demo_v0891_five_agent_hey_jude.sh" in validation_commands
+assert "bash adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh" in validation_commands
+
+assert rows["schema_version"] == "adl.v0891.wp13_demo_rows.v1"
+assert [row["demo_id"] for row in rows["rows"]] == ["D7", "D8", "D9"]
+PY
+
+grep -Fq "This packet makes D7, D8, and D9 reviewer-legible together" "$OUT_DIR/reviewer_brief.md" || {
+  echo "assertion failed: reviewer brief missing integration framing" >&2
+  exit 1
+}
+
+grep -Fq "WP-13 depends on WP-12" "$OUT_DIR/dependency_and_scope.md" || {
+  echo "assertion failed: dependency note missing WP-12 truth" >&2
+  exit 1
+}
+
+grep -Fq "consumes the merged WP-12 convergence surface" "$OUT_DIR/dependency_and_scope.md" || {
+  echo "assertion failed: dependency note missing merged WP-12 consumption truth" >&2
+  exit 1
+}
+
+if grep -R -E '/Users/|/private/tmp|/tmp/|Bearer |OPENAI_API_KEY|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|GITHUB_TOKEN' "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: private path or secret-like token leaked into generated artifacts" >&2
+  exit 1
+fi
+
+if grep -R -F "submitted to arXiv" "$OUT_DIR" >/dev/null 2>&1; then
+  echo "assertion failed: generated artifacts imply arXiv submission" >&2
+  exit 1
+fi
+
+echo "demo_v0891_wp13_demo_integration: ok"

--- a/demos/v0.89.1/arxiv_manuscript_workflow_demo.md
+++ b/demos/v0.89.1/arxiv_manuscript_workflow_demo.md
@@ -9,9 +9,9 @@ three-paper ADL publication program:
 
 The packet is intentionally honest about scope. The bounded
 `arxiv-paper-writer` contract belongs to WP-08 issue `#1929`, while WP-13 owns
-the final manuscript packet and publication follow-through. This demo therefore
-proves the source packet, role/order, review-gate, and manuscript-status shape
-without pretending final arXiv submission or completed manuscript delivery.
+the manuscript packet integration surface. This demo therefore proves the
+source packet, role/order, review-gate, and manuscript-status shape without
+pretending final arXiv submission.
 
 ## Command
 
@@ -43,8 +43,8 @@ artifacts/v0891/arxiv_manuscript_workflow/
 - The workflow role order is explicit before any future drafting step.
 - Claim boundaries are reviewable and separate repo-supported claims from future
   work.
-- The WP-08 writer contract and WP-13 manuscript boundary are recorded
-  truthfully instead of faking a full publication workflow.
+- The WP-08 writer contract and WP-13 manuscript packet boundary are recorded
+  truthfully instead of faking submission or publication.
 
 ## What It Does Not Claim
 
@@ -52,4 +52,4 @@ artifacts/v0891/arxiv_manuscript_workflow/
 - It does not claim submission-ready manuscripts.
 - It does not require private credentials, hidden chat transcripts, or local
   control-plane notes.
-- It does not complete WP-13 manuscript follow-through.
+- It does not submit or publish the papers.

--- a/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
+++ b/docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md
@@ -77,9 +77,9 @@ Additional environment / fixture requirements:
 | D4 | Self-attack scenario packet | `WP-06` self-attacking systems as architecture rather than rhetoric | `adl identity continuous-verification --out .adl/state/continuous_verification_self_attack_v1.json` | self-attack contract artifact with bounded layers, target/posture policy, and evidence/replay rules | reviewer can see the system's self-attack pattern before externalization and inspect the required evidence chain | scenario should remain posture-bounded and replay-legible | LANDED |
 | D5 | Flagship adversarial demo | `WP-07` full exploit -> replay -> mitigation -> promotion loop | `adl demo demo-h-v0891-adversarial-self-attack --run --trace --out .adl/reports/adversarial-demo --no-open` | `.adl/reports/adversarial-demo/demo-h-v0891-adversarial-self-attack/review_packet.json` | reviewer can answer what was attacked, how it was reproduced, what mitigation was applied, and whether replay post-fix succeeded | deterministic local replay compares the same request before and after mitigation | LANDED |
 | D6 | Operational skills substrate integration | `WP-08` - `WP-09` operational skills, composition, and bounded governance follow-through | `adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json`, `adl identity skill-composition --out .adl/state/skill_composition_model_v1.json`, and `adl identity delegation-refusal-coordination --out .adl/state/delegation_refusal_coordination_v1.json` | substrate/composition/governance contract packets | reviewer can see that adversarial work runs through explicit skill/composition surfaces with bounded delegation, refusal, approval-gate, and coordination outcomes | orchestration structure and governance outcome taxonomy should be deterministic even if node outputs remain stochastic | LANDED |
-| D7 | Reviewer-facing security proof package | `WP-10` - `WP-13` packaging convergence, milestone convergence, and integration demos | `adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json` and `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json` | provider-extension packaging packet + demo proof entry-point packet | reviewer can inspect milestone claims, carry-forward boundaries, and proof surfaces as one coherent package | `WP-10` and `WP-11` proof packets are deterministic; `WP-13` integration demos remain later work | PARTIAL |
-| D8 | Five-Agent Hey Jude MIDI demo | `WP-08` - `WP-10`, `WP-13` cross-provider coordination, human-in-the-loop orchestration, and integration delight surface | planned `WP-08` / `WP-13` coordination demo entry point | Hey Jude coordination packet + MIDI control trace + provider participation summary | reviewer can see one human plus four providers coordinating on one ADL runtime with explicit orchestration boundaries | bounded score/input should preserve composition shape, participant roles, and MIDI event ordering where declared | PLANNED |
-| D9 | ArXiv manuscript workflow packet | `WP-08`, `WP-13` bounded `arxiv-paper-writer` skill plus the initial three-paper publication program | `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh` | `artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json` | reviewer can see the bounded manuscript workflow packet for What Is ADL?, Gödel Agents and ADL, and Cognitive Spacetime Manifold without losing claim discipline or hiding the WP-08/WP-13 boundary | packet generation is deterministic; bounded source packets preserve role order, section structure, and packet shape | READY |
+| D7 | Reviewer-facing security proof package | `WP-10` - `WP-13` packaging convergence, milestone convergence, and integration demos | `adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json`, `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json`, and `bash adl/tools/demo_v0891_wp13_demo_integration.sh` | provider-extension packaging packet + demo proof entry-point packet + WP-13 integration manifest | reviewer can inspect milestone claims, carry-forward boundaries, D8, and D9 as one coherent package | identity packets and the WP-13 integration packet are deterministic; heavyweight child demos remain replayable through their own test commands | LANDED |
+| D8 | Five-Agent Hey Jude MIDI demo | `WP-08` - `WP-10`, `WP-13` cross-provider coordination, human-in-the-loop orchestration, and integration delight surface | `bash adl/tools/demo_v0891_five_agent_hey_jude.sh` | `artifacts/v0891/five_agent_hey_jude/performance_manifest.json` plus MIDI and participation artifacts | reviewer can see one human plus four providers coordinating on one ADL runtime with explicit orchestration boundaries | fixture-backed MVAVE Chocolate events preserve cue order and artifact shape | LANDED |
+| D9 | ArXiv manuscript workflow packet | `WP-08`, `WP-13` bounded `arxiv-paper-writer` skill plus the initial three-paper publication program | `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh` | `artifacts/v0891/arxiv_manuscript_workflow/demo_manifest.json` plus `manuscript_status/three_paper_status.json` | reviewer can see the bounded manuscript workflow packet for What Is ADL?, Gödel Agents and ADL, and Cognitive Spacetime Manifold without losing claim discipline or hiding the WP-08/WP-13 boundary | packet generation is deterministic; bounded source packets preserve role order, section structure, packet shape, and no-submission boundary | LANDED |
 
 Status guidance:
 - `PLANNED` = intended but not yet validated
@@ -91,9 +91,9 @@ Status guidance:
 Current planning truth:
 - the `v0.89.1` issue wave is open
 - rows `D1` through `D6` are landed from `WP-02` - `WP-09`
-- row `D7` is partial because the `WP-10` and `WP-11` proof packets exist, while `WP-12` / `WP-13` release-tail packaging is still active
-- row `D8` remains planned for `WP-13`
-- row `D9` is ready as a bounded manuscript workflow packet, with final three-paper manuscript convergence still owned by `WP-13`
+- row `D7` is landed through the `WP-10` / `WP-11` proof packets, `WP-12` convergence, and the `WP-13` integration packet
+- row `D8` is landed as a bounded five-agent Hey Jude MIDI integration demo
+- row `D9` is landed as a bounded manuscript workflow packet with final arXiv submission still out of scope
 - this matrix is a convergence surface for review-tail execution, not permission to claim later demo work before it exists
 
 Heavyweight proof-package rule:
@@ -338,26 +338,30 @@ Entry point:
 ```bash
 adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json
 adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json
+bash adl/tools/demo_v0891_wp13_demo_integration.sh
 ```
 
 Expected artifacts:
 - provider extension packaging contract packet
 - demo proof entry-point packet
+- WP-13 demo integration manifest
 - reviewer-facing adversarial/replay/trust packet index
 - milestone convergence and carry-forward note
 
 Primary proof surface:
 - `.adl/state/provider_extension_packaging_v1.json`
 - `.adl/state/demo_proof_entry_points_v1.json`
+- `artifacts/v0891/wp13_demo_integration/integration_manifest.json`
 
 Expected success signals:
 - reviewer can inspect the milestone as one coherent adversarial/runtime package
 - boundary with `v0.89` remains explicit and defensible
 - provider-security extension work is visible as deferred rather than silently promoted
+- D8 and D9 have runnable/testable proof entries rather than planned placeholders
 
 Known limits / caveats:
 - this is a heavyweight proof package and should not be confused with a quick demo row
-- `WP-11` lands the proof entry-point package, while `WP-13` still owns broader integration demo convergence
+- `WP-12` convergence has landed; `WP-13` consumes that convergence rather than closing or replacing WP-12
 - `WP-10` does not implement provider attestation, trust scoring, network posture enforcement, secret lifecycle enforcement, provider sandboxing, or external provider-security demos
 
 ---
@@ -374,35 +378,44 @@ Milestone claims / work packages covered:
 - `WP-10`
 - `WP-13`
 
-Planned entry point:
+Entry point:
 
 ```bash
-Defined when the official coordination/integration demo issues land.
+bash adl/tools/demo_v0891_five_agent_hey_jude.sh
 ```
 
 Expected artifacts:
-- Hey Jude coordination packet
-- MIDI control trace or event summary
-- provider participation and orchestration packet
-- reviewer-facing integration summary
+- `artifacts/v0891/five_agent_hey_jude/performance_manifest.json`
+- `artifacts/v0891/five_agent_hey_jude/cast.json`
+- `artifacts/v0891/five_agent_hey_jude/section_plan.json`
+- `artifacts/v0891/five_agent_hey_jude/cue_timeline.json`
+- `artifacts/v0891/five_agent_hey_jude/transcript.md`
+- `artifacts/v0891/five_agent_hey_jude/midi_event_log.json`
+- `artifacts/v0891/five_agent_hey_jude/provider_participation_summary.json`
+- `artifacts/v0891/five_agent_hey_jude/runtime/runs/v0-89-1-five-agent-hey-jude-midi-demo/run_summary.json`
 
 Primary proof surface:
-- five-agent Hey Jude demo packet
+- five-agent Hey Jude demo packet under `artifacts/v0891/five_agent_hey_jude/`
 
 Expected success signals:
 - reviewer can see human-in-the-loop orchestration rather than passive provider fan-out
 - cross-provider participation is explicit and bounded
 - the demo is charming without becoming structurally vague
 
+Validation:
+
+```bash
+bash adl/tools/test_demo_v0891_five_agent_hey_jude.sh
+```
+
 Source planning inputs:
 - `docs/planning/NEXT_MILESTONE_DEMO_CANDIDATES.md`
-- local Hey Jude planning memo
-- local Hey Jude implementation plan
-- local next-milestone candidate note
+- bounded demo doc: `demos/v0.89.1/five_agent_hey_jude_midi_demo.md`
 
 Known limits / caveats:
 - this row is a flagship delight/integration surface, not the core exploit/replay proof row
 - it should remain bounded and reviewer-legible rather than turning into an open-ended performance artifact
+- it uses section cues rather than storing a full lyric sheet in tracked repo artifacts
 
 ---
 
@@ -443,7 +456,13 @@ Expected success signals:
 - the paper workflow preserves claim discipline and distinguishes repo truth from future direction
 - the milestone can show real manuscript progress without pretending autonomous publication
 
+Validation:
+
+```bash
+bash adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh
+```
+
 Known limits / caveats:
 - this row is about bounded drafting and review workflow, not automatic submission or unverifiable authorship claims
-- WP-08 defines the writer skill and composition boundary; WP-13 still owns the three-paper manuscript status packet and publication follow-through
+- WP-08 defines the writer skill and composition boundary; WP-13 lands the three-paper manuscript status packet while leaving final arXiv submission out of scope
 - the WP-08 proof hooks are `adl identity operational-skills --out .adl/state/operational_skills_substrate_v1.json` and `adl identity skill-composition --out .adl/state/skill_composition_model_v1.json`

--- a/docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md
+++ b/docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md
@@ -64,8 +64,13 @@ WP-11 makes the demo matrix copy/paste-ready by collecting the landed adversaria
 WP-12 convergence note:
 - the promoted feature-doc band is considered landed through `WP-11`
 - remaining `v0.89.1` work should consume these feature docs as source-of-truth proof surfaces rather than reopening their scope
-- `WP-13` still owns integration demos, the five-agent Hey Jude demo, and the three-paper manuscript packet
+- `WP-13` consumes this convergence in the integration demo package, five-agent Hey Jude demo, and three-paper manuscript packet
 - full provider-security extension, broader long-lived-agent runtime work, and later governance/identity themes remain follow-on scope outside this milestone
+
+WP-13 proof hook:
+- `bash adl/tools/demo_v0891_wp13_demo_integration.sh`
+
+WP-13 lands the D7/D8/D9 integration packet, the five-agent Hey Jude MIDI demo, and the bounded three-paper manuscript workflow packet. It records the no-submission boundary for the publication track and consumes the merged WP-12 convergence state without reopening feature scope.
 
 ## Source Planning Corpus -> Implementation Home
 

--- a/docs/milestones/v0.89.1/README.md
+++ b/docs/milestones/v0.89.1/README.md
@@ -126,6 +126,9 @@ Additional validation surfaces:
 - adversarial runtime traces and reviewer-facing demo packets
 - provider extension packaging proof: `adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json`
 - demo proof entry-point package: `adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json`
+- WP-13 demo integration package: `bash adl/tools/demo_v0891_wp13_demo_integration.sh`
+- five-agent Hey Jude MIDI demo: `bash adl/tools/demo_v0891_five_agent_hey_jude.sh`
+- three-paper manuscript workflow packet: `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh`
 - quality-gate and review issue outputs
 
 Success criteria:

--- a/docs/milestones/v0.89.1/SPRINT_v0.89.1.md
+++ b/docs/milestones/v0.89.1/SPRINT_v0.89.1.md
@@ -83,6 +83,7 @@ Close the milestone using the normal ADL pattern: demos, quality gate, docs/revi
 ### Exit Criteria
 - reviewer-facing proof surfaces exist for the core `v0.89.1` claims
 - reviewer-legible manuscript packets exist for the three-paper arXiv slate
+- WP-13 demo integration is reproducible through `bash adl/tools/demo_v0891_wp13_demo_integration.sh`
 - accepted review findings are remediated or explicitly deferred
 - release and next-milestone handoff are explicit and bounded
 - quality, docs, and release surfaces are consistent with delivered work


### PR DESCRIPTION
Closes #1934

## Summary
WP-13 landed a bounded demo-integration package for the `v0.89.1` proof story. The work moves D7/D8/D9 from mixed partial/planned/ready status to reviewer-legible landed status, adds a deterministic WP-13 integration packet generator, keeps the five-agent Hey Jude MIDI and arXiv manuscript workflow demos runnable/testable, and updates the CLI proof-entry contract so docs and machine-readable proof surfaces agree.

Dependency truth: issue `#1933` / WP-12 merged while WP-13 was being prepared. This branch was rebased onto the merged WP-12 convergence state before publication.

## Artifacts
- `adl/tools/demo_v0891_wp13_demo_integration.sh`
- `adl/tools/test_demo_v0891_wp13_demo_integration.sh`
- Updated `adl identity demo-proof-entry-points` contract rows for D7, D8, and D9.
- Updated D9 manuscript workflow packet semantics so WP-13 owns the review-ready manuscript packet while final arXiv submission remains out of scope.
- Updated milestone docs: `DEMO_MATRIX_v0.89.1.md`, `FEATURE_DOCS_v0.89.1.md`, `README.md`, and `SPRINT_v0.89.1.md`.

## CI Janitor
- Fixed post-publish `adl-ci` clippy failures by replacing success-ratio manual zero-division guards with `checked_div` in `adl/src/execute/state/runtime_control.rs` and `adl/src/cli/run_artifacts/summary.rs` while preserving existing zero-step defaults.

## Validation
- `cargo fmt --manifest-path adl/Cargo.toml`
- `bash -n adl/tools/demo_v0891_wp13_demo_integration.sh`
- `bash -n adl/tools/test_demo_v0891_wp13_demo_integration.sh`
- `bash adl/tools/test_demo_v0891_wp13_demo_integration.sh`
- `bash adl/tools/test_demo_v0891_arxiv_manuscript_workflow.sh`
- `cargo test --manifest-path adl/Cargo.toml demo_proof_entry_points --quiet`
- `bash adl/tools/test_demo_v0891_five_agent_hey_jude.sh`
- Rebase validation reran the WP-13 focused demo and proof-entry checks after WP-12 merged.
- CI janitor validation reran `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`, `cargo test --manifest-path adl/Cargo.toml runtime_control --quiet`, `cargo test --manifest-path adl/Cargo.toml run_artifacts --quiet`, and `bash adl/tools/test_demo_v0891_wp13_demo_integration.sh`.
- Pattern search checked for remaining nearby zero-guarded division forms after the CI-only clippy failures.

## Local Artifacts
- Input card: `.adl/v0.89.1/tasks/issue-1934__v0-89-1-wp-13-demo-matrix-and-integration-demos/sip.md`
- Output card: `.adl/v0.89.1/tasks/issue-1934__v0-89-1-wp-13-demo-matrix-and-integration-demos/sor.md`
