### PR TITLE
[v0.90][backlog][skills] Add gap analysis skill

### DIFF
--- a/adl/tools/skills/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,98 @@
+# Gap Analysis Skill Input Schema
+
+Schema id: `gap_analysis.v1`
+
+## Purpose
+
+Compare an explicit expected baseline against observed implementation, docs,
+tests, review, PR, milestone, or closeout evidence and produce a bounded
+findings-first gap report.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `gap_analysis.v1`.
+- `mode`: one of `compare_issue_to_implementation`,
+  `compare_milestone_to_evidence`, `compare_spec_to_docs`,
+  `compare_review_to_closeout`, or `compare_packet_to_report`.
+- `expected_baseline`: issue, milestone, spec, PR, review packet, or closeout
+  source of intended truth.
+- `observed_evidence`: implementation, docs, tests, review, PR, report, or
+  closeout evidence to compare.
+- `policy`: comparison and stop-boundary policy.
+
+## Optional Fields
+
+- `artifact_root`: report destination.
+- `issue_ref`
+- `milestone_plan`
+- `spec_path`
+- `review_packet_path`
+- `report_path`
+- `closeout_record`
+
+## Policy Fields
+
+- `severity_floor`
+- `required_gap_types`
+- `uncertainty_policy`
+- `issue_creation_allowed`
+- `write_gap_artifact`
+- `stop_before_fix`
+- `stop_before_mutation`
+
+## Example
+
+```yaml
+skill_input_schema: gap_analysis.v1
+mode: compare_issue_to_implementation
+expected_baseline:
+  issue_ref: "#2044"
+  acceptance_criteria_path: .adl/v0.90/tasks/issue-2044__backlog-skills-add-gap-analysis-skill/stp.md
+observed_evidence:
+  changed_paths:
+    - adl/tools/skills/gap-analysis/SKILL.md
+    - adl/tools/skills/gap-analysis/adl-skill.yaml
+    - adl/tools/test_gap_analysis_skill_contracts.sh
+  validation_commands:
+    - bash adl/tools/test_gap_analysis_skill_contracts.sh
+policy:
+  severity_floor: P3
+  required_gap_types:
+    - missing_evidence
+    - implementation_gap
+    - docs_drift
+    - test_gap
+    - closeout_drift
+  uncertainty_policy: record_explicitly
+  issue_creation_allowed: false
+  write_gap_artifact: true
+  stop_before_fix: true
+  stop_before_mutation: true
+```
+
+## Output Contract
+
+Default artifact root:
+
+```text
+.adl/reviews/gap-analysis/<run_id>/
+```
+
+Required artifacts:
+
+- `gap_analysis_report.md`
+- `gap_analysis_report.json`
+
+Statuses:
+
+- `pass`: no gaps found.
+- `partial`: gaps or missing evidence exist.
+- `fail`: severe gap should block the requested closeout or release decision.
+- `not_run`: explicit baseline missing.
+- `blocked`: requested action violates stop boundary.
+
+## Stop Boundary
+
+The skill must not fix implementation, docs, tests, cards, or reports; create
+issues or PRs; approve closeout, publication, or release readiness; or mutate
+repositories.

--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -22,6 +22,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `repo-diagram-planner`
 - `architecture-diagram-reviewer`
 - `review-to-test-planner`
+- `gap-analysis`
 - `adr-curator`
 - `architecture-fitness-function-author`
 - `finding-to-issue-planner`
@@ -42,11 +43,12 @@ Recommended order:
 8. `repo-diagram-planner`
 9. `architecture-diagram-reviewer`
 10. `review-to-test-planner`
-11. `adr-curator`
-12. `architecture-fitness-function-author`
-13. `finding-to-issue-planner`
-14. `product-report-writer`
-15. `review-quality-evaluator`
+11. `gap-analysis`
+12. `adr-curator`
+13. `architecture-fitness-function-author`
+14. `finding-to-issue-planner`
+15. `product-report-writer`
+16. `review-quality-evaluator`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -61,6 +63,10 @@ handoffs without authoring or rendering diagrams.
 The review-to-test planner should run after specialist findings or synthesis
 exist. It maps findings to safe, bounded `test-generator` handoffs without
 writing tests or turning review follow-up into broad implementation work.
+The gap-analysis skill should run when a concrete expected baseline must be
+reconciled against observed implementation, docs, tests, review, report, PR, or
+closeout evidence. It emits source-grounded gap findings and stops before fixes,
+approval, publication, issue creation, PR creation, or repository mutation.
 The ADR curator should run after architecture findings, synthesis, migration
 notes, or repo evidence identify durable decisions that need Architecture
 Decision Record candidates. It drafts proposed ADR packets without accepting
@@ -302,6 +308,42 @@ policy:
   stop_after_plan: true
 ```
 
+## Gap Analysis Input Shape
+
+```yaml
+skill_input_schema: gap_analysis.v1
+mode: compare_issue_to_implementation | compare_milestone_to_evidence | compare_spec_to_docs | compare_review_to_closeout | compare_packet_to_report
+expected_baseline:
+  issue_ref: <issue or null>
+  milestone_plan: <path or null>
+  spec_path: <path or null>
+  review_packet_path: <path or null>
+  closeout_record: <path or null>
+observed_evidence:
+  changed_paths:
+    - <path>
+  validation_artifacts:
+    - <path>
+  docs_paths:
+    - <path>
+  report_path: <path or null>
+  closeout_record: <path or null>
+policy:
+  severity_floor: P0 | P1 | P2 | P3
+  required_gap_types:
+    - missing_evidence
+    - implementation_gap
+    - docs_drift
+    - test_gap
+    - closeout_drift
+    - scope_ambiguity
+  uncertainty_policy: record_explicitly
+  issue_creation_allowed: false
+  write_gap_artifact: true | false
+  stop_before_fix: true
+  stop_before_mutation: true
+```
+
 ## ADR Curator Input Shape
 
 ```yaml
@@ -438,6 +480,8 @@ The suite may:
 - plan bounded test-generation handoffs from review findings, including
   behavior under test, fixture needs, expected assertions, validation commands,
   and `generated` / `recommended` / `deferred` / `unsafe` status
+- compare explicit baselines to observed evidence and emit source-grounded gap
+  findings, missing-evidence records, uncertainty, and follow-up recommendations
 - draft source-grounded ADR candidate packets with status, context, decision,
   consequences, validation notes, supersession links, and approval boundaries
 - author bounded architecture fitness-function plans that separate
@@ -458,6 +502,8 @@ The suite must not:
 - author, edit, render, publish, or replace diagrams from the diagram review
   lane
 - write tests or fixtures from the review-to-test planning lane
+- fix gaps, create issues or PRs, approve closeout, approve release, or mutate
+  repositories from the gap-analysis lane
 - accept, reject, supersede, publish, or commit ADRs from the ADR curation lane
 - edit ADR files, docs, tests, CI, code, policy files, issues, or PRs from the
   ADR curation lane
@@ -494,6 +540,8 @@ Use this suite when:
   need explicit ownership
 - diagram planning needs to be source-grounded before asking `diagram-author` to
   create a specific visual artifact
+- expected issue, milestone, review, report, or closeout truth must be compared
+  against observed evidence before release or closeout
 - durable architecture decisions need proposed ADR packets before acceptance,
   implementation, or follow-up automation work
 - durable architecture rules need executable-check planning before separate

--- a/adl/tools/skills/gap-analysis/SKILL.md
+++ b/adl/tools/skills/gap-analysis/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: gap-analysis
+description: Compare an explicit expected baseline against observed implementation, docs, tests, review, PR, milestone, or closeout evidence and produce findings-first gap reports with severity, evidence, uncertainty, and bounded follow-up recommendations without fixing, approving, or mutating repositories.
+---
+
+# Gap Analysis
+
+Run a bounded gap review between what was expected and what evidence shows. This
+skill is a comparison and closeout-safety skill, not a code reviewer, not a
+remediator, not a publisher, and not an approval authority.
+
+Use this skill before issue closeout, milestone closeout, third-party review,
+release readiness, or customer-facing report publication when a specific
+baseline must be reconciled against observed truth.
+
+## Quick Start
+
+1. Confirm the expected baseline:
+   - issue acceptance criteria
+   - milestone plan
+   - feature spec
+   - PR scope
+   - review packet
+   - closeout record
+2. Confirm the observed evidence:
+   - changed files
+   - test results
+   - docs
+   - review artifacts
+   - PR body/checks
+   - output card or closeout record
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/analyze_gaps.py <gap-root> --out <artifact-root>`
+4. Review the gap report for source-grounded findings, uncertainty, and follow-up
+   recommendations.
+5. Stop before fixing gaps, creating issues, creating PRs, approving closeout, or
+   mutating repositories.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `mode`
+- `expected_baseline`
+- `observed_evidence`
+- `policy`
+
+Supported modes:
+
+- `compare_issue_to_implementation`
+- `compare_milestone_to_evidence`
+- `compare_spec_to_docs`
+- `compare_review_to_closeout`
+- `compare_packet_to_report`
+
+Useful policy fields:
+
+- `severity_floor`
+- `required_gap_types`
+- `uncertainty_policy`
+- `issue_creation_allowed`
+- `write_gap_artifact`
+- `stop_before_fix`
+- `stop_before_mutation`
+
+If there is no explicit expected baseline, stop and report `not_run`. Do not
+infer intended outcomes from vibes or from the absence of evidence.
+
+## Gap Types
+
+Classify gaps as:
+
+- `missing_evidence`: expected proof is absent or unreadable.
+- `implementation_gap`: expected behavior or artifact is not present in observed
+  implementation evidence.
+- `docs_drift`: docs claim something different from the expected or observed
+  truth.
+- `test_gap`: expected validation is missing, weak, skipped, or not linked to
+  behavior.
+- `closeout_drift`: output card, PR body, issue state, or closeout note overstates
+  integration, validation, scope, or merge truth.
+- `scope_ambiguity`: evidence is insufficient to decide whether a gap exists.
+
+## Severity Policy
+
+- `P0`: critical release or customer-facing truth break, security/privacy
+  exposure, or irreversible closeout failure.
+- `P1`: release-blocking mismatch, serious overclaim, missing high-risk proof, or
+  issue closeout that would mislead operators.
+- `P2`: meaningful implementation, docs, tests, review, or closeout gap that
+  should be fixed but does not block all work.
+- `P3`: lower-risk clarity, traceability, or caveat gap with concrete reviewer or
+  operator impact.
+
+Do not escalate speculation into a finding. If the evidence is insufficient,
+record `scope_ambiguity` or `missing_evidence` with the missing source named.
+
+## Output
+
+Write Markdown and JSON artifacts when an output root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/gap-analysis/<run_id>/
+```
+
+Required artifacts:
+
+- `gap_analysis_report.md`
+- `gap_analysis_report.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+This skill must not:
+
+- fix implementation, docs, tests, cards, or reports
+- create issues or PRs without explicit operator approval
+- close issues or approve releases
+- claim merge-readiness, release-readiness, remediation completion, compliance,
+  or publication approval
+- replace repo-code-review, security-threat-model, review-quality-evaluator, or
+  product-report-writer
+- treat absent evidence as proof of failure when uncertainty is the truthful
+  outcome
+
+Handoff candidates:
+
+- `finding-to-issue-planner` when human-approved issue candidates are needed.
+- `review-to-test-planner` when gaps are validation/test related.
+- `product-report-writer` or `review-quality-evaluator` when report truth is the
+  gap surface.
+- `pr-closeout` or `sor-editor` when closeout truth needs normalization.
+
+## Blocked States
+
+Return `not_run` when the expected baseline is missing or unreadable.
+
+Return `blocked` when the requested output would require fixing, approving,
+publishing, creating issues/PRs, or mutating a repository.
+
+Return `partial` when a report can be produced but important evidence is missing
+or ambiguous.

--- a/adl/tools/skills/gap-analysis/adl-skill.yaml
+++ b/adl/tools/skills/gap-analysis/adl-skill.yaml
@@ -1,0 +1,129 @@
+version: "0.1"
+kind: "adl-skill"
+id: "gap-analysis"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "gap_analysis.v1"
+    reference_doc: "../docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "expected_baseline"
+      - "observed_evidence"
+      - "policy"
+    mode_enum:
+      - "compare_issue_to_implementation"
+      - "compare_milestone_to_evidence"
+      - "compare_spec_to_docs"
+      - "compare_review_to_closeout"
+      - "compare_packet_to_report"
+    policy_fields:
+      - "severity_floor"
+      - "required_gap_types"
+      - "uncertainty_policy"
+      - "issue_creation_allowed"
+      - "write_gap_artifact"
+      - "stop_before_fix"
+      - "stop_before_mutation"
+    mode_requirements:
+      compare_issue_to_implementation:
+        required_target_fields:
+          - "issue_ref"
+          - "changed_paths"
+      compare_milestone_to_evidence:
+        required_target_fields:
+          - "milestone_plan"
+          - "evidence_root"
+      compare_spec_to_docs:
+        required_target_fields:
+          - "spec_path"
+          - "docs_paths"
+      compare_review_to_closeout:
+        required_target_fields:
+          - "review_artifact"
+          - "closeout_record"
+      compare_packet_to_report:
+        required_target_fields:
+          - "review_packet_path"
+          - "report_path"
+  intent:
+    - "gap_analysis"
+    - "expected_vs_observed_truth"
+    - "closeout_safety"
+    - "milestone_release_readiness"
+  required_inputs:
+    - "expected_baseline"
+    - "observed_evidence"
+    - "policy"
+  optional_inputs:
+    - "artifact_root"
+    - "issue_ref"
+    - "milestone_plan"
+    - "spec_path"
+    - "review_packet_path"
+    - "report_path"
+    - "closeout_record"
+  stop_if_missing:
+    - "expected_baseline"
+  prevalidation_rules:
+    - "expected_baseline_must_be_explicit"
+    - "skill_input_schema_must_equal_gap_analysis.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.stop_before_fix_must_be_true"
+    - "policy.stop_before_mutation_must_be_true"
+execution:
+  mode: "analysis_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/analyze_gaps.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<gap-root>"
+        - "--out <artifact-root>"
+        - "--run-id <id>"
+        - "--baseline <path>"
+        - "--observed <path>"
+  preferred_read_order:
+    - "expected_baseline.md"
+    - "observed_evidence.md"
+    - "acceptance criteria"
+    - "changed paths"
+    - "validation artifacts"
+    - "docs and review artifacts"
+    - "output cards and closeout records"
+  invocation_guidance: "require_explicit_baseline_before_analysis"
+boundaries:
+  must_not_run:
+    - "implementation_fixes"
+    - "docs_fixes"
+    - "test_generation"
+    - "tracker_item_creation"
+    - "pull_request_creation"
+    - "release_approval"
+    - "closeout_approval"
+    - "publication"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/gap-analysis/<run_id>/"
+  required_artifacts:
+    - "gap_analysis_report.md"
+    - "gap_analysis_report.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_approval_or_compliance_claims: true
+  no_mutation_without_operator_approval: true
+  manifest_declares_executables: true
+
+display_name: Gap Analysis
+short_description: Compare expected outcomes to observed evidence and report source-grounded gaps
+default_prompt: Compare an explicit expected baseline against observed implementation, docs, tests, review, PR, milestone, or closeout evidence. Emit findings-first gaps with severity, evidence, uncertainty, and bounded follow-up recommendations; stop before fixing, approving, creating issues or PRs, publishing, or mutating repositories.

--- a/adl/tools/skills/gap-analysis/agents/openai.yaml
+++ b/adl/tools/skills/gap-analysis/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Gap Analysis
+short_description: Compare expected outcomes to observed evidence and report source-grounded gaps
+default_prompt: Compare an explicit expected baseline against observed implementation, docs, tests, review, PR, milestone, or closeout evidence. Emit findings-first gaps with severity, evidence, uncertainty, and bounded follow-up recommendations; stop before fixing, approving, creating issues or PRs, publishing, or mutating repositories.

--- a/adl/tools/skills/gap-analysis/references/gap-analysis-playbook.md
+++ b/adl/tools/skills/gap-analysis/references/gap-analysis-playbook.md
@@ -1,0 +1,36 @@
+# Gap Analysis Playbook
+
+Use this playbook when comparing expected truth to observed truth.
+
+## Evidence Model
+
+- Expected baseline: the source of intent, such as an issue, feature spec,
+  milestone plan, review packet, PR scope, or closeout checklist.
+- Observed evidence: the artifacts that prove what happened, such as changed
+  files, validation results, docs, reports, PR state, or output cards.
+- Finding: a source-grounded mismatch or missing proof between expected and
+  observed truth.
+- Uncertainty: the honest state when evidence is insufficient.
+
+## Good Findings
+
+- Name the expected baseline.
+- Name the observed evidence.
+- State why the mismatch matters.
+- Preserve uncertainty.
+- Recommend a bounded follow-up without doing it.
+
+## Bad Findings
+
+- Treating missing evidence as proof of failure.
+- Rewriting the baseline to match the implementation.
+- Inventing scope not present in the issue, plan, or spec.
+- Calling a task complete without closeout or validation evidence.
+
+## Handoffs
+
+- Use `finding-to-issue-planner` after humans approve follow-up issue creation.
+- Use `review-to-test-planner` for validation gaps.
+- Use `sor-editor`, `sip-editor`, or `pr-closeout` for card or closeout truth
+  drift.
+- Use `review-quality-evaluator` for report-publication quality gates.

--- a/adl/tools/skills/gap-analysis/references/output-contract.md
+++ b/adl/tools/skills/gap-analysis/references/output-contract.md
@@ -1,0 +1,78 @@
+# Output Contract
+
+The gap-analysis skill produces findings-first gap reports from an explicit
+expected baseline and observed evidence.
+
+Default artifact root:
+
+```text
+.adl/reviews/gap-analysis/<run_id>/
+```
+
+## Required Artifacts
+
+### gap_analysis_report.md
+
+Required sections:
+
+- Gap Analysis Summary
+- Scope
+- Expected Baseline
+- Observed Evidence
+- Findings
+- Missing Evidence
+- Uncertainty
+- Recommended Follow-up
+- Stop Boundary
+
+### gap_analysis_report.json
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `status`
+- `scope`
+- `expected_baseline`
+- `observed_evidence`
+- `findings`
+- `missing_evidence`
+- `uncertainty`
+- `recommended_follow_up`
+- `stop_boundary`
+
+## Status Values
+
+- `pass`: no gaps were found for the supplied baseline and evidence.
+- `partial`: gaps or missing evidence exist, but the comparison was bounded and
+  useful.
+- `fail`: a severe gap or closeout/release truth mismatch should block the
+  requested closeout or release decision.
+- `not_run`: no explicit expected baseline was available.
+- `blocked`: the requested action would require fixing, approving, publishing,
+  creating issues or PRs, or mutating a repository.
+
+## Finding Shape
+
+Each finding must include:
+
+- stable id
+- gap type
+- severity
+- title
+- expected
+- observed
+- evidence
+- uncertainty
+- recommended follow-up
+- source artifact or path when available
+
+## Rules
+
+- Do not infer intended outcomes without an explicit baseline.
+- Distinguish missing evidence from proven failure.
+- Use repo-relative, issue-relative, or packet-relative paths.
+- Do not write absolute host paths into report artifacts.
+- Do not claim approval, release-readiness, merge-readiness, compliance,
+  publication approval, or remediation completion.
+- Do not create issues, PRs, tests, fixes, docs changes, or closeout edits.

--- a/adl/tools/skills/gap-analysis/scripts/analyze_gaps.py
+++ b/adl/tools/skills/gap-analysis/scripts/analyze_gaps.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Create a bounded gap-analysis report from explicit baseline/evidence files."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "adl.gap_analysis_report.v1"
+SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+GAP_TYPES = {
+    "missing_evidence",
+    "implementation_gap",
+    "docs_drift",
+    "test_gap",
+    "closeout_drift",
+    "scope_ambiguity",
+}
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def rel(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def extract_bullets_after(text: str, heading: str) -> list[str]:
+    pattern = re.compile(rf"^##+\s+{re.escape(heading)}\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        return []
+    next_heading = re.search(r"^##+\s+", text[match.end() :], re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(text)
+    section = text[match.end() : end]
+    return [line.strip()[2:].strip() for line in section.splitlines() if line.strip().startswith("- ")][:80]
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def normalize(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+
+
+def keyword_hit(expected: str, observed_text: str) -> bool:
+    words = [word for word in normalize(expected).split() if len(word) > 4]
+    if not words:
+        return False
+    observed = normalize(observed_text)
+    hits = sum(1 for word in set(words) if word in observed)
+    return hits >= max(1, min(3, len(set(words)) // 2))
+
+
+def line_value(text: str, key: str) -> str:
+    pattern = re.compile(rf"^\s*-\s*{re.escape(key)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    return match.group(1).strip() if match else ""
+
+
+def metadata(root: Path) -> dict[str, str]:
+    manifest = load_json(root / "gap_manifest.json")
+    if not isinstance(manifest, dict):
+        manifest = {}
+    return {
+        "run_id": str(manifest.get("run_id") or root.name),
+        "scope": str(manifest.get("scope") or line_value(read_text(root / "expected_baseline.md"), "Scope") or root.name),
+        "mode": str(manifest.get("mode") or "compare_issue_to_implementation"),
+    }
+
+
+def expected_items(text: str) -> list[dict[str, str]]:
+    bullets = (
+        extract_bullets_after(text, "Expected")
+        or extract_bullets_after(text, "Acceptance Criteria")
+        or extract_bullets_after(text, "Required Outcome")
+        or extract_bullets_after(text, "Baseline")
+    )
+    items = []
+    for index, bullet in enumerate(bullets, start=1):
+        gap_type = infer_gap_type(bullet)
+        items.append(
+            {
+                "id": f"E-{index:03d}",
+                "expected": bullet,
+                "gap_type": gap_type,
+                "severity": infer_severity(bullet, gap_type),
+            }
+        )
+    return items
+
+
+def infer_gap_type(text: str) -> str:
+    lowered = text.lower()
+    if any(word in lowered for word in ["test", "validation", "coverage", "proof"]):
+        return "test_gap"
+    if any(word in lowered for word in ["doc", "readme", "changelog", "guide"]):
+        return "docs_drift"
+    if any(word in lowered for word in ["closeout", "sor", "sip", "stp", "pr body", "issue state"]):
+        return "closeout_drift"
+    if any(word in lowered for word in ["evidence", "artifact", "report"]):
+        return "missing_evidence"
+    return "implementation_gap"
+
+
+def infer_severity(text: str, gap_type: str) -> str:
+    lowered = text.lower()
+    if any(word in lowered for word in ["security", "privacy", "release-blocking", "block release", "customer-facing"]):
+        return "P1"
+    if gap_type in {"closeout_drift", "test_gap"}:
+        return "P2"
+    return "P3"
+
+
+def observed_text(root: Path, explicit_observed: Path | None) -> tuple[str, list[str]]:
+    paths: list[Path] = []
+    if explicit_observed and explicit_observed.is_file():
+        paths.append(explicit_observed)
+    for candidate in [
+        root / "observed_evidence.md",
+        root / "implementation_evidence.md",
+        root / "validation_evidence.md",
+        root / "closeout_evidence.md",
+    ]:
+        if candidate.is_file() and candidate not in paths:
+            paths.append(candidate)
+    text_parts = []
+    for path in paths:
+        text_parts.append(f"\n<!-- {rel(root, path)} -->\n{read_text(path)}")
+    return "\n".join(text_parts), [rel(root, path) for path in paths]
+
+
+def explicit_gaps(root: Path) -> list[dict[str, str]]:
+    text = read_text(root / "known_gaps.md")
+    if not text:
+        return []
+    bullets = extract_bullets_after(text, "Gaps") or [line.strip()[2:] for line in text.splitlines() if line.strip().startswith("- ")]
+    findings = []
+    for index, bullet in enumerate(bullets, start=1):
+        gap_type = infer_gap_type(bullet)
+        findings.append(
+            {
+                "id": f"G-{index:03d}",
+                "gap_type": gap_type,
+                "severity": infer_severity(bullet, gap_type),
+                "title": bullet[:96],
+                "expected": "Recorded baseline expectation or review finding.",
+                "observed": bullet,
+                "evidence": "known_gaps.md",
+                "uncertainty": "low",
+                "recommended_follow_up": recommended_follow_up(gap_type),
+                "source_artifact": "known_gaps.md",
+            }
+        )
+    return findings
+
+
+def analyze(root: Path, baseline: Path | None, observed: Path | None) -> dict[str, object]:
+    baseline_path = baseline if baseline else root / "expected_baseline.md"
+    baseline_text = read_text(baseline_path)
+    meta = metadata(root)
+    observed_blob, observed_sources = observed_text(root, observed)
+    if not baseline_text:
+        return {
+            "schema": SCHEMA,
+            "created_at": now_utc(),
+            "run_id": meta["run_id"],
+            "status": "not_run",
+            "scope": meta["scope"],
+            "expected_baseline": {"path": rel(root, baseline_path), "items": []},
+            "observed_evidence": {"sources": observed_sources},
+            "findings": [],
+            "missing_evidence": ["Expected baseline missing or unreadable."],
+            "uncertainty": ["No baseline was available; no gap claims were made."],
+            "recommended_follow_up": ["Provide an explicit expected baseline."],
+            "stop_boundary": stop_boundary(),
+        }
+    items = expected_items(baseline_text)
+    findings = explicit_gaps(root)
+    missing: list[str] = []
+    uncertainty: list[str] = []
+    for item in items:
+        if keyword_hit(item["expected"], observed_blob):
+            continue
+        finding = {
+            "id": item["id"],
+            "gap_type": item["gap_type"],
+            "severity": item["severity"],
+            "title": item["expected"][:96],
+            "expected": item["expected"],
+            "observed": "No matching observed evidence was found.",
+            "evidence": "Observed evidence did not contain enough matching terms for this expectation.",
+            "uncertainty": "medium" if observed_blob else "high",
+            "recommended_follow_up": recommended_follow_up(item["gap_type"]),
+            "source_artifact": rel(root, baseline_path),
+        }
+        findings.append(finding)
+        missing.append(item["expected"])
+        if not observed_blob:
+            uncertainty.append(f"No observed evidence file was available for {item['id']}.")
+    findings = sorted(findings, key=lambda item: (SEVERITY_ORDER.get(str(item["severity"]), 9), str(item["id"])))
+    status = "pass" if not findings and items else "partial"
+    if any(item["severity"] in {"P0", "P1"} for item in findings):
+        status = "fail"
+    return {
+        "schema": SCHEMA,
+        "created_at": now_utc(),
+        "run_id": meta["run_id"],
+        "status": status,
+        "scope": meta["scope"],
+        "expected_baseline": {"path": rel(root, baseline_path), "items": items},
+        "observed_evidence": {"sources": observed_sources},
+        "findings": findings,
+        "missing_evidence": missing,
+        "uncertainty": uncertainty or ["Uncertainty is limited to the supplied evidence bundle."],
+        "recommended_follow_up": dedupe([str(item["recommended_follow_up"]) for item in findings]) or ["No follow-up required from this comparison."],
+        "stop_boundary": stop_boundary(),
+    }
+
+
+def recommended_follow_up(gap_type: str) -> str:
+    return {
+        "missing_evidence": "Attach or produce the missing proof artifact before closeout.",
+        "implementation_gap": "Open a bounded implementation follow-up after human review.",
+        "docs_drift": "Route to documentation update or docs review after confirming intended truth.",
+        "test_gap": "Route to review-to-test-planner or add focused validation evidence.",
+        "closeout_drift": "Normalize the output card, PR body, or closeout note before closure.",
+        "scope_ambiguity": "Clarify scope and rerun gap analysis with stronger evidence.",
+    }.get(gap_type, "Review manually before follow-up.")
+
+
+def dedupe(items: list[str]) -> list[str]:
+    seen = set()
+    out = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def stop_boundary() -> dict[str, bool]:
+    return {
+        "fixed_gaps": False,
+        "created_issues": False,
+        "created_prs": False,
+        "approved_closeout": False,
+        "approved_release": False,
+        "mutated_repository": False,
+    }
+
+
+def bullet_lines(items: list[Any]) -> str:
+    return "\n".join(f"- {item}" for item in items) if items else "- None."
+
+
+def finding_lines(findings: list[dict[str, str]]) -> str:
+    if not findings:
+        return "- No gaps found for the supplied baseline and evidence."
+    parts = []
+    for finding in findings:
+        parts.append(
+            f"""### {finding['id']}: [{finding['severity']}] {finding['title']}
+
+- Gap type: {finding['gap_type']}
+- Expected: {finding['expected']}
+- Observed: {finding['observed']}
+- Evidence: {finding['evidence']}
+- Uncertainty: {finding['uncertainty']}
+- Recommended follow-up: {finding['recommended_follow_up']}
+- Source artifact: {finding['source_artifact']}
+"""
+        )
+    return "\n".join(parts)
+
+
+def write_markdown(path: Path, report: dict[str, object]) -> None:
+    boundary = report["stop_boundary"]
+    content = f"""# Gap Analysis Report: {report['scope']}
+
+## Gap Analysis Summary
+
+- Status: {report['status']}
+- Run id: {report['run_id']}
+- Findings: {len(report['findings'])}
+
+## Scope
+
+- Scope: {report['scope']}
+
+## Expected Baseline
+
+- Baseline path: {report['expected_baseline']['path']}
+- Expected items: {len(report['expected_baseline']['items'])}
+
+## Observed Evidence
+
+{bullet_lines(report['observed_evidence']['sources'])}
+
+## Findings
+
+{finding_lines(report['findings'])}
+
+## Missing Evidence
+
+{bullet_lines(report['missing_evidence'])}
+
+## Uncertainty
+
+{bullet_lines(report['uncertainty'])}
+
+## Recommended Follow-up
+
+{bullet_lines(report['recommended_follow_up'])}
+
+## Stop Boundary
+
+- Fixed gaps: {str(boundary['fixed_gaps']).lower()}.
+- Created issues: {str(boundary['created_issues']).lower()}.
+- Created PRs: {str(boundary['created_prs']).lower()}.
+- Approved closeout: {str(boundary['approved_closeout']).lower()}.
+- Approved release: {str(boundary['approved_release']).lower()}.
+- Mutated repository: {str(boundary['mutated_repository']).lower()}.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gap_root", help="Directory containing expected_baseline.md and observed evidence")
+    parser.add_argument("--out", default=None, help="Gap analysis output root")
+    parser.add_argument("--run-id", default=None, help="Run id override")
+    parser.add_argument("--baseline", default=None, help="Explicit baseline path")
+    parser.add_argument("--observed", default=None, help="Explicit observed evidence path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.gap_root)
+    if not root.is_dir():
+        raise SystemExit(f"gap root does not exist: {root}")
+    baseline = Path(args.baseline) if args.baseline else None
+    observed = Path(args.observed) if args.observed else None
+    out_root = Path(args.out) if args.out else root / "gap-analysis"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+    report = analyze(root, baseline, observed)
+    if args.run_id:
+        report["run_id"] = args.run_id
+    write_json(out_root / "gap_analysis_report.json", report)
+    write_markdown(out_root / "gap_analysis_report.md", report)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_gap_analysis_skill_contracts.sh
+++ b/adl/tools/test_gap_analysis_skill_contracts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/gap-analysis/SKILL.md" ]]
+[[ -f "${skills_root}/gap-analysis/adl-skill.yaml" ]]
+[[ -f "${skills_root}/gap-analysis/agents/openai.yaml" ]]
+[[ -f "${skills_root}/gap-analysis/references/gap-analysis-playbook.md" ]]
+[[ -f "${skills_root}/gap-analysis/references/output-contract.md" ]]
+[[ -x "${skills_root}/gap-analysis/scripts/analyze_gaps.py" ]]
+[[ -f "${skills_root}/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "gap-analysis"' "${skills_root}/gap-analysis/adl-skill.yaml"
+grep -Fq 'id: "gap_analysis.v1"' "${skills_root}/gap-analysis/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md"' "${skills_root}/gap-analysis/adl-skill.yaml"
+grep -Fq "expected_baseline_must_be_explicit" "${skills_root}/gap-analysis/adl-skill.yaml"
+grep -Fq "Compare an explicit expected baseline" "${skills_root}/gap-analysis/SKILL.md"
+grep -Fq "Distinguish missing evidence from proven failure." "${skills_root}/gap-analysis/references/output-contract.md"
+grep -Fq "Schema id: \`gap_analysis.v1\`" "${skills_root}/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md"
+
+gap_root="${tmpdir}/gap"
+report_root="${tmpdir}/gap-report"
+mkdir -p "${gap_root}"
+cat >"${gap_root}/gap_manifest.json" <<'JSON'
+{
+  "run_id": "gap-analysis-contract-test",
+  "scope": "issue-2044",
+  "mode": "compare_issue_to_implementation"
+}
+JSON
+cat >"${gap_root}/expected_baseline.md" <<'MD'
+# Expected Baseline
+
+## Expected
+
+- Create gap-analysis skill bundle with SKILL metadata and bounded stop boundary.
+- Add validation contract tests for findings format and evidence guardrails.
+- Document input schema for explicit expected baseline and observed evidence.
+- Record closeout truth in output cards.
+MD
+cat >"${gap_root}/observed_evidence.md" <<'MD'
+# Observed Evidence
+
+- gap-analysis skill bundle includes SKILL metadata and a bounded stop boundary.
+- input schema documents explicit expected baseline and observed evidence.
+MD
+cat >"${gap_root}/known_gaps.md" <<'MD'
+# Known Gaps
+
+## Gaps
+
+- Validation contract tests for findings format and evidence guardrails are missing.
+MD
+
+python3 "${skills_root}/gap-analysis/scripts/analyze_gaps.py" \
+  "${gap_root}" --out "${report_root}" >/tmp/gap-analysis.out
+[[ -f "${report_root}/gap_analysis_report.json" ]]
+[[ -f "${report_root}/gap_analysis_report.md" ]]
+grep -Fq '"schema": "adl.gap_analysis_report.v1"' "${report_root}/gap_analysis_report.json"
+grep -Fq '"run_id": "gap-analysis-contract-test"' "${report_root}/gap_analysis_report.json"
+grep -Fq '"gap_type": "test_gap"' "${report_root}/gap_analysis_report.json"
+grep -Fq '"created_issues": false' "${report_root}/gap_analysis_report.json"
+grep -Fq '"mutated_repository": false' "${report_root}/gap_analysis_report.json"
+grep -Fq "## Gap Analysis Summary" "${report_root}/gap_analysis_report.md"
+grep -Fq "## Findings" "${report_root}/gap_analysis_report.md"
+grep -Fq "Created issues: false." "${report_root}/gap_analysis_report.md"
+grep -Fq "Mutated repository: false." "${report_root}/gap_analysis_report.md"
+
+missing_root="${tmpdir}/missing-baseline"
+mkdir -p "${missing_root}"
+python3 "${skills_root}/gap-analysis/scripts/analyze_gaps.py" \
+  "${missing_root}" --out "${tmpdir}/missing-report" >/tmp/gap-analysis-missing.out
+grep -Fq '"status": "not_run"' "${tmpdir}/missing-report/gap_analysis_report.json"
+
+if grep -R "${tmpdir}" "${report_root}" "${tmpdir}/missing-report" >/dev/null; then
+  echo "gap analysis artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/gap-analysis/SKILL.md"
+
+echo "PASS test_gap_analysis_skill_contracts"


### PR DESCRIPTION
Closes #2044

## Summary
Implemented a bounded `gap-analysis` operational skill for comparing an explicit expected baseline against observed implementation, docs, tests, review, PR, milestone, report, or closeout evidence. The skill emits findings-first Markdown and JSON gap reports with severity, evidence, uncertainty, missing-evidence handling, and follow-up recommendations while stopping before fixes, approvals, issue creation, PR creation, publication, or repository mutation.

## Artifacts
- `adl/tools/skills/gap-analysis/SKILL.md`
- `adl/tools/skills/gap-analysis/adl-skill.yaml`
- `adl/tools/skills/gap-analysis/agents/openai.yaml`
- `adl/tools/skills/gap-analysis/references/output-contract.md`
- `adl/tools/skills/gap-analysis/references/gap-analysis-playbook.md`
- `adl/tools/skills/gap-analysis/scripts/analyze_gaps.py`
- `adl/tools/skills/docs/GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_gap_analysis_skill_contracts.sh`
- Updated `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/skills/gap-analysis/scripts/analyze_gaps.py` verified helper syntax.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/gap-analysis/SKILL.md` verified skill frontmatter contract.
  - `bash adl/tools/test_gap_analysis_skill_contracts.sh` verified bundle structure, schema doc, helper outputs, missing-baseline guardrail, stop-boundary fields, and no temp absolute path leakage.
  - `bash adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh` verified the suite docs still satisfy the multi-agent review skill-suite contract.
  - `git diff --check` verified no whitespace errors.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2044__backlog-skills-add-gap-analysis-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2044__backlog-skills-add-gap-analysis-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-gap-analysis-skill-adl-tools-skills-gap-analysis-adl-tools-skills-docs-gap-analysis-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-gap-analysis-skill-contracts-sh-adl-v0-90-tasks-issue-2044-backlog-skills-add-gap-analysis-skill-sip-md-adl-v0-90-tasks-issue-2044-backlog-skills-add-gap-analysis-skill-sor-md