### PR TITLE
[v0.90][backlog][skills] Add repo packet builder skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -37,6 +37,7 @@ bash -n "$ROOT/adl/tools/codexw.sh"
 echo "Skipping codex_pr sanity check (no --paths configured)."
 sh "$ROOT/adl/tools/codexw.sh" --help >/dev/null 2>&1
 run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_review_skill_contracts.sh"
+run_step "repo-packet-builder contract check" bash "$ROOT/adl/tools/test_repo_packet_builder_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/docs/REPO_PACKET_BUILDER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REPO_PACKET_BUILDER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,78 @@
+# Repo Packet Builder Skill Input Schema
+
+Schema id: `repo_packet_builder.v1`
+
+Use this schema when invoking the `repo-packet-builder` skill with structured
+input.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must equal `repo_packet_builder.v1`.
+- `mode`: one supported mode.
+- `repo_root`: absolute path to the repository root.
+- `target`: object describing the scope.
+- `policy`: object describing packet-building policy.
+
+## Modes
+
+- `build_repository_packet`
+- `build_path_packet`
+- `build_branch_packet`
+- `build_diff_packet`
+- `refresh_packet`
+
+## Target Fields
+
+- `target_path`: required for `build_path_packet`.
+- `branch`: required for `build_branch_packet`.
+- `diff_base`: required for `build_diff_packet`.
+- `changed_paths`: optional path list.
+- `existing_packet_path`: required for `refresh_packet`.
+- `artifact_root`: optional output root.
+
+## Policy Fields
+
+- `scope_policy`: required; for example `whole_repo`, `path_only`,
+  `diff_plus_context`, or `refresh_existing`.
+- `privacy_mode`: required; for example `local_only`, `customer_private`, or
+  `public_safe_shape`.
+- `include_generated_code`: required boolean when structured input is used.
+- `include_vendor_code`: required boolean when structured input is used.
+- `context_budget`: required; may be a qualitative label or numeric budget.
+- `specialist_lanes`: required list when structured input is used.
+- `stop_before_review`: must be `true`.
+
+## Example
+
+```yaml
+skill_input_schema: repo_packet_builder.v1
+mode: build_repository_packet
+repo_root: /abs/path/to/repo
+target:
+  artifact_root: .adl/reviews/codebuddy/example-run
+policy:
+  scope_policy: whole_repo
+  privacy_mode: local_only
+  include_generated_code: false
+  include_vendor_code: false
+  context_budget: bounded
+  specialist_lanes:
+    - code
+    - security
+    - tests
+    - docs
+    - architecture
+    - dependencies
+  stop_before_review: true
+```
+
+## Stop Conditions
+
+Stop and report `blocked` when:
+
+- `repo_root` is missing.
+- the requested path/diff/branch target is missing.
+- policy is not explicit.
+- `stop_before_review` is false.
+- the artifact root cannot be written.
+

--- a/adl/tools/skills/repo-packet-builder/SKILL.md
+++ b/adl/tools/skills/repo-packet-builder/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: repo-packet-builder
+description: Build a bounded, source-grounded repository review packet for CodeBuddy-style specialist review lanes before any review, diagram, test, issue, or report skill runs.
+---
+
+# Repo Packet Builder
+
+Build the shared evidence packet that downstream CodeBuddy review skills consume.
+This skill is a packet-construction skill, not a reviewer and not a remediation
+workflow.
+
+The packet should make scope explicit before specialist agents start reading:
+what repo/ref was reviewed, which paths were included or excluded, which
+manifests/docs/tests/config surfaces exist, which high-signal files should be
+sampled first, and which specialist lanes should receive which evidence.
+
+## Quick Start
+
+1. Confirm the review target:
+   - whole repository
+   - path slice
+   - branch or diff context
+   - existing review packet refresh
+2. Run the deterministic packet helper when local filesystem access is
+   available:
+   - `scripts/build_repo_packet.py <repo-root> --out <artifact-root>`
+3. Review the generated packet for scope, exclusions, assumptions, and
+   specialist assignments.
+4. Stop after writing the packet. Hand it to review, diagram, test, redaction,
+   issue-planning, or report-writing skills as separate downstream work.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- `mode`
+- `target`
+- `policy`
+
+Supported modes:
+
+- `build_repository_packet`
+- `build_path_packet`
+- `build_branch_packet`
+- `build_diff_packet`
+- `refresh_packet`
+
+Useful target fields:
+
+- `target_path`
+- `branch`
+- `diff_base`
+- `changed_paths`
+- `existing_packet_path`
+- `artifact_root`
+
+Useful policy fields:
+
+- `scope_policy`
+- `privacy_mode`
+- `include_generated_code`
+- `include_vendor_code`
+- `context_budget`
+- `specialist_lanes`
+- `stop_before_review`
+
+If there is no concrete repo root or target scope, stop and report `blocked`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- review mode
+- included paths
+- excluded paths
+- non-reviewed surfaces
+- assumptions
+- known limits
+- whether the packet is for public, customer-private, or local-only use
+
+Do not silently expand from a path or diff review into a whole-repo review.
+
+### 2. Inventory The Repo
+
+Identify:
+
+- tracked files
+- top-level directories
+- dominant file extensions
+- likely application roots
+- likely code roots
+- docs surfaces
+- test surfaces
+- CI/build/tooling surfaces
+- package manifests and lockfiles
+- generated, vendored, build-output, and cache-heavy surfaces
+- largest files and largest code files
+
+Prefer `git ls-files` for deterministic tracked-file inventory. Fall back to a
+sorted filesystem walk only when the target is not a Git repository.
+
+### 3. Build Evidence Index
+
+Create relative-path evidence references only. Do not write absolute host paths
+into the packet artifacts unless the operator explicitly requests a private
+local diagnostic packet.
+
+Each evidence entry should include:
+
+- relative path
+- evidence category
+- line count when available
+- reason it is high signal
+- suggested specialist lanes
+
+### 4. Assign Specialist Lanes
+
+Assign bounded packet slices to downstream lanes:
+
+- `code`
+- `security`
+- `tests`
+- `docs`
+- `architecture`
+- `dependencies`
+- `diagrams`
+- `redaction`
+- `synthesis`
+
+Keep assignments as recommendations. This skill does not run the specialists.
+
+### 5. Emit Packet Artifacts
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/
+```
+
+Required artifacts:
+
+- `run_manifest.json`
+- `repo_scope.md`
+- `repo_inventory.json`
+- `evidence_index.json`
+- `specialist_assignments.json`
+
+Optional artifacts:
+
+- `packet_notes.md`
+- `redaction_todo.md`
+
+## Output Expectations
+
+Default output should include:
+
+- artifact root
+- review mode
+- included and excluded surfaces
+- generated files
+- packet quality caveats
+- next recommended skill lanes
+
+Use the output contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+Stop after producing or validating the packet.
+
+Do not:
+
+- perform code, security, docs, tests, dependency, or architecture review
+- generate diagrams
+- generate tests
+- create issues
+- write product reports
+- mutate customer repositories
+- publish packet artifacts externally
+- claim review findings or remediation readiness
+
+## Privacy Boundary
+
+The default packet is customer-safe in shape but not automatically publishable.
+Run `redaction-and-evidence-auditor` before any public/customer-facing report.
+
+Packet artifacts should use repo-relative paths. Avoid absolute paths, secrets,
+raw prompts, raw tool arguments, and excessive source excerpts.
+

--- a/adl/tools/skills/repo-packet-builder/adl-skill.yaml
+++ b/adl/tools/skills/repo-packet-builder/adl-skill.yaml
@@ -1,0 +1,135 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-packet-builder"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_packet_builder.v1"
+    reference_doc: "../docs/REPO_PACKET_BUILDER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "build_repository_packet"
+      - "build_path_packet"
+      - "build_branch_packet"
+      - "build_diff_packet"
+      - "refresh_packet"
+    policy_fields:
+      - "scope_policy"
+      - "privacy_mode"
+      - "include_generated_code"
+      - "include_vendor_code"
+      - "context_budget"
+      - "specialist_lanes"
+      - "stop_before_review"
+    mode_requirements:
+      build_repository_packet:
+        required_target_fields: []
+      build_path_packet:
+        required_target_fields:
+          - "target_path"
+      build_branch_packet:
+        required_target_fields:
+          - "branch"
+      build_diff_packet:
+        required_target_fields:
+          - "diff_base"
+      refresh_packet:
+        required_target_fields:
+          - "existing_packet_path"
+  intent:
+    - "repo_packet_construction"
+    - "review_scope_planning"
+    - "codebuddy_review_engine"
+    - "specialist_lane_assignment"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "target_path"
+    - "branch"
+    - "diff_base"
+    - "changed_paths"
+    - "existing_packet_path"
+    - "artifact_root"
+    - "context_budget"
+    - "specialist_lanes"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_packet_builder.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "build_path_packet_requires_target.target_path"
+    - "build_branch_packet_requires_target.branch"
+    - "build_diff_packet_requires_target.diff_base"
+    - "refresh_packet_requires_target.existing_packet_path"
+    - "policy.scope_policy_must_be_explicit"
+    - "policy.privacy_mode_must_be_explicit"
+    - "policy.context_budget_must_be_explicit"
+    - "policy.stop_before_review_must_be_true"
+execution:
+  mode: "packet_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/build_repo_packet.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<repo-root>"
+        - "--out <artifact-root>"
+        - "--mode <mode>"
+        - "--target-path <path>"
+        - "--diff-base <ref>"
+        - "--privacy-mode <mode>"
+  preferred_read_order:
+    - "repo_root"
+    - "target_scope"
+    - "top_level_manifests"
+    - "ci_and_tooling"
+    - "docs_surfaces"
+    - "test_surfaces"
+    - "code_roots"
+    - "largest_code_files"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  ignore_by_default:
+    - ".git/**"
+    - "node_modules/**"
+    - "dist/**"
+    - "build/**"
+    - "target/**"
+    - "coverage/**"
+    - ".next/**"
+    - ".venv/**"
+    - "venv/**"
+  must_not_run:
+    - "specialist_reviews"
+    - "diagram_generation"
+    - "test_generation"
+    - "issue_creation"
+    - "report_publication"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/codebuddy/<run_id>/"
+  required_artifacts:
+    - "run_manifest.json"
+    - "repo_scope.md"
+    - "repo_inventory.json"
+    - "evidence_index.json"
+    - "specialist_assignments.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: true
+

--- a/adl/tools/skills/repo-packet-builder/agents/openai.yaml
+++ b/adl/tools/skills/repo-packet-builder/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: Repo Packet Builder
+short_description: Build a bounded CodeBuddy repo review packet
+default_prompt: Build a source-grounded repository review packet with explicit scope, exclusions, evidence references, and specialist lane assignments. Stop before review or remediation.
+

--- a/adl/tools/skills/repo-packet-builder/references/output-contract.md
+++ b/adl/tools/skills/repo-packet-builder/references/output-contract.md
@@ -1,0 +1,112 @@
+# Output Contract
+
+The repo packet builder produces a CodeBuddy review packet root.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/
+```
+
+## Required Artifacts
+
+### run_manifest.json
+
+Required fields:
+
+- `schema`
+- `run_id`
+- `repo_name`
+- `repo_ref`
+- `review_mode`
+- `started_at`
+- `completed_at`
+- `skills_used`
+- `artifact_root`
+- `privacy_mode`
+- `publication_allowed`
+
+### repo_scope.md
+
+Required sections:
+
+- `# Repo Scope`
+- `## Scope Reviewed`
+- `## Included Paths`
+- `## Excluded Paths`
+- `## Non-Reviewed Surfaces`
+- `## Assumptions`
+- `## Known Limits`
+- `## Next Specialist Lanes`
+
+### repo_inventory.json
+
+Required fields:
+
+- `schema`
+- `repo_name`
+- `file_count`
+- `extension_counts`
+- `top_level_dirs`
+- `manifests`
+- `docs`
+- `tests`
+- `ci`
+- `likely_code_roots`
+- `largest_files`
+- `largest_code_files`
+
+### evidence_index.json
+
+Required fields:
+
+- `schema`
+- `evidence`
+
+Each evidence entry should include:
+
+- `path`
+- `category`
+- `line_count`
+- `reason`
+- `specialist_lanes`
+
+### specialist_assignments.json
+
+Required fields:
+
+- `schema`
+- `assignments`
+
+Default lanes:
+
+- `code`
+- `security`
+- `tests`
+- `docs`
+- `architecture`
+- `dependencies`
+- `diagrams`
+- `redaction`
+- `synthesis`
+
+## Rules
+
+- Use repo-relative paths.
+- Do not write absolute host paths into packet artifacts.
+- Do not include source excerpts by default.
+- Do not claim review findings.
+- Do not claim publication safety before redaction review.
+- Do not mutate the reviewed repository.
+
+## Success Summary
+
+When complete, report:
+
+- artifact root
+- review mode
+- generated artifacts
+- included/excluded scope summary
+- specialist lanes prepared
+- caveats and next skill
+

--- a/adl/tools/skills/repo-packet-builder/references/packet-playbook.md
+++ b/adl/tools/skills/repo-packet-builder/references/packet-playbook.md
@@ -1,0 +1,68 @@
+# Repo Packet Builder Playbook
+
+Use this playbook after the skill triggers and before any specialist review
+lane runs.
+
+## Packet Priorities
+
+Packet construction should answer:
+
+- What is the exact review scope?
+- What files and surfaces are included?
+- What files and surfaces are excluded?
+- Which repo evidence is high signal for each specialist lane?
+- What is known, assumed, unknown, and not reviewed?
+- What privacy mode controls evidence disclosure?
+
+## Scope Rules
+
+- Whole-repo mode may include all tracked files except ignored generated/vendor
+  surfaces.
+- Path mode must stay inside the requested target path.
+- Diff mode must include changed paths plus enough nearby context to make review
+  meaningful.
+- Refresh mode must preserve the original packet's scope unless explicitly
+  widened.
+
+## Evidence Categories
+
+Recommended categories:
+
+- `manifest`
+- `lockfile`
+- `ci`
+- `tooling`
+- `code`
+- `test`
+- `docs`
+- `architecture_docs`
+- `security_docs`
+- `demo`
+- `generated_or_vendor`
+- `large_file`
+
+## Specialist Lane Hints
+
+- `code`: executable source, entrypoints, stateful modules, large code files.
+- `security`: auth, secrets, filesystem/network IO, CI, scripts, config.
+- `tests`: test roots, fixtures, coverage config, validation commands.
+- `docs`: README, docs, milestone docs, onboarding, API/CLI docs.
+- `architecture`: architecture docs, module roots, manifests, runtime surfaces.
+- `dependencies`: package manifests, lockfiles, Docker/toolchain/CI config.
+- `diagrams`: architecture docs, module maps, workflow docs, generated packet
+  summaries.
+- `redaction`: all artifacts before publication.
+- `synthesis`: all specialist outputs after review lanes complete.
+
+## Quality Checks
+
+Before handing off:
+
+- Packet artifacts exist.
+- Paths are repo-relative.
+- Exclusions are explicit.
+- Non-reviewed surfaces are explicit.
+- Specialist assignments are bounded.
+- No review findings are invented.
+- No absolute host paths or secrets are written into public-shaped artifacts.
+

--- a/adl/tools/skills/repo-packet-builder/scripts/build_repo_packet.py
+++ b/adl/tools/skills/repo-packet-builder/scripts/build_repo_packet.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Build a deterministic CodeBuddy repository review packet."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+from collections import Counter, defaultdict
+from pathlib import Path
+
+SCHEMA_PREFIX = "codebuddy.repo_packet"
+IGNORED_DIR_NAMES = {
+    ".git",
+    "node_modules",
+    "dist",
+    "build",
+    "target",
+    "coverage",
+    ".next",
+    ".venv",
+    "venv",
+    "__pycache__",
+}
+MANIFEST_NAMES = {
+    "Cargo.toml",
+    "Cargo.lock",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "pyproject.toml",
+    "requirements.txt",
+    "go.mod",
+    "go.sum",
+    "pom.xml",
+    "build.gradle",
+    "settings.gradle",
+    "Dockerfile",
+    "docker-compose.yml",
+    "Makefile",
+}
+CODE_SUFFIXES = {
+    ".rs",
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".go",
+    ".java",
+    ".kt",
+    ".rb",
+    ".php",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".swift",
+    ".scala",
+    ".sh",
+}
+DOC_SUFFIXES = {".md", ".mdx", ".rst", ".adoc", ".txt"}
+MAX_LIST = 40
+
+
+def run_git(repo_root: Path, args: list[str]) -> tuple[int, str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+def tracked_files(repo_root: Path) -> list[str]:
+    code, stdout = run_git(repo_root, ["ls-files"])
+    if code == 0 and stdout:
+        return [line for line in stdout.splitlines() if line.strip()]
+    files: list[str] = []
+    for path in sorted(repo_root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root)
+        if any(part in IGNORED_DIR_NAMES for part in rel.parts):
+            continue
+        files.append(rel.as_posix())
+    return files
+
+
+def repo_ref(repo_root: Path) -> str:
+    code, stdout = run_git(repo_root, ["rev-parse", "--short", "HEAD"])
+    if code == 0 and stdout:
+        return stdout
+    return "unknown"
+
+
+def count_lines(path: Path) -> int:
+    try:
+        with path.open("rb") as handle:
+            return sum(1 for _ in handle)
+    except OSError:
+        return -1
+
+
+def is_test_path(path: Path) -> bool:
+    lowered = path.as_posix().lower()
+    parts = {part.lower() for part in path.parts}
+    stem = path.stem.lower()
+    return (
+        bool(parts & {"test", "tests", "__tests__", "spec", "specs"})
+        or stem.endswith("_test")
+        or stem.endswith("_spec")
+        or ".test." in lowered
+        or ".spec." in lowered
+    )
+
+
+def is_doc_path(path: Path) -> bool:
+    parts = {part.lower() for part in path.parts}
+    return path.suffix.lower() in DOC_SUFFIXES or bool(parts & {"doc", "docs", "documentation"})
+
+
+def is_ci_path(path: Path) -> bool:
+    lowered = path.as_posix().lower()
+    return lowered.startswith(".github/workflows/") or lowered.startswith(".gitlab-ci") or "ci" in path.parts
+
+
+def is_code_path(path: Path) -> bool:
+    parts = {part.lower() for part in path.parts}
+    return path.suffix.lower() in CODE_SUFFIXES or bool(parts & {"src", "lib", "app", "server", "client", "bin"})
+
+
+def is_manifest(path: Path) -> bool:
+    return path.name in MANIFEST_NAMES or path.name.endswith(".lock")
+
+
+def category_for(path: Path) -> str:
+    if is_manifest(path):
+        return "manifest"
+    if is_ci_path(path):
+        return "ci"
+    if is_test_path(path):
+        return "test"
+    if is_doc_path(path):
+        if "architecture" in {part.lower() for part in path.parts}:
+            return "architecture_docs"
+        return "docs"
+    if is_code_path(path):
+        return "code"
+    if any(part in IGNORED_DIR_NAMES for part in path.parts):
+        return "generated_or_vendor"
+    return "other"
+
+
+def lanes_for(category: str, path: Path) -> list[str]:
+    lanes: set[str] = set()
+    if category in {"code", "manifest", "ci"}:
+        lanes.add("code")
+    if category in {"manifest", "ci"} or path.suffix.lower() in {".sh", ".py", ".js", ".ts"}:
+        lanes.add("security")
+    if category == "test":
+        lanes.add("tests")
+    if category in {"docs", "architecture_docs"}:
+        lanes.add("docs")
+    if category in {"architecture_docs", "manifest", "code"}:
+        lanes.add("architecture")
+    if category in {"manifest", "ci"}:
+        lanes.add("dependencies")
+    if category in {"architecture_docs", "docs", "manifest", "code"}:
+        lanes.add("diagrams")
+    lanes.add("redaction")
+    lanes.add("synthesis")
+    return sorted(lanes)
+
+
+def limited(items: list[str], limit: int = MAX_LIST) -> list[str]:
+    return items[:limit]
+
+
+def inventory(repo_root: Path, files: list[str]) -> dict[str, object]:
+    ext_counts: Counter[str] = Counter()
+    top_dirs: Counter[str] = Counter()
+    code_roots: Counter[str] = Counter()
+    manifests: list[str] = []
+    docs: list[str] = []
+    tests: list[str] = []
+    ci: list[str] = []
+    largest_files: list[tuple[int, str]] = []
+    largest_code_files: list[tuple[int, str]] = []
+
+    for rel in files:
+        path = Path(rel)
+        full_path = repo_root / rel
+        ext_counts[path.suffix.lower() or "<no_ext>"] += 1
+        top_dirs[path.parts[0] if len(path.parts) > 1 else "."] += 1
+        line_count = count_lines(full_path)
+        largest_files.append((line_count, rel))
+        if is_code_path(path):
+            code_roots[path.parts[0] if len(path.parts) > 1 else "."] += 1
+            largest_code_files.append((line_count, rel))
+        if is_manifest(path):
+            manifests.append(rel)
+        if is_doc_path(path):
+            docs.append(rel)
+        if is_test_path(path):
+            tests.append(rel)
+        if is_ci_path(path):
+            ci.append(rel)
+
+    largest_files.sort(key=lambda item: (-item[0], item[1]))
+    largest_code_files.sort(key=lambda item: (-item[0], item[1]))
+
+    return {
+        "schema": f"{SCHEMA_PREFIX}.inventory.v1",
+        "repo_name": repo_root.name,
+        "file_count": len(files),
+        "extension_counts": dict(sorted(ext_counts.items())),
+        "top_level_dirs": dict(sorted(top_dirs.items())),
+        "manifests": sorted(manifests),
+        "docs": limited(sorted(docs)),
+        "tests": limited(sorted(tests)),
+        "ci": sorted(ci),
+        "likely_code_roots": [name for name, _ in code_roots.most_common(20)],
+        "largest_files": [{"path": path, "line_count": lines} for lines, path in largest_files[:20]],
+        "largest_code_files": [
+            {"path": path, "line_count": lines} for lines, path in largest_code_files[:20]
+        ],
+    }
+
+
+def build_evidence(repo_root: Path, files: list[str]) -> list[dict[str, object]]:
+    scored: list[tuple[int, str, dict[str, object]]] = []
+    for rel in files:
+        path = Path(rel)
+        category = category_for(path)
+        line_count = count_lines(repo_root / rel)
+        score = 0
+        reasons: list[str] = []
+        if category == "manifest":
+            score += 50
+            reasons.append("manifest or dependency/build surface")
+        if category == "ci":
+            score += 35
+            reasons.append("CI or automation surface")
+        if category == "architecture_docs":
+            score += 35
+            reasons.append("architecture documentation surface")
+        if category == "test":
+            score += 20
+            reasons.append("test or validation surface")
+        if category == "code":
+            score += 20
+            reasons.append("executable code surface")
+        if line_count > 500:
+            score += 10
+            reasons.append("large file")
+        if path.name.lower() in {"readme.md", "readme"}:
+            score += 20
+            reasons.append("top-level onboarding surface")
+        if score == 0:
+            continue
+        scored.append(
+            (
+                -score,
+                rel,
+                {
+                    "path": rel,
+                    "category": category,
+                    "line_count": line_count,
+                    "reason": "; ".join(reasons),
+                    "specialist_lanes": lanes_for(category, path),
+                },
+            )
+        )
+    return [entry for _, _, entry in sorted(scored)[:120]]
+
+
+def assignments_from_evidence(evidence: list[dict[str, object]]) -> dict[str, list[str]]:
+    assignments: dict[str, list[str]] = defaultdict(list)
+    for entry in evidence:
+        for lane in entry["specialist_lanes"]:
+            assignments[lane].append(str(entry["path"]))
+    for lane in ["code", "security", "tests", "docs", "architecture", "dependencies", "diagrams"]:
+        assignments.setdefault(lane, [])
+    assignments["redaction"] = ["run_manifest.json", "repo_scope.md", "repo_inventory.json", "evidence_index.json"]
+    assignments["synthesis"] = ["all specialist artifacts after review lanes complete"]
+    return {lane: limited(sorted(set(paths)), 30) for lane, paths in sorted(assignments.items())}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_scope(path: Path, args: argparse.Namespace, repo_name: str, inv: dict[str, object]) -> None:
+    included = [
+        "tracked repository files",
+        "top-level manifests",
+        "docs, tests, CI, and likely code roots",
+    ]
+    if args.target_path:
+        included = [f"path scope: {args.target_path}"]
+    excluded = sorted(f"{name}/**" for name in IGNORED_DIR_NAMES)
+    content = f"""# Repo Scope
+
+## Scope Reviewed
+
+- Repository: {repo_name}
+- Review mode: {args.mode}
+- Target path: {args.target_path or "not specified"}
+- Diff base: {args.diff_base or "not specified"}
+- Privacy mode: {args.privacy_mode}
+
+## Included Paths
+
+{chr(10).join(f"- {item}" for item in included)}
+
+## Excluded Paths
+
+{chr(10).join(f"- {item}" for item in excluded)}
+
+## Non-Reviewed Surfaces
+
+- Runtime behavior was not executed.
+- Specialist review lanes were not run by this packet builder.
+- Generated/vendor/cache surfaces are excluded by default.
+
+## Assumptions
+
+- Git-tracked files represent the intended review surface when available.
+- Repo-relative paths are sufficient evidence references for downstream lanes.
+
+## Known Limits
+
+- The packet contains path evidence and metadata, not source excerpts.
+- Publication safety requires a separate redaction/evidence audit.
+- Path or diff scope must be expanded explicitly if downstream reviewers need more context.
+
+## Next Specialist Lanes
+
+- code
+- security
+- tests
+- docs
+- architecture
+- dependencies
+- diagrams
+- redaction
+- synthesis
+
+## Inventory Summary
+
+- File count: {inv["file_count"]}
+- Manifest count: {len(inv["manifests"])}
+- Docs sampled: {len(inv["docs"])}
+- Tests sampled: {len(inv["tests"])}
+- CI files: {len(inv["ci"])}
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo_root", help="Repository root to inventory")
+    parser.add_argument("--out", default=None, help="Packet artifact root")
+    parser.add_argument("--mode", default="build_repository_packet", help="Packet mode")
+    parser.add_argument("--target-path", default=None, help="Optional path scope")
+    parser.add_argument("--diff-base", default=None, help="Optional diff base")
+    parser.add_argument("--privacy-mode", default="local_only", help="Privacy mode")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    if not repo_root.is_dir():
+        raise SystemExit(f"repo root does not exist: {repo_root}")
+
+    run_id = dt.datetime.now(dt.UTC).strftime("%Y%m%d-%H%M%S-repo-packet")
+    artifact_root = Path(args.out) if args.out else repo_root / ".adl" / "reviews" / "codebuddy" / run_id
+    if not artifact_root.is_absolute():
+        artifact_root = repo_root / artifact_root
+    artifact_root.mkdir(parents=True, exist_ok=True)
+
+    files = tracked_files(repo_root)
+    if args.target_path:
+        prefix = Path(args.target_path).as_posix().rstrip("/") + "/"
+        files = [path for path in files if path == args.target_path or path.startswith(prefix)]
+
+    inv = inventory(repo_root, files)
+    evidence = build_evidence(repo_root, files)
+    assignments = assignments_from_evidence(evidence)
+    now = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    manifest = {
+        "schema": f"{SCHEMA_PREFIX}.run_manifest.v1",
+        "run_id": run_id,
+        "repo_name": repo_root.name,
+        "repo_ref": repo_ref(repo_root),
+        "review_mode": args.mode,
+        "started_at": now,
+        "completed_at": now,
+        "skills_used": ["repo-packet-builder"],
+        "artifact_root": artifact_root.relative_to(repo_root).as_posix()
+        if artifact_root.is_relative_to(repo_root)
+        else artifact_root.name,
+        "privacy_mode": args.privacy_mode,
+        "publication_allowed": False,
+    }
+
+    write_json(artifact_root / "run_manifest.json", manifest)
+    write_scope(artifact_root / "repo_scope.md", args, repo_root.name, inv)
+    write_json(artifact_root / "repo_inventory.json", inv)
+    write_json(artifact_root / "evidence_index.json", {"schema": f"{SCHEMA_PREFIX}.evidence.v1", "evidence": evidence})
+    write_json(
+        artifact_root / "specialist_assignments.json",
+        {"schema": f"{SCHEMA_PREFIX}.assignments.v1", "assignments": assignments},
+    )
+
+    print(artifact_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -20,6 +20,8 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/pr-janitor/SKILL.md" ]]
   [[ -f "${root}/skills/pr-closeout/SKILL.md" ]]
   [[ -f "${root}/skills/repo-code-review/SKILL.md" ]]
+  [[ -f "${root}/skills/repo-packet-builder/SKILL.md" ]]
+  [[ -x "${root}/skills/repo-packet-builder/scripts/build_repo_packet.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -38,6 +40,7 @@ assert_skill_bundle() {
   grep -Fq "failed checks or merge conflicts" "${root}/skills/pr-janitor/SKILL.md"
   grep -Fq "post-merge and post-closure cleanup phase" "${root}/skills/pr-closeout/SKILL.md"
   grep -Fq "findings-first" "${root}/skills/repo-code-review/SKILL.md"
+  grep -Fq "packet-construction skill, not a reviewer" "${root}/skills/repo-packet-builder/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -56,6 +59,7 @@ assert_skill_bundle() {
     "${root}/skills/pr-janitor/SKILL.md" \
     "${root}/skills/pr-closeout/SKILL.md" \
     "${root}/skills/repo-code-review/SKILL.md" \
+    "${root}/skills/repo-packet-builder/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -76,6 +80,7 @@ ADL_OPERATIONAL_SKILLS_INSTALL_MODE=symlink bash "${repo_root}/adl/tools/install
 assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/pr-init" ]]
 [[ -L "${CODEX_HOME}/skills/pr-ready" ]]
+[[ -L "${CODEX_HOME}/skills/repo-packet-builder" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_repo_packet_builder_skill_contracts.sh
+++ b/adl/tools/test_repo_packet_builder_skill_contracts.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/repo-packet-builder/SKILL.md" ]]
+[[ -f "${skills_root}/repo-packet-builder/adl-skill.yaml" ]]
+[[ -f "${skills_root}/repo-packet-builder/agents/openai.yaml" ]]
+[[ -f "${skills_root}/repo-packet-builder/references/packet-playbook.md" ]]
+[[ -f "${skills_root}/repo-packet-builder/references/output-contract.md" ]]
+[[ -x "${skills_root}/repo-packet-builder/scripts/build_repo_packet.py" ]]
+[[ -f "${skills_root}/docs/REPO_PACKET_BUILDER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "repo-packet-builder"' "${skills_root}/repo-packet-builder/adl-skill.yaml"
+grep -Fq 'id: "repo_packet_builder.v1"' "${skills_root}/repo-packet-builder/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REPO_PACKET_BUILDER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/repo-packet-builder/adl-skill.yaml"
+grep -Fq "policy.stop_before_review_must_be_true" "${skills_root}/repo-packet-builder/adl-skill.yaml"
+grep -Fq "packet-construction skill, not a reviewer" "${skills_root}/repo-packet-builder/SKILL.md"
+grep -Fq "scripts/build_repo_packet.py" "${skills_root}/repo-packet-builder/SKILL.md"
+grep -Fq "Do not write absolute host paths" "${skills_root}/repo-packet-builder/SKILL.md"
+grep -Fq "Specialist Lane Hints" "${skills_root}/repo-packet-builder/references/packet-playbook.md"
+grep -Fq "run_manifest.json" "${skills_root}/repo-packet-builder/references/output-contract.md"
+grep -Fq "Schema id: \`repo_packet_builder.v1\`" "${skills_root}/docs/REPO_PACKET_BUILDER_SKILL_INPUT_SCHEMA.md"
+
+packet_root="${tmpdir}/packet"
+python3 "${skills_root}/repo-packet-builder/scripts/build_repo_packet.py" "${repo_root}" --out "${packet_root}" >/tmp/repo-packet-builder.out
+[[ -f "${packet_root}/run_manifest.json" ]]
+[[ -f "${packet_root}/repo_scope.md" ]]
+[[ -f "${packet_root}/repo_inventory.json" ]]
+[[ -f "${packet_root}/evidence_index.json" ]]
+[[ -f "${packet_root}/specialist_assignments.json" ]]
+grep -Fq '"schema": "codebuddy.repo_packet.run_manifest.v1"' "${packet_root}/run_manifest.json"
+grep -Fq '# Repo Scope' "${packet_root}/repo_scope.md"
+grep -Fq '"manifests"' "${packet_root}/repo_inventory.json"
+grep -Fq '"evidence"' "${packet_root}/evidence_index.json"
+grep -Fq '"assignments"' "${packet_root}/specialist_assignments.json"
+if grep -R "${repo_root}" "${packet_root}" >/dev/null; then
+  echo "repo packet should not leak absolute repo root" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/repo-packet-builder/SKILL.md"
+
+echo "PASS test_repo_packet_builder_skill_contracts"


### PR DESCRIPTION
Closes #2059

## Summary
Implemented the `repo-packet-builder` operational skill for CodeBuddy review packet construction. The skill builds a bounded, source-grounded packet before specialist reviews run, emits repo-relative evidence artifacts, assigns specialist lanes, and stops before review, diagram generation, test generation, issue creation, report writing, or publication.

## Artifacts
- `adl/tools/skills/repo-packet-builder/SKILL.md`
- `adl/tools/skills/repo-packet-builder/adl-skill.yaml`
- `adl/tools/skills/repo-packet-builder/agents/openai.yaml`
- `adl/tools/skills/repo-packet-builder/references/packet-playbook.md`
- `adl/tools/skills/repo-packet-builder/references/output-contract.md`
- `adl/tools/skills/repo-packet-builder/scripts/build_repo_packet.py`
- `adl/tools/skills/docs/REPO_PACKET_BUILDER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_repo_packet_builder_skill_contracts.sh`
- Updated `adl/tools/test_install_adl_operational_skills.sh`
- Updated `adl/tools/batched_checks.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_repo_packet_builder_skill_contracts.sh`: verified skill bundle files, metadata, schema docs, packet helper execution, required packet artifacts, and absence of absolute repo-root leakage in generated packet artifacts.
  - `bash adl/tools/test_install_adl_operational_skills.sh`: verified operational skill installation in copy and symlink modes includes `repo-packet-builder`.
  - `python3 -m py_compile adl/tools/skills/repo-packet-builder/scripts/build_repo_packet.py`: verified the Python helper parses.
  - `bash -n adl/tools/test_repo_packet_builder_skill_contracts.sh adl/tools/batched_checks.sh adl/tools/test_install_adl_operational_skills.sh`: verified touched shell scripts parse.
  - `python3 adl/tools/skills/repo-packet-builder/scripts/build_repo_packet.py . --out <temporary-output-root>`: smoke-tested packet generation against the ADL worktree.
  - `git diff --check`: verified whitespace sanity.
  - `bash adl/tools/batched_checks.sh`: ran skill contract checks, tracked `.adl` residue guard, Rust formatting, clippy, and tests.
- Results: PASS. One invalid validation attempt (`bash -n` on the Python helper) was corrected and replaced with `python3 -m py_compile`.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2059__backlog-skills-add-repo-packet-builder-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2059__backlog-skills-add-repo-packet-builder-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-repo-packet-builder-skill-adl-tools-skills-repo-packet-builder-skill-md-adl-tools-skills-repo-packet-builder-adl-skill-yaml-adl-tools-skills-repo-packet-builder-agents-openai-yaml-adl-tools-skills-repo-packet-builder-references-packet-playbook-md-adl-tools-skills-repo-packet-builder-references-output-contract-md-adl-tools-skills-repo-packet-builder-scripts-build-repo-packet-py-adl-tools-skills-docs-repo-packet-builder-skill-input-schema-md-adl-tools-test-repo-packet-builder-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2059-backlog-skills-add-repo-packet-builder-skill-sip-md-adl-v0-90-tasks-issue-2059-backlog-skills-add-repo-packet-builder-skill-sor-md