### PR TITLE
Daily Automated Test Coverage - 2026-04-17 09:53 Total Line Coverage: 90.30%

### DIFF
--- a/adl/src/cli/identity_cmd/tests.rs
+++ b/adl/src/cli/identity_cmd/tests.rs
@@ -1733,14 +1733,22 @@ fn resolve_identity_path_accepts_explicit_path_and_rejects_unknown_args() {
 
 #[test]
 fn repo_root_matches_git_toplevel() {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let repo = temp_repo("identity-repo-root");
+
+    let original_cwd = env::current_dir().expect("capture cwd");
+    env::set_current_dir(&repo).expect("set cwd to temp repo");
+
     let expected = PathBuf::from(
         run_git_capture(&["rev-parse", "--show-toplevel"])
             .expect("git top level")
             .trim(),
     );
-
     let resolved = repo_root().expect("repo root should resolve");
 
+    env::set_current_dir(original_cwd).expect("restore cwd");
     assert_eq!(resolved, expected);
 }
 

--- a/adl/src/cli/identity_cmd/tests.rs
+++ b/adl/src/cli/identity_cmd/tests.rs
@@ -7,8 +7,9 @@ use once_cell::sync::Lazy;
 use serde_json::Value;
 use std::env;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1741,4 +1742,40 @@ fn repo_root_matches_git_toplevel() {
     let resolved = repo_root().expect("repo root should resolve");
 
     assert_eq!(resolved, expected);
+}
+
+#[test]
+fn run_git_capture_rejects_non_utf8_stdout() {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let repo = temp_repo("identity-git-non-utf8");
+
+    let mut hash = Command::new(system_git_bin())
+        .args(["hash-object", "-w", "--stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .current_dir(&repo)
+        .spawn()
+        .expect("spawn hash-object");
+    hash.stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(&[0xff, 0xfe, 0xfd])
+        .expect("write invalid bytes");
+    let output = hash.wait_with_output().expect("hash-object output");
+    assert!(output.status.success(), "hash-object should succeed");
+
+    let oid = String::from_utf8(output.stdout)
+        .expect("oid utf8")
+        .trim()
+        .to_string();
+    assert!(!oid.is_empty(), "oid should be present");
+
+    let original_cwd = env::current_dir().expect("capture cwd");
+    env::set_current_dir(&repo).expect("set cwd to temp repo");
+    let err = run_git_capture(&["cat-file", "blob", oid.as_str()])
+        .expect_err("binary blob output should fail utf8 decode");
+    env::set_current_dir(original_cwd).expect("restore cwd");
+    assert!(err.to_string().contains("git output was not valid UTF-8"));
 }


### PR DESCRIPTION
## Daily coverage ratchet (2026-04-17 09:53 PDT)

- Baseline branch-local total line coverage: `90.29%`
- Final branch-local total line coverage: `90.30%`
- Delta (branch-local): `+0.01%`
- Fixed per-file floor: `80%`
- Final branch-local files below floor: `none`

### Refreshed current repository truth (`origin/main`)
- Refreshed total line coverage: `90.29%`
- Files below floor on refreshed truth:
  - `src/cli/identity_cmd/helpers.rs` (`79.07%`, `34/43`)

### Changed files
- `adl/src/cli/identity_cmd/tests.rs`

### What changed
- Added deterministic helper coverage tests around `identity_cmd` git helper behavior.
- Made `repo_root` helper test snapshot-safe by executing inside a temp initialized git repo.

### Next targets
- Raise `src/cli/identity_cmd/helpers.rs` on `origin/main` from `79.07%` to `>=80%`.
- Specifically cover remaining unexecuted helper branches (`--help`/exit path handling strategy and remaining repo-root related lines in snapshot conditions).
