### PR TITLE
[v0.90][backlog][tools] Refresh web task editor for current ADL skills

### DIFF
--- a/adl/tools/editor_action.sh
+++ b/adl/tools/editor_action.sh
@@ -14,6 +14,7 @@ usage() {
   cat <<'USAGE'
 Usage:
   adl/tools/editor_action.sh contract [--format text|json]
+  adl/tools/editor_action.sh prepare --phase init|doctor-ready|run|finish --issue <number> --slug <slug> [--version <vN.N[.P]>] [--title <title>] [--paths <paths>]
   adl/tools/editor_action.sh start --issue <number> --branch codex/<issue>-<slug> [--slug <slug>] [--dry-run]
 
 Purpose:
@@ -21,52 +22,88 @@ Purpose:
 
 Current actions:
   contract Print the supported near-term editor adapter surface.
-  start    Validate issue/branch pairing and invoke `adl/tools/pr.sh start`.
+  prepare  Validate fields and print one current lifecycle command for a human to run from the repo root.
+  start    Legacy compatibility action for the older v0.85 editor demo path.
 USAGE
 }
 
 emit_contract_text() {
   cat <<'EOF'
-editor_adapter_schema: editor.command_adapter.v1
+editor_adapter_schema: editor.command_adapter.v2
 supported_actions:
+  - action: prepare
+    adapter_entry: adl/tools/editor_action.sh prepare --phase init|doctor-ready|run|finish --issue <number> --slug <slug> [--version <vN.N[.P]>] [--title <title>] [--paths <paths>]
+    maps_to: copy-only adl/tools/pr.sh lifecycle command
+    invocation_mode: browser_prepared_human_run
+    browser_direct: false
+    status: supported
+    phases:
+      - init
+      - doctor-ready
+      - run
+      - finish
+legacy_compatibility_actions:
   - action: start
     adapter_entry: adl/tools/editor_action.sh start --issue <number> --branch codex/<issue>-<slug> [--slug <slug>] [--dry-run]
     maps_to: adl/tools/pr.sh start
-    invocation_mode: thin_adapter
+    invocation_mode: legacy_thin_adapter
     browser_direct: false
-    status: supported
+    status: deprecated_compatibility
 unsupported_browser_direct_actions:
+  - pr create
   - pr init
+  - pr doctor
+  - pr ready
   - pr run
   - pr finish
+  - pr janitor
+  - pr closeout
 notes:
-  - Browser/editor surfaces may prepare or copy supported commands, but must not claim direct invocation of unsupported lifecycle commands.
-  - The near-term adapter surface is intentionally narrow so browser logic does not duplicate control-plane behavior.
+  - Browser/editor surfaces may prepare or copy lifecycle commands, but must not claim direct browser execution.
+  - The current taught path is pr init, pr doctor/ready, pr run, pr finish, pr janitor, and pr closeout through repo-owned tooling and skills.
+  - The legacy start action remains only so older deterministic demos can keep validating compatibility until they are retired.
 EOF
 }
 
 emit_contract_json() {
   cat <<'EOF'
 {
-  "schema_version": "editor.command_adapter.v1",
+  "schema_version": "editor.command_adapter.v2",
   "supported_actions": [
+    {
+      "action": "prepare",
+      "adapter_entry": "adl/tools/editor_action.sh prepare --phase init|doctor-ready|run|finish --issue <number> --slug <slug> [--version <vN.N[.P]>] [--title <title>] [--paths <paths>]",
+      "maps_to": "copy-only adl/tools/pr.sh lifecycle command",
+      "invocation_mode": "browser_prepared_human_run",
+      "browser_direct": false,
+      "status": "supported",
+      "phases": ["init", "doctor-ready", "run", "finish"]
+    }
+  ],
+  "legacy_compatibility_actions": [
     {
       "action": "start",
       "adapter_entry": "adl/tools/editor_action.sh start --issue <number> --branch codex/<issue>-<slug> [--slug <slug>] [--dry-run]",
       "maps_to": "adl/tools/pr.sh start",
-      "invocation_mode": "thin_adapter",
+      "invocation_mode": "legacy_thin_adapter",
       "browser_direct": false,
-      "status": "supported"
+      "status": "deprecated_compatibility"
     }
   ],
   "unsupported_browser_direct_actions": [
+    "pr create",
     "pr init",
+    "pr doctor",
+    "pr ready",
     "pr run",
-    "pr finish"
+    "pr finish",
+    "pr janitor",
+    "pr closeout"
   ],
   "notes": [
-    "Browser/editor surfaces may prepare or copy supported commands, but must not claim direct invocation of unsupported lifecycle commands.",
-    "The near-term adapter surface is intentionally narrow so browser logic does not duplicate control-plane behavior."
+    "Browser/editor surfaces may prepare or copy lifecycle commands, but must not claim direct browser execution.",
+    "The current taught path is pr init, pr doctor/ready, pr run, pr finish, pr janitor, and pr closeout through repo-owned tooling and skills.",
+    "The legacy start action remains only so older deterministic demos can keep validating compatibility until they are retired."
   ]
 }
 EOF
@@ -92,12 +129,52 @@ derive_slug_from_branch() {
   echo "$slug"
 }
 
+shell_quote() {
+  local value="$1"
+  printf "'%s'" "${value//\'/\'\\\'\'}"
+}
+
+version_or_default() {
+  local value="$1"
+  if [[ -z "$value" ]]; then
+    echo "v0.90"
+    return
+  fi
+  [[ "$value" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)*$ ]] || die "version must match vN.N or vN.N.P"
+  echo "$value"
+}
+
+emit_prepare_command() {
+  local phase="$1" issue="$2" slug="$3" version="$4" title="$5" paths="$6"
+  case "$phase" in
+    init)
+      printf './adl/tools/pr.sh init %s --slug %s --version %s\n' "$issue" "$slug" "$version"
+      ;;
+    doctor-ready)
+      printf './adl/tools/pr.sh doctor %s --slug %s --version %s --mode ready\n' "$issue" "$slug" "$version"
+      ;;
+    run)
+      printf './adl/tools/pr.sh run %s --slug %s --version %s\n' "$issue" "$slug" "$version"
+      ;;
+    finish)
+      if [[ -z "$title" ]]; then
+        title="[${version}] Issue ${issue} closeout"
+      fi
+      if [[ -z "$paths" ]]; then
+        paths="<paths>"
+      fi
+      printf './adl/tools/pr.sh finish %s --title %s --paths %s\n' "$issue" "$(shell_quote "$title")" "$(shell_quote "$paths")"
+      ;;
+    *) die "--phase must be one of: init, doctor-ready, run, finish" ;;
+  esac
+}
+
 ACTION="${1:-}"
 [[ -n "$ACTION" ]] || { usage; exit 1; }
 shift || true
 
 case "$ACTION" in
-  start|contract) ;;
+  prepare|start|contract) ;;
   -h|--help) usage; exit 0 ;;
   *) die "unsupported action: $ACTION" ;;
 esac
@@ -107,14 +184,22 @@ BRANCH=""
 SLUG=""
 DRY_RUN=false
 FORMAT="text"
+PHASE=""
+VERSION=""
+TITLE=""
+PATHS_ARG=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --phase) PHASE="$2"; shift 2 ;;
     --issue) ISSUE="$2"; shift 2 ;;
     --branch) BRANCH="$2"; shift 2 ;;
     --slug) SLUG="$2"; shift 2 ;;
     --dry-run) DRY_RUN=true; shift ;;
     --format) FORMAT="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --title) TITLE="$2"; shift 2 ;;
+    --paths) PATHS_ARG="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
@@ -130,9 +215,19 @@ if [[ "$ACTION" == "contract" ]]; then
 fi
 
 [[ -n "$ISSUE" ]] || die "--issue is required"
-[[ -n "$BRANCH" ]] || die "--branch is required"
 
 ISSUE="$(normalize_issue_or_die "$ISSUE")"
+
+if [[ "$ACTION" == "prepare" ]]; then
+  [[ -n "$PHASE" ]] || die "--phase is required"
+  [[ -n "$SLUG" ]] || die "--slug is required"
+  [[ "$SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]] || die "slug must match [a-z0-9-]+"
+  VERSION="$(version_or_default "$VERSION")"
+  emit_prepare_command "$PHASE" "$ISSUE" "$SLUG" "$VERSION" "$TITLE" "$PATHS_ARG"
+  exit 0
+fi
+
+[[ -n "$BRANCH" ]] || die "--branch is required"
 
 if [[ -z "$SLUG" ]]; then
   SLUG="$(derive_slug_from_branch "$ISSUE" "$BRANCH")"

--- a/adl/tools/test_editor_action.sh
+++ b/adl/tools/test_editor_action.sh
@@ -13,20 +13,34 @@ fail() {
   exit 1
 }
 
-out="$(bash adl/tools/editor_action.sh start --issue 938 --branch codex/938-v085-editor-control-plane-adapter --dry-run)"
-[[ "$out" == "./adl/tools/pr.sh start 938 --slug v085-editor-control-plane-adapter" ]] || fail "dry-run should derive the slug from the branch"
-pass "dry-run derives slug from branch"
+out="$(bash adl/tools/editor_action.sh prepare --phase run --issue 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90)"
+[[ "$out" == "./adl/tools/pr.sh run 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90" ]] || fail "prepare should emit the current pr run command"
+pass "prepare emits current pr run command"
+
+out="$(bash adl/tools/editor_action.sh prepare --phase doctor-ready --issue 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90)"
+[[ "$out" == "./adl/tools/pr.sh doctor 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90 --mode ready" ]] || fail "prepare should emit the ready doctor command"
+pass "prepare emits ready doctor command"
+
+out="$(bash adl/tools/editor_action.sh prepare --phase finish --issue 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90 --title "[v0.90][tools] Refresh editor" --paths "docs/tooling/editor/README.md")"
+[[ "$out" == "./adl/tools/pr.sh finish 2053 --title '[v0.90][tools] Refresh editor' --paths 'docs/tooling/editor/README.md'" ]] || fail "prepare should shell-quote finish title and paths"
+pass "prepare emits quoted finish command"
 
 out="$(bash adl/tools/editor_action.sh contract)"
-[[ "$out" == *"editor_adapter_schema: editor.command_adapter.v1"* ]] || fail "contract text should include schema header"
-[[ "$out" == *"maps_to: adl/tools/pr.sh start"* ]] || fail "contract text should map the adapter to pr start"
+[[ "$out" == *"editor_adapter_schema: editor.command_adapter.v2"* ]] || fail "contract text should include schema header"
+[[ "$out" == *"action: prepare"* ]] || fail "contract text should expose prepare as the supported action"
+[[ "$out" == *"browser_prepared_human_run"* ]] || fail "contract text should state copy-only human-run mode"
 [[ "$out" == *"unsupported_browser_direct_actions:"* ]] || fail "contract text should list unsupported direct browser actions"
 pass "contract text exposes the supported adapter surface"
 
 out="$(bash adl/tools/editor_action.sh contract --format json)"
-[[ "$out" == *"\"schema_version\": \"editor.command_adapter.v1\""* ]] || fail "contract json should include schema version"
+[[ "$out" == *"\"schema_version\": \"editor.command_adapter.v2\""* ]] || fail "contract json should include schema version"
+[[ "$out" == *"\"action\": \"prepare\""* ]] || fail "contract json should expose prepare as the supported action"
 [[ "$out" == *"\"unsupported_browser_direct_actions\""* ]] || fail "contract json should list unsupported direct browser actions"
 pass "contract json exposes the supported adapter surface"
+
+out="$(bash adl/tools/editor_action.sh start --issue 938 --branch codex/938-v085-editor-control-plane-adapter --dry-run)"
+[[ "$out" == "./adl/tools/pr.sh start 938 --slug v085-editor-control-plane-adapter" ]] || fail "legacy dry-run should derive the slug from the branch"
+pass "legacy start dry-run remains compatible"
 
 if bash adl/tools/editor_action.sh start --issue 938 --branch codex/939-v085-editor-review-flow-integration --dry-run >/dev/null 2>&1; then
   fail "mismatched issue and branch should fail"
@@ -34,5 +48,5 @@ fi
 pass "mismatched issue and branch are rejected"
 
 out="$(bash adl/tools/editor_action.sh start --issue 938 --branch codex/938-v085-editor-control-plane-adapter --slug v085-editor-control-plane-adapter --dry-run)"
-[[ "$out" == "./adl/tools/pr.sh start 938 --slug v085-editor-control-plane-adapter" ]] || fail "explicit slug should still produce the same command"
-pass "explicit slug stays consistent"
+[[ "$out" == "./adl/tools/pr.sh start 938 --slug v085-editor-control-plane-adapter" ]] || fail "legacy explicit slug should still produce the same command"
+pass "legacy explicit slug stays consistent"

--- a/adl/tools/test_five_command_editor_truth.sh
+++ b/adl/tools/test_five_command_editor_truth.sh
@@ -28,19 +28,25 @@ grep -Fq '| `pr create` | yes | no | control-plane only |' "$ROOT_DIR/docs/tooli
   exit 1
 }
 grep -Fq '| `pr init` | yes | no | control-plane only |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
-  echo "assertion failed: command_adapter.md must keep pr init control-plane only" >&2
+  grep -Fq '| `pr init` | yes | no | copy-only prepared handoff |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
+    echo "assertion failed: command_adapter.md must keep pr init out of browser-direct execution" >&2
+    exit 1
+  }
+}
+grep -Fq '| `pr start` | legacy alias | no | deprecated compatibility only |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
+  echo "assertion failed: command_adapter.md must mark pr start as deprecated compatibility only" >&2
   exit 1
 }
-grep -Fq '| `pr start` | yes | yes, via `adl/tools/editor_action.sh start` | supported thin adapter |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
-  echo "assertion failed: command_adapter.md must keep pr start as the only browser-direct adapter surface" >&2
+grep -Fq '| `pr run` | yes | no | copy-only prepared handoff |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
+  echo "assertion failed: command_adapter.md must keep pr run out of browser-direct execution" >&2
   exit 1
 }
-grep -Fq '| `pr run` | yes | no | control-plane only |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
-  echo "assertion failed: command_adapter.md must keep pr run control-plane only" >&2
+grep -Fq '| `pr finish` | yes | no | copy-only prepared handoff |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
+  echo "assertion failed: command_adapter.md must keep pr finish out of browser-direct execution" >&2
   exit 1
 }
-grep -Fq '| `pr finish` | yes | no | control-plane only |' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
-  echo "assertion failed: command_adapter.md must keep pr finish control-plane only" >&2
+grep -Fq 'browser-prepared, human-run command handoff' "$ROOT_DIR/docs/tooling/editor/command_adapter.md" || {
+  echo "assertion failed: command_adapter.md must document copy-only human-run mode" >&2
   exit 1
 }
 

--- a/docs/tooling/editor/README.md
+++ b/docs/tooling/editor/README.md
@@ -1,6 +1,6 @@
 # Task Bundle Editor
 
-This directory contains the first bounded editor surface for ADL public task bundles.
+This directory contains the bounded editor surface for ADL task bundles and current workflow-skill handoff.
 
 Open:
 
@@ -16,7 +16,7 @@ The editor is intentionally simple:
   - `Structured Implementation Prompt` (SIP)
   - bounded review-first `Structured Output Record` (SOR) surface
 - exposes one bounded workflow action surface for:
-  - `pr start` via `adl/tools/editor_action.sh`
+  - copy-only lifecycle command preparation via `adl/tools/editor_action.sh prepare`
 - defines one explicit near-term adapter contract in:
   - `docs/tooling/editor/command_adapter.md`
 - exposes one bounded review-flow surface for:
@@ -42,14 +42,14 @@ The editor is intentionally simple:
   - summarizing whether the SOR is ready for handoff or needs iteration
   - checking proof, artifact verification, and follow-up coverage
   - generating a reviewer-facing note without inventing a second review system
-- keeps the historical tracked demo destination visible as a v0.85 task-bundle path under:
-  - `docs/records/v0.85/tasks/<task-id>/`
+- keeps the current local issue-bundle destination visible as:
+  - `.adl/<version>/tasks/<task-id>__<slug>/`
 
 ## What It Does Not Do Yet
 
 - it does not write files directly
-- it does not replace `pr start`, `pr run`, or `pr finish`
-- it does not imply direct browser invocation for the full authoring lifecycle
+- it does not replace `pr init`, `pr ready`/`pr doctor`, `pr run`, `pr finish`, `pr janitor`, or `pr closeout`
+- it does not imply direct browser invocation for the authoring lifecycle
 - it does not yet provide the full SOR decision loop or acceptance workflow
 - it does not try to replace human review judgment with browser-only automation
 - it does not yet execute the control plane directly from browser JS
@@ -58,16 +58,16 @@ The editor is intentionally simple:
 
 ## Why This Is Still Useful
 
-This first slice reduces structural editing fragility without pretending the full editor architecture already exists. It preserves the historical v0.85 public task-bundle model as a tracked proof surface, makes the three-card bundle visible as one workspace, and exposes a thin validated path back into the control plane without claiming that `docs/records/` is still the live canonical workflow destination.
+This slice reduces structural editing fragility without pretending the full editor architecture already exists. It makes the three-card bundle visible as one workspace, aligns the preview with the current `.adl` issue-bundle convention, and exposes a copy-only validated path back into the control plane without claiming browser direct execution.
 
 ## Canonical Demo / Proof Surface
 
-The historical tracked proof surface for this editor slice is:
+The proof surface for this editor slice is:
 
 - `docs/tooling/editor/command_adapter.md`
 - `docs/tooling/editor/demo.md`
+- `docs/tooling/editor/current_skill_wiring_demo.md`
 - `docs/tooling/editor/five_command_demo.md`
 - `docs/tooling/editor/five_command_regression_suite.md`
-- `docs/records/v0.85/tasks/task-v085-wp05-demo/`
 
-Review those together to see the actual supported loop and the remaining manual gaps.
+Review those together to see the actual supported loop, the legacy compatibility guardrails, and the remaining manual gaps.

--- a/docs/tooling/editor/command_adapter.md
+++ b/docs/tooling/editor/command_adapter.md
@@ -1,34 +1,41 @@
 # Editor Command Adapter Surface
 
-This document is the canonical near-term editor command adapter contract for v0.85.
+This document is the current editor command adapter contract for ADL task-bundle handoff.
 
-It defines what browser/editor surfaces may invoke directly, what they may only prepare or copy for a human to run, and what remains out of scope for direct browser invocation.
+It defines what browser/editor surfaces may prepare, what remains human-run through repo tooling and workflow skills, and what is explicitly out of scope for direct browser invocation.
 
 ## Contract
 
-The supported near-term adapter surface is intentionally narrow:
+The supported adapter surface is intentionally copy-only:
 
 - supported adapter action:
-  - `adl/tools/editor_action.sh start --issue <number> --branch codex/<issue>-<slug> [--slug <slug>] [--dry-run]`
+  - `adl/tools/editor_action.sh prepare --phase init|doctor-ready|run|finish --issue <number> --slug <slug> [--version <vN.N[.P]>] [--title <title>] [--paths <paths>]`
 - canonical control-plane mapping:
-  - `adl/tools/pr.sh start`
+  - `adl/tools/pr.sh init`
+  - `adl/tools/pr.sh doctor --mode ready`
+  - `adl/tools/pr.sh run`
+  - `adl/tools/pr.sh finish`
 - adapter mode:
-  - thin adapter only
+  - browser-prepared, human-run command handoff
 
 The browser/editor may:
 
-- prepare the adapter command
-- copy the adapter command for a human to run from the repo root
-- validate issue/branch pairing constraints before surfacing the command
+- prepare a lifecycle command
+- copy that command for a human to run from the repo root
+- validate issue, branch, slug, and version constraints before surfacing the command
 
 The browser/editor may not claim direct browser invocation of:
 
 - `pr create`
 - `pr init`
+- `pr doctor`
+- `pr ready`
 - `pr run`
 - `pr finish`
+- `pr janitor`
+- `pr closeout`
 
-Those commands exist in the repo control plane, but they are not part of the current browser-direct adapter surface for v0.85.
+Those commands exist in the repo control plane and related operational skills. They are not browser-direct actions.
 
 ## Why The Surface Is Narrow
 
@@ -36,21 +43,27 @@ The adapter must stay thin so the browser does not duplicate workflow logic alre
 
 That means:
 
-- browser code should not recreate `pr` lifecycle behavior in JavaScript
+- browser code should not recreate lifecycle behavior in JavaScript
 - browser code should not imply hidden direct execution paths
-- browser docs should distinguish:
-  - implemented control-plane commands
-  - supported browser-direct adapter actions
+- browser docs should distinguish implemented repo commands from browser-prepared command handoff
+- editor output should remain compatible with `pr-init`, `pr-ready`, `pr-run`, `pr-finish`, `pr-janitor`, `pr-closeout`, and the card editor skills
 
 ## Truth Table
 
-| Lifecycle command | Exists in repo | Browser-direct adapter support in v0.85 | Truthful near-term status |
+| Lifecycle command | Exists in repo | Browser-direct adapter support | Truthful editor status |
 | --- | --- | --- | --- |
 | `pr create` | yes | no | control-plane only |
-| `pr init` | yes | no | control-plane only |
-| `pr start` | yes | yes, via `adl/tools/editor_action.sh start` | supported thin adapter |
-| `pr run` | yes | no | control-plane only |
-| `pr finish` | yes | no | control-plane only |
+| `pr init` | yes | no | copy-only prepared handoff |
+| `pr doctor --mode ready` | yes | no | copy-only prepared handoff |
+| `pr run` | yes | no | copy-only prepared handoff |
+| `pr finish` | yes | no | copy-only prepared handoff |
+| `pr janitor` | skill-owned | no | out of browser scope |
+| `pr closeout` | skill-owned | no | out of browser scope |
+| `pr start` | legacy alias | no | deprecated compatibility only |
+
+## Legacy Compatibility
+
+`adl/tools/editor_action.sh start` remains available for older deterministic editor demos that still validate the v0.85 compatibility path. It is not the taught current workflow.
 
 ## Proof Surface
 
@@ -59,5 +72,6 @@ The contract is backed by:
 - `adl/tools/editor_action.sh`
 - `adl/tools/test_editor_action.sh`
 - `docs/tooling/editor/demo.md`
+- `docs/tooling/editor/current_skill_wiring_demo.md`
 
 The adapter surface should only be widened in a follow-on issue with matching docs, validation, and proof updates.

--- a/docs/tooling/editor/current_skill_wiring_demo.md
+++ b/docs/tooling/editor/current_skill_wiring_demo.md
@@ -1,0 +1,56 @@
+# Current Skill Wiring Demo
+
+This proof surface shows how the static task-bundle editor aligns with the current ADL workflow skill family without claiming direct browser execution.
+
+## Scenario
+
+Use the default editor state:
+
+- task id: `issue-2053`
+- title: `[v0.90][tools] Refresh web task editor for current ADL skills`
+- branch: `codex/2053-backlog-tools-refresh-web-task-editor-current-skills`
+- version: `v0.90`
+
+The editor should display:
+
+- current local bundle root: `.adl/v0.90/tasks/issue-2053__backlog-tools-refresh-web-task-editor-current-skills/`
+- current local card target for the active STP, SIP, or SOR card
+- a copy-only workflow action for the `pr-run` handoff
+
+## Command Proof
+
+The adapter command used by the editor is:
+
+- `adl/tools/editor_action.sh prepare --phase run --issue 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90`
+
+Expected output:
+
+- `./adl/tools/pr.sh run 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90`
+
+Additional supported handoffs:
+
+- `adl/tools/editor_action.sh prepare --phase init --issue 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90`
+- `adl/tools/editor_action.sh prepare --phase doctor-ready --issue 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90`
+- `adl/tools/editor_action.sh prepare --phase finish --issue 2053 --slug backlog-tools-refresh-web-task-editor-current-skills --version v0.90 --title "[v0.90][tools] Refresh web task editor for current ADL skills" --paths "docs/tooling/editor/README.md,docs/tooling/editor/index.html,docs/tooling/editor/task_bundle_editor.js,adl/tools/editor_action.sh"`
+
+## Skill Alignment
+
+The browser editor is a preparation surface only.
+
+It can help prepare commands for:
+
+- `pr-init`
+- `pr-ready` / doctor readiness
+- `pr-run`
+- `pr-finish`
+
+It must not take over:
+
+- `pr-janitor`
+- `pr-closeout`
+- STP, SIP, or SOR card-editor judgment
+- worktree binding or tracked file writes
+
+## Truth Boundary
+
+The editor may produce useful markdown previews, validation hints, review notes, and copyable commands. The repo-owned lifecycle still runs through the ADL control plane and associated skills.

--- a/docs/tooling/editor/demo.md
+++ b/docs/tooling/editor/demo.md
@@ -1,13 +1,13 @@
 # Editor Workflow Demo
 
-This bounded demo is the canonical proof surface for the current v0.85 editor slice.
+This bounded demo is the canonical proof surface for the current editor slice.
 
 It demonstrates the real workflow that now exists in the repo:
 
 - open one tracked task bundle
 - edit STP, SIP, and SOR in one workspace
 - see validation and rendered preview update live
-- prepare a bounded `pr start` action from the editor
+- prepare a bounded current lifecycle command from the editor
 - use the integrated SOR review flow to prepare a reviewer handoff
 
 The canonical near-term adapter contract for this slice is:
@@ -31,8 +31,8 @@ It does not claim a finished browser-only workflow platform.
    - valid task IDs, run IDs, versions, branch values, and enum values show passing checks
 6. Review the rendered artifact preview.
    - confirm the H1 uses the task title rather than a generic artifact-class heading
-7. Switch to `Structured Implementation Prompt` and confirm the historical demo bundle target changes to:
-   - `docs/records/v0.85/tasks/<task-id>/sip.md`
+7. Switch to `Structured Implementation Prompt` and confirm the current local bundle target changes to:
+   - `.adl/<version>/tasks/<task-id>__<slug>/sip.md`
 8. Switch to `Structured Output Record` and confirm the SOR card remains visibly linked in the same bundle workspace.
 9. Edit the SOR review fields and confirm the surface now supports:
    - integration state
@@ -43,13 +43,13 @@ It does not claim a finished browser-only workflow platform.
    - a bounded recommendation
    - a reviewer checklist tied to the SOR proof surface
    - a copyable review note that summarizes review focus and follow-ups
-11. Compare the preview output with the tracked historical example bundle:
-   - `docs/records/v0.85/tasks/task-v085-wp05-demo/stp.md`
-   - `docs/records/v0.85/tasks/task-v085-wp05-demo/sip.md`
-   - `docs/records/v0.85/tasks/task-v085-wp05-demo/sor.md`
-12. Return to the `Structured Task Prompt` card, set a numeric GitHub issue number that matches the branch prefix, and confirm the workflow action panel shows a ready `pr start` command.
+11. Compare the preview output with a current local issue bundle:
+   - `.adl/<version>/tasks/<task-id>__<slug>/stp.md`
+   - `.adl/<version>/tasks/<task-id>__<slug>/sip.md`
+   - `.adl/<version>/tasks/<task-id>__<slug>/sor.md`
+12. Return to the `Structured Task Prompt` card, set a numeric GitHub issue number that matches the branch prefix, and confirm the workflow action panel shows a ready `pr run` command.
 13. Copy the command from the editor and run it from the repo root:
-    - `adl/tools/editor_action.sh start --issue <issue-number> --branch codex/<issue>-<slug>`
+    - `adl/tools/editor_action.sh prepare --phase run --issue <issue-number> --slug <slug> --version <version>`
 14. Copy the review note from the Review Flow panel and confirm it summarizes:
     - the bounded recommendation
     - the current proof surface
@@ -60,15 +60,17 @@ It does not claim a finished browser-only workflow platform.
 - task bundle opens as a linked STP/SIP/SOR workspace
 - structured field editing and preview happen in the browser
 - validation feedback is visible while editing
-- bounded `pr start` command generation is available from the editor
+- bounded copy-only current lifecycle command generation is available from the editor
 - SOR review and reviewer handoff are visible in the same workspace
 
 ## Still Manual / Out Of Scope
 
 - `pr create` is not launched from the browser in this slice
 - `pr init` is not launched from the browser in this slice
+- `pr doctor` / `pr ready` is not launched from the browser in this slice
 - `pr run` is not launched from the browser in this slice
 - `pr finish` is not launched from the browser in this slice
+- `pr janitor` and `pr closeout` remain skill-owned, not browser-owned
 - final review judgment is still human-made
 - the browser does not write tracked files directly
 - no claim is made that this is already a full HTA platform
@@ -80,7 +82,7 @@ It does not claim a finished browser-only workflow platform.
 - the editor supports STP and SIP authoring while keeping SOR review visible and editable in the same workspace
 - the editor turns SOR proof/evidence fields into a bounded review loop rather than leaving review as a side conversation
 - the editor preview and validation are materially closer to the current STP/SIP contract expectations
-- the editor exposes one bounded validated control-plane action without duplicating workflow logic in browser code
+- the editor exposes bounded validated lifecycle command preparation without duplicating workflow logic in browser code
 - the demo makes the remaining manual steps explicit instead of hiding them
 - the editor keeps the public task-bundle destination visible
 - the editor reduces structural editing fragility by guiding required fields and rendering the final markdown artifact live

--- a/docs/tooling/editor/five_command_demo.md
+++ b/docs/tooling/editor/five_command_demo.md
@@ -1,6 +1,6 @@
 # Five-Command Editing Demo
 
-This is the bounded, truthful proof surface for the current v0.85 authoring lifecycle.
+This is the bounded, truthful proof surface for the historical five-command authoring lifecycle.
 
 Run:
 
@@ -11,14 +11,15 @@ Run:
 The demo exercises, in order:
 
 1. `pr init`
-2. the validated editor adapter dry-run for `pr start`
+2. the validated legacy editor adapter dry-run for `pr start`
 3. `pr start`
 4. `pr run`
 5. `pr finish`
 
-The adapter surface is truthful to the current editor contract:
+The adapter surface is truthful to the compatibility contract:
 
-- browser/editor direct support remains bounded to `adl/tools/editor_action.sh start`
+- browser/editor direct support remains unavailable
+- legacy command compatibility remains bounded to `adl/tools/editor_action.sh start`
 - the broader lifecycle commands still run through the repo-local control plane
 
 ## Proof Surface
@@ -41,7 +42,7 @@ The manifest records:
 ## Truth Boundaries
 
 - The demo uses mocked GitHub and mocked model-provider surfaces to keep the proof local and deterministic.
-- The editor/browser adapter remains thin and only prepares the `pr start` action.
+- The editor/browser adapter remains thin; the current taught path prepares copy-only lifecycle commands, while this demo keeps the older `pr start` compatibility check alive.
 - The demo does not claim direct browser execution for `pr init`, `pr run`, or `pr finish`.
 - The finish step intentionally uses `--no-checks` so the demo proves lifecycle sequencing and artifact linkage rather than full CI/validation throughput.
 
@@ -51,4 +52,4 @@ This is not a hidden parallel workflow. It uses the real `adl/tools/pr.sh` comma
 
 - `docs/tooling/editor/command_adapter.md`
 
-So it is a bounded but honest end-to-end proof of the current v0.85 authoring story.
+So it is a bounded but honest end-to-end compatibility proof for the older authoring story.

--- a/docs/tooling/editor/five_command_regression_suite.md
+++ b/docs/tooling/editor/five_command_regression_suite.md
@@ -1,6 +1,6 @@
 # Five-Command Regression Suite
 
-This is the canonical regression entrypoint for the implemented v0.85 editing lifecycle.
+This is the canonical regression entrypoint for the historical five-command editing lifecycle.
 
 Run:
 
@@ -18,8 +18,8 @@ The suite protects the shipped authoring surface and its truthful editor claims:
 It also verifies:
 
 - the installed `adl_pr_cycle` skill still matches the tracked contract and preserves the real authoring state machine
-- the browser/editor adapter remains bounded to `pr start`
-- the editor docs do not overclaim direct browser execution for the other commands
+- the legacy browser/editor adapter remains bounded to `pr start` compatibility
+- the current editor docs do not overclaim direct browser execution for lifecycle commands
 - the bounded demo still emits the expected lifecycle artifacts
 
 ## Suite Components

--- a/docs/tooling/editor/index.html
+++ b/docs/tooling/editor/index.html
@@ -9,12 +9,12 @@
 <body>
   <main class="page">
     <header class="hero">
-      <p class="eyebrow">WP-05 Editor Slice</p>
+      <p class="eyebrow">Current Skill Wiring Slice</p>
       <h1>ADL Task Bundle Editor</h1>
       <p class="lede">
         A bounded task-bundle workspace shell for Structured Task Prompts, Structured Implementation Prompts,
         and a real review-first Structured Output Record surface.
-        This editor keeps the public task-bundle model visible while reducing fragile raw markdown editing.
+        This editor keeps the current local task-bundle model visible while reducing fragile raw markdown editing.
       </p>
     </header>
 
@@ -22,15 +22,15 @@
       <div class="control-grid">
         <label>
           Task ID
-          <input id="task-id" type="text" placeholder="task-v085-wp05">
+          <input id="task-id" type="text" placeholder="issue-2053">
         </label>
         <label>
           Title
-          <input id="title" type="text" placeholder="[v0.85][WP-05] First authoring/editor surfaces">
+          <input id="title" type="text" placeholder="[v0.90][tools] Refresh web task editor for current ADL skills">
         </label>
         <label>
           Branch / Slug
-          <input id="branch" type="text" placeholder="codex/870-v085-wp05-first-editor-surfaces">
+          <input id="branch" type="text" placeholder="codex/2053-backlog-tools-refresh-web-task-editor-current-skills">
         </label>
       </div>
       <div class="bundle-path" id="bundle-root"></div>
@@ -48,11 +48,11 @@
     <section class="panel action-panel">
       <div class="section-header">
         <h2>Workflow Action</h2>
-        <p>Thin control-plane bridge. Run the copied command from the repo root.</p>
+        <p>Copy-only control-plane bridge. Run the copied command from the repo root.</p>
       </div>
       <div id="action-summary" class="action-summary"></div>
       <pre id="action-command" class="action-command"></pre>
-      <button id="copy-action" type="button">Copy pr start command</button>
+      <button id="copy-action" type="button">Copy pr run command</button>
     </section>
 
     <section class="panel review-panel">
@@ -104,14 +104,14 @@
     </section>
 
     <section class="panel notes">
-      <h2>First Slice Boundaries</h2>
+      <h2>Current Boundaries</h2>
       <ul>
-        <li>This issue establishes a task-bundle-native workspace shell with visible STP, SIP, and SOR cards.</li>
-        <li>STP and SIP remain the editable first-slice authoring surfaces in this issue.</li>
+        <li>This issue refreshes the task-bundle workspace shell for the current ADL workflow skill family.</li>
+        <li>STP and SIP remain editable authoring surfaces, and SOR remains an editable review-first closeout surface.</li>
         <li>SOR now has a bounded review-first surface for evidence, integration state, and follow-up structure.</li>
         <li>The review flow now turns SOR evidence, proof, and follow-up fields into a reviewer-facing checklist and bounded recommendation.</li>
-        <li>This editor demonstrates the historical tracked task-bundle model under <code>docs/records/&lt;scope&gt;/tasks/&lt;task-id&gt;/</code>.</li>
-        <li>The current canonical workflow state lives under <code>.adl/</code>; <code>docs/records/</code> is retained here as a bounded historical/public proof surface.</li>
+        <li>The editor prepares current lifecycle commands for a human to copy and run; browser direct execution remains out of scope.</li>
+        <li>The current canonical workflow state lives under <code>.adl/</code>; older <code>docs/records/</code> examples are historical proof surfaces only.</li>
       </ul>
     </section>
   </main>

--- a/docs/tooling/editor/pr_run_demo.md
+++ b/docs/tooling/editor/pr_run_demo.md
@@ -1,6 +1,6 @@
 # `pr run` Demo
 
-This is the bounded v0.85 proof surface for the supported `pr run` path.
+This is the bounded historical proof surface for the supported `pr run` path.
 
 What it proves:
 
@@ -9,7 +9,7 @@ What it proves:
 - the command resolves and executes a bounded ADL workflow over the runtime primitives
 - the command leaves behind canonical run artifacts that can be inspected deterministically
 
-Current v0.85 limitation:
+Current limitation:
 
 - `pr run` is the supported control-plane run surface today
 - browser/editor direct invocation remains follow-on work

--- a/docs/tooling/editor/task_bundle_editor.js
+++ b/docs/tooling/editor/task_bundle_editor.js
@@ -9,7 +9,7 @@ const ARTIFACTS = {
       { key: "issue_number", label: "GitHub Issue Number", required: false },
       { key: "status", label: "Status", required: true, defaultValue: "draft" },
       { key: "action", label: "Action", required: true, defaultValue: "edit" },
-      { key: "milestone_sprint", label: "Milestone Sprint", required: true, defaultValue: "Sprint 2" }
+      { key: "milestone_sprint", label: "Milestone Sprint", required: true, defaultValue: "v0.90 backlog" }
     ],
     sections: [
       ["goal", "Goal"],
@@ -25,9 +25,9 @@ const ARTIFACTS = {
       goal: "State the concrete outcome this task should produce.",
       required_outcome: "- Real code, docs, demo, or tests required\n- Docs-only completion is not sufficient",
       acceptance_criteria: "- At least one real surface ships\n- Bounded proof surface exists",
-      repo_inputs: "- docs/milestones/v0.85/WBS_v0.85.md",
-      dependencies: "- WP-04",
-      demo_expectations: "- Required demo: editor-workflow-demo",
+      repo_inputs: "- docs/tooling/editor/README.md\n- docs/default_workflow.md",
+      dependencies: "- Current ADL workflow skills",
+      demo_expectations: "- Required proof: editor_action prepare command and current-skill wiring demo",
       non_goals: "- Full long-term productization",
       notes: "- Future richer editors can build on this first slice."
     }
@@ -40,7 +40,7 @@ const ARTIFACTS = {
     metadata: [
       { key: "task_id", label: "Task ID", required: true },
       { key: "run_id", label: "Run ID", required: true },
-      { key: "version", label: "Version", required: true, defaultValue: "v0.85" },
+      { key: "version", label: "Version", required: true, defaultValue: "v0.90" },
       { key: "branch", label: "Branch", required: true },
       { key: "required_outcome_type", label: "Required Outcome Type", required: true, defaultValue: "code" },
       { key: "demo_required", label: "Demo Required", required: true, defaultValue: "true" }
@@ -62,9 +62,9 @@ const ARTIFACTS = {
       required_outcome: "- Ship code and docs\n- Produce a bounded proof surface",
       acceptance_criteria: "- Required commands pass\n- Demo/proof surface is captured",
       inputs: "- Source Structured Task Prompt\n- Relevant milestone docs",
-      target_files: "- docs/tooling/editor/index.html",
+      target_files: "- docs/tooling/editor/index.html\n- docs/tooling/editor/task_bundle_editor.js\n- adl/tools/editor_action.sh",
       validation_plan: "- Required commands:\n- Required tests:\n- Required artifacts / traces:",
-      demo_requirements: "- Required demo(s): editor-workflow-demo",
+      demo_requirements: "- Required demo(s): current-skill-wiring-demo",
       constraints: "- Preserve deterministic behavior\n- No absolute host paths",
       non_goals: "- Full productization",
       notes: "- Keep the slice bounded and honest."
@@ -78,7 +78,7 @@ const ARTIFACTS = {
     metadata: [
       { key: "task_id", label: "Task ID", required: true },
       { key: "run_id", label: "Run ID", required: true },
-      { key: "version", label: "Version", required: true, defaultValue: "v0.85" },
+      { key: "version", label: "Version", required: true, defaultValue: "v0.90" },
       { key: "branch", label: "Branch", required: true },
       { key: "status", label: "Status", required: true, defaultValue: "IN_PROGRESS" },
       { key: "integration_state", label: "Integration state", required: true, defaultValue: "pr_open" },
@@ -116,7 +116,7 @@ const ENUM_RULES = {
   },
   sor: {
     status: ["NOT_STARTED", "IN_PROGRESS", "DONE", "FAILED"],
-    integration_state: ["worktree_only", "pr_open", "merged"],
+    integration_state: ["worktree_only", "pr_open", "merged", "not_started", "local_only"],
     verification_scope: ["worktree", "pr_branch", "main_repo"]
   }
 };
@@ -243,9 +243,9 @@ function buildForm() {
     const note = document.createElement("div");
     note.className = "shell-note";
     note.innerHTML = `
-      <strong>SOR shell only in WP-05.</strong><br>
+      <strong>SOR review surface.</strong><br>
       This workspace proves that STP, SIP, and SOR stay linked as one task bundle.
-      Full SOR review, validation/provenance display, and decision flow land in the next review-surface slice.
+      Review, validation/provenance display, and decision flow remain bounded by the local card state.
     `;
     form.append(note);
   } else {
@@ -314,7 +314,7 @@ function artifactKey() {
 }
 
 function looksLikeTaskId(value) {
-  return /^task-[a-z0-9][a-z0-9-]*$/.test(value);
+  return /^task-[a-z0-9][a-z0-9-]*$/.test(value) || /^issue-[0-9]+$/.test(value);
 }
 
 function normalizedValue(value) {
@@ -329,52 +329,57 @@ function valueFor(id) {
 function updateBundlePath() {
   const artifact = ARTIFACTS[currentArtifact];
   const taskId = taskIdInput.value.trim() || "task-id";
-  bundleRoot.textContent = `Historical demo bundle root: docs/records/v0.85/tasks/${taskId}/`;
-  bundleActivePath.textContent = `Historical demo card target: docs/records/v0.85/tasks/${taskId}/${artifact.extension}`;
+  const version = draftFor("sip").metadata.version || "v0.90";
+  const branch = branchInput.value.trim();
+  const branchMatch = branch.match(/^codex\/([0-9]+)-([a-z0-9][a-z0-9-]*)$/);
+  const slug = branchMatch ? branchMatch[2] : "<slug>";
+  bundleRoot.textContent = `Current local bundle root: .adl/${version}/tasks/${taskId}__${slug}/`;
+  bundleActivePath.textContent = `Current local card target: .adl/${version}/tasks/${taskId}__${slug}/${artifact.extension} (copy-only preview; browser does not write tracked files)`;
 }
 
-function deriveStartAction() {
+function deriveLifecycleAction() {
   const stpDraft = draftFor("stp");
   const issueNumber = (valueFor("issue_number") || stpDraft.metadata.issue_number || "").trim();
   const branch = branchInput.value.trim();
   const branchMatch = branch.match(/^codex\/([0-9]+)-([a-z0-9][a-z0-9-]*)$/);
+  const version = draftFor("sip").metadata.version || "v0.90";
 
   if (!issueNumber) {
     return {
       ready: false,
-      summary: "Enter a GitHub Issue Number on the STP card to prepare the bounded pr start action.",
-      command: "adl/tools/editor_action.sh start --issue <issue-number> --branch codex/<issue>-<slug>"
+      summary: "Enter a GitHub Issue Number on the STP card to prepare a current lifecycle command.",
+      command: "adl/tools/editor_action.sh prepare --phase run --issue <issue-number> --slug <slug> --version <version>"
     };
   }
 
   if (!/^[0-9]+$/.test(issueNumber)) {
     return {
       ready: false,
-      summary: "GitHub Issue Number must be numeric before the editor can prepare a pr start command.",
-      command: "adl/tools/editor_action.sh start --issue <issue-number> --branch codex/<issue>-<slug>"
+      summary: "GitHub Issue Number must be numeric before the editor can prepare a lifecycle command.",
+      command: "adl/tools/editor_action.sh prepare --phase run --issue <issue-number> --slug <slug> --version <version>"
     };
   }
 
   if (!branchMatch) {
     return {
       ready: false,
-      summary: "Branch must match codex/<issue>-<slug> before the thin pr start adapter can run.",
-      command: "adl/tools/editor_action.sh start --issue <issue-number> --branch codex/<issue>-<slug>"
+      summary: "Branch must match codex/<issue>-<slug> so the editor can derive the issue slug safely.",
+      command: "adl/tools/editor_action.sh prepare --phase run --issue <issue-number> --slug <slug> --version <version>"
     };
   }
 
   if (branchMatch[1] !== issueNumber) {
     return {
       ready: false,
-      summary: "GitHub Issue Number and branch prefix must match before the adapter can invoke pr start safely.",
-      command: "adl/tools/editor_action.sh start --issue <issue-number> --branch codex/<issue>-<slug>"
+      summary: "GitHub Issue Number and branch prefix must match before the adapter can prepare a command safely.",
+      command: "adl/tools/editor_action.sh prepare --phase run --issue <issue-number> --slug <slug> --version <version>"
     };
   }
 
   return {
     ready: true,
-    summary: "Thin control-plane adapter is ready to invoke pr start through the existing validated workflow.",
-    command: `adl/tools/editor_action.sh start --issue ${issueNumber} --branch ${branch}`
+    summary: "Copy-only lifecycle adapter is ready. The browser prepares the current pr run command; a human runs it from the repo root.",
+    command: `adl/tools/editor_action.sh prepare --phase run --issue ${issueNumber} --slug ${branchMatch[2]} --version ${version}`
   };
 }
 
@@ -383,9 +388,9 @@ function validate(model) {
   const results = [];
 
   if (looksLikeTaskId(taskIdInput.value.trim())) {
-    results.push({ ok: true, text: "Task ID uses the public task-bundle format." });
+    results.push({ ok: true, text: "Task ID uses a current issue bundle or public task-bundle format." });
   } else {
-    results.push({ ok: false, text: "Task ID should look like task-v085-wp05 or task-0870." });
+    results.push({ ok: false, text: "Task ID should look like issue-2053, task-v090-wp05, or task-0870." });
   }
 
   if (titleInput.value.trim()) {
@@ -475,11 +480,11 @@ function validate(model) {
     results.push({ ok: true, text: "SOR is visibly linked in the workspace shell and participates in the bounded review flow." });
   }
 
-  const startAction = deriveStartAction();
-  if (modelArtifactKey === "stp" && startAction.ready) {
-    results.push({ ok: true, text: "Thin pr start adapter command is ready from the editor path." });
+  const lifecycleAction = deriveLifecycleAction();
+  if (modelArtifactKey === "stp" && lifecycleAction.ready) {
+    results.push({ ok: true, text: "Copy-only current lifecycle command is ready from the editor path." });
   } else if (modelArtifactKey === "stp") {
-    results.push({ ok: false, text: "Thin pr start adapter needs matching numeric issue number and codex/<issue>-<slug> branch values." });
+    results.push({ ok: false, text: "Lifecycle command preparation needs matching numeric issue number and codex/<issue>-<slug> branch values." });
   }
 
   return results;
@@ -653,11 +658,11 @@ function updateAll() {
   renderValidation(results);
   renderReviewFlow(reviewModel);
   preview.textContent = renderMarkdown(model);
-  const startAction = deriveStartAction();
-  actionSummary.textContent = startAction.summary;
-  actionCommand.textContent = startAction.command;
-  copyActionButton.disabled = !startAction.ready;
-  copyActionButton.textContent = startAction.ready ? "Copy pr start command" : "Fix issue + branch first";
+  const lifecycleAction = deriveLifecycleAction();
+  actionSummary.textContent = lifecycleAction.summary;
+  actionCommand.textContent = lifecycleAction.command;
+  copyActionButton.disabled = !lifecycleAction.ready;
+  copyActionButton.textContent = lifecycleAction.ready ? "Copy pr run command" : "Fix issue + branch first";
 }
 
 copyButton.addEventListener("click", async () => {
@@ -675,7 +680,7 @@ copyActionButton.addEventListener("click", async () => {
   await navigator.clipboard.writeText(actionCommand.textContent);
   copyActionButton.textContent = "Copied";
   window.setTimeout(() => {
-    copyActionButton.textContent = "Copy pr start command";
+    copyActionButton.textContent = "Copy pr run command";
   }, 1200);
 });
 
@@ -691,8 +696,8 @@ taskIdInput.addEventListener("input", updateAll);
 titleInput.addEventListener("input", updateAll);
 branchInput.addEventListener("input", updateAll);
 
-taskIdInput.value = "task-v085-wp05";
-titleInput.value = "[v0.85][WP-05] First authoring/editor surfaces";
-branchInput.value = "codex/870-v085-wp05-first-editor-surfaces";
+taskIdInput.value = "issue-2053";
+titleInput.value = "[v0.90][tools] Refresh web task editor for current ADL skills";
+branchInput.value = "codex/2053-backlog-tools-refresh-web-task-editor-current-skills";
 buildCards();
 buildForm();


### PR DESCRIPTION
Closes #2053

## Summary
Refreshed the web task-bundle editor so it points at the current ADL issue/worktree workflow rather than teaching the old v0.85 `pr start` surface as primary. The editor now presents current v0.90 defaults, shows `.adl/<version>/tasks/<task-id>__<slug>/` as the local bundle target, and prepares copy-only lifecycle commands through the repo-owned control plane.

Legacy `pr start` support remains only as a compatibility path for older deterministic editor demos.

## Artifacts
- `adl/tools/editor_action.sh`
- `adl/tools/test_editor_action.sh`
- `adl/tools/test_five_command_editor_truth.sh`
- `docs/tooling/editor/README.md`
- `docs/tooling/editor/command_adapter.md`
- `docs/tooling/editor/current_skill_wiring_demo.md`
- `docs/tooling/editor/demo.md`
- `docs/tooling/editor/five_command_demo.md`
- `docs/tooling/editor/five_command_regression_suite.md`
- `docs/tooling/editor/index.html`
- `docs/tooling/editor/pr_run_demo.md`
- `docs/tooling/editor/task_bundle_editor.js`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_editor_action.sh` verified current `prepare` command generation, adapter contract text/JSON, and legacy start compatibility.
  - `bash adl/tools/test_five_command_editor_truth.sh` verified editor docs keep lifecycle commands out of browser-direct execution and mark `pr start` as compatibility only.
  - `node --check docs/tooling/editor/task_bundle_editor.js` verified the browser editor JavaScript parses.
  - `bash -n adl/tools/editor_action.sh && bash -n adl/tools/test_editor_action.sh && bash -n adl/tools/test_five_command_editor_truth.sh` verified shell syntax.
  - `rg -n "v0\.85|pr start|docs/records|WP-05" docs/tooling/editor adl/tools/editor_action.sh adl/tools/test_editor_action.sh adl/tools/test_five_command_editor_truth.sh` verified remaining old-flow references are bounded to legacy or historical language.
  - `python3 adl/tools/check_v090_milestone_state.py --root .` was run from the open WP-11 compression checker worktree before and after this issue as the milestone-compression guardrail.
- Results: PASS for all commands run; compression guardrail remained PASS before and after this issue.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2053__backlog-tools-refresh-web-task-editor-current-skills/sip.md
- Output card: .adl/v0.90/tasks/issue-2053__backlog-tools-refresh-web-task-editor-current-skills/sor.md
- Idempotency-Key: v0-90-backlog-tools-refresh-web-task-editor-for-current-adl-skills-adl-tools-editor-action-sh-adl-tools-test-editor-action-sh-adl-tools-test-five-command-editor-truth-sh-docs-tooling-editor-readme-md-docs-tooling-editor-command-adapter-md-docs-tooling-editor-current-skill-wiring-demo-md-docs-tooling-editor-demo-md-docs-tooling-editor-five-command-demo-md-docs-tooling-editor-five-command-regression-suite-md-docs-tooling-editor-index-html-docs-tooling-editor-pr-run-demo-md-docs-tooling-editor-task-bundle-editor-js-adl-v0-90-tasks-issue-2053-backlog-tools-refresh-web-task-editor-current-skills-sip-md-adl-v0-90-tasks-issue-2053-backlog-tools-refresh-web-task-editor-current-skills-sor-md