### PR TITLE
[v0.90][backlog][skills] Add repo diagram planner skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -41,6 +41,7 @@ run_step "repo-packet-builder contract check" bash "$ROOT/adl/tools/test_repo_pa
 run_step "redaction-and-evidence-auditor contract check" bash "$ROOT/adl/tools/test_redaction_and_evidence_auditor_skill_contracts.sh"
 run_step "repo-architecture-review contract check" bash "$ROOT/adl/tools/test_repo_architecture_review_skill_contracts.sh"
 run_step "repo-dependency-review contract check" bash "$ROOT/adl/tools/test_repo_dependency_review_skill_contracts.sh"
+run_step "repo-diagram-planner contract check" bash "$ROOT/adl/tools/test_repo_diagram_planner_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -18,6 +18,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `repo-review-docs`
 - `repo-architecture-review`
 - `repo-dependency-review`
+- `repo-diagram-planner`
 - `repo-review-synthesis`
 
 ## Invocation Order
@@ -31,10 +32,14 @@ Recommended order:
 5. `repo-architecture-review`
 6. `repo-dependency-review`
 7. `repo-review-synthesis`
+8. `repo-diagram-planner`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
 available, and ideally after all required roles have reported.
+The diagram planner should normally run after packet building and after the
+specialist artifacts that may propose diagram work. It emits bounded task briefs
+for `diagram-author`; it is not itself a review or diagram-authoring lane.
 
 ## Shared Specialist Input Shape
 
@@ -173,6 +178,38 @@ Each specialist artifact should use this shape:
 - <bounded issue candidate or explicit none>
 ```
 
+## Diagram Planning Input Shape
+
+```yaml
+skill_input_schema: repo_diagram_planner.v1
+mode: plan_from_review_packet | plan_from_specialist_artifacts | plan_from_path | plan_from_issue | refresh_diagram_plan
+repo_root: /absolute/path
+target:
+  review_packet_path: <path or null>
+  specialist_artifacts:
+    architecture: <path or null>
+    security: <path or null>
+    dependency: <path or null>
+    docs: <path or null>
+  target_path: <path or null>
+  issue_number: <number or null>
+  doc_path: <path or null>
+  artifact_root: <path or null>
+policy:
+  audience: reviewers | maintainers | operators | users | mixed
+  diagram_goals:
+    - orientation
+    - architecture_boundaries
+    - workflow
+    - state
+    - data_flow
+    - dependencies
+    - responsibility_map
+  max_tasks: <number>
+  write_plan_artifact: true | false
+  stop_after_plan: true
+```
+
 ## Severity Rules
 
 - Preserve the highest severity attached to a merged finding unless the source
@@ -196,6 +233,7 @@ The suite may:
 - run bounded local validation commands when safe
 - write review artifacts under `.adl/reviews`
 - recommend follow-up issues
+- plan bounded diagram tasks for `diagram-author`
 
 The suite must not:
 - edit code, tests, docs, configs, or issue state
@@ -204,6 +242,8 @@ The suite must not:
 - run unbounded repository-wide analysis without a declared target
 - use network or paid data feeds
 - hide severity, disagreement, skipped roles, or residual risk
+- invent diagrams, render diagram assets, or publish visual artifacts from the
+  planning lane
 
 ## Relationship To `repo-code-review`
 
@@ -220,4 +260,6 @@ Use this suite when:
 - architecture boundaries, state models, layering, or drift need explicit ownership
 - dependency manifests, lockfiles, CI install paths, containers, or license cues
   need explicit ownership
+- diagram planning needs to be source-grounded before asking `diagram-author` to
+  create a specific visual artifact
 - the synthesis artifact should show specialist coverage and disagreement

--- a/adl/tools/skills/docs/REPO_DIAGRAM_PLANNER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REPO_DIAGRAM_PLANNER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,85 @@
+# Repo Diagram Planner Skill Input Schema
+
+Schema id: `repo_diagram_planner.v1`
+
+This schema describes the structured input accepted by the
+`repo-diagram-planner` skill. It is intentionally bounded so CodeBuddy can plan
+diagram work without authoring diagrams, rendering assets, publishing, or
+mutating customer repositories.
+
+## Required Shape
+
+```yaml
+skill_input_schema: repo_diagram_planner.v1
+mode: plan_from_review_packet | plan_from_specialist_artifacts | plan_from_path | plan_from_issue | refresh_diagram_plan
+repo_root: /absolute/path
+target:
+  review_packet_path: <path or null>
+  specialist_artifacts:
+    architecture: <path or null>
+    security: <path or null>
+    dependency: <path or null>
+    docs: <path or null>
+  target_path: <path or null>
+  issue_number: <number or null>
+  doc_path: <path or null>
+  artifact_root: <path or null>
+policy:
+  audience: reviewers | maintainers | operators | users | mixed
+  diagram_goals:
+    - orientation
+    - architecture_boundaries
+    - workflow
+    - state
+    - data_flow
+    - dependencies
+    - responsibility_map
+  max_tasks: 1
+  preferred_backends:
+    - mermaid
+    - structurizr
+    - d2
+    - plantuml
+  write_plan_artifact: true | false
+  stop_after_plan: true
+```
+
+## Required Fields
+
+- `skill_input_schema` must equal `repo_diagram_planner.v1`.
+- `mode` must be one of the supported planning modes.
+- `repo_root` must be absolute.
+- `target` must identify one bounded packet, artifact set, path, issue, or doc
+  target.
+- `policy.stop_after_plan` must be `true`.
+- `mode: plan_from_review_packet` requires `target.review_packet_path`.
+
+## Output Contract
+
+The skill writes or returns a source-grounded diagram planning artifact with:
+
+- diagram tasks
+- source evidence map
+- family and backend rationale
+- assumptions and unknowns
+- blocked or skipped candidates
+- validation performed
+- diagram-author handoff instructions
+- residual risk
+
+The skill may also generate deterministic scaffolding with
+`scripts/plan_repo_diagrams.py`.
+
+## Stop Boundary
+
+The skill must not:
+
+- author Mermaid, D2, PlantUML, Structurizr, SVG, PNG, or raster artifacts
+- render diagrams
+- publish diagrams
+- mutate the reviewed repository
+- create issues or PRs
+- replace `diagram-author` or specialist review skills
+- invent architecture, runtime behavior, dependency direction, trust boundaries,
+  data flows, or actor responsibilities
+

--- a/adl/tools/skills/repo-diagram-planner/SKILL.md
+++ b/adl/tools/skills/repo-diagram-planner/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: repo-diagram-planner
+description: Plan source-grounded diagram tasks for CodeBuddy-style repository reviews from repo packets, specialist findings, architecture maps, dependency surfaces, and docs evidence, then hand bounded diagram briefs to diagram-author without authoring diagram source or inventing repo behavior.
+---
+
+# Repo Diagram Planner
+
+Plan diagram work for a repository review without becoming the diagram author.
+This skill turns bounded CodeBuddy packet evidence and specialist review outputs
+into diagram task briefs that `diagram-author` can execute one at a time.
+
+Use this skill after `repo-packet-builder` has created a bounded review packet
+and after at least one specialist review artifact is available, or when an
+operator supplies an explicit repo/path/doc packet that needs diagram planning.
+
+## Quick Start
+
+1. Confirm the target scope:
+   - review packet
+   - specialist review artifacts
+   - path slice
+   - issue or doc packet
+2. Prefer CodeBuddy packet artifacts when available:
+   - `repo_scope.md`
+   - `repo_inventory.json`
+   - `evidence_index.json`
+   - `specialist_assignments.json`
+3. Run the deterministic planning helper when local packet access is available:
+   - `scripts/plan_repo_diagrams.py <packet-root> --out <artifact-root>`
+4. Inspect the generated diagram task candidates and prune unsupported or
+   duplicate tasks.
+5. Hand selected tasks to `diagram-author` as bounded briefs. Stop before
+   authoring diagram source, rendering, or publication.
+
+## Focus
+
+Prioritize diagram candidates that clarify:
+
+- architecture boundaries and C4-style context/container views
+- lifecycle, workflow, or orchestration paths
+- state machines and long-lived runtime transitions
+- data flows across trust boundaries
+- module, package, skill, or dependency relationships
+- issue/review handoff flows and specialist responsibility maps
+- docs claims that need a visual proof or orientation aid
+
+Prefer fewer, stronger diagrams over broad diagram inventory. Each candidate
+must have evidence, a communication goal, a suggested diagram family, a suggested
+backend, assumptions, unknowns, and a `diagram-author` handoff note.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `target.review_packet_path`
+  - `target.specialist_artifacts`
+  - `target.target_path`
+  - `target.issue_number`
+  - `target.doc_path`
+
+Useful additional inputs:
+
+- `artifact_root`
+- `audience`
+- `diagram_goals`
+- `max_tasks`
+- `preferred_backends`
+- `forbidden_assumptions`
+- `validation_mode`
+
+If there is no bounded source or target, stop and report `blocked`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- planning mode
+- source packet or artifact paths
+- included surfaces
+- excluded surfaces
+- audience and communication goals
+- assumptions and known limits
+
+Do not silently expand a path or diff planning pass into whole-repo planning.
+
+### 2. Collect Diagram Evidence
+
+Look for:
+
+- architecture evidence and architecture review candidate diagram tasks
+- runtime, workflow, lifecycle, state, orchestration, and scheduler surfaces
+- security trust-boundary or data-flow findings
+- dependency, package, and module relationship surfaces
+- docs that describe user journeys, setup paths, or operational lifecycles
+- existing diagrams and diagram sources
+
+Use repo-relative or packet-relative paths only.
+
+### 3. Select Diagram Families
+
+Choose the smallest useful diagram family:
+
+- `system_context` for audience orientation
+- `container_or_component` for architecture boundaries
+- `workflow` for process or lifecycle flows
+- `sequence` for actor/service interactions over time
+- `state` for lifecycle state machines
+- `data_flow` for trust boundaries and data movement
+- `dependency_graph` for module, package, or skill relationships
+- `responsibility_map` for review or agent handoffs
+
+Suggested backend defaults:
+
+- Mermaid for GitHub-friendly diagrams and issue/PR review surfaces
+- Structurizr DSL for C4 model families and multiple related architecture views
+- D2 for polished explanatory system maps
+- PlantUML for formal sequence/component/state diagrams
+- Markdown outline when evidence is insufficient for diagram source
+
+### 4. Emit Handoff Tasks
+
+Each task should include:
+
+- task id
+- diagram family
+- suggested backend
+- audience
+- goal
+- source evidence paths
+- assumptions and unknowns
+- claims that must not be made
+- renderer expectation
+- `diagram-author` handoff brief
+
+The planner may recommend tasks but must not execute `diagram-author`
+automatically unless the operator explicitly requests that as a separate step.
+
+## Output Expectations
+
+Default output should include:
+
+- findings or planning summary first
+- diagram task list
+- source evidence map
+- diagram family/backend rationale
+- assumptions and unknowns
+- blocked or skipped candidates
+- validation performed or not run
+- handoff instructions for `diagram-author`
+- residual planning risk
+
+Use `references/output-contract.md` and the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`.
+
+## Stop Boundary
+
+Stop after producing the diagram plan.
+
+Do not:
+
+- author Mermaid, D2, PlantUML, Structurizr, SVG, or raster diagram artifacts
+- render diagrams
+- publish diagrams
+- mutate customer repositories
+- create issues or PRs
+- replace `diagram-author`, architecture review, docs review, security review,
+  dependency review, or synthesis
+- invent architecture, runtime behavior, data flows, trust boundaries, or
+  dependencies that are not backed by the provided evidence
+
+## CodeBuddy Integration Notes
+
+This skill consumes CodeBuddy packet artifacts and specialist review artifacts,
+then produces a diagram planning artifact for downstream `diagram-author` runs.
+It is a planning and routing lane, not a review lane and not a diagram rendering
+lane.
+
+Deferred automation:
+
+- Reading specialist review artifacts directly to harvest finding-linked diagram
+  tasks.
+- Clustering duplicate diagram candidates across specialists.
+- Producing one-click `diagram-author` invocation packets.
+- Renderer availability probing through the `diagram-author` renderer setup
+  contract.
+

--- a/adl/tools/skills/repo-diagram-planner/adl-skill.yaml
+++ b/adl/tools/skills/repo-diagram-planner/adl-skill.yaml
@@ -1,0 +1,100 @@
+version: "0.1"
+kind: "adl-skill"
+id: "repo-diagram-planner"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "repo_diagram_planner.v1"
+    reference_doc: "../docs/REPO_DIAGRAM_PLANNER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "plan_from_review_packet"
+      - "plan_from_specialist_artifacts"
+      - "plan_from_path"
+      - "plan_from_issue"
+      - "refresh_diagram_plan"
+    policy_fields:
+      - "audience"
+      - "diagram_goals"
+      - "max_tasks"
+      - "preferred_backends"
+      - "write_plan_artifact"
+      - "stop_after_plan"
+  intent:
+    - "diagram_planning"
+    - "diagram_task_handoff"
+    - "codebuddy_review_engine"
+    - "source_grounded_visual_planning"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "review_packet_path"
+    - "specialist_artifacts"
+    - "target_path"
+    - "issue_number"
+    - "doc_path"
+    - "artifact_root"
+    - "diagram_goals"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_repo_diagram_planner.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.stop_after_plan_must_be_true"
+    - "plan_from_review_packet_requires_target.review_packet_path"
+execution:
+  mode: "planning_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_validation_when_bounded"
+  permitted_scripts:
+    - path: "scripts/plan_repo_diagrams.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<packet-root>"
+        - "--out <artifact-root>"
+        - "--repo-name <name>"
+        - "--max-tasks <n>"
+  preferred_read_order:
+    - "repo_scope.md"
+    - "specialist_assignments.json"
+    - "evidence_index.json"
+    - "repo_inventory.json"
+    - "architecture_review_artifacts"
+    - "security_review_artifacts"
+    - "dependency_review_artifacts"
+    - "docs_review_artifacts"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-repo-diagram-plan.md"
+  required_sections:
+    - "diagram_tasks"
+    - "source_evidence_map"
+    - "family_backend_rationale"
+    - "assumptions_and_unknowns"
+    - "blocked_or_skipped_candidates"
+    - "validation_performed"
+    - "diagram_author_handoff"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: true
+
+display_name: Repo Diagram Planner
+short_description: Plan source-grounded diagram tasks from CodeBuddy packets and specialist review evidence
+default_prompt: Produce a bounded source-grounded diagram plan from a repo packet or specialist artifacts. Stop before authoring diagram source, rendering, publishing, issues, PRs, or repo mutation.
+

--- a/adl/tools/skills/repo-diagram-planner/agents/openai.yaml
+++ b/adl/tools/skills/repo-diagram-planner/agents/openai.yaml
@@ -1,0 +1,5 @@
+name: repo-diagram-planner
+display_name: Repo Diagram Planner
+short_description: Plan source-grounded diagram tasks from CodeBuddy packets and specialist review evidence.
+default_prompt: Produce a bounded source-grounded diagram plan from a repo packet or specialist artifacts. Stop before authoring diagram source, rendering, publishing, issues, PRs, or repo mutation.
+

--- a/adl/tools/skills/repo-diagram-planner/references/diagram-planning-playbook.md
+++ b/adl/tools/skills/repo-diagram-planner/references/diagram-planning-playbook.md
@@ -1,0 +1,49 @@
+# Diagram Planning Playbook
+
+Use this playbook when selecting diagram tasks from CodeBuddy evidence.
+
+## Diagram Family Heuristics
+
+- Use `system_context` when the evidence has top-level docs, user-facing
+  README, or architecture overview surfaces and the audience needs orientation.
+- Use `container_or_component` when architecture review evidence mentions
+  modules, packages, services, components, adapters, tools, or runtime
+  boundaries.
+- Use `workflow` when evidence mentions lifecycle, queue, run, closeout,
+  conductor, planner, review, or issue handoff behavior.
+- Use `sequence` when evidence includes actor-to-system or service-to-service
+  interactions over time.
+- Use `state` when evidence includes issue states, runtime states, lifecycle
+  states, cache states, or long-lived-agent cycles.
+- Use `data_flow` when evidence includes trust boundaries, secrets, redaction,
+  uploads, network calls, external APIs, or customer data movement.
+- Use `dependency_graph` when evidence includes manifests, package managers,
+  module graphs, skill relationships, imports, or dependency review artifacts.
+- Use `responsibility_map` when evidence includes multiple agents, specialists,
+  skills, handoffs, or review-lane ownership.
+
+## Backend Heuristics
+
+- Mermaid: first choice for GitHub issues, PRs, Markdown docs, and lightweight
+  review artifacts.
+- Structurizr DSL: use for C4 families or multiple related architecture views.
+- D2: use for polished system maps or demo visuals when GitHub-native rendering
+  is less important.
+- PlantUML: use for strict UML sequence, component, deployment, or state models.
+- Markdown outline: use when evidence supports a diagram need but not diagram
+  source yet.
+
+## Quality Bar
+
+Good diagram tasks are:
+
+- evidence-bound
+- audience-specific
+- narrow enough for one `diagram-author` run
+- explicit about assumptions and unknowns
+- clear about claims that must not be made
+- honest about renderer expectations
+
+Reject or block tasks that require guessing architecture, security boundaries,
+data flows, deployment topology, or dependency direction from weak evidence.
+

--- a/adl/tools/skills/repo-diagram-planner/references/output-contract.md
+++ b/adl/tools/skills/repo-diagram-planner/references/output-contract.md
@@ -1,0 +1,105 @@
+# Output Contract
+
+The repo diagram planner skill produces a bounded diagram planning artifact for
+CodeBuddy-style multi-agent review. It does not author diagram source or render
+visual assets.
+
+Default artifact path:
+
+```text
+.adl/reviews/<timestamp>-repo-diagram-plan.md
+```
+
+Optional scaffold artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/diagram-plan/
+```
+
+## Required Markdown Sections
+
+### Metadata
+
+Required fields:
+
+- `Skill: repo-diagram-planner`
+- `Target`
+- `Date`
+- `Artifact`
+- `Packet`
+
+### Diagram Tasks
+
+Each task must include:
+
+- task id
+- diagram family
+- suggested backend
+- audience
+- communication goal
+- source evidence paths
+- assumptions
+- unknowns
+- claims not allowed
+- renderer expectation
+- handoff target: `diagram-author`
+
+### Source Evidence Map
+
+List packet-relative or repo-relative evidence paths used to justify each task.
+
+### Family / Backend Rationale
+
+Explain why each diagram family and backend was chosen. Prefer Mermaid for
+GitHub-friendly review surfaces unless the evidence calls for Structurizr, D2,
+PlantUML, or markdown-only planning.
+
+### Assumptions And Unknowns
+
+Separate source-backed structure from assumptions and unknowns.
+
+### Blocked Or Skipped Candidates
+
+Record diagram ideas that were skipped because evidence was insufficient,
+duplicated, or outside scope.
+
+### Validation Performed
+
+List commands and what they proved, or explain why validation was inspect-only.
+
+### Diagram Author Handoff
+
+Give the exact bounded brief that should be handed to `diagram-author` for each
+selected task.
+
+### Residual Risk
+
+Explain skipped sources, missing packet evidence, unexecuted rendering checks, or
+review limits.
+
+## JSON Plan Contract
+
+`scripts/plan_repo_diagrams.py` emits `repo_diagram_plan.json` with:
+
+- `schema`
+- `repo_name`
+- `packet_root`
+- `diagram_tasks`
+- `source_evidence_map`
+- `blocked_or_skipped_candidates`
+- `notes`
+
+It also emits `repo_diagram_plan.md` with the Markdown headings needed by the
+planning artifact.
+
+## Rules
+
+- Use repo-relative or packet-relative paths.
+- Do not write absolute host paths into artifacts.
+- Do not author diagram source or rendered diagram assets.
+- Do not publish diagrams.
+- Do not mutate the reviewed repository.
+- Do not invent architecture, runtime behavior, dependencies, trust boundaries,
+  data flows, or actor responsibilities that are not backed by evidence.
+- Preserve diagram planning tasks even when synthesis has not yet run.
+

--- a/adl/tools/skills/repo-diagram-planner/scripts/plan_repo_diagrams.py
+++ b/adl/tools/skills/repo-diagram-planner/scripts/plan_repo_diagrams.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Plan source-grounded diagram tasks from a CodeBuddy review packet."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from collections import defaultdict
+from pathlib import Path
+
+SCHEMA = "codebuddy.repo_diagram_plan.v1"
+MAX_DEFAULT_TASKS = 8
+
+FAMILY_KEYWORDS = {
+    "system_context": ("readme", "overview", "getting-started", "architecture", "milestone"),
+    "container_or_component": ("architecture", "component", "module", "package", "adapter", "runtime"),
+    "workflow": ("workflow", "lifecycle", "queue", "conductor", "closeout", "planner", "run", "issue"),
+    "sequence": ("api", "provider", "request", "response", "client", "server", "interaction"),
+    "state": ("state", "status", "transition", "cycle", "long-lived", "resume", "pause"),
+    "data_flow": ("security", "secret", "redaction", "privacy", "trust", "upload", "network", "external"),
+    "dependency_graph": ("dependency", "dependencies", "manifest", "lockfile", "package", "import", "skill"),
+    "responsibility_map": ("agent", "specialist", "handoff", "review", "skill", "lane", "synthesis"),
+}
+
+FAMILY_BACKENDS = {
+    "system_context": "mermaid",
+    "container_or_component": "structurizr",
+    "workflow": "mermaid",
+    "sequence": "plantuml",
+    "state": "mermaid",
+    "data_flow": "mermaid",
+    "dependency_graph": "mermaid",
+    "responsibility_map": "mermaid",
+}
+
+FAMILY_GOALS = {
+    "system_context": "Orient reviewers to the repo boundary, users, adjacent systems, and primary review scope.",
+    "container_or_component": "Clarify architecture boundaries and component responsibilities before diagram authoring.",
+    "workflow": "Explain a lifecycle or process path with source-backed steps and handoffs.",
+    "sequence": "Show time-ordered actor or service interaction only where evidence supports the messages.",
+    "state": "Clarify lifecycle states, transitions, and terminal conditions.",
+    "data_flow": "Map data movement and trust-boundary questions for a later source-grounded diagram.",
+    "dependency_graph": "Map dependency or skill relationships without asserting unsupported direction.",
+    "responsibility_map": "Clarify specialist, agent, or skill ownership and handoff boundaries.",
+}
+
+FAMILY_AUDIENCE = {
+    "system_context": "reviewers and maintainers",
+    "container_or_component": "architecture reviewers",
+    "workflow": "operators and reviewers",
+    "sequence": "implementation reviewers",
+    "state": "runtime and lifecycle reviewers",
+    "data_flow": "security and privacy reviewers",
+    "dependency_graph": "dependency and architecture reviewers",
+    "responsibility_map": "multi-agent review operators",
+}
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def evidence_entries(packet_root: Path) -> list[dict[str, object]]:
+    data = load_json(packet_root / "evidence_index.json")
+    if not isinstance(data, dict):
+        return []
+    evidence = data.get("evidence")
+    if not isinstance(evidence, list):
+        return []
+    return [item for item in evidence if isinstance(item, dict)]
+
+
+def evidence_text(entry: dict[str, object]) -> str:
+    parts = [
+        str(entry.get("path", "")),
+        str(entry.get("category", "")),
+        str(entry.get("reason", "")),
+        " ".join(str(lane) for lane in entry.get("specialist_lanes", []) if isinstance(lane, str)),
+    ]
+    return " ".join(parts).lower()
+
+
+def candidate_families(entry: dict[str, object]) -> set[str]:
+    text = evidence_text(entry)
+    families = {
+        family
+        for family, keywords in FAMILY_KEYWORDS.items()
+        if any(keyword in text for keyword in keywords)
+    }
+    lanes = entry.get("specialist_lanes")
+    if isinstance(lanes, list):
+        if "architecture" in lanes:
+            families.add("container_or_component")
+        if "security" in lanes:
+            families.add("data_flow")
+        if "dependency" in lanes or "dependencies" in lanes:
+            families.add("dependency_graph")
+        if "diagrams" in lanes:
+            families.add("system_context")
+    return families
+
+
+def select_evidence_by_family(entries: list[dict[str, object]]) -> dict[str, list[dict[str, object]]]:
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for entry in entries:
+        path = str(entry.get("path", ""))
+        if not path:
+            continue
+        for family in candidate_families(entry):
+            grouped[family].append(entry)
+    return {
+        family: sorted(items, key=lambda item: str(item.get("path", "")))[:10]
+        for family, items in sorted(grouped.items())
+    }
+
+
+def task_id(index: int, family: str) -> str:
+    return f"diagram-{index:02d}-{family.replace('_', '-')}"
+
+
+def build_tasks(grouped: dict[str, list[dict[str, object]]], max_tasks: int) -> list[dict[str, object]]:
+    priority = [
+        "system_context",
+        "container_or_component",
+        "workflow",
+        "state",
+        "data_flow",
+        "dependency_graph",
+        "responsibility_map",
+        "sequence",
+    ]
+    tasks: list[dict[str, object]] = []
+    for family in priority:
+        evidence = grouped.get(family, [])
+        if not evidence:
+            continue
+        index = len(tasks) + 1
+        paths = [str(item.get("path", "")) for item in evidence if str(item.get("path", ""))]
+        tasks.append(
+            {
+                "id": task_id(index, family),
+                "diagram_family": family,
+                "suggested_backend": FAMILY_BACKENDS[family],
+                "audience": FAMILY_AUDIENCE[family],
+                "goal": FAMILY_GOALS[family],
+                "source_evidence": paths,
+                "assumptions": [
+                    "Diagram-author must treat this as a planning brief and verify each relationship before authoring source."
+                ],
+                "unknowns": [
+                    "Exact diagram nodes, edges, labels, and renderer settings are not selected by this planner."
+                ],
+                "claims_not_allowed": [
+                    "Do not claim runtime behavior, dependency direction, trust boundaries, or deployment topology unless a cited source supports it."
+                ],
+                "renderer_expectation": "renderer selected later by diagram-author; no rendered artifact is created by this planner",
+                "handoff": {
+                    "skill": "diagram-author",
+                    "brief": f"Create one source-grounded {family.replace('_', ' ')} diagram from the listed evidence paths. Preserve assumptions and unknowns.",
+                },
+            }
+        )
+        if len(tasks) >= max_tasks:
+            break
+    return tasks
+
+
+def build_evidence_map(tasks: list[dict[str, object]]) -> dict[str, list[str]]:
+    return {
+        str(task["id"]): list(task["source_evidence"])
+        for task in tasks
+    }
+
+
+def build_skipped(grouped: dict[str, list[dict[str, object]]], tasks: list[dict[str, object]]) -> list[dict[str, str]]:
+    selected = {str(task["diagram_family"]) for task in tasks}
+    skipped: list[dict[str, str]] = []
+    for family in sorted(grouped):
+        if family not in selected:
+            skipped.append(
+                {
+                    "diagram_family": family,
+                    "reason": "Candidate evidence exists but max_tasks or priority ordering deferred it.",
+                }
+            )
+    if not grouped:
+        skipped.append(
+            {
+                "diagram_family": "all",
+                "reason": "No source evidence strongly indicated a bounded diagram task.",
+            }
+        )
+    return skipped
+
+
+def task_lines(tasks: list[dict[str, object]]) -> str:
+    if not tasks:
+        return "- No diagram tasks selected."
+    lines: list[str] = []
+    for task in tasks:
+        lines.extend(
+            [
+                f"- {task['id']}: {task['diagram_family']} via {task['suggested_backend']}",
+                f"  Goal: {task['goal']}",
+                f"  Audience: {task['audience']}",
+                f"  Evidence: {', '.join(task['source_evidence'])}",
+                f"  Handoff: {task['handoff']['skill']} - {task['handoff']['brief']}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def evidence_map_lines(evidence_map: dict[str, list[str]]) -> str:
+    if not evidence_map:
+        return "- No evidence map produced."
+    lines: list[str] = []
+    for task, paths in sorted(evidence_map.items()):
+        lines.append(f"- {task}:")
+        for path in paths:
+            lines.append(f"  - {path}")
+    return "\n".join(lines)
+
+
+def skipped_lines(skipped: list[dict[str, str]]) -> str:
+    return "\n".join(f"- {item['diagram_family']}: {item['reason']}" for item in skipped) or "- None."
+
+
+def rationale_lines(tasks: list[dict[str, object]]) -> str:
+    return "\n".join(
+        f"- {task['id']}: {task['diagram_family']} fits the selected evidence; {task['suggested_backend']} is the suggested backend."
+        for task in tasks
+    ) or "- No backend rationale because no tasks were selected."
+
+
+def handoff_lines(tasks: list[dict[str, object]]) -> str:
+    return "\n".join(
+        f"- {task['id']}: Send to `diagram-author` with evidence {', '.join(task['source_evidence'])}."
+        for task in tasks
+    ) or "- No handoff because no tasks were selected."
+
+
+def write_markdown(path: Path, plan: dict[str, object]) -> None:
+    content = f"""# Repo Diagram Plan
+
+## Metadata
+
+- Skill: repo-diagram-planner
+- Repo: {plan["repo_name"]}
+- Packet: {plan["packet_root"]}
+- Date: {plan["created_at"]}
+
+## Diagram Tasks
+
+{task_lines(plan["diagram_tasks"])}
+
+## Source Evidence Map
+
+{evidence_map_lines(plan["source_evidence_map"])}
+
+## Family / Backend Rationale
+
+{rationale_lines(plan["diagram_tasks"])}
+
+## Assumptions And Unknowns
+
+- Planner output is a handoff brief, not diagram source.
+- Diagram-author must verify every node, edge, label, and claim before creating diagram source.
+- Renderer availability is not checked by this planner.
+
+## Blocked Or Skipped Candidates
+
+{skipped_lines(plan["blocked_or_skipped_candidates"])}
+
+## Validation Performed
+
+- Scaffold generation only; no rendering, publication, or repository mutation was performed.
+
+## Diagram Author Handoff
+
+{handoff_lines(plan["diagram_tasks"])}
+
+## Residual Risk
+
+- This plan is only as complete as the packet evidence. Missing specialist artifacts may hide better diagram candidates.
+- No diagram source, SVG, PNG, or other rendered artifact was created by this planner.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet_root", help="CodeBuddy review packet root")
+    parser.add_argument("--out", default=None, help="Diagram plan output root")
+    parser.add_argument("--repo-name", default=None, help="Repo name override")
+    parser.add_argument("--max-tasks", type=int, default=MAX_DEFAULT_TASKS, help="Maximum diagram tasks to emit")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    packet_root = Path(args.packet_root).resolve()
+    if not packet_root.is_dir():
+        raise SystemExit(f"packet root does not exist: {packet_root}")
+    if args.max_tasks < 1:
+        raise SystemExit("--max-tasks must be greater than zero")
+
+    out_root = Path(args.out) if args.out else packet_root / "diagram-plan"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_json(packet_root / "run_manifest.json")
+    repo_name = args.repo_name
+    if repo_name is None and isinstance(manifest, dict):
+        repo_name = str(manifest.get("repo_name", "") or "")
+    repo_name = repo_name or packet_root.name
+
+    entries = sorted(evidence_entries(packet_root), key=lambda item: str(item.get("path", "")))
+    grouped = select_evidence_by_family(entries)
+    tasks = build_tasks(grouped, args.max_tasks)
+    plan = {
+        "schema": SCHEMA,
+        "repo_name": repo_name,
+        "packet_root": packet_root.name,
+        "created_at": now_utc(),
+        "diagram_tasks": tasks,
+        "source_evidence_map": build_evidence_map(tasks),
+        "blocked_or_skipped_candidates": build_skipped(grouped, tasks),
+        "notes": [
+            "Planner output is deterministic except for created_at.",
+            "Paths are packet evidence paths, not absolute host paths.",
+            "This planner does not author diagram source, render diagrams, publish diagrams, or mutate repositories.",
+            "Each selected task must be handed to diagram-author as a separate bounded task.",
+        ],
+    }
+    write_json(out_root / "repo_diagram_plan.json", plan)
+    write_markdown(out_root / "repo_diagram_plan.md", plan)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -28,6 +28,8 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/repo-architecture-review/scripts/prepare_architecture_review.py" ]]
   [[ -f "${root}/skills/repo-dependency-review/SKILL.md" ]]
   [[ -x "${root}/skills/repo-dependency-review/scripts/prepare_dependency_review.py" ]]
+  [[ -f "${root}/skills/repo-diagram-planner/SKILL.md" ]]
+  [[ -x "${root}/skills/repo-diagram-planner/scripts/plan_repo_diagrams.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -50,6 +52,7 @@ assert_skill_bundle() {
   grep -Fq "safety gate, not a reviewer" "${root}/skills/redaction-and-evidence-auditor/SKILL.md"
   grep -Fq "findings-first and source-grounded" "${root}/skills/repo-architecture-review/SKILL.md"
   grep -Fq "dependency and supply-chain surfaces" "${root}/skills/repo-dependency-review/SKILL.md"
+  grep -Fq "without becoming the diagram author" "${root}/skills/repo-diagram-planner/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -72,6 +75,7 @@ assert_skill_bundle() {
     "${root}/skills/redaction-and-evidence-auditor/SKILL.md" \
     "${root}/skills/repo-architecture-review/SKILL.md" \
     "${root}/skills/repo-dependency-review/SKILL.md" \
+    "${root}/skills/repo-diagram-planner/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -96,6 +100,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/redaction-and-evidence-auditor" ]]
 [[ -L "${CODEX_HOME}/skills/repo-architecture-review" ]]
 [[ -L "${CODEX_HOME}/skills/repo-dependency-review" ]]
+[[ -L "${CODEX_HOME}/skills/repo-diagram-planner" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_repo_diagram_planner_skill_contracts.sh
+++ b/adl/tools/test_repo_diagram_planner_skill_contracts.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/repo-diagram-planner/SKILL.md" ]]
+[[ -f "${skills_root}/repo-diagram-planner/adl-skill.yaml" ]]
+[[ -f "${skills_root}/repo-diagram-planner/agents/openai.yaml" ]]
+[[ -f "${skills_root}/repo-diagram-planner/references/diagram-planning-playbook.md" ]]
+[[ -f "${skills_root}/repo-diagram-planner/references/output-contract.md" ]]
+[[ -x "${skills_root}/repo-diagram-planner/scripts/plan_repo_diagrams.py" ]]
+[[ -f "${skills_root}/docs/REPO_DIAGRAM_PLANNER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "repo-diagram-planner"' "${skills_root}/repo-diagram-planner/adl-skill.yaml"
+grep -Fq 'id: "repo_diagram_planner.v1"' "${skills_root}/repo-diagram-planner/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REPO_DIAGRAM_PLANNER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/repo-diagram-planner/adl-skill.yaml"
+grep -Fq "plan_from_review_packet_requires_target.review_packet_path" "${skills_root}/repo-diagram-planner/adl-skill.yaml"
+grep -Fq "Plan diagram work for a repository review without becoming the diagram author" "${skills_root}/repo-diagram-planner/SKILL.md"
+grep -Fq "scripts/plan_repo_diagrams.py" "${skills_root}/repo-diagram-planner/SKILL.md"
+grep -Fq "Do not author diagram source or rendered diagram assets" "${skills_root}/repo-diagram-planner/references/output-contract.md"
+grep -Fq "Schema id: \`repo_diagram_planner.v1\`" "${skills_root}/docs/REPO_DIAGRAM_PLANNER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "repo-diagram-planner" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+packet_root="${tmpdir}/packet"
+plan_root="${tmpdir}/diagram-plan"
+mkdir -p "${packet_root}"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "diagram-planner-contract-test",
+  "repo_name": "example-repo",
+  "publication_allowed": false
+}
+JSON
+cat >"${packet_root}/evidence_index.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.evidence.v1",
+  "evidence": [
+    {
+      "path": "docs/architecture/runtime.md",
+      "category": "architecture_docs",
+      "line_count": 42,
+      "reason": "architecture overview and runtime boundary surface",
+      "specialist_lanes": ["architecture", "docs", "diagrams", "synthesis"]
+    },
+    {
+      "path": "adl/src/execute/state.rs",
+      "category": "code",
+      "line_count": 220,
+      "reason": "runtime state lifecycle implementation",
+      "specialist_lanes": ["architecture", "code", "tests", "diagrams", "synthesis"]
+    },
+    {
+      "path": "adl/tools/skills/repo-review-synthesis/SKILL.md",
+      "category": "docs",
+      "line_count": 90,
+      "reason": "multi-agent specialist handoff and synthesis lane",
+      "specialist_lanes": ["docs", "diagrams", "synthesis"]
+    },
+    {
+      "path": "Cargo.toml",
+      "category": "manifest",
+      "line_count": 60,
+      "reason": "dependency manifest",
+      "specialist_lanes": ["dependency", "diagrams", "synthesis"]
+    },
+    {
+      "path": "README.md",
+      "category": "docs",
+      "line_count": 20,
+      "reason": "onboarding surface",
+      "specialist_lanes": ["docs", "synthesis"]
+    }
+  ]
+}
+JSON
+
+python3 "${skills_root}/repo-diagram-planner/scripts/plan_repo_diagrams.py" \
+  "${packet_root}" --out "${plan_root}" --max-tasks 4 >/tmp/repo-diagram-planner.out
+[[ -f "${plan_root}/repo_diagram_plan.json" ]]
+[[ -f "${plan_root}/repo_diagram_plan.md" ]]
+grep -Fq '"schema": "codebuddy.repo_diagram_plan.v1"' "${plan_root}/repo_diagram_plan.json"
+grep -Fq '"repo_name": "example-repo"' "${plan_root}/repo_diagram_plan.json"
+grep -Fq '"diagram_family": "system_context"' "${plan_root}/repo_diagram_plan.json"
+grep -Fq '"diagram_family": "container_or_component"' "${plan_root}/repo_diagram_plan.json"
+grep -Fq '"skill": "diagram-author"' "${plan_root}/repo_diagram_plan.json"
+grep -Fq 'Diagram Tasks' "${plan_root}/repo_diagram_plan.md"
+grep -Fq 'Source Evidence Map' "${plan_root}/repo_diagram_plan.md"
+grep -Fq 'Family / Backend Rationale' "${plan_root}/repo_diagram_plan.md"
+grep -Fq 'Diagram Author Handoff' "${plan_root}/repo_diagram_plan.md"
+if grep -R "${tmpdir}" "${plan_root}" >/dev/null; then
+  echo "diagram planner output should not leak absolute temp paths" >&2
+  exit 1
+fi
+if grep -R '```mermaid\|@startuml\|<svg\|\.png' "${plan_root}" >/dev/null; then
+  echo "diagram planner should not author diagram source or rendered assets" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/repo-diagram-planner/SKILL.md"
+
+echo "PASS test_repo_diagram_planner_skill_contracts"


### PR DESCRIPTION
Closes #2067

## Summary
Implemented the `repo-diagram-planner` CodeBuddy support skill. The skill plans
source-grounded diagram tasks from CodeBuddy packet evidence and specialist
review artifacts, emits bounded handoff briefs for `diagram-author`, and
explicitly stops before diagram source authoring, rendering, publishing, issue
creation, PR creation, or repository mutation.

## Artifacts
- `adl/tools/skills/repo-diagram-planner/SKILL.md`
- `adl/tools/skills/repo-diagram-planner/adl-skill.yaml`
- `adl/tools/skills/repo-diagram-planner/agents/openai.yaml`
- `adl/tools/skills/repo-diagram-planner/references/output-contract.md`
- `adl/tools/skills/repo-diagram-planner/references/diagram-planning-playbook.md`
- `adl/tools/skills/repo-diagram-planner/scripts/plan_repo_diagrams.py`
- `adl/tools/skills/docs/REPO_DIAGRAM_PLANNER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_repo_diagram_planner_skill_contracts.sh`
- Updated `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
- Updated `adl/tools/test_install_adl_operational_skills.sh`
- Updated `adl/tools/batched_checks.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_repo_diagram_planner_skill_contracts.sh`: verifies the
    new skill bundle, ADL metadata, planning helper behavior, generated plan
    sections, no absolute temp path leakage, no diagram-source emission, and
    frontmatter validity.
  - `bash adl/tools/test_install_adl_operational_skills.sh`: verifies the
    operational skill installer installs the new skill in copy and symlink modes.
  - `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile adl/tools/skills/repo-diagram-planner/scripts/plan_repo_diagrams.py`: verifies helper syntax.
  - `bash -n adl/tools/test_repo_diagram_planner_skill_contracts.sh adl/tools/test_install_adl_operational_skills.sh adl/tools/batched_checks.sh`: verifies shell syntax for changed validation scripts.
  - `git diff --check`: verifies whitespace cleanliness.
  - `bash adl/tools/batched_checks.sh`: verifies the repository batched gates,
    including skill contracts, residue guard, `cargo fmt --check`,
    `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2067__backlog-skills-add-repo-diagram-planner-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2067__backlog-skills-add-repo-diagram-planner-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-repo-diagram-planner-skill-adl-tools-skills-repo-diagram-planner-adl-tools-skills-docs-repo-diagram-planner-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-repo-diagram-planner-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2067-backlog-skills-add-repo-diagram-planner-skill-sip-md-adl-v0-90-tasks-issue-2067-backlog-skills-add-repo-diagram-planner-skill-sor-md