### PR TITLE
[v0.90][backlog][skills] Add review quality evaluator skill

### DIFF
--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -26,6 +26,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `architecture-fitness-function-author`
 - `finding-to-issue-planner`
 - `product-report-writer`
+- `review-quality-evaluator`
 
 ## Invocation Order
 
@@ -45,6 +46,7 @@ Recommended order:
 12. `architecture-fitness-function-author`
 13. `finding-to-issue-planner`
 14. `product-report-writer`
+15. `review-quality-evaluator`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -74,6 +76,12 @@ The product report writer should run after the review packet has enough
 specialist, synthesis, diagram, test, issue-planning, redaction, and quality
 evidence to produce a customer-grade report. It writes report artifacts only and
 stops before publication, approval claims, remediation, or repository mutation.
+The review quality evaluator should run after specialist evidence, synthesis,
+redaction, diagram/test follow-through planning, and product report writing have
+produced the candidate packet/report. It emits pass, partial, fail, or not-run
+with concrete blockers and warnings, and it stops before publication, approval
+claims, remediation, issue creation, PR creation, tests, diagrams, or repository
+mutation.
 
 ## Shared Specialist Input Shape
 
@@ -377,6 +385,29 @@ policy:
   stop_before_mutation: true
 ```
 
+## Review Quality Evaluator Input Shape
+
+```yaml
+skill_input_schema: review_quality_evaluator.v1
+mode: evaluate_packet | evaluate_report | evaluate_synthesis | pre_publication_gate
+artifact_root: <review packet or report root>
+publication_intent: none | internal_review | customer_private | public_candidate
+policy:
+  required_roles:
+    - code
+    - security
+    - tests
+    - docs
+    - architecture
+  severity_floor: P0 | P1 | P2 | P3
+  require_redaction_status: true | false
+  require_template_sections: true | false
+  reject_unsupported_claims: true
+  write_evaluation_artifact: true | false
+  stop_before_publication: true
+  stop_before_mutation: true
+```
+
 ## Severity Rules
 
 - Preserve the highest severity attached to a merged finding unless the source
@@ -417,6 +448,9 @@ The suite may:
 - write customer-grade product report artifacts from existing review packet
   evidence while preserving severity, disagreement, publication boundaries,
   caveats, and residual risk
+- evaluate packet and report quality against evidence, severity, actionability,
+  duplication, unsupported-claim, specialist-coverage, template-compliance,
+  residual-risk, and publication-safety gates before customer-facing use
 
 The suite must not:
 - edit code, tests, docs, configs, or issue state
@@ -439,6 +473,9 @@ The suite must not:
   approval
 - publish reports, claim approval, claim compliance, claim merge-readiness, or
   claim remediation completion from the product report writing lane
+- publish reports, approve reports, rewrite reports, claim customer readiness,
+  create issues or PRs, run specialist lanes, generate tests or diagrams, or
+  mutate repositories from the review-quality evaluation lane
 
 ## Relationship To `repo-code-review`
 
@@ -463,4 +500,6 @@ Use this suite when:
   implementation work installs tests, policy checks, or CI gates
 - a customer-grade report is needed from completed review artifacts without
   turning report writing into publication, approval, or remediation
+- a customer-facing packet or report needs a third-party-review-style quality
+  gate before publication or delivery
 - the synthesis artifact should show specialist coverage and disagreement

--- a/adl/tools/skills/docs/REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,89 @@
+# Review Quality Evaluator Skill Input Schema
+
+Schema id: `review_quality_evaluator.v1`
+
+## Purpose
+
+Evaluate a CodeBuddy review packet, product report, synthesis artifact, or
+specialist artifact bundle against the review quality bar before customer-facing
+use.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `review_quality_evaluator.v1`.
+- `mode`: one of `evaluate_packet`, `evaluate_report`, `evaluate_synthesis`, or
+  `pre_publication_gate`.
+- `artifact_root`: packet or report artifact root.
+- `publication_intent`: `none`, `internal_review`, `customer_private`, or
+  `public_candidate`.
+- `policy`: quality-gate and stop-boundary policy.
+
+## Optional Fields
+
+- `report_path`: explicit report artifact for report-only evaluation.
+- `synthesis_artifact`: explicit synthesis artifact.
+- `specialist_artifacts`: map of specialist artifact paths.
+- `output_root`: quality evaluation artifact destination.
+- `redaction_report_path`: explicit redaction report path.
+- `product_report_path`: explicit product report path.
+
+## Policy Fields
+
+- `publication_intent`
+- `required_roles`
+- `severity_floor`
+- `require_redaction_status`
+- `require_template_sections`
+- `reject_unsupported_claims`
+- `write_evaluation_artifact`
+- `stop_before_publication`
+- `stop_before_mutation`
+
+## Example
+
+```yaml
+skill_input_schema: review_quality_evaluator.v1
+mode: pre_publication_gate
+artifact_root: .adl/reviews/codebuddy/run-2026-04-18
+publication_intent: customer_private
+policy:
+  required_roles:
+    - code
+    - security
+    - tests
+    - docs
+    - architecture
+  severity_floor: P3
+  require_redaction_status: true
+  require_template_sections: true
+  reject_unsupported_claims: true
+  write_evaluation_artifact: true
+  stop_before_publication: true
+  stop_before_mutation: true
+```
+
+## Output Contract
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/quality-evaluation/
+```
+
+Required artifacts:
+
+- `review_quality_evaluation.md`
+- `review_quality_evaluation.json`
+
+Statuses:
+
+- `pass`: no blockers or warnings.
+- `partial`: warnings need human review before customer-facing use.
+- `fail`: blockers should prevent publication.
+- `not_run`: source missing or unreadable.
+
+## Stop Boundary
+
+The skill must not publish reports, claim approval or compliance, create issues
+or PRs, generate tests or diagrams, run specialist reviews, rewrite reports, or
+mutate customer repositories.

--- a/adl/tools/skills/review-quality-evaluator/SKILL.md
+++ b/adl/tools/skills/review-quality-evaluator/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: review-quality-evaluator
+description: Evaluate CodeBuddy review packets and reports against the third-party-review quality bar for evidence quality, severity accuracy, actionability, duplication, unsupported claims, specialist coverage, template compliance, residual risk clarity, and publication safety before customer-facing use.
+---
+
+# Review Quality Evaluator
+
+Evaluate a CodeBuddy review packet or product report before it becomes a
+customer-facing artifact. This skill is a quality gate, not a specialist
+reviewer, not a remediator, not a publisher, and not an approval authority.
+
+Use this skill after packet building, specialist reviews, synthesis, redaction,
+diagram review, test planning, issue planning, and report writing have produced
+the artifacts that need to be judged.
+
+## Quick Start
+
+1. Confirm the evaluation source:
+   - CodeBuddy packet root
+   - product report artifact root
+   - synthesis or final report
+   - specialist artifact bundle
+2. Confirm publication intent and required specialist roles.
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/evaluate_review_quality.py <packet-root> --out <artifact-root>`
+4. Review the gate status, blocking reasons, warnings, and scorecard.
+5. Stop before publication, approval claims, issue creation, PR creation,
+   remediation, report rewriting, specialist review, or customer repository
+   mutation.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `artifact_root` or `packet_root`
+- `mode`
+- `publication_intent`
+- `policy`
+
+Supported modes:
+
+- `evaluate_packet`
+- `evaluate_report`
+- `evaluate_synthesis`
+- `pre_publication_gate`
+
+Useful policy fields:
+
+- `publication_intent`
+- `required_roles`
+- `severity_floor`
+- `require_redaction_status`
+- `require_template_sections`
+- `reject_unsupported_claims`
+- `write_evaluation_artifact`
+- `stop_before_publication`
+- `stop_before_mutation`
+
+If there is no concrete artifact root or report source, stop and report
+`not_run`.
+
+## Workflow
+
+### 1. Establish Gate Boundary
+
+Record:
+
+- packet or report source
+- repo name and ref, if present
+- publication intent
+- required specialist roles
+- report template sections expected
+- redaction status
+- non-reviewed surfaces and assumptions
+
+Do not upgrade publication readiness. This skill can only report whether the
+quality gate passes, partially passes, fails, or could not run.
+
+### 2. Evaluate Review Quality
+
+Check:
+
+- findings have evidence, impact, recommended action, and validation gap
+- severity is justified by concrete impact
+- findings are ordered by severity where possible
+- duplicate findings are linked, merged, or explicitly preserved
+- unsupported approval, compliance, publication, or remediation claims are absent
+- specialist coverage is present or missing roles are clearly caveated
+- report sections follow the CodeBuddy review template standard
+- non-reviewed surfaces, caveats, disagreements, and residual risks are visible
+- redaction and evidence-boundary artifacts exist before customer-facing output
+
+### 3. Classify The Gate
+
+Use these statuses:
+
+- `pass`: the source satisfies the required quality checks for internal review.
+- `partial`: the source is usable but warnings or missing non-blocking evidence
+  remain.
+- `fail`: one or more blockers should prevent customer-facing publication.
+- `not_run`: no readable source was available.
+
+Use blockers for missing evidence on findings, unsupported publication or
+approval claims, missing redaction before customer-facing publication, unclear
+scope, hidden residual risk, or missing required template sections.
+
+Use warnings for missing optional specialist roles, weak actionability, duplicate
+findings that need manual review, or incomplete validation gaps.
+
+### 4. Stop Before Publication
+
+This skill must not:
+
+- publish, send, or approve a report
+- claim compliance, merge-readiness, remediation completion, or security approval
+- create issues, pull requests, tests, diagrams, ADRs, or fixes
+- edit or rewrite customer reports
+- edit customer repositories
+- run specialist review lanes
+- hide missing coverage or residual risk
+
+Handoff candidates to:
+
+- `product-report-writer` when the quality gate finds report structure gaps
+- `redaction-and-evidence-auditor` when publication safety is missing or unsafe
+- `repo-review-synthesis` when specialist disagreement or dedupe is unresolved
+- `finding-to-issue-planner` for approved follow-through after human review
+
+## Output
+
+Write Markdown and JSON quality artifacts when an output root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/quality-evaluation/
+```
+
+Required artifacts:
+
+- `review_quality_evaluation.md`
+- `review_quality_evaluation.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Blocked States
+
+Return `not_run` when the source is missing or unreadable.
+
+Return `fail` when:
+
+- findings lack evidence
+- severity lacks impact justification
+- scope or non-reviewed surfaces are unclear
+- customer-facing publication lacks redaction status
+- unsupported approval, compliance, merge-readiness, publication, or remediation
+  claims appear
+- required template sections are missing
+
+Return `partial` when the review can be used internally but missing specialist
+coverage, weak actionability, duplicated findings, or incomplete caveats need
+human review before publication.

--- a/adl/tools/skills/review-quality-evaluator/adl-skill.yaml
+++ b/adl/tools/skills/review-quality-evaluator/adl-skill.yaml
@@ -1,0 +1,130 @@
+version: "0.1"
+kind: "adl-skill"
+id: "review-quality-evaluator"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "review_quality_evaluator.v1"
+    reference_doc: "../docs/REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "artifact_root"
+      - "publication_intent"
+      - "policy"
+    mode_enum:
+      - "evaluate_packet"
+      - "evaluate_report"
+      - "evaluate_synthesis"
+      - "pre_publication_gate"
+    policy_fields:
+      - "publication_intent"
+      - "required_roles"
+      - "severity_floor"
+      - "require_redaction_status"
+      - "require_template_sections"
+      - "reject_unsupported_claims"
+      - "write_evaluation_artifact"
+      - "stop_before_publication"
+      - "stop_before_mutation"
+    mode_requirements:
+      evaluate_packet:
+        required_target_fields:
+          - "artifact_root"
+      evaluate_report:
+        required_target_fields:
+          - "report_path"
+      evaluate_synthesis:
+        required_target_fields:
+          - "synthesis_artifact"
+      pre_publication_gate:
+        required_target_fields:
+          - "artifact_root"
+          - "redaction_report_path"
+  intent:
+    - "review_quality_gate"
+    - "codebuddy_review_engine"
+    - "third_party_review_quality_bar"
+    - "pre_publication_quality_check"
+  required_inputs:
+    - "artifact_root"
+    - "publication_intent"
+    - "policy"
+  optional_inputs:
+    - "report_path"
+    - "synthesis_artifact"
+    - "specialist_artifacts"
+    - "output_root"
+    - "redaction_report_path"
+    - "product_report_path"
+  stop_if_missing:
+    - "artifact_root"
+  prevalidation_rules:
+    - "artifact_root_must_exist"
+    - "skill_input_schema_must_equal_review_quality_evaluator.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "publication_intent_must_be_explicit"
+    - "policy.stop_before_publication_must_be_true"
+    - "policy.stop_before_mutation_must_be_true"
+    - "policy.reject_unsupported_claims_must_be_true"
+execution:
+  mode: "quality_gate_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/evaluate_review_quality.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<packet-root>"
+        - "--out <artifact-root>"
+        - "--publication-intent <intent>"
+        - "--required-role <role>"
+  preferred_read_order:
+    - "run_manifest.json"
+    - "repo_scope.md"
+    - "final_report.md"
+    - "product-report/codebuddy_product_report.md"
+    - "synthesis.md"
+    - "specialist review artifacts"
+    - "redaction report"
+    - "diagram manifests and reviews"
+    - "test recommendation artifacts"
+    - "issue planning artifacts"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  must_not_run:
+    - "publication"
+    - "approval_claims"
+    - "compliance_claims"
+    - "remediation_complete_claims"
+    - "tracker_item_creation"
+    - "pull_request_creation"
+    - "specialist_reviews"
+    - "test_generation"
+    - "diagram_generation"
+    - "report_rewriting"
+    - "customer_repository_mutation"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/codebuddy/<run_id>/quality-evaluation/"
+  required_artifacts:
+    - "review_quality_evaluation.md"
+    - "review_quality_evaluation.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  publication_requires_redaction_gate: true
+  unsupported_claims_are_blockers: true
+  no_approval_or_compliance_claims: true
+  manifest_declares_executables: true
+
+display_name: Review Quality Evaluator
+short_description: Gate CodeBuddy packets and reports against the third-party-review quality bar
+default_prompt: Evaluate a CodeBuddy review packet or report for evidence quality, severity accuracy, actionability, duplication, unsupported claims, specialist coverage, template compliance, residual risk clarity, and publication safety. Emit pass, partial, fail, or not-run with concrete reasons; stop before publication, approval claims, remediation, issue creation, PRs, tests, diagrams, or repository mutation.

--- a/adl/tools/skills/review-quality-evaluator/agents/openai.yaml
+++ b/adl/tools/skills/review-quality-evaluator/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Review Quality Evaluator
+short_description: Gate CodeBuddy packets and reports against the third-party-review quality bar
+default_prompt: Evaluate a CodeBuddy review packet or report for evidence quality, severity accuracy, actionability, duplication, unsupported claims, specialist coverage, template compliance, residual risk clarity, and publication safety. Emit pass, partial, fail, or not-run with concrete reasons; stop before publication, approval claims, remediation, issue creation, PRs, tests, diagrams, or repository mutation.

--- a/adl/tools/skills/review-quality-evaluator/references/evaluation-playbook.md
+++ b/adl/tools/skills/review-quality-evaluator/references/evaluation-playbook.md
@@ -1,0 +1,39 @@
+# Evaluation Playbook
+
+Use this playbook when evaluating a CodeBuddy review packet or product report.
+
+## Quality Bar
+
+- Findings are first-class and ordered by severity where possible.
+- Each finding has evidence, impact, recommended action, and validation gap.
+- Severity labels match concrete user, customer, security, or operational impact.
+- Scope, exclusions, assumptions, and non-reviewed surfaces are visible.
+- Specialist disagreement is preserved or explicitly absent.
+- Diagrams and generated tests are tied to source evidence and findings.
+- Redaction and evidence-boundary status is visible before customer-facing use.
+- Residual risk is stated plainly.
+
+## Blocker Examples
+
+- A finding has no evidence.
+- A report claims approval, compliance, remediation completion, publication
+  approval, or merge-readiness without a source artifact proving that status.
+- Customer-facing publication is requested with no redaction report.
+- The reviewed scope is unclear.
+- Required report sections are missing.
+- Residual risk and non-reviewed surfaces are absent.
+
+## Warning Examples
+
+- A specialist role is missing but the report caveats the gap.
+- Findings are actionable but validation gaps are incomplete.
+- Duplicate findings are present and need manual dedupe.
+- Diagram or test artifacts are missing for a packet that can still be reviewed
+  internally.
+
+## Handoff Guidance
+
+- Send missing redaction or unsafe evidence to `redaction-and-evidence-auditor`.
+- Send weak final report structure to `product-report-writer`.
+- Send unresolved disagreement or duplicate findings to `repo-review-synthesis`.
+- Send approved follow-through candidates to `finding-to-issue-planner`.

--- a/adl/tools/skills/review-quality-evaluator/references/output-contract.md
+++ b/adl/tools/skills/review-quality-evaluator/references/output-contract.md
@@ -1,0 +1,72 @@
+# Output Contract
+
+The review-quality-evaluator skill produces CodeBuddy quality-gate artifacts
+from existing review packet or report evidence.
+
+Default artifact root:
+
+```text
+.adl/reviews/codebuddy/<run_id>/quality-evaluation/
+```
+
+## Required Artifacts
+
+### review_quality_evaluation.md
+
+Required sections:
+
+- Quality Gate Summary
+- Scope And Source
+- Scorecard
+- Blocking Issues
+- Warnings
+- Specialist Coverage
+- Template Compliance
+- Unsupported Claims Check
+- Residual Risk Clarity
+- Publication Boundary
+- Recommended Handoffs
+
+### review_quality_evaluation.json
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `repo_name`
+- `repo_ref`
+- `status`
+- `publication_intent`
+- `score`
+- `scorecard`
+- `blocking_issues`
+- `warnings`
+- `specialist_coverage`
+- `template_compliance`
+- `unsupported_claims`
+- `residual_risk_clarity`
+- `publication_boundary`
+- `recommended_handoffs`
+
+## Status Values
+
+- `pass`: no blockers or warnings were found for the requested gate.
+- `partial`: no blockers were found, but warnings need human review.
+- `fail`: one or more blockers should prevent customer-facing publication.
+- `not_run`: no readable packet or report source was available.
+
+## Rules
+
+- Use repo-relative or packet-relative paths.
+- Do not write absolute host paths into quality artifacts.
+- Treat unsupported approval, compliance, publication, merge-readiness, or
+  remediation-complete claims as blockers.
+- Treat missing finding evidence as a blocker.
+- Treat missing redaction status as a blocker for customer-private or public
+  publication intent.
+- Preserve missing specialist roles as coverage warnings unless policy marks
+  them required blockers.
+- Do not publish or transmit reports.
+- Do not create issues, PRs, tests, diagrams, ADRs, fixes, or repository edits.
+- Surface caveats, non-reviewed surfaces, disagreements, and residual risk
+  instead of smoothing them over.

--- a/adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py
+++ b/adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""Evaluate CodeBuddy review packet quality without publishing or mutating."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "codebuddy.review_quality_evaluation.v1"
+SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+DEFAULT_REQUIRED_ROLES = ["code", "security", "tests", "docs", "architecture"]
+REQUIRED_REPORT_SECTIONS = [
+    "Executive Summary",
+    "Review Scope",
+    "Top Findings",
+    "Architecture Summary",
+    "Security And Privacy Notes",
+    "Test Recommendations",
+    "Remediation Sequence",
+    "Residual Risks",
+]
+UNSUPPORTED_CLAIM_RE = re.compile(
+    r"\b(approved|approval|compliant|compliance|merge[- ]?ready|production[- ]?ready|"
+    r"remediation (?:complete|completed)|publication (?:approved|ready)|safe to publish)\b",
+    re.IGNORECASE,
+)
+FINDING_RE = re.compile(
+    r"^#{2,4}[ \t]+(?:Finding[ \t]+)?(?P<id>[A-Za-z0-9_.:-]+)?[ \t]*:?[ \t]*(?:\[(?P<severity>P[0-3])\])?[ \t]*(?P<title>[^\n#].*?)\s*$",
+    re.MULTILINE,
+)
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def packet_relative(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def line_value(block: str, key: str) -> str:
+    pattern = re.compile(rf"^\s*-\s*{re.escape(key)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(block)
+    return match.group(1).strip() if match else ""
+
+
+def section_present(text: str, heading: str) -> bool:
+    normalized = re.sub(r"\s+", " ", heading.strip()).lower()
+    for line in text.splitlines():
+        candidate = line.lstrip("# ").strip()
+        candidate = re.sub(r"\s+", " ", candidate).lower()
+        if candidate == normalized:
+            return True
+    return False
+
+
+def extract_bullets_after(text: str, heading: str) -> list[str]:
+    pattern = re.compile(rf"^##+\s+{re.escape(heading)}\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        return []
+    next_heading = re.search(r"^##+\s+", text[match.end() :], re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(text)
+    section = text[match.end() : end]
+    return [line.strip()[2:].strip() for line in section.splitlines() if line.strip().startswith("- ")][:20]
+
+
+def read_manifest(root: Path) -> dict[str, object]:
+    manifest = load_json(root / "run_manifest.json")
+    if not isinstance(manifest, dict):
+        manifest = {}
+    return {
+        "run_id": str(manifest.get("run_id") or root.name),
+        "repo_name": str(manifest.get("repo_name") or root.name),
+        "repo_ref": str(manifest.get("repo_ref") or "not recorded"),
+        "review_mode": str(manifest.get("review_mode") or "not recorded"),
+        "privacy_mode": str(manifest.get("privacy_mode") or "not recorded"),
+        "publication_allowed": bool(manifest.get("publication_allowed", False)),
+    }
+
+
+def preferred_review_sources(root: Path) -> list[Path]:
+    preferred = [
+        root / "final_report.md",
+        root / "product-report" / "codebuddy_product_report.md",
+        root / "synthesis.md",
+        root / "specialist_reviews" / "synthesis.md",
+        root / "specialist_reviews" / "code.md",
+        root / "specialist_reviews" / "security.md",
+        root / "specialist_reviews" / "tests.md",
+        root / "specialist_reviews" / "docs.md",
+        root / "specialist_reviews" / "architecture.md",
+        root / "specialist_reviews" / "dependencies.md",
+        root / "redaction_report.md",
+    ]
+    found = [path for path in preferred if path.is_file()]
+    if found:
+        return found
+    return sorted(path for path in root.rglob("*.md") if "quality-evaluation" not in path.parts)[:50]
+
+
+def all_review_text(root: Path) -> str:
+    chunks = []
+    for path in preferred_review_sources(root):
+        chunks.append(f"\n<!-- {packet_relative(root, path)} -->\n{read_text(path)}")
+    return "\n".join(chunks)
+
+
+def clean_title(title: str) -> str:
+    title = re.sub(r"^\[[Pp][0-3]\]\s*", "", title).strip()
+    return re.sub(r"\s+", " ", title).rstrip("# ").strip()
+
+
+def severity_from_block(heading_severity: str | None, block: str) -> str:
+    if heading_severity:
+        return heading_severity.upper()
+    for key in ("Severity", "Priority"):
+        value = line_value(block, key)
+        match = re.search(r"\bP[0-3]\b", value.upper())
+        if match:
+            return match.group(0)
+    match = re.search(r"\bP[0-3]\b", block.upper())
+    return match.group(0) if match else "P2"
+
+
+def role_from_path(path: Path, block: str) -> str:
+    value = line_value(block, "Role") or line_value(block, "Source role")
+    if value:
+        return value.lower()
+    lowered = f"{path.as_posix()} {block}".lower()
+    for role in ("security", "tests", "docs", "architecture", "dependency", "diagram", "code"):
+        if role in lowered:
+            return "dependencies" if role == "dependency" else role
+    return "review"
+
+
+def split_findings(root: Path) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for path in preferred_review_sources(root):
+        text = read_text(path)
+        matches = [
+            match
+            for match in FINDING_RE.finditer(text)
+            if re.match(r"^#{2,4}\s+Finding\s+", match.group(0), re.IGNORECASE)
+        ]
+        for index, match in enumerate(matches):
+            start = match.end()
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            block = text[start:end].strip()
+            findings.append(
+                {
+                    "finding_id": str(match.group("id") or f"{path.stem}-{index + 1}").strip(": "),
+                    "title": clean_title(match.group("title")),
+                    "severity": severity_from_block(match.group("severity"), block),
+                    "role": role_from_path(path, block),
+                    "source_artifact": packet_relative(root, path),
+                    "evidence": line_value(block, "Evidence"),
+                    "impact": line_value(block, "Impact") or line_value(block, "User/customer impact"),
+                    "recommended_action": line_value(block, "Recommended action"),
+                    "validation_gap": line_value(block, "Validation gap")
+                    or line_value(block, "Validation or proof gap"),
+                    "related_findings": line_value(block, "Related findings"),
+                    "raw_block": block,
+                }
+            )
+    return sorted(findings, key=lambda item: (SEVERITY_ORDER.get(str(item["severity"]), 9), str(item["finding_id"])))
+
+
+def source_scope(root: Path) -> dict[str, object]:
+    text = read_text(root / "repo_scope.md")
+    if not text:
+        return {
+            "present": False,
+            "included_paths": [],
+            "excluded_paths": [],
+            "non_reviewed_surfaces": [],
+            "assumptions": [],
+        }
+    return {
+        "present": True,
+        "included_paths": extract_bullets_after(text, "Included paths"),
+        "excluded_paths": extract_bullets_after(text, "Excluded paths"),
+        "non_reviewed_surfaces": extract_bullets_after(text, "Non-reviewed surfaces"),
+        "assumptions": extract_bullets_after(text, "Assumptions"),
+    }
+
+
+def role_coverage(root: Path, required_roles: list[str]) -> dict[str, object]:
+    sources = preferred_review_sources(root)
+    source_names = {packet_relative(root, path).lower() for path in sources}
+    present: dict[str, bool] = {}
+    for role in required_roles:
+        role_l = role.lower()
+        present[role_l] = any(
+            f"/{role_l}.md" in f"/{name}" or role_l in read_text(path).lower().splitlines()[0:5]
+            for name, path in [(packet_relative(root, item).lower(), item) for item in sources]
+        )
+    missing = [role for role, exists in present.items() if not exists]
+    return {
+        "required_roles": required_roles,
+        "present_roles": [role for role, exists in present.items() if exists],
+        "missing_roles": missing,
+        "source_artifacts": sorted(source_names),
+    }
+
+
+def template_compliance(text: str) -> dict[str, object]:
+    missing = [heading for heading in REQUIRED_REPORT_SECTIONS if not section_present(text, heading)]
+    return {
+        "required_sections": REQUIRED_REPORT_SECTIONS,
+        "missing_sections": missing,
+        "status": "pass" if not missing else "fail",
+    }
+
+
+def unsupported_claims(root: Path) -> list[dict[str, str]]:
+    claims: list[dict[str, str]] = []
+    for path in preferred_review_sources(root):
+        for line_no, line in enumerate(read_text(path).splitlines(), start=1):
+            match = UNSUPPORTED_CLAIM_RE.search(line)
+            if match:
+                lowered = line.lower()
+                if "claimed: false" in lowered or "published by this skill: false" in lowered:
+                    continue
+                claims.append(
+                    {
+                        "source_artifact": packet_relative(root, path),
+                        "line": str(line_no),
+                        "claim": match.group(0),
+                        "sample": line.strip()[:180],
+                    }
+                )
+    return claims
+
+
+def redaction_present(root: Path) -> bool:
+    return any(path.is_file() for path in [root / "redaction_report.md", root / "redaction-audit" / "redaction_report.md"])
+
+
+def duplicate_titles(findings: list[dict[str, object]]) -> list[str]:
+    seen: dict[str, int] = {}
+    for finding in findings:
+        title = str(finding.get("title", "")).lower()
+        normalized = re.sub(r"[^a-z0-9]+", " ", title).strip()
+        if normalized:
+            seen[normalized] = seen.get(normalized, 0) + 1
+    return [title for title, count in seen.items() if count > 1]
+
+
+def evaluate(root: Path, publication_intent: str, required_roles: list[str]) -> dict[str, object]:
+    manifest = read_manifest(root)
+    text = all_review_text(root)
+    findings = split_findings(root)
+    scope = source_scope(root)
+    coverage = role_coverage(root, required_roles)
+    template = template_compliance(text)
+    claims = unsupported_claims(root)
+    blockers: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+
+    if not preferred_review_sources(root):
+        return {
+            "schema": SCHEMA,
+            "created_at": now_utc(),
+            "run_id": manifest["run_id"],
+            "repo_name": manifest["repo_name"],
+            "repo_ref": manifest["repo_ref"],
+            "status": "not_run",
+            "publication_intent": publication_intent,
+            "score": 0,
+            "scorecard": {},
+            "blocking_issues": [{"check": "source", "reason": "No readable review source was found."}],
+            "warnings": [],
+            "specialist_coverage": coverage,
+            "template_compliance": template,
+            "unsupported_claims": [],
+            "residual_risk_clarity": {"status": "not_run"},
+            "publication_boundary": publication_boundary(manifest, publication_intent),
+            "recommended_handoffs": ["repo-packet-builder"],
+        }
+
+    if not scope["present"] or not scope["non_reviewed_surfaces"]:
+        blockers.append({"check": "scope", "reason": "Scope or non-reviewed surfaces are missing."})
+    if not findings:
+        blockers.append({"check": "findings", "reason": "No findings were extracted from the review source."})
+    for finding in findings:
+        missing = [
+            key
+            for key in ("evidence", "impact", "recommended_action", "validation_gap")
+            if not finding.get(key)
+        ]
+        if "evidence" in missing:
+            blockers.append(
+                {
+                    "check": "finding_evidence",
+                    "reason": f"Finding {finding['finding_id']} is missing evidence.",
+                    "source_artifact": str(finding["source_artifact"]),
+                }
+            )
+        if "impact" in missing:
+            blockers.append(
+                {
+                    "check": "severity_accuracy",
+                    "reason": f"Finding {finding['finding_id']} has no impact justification for severity.",
+                    "source_artifact": str(finding["source_artifact"]),
+                }
+            )
+        if "recommended_action" in missing or "validation_gap" in missing:
+            warnings.append(
+                {
+                    "check": "actionability",
+                    "reason": f"Finding {finding['finding_id']} has incomplete action or validation guidance.",
+                    "source_artifact": str(finding["source_artifact"]),
+                }
+            )
+    if publication_intent in {"customer_private", "public_candidate"} and not redaction_present(root):
+        blockers.append({"check": "redaction", "reason": "Customer-facing publication intent requires redaction status."})
+    if template["missing_sections"]:
+        blockers.append(
+            {
+                "check": "template_compliance",
+                "reason": "Required report sections are missing: " + ", ".join(template["missing_sections"]),
+            }
+        )
+    for claim in claims:
+        blockers.append(
+            {
+                "check": "unsupported_claim",
+                "reason": f"Unsupported claim appears in {claim['source_artifact']} line {claim['line']}: {claim['claim']}",
+            }
+        )
+    for role in coverage["missing_roles"]:
+        warnings.append({"check": "specialist_coverage", "reason": f"Required specialist role missing or not visible: {role}"})
+    for title in duplicate_titles(findings):
+        warnings.append({"check": "duplication", "reason": f"Potential duplicate finding title needs synthesis review: {title}"})
+
+    residual_ok = section_present(text, "Residual Risk") or section_present(text, "Residual Risks") or bool(scope["non_reviewed_surfaces"])
+    if not residual_ok:
+        blockers.append({"check": "residual_risk", "reason": "Residual risk or non-reviewed surfaces are not visible."})
+
+    scorecard = {
+        "evidence_quality": "fail" if any(item["check"] == "finding_evidence" for item in blockers) else "pass",
+        "severity_accuracy": "fail" if any(item["check"] == "severity_accuracy" for item in blockers) else "pass",
+        "actionability": "partial" if any(item["check"] == "actionability" for item in warnings) else "pass",
+        "duplication": "partial" if any(item["check"] == "duplication" for item in warnings) else "pass",
+        "unsupported_claims": "fail" if claims else "pass",
+        "specialist_coverage": "partial" if coverage["missing_roles"] else "pass",
+        "template_compliance": template["status"],
+        "residual_risk_clarity": "pass" if residual_ok else "fail",
+        "redaction_status": "pass" if redaction_present(root) else "partial",
+    }
+    status = "fail" if blockers else "partial" if warnings else "pass"
+    score = quality_score(scorecard, blockers, warnings)
+    return {
+        "schema": SCHEMA,
+        "created_at": now_utc(),
+        "run_id": manifest["run_id"],
+        "repo_name": manifest["repo_name"],
+        "repo_ref": manifest["repo_ref"],
+        "status": status,
+        "publication_intent": publication_intent,
+        "score": score,
+        "scorecard": scorecard,
+        "blocking_issues": blockers,
+        "warnings": warnings,
+        "specialist_coverage": coverage,
+        "template_compliance": template,
+        "unsupported_claims": claims,
+        "residual_risk_clarity": {
+            "status": "pass" if residual_ok else "fail",
+            "non_reviewed_surfaces": scope["non_reviewed_surfaces"],
+        },
+        "publication_boundary": publication_boundary(manifest, publication_intent),
+        "recommended_handoffs": recommended_handoffs(blockers, warnings),
+    }
+
+
+def quality_score(scorecard: dict[str, str], blockers: list[dict[str, str]], warnings: list[dict[str, str]]) -> int:
+    score = 100
+    score -= 15 * len(blockers)
+    score -= 5 * len(warnings)
+    score -= 10 * sum(1 for value in scorecard.values() if value == "partial")
+    score -= 20 * sum(1 for value in scorecard.values() if value == "fail")
+    return max(score, 0)
+
+
+def publication_boundary(manifest: dict[str, object], publication_intent: str) -> dict[str, object]:
+    return {
+        "publication_intent": publication_intent,
+        "privacy_mode": manifest["privacy_mode"],
+        "publication_allowed_by_source": manifest["publication_allowed"],
+        "published_by_skill": False,
+        "approval_claimed": False,
+        "compliance_claimed": False,
+        "remediation_complete_claimed": False,
+    }
+
+
+def recommended_handoffs(blockers: list[dict[str, str]], warnings: list[dict[str, str]]) -> list[str]:
+    checks = {item["check"] for item in blockers + warnings}
+    handoffs: list[str] = []
+    if "redaction" in checks or "unsupported_claim" in checks:
+        handoffs.append("redaction-and-evidence-auditor")
+    if "template_compliance" in checks or "actionability" in checks or "residual_risk" in checks:
+        handoffs.append("product-report-writer")
+    if "duplication" in checks or "specialist_coverage" in checks:
+        handoffs.append("repo-review-synthesis")
+    if "finding_evidence" in checks or "severity_accuracy" in checks:
+        handoffs.append("owning specialist reviewer")
+    return handoffs or ["human review"]
+
+
+def bullet_lines(items: list[object]) -> str:
+    if not items:
+        return "- None."
+    return "\n".join(f"- {item}" for item in items)
+
+
+def issue_lines(items: list[dict[str, str]]) -> str:
+    if not items:
+        return "- None."
+    lines = []
+    for item in items:
+        reason = item.get("reason", "No reason recorded.")
+        source = item.get("source_artifact")
+        suffix = f" Source: {source}." if source else ""
+        lines.append(f"- {item.get('check', 'check')}: {reason}{suffix}")
+    return "\n".join(lines)
+
+
+def scorecard_lines(scorecard: dict[str, str]) -> str:
+    return "\n".join(f"- {key.replace('_', ' ').title()}: {value}" for key, value in sorted(scorecard.items()))
+
+
+def write_markdown(path: Path, evaluation: dict[str, object]) -> None:
+    coverage = evaluation["specialist_coverage"]
+    template = evaluation["template_compliance"]
+    boundary = evaluation["publication_boundary"]
+    content = f"""# CodeBuddy Review Quality Evaluation: {evaluation['repo_name']}
+
+## Quality Gate Summary
+
+- Status: {evaluation['status']}
+- Score: {evaluation['score']}
+- Publication intent: {evaluation['publication_intent']}
+- Repo ref: {evaluation['repo_ref']}
+
+## Scope And Source
+
+- Run id: {evaluation['run_id']}
+- Source artifacts: {', '.join(coverage.get('source_artifacts') or ['none'])}
+
+## Scorecard
+
+{scorecard_lines(evaluation['scorecard'])}
+
+## Blocking Issues
+
+{issue_lines(evaluation['blocking_issues'])}
+
+## Warnings
+
+{issue_lines(evaluation['warnings'])}
+
+## Specialist Coverage
+
+- Present roles: {', '.join(coverage.get('present_roles') or ['none'])}
+- Missing roles: {', '.join(coverage.get('missing_roles') or ['none'])}
+
+## Template Compliance
+
+- Status: {template['status']}
+- Missing sections: {', '.join(template.get('missing_sections') or ['none'])}
+
+## Unsupported Claims Check
+
+{issue_lines([{'check': 'unsupported_claim', 'reason': item.get('sample', ''), 'source_artifact': item.get('source_artifact', '')} for item in evaluation['unsupported_claims']])}
+
+## Residual Risk Clarity
+
+- Status: {evaluation['residual_risk_clarity']['status']}
+- Non-reviewed surfaces: {', '.join(evaluation['residual_risk_clarity'].get('non_reviewed_surfaces') or ['none extracted'])}
+
+## Publication Boundary
+
+- Published by this skill: false.
+- Approval claimed: false.
+- Compliance claimed: false.
+- Remediation complete claimed: false.
+- Publication allowed by source manifest: {str(boundary['publication_allowed_by_source']).lower()}.
+
+## Recommended Handoffs
+
+{bullet_lines(evaluation['recommended_handoffs'])}
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet_root", help="CodeBuddy packet or report artifact root")
+    parser.add_argument("--out", default=None, help="Quality evaluation artifact root")
+    parser.add_argument("--publication-intent", default="internal_review", help="Publication intent")
+    parser.add_argument("--required-role", action="append", default=[], help="Required specialist role")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.packet_root)
+    if not root.is_dir():
+        raise SystemExit(f"packet root does not exist: {root}")
+    out_root = Path(args.out) if args.out else root / "quality-evaluation"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+    required_roles = args.required_role or DEFAULT_REQUIRED_ROLES
+    evaluation = evaluate(root, args.publication_intent, required_roles)
+    write_json(out_root / "review_quality_evaluation.json", evaluation)
+    write_markdown(out_root / "review_quality_evaluation.md", evaluation)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_review_quality_evaluator_skill_contracts.sh
+++ b/adl/tools/test_review_quality_evaluator_skill_contracts.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/review-quality-evaluator/SKILL.md" ]]
+[[ -f "${skills_root}/review-quality-evaluator/adl-skill.yaml" ]]
+[[ -f "${skills_root}/review-quality-evaluator/agents/openai.yaml" ]]
+[[ -f "${skills_root}/review-quality-evaluator/references/evaluation-playbook.md" ]]
+[[ -f "${skills_root}/review-quality-evaluator/references/output-contract.md" ]]
+[[ -x "${skills_root}/review-quality-evaluator/scripts/evaluate_review_quality.py" ]]
+[[ -f "${skills_root}/docs/REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "review-quality-evaluator"' "${skills_root}/review-quality-evaluator/adl-skill.yaml"
+grep -Fq 'id: "review_quality_evaluator.v1"' "${skills_root}/review-quality-evaluator/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md"' "${skills_root}/review-quality-evaluator/adl-skill.yaml"
+grep -Fq "policy.reject_unsupported_claims_must_be_true" "${skills_root}/review-quality-evaluator/adl-skill.yaml"
+grep -Fq "Evaluate a CodeBuddy review packet" "${skills_root}/review-quality-evaluator/SKILL.md"
+grep -Fq "Treat unsupported approval, compliance, publication, merge-readiness, or" "${skills_root}/review-quality-evaluator/references/output-contract.md"
+grep -Fq "Schema id: \`review_quality_evaluator.v1\`" "${skills_root}/docs/REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md"
+grep -Fq "review-quality-evaluator" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md"
+
+packet_root="${tmpdir}/packet"
+quality_root="${tmpdir}/quality-evaluation"
+mkdir -p "${packet_root}/specialist_reviews" "${packet_root}/product-report"
+cat >"${packet_root}/run_manifest.json" <<'JSON'
+{
+  "schema": "codebuddy.repo_packet.run_manifest.v1",
+  "run_id": "review-quality-contract-test",
+  "repo_name": "example-repo",
+  "repo_ref": "abc123",
+  "review_mode": "release_review",
+  "privacy_mode": "customer_private",
+  "publication_allowed": false
+}
+JSON
+cat >"${packet_root}/repo_scope.md" <<'MD'
+# Repo Scope
+
+## Included paths
+
+- src
+- docs
+
+## Excluded paths
+
+- target
+
+## Non-reviewed surfaces
+
+- generated artifacts
+
+## Assumptions
+
+- Review is bounded to release-critical surfaces.
+MD
+cat >"${packet_root}/specialist_reviews/code.md" <<'MD'
+# Code Review
+
+## Findings
+
+### Finding C-001: [P1] Missing report quality gate
+
+- Role: code
+- Confidence: high
+- Affected path or artifact: adl/tools/report.sh
+- Trigger scenario: a report can be produced without a quality-gate artifact.
+- Evidence: the packet contains a final report but no quality evaluation.
+- User/customer impact: customers may receive a weak report that hides review gaps.
+- Recommended action: require a quality evaluation artifact before publication.
+- Validation or proof gap: add a focused contract test for the quality gate.
+- Related findings: none
+MD
+cat >"${packet_root}/specialist_reviews/security.md" <<'MD'
+# Security Review
+
+## Findings
+
+### Finding S-001: [P2] Redaction gate must remain visible
+
+- Role: security
+- Confidence: medium
+- Affected path or artifact: redaction_report.md
+- Trigger scenario: customer-private output is prepared without visible redaction status.
+- Evidence: publication intent is customer-private and redaction is required.
+- User/customer impact: private paths or source excerpts could leak.
+- Recommended action: require redaction status in the quality gate.
+- Validation or proof gap: verify customer-private output fails without redaction.
+MD
+cat >"${packet_root}/final_report.md" <<'MD'
+# CodeBuddy Review Report: example-repo
+
+## Executive Summary
+
+- Overall risk: high
+
+## Review Scope
+
+- Repository: example-repo
+
+## Top Findings
+
+### Finding C-001: [P1] Missing report quality gate
+
+- Source role: code
+- Confidence: high
+- Evidence: the packet contains a final report but no quality evaluation.
+- Impact: customers may receive a weak report that hides review gaps.
+- Recommended action: require a quality evaluation artifact before publication.
+- Validation gap: add a focused contract test for the quality gate.
+
+## Architecture Summary
+
+- No architecture-specific findings.
+
+## Security And Privacy Notes
+
+- Redaction result: pass.
+
+## Test Recommendations
+
+- Linked finding: C-001.
+
+## Remediation Sequence
+
+1. Add quality-gate contract.
+
+## Residual Risks
+
+- Specialist coverage remains bounded.
+MD
+cat >"${packet_root}/redaction_report.md" <<'MD'
+# Redaction Report
+
+- Final publication status: pass.
+MD
+
+python3 "${skills_root}/review-quality-evaluator/scripts/evaluate_review_quality.py" \
+  "${packet_root}" --out "${quality_root}" --publication-intent customer_private \
+  --required-role code --required-role security >/tmp/review-quality-evaluator.out
+[[ -f "${quality_root}/review_quality_evaluation.json" ]]
+[[ -f "${quality_root}/review_quality_evaluation.md" ]]
+grep -Fq '"schema": "codebuddy.review_quality_evaluation.v1"' "${quality_root}/review_quality_evaluation.json"
+grep -Fq '"repo_name": "example-repo"' "${quality_root}/review_quality_evaluation.json"
+grep -Fq '"status": "pass"' "${quality_root}/review_quality_evaluation.json"
+grep -Fq '"publication_intent": "customer_private"' "${quality_root}/review_quality_evaluation.json"
+grep -Fq '"published_by_skill": false' "${quality_root}/review_quality_evaluation.json"
+grep -Fq '"approval_claimed": false' "${quality_root}/review_quality_evaluation.json"
+grep -Fq "## Quality Gate Summary" "${quality_root}/review_quality_evaluation.md"
+grep -Fq "## Scorecard" "${quality_root}/review_quality_evaluation.md"
+grep -Fq "## Publication Boundary" "${quality_root}/review_quality_evaluation.md"
+
+rm "${packet_root}/redaction_report.md"
+python3 "${skills_root}/review-quality-evaluator/scripts/evaluate_review_quality.py" \
+  "${packet_root}" --out "${quality_root}/fail" --publication-intent customer_private \
+  --required-role code --required-role security >/tmp/review-quality-evaluator-fail.out
+grep -Fq '"status": "fail"' "${quality_root}/fail/review_quality_evaluation.json"
+grep -Fq '"check": "redaction"' "${quality_root}/fail/review_quality_evaluation.json"
+
+if grep -R "${tmpdir}" "${quality_root}" >/dev/null; then
+  echo "review quality artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/review-quality-evaluator/SKILL.md"
+
+echo "PASS test_review_quality_evaluator_skill_contracts"


### PR DESCRIPTION
Closes #2070

## Summary
Implemented a bounded CodeBuddy review-quality evaluator skill. The skill grades existing packets and reports against evidence quality, severity accuracy, actionability, duplication, unsupported-claim, specialist-coverage, template-compliance, residual-risk, and publication-safety checks, then emits pass, partial, fail, or not-run artifacts without publishing, remediating, or mutating repositories.

## Artifacts
- `adl/tools/skills/review-quality-evaluator/SKILL.md`
- `adl/tools/skills/review-quality-evaluator/adl-skill.yaml`
- `adl/tools/skills/review-quality-evaluator/agents/openai.yaml`
- `adl/tools/skills/review-quality-evaluator/references/output-contract.md`
- `adl/tools/skills/review-quality-evaluator/references/evaluation-playbook.md`
- `adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py`
- `adl/tools/skills/docs/REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_review_quality_evaluator_skill_contracts.sh`
- Updated `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py` verified helper syntax.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/review-quality-evaluator/SKILL.md` verified skill frontmatter contract.
  - `bash adl/tools/test_review_quality_evaluator_skill_contracts.sh` verified bundle shape, schema doc, suite integration, deterministic helper output, pass/fail quality-gate classification, publication-boundary fields, and no temp path leakage.
  - `bash adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh` verified the suite docs still satisfy the multi-agent review skill-suite contract.
  - `git diff --check` verified no whitespace errors.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2070__backlog-skills-add-review-quality-evaluator-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2070__backlog-skills-add-review-quality-evaluator-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-review-quality-evaluator-skill-adl-tools-skills-review-quality-evaluator-adl-tools-skills-docs-review-quality-evaluator-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-review-quality-evaluator-skill-contracts-sh-adl-v0-90-tasks-issue-2070-backlog-skills-add-review-quality-evaluator-skill-sip-md-adl-v0-90-tasks-issue-2070-backlog-skills-add-review-quality-evaluator-skill-sor-md