### PR TITLE
[v0.89.1][security] Require trusted key source for run signature enforcement

### DIFF
--- a/adl/src/cli/run.rs
+++ b/adl/src/cli/run.rs
@@ -31,6 +31,8 @@ pub(crate) fn run_workflow(args: &[String]) -> Result<()> {
     let mut quiet = false;
     let mut do_open = false;
     let mut allow_unsigned = false;
+    let mut allow_embedded_signature_key = false;
+    let mut signature_key_path: Option<PathBuf> = None;
     let mut resume_path: Option<PathBuf> = None;
     let mut steer_path: Option<PathBuf> = None;
     let mut overlay_path: Option<PathBuf> = None;
@@ -82,6 +84,16 @@ pub(crate) fn run_workflow(args: &[String]) -> Result<()> {
             "--quiet" | "--no-step-output" => quiet = true,
             "--open" | "--open-artifacts" => do_open = true,
             "--allow-unsigned" => allow_unsigned = true,
+            "--allow-embedded-signature-key" => allow_embedded_signature_key = true,
+            "--signature-key" => {
+                let Some(path) = args.get(i + 1) else {
+                    eprintln!("--signature-key requires a public key path");
+                    eprintln!("{}", usage());
+                    std::process::exit(2);
+                };
+                signature_key_path = Some(PathBuf::from(path));
+                i += 1;
+            }
             "--help" | "-h" => {
                 println!("{}", usage());
                 return Ok(());
@@ -130,7 +142,22 @@ pub(crate) fn run_workflow(args: &[String]) -> Result<()> {
         || std::env::var("ADL_ALLOW_UNSIGNED")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-    enforce_signature_policy(&doc, do_run, allow_unsigned)?;
+    let allow_embedded_signature_key = allow_embedded_signature_key
+        || std::env::var("ADL_ALLOW_EMBEDDED_SIGNATURE_KEY")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+    let signature_key_path = signature_key_path.or_else(|| {
+        std::env::var_os("ADL_SIGNATURE_KEY")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    });
+    enforce_signature_policy(
+        &doc,
+        do_run,
+        allow_unsigned,
+        signature_key_path.as_deref(),
+        allow_embedded_signature_key,
+    )?;
 
     let resolved = match resolve::resolve_run(&doc) {
         Ok(resolved) => resolved,
@@ -455,7 +482,19 @@ pub(crate) fn real_resume(args: &[String]) -> Result<()> {
     let allow_unsigned = std::env::var("ADL_ALLOW_UNSIGNED")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-    enforce_signature_policy(&doc, true, allow_unsigned)?;
+    let allow_embedded_signature_key = std::env::var("ADL_ALLOW_EMBEDDED_SIGNATURE_KEY")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let signature_key_path = std::env::var_os("ADL_SIGNATURE_KEY")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    enforce_signature_policy(
+        &doc,
+        true,
+        allow_unsigned,
+        signature_key_path.as_deref(),
+        allow_embedded_signature_key,
+    )?;
 
     let resolved = resolve::resolve_run(&doc)?;
     validate_pause_artifact_for_resume(&pause_artifact, run_id, &resolved)?;
@@ -584,10 +623,27 @@ pub(crate) fn enforce_signature_policy(
     doc: &adl::AdlDoc,
     do_run: bool,
     allow_unsigned: bool,
+    public_key_path: Option<&Path>,
+    allow_embedded_signature_key: bool,
 ) -> Result<()> {
     if do_run && doc.version.trim() == "0.5" && !allow_unsigned {
-        signing::verify_doc(doc, None)
-            .with_context(|| "signature enforcement failed (use --allow-unsigned for dev)")?;
+        let allowed_key_sources = if allow_embedded_signature_key {
+            vec![
+                signing::VerificationKeySource::Embedded,
+                signing::VerificationKeySource::ExplicitKey,
+            ]
+        } else {
+            vec![signing::VerificationKeySource::ExplicitKey]
+        };
+        let profile = signing::VerificationProfile {
+            require_signature: true,
+            require_key_id: false,
+            allowed_algs: vec!["ed25519".to_string()],
+            allowed_key_sources,
+        };
+        signing::verify_doc_with_profile(doc, public_key_path, &profile).with_context(|| {
+            "signature enforcement failed (use --signature-key <public_key_path> for trusted runtime verification, --allow-embedded-signature-key for dev self-signed workflows, or --allow-unsigned for unsigned dev runs)"
+        })?;
     }
     Ok(())
 }

--- a/adl/src/cli/tests/run_state/basics.rs
+++ b/adl/src/cli/tests/run_state/basics.rs
@@ -45,7 +45,9 @@ fn enforce_signature_policy_skips_when_not_running_or_not_v0_5() {
         },
     };
 
-    enforce_signature_policy(&mk_doc("0.5"), false, false).expect("do_run=false should skip");
-    enforce_signature_policy(&mk_doc("0.4"), true, false).expect("v0.4 should skip");
-    enforce_signature_policy(&mk_doc("0.5"), true, true).expect("allow_unsigned should skip");
+    enforce_signature_policy(&mk_doc("0.5"), false, false, None, false)
+        .expect("do_run=false should skip");
+    enforce_signature_policy(&mk_doc("0.4"), true, false, None, false).expect("v0.4 should skip");
+    enforce_signature_policy(&mk_doc("0.5"), true, true, None, false)
+        .expect("allow_unsigned should skip");
 }

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -31,7 +31,7 @@ pub fn usage() -> &'static str {
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]
   adl pr run <issue> [--prefix <prefix>] [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>] [--allow-open-pr-wave]
-  adl pr run <adl.yaml> [--trace] [--allow-unsigned] [--runs-root <dir>] [--out <dir>]
+  adl pr run <adl.yaml> [--trace] [--signature-key <public_key_path>] [--allow-embedded-signature-key] [--allow-unsigned] [--runs-root <dir>] [--out <dir>]
   adl pr doctor <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue] [--mode full|ready|preflight] [--json]
   adl pr finish <issue> --title <title> [--body <text>] [--paths <csv>] [-f|--input <path>] [--output-card <path>] [--no-checks] [--no-close] [--ready] [--merge] [--no-open]
   adl pr closeout <issue> [--slug <slug>] [--version <v>] [--no-fetch-issue]
@@ -58,6 +58,10 @@ Options:
   --quiet            Suppress per-step output bodies (--no-step-output also accepted)
   --open             Open the first written HTML artifact after a successful run
   --no-open          Disable artifact auto-open for demo runs
+  --signature-key <path>
+                    Verify signed runtime workflows against this trusted public key
+  --allow-embedded-signature-key
+                    Allow embedded self-signed workflow keys (dev-only override)
   --allow-unsigned   Allow running unsigned workflows (dev-only override)
   -V, --version      Show the ADL CLI version
   -h, --help         Show this help

--- a/adl/tests/signing_tests.rs
+++ b/adl/tests/signing_tests.rs
@@ -250,7 +250,7 @@ fn run_enforces_signature_by_default_and_allows_override() {
 }
 
 #[test]
-fn signed_run_executes_without_allow_unsigned() {
+fn signed_run_requires_trusted_signature_key_by_default() {
     let base = tmp_dir("sign-enforce-signed");
     let _bin = write_mock_ollama(&base);
     let _path_guard = EnvVarGuard::set("PATH", prepend_path(&base));
@@ -272,8 +272,83 @@ fn signed_run_executes_without_allow_unsigned() {
 
     let out = run_swarm(&[signed.to_str().unwrap(), "--run"]);
     assert!(
+        !out.status.success(),
+        "signed run with only an embedded key should not satisfy runtime trust by default"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("SIGN_POLICY_DISALLOWED_KEY_SOURCE"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--signature-key"),
+        "stderr should guide operator toward trusted key source:\n{stderr}"
+    );
+}
+
+#[test]
+fn signed_run_executes_with_explicit_trusted_signature_key() {
+    let base = tmp_dir("sign-enforce-explicit-key");
+    let _bin = write_mock_ollama(&base);
+    let _path_guard = EnvVarGuard::set("PATH", prepend_path(&base));
+    let unsigned = write_unsigned_fixture(&base);
+    let key_dir = base.join(".keys");
+    let signed = base.join("signed.adl.yaml");
+
+    let keygen = run_swarm(&["keygen", "--out-dir", key_dir.to_str().unwrap()]);
+    assert!(keygen.status.success());
+    let sign = run_swarm(&[
+        "sign",
+        unsigned.to_str().unwrap(),
+        "--key",
+        key_dir.join("ed25519-private.b64").to_str().unwrap(),
+        "--out",
+        signed.to_str().unwrap(),
+    ]);
+    assert!(sign.status.success(), "sign failed");
+
+    let out = run_swarm(&[
+        signed.to_str().unwrap(),
+        "--run",
+        "--signature-key",
+        key_dir.join("ed25519-public.b64").to_str().unwrap(),
+    ]);
+    assert!(
         out.status.success(),
-        "signed run should pass without --allow-unsigned:\n{}",
+        "signed run should pass with an explicit trusted key:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn signed_run_executes_with_explicit_embedded_key_dev_override() {
+    let base = tmp_dir("sign-enforce-embedded-dev");
+    let _bin = write_mock_ollama(&base);
+    let _path_guard = EnvVarGuard::set("PATH", prepend_path(&base));
+    let unsigned = write_unsigned_fixture(&base);
+    let key_dir = base.join(".keys");
+    let signed = base.join("signed.adl.yaml");
+
+    let keygen = run_swarm(&["keygen", "--out-dir", key_dir.to_str().unwrap()]);
+    assert!(keygen.status.success());
+    let sign = run_swarm(&[
+        "sign",
+        unsigned.to_str().unwrap(),
+        "--key",
+        key_dir.join("ed25519-private.b64").to_str().unwrap(),
+        "--out",
+        signed.to_str().unwrap(),
+    ]);
+    assert!(sign.status.success(), "sign failed");
+
+    let out = run_swarm(&[
+        signed.to_str().unwrap(),
+        "--run",
+        "--allow-embedded-signature-key",
+    ]);
+    assert!(
+        out.status.success(),
+        "explicit embedded-key dev override should preserve self-signed workflow runs:\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
 }


### PR DESCRIPTION
Closes #1994

## Summary
Runtime signature enforcement now separates cryptographic integrity from trusted provenance. `adl run` requires a trusted explicit public key by default for signed v0.5 workflows, while embedded self-signed keys require the explicit dev-only `--allow-embedded-signature-key` opt-in. Unsigned dev runs remain gated behind the existing `--allow-unsigned` override.

This remediates WP-16 internal review finding F1.

## Artifacts
- Code changes in `adl/src/cli/run.rs`.
- CLI usage update in `adl/src/cli/usage.rs`.
- Regression tests in `adl/tests/signing_tests.rs`.
- Updated internal unit-test call site in `adl/src/cli/tests/run_state/basics.rs`.

## Validation
- Validation commands and their purpose:
  - `cargo fmt -- --check`: verified the Rust source and test formatting.
  - `cargo test --test signing_tests -- --nocapture`: verified signing CLI behavior, including default rejection of embedded keys, trusted explicit-key success, embedded-key dev override success, unsigned default failure, and unsigned dev override success.
  - `cargo test cli::tests::run_state::basics::enforce_signature_policy_skips_when_not_running_or_not_v0_5 --lib -- --nocapture`: compiled the updated internal enforcement call path; no matching public unit test executed under that filter.
- Results: formatting passed; `signing_tests` passed 13/13; the narrow internal unit filter compiled successfully but ran zero tests.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1994__v0-89-1-security-require-trusted-key-source-for-run-signature-enforcement/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1994__v0-89-1-security-require-trusted-key-source-for-run-signature-enforcement/sor.md
- Idempotency-Key: v0-89-1-security-require-trusted-key-source-for-run-signature-enforcement-adl-src-cli-run-rs-adl-src-cli-usage-rs-adl-src-cli-tests-run-state-basics-rs-adl-tests-signing-tests-rs-adl-v0-89-1-tasks-issue-1994-v0-89-1-security-require-trusted-key-source-for-run-signature-enforcement-sip-md-adl-v0-89-1-tasks-issue-1994-v0-89-1-security-require-trusted-key-source-for-run-signature-enforcement-sor-md