### PR TITLE
[v0.90][backlog][skills] Add diagram author skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -41,6 +41,7 @@ run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generat
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"
 run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_paper_writer_skill_contracts.sh"
+run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_author_skill_contracts.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
 echo "• Running adl checks (batched)…"
 (

--- a/adl/tools/skills/diagram-author/SKILL.md
+++ b/adl/tools/skills/diagram-author/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: diagram-author
+description: Create one source-grounded diagram packet from a bounded brief, issue, code slice, doc packet, or review surface. Use when the user wants architecture diagrams, workflow diagrams, dependency maps, sequence/state/data-flow diagrams, C4 views, Mermaid/D2/PlantUML/Structurizr sources, or diagram review notes without inventing system behavior.
+---
+
+# Diagram Author
+
+Create or revise one source-grounded diagram packet.
+
+This skill is a diagram-as-code and model-as-code router. It chooses the
+smallest useful diagram family and source format for the communication goal,
+then produces a reviewable diagram packet with assumptions and validation
+notes.
+
+This skill is allowed to:
+- inspect one bounded source packet, issue, code slice, doc packet, or review surface
+- choose a diagram family and backend: Mermaid, D2, PlantUML, Structurizr DSL, or no-render markdown
+- draft diagram source plus rationale, assumptions, and validation commands
+- write one bounded diagram packet or review artifact
+- recommend rendering commands when the relevant tool exists locally
+
+It is not allowed to:
+- invent architecture, runtime behavior, trust boundaries, dependencies, or data flows
+- treat UML as the default when a simpler diagram communicates better
+- publish diagrams to external tools or docs sites without explicit separate approval
+- silently replace architecture review, security review, or implementation proof
+- broaden into repo-wide diagram inventory work without a bounded target
+
+## Quick Start
+
+1. Confirm the concrete source packet or target surface.
+2. Identify the audience, communication goal, and required fidelity.
+3. Select the diagram family and backend.
+4. Read `references/diagram-playbook.md` when choosing diagram types or tools.
+5. Read `references/output-contract.md` when writing a diagram packet.
+6. Draft the diagram source with explicit assumptions and unknowns.
+7. Add validation/render instructions.
+8. Stop before publication or unbounded redesign.
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete target:
+  - `target.source_packet_path`
+  - `target.source_packet_text`
+  - `target.issue_number`
+  - `target.code_path`
+  - `target.doc_path`
+
+Useful additional inputs:
+- `artifact_root`
+- `diagram_goal`
+- `audience`
+- `preferred_backend`
+- `required_diagram_family`
+- `render_policy`
+- `validation_mode`
+- `forbidden_assumptions`
+
+If there is no bounded source or target, stop and report `blocked`.
+
+## Workflow
+
+### 1. Resolve The Evidence Source
+
+Prefer:
+1. explicit source packet path
+2. explicit source packet text
+3. issue number plus local STP/SIP/SOR or linked docs
+4. bounded code path
+5. bounded doc path
+
+Record source gaps instead of filling them with plausible architecture.
+
+### 2. Choose Diagram Family
+
+Choose from the communication goal:
+- flowchart for process, workflow, or lifecycle
+- sequence for actor/service interaction over time
+- state for lifecycle state machines
+- dependency graph for modules, packages, or issue relationships
+- data-flow for movement of data across trust boundaries
+- C4/Structurizr for architecture views that need model consistency
+- UML/PlantUML for formal class, component, deployment, or strict sequence diagrams
+- D2 for polished system maps, explainers, and presentation-ready visual maps
+- Mermaid for GitHub-friendly markdown diagrams and lightweight docs
+
+Do not choose formal UML just because the request says "diagram" unless the
+user asks for UML or the source calls for formal modeling.
+
+### 3. Choose Backend
+
+Default backend order:
+1. Mermaid for GitHub/Markdown-native docs and quick reviewable diagrams
+2. Structurizr DSL for C4 architecture models and multiple related views
+3. D2 for polished system maps and demo/presentation explainers
+4. PlantUML for strict UML semantics or advanced UML diagram families
+5. Markdown outline when evidence is insufficient for diagram source
+
+When the backend is chosen, explain why.
+
+### 4. Draft The Packet
+
+Include:
+- diagram source
+- backend and diagram family
+- source evidence
+- assumptions and unknowns
+- validation/render commands
+- accessibility notes such as title, description, and readable labels
+
+### 5. Validate Boundaries
+
+Before returning, check:
+- no unsupported architecture or runtime claim was added
+- assumptions are labeled separately from source-backed structure
+- rendering/publishing did not happen unless explicitly requested
+- selected backend matches the audience and doc surface
+- the packet has a clear next review step
+
+## Output Expectations
+
+Default output should include:
+- target source packet
+- diagram goal and audience
+- selected diagram family and backend
+- diagram source or explicit reason no source was emitted
+- assumptions and unknowns
+- validation/render instructions
+- publication boundary
+- recommended next step
+
+When ADL expects a structured artifact, follow `references/output-contract.md`.
+
+## Design Basis
+
+Within this skill bundle, the operational details live in:
+- `references/diagram-playbook.md`
+- `references/output-contract.md`
+
+The operator-facing invocation contract lives in:
+- `/Users/daniel/git/agent-design-language/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md`
+
+Prefer the tracked repo copies of these docs over memory when the bundle evolves.

--- a/adl/tools/skills/diagram-author/SKILL.md
+++ b/adl/tools/skills/diagram-author/SKILL.md
@@ -16,6 +16,7 @@ This skill is allowed to:
 - inspect one bounded source packet, issue, code slice, doc packet, or review surface
 - choose a diagram family and backend: Mermaid, D2, PlantUML, Structurizr DSL, or no-render markdown
 - draft diagram source plus rationale, assumptions, and validation commands
+- render SVG and optional PNG artifacts when the requested renderer is already available locally or rendering is explicitly required
 - write one bounded diagram packet or review artifact
 - recommend rendering commands when the relevant tool exists locally
 
@@ -23,6 +24,7 @@ It is not allowed to:
 - invent architecture, runtime behavior, trust boundaries, dependencies, or data flows
 - treat UML as the default when a simpler diagram communicates better
 - publish diagrams to external tools or docs sites without explicit separate approval
+- claim a rendered artifact exists unless rendering actually ran
 - silently replace architecture review, security review, or implementation proof
 - broaden into repo-wide diagram inventory work without a bounded target
 
@@ -34,8 +36,9 @@ It is not allowed to:
 4. Read `references/diagram-playbook.md` when choosing diagram types or tools.
 5. Read `references/output-contract.md` when writing a diagram packet.
 6. Draft the diagram source with explicit assumptions and unknowns.
-7. Add validation/render instructions.
-8. Stop before publication or unbounded redesign.
+7. If rendering is requested, use `scripts/render_diagrams.sh` and record PASS, SKIP, or FAIL truthfully.
+8. Add validation/render instructions.
+9. Stop before publication or unbounded redesign.
 
 ## Required Inputs
 
@@ -98,6 +101,10 @@ Default backend order:
 4. PlantUML for strict UML semantics or advanced UML diagram families
 5. Markdown outline when evidence is insufficient for diagram source
 
+Treat "renders in the current surface" as a first-class selection criterion.
+If the user asks to show a diagram in GitHub Markdown, Codex chat, an issue, or
+a PR body, prefer Mermaid unless another backend is explicitly required.
+
 When the backend is chosen, explain why.
 
 ### 4. Draft The Packet
@@ -110,7 +117,31 @@ Include:
 - validation/render commands
 - accessibility notes such as title, description, and readable labels
 
-### 5. Validate Boundaries
+### 5. Render When Requested
+
+Rendering is optional unless `policy.render_policy` is `render_required`.
+
+Use:
+
+```sh
+adl/tools/skills/diagram-author/scripts/render_diagrams.sh \
+  --input <diagram-source-dir> \
+  --out <artifact-dir> \
+  --formats svg,png
+```
+
+Renderer behavior:
+- Mermaid uses `mmdc`
+- D2 uses `d2`
+- PlantUML uses `plantuml`
+- Structurizr DSL uses `structurizr validate` and `structurizr export`
+- PNG derivation can use ImageMagick `convert` when SVG exists
+
+If a renderer is missing and rendering is not required, record `SKIP` rather
+than failing or inventing a rendered artifact. Prefer SVG as the durable visual
+asset. Use raster formats such as PNG only for surfaces that cannot consume SVG.
+
+### 6. Validate Boundaries
 
 Before returning, check:
 - no unsupported architecture or runtime claim was added

--- a/adl/tools/skills/diagram-author/SKILL.md
+++ b/adl/tools/skills/diagram-author/SKILL.md
@@ -37,8 +37,9 @@ It is not allowed to:
 5. Read `references/output-contract.md` when writing a diagram packet.
 6. Draft the diagram source with explicit assumptions and unknowns.
 7. If rendering is requested, use `scripts/render_diagrams.sh` and record PASS, SKIP, or FAIL truthfully.
-8. Add validation/render instructions.
-9. Stop before publication or unbounded redesign.
+8. Read `references/renderer-setup.md` when renderer installation, caches, or sandbox behavior matters.
+9. Add validation/render instructions.
+10. Stop before publication or unbounded redesign.
 
 ## Required Inputs
 
@@ -136,6 +137,8 @@ Renderer behavior:
 - PlantUML uses `plantuml`
 - Structurizr DSL uses `structurizr validate` and `structurizr export`
 - PNG derivation can use ImageMagick `convert` when SVG exists
+- `--skip-backends` can bypass a renderer that is optional, unavailable, or
+  blocked by the current sandbox
 
 If a renderer is missing and rendering is not required, record `SKIP` rather
 than failing or inventing a rendered artifact. Prefer SVG as the durable visual
@@ -169,6 +172,7 @@ When ADL expects a structured artifact, follow `references/output-contract.md`.
 Within this skill bundle, the operational details live in:
 - `references/diagram-playbook.md`
 - `references/output-contract.md`
+- `references/renderer-setup.md`
 
 The operator-facing invocation contract lives in:
 - `/Users/daniel/git/agent-design-language/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md`

--- a/adl/tools/skills/diagram-author/adl-skill.yaml
+++ b/adl/tools/skills/diagram-author/adl-skill.yaml
@@ -1,0 +1,125 @@
+version: "0.1"
+kind: "adl-skill"
+id: "diagram-author"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "diagram_author.v1"
+    reference_doc: "../docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "draft_from_source_packet"
+      - "draft_from_issue"
+      - "draft_from_code"
+      - "review_or_revise_diagram"
+    policy_fields:
+      - "backend_policy"
+      - "truth_policy"
+      - "render_policy"
+      - "validation_mode"
+      - "stop_before_publication"
+    mode_requirements:
+      draft_from_source_packet:
+        required_target_fields:
+          - "source_packet_path"
+      draft_from_issue:
+        required_target_fields:
+          - "issue_number"
+      draft_from_code:
+        required_target_fields:
+          - "code_path"
+      review_or_revise_diagram:
+        required_target_fields:
+          - "diagram_path"
+  intent:
+    - "diagram_authoring"
+    - "diagram_as_code"
+    - "architecture_visualization"
+    - "workflow_visualization"
+    - "source_grounded_visual_explanation"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "source_packet_path"
+    - "source_packet_text"
+    - "issue_number"
+    - "code_path"
+    - "doc_path"
+    - "diagram_path"
+    - "artifact_root"
+    - "diagram_goal"
+    - "audience"
+    - "preferred_backend"
+    - "required_diagram_family"
+    - "forbidden_assumptions"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_diagram_author.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "draft_from_source_packet_requires_target.source_packet_path"
+    - "draft_from_issue_requires_target.issue_number"
+    - "draft_from_code_requires_target.code_path"
+    - "review_or_revise_diagram_requires_target.diagram_path"
+    - "policy.backend_policy_must_be_explicit"
+    - "policy.truth_policy_must_be_explicit"
+    - "policy.render_policy_must_be_explicit"
+    - "policy.validation_mode_must_be_explicit"
+    - "policy.stop_before_publication_must_be_true"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: true
+  preferred_read_order:
+    - "source_packet"
+    - "issue_bundle"
+    - "code_or_doc_target"
+    - "existing_diagram"
+    - "diagram_playbook"
+  preferred_commands:
+    - "rg --files"
+    - "rg -n"
+    - "mmdc -i <input.mmd> -o <output.svg>"
+    - "d2 <input.d2> <output.svg>"
+    - "java -jar plantuml.jar -tsvg <input.puml>"
+    - "structurizr validate -workspace <workspace.dsl>"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+    - "diagram packet artifacts"
+    - "bounded docs/demo diagram sources"
+  must_not_write:
+    - "external publishing platforms"
+    - "unrelated issue bundles"
+    - "unrelated worktrees"
+    - "unbounded architecture rewrites"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-diagram-author.md"
+  required_sections:
+    - "status"
+    - "target"
+    - "diagram_decision"
+    - "diagram_packet"
+    - "truth_boundary"
+    - "render_validation"
+    - "publication_boundary"
+    - "follow_up"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/diagram-author/adl-skill.yaml
+++ b/adl/tools/skills/diagram-author/adl-skill.yaml
@@ -26,6 +26,7 @@ admission:
       - "truth_policy"
       - "render_policy"
       - "validation_mode"
+      - "output_formats"
       - "stop_before_publication"
     mode_requirements:
       draft_from_source_packet:
@@ -60,6 +61,7 @@ admission:
     - "audience"
     - "preferred_backend"
     - "required_diagram_family"
+    - "output_formats"
     - "forbidden_assumptions"
   stop_if_missing:
     - "repo_root"
@@ -75,6 +77,8 @@ admission:
     - "policy.truth_policy_must_be_explicit"
     - "policy.render_policy_must_be_explicit"
     - "policy.validation_mode_must_be_explicit"
+    - "policy.output_formats_defaults_to_svg_when_omitted"
+    - "policy.output_formats_may_only_include_svg_or_png"
     - "policy.stop_before_publication_must_be_true"
 execution:
   mode: "auto_apply"
@@ -90,9 +94,10 @@ execution:
   preferred_commands:
     - "rg --files"
     - "rg -n"
+    - "adl/tools/skills/diagram-author/scripts/render_diagrams.sh --input <source-dir> --out <artifact-dir> --formats svg,png"
     - "mmdc -i <input.mmd> -o <output.svg>"
     - "d2 <input.d2> <output.svg>"
-    - "java -jar plantuml.jar -tsvg <input.puml>"
+    - "plantuml -tsvg <input.puml>"
     - "structurizr validate -workspace <workspace.dsl>"
   invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
 boundaries:
@@ -117,9 +122,10 @@ outputs:
     - "diagram_packet"
     - "truth_boundary"
     - "render_validation"
+    - "rendered_artifacts"
     - "publication_boundary"
     - "follow_up"
 security:
   trusted_root_required: true
   deny_symlink_escape: true
-  manifest_declares_executables: false
+  manifest_declares_executables: true

--- a/adl/tools/skills/diagram-author/adl-skill.yaml
+++ b/adl/tools/skills/diagram-author/adl-skill.yaml
@@ -91,10 +91,12 @@ execution:
     - "code_or_doc_target"
     - "existing_diagram"
     - "diagram_playbook"
+    - "renderer_setup"
   preferred_commands:
     - "rg --files"
     - "rg -n"
     - "adl/tools/skills/diagram-author/scripts/render_diagrams.sh --input <source-dir> --out <artifact-dir> --formats svg,png"
+    - "adl/tools/skills/diagram-author/scripts/render_diagrams.sh --input <source-dir> --out <artifact-dir> --formats svg,png --skip-backends mermaid"
     - "mmdc -i <input.mmd> -o <output.svg>"
     - "d2 <input.d2> <output.svg>"
     - "plantuml -tsvg <input.puml>"

--- a/adl/tools/skills/diagram-author/agents/openai.yaml
+++ b/adl/tools/skills/diagram-author/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Diagram Author
+short_description: Create source-grounded diagram-as-code packets with the right backend
+default_prompt: Turn one bounded source packet, issue, code slice, or doc surface into a reviewable diagram packet, choose Mermaid, D2, PlantUML, or Structurizr deliberately, and label assumptions before rendering or publication.

--- a/adl/tools/skills/diagram-author/references/diagram-playbook.md
+++ b/adl/tools/skills/diagram-author/references/diagram-playbook.md
@@ -74,6 +74,9 @@ Check local availability:
 adl/tools/skills/diagram-author/scripts/render_diagrams.sh --check-tools
 ```
 
+For install, cache, sandbox, and Rust-integration guidance, read
+`references/renderer-setup.md`.
+
 Examples:
 
 ```sh

--- a/adl/tools/skills/diagram-author/references/diagram-playbook.md
+++ b/adl/tools/skills/diagram-author/references/diagram-playbook.md
@@ -1,6 +1,7 @@
 # Diagram Playbook
 
-This skill stops at a reviewable diagram packet.
+This skill stops at a reviewable diagram packet unless rendering is explicitly
+requested by policy. Rendering still stops before external publication.
 
 ## Backend Selection
 
@@ -18,6 +19,22 @@ Mermaid is the default for ADL docs because it is easy to review in Markdown.
 Structurizr DSL is preferred when the durable artifact is a C4 model rather
 than a single picture. D2 is preferred when visual quality and layout matter.
 PlantUML is a specialist path for formal UML, not the default.
+
+## Render Policy
+
+Use three output tiers:
+
+1. Inline preview: Mermaid source for GitHub, PRs, issues, docs, and Codex chat.
+2. Review packet: source files plus commands and truth-boundary notes.
+3. Rendered asset packet: source files plus generated SVG/PNG artifacts when
+   local renderers exist or rendering is explicitly required.
+
+Prefer SVG as the durable rendered artifact. SVG scales cleanly and is suitable
+for docs and review. Produce PNG only when the target surface cannot use SVG or
+when the user explicitly asks for raster output.
+
+Do not produce raster screenshots as the canonical artifact when source or SVG
+would be reviewable.
 
 ## Diagram Families
 
@@ -42,6 +59,21 @@ PlantUML is a specialist path for formal UML, not the default.
 
 Use commands only when the tool exists locally or the user explicitly asks to install/use it.
 
+The bundled renderer harness is:
+
+```sh
+adl/tools/skills/diagram-author/scripts/render_diagrams.sh \
+  --input <diagram-source-dir> \
+  --out <artifact-dir> \
+  --formats svg,png
+```
+
+Check local availability:
+
+```sh
+adl/tools/skills/diagram-author/scripts/render_diagrams.sh --check-tools
+```
+
 Examples:
 
 ```sh
@@ -52,6 +84,8 @@ structurizr validate -workspace workspace.dsl
 ```
 
 If no renderer is available, provide the source and mark rendering as `not_run`.
+If a renderer is unavailable and rendering is optional, mark the individual
+source as `SKIP` rather than failing the whole packet.
 
 ## Accessibility And Review
 

--- a/adl/tools/skills/diagram-author/references/diagram-playbook.md
+++ b/adl/tools/skills/diagram-author/references/diagram-playbook.md
@@ -1,0 +1,62 @@
+# Diagram Playbook
+
+This skill stops at a reviewable diagram packet.
+
+## Backend Selection
+
+Use this default decision table:
+
+| Goal | Preferred backend |
+| --- | --- |
+| GitHub/Markdown-native flow, sequence, state, ER, timeline, or simple architecture docs | Mermaid |
+| C4 architecture model with multiple related views | Structurizr DSL |
+| Polished explainer, demo visual, system map, or presentation-friendly diagram | D2 |
+| Formal UML class, component, deployment, strict sequence, or timing diagram | PlantUML |
+| Evidence is insufficient for precise structure | Markdown outline with gaps |
+
+Mermaid is the default for ADL docs because it is easy to review in Markdown.
+Structurizr DSL is preferred when the durable artifact is a C4 model rather
+than a single picture. D2 is preferred when visual quality and layout matter.
+PlantUML is a specialist path for formal UML, not the default.
+
+## Diagram Families
+
+- Flowchart: process, workflow, lifecycle, branching decisions.
+- Sequence: interactions over time between agents, services, users, or tools.
+- State: lifecycle states and allowed transitions.
+- Dependency graph: modules, packages, skills, issues, or build relationships.
+- Data-flow: data movement, storage, processing, and trust boundaries.
+- C4: system context, container, component, dynamic, and deployment views.
+- UML: class, component, deployment, timing, object, or strict sequence models.
+- Concept map: explanatory relationships when a formal model is too heavy.
+
+## Evidence Rules
+
+- Source-backed nodes and edges should map to text, code, issue cards, docs, or runtime artifacts.
+- Assumed nodes and edges must be labeled as assumptions.
+- Unknown relationships should be called out in notes instead of drawn as fact.
+- Security or trust-boundary edges require explicit evidence or a security-review caveat.
+- Do not collapse two different concepts into one node just to simplify layout.
+
+## Render And Validation Commands
+
+Use commands only when the tool exists locally or the user explicitly asks to install/use it.
+
+Examples:
+
+```sh
+mmdc -i diagram.mmd -o diagram.svg
+d2 diagram.d2 diagram.svg
+java -jar plantuml.jar -tsvg diagram.puml
+structurizr validate -workspace workspace.dsl
+```
+
+If no renderer is available, provide the source and mark rendering as `not_run`.
+
+## Accessibility And Review
+
+- Include a short title and description in the packet.
+- Prefer readable labels over compact internal names.
+- Keep diagrams small enough to review; split large diagrams by view.
+- Add legend/key notes when colors, shapes, or line styles have meaning.
+- Prefer SVG for review and publication handoff.

--- a/adl/tools/skills/diagram-author/references/output-contract.md
+++ b/adl/tools/skills/diagram-author/references/output-contract.md
@@ -1,0 +1,59 @@
+# Output Contract
+
+The default `diagram-author` artifact is markdown with these sections in this order:
+
+```md
+## Metadata
+- Skill: diagram-author
+- Subject: <source packet, issue, code path, or doc path>
+- Date: <UTC timestamp or calendar date>
+- Output Location: <path or none>
+
+## Target
+- Mode: draft_from_source_packet | draft_from_issue | draft_from_code | review_or_revise_diagram
+- Source: <path, issue, doc, code path, or inline target>
+- Audience: <engineer | reviewer | user | stakeholder | unknown>
+- Diagram Goal: <explain | prove | compare | debug | document | review>
+
+## Diagram Decision
+- Diagram Family: flowchart | sequence | state | dependency | data_flow | c4 | uml | concept_map | other
+- Backend: mermaid | d2 | plantuml | structurizr | markdown_outline
+- Rationale: <why this backend/family fits>
+
+## Diagram Packet
+- Primary Diagram Source: <path or inline fenced source>
+- Rendered Artifact: <path or none>
+- Result: PASS | FAIL | PARTIAL | NOT_RUN
+
+## Truth Boundary
+- Source-Backed Elements:
+  - <bounded list or none>
+- Assumptions:
+  - <bounded list or none>
+- Unknowns:
+  - <bounded list or none>
+- Unsupported Claims Added: true | false
+
+## Render Validation
+- Render Attempted: true | false
+- Validation Command: <command or none>
+- Validation Result: PASS | FAIL | NOT_RUN
+- Notes: <bounded summary>
+
+## Publication Boundary
+- Publication Attempted: true | false
+- External Tool Upload Attempted: true | false
+- Human Review Required: true | false
+- Reason: <must explain why publication/upload is out of scope unless explicitly requested>
+
+## Follow-up
+- Recommended Next Step: <one bounded next action or explicit none>
+```
+
+## Rules
+
+- Do not invent architecture, dependencies, data flows, or runtime behavior.
+- Do not make UML the default when a simpler diagram communicates better.
+- Do not hide assumptions; list them in the truth-boundary section.
+- Do not claim a rendered artifact exists unless rendering actually ran.
+- Do not emit raw secrets, raw prompts, raw tool arguments, or unjustified absolute host paths.

--- a/adl/tools/skills/diagram-author/references/output-contract.md
+++ b/adl/tools/skills/diagram-author/references/output-contract.md
@@ -40,6 +40,16 @@ The default `diagram-author` artifact is markdown with these sections in this or
 - Validation Result: PASS | FAIL | NOT_RUN
 - Notes: <bounded summary>
 
+## Rendered Artifacts
+- SVG Artifacts:
+  - <path or none>
+- Raster Artifacts:
+  - <path or none>
+- Source-Only Artifacts:
+  - <path or none>
+- Skipped Renderers:
+  - <backend and reason or none>
+
 ## Publication Boundary
 - Publication Attempted: true | false
 - External Tool Upload Attempted: true | false
@@ -56,4 +66,5 @@ The default `diagram-author` artifact is markdown with these sections in this or
 - Do not make UML the default when a simpler diagram communicates better.
 - Do not hide assumptions; list them in the truth-boundary section.
 - Do not claim a rendered artifact exists unless rendering actually ran.
+- Prefer SVG for durable rendered artifacts and PNG only for raster-only surfaces.
 - Do not emit raw secrets, raw prompts, raw tool arguments, or unjustified absolute host paths.

--- a/adl/tools/skills/diagram-author/references/renderer-setup.md
+++ b/adl/tools/skills/diagram-author/references/renderer-setup.md
@@ -1,0 +1,120 @@
+# Renderer Setup
+
+The `diagram-author` skill is source-first and SVG-first.
+
+Mermaid source remains the default for GitHub, PRs, issues, Markdown docs, and
+Codex chat because those surfaces can render Mermaid inline. External rendered
+assets are optional unless the caller asks for `render_required`.
+
+## Recommended macOS Install
+
+Use Homebrew for the current CLI renderer path:
+
+```sh
+brew install mermaid-cli d2 plantuml graphviz librsvg
+```
+
+This provides:
+
+- `mmdc` for Mermaid source to SVG.
+- `d2` for D2 source to SVG.
+- `plantuml` for PlantUML source to SVG.
+- `dot` from Graphviz for PlantUML diagram families that need DOT layout.
+- `rsvg-convert` from librsvg for SVG to PNG rasterization.
+
+Optional:
+
+```sh
+brew install structurizr-cli
+```
+
+Structurizr is useful for C4/model-consistent architecture packets, but treat it
+as specialized. Homebrew marks `structurizr-cli` as deprecated because upstream
+is archived, so it should not be required for the default ADL diagram path.
+
+## First-Run Browser Caches
+
+Some renderers use browser engines under the hood:
+
+- Mermaid CLI uses Puppeteer.
+- D2 may use Playwright for some raster paths.
+
+The ADL renderer harness keeps browser caches repo-local by default:
+
+```sh
+ADL_DIAGRAM_RENDER_CACHE=.adl/.cache/diagram-renderers \
+  adl/tools/skills/diagram-author/scripts/render_diagrams.sh \
+  --input .adl/docs/TBD/diagram-test \
+  --out .adl/docs/TBD/diagram-test/rendered \
+  --formats svg,png
+```
+
+If Mermaid CLI asks for a Puppeteer browser, install it into the same repo-local
+cache:
+
+```sh
+npm_config_cache=.adl/.cache/npm \
+PUPPETEER_CACHE_DIR=.adl/.cache/diagram-renderers/puppeteer \
+npx puppeteer browsers install chrome-headless-shell@131.0.6778.204
+```
+
+The exact Chrome version can change with `mermaid-cli`. If `mmdc` reports a
+different required version, install that version instead.
+
+## Sandbox Notes
+
+Headless browsers may fail in restricted macOS sandboxes even when installed.
+The symptom is usually a Chromium mach-service or browser-launch error.
+
+Recommended behavior:
+
+- Prefer Mermaid inline preview for chat/GitHub surfaces.
+- Render D2 and PlantUML through the harness when those CLIs work locally.
+- Use `--skip-backends mermaid` in restricted sandboxes where Chromium cannot
+  launch.
+- Run Mermaid rendering from a normal terminal if the sandbox blocks Chromium.
+
+Example:
+
+```sh
+adl/tools/skills/diagram-author/scripts/render_diagrams.sh \
+  --input .adl/docs/TBD/diagram-test \
+  --out .adl/docs/TBD/diagram-test/rendered \
+  --formats svg,png \
+  --skip-backends mermaid
+```
+
+## User Assistance Model
+
+The skill should help users with rendering in this order:
+
+1. Run `render_diagrams.sh --check-tools` and report missing tools.
+2. Recommend the smallest install set for the requested backends.
+3. Keep browser and npm caches under `.adl/.cache/` when possible.
+4. Prefer SVG as the durable visual artifact.
+5. Derive PNG from SVG with `rsvg-convert` or ImageMagick rather than asking
+   each renderer for native raster output.
+6. Record `SKIP` for optional missing or sandbox-blocked renderers instead of
+   pretending a rendered artifact exists.
+
+## Rust Integration Options
+
+Current CLI renderers are the safest first-class path because they match the
+upstream diagram languages.
+
+Potential Rust-backed improvements:
+
+- `mermaid-rs-renderer`: promising pure-Rust Mermaid SVG/PNG renderer. This is
+  the most interesting candidate for reducing the Node/Puppeteer dependency in
+  ADL's default path.
+- `resvg` / `usvg`: useful for SVG to PNG conversion if ADL wants a Rust-native
+  rasterization step instead of shelling out to `rsvg-convert` or ImageMagick.
+- `graphviz-rust` / related crates: useful for DOT parsing/generation, but not
+  a replacement for full D2, Mermaid, PlantUML, or Structurizr rendering.
+- `mdbook-d2` and `mdbook-plantuml`: useful reference points for docs pipelines,
+  but they are mdBook integrations rather than general ADL renderer engines.
+- PlantUML crates mostly encode URLs, parse syntax, or call PlantUML server; the
+  local high-fidelity renderer is still the Java `plantuml` CLI.
+
+Recommendation: keep the current CLI harness for v0.90, then open a follow-up
+issue to evaluate `mermaid-rs-renderer` as an optional Rust-native Mermaid path.

--- a/adl/tools/skills/diagram-author/scripts/render_diagrams.sh
+++ b/adl/tools/skills/diagram-author/scripts/render_diagrams.sh
@@ -11,6 +11,8 @@ Options:
   --input DIR       Directory containing diagram sources.
   --out DIR         Output directory for rendered artifacts and manifest.
   --formats LIST    Comma-separated formats. Supported: svg,png. Default: svg.
+  --skip-backends LIST
+                   Comma-separated backends to skip. Supported: mermaid,d2,plantuml,structurizr.
   --required        Fail when a renderer required for a discovered source is missing.
   --dry-run         Report planned actions without rendering.
   --check-tools     Print renderer availability and exit.
@@ -30,6 +32,7 @@ formats="svg"
 required=false
 dry_run=false
 check_tools=false
+skip_backends=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,6 +46,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --formats)
       formats="${2:-}"
+      shift 2
+      ;;
+    --skip-backends)
+      skip_backends="${2:-}"
       shift 2
       ;;
     --required)
@@ -102,6 +109,15 @@ if [[ ! -d "$input_dir" ]]; then
   exit 2
 fi
 
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cache_root="${ADL_DIAGRAM_RENDER_CACHE:-${repo_root}/.adl/.cache/diagram-renderers}"
+mkdir -p "$cache_root"
+
+# Keep renderer browser downloads local to the repository unless callers opt out.
+# Mermaid CLI uses Puppeteer; D2 may use Playwright for raster output.
+export PUPPETEER_CACHE_DIR="${PUPPETEER_CACHE_DIR:-${cache_root}/puppeteer}"
+export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-${cache_root}/playwright}"
+
 case ",${formats}," in
   *",svg,"*|*",png,"*) ;;
   *)
@@ -149,6 +165,13 @@ want_format() {
   esac
 }
 
+backend_skipped() {
+  case ",${skip_backends}," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 png_from_svg() {
   local svg="$1"
   local png="$2"
@@ -160,13 +183,16 @@ png_from_svg() {
     return
   fi
 
-  if have convert; then
+  if have rsvg-convert; then
+    rsvg-convert "$svg" -o "$png"
+    record "$backend" "$source" "PASS" "$png" "derived PNG from SVG with rsvg-convert"
+  elif have convert; then
     convert "$svg" "$png"
-    record "$backend" "$source" "PASS" "$png" "derived PNG from SVG"
+    record "$backend" "$source" "PASS" "$png" "derived PNG from SVG with convert"
   else
-    record "$backend" "$source" "SKIP" "$png" "missing raster converter: convert"
+    record "$backend" "$source" "SKIP" "$png" "missing raster converter: rsvg-convert or convert"
     if [[ "$required" == true ]]; then
-      echo "render_diagrams: required raster converter missing: convert" >&2
+      echo "render_diagrams: required raster converter missing: rsvg-convert or convert" >&2
       exit 1
     fi
   fi
@@ -187,18 +213,27 @@ render_mermaid_file() {
     if [[ "$dry_run" == true ]]; then
       record "mermaid" "$source" "PLAN" "$svg" "would render SVG with mmdc"
     else
-      mmdc -i "$source" -o "$svg"
-      record "mermaid" "$source" "PASS" "$svg" "rendered SVG with mmdc"
+      if mmdc -i "$source" -o "$svg"; then
+        record "mermaid" "$source" "PASS" "$svg" "rendered SVG with mmdc"
+      else
+        record "mermaid" "$source" "FAIL" "$svg" "mmdc SVG render failed"
+        [[ "$required" == true ]] && exit 1
+        return
+      fi
     fi
   fi
 
   if want_format png; then
-    if [[ "$dry_run" == true ]]; then
-      record "mermaid" "$source" "PLAN" "$png" "would render PNG with mmdc"
-    else
-      mmdc -i "$source" -o "$png"
-      record "mermaid" "$source" "PASS" "$png" "rendered PNG with mmdc"
+    if [[ ! -f "$svg" && "$dry_run" != true ]]; then
+      if mmdc -i "$source" -o "$svg"; then
+        record "mermaid" "$source" "PASS" "$svg" "rendered intermediate SVG with mmdc"
+      else
+        record "mermaid" "$source" "FAIL" "$png" "mmdc SVG render failed before PNG conversion"
+        [[ "$required" == true ]] && exit 1
+        return
+      fi
     fi
+    png_from_svg "$svg" "$png" "$source" "mermaid"
   fi
 }
 
@@ -248,18 +283,27 @@ render_d2_file() {
     if [[ "$dry_run" == true ]]; then
       record "d2" "$source" "PLAN" "$svg" "would render SVG with d2"
     else
-      d2 "$source" "$svg"
-      record "d2" "$source" "PASS" "$svg" "rendered SVG with d2"
+      if d2 "$source" "$svg"; then
+        record "d2" "$source" "PASS" "$svg" "rendered SVG with d2"
+      else
+        record "d2" "$source" "FAIL" "$svg" "d2 SVG render failed"
+        [[ "$required" == true ]] && exit 1
+        return
+      fi
     fi
   fi
 
   if want_format png; then
-    if [[ "$dry_run" == true ]]; then
-      record "d2" "$source" "PLAN" "$png" "would render PNG with d2"
-    else
-      d2 "$source" "$png"
-      record "d2" "$source" "PASS" "$png" "rendered PNG with d2"
+    if [[ ! -f "$svg" && "$dry_run" != true ]]; then
+      if d2 "$source" "$svg"; then
+        record "d2" "$source" "PASS" "$svg" "rendered intermediate SVG with d2"
+      else
+        record "d2" "$source" "FAIL" "$png" "d2 SVG render failed before PNG conversion"
+        [[ "$required" == true ]] && exit 1
+        return
+      fi
     fi
+    png_from_svg "$svg" "$png" "$source" "d2"
   fi
 }
 
@@ -278,18 +322,27 @@ render_plantuml_file() {
     if [[ "$dry_run" == true ]]; then
       record "plantuml" "$source" "PLAN" "$svg" "would render SVG with plantuml"
     else
-      plantuml -tsvg -pipe < "$source" > "$svg"
-      record "plantuml" "$source" "PASS" "$svg" "rendered SVG with plantuml"
+      if plantuml -tsvg -pipe < "$source" > "$svg"; then
+        record "plantuml" "$source" "PASS" "$svg" "rendered SVG with plantuml"
+      else
+        record "plantuml" "$source" "FAIL" "$svg" "plantuml SVG render failed"
+        [[ "$required" == true ]] && exit 1
+        return
+      fi
     fi
   fi
 
   if want_format png; then
-    if [[ "$dry_run" == true ]]; then
-      record "plantuml" "$source" "PLAN" "$png" "would render PNG with plantuml"
-    else
-      plantuml -tpng -pipe < "$source" > "$png"
-      record "plantuml" "$source" "PASS" "$png" "rendered PNG with plantuml"
+    if [[ ! -f "$svg" && "$dry_run" != true ]]; then
+      if plantuml -tsvg -pipe < "$source" > "$svg"; then
+        record "plantuml" "$source" "PASS" "$svg" "rendered intermediate SVG with plantuml"
+      else
+        record "plantuml" "$source" "FAIL" "$png" "plantuml SVG render failed before PNG conversion"
+        [[ "$required" == true ]] && exit 1
+        return
+      fi
     fi
+    png_from_svg "$svg" "$png" "$source" "plantuml"
   fi
 }
 
@@ -321,19 +374,39 @@ for source in "$input_dir"/*; do
   stem="${filename%.*}"
   case "$source" in
     *.mmd|*.mermaid)
-      render_mermaid_file "$source" "$stem"
+      if backend_skipped mermaid; then
+        record "mermaid" "$source" "SKIP" "-" "backend skipped by operator"
+      else
+        render_mermaid_file "$source" "$stem"
+      fi
       ;;
     *.md)
-      extract_mermaid_from_markdown "$source" "$stem"
+      if backend_skipped mermaid; then
+        record "mermaid" "$source" "SKIP" "-" "backend skipped by operator"
+      else
+        extract_mermaid_from_markdown "$source" "$stem"
+      fi
       ;;
     *.d2)
-      render_d2_file "$source" "$stem"
+      if backend_skipped d2; then
+        record "d2" "$source" "SKIP" "-" "backend skipped by operator"
+      else
+        render_d2_file "$source" "$stem"
+      fi
       ;;
     *.puml|*.plantuml)
-      render_plantuml_file "$source" "$stem"
+      if backend_skipped plantuml; then
+        record "plantuml" "$source" "SKIP" "-" "backend skipped by operator"
+      else
+        render_plantuml_file "$source" "$stem"
+      fi
       ;;
     *.dsl)
-      render_structurizr_file "$source" "$stem"
+      if backend_skipped structurizr; then
+        record "structurizr" "$source" "SKIP" "-" "backend skipped by operator"
+      else
+        render_structurizr_file "$source" "$stem"
+      fi
       ;;
     *)
       record "unknown" "$source" "SKIP" "-" "unsupported extension"

--- a/adl/tools/skills/diagram-author/scripts/render_diagrams.sh
+++ b/adl/tools/skills/diagram-author/scripts/render_diagrams.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: render_diagrams.sh --input DIR --out DIR [options]
+
+Render diagram-author source files when local renderers are available.
+
+Options:
+  --input DIR       Directory containing diagram sources.
+  --out DIR         Output directory for rendered artifacts and manifest.
+  --formats LIST    Comma-separated formats. Supported: svg,png. Default: svg.
+  --required        Fail when a renderer required for a discovered source is missing.
+  --dry-run         Report planned actions without rendering.
+  --check-tools     Print renderer availability and exit.
+  -h, --help        Show this help.
+
+Supported inputs:
+  Mermaid:      .mmd, .mermaid, and markdown files with ```mermaid fences
+  D2:           .d2
+  PlantUML:     .puml, .plantuml
+  Structurizr:  .dsl (validate/export source model; raster output is downstream)
+USAGE
+}
+
+input_dir=""
+out_dir=""
+formats="svg"
+required=false
+dry_run=false
+check_tools=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input)
+      input_dir="${2:-}"
+      shift 2
+      ;;
+    --out)
+      out_dir="${2:-}"
+      shift 2
+      ;;
+    --formats)
+      formats="${2:-}"
+      shift 2
+      ;;
+    --required)
+      required=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    --check-tools)
+      check_tools=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "render_diagrams: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+tool_status() {
+  local tool="$1"
+  if have "$tool"; then
+    printf '%s\tavailable\t%s\n' "$tool" "$(command -v "$tool")"
+  else
+    printf '%s\tmissing\t-\n' "$tool"
+  fi
+}
+
+if [[ "$check_tools" == true ]]; then
+  tool_status mmdc
+  tool_status d2
+  tool_status plantuml
+  tool_status structurizr
+  tool_status convert
+  exit 0
+fi
+
+if [[ -z "$input_dir" || -z "$out_dir" ]]; then
+  echo "render_diagrams: --input and --out are required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -d "$input_dir" ]]; then
+  echo "render_diagrams: input directory not found: $input_dir" >&2
+  exit 2
+fi
+
+case ",${formats}," in
+  *",svg,"*|*",png,"*) ;;
+  *)
+    echo "render_diagrams: --formats must include svg and/or png" >&2
+    exit 2
+    ;;
+esac
+
+for format in ${formats//,/ }; do
+  case "$format" in
+    svg|png) ;;
+    *)
+      echo "render_diagrams: unsupported format: $format" >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$out_dir"
+manifest="${out_dir}/render-manifest.tsv"
+tmp_dir="${out_dir}/.tmp"
+mkdir -p "$tmp_dir"
+
+printf 'backend\tsource\tstatus\tartifact\tnote\n' > "$manifest"
+
+record() {
+  printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >> "$manifest"
+}
+
+missing_tool() {
+  local backend="$1"
+  local source="$2"
+  local tool="$3"
+  record "$backend" "$source" "SKIP" "-" "missing renderer: ${tool}"
+  if [[ "$required" == true ]]; then
+    echo "render_diagrams: required renderer missing for ${source}: ${tool}" >&2
+    exit 1
+  fi
+}
+
+want_format() {
+  case ",${formats}," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+png_from_svg() {
+  local svg="$1"
+  local png="$2"
+  local source="$3"
+  local backend="$4"
+
+  if [[ "$dry_run" == true ]]; then
+    record "$backend" "$source" "PLAN" "$png" "would derive PNG from SVG"
+    return
+  fi
+
+  if have convert; then
+    convert "$svg" "$png"
+    record "$backend" "$source" "PASS" "$png" "derived PNG from SVG"
+  else
+    record "$backend" "$source" "SKIP" "$png" "missing raster converter: convert"
+    if [[ "$required" == true ]]; then
+      echo "render_diagrams: required raster converter missing: convert" >&2
+      exit 1
+    fi
+  fi
+}
+
+render_mermaid_file() {
+  local source="$1"
+  local stem="$2"
+  local svg="${out_dir}/${stem}.svg"
+  local png="${out_dir}/${stem}.png"
+
+  if ! have mmdc; then
+    missing_tool "mermaid" "$source" "mmdc"
+    return
+  fi
+
+  if want_format svg; then
+    if [[ "$dry_run" == true ]]; then
+      record "mermaid" "$source" "PLAN" "$svg" "would render SVG with mmdc"
+    else
+      mmdc -i "$source" -o "$svg"
+      record "mermaid" "$source" "PASS" "$svg" "rendered SVG with mmdc"
+    fi
+  fi
+
+  if want_format png; then
+    if [[ "$dry_run" == true ]]; then
+      record "mermaid" "$source" "PLAN" "$png" "would render PNG with mmdc"
+    else
+      mmdc -i "$source" -o "$png"
+      record "mermaid" "$source" "PASS" "$png" "rendered PNG with mmdc"
+    fi
+  fi
+}
+
+extract_mermaid_from_markdown() {
+  local source="$1"
+  local base="$2"
+  local count=0
+  local in_block=0
+  local current=""
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$in_block" -eq 0 && "$line" == '```mermaid'* ]]; then
+      count=$((count + 1))
+      current="${tmp_dir}/${base}-${count}.mmd"
+      : > "$current"
+      in_block=1
+      continue
+    fi
+    if [[ "$in_block" -eq 1 && "$line" == '```' ]]; then
+      render_mermaid_file "$current" "${base}-${count}"
+      in_block=0
+      current=""
+      continue
+    fi
+    if [[ "$in_block" -eq 1 ]]; then
+      printf '%s\n' "$line" >> "$current"
+    fi
+  done < "$source"
+
+  if [[ "$count" -eq 0 ]]; then
+    record "mermaid" "$source" "SKIP" "-" "no mermaid fence found"
+  fi
+}
+
+render_d2_file() {
+  local source="$1"
+  local stem="$2"
+  local svg="${out_dir}/${stem}.svg"
+  local png="${out_dir}/${stem}.png"
+
+  if ! have d2; then
+    missing_tool "d2" "$source" "d2"
+    return
+  fi
+
+  if want_format svg; then
+    if [[ "$dry_run" == true ]]; then
+      record "d2" "$source" "PLAN" "$svg" "would render SVG with d2"
+    else
+      d2 "$source" "$svg"
+      record "d2" "$source" "PASS" "$svg" "rendered SVG with d2"
+    fi
+  fi
+
+  if want_format png; then
+    if [[ "$dry_run" == true ]]; then
+      record "d2" "$source" "PLAN" "$png" "would render PNG with d2"
+    else
+      d2 "$source" "$png"
+      record "d2" "$source" "PASS" "$png" "rendered PNG with d2"
+    fi
+  fi
+}
+
+render_plantuml_file() {
+  local source="$1"
+  local stem="$2"
+  local svg="${out_dir}/${stem}.svg"
+  local png="${out_dir}/${stem}.png"
+
+  if ! have plantuml; then
+    missing_tool "plantuml" "$source" "plantuml"
+    return
+  fi
+
+  if want_format svg; then
+    if [[ "$dry_run" == true ]]; then
+      record "plantuml" "$source" "PLAN" "$svg" "would render SVG with plantuml"
+    else
+      plantuml -tsvg -pipe < "$source" > "$svg"
+      record "plantuml" "$source" "PASS" "$svg" "rendered SVG with plantuml"
+    fi
+  fi
+
+  if want_format png; then
+    if [[ "$dry_run" == true ]]; then
+      record "plantuml" "$source" "PLAN" "$png" "would render PNG with plantuml"
+    else
+      plantuml -tpng -pipe < "$source" > "$png"
+      record "plantuml" "$source" "PASS" "$png" "rendered PNG with plantuml"
+    fi
+  fi
+}
+
+render_structurizr_file() {
+  local source="$1"
+  local stem="$2"
+  local export_dir="${out_dir}/${stem}-structurizr-export"
+
+  if ! have structurizr; then
+    missing_tool "structurizr" "$source" "structurizr"
+    return
+  fi
+
+  if [[ "$dry_run" == true ]]; then
+    record "structurizr" "$source" "PLAN" "$export_dir" "would validate and export Mermaid sources"
+    return
+  fi
+
+  structurizr validate -workspace "$source"
+  mkdir -p "$export_dir"
+  structurizr export -workspace "$source" -format mermaid -output "$export_dir"
+  record "structurizr" "$source" "PASS" "$export_dir" "validated DSL and exported Mermaid sources"
+}
+
+shopt -s nullglob
+for source in "$input_dir"/*; do
+  [[ -f "$source" ]] || continue
+  filename="$(basename "$source")"
+  stem="${filename%.*}"
+  case "$source" in
+    *.mmd|*.mermaid)
+      render_mermaid_file "$source" "$stem"
+      ;;
+    *.md)
+      extract_mermaid_from_markdown "$source" "$stem"
+      ;;
+    *.d2)
+      render_d2_file "$source" "$stem"
+      ;;
+    *.puml|*.plantuml)
+      render_plantuml_file "$source" "$stem"
+      ;;
+    *.dsl)
+      render_structurizr_file "$source" "$stem"
+      ;;
+    *)
+      record "unknown" "$source" "SKIP" "-" "unsupported extension"
+      ;;
+  esac
+done
+
+if want_format png && want_format svg; then
+  for svg in "$out_dir"/*.svg; do
+    [[ -f "$svg" ]] || continue
+    png="${svg%.svg}.png"
+    [[ -f "$png" ]] && continue
+    png_from_svg "$svg" "$png" "$svg" "svg-rasterize"
+  done
+fi
+
+rm -rf "$tmp_dir"
+echo "render_diagrams: wrote ${manifest}"

--- a/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md
@@ -152,5 +152,7 @@ policy:
   D2 for polished explainers, and PlantUML for formal UML
 - use `adl/tools/skills/diagram-author/scripts/render_diagrams.sh` for local
   SVG/PNG generation when renderers are available
+- use `references/renderer-setup.md` for Homebrew install commands, repo-local
+  browser caches, sandbox caveats, and Rust-native renderer options
 - keep assumptions, unknowns, and unsupported claims out of the diagram body or
   label them explicitly in the packet

--- a/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,144 @@
+# Diagram Author Skill Input Schema
+
+Schema id: `diagram_author.v1`
+
+## Purpose
+
+Provide one structured invocation shape for the bounded `diagram-author` skill.
+
+The skill should turn one concrete source packet, issue, code slice, doc packet,
+or existing diagram into a reviewable diagram-as-code packet while preserving
+source truth and stopping before external publication.
+
+## Supported Modes
+
+- `draft_from_source_packet`
+- `draft_from_issue`
+- `draft_from_code`
+- `review_or_revise_diagram`
+
+## Top-Level Shape
+
+```yaml
+skill_input_schema: diagram_author.v1
+mode: draft_from_source_packet | draft_from_issue | draft_from_code | review_or_revise_diagram
+repo_root: /absolute/path
+target:
+  source_packet_path: <path or null>
+  source_packet_text: <string or null>
+  issue_number: <integer or null>
+  code_path: <path or null>
+  doc_path: <path or null>
+  diagram_path: <path or null>
+  artifact_root: <path or null>
+  diagram_goal: explain | prove | compare | debug | document | review | unknown
+  audience: engineer | reviewer | user | stakeholder | unknown
+  preferred_backend: mermaid | d2 | plantuml | structurizr | auto
+  required_diagram_family: flowchart | sequence | state | dependency | data_flow | c4 | uml | concept_map | auto
+  forbidden_assumptions:
+    - <string>
+policy:
+  backend_policy: auto_select | prefer_requested | require_requested
+  truth_policy: strict_source_bound | mark_assumptions
+  render_policy: source_only | render_if_tool_available | render_required
+  validation_mode: syntax_only | render_check | artifact_only | none
+  stop_before_publication: true
+```
+
+## Mode Requirements
+
+### `draft_from_source_packet`
+
+Requires:
+
+- `target.source_packet_path`
+
+Use when:
+
+- a bounded packet of facts should become a diagram packet
+
+### `draft_from_issue`
+
+Requires:
+
+- `target.issue_number`
+
+Use when:
+
+- an issue and its local ADL cards should become a diagram packet
+
+### `draft_from_code`
+
+Requires:
+
+- `target.code_path`
+
+Use when:
+
+- one bounded code surface should become a dependency, flow, state, or interaction diagram
+
+### `review_or_revise_diagram`
+
+Requires:
+
+- `target.diagram_path`
+
+Use when:
+
+- an existing diagram source should be reviewed, corrected, or revised against bounded evidence
+
+## Policy Fields
+
+- `backend_policy`
+  - required
+  - one of `auto_select`, `prefer_requested`, or `require_requested`
+- `truth_policy`
+  - required
+  - one of `strict_source_bound` or `mark_assumptions`
+- `render_policy`
+  - required
+  - one of `source_only`, `render_if_tool_available`, or `render_required`
+- `validation_mode`
+  - required
+  - one of `syntax_only`, `render_check`, `artifact_only`, or `none`
+- `stop_before_publication`
+  - must be `true`
+
+## Example Invocation
+
+```yaml
+Use $diagram-author at /Users/daniel/git/agent-design-language/adl/tools/skills/diagram-author/SKILL.md with this validated input:
+
+skill_input_schema: diagram_author.v1
+mode: draft_from_issue
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  source_packet_path: null
+  source_packet_text: null
+  issue_number: 2041
+  code_path: null
+  doc_path: null
+  diagram_path: null
+  artifact_root: .adl/reviews
+  diagram_goal: document
+  audience: engineer
+  preferred_backend: auto
+  required_diagram_family: auto
+  forbidden_assumptions:
+    - hidden runtime behavior
+    - undocumented trust boundaries
+policy:
+  backend_policy: auto_select
+  truth_policy: mark_assumptions
+  render_policy: source_only
+  validation_mode: artifact_only
+  stop_before_publication: true
+```
+
+## Notes
+
+- prefer reviewable diagram source over image-only artifacts
+- choose Mermaid for lightweight docs, Structurizr DSL for C4 model consistency,
+  D2 for polished explainers, and PlantUML for formal UML
+- keep assumptions, unknowns, and unsupported claims out of the diagram body or
+  label them explicitly in the packet

--- a/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md
@@ -42,6 +42,9 @@ policy:
   truth_policy: strict_source_bound | mark_assumptions
   render_policy: source_only | render_if_tool_available | render_required
   validation_mode: syntax_only | render_check | artifact_only | none
+  output_formats:
+    - svg
+    - png
   stop_before_publication: true
 ```
 
@@ -98,6 +101,11 @@ Use when:
 - `render_policy`
   - required
   - one of `source_only`, `render_if_tool_available`, or `render_required`
+- `output_formats`
+  - optional
+  - list containing `svg`, `png`, or both
+  - default is `svg`
+  - prefer `svg`; use `png` only when raster output is explicitly useful
 - `validation_mode`
   - required
   - one of `syntax_only`, `render_check`, `artifact_only`, or `none`
@@ -130,8 +138,10 @@ target:
 policy:
   backend_policy: auto_select
   truth_policy: mark_assumptions
-  render_policy: source_only
-  validation_mode: artifact_only
+  render_policy: render_if_tool_available
+  validation_mode: render_check
+  output_formats:
+    - svg
   stop_before_publication: true
 ```
 
@@ -140,5 +150,7 @@ policy:
 - prefer reviewable diagram source over image-only artifacts
 - choose Mermaid for lightweight docs, Structurizr DSL for C4 model consistency,
   D2 for polished explainers, and PlantUML for formal UML
+- use `adl/tools/skills/diagram-author/scripts/render_diagrams.sh` for local
+  SVG/PNG generation when renderers are available
 - keep assumptions, unknowns, and unsupported claims out of the diagram body or
   label them explicitly in the packet

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -26,6 +26,7 @@ The tracked skill set is:
 - `demo-operator`
 - `medium-article-writer`
 - `arxiv-paper-writer`
+- `diagram-author`
 - `stp-editor`
 - `sip-editor`
 - `sor-editor`
@@ -49,6 +50,7 @@ The normal workflow is:
 `demo-operator` is a bounded helper skill for running one named demo and classifying the proof result consistently.
 `medium-article-writer` is a bounded helper skill for turning one concrete article brief into a reviewer-friendly Medium packet without publishing.
 `arxiv-paper-writer` is a bounded helper skill for turning one concrete scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, or inventing citations.
+`diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 
 The three editor skills are helper skills:
@@ -1651,6 +1653,130 @@ policy:
   validation_mode: artifact_only
   stop_before_submission: true
 Draft the bounded packet, surface citation and claim gaps, and stop before submission.
+```
+
+## `diagram-author`
+
+### Purpose
+
+`diagram-author` creates or revises one source-grounded diagram packet from a
+bounded brief, issue, code slice, doc packet, or review surface.
+
+It is a bounded helper skill for diagram-as-code and model-as-code work, not a
+general architecture approval workflow.
+
+### When To Use It
+
+Use it when:
+
+- a source packet should become a Mermaid, D2, PlantUML, Structurizr DSL, or
+  markdown-outline diagram packet
+- the operator needs a diagram type/backend recommendation before drawing
+- the output should preserve assumptions, unknowns, and render instructions
+- the diagram should be reviewable as text before publication or rendering
+
+Do not use it for:
+
+- inventing architecture, data flow, dependencies, or runtime behavior
+- treating UML as the default when a simpler diagram communicates better
+- publishing diagrams to external platforms without separate approval
+- replacing architecture, security, or implementation review
+
+### Required Inputs
+
+Minimum:
+
+- `repo_root`
+- structured invocation should use `skill_input_schema: diagram_author.v1`
+- one of:
+  - `target.source_packet_path`
+  - `target.source_packet_text`
+  - `target.issue_number`
+  - `target.code_path`
+  - `target.doc_path`
+
+### Input Schema
+
+Canonical schema:
+
+- `adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md`
+
+Schema id:
+
+- `diagram_author.v1`
+
+Structured invocation shape:
+
+```yaml
+skill_input_schema: diagram_author.v1
+mode: draft_from_source_packet | draft_from_issue | draft_from_code | review_or_revise_diagram
+repo_root: /absolute/path
+target:
+  source_packet_path: <path or null>
+  source_packet_text: <string or null>
+  issue_number: <integer or null>
+  code_path: <path or null>
+  doc_path: <path or null>
+  diagram_path: <path or null>
+  artifact_root: <path or null>
+  diagram_goal: explain | prove | compare | debug | document | review | unknown
+  audience: engineer | reviewer | user | stakeholder | unknown
+  preferred_backend: mermaid | d2 | plantuml | structurizr | auto
+  required_diagram_family: flowchart | sequence | state | dependency | data_flow | c4 | uml | concept_map | auto
+  forbidden_assumptions:
+    - <string>
+policy:
+  backend_policy: auto_select | prefer_requested | require_requested
+  truth_policy: strict_source_bound | mark_assumptions
+  render_policy: source_only | render_if_tool_available | render_required
+  validation_mode: syntax_only | render_check | artifact_only | none
+  stop_before_publication: true
+```
+
+### Output And Stop Boundary
+
+Expected output includes:
+
+- target source packet or issue/code/doc surface
+- selected diagram family and backend
+- diagram source or a markdown outline when evidence is insufficient
+- assumptions and unknowns
+- render/validation instructions
+- publication boundary
+- follow-up recommendation
+
+The skill may write one bounded diagram packet or diagram source artifact.
+It must stop before external publication, broad architecture redesign, or
+unsupported visual claims.
+
+### Example Invocation
+
+```yaml
+Use $diagram-author at /Users/daniel/git/agent-design-language/adl/tools/skills/diagram-author/SKILL.md with:
+skill_input_schema: diagram_author.v1
+mode: draft_from_issue
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  source_packet_path: null
+  source_packet_text: null
+  issue_number: 2041
+  code_path: null
+  doc_path: null
+  diagram_path: null
+  artifact_root: .adl/reviews
+  diagram_goal: document
+  audience: engineer
+  preferred_backend: auto
+  required_diagram_family: auto
+  forbidden_assumptions:
+    - hidden runtime behavior
+policy:
+  backend_policy: auto_select
+  truth_policy: mark_assumptions
+  render_policy: source_only
+  validation_mode: artifact_only
+  stop_before_publication: true
+Create the bounded diagram packet, explain backend choice, and stop before publication.
 ```
 
 ## Choosing The Right Skill

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -50,7 +50,7 @@ The normal workflow is:
 `demo-operator` is a bounded helper skill for running one named demo and classifying the proof result consistently.
 `medium-article-writer` is a bounded helper skill for turning one concrete article brief into a reviewer-friendly Medium packet without publishing.
 `arxiv-paper-writer` is a bounded helper skill for turning one concrete scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, or inventing citations.
-`diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection and truth boundaries.
+`diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 
 The three editor skills are helper skills:
@@ -1674,6 +1674,8 @@ Use it when:
 - the operator needs a diagram type/backend recommendation before drawing
 - the output should preserve assumptions, unknowns, and render instructions
 - the diagram should be reviewable as text before publication or rendering
+- local renderers should produce SVG or PNG artifacts without uploading to an
+  external service
 
 Do not use it for:
 
@@ -1730,6 +1732,9 @@ policy:
   truth_policy: strict_source_bound | mark_assumptions
   render_policy: source_only | render_if_tool_available | render_required
   validation_mode: syntax_only | render_check | artifact_only | none
+  output_formats:
+    - svg
+    - png
   stop_before_publication: true
 ```
 
@@ -1740,12 +1745,17 @@ Expected output includes:
 - target source packet or issue/code/doc surface
 - selected diagram family and backend
 - diagram source or a markdown outline when evidence is insufficient
+- rendered SVG/PNG artifacts when rendering is requested and tools are present
 - assumptions and unknowns
 - render/validation instructions
 - publication boundary
 - follow-up recommendation
 
-The skill may write one bounded diagram packet or diagram source artifact.
+The skill may write one bounded diagram packet, diagram source artifact, or
+rendered local artifact packet. Use `adl/tools/skills/diagram-author/scripts/render_diagrams.sh`
+for SVG/PNG generation. Prefer Mermaid when the diagram needs to render inline
+in GitHub, PRs, issues, docs, or Codex chat. Prefer SVG as the durable rendered
+asset and PNG only for raster-only consumers.
 It must stop before external publication, broad architecture redesign, or
 unsupported visual claims.
 
@@ -1773,8 +1783,10 @@ target:
 policy:
   backend_policy: auto_select
   truth_policy: mark_assumptions
-  render_policy: source_only
-  validation_mode: artifact_only
+  render_policy: render_if_tool_available
+  validation_mode: render_check
+  output_formats:
+    - svg
   stop_before_publication: true
 Create the bounded diagram packet, explain backend choice, and stop before publication.
 ```

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -1756,6 +1756,9 @@ rendered local artifact packet. Use `adl/tools/skills/diagram-author/scripts/ren
 for SVG/PNG generation. Prefer Mermaid when the diagram needs to render inline
 in GitHub, PRs, issues, docs, or Codex chat. Prefer SVG as the durable rendered
 asset and PNG only for raster-only consumers.
+Use `adl/tools/skills/diagram-author/references/renderer-setup.md` for local
+renderer installation, browser-cache handling, sandbox caveats, and Rust-native
+renderer follow-up options.
 It must stop before external publication, broad architecture redesign, or
 unsupported visual claims.
 

--- a/adl/tools/test_diagram_author_skill_contracts.sh
+++ b/adl/tools/test_diagram_author_skill_contracts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/diagram-author/SKILL.md" ]]
+[[ -f "${skills_root}/diagram-author/adl-skill.yaml" ]]
+[[ -f "${skills_root}/diagram-author/agents/openai.yaml" ]]
+[[ -f "${skills_root}/diagram-author/references/diagram-playbook.md" ]]
+[[ -f "${skills_root}/diagram-author/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "diagram_author.v1"' "${skills_root}/diagram-author/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/diagram-author/adl-skill.yaml"
+grep -Fq "policy.backend_policy_must_be_explicit" "${skills_root}/diagram-author/adl-skill.yaml"
+grep -Fq "policy.stop_before_publication_must_be_true" "${skills_root}/diagram-author/adl-skill.yaml"
+grep -Fq "Mermaid, D2, PlantUML, Structurizr DSL" "${skills_root}/diagram-author/SKILL.md"
+grep -Fq "Do not choose formal UML just because the request says \"diagram\"" "${skills_root}/diagram-author/SKILL.md"
+grep -Fq "This skill stops at a reviewable diagram packet." "${skills_root}/diagram-author/references/diagram-playbook.md"
+grep -Fq "Publication Attempted: true | false" "${skills_root}/diagram-author/references/output-contract.md"
+grep -Fq 'Schema id: `diagram_author.v1`' "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md"
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/diagram-author/SKILL.md"
+
+echo "PASS test_diagram_author_skill_contracts"

--- a/adl/tools/test_diagram_author_skill_contracts.sh
+++ b/adl/tools/test_diagram_author_skill_contracts.sh
@@ -9,6 +9,7 @@ skills_root="${repo_root}/adl/tools/skills"
 [[ -f "${skills_root}/diagram-author/agents/openai.yaml" ]]
 [[ -f "${skills_root}/diagram-author/references/diagram-playbook.md" ]]
 [[ -f "${skills_root}/diagram-author/references/output-contract.md" ]]
+[[ -f "${skills_root}/diagram-author/references/renderer-setup.md" ]]
 [[ -x "${skills_root}/diagram-author/scripts/render_diagrams.sh" ]]
 [[ -f "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md" ]]
 
@@ -20,6 +21,8 @@ grep -Fq "Mermaid, D2, PlantUML, Structurizr DSL" "${skills_root}/diagram-author
 grep -Fq "Do not choose formal UML just because the request says \"diagram\"" "${skills_root}/diagram-author/SKILL.md"
 grep -Fq "scripts/render_diagrams.sh" "${skills_root}/diagram-author/SKILL.md"
 grep -Fq "Prefer SVG as the durable rendered artifact." "${skills_root}/diagram-author/references/diagram-playbook.md"
+grep -Fq "brew install mermaid-cli d2 plantuml graphviz librsvg" "${skills_root}/diagram-author/references/renderer-setup.md"
+grep -Fq "mermaid-rs-renderer" "${skills_root}/diagram-author/references/renderer-setup.md"
 grep -Fq "Publication Attempted: true | false" "${skills_root}/diagram-author/references/output-contract.md"
 grep -Fq "Rendered Artifacts" "${skills_root}/diagram-author/references/output-contract.md"
 grep -Fq 'Schema id: `diagram_author.v1`' "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md"
@@ -27,6 +30,7 @@ grep -Fq "output_formats" "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA
 
 "${skills_root}/diagram-author/scripts/render_diagrams.sh" --check-tools >/tmp/diagram-author-render-tools.tsv
 "${skills_root}/diagram-author/scripts/render_diagrams.sh" --help | grep -Fq "Supported inputs:"
+"${skills_root}/diagram-author/scripts/render_diagrams.sh" --help | grep -Fq "skip-backends"
 
 bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
   "${skills_root}/diagram-author/SKILL.md"

--- a/adl/tools/test_diagram_author_skill_contracts.sh
+++ b/adl/tools/test_diagram_author_skill_contracts.sh
@@ -9,6 +9,7 @@ skills_root="${repo_root}/adl/tools/skills"
 [[ -f "${skills_root}/diagram-author/agents/openai.yaml" ]]
 [[ -f "${skills_root}/diagram-author/references/diagram-playbook.md" ]]
 [[ -f "${skills_root}/diagram-author/references/output-contract.md" ]]
+[[ -x "${skills_root}/diagram-author/scripts/render_diagrams.sh" ]]
 [[ -f "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq 'id: "diagram_author.v1"' "${skills_root}/diagram-author/adl-skill.yaml"
@@ -17,9 +18,15 @@ grep -Fq "policy.backend_policy_must_be_explicit" "${skills_root}/diagram-author
 grep -Fq "policy.stop_before_publication_must_be_true" "${skills_root}/diagram-author/adl-skill.yaml"
 grep -Fq "Mermaid, D2, PlantUML, Structurizr DSL" "${skills_root}/diagram-author/SKILL.md"
 grep -Fq "Do not choose formal UML just because the request says \"diagram\"" "${skills_root}/diagram-author/SKILL.md"
-grep -Fq "This skill stops at a reviewable diagram packet." "${skills_root}/diagram-author/references/diagram-playbook.md"
+grep -Fq "scripts/render_diagrams.sh" "${skills_root}/diagram-author/SKILL.md"
+grep -Fq "Prefer SVG as the durable rendered artifact." "${skills_root}/diagram-author/references/diagram-playbook.md"
 grep -Fq "Publication Attempted: true | false" "${skills_root}/diagram-author/references/output-contract.md"
+grep -Fq "Rendered Artifacts" "${skills_root}/diagram-author/references/output-contract.md"
 grep -Fq 'Schema id: `diagram_author.v1`' "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md"
+grep -Fq "output_formats" "${skills_root}/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md"
+
+"${skills_root}/diagram-author/scripts/render_diagrams.sh" --check-tools >/tmp/diagram-author-render-tools.tsv
+"${skills_root}/diagram-author/scripts/render_diagrams.sh" --help | grep -Fq "Supported inputs:"
 
 bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
   "${skills_root}/diagram-author/SKILL.md"

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -25,6 +25,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
   [[ -f "${root}/skills/arxiv-paper-writer/SKILL.md" ]]
   [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
+  [[ -x "${root}/skills/diagram-author/scripts/render_diagrams.sh" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review test-generator demo-operator medium-article-writer arxiv-paper-writer stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -24,6 +24,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
   [[ -f "${root}/skills/arxiv-paper-writer/SKILL.md" ]]
+  [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]
@@ -40,6 +41,7 @@ assert_skill_bundle() {
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
   grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
+  grep -Fq "diagram-as-code and model-as-code router" "${root}/skills/diagram-author/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
   grep -Fq "truthful execution and integration state" "${root}/skills/sor-editor/SKILL.md"
@@ -57,6 +59,7 @@ assert_skill_bundle() {
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
     "${root}/skills/arxiv-paper-writer/SKILL.md" \
+    "${root}/skills/diagram-author/SKILL.md" \
     "${root}/skills/stp-editor/SKILL.md" \
     "${root}/skills/sip-editor/SKILL.md" \
     "${root}/skills/sor-editor/SKILL.md"
@@ -73,6 +76,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/pr-init" ]]
 [[ -L "${CODEX_HOME}/skills/pr-ready" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
+[[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]
 
 malformed_root="${tmpdir}/malformed-skills"


### PR DESCRIPTION
Closes #2041

## Summary
Implemented `diagram-author` as a first-class ADL operational skill for source-grounded diagram-as-code and model-as-code packets. The skill selects Mermaid, Structurizr DSL, D2, PlantUML, or markdown-outline output based on evidence, audience, and communication goal while preserving truth boundaries, optionally rendering local SVG/PNG artifacts, and stopping before external publication.

## Artifacts
- `adl/tools/skills/diagram-author/SKILL.md`
- `adl/tools/skills/diagram-author/adl-skill.yaml`
- `adl/tools/skills/diagram-author/agents/openai.yaml`
- `adl/tools/skills/diagram-author/scripts/render_diagrams.sh`
- `adl/tools/skills/diagram-author/references/diagram-playbook.md`
- `adl/tools/skills/diagram-author/references/output-contract.md`
- `adl/tools/skills/diagram-author/references/renderer-setup.md`
- `adl/tools/skills/docs/DIAGRAM_AUTHOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_diagram_author_skill_contracts.sh`
- Updates to `adl/tools/test_install_adl_operational_skills.sh`, `adl/tools/batched_checks.sh`, and `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_diagram_author_skill_contracts.sh`: verifies the diagram-author skill bundle and contract surfaces.
  - `bash adl/tools/test_install_adl_operational_skills.sh`: verifies operational skill installation includes diagram-author in copy and symlink modes.
  - `bash adl/tools/skills/diagram-author/scripts/render_diagrams.sh --check-tools`: verifies renderer discovery reports installed and missing tools without failing.
  - `bash adl/tools/skills/diagram-author/scripts/render_diagrams.sh --input .adl/docs/TBD/diagram-test --out <temp-render-dir> --formats svg,png --skip-backends mermaid`: verifies the renderer manifest path, D2/PlantUML SVG rendering, PNG derivation from SVG, and optional SKIP semantics for sandbox-blocked or missing backends.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/diagram-author/SKILL.md`: verifies skill frontmatter.
  - `bash adl/tools/batched_checks.sh`: verifies standard tooling contracts and Rust formatting, linting, and tests.
- Results: PASS for all commands.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2041__backlog-skills-add-diagram-author-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2041__backlog-skills-add-diagram-author-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-diagram-author-skill-adl-tools-skills-diagram-author-skill-md-adl-tools-skills-diagram-author-adl-skill-yaml-adl-tools-skills-diagram-author-agents-openai-yaml-adl-tools-skills-diagram-author-scripts-render-diagrams-sh-adl-tools-skills-diagram-author-references-diagram-playbook-md-adl-tools-skills-diagram-author-references-output-contract-md-adl-tools-skills-diagram-author-references-renderer-setup-md-adl-tools-skills-docs-diagram-author-skill-input-schema-md-adl-tools-test-diagram-author-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-tools-skills-docs-operational-skills-guide-md-adl-v0-90-tasks-issue-2041-backlog-skills-add-diagram-author-skill-sip-md-adl-v0-90-tasks-issue-2041-backlog-skills-add-diagram-author-skill-sor-md