### PR TITLE
[v0.89.1][docs] Add v0.90 planning lane handoff

### DIFF
--- a/docs/milestones/v0.90/EARLY_PLANNING_LANE_HANDOFF_v0.90.md
+++ b/docs/milestones/v0.90/EARLY_PLANNING_LANE_HANDOFF_v0.90.md
@@ -1,0 +1,112 @@
+# v0.90 Early Planning Lane Handoff
+
+## Purpose
+
+This handoff records the early v0.90 planning lane prepared during the v0.89.1
+release tail. It gives WP-19 a tracked review surface without promoting the
+entire local planning corpus prematurely.
+
+The local planning lane remains source material. WP-19 owns the final decision
+to promote, rewrite, split, or defer each planning surface before the release
+ceremony.
+
+## Current State
+
+Owner issue: #1986
+
+Related roadmap correction: #2006 / PR #2007
+
+Promotion gate: v0.89.1 WP-19
+
+Release ceremony dependency: v0.89.1 WP-20
+
+Status: ready for WP-19 reconciliation
+
+## Local Planning Corpus
+
+The local planning lane has the same shape as the intended milestone package:
+
+- root planning docs for v0.90
+- feature drafts
+- idea and backgrounder drafts
+- a local issue-wave YAML seed
+- an explicit planning inventory and WP-19 handoff note
+
+The local source material is not release truth by itself. It exists so WP-19 can
+move quickly without rediscovering the v0.90 story from chat history.
+
+## Reconciled Roadmap Boundary
+
+PR #2007 added the tracked Runtime v2 and birthday-boundary roadmap. WP-19
+should treat that roadmap as upstream of the v0.90 handoff:
+
+- v0.90 remains the long-lived bounded runtime milestone.
+- v0.90.1 owns the Runtime v2 foundation prototype.
+- v0.90.2 owns Runtime v2 hardening, invariant tests, violation artifacts,
+  recovery, and security-boundary proof surfaces.
+- v0.91 remains additive moral and emotional civilization work.
+- v0.92 owns the first true Gödel-agent birthday.
+
+This means v0.90 should not absorb the full Runtime v2, the full moral and
+emotional civilization package, or the first birth event. It should prepare the
+long-lived runtime band and make the follow-on sequence obvious.
+
+## Strong v0.90 Candidates
+
+These local planning surfaces are close to the v0.90 center of gravity and
+should be reviewed first by WP-19:
+
+- long-lived agent runtime feature set
+- supervisor heartbeat
+- agent cycle contract
+- state and continuity handles
+- operator control and safety
+- stock league long-lived agent demo
+- urgency and task prioritization, if narrowed to scheduling and supervision
+
+## Needs Scope Decision
+
+These are useful, but WP-19 should decide whether they belong in core v0.90,
+supporting scope, or a later band:
+
+- hypothesis engine reasoning graph
+- signed trace architecture
+- trace query language
+
+The practical question is whether v0.90 can include them without weakening the
+long-lived runtime milestone. If not, WP-19 should extract the minimal inspection
+requirements and defer the larger architectures.
+
+## Likely Later-Band Inputs
+
+These planning docs remain valuable, but probably should not be promoted as
+core v0.90 feature work:
+
+- cross-agent temporal alignment
+- temporal accountability
+- timeline forks and counterfactuals
+- later temporal and society cluster map
+
+They should receive explicit later-milestone or backlog placement instead of
+being silently carried forward.
+
+## WP-19 Homecoming Checklist
+
+WP-19 should complete the following before WP-20 release ceremony starts:
+
+- confirm the v0.90 milestone thesis
+- reconcile the v0.90 local planning lane with the Runtime v2 roadmap from PR #2007
+- decide which local feature drafts become tracked milestone feature docs
+- decide which local idea/backgrounder drafts become tracked ideas docs
+- rewrite or defer material that is too large or too future-facing
+- update the v0.90 WBS, sprint plan, demo matrix, checklist, release plan,
+  release notes, feature index, and issue-wave YAML together
+- ensure every promoted file has a work-package home
+- ensure every deferred file has an explicit later milestone or backlog home
+
+## Non-Goals
+
+- Do not treat this handoff as the final v0.90 milestone package.
+- Do not open the v0.90 issue wave from this handoff.
+- Do not promote local-only planning docs without WP-19 review.
+- Do not move the first true Gödel-agent birthday earlier than v0.92.

--- a/docs/milestones/v0.90/README.md
+++ b/docs/milestones/v0.90/README.md
@@ -80,6 +80,7 @@ Supporting / domain-specific docs:
 - {{supporting_doc_2}}
 - {{supporting_doc_3}}
 - Maintainability hotspot split plan: `docs/milestones/v0.90/MAINTAINABILITY_HOTSPOT_SPLIT_PLAN_v0.90.md`
+- Early planning lane handoff: `docs/milestones/v0.90/EARLY_PLANNING_LANE_HANDOFF_v0.90.md`
 
 ## Execution Model
 


### PR DESCRIPTION
Closes #1986

## Summary
Advanced the local-only v0.90 planning lane into a milestone-shaped draft package, then added a tracked handoff surface after PR #2007 landed so WP-19 can reconcile the local lane against the Runtime v2 roadmap and birthday-boundary decisions.

Issue #1986 is ready for PR review as the planning-lane wrapper. WP-19 remains responsible for promoting, rewriting, or deferring the underlying planning corpus before WP-20 release ceremony.

## Artifacts
- `.adl/docs/v0.90planning/README.md`
- `.adl/docs/v0.90planning/VISION_v0.90.md`
- `.adl/docs/v0.90planning/DESIGN_v0.90.md`
- `.adl/docs/v0.90planning/WBS_v0.90.md`
- `.adl/docs/v0.90planning/SPRINT_v0.90.md`
- `.adl/docs/v0.90planning/DECISIONS_v0.90.md`
- `.adl/docs/v0.90planning/FEATURE_DOCS_v0.90.md`
- `.adl/docs/v0.90planning/DEMO_MATRIX_v0.90.md`
- `.adl/docs/v0.90planning/MILESTONE_CHECKLIST_v0.90.md`
- `.adl/docs/v0.90planning/RELEASE_PLAN_v0.90.md`
- `.adl/docs/v0.90planning/RELEASE_NOTES_v0.90.md`
- `.adl/docs/v0.90planning/WP_ISSUE_WAVE_v0.90.yaml`
- `.adl/docs/v0.90planning/EARLY_PLANNING_LANE.md`
- `.adl/docs/v0.90planning/V090_PLANNING_INVENTORY_AND_WP19_HANDOFF.md`
- `.adl/docs/v0.90planning/features/README.md`
- `.adl/docs/v0.90planning/ideas/README.md`
- existing v0.90 source docs reorganized under `.adl/docs/v0.90planning/features/` and `.adl/docs/v0.90planning/ideas/`
- `docs/milestones/v0.90/EARLY_PLANNING_LANE_HANDOFF_v0.90.md`
- `docs/milestones/v0.90/README.md`

## Validation
- Validation commands and their purpose:
  - `adl/tools/pr.sh doctor 1986 --slug v0-89-1-docs-start-early-v0-90-planning-lane --version v0.89.1 --json` verified source prompt, cards, queue, preflight, and branch/worktree lifecycle state
  - `adl/tools/pr.sh run 1986 --slug v0-89-1-docs-start-early-v0-90-planning-lane --version v0.89.1` bound the issue worktree through the repo-native lifecycle
  - `find .adl/docs/v0.90planning -maxdepth 2 -type f` verified the local v0.90 package layout
  - `ruby -e 'require "yaml"; YAML.load_file(".adl/docs/v0.90planning/WP_ISSUE_WAVE_v0.90.yaml"); puts "yaml ok"'` verified YAML parseability
  - `rg -n '\{\{|\}\}' <local v0.90 root planning docs>` verified root planning docs do not still contain copied template placeholders
  - `git status --short --branch` verified the primary checkout remains clean on main for tracked files
  - a targeted path-leakage scan over the local root planning docs and issue-wave YAML found no absolute host path or issue-worktree markers
  - `git merge --ff-only origin/main` verified the issue branch could advance cleanly to current main after PR #2007
  - a path-leakage scan over the tracked v0.90 handoff docs found no local host paths, worktree paths, or ignored planning-doc path references
  - a roadmap contradiction scan over the tracked v0.90 handoff docs found no claims that v0.90 or v0.91 owns the first true birthday
- Results:
  - all validation checks passed
  - the early planning lane remains local source material
  - tracked handoff docs are ready for PR review

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-1986__v0-89-1-docs-start-early-v0-90-planning-lane/sip.md
- Output card: .adl/v0.89.1/tasks/issue-1986__v0-89-1-docs-start-early-v0-90-planning-lane/sor.md
- Idempotency-Key: v0-89-1-docs-add-v0-90-planning-lane-handoff-docs-milestones-v0-90-early-planning-lane-handoff-v0-90-md-docs-milestones-v0-90-readme-md-adl-v0-89-1-tasks-issue-1986-v0-89-1-docs-start-early-v0-90-planning-lane-sip-md-adl-v0-89-1-tasks-issue-1986-v0-89-1-docs-start-early-v0-90-planning-lane-sor-md