### PR TITLE
[v0.90][backlog][skills] Add finding-to-issue planner skill

### DIFF
--- a/adl/tools/skills/docs/FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,49 @@
+# Finding To Issue Planner Skill Input Schema
+
+Schema id: `finding_to_issue_planner.v1`
+
+This schema describes structured input for the `finding-to-issue-planner`
+skill. The skill drafts issue candidates from review findings and stops before
+tracker creation or repository mutation.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `finding_to_issue_planner.v1`.
+- `mode`: one of the supported modes below.
+- `finding_source`: review artifact path, synthesis report path, or packet root.
+- `policy`: explicit approval and mutation-boundary policy.
+
+## Supported Modes
+
+- `plan_from_review`: plan candidates from one specialist review artifact.
+- `plan_from_synthesis`: plan candidates from a synthesis or final report.
+- `plan_from_packet`: plan candidates from a packet root containing review
+  artifacts.
+- `refresh_issue_plan`: refresh an existing candidate plan after review edits.
+
+## Policy Fields
+
+- `approval_required`: must be true.
+- `tracker_creation_allowed`: must be false for this skill.
+- `grouping_policy`: exact, conservative, or none.
+- `severity_floor`: P0, P1, P2, or P3.
+- `preserve_specialist_disagreement`: must be true.
+- `stop_before_mutation`: must be true.
+
+## Optional Fields
+
+- `artifact_root`: output directory for `issue_candidates.md` and
+  `issue_candidates.json`.
+- `tracker`: target tracker name for wording, such as GitHub.
+- `existing_plan_path`: required for `refresh_issue_plan`.
+- `dependency_links`: known upstream/downstream issue or finding links.
+
+## Output Contract
+
+The skill emits candidate-only artifacts:
+
+- `issue_candidates.md`
+- `issue_candidates.json`
+
+The skill must not create tracker items, pull requests, remediation branches,
+tests, fixes, or customer-facing reports.

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -22,6 +22,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `architecture-diagram-reviewer`
 - `review-to-test-planner`
 - `repo-review-synthesis`
+- `finding-to-issue-planner`
 
 ## Invocation Order
 
@@ -37,6 +38,7 @@ Recommended order:
 8. `repo-diagram-planner`
 9. `architecture-diagram-reviewer`
 10. `review-to-test-planner`
+11. `finding-to-issue-planner`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -51,6 +53,9 @@ handoffs without authoring or rendering diagrams.
 The review-to-test planner should run after specialist findings or synthesis
 exist. It maps findings to safe, bounded `test-generator` handoffs without
 writing tests or turning review follow-up into broad implementation work.
+The finding-to-issue planner should run only after review findings exist. It
+emits grouped, human-approved issue candidates and stops before tracker
+creation, PR creation, remediation, or test generation.
 
 ## Shared Specialist Input Shape
 
@@ -271,6 +276,21 @@ policy:
   stop_after_plan: true
 ```
 
+## Finding To Issue Planner Input Shape
+
+```yaml
+skill_input_schema: finding_to_issue_planner.v1
+mode: plan_from_review | plan_from_synthesis | plan_from_packet | refresh_issue_plan
+finding_source: <review artifact or packet root>
+policy:
+  approval_required: true
+  tracker_creation_allowed: false
+  grouping_policy: exact | conservative | none
+  severity_floor: P0 | P1 | P2 | P3
+  preserve_specialist_disagreement: true
+  stop_before_mutation: true
+```
+
 ## Severity Rules
 
 - Preserve the highest severity attached to a merged finding unless the source
@@ -301,6 +321,8 @@ The suite may:
 - plan bounded test-generation handoffs from review findings, including
   behavior under test, fixture needs, expected assertions, validation commands,
   and `generated` / `recommended` / `deferred` / `unsafe` status
+- draft grouped issue candidates from findings after explicit review evidence
+  exists, while preserving highest severity and specialist disagreement
 
 The suite must not:
 - edit code, tests, docs, configs, or issue state
@@ -314,6 +336,8 @@ The suite must not:
 - hide severity, disagreement, skipped roles, or residual risk
 - invent diagrams, render diagram assets, or publish visual artifacts from the
   planning lane
+- create tracker items from the issue-planning lane without explicit operator
+  approval
 
 ## Relationship To `repo-code-review`
 

--- a/adl/tools/skills/finding-to-issue-planner/SKILL.md
+++ b/adl/tools/skills/finding-to-issue-planner/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: finding-to-issue-planner
+description: Convert CodeBuddy review findings into grouped, reviewable issue candidates with titles, bodies, evidence, acceptance criteria, non-goals, validation plans, and dependency links while stopping before tracker creation or repository mutation.
+---
+
+# Finding To Issue Planner
+
+Convert source-grounded CodeBuddy review findings into human-reviewable issue
+candidates. This skill is a planning and approval-boundary skill, not a tracker
+mutation skill and not a remediation workflow.
+
+Use this skill after specialist review, synthesis, redaction, or quality-gate
+artifacts identify findings that may need follow-up issues.
+
+## Quick Start
+
+1. Confirm the finding source:
+   - specialist review artifact
+   - synthesis report
+   - review packet root
+   - existing finding list
+2. Confirm the target tracker style and approval policy.
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/plan_review_issues.py <finding-file-or-root> --out <artifact-root>`
+4. Review the emitted issue candidates for severity, evidence, grouping, and
+   acceptance criteria.
+5. Stop before issue creation. Hand approved candidates to the operator or a
+   separate issue-creation workflow.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `finding_source`
+- `mode`
+- `policy`
+
+Supported modes:
+
+- `plan_from_review`
+- `plan_from_synthesis`
+- `plan_from_packet`
+- `refresh_issue_plan`
+
+Useful policy fields:
+
+- `approval_required`
+- `tracker_creation_allowed`
+- `grouping_policy`
+- `severity_floor`
+- `preserve_specialist_disagreement`
+- `stop_before_mutation`
+
+If there is no concrete finding source, stop and report `not_run`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- source artifact or packet root
+- review roles included
+- non-reviewed surfaces
+- target tracker, if known
+- approval boundary
+- severity floor
+- grouping policy
+
+Do not infer customer approval. If approval is absent, emit candidates only.
+
+### 2. Extract Findings
+
+For each finding, preserve:
+
+- stable finding id, if present
+- severity
+- confidence
+- source role or specialist
+- title
+- affected path or artifact
+- trigger scenario
+- evidence
+- impact
+- recommended action
+- validation or proof gap
+- related findings
+
+Do not create issues from unsupported claims. Mark weak or incomplete findings
+as `needs_human_review` or `deferred` rather than making them look ready.
+
+### 3. Group Without Hiding Severity
+
+Group exact or near-duplicate findings only when the evidence supports the same
+remediation target.
+
+When grouping:
+
+- preserve every source finding id
+- preserve the highest severity
+- preserve specialist disagreement
+- list secondary affected paths
+- avoid collapsing distinct root causes into one issue
+
+### 4. Draft Issue Candidates
+
+Each candidate must include:
+
+- title
+- severity
+- source finding ids
+- source roles
+- evidence summary
+- affected paths or artifacts
+- problem statement
+- acceptance criteria
+- validation plan
+- non-goals
+- dependency or ordering notes
+- approval status
+
+Titles should be specific enough for a tracker list and boring enough to be
+searchable. Avoid dramatic language and avoid claiming confirmed impact beyond
+the evidence.
+
+### 5. Stop Before Mutation
+
+This skill must not:
+
+- create GitHub, Linear, Jira, or other tracker items
+- open pull requests
+- edit customer repositories
+- generate fixes
+- generate tests directly
+- synthesize a final customer report
+
+Handoff candidates to:
+
+- `review-to-test-planner` for test task planning
+- `test-generator` for approved bounded test generation
+- `pr-init` or the repo workflow conductor only after explicit operator approval
+- `product-report-writer` for customer report language
+
+## Output
+
+Write a Markdown issue plan and a JSON issue-candidate list when an artifact
+root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/issue-planning/
+```
+
+Required artifacts:
+
+- `issue_candidates.md`
+- `issue_candidates.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Blocked States
+
+Return `not_run` when the source is missing or unreadable.
+
+Return `blocked` when:
+
+- tracker creation was requested without explicit approval
+- findings lack evidence
+- the requested grouping would hide severity or disagreement
+- the source artifact includes private data that has not passed the configured
+  redaction gate
+
+Return `partial` when some findings can be planned and others must be deferred.

--- a/adl/tools/skills/finding-to-issue-planner/adl-skill.yaml
+++ b/adl/tools/skills/finding-to-issue-planner/adl-skill.yaml
@@ -1,0 +1,111 @@
+version: "0.1"
+kind: "adl-skill"
+id: "finding-to-issue-planner"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "finding_to_issue_planner.v1"
+    reference_doc: "../docs/FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "finding_source"
+      - "policy"
+    mode_enum:
+      - "plan_from_review"
+      - "plan_from_synthesis"
+      - "plan_from_packet"
+      - "refresh_issue_plan"
+    policy_fields:
+      - "approval_required"
+      - "tracker_creation_allowed"
+      - "grouping_policy"
+      - "severity_floor"
+      - "preserve_specialist_disagreement"
+      - "stop_before_mutation"
+    mode_requirements:
+      plan_from_review:
+        required_target_fields:
+          - "finding_source"
+      plan_from_synthesis:
+        required_target_fields:
+          - "finding_source"
+      plan_from_packet:
+        required_target_fields:
+          - "finding_source"
+      refresh_issue_plan:
+        required_target_fields:
+          - "existing_plan_path"
+  intent:
+    - "finding_to_issue_planning"
+    - "review_follow_through"
+    - "codebuddy_review_engine"
+    - "approval_boundary"
+  required_inputs:
+    - "finding_source"
+  optional_inputs:
+    - "artifact_root"
+    - "tracker"
+    - "severity_floor"
+    - "existing_plan_path"
+    - "dependency_links"
+  stop_if_missing:
+    - "finding_source"
+  prevalidation_rules:
+    - "finding_source_must_exist"
+    - "skill_input_schema_must_equal_finding_to_issue_planner.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.approval_required_must_be_true"
+    - "policy.tracker_creation_allowed_must_be_false"
+    - "policy.stop_before_mutation_must_be_true"
+    - "policy.preserve_specialist_disagreement_must_be_true"
+execution:
+  mode: "issue_candidates_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/plan_review_issues.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<finding-source>"
+        - "--out <artifact-root>"
+        - "--tracker <name>"
+        - "--severity-floor <P0|P1|P2|P3>"
+  preferred_read_order:
+    - "run_manifest.json"
+    - "repo_scope.md"
+    - "specialist review artifacts"
+    - "final_report.md"
+    - "redaction_report.md"
+    - "quality evaluation"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  must_not_run:
+    - "tracker_item_creation"
+    - "pull_request_creation"
+    - "remediation_implementation"
+    - "test_generation"
+    - "customer_repository_mutation"
+    - "final_report_publication"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/codebuddy/<run_id>/issue-planning/"
+  required_artifacts:
+    - "issue_candidates.md"
+    - "issue_candidates.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_tracker_mutation_without_approval: true
+  manifest_declares_executables: true
+
+display_name: Finding To Issue Planner
+short_description: Draft reviewable issue candidates from CodeBuddy findings
+default_prompt: Turn CodeBuddy review findings into grouped issue candidates with evidence, acceptance criteria, validation plans, and approval boundaries. Stop before tracker creation or repository mutation.

--- a/adl/tools/skills/finding-to-issue-planner/agents/openai.yaml
+++ b/adl/tools/skills/finding-to-issue-planner/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Finding To Issue Planner
+short_description: Draft reviewable issue candidates from CodeBuddy findings
+default_prompt: Turn CodeBuddy review findings into grouped issue candidates with evidence, acceptance criteria, validation plans, and approval boundaries. Stop before tracker creation or repository mutation.

--- a/adl/tools/skills/finding-to-issue-planner/references/output-contract.md
+++ b/adl/tools/skills/finding-to-issue-planner/references/output-contract.md
@@ -1,0 +1,90 @@
+# Output Contract
+
+The finding-to-issue planner skill produces issue candidates from CodeBuddy
+review findings without creating tracker items.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/issue-planning/
+```
+
+## Required Artifacts
+
+### issue_candidates.md
+
+Required sections:
+
+- Metadata
+- Scope
+- Issue Candidates
+- Deferred Findings
+- Approval Boundary
+- Validation Notes
+- Residual Risk
+
+Each issue candidate must include:
+
+- candidate id
+- proposed title
+- severity
+- source finding ids
+- source roles
+- confidence
+- affected paths or artifacts
+- evidence summary
+- problem statement
+- acceptance criteria
+- validation plan
+- non-goals
+- dependencies or ordering notes
+- approval status
+
+### issue_candidates.json
+
+Required top-level fields:
+
+- `schema`
+- `source`
+- `tracker`
+- `status`
+- `candidate_count`
+- `deferred_count`
+- `candidates`
+- `deferred_findings`
+- `approval_boundary`
+
+Each candidate object must include:
+
+- `candidate_id`
+- `title`
+- `severity`
+- `source_finding_ids`
+- `source_roles`
+- `confidence`
+- `affected_paths`
+- `evidence`
+- `problem`
+- `acceptance_criteria`
+- `validation_plan`
+- `non_goals`
+- `dependencies`
+- `approval_status`
+
+## Status Values
+
+- `pass`: candidates were produced and no findings were deferred.
+- `partial`: candidates were produced and at least one finding was deferred.
+- `not_run`: no readable findings were available.
+- `blocked`: explicit requested behavior would cross the mutation boundary or
+  hide severity, disagreement, or missing evidence.
+
+## Rules
+
+- Use repo-relative or packet-relative paths.
+- Do not write absolute host paths into artifacts.
+- Do not create issues, PRs, remediation branches, tests, or tracker items.
+- Do not claim operator approval unless it is explicitly present in the input.
+- Preserve highest severity when grouping findings.
+- Preserve specialist disagreement in grouped candidates.
+- Mark findings without evidence as deferred rather than ready.

--- a/adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py
+++ b/adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Plan human-approved issue candidates from CodeBuddy review findings."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import re
+from pathlib import Path
+
+SCHEMA = "codebuddy.finding_to_issue_planner.v1"
+FINDING_HEADING_RE = re.compile(
+    r"^#{2,4}[ \t]+(?:Finding[ \t]+)?(?P<id>[A-Za-z0-9_.:-]+)?[ \t]*:?[ \t]*(?:\[(?P<severity>P[0-3])\])?[ \t]*(?P<title>[^\n#].*?)\s*$",
+    re.MULTILINE,
+)
+SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+DEFAULT_NON_GOALS = [
+    "Do not broaden into unrelated remediation.",
+    "Do not claim the issue is fixed until validation evidence exists.",
+    "Do not create tracker items without explicit operator approval.",
+]
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def source_files(source: Path) -> list[Path]:
+    if source.is_file():
+        return [source]
+    if not source.is_dir():
+        return []
+    preferred = [
+        source / "final_report.md",
+        source / "synthesis.md",
+        source / "specialist_reviews" / "code.md",
+        source / "specialist_reviews" / "security.md",
+        source / "specialist_reviews" / "tests.md",
+        source / "specialist_reviews" / "docs.md",
+        source / "specialist_reviews" / "architecture.md",
+        source / "specialist_reviews" / "dependencies.md",
+    ]
+    files = [path for path in preferred if path.is_file()]
+    if files:
+        return files
+    return sorted(source.rglob("*.md"))[:30]
+
+
+def line_value(block: str, key: str) -> str:
+    pattern = re.compile(rf"^\s*-\s*{re.escape(key)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(block)
+    return match.group(1).strip() if match else ""
+
+
+def clean_title(title: str) -> str:
+    title = re.sub(r"^\[[Pp][0-3]\]\s*", "", title).strip()
+    title = re.sub(r"\s+", " ", title)
+    return title.rstrip("# ").strip()
+
+
+def severity_from_block(heading_severity: str | None, block: str) -> str:
+    if heading_severity:
+        return heading_severity.upper()
+    value = line_value(block, "Severity")
+    match = re.search(r"\bP[0-3]\b", value.upper())
+    return match.group(0) if match else "P2"
+
+
+def confidence_from_block(block: str) -> str:
+    value = line_value(block, "Confidence")
+    if value:
+        return value
+    lowered = block.lower()
+    if "confidence: high" in lowered:
+        return "high"
+    if "confidence: low" in lowered:
+        return "low"
+    return "medium"
+
+
+def split_findings(path: Path) -> list[dict[str, object]]:
+    text = read_text(path)
+    matches = [
+        match
+        for match in FINDING_HEADING_RE.finditer(text)
+        if re.match(r"^#{2,4}\s+Finding\s+", match.group(0), re.IGNORECASE)
+    ]
+    findings: list[dict[str, object]] = []
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        block = text[start:end].strip()
+        raw_title = clean_title(match.group("title"))
+        severity = severity_from_block(match.group("severity"), block)
+        finding_id = match.group("id") or f"{path.stem}-{index + 1}"
+        role = line_value(block, "Role") or line_value(block, "Source role") or infer_role(path, block)
+        evidence = line_value(block, "Evidence") or line_value(block, "Validation or proof gap")
+        action = line_value(block, "Recommended action") or line_value(block, "Recommended follow-up owner")
+        impact = line_value(block, "User/customer impact") or line_value(block, "Impact")
+        affected = line_value(block, "Affected path or artifact") or line_value(block, "Affected path")
+        findings.append(
+            {
+                "finding_id": str(finding_id).strip(": "),
+                "title": raw_title,
+                "severity": severity,
+                "confidence": confidence_from_block(block),
+                "role": role,
+                "source_file": path.name,
+                "affected_path": affected,
+                "evidence": evidence,
+                "recommended_action": action,
+                "impact": impact,
+                "body": block,
+            }
+        )
+    return findings
+
+
+def infer_role(path: Path, block: str) -> str:
+    lowered = f"{path.as_posix()} {block}".lower()
+    for role in ("security", "tests", "docs", "architecture", "dependencies", "diagram", "code"):
+        if role in lowered:
+            return role
+    return "review"
+
+
+def normalize_group_key(finding: dict[str, object]) -> str:
+    title = str(finding["title"]).lower()
+    title = re.sub(r"[^a-z0-9]+", " ", title).strip()
+    affected = str(finding.get("affected_path", "")).lower().strip()
+    return f"{title}|{affected}"
+
+
+def highest_severity(findings: list[dict[str, object]]) -> str:
+    return min((str(item["severity"]) for item in findings), key=lambda item: SEVERITY_ORDER.get(item, 9))
+
+
+def candidate_id(group_key: str) -> str:
+    digest = hashlib.sha1(group_key.encode("utf-8")).hexdigest()[:8]
+    return f"issue-candidate-{digest}"
+
+
+def candidate_from_group(group_key: str, findings: list[dict[str, object]], tracker: str) -> dict[str, object]:
+    primary = findings[0]
+    severity = highest_severity(findings)
+    roles = sorted({str(item.get("role") or "review") for item in findings})
+    affected_paths = sorted({str(item.get("affected_path") or "") for item in findings if item.get("affected_path")})
+    evidence_items = [str(item.get("evidence") or "").strip() for item in findings if item.get("evidence")]
+    action = str(primary.get("recommended_action") or "Address the review finding with a bounded fix.")
+    problem = str(primary.get("impact") or primary.get("title") or "Review finding requires follow-up.")
+    title = f"[{severity}] {primary['title']}"
+    return {
+        "candidate_id": candidate_id(group_key),
+        "title": title,
+        "severity": severity,
+        "source_finding_ids": [str(item["finding_id"]) for item in findings],
+        "source_roles": roles,
+        "confidence": str(primary.get("confidence") or "medium"),
+        "affected_paths": affected_paths,
+        "evidence": evidence_items or ["Evidence was not extracted cleanly; human review required before tracker creation."],
+        "problem": problem,
+        "recommended_action": action,
+        "acceptance_criteria": [
+            "The issue states the source finding evidence and affected surface.",
+            "The fix or follow-up remains bounded to the finding scope.",
+            "Validation evidence is recorded before closeout.",
+        ],
+        "validation_plan": [
+            "Run the smallest targeted test, lint, review, or demo command that proves the finding is addressed.",
+            "Record any commands not run and why.",
+        ],
+        "non_goals": DEFAULT_NON_GOALS,
+        "dependencies": dependency_notes(findings),
+        "approval_status": "candidate_only",
+        "tracker": tracker,
+    }
+
+
+def dependency_notes(findings: list[dict[str, object]]) -> list[str]:
+    notes: list[str] = []
+    for item in findings:
+        related = line_value(str(item.get("body", "")), "Related findings")
+        if related:
+            notes.append(f"Related findings: {related}")
+    return notes or ["No dependency links extracted."]
+
+
+def severity_allowed(severity: str, floor: str) -> bool:
+    return SEVERITY_ORDER.get(severity, 9) <= SEVERITY_ORDER.get(floor, 3)
+
+
+def build_plan(source: Path, tracker: str, severity_floor: str) -> dict[str, object]:
+    findings: list[dict[str, object]] = []
+    for path in source_files(source):
+        findings.extend(split_findings(path))
+
+    deferred: list[dict[str, object]] = []
+    groups: dict[str, list[dict[str, object]]] = {}
+    for finding in findings:
+        if not severity_allowed(str(finding["severity"]), severity_floor):
+            deferred.append({**finding, "deferred_reason": f"below severity floor {severity_floor}"})
+            continue
+        if not str(finding.get("evidence") or "").strip():
+            deferred.append({**finding, "deferred_reason": "missing extracted evidence"})
+            continue
+        groups.setdefault(normalize_group_key(finding), []).append(finding)
+
+    candidates = [candidate_from_group(key, items, tracker) for key, items in sorted(groups.items())]
+    status = "not_run"
+    if candidates and deferred:
+        status = "partial"
+    elif candidates:
+        status = "pass"
+    elif deferred:
+        status = "partial"
+
+    return {
+        "schema": SCHEMA,
+        "source": source.name,
+        "created_at": now_utc(),
+        "tracker": tracker,
+        "status": status,
+        "candidate_count": len(candidates),
+        "deferred_count": len(deferred),
+        "candidates": candidates,
+        "deferred_findings": deferred,
+        "approval_boundary": {
+            "tracker_creation_allowed": False,
+            "approval_required": True,
+            "mutation_performed": False,
+        },
+    }
+
+
+def write_markdown(path: Path, plan: dict[str, object]) -> None:
+    candidates = plan["candidates"]
+    deferred = plan["deferred_findings"]
+    candidate_lines = []
+    for candidate in candidates:
+        evidence = "\n".join(f"  - {item}" for item in candidate["evidence"])
+        criteria = "\n".join(f"  - {item}" for item in candidate["acceptance_criteria"])
+        validation = "\n".join(f"  - {item}" for item in candidate["validation_plan"])
+        candidate_lines.append(
+            f"""### {candidate['candidate_id']}: {candidate['title']}
+
+- Severity: {candidate['severity']}
+- Source findings: {', '.join(candidate['source_finding_ids'])}
+- Source roles: {', '.join(candidate['source_roles'])}
+- Confidence: {candidate['confidence']}
+- Affected paths: {', '.join(candidate['affected_paths']) or 'not extracted'}
+- Approval status: {candidate['approval_status']}
+- Problem: {candidate['problem']}
+- Recommended action: {candidate['recommended_action']}
+- Evidence:
+{evidence}
+- Acceptance criteria:
+{criteria}
+- Validation plan:
+{validation}
+- Non-goals:
+  - {'; '.join(candidate['non_goals'])}
+- Dependencies: {'; '.join(candidate['dependencies'])}
+"""
+        )
+    deferred_lines = []
+    for finding in deferred:
+        deferred_lines.append(
+            f"- {finding.get('finding_id')}: [{finding.get('severity')}] {finding.get('title')} ({finding.get('deferred_reason')})"
+        )
+
+    content = f"""# Finding To Issue Plan
+
+## Metadata
+
+- Skill: finding-to-issue-planner
+- Source: {plan['source']}
+- Tracker: {plan['tracker']}
+- Status: {plan['status']}
+- Date: {plan['created_at']}
+
+## Scope
+
+- Candidate count: {plan['candidate_count']}
+- Deferred finding count: {plan['deferred_count']}
+- Tracker creation allowed: false
+
+## Issue Candidates
+
+{chr(10).join(candidate_lines) if candidate_lines else '- No issue candidates generated.'}
+
+## Deferred Findings
+
+{chr(10).join(deferred_lines) if deferred_lines else '- None.'}
+
+## Approval Boundary
+
+- Human approval is required before tracker mutation.
+- No issues, PRs, tests, or remediation branches were created by this skill.
+
+## Validation Notes
+
+- This artifact is a planning surface. It does not prove remediation.
+- Each approved candidate needs its own execution validation.
+
+## Residual Risk
+
+- Markdown extraction may miss custom finding formats; manually review deferred findings and grouped candidates before issue creation.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("finding_source", help="Review markdown file or CodeBuddy packet root")
+    parser.add_argument("--out", default=None, help="Issue-planning artifact root")
+    parser.add_argument("--tracker", default="github", help="Target tracker name for candidate wording")
+    parser.add_argument("--severity-floor", default="P3", choices=["P0", "P1", "P2", "P3"])
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    source = Path(args.finding_source)
+    if not source.exists():
+        raise SystemExit(f"finding source does not exist: {source}")
+
+    out_root = Path(args.out) if args.out else source.parent / "issue-planning"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    plan = build_plan(source, args.tracker, args.severity_floor)
+    write_json(out_root / "issue_candidates.json", plan)
+    write_markdown(out_root / "issue_candidates.md", plan)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_finding_to_issue_planner_skill_contracts.sh
+++ b/adl/tools/test_finding_to_issue_planner_skill_contracts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/finding-to-issue-planner/SKILL.md" ]]
+[[ -f "${skills_root}/finding-to-issue-planner/adl-skill.yaml" ]]
+[[ -f "${skills_root}/finding-to-issue-planner/agents/openai.yaml" ]]
+[[ -f "${skills_root}/finding-to-issue-planner/references/output-contract.md" ]]
+[[ -x "${skills_root}/finding-to-issue-planner/scripts/plan_review_issues.py" ]]
+[[ -f "${skills_root}/docs/FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "finding-to-issue-planner"' "${skills_root}/finding-to-issue-planner/adl-skill.yaml"
+grep -Fq 'id: "finding_to_issue_planner.v1"' "${skills_root}/finding-to-issue-planner/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/finding-to-issue-planner/adl-skill.yaml"
+grep -Fq "tracker_creation_allowed_must_be_false" "${skills_root}/finding-to-issue-planner/adl-skill.yaml"
+grep -Fq "Convert CodeBuddy review findings into grouped, reviewable issue candidates" "${skills_root}/finding-to-issue-planner/SKILL.md"
+grep -Fq "Do not create issues, PRs, remediation branches, tests, or tracker items." "${skills_root}/finding-to-issue-planner/references/output-contract.md"
+grep -Fq "Schema id: \`finding_to_issue_planner.v1\`" "${skills_root}/docs/FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "finding-to-issue-planner" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+review_path="${tmpdir}/review.md"
+out_root="${tmpdir}/issue-plan"
+cat >"${review_path}" <<'MARKDOWN'
+# Code Review: example
+
+## Findings
+
+### Finding C-001: [P1] Unsafe root checkout mutation path
+
+- Role: code
+- Confidence: high
+- Affected path or artifact: adl/tools/pr.sh
+- Trigger scenario: execution runs from root main with tracked edits.
+- Evidence: the review packet shows the helper accepts mutation before worktree binding.
+- User/customer impact: operators can accidentally write tracked implementation changes on main.
+- Recommended action: reject root-main tracked mutations and force issue worktree execution.
+- Validation or proof gap: add a focused shell-contract test.
+- Related findings: S-002
+
+### Finding S-002: [P2] Unsafe root checkout mutation path
+
+- Role: security
+- Confidence: medium
+- Affected path or artifact: adl/tools/pr.sh
+- Trigger scenario: unsafe state can hide local drift.
+- Evidence: the security review found the same mutation boundary.
+- User/customer impact: local drift can reach review artifacts.
+- Recommended action: preserve the root checkout safety gate.
+MARKDOWN
+
+python3 "${skills_root}/finding-to-issue-planner/scripts/plan_review_issues.py" \
+  "${review_path}" --out "${out_root}" --tracker github >/tmp/finding-to-issue-planner.out
+
+[[ -f "${out_root}/issue_candidates.json" ]]
+[[ -f "${out_root}/issue_candidates.md" ]]
+grep -Fq '"schema": "codebuddy.finding_to_issue_planner.v1"' "${out_root}/issue_candidates.json"
+grep -Fq '"candidate_count": 1' "${out_root}/issue_candidates.json"
+grep -Fq '"severity": "P1"' "${out_root}/issue_candidates.json"
+grep -Fq '"source_finding_ids": [' "${out_root}/issue_candidates.json"
+grep -Fq '"C-001"' "${out_root}/issue_candidates.json"
+grep -Fq '"S-002"' "${out_root}/issue_candidates.json"
+grep -Fq "Human approval is required before tracker mutation." "${out_root}/issue_candidates.md"
+grep -Fq "No issues, PRs, tests, or remediation branches were created" "${out_root}/issue_candidates.md"
+if grep -R "${tmpdir}" "${out_root}" >/dev/null; then
+  echo "issue planning artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/finding-to-issue-planner/SKILL.md"
+
+echo "PASS test_finding_to_issue_planner_skill_contracts"


### PR DESCRIPTION
Closes #2065

## Summary
Implemented the CodeBuddy finding-to-issue planner skill. The new skill converts
review findings into grouped, approval-bound issue candidates and explicitly
stops before tracker creation, pull request creation, remediation, test
generation, or customer repository mutation.

## Artifacts
- `adl/tools/skills/finding-to-issue-planner/SKILL.md`
- `adl/tools/skills/finding-to-issue-planner/adl-skill.yaml`
- `adl/tools/skills/finding-to-issue-planner/agents/openai.yaml`
- `adl/tools/skills/finding-to-issue-planner/references/output-contract.md`
- `adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py`
- `adl/tools/skills/docs/FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_finding_to_issue_planner_skill_contracts.sh`
- Updated `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_finding_to_issue_planner_skill_contracts.sh` verified
    the skill contract, deterministic helper output, duplicate grouping, and
    approval boundary.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/finding-to-issue-planner/SKILL.md adl/tools/skills/repo-packet-builder/SKILL.md adl/tools/skills/repo-architecture-review/SKILL.md` verified valid skill frontmatter for the new skill and nearby CodeBuddy skill references.
  - `python3 -m py_compile adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py` verified the helper script parses as Python.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2065__backlog-skills-add-finding-to-issue-planner-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2065__backlog-skills-add-finding-to-issue-planner-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-finding-to-issue-planner-skill-adl-tools-skills-finding-to-issue-planner-adl-tools-skills-docs-finding-to-issue-planner-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-finding-to-issue-planner-skill-contracts-sh-adl-v0-90-tasks-issue-2065-backlog-skills-add-finding-to-issue-planner-skill-sip-md-adl-v0-90-tasks-issue-2065-backlog-skills-add-finding-to-issue-planner-skill-sor-md