### PR TITLE
[v0.90][backlog][skills] Add architecture fitness function author skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -44,6 +44,7 @@ run_step "repo-dependency-review contract check" bash "$ROOT/adl/tools/test_repo
 run_step "repo-diagram-planner contract check" bash "$ROOT/adl/tools/test_repo_diagram_planner_skill_contracts.sh"
 run_step "architecture-diagram-reviewer contract check" bash "$ROOT/adl/tools/test_architecture_diagram_reviewer_skill_contracts.sh"
 run_step "review-to-test-planner contract check" bash "$ROOT/adl/tools/test_review_to_test_planner_skill_contracts.sh"
+run_step "architecture-fitness-function-author contract check" bash "$ROOT/adl/tools/test_architecture_fitness_function_author_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/architecture-fitness-function-author/SKILL.md
+++ b/adl/tools/skills/architecture-fitness-function-author/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: architecture-fitness-function-author
+description: Author bounded architecture fitness-function plans from CodeBuddy review packets, architecture reviews, findings, or repo evidence by separating machine-checkable invariants from human judgment and proposing dependency rules, forbidden imports, contract tests, docs checks, CI gates, validation commands, expected failure modes, and deferred automation without mutating repositories.
+---
+
+# Architecture Fitness Function Author
+
+Author reviewable architecture fitness-function plans from architecture rules
+and review findings. This skill turns recurring architecture risks into bounded checks where practical.
+
+It is an authoring lane for fitness-function specifications and handoffs, not a
+repo mutation lane. It may propose check logic, validation commands, failure
+modes, and CI placement, but it must not edit customer repositories, CI files,
+tests, or production code unless a separate implementation issue explicitly
+authorizes that work.
+
+## Quick Start
+
+1. Confirm the bounded target:
+   - CodeBuddy review packet
+   - architecture review artifact
+   - synthesis artifact
+   - findings file
+   - repo path with architecture policy evidence
+2. Prefer packet artifacts when available:
+   - `evidence_index.json`
+   - `repo_inventory.json`
+   - `run_manifest.json`
+   - architecture review artifact
+3. Run the deterministic authoring scaffold when local access is available:
+   - `scripts/author_architecture_fitness_functions.py <source-root> --out <artifact-root>`
+4. Inspect the emitted candidate checks and tighten the specs.
+5. Hand implementation-ready checks to the appropriate downstream lane. Stop
+   before editing tests, CI, docs, policies, issues, PRs, or customer repo files.
+
+## Focus
+
+Prioritize:
+
+- dependency direction and layering rules
+- forbidden imports or forbidden path relationships
+- runtime lifecycle and state-transition contracts
+- docs truth checks for architecture claims
+- contract tests for architecture boundaries
+- CI gate candidates with clear validation commands
+- expected failure messages and false-positive risks
+- separation of machine-checkable invariants from human-judgment review items
+- deferred automation boundaries when a rule cannot be safely automated yet
+
+Defer primary ownership of these areas:
+
+- finding original architecture defects: `repo-architecture-review`
+- writing tests: `test-generator`
+- planning test work from general findings: `review-to-test-planner`
+- creating follow-up issues: `finding-to-issue-planner`
+- writing ADRs: `adr-curator`
+- editing CI or repo policy files: implementation issue workflow
+- final report synthesis: `repo-review-synthesis` or report writer skills
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `target.review_packet_path`
+  - `target.architecture_review_artifact`
+  - `target.findings_file`
+  - `target.target_path`
+
+Useful additional inputs:
+
+- `artifact_root`
+- `allowed_check_types`
+- `ci_system`
+- `validation_mode`
+- `policy_scope`
+- `implementation_allowed`
+- `risk_tolerance`
+
+If there is no bounded architecture rule, finding, or evidence source, stop and
+report `blocked`.
+
+## Workflow
+
+### 1. Establish Scope
+
+Record:
+
+- source artifacts reviewed
+- architecture surfaces consulted
+- target repo/path scope
+- assumed CI or validation environment
+- whether implementation is allowed
+
+Do not widen a single architecture finding into a whole-repo policy program.
+
+### 2. Extract Candidate Invariants
+
+Look for:
+
+- boundary terms such as layer, adapter, runtime, CLI, persistence, state, and
+  provider
+- dependency terms such as import, dependency, manifest, package, module, and
+  ownership
+- contract terms such as schema, validation, policy, lifecycle, and state
+- docs-truth terms such as command, README, guide, milestone, and architecture
+  claim
+
+For each candidate, decide whether it is:
+
+- `machine_checkable`: can be expressed as a deterministic local check
+- `human_judgment`: needs reviewer judgment or architectural decision first
+- `deferred`: lacks source evidence, stable rule shape, or safe implementation
+
+### 3. Author Fitness Function Specs
+
+For machine-checkable candidates, include:
+
+- rule id
+- invariant statement
+- source evidence
+- check type
+- suggested implementation surface
+- validation command
+- expected failure mode
+- false-positive risks
+- downstream owner
+
+For human-judgment candidates, include:
+
+- decision needed
+- evidence gap
+- suggested follow-up owner
+- automation boundary
+
+### 4. Emit Handoffs
+
+Recommended handoffs:
+
+- `test-generator` for contract-test implementation
+- implementation issue workflow for CI gates or repo policy scripts
+- `repo-architecture-review` for unresolved architecture evidence
+- `adr-curator` for durable decisions that need an ADR before automation
+
+Do not invoke downstream skills automatically unless the operator explicitly
+asks for that follow-on execution.
+
+## Output Expectations
+
+Default output should include:
+
+- fitness-function catalog
+- machine-checkable invariants
+- human-judgment candidates
+- deferred automation boundaries
+- validation command plan
+- expected failure modes
+- implementation handoffs
+- validation performed or not run
+- residual architecture risk
+
+Use `references/output-contract.md` and the shared suite contract in
+`adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`.
+
+## Stop Boundary
+
+Stop after producing the architecture fitness-function plan.
+
+Do not:
+
+- edit tests, CI, docs, production code, policy files, or issue state
+- mutate customer repositories
+- create issues or PRs
+- claim a fitness function is installed when only a plan exists
+- replace architecture review, ADR writing, test generation, or implementation
+  workflow
+- use network or paid services
+
+## CodeBuddy Integration Notes
+
+This skill consumes CodeBuddy packet artifacts and architecture review outputs.
+It produces fitness-function plans that can feed test generation, implementation
+issues, CI hardening, ADR work, or final synthesis/report writing.
+
+Deferred automation:
+
+- language-specific dependency graph extraction
+- project-specific import-rule generation
+- CI provider-specific gate patching
+- coverage-linked confidence scoring
+- batch execution of approved check implementations

--- a/adl/tools/skills/architecture-fitness-function-author/adl-skill.yaml
+++ b/adl/tools/skills/architecture-fitness-function-author/adl-skill.yaml
@@ -1,0 +1,98 @@
+version: "0.1"
+kind: "adl-skill"
+id: "architecture-fitness-function-author"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "architecture_fitness_function_author.v1"
+    reference_doc: "../docs/ARCHITECTURE_FITNESS_FUNCTION_AUTHOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "author_from_review_packet"
+      - "author_from_architecture_review"
+      - "author_from_findings_file"
+      - "author_from_path"
+    policy_fields:
+      - "allowed_check_types"
+      - "validation_mode"
+      - "implementation_allowed"
+      - "ci_gate_allowed"
+      - "write_plan_artifact"
+      - "stop_after_plan"
+  intent:
+    - "architecture_fitness_function_authoring"
+    - "architecture_policy_checks"
+    - "fitness_function_planning"
+    - "codebuddy_review_engine"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "review_packet_path"
+    - "architecture_review_artifact"
+    - "findings_file"
+    - "target_path"
+    - "artifact_root"
+    - "allowed_check_types"
+    - "ci_system"
+  stop_if_missing:
+    - "repo_root"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_architecture_fitness_function_author.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.stop_after_plan_must_be_true"
+    - "author_from_review_packet_requires_target.review_packet_path"
+    - "author_from_findings_file_requires_target.findings_file"
+execution:
+  mode: "planning_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  test_policy: "run_targeted_local_validation_when_bounded"
+  permitted_scripts:
+    - path: "scripts/author_architecture_fitness_functions.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<source-root>"
+        - "--out <artifact-root>"
+        - "--repo-name <name>"
+        - "--max-rules <n>"
+  preferred_read_order:
+    - "architecture_review_artifact"
+    - "repo-review-synthesis artifact"
+    - "evidence_index.json"
+    - "repo_inventory.json"
+    - "repo_scope.md"
+    - "findings_file"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-architecture-fitness-functions.md"
+  required_sections:
+    - "fitness_function_catalog"
+    - "machine_checkable_invariants"
+    - "human_judgment_candidates"
+    - "deferred_automation_boundaries"
+    - "validation_command_plan"
+    - "expected_failure_modes"
+    - "implementation_handoffs"
+    - "validation_performed"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: true
+
+display_name: Architecture Fitness Function Author
+short_description: Author source-grounded architecture fitness-function plans and implementation handoffs
+default_prompt: Author bounded architecture fitness-function specs from review evidence. Stop after the plan; do not edit tests, CI, docs, policies, issues, PRs, or repo files.

--- a/adl/tools/skills/architecture-fitness-function-author/agents/openai.yaml
+++ b/adl/tools/skills/architecture-fitness-function-author/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Architecture Fitness Function Author
+short_description: Author source-grounded architecture fitness-function plans and implementation handoffs.
+default_prompt: Author bounded architecture fitness-function specs from review evidence. Stop after the plan; do not edit tests, CI, docs, policies, issues, PRs, or repo files.

--- a/adl/tools/skills/architecture-fitness-function-author/references/fitness-function-playbook.md
+++ b/adl/tools/skills/architecture-fitness-function-author/references/fitness-function-playbook.md
@@ -1,0 +1,33 @@
+# Architecture Fitness Function Playbook
+
+Use this reference when turning architecture findings into executable checks.
+
+## Candidate Types
+
+- `dependency_rule`: dependency direction, package boundary, forbidden import,
+  or module ownership rule.
+- `contract_test`: runtime lifecycle, state transition, provider boundary, or
+  artifact contract that can be checked with a focused test.
+- `docs_check`: documented command, architecture claim, or milestone truth check.
+- `ci_gate`: wrapper that runs existing deterministic checks in CI.
+- `repo_policy_check`: repo-specific script or lint that enforces local policy.
+- `manual_review_gate`: rule needs human architectural judgment before
+  automation.
+
+## Classification Rules
+
+- Use `machine_checkable` when a deterministic local command can pass/fail the
+  invariant without external services or human interpretation.
+- Use `human_judgment` when the invariant needs an ADR, architecture decision,
+  or reviewer interpretation before automation.
+- Use `deferred` when evidence is insufficient, the target path is unknown, or
+  implementation would require production services, credentials, network, or
+  unbounded mutation.
+
+## Failure-Mode Guidance
+
+- Dependency rule: name the forbidden source and target direction.
+- Contract test: name the expected transition, state, or artifact field.
+- Docs check: name the stale claim or command truth being guarded.
+- CI gate: name the command and why a failure should block merge.
+- Repo policy check: name the local policy and expected diagnostic.

--- a/adl/tools/skills/architecture-fitness-function-author/references/output-contract.md
+++ b/adl/tools/skills/architecture-fitness-function-author/references/output-contract.md
@@ -1,0 +1,32 @@
+# Architecture Fitness Function Author Output Contract
+
+The architecture fitness-function author emits a plan and check specification
+artifact. It does not install checks or mutate repositories.
+
+Required sections:
+
+- Fitness Function Catalog
+- Machine-Checkable Invariants
+- Human-Judgment Candidates
+- Deferred Automation Boundaries
+- Validation Command Plan
+- Expected Failure Modes
+- Implementation Handoffs
+- Validation Performed
+- Residual Risk
+
+Each fitness-function candidate must include:
+
+- rule id
+- source evidence
+- invariant statement
+- classification: `machine_checkable`, `human_judgment`, or `deferred`
+- check type
+- suggested implementation surface
+- validation command
+- expected failure mode
+- false-positive risk
+- downstream owner
+
+Do not edit tests, CI, docs, policies, production code, issues, PRs, or customer
+repository files from this skill.

--- a/adl/tools/skills/architecture-fitness-function-author/scripts/author_architecture_fitness_functions.py
+++ b/adl/tools/skills/architecture-fitness-function-author/scripts/author_architecture_fitness_functions.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Author architecture fitness-function specs from review evidence."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+SCHEMA = "codebuddy.architecture_fitness_functions.v1"
+SOURCE_EXTENSIONS = {".md", ".json", ".txt", ".yaml", ".yml", ".toml"}
+MACHINE_TERMS = (
+    "import",
+    "dependency",
+    "forbidden",
+    "must not",
+    "contract",
+    "schema",
+    "validate",
+    "check",
+    "ci",
+    "test",
+    "command",
+    "state",
+    "lifecycle",
+)
+HUMAN_TERMS = ("adr", "decision", "tradeoff", "judgment", "architecture decision", "ownership")
+DEFER_TERMS = ("unknown", "external service", "production", "credential", "secret", "manual only")
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def relative_to_root(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def source_files(source_root: Path) -> list[Path]:
+    if source_root.is_file():
+        return [source_root] if source_root.suffix.lower() in SOURCE_EXTENSIONS else []
+    files: list[Path] = []
+    for path in source_root.rglob("*"):
+        if path.is_file() and path.suffix.lower() in SOURCE_EXTENSIONS:
+            if "architecture_fitness_functions" in path.name:
+                continue
+            files.append(path)
+    return sorted(files, key=lambda item: item.as_posix())
+
+
+def read_text(path: Path) -> str:
+    try:
+        if path.suffix.lower() == ".json":
+            return json.dumps(load_json(path), indent=2, sort_keys=True)
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(re.search(rf"(?<![A-Za-z0-9_]){re.escape(term)}(?![A-Za-z0-9_])", text) for term in terms)
+
+
+def evidence_entries(root: Path) -> list[dict[str, object]]:
+    candidates = [root / "evidence_index.json"]
+    if root.is_dir():
+        candidates.extend(sorted(root.rglob("evidence_index.json")))
+    for candidate in candidates:
+        data = load_json(candidate)
+        if isinstance(data, dict) and isinstance(data.get("evidence"), list):
+            return [item for item in data["evidence"] if isinstance(item, dict)]
+    return []
+
+
+def candidate_blocks(path: Path, text: str) -> list[dict[str, str]]:
+    markers = list(
+        re.finditer(
+            r"(?im)^(?:#{1,4}\s*)?(?:Finding\s+\d+|Candidate Fitness Functions?|Architecture Map|Fitness|Rule|\[?P[0-3]\]?)|^\s*-\s*Rule:",
+            text,
+        )
+    )
+    if not markers and contains_any(text.lower(), MACHINE_TERMS + HUMAN_TERMS):
+        markers = [re.match(r"", text)]  # type: ignore[list-item]
+    if not markers:
+        return []
+    starts = [marker.start() for marker in markers if marker is not None]
+    starts.append(len(text))
+    blocks: list[dict[str, str]] = []
+    for index, start in enumerate(starts[:-1]):
+        block = text[start:starts[index + 1]].strip()
+        if not block:
+            continue
+        blocks.append(
+            {
+                "id": f"{path.stem}-fitness-{index + 1:02d}",
+                "source": path.name,
+                "title": title_from_block(block, f"Architecture fitness candidate from {path.name}"),
+                "text": block,
+                "path": extract_path(block),
+            }
+        )
+    return blocks
+
+
+def title_from_block(block: str, fallback: str) -> str:
+    for line in block.splitlines():
+        clean = line.strip(" -#")
+        clean = re.sub(r"^\[?P[0-3]\]?\s*:?\s*", "", clean)
+        clean = re.sub(r"^(Finding|Rule|Fitness)\s+\d+\s*:?\s*", "", clean, flags=re.IGNORECASE)
+        if len(clean) > 8:
+            return clean[:140]
+    return fallback
+
+
+def extract_path(block: str) -> str:
+    patterns = (
+        r"(?:^|\n)\s*(?:File|Source|Path):\s*`?([^`\n]+?)`?\s*(?:\n|$)",
+        r'"path"\s*:\s*"([^"]+)"',
+        r"([A-Za-z0-9_./-]+\.(?:rs|py|js|jsx|ts|tsx|sh|md|toml|yaml|yml|json))",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, block)
+        if match:
+            value = match.group(1).strip()
+            if value.lower() not in {"none", "unknown", "n/a"}:
+                return value
+    return "unknown"
+
+
+def evidence_candidates(entries: list[dict[str, object]]) -> list[dict[str, str]]:
+    candidates: list[dict[str, str]] = []
+    for index, entry in enumerate(sorted(entries, key=lambda item: str(item.get("path", "")))[:60], start=1):
+        path = str(entry.get("path", ""))
+        reason = str(entry.get("reason", ""))
+        category = str(entry.get("category", ""))
+        text = f"{path} {reason} {category}".lower()
+        if contains_any(text, MACHINE_TERMS + HUMAN_TERMS):
+            candidates.append(
+                {
+                    "id": f"evidence-fitness-{index:02d}",
+                    "source": "evidence_index.json",
+                    "title": f"Guard architecture contract represented by {path}",
+                    "text": f"{reason} {category}",
+                    "path": path or "unknown",
+                }
+            )
+    return candidates
+
+
+def collect_candidates(root: Path, files: list[Path]) -> list[dict[str, str]]:
+    candidates: list[dict[str, str]] = []
+    for path in files:
+        candidates.extend(candidate_blocks(path, read_text(path)))
+    candidates.extend(evidence_candidates(evidence_entries(root)))
+    deduped: dict[tuple[str, str], dict[str, str]] = {}
+    for candidate in candidates:
+        key = (candidate["title"].lower(), candidate["path"])
+        deduped.setdefault(key, candidate)
+    return sorted(deduped.values(), key=lambda item: (item["source"], item["id"]))[:80]
+
+
+def classify(candidate: dict[str, str]) -> str:
+    text = f"{candidate['title']} {candidate['text']} {candidate['path']}".lower()
+    if candidate["path"] == "unknown" or contains_any(text, DEFER_TERMS):
+        return "deferred"
+    if contains_any(text, HUMAN_TERMS) and not contains_any(text, MACHINE_TERMS):
+        return "human_judgment"
+    if contains_any(text, MACHINE_TERMS):
+        return "machine_checkable"
+    return "human_judgment"
+
+
+def check_type(candidate: dict[str, str]) -> str:
+    text = f"{candidate['title']} {candidate['text']} {candidate['path']}".lower()
+    path = candidate["path"].lower()
+    if "import" in text or "forbidden" in text or "dependency" in text or path.endswith((".toml", ".json", ".yaml", ".yml")):
+        return "dependency_rule"
+    if "docs" in text or path.endswith(".md") or "command" in text:
+        return "docs_check"
+    if "ci" in text or "gate" in text:
+        return "ci_gate"
+    if "policy" in text or "validate" in text or "schema" in text:
+        return "repo_policy_check"
+    if "state" in text or "lifecycle" in text or "contract" in text or path.endswith((".rs", ".py", ".ts", ".js")):
+        return "contract_test"
+    return "manual_review_gate"
+
+
+def implementation_surface(candidate: dict[str, str], kind: str) -> str:
+    path = candidate["path"]
+    if kind == "dependency_rule":
+        return "repo-local dependency/import policy script or lint rule"
+    if kind == "docs_check":
+        return "docs validation or smoke-test script"
+    if kind == "ci_gate":
+        return "existing CI workflow invoking a deterministic local command"
+    if kind == "repo_policy_check":
+        return "repo-local validation script"
+    if kind == "contract_test":
+        if path.endswith(".rs"):
+            return "Rust unit/integration test near the affected module"
+        return "focused contract test near the affected subsystem"
+    return "architecture review checklist or ADR"
+
+
+def validation_command(kind: str, path: str) -> str:
+    if kind == "contract_test" and path.endswith(".rs"):
+        return "cd adl && cargo test"
+    if kind == "docs_check":
+        return "bash adl/tools/batched_checks.sh"
+    if kind in {"dependency_rule", "repo_policy_check", "ci_gate"}:
+        return "bash <repo-local-architecture-check>.sh"
+    return "manual architecture review or ADR approval required"
+
+
+def expected_failure(candidate: dict[str, str], kind: str) -> str:
+    if kind == "dependency_rule":
+        return "fails when a forbidden dependency direction, import, or package relationship is introduced"
+    if kind == "contract_test":
+        return "fails when the architecture contract or lifecycle behavior changes unexpectedly"
+    if kind == "docs_check":
+        return "fails when architecture docs or commands drift from repo truth"
+    if kind == "ci_gate":
+        return "fails the merge gate when the deterministic local architecture check fails"
+    if kind == "repo_policy_check":
+        return "fails with a stable diagnostic naming the violated repo policy"
+    return "blocks automation until an explicit architecture decision is recorded"
+
+
+def build_rules(candidates: list[dict[str, str]], max_rules: int) -> list[dict[str, object]]:
+    rules: list[dict[str, object]] = []
+    for index, candidate in enumerate(candidates[:max_rules], start=1):
+        classification = classify(candidate)
+        kind = check_type(candidate)
+        path = candidate["path"]
+        rules.append(
+            {
+                "id": f"architecture-fitness-{index:02d}",
+                "source_candidate": candidate["id"],
+                "source_artifact": candidate["source"],
+                "source_evidence": path,
+                "invariant": invariant_statement(candidate, kind),
+                "classification": classification,
+                "check_type": kind,
+                "suggested_implementation_surface": implementation_surface(candidate, kind),
+                "validation_command": validation_command(kind, path),
+                "expected_failure_mode": expected_failure(candidate, kind),
+                "false_positive_risk": false_positive_risk(classification, kind),
+                "downstream_owner": downstream_owner(classification, kind),
+            }
+        )
+    if not rules:
+        rules.append(
+            {
+                "id": "architecture-fitness-00",
+                "source_candidate": "none",
+                "source_artifact": "none",
+                "source_evidence": "unknown",
+                "invariant": "blocked until architecture evidence or findings are supplied",
+                "classification": "deferred",
+                "check_type": "manual_review_gate",
+                "suggested_implementation_surface": "none",
+                "validation_command": "not run",
+                "expected_failure_mode": "not applicable",
+                "false_positive_risk": "not applicable",
+                "downstream_owner": "operator",
+            }
+        )
+    return rules
+
+
+def invariant_statement(candidate: dict[str, str], kind: str) -> str:
+    title = re.sub(r"\s+", " ", candidate["title"]).strip()
+    if kind == "dependency_rule":
+        return f"Dependency and import direction around {candidate['path']} stays within the intended architecture boundary."
+    if kind == "docs_check":
+        return f"Architecture documentation claim remains true: {title}."
+    if kind == "contract_test":
+        return f"Architecture behavior remains stable: {title}."
+    if kind == "ci_gate":
+        return f"CI runs a deterministic architecture guard for {candidate['path']}."
+    if kind == "repo_policy_check":
+        return f"Repo policy represented by {candidate['path']} remains enforceable."
+    return f"Architecture decision remains explicit before automation: {title}."
+
+
+def false_positive_risk(classification: str, kind: str) -> str:
+    if classification == "deferred":
+        return "high until evidence and stable rule shape are available"
+    if classification == "human_judgment":
+        return "medium until an ADR or reviewer decision narrows the rule"
+    if kind == "dependency_rule":
+        return "medium if generated code or test fixtures intentionally cross boundaries"
+    return "low to medium depending on repo-specific fixture and path exclusions"
+
+
+def downstream_owner(classification: str, kind: str) -> str:
+    if classification == "deferred":
+        return "operator"
+    if classification == "human_judgment" or kind == "manual_review_gate":
+        return "adr-curator"
+    if kind == "contract_test":
+        return "test-generator"
+    return "implementation issue workflow"
+
+
+def rule_lines(rules: list[dict[str, object]], classification: str | None = None) -> str:
+    selected = [rule for rule in rules if classification is None or rule["classification"] == classification]
+    if not selected:
+        return "- None."
+    lines: list[str] = []
+    for rule in selected:
+        lines.extend(
+            [
+                f"- {rule['id']}: {rule['classification']} / {rule['check_type']}",
+                f"  Invariant: {rule['invariant']}",
+                f"  Evidence: {rule['source_evidence']}",
+                f"  Validation: {rule['validation_command']}",
+                f"  Failure mode: {rule['expected_failure_mode']}",
+                f"  Owner: {rule['downstream_owner']}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def write_markdown(path: Path, plan: dict[str, object]) -> None:
+    rules = plan["fitness_function_catalog"]
+    summary = plan["classification_summary"]
+    content = f"""# Architecture Fitness Functions
+
+## Metadata
+
+- Skill: architecture-fitness-function-author
+- Repo: {plan["repo_name"]}
+- Source Root: {plan["source_root"]}
+- Date: {plan["created_at"]}
+
+## Fitness Function Catalog
+
+{rule_lines(rules)}
+
+## Machine-Checkable Invariants
+
+{rule_lines(rules, "machine_checkable")}
+
+## Human-Judgment Candidates
+
+{rule_lines(rules, "human_judgment")}
+
+## Deferred Automation Boundaries
+
+{rule_lines(rules, "deferred")}
+
+## Validation Command Plan
+
+{chr(10).join(f"- {rule['id']}: {rule['validation_command']}" for rule in rules)}
+
+## Expected Failure Modes
+
+{chr(10).join(f"- {rule['id']}: {rule['expected_failure_mode']}" for rule in rules)}
+
+## Implementation Handoffs
+
+{chr(10).join(f"- {rule['id']}: {rule['downstream_owner']}" for rule in rules)}
+
+## Classification Summary
+
+- machine_checkable: {summary.get("machine_checkable", 0)}
+- human_judgment: {summary.get("human_judgment", 0)}
+- deferred: {summary.get("deferred", 0)}
+
+## Validation Performed
+
+- Scaffold generation only; no tests, CI, docs, policies, issues, PRs, or repository files were changed.
+
+## Residual Risk
+
+- Rule extraction is heuristic and must be reviewed before implementation.
+- Validation commands are proposed, not executed proof that a check has been installed.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_root", help="Review packet, architecture review artifact root, findings file, or evidence root")
+    parser.add_argument("--out", default=None, help="Architecture fitness-function output root")
+    parser.add_argument("--repo-name", default=None, help="Repo name override")
+    parser.add_argument("--max-rules", type=int, default=12, help="Maximum rules to emit")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    source_root = Path(args.source_root).resolve()
+    if not source_root.exists():
+        raise SystemExit(f"source root does not exist: {source_root}")
+    out_root = Path(args.out) if args.out else source_root / "architecture-fitness-functions"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_json(source_root / "run_manifest.json") if source_root.is_dir() else {}
+    repo_name = args.repo_name
+    if repo_name is None and isinstance(manifest, dict):
+        repo_name = str(manifest.get("repo_name", "") or "")
+    repo_name = repo_name or source_root.stem
+
+    files = source_files(source_root)
+    candidates = collect_candidates(source_root, files)
+    rules = build_rules(candidates, max(args.max_rules, 1))
+    summary = Counter(str(rule["classification"]) for rule in rules)
+    for classification in ("machine_checkable", "human_judgment", "deferred"):
+        summary.setdefault(classification, 0)
+    plan = {
+        "schema": SCHEMA,
+        "repo_name": repo_name,
+        "source_root": source_root.name,
+        "created_at": now_utc(),
+        "reviewed_artifacts": [relative_to_root(source_root, path) for path in files],
+        "classification_summary": dict(sorted(summary.items())),
+        "fitness_function_catalog": rules,
+        "notes": [
+            "Planner does not install checks or mutate repositories.",
+            "Paths are source-root-relative or source evidence strings, not absolute host paths.",
+            "Machine-checkable rules still require review before implementation.",
+        ],
+    }
+    write_json(out_root / "architecture_fitness_functions.json", plan)
+    write_markdown(out_root / "architecture_fitness_functions.md", plan)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/skills/docs/ARCHITECTURE_FITNESS_FUNCTION_AUTHOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/ARCHITECTURE_FITNESS_FUNCTION_AUTHOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,75 @@
+# Architecture Fitness Function Author Skill Input Schema
+
+Schema id: `architecture_fitness_function_author.v1`
+
+This schema describes structured input accepted by the
+`architecture-fitness-function-author` skill. It is bounded so CodeBuddy can
+author reviewable fitness-function specs without editing tests, CI, docs,
+policies, issues, PRs, or customer repository files.
+
+## Required Shape
+
+```yaml
+skill_input_schema: architecture_fitness_function_author.v1
+mode: author_from_review_packet | author_from_architecture_review | author_from_findings_file | author_from_path
+repo_root: /absolute/path
+target:
+  review_packet_path: <path or null>
+  architecture_review_artifact: <path or null>
+  findings_file: <path or null>
+  target_path: <path or null>
+  artifact_root: <path or null>
+policy:
+  allowed_check_types:
+    - dependency_rule
+    - forbidden_import
+    - contract_test
+    - docs_check
+    - ci_gate
+    - repo_policy_check
+  validation_mode: targeted | inspect_only | none
+  implementation_allowed: false
+  ci_gate_allowed: true | false
+  write_plan_artifact: true | false
+  stop_after_plan: true
+```
+
+## Required Fields
+
+- `skill_input_schema` must equal
+  `architecture_fitness_function_author.v1`.
+- `mode` must be one of the supported authoring modes.
+- `repo_root` must be absolute.
+- `target` must identify one bounded review packet, architecture review
+  artifact, findings file, or target path.
+- `policy.stop_after_plan` must be `true`.
+- `mode: author_from_review_packet` requires `target.review_packet_path`.
+- `mode: author_from_findings_file` requires `target.findings_file`.
+
+## Output Contract
+
+The skill writes or returns a fitness-function plan with:
+
+- fitness-function catalog
+- machine-checkable invariants
+- human-judgment candidates
+- deferred automation boundaries
+- validation command plan
+- expected failure modes
+- implementation handoffs
+- validation performed
+- residual risk
+
+The skill may also generate deterministic scaffolding with
+`scripts/author_architecture_fitness_functions.py`.
+
+## Stop Boundary
+
+The skill must not:
+
+- edit tests, CI, docs, policy files, production code, issues, or PRs
+- mutate customer repositories
+- run network or paid services
+- claim a check is installed when only a plan exists
+- replace architecture review, ADR writing, test generation, or implementation
+  workflow

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -21,6 +21,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `repo-diagram-planner`
 - `architecture-diagram-reviewer`
 - `review-to-test-planner`
+- `architecture-fitness-function-author`
 - `repo-review-synthesis`
 
 ## Invocation Order
@@ -37,6 +38,7 @@ Recommended order:
 8. `repo-diagram-planner`
 9. `architecture-diagram-reviewer`
 10. `review-to-test-planner`
+11. `architecture-fitness-function-author`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -51,6 +53,10 @@ handoffs without authoring or rendering diagrams.
 The review-to-test planner should run after specialist findings or synthesis
 exist. It maps findings to safe, bounded `test-generator` handoffs without
 writing tests or turning review follow-up into broad implementation work.
+The architecture fitness-function author should run after architecture findings
+or synthesis identify durable architecture rules worth preserving. It separates
+machine-checkable invariants from human-judgment candidates and deferred
+automation before any tests, CI gates, policy files, or repo checks are edited.
 
 ## Shared Specialist Input Shape
 
@@ -271,6 +277,33 @@ policy:
   stop_after_plan: true
 ```
 
+## Architecture Fitness Function Author Input Shape
+
+```yaml
+skill_input_schema: architecture_fitness_function_author.v1
+mode: author_from_review_packet | author_from_architecture_review | author_from_findings_file | author_from_path
+repo_root: /absolute/path
+target:
+  review_packet_path: <path or null>
+  architecture_review_artifact: <path or null>
+  findings_file: <path or null>
+  target_path: <path or null>
+  artifact_root: <path or null>
+policy:
+  allowed_check_types:
+    - dependency_rule
+    - forbidden_import
+    - contract_test
+    - docs_check
+    - ci_gate
+    - repo_policy_check
+  validation_mode: targeted | inspect_only | none
+  implementation_allowed: false
+  ci_gate_allowed: true | false
+  write_plan_artifact: true | false
+  stop_after_plan: true
+```
+
 ## Severity Rules
 
 - Preserve the highest severity attached to a merged finding unless the source
@@ -301,6 +334,9 @@ The suite may:
 - plan bounded test-generation handoffs from review findings, including
   behavior under test, fixture needs, expected assertions, validation commands,
   and `generated` / `recommended` / `deferred` / `unsafe` status
+- author bounded architecture fitness-function plans that separate
+  machine-checkable invariants, human-judgment candidates, deferred automation,
+  validation commands, expected failure modes, and implementation handoffs
 
 The suite must not:
 - edit code, tests, docs, configs, or issue state
@@ -308,6 +344,8 @@ The suite must not:
 - author, edit, render, publish, or replace diagrams from the diagram review
   lane
 - write tests or fixtures from the review-to-test planning lane
+- install or modify tests, CI gates, docs checks, dependency rules, policy files,
+  issues, or PRs from the architecture fitness-function authoring lane
 - claim remediation
 - run unbounded repository-wide analysis without a declared target
 - use network or paid data feeds
@@ -332,4 +370,6 @@ Use this suite when:
   need explicit ownership
 - diagram planning needs to be source-grounded before asking `diagram-author` to
   create a specific visual artifact
+- durable architecture rules need executable-check planning before separate
+  implementation work installs tests, policy checks, or CI gates
 - the synthesis artifact should show specialist coverage and disagreement

--- a/adl/tools/test_architecture_fitness_function_author_skill_contracts.sh
+++ b/adl/tools/test_architecture_fitness_function_author_skill_contracts.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/architecture-fitness-function-author/SKILL.md" ]]
+[[ -f "${skills_root}/architecture-fitness-function-author/adl-skill.yaml" ]]
+[[ -f "${skills_root}/architecture-fitness-function-author/agents/openai.yaml" ]]
+[[ -f "${skills_root}/architecture-fitness-function-author/references/fitness-function-playbook.md" ]]
+[[ -f "${skills_root}/architecture-fitness-function-author/references/output-contract.md" ]]
+[[ -x "${skills_root}/architecture-fitness-function-author/scripts/author_architecture_fitness_functions.py" ]]
+[[ -f "${skills_root}/docs/ARCHITECTURE_FITNESS_FUNCTION_AUTHOR_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "architecture-fitness-function-author"' "${skills_root}/architecture-fitness-function-author/adl-skill.yaml"
+grep -Fq 'id: "architecture_fitness_function_author.v1"' "${skills_root}/architecture-fitness-function-author/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/ARCHITECTURE_FITNESS_FUNCTION_AUTHOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/architecture-fitness-function-author/adl-skill.yaml"
+grep -Fq "author_from_review_packet_requires_target.review_packet_path" "${skills_root}/architecture-fitness-function-author/adl-skill.yaml"
+grep -Fq "turns recurring architecture risks into bounded checks" "${skills_root}/architecture-fitness-function-author/SKILL.md"
+grep -Fq "scripts/author_architecture_fitness_functions.py" "${skills_root}/architecture-fitness-function-author/SKILL.md"
+grep -Fq "Do not edit tests" "${skills_root}/architecture-fitness-function-author/references/output-contract.md"
+grep -Fq "Schema id: \`architecture_fitness_function_author.v1\`" "${skills_root}/docs/ARCHITECTURE_FITNESS_FUNCTION_AUTHOR_SKILL_INPUT_SCHEMA.md"
+grep -Fq "architecture-fitness-function-author" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+packet_root="${tmpdir}/packet"
+plan_root="${tmpdir}/fitness-functions"
+mkdir -p "${packet_root}"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "architecture-fitness-function-author-contract-test",
+  "repo_name": "example-repo",
+  "publication_allowed": false
+}
+JSON
+cat >"${packet_root}/evidence_index.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.evidence.v1",
+  "evidence": [
+    {
+      "path": "adl/src/execute/state.rs",
+      "category": "code",
+      "line_count": 220,
+      "reason": "runtime state lifecycle contract should remain stable",
+      "specialist_lanes": ["architecture", "tests", "synthesis"]
+    },
+    {
+      "path": "Cargo.toml",
+      "category": "manifest",
+      "line_count": 80,
+      "reason": "dependency boundary and package policy surface",
+      "specialist_lanes": ["architecture", "dependency", "synthesis"]
+    }
+  ]
+}
+JSON
+cat >"${packet_root}/architecture-review.md" <<'MD'
+# Architecture Review
+
+## Candidate Fitness Functions
+
+- Rule: CLI code must not import runtime-internal state modules directly.
+  Source: adl/src/execute/state.rs
+  Rationale: Preserve runtime lifecycle ownership and dependency direction.
+
+- Rule: The provider boundary decision needs an ADR before automation.
+  Source: docs/architecture/provider-boundary.md
+  Rationale: The tradeoff is still human judgment.
+MD
+
+python3 "${skills_root}/architecture-fitness-function-author/scripts/author_architecture_fitness_functions.py" \
+  "${packet_root}" --out "${plan_root}" --max-rules 6 >/tmp/architecture-fitness-function-author.out
+[[ -f "${plan_root}/architecture_fitness_functions.json" ]]
+[[ -f "${plan_root}/architecture_fitness_functions.md" ]]
+grep -Fq '"schema": "codebuddy.architecture_fitness_functions.v1"' "${plan_root}/architecture_fitness_functions.json"
+grep -Fq '"repo_name": "example-repo"' "${plan_root}/architecture_fitness_functions.json"
+grep -Fq '"classification": "machine_checkable"' "${plan_root}/architecture_fitness_functions.json"
+grep -Fq '"classification": "human_judgment"' "${plan_root}/architecture_fitness_functions.json"
+grep -Fq 'Machine-Checkable Invariants' "${plan_root}/architecture_fitness_functions.md"
+grep -Fq 'Human-Judgment Candidates' "${plan_root}/architecture_fitness_functions.md"
+grep -Fq 'Expected Failure Modes' "${plan_root}/architecture_fitness_functions.md"
+grep -Fq 'Implementation Handoffs' "${plan_root}/architecture_fitness_functions.md"
+if grep -R "${tmpdir}" "${plan_root}" >/dev/null; then
+  echo "architecture fitness-function plan should not leak absolute temp paths" >&2
+  exit 1
+fi
+if find "${plan_root}" -name '*.rs' -o -name '*.sh' -o -name '*.yml' | grep -q .; then
+  echo "architecture fitness-function author should not write implementation files" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/architecture-fitness-function-author/SKILL.md"
+
+echo "PASS test_architecture_fitness_function_author_skill_contracts"

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner architecture-fitness-function-author test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -34,6 +34,8 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/architecture-diagram-reviewer/scripts/review_architecture_diagrams.py" ]]
   [[ -f "${root}/skills/review-to-test-planner/SKILL.md" ]]
   [[ -x "${root}/skills/review-to-test-planner/scripts/plan_review_tests.py" ]]
+  [[ -f "${root}/skills/architecture-fitness-function-author/SKILL.md" ]]
+  [[ -x "${root}/skills/architecture-fitness-function-author/scripts/author_architecture_fitness_functions.py" ]]
   [[ -f "${root}/skills/test-generator/SKILL.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
@@ -59,6 +61,7 @@ assert_skill_bundle() {
   grep -Fq "without becoming the diagram author" "${root}/skills/repo-diagram-planner/SKILL.md"
   grep -Fq 'quality gate after `diagram-author`' "${root}/skills/architecture-diagram-reviewer/SKILL.md"
   grep -Fq 'between review artifacts and `test-generator`' "${root}/skills/review-to-test-planner/SKILL.md"
+  grep -Fq "turns recurring architecture risks into bounded checks" "${root}/skills/architecture-fitness-function-author/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
@@ -84,6 +87,7 @@ assert_skill_bundle() {
     "${root}/skills/repo-diagram-planner/SKILL.md" \
     "${root}/skills/architecture-diagram-reviewer/SKILL.md" \
     "${root}/skills/review-to-test-planner/SKILL.md" \
+    "${root}/skills/architecture-fitness-function-author/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
@@ -111,6 +115,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/repo-diagram-planner" ]]
 [[ -L "${CODEX_HOME}/skills/architecture-diagram-reviewer" ]]
 [[ -L "${CODEX_HOME}/skills/review-to-test-planner" ]]
+[[ -L "${CODEX_HOME}/skills/architecture-fitness-function-author" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]


### PR DESCRIPTION
Closes #2066

## Summary
Implemented the `architecture-fitness-function-author` skill as a bounded
CodeBuddy authoring lane. The skill turns architecture review evidence into a
reviewable fitness-function plan, separating machine-checkable invariants from
human-judgment candidates and deferred automation boundaries without mutating
tests, CI, docs, policy files, issues, PRs, or customer repositories.

## Artifacts
- `adl/tools/skills/architecture-fitness-function-author/SKILL.md`
- `adl/tools/skills/architecture-fitness-function-author/adl-skill.yaml`
- `adl/tools/skills/architecture-fitness-function-author/agents/openai.yaml`
- `adl/tools/skills/architecture-fitness-function-author/references/output-contract.md`
- `adl/tools/skills/architecture-fitness-function-author/references/fitness-function-playbook.md`
- `adl/tools/skills/architecture-fitness-function-author/scripts/author_architecture_fitness_functions.py`
- `adl/tools/skills/docs/ARCHITECTURE_FITNESS_FUNCTION_AUTHOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_architecture_fitness_function_author_skill_contracts.sh`
- Updated `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
- Updated `adl/tools/test_install_adl_operational_skills.sh`
- Updated `adl/tools/batched_checks.sh`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/test_architecture_fitness_function_author_skill_contracts.sh adl/tools/test_install_adl_operational_skills.sh adl/tools/batched_checks.sh` verified shell syntax for the new and touched validation scripts.
  - `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile adl/tools/skills/architecture-fitness-function-author/scripts/author_architecture_fitness_functions.py` verified the scaffold script compiles without writing cache files.
  - `bash adl/tools/test_architecture_fitness_function_author_skill_contracts.sh` verified the new skill bundle, schema references, deterministic scaffold output, classification coverage, and no implementation-file writes.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified copy and symlink installation include the new skill and validate its frontmatter.
  - `git diff --check` verified whitespace cleanliness.
  - `bash adl/tools/batched_checks.sh` verified the full ADL tooling suite, skill contracts, Rust formatting, Rust clippy, and Rust tests.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2066__backlog-skills-add-architecture-fitness-function-author-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2066__backlog-skills-add-architecture-fitness-function-author-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-architecture-fitness-function-author-skill-adl-tools-skills-architecture-fitness-function-author-adl-tools-skills-docs-architecture-fitness-function-author-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-architecture-fitness-function-author-skill-contracts-sh-adl-tools-test-install-adl-operational-skills-sh-adl-tools-batched-checks-sh-adl-v0-90-tasks-issue-2066-backlog-skills-add-architecture-fitness-function-author-skill-sip-md-adl-v0-90-tasks-issue-2066-backlog-skills-add-architecture-fitness-function-author-skill-sor-md