### PR TITLE
[v0.90][backlog][skills] Add product report writer skill

### DIFF
--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -22,6 +22,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `architecture-diagram-reviewer`
 - `review-to-test-planner`
 - `architecture-fitness-function-author`
+- `product-report-writer`
 - `repo-review-synthesis`
 - `finding-to-issue-planner`
 
@@ -41,6 +42,7 @@ Recommended order:
 10. `review-to-test-planner`
 11. `architecture-fitness-function-author`
 12. `finding-to-issue-planner`
+13. `product-report-writer`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -62,6 +64,10 @@ automation before any tests, CI gates, policy files, or repo checks are edited.
 The finding-to-issue planner should run only after review findings exist. It
 emits grouped, human-approved issue candidates and stops before tracker
 creation, PR creation, remediation, or test generation.
+The product report writer should run after the review packet has enough
+specialist, synthesis, diagram, test, issue-planning, redaction, and quality
+evidence to produce a customer-grade report. It writes report artifacts only and
+stops before publication, approval claims, remediation, or repository mutation.
 
 ## Shared Specialist Input Shape
 
@@ -324,6 +330,23 @@ policy:
   stop_before_mutation: true
 ```
 
+## Product Report Writer Input Shape
+
+```yaml
+skill_input_schema: product_report_writer.v1
+mode: write_from_packet | write_from_synthesis | write_from_specialist_artifacts | refresh_report
+artifact_root: <review packet root>
+audience: internal_review | customer_private | public_candidate
+policy:
+  privacy_mode: local_only | customer_private | public_candidate
+  publication_intent: none | internal_review | customer_private | public_candidate
+  write_report_artifact: true | false
+  require_redaction_status: true | false
+  preserve_specialist_disagreement: true
+  stop_before_publication: true
+  stop_before_mutation: true
+```
+
 ## Severity Rules
 
 - Preserve the highest severity attached to a merged finding unless the source
@@ -359,6 +382,9 @@ The suite may:
   validation commands, expected failure modes, and implementation handoffs
 - draft grouped issue candidates from findings after explicit review evidence
   exists, while preserving highest severity and specialist disagreement
+- write customer-grade product report artifacts from existing review packet
+  evidence while preserving severity, disagreement, publication boundaries,
+  caveats, and residual risk
 
 The suite must not:
 - edit code, tests, docs, configs, or issue state
@@ -376,6 +402,8 @@ The suite must not:
   planning lane
 - create tracker items from the issue-planning lane without explicit operator
   approval
+- publish reports, claim approval, claim compliance, claim merge-readiness, or
+  claim remediation completion from the product report writing lane
 
 ## Relationship To `repo-code-review`
 
@@ -396,4 +424,6 @@ Use this suite when:
   create a specific visual artifact
 - durable architecture rules need executable-check planning before separate
   implementation work installs tests, policy checks, or CI gates
+- a customer-grade report is needed from completed review artifacts without
+  turning report writing into publication, approval, or remediation
 - the synthesis artifact should show specialist coverage and disagreement

--- a/adl/tools/skills/docs/PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,58 @@
+# Product Report Writer Skill Input Schema
+
+Schema id: `product_report_writer.v1`
+
+This schema describes structured input for the `product-report-writer` skill.
+The skill writes customer-grade CodeBuddy report artifacts from existing review
+packet evidence and stops before publication or mutation.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `product_report_writer.v1`.
+- `mode`: one of the supported modes below.
+- `artifact_root`: review packet root or report artifact source.
+- `audience`: intended audience, such as `internal_review`,
+  `customer_private`, or `public_candidate`.
+- `policy`: explicit report, privacy, and stop-boundary policy.
+
+## Supported Modes
+
+- `write_from_packet`: write from a CodeBuddy packet root.
+- `write_from_synthesis`: write from a synthesis artifact plus supporting
+  packet context.
+- `write_from_specialist_artifacts`: write from specialist review artifacts.
+- `refresh_report`: refresh an existing report after source artifacts change.
+
+## Policy Fields
+
+- `privacy_mode`: local_only, customer_private, public_candidate, or another
+  explicit project policy value.
+- `publication_intent`: none, internal_review, customer_private, or
+  public_candidate.
+- `write_report_artifact`: whether to write Markdown/JSON report artifacts.
+- `require_redaction_status`: whether redaction evidence is required before
+  report completion.
+- `preserve_specialist_disagreement`: must be true.
+- `stop_before_publication`: must be true.
+- `stop_before_mutation`: must be true.
+
+## Optional Fields
+
+- `synthesis_artifact`: synthesis report to prioritize for findings.
+- `specialist_artifacts`: role-to-path map for specialist artifacts.
+- `existing_report_path`: required for `refresh_report`.
+- `output_root`: output directory for `codebuddy_product_report.md` and
+  `codebuddy_product_report.json`.
+- `quality_gate_path`: review-quality evaluator artifact, when available.
+- `redaction_report_path`: redaction report artifact, when available.
+
+## Output Contract
+
+The skill emits report-only artifacts:
+
+- `codebuddy_product_report.md`
+- `codebuddy_product_report.json`
+
+The skill must not publish reports, create tracker items, open PRs, write tests,
+generate diagrams, implement fixes, mutate customer repositories, or claim
+approval, compliance, merge-readiness, or remediation completion.

--- a/adl/tools/skills/product-report-writer/SKILL.md
+++ b/adl/tools/skills/product-report-writer/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: product-report-writer
+description: Turn CodeBuddy review packet artifacts into customer-grade product reports with executive summary, scope, top findings, architecture summary, diagrams, test recommendations, remediation sequence, caveats, and residual risks while preserving severity, disagreement, and publication boundaries.
+---
+
+# Product Report Writer
+
+Write a customer-grade CodeBuddy review report from already-produced review
+artifacts. This skill is a report-writing and packaging skill, not a reviewer,
+not a remediator, not a publisher, and not an approval authority.
+
+Use this skill after review packet construction, specialist reviews, synthesis,
+diagram planning/review, test planning, redaction, and issue planning have
+produced the evidence needed for a report.
+
+## Quick Start
+
+1. Confirm the report source:
+   - CodeBuddy packet root
+   - synthesis artifact
+   - specialist artifact bundle
+   - existing draft report refresh
+2. Confirm audience, privacy mode, and publication intent.
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/write_product_report.py <packet-root> --out <artifact-root>`
+4. Review the report for evidence boundaries, severity preservation, specialist
+   disagreement, and residual risk.
+5. Stop before publication, approval, customer delivery, issue creation, PR
+   creation, remediation, or repository mutation.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `artifact_root` or `packet_root`
+- `mode`
+- `audience`
+- `policy`
+
+Supported modes:
+
+- `write_from_packet`
+- `write_from_synthesis`
+- `write_from_specialist_artifacts`
+- `refresh_report`
+
+Useful policy fields:
+
+- `privacy_mode`
+- `publication_intent`
+- `write_report_artifact`
+- `require_redaction_status`
+- `preserve_specialist_disagreement`
+- `stop_before_publication`
+- `stop_before_mutation`
+
+If there is no concrete artifact root or report source, stop and report
+`not_run`.
+
+## Workflow
+
+### 1. Establish Report Boundary
+
+Record:
+
+- artifact root or source report
+- repo name and ref, if present
+- audience
+- privacy mode
+- publication intent
+- redaction status
+- specialist artifacts included
+- non-reviewed surfaces
+
+Do not upgrade publication readiness. If redaction or quality-gate evidence is
+missing, make that caveat prominent.
+
+### 2. Preserve Review Truth
+
+Carry forward:
+
+- highest severity per finding
+- source roles
+- confidence
+- evidence summary
+- impact
+- recommended action
+- validation gap
+- specialist disagreement
+- residual risk
+- non-reviewed surfaces
+
+Do not rewrite findings into softer product language that hides severity,
+uncertainty, or disagreement.
+
+### 3. Write The Report
+
+The report should include:
+
+- executive summary
+- review scope
+- top findings
+- architecture summary
+- security and privacy notes
+- diagram links
+- test recommendations
+- documentation and onboarding notes
+- remediation sequence
+- caveats and residual risks
+- appendix of source artifacts
+
+Keep the report useful to a customer or leadership reader without losing enough
+evidence for an engineer to act.
+
+### 4. Stop Before Publication
+
+This skill must not:
+
+- publish or send a report
+- claim approval, compliance, merge-readiness, or remediation completion
+- create issues, pull requests, tests, diagrams, ADRs, or fixes
+- edit customer repositories
+- run specialist review lanes
+- hide missing redaction, quality-gate, or specialist coverage
+
+Handoff candidates to:
+
+- `redaction-and-evidence-auditor` before customer-facing use
+- `review-quality-evaluator` before publication candidate status
+- `finding-to-issue-planner` for approved issue follow-through
+- `review-to-test-planner` for approved test planning
+- `diagram-author` or `repo-diagram-planner` when diagram evidence is missing
+
+## Output
+
+Write Markdown and JSON report artifacts when an output root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/product-report/
+```
+
+Required artifacts:
+
+- `codebuddy_product_report.md`
+- `codebuddy_product_report.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Blocked States
+
+Return `not_run` when the source is missing or unreadable.
+
+Return `blocked` when:
+
+- publication was requested without redaction status
+- the source has findings without evidence
+- the requested report would hide severity or disagreement
+- the report is asked to claim compliance, approval, merge-readiness, or
+  remediation completion without proof
+
+Return `partial` when a report can be drafted but important specialist,
+redaction, diagram, test, or quality-gate evidence is missing.

--- a/adl/tools/skills/product-report-writer/adl-skill.yaml
+++ b/adl/tools/skills/product-report-writer/adl-skill.yaml
@@ -1,0 +1,126 @@
+version: "0.1"
+kind: "adl-skill"
+id: "product-report-writer"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "product_report_writer.v1"
+    reference_doc: "../docs/PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "artifact_root"
+      - "audience"
+      - "policy"
+    mode_enum:
+      - "write_from_packet"
+      - "write_from_synthesis"
+      - "write_from_specialist_artifacts"
+      - "refresh_report"
+    policy_fields:
+      - "privacy_mode"
+      - "publication_intent"
+      - "write_report_artifact"
+      - "require_redaction_status"
+      - "preserve_specialist_disagreement"
+      - "stop_before_publication"
+      - "stop_before_mutation"
+    mode_requirements:
+      write_from_packet:
+        required_target_fields:
+          - "artifact_root"
+      write_from_synthesis:
+        required_target_fields:
+          - "synthesis_artifact"
+      write_from_specialist_artifacts:
+        required_target_fields:
+          - "specialist_artifacts"
+      refresh_report:
+        required_target_fields:
+          - "existing_report_path"
+  intent:
+    - "product_report_writing"
+    - "codebuddy_review_engine"
+    - "customer_grade_report"
+    - "review_packet_synthesis"
+  required_inputs:
+    - "artifact_root"
+    - "audience"
+  optional_inputs:
+    - "synthesis_artifact"
+    - "specialist_artifacts"
+    - "existing_report_path"
+    - "output_root"
+    - "quality_gate_path"
+    - "redaction_report_path"
+  stop_if_missing:
+    - "artifact_root"
+  prevalidation_rules:
+    - "artifact_root_must_exist"
+    - "skill_input_schema_must_equal_product_report_writer.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "audience_must_be_explicit"
+    - "policy.privacy_mode_must_be_explicit"
+    - "policy.publication_intent_must_be_explicit"
+    - "policy.stop_before_publication_must_be_true"
+    - "policy.stop_before_mutation_must_be_true"
+    - "policy.preserve_specialist_disagreement_must_be_true"
+execution:
+  mode: "report_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/write_product_report.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<packet-root>"
+        - "--out <artifact-root>"
+        - "--audience <audience>"
+        - "--repo-name <name>"
+  preferred_read_order:
+    - "run_manifest.json"
+    - "repo_scope.md"
+    - "final_report.md"
+    - "synthesis.md"
+    - "specialist review artifacts"
+    - "diagram manifests and reviews"
+    - "test recommendation artifacts"
+    - "issue planning artifacts"
+    - "redaction report"
+    - "quality evaluation"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  must_not_run:
+    - "publication"
+    - "approval_claims"
+    - "compliance_claims"
+    - "remediation_complete_claims"
+    - "tracker_item_creation"
+    - "pull_request_creation"
+    - "specialist_reviews"
+    - "test_generation"
+    - "diagram_generation"
+    - "customer_repository_mutation"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/codebuddy/<run_id>/product-report/"
+  required_artifacts:
+    - "codebuddy_product_report.md"
+    - "codebuddy_product_report.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  publication_requires_redaction_gate: true
+  no_approval_or_compliance_claims: true
+  manifest_declares_executables: true
+
+display_name: Product Report Writer
+short_description: Write customer-grade CodeBuddy reports from review packet artifacts
+default_prompt: Write a customer-grade CodeBuddy report from existing review artifacts. Preserve severity, evidence, disagreement, caveats, privacy status, and residual risk; stop before publication, approval claims, issue creation, PRs, remediation, tests, or repository mutation.

--- a/adl/tools/skills/product-report-writer/agents/openai.yaml
+++ b/adl/tools/skills/product-report-writer/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Product Report Writer
+short_description: Write customer-grade CodeBuddy reports from review packet artifacts
+default_prompt: Write a customer-grade CodeBuddy report from existing review artifacts. Preserve severity, evidence, disagreement, caveats, privacy status, and residual risk; stop before publication, approval claims, issue creation, PRs, remediation, tests, or repository mutation.

--- a/adl/tools/skills/product-report-writer/references/output-contract.md
+++ b/adl/tools/skills/product-report-writer/references/output-contract.md
@@ -1,0 +1,72 @@
+# Output Contract
+
+The product-report-writer skill produces customer-grade CodeBuddy report
+artifacts from existing review evidence.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/product-report/
+```
+
+## Required Artifacts
+
+### codebuddy_product_report.md
+
+Required sections:
+
+- Executive Summary
+- Review Scope
+- Top Findings
+- Architecture Summary
+- Security And Privacy Notes
+- Diagram Links
+- Test Recommendations
+- Documentation And Onboarding Notes
+- Remediation Sequence
+- Caveats And Residual Risks
+- Appendix
+- Publication Boundary
+
+### codebuddy_product_report.json
+
+Required top-level fields:
+
+- `schema`
+- `repo_name`
+- `run_id`
+- `status`
+- `audience`
+- `publication_boundary`
+- `scope`
+- `top_findings`
+- `architecture_summary`
+- `security_privacy_notes`
+- `diagram_links`
+- `test_recommendations`
+- `remediation_sequence`
+- `residual_risks`
+- `appendix`
+
+## Status Values
+
+- `pass`: report is complete for internal review and no required inputs are
+  missing.
+- `partial`: report was written but missing evidence, redaction, quality, or
+  specialist coverage must be reviewed.
+- `not_run`: no readable packet or report source was available.
+- `blocked`: the requested output would overclaim approval, compliance,
+  publication readiness, remediation completion, or hide evidence boundaries.
+
+## Rules
+
+- Use repo-relative or packet-relative paths.
+- Do not write absolute host paths into report artifacts.
+- Do not claim approval, compliance, merge-readiness, remediation completion, or
+  publication readiness unless a source artifact explicitly proves it.
+- Do not publish or transmit the report.
+- Do not create issues, PRs, tests, diagrams, ADRs, or fixes.
+- Preserve highest severity and specialist disagreement.
+- Include non-reviewed surfaces, caveats, and residual risk.
+- Surface missing redaction, quality-gate, diagram, test, or specialist evidence
+  as caveats instead of hiding them.

--- a/adl/tools/skills/product-report-writer/references/report-writing-playbook.md
+++ b/adl/tools/skills/product-report-writer/references/report-writing-playbook.md
@@ -1,0 +1,34 @@
+# Report Writing Playbook
+
+Use this playbook when shaping a CodeBuddy product report.
+
+## Report Voice
+
+- Start with the decision-relevant picture before implementation detail.
+- Keep findings concrete and evidence-backed.
+- Preserve severity labels and confidence.
+- Use clear product language, but do not remove engineering specificity.
+- Say what was not reviewed.
+- Say what was not proven.
+
+## Evidence Rules
+
+- Prefer synthesis findings when present.
+- Fall back to specialist artifacts when synthesis is missing.
+- Treat diagram, test, issue, redaction, and quality artifacts as supporting
+  evidence, not as proof of remediation.
+- Report missing artifacts as caveats.
+
+## Forbidden Claims
+
+Do not claim:
+
+- merge approval
+- security approval
+- compliance
+- production readiness
+- remediation completion
+- publication approval
+- customer delivery approval
+
+unless a source artifact explicitly provides that verified state.

--- a/adl/tools/skills/product-report-writer/scripts/write_product_report.py
+++ b/adl/tools/skills/product-report-writer/scripts/write_product_report.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Write a CodeBuddy product report from existing review packet artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "codebuddy.product_report.v1"
+FINDING_RE = re.compile(
+    r"^#{2,4}[ \t]+(?:Finding[ \t]+)?(?P<id>[A-Za-z0-9_.:-]+)?[ \t]*:?[ \t]*(?:\[(?P<severity>P[0-3])\])?[ \t]*(?P<title>[^\n#].*?)\s*$",
+    re.MULTILINE,
+)
+SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def packet_relative(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def line_value(block: str, key: str) -> str:
+    pattern = re.compile(rf"^\s*-\s*{re.escape(key)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(block)
+    return match.group(1).strip() if match else ""
+
+
+def clean_title(title: str) -> str:
+    title = re.sub(r"^\[[Pp][0-3]\]\s*", "", title).strip()
+    title = re.sub(r"\s+", " ", title)
+    return title.rstrip("# ").strip()
+
+
+def severity_from_block(heading_severity: str | None, block: str) -> str:
+    if heading_severity:
+        return heading_severity.upper()
+    for key in ("Severity", "Priority"):
+        value = line_value(block, key)
+        match = re.search(r"\bP[0-3]\b", value.upper())
+        if match:
+            return match.group(0)
+    match = re.search(r"\bP[0-3]\b", block.upper())
+    return match.group(0) if match else "P2"
+
+
+def confidence_from_block(block: str) -> str:
+    value = line_value(block, "Confidence")
+    if value:
+        return value
+    lowered = block.lower()
+    if "confidence: high" in lowered:
+        return "high"
+    if "confidence: low" in lowered:
+        return "low"
+    return "medium"
+
+
+def role_from_path(path: Path, block: str) -> str:
+    value = line_value(block, "Role") or line_value(block, "Source role")
+    if value:
+        return value
+    lowered = f"{path.as_posix()} {block}".lower()
+    for role in ("security", "tests", "docs", "architecture", "dependencies", "diagram", "code"):
+        if role in lowered:
+            return role
+    return "review"
+
+
+def finding_sources(root: Path) -> list[Path]:
+    preferred = [
+        root / "final_report.md",
+        root / "synthesis.md",
+        root / "specialist_reviews" / "synthesis.md",
+        root / "specialist_reviews" / "code.md",
+        root / "specialist_reviews" / "security.md",
+        root / "specialist_reviews" / "tests.md",
+        root / "specialist_reviews" / "docs.md",
+        root / "specialist_reviews" / "architecture.md",
+        root / "specialist_reviews" / "dependencies.md",
+    ]
+    found = [path for path in preferred if path.is_file()]
+    if found:
+        return found
+    return sorted(root.rglob("*.md"))[:40]
+
+
+def split_findings(root: Path) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for path in finding_sources(root):
+        text = read_text(path)
+        matches = [
+            match
+            for match in FINDING_RE.finditer(text)
+            if re.match(r"^#{2,4}\s+Finding\s+", match.group(0), re.IGNORECASE)
+        ]
+        for index, match in enumerate(matches):
+            start = match.end()
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            block = text[start:end].strip()
+            severity = severity_from_block(match.group("severity"), block)
+            finding_id = str(match.group("id") or f"{path.stem}-{index + 1}").strip(": ")
+            findings.append(
+                {
+                    "finding_id": finding_id,
+                    "title": clean_title(match.group("title")),
+                    "severity": severity,
+                    "confidence": confidence_from_block(block),
+                    "source_role": role_from_path(path, block),
+                    "source_artifact": packet_relative(root, path),
+                    "affected_path": line_value(block, "Affected path or artifact")
+                    or line_value(block, "File")
+                    or line_value(block, "Affected path"),
+                    "evidence": line_value(block, "Evidence"),
+                    "impact": line_value(block, "Impact") or line_value(block, "User/customer impact"),
+                    "recommended_action": line_value(block, "Recommended action"),
+                    "validation_gap": line_value(block, "Validation gap")
+                    or line_value(block, "Validation or proof gap"),
+                    "related_findings": line_value(block, "Related findings"),
+                }
+            )
+    return sorted(findings, key=lambda item: (SEVERITY_ORDER.get(str(item["severity"]), 9), str(item["finding_id"])))
+
+
+def scope_from_repo_scope(root: Path) -> dict[str, object]:
+    text = read_text(root / "repo_scope.md")
+    if not text:
+        return {
+            "included_paths": [],
+            "excluded_paths": [],
+            "non_reviewed_surfaces": ["repo_scope.md missing from packet"],
+            "assumptions": [],
+        }
+    return {
+        "included_paths": extract_bullets_after(text, "Included paths"),
+        "excluded_paths": extract_bullets_after(text, "Excluded paths"),
+        "non_reviewed_surfaces": extract_bullets_after(text, "Non-reviewed surfaces"),
+        "assumptions": extract_bullets_after(text, "Assumptions"),
+    }
+
+
+def extract_bullets_after(text: str, heading: str) -> list[str]:
+    pattern = re.compile(rf"^##+\s+{re.escape(heading)}\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        return []
+    next_heading = re.search(r"^##+\s+", text[match.end() :], re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(text)
+    section = text[match.end() : end]
+    bullets = [line.strip()[2:].strip() for line in section.splitlines() if line.strip().startswith("- ")]
+    return bullets[:20]
+
+
+def read_manifest(root: Path, repo_name_override: str | None) -> dict[str, object]:
+    manifest = load_json(root / "run_manifest.json")
+    if not isinstance(manifest, dict):
+        manifest = {}
+    repo_name = repo_name_override or str(manifest.get("repo_name") or root.name)
+    return {
+        "run_id": str(manifest.get("run_id") or root.name),
+        "repo_name": repo_name,
+        "repo_ref": str(manifest.get("repo_ref") or "not recorded"),
+        "review_mode": str(manifest.get("review_mode") or "not recorded"),
+        "privacy_mode": str(manifest.get("privacy_mode") or "not recorded"),
+        "publication_allowed": bool(manifest.get("publication_allowed", False)),
+    }
+
+
+def artifact_status(root: Path) -> dict[str, object]:
+    return {
+        "redaction_report": (root / "redaction_report.md").is_file(),
+        "quality_evaluation": any(path.is_file() for path in [root / "quality_evaluation.md", root / "review_quality.md"]),
+        "diagram_manifest": any(path.is_file() for path in [root / "diagrams" / "diagram_manifest.md", root / "diagram_manifest.md"]),
+        "test_plan": any(path.is_file() for path in [root / "test_recommendations" / "test_gap_report.md", root / "review-to-test-plan" / "review_to_test_plan.md"]),
+        "issue_plan": any(path.is_file() for path in [root / "issue-planning" / "issue_candidates.md"]),
+    }
+
+
+def diagram_links(root: Path) -> list[str]:
+    links: list[str] = []
+    for rel in ("diagrams/diagram_manifest.md", "diagram_manifest.md"):
+        path = root / rel
+        if path.is_file():
+            links.append(rel)
+    return links or ["No diagram manifest found in packet."]
+
+
+def test_recommendations(root: Path) -> list[str]:
+    paths = [
+        root / "test_recommendations" / "test_gap_report.md",
+        root / "review-to-test-plan" / "review_to_test_plan.md",
+    ]
+    found = [packet_relative(root, path) for path in paths if path.is_file()]
+    return found or ["No test recommendation artifact found in packet."]
+
+
+def remediation_sequence(findings: list[dict[str, object]]) -> list[str]:
+    if not findings:
+        return ["No finding-backed remediation sequence could be generated."]
+    sequence = []
+    for finding in findings[:5]:
+        action = str(finding.get("recommended_action") or "Address the finding with a bounded fix.")
+        sequence.append(f"[{finding['severity']}] {finding['title']}: {action}")
+    return sequence
+
+
+def residual_risks(scope: dict[str, object], artifacts: dict[str, object], findings: list[dict[str, object]]) -> list[str]:
+    risks: list[str] = []
+    if scope.get("non_reviewed_surfaces"):
+        risks.append("Non-reviewed surfaces remain and should be checked before broad release decisions.")
+    for key, present in artifacts.items():
+        if not present:
+            risks.append(f"{key.replace('_', ' ')} was not found in the packet.")
+    if any(not finding.get("evidence") for finding in findings):
+        risks.append("At least one finding is missing extracted evidence and needs manual review.")
+    return risks or ["No additional residual risk beyond the reviewed findings was extracted."]
+
+
+def build_report(root: Path, audience: str, repo_name_override: str | None) -> dict[str, object]:
+    manifest = read_manifest(root, repo_name_override)
+    findings = split_findings(root)
+    scope = scope_from_repo_scope(root)
+    artifacts = artifact_status(root)
+    residual = residual_risks(scope, artifacts, findings)
+    status = "pass" if artifacts["redaction_report"] and findings else "partial"
+    return {
+        "schema": SCHEMA,
+        "created_at": now_utc(),
+        "repo_name": manifest["repo_name"],
+        "repo_ref": manifest["repo_ref"],
+        "run_id": manifest["run_id"],
+        "status": status,
+        "audience": audience,
+        "publication_boundary": {
+            "privacy_mode": manifest["privacy_mode"],
+            "publication_allowed_by_source": manifest["publication_allowed"],
+            "published_by_skill": False,
+            "approval_claimed": False,
+            "compliance_claimed": False,
+            "remediation_complete_claimed": False,
+        },
+        "scope": scope,
+        "top_findings": findings[:8],
+        "architecture_summary": architecture_summary(findings, artifacts),
+        "security_privacy_notes": security_privacy_notes(findings, artifacts, manifest),
+        "diagram_links": diagram_links(root),
+        "test_recommendations": test_recommendations(root),
+        "documentation_onboarding_notes": docs_notes(findings),
+        "remediation_sequence": remediation_sequence(findings),
+        "residual_risks": residual,
+        "appendix": appendix(root),
+    }
+
+
+def architecture_summary(findings: list[dict[str, object]], artifacts: dict[str, object]) -> list[str]:
+    arch = [finding for finding in findings if "architecture" in str(finding.get("source_role", "")).lower()]
+    notes = [f"[{item['severity']}] {item['title']}" for item in arch[:5]]
+    if artifacts["diagram_manifest"]:
+        notes.append("Diagram artifacts are present; verify diagram truth boundaries before publication.")
+    return notes or ["No architecture-specific finding was extracted from the packet."]
+
+
+def security_privacy_notes(findings: list[dict[str, object]], artifacts: dict[str, object], manifest: dict[str, object]) -> list[str]:
+    notes = [f"[{item['severity']}] {item['title']}" for item in findings if "security" in str(item.get("source_role", "")).lower()]
+    notes.append(f"Privacy mode: {manifest['privacy_mode']}.")
+    notes.append("Redaction report present." if artifacts["redaction_report"] else "Redaction report missing; do not publish until reviewed.")
+    return notes
+
+
+def docs_notes(findings: list[dict[str, object]]) -> list[str]:
+    docs = [finding for finding in findings if "docs" in str(finding.get("source_role", "")).lower()]
+    return [f"[{item['severity']}] {item['title']}" for item in docs[:5]] or ["No documentation-specific finding was extracted from the packet."]
+
+
+def appendix(root: Path) -> list[str]:
+    names = []
+    for rel in (
+        "run_manifest.json",
+        "repo_scope.md",
+        "final_report.md",
+        "synthesis.md",
+        "redaction_report.md",
+        "quality_evaluation.md",
+        "diagrams/diagram_manifest.md",
+        "test_recommendations/test_gap_report.md",
+        "issue-planning/issue_candidates.md",
+    ):
+        if (root / rel).is_file():
+            names.append(rel)
+    return names
+
+
+def bullet_lines(items: list[object]) -> str:
+    return "\n".join(f"- {item}" for item in items) if items else "- None extracted."
+
+
+def write_markdown(path: Path, report: dict[str, object]) -> None:
+    findings = report["top_findings"]
+    finding_lines = []
+    for finding in findings:
+        finding_lines.append(
+            f"""### Finding {finding['finding_id']}: [{finding['severity']}] {finding['title']}
+
+- Source role: {finding['source_role']}
+- Confidence: {finding['confidence']}
+- Affected path or artifact: {finding.get('affected_path') or 'not extracted'}
+- Evidence: {finding.get('evidence') or 'not extracted; manual review required'}
+- Impact: {finding.get('impact') or 'not extracted'}
+- Recommended action: {finding.get('recommended_action') or 'not extracted'}
+- Validation gap: {finding.get('validation_gap') or 'not extracted'}
+- Source artifact: {finding['source_artifact']}
+"""
+        )
+    scope = report["scope"]
+    boundary = report["publication_boundary"]
+    content = f"""# CodeBuddy Review Report: {report['repo_name']}
+
+## Executive Summary
+
+- Overall risk: {overall_risk(findings)}
+- Top risks: {', '.join(str(item['title']) for item in findings[:3]) if findings else 'No findings extracted.'}
+- Recommended remediation sequence: see Remediation Sequence.
+- Publication/privacy status: privacy mode {boundary['privacy_mode']}; published by this skill: false.
+
+## Review Scope
+
+- Repository: {report['repo_name']}
+- Ref / branch / diff: {report['repo_ref']}
+- Audience: {report['audience']}
+- Included paths: {', '.join(scope.get('included_paths') or ['not extracted'])}
+- Excluded paths: {', '.join(scope.get('excluded_paths') or ['not extracted'])}
+- Non-reviewed surfaces: {', '.join(scope.get('non_reviewed_surfaces') or ['not extracted'])}
+- Assumptions: {', '.join(scope.get('assumptions') or ['not extracted'])}
+
+## Top Findings
+
+{chr(10).join(finding_lines) if finding_lines else '- No top findings extracted from the supplied packet.'}
+
+## Architecture Summary
+
+{bullet_lines(report['architecture_summary'])}
+
+## Security And Privacy Notes
+
+{bullet_lines(report['security_privacy_notes'])}
+
+## Diagram Links
+
+{bullet_lines(report['diagram_links'])}
+
+## Test Recommendations
+
+{bullet_lines(report['test_recommendations'])}
+
+## Documentation And Onboarding Notes
+
+{bullet_lines(report['documentation_onboarding_notes'])}
+
+## Remediation Sequence
+
+{numbered_lines(report['remediation_sequence'])}
+
+## Caveats And Residual Risks
+
+{bullet_lines(report['residual_risks'])}
+
+## Appendix
+
+{bullet_lines(report['appendix'])}
+
+## Publication Boundary
+
+- This report was generated for review, not published.
+- Approval claimed: false.
+- Compliance claimed: false.
+- Remediation complete claimed: false.
+- Publication allowed by source manifest: {str(boundary['publication_allowed_by_source']).lower()}.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def overall_risk(findings: list[dict[str, object]]) -> str:
+    if not findings:
+        return "unknown"
+    severity = str(findings[0]["severity"])
+    return {"P0": "critical", "P1": "high", "P2": "medium", "P3": "low"}.get(severity, "unknown")
+
+
+def numbered_lines(items: list[object]) -> str:
+    return "\n".join(f"{index}. {item}" for index, item in enumerate(items, start=1)) if items else "1. None extracted."
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet_root", help="CodeBuddy review packet root")
+    parser.add_argument("--out", default=None, help="Product report artifact root")
+    parser.add_argument("--audience", default="customer_private", help="Report audience")
+    parser.add_argument("--repo-name", default=None, help="Repo name override")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.packet_root)
+    if not root.is_dir():
+        raise SystemExit(f"packet root does not exist: {root}")
+    out_root = Path(args.out) if args.out else root / "product-report"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    report = build_report(root, args.audience, args.repo_name)
+    write_json(out_root / "codebuddy_product_report.json", report)
+    write_markdown(out_root / "codebuddy_product_report.md", report)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_product_report_writer_skill_contracts.sh
+++ b/adl/tools/test_product_report_writer_skill_contracts.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/product-report-writer/SKILL.md" ]]
+[[ -f "${skills_root}/product-report-writer/adl-skill.yaml" ]]
+[[ -f "${skills_root}/product-report-writer/agents/openai.yaml" ]]
+[[ -f "${skills_root}/product-report-writer/references/report-writing-playbook.md" ]]
+[[ -f "${skills_root}/product-report-writer/references/output-contract.md" ]]
+[[ -x "${skills_root}/product-report-writer/scripts/write_product_report.py" ]]
+[[ -f "${skills_root}/docs/PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "product-report-writer"' "${skills_root}/product-report-writer/adl-skill.yaml"
+grep -Fq 'id: "product_report_writer.v1"' "${skills_root}/product-report-writer/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/product-report-writer/adl-skill.yaml"
+grep -Fq "policy.stop_before_publication_must_be_true" "${skills_root}/product-report-writer/adl-skill.yaml"
+grep -Fq "Write a customer-grade CodeBuddy review report" "${skills_root}/product-report-writer/SKILL.md"
+grep -Fq "Do not claim approval, compliance, merge-readiness, remediation completion" "${skills_root}/product-report-writer/references/output-contract.md"
+grep -Fq "Schema id: \`product_report_writer.v1\`" "${skills_root}/docs/PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "product-report-writer" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+packet_root="${tmpdir}/packet"
+report_root="${tmpdir}/product-report"
+mkdir -p "${packet_root}/specialist_reviews" "${packet_root}/diagrams" "${packet_root}/test_recommendations"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "product-report-contract-test",
+  "repo_name": "example-repo",
+  "repo_ref": "abc123",
+  "review_mode": "release_review",
+  "privacy_mode": "customer_private",
+  "publication_allowed": false
+}
+JSON
+cat >"${packet_root}/repo_scope.md" <<'MD'
+# Repo Scope
+
+## Included paths
+
+- adl/src
+- adl/tools
+
+## Excluded paths
+
+- target
+
+## Non-reviewed surfaces
+
+- generated artifacts
+
+## Assumptions
+
+- Review packet is bounded to release-critical surfaces.
+MD
+cat >"${packet_root}/specialist_reviews/code.md" <<'MD'
+# Code Review
+
+## Findings
+
+### Finding C-001: [P1] Unsafe report overclaim path
+
+- Role: code
+- Confidence: high
+- Affected path or artifact: adl/tools/report.sh
+- Trigger scenario: report language claims approval without evidence.
+- Evidence: the synthesis packet contains an approval-like phrase without a redaction or quality gate.
+- User/customer impact: customers may believe remediation or approval happened when it did not.
+- Recommended action: require explicit publication boundary language.
+- Validation or proof gap: add report contract validation.
+- Related findings: D-002
+MD
+cat >"${packet_root}/specialist_reviews/docs.md" <<'MD'
+# Docs Review
+
+## Findings
+
+### Finding D-002: [P2] Unsafe report overclaim path
+
+- Role: docs
+- Confidence: medium
+- Affected path or artifact: docs/review.md
+- Evidence: docs wording can hide missing quality-gate status.
+- User/customer impact: reviewer handoff may overstate certainty.
+- Recommended action: surface missing gates in caveats.
+MD
+cat >"${packet_root}/redaction_report.md" <<'MD'
+# Redaction Report
+
+- Final publication status: partial.
+MD
+cat >"${packet_root}/diagrams/diagram_manifest.md" <<'MD'
+# Diagram Manifest
+MD
+cat >"${packet_root}/test_recommendations/test_gap_report.md" <<'MD'
+# Test Gap Report
+MD
+
+python3 "${skills_root}/product-report-writer/scripts/write_product_report.py" \
+  "${packet_root}" --out "${report_root}" --audience customer_private >/tmp/product-report-writer.out
+[[ -f "${report_root}/codebuddy_product_report.json" ]]
+[[ -f "${report_root}/codebuddy_product_report.md" ]]
+grep -Fq '"schema": "codebuddy.product_report.v1"' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"repo_name": "example-repo"' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"severity": "P1"' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"published_by_skill": false' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"approval_claimed": false' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"remediation_complete_claimed": false' "${report_root}/codebuddy_product_report.json"
+grep -Fq "## Executive Summary" "${report_root}/codebuddy_product_report.md"
+grep -Fq "## Top Findings" "${report_root}/codebuddy_product_report.md"
+grep -Fq "## Caveats And Residual Risks" "${report_root}/codebuddy_product_report.md"
+grep -Fq "Approval claimed: false." "${report_root}/codebuddy_product_report.md"
+grep -Fq "Compliance claimed: false." "${report_root}/codebuddy_product_report.md"
+grep -Fq "Remediation complete claimed: false." "${report_root}/codebuddy_product_report.md"
+if grep -R "${tmpdir}" "${report_root}" >/dev/null; then
+  echo "product report artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/product-report-writer/SKILL.md"
+
+echo "PASS test_product_report_writer_skill_contracts"


### PR DESCRIPTION
Closes #2069

## Summary
Implemented the CodeBuddy product report writer skill. The skill turns existing
review packet artifacts into report-only Markdown and JSON outputs while
preserving severity, evidence, specialist disagreement, privacy/publication
status, caveats, and residual risk. It stops before publication, approval
claims, compliance claims, remediation-complete claims, issue creation, PR
creation, tests, diagrams, or repository mutation.

## Artifacts
- `adl/tools/skills/product-report-writer/SKILL.md`
- `adl/tools/skills/product-report-writer/adl-skill.yaml`
- `adl/tools/skills/product-report-writer/agents/openai.yaml`
- `adl/tools/skills/product-report-writer/references/output-contract.md`
- `adl/tools/skills/product-report-writer/references/report-writing-playbook.md`
- `adl/tools/skills/product-report-writer/scripts/write_product_report.py`
- `adl/tools/skills/docs/PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_product_report_writer_skill_contracts.sh`
- Updated `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_product_report_writer_skill_contracts.sh` verified the
    skill contract, deterministic report helper output, publication-boundary
    fields, required report sections, and absolute path leakage guard.
  - `python3 -m py_compile adl/tools/skills/product-report-writer/scripts/write_product_report.py`
    verified the helper parses as Python.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/product-report-writer/SKILL.md`
    verified valid skill frontmatter.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2069__backlog-skills-add-product-report-writer-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2069__backlog-skills-add-product-report-writer-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-product-report-writer-skill-adl-tools-skills-product-report-writer-adl-tools-skills-docs-product-report-writer-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-product-report-writer-skill-contracts-sh-adl-v0-90-tasks-issue-2069-backlog-skills-add-product-report-writer-skill-sip-md-adl-v0-90-tasks-issue-2069-backlog-skills-add-product-report-writer-skill-sor-md