### PR TITLE
[v0.89.1][release] Correct Cargo version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,45 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
-## v0.89 (Governed Adaptation Review Tail In Progress)
+## v0.89.1 (Adversarial Runtime Review Tail In Progress)
 
-Status: Core implementation and proof-convergence wave landed through `WP-13`; next-milestone planning landed through `WP-19`; quality/docs/review/remediation/release tail remains in progress.
+Status: Core adversarial/runtime implementation, proof surfaces, internal review, and internal-review remediation have landed; third-party review and release ceremony remain in progress.
+
+Summary:
+- ADL now has a real `v0.89.1` milestone package on `main`, centered on one adversarial-runtime band:
+  `adversarial posture -> red/blue/purple roles -> execution runner -> exploit artifact -> replay manifest -> continuous verification -> self-attack -> review evidence`
+- The promoted `v0.89.1` feature-doc set covers the adversarial runtime model, red/blue agent architecture, adversarial execution runner, exploit artifact schema, replay manifest, continuous verification, self-attacking systems, and supporting operational-skill substrate
+- The bounded `v0.89.1` proof package includes the adversarial/security demo rows, provider-proof packaging, quality-gate evidence, docs-review convergence, internal review, and accepted internal-review remediation
+- The milestone also introduces the bounded `arxiv-paper-writer` workflow and the initial three-paper manuscript program for `What Is ADL?`, `Gödel Agents and ADL`, and `Cognitive Spacetime Manifold`
+- The crate version is now `0.89.1`; final third-party review findings, release ceremony, tag publication, and GitHub release copy remain owned by the release tail
+
+References:
+- `docs/milestones/v0.89.1/README.md`
+- `docs/milestones/v0.89.1/WBS_v0.89.1.md`
+- `docs/milestones/v0.89.1/SPRINT_v0.89.1.md`
+- `docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md`
+- `docs/milestones/v0.89.1/FEATURE_DOCS_v0.89.1.md`
+- `docs/milestones/v0.89.1/QUALITY_GATE_v0.89.1.md`
+- `docs/milestones/v0.89.1/DOCS_REVIEW_v0.89.1.md`
+- `docs/milestones/v0.89.1/INTERNAL_REVIEW_v0.89.1.md`
+- `docs/milestones/v0.89.1/RELEASE_PLAN_v0.89.1.md`
+- `docs/milestones/v0.89.1/RELEASE_NOTES_v0.89.1.md`
+
+Not yet claimed in v0.89.1:
+- third-party review completion and accepted third-party finding remediation
+- release ceremony completion, final tag publication, and GitHub release publication
+- the later Runtime v2, moral-governance, birthday, and polis-defense bands planned for later milestones
+
+## v0.89 (Completed Governed Adaptation Milestone)
+
+Status: Completed.
 
 Summary:
 - ADL now has a real `v0.89` milestone on `main`, centered on one governed-adaptation package:
   `convergence -> judgment -> decision/action mediation -> skill execution -> experiment evidence -> ObsMem explanation -> security posture/trust`
 - The promoted `v0.89` feature-doc set now covers AEE convergence, Freedom Gate v2, decision surfaces, action mediation, the skill model/protocol, the Godel experiment system, ObsMem evidence/ranking, and the main-band security/trust/posture contract
 - The bounded `v0.89` proof package now exists through the canonical demo matrix and the landed D1-D7 walkthrough/proof rows
-- Demo/proof convergence work has landed through `WP-13`, and the explicit tracked `v0.89.1` package is now prepared on `main` as the bounded next-milestone handoff
-- The remaining open work is the normal milestone tail: quality gate, docs/review alignment, internal review, 3rd-party review, findings remediation, and release ceremony
+- Demo/proof convergence work landed through `WP-13`, and the tracked `v0.89.1` package became the bounded adversarial-runtime follow-on
 
 References:
 - `docs/milestones/v0.89/README.md`
@@ -23,13 +51,10 @@ References:
 - `docs/milestones/v0.89/MILESTONE_CHECKLIST_v0.89.md`
 - `docs/milestones/v0.89/RELEASE_PLAN_v0.89.md`
 - `docs/milestones/v0.89/RELEASE_NOTES_v0.89.md`
-- `docs/milestones/v0.89.1/README.md`
 
 Not yet claimed in v0.89:
-- final quality-gate closure
-- internal review, external / 3rd-party review, and accepted-findings remediation completion
-- release ceremony completion and version/tag publication
-- the adversarial runtime/exploit-replay package, which remains explicitly deferred to `v0.89.1`
+- the adversarial runtime/exploit-replay package, which belongs to `v0.89.1`
+- later Runtime v2, moral-governance, birthday, and polis-defense work that belongs to later milestones
 
 ## v0.88 (Temporal / Chronosense + Instinct Review Tail In Progress)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This is the best top-level entrypoint if you want to see the active milestone's 
 
 ### If you want the flagship current demo
 
-Run the five-agent Hey Jude MIDI package, the flagship bounded multi-agent demo carried into the `v0.89.1` review wave:
+Run the five-agent Hey Jude MIDI package, the flagship bounded multi-agent demo carried into the `v0.89.1` milestone:
 
 ```bash
 bash adl/tools/demo_v0891_five_agent_hey_jude.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But those artifacts are not the whole story. In the current repository, they are
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.89%20active-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.89.1%20active-blue)
 
 Today, ADL includes:
 - a reference Rust runtime and CLI for deterministic workflow execution
@@ -44,20 +44,20 @@ cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-87-1-mi
 
 ### If you want the current milestone proof package
 
-Run the integrated `v0.89` reviewer surface:
+Run the integrated `v0.89.1` quality and review-tail surface:
 
 ```bash
-bash adl/tools/demo_v089_review_surface.sh
+bash adl/tools/demo_v0891_quality_gate.sh
 ```
 
-This is the best top-level entrypoint if you want to see what ADL currently proves in the active milestone.
+This is the best top-level entrypoint if you want to see the active milestone's current release-tail proof surface.
 
 ### If you want the flagship current demo
 
-Run the refreshed `Paper Sonata` package, the flagship bounded demo carried into the `v0.89` review wave:
+Run the five-agent Hey Jude MIDI package, the flagship bounded multi-agent demo carried into the `v0.89.1` review wave:
 
 ```bash
-bash adl/tools/demo_v088_paper_sonata.sh
+bash adl/tools/demo_v0891_five_agent_hey_jude.sh
 ```
 
 ### If you want the previous runtime milestone package
@@ -104,45 +104,60 @@ Other useful entrypoints:
 
 ## Current Status
 
-- Active milestone: **v0.89**
-- Current crate version on `main`: **0.88.0**
-- Version note: **the active review/release tail has moved to `v0.89`, but the crate version remains `0.88.0` on `main` until the bounded `v0.89` release ceremony lands and publication is finalized**
-- Most recently completed milestone package: **v0.88**
-- Previous completed milestone: **v0.87.1**
+- Active milestone: **v0.89.1**
+- Current crate version on `main`: **0.89.1**
+- Version note: **the active review/release tail has moved to `v0.89.1`; final third-party review findings, accepted remediation, release ceremony, tag publication, and GitHub release publication remain release-tail work**
+- Most recently completed milestone package: **v0.89**
+- Previous completed milestone: **v0.88**
 - Project changelog: `CHANGELOG.md`
 
 ADL is in active development. This repository contains both implemented runtime surfaces and milestone/spec/planning documents. Read the milestone docs as bounded engineering records: they distinguish what has shipped, what is under active review or closeout, what is demoable, and what is still planned.
 
 ## Current Milestone
 
-`v0.89` is the current active milestone. It carries ADL from bounded cognition and persistence into governed adaptive behavior:
-- AEE convergence and stop-condition semantics
-- Freedom Gate v2, decision/action mediation, and governed skill execution
-- experiment, ObsMem evidence/ranking, and security/trust planning surfaces
+`v0.89.1` is the current active milestone. It carries ADL from governed adaptive execution into adversarial runtime and reviewable exploit-evidence behavior:
+- adversarial runtime architecture and red/blue/purple execution structure
+- exploit artifact and replay-manifest surfaces
+- continuous verification, exploit generation, and bounded self-attack patterns
+- operational skill substrate and composition surfaces for governed execution
+- bounded manuscript workflow for the initial ADL three-paper program
 
-The core implementation wave is landed through `WP-13`, and the repository is now in quality, docs, review, findings remediation, next-milestone planning, and release-tail work.
+The core implementation and proof wave is landed through the tracked `v0.89.1` release-tail surfaces, and the repository is now in third-party review, accepted-finding remediation, next-milestone planning reconciliation, and release ceremony.
 
-Best current `v0.89` entrypoints:
-- integrated reviewer package: `bash adl/tools/demo_v089_review_surface.sh`
-- flagship bounded demo package: `bash adl/tools/demo_v088_paper_sonata.sh` with reviewer guide `demos/v0.89/paper_sonata_demo_refresh.md`
-- milestone docs: `docs/milestones/v0.89/README.md`
+Best current `v0.89.1` entrypoints:
+- quality-gate package: `bash adl/tools/demo_v0891_quality_gate.sh`
+- integration-demo package: `bash adl/tools/demo_v0891_wp13_demo_integration.sh`
+- flagship bounded demo package: `bash adl/tools/demo_v0891_five_agent_hey_jude.sh`
+- manuscript workflow package: `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh`
+- milestone docs: `docs/milestones/v0.89.1/README.md`
 
 ## Recent Milestones
 
-### v0.89 - Governed Adaptive Execution and Review-Tail Milestone
+### v0.89.1 - Adversarial Runtime and Review-Tail Milestone
 
-v0.89 is the current active milestone. The core execution wave is landed through `WP-13`, and the repository is now in quality, review, findings remediation, next-milestone planning, and release-tail work.
+v0.89.1 is the current active milestone. The adversarial/runtime implementation and proof surfaces have landed, and the repository is now in third-party review, accepted-finding remediation, next-milestone planning reconciliation, and release ceremony.
+
+Key features:
+- adversarial runtime model and red/blue/purple execution architecture
+- exploit artifact schema, replay manifest, continuous verification, and self-attack proof surfaces
+- provider-proof packaging, proof-entry-point integration, and quality-gate review surfaces
+- five-agent Hey Jude MIDI demo and bounded arXiv manuscript workflow packet
+- active release-tail handoff into third-party review, accepted remediation, and final release ceremony
+
+### v0.89 - Completed Governed Adaptive Execution Milestone
+
+v0.89 is the completed governed-adaptation milestone. The core execution wave landed through `WP-13`, and its release-tail work handed off the adversarial/runtime carry-forward into `v0.89.1`.
 
 Key features:
 - AEE 1.0 convergence and bounded stop-family proof surfaces
 - Freedom Gate v2, decision/action mediation, and governed skill execution contracts
 - experiment records, ObsMem evidence/ranking, and security/trust planning carried into one canonical package
 - bounded provider-participation demos plus an integrated `v0.89` reviewer surface
-- active handoff into internal review, 3rd-party review, remediation, `v0.89.1` planning, and release ceremony
+- completed handoff into the `v0.89.1` adversarial/runtime follow-on
 
 ### v0.88 - Temporal / Chronosense + Instinct Review-Tail Milestone
 
-v0.88 is the most recently completed milestone package. Its implementation wave completed through `WP-13`, and its review-tail work set up the current `v0.89` governance band.
+v0.88 is the prior temporal / chronosense and instinct milestone package. Its implementation wave completed through `WP-13`, and its review-tail work set up the `v0.89` governance band.
 
 Key features:
 - promoted temporal / chronosense and instinct / bounded-agency feature-doc package
@@ -224,7 +239,8 @@ ADL includes both ordinary demos and heavyweight reviewer or release proof packa
 
 Start here:
 - canonical user-facing demo index: `demos/README.md`
-- current milestone reviewer package: `bash adl/tools/demo_v089_review_surface.sh`
+- current milestone quality-gate package: `bash adl/tools/demo_v0891_quality_gate.sh`
+- current milestone integration-demo package: `bash adl/tools/demo_v0891_wp13_demo_integration.sh`
 
 Important supporting demo/readiness docs:
 - `docs/tooling/editor/README.md`

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.89.0"
+version = "0.89.1"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"

--- a/demos/README.md
+++ b/demos/README.md
@@ -22,16 +22,16 @@ If you want the historical `v0.8` flagship demo surface:
 cargo run --manifest-path demos/transpiler_demo/Cargo.toml --quiet
 ```
 
-If you want the current `v0.87.1` reviewer proof suite:
+If you want the current `v0.89.1` quality-gate proof package:
 
 ```bash
-bash adl/tools/demo_v0871_suite.sh
+bash adl/tools/demo_v0891_quality_gate.sh
 ```
 
-If you want the current `v0.87` substrate demo program:
+If you want the current `v0.89.1` integration demo package:
 
 ```bash
-bash adl/tools/demo_v087_suite.sh
+bash adl/tools/demo_v0891_wp13_demo_integration.sh
 ```
 
 If you want the local Codex CLI + Ollama operational-skills demo:
@@ -46,16 +46,16 @@ If you want the bounded Claude + ChatGPT tea discussion demo:
 bash adl/tools/demo_v0871_multi_agent_discussion.sh
 ```
 
-If you want the bounded Gemma 4 issue-clerk demo:
+If you want the bounded five-agent Hey Jude MIDI demo:
 
 ```bash
-bash adl/tools/demo_v089_gemma4_issue_clerk.sh --dry-run
+bash adl/tools/demo_v0891_five_agent_hey_jude.sh
 ```
 
-If you want the refreshed Paper Sonata flagship demo:
+If you want the bounded arXiv manuscript workflow demo:
 
 ```bash
-bash adl/tools/demo_v088_paper_sonata.sh
+bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh
 ```
 
 If you want the bounded multi-agent repo code review demo:
@@ -87,6 +87,8 @@ Current heavyweight proof-package examples:
 - `bash adl/tools/demo_v0871_quality_gate.sh`
 - `bash adl/tools/demo_v0871_release_review_package.sh`
 - `bash adl/tools/demo_v088_review_surface.sh`
+- `bash adl/tools/demo_v0891_quality_gate.sh`
+- `bash adl/tools/demo_v0891_wp13_demo_integration.sh`
 
 When planning a demo sweep, do not assume every proof-package command above belongs in the ordinary demo lane.
 
@@ -178,6 +180,26 @@ rejected truthfully.
 Use `v0.89/paper_sonata_demo_refresh.md` for the refreshed reviewer-facing
 Paper Sonata package. It keeps the bounded flagship workflow, but adds a packet
 manifest, claim matrix, revision requests, and a clearer reviewer brief.
+
+### v0.89.1 adversarial/runtime and publication demos
+
+- `v0.89.1/five_agent_hey_jude_midi_demo.md`
+- `v0.89.1/arxiv_manuscript_workflow_demo.md`
+- `v0.89.1/gemini_provider_harmony_roundtable_demo.md`
+- `v0.89.1/deep_agents_comparative_wave_follow_on_demo.md`
+- `v0.89.1/long_lived_stock_league_demo.md`
+
+Use `bash adl/tools/demo_v0891_quality_gate.sh` for the current release-tail
+quality-gate proof package.
+
+Use `bash adl/tools/demo_v0891_wp13_demo_integration.sh` for the integrated
+`v0.89.1` demo package.
+
+Use `bash adl/tools/demo_v0891_five_agent_hey_jude.sh` for the flagship bounded
+multi-agent music demo.
+
+Use `bash adl/tools/demo_v0891_arxiv_manuscript_workflow.sh` for the bounded
+manuscript workflow packet.
 
 Use `v0.89/multi_agent_repo_code_review_demo.md` for a bounded specialist-reviewer
 demo where ADL prepares one repo review packet, emits code/security/test/docs

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -49,7 +49,7 @@ can survive code review, ops review, and postmortem analysis.
 
 The current repo truth is:
 - active milestone: `v0.89.1`
-- current crate version on `main`: `0.89.0`
+- current crate version on `main`: `0.89.1`
 - most recently completed governed-adaptation milestone package: `v0.89`
 - most recently completed runtime-completion milestone package before that: `v0.87.1`
 

--- a/docs/planning/NEXT_MILESTONE_DEMO_CANDIDATES.md
+++ b/docs/planning/NEXT_MILESTONE_DEMO_CANDIDATES.md
@@ -40,9 +40,9 @@ Promote this when we want one future-demo slice that ties together:
 
 ### Primary Sources
 
-- `.adl/docs/TBD/FIVE_AGENT_HEY_JUDE_MIDI_DEMO_PLAN.md`
-- `.adl/docs/TBD/FIVE_AGENT_HEY_JUDE_MIDI_DEMO_IMPLEMENTATION_PLAN.md`
-- `.adl/docs/TBD/NEXT_MILESTONE_CANDIDATE_FIVE_AGENT_HEY_JUDE_MIDI_DEMO.md`
+- `demos/v0.89.1/five_agent_hey_jude_midi_demo.md`
+- `docs/milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md`
+- `docs/milestones/v0.89.1/RELEASE_NOTES_v0.89.1.md`
 
 ### Recommended Promotion Test
 


### PR DESCRIPTION
Closes #2013

## Summary
Corrected the v0.89.1 release metadata so the Rust package version, lockfile package entry, and project changelog match the active milestone. The changelog now opens with a v0.89.1 entry and no longer presents v0.89 as the active review-tail milestone.

## Artifacts
- Updated `adl/Cargo.toml`.
- Updated `adl/Cargo.lock`.
- Updated `CHANGELOG.md`.

## Validation
- Validation commands and their purpose:
  - `cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1`: verified the package metadata reports version `0.89.1`.
  - `rg -n 'version = "0\.89\.0"|prepared on .main.|release tail remains in progress|Governed Adaptation Review Tail In Progress' adl/Cargo.toml adl/Cargo.lock CHANGELOG.md`: checked the touched release metadata surfaces for the stale version and stale active-milestone wording.
  - `git diff --stat && git diff -- adl/Cargo.toml adl/Cargo.lock CHANGELOG.md`: reviewed the exact release-metadata diff before finish.
  - `git status --short --branch`: confirmed root main remained untouched during issue execution.
- Results: PASS. Cargo metadata reports `0.89.1`; no stale `0.89.0` package version remains in the touched Cargo surfaces; changelog opens with v0.89.1.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Notes
Closes #2013\n\nCorrects the v0.89.1 release metadata by bumping the Rust package and lockfile version to 0.89.1 and making the changelog open with the active v0.89.1 release-tail state. This PR is intentionally narrow and independent from #2012.

## Local Artifacts
- Input card:  .adl/v0.89.1/tasks/issue-2013__v0-89-1-release-correct-cargo-version-and-changelog/sip.md
- Output card: .adl/v0.89.1/tasks/issue-2013__v0-89-1-release-correct-cargo-version-and-changelog/sor.md
- Idempotency-Key: v0-89-1-release-correct-cargo-version-and-changelog-adl-cargo-toml-adl-cargo-lock-changelog-md-adl-v0-89-1-tasks-issue-2013-v0-89-1-release-correct-cargo-version-and-changelog-sip-md-adl-v0-89-1-tasks-issue-2013-v0-89-1-release-correct-cargo-version-and-changelog-sor-md