### PR TITLE
[v0.90][WP-06] Minimal inspection and trace boundary

### DIFF
--- a/adl/src/cli/agent_cmd.rs
+++ b/adl/src/cli/agent_cmd.rs
@@ -1,12 +1,12 @@
 use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 
-use ::adl::long_lived_agent::{self, RunOptions, TickOptions};
+use ::adl::long_lived_agent::{self, InspectOptions, RunOptions, TickOptions};
 
 pub(crate) fn real_agent(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "agent requires a subcommand: tick | run | status | stop"
+            "agent requires a subcommand: tick | run | status | inspect | stop"
         ));
     };
 
@@ -14,13 +14,14 @@ pub(crate) fn real_agent(args: &[String]) -> Result<()> {
         "tick" => real_tick(&args[1..]),
         "run" => real_run(&args[1..]),
         "status" => real_status(&args[1..]),
+        "inspect" => real_inspect(&args[1..]),
         "stop" => real_stop(&args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         other => Err(anyhow!(
-            "unknown agent subcommand '{other}' (expected tick, run, status, stop)"
+            "unknown agent subcommand '{other}' (expected tick, run, status, inspect, stop)"
         )),
     }
 }
@@ -120,6 +121,33 @@ fn real_status(args: &[String]) -> Result<()> {
     print_status(&status, parsed.json_output)
 }
 
+fn real_inspect(args: &[String]) -> Result<()> {
+    let mut parsed = AgentArgs::default();
+    let mut cycle_id: Option<String> = None;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--spec" => {
+                parsed.spec = Some(PathBuf::from(required_value(args, i, "--spec")?));
+                i += 1;
+            }
+            "--cycle" => {
+                cycle_id = Some(required_value(args, i, "--cycle")?.to_string());
+                i += 1;
+            }
+            "--json" => parsed.json_output = true,
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => return Err(anyhow!("unknown arg for agent inspect: {other}")),
+        }
+        i += 1;
+    }
+    let packet = long_lived_agent::inspect(&parsed.spec()?, InspectOptions { cycle_id })?;
+    print_inspection(&packet, parsed.json_output)
+}
+
 fn real_stop(args: &[String]) -> Result<()> {
     let mut parsed = AgentArgs::default();
     let mut reason: Option<String> = None;
@@ -210,6 +238,97 @@ fn print_status(status: &long_lived_agent::StatusRecord, json_output: bool) -> R
             .as_ref()
             .map(|error| format!("{}: {}", error.class, error.message))
             .unwrap_or_else(|| "none".to_string())
+    );
+    Ok(())
+}
+
+fn print_inspection(packet: &serde_json::Value, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(packet)?);
+        return Ok(());
+    }
+    println!(
+        "agent: {}",
+        packet
+            .get("agent_instance_id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown")
+    );
+    println!(
+        "state: {}",
+        packet
+            .get("status")
+            .and_then(|status| status.get("state"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown")
+    );
+    println!(
+        "status ref: {}",
+        packet
+            .get("status_ref")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("status.json")
+    );
+    if let Some(cycle) = packet.get("selected_cycle") {
+        println!(
+            "cycle: {} {}",
+            cycle
+                .get("cycle_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown"),
+            cycle
+                .get("status")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown")
+        );
+        let refs = cycle.get("refs").unwrap_or(&serde_json::Value::Null);
+        println!(
+            "manifest: {}",
+            refs.get("manifest")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("missing")
+        );
+        println!(
+            "guardrails: {} {}",
+            refs.get("guardrail_report")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("missing"),
+            cycle
+                .get("guardrails")
+                .and_then(|guardrails| guardrails.get("status"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown")
+        );
+        println!(
+            "summary: {}",
+            refs.get("cycle_summary")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("missing")
+        );
+        println!(
+            "run ref: {}",
+            refs.get("run_ref")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("missing")
+        );
+    } else {
+        println!("cycle: none");
+    }
+    println!(
+        "trace/query: {}",
+        packet
+            .get("trace_query_decision")
+            .and_then(|decision| decision.get("status"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown")
+    );
+    println!(
+        "proof: {}",
+        packet
+            .get("reviewer_proof")
+            .and_then(|proof| proof.get("status"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown")
     );
     Ok(())
 }
@@ -333,6 +452,7 @@ memory:
         assert!(real_agent(&args(&["tick", "--help"])).is_ok());
         assert!(real_agent(&args(&["run", "--help"])).is_ok());
         assert!(real_agent(&args(&["status", "--help"])).is_ok());
+        assert!(real_agent(&args(&["inspect", "--help"])).is_ok());
         assert!(real_agent(&args(&["stop", "--help"])).is_ok());
 
         assert_err_contains(real_agent(&args(&[])), "agent requires a subcommand");
@@ -364,6 +484,11 @@ memory:
         );
         assert_err_contains(real_agent(&args(&["run", "--bogus"])), "unknown arg");
         assert_err_contains(real_agent(&args(&["status", "--bogus"])), "unknown arg");
+        assert_err_contains(real_agent(&args(&["inspect", "--bogus"])), "unknown arg");
+        assert_err_contains(
+            real_agent(&args(&["inspect", "--cycle"])),
+            "--cycle requires a value",
+        );
         assert_err_contains(
             real_agent(&args(&["stop", "--reason"])),
             "--reason requires a value",
@@ -401,6 +526,16 @@ memory:
 
         assert!(real_agent(&args(&["status", "--spec", spec])).is_ok());
         assert!(real_agent(&args(&["status", "--spec", spec, "--json"])).is_ok());
+        assert!(real_agent(&args(&["inspect", "--spec", spec])).is_ok());
+        assert!(real_agent(&args(&[
+            "inspect",
+            "--spec",
+            spec,
+            "--cycle",
+            "cycle-000002",
+            "--json",
+        ]))
+        .is_ok());
         assert!(real_agent(&args(&[
             "stop",
             "--spec",

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -5,6 +5,7 @@ pub fn usage() -> &'static str {
   adl agent tick --spec <agent-spec.yaml> [--recover-stale-lease] [--json]
   adl agent run --spec <agent-spec.yaml> --max-cycles <n> [--interval-secs <n>] [--no-sleep] [--recover-stale-lease] [--json]
   adl agent status --spec <agent-spec.yaml> [--json]
+  adl agent inspect --spec <agent-spec.yaml> [--cycle <cycle-id>] [--json]
   adl agent stop --spec <agent-spec.yaml> --reason <text> [--json]
   adl artifact validate-control-path --root <dir>
   adl demo <name> [--print-plan] [--trace] [--run] [--out <dir>] [--quiet] [--open] [--no-open]
@@ -76,6 +77,7 @@ Examples:
   adl agent tick --spec .adl/long_lived_agents/example-agent.yaml
   adl agent run --spec .adl/long_lived_agents/example-agent.yaml --max-cycles 3 --no-sleep
   adl agent status --spec .adl/long_lived_agents/example-agent.yaml --json
+  adl agent inspect --spec .adl/long_lived_agents/example-agent.yaml --json
   adl agent stop --spec .adl/long_lived_agents/example-agent.yaml --reason \"operator pause\"
   adl artifact validate-control-path --root /tmp/adl-v086-control-path-demo/demo-g-v086-control-path
   ADL_OLLAMA_BIN=adl/tools/mock_ollama_v0_4.sh adl examples/v0-4-demo-fork-join.adl.yaml --run --trace --out ./out

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -25,6 +25,7 @@ const CYCLE_LEDGER_ENTRY_SCHEMA: &str = "adl.long_lived_agent_cycle_ledger_entry
 const PROVIDER_BINDING_SCHEMA: &str = "adl.long_lived_agent_provider_binding.v1";
 const MEMORY_INDEX_SCHEMA: &str = "adl.long_lived_agent_memory_index.v1";
 const OPERATOR_EVENT_SCHEMA: &str = "adl.long_lived_agent_operator_event.v1";
+const INSPECTION_PACKET_SCHEMA: &str = "adl.long_lived_agent_inspection_packet.v1";
 const DEFAULT_MAX_CYCLE_RUNTIME_SECS: u64 = 120;
 const DEFAULT_MAX_CONSECUTIVE_FAILURES: u64 = 2;
 const STOP_MODE_BEFORE_NEXT_CYCLE: &str = "stop_before_next_cycle";
@@ -143,6 +144,11 @@ pub struct RunOptions {
     pub interval_secs: Option<u64>,
     pub no_sleep: bool,
     pub recover_stale_lease: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InspectOptions {
+    pub cycle_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -370,6 +376,57 @@ pub fn stop(spec_path: &Path, reason: &str) -> Result<StatusRecord> {
         "operator",
         "operator_stop_requested",
     )
+}
+
+pub fn inspect(spec_path: &Path, options: InspectOptions) -> Result<Value> {
+    let status = status(spec_path)?;
+    let loaded = load_spec(spec_path)?;
+    let ledger = ledger_cursor(&loaded)?;
+    let selected_cycle_id = options
+        .cycle_id
+        .clone()
+        .or_else(|| status.last_cycle_id.clone())
+        .or(ledger.latest_cycle_id);
+    let selected_cycle = selected_cycle_id
+        .as_deref()
+        .map(|cycle_id| inspect_cycle(&loaded, cycle_id))
+        .transpose()?;
+    let proof_status = if selected_cycle.is_some() {
+        "pass"
+    } else {
+        "no_cycle_available"
+    };
+
+    Ok(json!({
+        "schema": INSPECTION_PACKET_SCHEMA,
+        "agent_instance_id": loaded.spec.agent_instance_id.clone(),
+        "generated_at": Utc::now(),
+        "state_root_ref": path_artifact_ref(&loaded.spec.state_root),
+        "status_ref": "status.json",
+        "status": status,
+        "cycle_count": ledger.count,
+        "selected_cycle_id": selected_cycle_id,
+        "selected_cycle": selected_cycle,
+        "reviewer_proof": {
+            "status": proof_status,
+            "status_ref": {
+                "path": "status.json",
+                "exists": status_path(&loaded).exists()
+            },
+            "cycle_ref_status": if proof_status == "pass" {
+                "selected_cycle_artifacts_present"
+            } else {
+                "no_cycle_selected"
+            }
+        },
+        "trace_query_decision": {
+            "status": "deferred_full_platform",
+            "minimal_v0_90_boundary": "inspection packet over status, cycle manifest, guardrail report, run_ref, and cycle summary artifacts",
+            "full_tql_platform": "deferred",
+            "full_signed_trace_architecture": "deferred",
+            "reason": "WP-06 accepts the narrow reviewer inspection slice and does not widen into TQL or signed-trace architecture."
+        }
+    }))
 }
 
 fn validate_spec(spec: &AgentSpec) -> Result<()> {
@@ -1343,6 +1400,137 @@ fn append_operator_event(loaded: &LoadedAgentSpec, event: &str, details: Value) 
     append_jsonl(&operator_events_path(loaded), &record)
 }
 
+fn inspect_cycle(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<Value> {
+    validate_cycle_ref(cycle_id)?;
+    let manifest_ref = format!("cycles/{cycle_id}/cycle_manifest.json");
+    let guardrail_ref = format!("cycles/{cycle_id}/guardrail_report.json");
+    let summary_ref = format!("cycles/{cycle_id}/cycle_summary.md");
+    let decision_result_ref = format!("cycles/{cycle_id}/decision_result.json");
+    let run_ref_ref = format!("cycles/{cycle_id}/run_ref.json");
+    let memory_writes_ref = format!("cycles/{cycle_id}/memory_writes.jsonl");
+
+    let manifest = read_state_json_artifact(loaded, &manifest_ref)?;
+    let guardrail_report = read_state_json_artifact(loaded, &guardrail_ref)?;
+    let run_ref = read_state_json_artifact(loaded, &run_ref_ref)?;
+    let summary = read_state_text_artifact(loaded, &summary_ref)?;
+    let guardrail_checks = guardrail_check_summary(&guardrail_report);
+    let failed_guardrail_checks = guardrail_checks
+        .iter()
+        .filter_map(|check| {
+            if check.get("result").and_then(Value::as_str) == Some("fail") {
+                check
+                    .get("check_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "cycle_id": cycle_id,
+        "status": manifest.get("status").cloned().unwrap_or(Value::Null),
+        "workflow_kind": manifest.get("workflow_kind").cloned().unwrap_or(Value::Null),
+        "workflow_ref": manifest.get("workflow_ref").cloned().unwrap_or(Value::Null),
+        "refs": {
+            "manifest": manifest_ref,
+            "guardrail_report": guardrail_ref,
+            "cycle_summary": summary_ref,
+            "decision_result": decision_result_ref,
+            "run_ref": run_ref_ref,
+            "memory_writes": memory_writes_ref
+        },
+        "manifest": {
+            "input_hash": manifest.get("input_hash").cloned().unwrap_or(Value::Null),
+            "output_hash": manifest.get("output_hash").cloned().unwrap_or(Value::Null),
+            "previous_cycle_id": manifest.get("previous_cycle_id").cloned().unwrap_or(Value::Null),
+            "not_financial_advice": manifest.get("not_financial_advice").cloned().unwrap_or(Value::Null)
+        },
+        "guardrails": {
+            "status": guardrail_report.get("status").cloned().unwrap_or(Value::Null),
+            "checks": guardrail_checks,
+            "failed_checks": failed_guardrail_checks,
+            "rejected_actions": guardrail_report
+                .get("rejected_actions")
+                .cloned()
+                .unwrap_or_else(|| json!([]))
+        },
+        "summary_preview": summary_preview(&summary),
+        "trace_boundary": {
+            "run_ref": run_ref_ref,
+            "trace_ref": run_ref.get("trace_ref").cloned().unwrap_or(Value::Null),
+            "status": if run_ref.get("trace_ref").is_some_and(|value| !value.is_null()) {
+                "trace_ref_available"
+            } else {
+                "cycle_artifact_only"
+            }
+        }
+    }))
+}
+
+fn validate_cycle_ref(cycle_id: &str) -> Result<()> {
+    let Some(suffix) = cycle_id.strip_prefix("cycle-") else {
+        return Err(anyhow!(
+            "agent inspect --cycle must use a generated cycle id like cycle-000001"
+        ));
+    };
+    if suffix.len() != 6 || !suffix.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(anyhow!(
+            "agent inspect --cycle must use a generated cycle id like cycle-000001"
+        ));
+    }
+    Ok(())
+}
+
+fn read_state_json_artifact(loaded: &LoadedAgentSpec, artifact_ref: &str) -> Result<Value> {
+    let path = loaded.state_root.join(artifact_ref);
+    if !path.exists() {
+        return Err(anyhow!("inspection artifact missing: {artifact_ref}"));
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("failed reading inspection artifact {artifact_ref}"))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed parsing inspection artifact {artifact_ref}"))
+}
+
+fn read_state_text_artifact(loaded: &LoadedAgentSpec, artifact_ref: &str) -> Result<String> {
+    let path = loaded.state_root.join(artifact_ref);
+    if !path.exists() {
+        return Err(anyhow!("inspection artifact missing: {artifact_ref}"));
+    }
+    fs::read_to_string(&path)
+        .with_context(|| format!("failed reading inspection artifact {artifact_ref}"))
+}
+
+fn guardrail_check_summary(guardrail_report: &Value) -> Vec<Value> {
+    guardrail_report
+        .get("checks")
+        .and_then(Value::as_array)
+        .map(|checks| {
+            checks
+                .iter()
+                .map(|check| {
+                    json!({
+                        "check_id": check.get("check_id").cloned().unwrap_or(Value::Null),
+                        "result": check.get("result").cloned().unwrap_or(Value::Null)
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn summary_preview(summary: &str) -> Vec<String> {
+    summary
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(6)
+        .map(str::to_string)
+        .collect()
+}
+
 fn sha256_json(value: &Value) -> Result<String> {
     let bytes = serde_json::to_vec(value)?;
     let digest = Sha256::digest(bytes);
@@ -1937,6 +2125,93 @@ memory:
         )
         .expect("parse manifest");
         assert_eq!(manifest["previous_cycle_id"], "cycle-000001");
+    }
+
+    #[test]
+    fn inspect_latest_cycle_emits_reviewer_proof_packet() {
+        let root = temp_dir("inspect-latest");
+        let spec = write_spec(&root);
+        run(
+            &spec,
+            RunOptions {
+                max_cycles: 2,
+                interval_secs: None,
+                no_sleep: true,
+                recover_stale_lease: false,
+            },
+        )
+        .expect("run");
+
+        let packet = inspect(&spec, InspectOptions::default()).expect("inspect latest");
+
+        assert_eq!(packet["schema"], INSPECTION_PACKET_SCHEMA);
+        assert_eq!(packet["agent_instance_id"], "test-agent");
+        assert_eq!(packet["reviewer_proof"]["status"], "pass");
+        assert_eq!(
+            packet["selected_cycle"]["refs"]["manifest"],
+            "cycles/cycle-000002/cycle_manifest.json"
+        );
+        assert_eq!(
+            packet["selected_cycle"]["refs"]["guardrail_report"],
+            "cycles/cycle-000002/guardrail_report.json"
+        );
+        assert_eq!(
+            packet["selected_cycle"]["refs"]["cycle_summary"],
+            "cycles/cycle-000002/cycle_summary.md"
+        );
+        assert_eq!(packet["selected_cycle"]["guardrails"]["status"], "pass");
+        assert_eq!(
+            packet["selected_cycle"]["trace_boundary"]["status"],
+            "cycle_artifact_only"
+        );
+        assert_eq!(
+            packet["trace_query_decision"]["full_tql_platform"],
+            "deferred"
+        );
+        assert_eq!(
+            packet["trace_query_decision"]["full_signed_trace_architecture"],
+            "deferred"
+        );
+        let raw = serde_json::to_string(&packet).expect("serialize packet");
+        assert!(!raw.contains(root.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn inspect_specific_cycle_and_rejects_unsafe_cycle_refs() {
+        let root = temp_dir("inspect-specific");
+        let spec = write_spec(&root);
+        run(
+            &spec,
+            RunOptions {
+                max_cycles: 2,
+                interval_secs: None,
+                no_sleep: true,
+                recover_stale_lease: false,
+            },
+        )
+        .expect("run");
+
+        let packet = inspect(
+            &spec,
+            InspectOptions {
+                cycle_id: Some("cycle-000001".to_string()),
+            },
+        )
+        .expect("inspect selected cycle");
+
+        assert_eq!(packet["selected_cycle"]["cycle_id"], "cycle-000001");
+        assert_eq!(
+            packet["selected_cycle"]["refs"]["run_ref"],
+            "cycles/cycle-000001/run_ref.json"
+        );
+        let err = inspect(
+            &spec,
+            InspectOptions {
+                cycle_id: Some("../cycle-000001".to_string()),
+            },
+        )
+        .expect_err("unsafe cycle ref rejected");
+        assert!(err.to_string().contains("generated cycle id"));
     }
 
     #[test]

--- a/adl/tests/cli_smoke/agent.rs
+++ b/adl/tests/cli_smoke/agent.rs
@@ -114,4 +114,36 @@ memory:
         status_stdout.contains("\"state\": \"completed\""),
         "stdout:\n{status_stdout}"
     );
+
+    let inspect = run_adl(&["agent", "inspect", "--spec", spec_str, "--json"]);
+    assert!(
+        inspect.status.success(),
+        "expected agent inspect success, stderr:\n{}",
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    let inspect_stdout = String::from_utf8_lossy(&inspect.stdout);
+    assert!(
+        inspect_stdout.contains("\"schema\": \"adl.long_lived_agent_inspection_packet.v1\""),
+        "stdout:\n{inspect_stdout}"
+    );
+    assert!(
+        inspect_stdout.contains("\"manifest\": \"cycles/cycle-000003/cycle_manifest.json\""),
+        "stdout:\n{inspect_stdout}"
+    );
+    assert!(
+        inspect_stdout
+            .contains("\"guardrail_report\": \"cycles/cycle-000003/guardrail_report.json\""),
+        "stdout:\n{inspect_stdout}"
+    );
+
+    let human_inspect = run_adl(&["agent", "inspect", "--spec", spec_str]);
+    assert!(
+        human_inspect.status.success(),
+        "expected human agent inspect success, stderr:\n{}",
+        String::from_utf8_lossy(&human_inspect.stderr)
+    );
+    let human_inspect_stdout = String::from_utf8_lossy(&human_inspect.stdout);
+    assert!(human_inspect_stdout.contains("agent: smoke-agent"));
+    assert!(human_inspect_stdout.contains("cycle: cycle-000003 success"));
+    assert!(human_inspect_stdout.contains("proof: pass"));
 }

--- a/docs/milestones/v0.90/features/FEATURE_LONG_LIVED_OPERATOR_CONTROL_AND_SAFETY.md
+++ b/docs/milestones/v0.90/features/FEATURE_LONG_LIVED_OPERATOR_CONTROL_AND_SAFETY.md
@@ -157,6 +157,22 @@ last error: none
 
 JSON output reads from `status.json`.
 
+## Inspection Command
+
+`inspect` is the v0.90 reviewer proof surface. It reads the existing status and
+cycle artifacts and emits a compact packet pointing at the status record, latest
+or selected cycle manifest, guardrail report, run reference, and cycle summary:
+
+```bash
+adl agent inspect --spec stock-league-value-monk.yaml
+adl agent inspect --spec stock-league-value-monk.yaml --cycle cycle-000003 --json
+```
+
+The v0.90 decision is intentionally narrow: `inspect` may expose the cycle
+`run_ref.json` and any trace reference already recorded there, but a full TQL
+platform and a full signed-trace architecture remain deferred unless a later
+work package explicitly accepts that scope.
+
 ## Failure Behavior
 
 ### Workflow Failure


### PR DESCRIPTION
Closes #2025

## Summary
Implemented the v0.90 minimal inspection and trace boundary for supervised long-lived agents. The new `adl agent inspect` command reads the existing status and cycle artifact tree, emits a reviewer-proof packet in JSON, and provides concise human output that points at the live status, cycle manifest, guardrail report, cycle summary, decision result, run reference, and memory write refs without requiring reviewers to manually traverse the whole artifact tree.

The accepted v0.90 boundary is intentionally narrow: this WP adds inspection over existing supervised-agent artifacts and records that full TQL / general trace-query architecture is deferred to a later WP.

## Artifacts
- `adl/src/long_lived_agent.rs` adds the inspection packet schema, `InspectOptions`, cycle selection, artifact reference collection, guardrail/summary extraction, and explicit trace-query deferral metadata.
- `adl/src/cli/agent_cmd.rs` adds `adl agent inspect --spec <agent-spec.yaml> [--cycle <cycle-id>] [--json]` parsing plus human and JSON output modes.
- `adl/src/cli/usage.rs` advertises the new inspection command and example.
- `adl/tests/cli_smoke/agent.rs` proves the CLI inspection packet and human output against real supervised-agent run artifacts.
- `docs/milestones/v0.90/features/FEATURE_LONG_LIVED_OPERATOR_CONTROL_AND_SAFETY.md` documents the inspection command and v0.90 trace boundary.

## Validation
- Validation commands and their purpose:
  - `adl/tools/pr.sh doctor 2025 --json --slug v0-90-wp-06-minimal-inspection-and-trace-boundary --version v0.90` verified the issue cards were structurally ready before run binding.
  - `adl/tools/pr.sh run 2025 --slug v0-90-wp-06-minimal-inspection-and-trace-boundary --title "[v0.90][WP-06] Minimal inspection and trace boundary" --version v0.90 --allow-open-pr-wave` bound the branch and worktree after conductor review.
  - `cargo fmt --manifest-path adl/Cargo.toml` formatted the Rust changes.
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check` verified formatting stayed clean.
  - `cargo test --manifest-path adl/Cargo.toml long_lived_agent::tests::inspect -- --nocapture` verified the inspection packet, explicit cycle selection, and unsafe cycle rejection unit tests.
  - `cargo test --manifest-path adl/Cargo.toml agent_commands_execute_success_paths -- --nocapture` verified CLI dispatch success paths including `agent inspect`.
  - `cargo test --manifest-path adl/Cargo.toml agent_run_writes_bounded_cycles_and_status -- --nocapture` verified the smoke fixture that produces supervised-agent status and cycles.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings` verified the changed Rust code remains warning-free.
  - `cargo test --manifest-path adl/Cargo.toml` verified the full Rust test suite.
  - `cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info` generated the coverage dataset used for gate enforcement.
  - `cargo llvm-cov report --json --summary-only --output-path coverage-summary.json` generated the numeric coverage summary.
  - `bash tools/enforce_coverage_gates.sh coverage-summary.json` enforced workspace and per-file coverage gates.
- Results: PASS. Full tests passed. Coverage gate passed with workspace line coverage at 92.43%; `adl/src/long_lived_agent.rs` line coverage at 90.61%; `adl/src/cli/agent_cmd.rs` line coverage at 96.02%.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2025__v0-90-wp-06-minimal-inspection-and-trace-boundary/sip.md
- Output card: .adl/v0.90/tasks/issue-2025__v0-90-wp-06-minimal-inspection-and-trace-boundary/sor.md
- Idempotency-Key: v0-90-wp-06-minimal-inspection-and-trace-boundary-adl-src-long-lived-agent-rs-adl-src-cli-agent-cmd-rs-adl-src-cli-usage-rs-adl-tests-cli-smoke-agent-rs-docs-milestones-v0-90-features-feature-long-lived-operator-control-and-safety-md-adl-v0-90-tasks-issue-2025-v0-90-wp-06-minimal-inspection-and-trace-boundary-sip-md-adl-v0-90-tasks-issue-2025-v0-90-wp-06-minimal-inspection-and-trace-boundary-sor-md