### PR TITLE
[v0.90][backlog][skills] Add repo architecture review skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -39,6 +39,7 @@ sh "$ROOT/adl/tools/codexw.sh" --help >/dev/null 2>&1
 run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_review_skill_contracts.sh"
 run_step "repo-packet-builder contract check" bash "$ROOT/adl/tools/test_repo_packet_builder_skill_contracts.sh"
 run_step "redaction-and-evidence-auditor contract check" bash "$ROOT/adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh"
+run_step "repo-architecture-review contract check" bash "$ROOT/adl/tools/test_repo_architecture_review_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -16,6 +16,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `repo-review-security`
 - `repo-review-tests`
 - `repo-review-docs`
+- `repo-architecture-review`
 - `repo-review-synthesis`
 
 ## Invocation Order
@@ -26,7 +27,8 @@ Recommended order:
 2. `repo-review-security`
 3. `repo-review-tests`
 4. `repo-review-docs`
-5. `repo-review-synthesis`
+5. `repo-architecture-review`
+6. `repo-review-synthesis`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -35,7 +37,7 @@ available, and ideally after all required roles have reported.
 ## Shared Specialist Input Shape
 
 ```yaml
-skill_input_schema: repo_review_code.v1 | repo_review_security.v1 | repo_review_tests.v1 | repo_review_docs.v1
+skill_input_schema: repo_review_code.v1 | repo_review_security.v1 | repo_review_tests.v1 | repo_review_docs.v1 | repo_architecture_review.v1
 mode: review_repository | review_path | review_branch | review_diff | review_packet
 repo_root: /absolute/path
 target:
@@ -68,6 +70,7 @@ target:
     security: <path or null>
     tests: <path or null>
     docs: <path or null>
+    architecture: <path or null>
   artifact_root: <path or null>
 policy:
   required_roles:
@@ -75,6 +78,7 @@ policy:
     - security
     - tests
     - docs
+    - architecture
   severity_policy: preserve_highest | preserve_role_severity
   write_review_artifact: true | false
   stop_after_synthesis: true
@@ -86,7 +90,7 @@ Each specialist artifact should use this shape:
 
 ```md
 ## Metadata
-- Skill: repo-review-code | repo-review-security | repo-review-tests | repo-review-docs
+- Skill: repo-review-code | repo-review-security | repo-review-tests | repo-review-docs | repo-architecture-review
 - Target: <repo/path/branch/diff>
 - Date: <UTC timestamp or calendar date>
 - Artifact: <path or none>
@@ -94,7 +98,7 @@ Each specialist artifact should use this shape:
 ## Findings
 - <priority>: <title>
   File: <repo-relative path or none>
-  Role: <code | security | tests | docs>
+  Role: <code | security | tests | docs | architecture>
   Scenario: <trigger or review condition>
   Impact: <behavioral consequence>
   Evidence: <specific code/doc/test/config observation>
@@ -115,6 +119,7 @@ Each specialist artifact should use this shape:
 - `repo-review-security` must include `trust_boundaries` and asset/attacker notes when relevant.
 - `repo-review-tests` must include a `missing_proof_map` when coverage gaps are found.
 - `repo-review-docs` must include `commands_or_claims_checked` when docs make runnable claims.
+- `repo-architecture-review` must include an `architecture_map`, candidate diagram tasks, candidate ADRs, and candidate fitness functions.
 
 ## Synthesis Output Contract
 
@@ -128,6 +133,7 @@ Each specialist artifact should use this shape:
   - security: <path or missing>
   - tests: <path or missing>
   - docs: <path or missing>
+  - architecture: <path or missing>
 
 ## Findings
 - <priority>: <title>
@@ -142,6 +148,7 @@ Each specialist artifact should use this shape:
 - Security: present | missing | skipped
 - Tests: present | missing | skipped
 - Docs: present | missing | skipped
+- Architecture: present | missing | skipped
 
 ## Dedupe Notes
 - <what was merged and why>
@@ -168,6 +175,8 @@ Each specialist artifact should use this shape:
 - Do not hide missing tests behind a "no code defect found" result.
 - Do not convert docs truth drift into style feedback when it affects reviewer
   reproducibility or operator safety.
+- Do not collapse architecture drift into code style or docs polish when it
+  affects boundaries, layering, lifecycle, or state ownership.
 - Mark disagreement explicitly instead of silently choosing one role's view.
 
 ## Boundaries
@@ -198,4 +207,5 @@ Use this suite when:
 - the review is deep or release-adjacent
 - role separation is useful for traceability
 - security, tests, or docs need explicit ownership
+- architecture boundaries, state models, layering, or drift need explicit ownership
 - the synthesis artifact should show specialist coverage and disagreement

--- a/adl/tools/skills/docs/REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,89 @@
+# Repo Architecture Review Skill Input Schema
+
+Schema id: `repo_architecture_review.v1`
+
+Use this schema for structured invocations of the
+`repo-architecture-review` skill.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must equal `repo_architecture_review.v1`
+- `mode`: one of the supported review modes
+- `repo_root`: absolute repository root
+- `target`: concrete review target
+- `policy`: explicit review policy
+
+## Supported Modes
+
+- `review_repository`
+- `review_path`
+- `review_branch`
+- `review_diff`
+- `review_packet`
+
+## Target Fields
+
+At least one target field should be concrete:
+
+- `target_path`
+- `branch`
+- `diff_base`
+- `review_packet_path`
+- `changed_paths`
+- `artifact_root`
+
+`review_packet` mode requires `review_packet_path`.
+
+## Required Policy Fields
+
+- `review_depth`: `quick`, `standard`, or `deep`
+- `validation_mode`: `targeted`, `inspect_only`, or `none`
+- `write_review_artifact`: boolean
+- `stop_after_review`: must be true
+- `architecture_focus`: optional list or string naming focus areas
+
+## Example
+
+```yaml
+skill_input_schema: repo_architecture_review.v1
+mode: review_packet
+repo_root: /absolute/path/to/repo
+target:
+  target_path: null
+  branch: null
+  diff_base: null
+  review_packet_path: .adl/reviews/codebuddy/20260417-120000-repo-packet
+  changed_paths: []
+  artifact_root: .adl/reviews/codebuddy/20260417-120000-repo-packet/architecture-review
+policy:
+  review_depth: deep
+  validation_mode: inspect_only
+  write_review_artifact: true
+  stop_after_review: true
+  architecture_focus:
+    - boundaries
+    - layering
+    - runtime_state
+    - drift
+```
+
+## Output
+
+The skill writes or returns a findings-first architecture review artifact with:
+
+- findings
+- architecture map
+- reviewed surfaces
+- candidate diagram tasks
+- candidate ADRs
+- candidate fitness functions
+- validation performed
+- residual risk
+
+The deterministic scaffold helper may write:
+
+- `architecture_review_scaffold.md`
+- `architecture_review_scaffold.json`
+
+See `repo-architecture-review/references/output-contract.md`.
+

--- a/adl/tools/skills/repo-architecture-review/SKILL.md
+++ b/adl/tools/skills/repo-architecture-review/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: repo-architecture-review
+description: Specialist architecture reviewer for CodeBuddy-style repository reviews focused on boundaries, layering, coupling, runtime/state models, architecture drift, and follow-up architecture tasks without taking over code, security, tests, docs, diagrams, ADR writing, fitness-function authoring, or synthesis roles.
+---
+
+# Repo Architecture Review
+
+Review repository architecture as one specialist in the CodeBuddy multi-agent
+review suite. This skill is findings-first and source-grounded. It may inspect
+code, manifests, docs, and a CodeBuddy review packet, but it must not edit the
+repository or claim merge approval.
+
+Use this skill after `repo-packet-builder` has created a bounded review packet,
+or when an operator gives an explicit repo/path/diff scope.
+
+## Quick Start
+
+1. Confirm the target scope:
+   - repository
+   - path slice
+   - branch
+   - diff
+   - existing review packet
+2. Prefer a `repo-packet-builder` packet when available, especially
+   `repo_scope.md`, `repo_inventory.json`, `evidence_index.json`, and
+   `specialist_assignments.json`.
+3. Run the deterministic scaffold helper when local packet access is available:
+   - `scripts/prepare_architecture_review.py <packet-root> --out <artifact-root>`
+4. Inspect the high-signal architecture surfaces and write a findings-first
+   review artifact.
+5. Hand candidate diagram tasks to `diagram-author`, ADR candidates to
+   `adr-curator` when available, fitness-function candidates to
+   `architecture-fitness-function-author` when available, and final dedupe to
+   `repo-review-synthesis`.
+
+## Focus
+
+Prioritize:
+
+- module and package boundaries
+- layering and dependency direction
+- coupling between runtime, CLI, tests, demos, docs, and tooling
+- state ownership, lifecycle transitions, and persistence boundaries
+- concurrency, orchestration, and long-lived runtime boundaries
+- architecture drift between code, docs, diagrams, and issue cards
+- missing ADRs or implicit architecture decisions
+- candidate architecture fitness checks that would prevent repeat drift
+
+Defer primary ownership of these areas to other specialists:
+
+- implementation correctness: `repo-review-code`
+- security trust boundaries and abuse paths: `repo-review-security`
+- missing test coverage: `repo-review-tests`
+- documentation truth and onboarding drift: `repo-review-docs`
+- diagram rendering or diagram source authoring: `diagram-author`
+- final cross-role dedupe and severity ordering: `repo-review-synthesis`
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `target.target_path`
+  - `target.branch`
+  - `target.diff_base`
+  - `target.review_packet_path`
+
+Useful additional inputs:
+
+- `changed_paths`
+- `review_depth`
+- `artifact_root`
+- `exclude_paths`
+- `validation_mode`
+- `architecture_focus`
+
+If there is no concrete repo or packet target, stop and report `blocked`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- review mode
+- included architecture surfaces
+- excluded surfaces
+- assumptions and known limits
+- whether the review is architecture-only or part of a multi-agent review
+
+Do not silently expand a path or diff review into a whole-repo review.
+
+### 2. Map Architecture Surfaces
+
+Look for:
+
+- top-level manifests and package boundaries
+- CLI and runtime entrypoints
+- service/module directories
+- state, persistence, and artifact layout modules
+- orchestration, workflow, scheduler, and lifecycle code
+- docs that describe architecture, demos, roadmap, or milestones
+- tests that encode architecture contracts
+- existing diagrams and ADR-like records
+
+### 3. Review For Architecture Findings
+
+Findings should be behaviorally meaningful. Avoid style-only comments.
+
+Use this priority scale:
+
+- `P0`: architecture defect can cause data loss, unsafe execution, or severe
+  trust-boundary failure
+- `P1`: architecture drift or boundary failure can send operators or agents into
+  the wrong lifecycle, persistence model, or integration path
+- `P2`: coupling or missing architecture contract is likely to create recurring
+  implementation or review defects
+- `P3`: useful architecture hygiene issue with bounded follow-up value
+
+Each finding should include:
+
+- trigger scenario
+- affected boundary or layer
+- file/path evidence
+- impact
+- recommended follow-up owner
+
+### 4. Emit Follow-Up Candidates
+
+Include candidate follow-ups, but do not execute them:
+
+- diagram task candidates
+- ADR candidates
+- architecture fitness-function candidates
+- issue candidates
+
+These are handoff notes, not created issues or authored diagrams.
+
+## Output Expectations
+
+Default output should include:
+
+- findings first
+- assumptions
+- reviewed architecture surfaces
+- architecture map summary
+- candidate diagram tasks
+- candidate ADRs
+- candidate fitness functions
+- validation performed or not run
+- residual architecture risk
+
+Use `references/output-contract.md` and the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`.
+
+## Stop Boundary
+
+Stop after producing the architecture-review artifact.
+
+Do not:
+
+- edit code, docs, tests, configs, diagrams, or ADRs
+- silently run the whole multi-agent review workflow
+- author diagrams directly
+- author ADRs directly
+- author fitness-function code directly
+- create issues or PRs
+- downgrade findings from other specialist roles
+- claim approval, merge readiness, or remediation completion
+
+## CodeBuddy Integration Notes
+
+This skill consumes CodeBuddy packet artifacts and produces a specialist
+architecture review artifact for synthesis. It is compatible with
+`repo-packet-builder` and should run before `repo-review-synthesis` when the
+operator wants architecture coverage as a first-class review lane.
+
+Deferred automation:
+
+- Architecture graph extraction from language-specific dependency analyzers.
+- C4/UML/Structurizr generation handoff to `diagram-author`.
+- Executable architecture fitness-function implementation by a dedicated
+  follow-up skill.
+

--- a/adl/tools/skills/repo-architecture-review/adl-skill.yaml
+++ b/adl/tools/skills/repo-architecture-review/adl-skill.yaml
@@ -1,0 +1,101 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-architecture-review"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_architecture_review.v1"
+    reference_doc: "../docs/REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_repository"
+      - "review_path"
+      - "review_branch"
+      - "review_diff"
+      - "review_packet"
+    policy_fields:
+      - "review_depth"
+      - "validation_mode"
+      - "write_review_artifact"
+      - "stop_after_review"
+      - "architecture_focus"
+  intent:
+    - "architecture_review"
+    - "boundary_review"
+    - "layering_review"
+    - "architecture_drift_review"
+    - "codebuddy_review_engine"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "target_path"
+    - "branch"
+    - "diff_base"
+    - "changed_paths"
+    - "review_packet_path"
+    - "artifact_root"
+    - "architecture_focus"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_architecture_review.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.review_depth_must_be_explicit"
+    - "policy.stop_after_review_must_be_true"
+    - "review_packet_mode_requires_target.review_packet_path"
+execution:
+  mode: "findings_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_validation_when_bounded"
+  permitted_scripts:
+    - path: "scripts/prepare_architecture_review.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<packet-root>"
+        - "--out <artifact-root>"
+        - "--repo-name <name>"
+  preferred_read_order:
+    - "repo_scope.md"
+    - "specialist_assignments.json"
+    - "evidence_index.json"
+    - "repo_inventory.json"
+    - "architecture_docs"
+    - "manifests"
+    - "runtime_entrypoints"
+    - "state_and_lifecycle_modules"
+    - "tests_encoding_architecture_contracts"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-architecture-review.md"
+  required_sections:
+    - "findings"
+    - "architecture_map"
+    - "reviewed_surfaces"
+    - "candidate_diagram_tasks"
+    - "candidate_adrs"
+    - "candidate_fitness_functions"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: true
+
+display_name: Repo Architecture Review
+short_description: Review repository architecture boundaries, layering, coupling, state, and drift
+default_prompt: Perform a bounded, findings-first architecture review from a repo scope or CodeBuddy packet. Stop after the specialist artifact and hand off diagrams, ADRs, fitness functions, issues, and synthesis to separate skills.
+

--- a/adl/tools/skills/repo-architecture-review/agents/openai.yaml
+++ b/adl/tools/skills/repo-architecture-review/agents/openai.yaml
@@ -1,0 +1,9 @@
+model: gpt-5.4
+reasoning_effort: high
+temperature: 0
+instructions:
+  - Review architecture boundaries, layering, coupling, lifecycle, state, and drift.
+  - Emit findings first with source-grounded evidence.
+  - Keep diagram, ADR, fitness-function, issue creation, and synthesis as handoffs.
+  - Do not edit repository files or claim merge approval.
+

--- a/adl/tools/skills/repo-architecture-review/references/architecture-playbook.md
+++ b/adl/tools/skills/repo-architecture-review/references/architecture-playbook.md
@@ -1,0 +1,49 @@
+# Architecture Review Playbook
+
+Use this playbook to turn a CodeBuddy packet or bounded repo slice into an
+architecture-review artifact.
+
+## Boundary Questions
+
+- What are the major modules, packages, services, or runtime layers?
+- Which boundaries are explicit in code, config, tests, docs, or diagrams?
+- Which boundaries are only tribal knowledge?
+- Are state ownership and lifecycle transitions visible?
+- Are orchestration and execution paths separated from presentation, docs, or
+  demo surfaces?
+- Can a future contributor tell which layer owns a behavior?
+
+## Drift Questions
+
+- Do docs, demos, diagrams, issue cards, and code describe the same architecture?
+- Has implementation moved without updating architecture records?
+- Are old compatibility paths still presented as preferred paths?
+- Do tests encode the intended architecture or only low-level behavior?
+
+## Coupling Questions
+
+- Are feature boundaries coupled through shared mutable state, global files, or
+  implicit path conventions?
+- Are dependency directions stable?
+- Are generated artifacts, local-only cards, public docs, and runtime outputs
+  clearly separated?
+- Are long-lived agent, review, demo, and PR lifecycle surfaces accidentally
+  sharing policy?
+
+## Follow-Up Handoff Types
+
+- Diagram task: when reviewers need C4, sequence, lifecycle, state, or
+  dependency visuals to understand the system.
+- ADR candidate: when an architecture decision is real but not captured.
+- Fitness-function candidate: when an architecture rule should be executable in
+  CI or local checks.
+- Issue candidate: when a bounded implementation or documentation correction is
+  needed.
+
+## Severity Guidance
+
+- `P0`: unsafe architecture boundary with severe operational consequences.
+- `P1`: wrong lifecycle or integration path likely under normal operation.
+- `P2`: recurring drift, coupling, or missing contract likely to create defects.
+- `P3`: bounded architecture hygiene improvement.
+

--- a/adl/tools/skills/repo-architecture-review/references/output-contract.md
+++ b/adl/tools/skills/repo-architecture-review/references/output-contract.md
@@ -1,0 +1,112 @@
+# Output Contract
+
+The repo architecture review skill produces a specialist architecture review
+artifact for CodeBuddy-style multi-agent review.
+
+Default artifact path:
+
+```text
+.adl/reviews/<timestamp>-repo-architecture-review.md
+```
+
+Optional scaffold artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/architecture-review/
+```
+
+## Required Markdown Sections
+
+### Metadata
+
+Required fields:
+
+- `Skill: repo-architecture-review`
+- `Target`
+- `Date`
+- `Artifact`
+- `Packet`
+
+### Findings
+
+Findings must come first after metadata.
+
+Each finding must include:
+
+- priority
+- title
+- file or evidence path
+- role: `architecture`
+- scenario
+- architecture boundary or layer
+- impact
+- evidence
+- recommended follow-up owner
+
+If no material findings are found, state that explicitly and include residual
+risk.
+
+### Architecture Map
+
+Summarize:
+
+- top-level modules or packages
+- primary entrypoints
+- runtime boundaries
+- state or persistence boundaries
+- integration boundaries
+- docs or diagrams consulted
+
+### Reviewed Surfaces
+
+List bounded source-grounded surfaces by repo-relative path or packet-relative
+artifact path.
+
+### Candidate Diagram Tasks
+
+List candidate handoffs for `diagram-author`, or state that none were found.
+
+### Candidate ADRs
+
+List candidate architecture decisions that should be captured by an ADR writer
+or curator, or state that none were found.
+
+### Candidate Fitness Functions
+
+List executable architecture guard candidates, or state that none were found.
+
+### Validation Performed
+
+List commands and what they proved, or explain why validation was inspect-only.
+
+### Residual Risk
+
+Explain skipped surfaces, missing packet evidence, unexecuted commands, or
+review limits.
+
+## JSON Scaffold Contract
+
+`scripts/prepare_architecture_review.py` emits
+`architecture_review_scaffold.json` with:
+
+- `schema`
+- `repo_name`
+- `packet_root`
+- `architecture_evidence`
+- `candidate_diagram_tasks`
+- `candidate_adr_topics`
+- `candidate_fitness_functions`
+- `notes`
+
+It also emits `architecture_review_scaffold.md` with the Markdown headings
+needed by the specialist review artifact.
+
+## Rules
+
+- Use repo-relative or packet-relative paths.
+- Do not write absolute host paths into artifacts.
+- Do not author diagrams, ADRs, fitness-function code, issues, or synthesis.
+- Do not mutate the reviewed repository.
+- Preserve architecture findings even when code/security/tests/docs specialists
+  have not reviewed the same surface.
+

--- a/adl/tools/skills/repo-architecture-review/scripts/prepare_architecture_review.py
+++ b/adl/tools/skills/repo-architecture-review/scripts/prepare_architecture_review.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Prepare deterministic scaffolding for a CodeBuddy architecture review."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+
+SCHEMA = "codebuddy.repo_architecture_review.scaffold.v1"
+ARCHITECTURE_CATEGORIES = {"architecture_docs", "docs", "manifest", "ci", "code", "test"}
+ARCHITECTURE_TERMS = (
+    "architecture",
+    "runtime",
+    "state",
+    "lifecycle",
+    "workflow",
+    "orchestration",
+    "boundary",
+    "diagram",
+    "adr",
+    "review",
+    "skill",
+    "agent",
+)
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def packet_relative(packet_root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(packet_root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def evidence_entries(packet_root: Path) -> list[dict[str, object]]:
+    data = load_json(packet_root / "evidence_index.json")
+    if not isinstance(data, dict):
+        return []
+    evidence = data.get("evidence")
+    if not isinstance(evidence, list):
+        return []
+    entries: list[dict[str, object]] = []
+    for item in evidence:
+        if isinstance(item, dict):
+            entries.append(item)
+    return entries
+
+
+def is_architecture_evidence(entry: dict[str, object]) -> bool:
+    category = str(entry.get("category", ""))
+    path = str(entry.get("path", "")).lower()
+    reason = str(entry.get("reason", "")).lower()
+    lanes = entry.get("specialist_lanes")
+    lane_match = isinstance(lanes, list) and "architecture" in lanes
+    term_match = any(term in path or term in reason for term in ARCHITECTURE_TERMS)
+    return lane_match or category in ARCHITECTURE_CATEGORIES and term_match
+
+
+def build_candidate_diagram_tasks(entries: list[dict[str, object]]) -> list[dict[str, str]]:
+    tasks: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        lowered = path.lower()
+        if not path or path in seen:
+            continue
+        if any(term in lowered for term in ("workflow", "runtime", "state", "lifecycle", "architecture")):
+            tasks.append(
+                {
+                    "type": "architecture_diagram",
+                    "source": path,
+                    "handoff": "diagram-author",
+                    "reason": "High-signal architecture surface likely benefits from a visual boundary or lifecycle view.",
+                }
+            )
+            seen.add(path)
+    return tasks[:12]
+
+
+def build_candidate_adr_topics(entries: list[dict[str, object]]) -> list[dict[str, str]]:
+    topics: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        lowered = path.lower()
+        if not path or path in seen:
+            continue
+        if any(term in lowered for term in ("policy", "runtime", "workflow", "provider", "skill", "agent")):
+            topics.append(
+                {
+                    "topic": f"Architecture decision around {path}",
+                    "source": path,
+                    "handoff": "adr-curator",
+                    "reason": "Surface appears to encode durable architecture policy or runtime structure.",
+                }
+            )
+            seen.add(path)
+    return topics[:12]
+
+
+def build_candidate_fitness_functions(entries: list[dict[str, object]]) -> list[dict[str, str]]:
+    candidates: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        lowered = path.lower()
+        if not path or path in seen:
+            continue
+        if any(term in lowered for term in ("test", "check", "lint", "validate", "policy", "contract")):
+            candidates.append(
+                {
+                    "candidate": f"Guard architecture contract represented by {path}",
+                    "source": path,
+                    "handoff": "architecture-fitness-function-author",
+                    "reason": "Surface suggests an executable architecture rule or contract boundary.",
+                }
+            )
+            seen.add(path)
+    return candidates[:12]
+
+
+def write_markdown(path: Path, scaffold: dict[str, object]) -> None:
+    evidence = scaffold["architecture_evidence"]
+    evidence_lines = "\n".join(
+        f"- {item['path']} ({item.get('category', 'unknown')}): {item.get('reason', 'architecture evidence')}"
+        for item in evidence
+    ) or "- No architecture evidence selected from packet."
+    diagram_lines = "\n".join(
+        f"- {item['source']}: {item['reason']} Handoff: {item['handoff']}"
+        for item in scaffold["candidate_diagram_tasks"]
+    ) or "- None identified by scaffold."
+    adr_lines = "\n".join(
+        f"- {item['topic']} Source: {item['source']}. Handoff: {item['handoff']}"
+        for item in scaffold["candidate_adr_topics"]
+    ) or "- None identified by scaffold."
+    fitness_lines = "\n".join(
+        f"- {item['candidate']} Source: {item['source']}. Handoff: {item['handoff']}"
+        for item in scaffold["candidate_fitness_functions"]
+    ) or "- None identified by scaffold."
+
+    content = f"""# Repo Architecture Review Scaffold
+
+## Metadata
+
+- Skill: repo-architecture-review
+- Repo: {scaffold["repo_name"]}
+- Packet: {scaffold["packet_root"]}
+- Date: {scaffold["created_at"]}
+
+## Findings
+
+- No findings have been written yet. Replace this section with findings-first architecture review output after inspection.
+
+## Architecture Map
+
+- Use the evidence below to map modules, layers, runtime boundaries, state ownership, integration points, and drift surfaces.
+
+## Reviewed Surfaces
+
+{evidence_lines}
+
+## Candidate Diagram Tasks
+
+{diagram_lines}
+
+## Candidate ADRs
+
+{adr_lines}
+
+## Candidate Fitness Functions
+
+{fitness_lines}
+
+## Validation Performed
+
+- Scaffold generation only; no repository validation commands were run by this helper.
+
+## Residual Risk
+
+- This scaffold is not a review finding artifact. A reviewer must inspect the selected surfaces and record findings or an explicit no-material-findings result.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet_root", help="CodeBuddy review packet root")
+    parser.add_argument("--out", default=None, help="Architecture review scaffold output root")
+    parser.add_argument("--repo-name", default=None, help="Repo name override")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    packet_root = Path(args.packet_root).resolve()
+    if not packet_root.is_dir():
+        raise SystemExit(f"packet root does not exist: {packet_root}")
+
+    out_root = Path(args.out) if args.out else packet_root / "architecture-review"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_json(packet_root / "run_manifest.json")
+    repo_name = args.repo_name
+    if repo_name is None and isinstance(manifest, dict):
+        repo_name = str(manifest.get("repo_name", "") or "")
+    repo_name = repo_name or packet_root.name
+
+    entries = [entry for entry in evidence_entries(packet_root) if is_architecture_evidence(entry)]
+    entries = sorted(entries, key=lambda item: str(item.get("path", "")))[:60]
+    scaffold = {
+        "schema": SCHEMA,
+        "repo_name": repo_name,
+        "packet_root": packet_root.name,
+        "created_at": now_utc(),
+        "architecture_evidence": entries,
+        "candidate_diagram_tasks": build_candidate_diagram_tasks(entries),
+        "candidate_adr_topics": build_candidate_adr_topics(entries),
+        "candidate_fitness_functions": build_candidate_fitness_functions(entries),
+        "notes": [
+            "Scaffold is deterministic except for created_at.",
+            "Paths are packet evidence paths, not absolute host paths.",
+            "Reviewer must replace scaffold findings with source-grounded architecture review findings.",
+        ],
+    }
+    write_json(out_root / "architecture_review_scaffold.json", scaffold)
+    write_markdown(out_root / "architecture_review_scaffold.md", scaffold)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -24,6 +24,8 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/repo-packet-builder/scripts/build_repo_packet.py" ]]
   [[ -f "${root}/skills/redaction-and-evidence-auditor/SKILL.md" ]]
   [[ -x "${root}/skills/redaction-and-evidence-auditor/scripts/audit_review_packet.py" ]]
+  [[ -f "${root}/skills/repo-architecture-review/SKILL.md" ]]
+  [[ -x "${root}/skills/repo-architecture-review/scripts/prepare_architecture_review.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -44,6 +46,7 @@ assert_skill_bundle() {
   grep -Fq "findings-first" "${root}/skills/repo-code-review/SKILL.md"
   grep -Fq "packet-construction skill, not a reviewer" "${root}/skills/repo-packet-builder/SKILL.md"
   grep -Fq "safety gate, not a reviewer" "${root}/skills/redaction-and-evidence-auditor/SKILL.md"
+  grep -Fq "findings-first and source-grounded" "${root}/skills/repo-architecture-review/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -64,6 +67,7 @@ assert_skill_bundle() {
     "${root}/skills/repo-code-review/SKILL.md" \
     "${root}/skills/repo-packet-builder/SKILL.md" \
     "${root}/skills/redaction-and-evidence-auditor/SKILL.md" \
+    "${root}/skills/repo-architecture-review/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -86,6 +90,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/pr-ready" ]]
 [[ -L "${CODEX_HOME}/skills/repo-packet-builder" ]]
 [[ -L "${CODEX_HOME}/skills/redaction-and-evidence-auditor" ]]
+[[ -L "${CODEX_HOME}/skills/repo-architecture-review" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_repo_architecture_review_skill_contracts.sh
+++ b/adl/tools/test_repo_architecture_review_skill_contracts.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/repo-architecture-review/SKILL.md" ]]
+[[ -f "${skills_root}/repo-architecture-review/adl-skill.yaml" ]]
+[[ -f "${skills_root}/repo-architecture-review/agents/openai.yaml" ]]
+[[ -f "${skills_root}/repo-architecture-review/references/architecture-playbook.md" ]]
+[[ -f "${skills_root}/repo-architecture-review/references/output-contract.md" ]]
+[[ -x "${skills_root}/repo-architecture-review/scripts/prepare_architecture_review.py" ]]
+[[ -f "${skills_root}/docs/REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "repo-architecture-review"' "${skills_root}/repo-architecture-review/adl-skill.yaml"
+grep -Fq 'id: "repo_architecture_review.v1"' "${skills_root}/repo-architecture-review/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md"' "${skills_root}/repo-architecture-review/adl-skill.yaml"
+grep -Fq "review_packet_mode_requires_target.review_packet_path" "${skills_root}/repo-architecture-review/adl-skill.yaml"
+grep -Fq "findings-first and source-grounded" "${skills_root}/repo-architecture-review/SKILL.md"
+grep -Fq "scripts/prepare_architecture_review.py" "${skills_root}/repo-architecture-review/SKILL.md"
+grep -Fq "Do not author diagrams, ADRs, fitness-function code, issues, or synthesis" "${skills_root}/repo-architecture-review/references/output-contract.md"
+grep -Fq "Schema id: \`repo_architecture_review.v1\`" "${skills_root}/docs/REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md"
+grep -Fq "repo-architecture-review" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+packet_root="${tmpdir}/packet"
+scaffold_root="${tmpdir}/architecture"
+mkdir -p "${packet_root}"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "architecture-contract-test",
+  "repo_name": "example-repo",
+  "publication_allowed": false
+}
+JSON
+cat >"${packet_root}/evidence_index.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.evidence.v1",
+  "evidence": [
+    {
+      "path": "docs/architecture/runtime.md",
+      "category": "architecture_docs",
+      "line_count": 42,
+      "reason": "architecture documentation surface",
+      "specialist_lanes": ["architecture", "docs", "diagrams", "synthesis"]
+    },
+    {
+      "path": "adl/src/execute/state.rs",
+      "category": "code",
+      "line_count": 220,
+      "reason": "runtime state lifecycle implementation",
+      "specialist_lanes": ["architecture", "code", "tests", "synthesis"]
+    },
+    {
+      "path": "README.md",
+      "category": "docs",
+      "line_count": 12,
+      "reason": "onboarding surface",
+      "specialist_lanes": ["docs", "synthesis"]
+    }
+  ]
+}
+JSON
+
+python3 "${skills_root}/repo-architecture-review/scripts/prepare_architecture_review.py" \
+  "${packet_root}" --out "${scaffold_root}" >/tmp/repo-architecture-review.out
+[[ -f "${scaffold_root}/architecture_review_scaffold.json" ]]
+[[ -f "${scaffold_root}/architecture_review_scaffold.md" ]]
+grep -Fq '"schema": "codebuddy.repo_architecture_review.scaffold.v1"' "${scaffold_root}/architecture_review_scaffold.json"
+grep -Fq '"repo_name": "example-repo"' "${scaffold_root}/architecture_review_scaffold.json"
+grep -Fq 'docs/architecture/runtime.md' "${scaffold_root}/architecture_review_scaffold.json"
+grep -Fq 'adl/src/execute/state.rs' "${scaffold_root}/architecture_review_scaffold.md"
+grep -Fq 'Candidate Diagram Tasks' "${scaffold_root}/architecture_review_scaffold.md"
+grep -Fq 'Candidate ADRs' "${scaffold_root}/architecture_review_scaffold.md"
+grep -Fq 'Candidate Fitness Functions' "${scaffold_root}/architecture_review_scaffold.md"
+if grep -R "${tmpdir}" "${scaffold_root}" >/dev/null; then
+  echo "architecture review scaffold should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/repo-architecture-review/SKILL.md"
+
+echo "PASS test_repo_architecture_review_skill_contracts"


### PR DESCRIPTION
Closes #2061

## Summary
Added a first-class `repo-architecture-review` ADL skill for CodeBuddy-style multi-agent repository review. The skill owns architecture findings around boundaries, layering, coupling, lifecycle/state models, runtime boundaries, and architecture drift while handing diagrams, ADRs, fitness functions, issue creation, and synthesis to separate skills.

## Artifacts
- `adl/tools/skills/repo-architecture-review/SKILL.md`
- `adl/tools/skills/repo-architecture-review/adl-skill.yaml`
- `adl/tools/skills/repo-architecture-review/agents/openai.yaml`
- `adl/tools/skills/repo-architecture-review/references/output-contract.md`
- `adl/tools/skills/repo-architecture-review/references/architecture-playbook.md`
- `adl/tools/skills/repo-architecture-review/scripts/prepare_architecture_review.py`
- `adl/tools/skills/docs/REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_repo_architecture_review_skill_contracts.sh`
- `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_repo_architecture_review_skill_contracts.sh`: proves the new architecture specialist skill contract, deterministic scaffold helper, handoff sections, and no temporary absolute-path leakage.
  - `bash adl/tools/test_install_adl_operational_skills.sh`: proves operational skill installation includes the architecture reviewer in copy and symlink modes.
  - `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile adl/tools/skills/repo-architecture-review/scripts/prepare_architecture_review.py`: verifies Python syntax for the helper without intentionally retaining bytecode.
  - `bash -n adl/tools/test_repo_architecture_review_skill_contracts.sh adl/tools/test_install_adl_operational_skills.sh adl/tools/batched_checks.sh`: verifies shell syntax for touched shell scripts.
  - `git diff --check`: verifies whitespace and patch hygiene.
  - `bash adl/tools/batched_checks.sh`: runs all skill contract checks, `.adl` issue-record residue guard, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
- Results: PASS for all commands.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2061__backlog-skills-add-repo-architecture-review-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2061__backlog-skills-add-repo-architecture-review-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-repo-architecture-review-skill-adl-tools-skills-repo-architecture-review-adl-tools-skills-docs-repo-architecture-review-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-repo-architecture-review-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2061-backlog-skills-add-repo-architecture-review-skill-sip-md-adl-v0-90-tasks-issue-2061-backlog-skills-add-repo-architecture-review-skill-sor-md