### PR TITLE
[v0.89.1][runtime] Make provider error truncation UTF-8 safe

### DIFF
--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -40,13 +40,22 @@ fn acquire_invocation_artifact_lock(path: &Path) -> std::io::Result<InvocationAr
     ))
 }
 
-fn truncate_provider_body(text: &str) -> &str {
+const MAX_PROVIDER_ERROR_BODY_BYTES: usize = 200;
+
+fn truncate_provider_body(text: &str) -> String {
     let trimmed = text.trim();
-    if trimmed.len() > 200 {
-        &trimmed[..200]
-    } else {
-        trimmed
+    if trimmed.len() <= MAX_PROVIDER_ERROR_BODY_BYTES {
+        return trimmed.to_string();
     }
+
+    let end = trimmed
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .chain(std::iter::once(trimmed.len()))
+        .take_while(|idx| *idx <= MAX_PROVIDER_ERROR_BODY_BYTES)
+        .last()
+        .unwrap_or(0);
+    trimmed[..end].to_string()
 }
 
 fn provider_http_json(
@@ -555,12 +564,6 @@ impl Provider for HttpProvider {
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().unwrap_or_default();
-            let trimmed = text.trim();
-            let trimmed = if trimmed.len() > 200 {
-                &trimmed[..200]
-            } else {
-                trimmed
-            };
             let class = if status.is_client_error() {
                 "client_error"
             } else if status.is_server_error() {
@@ -568,7 +571,10 @@ impl Provider for HttpProvider {
             } else {
                 "http_error"
             };
-            let msg = format!("kind={class} status={status} body={trimmed}");
+            let msg = format!(
+                "kind={class} status={status} body={}",
+                truncate_provider_body(&text)
+            );
             if status.is_client_error() {
                 return Err(runtime_error_non_retryable("http", msg));
             }

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -531,6 +531,12 @@ fn helper_validation_and_extraction_paths_are_exercised() {
     assert_eq!(truncate_provider_body(&long_text).len(), 200);
     assert_eq!(truncate_provider_body("  short body  "), "short body");
 
+    let multibyte_boundary = format!("{}étail", "x".repeat(199));
+    let truncated = truncate_provider_body(&multibyte_boundary);
+    assert_eq!(truncated.len(), 199);
+    assert_eq!(truncated.chars().count(), 199);
+    assert!(truncated.ends_with('x'));
+
     assert_eq!(
         extract_openai_output_text(&json!({
             "output": [{"content": [{"text": ""}, {"text": " useful " }]}]


### PR DESCRIPTION
Closes #1995

## Summary
Provider HTTP error-body truncation is now UTF-8 safe. The shared provider error helper keeps the same 200-byte preview budget but chooses a valid character boundary before slicing, preventing multibyte response text from panicking during error formatting.

This remediates WP-16 internal review finding F2.

## Artifacts
- Code change in `adl/src/provider/http_family.rs`.
- Regression coverage in `adl/src/provider/http_family/tests.rs`.

## Validation
- Validation commands and their purpose:
  - `cargo fmt -- --check`: verified formatting.
  - `cargo test provider::http_family::tests::helper_validation_and_extraction_paths_are_exercised --lib -- --nocapture`: verified helper behavior including multibyte boundary-safe truncation.
  - `cargo test --test provider_tests http_provider_long_error_body_is_truncated_deterministically -- --nocapture`: verified the existing provider error truncation regression still passes.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1995__v0-89-1-runtime-make-provider-error-truncation-utf-8-safe/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1995__v0-89-1-runtime-make-provider-error-truncation-utf-8-safe/sor.md
- Idempotency-Key: v0-89-1-runtime-make-provider-error-truncation-utf-8-safe-adl-src-provider-http-family-rs-adl-src-provider-http-family-tests-rs-adl-v0-89-1-tasks-issue-1995-v0-89-1-runtime-make-provider-error-truncation-utf-8-safe-sip-md-adl-v0-89-1-tasks-issue-1995-v0-89-1-runtime-make-provider-error-truncation-utf-8-safe-sor-md