### PR TITLE
[v0.90][backlog][skills] Add architecture diagram reviewer skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -42,6 +42,7 @@ run_step "redaction-and-evidence-auditor contract check" bash "$ROOT/adl/tools/t
 run_step "repo-architecture-review contract check" bash "$ROOT/adl/tools/test_repo_architecture_review_skill_contracts.sh"
 run_step "repo-dependency-review contract check" bash "$ROOT/adl/tools/test_repo_dependency_review_skill_contracts.sh"
 run_step "repo-diagram-planner contract check" bash "$ROOT/adl/tools/test_repo_diagram_planner_skill_contracts.sh"
+run_step "architecture-diagram-reviewer contract check" bash "$ROOT/adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/architecture-diagram-reviewer/SKILL.md
+++ b/adl/tools/skills/architecture-diagram-reviewer/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: architecture-diagram-reviewer
+description: Review architecture diagram packets for CodeBuddy-style repository reviews against source evidence, diagram plans, architecture findings, assumptions, unknowns, renderer status, labels, nodes, edges, and unsupported claims without authoring diagrams, rendering assets, or mutating repositories.
+---
+
+# Architecture Diagram Reviewer
+
+Review finished or draft architecture diagram packets for truth, completeness,
+and usability. This skill is a quality gate after `diagram-author`, not a
+diagram generation skill.
+
+Use this skill when a CodeBuddy review needs a source-grounded check of diagram
+claims, diagram source, rendered status, labels, assumptions, unknowns, and
+handoff corrections before a diagram is included in a report or customer-facing
+packet.
+
+## Quick Start
+
+1. Confirm the bounded review target:
+   - diagram packet
+   - diagram source directory
+   - rendered artifact directory
+   - CodeBuddy review packet
+   - specialist architecture or diagram plan artifact
+2. Prefer CodeBuddy packet artifacts when available:
+   - `evidence_index.json`
+   - `repo_inventory.json`
+   - `repo_scope.md`
+   - `specialist_assignments.json`
+3. Run the deterministic review helper when local access is available:
+   - `scripts/review_architecture_diagrams.py <packet-root> <diagram-root> --out <artifact-root>`
+4. Inspect the generated scaffold and write findings-first review output.
+5. Hand corrections back to `repo-diagram-planner` or `diagram-author`. Stop
+   before editing diagram source, rendering, publishing, or opening issues.
+
+## Focus
+
+Prioritize:
+
+- unsupported nodes, edges, labels, or claims
+- missing major components that are present in evidence and relevant to the
+  stated diagram goal
+- stale component names, lifecycle names, or backend labels
+- hidden assumptions or unlabeled unknowns
+- unrenderable diagram source or renderer status overclaims
+- visually misleading structure, such as direction arrows that imply unsupported
+  dependency or trust-boundary relationships
+- missing accessibility basics, such as title, caption, legend, and readable
+  labels
+- mismatch between diagram family/backend and intended audience
+
+Defer primary ownership of these areas:
+
+- selecting diagram candidates: `repo-diagram-planner`
+- authoring diagram source or rendering: `diagram-author`
+- architecture findings: `repo-architecture-review`
+- docs truth drift: `repo-review-docs`
+- security trust-boundary findings: `repo-review-security`
+- final report synthesis: `repo-review-synthesis` or a report writer
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `target.diagram_packet_path`
+  - `target.diagram_source_path`
+  - `target.rendered_artifact_path`
+  - `target.review_packet_path`
+
+Useful additional inputs:
+
+- `diagram_plan_path`
+- `architecture_review_artifact`
+- `artifact_root`
+- `audience`
+- `validation_mode`
+- `renderer_status`
+- `expected_diagram_family`
+- `forbidden_claims`
+
+If there is no bounded diagram target, stop and report `blocked`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- diagram packet or source paths reviewed
+- packet evidence consulted
+- diagram family and backend
+- rendered artifacts checked or not checked
+- assumptions and known limits
+
+Do not silently expand a single diagram review into a whole-repo diagram audit.
+
+### 2. Compare Diagram To Evidence
+
+Check whether:
+
+- nodes map to source evidence or are explicitly marked as assumptions
+- edges and arrows are supported by code, docs, architecture review, or diagram
+  plan evidence
+- labels match current repo terms and do not overclaim behavior
+- omitted high-signal components are intentional or documented as out of scope
+- trust boundaries, data flows, and dependency direction are not guessed
+- renderer status is truthful
+
+### 3. Review For Findings
+
+Use this priority scale:
+
+- `P0`: diagram can cause unsafe operational, security, or customer-facing
+  misunderstanding in a high-risk context
+- `P1`: diagram materially misrepresents architecture, lifecycle, trust
+  boundary, dependency direction, or rendered status
+- `P2`: diagram omits important evidence, uses stale labels, or hides
+  assumptions likely to mislead reviewers
+- `P3`: useful diagram quality issue with bounded correction value
+
+Each finding should include:
+
+- affected diagram file or rendered artifact
+- unsupported or missing claim
+- source evidence
+- impact
+- recommended follow-up owner
+
+### 4. Emit Corrections
+
+Recommend bounded corrections, but do not perform them:
+
+- update diagram plan: `repo-diagram-planner`
+- revise diagram source or render: `diagram-author`
+- re-check architecture evidence: `repo-architecture-review`
+- re-check trust-boundary claim: `repo-review-security`
+
+## Output Expectations
+
+Default output should include:
+
+- findings first
+- reviewed diagrams
+- evidence coverage map
+- unsupported claim checks
+- missing component checks
+- renderer status checks
+- accessibility and readability notes
+- correction handoffs
+- validation performed or not run
+- residual diagram risk
+
+Use `references/output-contract.md` and the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`.
+
+## Stop Boundary
+
+Stop after producing the diagram review artifact.
+
+Do not:
+
+- author or edit Mermaid, D2, PlantUML, Structurizr, SVG, PNG, or raster assets
+- render diagrams
+- publish diagrams
+- mutate customer repositories
+- create issues or PRs
+- replace `diagram-author`, `repo-diagram-planner`, architecture review, security
+  review, docs review, or synthesis
+- claim the diagram is correct unless source evidence and renderer status were
+  actually checked
+
+## CodeBuddy Integration Notes
+
+This skill consumes CodeBuddy packet artifacts, diagram plans, and diagram
+packets. It produces a specialist diagram review artifact that can feed report
+writing, synthesis, or a bounded `diagram-author` correction pass.
+
+Deferred automation:
+
+- Diagram source parsing by backend.
+- Rendered SVG/PNG visual inspection and accessibility scoring.
+- Direct comparison with `repo-diagram-planner` task ids.
+- Optional renderer dry-run delegation through `diagram-author`.
+

--- a/adl/tools/skills/architecture-diagram-reviewer/adl-skill.yaml
+++ b/adl/tools/skills/architecture-diagram-reviewer/adl-skill.yaml
@@ -1,0 +1,100 @@
+version: "0.1"
+kind: "adl-skill"
+id: "architecture-diagram-reviewer"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "architecture_diagram_reviewer.v1"
+    reference_doc: "../docs/ARCHITECTURE_DIAGRAM_REVIEWER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "review_diagram_packet"
+      - "review_diagram_source"
+      - "review_rendered_artifacts"
+      - "review_diagram_against_packet"
+    policy_fields:
+      - "audience"
+      - "validation_mode"
+      - "renderer_status_required"
+      - "write_review_artifact"
+      - "stop_after_review"
+  intent:
+    - "architecture_diagram_review"
+    - "diagram_truth_review"
+    - "diagram_evidence_review"
+    - "codebuddy_review_engine"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "diagram_packet_path"
+    - "diagram_source_path"
+    - "rendered_artifact_path"
+    - "review_packet_path"
+    - "diagram_plan_path"
+    - "architecture_review_artifact"
+    - "artifact_root"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_architecture_diagram_reviewer.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.stop_after_review_must_be_true"
+    - "review_diagram_against_packet_requires_target.review_packet_path"
+execution:
+  mode: "review_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_validation_when_bounded"
+  permitted_scripts:
+    - path: "scripts/review_architecture_diagrams.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<packet-root>"
+        - "<diagram-root>"
+        - "--out <artifact-root>"
+        - "--repo-name <name>"
+  preferred_read_order:
+    - "diagram_packet"
+    - "diagram_source"
+    - "render_manifest"
+    - "repo_scope.md"
+    - "evidence_index.json"
+    - "repo_inventory.json"
+    - "diagram_plan_artifact"
+    - "architecture_review_artifact"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-architecture-diagram-review.md"
+  required_sections:
+    - "findings"
+    - "reviewed_diagrams"
+    - "evidence_coverage_map"
+    - "unsupported_claim_checks"
+    - "missing_component_checks"
+    - "renderer_status_checks"
+    - "accessibility_readability_notes"
+    - "correction_handoffs"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: true
+
+display_name: Architecture Diagram Reviewer
+short_description: Review architecture diagrams against source evidence, assumptions, and renderer truth
+default_prompt: Review a bounded architecture diagram packet against source evidence. Stop after findings and correction handoffs; do not author, render, publish, create issues, or mutate the repo.
+

--- a/adl/tools/skills/architecture-diagram-reviewer/agents/openai.yaml
+++ b/adl/tools/skills/architecture-diagram-reviewer/agents/openai.yaml
@@ -1,0 +1,5 @@
+name: architecture-diagram-reviewer
+display_name: Architecture Diagram Reviewer
+short_description: Review architecture diagrams against source evidence, assumptions, and renderer truth.
+default_prompt: Review a bounded architecture diagram packet against source evidence. Stop after findings and correction handoffs; do not author, render, publish, create issues, or mutate the repo.
+

--- a/adl/tools/skills/architecture-diagram-reviewer/references/diagram-review-playbook.md
+++ b/adl/tools/skills/architecture-diagram-reviewer/references/diagram-review-playbook.md
@@ -1,0 +1,35 @@
+# Diagram Review Playbook
+
+Use this playbook when reviewing architecture diagram packets.
+
+## High-Signal Checks
+
+- Does each node map to a source-backed component, actor, module, external
+  system, or explicitly labeled assumption?
+- Does each edge or arrow have evidence for direction, ordering, dependency,
+  control flow, data flow, or trust-boundary meaning?
+- Does the diagram omit a major component that appears in the evidence and is
+  relevant to the diagram goal?
+- Are unknowns, non-goals, and excluded surfaces visible?
+- Does the diagram use current repo names rather than stale issue or milestone
+  labels?
+- Does renderer status match the actual artifacts present?
+- Are title, caption, legend, and labels readable for the target audience?
+
+## Backend-Specific Hints
+
+- Mermaid: check GitHub readability, concise labels, and no overloaded arrows.
+- D2: check presentation polish without adding unsupported decorative structure.
+- PlantUML: check formal sequence/component/state semantics against evidence.
+- Structurizr: check C4 levels, model consistency, and view boundaries.
+- SVG/PNG: check that rendered artifacts exist only when renderer status claims
+  they exist.
+
+## Correction Ownership
+
+- Planning mismatch: send back to `repo-diagram-planner`.
+- Diagram source or render issue: send back to `diagram-author`.
+- Architecture truth issue: send back to `repo-architecture-review`.
+- Trust-boundary or data-flow issue: send back to `repo-review-security`.
+- Docs mismatch: send back to `repo-review-docs`.
+

--- a/adl/tools/skills/architecture-diagram-reviewer/references/output-contract.md
+++ b/adl/tools/skills/architecture-diagram-reviewer/references/output-contract.md
@@ -1,0 +1,121 @@
+# Output Contract
+
+The architecture diagram reviewer skill produces a specialist diagram review
+artifact for CodeBuddy-style repository review. It does not author diagram
+source or render visual assets.
+
+Default artifact path:
+
+```text
+.adl/reviews/<timestamp>-architecture-diagram-review.md
+```
+
+Optional scaffold artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/architecture-diagram-review/
+```
+
+## Required Markdown Sections
+
+### Metadata
+
+Required fields:
+
+- `Skill: architecture-diagram-reviewer`
+- `Target`
+- `Date`
+- `Artifact`
+- `Packet`
+
+### Findings
+
+Findings must come first after metadata.
+
+Each finding must include:
+
+- priority
+- title
+- diagram file or artifact
+- role: `architecture-diagram`
+- scenario
+- unsupported, stale, missing, or unrenderable claim
+- evidence
+- impact
+- recommended follow-up owner
+
+If no material findings are found, state that explicitly and include residual
+risk.
+
+### Reviewed Diagrams
+
+List bounded diagram source files, packets, or rendered artifacts reviewed.
+
+### Evidence Coverage Map
+
+Map diagram files to source evidence paths. Use packet-relative or repo-relative
+paths.
+
+### Unsupported Claim Checks
+
+Record any nodes, edges, labels, trust boundaries, data flows, lifecycle steps,
+or dependencies that lack source evidence.
+
+### Missing Component Checks
+
+Record high-signal evidence surfaces that may need representation or explicit
+out-of-scope notes.
+
+### Renderer Status Checks
+
+Record whether source, SVG, PNG, or other rendered artifacts exist. Do not claim
+rendering succeeded unless evidence exists or a render command was run.
+
+### Accessibility And Readability Notes
+
+Check title, caption, legend, label readability, layout clarity, and audience fit.
+
+### Correction Handoffs
+
+List bounded handoffs to `diagram-author`, `repo-diagram-planner`,
+`repo-architecture-review`, or other specialists.
+
+### Validation Performed
+
+List commands and what they proved, or explain why validation was inspect-only.
+
+### Residual Risk
+
+Explain skipped sources, unparsed diagram syntax, missing rendered assets, or
+review limits.
+
+## JSON Scaffold Contract
+
+`scripts/review_architecture_diagrams.py` emits
+`architecture_diagram_review_scaffold.json` with:
+
+- `schema`
+- `repo_name`
+- `packet_root`
+- `diagram_root`
+- `reviewed_diagrams`
+- `evidence_coverage_map`
+- `unsupported_claim_checks`
+- `missing_component_checks`
+- `renderer_status_checks`
+- `correction_handoffs`
+- `notes`
+
+It also emits `architecture_diagram_review_scaffold.md` with the Markdown
+headings needed by the specialist review artifact.
+
+## Rules
+
+- Use repo-relative or packet-relative paths.
+- Do not write absolute host paths into artifacts.
+- Do not author or edit diagram source.
+- Do not render diagrams.
+- Do not publish diagrams.
+- Do not mutate the reviewed repository.
+- Do not claim diagram correctness without source evidence.
+

--- a/adl/tools/skills/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py
+++ b/adl/tools/skills/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Prepare deterministic scaffolding for architecture diagram review."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from pathlib import Path
+
+SCHEMA = "codebuddy.architecture_diagram_review.scaffold.v1"
+DIAGRAM_EXTENSIONS = {".mmd", ".mermaid", ".d2", ".puml", ".plantuml", ".dsl", ".md"}
+RENDERED_EXTENSIONS = {".svg", ".png", ".jpg", ".jpeg", ".pdf"}
+ARCHITECTURE_TERMS = (
+    "architecture",
+    "component",
+    "container",
+    "runtime",
+    "workflow",
+    "state",
+    "lifecycle",
+    "boundary",
+    "diagram",
+    "skill",
+    "agent",
+    "dependency",
+    "security",
+)
+UNSUPPORTED_MARKERS = (
+    "unsupported",
+    "todo-evidence",
+    "needs evidence",
+    "invented",
+    "guess",
+)
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def relative_to_root(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def evidence_entries(packet_root: Path) -> list[dict[str, object]]:
+    data = load_json(packet_root / "evidence_index.json")
+    if not isinstance(data, dict):
+        return []
+    evidence = data.get("evidence")
+    if not isinstance(evidence, list):
+        return []
+    return [item for item in evidence if isinstance(item, dict)]
+
+
+def architecture_evidence(entries: list[dict[str, object]]) -> list[dict[str, object]]:
+    selected: list[dict[str, object]] = []
+    for entry in entries:
+        text = " ".join(
+            [
+                str(entry.get("path", "")),
+                str(entry.get("category", "")),
+                str(entry.get("reason", "")),
+                " ".join(str(lane) for lane in entry.get("specialist_lanes", []) if isinstance(lane, str)),
+            ]
+        ).lower()
+        if any(term in text for term in ARCHITECTURE_TERMS):
+            selected.append(entry)
+    return sorted(selected, key=lambda item: str(item.get("path", "")))[:60]
+
+
+def diagram_files(diagram_root: Path) -> list[Path]:
+    if diagram_root.is_file():
+        return [diagram_root] if diagram_root.suffix.lower() in DIAGRAM_EXTENSIONS | RENDERED_EXTENSIONS else []
+    files: list[Path] = []
+    for path in diagram_root.rglob("*"):
+        if path.is_file() and path.suffix.lower() in DIAGRAM_EXTENSIONS | RENDERED_EXTENSIONS:
+            files.append(path)
+    return sorted(files, key=lambda item: item.as_posix())
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def tokenize_evidence(entries: list[dict[str, object]]) -> set[str]:
+    tokens: set[str] = set()
+    for entry in entries:
+        for value in (entry.get("path", ""), entry.get("reason", ""), entry.get("category", "")):
+            for token in re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", str(value).lower()):
+                tokens.add(token)
+    return tokens
+
+
+def diagram_claim_tokens(text: str) -> set[str]:
+    ignored = {
+        "graph",
+        "flowchart",
+        "sequenceDiagram",
+        "participant",
+        "classDiagram",
+        "stateDiagram",
+        "direction",
+        "subgraph",
+        "style",
+        "title",
+        "note",
+    }
+    tokens = {
+        token.lower()
+        for token in re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", text)
+        if token not in ignored
+    }
+    return {token for token in tokens if not token.startswith("http")}
+
+
+def unsupported_claim_checks(root: Path, diagrams: list[Path], evidence_tokens: set[str]) -> list[dict[str, str]]:
+    checks: list[dict[str, str]] = []
+    for diagram in diagrams:
+        if diagram.suffix.lower() in RENDERED_EXTENSIONS:
+            continue
+        text = read_text(diagram)
+        lowered = text.lower()
+        if any(marker in lowered for marker in UNSUPPORTED_MARKERS):
+            checks.append(
+                {
+                    "diagram": relative_to_root(root, diagram),
+                    "claim": "source contains an explicit unsupported/evidence marker",
+                    "severity": "review_required",
+                    "handoff": "diagram-author",
+                }
+            )
+        candidate_tokens = sorted(diagram_claim_tokens(text) - evidence_tokens)
+        filtered = [token for token in candidate_tokens if token not in {"mermaid", "plantuml", "structurizr"}]
+        if filtered:
+            checks.append(
+                {
+                    "diagram": relative_to_root(root, diagram),
+                    "claim": ", ".join(filtered[:12]),
+                    "severity": "needs_evidence_check",
+                    "handoff": "diagram-author",
+                }
+            )
+    return checks[:20]
+
+
+def missing_component_checks(entries: list[dict[str, object]], diagrams: list[Path]) -> list[dict[str, str]]:
+    diagram_text = "\n".join(read_text(path).lower() for path in diagrams if path.suffix.lower() not in RENDERED_EXTENSIONS)
+    checks: list[dict[str, str]] = []
+    for entry in entries[:20]:
+        path = str(entry.get("path", ""))
+        if not path:
+            continue
+        stem = Path(path).stem.lower()
+        if stem and stem not in diagram_text:
+            checks.append(
+                {
+                    "evidence": path,
+                    "check": "high-signal evidence surface may be omitted or needs explicit out-of-scope note",
+                    "handoff": "repo-diagram-planner",
+                }
+            )
+    return checks[:12]
+
+
+def renderer_status(root: Path, diagrams: list[Path]) -> list[dict[str, str]]:
+    statuses: list[dict[str, str]] = []
+    by_stem: dict[str, set[str]] = {}
+    for diagram in diagrams:
+        by_stem.setdefault(diagram.stem, set()).add(diagram.suffix.lower())
+    for stem, suffixes in sorted(by_stem.items()):
+        source_exts = sorted(suffixes & DIAGRAM_EXTENSIONS)
+        rendered_exts = sorted(suffixes & RENDERED_EXTENSIONS)
+        statuses.append(
+            {
+                "diagram": stem,
+                "source": ",".join(source_exts) if source_exts else "missing",
+                "rendered": ",".join(rendered_exts) if rendered_exts else "missing",
+                "status": "rendered_present" if rendered_exts else "source_only",
+            }
+        )
+    if not statuses:
+        statuses.append(
+            {
+                "diagram": "none",
+                "source": "missing",
+                "rendered": "missing",
+                "status": "blocked_no_diagram_files",
+            }
+        )
+    return statuses
+
+
+def correction_handoffs(unsupported: list[dict[str, str]], missing: list[dict[str, str]]) -> list[dict[str, str]]:
+    handoffs: list[dict[str, str]] = []
+    if unsupported:
+        handoffs.append(
+            {
+                "skill": "diagram-author",
+                "reason": "Diagram source has unsupported or evidence-uncertain claims that need bounded source correction.",
+            }
+        )
+    if missing:
+        handoffs.append(
+            {
+                "skill": "repo-diagram-planner",
+                "reason": "Diagram plan may need to include or explicitly exclude high-signal evidence surfaces.",
+            }
+        )
+    if not handoffs:
+        handoffs.append(
+            {
+                "skill": "repo-review-synthesis",
+                "reason": "No scaffold-level correction handoff was generated; synthesis may consume the review artifact.",
+            }
+        )
+    return handoffs
+
+
+def lines(items: list[dict[str, str]], keys: tuple[str, ...]) -> str:
+    if not items:
+        return "- None."
+    rendered: list[str] = []
+    for item in items:
+        rendered.append("- " + "; ".join(f"{key}: {item.get(key, '')}" for key in keys))
+    return "\n".join(rendered)
+
+
+def write_markdown(path: Path, scaffold: dict[str, object]) -> None:
+    reviewed = scaffold["reviewed_diagrams"]
+    reviewed_lines = "\n".join(f"- {item}" for item in reviewed) or "- No diagram files found."
+    evidence_map = scaffold["evidence_coverage_map"]
+    evidence_lines = "\n".join(
+        f"- {diagram}: {', '.join(paths)}" for diagram, paths in sorted(evidence_map.items())
+    ) or "- No evidence map generated."
+    content = f"""# Architecture Diagram Review Scaffold
+
+## Metadata
+
+- Skill: architecture-diagram-reviewer
+- Repo: {scaffold["repo_name"]}
+- Packet: {scaffold["packet_root"]}
+- Diagram Root: {scaffold["diagram_root"]}
+- Date: {scaffold["created_at"]}
+
+## Findings
+
+- No findings have been written yet. Replace this section with findings-first diagram review output after inspection.
+
+## Reviewed Diagrams
+
+{reviewed_lines}
+
+## Evidence Coverage Map
+
+{evidence_lines}
+
+## Unsupported Claim Checks
+
+{lines(scaffold["unsupported_claim_checks"], ("diagram", "claim", "severity", "handoff"))}
+
+## Missing Component Checks
+
+{lines(scaffold["missing_component_checks"], ("evidence", "check", "handoff"))}
+
+## Renderer Status Checks
+
+{lines(scaffold["renderer_status_checks"], ("diagram", "source", "rendered", "status"))}
+
+## Accessibility And Readability Notes
+
+- Scaffold does not perform visual inspection. Reviewer should check title, caption, legend, label length, contrast, and audience fit.
+
+## Correction Handoffs
+
+{lines(scaffold["correction_handoffs"], ("skill", "reason"))}
+
+## Validation Performed
+
+- Scaffold generation only; no rendering, publication, or repository mutation was performed.
+
+## Residual Risk
+
+- Source parsing is heuristic and does not prove diagram correctness.
+- Rendered visual quality was not inspected by this helper.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet_root", help="CodeBuddy review packet root")
+    parser.add_argument("diagram_root", help="Diagram packet, diagram source file, or rendered artifact root")
+    parser.add_argument("--out", default=None, help="Architecture diagram review scaffold output root")
+    parser.add_argument("--repo-name", default=None, help="Repo name override")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    packet_root = Path(args.packet_root).resolve()
+    diagram_root = Path(args.diagram_root).resolve()
+    if not packet_root.is_dir():
+        raise SystemExit(f"packet root does not exist: {packet_root}")
+    if not diagram_root.exists():
+        raise SystemExit(f"diagram root does not exist: {diagram_root}")
+
+    out_root = Path(args.out) if args.out else packet_root / "architecture-diagram-review"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_json(packet_root / "run_manifest.json")
+    repo_name = args.repo_name
+    if repo_name is None and isinstance(manifest, dict):
+        repo_name = str(manifest.get("repo_name", "") or "")
+    repo_name = repo_name or packet_root.name
+
+    evidence = architecture_evidence(evidence_entries(packet_root))
+    diagrams = diagram_files(diagram_root)
+    evidence_tokens = tokenize_evidence(evidence)
+    unsupported = unsupported_claim_checks(diagram_root, diagrams, evidence_tokens)
+    missing = missing_component_checks(evidence, diagrams)
+    reviewed = [relative_to_root(diagram_root, path) for path in diagrams]
+    evidence_paths = [str(entry.get("path", "")) for entry in evidence if str(entry.get("path", ""))]
+    scaffold = {
+        "schema": SCHEMA,
+        "repo_name": repo_name,
+        "packet_root": packet_root.name,
+        "diagram_root": diagram_root.name,
+        "created_at": now_utc(),
+        "reviewed_diagrams": reviewed,
+        "evidence_coverage_map": {diagram: evidence_paths[:12] for diagram in reviewed},
+        "unsupported_claim_checks": unsupported,
+        "missing_component_checks": missing,
+        "renderer_status_checks": renderer_status(diagram_root, diagrams),
+        "correction_handoffs": correction_handoffs(unsupported, missing),
+        "notes": [
+            "Scaffold is deterministic except for created_at.",
+            "Paths are packet-relative or diagram-root-relative, not absolute host paths.",
+            "Helper does not author, edit, render, publish, or mutate diagrams.",
+        ],
+    }
+    write_json(out_root / "architecture_diagram_review_scaffold.json", scaffold)
+    write_markdown(out_root / "architecture_diagram_review_scaffold.md", scaffold)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/skills/docs/ARCHITECTURE_DIAGRAM_REVIEWER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/ARCHITECTURE_DIAGRAM_REVIEWER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,71 @@
+# Architecture Diagram Reviewer Skill Input Schema
+
+Schema id: `architecture_diagram_reviewer.v1`
+
+This schema describes structured input accepted by the
+`architecture-diagram-reviewer` skill. It is bounded so CodeBuddy can check
+diagram truth and quality without authoring diagrams, rendering assets,
+publishing, or mutating customer repositories.
+
+## Required Shape
+
+```yaml
+skill_input_schema: architecture_diagram_reviewer.v1
+mode: review_diagram_packet | review_diagram_source | review_rendered_artifacts | review_diagram_against_packet
+repo_root: /absolute/path
+target:
+  diagram_packet_path: <path or null>
+  diagram_source_path: <path or null>
+  rendered_artifact_path: <path or null>
+  review_packet_path: <path or null>
+  diagram_plan_path: <path or null>
+  architecture_review_artifact: <path or null>
+  artifact_root: <path or null>
+policy:
+  audience: reviewers | maintainers | operators | users | mixed
+  validation_mode: targeted | inspect_only | none
+  renderer_status_required: true | false
+  write_review_artifact: true | false
+  stop_after_review: true
+```
+
+## Required Fields
+
+- `skill_input_schema` must equal `architecture_diagram_reviewer.v1`.
+- `mode` must be one of the supported review modes.
+- `repo_root` must be absolute.
+- `target` must identify one bounded diagram packet, diagram source, rendered
+  artifact, or review packet target.
+- `policy.stop_after_review` must be `true`.
+- `mode: review_diagram_against_packet` requires `target.review_packet_path`.
+
+## Output Contract
+
+The skill writes or returns a findings-first diagram review artifact with:
+
+- findings
+- reviewed diagrams
+- evidence coverage map
+- unsupported claim checks
+- missing component checks
+- renderer status checks
+- accessibility and readability notes
+- correction handoffs
+- validation performed
+- residual risk
+
+The skill may also generate deterministic scaffolding with
+`scripts/review_architecture_diagrams.py`.
+
+## Stop Boundary
+
+The skill must not:
+
+- author or edit Mermaid, D2, PlantUML, Structurizr, SVG, PNG, or raster assets
+- render diagrams
+- publish diagrams
+- mutate the reviewed repository
+- create issues or PRs
+- replace `diagram-author`, `repo-diagram-planner`, or specialist review skills
+- claim diagram correctness without source evidence and renderer truth
+

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -19,6 +19,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `repo-architecture-review`
 - `repo-dependency-review`
 - `repo-diagram-planner`
+- `architecture-diagram-reviewer`
 - `repo-review-synthesis`
 
 ## Invocation Order
@@ -33,6 +34,7 @@ Recommended order:
 6. `repo-dependency-review`
 7. `repo-review-synthesis`
 8. `repo-diagram-planner`
+9. `architecture-diagram-reviewer`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -40,6 +42,10 @@ available, and ideally after all required roles have reported.
 The diagram planner should normally run after packet building and after the
 specialist artifacts that may propose diagram work. It emits bounded task briefs
 for `diagram-author`; it is not itself a review or diagram-authoring lane.
+The architecture diagram reviewer should run after `diagram-author` has produced
+a diagram packet or source set. It is a source-grounded quality gate that checks
+diagram truth, renderability evidence, assumptions, unknowns, and correction
+handoffs without authoring or rendering diagrams.
 
 ## Shared Specialist Input Shape
 
@@ -210,6 +216,28 @@ policy:
   stop_after_plan: true
 ```
 
+## Architecture Diagram Review Input Shape
+
+```yaml
+skill_input_schema: architecture_diagram_reviewer.v1
+mode: review_diagram_packet | review_diagram_sources | review_rendered_artifacts | review_revision
+repo_root: /absolute/path
+target:
+  review_packet_path: <path or null>
+  diagram_packet_path: <path or null>
+  diagram_sources:
+    - <path>
+  rendered_artifacts:
+    - <path>
+  artifact_root: <path or null>
+policy:
+  evidence_required: true
+  render_status_required: true
+  correction_handoff: diagram_planner | diagram_author | both | none
+  write_review_artifact: true | false
+  stop_after_review: true
+```
+
 ## Severity Rules
 
 - Preserve the highest severity attached to a merged finding unless the source
@@ -234,10 +262,15 @@ The suite may:
 - write review artifacts under `.adl/reviews`
 - recommend follow-up issues
 - plan bounded diagram tasks for `diagram-author`
+- review diagram packets and rendered artifact metadata for source-grounded
+  truth, missing major components, unsupported relationships, stale labels,
+  unrenderable sources, and correction handoffs
 
 The suite must not:
 - edit code, tests, docs, configs, or issue state
 - claim merge approval
+- author, edit, render, publish, or replace diagrams from the diagram review
+  lane
 - claim remediation
 - run unbounded repository-wide analysis without a declared target
 - use network or paid data feeds

--- a/adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh
+++ b/adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/architecture-diagram-reviewer/SKILL.md" ]]
+[[ -f "${skills_root}/architecture-diagram-reviewer/adl-skill.yaml" ]]
+[[ -f "${skills_root}/architecture-diagram-reviewer/agents/openai.yaml" ]]
+[[ -f "${skills_root}/architecture-diagram-reviewer/references/diagram-review-playbook.md" ]]
+[[ -f "${skills_root}/architecture-diagram-reviewer/references/output-contract.md" ]]
+[[ -x "${skills_root}/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py" ]]
+[[ -f "${skills_root}/docs/ARCHITECTURE_DIAGRAM_REVIEWER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "architecture-diagram-reviewer"' "${skills_root}/architecture-diagram-reviewer/adl-skill.yaml"
+grep -Fq 'id: "architecture_diagram_reviewer.v1"' "${skills_root}/architecture-diagram-reviewer/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/ARCHITECTURE_DIAGRAM_REVIEWER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/architecture-diagram-reviewer/adl-skill.yaml"
+grep -Fq "review_diagram_against_packet_requires_target.review_packet_path" "${skills_root}/architecture-diagram-reviewer/adl-skill.yaml"
+grep -Fq "quality gate after \`diagram-author\`" "${skills_root}/architecture-diagram-reviewer/SKILL.md"
+grep -Fq "scripts/review_architecture_diagrams.py" "${skills_root}/architecture-diagram-reviewer/SKILL.md"
+grep -Fq "Do not author or edit diagram source" "${skills_root}/architecture-diagram-reviewer/references/output-contract.md"
+grep -Fq "Schema id: \`architecture_diagram_reviewer.v1\`" "${skills_root}/docs/ARCHITECTURE_DIAGRAM_REVIEWER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "architecture-diagram-reviewer" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+packet_root="${tmpdir}/packet"
+diagram_root="${tmpdir}/diagrams"
+review_root="${tmpdir}/diagram-review"
+mkdir -p "${packet_root}" "${diagram_root}"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "architecture-diagram-review-contract-test",
+  "repo_name": "example-repo",
+  "publication_allowed": false
+}
+JSON
+cat >"${packet_root}/evidence_index.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.evidence.v1",
+  "evidence": [
+    {
+      "path": "docs/architecture/runtime.md",
+      "category": "architecture_docs",
+      "line_count": 42,
+      "reason": "runtime architecture boundary surface",
+      "specialist_lanes": ["architecture", "docs", "diagrams", "synthesis"]
+    },
+    {
+      "path": "adl/src/execute/state.rs",
+      "category": "code",
+      "line_count": 220,
+      "reason": "runtime state lifecycle implementation",
+      "specialist_lanes": ["architecture", "code", "tests", "diagrams", "synthesis"]
+    },
+    {
+      "path": "adl/tools/skills/diagram-author/SKILL.md",
+      "category": "docs",
+      "line_count": 120,
+      "reason": "diagram author source-grounded handoff",
+      "specialist_lanes": ["docs", "diagrams", "synthesis"]
+    }
+  ]
+}
+JSON
+cat >"${diagram_root}/runtime.mmd" <<'MMD'
+flowchart TD
+  Runtime["runtime state lifecycle"] --> DiagramAuthor["diagram author"]
+  Runtime --> UnsupportedThing["unsupported-node needs evidence"]
+MMD
+
+python3 "${skills_root}/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py" \
+  "${packet_root}" "${diagram_root}" --out "${review_root}" >/tmp/architecture-diagram-reviewer.out
+[[ -f "${review_root}/architecture_diagram_review_scaffold.json" ]]
+[[ -f "${review_root}/architecture_diagram_review_scaffold.md" ]]
+grep -Fq '"schema": "codebuddy.architecture_diagram_review.scaffold.v1"' "${review_root}/architecture_diagram_review_scaffold.json"
+grep -Fq '"repo_name": "example-repo"' "${review_root}/architecture_diagram_review_scaffold.json"
+grep -Fq 'runtime.mmd' "${review_root}/architecture_diagram_review_scaffold.json"
+grep -Fq 'unsupported/evidence marker' "${review_root}/architecture_diagram_review_scaffold.md"
+grep -Fq 'Renderer Status Checks' "${review_root}/architecture_diagram_review_scaffold.md"
+grep -Fq 'Correction Handoffs' "${review_root}/architecture_diagram_review_scaffold.md"
+if grep -R "${tmpdir}" "${review_root}" >/dev/null; then
+  echo "architecture diagram review scaffold should not leak absolute temp paths" >&2
+  exit 1
+fi
+if find "${review_root}" -name '*.svg' -o -name '*.png' | grep -q .; then
+  echo "architecture diagram reviewer should not render visual assets" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/architecture-diagram-reviewer/SKILL.md"
+
+echo "PASS test_architecture_diagram_reviewer_skill_contracts"
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -30,6 +30,8 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/repo-dependency-review/scripts/prepare_dependency_review.py" ]]
   [[ -f "${root}/skills/repo-diagram-planner/SKILL.md" ]]
   [[ -x "${root}/skills/repo-diagram-planner/scripts/plan_repo_diagrams.py" ]]
+  [[ -f "${root}/skills/architecture-diagram-reviewer/SKILL.md" ]]
+  [[ -x "${root}/skills/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -53,6 +55,7 @@ assert_skill_bundle() {
   grep -Fq "findings-first and source-grounded" "${root}/skills/repo-architecture-review/SKILL.md"
   grep -Fq "dependency and supply-chain surfaces" "${root}/skills/repo-dependency-review/SKILL.md"
   grep -Fq "without becoming the diagram author" "${root}/skills/repo-diagram-planner/SKILL.md"
+  grep -Fq 'quality gate after `diagram-author`' "${root}/skills/architecture-diagram-reviewer/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -76,6 +79,7 @@ assert_skill_bundle() {
     "${root}/skills/repo-architecture-review/SKILL.md" \
     "${root}/skills/repo-dependency-review/SKILL.md" \
     "${root}/skills/repo-diagram-planner/SKILL.md" \
+    "${root}/skills/architecture-diagram-reviewer/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -101,6 +105,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/repo-architecture-review" ]]
 [[ -L "${CODEX_HOME}/skills/repo-dependency-review" ]]
 [[ -L "${CODEX_HOME}/skills/repo-diagram-planner" ]]
+[[ -L "${CODEX_HOME}/skills/architecture-diagram-reviewer" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]


### PR DESCRIPTION
Closes #2063

## Summary
Implemented the `architecture-diagram-reviewer` skill as a CodeBuddy diagram
quality gate that reviews finished or draft diagram packets against source
evidence, renderer status, assumptions, unknowns, and correction handoffs
without authoring, rendering, publishing, mutating repositories, or absorbing
`diagram-author` and `repo-diagram-planner`.

## Artifacts
- `adl/tools/skills/architecture-diagram-reviewer/SKILL.md`
- `adl/tools/skills/architecture-diagram-reviewer/adl-skill.yaml`
- `adl/tools/skills/architecture-diagram-reviewer/agents/openai.yaml`
- `adl/tools/skills/architecture-diagram-reviewer/references/output-contract.md`
- `adl/tools/skills/architecture-diagram-reviewer/references/diagram-review-playbook.md`
- `adl/tools/skills/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py`
- `adl/tools/skills/docs/ARCHITECTURE_DIAGRAM_REVIEWER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh`
- Updates to `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
- Updates to `adl/tools/test_install_adl_operational_skills.sh`
- Updates to `adl/tools/batched_checks.sh`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh adl/tools/test_install_adl_operational_skills.sh adl/tools/batched_checks.sh` checked shell syntax for the new and modified validation scripts.
  - `bash adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh` verified the new skill bundle, ADL metadata, docs, deterministic scaffold helper, no-render boundary, no absolute temp-path leakage, and frontmatter.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified operational skill installation includes `architecture-diagram-reviewer` in copy and symlink modes.
  - `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile adl/tools/skills/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py` verified the Python helper parses.
  - `git diff --check` verified whitespace safety.
  - `bash adl/tools/batched_checks.sh` verified all skill contract checks, residue guard, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2063__backlog-skills-add-architecture-diagram-reviewer-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2063__backlog-skills-add-architecture-diagram-reviewer-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-architecture-diagram-reviewer-skill-adl-tools-skills-architecture-diagram-reviewer-adl-tools-skills-docs-architecture-diagram-reviewer-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-architecture-diagram-reviewer-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2063-backlog-skills-add-architecture-diagram-reviewer-skill-sip-md-adl-v0-90-tasks-issue-2063-backlog-skills-add-architecture-diagram-reviewer-skill-sor-md