### PR TITLE
[v0.90][backlog][skills] Add review-to-test planner skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -43,6 +43,7 @@ run_step "repo-architecture-review contract check" bash "$ROOT/adl/tools/test_re
 run_step "repo-dependency-review contract check" bash "$ROOT/adl/tools/test_repo_dependency_review_skill_contracts.sh"
 run_step "repo-diagram-planner contract check" bash "$ROOT/adl/tools/test_repo_diagram_planner_skill_contracts.sh"
 run_step "architecture-diagram-reviewer contract check" bash "$ROOT/adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh"
+run_step "review-to-test-planner contract check" bash "$ROOT/adl/tools/test_review_to_test_planner_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -20,6 +20,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `repo-dependency-review`
 - `repo-diagram-planner`
 - `architecture-diagram-reviewer`
+- `review-to-test-planner`
 - `repo-review-synthesis`
 
 ## Invocation Order
@@ -35,6 +36,7 @@ Recommended order:
 7. `repo-review-synthesis`
 8. `repo-diagram-planner`
 9. `architecture-diagram-reviewer`
+10. `review-to-test-planner`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -46,6 +48,9 @@ The architecture diagram reviewer should run after `diagram-author` has produced
 a diagram packet or source set. It is a source-grounded quality gate that checks
 diagram truth, renderability evidence, assumptions, unknowns, and correction
 handoffs without authoring or rendering diagrams.
+The review-to-test planner should run after specialist findings or synthesis
+exist. It maps findings to safe, bounded `test-generator` handoffs without
+writing tests or turning review follow-up into broad implementation work.
 
 ## Shared Specialist Input Shape
 
@@ -238,6 +243,34 @@ policy:
   stop_after_review: true
 ```
 
+## Review To Test Planning Input Shape
+
+```yaml
+skill_input_schema: review_to_test_planner.v1
+mode: plan_from_review_packet | plan_from_specialist_artifacts | plan_from_synthesis | plan_from_findings_file
+repo_root: /absolute/path
+target:
+  review_packet_path: <path or null>
+  specialist_artifacts:
+    code: <path or null>
+    security: <path or null>
+    tests: <path or null>
+    docs: <path or null>
+    architecture: <path or null>
+    dependency: <path or null>
+    synthesis: <path or null>
+  synthesis_artifact: <path or null>
+  findings_file: <path or null>
+  artifact_root: <path or null>
+policy:
+  test_depth: focused | moderate
+  validation_mode: targeted | inspect_only | none
+  allow_handoff_generation: true | false
+  unsafe_task_policy: mark_unsafe | skip
+  write_plan_artifact: true | false
+  stop_after_plan: true
+```
+
 ## Severity Rules
 
 - Preserve the highest severity attached to a merged finding unless the source
@@ -265,12 +298,16 @@ The suite may:
 - review diagram packets and rendered artifact metadata for source-grounded
   truth, missing major components, unsupported relationships, stale labels,
   unrenderable sources, and correction handoffs
+- plan bounded test-generation handoffs from review findings, including
+  behavior under test, fixture needs, expected assertions, validation commands,
+  and `generated` / `recommended` / `deferred` / `unsafe` status
 
 The suite must not:
 - edit code, tests, docs, configs, or issue state
 - claim merge approval
 - author, edit, render, publish, or replace diagrams from the diagram review
   lane
+- write tests or fixtures from the review-to-test planning lane
 - claim remediation
 - run unbounded repository-wide analysis without a declared target
 - use network or paid data feeds

--- a/adl/tools/skills/docs/REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,79 @@
+# Review To Test Planner Skill Input Schema
+
+Schema id: `review_to_test_planner.v1`
+
+This schema describes structured input accepted by the
+`review-to-test-planner` skill. It is bounded so CodeBuddy can convert review
+findings into test-generation briefs without writing tests, creating issues,
+opening PRs, or mutating customer repositories.
+
+## Required Shape
+
+```yaml
+skill_input_schema: review_to_test_planner.v1
+mode: plan_from_review_packet | plan_from_specialist_artifacts | plan_from_synthesis | plan_from_findings_file
+repo_root: /absolute/path
+target:
+  review_packet_path: <path or null>
+  specialist_artifacts:
+    code: <path or null>
+    security: <path or null>
+    tests: <path or null>
+    docs: <path or null>
+    architecture: <path or null>
+    dependency: <path or null>
+    synthesis: <path or null>
+  synthesis_artifact: <path or null>
+  findings_file: <path or null>
+  artifact_root: <path or null>
+  diff_base: <string or null>
+  changed_paths:
+    - <path>
+policy:
+  test_depth: focused | moderate
+  validation_mode: targeted | inspect_only | none
+  allow_handoff_generation: true | false
+  unsafe_task_policy: mark_unsafe | skip
+  write_plan_artifact: true | false
+  stop_after_plan: true
+```
+
+## Required Fields
+
+- `skill_input_schema` must equal `review_to_test_planner.v1`.
+- `mode` must be one of the supported planning modes.
+- `repo_root` must be absolute.
+- `target` must identify one bounded review packet, specialist artifact set,
+  synthesis artifact, or findings file.
+- `policy.stop_after_plan` must be `true`.
+- `mode: plan_from_review_packet` requires `target.review_packet_path`.
+- `mode: plan_from_findings_file` requires `target.findings_file`.
+
+## Output Contract
+
+The skill writes or returns a planning artifact with:
+
+- findings-to-test map
+- generation-status summary
+- test task briefs
+- fixture and assertion map
+- validation command plan
+- test-generator handoffs
+- deferred and unsafe tasks
+- validation performed
+- residual risk
+
+The skill may also generate deterministic scaffolding with
+`scripts/plan_review_tests.py`.
+
+## Stop Boundary
+
+The skill must not:
+
+- write tests, fixtures, snapshots, or production code
+- mutate the reviewed repository
+- create issues or PRs
+- invoke `test-generator` automatically
+- replace review specialists, synthesis, finding-to-issue planning, or
+  implementation workflow
+- claim tests exist when only planning artifacts were produced

--- a/adl/tools/skills/review-to-test-planner/SKILL.md
+++ b/adl/tools/skills/review-to-test-planner/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: review-to-test-planner
+description: Plan bounded test-generation tasks from CodeBuddy review findings, specialist review artifacts, or review packets by mapping findings to behavior under test, suggested test locations, fixtures, assertions, validation commands, and safe test-generator handoffs without writing tests or mutating repositories.
+---
+
+# Review To Test Planner
+
+Plan follow-up test work from review findings. This skill sits between review
+artifacts and `test-generator`: it translates findings into bounded test briefs,
+but it does not write tests. In short, it is the bridge between review artifacts and `test-generator`.
+
+Use this skill when CodeBuddy or an operator has findings from repo review,
+security review, architecture review, dependency review, docs review, synthesis,
+or third-party review and wants a source-grounded plan for what should be tested
+next.
+
+## Quick Start
+
+1. Confirm the bounded review target:
+   - review packet
+   - specialist artifact directory
+   - synthesis artifact
+   - single review file
+2. Prefer CodeBuddy packet artifacts when available:
+   - `evidence_index.json`
+   - `repo_inventory.json`
+   - `run_manifest.json`
+   - specialist review artifacts
+3. Run the deterministic planner when local access is available:
+   - `scripts/plan_review_tests.py <review-root> --out <artifact-root>`
+4. Inspect the generated plan and tighten any findings that need human judgment.
+5. Hand only safe, concrete tasks to `test-generator`. Stop before writing tests,
+   fixtures, issues, PRs, or customer-repo changes.
+
+## Focus
+
+Prioritize:
+
+- behavior under test, not generic coverage advice
+- the smallest meaningful test target for each finding
+- suggested test location and framework based on source path evidence
+- fixture needs and negative cases
+- expected assertions and validation commands
+- whether the finding is safe for automated test generation
+- explicit `test-generator` handoff blocks for safe tasks
+
+Classify each task with one generation status:
+
+- `generated`: a complete handoff brief already exists and can be passed to
+  `test-generator` without additional planning.
+- `recommended`: enough evidence exists to recommend a bounded test-generation
+  task, but a human/operator should still decide whether to run it.
+- `deferred`: more evidence, implementation context, or product decision is
+  needed before test generation.
+- `unsafe`: automated test generation should not proceed because the task would
+  risk secrets, production systems, destructive behavior, privacy, or unbounded
+  repo mutation.
+
+Defer primary ownership of these areas:
+
+- writing tests or fixtures: `test-generator`
+- identifying original findings: review specialist skills
+- fixing production code: implementation issue workflow
+- creating issues from findings: finding-to-issue planner
+- final synthesis/report writing: synthesis or report writer skills
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `target.review_packet_path`
+  - `target.review_artifact_path`
+  - `target.specialist_artifacts`
+  - `target.findings_file`
+
+Useful additional inputs:
+
+- `artifact_root`
+- `diff_base`
+- `changed_paths`
+- `test_framework_hint`
+- `validation_mode`
+- `generation_policy`
+- `allowed_test_roots`
+- `blocked_test_roots`
+
+If there is no bounded review artifact or finding source, stop and report
+`blocked`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- reviewed artifact paths
+- finding sources considered
+- evidence packet consulted
+- test framework hints
+- blocked paths or unsafe domains
+
+Do not widen a single review artifact into a whole-repo test strategy unless the
+input is explicitly a whole-repo review packet.
+
+### 2. Map Findings To Behavior
+
+For each finding, identify:
+
+- priority and title
+- affected file or subsystem
+- behavior under test
+- risk or regression scenario
+- source evidence
+- likely test framework and test location
+- fixture/setup needs
+- core assertions
+- validation command
+
+If the behavior or target file cannot be named concretely, mark the task
+`deferred`.
+
+### 3. Classify Generation Safety
+
+Mark a task `unsafe` when test generation would require:
+
+- real credentials, secrets, or production accounts
+- destructive filesystem, database, network, billing, or deployment actions
+- unbounded customer-repo mutation
+- broad refactors rather than focused tests
+- guessing behavior not supported by review evidence
+
+Only safe tasks should include a ready `test-generator` handoff.
+
+### 4. Emit Handoffs
+
+For `generated` and `recommended` tasks, include a structured handoff that can
+be reviewed before invoking `test-generator`.
+
+The handoff should specify:
+
+- `skill_input_schema: test_generator.v1`
+- mode
+- repo root
+- target file/path/worktree/diff
+- target behavior
+- acceptance surface
+- test depth
+- fixture policy
+- validation mode
+- `stop_after_generation: true`
+
+Do not invoke `test-generator` unless the operator explicitly asks for the
+follow-on execution.
+
+## Output Expectations
+
+Default output should include:
+
+- findings-to-test map
+- generation-status summary
+- test task briefs
+- fixture and assertion map
+- validation command plan
+- safe `test-generator` handoffs
+- deferred and unsafe tasks
+- validation performed or not run
+- residual test-planning risk
+
+Use `references/output-contract.md` and the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`.
+
+## Stop Boundary
+
+Stop after producing the test planning artifact.
+
+Do not:
+
+- write tests, fixtures, snapshots, or production code
+- mutate customer repositories
+- create issues or PRs
+- call `test-generator` automatically
+- claim tests are generated when only a plan exists
+- replace review specialists, synthesis, finding-to-issue planning, or
+  implementation workflow
+
+## CodeBuddy Integration Notes
+
+This skill consumes CodeBuddy review packets and specialist artifacts. It
+produces a review-to-test plan that can feed `test-generator`, synthesis,
+product reports, or milestone follow-up triage.
+
+Deferred automation:
+
+- richer parsing for third-party PDF review extracts
+- repository-specific framework discovery from package manifests
+- direct confidence scoring from executed coverage data
+- optional batch handoff execution through a separate conductor-approved flow

--- a/adl/tools/skills/review-to-test-planner/adl-skill.yaml
+++ b/adl/tools/skills/review-to-test-planner/adl-skill.yaml
@@ -1,0 +1,101 @@
+version: "0.1"
+kind: "adl-skill"
+id: "review-to-test-planner"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "review_to_test_planner.v1"
+    reference_doc: "../docs/REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "plan_from_review_packet"
+      - "plan_from_specialist_artifacts"
+      - "plan_from_synthesis"
+      - "plan_from_findings_file"
+    policy_fields:
+      - "test_depth"
+      - "validation_mode"
+      - "allow_handoff_generation"
+      - "unsafe_task_policy"
+      - "write_plan_artifact"
+      - "stop_after_plan"
+  intent:
+    - "review_to_test_planning"
+    - "finding_test_mapping"
+    - "test_generator_handoff"
+    - "codebuddy_review_engine"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "review_packet_path"
+    - "specialist_artifacts"
+    - "synthesis_artifact"
+    - "findings_file"
+    - "artifact_root"
+    - "diff_base"
+    - "changed_paths"
+    - "test_framework_hint"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_review_to_test_planner.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.stop_after_plan_must_be_true"
+    - "plan_from_review_packet_requires_target.review_packet_path"
+    - "plan_from_findings_file_requires_target.findings_file"
+execution:
+  mode: "planning_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_validation_when_bounded"
+  permitted_scripts:
+    - path: "scripts/plan_review_tests.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<review-root>"
+        - "--out <artifact-root>"
+        - "--repo-name <name>"
+        - "--max-tasks <n>"
+  preferred_read_order:
+    - "synthesis_review_artifact"
+    - "repo-review-tests artifact"
+    - "repo-review-code artifact"
+    - "repo-review-security artifact"
+    - "repo-architecture-review artifact"
+    - "repo-dependency-review artifact"
+    - "evidence_index.json"
+    - "repo_inventory.json"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-review-to-test-plan.md"
+  required_sections:
+    - "findings_to_test_map"
+    - "generation_status_summary"
+    - "test_task_briefs"
+    - "fixture_and_assertion_map"
+    - "validation_command_plan"
+    - "test_generator_handoffs"
+    - "deferred_and_unsafe_tasks"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: true
+
+display_name: Review To Test Planner
+short_description: Map review findings to bounded test-generation tasks and safe test-generator handoffs
+default_prompt: Plan bounded test-generation follow-up from review findings. Stop after the plan and handoff briefs; do not write tests, create issues, open PRs, or mutate the repo.

--- a/adl/tools/skills/review-to-test-planner/agents/openai.yaml
+++ b/adl/tools/skills/review-to-test-planner/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Review To Test Planner
+short_description: Map review findings to bounded test-generation tasks and safe test-generator handoffs.
+default_prompt: Plan bounded test-generation follow-up from review findings. Stop after the plan and handoff briefs; do not write tests, create issues, open PRs, or mutate the repo.

--- a/adl/tools/skills/review-to-test-planner/references/output-contract.md
+++ b/adl/tools/skills/review-to-test-planner/references/output-contract.md
@@ -1,0 +1,34 @@
+# Review To Test Planner Output Contract
+
+The review-to-test planner emits a planning artifact, not tests.
+
+Required sections:
+
+- Findings To Test Map
+- Generation Status Summary
+- Test Task Briefs
+- Fixture And Assertion Map
+- Validation Command Plan
+- Test Generator Handoffs
+- Deferred And Unsafe Tasks
+- Validation Performed
+- Residual Risk
+
+Each task must include:
+
+- source finding id or title
+- priority
+- affected source path or explicit `unknown`
+- behavior under test
+- suggested test location
+- fixture needs
+- expected assertions
+- validation command
+- generation status: `generated`, `recommended`, `deferred`, or `unsafe`
+- handoff owner
+
+Safe tasks may include a `test-generator` handoff, but this skill must not run
+that handoff.
+
+Do not write tests, fixtures, snapshots, production code, issues, PRs, or
+customer-repo changes from this skill.

--- a/adl/tools/skills/review-to-test-planner/references/test-planning-playbook.md
+++ b/adl/tools/skills/review-to-test-planner/references/test-planning-playbook.md
@@ -1,0 +1,38 @@
+# Review To Test Planning Playbook
+
+Use this reference when converting review findings into test work.
+
+## Mapping Rules
+
+- Prefer one finding to one focused test task.
+- Merge findings only when they point to the same behavior and source path.
+- Keep the behavior under test concrete and observable.
+- Treat missing source path, missing behavior, or broad architectural concern as
+  `deferred`.
+- Treat real secrets, production accounts, destructive operations, billing,
+  deployment, or unbounded mutation as `unsafe`.
+- Prefer targeted validation commands over whole-repo commands unless the repo
+  has no narrower truthful check.
+
+## Test Location Heuristics
+
+- Rust source: nearby module test or `adl/tests/<stem>_tests.rs`.
+- Python source: `tests/test_<stem>.py`.
+- JavaScript or TypeScript source: nearby `<stem>.test.ts` or
+  `<stem>.test.tsx`.
+- Shell script: `tests/<stem>.bats` or existing shell contract test.
+- Markdown/docs command truth: docs validation or smoke test near existing docs
+  tooling.
+- Unknown file: defer until implementation context is available.
+
+## Assertion Heuristics
+
+- Parsing finding: assert accepted valid input and rejected invalid input.
+- Permission finding: assert allowed and denied paths.
+- Retry/timeout finding: assert retry count, terminal status, and sanitized
+  error.
+- Redaction finding: assert no secrets, absolute host paths, or prompt/tool
+  argument leakage.
+- Docs command finding: assert the documented command runs or mark docs-only
+  correction as outside test generation.
+- Dependency finding: assert install/check command or manifest policy behavior.

--- a/adl/tools/skills/review-to-test-planner/scripts/plan_review_tests.py
+++ b/adl/tools/skills/review-to-test-planner/scripts/plan_review_tests.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Plan bounded test-generation tasks from review findings."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+SCHEMA = "codebuddy.review_to_test_plan.v1"
+STATUS_VALUES = ("generated", "recommended", "deferred", "unsafe")
+REVIEW_EXTENSIONS = {".md", ".json", ".txt"}
+UNSAFE_TERMS = (
+    "real credential",
+    "credential",
+    "secret",
+    "production",
+    "billing",
+    "payment",
+    "delete",
+    "destructive",
+    "deploy",
+    "external service",
+    "private key",
+)
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def relative_to_root(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def review_files(review_root: Path) -> list[Path]:
+    if review_root.is_file():
+        return [review_root] if review_root.suffix.lower() in REVIEW_EXTENSIONS else []
+    files: list[Path] = []
+    for path in review_root.rglob("*"):
+        if path.is_file() and path.suffix.lower() in REVIEW_EXTENSIONS:
+            if "review_to_test_plan" in path.name:
+                continue
+            files.append(path)
+    return sorted(files, key=lambda item: item.as_posix())
+
+
+def read_text(path: Path) -> str:
+    try:
+        if path.suffix.lower() == ".json":
+            return json.dumps(load_json(path), indent=2, sort_keys=True)
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def evidence_entries(root: Path) -> list[dict[str, object]]:
+    candidates = [root / "evidence_index.json"]
+    if root.is_dir():
+        candidates.extend(sorted(root.rglob("evidence_index.json")))
+    for candidate in candidates:
+        data = load_json(candidate)
+        if isinstance(data, dict) and isinstance(data.get("evidence"), list):
+            return [item for item in data["evidence"] if isinstance(item, dict)]
+    return []
+
+
+def extract_path(block: str) -> str:
+    patterns = (
+        r"(?:^|\n)\s*File:\s*`?([^`\n]+?)`?\s*(?:\n|$)",
+        r'"file"\s*:\s*"([^"]+)"',
+        r'"path"\s*:\s*"([^"]+)"',
+        r"([A-Za-z0-9_./-]+\.(?:rs|py|js|jsx|ts|tsx|sh|md|toml|yaml|yml|json))",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, block)
+        if match:
+            value = match.group(1).strip()
+            if value.lower() not in {"none", "n/a", "unknown"}:
+                return value
+    return "unknown"
+
+
+def extract_priority(text: str) -> str:
+    match = re.search(r"\bP([0-3])\b|\[P([0-3])\]", text)
+    if not match:
+        return "P3"
+    return f"P{match.group(1) or match.group(2)}"
+
+
+def title_from_block(block: str, fallback: str) -> str:
+    for line in block.splitlines():
+        clean = line.strip(" -#")
+        if not clean:
+            continue
+        clean = re.sub(r"^\[?P[0-3]\]?\s*:?\s*", "", clean)
+        clean = re.sub(r"^Finding\s+\d+\s*:?\s*", "", clean, flags=re.IGNORECASE)
+        if len(clean) > 6:
+            return clean[:140]
+    return fallback
+
+
+def split_finding_blocks(path: Path, text: str) -> list[dict[str, str]]:
+    markers = list(re.finditer(r"(?im)^(?:#{1,4}\s*)?(?:Finding\s+\d+|\[?P[0-3]\]?|-\s*P[0-3]\s*:)", text))
+    blocks: list[dict[str, str]] = []
+    if not markers:
+        if re.search(r"(?i)missing.*test|coverage|assert|validation|regression|proof", text):
+            markers = [re.match(r"", text) or re.search(r"", text)]  # type: ignore[list-item]
+        else:
+            return blocks
+    starts = [marker.start() for marker in markers]
+    starts.append(len(text))
+    for index, start in enumerate(starts[:-1]):
+        block = text[start:starts[index + 1]].strip()
+        if not block:
+            continue
+        blocks.append(
+            {
+                "id": f"{path.stem}-finding-{index + 1:02d}",
+                "source": path.name,
+                "priority": extract_priority(block),
+                "title": title_from_block(block, f"Finding from {path.name}"),
+                "file": extract_path(block),
+                "text": block,
+            }
+        )
+    return blocks
+
+
+def collect_findings(root: Path, files: list[Path]) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for path in files:
+        findings.extend(split_finding_blocks(path, read_text(path)))
+    deduped: dict[tuple[str, str], dict[str, str]] = {}
+    for finding in findings:
+        key = (finding["title"].lower(), finding["file"])
+        deduped.setdefault(key, finding)
+    return sorted(deduped.values(), key=lambda item: (item["priority"], item["source"], item["id"]))[:80]
+
+
+def source_hint_from_evidence(finding: dict[str, str], evidence: list[dict[str, object]]) -> str:
+    if finding["file"] != "unknown":
+        return finding["file"]
+    text = (finding["title"] + " " + finding["text"]).lower()
+    for entry in evidence:
+        path = str(entry.get("path", ""))
+        reason = str(entry.get("reason", "")).lower()
+        if path and any(token in reason or token in path.lower() for token in re.findall(r"[a-z][a-z0-9_-]{3,}", text)[:8]):
+            return path
+    return "unknown"
+
+
+def test_framework_for(path: str) -> str:
+    suffix = Path(path).suffix.lower()
+    if suffix == ".rs":
+        return "cargo test"
+    if suffix == ".py":
+        return "pytest"
+    if suffix in {".ts", ".tsx", ".js", ".jsx"}:
+        return "npm test"
+    if suffix == ".sh":
+        return "shell contract test"
+    if suffix in {".md", ".yaml", ".yml", ".toml", ".json"}:
+        return "repo validation or smoke test"
+    return "unknown"
+
+
+def suggested_test_location(path: str, framework: str) -> str:
+    if path == "unknown":
+        return "unknown"
+    source = Path(path)
+    stem = source.stem.replace("-", "_")
+    if framework == "cargo test":
+        return f"adl/tests/{stem}_tests.rs"
+    if framework == "pytest":
+        return f"tests/test_{stem}.py"
+    if framework == "npm test":
+        return f"{source.parent.as_posix()}/{stem}.test{source.suffix}"
+    if framework == "shell contract test":
+        return f"tests/{stem}.bats"
+    return f"existing validation near {path}"
+
+
+def validation_command(path: str, framework: str) -> str:
+    if framework == "cargo test":
+        return "cd adl && cargo test"
+    if framework == "pytest":
+        return "pytest"
+    if framework == "npm test":
+        return "npm test"
+    if framework == "shell contract test":
+        return "bash <focused-contract-test>.sh"
+    if path.endswith((".md", ".yaml", ".yml", ".toml", ".json")):
+        return "bash adl/tools/batched_checks.sh"
+    return "targeted validation command required after implementation context is known"
+
+
+def behavior_under_test(finding: dict[str, str]) -> str:
+    text = re.sub(r"\s+", " ", finding["title"]).strip()
+    text = re.sub(r"^\[?P[0-3]\]?\s*", "", text)
+    return text[:120] or "review finding behavior"
+
+
+def classify(finding: dict[str, str], source_path: str) -> str:
+    block = (finding["title"] + " " + finding["text"]).lower()
+    if any(term in block for term in UNSAFE_TERMS):
+        return "unsafe"
+    if source_path == "unknown" or len(behavior_under_test(finding)) < 10:
+        return "deferred"
+    if "test_generator" in block or "test-generator" in block:
+        return "generated"
+    return "recommended"
+
+
+def build_tasks(findings: list[dict[str, str]], evidence: list[dict[str, object]], max_tasks: int) -> list[dict[str, object]]:
+    tasks: list[dict[str, object]] = []
+    for index, finding in enumerate(findings[:max_tasks], start=1):
+        source_path = source_hint_from_evidence(finding, evidence)
+        framework = test_framework_for(source_path)
+        status = classify(finding, source_path)
+        behavior = behavior_under_test(finding)
+        task = {
+            "id": f"test-plan-{index:02d}",
+            "source_finding": finding["id"],
+            "source_artifact": finding["source"],
+            "priority": finding["priority"],
+            "title": finding["title"],
+            "affected_source_path": source_path,
+            "behavior_under_test": behavior,
+            "suggested_test_location": suggested_test_location(source_path, framework),
+            "fixture_needs": fixture_needs(finding, source_path),
+            "expected_assertions": expected_assertions(finding),
+            "validation_command": validation_command(source_path, framework),
+            "generation_status": status,
+            "handoff_owner": "test-generator" if status in {"generated", "recommended"} else "operator",
+        }
+        task["test_generator_handoff"] = test_generator_handoff(task) if status in {"generated", "recommended"} else {}
+        tasks.append(task)
+    if not tasks:
+        tasks.append(
+            {
+                "id": "test-plan-00",
+                "source_finding": "none",
+                "source_artifact": "none",
+                "priority": "P3",
+                "title": "No concrete review findings were available for test planning",
+                "affected_source_path": "unknown",
+                "behavior_under_test": "blocked until findings are supplied",
+                "suggested_test_location": "unknown",
+                "fixture_needs": ["review finding source"],
+                "expected_assertions": ["not applicable"],
+                "validation_command": "not run",
+                "generation_status": "deferred",
+                "handoff_owner": "operator",
+                "test_generator_handoff": {},
+            }
+        )
+    return tasks
+
+
+def fixture_needs(finding: dict[str, str], source_path: str) -> list[str]:
+    block = finding["text"].lower()
+    needs: list[str] = []
+    if "retry" in block or "timeout" in block:
+        needs.append("mock timeout/retry fixture")
+    if "permission" in block or "auth" in block:
+        needs.append("allowed and denied authorization fixture")
+    if "redact" in block or "secret" in block:
+        needs.append("synthetic secret-like fixture only")
+    if "parse" in block or source_path.endswith((".json", ".yaml", ".yml", ".toml")):
+        needs.append("valid and invalid parser fixture")
+    if not needs:
+        needs.append("minimal fixture matching the reviewed behavior")
+    return needs
+
+
+def expected_assertions(finding: dict[str, str]) -> list[str]:
+    block = finding["text"].lower()
+    assertions = ["assert the reviewed behavior is directly exercised"]
+    if "missing" in block or "coverage" in block:
+        assertions.append("assert the previously missing path fails or passes explicitly")
+    if "redact" in block or "secret" in block:
+        assertions.append("assert no secret-like or absolute host path content is emitted")
+    if "error" in block or "failure" in block:
+        assertions.append("assert stable failure status and message")
+    if "docs" in block or "command" in block:
+        assertions.append("assert documented command truth or mark docs-only remediation")
+    return assertions
+
+
+def test_generator_handoff(task: dict[str, object]) -> dict[str, object]:
+    return {
+        "skill_input_schema": "test_generator.v1",
+        "mode": "generate_for_path" if task["affected_source_path"] != "unknown" else "generate_for_issue",
+        "target": {
+            "target_path": task["affected_source_path"],
+            "changed_paths": [task["affected_source_path"]] if task["affected_source_path"] != "unknown" else [],
+            "target_behavior": task["behavior_under_test"],
+            "acceptance_surface": task["title"],
+        },
+        "policy": {
+            "test_depth": "focused",
+            "allow_new_test_files": True,
+            "allow_fixture_updates": True,
+            "validation_mode": "targeted",
+            "stop_after_generation": True,
+        },
+    }
+
+
+def task_lines(tasks: list[dict[str, object]]) -> str:
+    rendered: list[str] = []
+    for task in tasks:
+        rendered.extend(
+            [
+                f"- {task['id']}: {task['generation_status']} - {task['title']}",
+                f"  Source: {task['affected_source_path']}",
+                f"  Behavior: {task['behavior_under_test']}",
+                f"  Test location: {task['suggested_test_location']}",
+                f"  Validation: {task['validation_command']}",
+            ]
+        )
+    return "\n".join(rendered)
+
+
+def list_lines(items: list[str]) -> str:
+    return "\n".join(f"  - {item}" for item in items)
+
+
+def handoff_lines(tasks: list[dict[str, object]]) -> str:
+    safe = [task for task in tasks if task["generation_status"] in {"generated", "recommended"}]
+    if not safe:
+        return "- No safe `test-generator` handoffs were produced."
+    lines: list[str] = []
+    for task in safe:
+        lines.append(f"- {task['id']}: hand to `test-generator` for `{task['affected_source_path']}`.")
+    return "\n".join(lines)
+
+
+def deferred_lines(tasks: list[dict[str, object]]) -> str:
+    selected = [task for task in tasks if task["generation_status"] in {"deferred", "unsafe"}]
+    if not selected:
+        return "- None."
+    return "\n".join(f"- {task['id']}: {task['generation_status']} - {task['title']}" for task in selected)
+
+
+def write_markdown(path: Path, plan: dict[str, object]) -> None:
+    tasks = plan["test_task_briefs"]
+    summary = plan["generation_status_summary"]
+    fixture_lines: list[str] = []
+    for task in tasks:
+        fixture_lines.append(f"- {task['id']}:")
+        fixture_lines.append("  Fixtures:")
+        fixture_lines.append(list_lines(task["fixture_needs"]))
+        fixture_lines.append("  Assertions:")
+        fixture_lines.append(list_lines(task["expected_assertions"]))
+    content = f"""# Review To Test Plan
+
+## Metadata
+
+- Skill: review-to-test-planner
+- Repo: {plan["repo_name"]}
+- Review Root: {plan["review_root"]}
+- Date: {plan["created_at"]}
+
+## Findings To Test Map
+
+{task_lines(tasks)}
+
+## Generation Status Summary
+
+- generated: {summary.get("generated", 0)}
+- recommended: {summary.get("recommended", 0)}
+- deferred: {summary.get("deferred", 0)}
+- unsafe: {summary.get("unsafe", 0)}
+
+## Test Task Briefs
+
+{task_lines(tasks)}
+
+## Fixture And Assertion Map
+
+{chr(10).join(fixture_lines)}
+
+## Validation Command Plan
+
+{chr(10).join(f"- {task['id']}: {task['validation_command']}" for task in tasks)}
+
+## Test Generator Handoffs
+
+{handoff_lines(tasks)}
+
+## Deferred And Unsafe Tasks
+
+{deferred_lines(tasks)}
+
+## Validation Performed
+
+- Scaffold generation only; no tests, fixtures, issues, PRs, or repository mutations were performed.
+
+## Residual Risk
+
+- Finding parsing is heuristic and should be reviewed before executing test-generation handoffs.
+- Planned validation commands may need tightening after implementation context is loaded by `test-generator`.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("review_root", help="Review packet, specialist artifact root, or findings file")
+    parser.add_argument("--out", default=None, help="Review-to-test plan output root")
+    parser.add_argument("--repo-name", default=None, help="Repo name override")
+    parser.add_argument("--max-tasks", type=int, default=12, help="Maximum test tasks to emit")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    review_root = Path(args.review_root).resolve()
+    if not review_root.exists():
+        raise SystemExit(f"review root does not exist: {review_root}")
+    out_root = Path(args.out) if args.out else review_root / "review-to-test-plan"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_json(review_root / "run_manifest.json") if review_root.is_dir() else {}
+    repo_name = args.repo_name
+    if repo_name is None and isinstance(manifest, dict):
+        repo_name = str(manifest.get("repo_name", "") or "")
+    repo_name = repo_name or review_root.stem
+
+    files = review_files(review_root)
+    evidence = evidence_entries(review_root)
+    findings = collect_findings(review_root, files)
+    tasks = build_tasks(findings, evidence, max(args.max_tasks, 1))
+    summary = Counter(str(task["generation_status"]) for task in tasks)
+    for status in STATUS_VALUES:
+        summary.setdefault(status, 0)
+    plan = {
+        "schema": SCHEMA,
+        "repo_name": repo_name,
+        "review_root": review_root.name,
+        "created_at": now_utc(),
+        "reviewed_artifacts": [relative_to_root(review_root, path) for path in files],
+        "findings_to_test_map": {
+            str(task["source_finding"]): str(task["id"])
+            for task in tasks
+        },
+        "generation_status_summary": dict(sorted(summary.items())),
+        "test_task_briefs": tasks,
+        "notes": [
+            "Planner does not write tests or fixtures.",
+            "Paths are review-root-relative or source-path strings, not absolute host paths.",
+            "Safe tasks may be handed to test-generator only after operator approval.",
+        ],
+    }
+    write_json(out_root / "review_to_test_plan.json", plan)
+    write_markdown(out_root / "review_to_test_plan.md", plan)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -32,6 +32,8 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/repo-diagram-planner/scripts/plan_repo_diagrams.py" ]]
   [[ -f "${root}/skills/architecture-diagram-reviewer/SKILL.md" ]]
   [[ -x "${root}/skills/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py" ]]
+  [[ -f "${root}/skills/review-to-test-planner/SKILL.md" ]]
+  [[ -x "${root}/skills/review-to-test-planner/scripts/plan_review_tests.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -56,6 +58,7 @@ assert_skill_bundle() {
   grep -Fq "dependency and supply-chain surfaces" "${root}/skills/repo-dependency-review/SKILL.md"
   grep -Fq "without becoming the diagram author" "${root}/skills/repo-diagram-planner/SKILL.md"
   grep -Fq 'quality gate after `diagram-author`' "${root}/skills/architecture-diagram-reviewer/SKILL.md"
+  grep -Fq 'between review artifacts and `test-generator`' "${root}/skills/review-to-test-planner/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -80,6 +83,7 @@ assert_skill_bundle() {
     "${root}/skills/repo-dependency-review/SKILL.md" \
     "${root}/skills/repo-diagram-planner/SKILL.md" \
     "${root}/skills/architecture-diagram-reviewer/SKILL.md" \
+    "${root}/skills/review-to-test-planner/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -106,6 +110,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/repo-dependency-review" ]]
 [[ -L "${CODEX_HOME}/skills/repo-diagram-planner" ]]
 [[ -L "${CODEX_HOME}/skills/architecture-diagram-reviewer" ]]
+[[ -L "${CODEX_HOME}/skills/review-to-test-planner" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_review_to_test_planner_skill_contracts.sh
+++ b/adl/tools/test_review_to_test_planner_skill_contracts.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/review-to-test-planner/SKILL.md" ]]
+[[ -f "${skills_root}/review-to-test-planner/adl-skill.yaml" ]]
+[[ -f "${skills_root}/review-to-test-planner/agents/openai.yaml" ]]
+[[ -f "${skills_root}/review-to-test-planner/references/test-planning-playbook.md" ]]
+[[ -f "${skills_root}/review-to-test-planner/references/output-contract.md" ]]
+[[ -x "${skills_root}/review-to-test-planner/scripts/plan_review_tests.py" ]]
+[[ -f "${skills_root}/docs/REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "review-to-test-planner"' "${skills_root}/review-to-test-planner/adl-skill.yaml"
+grep -Fq 'id: "review_to_test_planner.v1"' "${skills_root}/review-to-test-planner/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/review-to-test-planner/adl-skill.yaml"
+grep -Fq "plan_from_review_packet_requires_target.review_packet_path" "${skills_root}/review-to-test-planner/adl-skill.yaml"
+grep -Fq "between review artifacts and \`test-generator\`" "${skills_root}/review-to-test-planner/SKILL.md"
+grep -Fq "scripts/plan_review_tests.py" "${skills_root}/review-to-test-planner/SKILL.md"
+grep -Fq "Do not write tests" "${skills_root}/review-to-test-planner/references/output-contract.md"
+grep -Fq "Schema id: \`review_to_test_planner.v1\`" "${skills_root}/docs/REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "review-to-test-planner" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+review_root="${tmpdir}/review-packet"
+plan_root="${tmpdir}/review-to-test-plan"
+mkdir -p "${review_root}"
+cat >"${review_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "review-to-test-planner-contract-test",
+  "repo_name": "example-repo",
+  "publication_allowed": false
+}
+JSON
+cat >"${review_root}/evidence_index.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.evidence.v1",
+  "evidence": [
+    {
+      "path": "adl/src/execute/state.rs",
+      "category": "code",
+      "line_count": 220,
+      "reason": "runtime state lifecycle implementation with pause and resume behavior",
+      "specialist_lanes": ["code", "tests", "synthesis"]
+    },
+    {
+      "path": "adl/tools/redact.sh",
+      "category": "tooling",
+      "line_count": 40,
+      "reason": "redaction helper protects synthetic secret output",
+      "specialist_lanes": ["security", "tests", "synthesis"]
+    }
+  ]
+}
+JSON
+cat >"${review_root}/synthesis.md" <<'MD'
+# Review
+
+## Finding 1
+
+[P1] Resume skips stale runtime state
+File: adl/src/execute/state.rs
+Scenario: A paused run resumes after the state file changes.
+Impact: The runtime can report success without exercising the recovery path.
+Evidence: The state lifecycle implementation lacks a direct regression proof.
+
+## Finding 2
+
+[P2] Real credential redaction must not use production secrets
+File: adl/tools/redact.sh
+Scenario: Tests need secret-like inputs.
+Impact: Unsafe test generation could expose credentials if it uses real data.
+Evidence: Use synthetic secret-like values only.
+MD
+
+python3 "${skills_root}/review-to-test-planner/scripts/plan_review_tests.py" \
+  "${review_root}" --out "${plan_root}" --max-tasks 4 >/tmp/review-to-test-planner.out
+[[ -f "${plan_root}/review_to_test_plan.json" ]]
+[[ -f "${plan_root}/review_to_test_plan.md" ]]
+grep -Fq '"schema": "codebuddy.review_to_test_plan.v1"' "${plan_root}/review_to_test_plan.json"
+grep -Fq '"repo_name": "example-repo"' "${plan_root}/review_to_test_plan.json"
+grep -Fq '"generation_status": "recommended"' "${plan_root}/review_to_test_plan.json"
+grep -Fq '"generation_status": "unsafe"' "${plan_root}/review_to_test_plan.json"
+grep -Fq '"skill_input_schema": "test_generator.v1"' "${plan_root}/review_to_test_plan.json"
+grep -Fq 'Findings To Test Map' "${plan_root}/review_to_test_plan.md"
+grep -Fq 'Generation Status Summary' "${plan_root}/review_to_test_plan.md"
+grep -Fq 'Test Generator Handoffs' "${plan_root}/review_to_test_plan.md"
+grep -Fq 'Deferred And Unsafe Tasks' "${plan_root}/review_to_test_plan.md"
+if grep -R "${tmpdir}" "${plan_root}" >/dev/null; then
+  echo "review-to-test plan should not leak absolute temp paths" >&2
+  exit 1
+fi
+if find "${plan_root}" -name '*_test.rs' -o -name 'test_*.py' -o -name '*.test.ts' | grep -q .; then
+  echo "review-to-test planner should not write test files" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/review-to-test-planner/SKILL.md"
+
+echo "PASS test_review_to_test_planner_skill_contracts"


### PR DESCRIPTION
Closes #2064

## Summary
Implemented the `review-to-test-planner` skill as a CodeBuddy follow-through
planning lane that maps review findings to bounded test-generation briefs,
generation-status classifications, validation commands, and safe
`test-generator` handoffs without writing tests, creating issues, opening PRs,
or mutating customer repositories.

## Artifacts
- `adl/tools/skills/review-to-test-planner/SKILL.md`
- `adl/tools/skills/review-to-test-planner/adl-skill.yaml`
- `adl/tools/skills/review-to-test-planner/agents/openai.yaml`
- `adl/tools/skills/review-to-test-planner/references/output-contract.md`
- `adl/tools/skills/review-to-test-planner/references/test-planning-playbook.md`
- `adl/tools/skills/review-to-test-planner/scripts/plan_review_tests.py`
- `adl/tools/skills/docs/REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_review_to_test_planner_skill_contracts.sh`
- Updates to `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
- Updates to `adl/tools/test_install_adl_operational_skills.sh`
- Updates to `adl/tools/batched_checks.sh`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/test_review_to_test_planner_skill_contracts.sh adl/tools/test_install_adl_operational_skills.sh adl/tools/batched_checks.sh` checked shell syntax for the new and modified validation scripts.
  - `bash adl/tools/test_review_to_test_planner_skill_contracts.sh` verified the new skill bundle, ADL metadata, docs, helper script, deterministic output, status classification, safe handoffs, no test writing, no absolute temp-path leakage, and frontmatter.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified operational skill installation includes `review-to-test-planner` in copy and symlink modes.
  - `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile adl/tools/skills/review-to-test-planner/scripts/plan_review_tests.py` verified the Python helper parses.
  - `git diff --check` verified whitespace safety.
  - `bash adl/tools/batched_checks.sh` verified all skill contract checks, residue guard, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2064__backlog-skills-add-review-to-test-planner-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2064__backlog-skills-add-review-to-test-planner-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-review-to-test-planner-skill-adl-tools-skills-review-to-test-planner-adl-tools-skills-docs-review-to-test-planner-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-review-to-test-planner-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2064-backlog-skills-add-review-to-test-planner-skill-sip-md-adl-v0-90-tasks-issue-2064-backlog-skills-add-review-to-test-planner-skill-sor-md