### PR TITLE
[v0.90][backlog][skills] Add redaction and evidence auditor skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -38,6 +38,7 @@ echo "Skipping codex_pr sanity check (no --paths configured)."
 sh "$ROOT/adl/tools/codexw.sh" --help >/dev/null 2>&1
 run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_review_skill_contracts.sh"
 run_step "repo-packet-builder contract check" bash "$ROOT/adl/tools/test_repo_packet_builder_skill_contracts.sh"
+run_step "redaction-and-evidence-auditor contract check" bash "$ROOT/adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/docs/REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,68 @@
+# Redaction And Evidence Auditor Skill Input Schema
+
+Schema id: `redaction_and_evidence_auditor.v1`
+
+Use this schema for structured invocations of the
+`redaction-and-evidence-auditor` skill.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must equal `redaction_and_evidence_auditor.v1`
+- `mode`: one of the supported modes
+- `artifact_root`: packet, review bundle, or report root to audit
+- `audience`: intended audience
+- `policy`: explicit audit and mutation policy
+
+## Supported Modes
+
+- `audit_packet`
+- `audit_report`
+- `audit_review_bundle`
+- `pre_publication_gate`
+
+## Audience Values
+
+- `local_only`
+- `customer_private`
+- `public_candidate`
+
+## Required Policy Fields
+
+- `privacy_mode`
+- `publication_intent`
+- `allow_internal_urls`
+- `allow_private_paths`
+- `allow_source_excerpts`
+- `max_excerpt_lines`
+- `stop_before_mutation`
+
+`stop_before_mutation` must be true. This skill audits only; it does not edit
+or redact artifacts in place.
+
+## Example
+
+```yaml
+skill_input_schema: redaction_and_evidence_auditor.v1
+mode: pre_publication_gate
+artifact_root: .adl/reviews/codebuddy/20260417-120000-repo-packet
+audience: customer_private
+policy:
+  privacy_mode: customer_private
+  publication_intent: customer_report
+  allow_internal_urls: false
+  allow_private_paths: false
+  allow_source_excerpts: true
+  max_excerpt_lines: 80
+  stop_before_mutation: true
+```
+
+## Output
+
+The skill writes:
+
+- `redaction_report.md`
+- `redaction_report.json`
+- optional `blocked_publication_note.md`
+
+See `redaction-and-evidence-auditor/references/output-contract.md`.
+

--- a/adl/tools/skills/redaction-and-evidence-auditor/SKILL.md
+++ b/adl/tools/skills/redaction-and-evidence-auditor/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: redaction-and-evidence-auditor
+description: Audit CodeBuddy review packets and final reports for privacy, publication, and evidence-boundary risks before customer-facing use.
+---
+
+# Redaction And Evidence Auditor
+
+Audit a CodeBuddy packet, specialist review output, or final report for privacy,
+publication, and evidence-boundary risks. This skill is a safety gate, not a reviewer,
+not a publisher, and not a remediation workflow.
+
+Use this skill after `repo-packet-builder` and before any customer-facing,
+public, or cross-team report is shared.
+
+## Quick Start
+
+1. Confirm the artifact root or report path to audit.
+2. Confirm the intended audience:
+   - `local_only`
+   - `customer_private`
+   - `public_candidate`
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/audit_review_packet.py <artifact-root> --out <report-root>`
+4. Review the emitted redaction report.
+5. Stop after the audit. Hand unsafe packets back to the owning skill or
+   operator for explicit remediation.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `artifact_root`
+- `mode`
+- `audience`
+- `policy`
+
+Supported modes:
+
+- `audit_packet`
+- `audit_report`
+- `audit_review_bundle`
+- `pre_publication_gate`
+
+Useful policy fields:
+
+- `privacy_mode`
+- `publication_intent`
+- `allow_internal_urls`
+- `allow_private_paths`
+- `allow_source_excerpts`
+- `max_excerpt_lines`
+- `stop_before_mutation`
+
+If there is no concrete artifact root or report file, stop and report
+`not_run`.
+
+## Workflow
+
+### 1. Establish Publication Context
+
+Record:
+
+- artifact or report root
+- intended audience
+- whether publication is requested
+- privacy mode from the packet manifest, when present
+- whether `publication_allowed` is already false
+
+Do not upgrade publication status. This skill can only preserve or downgrade
+publication readiness.
+
+### 2. Scan For Unsafe Evidence
+
+Look for:
+
+- likely secrets and tokens
+- private host paths
+- internal URLs and private network addresses
+- provider exposure gaps
+- raw prompt or tool-argument leakage
+- excessive source excerpts
+- artifact paths that are not repo-relative when the packet is meant to be
+  portable
+
+Keep findings evidence-bounded. Do not print full secret values in the report.
+
+### 3. Classify Findings
+
+Use these severities:
+
+- `blocker`: must block publication or customer-facing sharing
+- `warning`: needs review before sharing
+- `info`: useful caveat but not blocking
+
+Use these statuses:
+
+- `pass`: no blocking or warning findings
+- `partial`: warnings exist but no blockers
+- `fail`: one or more blockers exist
+- `not_run`: missing inputs or unreadable target
+
+### 4. Emit Audit Artifacts
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/redaction-audit/
+```
+
+Required artifacts:
+
+- `redaction_report.md`
+- `redaction_report.json`
+
+Optional artifacts:
+
+- `blocked_publication_note.md`
+
+## Output Expectations
+
+Default output should include:
+
+- status
+- publication recommendation
+- files scanned
+- blocker, warning, and info counts
+- redacted finding samples
+- evidence-boundary notes
+- required remediation owner or downstream skill
+
+Use the output contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+Stop after producing the audit report.
+
+Do not:
+
+- edit, redact, or delete customer artifacts
+- mutate the reviewed repository
+- publish the report externally
+- create GitHub issues or PRs
+- rerun specialist review lanes
+- claim that a packet is secure beyond the scanned surfaces
+- expose full secret values in findings
+
+## CodeBuddy Integration Notes
+
+This skill is designed to sit after `.adl/docs/TBD/codebuddy_ai/REVIEW_PACKET_SPEC.md`
+packet construction and before reports following
+`.adl/docs/TBD/codebuddy_ai/REVIEW_TEMPLATE_STANDARD.md` are shared. If those
+planning docs are not present in a downstream checkout, use this skill's
+`references/output-contract.md` as the local review-safety contract.
+
+Deferred automation:
+
+- CI gating for customer-facing report publication.
+- Model-assisted over-disclosure checks for long prose sections.
+- Provider-specific secret classifiers beyond the deterministic patterns in the
+  helper script.

--- a/adl/tools/skills/redaction-and-evidence-auditor/adl-skill.yaml
+++ b/adl/tools/skills/redaction-and-evidence-auditor/adl-skill.yaml
@@ -1,0 +1,115 @@
+version: "0.1"
+kind: "adl-skill"
+id: "redaction-and-evidence-auditor"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "redaction_and_evidence_auditor.v1"
+    reference_doc: "../docs/REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "artifact_root"
+      - "audience"
+      - "policy"
+    mode_enum:
+      - "audit_packet"
+      - "audit_report"
+      - "audit_review_bundle"
+      - "pre_publication_gate"
+    policy_fields:
+      - "privacy_mode"
+      - "publication_intent"
+      - "allow_internal_urls"
+      - "allow_private_paths"
+      - "allow_source_excerpts"
+      - "max_excerpt_lines"
+      - "stop_before_mutation"
+    mode_requirements:
+      audit_packet:
+        required_target_fields:
+          - "artifact_root"
+      audit_report:
+        required_target_fields:
+          - "artifact_root"
+      audit_review_bundle:
+        required_target_fields:
+          - "artifact_root"
+      pre_publication_gate:
+        required_target_fields:
+          - "artifact_root"
+          - "audience"
+  intent:
+    - "redaction_audit"
+    - "evidence_boundary_review"
+    - "publication_safety_gate"
+    - "codebuddy_review_engine"
+  required_inputs:
+    - "artifact_root"
+    - "audience"
+  optional_inputs:
+    - "report_path"
+    - "review_packet_path"
+    - "output_root"
+    - "max_excerpt_lines"
+    - "allowed_internal_domains"
+  stop_if_missing:
+    - "artifact_root"
+  prevalidation_rules:
+    - "artifact_root_must_exist"
+    - "skill_input_schema_must_equal_redaction_and_evidence_auditor.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "audience_must_be_explicit"
+    - "policy.privacy_mode_must_be_explicit"
+    - "policy.publication_intent_must_be_explicit"
+    - "policy.stop_before_mutation_must_be_true"
+execution:
+  mode: "audit_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/audit_review_packet.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<artifact-root>"
+        - "--out <report-root>"
+        - "--audience <audience>"
+        - "--max-excerpt-lines <count>"
+  preferred_read_order:
+    - "run_manifest.json"
+    - "repo_scope.md"
+    - "redaction_report.json"
+    - "specialist review outputs"
+    - "final report markdown"
+    - "supporting json artifacts"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  must_not_run:
+    - "artifact_mutation"
+    - "secret_redaction_in_place"
+    - "specialist_reviews"
+    - "issue_creation"
+    - "report_publication"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/codebuddy/<run_id>/redaction-audit/"
+  required_artifacts:
+    - "redaction_report.md"
+    - "redaction_report.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  secret_values_must_be_masked: true
+  manifest_declares_executables: true
+
+display_name: Redaction And Evidence Auditor
+short_description: Audit CodeBuddy packets and reports before publication
+default_prompt: Audit a CodeBuddy review packet or report for secrets, private paths, internal URLs, source over-disclosure, and publication safety. Stop before mutation or publication.
+

--- a/adl/tools/skills/redaction-and-evidence-auditor/agents/openai.yaml
+++ b/adl/tools/skills/redaction-and-evidence-auditor/agents/openai.yaml
@@ -1,0 +1,9 @@
+model: gpt-5.4
+reasoning_effort: medium
+temperature: 0
+instructions:
+  - Audit only the supplied packet or report surfaces.
+  - Mask sensitive values in findings.
+  - Do not mutate customer artifacts.
+  - Do not publish, create issues, or run downstream review lanes.
+

--- a/adl/tools/skills/redaction-and-evidence-auditor/references/output-contract.md
+++ b/adl/tools/skills/redaction-and-evidence-auditor/references/output-contract.md
@@ -1,0 +1,77 @@
+# Output Contract
+
+The redaction and evidence auditor produces a publication-safety gate report for
+a CodeBuddy review packet, specialist review bundle, or final report.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/redaction-audit/
+```
+
+## Required Artifacts
+
+### redaction_report.json
+
+Required fields:
+
+- `schema`
+- `status`
+- `publication_recommendation`
+- `audience`
+- `artifact_root`
+- `files_scanned`
+- `findings`
+- `counts`
+- `started_at`
+- `completed_at`
+- `notes`
+
+Each finding must include:
+
+- `severity`
+- `category`
+- `path`
+- `line`
+- `message`
+- `sample`
+- `recommendation`
+
+The `sample` field must mask secret-like material.
+
+### redaction_report.md
+
+Required sections:
+
+- `# Redaction And Evidence Audit`
+- `## Verdict`
+- `## Publication Recommendation`
+- `## Scope`
+- `## Findings`
+- `## Evidence Boundary Notes`
+- `## Required Follow-Up`
+
+## Status Rules
+
+- `pass`: no blocker or warning findings.
+- `partial`: warning findings exist but no blockers.
+- `fail`: one or more blocker findings exist.
+- `not_run`: the target could not be audited.
+
+## Publication Recommendation
+
+- `allow_internal`: no blocking or warning issues for internal use.
+- `hold_for_review`: warnings exist or publication context is incomplete.
+- `block_publication`: blockers exist or manifest already forbids publication.
+- `not_run`: audit did not run.
+
+## Rules
+
+- Do not include full secret values.
+- Use paths relative to the audited artifact root.
+- Do not write absolute host paths into the audit artifacts.
+- Do not mutate audited artifacts.
+- Do not claim security approval beyond the scanned packet or report.
+- If `publication_allowed` is false in `run_manifest.json`, preserve that
+  constraint unless an explicit downstream operator changes it.
+

--- a/adl/tools/skills/redaction-and-evidence-auditor/references/redaction-playbook.md
+++ b/adl/tools/skills/redaction-and-evidence-auditor/references/redaction-playbook.md
@@ -1,0 +1,38 @@
+# Redaction Playbook
+
+Use this playbook when interpreting the deterministic helper output or
+performing a manual audit.
+
+## Blockers
+
+- Secret-like values: API keys, private keys, OAuth tokens, GitHub tokens, Slack
+  tokens, cloud access keys, or environment assignments containing credentials.
+- Private host paths in a customer-facing or public candidate report.
+- Raw prompt or tool argument dumps that expose hidden operating context.
+- Source excerpts that are too long for the review purpose.
+- Manifest says `publication_allowed: false` and the target is a
+  customer-facing or public candidate artifact.
+
+## Warnings
+
+- Internal URLs, localhost URLs, or private IP addresses.
+- Provider/model names or infrastructure details not needed by the audience.
+- Evidence references that are ambiguous or not repo-relative.
+- Missing manifest or missing audience declaration.
+
+## Safe Defaults
+
+- Mask secret samples.
+- Preserve evidence path shape without absolute host roots.
+- Downgrade publication readiness when uncertain.
+- Send remediation back to the owner of the source artifact instead of editing
+  it in place.
+
+## Handoff Targets
+
+- Packet shape problems: `repo-packet-builder`.
+- Review over-disclosure: the specialist review skill that generated the
+  artifact.
+- Report template drift: synthesis or product report writer.
+- Security review gaps: security reviewer or threat-model skill.
+

--- a/adl/tools/skills/redaction-and-evidence-auditor/scripts/audit_review_packet.py
+++ b/adl/tools/skills/redaction-and-evidence-auditor/scripts/audit_review_packet.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Audit a CodeBuddy review packet for redaction and evidence-boundary risks."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+TEXT_SUFFIXES = {".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".csv", ".log"}
+DEFAULT_MAX_EXCERPT_LINES = 80
+
+SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("openai_api_key", re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b")),
+    ("anthropic_api_key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{12,}\b")),
+    ("github_token", re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b")),
+    ("github_pat", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")),
+    ("slack_token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{12,}\b")),
+    ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("private_key", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    (
+        "credential_assignment",
+        re.compile(
+            r"\b(?:API_KEY|TOKEN|SECRET|PASSWORD|OPENAI_API_KEY|ANTHROPIC_API_KEY)\s*=\s*[^\s]+",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+PRIVATE_PATH_PATTERN = re.compile(r"(?<![\w.-])(?:/Users/|/home/|/private/var/|/var/folders/|[A-Za-z]:\\)")
+INTERNAL_URL_PATTERN = re.compile(
+    r"\bhttps?://(?:localhost|127\.0\.0\.1|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|"
+    r"192\.168\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|"
+    r"[^/\s]*\.local)(?::\d+)?[^\s)]*",
+    re.IGNORECASE,
+)
+PROMPT_LEAK_PATTERN = re.compile(r"\b(?:system prompt|developer message|tool arguments|raw prompt)\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    category: str
+    path: str
+    line: int
+    message: str
+    sample: str
+    recommendation: str
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def mask_sample(sample: str) -> str:
+    text = sample.strip()
+    for _, pattern in SECRET_PATTERNS:
+        text = pattern.sub(lambda match: mask_secret(match.group(0)), text)
+    text = re.sub(r"\s+", " ", text)
+    return text[:180]
+
+
+def mask_secret(value: str) -> str:
+    if len(value) <= 8:
+        return "<masked>"
+    return f"{value[:4]}...{value[-4:]}"
+
+
+def is_text_file(path: Path) -> bool:
+    return path.suffix.lower() in TEXT_SUFFIXES or path.name in {"Dockerfile", "Makefile"}
+
+
+def iter_files(root: Path) -> list[Path]:
+    return sorted(path for path in root.rglob("*") if path.is_file() and is_text_file(path))
+
+
+def relative_path(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def read_manifest(root: Path) -> dict[str, object]:
+    manifest_path = root / "run_manifest.json"
+    if not manifest_path.is_file():
+        return {}
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def scan_lines(root: Path, path: Path, max_excerpt_lines: int) -> list[Finding]:
+    findings: list[Finding] = []
+    rel = relative_path(root, path)
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return [
+            Finding(
+                "warning",
+                "unreadable_file",
+                rel,
+                0,
+                f"Could not read file: {exc.__class__.__name__}",
+                "",
+                "Confirm whether this artifact should be part of the audit surface.",
+            )
+        ]
+
+    fence_start = 0
+    in_fence = False
+    for index, line in enumerate(lines, start=1):
+        for category, pattern in SECRET_PATTERNS:
+            if pattern.search(line):
+                findings.append(
+                    Finding(
+                        "blocker",
+                        category,
+                        rel,
+                        index,
+                        "Secret-like value appears in an audit surface.",
+                        mask_sample(line),
+                        "Remove the value from the artifact and rotate it if it was real.",
+                    )
+                )
+        if PRIVATE_PATH_PATTERN.search(line):
+            findings.append(
+                Finding(
+                    "blocker",
+                    "private_host_path",
+                    rel,
+                    index,
+                    "Private host path appears in an artifact intended to be portable.",
+                    mask_sample(line),
+                    "Replace host-specific paths with repo-relative paths or placeholders.",
+                )
+            )
+        if INTERNAL_URL_PATTERN.search(line):
+            findings.append(
+                Finding(
+                    "warning",
+                    "internal_url",
+                    rel,
+                    index,
+                    "Internal URL or private network address appears in the artifact.",
+                    mask_sample(line),
+                    "Confirm audience suitability or replace with a generic endpoint label.",
+                )
+            )
+        if PROMPT_LEAK_PATTERN.search(line):
+            findings.append(
+                Finding(
+                    "warning",
+                    "prompt_or_tool_leak",
+                    rel,
+                    index,
+                    "Prompt or tool execution details may be exposed.",
+                    mask_sample(line),
+                    "Summarize the evidence without exposing hidden prompts or raw tool arguments.",
+                )
+            )
+
+        if line.strip().startswith("```"):
+            if not in_fence:
+                fence_start = index
+                in_fence = True
+            else:
+                fence_len = index - fence_start - 1
+                if fence_len > max_excerpt_lines:
+                    findings.append(
+                        Finding(
+                            "warning",
+                            "excessive_source_excerpt",
+                            rel,
+                            fence_start,
+                            "Fenced source excerpt exceeds the configured line limit.",
+                            f"fenced block length: {fence_len} lines",
+                            "Replace long source excerpts with path and line references.",
+                        )
+                    )
+                in_fence = False
+
+    return findings
+
+
+def status_from_findings(findings: list[Finding]) -> str:
+    if any(finding.severity == "blocker" for finding in findings):
+        return "fail"
+    if any(finding.severity == "warning" for finding in findings):
+        return "partial"
+    return "pass"
+
+
+def recommendation(status: str, manifest: dict[str, object], audience: str) -> str:
+    if status == "not_run":
+        return "not_run"
+    if manifest.get("publication_allowed") is False and audience in {"customer_private", "public_candidate"}:
+        return "block_publication"
+    if status == "fail":
+        return "block_publication"
+    if status == "partial" or audience == "public_candidate":
+        return "hold_for_review"
+    return "allow_internal"
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(path: Path, report: dict[str, object]) -> None:
+    findings = report["findings"]
+    if findings:
+        findings_md = "\n".join(
+            "- [{severity}] {category} in {path}:{line} - {message} Sample: `{sample}`".format(**finding)
+            for finding in findings
+        )
+    else:
+        findings_md = "- No blocker or warning findings."
+
+    content = f"""# Redaction And Evidence Audit
+
+## Verdict
+
+- Status: {report["status"]}
+- Files scanned: {report["files_scanned"]}
+- Blockers: {report["counts"]["blocker"]}
+- Warnings: {report["counts"]["warning"]}
+- Info: {report["counts"]["info"]}
+
+## Publication Recommendation
+
+- Recommendation: {report["publication_recommendation"]}
+- Audience: {report["audience"]}
+
+## Scope
+
+- Artifact root: {report["artifact_root"]}
+- Started at: {report["started_at"]}
+- Completed at: {report["completed_at"]}
+
+## Findings
+
+{findings_md}
+
+## Evidence Boundary Notes
+
+- Secret-like samples are masked.
+- Paths are relative to the audited artifact root.
+- This audit does not mutate source artifacts.
+- This audit does not replace specialist code, security, docs, or test review.
+
+## Required Follow-Up
+
+{required_follow_up(str(report["publication_recommendation"]))}
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def required_follow_up(publication_recommendation: str) -> str:
+    if publication_recommendation == "block_publication":
+        return "- Block sharing until the owning artifact producer removes or replaces unsafe evidence."
+    if publication_recommendation == "hold_for_review":
+        return "- Review warnings manually before customer-facing or public sharing."
+    if publication_recommendation == "allow_internal":
+        return "- Keep the report internal unless a later pre-publication gate explicitly approves broader sharing."
+    return "- Re-run the audit with a readable artifact root."
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact_root", help="Packet, review bundle, or report root to audit")
+    parser.add_argument("--out", default=None, help="Audit artifact root")
+    parser.add_argument("--audience", default="local_only", choices=["local_only", "customer_private", "public_candidate"])
+    parser.add_argument("--max-excerpt-lines", type=int, default=DEFAULT_MAX_EXCERPT_LINES)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    started_at = now_utc()
+    root = Path(args.artifact_root).resolve()
+    out_root = Path(args.out) if args.out else root / "redaction-audit"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    if not root.exists():
+        report = {
+            "schema": "codebuddy.redaction_audit.v1",
+            "status": "not_run",
+            "publication_recommendation": "not_run",
+            "audience": args.audience,
+            "artifact_root": root.name,
+            "files_scanned": 0,
+            "findings": [],
+            "counts": {"blocker": 0, "warning": 0, "info": 0},
+            "started_at": started_at,
+            "completed_at": now_utc(),
+            "notes": ["artifact root does not exist"],
+        }
+        write_json(out_root / "redaction_report.json", report)
+        write_markdown(out_root / "redaction_report.md", report)
+        print(out_root)
+        return 1
+
+    manifest = read_manifest(root)
+    files = iter_files(root)
+    findings: list[Finding] = []
+    for path in files:
+        if out_root in path.parents:
+            continue
+        findings.extend(scan_lines(root, path, args.max_excerpt_lines))
+
+    if not manifest:
+        findings.append(
+            Finding(
+                "warning",
+                "missing_manifest",
+                "run_manifest.json",
+                0,
+                "No CodeBuddy run manifest was found.",
+                "",
+                "Add or repair the packet manifest before publication gating.",
+            )
+        )
+    elif manifest.get("publication_allowed") is False and args.audience in {"customer_private", "public_candidate"}:
+        findings.append(
+            Finding(
+                "blocker",
+                "publication_forbidden_by_manifest",
+                "run_manifest.json",
+                0,
+                "Packet manifest forbids publication for the requested audience.",
+                '"publication_allowed": false',
+                "Keep the artifact internal or run an explicit remediation and approval workflow.",
+            )
+        )
+
+    status = status_from_findings(findings)
+    counts = {
+        "blocker": sum(1 for finding in findings if finding.severity == "blocker"),
+        "warning": sum(1 for finding in findings if finding.severity == "warning"),
+        "info": sum(1 for finding in findings if finding.severity == "info"),
+    }
+    report = {
+        "schema": "codebuddy.redaction_audit.v1",
+        "status": status,
+        "publication_recommendation": recommendation(status, manifest, args.audience),
+        "audience": args.audience,
+        "artifact_root": root.name,
+        "files_scanned": len(files),
+        "findings": [asdict(finding) for finding in findings],
+        "counts": counts,
+        "started_at": started_at,
+        "completed_at": now_utc(),
+        "notes": [
+            "Audit is deterministic and read-only.",
+            "Findings are bounded to text-like artifacts under the audited root.",
+        ],
+    }
+
+    write_json(out_root / "redaction_report.json", report)
+    write_markdown(out_root / "redaction_report.md", report)
+    if report["publication_recommendation"] == "block_publication":
+        (out_root / "blocked_publication_note.md").write_text(
+            "# Blocked Publication\n\nDo not share this packet until blocker findings are resolved.\n",
+            encoding="utf-8",
+        )
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -22,6 +22,8 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/repo-code-review/SKILL.md" ]]
   [[ -f "${root}/skills/repo-packet-builder/SKILL.md" ]]
   [[ -x "${root}/skills/repo-packet-builder/scripts/build_repo_packet.py" ]]
+  [[ -f "${root}/skills/redaction-and-evidence-auditor/SKILL.md" ]]
+  [[ -x "${root}/skills/redaction-and-evidence-auditor/scripts/audit_review_packet.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -41,6 +43,7 @@ assert_skill_bundle() {
   grep -Fq "post-merge and post-closure cleanup phase" "${root}/skills/pr-closeout/SKILL.md"
   grep -Fq "findings-first" "${root}/skills/repo-code-review/SKILL.md"
   grep -Fq "packet-construction skill, not a reviewer" "${root}/skills/repo-packet-builder/SKILL.md"
+  grep -Fq "safety gate, not a reviewer" "${root}/skills/redaction-and-evidence-auditor/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -60,6 +63,7 @@ assert_skill_bundle() {
     "${root}/skills/pr-closeout/SKILL.md" \
     "${root}/skills/repo-code-review/SKILL.md" \
     "${root}/skills/repo-packet-builder/SKILL.md" \
+    "${root}/skills/redaction-and-evidence-auditor/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -81,6 +85,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/pr-init" ]]
 [[ -L "${CODEX_HOME}/skills/pr-ready" ]]
 [[ -L "${CODEX_HOME}/skills/repo-packet-builder" ]]
+[[ -L "${CODEX_HOME}/skills/redaction-and-evidence-auditor" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh
+++ b/adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/redaction-and-evidence-auditor/SKILL.md" ]]
+[[ -f "${skills_root}/redaction-and-evidence-auditor/adl-skill.yaml" ]]
+[[ -f "${skills_root}/redaction-and-evidence-auditor/agents/openai.yaml" ]]
+[[ -f "${skills_root}/redaction-and-evidence-auditor/references/redaction-playbook.md" ]]
+[[ -f "${skills_root}/redaction-and-evidence-auditor/references/output-contract.md" ]]
+[[ -x "${skills_root}/redaction-and-evidence-auditor/scripts/audit_review_packet.py" ]]
+[[ -f "${skills_root}/docs/REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "redaction-and-evidence-auditor"' "${skills_root}/redaction-and-evidence-auditor/adl-skill.yaml"
+grep -Fq 'id: "redaction_and_evidence_auditor.v1"' "${skills_root}/redaction-and-evidence-auditor/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/redaction-and-evidence-auditor/adl-skill.yaml"
+grep -Fq "policy.stop_before_mutation_must_be_true" "${skills_root}/redaction-and-evidence-auditor/adl-skill.yaml"
+grep -Fq "safety gate, not a reviewer" "${skills_root}/redaction-and-evidence-auditor/SKILL.md"
+grep -Fq "scripts/audit_review_packet.py" "${skills_root}/redaction-and-evidence-auditor/SKILL.md"
+grep -Fq "Do not include full secret values" "${skills_root}/redaction-and-evidence-auditor/references/output-contract.md"
+grep -Fq "Schema id: \`redaction_and_evidence_auditor.v1\`" "${skills_root}/docs/REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md"
+
+packet_root="${tmpdir}/packet"
+audit_root="${tmpdir}/audit"
+mkdir -p "${packet_root}"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "contract-test",
+  "publication_allowed": true,
+  "privacy_mode": "local_only"
+}
+JSON
+cat >"${packet_root}/repo_scope.md" <<'EOF'
+# Repo Scope
+
+This packet uses repo-relative paths only.
+EOF
+
+python3 "${skills_root}/redaction-and-evidence-auditor/scripts/audit_review_packet.py" \
+  "${packet_root}" --out "${audit_root}" >/tmp/redaction-auditor-pass.out
+[[ -f "${audit_root}/redaction_report.json" ]]
+[[ -f "${audit_root}/redaction_report.md" ]]
+grep -Fq '"status": "pass"' "${audit_root}/redaction_report.json"
+grep -Fq '"publication_recommendation": "allow_internal"' "${audit_root}/redaction_report.json"
+if grep -R "${tmpdir}" "${audit_root}" >/dev/null; then
+  echo "audit output should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+unsafe_packet="${tmpdir}/unsafe-packet"
+unsafe_audit="${tmpdir}/unsafe-audit"
+mkdir -p "${unsafe_packet}"
+cat >"${unsafe_packet}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "unsafe-contract-test",
+  "publication_allowed": false,
+  "privacy_mode": "local_only"
+}
+JSON
+cat >"${unsafe_packet}/review.md" <<'EOF'
+The tool emitted OPENAI_API_KEY=sk-test-redaction-example-000000000000
+The local file path was /Users/example/project/private.txt
+See http://127.0.0.1:8080/debug for details.
+EOF
+
+python3 "${skills_root}/redaction-and-evidence-auditor/scripts/audit_review_packet.py" \
+  "${unsafe_packet}" --out "${unsafe_audit}" --audience customer_private >/tmp/redaction-auditor-fail.out
+grep -Fq '"status": "fail"' "${unsafe_audit}/redaction_report.json"
+grep -Fq '"publication_recommendation": "block_publication"' "${unsafe_audit}/redaction_report.json"
+grep -Fq '"category": "credential_assignment"' "${unsafe_audit}/redaction_report.json"
+grep -Fq '"category": "private_host_path"' "${unsafe_audit}/redaction_report.json"
+grep -Fq '"category": "internal_url"' "${unsafe_audit}/redaction_report.json"
+if grep -R "sk-test-redaction-example-000000000000" "${unsafe_audit}" >/dev/null; then
+  echo "audit output should mask secret-like values" >&2
+  exit 1
+fi
+[[ -f "${unsafe_audit}/blocked_publication_note.md" ]]
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/redaction-and-evidence-auditor/SKILL.md"
+
+echo "PASS test_redaction_and_evidence_auditor_skill_contracts"


### PR DESCRIPTION
Closes #2060

## Summary
Added a first-class `redaction-and-evidence-auditor` ADL skill for CodeBuddy review safety gating. The skill audits review packets and reports for likely secrets, private host paths, internal URLs, prompt/tool leakage, excessive source excerpts, and manifest-level publication blocks, then emits bounded Markdown and JSON redaction reports without mutating customer artifacts.

## Artifacts
- `adl/tools/skills/redaction-and-evidence-auditor/SKILL.md`
- `adl/tools/skills/redaction-and-evidence-auditor/adl-skill.yaml`
- `adl/tools/skills/redaction-and-evidence-auditor/agents/openai.yaml`
- `adl/tools/skills/redaction-and-evidence-auditor/references/output-contract.md`
- `adl/tools/skills/redaction-and-evidence-auditor/references/redaction-playbook.md`
- `adl/tools/skills/redaction-and-evidence-auditor/scripts/audit_review_packet.py`
- `adl/tools/skills/docs/REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh`: proves the new skill contract, deterministic helper outputs, secret masking, and publication blocking behavior.
  - `bash adl/tools/test_install_adl_operational_skills.sh`: proves operational skill installation includes the auditor in copy and symlink modes.
  - `python3 -m py_compile adl/tools/skills/redaction-and-evidence-auditor/scripts/audit_review_packet.py`: verifies Python syntax for the helper; generated bytecode was removed afterward.
  - `bash -n adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh adl/tools/test_install_adl_operational_skills.sh adl/tools/batched_checks.sh`: verifies shell syntax for touched shell scripts.
  - `git diff --check`: verifies whitespace and patch hygiene.
  - `bash adl/tools/batched_checks.sh`: runs the repo batched suite, including all skill contract checks, `.adl` issue-record residue guard, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
- Results: PASS for all commands.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2060__backlog-skills-add-redaction-and-evidence-auditor-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2060__backlog-skills-add-redaction-and-evidence-auditor-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-redaction-and-evidence-auditor-skill-adl-tools-skills-redaction-and-evidence-auditor-adl-tools-skills-docs-redaction-and-evidence-auditor-skill-input-schema-md-adl-tools-test-redaction-and-evidence-auditor-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2060-backlog-skills-add-redaction-and-evidence-auditor-skill-sip-md-adl-v0-90-tasks-issue-2060-backlog-skills-add-redaction-and-evidence-auditor-skill-sor-md