### PR TITLE
[v0.89.1][runtime] Classify deterministic setup failures as non-retryable

### DIFF
--- a/adl/src/execute/runner.rs
+++ b/adl/src/execute/runner.rs
@@ -26,6 +26,36 @@ type StepJob = Box<dyn FnOnce() -> (String, Result<StepRunSuccess>) + Send>;
 pub const DELEGATION_POLICY_DENY_CODE: &str = "DELEGATION_POLICY_DENY";
 pub const DELEGATION_POLICY_APPROVAL_REQUIRED_CODE: &str = "DELEGATION_POLICY_APPROVAL_REQUIRED";
 
+#[derive(Debug)]
+struct DeterministicSetupError {
+    message: String,
+}
+
+impl DeterministicSetupError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for DeterministicSetupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for DeterministicSetupError {}
+
+fn deterministic_setup_error(message: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::new(DeterministicSetupError::new(message))
+}
+
+fn is_deterministic_setup_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<DeterministicSetupError>().is_some())
+}
+
 fn effective_prompt_with_defaults_from_doc(
     step: &crate::resolve::ResolvedStep,
     doc: &crate::adl::AdlDoc,
@@ -309,35 +339,44 @@ where
         let mut attempt_stream_chunks: Vec<String> = Vec::new();
         let result = (|| -> Result<StepRunSuccess> {
             let p = effective_prompt_with_defaults_from_doc(step, doc).ok_or_else(|| {
-                anyhow!(
+                deterministic_setup_error(format!(
                     "step '{}' has no effective prompt (step.prompt or task.prompt required)",
                     step_id
-                )
+                ))
             })?;
 
-            let merged_inputs = resolve_state_inputs(&step.id, &step.inputs, saved_state)
-                .with_context(|| format!("failed to resolve inputs for step '{}'", step_id))?;
+            let merged_inputs =
+                resolve_state_inputs(&step.id, &step.inputs, saved_state).map_err(|err| {
+                    err.context(DeterministicSetupError::new(format!(
+                        "failed to resolve inputs for step '{}'",
+                        step_id
+                    )))
+                })?;
             let missing = missing_prompt_inputs(&p, &merged_inputs);
             if !missing.is_empty() {
-                return Err(anyhow!(
+                return Err(deterministic_setup_error(format!(
                     "step '{}' missing input bindings for: {} (provide inputs or prior state)",
                     step_id,
                     missing.join(", ")
-                ));
+                )));
             }
 
-            let inputs = materialize_inputs(merged_inputs, adl_base_dir)
-                .with_context(|| format!("failed to materialize inputs for step '{}'", step_id))?;
+            let inputs = materialize_inputs(merged_inputs, adl_base_dir).map_err(|err| {
+                err.context(DeterministicSetupError::new(format!(
+                    "failed to materialize inputs for step '{}'",
+                    step_id
+                )))
+            })?;
 
             let prompt_text = prompt::trace_prompt_assembly(&p, &inputs);
             let prompt_hash = prompt::hash_prompt(&prompt_text);
             on_prompt_hash(&prompt_hash);
 
-            let spec = doc.providers.get(provider_id).with_context(|| {
-                format!(
+            let spec = doc.providers.get(provider_id).ok_or_else(|| {
+                deterministic_setup_error(format!(
                     "step '{}' references unknown provider '{}'",
                     step_id, provider_id
-                )
+                ))
             })?;
             let model_override = step
                 .agent
@@ -349,13 +388,12 @@ where
 
             let model_output = match placement {
                 crate::adl::PlacementMode::Local => {
+                    let build_context = DeterministicSetupError::new(format!(
+                        "failed to build provider '{}' for step '{}'",
+                        provider_id, step_id
+                    ));
                     let prov = provider::build_provider_for_id(provider_id, spec, model_override)
-                        .with_context(|| {
-                        format!(
-                            "failed to build provider '{}' for step '{}'",
-                            provider_id, step_id
-                        )
-                    })?;
+                        .map_err(|err| err.context(build_context))?;
                     let mut on_chunk = |chunk: &str| {
                         if capture_stream_chunks && !chunk.is_empty() {
                             attempt_stream_chunks.push(chunk.to_string());
@@ -444,7 +482,8 @@ where
             Ok(success) => return std::result::Result::Ok(success),
             Err(err) => {
                 last_stream_chunks = attempt_stream_chunks;
-                let retryable = provider::is_retryable_error(&err);
+                let retryable =
+                    !is_deterministic_setup_error(&err) && provider::is_retryable_error(&err);
                 last_err = Some(err);
                 if !retryable || attempt >= max_attempts {
                     break;

--- a/adl/src/execute/tests.rs
+++ b/adl/src/execute/tests.rs
@@ -99,6 +99,31 @@ fn remote_retry_step(max_attempts: u32) -> crate::resolve::ResolvedStep {
     }
 }
 
+fn local_retry_step(max_attempts: u32) -> crate::resolve::ResolvedStep {
+    crate::resolve::ResolvedStep {
+        id: "local-step".to_string(),
+        agent: None,
+        provider: Some("p1".to_string()),
+        placement: Some(PlacementMode::Local),
+        task: None,
+        call: None,
+        with: HashMap::new(),
+        as_ns: None,
+        delegation: None,
+        conversation: None,
+        prompt: Some(PromptSpec {
+            user: Some("hello".to_string()),
+            ..Default::default()
+        }),
+        inputs: HashMap::new(),
+        guards: vec![],
+        save_as: None,
+        write_to: None,
+        on_error: None,
+        retry: Some(StepRetry { max_attempts }),
+    }
+}
+
 fn delegated_step(id: &str) -> crate::resolve::ResolvedStep {
     crate::resolve::ResolvedStep {
         id: id.to_string(),
@@ -557,6 +582,63 @@ fn execute_step_with_retry_does_not_retry_remote_schema_violation() {
     assert_eq!(failure.attempts, 1);
     assert!(
         failure.err.to_string().contains("REMOTE_SCHEMA_VIOLATION"),
+        "unexpected error: {:#}",
+        failure.err
+    );
+}
+
+#[test]
+fn execute_step_with_retry_does_not_retry_missing_prompt_binding() {
+    let doc = minimal_resolved().doc;
+    let mut step = local_retry_step(3);
+    step.prompt = Some(PromptSpec {
+        user: Some("hello {{name}}".to_string()),
+        ..Default::default()
+    });
+
+    let failure = execute_step_with_retry_core(
+        &step,
+        &doc,
+        "run-1",
+        "wf-1",
+        &HashMap::new(),
+        std::path::Path::new("."),
+        false,
+        |_| {},
+    )
+    .expect_err("missing prompt binding should fail");
+
+    assert_eq!(failure.attempts, 1);
+    assert!(
+        failure.err.to_string().contains("missing input bindings"),
+        "unexpected error: {:#}",
+        failure.err
+    );
+}
+
+#[test]
+fn execute_step_with_retry_does_not_retry_unknown_provider_setup_failure() {
+    let doc = minimal_resolved().doc;
+    let step = local_retry_step(4);
+
+    let failure = execute_step_with_retry_core(
+        &step,
+        &doc,
+        "run-1",
+        "wf-1",
+        &HashMap::new(),
+        std::path::Path::new("."),
+        false,
+        |_| {},
+    )
+    .expect_err("unknown provider should fail");
+
+    assert_eq!(failure.attempts, 1);
+    assert!(
+        failure
+            .err
+            .to_string()
+            .contains("references unknown provider 'p1'"),
         "unexpected error: {:#}",
         failure.err
     );


### PR DESCRIPTION
Closes #1997

## Summary
Implemented the WP-16 F4 retry classification fix. The execution retry loop now marks deterministic setup failures with a typed internal error and refuses to retry them even when `retry.max_attempts` is greater than one. Transient provider and remote failures continue to use the existing provider/remote retryability classifiers.

## Artifacts
- Updated deterministic setup classification in `adl/src/execute/runner.rs`.
- Added regression tests in `adl/src/execute/tests.rs` for missing prompt bindings and unknown provider setup failures stopping after one attempt.

## Validation
- Validation commands and their purpose:
  - `cargo fmt -- --check` verified Rust formatting.
  - `cargo test execute::tests::execute_step_with_retry_does_not_retry_missing_prompt_binding --lib -- --nocapture` verified missing prompt binding failures stop after one attempt with a retry budget.
  - `cargo test execute::tests::execute_step_with_retry_does_not_retry_unknown_provider_setup_failure --lib -- --nocapture` verified unknown provider setup failures stop after one attempt with a retry budget.
  - `cargo test execute::tests::execute_step_with_retry_does_not_retry_remote_schema_violation --lib -- --nocapture` verified the existing deterministic remote schema failure remains non-retryable.
  - `cargo test execute::tests --lib -- --nocapture` verified the complete execute unit-test module.
  - `cargo test run_flows::run_http_retry_succeeds_on_second_attempt_after_5xx --test execute_tests -- --nocapture` verified transient HTTP provider failures still retry successfully.
- Results: all listed validations passed.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1997__v0-89-1-runtime-classify-deterministic-setup-failures-as-non-retryable/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1997__v0-89-1-runtime-classify-deterministic-setup-failures-as-non-retryable/sor.md
- Idempotency-Key: v0-89-1-runtime-classify-deterministic-setup-failures-as-non-retryable-adl-src-execute-runner-rs-adl-src-execute-tests-rs-adl-v0-89-1-tasks-issue-1997-v0-89-1-runtime-classify-deterministic-setup-failures-as-non-retryable-sip-md-adl-v0-89-1-tasks-issue-1997-v0-89-1-runtime-classify-deterministic-setup-failures-as-non-retryable-sor-md