### PR TITLE
[v0.90][backlog][skills] Add repo dependency review skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -40,6 +40,7 @@ run_step "repo-code-review contract check" bash "$ROOT/adl/tools/test_repo_code_
 run_step "repo-packet-builder contract check" bash "$ROOT/adl/tools/test_repo_packet_builder_skill_contracts.sh"
 run_step "redaction-and-evidence-auditor contract check" bash "$ROOT/adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh"
 run_step "repo-architecture-review contract check" bash "$ROOT/adl/tools/test_repo_architecture_review_skill_contracts.sh"
+run_step "repo-dependency-review contract check" bash "$ROOT/adl/tools/test_repo_dependency_review_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -17,6 +17,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `repo-review-tests`
 - `repo-review-docs`
 - `repo-architecture-review`
+- `repo-dependency-review`
 - `repo-review-synthesis`
 
 ## Invocation Order
@@ -28,7 +29,8 @@ Recommended order:
 3. `repo-review-tests`
 4. `repo-review-docs`
 5. `repo-architecture-review`
-6. `repo-review-synthesis`
+6. `repo-dependency-review`
+7. `repo-review-synthesis`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -37,7 +39,7 @@ available, and ideally after all required roles have reported.
 ## Shared Specialist Input Shape
 
 ```yaml
-skill_input_schema: repo_review_code.v1 | repo_review_security.v1 | repo_review_tests.v1 | repo_review_docs.v1 | repo_architecture_review.v1
+skill_input_schema: repo_review_code.v1 | repo_review_security.v1 | repo_review_tests.v1 | repo_review_docs.v1 | repo_architecture_review.v1 | repo_dependency_review.v1
 mode: review_repository | review_path | review_branch | review_diff | review_packet
 repo_root: /absolute/path
 target:
@@ -71,6 +73,7 @@ target:
     tests: <path or null>
     docs: <path or null>
     architecture: <path or null>
+    dependency: <path or null>
   artifact_root: <path or null>
 policy:
   required_roles:
@@ -79,6 +82,7 @@ policy:
     - tests
     - docs
     - architecture
+    - dependency
   severity_policy: preserve_highest | preserve_role_severity
   write_review_artifact: true | false
   stop_after_synthesis: true
@@ -90,7 +94,7 @@ Each specialist artifact should use this shape:
 
 ```md
 ## Metadata
-- Skill: repo-review-code | repo-review-security | repo-review-tests | repo-review-docs | repo-architecture-review
+- Skill: repo-review-code | repo-review-security | repo-review-tests | repo-review-docs | repo-architecture-review | repo-dependency-review
 - Target: <repo/path/branch/diff>
 - Date: <UTC timestamp or calendar date>
 - Artifact: <path or none>
@@ -98,7 +102,7 @@ Each specialist artifact should use this shape:
 ## Findings
 - <priority>: <title>
   File: <repo-relative path or none>
-  Role: <code | security | tests | docs | architecture>
+  Role: <code | security | tests | docs | architecture | dependency>
   Scenario: <trigger or review condition>
   Impact: <behavioral consequence>
   Evidence: <specific code/doc/test/config observation>
@@ -120,6 +124,7 @@ Each specialist artifact should use this shape:
 - `repo-review-tests` must include a `missing_proof_map` when coverage gaps are found.
 - `repo-review-docs` must include `commands_or_claims_checked` when docs make runnable claims.
 - `repo-architecture-review` must include an `architecture_map`, candidate diagram tasks, candidate ADRs, and candidate fitness functions.
+- `repo-dependency-review` must include a `dependency_surface_map`, candidate supply-chain findings, candidate dependency test gaps, and candidate license review notes.
 
 ## Synthesis Output Contract
 
@@ -134,6 +139,7 @@ Each specialist artifact should use this shape:
   - tests: <path or missing>
   - docs: <path or missing>
   - architecture: <path or missing>
+  - dependency: <path or missing>
 
 ## Findings
 - <priority>: <title>
@@ -149,6 +155,7 @@ Each specialist artifact should use this shape:
 - Tests: present | missing | skipped
 - Docs: present | missing | skipped
 - Architecture: present | missing | skipped
+- Dependency: present | missing | skipped
 
 ## Dedupe Notes
 - <what was merged and why>
@@ -177,6 +184,9 @@ Each specialist artifact should use this shape:
   reproducibility or operator safety.
 - Do not collapse architecture drift into code style or docs polish when it
   affects boundaries, layering, lifecycle, or state ownership.
+- Do not collapse dependency and supply-chain drift into generic security or
+  test feedback when it affects installability, package manager policy,
+  lockfile truth, license-sensitive evidence, or release reproducibility.
 - Mark disagreement explicitly instead of silently choosing one role's view.
 
 ## Boundaries
@@ -208,4 +218,6 @@ Use this suite when:
 - role separation is useful for traceability
 - security, tests, or docs need explicit ownership
 - architecture boundaries, state models, layering, or drift need explicit ownership
+- dependency manifests, lockfiles, CI install paths, containers, or license cues
+  need explicit ownership
 - the synthesis artifact should show specialist coverage and disagreement

--- a/adl/tools/skills/docs/REPO_DEPENDENCY_REVIEW_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REPO_DEPENDENCY_REVIEW_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,74 @@
+# Repo Dependency Review Skill Input Schema
+
+Schema id: `repo_dependency_review.v1`
+
+This schema describes the structured input accepted by the
+`repo-dependency-review` skill. It is intentionally small so CodeBuddy can route
+dependency and supply-chain review without giving the specialist permission to
+perform upgrades or mutate customer repositories.
+
+## Required Shape
+
+```yaml
+skill_input_schema: repo_dependency_review.v1
+mode: review_repository | review_path | review_branch | review_diff | review_packet
+repo_root: /absolute/path
+target:
+  target_path: <path or null>
+  branch: <string or null>
+  diff_base: <string or null>
+  review_packet_path: <path or null>
+  changed_paths:
+    - <path>
+  artifact_root: <path or null>
+policy:
+  review_depth: quick | standard | deep
+  validation_mode: targeted | inspect_only | none
+  write_review_artifact: true | false
+  stop_after_review: true
+  dependency_focus:
+    - manifests
+    - lockfiles
+    - ci_dependency_setup
+    - containers
+    - license_cues
+```
+
+## Required Fields
+
+- `skill_input_schema` must equal `repo_dependency_review.v1`.
+- `mode` must be one of the supported review modes.
+- `repo_root` must be absolute.
+- `target` must identify one bounded repository, path, branch, diff, or packet
+  target.
+- `policy.review_depth` must be explicit.
+- `policy.stop_after_review` must be `true`.
+- `mode: review_packet` requires `target.review_packet_path`.
+
+## Output Contract
+
+The skill writes or returns a findings-first dependency review artifact with:
+
+- findings
+- dependency surface map
+- reviewed surfaces
+- candidate supply-chain findings
+- candidate dependency test gaps
+- candidate license review notes
+- validation performed
+- residual risk
+
+The skill may also generate deterministic scaffolding with
+`scripts/prepare_dependency_review.py`.
+
+## Stop Boundary
+
+The skill must not:
+
+- edit the reviewed repository
+- install, upgrade, downgrade, pin, unpin, vendor, or remove dependencies
+- run external vulnerability feeds without an explicit offline source packet
+- make legal determinations
+- create issues or PRs
+- perform synthesis or claim remediation completion
+

--- a/adl/tools/skills/repo-dependency-review/SKILL.md
+++ b/adl/tools/skills/repo-dependency-review/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: repo-dependency-review
+description: Specialist dependency and supply-chain reviewer for CodeBuddy-style repository reviews focused on manifests, lockfiles, package manager configuration, toolchains, Docker and CI dependency setup, license-sensitive cues, dependency drift, and dependency-related test gaps without performing upgrades or remediation.
+---
+
+# Repo Dependency Review
+
+Review repository dependency and supply-chain surfaces as one specialist in the
+CodeBuddy multi-agent review suite. This skill is findings-first and
+source-grounded. It may inspect code, manifests, lockfiles, Dockerfiles, CI
+configuration, package-manager configuration, and a CodeBuddy review packet, but
+it must not edit the repository, upgrade dependencies, or claim merge approval.
+
+Use this skill after `repo-packet-builder` has created a bounded review packet,
+or when an operator gives an explicit repo/path/diff scope.
+
+## Quick Start
+
+1. Confirm the target scope:
+   - repository
+   - path slice
+   - branch
+   - diff
+   - existing review packet
+2. Prefer a `repo-packet-builder` packet when available, especially
+   `repo_scope.md`, `repo_inventory.json`, `evidence_index.json`, and
+   `specialist_assignments.json`.
+3. Run the deterministic scaffold helper when local packet access is available:
+   - `scripts/prepare_dependency_review.py <packet-root> --out <artifact-root>`
+4. Inspect dependency and supply-chain surfaces and write a findings-first
+   specialist review artifact.
+5. Hand final dedupe to `repo-review-synthesis`. Hand remediation ideas to a
+   future issue or maintainer-owned upgrade plan, not to this skill.
+
+## Focus
+
+Prioritize:
+
+- manifest and lockfile consistency
+- unsupported, stale, overbroad, or risky dependency declarations
+- package manager configuration and install determinism
+- Docker, compose, devcontainer, and runtime image dependency setup
+- CI workflow dependency bootstrap and cache behavior
+- toolchain version drift across docs, manifests, CI, and lockfiles
+- dependency-related test gaps, such as missing install or import smoke tests
+- license-sensitive dependency cues that require human or legal follow-up
+- supply-chain trust boundaries, including scripts, registries, vendored code,
+  generated dependency files, and pinned versus floating versions
+
+Defer primary ownership of these areas to other specialists:
+
+- implementation correctness: `repo-review-code`
+- security exploitation and abuse paths: `repo-review-security`
+- general missing coverage: `repo-review-tests`
+- documentation truth and onboarding drift: `repo-review-docs`
+- architecture boundaries and layering: `repo-architecture-review`
+- final cross-role dedupe and severity ordering: `repo-review-synthesis`
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `target.target_path`
+  - `target.branch`
+  - `target.diff_base`
+  - `target.review_packet_path`
+
+Useful additional inputs:
+
+- `changed_paths`
+- `review_depth`
+- `artifact_root`
+- `exclude_paths`
+- `validation_mode`
+- `dependency_focus`
+
+If there is no concrete repo or packet target, stop and report `blocked`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- review mode
+- included dependency surfaces
+- excluded dependency surfaces
+- assumptions and known limits
+- whether the review is dependency-only or part of a multi-agent review
+
+Do not silently expand a path or diff review into a whole-repo review.
+
+### 2. Map Dependency Surfaces
+
+Look for:
+
+- language manifests and lockfiles
+- package manager configuration
+- runtime images, Dockerfiles, compose files, and devcontainers
+- CI setup, install, cache, and dependency audit steps
+- generated or vendored dependency directories
+- dependency metadata in docs, demos, examples, and setup scripts
+- license files, notices, third-party attributions, and copied code markers
+- tests that prove installability, imports, CLI startup, or packaging behavior
+
+### 3. Review For Dependency Findings
+
+Findings should be behaviorally meaningful. Avoid style-only comments.
+
+Use this priority scale:
+
+- `P0`: dependency flaw can enable severe compromise, unsafe execution, or
+  broken release artifacts in normal use
+- `P1`: install, packaging, lockfile, or supply-chain drift can block users,
+  CI, releases, or trusted review results
+- `P2`: dependency policy, pinning, cache, or test gaps are likely to cause
+  recurring regressions or unreviewed supply-chain exposure
+- `P3`: useful dependency hygiene issue with bounded follow-up value
+
+Each finding should include:
+
+- trigger scenario
+- affected dependency surface
+- file/path evidence
+- impact
+- recommended follow-up owner
+
+### 4. Emit Follow-Up Candidates
+
+Include candidate follow-ups, but do not execute them:
+
+- upgrade or pinning issue candidates
+- dependency policy candidates
+- install or packaging test candidates
+- license review candidates
+
+These are handoff notes, not created issues or performed remediation.
+
+## Output Expectations
+
+Default output should include:
+
+- findings first
+- assumptions
+- reviewed dependency surfaces
+- dependency surface map
+- candidate supply-chain findings
+- candidate dependency test gaps
+- candidate license review notes
+- validation performed or not run
+- residual dependency risk
+
+Use `references/output-contract.md` and the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`.
+
+## Stop Boundary
+
+Stop after producing the dependency-review artifact.
+
+Do not:
+
+- edit code, docs, tests, configs, lockfiles, manifests, Dockerfiles, or CI
+- install, upgrade, downgrade, pin, unpin, vendor, or remove dependencies
+- run external vulnerability feeds or paid data sources
+- silently run the whole multi-agent review workflow
+- create issues or PRs
+- perform license/legal determinations
+- downgrade findings from other specialist roles
+- claim approval, merge readiness, or remediation completion
+
+## CodeBuddy Integration Notes
+
+This skill consumes CodeBuddy packet artifacts and produces a specialist
+dependency review artifact for synthesis. It is compatible with
+`repo-packet-builder` and should run before `repo-review-synthesis` when the
+operator wants dependency and supply-chain coverage as a first-class review
+lane.
+
+Deferred automation:
+
+- Optional SBOM generation and parsing.
+- Optional ecosystem-specific vulnerability database integrations.
+- License policy allow/deny-list integration.
+- Package-manager-specific lockfile consistency analyzers.

--- a/adl/tools/skills/repo-dependency-review/adl-skill.yaml
+++ b/adl/tools/skills/repo-dependency-review/adl-skill.yaml
@@ -1,0 +1,103 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-dependency-review"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_dependency_review.v1"
+    reference_doc: "../docs/REPO_DEPENDENCY_REVIEW_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_repository"
+      - "review_path"
+      - "review_branch"
+      - "review_diff"
+      - "review_packet"
+    policy_fields:
+      - "review_depth"
+      - "validation_mode"
+      - "write_review_artifact"
+      - "stop_after_review"
+      - "dependency_focus"
+  intent:
+    - "dependency_review"
+    - "supply_chain_review"
+    - "manifest_review"
+    - "lockfile_review"
+    - "codebuddy_review_engine"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "target_path"
+    - "branch"
+    - "diff_base"
+    - "changed_paths"
+    - "review_packet_path"
+    - "artifact_root"
+    - "dependency_focus"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_dependency_review.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.review_depth_must_be_explicit"
+    - "policy.stop_after_review_must_be_true"
+    - "review_packet_mode_requires_target.review_packet_path"
+execution:
+  mode: "findings_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_validation_when_bounded"
+  permitted_scripts:
+    - path: "scripts/prepare_dependency_review.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<packet-root>"
+        - "--out <artifact-root>"
+        - "--repo-name <name>"
+  preferred_read_order:
+    - "repo_scope.md"
+    - "specialist_assignments.json"
+    - "evidence_index.json"
+    - "repo_inventory.json"
+    - "manifests"
+    - "lockfiles"
+    - "package_manager_config"
+    - "docker_and_runtime_images"
+    - "ci_dependency_setup"
+    - "license_and_notice_files"
+    - "tests_encoding_install_or_packaging_contracts"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-dependency-review.md"
+  required_sections:
+    - "findings"
+    - "dependency_surface_map"
+    - "reviewed_surfaces"
+    - "candidate_supply_chain_findings"
+    - "candidate_dependency_test_gaps"
+    - "candidate_license_review_notes"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: true
+
+display_name: Repo Dependency Review
+short_description: Review dependency manifests, lockfiles, CI and Docker setup, license cues, and supply-chain drift
+default_prompt: Perform a bounded, findings-first dependency and supply-chain review from a repo scope or CodeBuddy packet. Stop after the specialist artifact and hand off remediation, tests, issues, and synthesis to separate skills.
+

--- a/adl/tools/skills/repo-dependency-review/agents/openai.yaml
+++ b/adl/tools/skills/repo-dependency-review/agents/openai.yaml
@@ -1,0 +1,5 @@
+name: repo-dependency-review
+display_name: Repo Dependency Review
+short_description: Review manifests, lockfiles, CI and Docker dependency setup, license cues, and supply-chain drift.
+default_prompt: Perform a bounded, findings-first dependency and supply-chain review from a repo scope or CodeBuddy packet. Stop after the specialist artifact and hand off remediation, tests, issues, and synthesis to separate skills.
+

--- a/adl/tools/skills/repo-dependency-review/references/dependency-playbook.md
+++ b/adl/tools/skills/repo-dependency-review/references/dependency-playbook.md
@@ -1,0 +1,51 @@
+# Dependency Review Playbook
+
+Use this playbook when the dependency review needs deeper heuristics than the
+core `SKILL.md` workflow.
+
+## High-Signal Surfaces
+
+- Python: `pyproject.toml`, `setup.cfg`, `setup.py`, `requirements*.txt`,
+  `uv.lock`, `poetry.lock`, `Pipfile.lock`, `.python-version`.
+- JavaScript and TypeScript: `package.json`, `package-lock.json`,
+  `pnpm-lock.yaml`, `yarn.lock`, `.npmrc`, `.yarnrc.yml`, `nvmrc`.
+- Rust: `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`.
+- Go: `go.mod`, `go.sum`.
+- JVM: `pom.xml`, `build.gradle`, `gradle.lockfile`, `settings.gradle`.
+- Containers and runtime images: `Dockerfile`, `docker-compose.yml`,
+  `.devcontainer/devcontainer.json`.
+- CI and release: `.github/workflows/*.yml`, build scripts, install scripts,
+  packaging scripts, release workflows.
+- Licensing and attribution: `LICENSE*`, `NOTICE*`, `THIRD_PARTY*`,
+  `COPYING*`, vendored directories, generated dependency reports.
+
+## Finding Heuristics
+
+Prefer concrete findings when evidence shows:
+
+- a manifest changed without a corresponding lockfile update
+- multiple package managers appear to own the same ecosystem without a documented
+  policy
+- CI uses floating toolchain or runtime versions that contradict repo metadata
+- Docker images or setup actions float at broad tags in release-critical paths
+- dependency install paths are documented but not tested
+- dependency cache keys ignore lockfiles or toolchain versions
+- generated or vendored dependency files are reviewed as first-party code
+- license-sensitive dependencies or copied code are present without attribution
+  follow-up
+
+Avoid findings when the only issue is personal preference. Dependency reviews
+should describe the failing scenario, not merely the desired style.
+
+## Validation Ideas
+
+Run validation only when bounded and safe:
+
+- lockfile consistency checks available in the repo
+- package manager dry-run or frozen install checks already used by CI
+- shell syntax checks for install scripts
+- local test targets that prove import, startup, or packaging behavior
+
+Do not run network installs or ecosystem audit commands unless the operator has
+explicitly allowed network access for the review.
+

--- a/adl/tools/skills/repo-dependency-review/references/output-contract.md
+++ b/adl/tools/skills/repo-dependency-review/references/output-contract.md
@@ -1,0 +1,119 @@
+# Output Contract
+
+The repo dependency review skill produces a specialist dependency and
+supply-chain review artifact for CodeBuddy-style multi-agent review.
+
+Default artifact path:
+
+```text
+.adl/reviews/<timestamp>-repo-dependency-review.md
+```
+
+Optional scaffold artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/dependency-review/
+```
+
+## Required Markdown Sections
+
+### Metadata
+
+Required fields:
+
+- `Skill: repo-dependency-review`
+- `Target`
+- `Date`
+- `Artifact`
+- `Packet`
+
+### Findings
+
+Findings must come first after metadata.
+
+Each finding must include:
+
+- priority
+- title
+- file or evidence path
+- role: `dependency`
+- scenario
+- dependency surface
+- impact
+- evidence
+- recommended follow-up owner
+
+If no material findings are found, state that explicitly and include residual
+risk.
+
+### Dependency Surface Map
+
+Summarize:
+
+- manifests and lockfiles
+- package manager configuration
+- runtime image and container dependency setup
+- CI dependency bootstrap and caches
+- generated or vendored dependency surfaces
+- license and attribution surfaces
+- tests that prove install, packaging, import, or dependency behavior
+
+### Reviewed Surfaces
+
+List bounded source-grounded surfaces by repo-relative path or packet-relative
+artifact path.
+
+### Candidate Supply-Chain Findings
+
+List candidate dependency or supply-chain findings for reviewer inspection, or
+state that none were found by the scaffold.
+
+### Candidate Dependency Test Gaps
+
+List install, packaging, import, lockfile, or toolchain proof gaps, or state that
+none were found.
+
+### Candidate License Review Notes
+
+List license-sensitive cues that need human review, or state that none were
+found. Do not make legal determinations.
+
+### Validation Performed
+
+List commands and what they proved, or explain why validation was inspect-only.
+
+### Residual Risk
+
+Explain skipped ecosystems, missing packet evidence, unexecuted commands, lack of
+network vulnerability data, or review limits.
+
+## JSON Scaffold Contract
+
+`scripts/prepare_dependency_review.py` emits
+`dependency_review_scaffold.json` with:
+
+- `schema`
+- `repo_name`
+- `packet_root`
+- `dependency_evidence`
+- `dependency_surface_map`
+- `candidate_supply_chain_findings`
+- `candidate_dependency_test_gaps`
+- `candidate_license_review_notes`
+- `notes`
+
+It also emits `dependency_review_scaffold.md` with the Markdown headings needed
+by the specialist review artifact.
+
+## Rules
+
+- Use repo-relative or packet-relative paths.
+- Do not write absolute host paths into artifacts.
+- Do not install, upgrade, downgrade, pin, unpin, vendor, or remove dependencies.
+- Do not perform legal determinations.
+- Do not use external vulnerability feeds unless an operator explicitly supplies
+  an offline, bounded source packet.
+- Do not mutate the reviewed repository.
+- Preserve dependency findings even when code/security/tests/docs specialists
+  have not reviewed the same surface.
+

--- a/adl/tools/skills/repo-dependency-review/scripts/prepare_dependency_review.py
+++ b/adl/tools/skills/repo-dependency-review/scripts/prepare_dependency_review.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Prepare deterministic scaffolding for a CodeBuddy dependency review."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+
+SCHEMA = "codebuddy.repo_dependency_review.scaffold.v1"
+DEPENDENCY_CATEGORIES = {
+    "ci",
+    "code",
+    "config",
+    "dependency",
+    "dependencies",
+    "docker",
+    "docs",
+    "lockfile",
+    "manifest",
+    "package_manager",
+    "test",
+}
+DEPENDENCY_TERMS = (
+    "cargo",
+    "ci",
+    "compose",
+    "container",
+    "dependency",
+    "dependencies",
+    "devcontainer",
+    "docker",
+    "install",
+    "license",
+    "lock",
+    "manifest",
+    "notice",
+    "npm",
+    "package",
+    "pip",
+    "pnpm",
+    "poetry",
+    "requirements",
+    "setup",
+    "supply",
+    "third_party",
+    "toolchain",
+    "vendor",
+    "yarn",
+)
+MANIFEST_NAMES = {
+    "cargo.toml",
+    "go.mod",
+    "package.json",
+    "pom.xml",
+    "pyproject.toml",
+    "requirements.txt",
+    "setup.cfg",
+    "setup.py",
+}
+LOCKFILE_NAMES = {
+    "cargo.lock",
+    "go.sum",
+    "gradle.lockfile",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "uv.lock",
+    "yarn.lock",
+}
+LICENSE_TERMS = ("license", "notice", "copying", "third_party", "third-party", "attribution")
+CI_TERMS = (".github/workflows", "gitlab-ci", "circleci", "buildkite", "azure-pipelines")
+CONTAINER_TERMS = ("dockerfile", "docker-compose", ".devcontainer", "containerfile")
+TEST_TERMS = ("test", "check", "validate", "smoke", "install")
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def evidence_entries(packet_root: Path) -> list[dict[str, object]]:
+    data = load_json(packet_root / "evidence_index.json")
+    if not isinstance(data, dict):
+        return []
+    evidence = data.get("evidence")
+    if not isinstance(evidence, list):
+        return []
+    return [item for item in evidence if isinstance(item, dict)]
+
+
+def classify_dependency_surface(entry: dict[str, object]) -> str:
+    path = str(entry.get("path", ""))
+    lowered = path.lower()
+    name = Path(lowered).name
+    category = str(entry.get("category", "")).lower()
+    if name in LOCKFILE_NAMES or "lockfile" in category:
+        return "lockfile"
+    if name in MANIFEST_NAMES or "manifest" in category:
+        return "manifest"
+    if any(term in lowered for term in CI_TERMS) or category == "ci":
+        return "ci_dependency_setup"
+    if any(term in lowered for term in CONTAINER_TERMS) or category == "docker":
+        return "container_dependency_setup"
+    if any(term in lowered for term in LICENSE_TERMS):
+        return "license_or_attribution"
+    if "vendor" in lowered or "third_party" in lowered or "third-party" in lowered:
+        return "vendored_or_generated_dependency"
+    if any(term in lowered for term in TEST_TERMS) or category == "test":
+        return "dependency_test_surface"
+    if "package" in lowered or "dependency" in lowered or "toolchain" in lowered:
+        return "package_manager_config"
+    return "dependency_related"
+
+
+def is_dependency_evidence(entry: dict[str, object]) -> bool:
+    category = str(entry.get("category", "")).lower()
+    path = str(entry.get("path", "")).lower()
+    reason = str(entry.get("reason", "")).lower()
+    lanes = entry.get("specialist_lanes")
+    lane_match = isinstance(lanes, list) and "dependency" in lanes
+    name = Path(path).name
+    term_match = any(term in path or term in reason for term in DEPENDENCY_TERMS)
+    known_file_match = name in MANIFEST_NAMES or name in LOCKFILE_NAMES
+    return lane_match or known_file_match or term_match or category in DEPENDENCY_CATEGORIES
+
+
+def build_surface_map(entries: list[dict[str, object]]) -> dict[str, list[str]]:
+    surfaces: dict[str, list[str]] = {}
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        if not path:
+            continue
+        surface = classify_dependency_surface(entry)
+        surfaces.setdefault(surface, [])
+        if path not in surfaces[surface]:
+            surfaces[surface].append(path)
+    return {key: sorted(value) for key, value in sorted(surfaces.items())}
+
+
+def build_candidate_supply_chain_findings(entries: list[dict[str, object]]) -> list[dict[str, str]]:
+    candidates: list[dict[str, str]] = []
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        if not path:
+            continue
+        surface = classify_dependency_surface(entry)
+        lowered = path.lower()
+        if surface in {"manifest", "lockfile", "ci_dependency_setup", "container_dependency_setup"}:
+            candidates.append(
+                {
+                    "surface": surface,
+                    "source": path,
+                    "reason": "Review for pinning, lockfile consistency, floating versions, cache keys, and install determinism.",
+                }
+            )
+        elif "vendor" in lowered or "third_party" in lowered or "third-party" in lowered:
+            candidates.append(
+                {
+                    "surface": surface,
+                    "source": path,
+                    "reason": "Review whether vendored or copied dependency evidence is intentionally scoped and attributed.",
+                }
+            )
+    return candidates[:16]
+
+
+def build_candidate_dependency_test_gaps(entries: list[dict[str, object]]) -> list[dict[str, str]]:
+    candidates: list[dict[str, str]] = []
+    has_manifest_or_lock = any(classify_dependency_surface(entry) in {"manifest", "lockfile"} for entry in entries)
+    has_test_surface = any(classify_dependency_surface(entry) == "dependency_test_surface" for entry in entries)
+    if has_manifest_or_lock and not has_test_surface:
+        candidates.append(
+            {
+                "candidate": "Add bounded install or import smoke proof for dependency changes.",
+                "source": "manifest_or_lockfile_surfaces",
+                "reason": "Packet includes dependency declarations without an obvious dependency-focused test surface.",
+            }
+        )
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        lowered = path.lower()
+        if path and any(term in lowered for term in ("dockerfile", "compose", ".github/workflows")):
+            candidates.append(
+                {
+                    "candidate": f"Verify dependency bootstrap path represented by {path}",
+                    "source": path,
+                    "reason": "Runtime or CI dependency setup often needs a smoke check to catch drift.",
+                }
+            )
+    return candidates[:12]
+
+
+def build_candidate_license_notes(entries: list[dict[str, object]]) -> list[dict[str, str]]:
+    notes: list[dict[str, str]] = []
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        lowered = path.lower()
+        if path and any(term in lowered for term in LICENSE_TERMS):
+            notes.append(
+                {
+                    "source": path,
+                    "reason": "License or attribution surface should be checked by a human reviewer; this scaffold does not make legal determinations.",
+                }
+            )
+    return notes[:12]
+
+
+def lines_for_surface_map(surface_map: dict[str, list[str]]) -> str:
+    if not surface_map:
+        return "- No dependency surfaces selected from packet."
+    lines: list[str] = []
+    for surface, paths in surface_map.items():
+        lines.append(f"- {surface}:")
+        for path in paths:
+            lines.append(f"  - {path}")
+    return "\n".join(lines)
+
+
+def write_markdown(path: Path, scaffold: dict[str, object]) -> None:
+    evidence = scaffold["dependency_evidence"]
+    evidence_lines = "\n".join(
+        f"- {item['path']} ({classify_dependency_surface(item)}): {item.get('reason', 'dependency evidence')}"
+        for item in evidence
+    ) or "- No dependency evidence selected from packet."
+    supply_lines = "\n".join(
+        f"- {item['source']} ({item['surface']}): {item['reason']}"
+        for item in scaffold["candidate_supply_chain_findings"]
+    ) or "- None identified by scaffold."
+    test_lines = "\n".join(
+        f"- {item['candidate']} Source: {item['source']}. Reason: {item['reason']}"
+        for item in scaffold["candidate_dependency_test_gaps"]
+    ) or "- None identified by scaffold."
+    license_lines = "\n".join(
+        f"- {item['source']}: {item['reason']}"
+        for item in scaffold["candidate_license_review_notes"]
+    ) or "- None identified by scaffold."
+
+    content = f"""# Repo Dependency Review Scaffold
+
+## Metadata
+
+- Skill: repo-dependency-review
+- Repo: {scaffold["repo_name"]}
+- Packet: {scaffold["packet_root"]}
+- Date: {scaffold["created_at"]}
+
+## Findings
+
+- No findings have been written yet. Replace this section with findings-first dependency review output after inspection.
+
+## Dependency Surface Map
+
+{lines_for_surface_map(scaffold["dependency_surface_map"])}
+
+## Reviewed Surfaces
+
+{evidence_lines}
+
+## Candidate Supply-Chain Findings
+
+{supply_lines}
+
+## Candidate Dependency Test Gaps
+
+{test_lines}
+
+## Candidate License Review Notes
+
+{license_lines}
+
+## Validation Performed
+
+- Scaffold generation only; no repository validation commands were run by this helper.
+
+## Residual Risk
+
+- This scaffold is not a review finding artifact. A reviewer must inspect the selected surfaces and record findings or an explicit no-material-findings result.
+- This helper does not query external vulnerability databases or perform legal review.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet_root", help="CodeBuddy review packet root")
+    parser.add_argument("--out", default=None, help="Dependency review scaffold output root")
+    parser.add_argument("--repo-name", default=None, help="Repo name override")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    packet_root = Path(args.packet_root).resolve()
+    if not packet_root.is_dir():
+        raise SystemExit(f"packet root does not exist: {packet_root}")
+
+    out_root = Path(args.out) if args.out else packet_root / "dependency-review"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_json(packet_root / "run_manifest.json")
+    repo_name = args.repo_name
+    if repo_name is None and isinstance(manifest, dict):
+        repo_name = str(manifest.get("repo_name", "") or "")
+    repo_name = repo_name or packet_root.name
+
+    entries = [entry for entry in evidence_entries(packet_root) if is_dependency_evidence(entry)]
+    entries = sorted(entries, key=lambda item: str(item.get("path", "")))[:80]
+    scaffold = {
+        "schema": SCHEMA,
+        "repo_name": repo_name,
+        "packet_root": packet_root.name,
+        "created_at": now_utc(),
+        "dependency_evidence": entries,
+        "dependency_surface_map": build_surface_map(entries),
+        "candidate_supply_chain_findings": build_candidate_supply_chain_findings(entries),
+        "candidate_dependency_test_gaps": build_candidate_dependency_test_gaps(entries),
+        "candidate_license_review_notes": build_candidate_license_notes(entries),
+        "notes": [
+            "Scaffold is deterministic except for created_at.",
+            "Paths are packet evidence paths, not absolute host paths.",
+            "Reviewer must replace scaffold findings with source-grounded dependency review findings.",
+            "Helper does not install dependencies, mutate lockfiles, use network feeds, or make legal determinations.",
+        ],
+    }
+    write_json(out_root / "dependency_review_scaffold.json", scaffold)
+    write_markdown(out_root / "dependency_review_scaffold.md", scaffold)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -26,6 +26,8 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/redaction-and-evidence-auditor/scripts/audit_review_packet.py" ]]
   [[ -f "${root}/skills/repo-architecture-review/SKILL.md" ]]
   [[ -x "${root}/skills/repo-architecture-review/scripts/prepare_architecture_review.py" ]]
+  [[ -f "${root}/skills/repo-dependency-review/SKILL.md" ]]
+  [[ -x "${root}/skills/repo-dependency-review/scripts/prepare_dependency_review.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -47,6 +49,7 @@ assert_skill_bundle() {
   grep -Fq "packet-construction skill, not a reviewer" "${root}/skills/repo-packet-builder/SKILL.md"
   grep -Fq "safety gate, not a reviewer" "${root}/skills/redaction-and-evidence-auditor/SKILL.md"
   grep -Fq "findings-first and source-grounded" "${root}/skills/repo-architecture-review/SKILL.md"
+  grep -Fq "dependency and supply-chain surfaces" "${root}/skills/repo-dependency-review/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -68,6 +71,7 @@ assert_skill_bundle() {
     "${root}/skills/repo-packet-builder/SKILL.md" \
     "${root}/skills/redaction-and-evidence-auditor/SKILL.md" \
     "${root}/skills/repo-architecture-review/SKILL.md" \
+    "${root}/skills/repo-dependency-review/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -91,6 +95,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/repo-packet-builder" ]]
 [[ -L "${CODEX_HOME}/skills/redaction-and-evidence-auditor" ]]
 [[ -L "${CODEX_HOME}/skills/repo-architecture-review" ]]
+[[ -L "${CODEX_HOME}/skills/repo-dependency-review" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_repo_dependency_review_skill_contracts.sh
+++ b/adl/tools/test_repo_dependency_review_skill_contracts.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/repo-dependency-review/SKILL.md" ]]
+[[ -f "${skills_root}/repo-dependency-review/adl-skill.yaml" ]]
+[[ -f "${skills_root}/repo-dependency-review/agents/openai.yaml" ]]
+[[ -f "${skills_root}/repo-dependency-review/references/dependency-playbook.md" ]]
+[[ -f "${skills_root}/repo-dependency-review/references/output-contract.md" ]]
+[[ -x "${skills_root}/repo-dependency-review/scripts/prepare_dependency_review.py" ]]
+[[ -f "${skills_root}/docs/REPO_DEPENDENCY_REVIEW_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "repo-dependency-review"' "${skills_root}/repo-dependency-review/adl-skill.yaml"
+grep -Fq 'id: "repo_dependency_review.v1"' "${skills_root}/repo-dependency-review/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REPO_DEPENDENCY_REVIEW_SKILL_INPUT_SCHEMA.md"' "${skills_root}/repo-dependency-review/adl-skill.yaml"
+grep -Fq "review_packet_mode_requires_target.review_packet_path" "${skills_root}/repo-dependency-review/adl-skill.yaml"
+grep -Fq "findings-first" "${skills_root}/repo-dependency-review/SKILL.md"
+grep -Fq "scripts/prepare_dependency_review.py" "${skills_root}/repo-dependency-review/SKILL.md"
+grep -Fq "Do not install, upgrade, downgrade, pin, unpin, vendor, or remove dependencies" "${skills_root}/repo-dependency-review/references/output-contract.md"
+grep -Fq "Schema id: \`repo_dependency_review.v1\`" "${skills_root}/docs/REPO_DEPENDENCY_REVIEW_SKILL_INPUT_SCHEMA.md"
+grep -Fq "repo-dependency-review" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+packet_root="${tmpdir}/packet"
+scaffold_root="${tmpdir}/dependency"
+mkdir -p "${packet_root}"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "dependency-contract-test",
+  "repo_name": "example-repo",
+  "publication_allowed": false
+}
+JSON
+cat >"${packet_root}/evidence_index.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.evidence.v1",
+  "evidence": [
+    {
+      "path": "Cargo.toml",
+      "category": "manifest",
+      "line_count": 42,
+      "reason": "Rust dependency manifest",
+      "specialist_lanes": ["dependency", "code", "security", "synthesis"]
+    },
+    {
+      "path": "Cargo.lock",
+      "category": "lockfile",
+      "line_count": 220,
+      "reason": "Rust lockfile",
+      "specialist_lanes": ["dependency", "synthesis"]
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "category": "ci",
+      "line_count": 88,
+      "reason": "CI dependency bootstrap and cache setup",
+      "specialist_lanes": ["dependency", "tests", "synthesis"]
+    },
+    {
+      "path": "Dockerfile",
+      "category": "docker",
+      "line_count": 39,
+      "reason": "runtime image dependency setup",
+      "specialist_lanes": ["dependency", "security", "synthesis"]
+    },
+    {
+      "path": "NOTICE",
+      "category": "docs",
+      "line_count": 12,
+      "reason": "license attribution surface",
+      "specialist_lanes": ["dependency", "docs", "synthesis"]
+    },
+    {
+      "path": "README.md",
+      "category": "docs",
+      "line_count": 20,
+      "reason": "onboarding surface",
+      "specialist_lanes": ["docs", "synthesis"]
+    }
+  ]
+}
+JSON
+
+python3 "${skills_root}/repo-dependency-review/scripts/prepare_dependency_review.py" \
+  "${packet_root}" --out "${scaffold_root}" >/tmp/repo-dependency-review.out
+[[ -f "${scaffold_root}/dependency_review_scaffold.json" ]]
+[[ -f "${scaffold_root}/dependency_review_scaffold.md" ]]
+grep -Fq '"schema": "codebuddy.repo_dependency_review.scaffold.v1"' "${scaffold_root}/dependency_review_scaffold.json"
+grep -Fq '"repo_name": "example-repo"' "${scaffold_root}/dependency_review_scaffold.json"
+grep -Fq 'Cargo.toml' "${scaffold_root}/dependency_review_scaffold.json"
+grep -Fq 'Cargo.lock' "${scaffold_root}/dependency_review_scaffold.md"
+grep -Fq 'Dependency Surface Map' "${scaffold_root}/dependency_review_scaffold.md"
+grep -Fq 'Candidate Supply-Chain Findings' "${scaffold_root}/dependency_review_scaffold.md"
+grep -Fq 'Candidate Dependency Test Gaps' "${scaffold_root}/dependency_review_scaffold.md"
+grep -Fq 'Candidate License Review Notes' "${scaffold_root}/dependency_review_scaffold.md"
+if grep -R "${tmpdir}" "${scaffold_root}" >/dev/null; then
+  echo "dependency review scaffold should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/repo-dependency-review/SKILL.md"
+
+echo "PASS test_repo_dependency_review_skill_contracts"


### PR DESCRIPTION
Closes #2062

## Summary
Implemented the `repo-dependency-review` CodeBuddy specialist skill. The skill
reviews dependency and supply-chain surfaces from bounded repo scopes or
CodeBuddy packets, produces findings-first specialist artifacts, and explicitly
stops before dependency upgrades, remediation, legal determinations, issue
creation, or synthesis.

## Artifacts
- `adl/tools/skills/repo-dependency-review/SKILL.md`
- `adl/tools/skills/repo-dependency-review/adl-skill.yaml`
- `adl/tools/skills/repo-dependency-review/agents/openai.yaml`
- `adl/tools/skills/repo-dependency-review/references/output-contract.md`
- `adl/tools/skills/repo-dependency-review/references/dependency-playbook.md`
- `adl/tools/skills/repo-dependency-review/scripts/prepare_dependency_review.py`
- `adl/tools/skills/docs/REPO_DEPENDENCY_REVIEW_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_repo_dependency_review_skill_contracts.sh`
- Updated `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
- Updated `adl/tools/test_install_adl_operational_skills.sh`
- Updated `adl/tools/batched_checks.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_repo_dependency_review_skill_contracts.sh`: verifies the
    new skill bundle, ADL metadata, scaffold helper behavior, generated scaffold
    sections, no absolute temp path leakage, and frontmatter validity.
  - `bash adl/tools/test_install_adl_operational_skills.sh`: verifies the
    operational skill installer installs the new skill in copy and symlink modes.
  - `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile adl/tools/skills/repo-dependency-review/scripts/prepare_dependency_review.py`: verifies helper syntax.
  - `bash -n adl/tools/test_repo_dependency_review_skill_contracts.sh adl/tools/test_install_adl_operational_skills.sh adl/tools/batched_checks.sh`: verifies shell syntax for changed validation scripts.
  - `git diff --check`: verifies whitespace cleanliness.
  - `bash adl/tools/batched_checks.sh`: verifies the repository batched gates,
    including skill contracts, residue guard, `cargo fmt --check`,
    `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2062__backlog-skills-add-repo-dependency-review-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2062__backlog-skills-add-repo-dependency-review-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-repo-dependency-review-skill-adl-tools-skills-repo-dependency-review-adl-tools-skills-docs-repo-dependency-review-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-repo-dependency-review-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2062-backlog-skills-add-repo-dependency-review-skill-sip-md-adl-v0-90-tasks-issue-2062-backlog-skills-add-repo-dependency-review-skill-sor-md