### PR TITLE
[v0.90][backlog][tools] Clean up coverage profile artifacts

### DIFF
--- a/adl/.gitignore
+++ b/adl/.gitignore
@@ -14,3 +14,4 @@ cov.old/
 adl/coverage/
 adl/coverage.last/
 coverage-summary.json
+coverage-summary.txt

--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -26,6 +26,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `closeout_completed_issue_wave.sh`: bounded local catch-up helper that runs `pr closeout` across closed/completed issue bundles for a milestone version so local-only `.adl` truth can converge after merge or main sync.
 - `check_milestone_closed_issue_sor_truth.sh`: milestone closed-issue bundle truth gate for local-only `.adl` task bundles; verifies canonical `stp.md`, `sip.md`, and final `sor.md` truth for closed/completed issues.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
+- `clean_coverage_artifacts.sh`: removes local generated coverage summaries and loose LLVM profile shards after coverage/report runs.
 - `report_large_rust_modules.sh`: non-blocking Rust source-and-test module size report for maintainability review.
 - `open_artifact.sh`: convenience opener for cards/reports.
 - `update_reports_index.sh`, `update_latest_reports.sh`: report index maintenance.
@@ -109,6 +110,9 @@ bash adl/tools/demo_v089_quality_gate.sh
 
 # enforce coverage thresholds from coverage-summary.json
 cd ./adl/ && bash tools/enforce_coverage_gates.sh coverage-summary.json
+
+# remove local generated coverage artifacts after they are no longer needed
+./adl/tools/clean_coverage_artifacts.sh --include-worktrees
 
 # report large Rust source and test modules without failing the build
 ./adl/tools/report_large_rust_modules.sh

--- a/adl/tools/clean_coverage_artifacts.sh
+++ b/adl/tools/clean_coverage_artifacts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/clean_coverage_artifacts.sh [--dry-run] [--include-worktrees]
+
+Deletes local generated coverage artifacts that should not be committed:
+  - adl/coverage-summary.json
+  - adl/coverage-summary.txt
+  - adl/lcov.info
+  - loose *.profraw and *.profdata files outside target/
+
+By default this cleans the current checkout only. Use --include-worktrees to
+also clean stale local worktree checkouts under .worktrees/.
+USAGE
+}
+
+dry_run=false
+include_worktrees=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=true
+      ;;
+    --include-worktrees)
+      include_worktrees=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "clean-coverage-artifacts: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+delete_file() {
+  local path="$1"
+  if [ "$dry_run" = true ]; then
+    printf 'would remove %s\n' "$path"
+  else
+    rm -f -- "$path"
+    printf 'removed %s\n' "$path"
+  fi
+}
+
+clean_checkout() {
+  local checkout_root="$1"
+
+  for path in \
+    "$checkout_root/adl/coverage-summary.json" \
+    "$checkout_root/adl/coverage-summary.txt" \
+    "$checkout_root/adl/lcov.info"
+  do
+    [ -f "$path" ] && delete_file "$path"
+  done
+
+  find "$checkout_root" \
+    \( \
+      -path "$checkout_root/.git" \
+      -o -path "$checkout_root/.worktrees" \
+      -o -path "$checkout_root/target" \
+      -o -path "$checkout_root/adl/target" \
+    \) -prune \
+    -o -type f \( -name '*.profraw' -o -name '*.profdata' \) -print |
+    while IFS= read -r path; do
+      delete_file "$path"
+    done
+}
+
+clean_checkout "$repo_root"
+
+if [ "$include_worktrees" = true ] && [ -d "$repo_root/.worktrees" ]; then
+  find "$repo_root/.worktrees" -mindepth 1 -maxdepth 1 -type d -print |
+    while IFS= read -r worktree; do
+      clean_checkout "$worktree"
+    done
+fi


### PR DESCRIPTION
Closes #2085

## Summary
Added a bounded cleanup helper for generated Rust/LLVM coverage artifacts and
removed stale generated coverage artifacts from old issue worktrees. The root
checkout was not mutated because Daniel explicitly stopped root-main cleanup.

## Artifacts
- `adl/tools/clean_coverage_artifacts.sh`
- Updated `adl/.gitignore`
- Updated `adl/tools/README.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/clean_coverage_artifacts.sh` checked shell syntax.
  - `adl/tools/clean_coverage_artifacts.sh --dry-run` checked planned deletion output against disposable generated artifacts.
  - `adl/tools/clean_coverage_artifacts.sh` removed disposable generated artifacts in the issue worktree.
  - `test ! -e ...` verified disposable generated artifacts were actually removed.
  - `find <repo>/.worktrees ... | wc -l` verified stale worktree generated artifact count reached 0 outside target directories.
  - `git diff --check` checked whitespace and patch hygiene.
- Results: PASS.
- Validation profile: FOCUSED_LOCAL_CI_GATED.
- Full local validation: not run.
- CI requirement: required before merge.
- Rationale: this is a narrow shell-helper, ignore-rule, and tooling-doc cleanup with focused shell syntax and artifact-behavior validation.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2085__clean-up-coverage-profile-artifacts/sip.md
- Output card: .adl/v0.90/tasks/issue-2085__clean-up-coverage-profile-artifacts/sor.md
- Idempotency-Key: v0-90-backlog-tools-clean-up-coverage-profile-artifacts-adl-gitignore-adl-tools-readme-md-adl-tools-clean-coverage-artifacts-sh-adl-v0-90-tasks-issue-2085-clean-up-coverage-profile-artifacts-sip-md-adl-v0-90-tasks-issue-2085-clean-up-coverage-profile-artifacts-sor-md