### PR TITLE
[v0.89.1][security] Bind provider credentials to trusted endpoints

### DIFF
--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 
 mod config;
 
-use config::{auth_env_for, ollama_generate_endpoint, vendor_endpoint, HttpAuth};
+use config::{
+    auth_env_for, ollama_generate_endpoint, validate_http_credential_endpoint,
+    validate_vendor_credential_endpoint, vendor_endpoint, HttpAuth,
+};
 pub(crate) use config::{cfg_u64, timeout_secs};
 
 struct InvocationArtifactLock {
@@ -241,9 +244,19 @@ impl OpenAiProvider {
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,
     ) -> Result<Self> {
+        let endpoint = vendor_endpoint(spec, target, OPENAI_RESPONSES_ENDPOINT, "openai")?;
+        let auth_env = auth_env_for(spec, "OPENAI_API_KEY")?;
+        validate_vendor_credential_endpoint(
+            spec,
+            "openai",
+            &endpoint,
+            &auth_env,
+            "OPENAI_API_KEY",
+            &["api.openai.com"],
+        )?;
         Ok(Self {
-            endpoint: vendor_endpoint(spec, target, OPENAI_RESPONSES_ENDPOINT, "openai")?,
-            auth_env: auth_env_for(spec, "OPENAI_API_KEY")?,
+            endpoint,
+            auth_env,
             model: target.provider_model_id.clone(),
             max_output_tokens: cfg_u64(&spec.config, "max_output_tokens").unwrap_or(220),
             timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
@@ -298,9 +311,19 @@ impl AnthropicProvider {
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,
     ) -> Result<Self> {
+        let endpoint = vendor_endpoint(spec, target, ANTHROPIC_MESSAGES_ENDPOINT, "anthropic")?;
+        let auth_env = auth_env_for(spec, "ANTHROPIC_API_KEY")?;
+        validate_vendor_credential_endpoint(
+            spec,
+            "anthropic",
+            &endpoint,
+            &auth_env,
+            "ANTHROPIC_API_KEY",
+            &["api.anthropic.com"],
+        )?;
         Ok(Self {
-            endpoint: vendor_endpoint(spec, target, ANTHROPIC_MESSAGES_ENDPOINT, "anthropic")?,
-            auth_env: auth_env_for(spec, "ANTHROPIC_API_KEY")?,
+            endpoint,
+            auth_env,
             model: target.provider_model_id.clone(),
             max_tokens: cfg_u64(&spec.config, "max_tokens")
                 .or_else(|| cfg_u64(&spec.config, "max_output_tokens"))
@@ -485,6 +508,9 @@ impl HttpProvider {
         } else {
             None
         };
+        if auth.is_some() {
+            validate_http_credential_endpoint(cfg, &endpoint)?;
+        }
 
         Ok(Self {
             endpoint,

--- a/adl/src/provider/http_family/config.rs
+++ b/adl/src/provider/http_family/config.rs
@@ -5,6 +5,81 @@ pub(super) fn cfg_str<'a>(cfg: &'a HashMap<String, Value>, key: &str) -> Option<
     cfg.get(key).and_then(|v| v.as_str()).map(str::trim)
 }
 
+fn cfg_bool(cfg: &HashMap<String, Value>, key: &str, provider_label: &str) -> Result<bool> {
+    match cfg.get(key) {
+        None => Ok(false),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(invalid_config(
+            provider_label,
+            format!("config.{key} must be a boolean when provided"),
+        )),
+    }
+}
+
+fn endpoint_host(endpoint: &str) -> Option<String> {
+    Url::parse(endpoint)
+        .ok()
+        .and_then(|url| url.host_str().map(|host| host.to_ascii_lowercase()))
+}
+
+fn is_loopback_endpoint(endpoint: &str) -> bool {
+    matches!(
+        endpoint_host(endpoint).as_deref(),
+        Some("localhost") | Some("127.0.0.1") | Some("::1")
+    )
+}
+
+fn is_trusted_vendor_endpoint(endpoint: &str, trusted_hosts: &[&str]) -> bool {
+    let Some(host) = endpoint_host(endpoint) else {
+        return false;
+    };
+    trusted_hosts
+        .iter()
+        .any(|trusted| host == trusted.to_ascii_lowercase())
+}
+
+pub(super) fn validate_vendor_credential_endpoint(
+    spec: &adl::ProviderSpec,
+    provider_label: &str,
+    endpoint: &str,
+    auth_env: &str,
+    default_auth_env: &str,
+    trusted_hosts: &[&str],
+) -> Result<()> {
+    if is_loopback_endpoint(endpoint)
+        || is_trusted_vendor_endpoint(endpoint, trusted_hosts)
+        || cfg_bool(&spec.config, "trust_custom_endpoint", provider_label)?
+    {
+        return Ok(());
+    }
+
+    let env_hint = if auth_env == default_auth_env {
+        format!("default {default_auth_env}")
+    } else {
+        format!("configured {auth_env}")
+    };
+    Err(invalid_config(
+        provider_label,
+        format!(
+            "refusing to send {env_hint} credentials to untrusted endpoint '{endpoint}'; use the vendor endpoint, a loopback endpoint, or set config.trust_custom_endpoint: true for intentional custom credential endpoints"
+        ),
+    ))
+}
+
+pub(super) fn validate_http_credential_endpoint(
+    cfg: &HashMap<String, Value>,
+    endpoint: &str,
+) -> Result<()> {
+    if is_loopback_endpoint(endpoint) || cfg_bool(cfg, "trust_custom_endpoint", "http")? {
+        return Ok(());
+    }
+
+    Err(invalid_config(
+        "http",
+        "config.auth requires config.trust_custom_endpoint: true for non-loopback bearer endpoints",
+    ))
+}
+
 pub(super) fn auth_env_for(spec: &adl::ProviderSpec, default_env: &str) -> Result<String> {
     let Some(auth_val) = spec.config.get("auth") else {
         return Ok(default_env.to_string());

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -421,6 +421,58 @@ fn http_provider_complete_and_helper_errors_cover_status_and_validation() {
         .to_string()
         .contains("endpoint must use https://"));
 
+    let untrusted_openai_spec = provider_spec(
+        "openai",
+        "https://proxy.example.com/v1/responses",
+        Some("OPENAI_API_KEY"),
+        &[],
+    );
+    let untrusted_openai_err = OpenAiProvider::from_target(
+        &untrusted_openai_spec,
+        &provider_target(
+            "openai",
+            "https://proxy.example.com/v1/responses".to_string(),
+            "gpt-test",
+        ),
+    )
+    .expect_err("default OpenAI credentials should not go to untrusted remote endpoints");
+    assert!(untrusted_openai_err
+        .to_string()
+        .contains("config.trust_custom_endpoint"));
+
+    let mut trusted_openai_spec = untrusted_openai_spec.clone();
+    trusted_openai_spec
+        .config
+        .insert("trust_custom_endpoint".to_string(), json!(true));
+    OpenAiProvider::from_target(
+        &trusted_openai_spec,
+        &provider_target(
+            "openai",
+            "https://proxy.example.com/v1/responses".to_string(),
+            "gpt-test",
+        ),
+    )
+    .expect("explicitly trusted OpenAI custom endpoint should build");
+
+    let untrusted_anthropic_spec = provider_spec(
+        "anthropic",
+        "https://proxy.example.com/v1/messages",
+        Some("ANTHROPIC_API_KEY"),
+        &[],
+    );
+    let untrusted_anthropic_err = AnthropicProvider::from_target(
+        &untrusted_anthropic_spec,
+        &provider_target(
+            "anthropic",
+            "https://proxy.example.com/v1/messages".to_string(),
+            "claude-test",
+        ),
+    )
+    .expect_err("default Anthropic credentials should not go to untrusted remote endpoints");
+    assert!(untrusted_anthropic_err
+        .to_string()
+        .contains("config.trust_custom_endpoint"));
+
     assert_eq!(
         extract_openai_output_text(&json!({"output_text": "  openai inline  "})),
         Some("openai inline".to_string())
@@ -526,6 +578,36 @@ fn helper_validation_and_extraction_paths_are_exercised() {
     .expect_err("empty endpoint override should fail")
     .to_string()
     .contains("config.endpoint must not be empty"));
+
+    OpenAiProvider::from_target(
+        &default_spec,
+        &ProviderInvocationTargetV1 {
+            endpoint: None,
+            base_url: None,
+            ..provider_target("openai", String::new(), "gpt-test")
+        },
+    )
+    .expect("default OpenAI vendor endpoint should build with default credentials");
+
+    let mut bad_trust_flag = default_spec.clone();
+    bad_trust_flag
+        .config
+        .insert("trust_custom_endpoint".to_string(), json!("yes"));
+    bad_trust_flag.config.insert(
+        "endpoint".to_string(),
+        json!("https://proxy.example.com/v1/responses"),
+    );
+    assert!(OpenAiProvider::from_target(
+        &bad_trust_flag,
+        &provider_target(
+            "openai",
+            "https://proxy.example.com/v1/responses".to_string(),
+            "gpt-test"
+        )
+    )
+    .expect_err("non-boolean trust flag should fail")
+    .to_string()
+    .contains("config.trust_custom_endpoint must be a boolean"));
 
     let long_text = format!("  {}  ", "x".repeat(250));
     assert_eq!(truncate_provider_body(&long_text).len(), 200);
@@ -688,4 +770,21 @@ fn invocation_artifact_and_http_constructor_error_paths_are_exercised() {
         .expect_err("missing auth env should fail")
         .to_string()
         .contains("config.auth.env is required"));
+
+    let mut untrusted_bearer_spec = provider_spec(
+        "http",
+        "https://api.example.com/v1/complete",
+        Some("HTTP_API_KEY"),
+        &[],
+    );
+    assert!(HttpProvider::from_target(&untrusted_bearer_spec, &target)
+        .expect_err("remote bearer auth should require explicit endpoint trust")
+        .to_string()
+        .contains("config.trust_custom_endpoint: true"));
+
+    untrusted_bearer_spec
+        .config
+        .insert("trust_custom_endpoint".to_string(), json!(true));
+    HttpProvider::from_target(&untrusted_bearer_spec, &target)
+        .expect("explicitly trusted remote bearer endpoint should build");
 }


### PR DESCRIPTION
Closes #1996

## Summary
Implemented the WP-16 F3 provider credential trust boundary. Native OpenAI and Anthropic provider constructors now refuse to bind bearer credentials to non-loopback, non-vendor hosts unless `config.trust_custom_endpoint: true` is explicitly set. Generic HTTP bearer auth now requires the same explicit trust flag for non-loopback endpoints while preserving unauthenticated HTTPS and loopback test/local workflows.

## Artifacts
- Updated runtime provider credential trust policy in `adl/src/provider/http_family/config.rs`.
- Applied the trust policy from native OpenAI, native Anthropic, and generic HTTP provider constructors in `adl/src/provider/http_family.rs`.
- Added regression coverage in `adl/src/provider/http_family/tests.rs` for default vendor credentials, loopback preservation, untrusted custom endpoint rejection, explicit trust opt-in, malformed trust flags, and generic HTTP bearer-auth trust requirements.

## Validation
- Validation commands and their purpose:
  - `cargo fmt -- --check` verified Rust formatting after edits.
  - `cargo test provider::http_family::tests::helper_validation_and_extraction_paths_are_exercised --lib -- --nocapture` verified helper validation, default vendor endpoint behavior, malformed trust flag handling, and extraction helpers.
  - `cargo test provider::http_family::tests::http_provider_complete_and_helper_errors_cover_status_and_validation --lib -- --nocapture` verified native provider helper/error paths plus custom endpoint rejection and explicit trust opt-in.
  - `cargo test provider::http_family::tests::invocation_artifact_and_http_constructor_error_paths_are_exercised --lib -- --nocapture` verified generic HTTP constructor validation and bearer-auth trust requirements.
  - `cargo test --test provider_tests -- --nocapture` verified provider integration coverage, profile expansion, timeout handling, native provider translation, and HTTP provider behavior.
  - `cargo test provider::http_family::tests --lib -- --nocapture` verified the complete provider HTTP family unit-test module.
- Results: all listed validations passed.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1996__v0-89-1-security-bind-provider-credentials-to-trusted-endpoints/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1996__v0-89-1-security-bind-provider-credentials-to-trusted-endpoints/sor.md
- Idempotency-Key: v0-89-1-security-bind-provider-credentials-to-trusted-endpoints-adl-src-provider-http-family-config-rs-adl-src-provider-http-family-rs-adl-src-provider-http-family-tests-rs-adl-v0-89-1-tasks-issue-1996-v0-89-1-security-bind-provider-credentials-to-trusted-endpoints-sip-md-adl-v0-89-1-tasks-issue-1996-v0-89-1-security-bind-provider-credentials-to-trusted-endpoints-sor-md