### PR TITLE
Add first-class ADL architecture packet

### DIFF
--- a/adl/tools/demo_v090_architecture_document_generation.sh
+++ b/adl/tools/demo_v090_architecture_document_generation.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v090/adl_architecture_document_generation}"
+
+artifact_label="custom-artifact-root"
+case "$OUT_DIR" in
+  "$ROOT_DIR"/*)
+    artifact_label="${OUT_DIR#"$ROOT_DIR"/}"
+    ;;
+esac
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+(
+  cd "$ROOT_DIR"
+  python3 adl/tools/validate_architecture_docs.py >/dev/null
+)
+
+cat >"$OUT_DIR/architecture_generation_manifest.json" <<EOF_JSON
+{
+  "schema_version": "adl.v090.architecture_document_generation_demo.v1",
+  "demo_id": "D9",
+  "demo_name": "ADL architecture document generation",
+  "classification": "proving",
+  "classification_reason": "The tracked architecture packet, diagram packet, automation plan, generation plan, and proof notes are present and pass deterministic validation.",
+  "artifact_root": "$artifact_label",
+  "docs": [
+    "docs/architecture/ADL_ARCHITECTURE.md",
+    "docs/architecture/ARCHITECTURE_REVIEW_AUTOMATION.md",
+    "docs/architecture/ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md",
+    "docs/architecture/diagrams/DIAGRAM_PACKET.md",
+    "docs/architecture/adr/CANDIDATE_ADRS.md"
+  ],
+  "diagram_sources": [
+    "docs/architecture/diagrams/system_context.mmd",
+    "docs/architecture/diagrams/runtime_lifecycle.mmd",
+    "docs/architecture/diagrams/control_plane_lifecycle.mmd",
+    "docs/architecture/diagrams/task_bundle_state.mmd",
+    "docs/architecture/diagrams/skill_orchestration.mmd",
+    "docs/architecture/diagrams/artifact_data_flow.mmd",
+    "docs/architecture/diagrams/trust_boundaries.mmd"
+  ],
+  "skills_represented": [
+    "workflow-conductor",
+    "pr-run",
+    "diagram-author",
+    "security-threat-model",
+    "repo-architecture-review",
+    "architecture-fitness-function-author"
+  ],
+  "missing_skill_dependencies": [
+    "documentation-specialist",
+    "gap-analysis"
+  ],
+  "publication_allowed": false
+}
+EOF_JSON
+
+cat >"$OUT_DIR/architecture_review_note.md" <<'EOF_MD'
+# Architecture Review Note
+
+## Scope
+
+This proof packet reviews the tracked ADL architecture packet and its source
+evidence. It does not inspect private worktrees or local session traces.
+
+## Findings
+
+No blocking architecture finding was introduced by this packet. The main design
+risk remains process drift: if conductor, lifecycle, specialist, and closeout
+skills are bypassed, repository truth can again diverge from GitHub truth.
+
+## Evidence
+
+- `docs/architecture/ADL_ARCHITECTURE.md`
+- `docs/default_workflow.md`
+- `adl/src/control_plane.rs`
+- `adl/src/trace.rs`
+- `adl/src/long_lived_agent.rs`
+
+## Residual Risk
+
+The documentation specialist and gap-analysis skills are still backlog
+dependencies. Their absence is recorded in the generation plan rather than
+hidden by the demo.
+EOF_MD
+
+cat >"$OUT_DIR/diagram_review_note.md" <<'EOF_MD'
+# Diagram Review Note
+
+## Result
+
+The architecture packet contains seven Mermaid diagram sources. Each source has
+an evidence comment and an assumptions comment, and the diagram packet records
+purpose, evidence, assumptions, validation, and excluded claims.
+
+## Render Status
+
+The default proof path validates diagram source text. Rendering to SVG is an
+optional local step when Mermaid CLI is installed.
+EOF_MD
+
+cat >"$OUT_DIR/threat_boundary_note.md" <<'EOF_MD'
+# Threat Boundary Note
+
+## Boundaries Reviewed
+
+- ADL document parsing boundary
+- Provider transport boundary
+- Tool and delegation boundary
+- Filesystem sandbox boundary
+- Remote execution signature boundary
+- Publication and redaction boundary
+
+## Assumption
+
+This is a bounded architecture threat-boundary review, not a full abuse-case
+enumeration for every provider or deployment mode.
+EOF_MD
+
+cat >"$OUT_DIR/fitness_function_note.md" <<'EOF_MD'
+# Fitness Function Note
+
+## Candidate Checks
+
+- Architecture packet file existence.
+- Diagram packet coverage for every diagram source.
+- Private host-path and secret-marker scan.
+- Required architecture sections.
+- Demo matrix command truth.
+- Worktree-first issue execution in lifecycle docs.
+
+## Human Gates
+
+- Severity assessment.
+- Diagram completeness.
+- ADR promotion.
+- Publication approval.
+EOF_MD
+
+(
+  cd "$ROOT_DIR"
+  python3 adl/tools/validate_architecture_docs.py "$ROOT_DIR" "$OUT_DIR" >/dev/null
+)
+
+echo "demo_v090_architecture_document_generation: ok"

--- a/adl/tools/test_demo_v090_architecture_document_generation.sh
+++ b/adl/tools/test_demo_v090_architecture_document_generation.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+OUT_DIR="$TMPDIR_ROOT/adl_architecture_document_generation"
+
+(
+  cd "$ROOT_DIR"
+  bash adl/tools/demo_v090_architecture_document_generation.sh "$OUT_DIR" >/dev/null
+  python3 adl/tools/validate_architecture_docs.py "$ROOT_DIR" "$OUT_DIR" >/dev/null
+)
+
+for required in \
+  "$OUT_DIR/architecture_generation_manifest.json" \
+  "$OUT_DIR/architecture_review_note.md" \
+  "$OUT_DIR/diagram_review_note.md" \
+  "$OUT_DIR/threat_boundary_note.md" \
+  "$OUT_DIR/fitness_function_note.md"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+python3 - "$OUT_DIR/architecture_generation_manifest.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert manifest["schema_version"] == "adl.v090.architecture_document_generation_demo.v1"
+assert manifest["classification"] == "proving"
+assert len(manifest["diagram_sources"]) >= 7
+assert "diagram-author" in manifest["skills_represented"]
+assert "documentation-specialist" in manifest["missing_skill_dependencies"]
+PY
+
+for leaked_text in \
+  "/Users/alice/private.txt" \
+  "/private/tmp/adl-leak" \
+  "OPENAI_API_KEY=secret"; do
+  LEAK_DIR="$TMPDIR_ROOT/leak-check"
+  rm -rf "$LEAK_DIR"
+  cp -R "$OUT_DIR" "$LEAK_DIR"
+  printf '\nInjected leak: %s\n' "$leaked_text" >> "$LEAK_DIR/architecture_review_note.md"
+  if python3 "$ROOT_DIR/adl/tools/validate_architecture_docs.py" "$ROOT_DIR" "$LEAK_DIR" >/dev/null 2>&1; then
+    echo "assertion failed: validator accepted leaked text $leaked_text" >&2
+    exit 1
+  fi
+done
+
+echo "demo_v090_architecture_document_generation: ok"

--- a/adl/tools/validate_architecture_docs.py
+++ b/adl/tools/validate_architecture_docs.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ABSOLUTE_HOST_PATH_RE = re.compile(
+    r"(?:(?<![A-Za-z0-9._-])/(?:Users|home)/[^/\s`]+(?:/[^\s`]*)*)|"
+    r"(?:(?<![A-Za-z0-9._-])/(?:private|var|tmp|etc|opt|srv|root)/[^\s`]+)|"
+    r"(?:[A-Za-z]:\\\\[^\s`]+)"
+)
+
+SECRET_MARKER_RE = re.compile(
+    r"(?:OPENAI_API_KEY|ANTHROPIC_API_KEY|GOOGLE_API_KEY|Bearer\s+[A-Za-z0-9._-]+|sk-[A-Za-z0-9]{8,})"
+)
+
+REQUIRED_DOCS = [
+    "docs/architecture/README.md",
+    "docs/architecture/ADL_ARCHITECTURE.md",
+    "docs/architecture/ARCHITECTURE_REVIEW_AUTOMATION.md",
+    "docs/architecture/ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md",
+    "docs/architecture/adr/README.md",
+    "docs/architecture/adr/CANDIDATE_ADRS.md",
+    "docs/architecture/diagrams/README.md",
+    "docs/architecture/diagrams/DIAGRAM_PACKET.md",
+]
+
+REQUIRED_DIAGRAMS = [
+    "system_context.mmd",
+    "runtime_lifecycle.mmd",
+    "control_plane_lifecycle.mmd",
+    "task_bundle_state.mmd",
+    "skill_orchestration.mmd",
+    "artifact_data_flow.mmd",
+    "trust_boundaries.mmd",
+]
+
+ARCHITECTURE_SECTIONS = [
+    "# ADL Architecture",
+    "## Scope And Evidence",
+    "## System Context",
+    "## Runtime Model",
+    "## Authoring And Control Plane",
+    "## Task Bundle Lifecycle",
+    "## Provider And Tool Boundaries",
+    "## Trace And Artifact Truth",
+    "## Security And Trust Boundaries",
+    "## Long-Lived Agent Layer",
+    "## Operational Skills",
+    "## Review And Release Surfaces",
+    "## Architecture Invariants",
+    "## Known Gaps",
+    "## Diagram Index",
+    "## ADR Candidates",
+]
+
+AUTOMATION_SECTIONS = [
+    "# Architecture Review Automation",
+    "## Review Pipeline",
+    "## Machine-Checkable Invariants",
+    "## Human-Judgment Gates",
+    "## Specialist Roles",
+    "## Missing Or Backlog Skills",
+    "## Automation Boundaries",
+    "## Suggested CI Gates",
+]
+
+PLAN_SECTIONS = [
+    "# Architecture Document Generation Plan",
+    "## Goal",
+    "## Inputs",
+    "## Skill Order",
+    "## Output Template",
+    "## Diagram Template",
+    "## Review Template",
+    "## Machine Validation",
+    "## Deferred Dependencies",
+    "## Non-Goals",
+]
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def ordered_sections(text: str, sections: list[str], label: str) -> None:
+    last = -1
+    for section in sections:
+        idx = text.find(section)
+        require(idx >= 0, f"{label}: missing section {section}")
+        require(idx > last, f"{label}: section out of order: {section}")
+        last = idx
+
+
+def scan_text(path: Path, text: str) -> None:
+    path_match = ABSOLUTE_HOST_PATH_RE.search(text)
+    if path_match is not None:
+        raise SystemExit(f"{path}: absolute host path leaked: {path_match.group(0)}")
+    secret_match = SECRET_MARKER_RE.search(text)
+    if secret_match is not None:
+        raise SystemExit(f"{path}: secret-like marker leaked: {secret_match.group(0)}")
+
+
+def check_docs(repo_root: Path) -> None:
+    for rel in REQUIRED_DOCS:
+        path = repo_root / rel
+        require(path.is_file(), f"missing required architecture doc: {rel}")
+        scan_text(path, path.read_text(encoding="utf-8"))
+
+    architecture = (repo_root / "docs/architecture/ADL_ARCHITECTURE.md").read_text(
+        encoding="utf-8"
+    )
+    ordered_sections(architecture, ARCHITECTURE_SECTIONS, "ADL_ARCHITECTURE.md")
+    for marker in [
+        "adl/src/adl/types.rs",
+        "adl/src/execution_plan.rs",
+        "adl/src/trace.rs",
+        "adl/src/control_plane.rs",
+        "adl/src/long_lived_agent.rs",
+        "docs/default_workflow.md",
+    ]:
+        require(marker in architecture, f"ADL_ARCHITECTURE.md lacks evidence marker {marker}")
+
+    automation = (
+        repo_root / "docs/architecture/ARCHITECTURE_REVIEW_AUTOMATION.md"
+    ).read_text(encoding="utf-8")
+    ordered_sections(automation, AUTOMATION_SECTIONS, "ARCHITECTURE_REVIEW_AUTOMATION.md")
+    require("Machine-Checkable" in automation, "automation doc lacks machine checks")
+    require("Human-Judgment" in automation, "automation doc lacks human judgment gate")
+
+    plan = (
+        repo_root / "docs/architecture/ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+    ordered_sections(plan, PLAN_SECTIONS, "ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md")
+    require("#2042" in plan and "#2044" in plan, "generation plan lacks backlog dependencies")
+
+    packet = (repo_root / "docs/architecture/diagrams/DIAGRAM_PACKET.md").read_text(
+        encoding="utf-8"
+    )
+    for diagram in REQUIRED_DIAGRAMS:
+        rel = f"docs/architecture/diagrams/{diagram}"
+        path = repo_root / rel
+        require(path.is_file(), f"missing required diagram source: {rel}")
+        text = path.read_text(encoding="utf-8")
+        scan_text(path, text)
+        require(
+            "%% Evidence:" in text and "%% Assumptions:" in text,
+            f"{rel} lacks evidence or assumptions comments",
+        )
+        require(
+            "flowchart" in text or "stateDiagram" in text,
+            f"{rel} is not recognized as a Mermaid source",
+        )
+        require(diagram in packet, f"DIAGRAM_PACKET.md does not list {diagram}")
+
+
+def check_artifacts(artifact_root: Path) -> None:
+    require(artifact_root.is_dir(), f"artifact root not found: {artifact_root}")
+    required = [
+        "architecture_generation_manifest.json",
+        "architecture_review_note.md",
+        "diagram_review_note.md",
+        "threat_boundary_note.md",
+        "fitness_function_note.md",
+    ]
+    for rel in required:
+        path = artifact_root / rel
+        require(path.is_file(), f"missing required architecture artifact: {rel}")
+        scan_text(path, path.read_text(encoding="utf-8"))
+
+    manifest = json.loads(
+        (artifact_root / "architecture_generation_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    require(
+        manifest.get("schema_version") == "adl.v090.architecture_document_generation_demo.v1",
+        "architecture generation manifest schema mismatch",
+    )
+    require(manifest.get("classification") == "proving", "demo classification must be proving")
+    require(len(manifest.get("diagram_sources", [])) >= 7, "manifest lacks diagram sources")
+    require(
+        "repo-architecture-review" in manifest.get("skills_represented", []),
+        "manifest lacks architecture review skill representation",
+    )
+
+
+def main() -> int:
+    repo_root = Path(sys.argv[1]).resolve() if len(sys.argv) >= 2 else Path.cwd()
+    artifact_root = Path(sys.argv[2]).resolve() if len(sys.argv) >= 3 else None
+    check_docs(repo_root)
+    if artifact_root is not None:
+        check_artifacts(artifact_root)
+    print("validate_architecture_docs: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/README.md
+++ b/demos/README.md
@@ -70,6 +70,12 @@ If you want the CodeBuddy multi-agent review showcase packet:
 bash adl/tools/demo_v090_codebuddy_review_showcase.sh
 ```
 
+If you want the ADL architecture document generation proof packet:
+
+```bash
+bash adl/tools/demo_v090_architecture_document_generation.sh
+```
+
 ## Demo Categories
 
 - Runtime workflow demos live in `adl/examples/`.

--- a/demos/v0.90/adl_architecture_document_generation_demo.md
+++ b/demos/v0.90/adl_architecture_document_generation_demo.md
@@ -1,0 +1,48 @@
+# ADL Architecture Document Generation Demo
+
+## Purpose
+
+This v0.90 demo proves that ADL can maintain a first-class, source-grounded
+architecture packet for itself. The packet includes a canonical architecture
+document, diagram sources, review automation guidance, generation planning,
+candidate ADRs, and deterministic validation.
+
+## Run
+
+From repository root:
+
+```bash
+bash adl/tools/demo_v090_architecture_document_generation.sh
+```
+
+The demo writes ignored proof artifacts under:
+
+```text
+artifacts/v090/adl_architecture_document_generation/
+```
+
+## What It Proves
+
+- Required architecture documents exist in tracked public docs.
+- Required diagram sources exist and include evidence and assumptions.
+- Public docs and generated proof notes are scanned for private host paths and
+  common secret markers.
+- Architecture review automation separates machine-checkable invariants from
+  human judgment.
+- Missing documentation-specialist and gap-analysis skills are recorded rather
+  than hidden.
+
+## What It Does Not Prove
+
+- It does not render every diagram to SVG by default.
+- It does not run live model providers.
+- It does not accept ADRs.
+- It does not publish customer-facing reports.
+- It does not claim every ADL subsystem is fully documented.
+
+## Validation
+
+```bash
+bash adl/tools/test_demo_v090_architecture_document_generation.sh
+python3 adl/tools/validate_architecture_docs.py
+```

--- a/docs/architecture/ADL_ARCHITECTURE.md
+++ b/docs/architecture/ADL_ARCHITECTURE.md
@@ -1,0 +1,265 @@
+# ADL Architecture
+
+## Scope And Evidence
+
+This document describes the tracked ADL runtime, control-plane, workflow-skill,
+and review architecture as of v0.90. It is source-grounded in public repository
+files only. It does not claim behavior from private worktrees, local traces, or
+untracked planning notes.
+
+Primary evidence:
+
+- `adl/src/adl/types.rs` defines providers, tools, agents, tasks, runs,
+  workflows, steps, delegation metadata, and conversation metadata.
+- `adl/src/execution_plan.rs` compiles workflows and reusable patterns into
+  acyclic execution plans.
+- `adl/src/execute/mod.rs` runs sequential and concurrent workflows, records
+  lifecycle phases, enforces scheduler and delegation policy, and validates
+  write paths.
+- `adl/src/trace.rs` records lifecycle, scheduling, step, prompt, delegation,
+  call, and completion events.
+- `adl/src/artifacts.rs` defines deterministic run artifact paths.
+- `adl/src/provider/mod.rs` and `docs/architecture/PROVIDER_CAPABILITY_AND_TRANSPORT_ARCHITECTURE.md`
+  define provider construction, retry classification, and provider identity
+  boundaries.
+- `adl/src/signing.rs`, `adl/src/sandbox.rs`, and
+  `adl/src/remote_exec/security.rs` define signing, sandbox path validation,
+  and remote-execution envelope validation.
+- `adl/src/control_plane.rs`, `docs/default_workflow.md`, and the `pr-*`
+  skills define the issue, task-bundle, branch, worktree, PR, and closeout
+  lifecycle.
+- `docs/milestones/v0.89.1/features/OPERATIONAL_SKILLS_SUBSTRATE.md` and
+  `docs/milestones/v0.89.1/features/SKILL_COMPOSITION_MODEL.md` define the
+  skill composition model used by the ADL workflow skills.
+- `docs/milestones/v0.90/DESIGN_v0.90.md` and `adl/src/long_lived_agent.rs`
+  define the v0.90 long-lived-agent substrate.
+
+## System Context
+
+ADL is a repository-first agent orchestration system. It represents work as
+versioned documents, compiles those documents into bounded execution plans,
+runs those plans through explicit provider and tool boundaries, records
+truth-bearing traces and artifacts, and uses a PR/worktree control plane for
+human-reviewable repository changes.
+
+The architecture has two closely related layers:
+
+- The runtime layer executes ADL documents and emits reviewable artifacts.
+- The authoring/control-plane layer turns issues into task bundles, binds
+  isolated worktrees, publishes PRs, monitors review state, and closes issues
+  truthfully.
+
+The workflow-skill layer sits above both. Skills are not hidden magic prompts.
+They are bounded procedures that route to specific lifecycle actions, edit
+specific card types, run specialist review lanes, or generate artifacts with
+explicit evidence and validation.
+
+## Runtime Model
+
+An ADL run starts with a typed document. Providers, tools, agents, tasks, and
+runs are parsed into strongly typed Rust structures with unknown fields denied
+on the core specs. A run resolves either a referenced workflow or an inline
+workflow. A workflow contains steps with optional state outputs, write targets,
+call semantics, delegation metadata, and conversation metadata.
+
+The planner builds an `ExecutionPlan` from resolved steps. Saved state
+references create dependencies. Duplicate step ids, duplicate saved-state keys,
+unknown saved-state references, self-dependencies, and cycles are rejected
+before execution. Concurrent workflows add fork/join structure while preserving
+deterministic ordering.
+
+Execution proceeds through explicit lifecycle phases. The runtime records
+scheduler policy, step starts, prompt assembly hashes, output chunks,
+delegation decisions, call entry/exit, failures, and run completion. The trace
+is therefore the audit surface for what the runtime actually attempted, rather
+than a retroactive prose summary.
+
+## Authoring And Control Plane
+
+The ADL control plane uses GitHub issues as work intents and repository-local
+cards as the canonical execution packet:
+
+- STP: the bounded task prompt and acceptance contract.
+- SIP: the input state and worktree binding.
+- SOR: the output record, validation results, PR state, and closeout truth.
+
+`adl/src/control_plane.rs` defines deterministic issue prompt paths, task bundle
+paths, branch names, and default worktree paths. The default ADL lifecycle is:
+
+1. `pr init` creates or normalizes the issue prompt and task bundle.
+2. `pr ready` verifies that the issue and cards are structurally ready.
+3. `pr run` binds an execution worktree and performs bounded implementation.
+4. `pr finish` stages intended paths, runs validation, and publishes or updates
+   a draft PR.
+5. `pr janitor` monitors PR checks, conflicts, and review state.
+6. `pr closeout` verifies integration truth, normalizes final cards, and prunes
+   the local execution surface.
+
+The root checkout remains the stable coordination checkout. Tracked
+implementation work belongs in issue-specific worktrees, not on the root branch.
+
+## Task Bundle Lifecycle
+
+Task bundles are intentionally separate from PR state. This prevents a merged PR
+from being mistaken for a closed issue or a local worktree from being mistaken
+for integrated repository truth.
+
+The task bundle lifecycle is:
+
+1. Issue intent is captured in a tracked or generated issue prompt.
+2. STP/SIP/SOR cards are created in the versioned task area.
+3. `pr run` copies or binds the executable packet into the worktree.
+4. Implementation and validation happen inside the worktree.
+5. `pr finish` records the publication state in SOR.
+6. `pr closeout` reconciles GitHub closure, PR merge state, final cards, and
+   local worktree cleanup.
+
+This split is important for ADL because many failures in prior milestones were
+not code failures. They were truth-model failures: closed GitHub issues with
+stale cards, merged PRs with uncleared worktrees, or local residue that made
+future operators think work was still active.
+
+## Provider And Tool Boundaries
+
+Providers are configured separately from agents and tasks. Agents reference a
+provider and model; tasks define prompts and tool allowlists; runs bind workflow
+and default behavior. Provider construction classifies schema errors, provider
+runtime errors, timeouts, panics, and retryability. Provider identity is also
+separated in the provider-capability architecture so human-readable model refs,
+transport-specific ids, and policy decisions do not collapse into one string.
+
+Tools are intentionally not equivalent to arbitrary filesystem or network
+access. Tool specs are typed, task tool allowlists are explicit, and delegation
+policy can evaluate tool invocation, provider calls, remote execution, and
+filesystem read/write requests.
+
+## Trace And Artifact Truth
+
+ADL treats traces and artifacts as the truth model for runtime behavior. The
+artifact layer builds deterministic paths under a run-scoped root, including
+run metadata, step records, pause state, status, manifests, outputs, logs,
+trace files, learning artifacts, and control-path proof artifacts.
+
+The trace architecture provides event-level evidence for:
+
+- lifecycle phase transitions
+- scheduler and concurrency policy
+- prompt assembly
+- step output streaming
+- delegation requests and policy decisions
+- nested workflow calls
+- failures and completion
+
+This allows reviewers to distinguish what was executed from what was merely
+planned or described.
+
+## Security And Trust Boundaries
+
+ADL has several explicit trust boundaries:
+
+- Repository input boundary: ADL documents are parsed and validated before
+  execution.
+- Provider boundary: model calls cross from local runtime into local or remote
+  providers.
+- Tool boundary: task-level tool use is governed by allowlists and delegation
+  policy.
+- Filesystem boundary: write paths are resolved under sandbox constraints and
+  host-absolute path leaks are avoided in stable errors.
+- Remote execution boundary: execute requests can require signed envelopes,
+  allowed algorithms, key sources, key ids, and requested-path validation.
+- Publication boundary: generated review reports and architecture packets must
+  pass redaction and evidence gates before being treated as customer-facing.
+
+The architecture does not claim that all future workflows are safe by default.
+It claims that safety-sensitive crossings are represented explicitly enough to
+be validated, reviewed, and strengthened.
+
+## Long-Lived Agent Layer
+
+v0.90 adds a long-lived-agent substrate for bounded recurring work. The current
+runtime state model includes specs, leases, status records, stop records, cycle
+manifests, observations, decision requests/results, run refs, memory writes,
+guardrail reports, continuity records, cycle ledger entries, provider bindings,
+memory indexes, operator events, and inspection packets.
+
+The key architectural constraint is that long-lived agents still run through
+bounded cycles. A heartbeat may schedule repeated cycles, but each cycle must
+have a lease, status, artifacts, and operator controls. The long-lived layer is
+therefore an extension of the trace/artifact truth model, not a replacement for
+bounded execution.
+
+## Operational Skills
+
+ADL skills implement the operational procedure around the runtime. The skill
+composition model is a deterministic graph over stochastic nodes. A conductor
+skill may route to a lifecycle skill, but it must not absorb the routed skill's
+responsibility. Specialist skills can produce review packets, diagrams,
+threat-boundary notes, test plans, issue candidates, ADR candidates, fitness
+function plans, and product reports.
+
+The important architectural invariant is modularity: the conductor coordinates,
+the lifecycle skill executes the lifecycle step, and specialist skills produce
+bounded artifacts. If a session bypasses this separation, it becomes difficult
+to audit what happened and why.
+
+## Review And Release Surfaces
+
+ADL releases are backed by milestone docs, demos, validation scripts, review
+packets, and GitHub issue/PR state. The v0.90 review stack adds CodeBuddy-style
+skills for repo-packet building, code review, security review, test review,
+docs review, architecture review, dependency review, diagram planning, diagram
+authoring, redaction, issue planning, ADR curation, fitness-function planning,
+product reporting, and review-quality evaluation.
+
+Architecture review uses the same packet-first discipline:
+
+- collect bounded source evidence
+- assign specialist lanes
+- synthesize findings without hiding disagreement
+- generate diagrams only from evidence
+- separate machine-checkable invariants from human judgment
+- record residual risk and missing coverage
+
+## Architecture Invariants
+
+These invariants are intended to become automated checks where practical:
+
+- Implementation work for tracked issues occurs in issue worktrees.
+- STP/SIP/SOR cards exist before issue execution begins.
+- SOR does not claim merge, closure, or validation that did not happen.
+- Public architecture docs do not contain host-absolute private paths or secret
+  markers.
+- Diagrams include evidence, assumptions, and render or validation commands.
+- Provider selection remains separate from provider transport ids and policy.
+- Runtime traces distinguish execution from planning.
+- Long-lived agents emit cycle-scoped truth instead of relying on memory alone.
+- Closeout verifies GitHub state, local cards, and worktree cleanup.
+
+## Known Gaps
+
+- Documentation specialist automation is tracked separately and should help
+  maintain this packet once available.
+- Gap-analysis automation is tracked separately and should compare architecture
+  claims against code, demos, and release docs.
+- Closeout automation still needs permanent guardrails so merged issues cannot
+  leave stale local truth behind.
+- Architecture review quality should continue converging toward the third-party
+  review bar: evidence-rich, severity-accurate, actionable, and candid about
+  residual risk.
+
+## Diagram Index
+
+See `diagrams/DIAGRAM_PACKET.md` for diagram evidence and assumptions.
+
+- `diagrams/system_context.mmd`
+- `diagrams/runtime_lifecycle.mmd`
+- `diagrams/control_plane_lifecycle.mmd`
+- `diagrams/task_bundle_state.mmd`
+- `diagrams/skill_orchestration.mmd`
+- `diagrams/artifact_data_flow.mmd`
+- `diagrams/trust_boundaries.mmd`
+
+## ADR Candidates
+
+See `adr/CANDIDATE_ADRS.md`. The ADRs are candidates, not accepted decisions,
+until a human reviewer explicitly promotes them.

--- a/docs/architecture/ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md
+++ b/docs/architecture/ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md
@@ -1,0 +1,103 @@
+# Architecture Document Generation Plan
+
+## Goal
+
+Generate first-class ADL architecture documentation from bounded repository
+evidence, specialist review artifacts, and explicit validation gates. The output
+must be reviewable by humans and safe to track publicly.
+
+## Inputs
+
+- Runtime source: `adl/src`
+- Tooling source: `adl/tools`
+- Demo source: `demos`
+- Milestone source: `docs/milestones/v0.90`
+- Existing architecture source: `docs/architecture`
+- Workflow source: `docs/default_workflow.md`
+- Operational skills source:
+  `docs/milestones/v0.89.1/features/OPERATIONAL_SKILLS_SUBSTRATE.md`
+- Skill composition source:
+  `docs/milestones/v0.89.1/features/SKILL_COMPOSITION_MODEL.md`
+
+## Skill Order
+
+1. Use the conductor to identify lifecycle state and route to `pr-run`.
+2. Use source inspection to build a bounded evidence map.
+3. Use `repo-architecture-review` to identify architecture boundaries and
+   risks.
+4. Use `security-threat-model` or a bounded threat-boundary review for trust
+   boundary notes.
+5. Use `diagram-author` to create diagram sources from the evidence map.
+6. Use `architecture-fitness-function-author` to define machine-checkable
+   invariants and human judgment gates.
+7. Use `pr-finish` to publish the result for review.
+8. Use `pr-janitor` and `pr-closeout` after publication and merge.
+
+## Output Template
+
+Every generated architecture packet should include:
+
+- Canonical architecture narrative.
+- Diagram packet with evidence, assumptions, and validation commands.
+- Review automation plan.
+- Document-generation plan.
+- Candidate ADR list.
+- Proof/demo artifact.
+- Validation script or command.
+- Residual-risk and missing-skill notes.
+
+## Diagram Template
+
+Every diagram should have:
+
+- Diagram id and source path.
+- Purpose.
+- Evidence paths.
+- Assumptions.
+- Render or validation command.
+- Unsupported claims explicitly excluded.
+
+## Review Template
+
+Architecture reviews should use a findings-first format:
+
+- Finding title with severity.
+- Affected path or architecture surface.
+- Trigger scenario.
+- Evidence.
+- User or operator impact.
+- Recommended action.
+- Validation or proof gap.
+- Residual risk.
+
+## Machine Validation
+
+The first validation surface is:
+
+```bash
+python3 adl/tools/validate_architecture_docs.py
+```
+
+The first deterministic proof packet is:
+
+```bash
+bash adl/tools/demo_v090_architecture_document_generation.sh
+```
+
+## Deferred Dependencies
+
+- Documentation specialist issue `#2042` should improve wording, navigation,
+  onboarding, and public doc quality.
+- Gap analysis issue `#2044` should compare the packet against implementation,
+  demos, release state, and closeout records.
+- Permanent closeout fixes should ensure generated architecture packets do not
+  become stale after PR merge.
+
+## Non-Goals
+
+- No direct publication to external sites.
+- No acceptance of ADRs without human review.
+- No claim that all diagrams are complete system specifications.
+- No live model calls required for the default proof packet.
+- No use of private local traces or host-specific worktree paths as public
+  evidence.

--- a/docs/architecture/ARCHITECTURE_REVIEW_AUTOMATION.md
+++ b/docs/architecture/ARCHITECTURE_REVIEW_AUTOMATION.md
@@ -1,0 +1,97 @@
+# Architecture Review Automation
+
+## Purpose
+
+This document defines how ADL should generate and review architecture packets
+without replacing human architecture judgment. The pipeline is designed for the
+CodeBuddy-style review family and for ADL's own milestone review process.
+
+## Review Pipeline
+
+1. Build a bounded evidence packet.
+2. Run architecture review against the packet.
+3. Run docs, code, security, dependency, and test specialist reviews where
+   relevant.
+4. Ask the diagram planner for diagram briefs.
+5. Ask the diagram author to create source-grounded diagrams.
+6. Ask the architecture diagram reviewer to validate labels, edges, evidence,
+   assumptions, and unsupported claims.
+7. Run redaction and evidence-boundary review before publication.
+8. Ask the fitness-function author to separate machine-checkable invariants
+   from human judgment.
+9. Synthesize findings into a product-grade or milestone-grade report.
+10. Run review-quality evaluation before using the report externally.
+
+## Machine-Checkable Invariants
+
+These checks can be automated today or with small follow-up scripts:
+
+- Required architecture packet files exist under `docs/architecture`.
+- Diagram sources exist under `docs/architecture/diagrams`.
+- `DIAGRAM_PACKET.md` lists every diagram source.
+- Public architecture docs contain no host-absolute private paths or common
+  secret markers.
+- Architecture docs include evidence, assumptions, validation, residual risk,
+  and known-gap sections.
+- Demo matrix entries do not claim a command before the command exists.
+- Issue work has STP, SIP, and SOR cards before `pr run`.
+- Worktree-bound implementation is used for tracked issues.
+- SOR closeout claims match GitHub issue and PR state.
+- Provider docs keep model refs, transport ids, and policy decisions separate.
+- Long-lived-agent docs describe cycle-scoped artifacts and operator controls.
+
+## Human-Judgment Gates
+
+These checks should remain explicitly human-reviewed:
+
+- Whether an architecture finding severity matches user impact.
+- Whether a diagram hides an important boundary or implies unsupported behavior.
+- Whether a tradeoff deserves an ADR or only an implementation note.
+- Whether a runtime capability is mature enough to be claimed publicly.
+- Whether a demo is genuinely proving, merely illustrative, skipped, or failed.
+- Whether publication is appropriate after redaction passes.
+
+## Specialist Roles
+
+- `repo-packet-builder`: gathers bounded evidence.
+- `repo-architecture-review`: reviews layering, coupling, lifecycle, state, and
+  architecture drift.
+- `repo-review-security`: reviews trust boundaries, secrets, unsafe IO,
+  privilege, injection, and abuse paths.
+- `repo-review-tests`: reviews executable proof and missing coverage.
+- `repo-review-docs`: reviews onboarding, command truth, stale docs, and
+  overclaims.
+- `repo-dependency-review`: reviews supply-chain and dependency drift.
+- `repo-diagram-planner`: turns review evidence into diagram briefs.
+- `diagram-author`: authors source-grounded diagram sources.
+- `architecture-diagram-reviewer`: validates diagram truth.
+- `redaction-and-evidence-auditor`: blocks unsafe publication.
+- `architecture-fitness-function-author`: proposes checkable invariants and CI
+  gates.
+- `review-quality-evaluator`: checks quality against the third-party review bar.
+
+## Missing Or Backlog Skills
+
+- Documentation specialist: should maintain packet readability, navigation,
+  examples, and command truth.
+- Gap analysis skill: should compare architecture claims against code, tests,
+  demos, issue state, and milestone docs.
+- Architecture-document writer: may eventually own the synthesis step for docs
+  like `ADL_ARCHITECTURE.md`, but should consume specialist outputs instead of
+  inventing claims.
+
+## Automation Boundaries
+
+Automation may create draft packets, diagrams, issue candidates, and validation
+reports. It must not silently accept ADRs, merge PRs, close issues, publish
+customer reports, or claim release readiness. Those remain explicit operator
+decisions.
+
+## Suggested CI Gates
+
+- Run `python3 adl/tools/validate_architecture_docs.py` when files under
+  `docs/architecture`, `demos/README.md`, or the v0.90 demo matrix change.
+- Run architecture packet validation before review publication.
+- Run diagram renderer checks when renderer dependencies are available.
+- Run a closeout truth gate after merge to ensure issue closure, final SOR
+  truth, and worktree pruning are aligned.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,32 @@
+# ADL Architecture Packet
+
+This directory is the public, tracked entrypoint for ADL architecture review
+and architecture-document generation.
+
+## Documents
+
+- `ADL_ARCHITECTURE.md` is the canonical source-grounded architecture narrative.
+- `ARCHITECTURE_REVIEW_AUTOMATION.md` defines the repeatable review pipeline,
+  including machine-checkable invariants and human judgment gates.
+- `ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md` defines the document-generation
+  workflow that future documentation and gap-analysis skills should follow.
+- `diagrams/DIAGRAM_PACKET.md` indexes the diagram sources and their evidence.
+- `adr/CANDIDATE_ADRS.md` records architecture decisions that should be promoted
+  only after human review.
+
+## Validation
+
+Run this from repository root:
+
+```bash
+python3 adl/tools/validate_architecture_docs.py
+```
+
+Run the deterministic proof packet:
+
+```bash
+bash adl/tools/demo_v090_architecture_document_generation.sh
+```
+
+The proof packet writes ignored reviewer artifacts under
+`artifacts/v090/adl_architecture_document_generation/`.

--- a/docs/architecture/adr/CANDIDATE_ADRS.md
+++ b/docs/architecture/adr/CANDIDATE_ADRS.md
@@ -1,0 +1,54 @@
+# Candidate ADRs
+
+## Status
+
+These are proposed decisions extracted from the v0.90 architecture packet. They
+are not accepted ADRs until reviewed and promoted.
+
+## Candidate 0001: Trace And Artifacts As Runtime Truth
+
+- Proposed status: candidate
+- Context: ADL runtime behavior can be misunderstood if final prose summaries
+  are treated as proof.
+- Proposed decision: runtime truth should be reconstructed from trace events
+  and deterministic run artifacts, with prose reports treated as interpretation.
+- Consequences: validators and reviewers should prefer trace/artifact evidence
+  over ungrounded claims.
+- Evidence: `adl/src/trace.rs`, `adl/src/artifacts.rs`,
+  `docs/architecture/TRACE_SYSTEM_ARCHITECTURE.md`.
+
+## Candidate 0002: Worktree-First Issue Execution
+
+- Proposed status: candidate
+- Context: implementation on the root checkout creates drift, conflicts, and
+  closeout ambiguity.
+- Proposed decision: tracked issue implementation should run in issue-specific
+  worktrees with STP/SIP/SOR truth recorded before finish and closeout.
+- Consequences: conductor and lifecycle skills must route to worktree-bound
+  execution, and closeout must reconcile GitHub and local truth.
+- Evidence: `docs/default_workflow.md`, `adl/src/control_plane.rs`, `pr-*`
+  skills.
+
+## Candidate 0003: Modular Skill Composition
+
+- Proposed status: candidate
+- Context: conductor-style prompts can accidentally absorb downstream skills and
+  hide lifecycle responsibility.
+- Proposed decision: the conductor coordinates and routes, while lifecycle and
+  specialist skills own their bounded tasks.
+- Consequences: multi-skill workflows remain auditable and easier to debug.
+- Evidence: `docs/milestones/v0.89.1/features/SKILL_COMPOSITION_MODEL.md`,
+  `docs/milestones/v0.89.1/features/OPERATIONAL_SKILLS_SUBSTRATE.md`.
+
+## Candidate 0004: Long-Lived Agents Are Cycle-Bounded
+
+- Proposed status: candidate
+- Context: continuous agents can obscure state, authority, and failure history
+  unless each cycle is bounded.
+- Proposed decision: long-lived agents should emit cycle-scoped leases, status,
+  manifests, observations, decisions, run refs, guardrails, continuity records,
+  and inspection packets.
+- Consequences: long-lived demos can show continuity without bypassing operator
+  control or artifact truth.
+- Evidence: `adl/src/long_lived_agent.rs`,
+  `docs/milestones/v0.90/DESIGN_v0.90.md`.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -1,0 +1,10 @@
+# Architecture Decision Records
+
+This directory stores ADL architecture decision records and ADR candidates.
+
+Current tracked file:
+
+- `CANDIDATE_ADRS.md`
+
+Candidate ADRs are not accepted decisions. Promote them only after human review
+and an explicit status change.

--- a/docs/architecture/diagrams/DIAGRAM_PACKET.md
+++ b/docs/architecture/diagrams/DIAGRAM_PACKET.md
@@ -1,0 +1,86 @@
+# ADL Architecture Diagram Packet
+
+## Validation
+
+Run source validation:
+
+```bash
+python3 adl/tools/validate_architecture_docs.py
+```
+
+Optional Mermaid rendering, when Mermaid CLI is installed:
+
+```bash
+mmdc -i docs/architecture/diagrams/system_context.mmd -o artifacts/diagrams/adl-system-context.svg
+```
+
+## Diagram A1: System Context
+
+- Source: `docs/architecture/diagrams/system_context.mmd`
+- Purpose: show ADL's operator, GitHub, skill, runtime, provider, tool, artifact,
+  and documentation boundaries.
+- Evidence: `docs/architecture/ADL_ARCHITECTURE.md`,
+  `adl/src/adl/types.rs`, `docs/default_workflow.md`.
+- Assumptions: external providers and GitHub are boundaries, not ADL internals.
+- Unsupported claims excluded: no claim that GitHub merge is automatic.
+
+## Diagram A2: Runtime Lifecycle
+
+- Source: `docs/architecture/diagrams/runtime_lifecycle.mmd`
+- Purpose: show parse, resolve, plan, schedule, execute, trace, artifact, and
+  finish flow.
+- Evidence: `adl/src/execution_plan.rs`, `adl/src/execute/mod.rs`,
+  `adl/src/trace.rs`, `adl/src/artifacts.rs`.
+- Assumptions: labels summarize code paths rather than all internal functions.
+- Unsupported claims excluded: no claim that every provider/tool path has equal
+  maturity.
+
+## Diagram A3: Control Plane Lifecycle
+
+- Source: `docs/architecture/diagrams/control_plane_lifecycle.mmd`
+- Purpose: show issue-to-closeout lifecycle and worktree-first execution.
+- Evidence: `docs/default_workflow.md`, `adl/src/control_plane.rs`, `pr-*`
+  skills.
+- Assumptions: merge remains a human/repository event.
+- Unsupported claims excluded: no silent merge or silent closeout behavior.
+
+## Diagram A4: Task Bundle State
+
+- Source: `docs/architecture/diagrams/task_bundle_state.mmd`
+- Purpose: show STP/SIP/SOR bundle state transitions.
+- Evidence: `adl/src/control_plane.rs`, `docs/default_workflow.md`.
+- Assumptions: state labels describe lifecycle truth, not a single Rust enum.
+- Unsupported claims excluded: no guarantee that every historic bundle is clean.
+
+## Diagram A5: Skill Orchestration
+
+- Source: `docs/architecture/diagrams/skill_orchestration.mmd`
+- Purpose: show conductor, lifecycle, editor, specialist, diagram, redaction,
+  fitness, and report skill boundaries.
+- Evidence:
+  `docs/milestones/v0.89.1/features/SKILL_COMPOSITION_MODEL.md`,
+  `docs/milestones/v0.89.1/features/OPERATIONAL_SKILLS_SUBSTRATE.md`.
+- Assumptions: specialist skill names are representative of the current
+  CodeBuddy review stack.
+- Unsupported claims excluded: no claim that conductor owns downstream work.
+
+## Diagram A6: Artifact Data Flow
+
+- Source: `docs/architecture/diagrams/artifact_data_flow.mmd`
+- Purpose: show deterministic run artifact families used for reviewer
+  reconstruction.
+- Evidence: `adl/src/artifacts.rs`, `adl/src/trace.rs`,
+  `docs/architecture/TRACE_SYSTEM_ARCHITECTURE.md`.
+- Assumptions: artifact groups summarize deterministic path families.
+- Unsupported claims excluded: no claim that prose reports are the runtime truth.
+
+## Diagram A7: Trust Boundaries
+
+- Source: `docs/architecture/diagrams/trust_boundaries.mmd`
+- Purpose: show document, runtime, sandbox, signing, remote execution, provider,
+  and publication boundaries.
+- Evidence: `adl/src/signing.rs`, `adl/src/sandbox.rs`,
+  `adl/src/remote_exec/security.rs`, `adl/src/provider/mod.rs`.
+- Assumptions: publication is a review-process boundary, not a Rust module
+  boundary.
+- Unsupported claims excluded: no claim that all workflows are safe by default.

--- a/docs/architecture/diagrams/README.md
+++ b/docs/architecture/diagrams/README.md
@@ -1,0 +1,11 @@
+# Architecture Diagrams
+
+This directory contains source-grounded diagram sources for the ADL architecture
+packet.
+
+Use `DIAGRAM_PACKET.md` as the reviewer index. Mermaid sources can be rendered
+with Mermaid CLI when available, or validated as source text by:
+
+```bash
+python3 adl/tools/validate_architecture_docs.py
+```

--- a/docs/architecture/diagrams/artifact_data_flow.mmd
+++ b/docs/architecture/diagrams/artifact_data_flow.mmd
@@ -1,0 +1,24 @@
+%% Evidence: adl/src/artifacts.rs, adl/src/trace.rs, docs/architecture/TRACE_SYSTEM_ARCHITECTURE.md
+%% Assumptions: artifact groups summarize deterministic path families.
+flowchart LR
+  Run["Run id"]
+  RunJson["run.json"]
+  Steps["steps.json"]
+  Status["run_status.json"]
+  Trace["logs/trace_v1.json"]
+  Outputs["outputs/"]
+  Control["control_path/"]
+  Review["Reviewer reconstruction"]
+
+  Run --> RunJson
+  Run --> Steps
+  Run --> Status
+  Run --> Trace
+  Run --> Outputs
+  Run --> Control
+  RunJson --> Review
+  Steps --> Review
+  Status --> Review
+  Trace --> Review
+  Outputs --> Review
+  Control --> Review

--- a/docs/architecture/diagrams/control_plane_lifecycle.mmd
+++ b/docs/architecture/diagrams/control_plane_lifecycle.mmd
@@ -1,0 +1,21 @@
+%% Evidence: docs/default_workflow.md, adl/src/control_plane.rs, pr-init/pr-ready/pr-run/pr-finish/pr-janitor/pr-closeout skills
+%% Assumptions: GitHub merge action remains a human/repository event, not an automatic ADL mutation.
+flowchart LR
+  Issue["Issue intent"]
+  Init["pr init"]
+  Ready["pr ready"]
+  Run["pr run in issue worktree"]
+  Finish["pr finish draft PR"]
+  Janitor["pr janitor"]
+  Merge["Human review and merge"]
+  Closeout["pr closeout"]
+  Prune["Pruned local execution surface"]
+
+  Issue --> Init
+  Init --> Ready
+  Ready --> Run
+  Run --> Finish
+  Finish --> Janitor
+  Janitor --> Merge
+  Merge --> Closeout
+  Closeout --> Prune

--- a/docs/architecture/diagrams/runtime_lifecycle.mmd
+++ b/docs/architecture/diagrams/runtime_lifecycle.mmd
@@ -1,0 +1,24 @@
+%% Evidence: adl/src/execution_plan.rs, adl/src/execute/mod.rs, adl/src/trace.rs, adl/src/artifacts.rs
+%% Assumptions: lifecycle labels summarize code paths rather than every internal function.
+flowchart TD
+  Parse["Parse typed ADL document"]
+  Resolve["Resolve run workflow"]
+  Plan["Build acyclic execution plan"]
+  Schedule["Apply scheduler policy"]
+  Execute["Execute steps and calls"]
+  Delegate["Evaluate delegation policy"]
+  Provider["Call provider or tool boundary"]
+  Trace["Record trace events"]
+  Artifacts["Write run artifacts"]
+  Finish["Finish or fail run"]
+
+  Parse --> Resolve
+  Resolve --> Plan
+  Plan --> Schedule
+  Schedule --> Execute
+  Execute --> Delegate
+  Delegate --> Provider
+  Provider --> Trace
+  Execute --> Trace
+  Trace --> Artifacts
+  Artifacts --> Finish

--- a/docs/architecture/diagrams/skill_orchestration.mmd
+++ b/docs/architecture/diagrams/skill_orchestration.mmd
@@ -1,0 +1,23 @@
+%% Evidence: docs/milestones/v0.89.1/features/SKILL_COMPOSITION_MODEL.md, docs/milestones/v0.89.1/features/OPERATIONAL_SKILLS_SUBSTRATE.md
+%% Assumptions: specialist skill names are representative of the current CodeBuddy review stack.
+flowchart TD
+  Conductor["workflow-conductor"]
+  Lifecycle["Lifecycle skills"]
+  Editors["STP SIP SOR editors"]
+  Packet["repo-packet-builder"]
+  Specialists["Code security tests docs architecture dependency reviewers"]
+  Diagrams["diagram planner and diagram-author"]
+  Redaction["redaction and evidence auditor"]
+  Fitness["architecture fitness-function author"]
+  Report["product report and review-quality evaluator"]
+
+  Conductor --> Lifecycle
+  Conductor --> Editors
+  Lifecycle --> Packet
+  Packet --> Specialists
+  Specialists --> Diagrams
+  Specialists --> Redaction
+  Specialists --> Fitness
+  Diagrams --> Report
+  Redaction --> Report
+  Fitness --> Report

--- a/docs/architecture/diagrams/system_context.mmd
+++ b/docs/architecture/diagrams/system_context.mmd
@@ -1,0 +1,23 @@
+%% Evidence: docs/architecture/ADL_ARCHITECTURE.md, adl/src/adl/types.rs, docs/default_workflow.md
+%% Assumptions: external providers and GitHub are represented as boundaries, not as controlled ADL internals.
+flowchart LR
+  Operator["Operator / reviewer"]
+  Issue["GitHub issue"]
+  PR["GitHub PR"]
+  Skills["ADL workflow skills"]
+  Runtime["ADL runtime"]
+  Providers["Model providers"]
+  Tools["Tools and local scripts"]
+  Artifacts["Trace and artifacts"]
+  Docs["Architecture docs and demos"]
+
+  Operator --> Issue
+  Issue --> Skills
+  Skills --> Runtime
+  Runtime --> Providers
+  Runtime --> Tools
+  Runtime --> Artifacts
+  Skills --> PR
+  Artifacts --> Docs
+  PR --> Operator
+  Docs --> Operator

--- a/docs/architecture/diagrams/task_bundle_state.mmd
+++ b/docs/architecture/diagrams/task_bundle_state.mmd
@@ -1,0 +1,14 @@
+%% Evidence: adl/src/control_plane.rs, docs/default_workflow.md
+%% Assumptions: state names describe lifecycle truth, not a single enum in the source.
+stateDiagram-v2
+  [*] --> IssueCaptured
+  IssueCaptured --> BundleInitialized: STP SIP SOR created
+  BundleInitialized --> ReadyChecked: doctor pass
+  ReadyChecked --> WorktreeBound: pr run
+  WorktreeBound --> Implemented: bounded edits and validation
+  Implemented --> Published: pr finish
+  Published --> Integrated: PR merged or no-PR disposition
+  Integrated --> ClosedOut: pr closeout
+  ClosedOut --> [*]
+  ReadyChecked --> NeedsRepair: doctor fail
+  NeedsRepair --> BundleInitialized: editor skill repair

--- a/docs/architecture/diagrams/trust_boundaries.mmd
+++ b/docs/architecture/diagrams/trust_boundaries.mmd
@@ -1,0 +1,19 @@
+%% Evidence: adl/src/signing.rs, adl/src/sandbox.rs, adl/src/remote_exec/security.rs, adl/src/provider/mod.rs
+%% Assumptions: publication gate is a review-process boundary, not a Rust module boundary.
+flowchart TD
+  Doc["ADL document"]
+  Parser["Typed parser and validator"]
+  Runtime["Runtime"]
+  Sandbox["Sandbox path validation"]
+  Signing["Signature verification"]
+  Remote["Remote execute request"]
+  Provider["Provider transport"]
+  Publication["Report publication gate"]
+
+  Doc --> Parser
+  Parser --> Runtime
+  Runtime --> Sandbox
+  Runtime --> Provider
+  Remote --> Signing
+  Signing --> Runtime
+  Runtime --> Publication

--- a/docs/milestones/v0.90/DEMO_MATRIX_v0.90.md
+++ b/docs/milestones/v0.90/DEMO_MATRIX_v0.90.md
@@ -24,6 +24,7 @@ Define the planned proof surfaces for v0.90 before implementation starts.
 | D6 | Repo visibility proof packet | ADL can map one milestone or feature slice from canonical docs to implementation, tests, demos, and review surfaces | `docs/milestones/v0.90/repo_visibility/` | manifest and code-doc-demo linkage report | landed by `#2031` |
 | D7 | Milestone compression pilot | ADL can detect milestone drift from canonical state without silently mutating release truth | `python3 adl/tools/check_v090_milestone_state.py` | canonical state file, drift-check output, and generated status summary | landed by `#2030` |
 | D8 | CodeBuddy multi-agent review showcase | ADL can present the CodeBuddy review-engine skill family as a product-style, packet-first repo review workflow without building the web app or mutating customer repos | `bash adl/tools/demo_v090_codebuddy_review_showcase.sh` | `artifacts/v090/codebuddy_review_showcase/run_manifest.json`, specialist reviews, redaction report, diagram artifacts, final report, and demo-operator classification | landed by `#2072`; intentionally `non_proving` until `#2070` lands |
+| D9 | ADL architecture document generation | ADL can maintain a source-grounded first-class architecture packet with diagrams, review automation, generation planning, candidate ADRs, and deterministic validation | `bash adl/tools/demo_v090_architecture_document_generation.sh` | `docs/architecture/`, `docs/architecture/diagrams/`, and `artifacts/v090/adl_architecture_document_generation/architecture_generation_manifest.json` | landed by `#2055` |
 
 ## Safety Rules
 
@@ -58,6 +59,15 @@ The CodeBuddy showcase packet must:
 - avoid live provider calls, customer repositories, billing, and product-app
   assumptions in the default demo path
 - block publication until redaction and evidence gates are explicit
+
+The architecture document generation packet must:
+
+- keep architecture claims source-grounded in tracked repository evidence
+- include evidence, assumptions, and validation notes for every diagram source
+- separate machine-checkable invariants from human architecture judgment
+- record missing documentation-specialist and gap-analysis skill dependencies
+- avoid private local trace paths, host-absolute paths, and secret markers in
+  public docs or proof artifacts
 
 ## Validation Expectations
 


### PR DESCRIPTION
Closes #2055

## Summary
Created the first tracked ADL architecture packet for v0.90. The packet covers
runtime, control-plane, task-bundle, worktree/PR, provider/tool, trace/artifact,
security-boundary, long-lived-agent, operational-skill, and review/release
architecture. It includes diagram sources, review automation guidance,
document-generation planning, candidate ADRs, and a deterministic proof demo.

## Artifacts
- `docs/architecture/README.md`
- `docs/architecture/ADL_ARCHITECTURE.md`
- `docs/architecture/ARCHITECTURE_REVIEW_AUTOMATION.md`
- `docs/architecture/ARCHITECTURE_DOCUMENT_GENERATION_PLAN.md`
- `docs/architecture/adr/README.md`
- `docs/architecture/adr/CANDIDATE_ADRS.md`
- `docs/architecture/diagrams/README.md`
- `docs/architecture/diagrams/DIAGRAM_PACKET.md`
- `docs/architecture/diagrams/system_context.mmd`
- `docs/architecture/diagrams/runtime_lifecycle.mmd`
- `docs/architecture/diagrams/control_plane_lifecycle.mmd`
- `docs/architecture/diagrams/task_bundle_state.mmd`
- `docs/architecture/diagrams/skill_orchestration.mmd`
- `docs/architecture/diagrams/artifact_data_flow.mmd`
- `docs/architecture/diagrams/trust_boundaries.mmd`
- `demos/v0.90/adl_architecture_document_generation_demo.md`
- `adl/tools/demo_v090_architecture_document_generation.sh`
- `adl/tools/test_demo_v090_architecture_document_generation.sh`
- `adl/tools/validate_architecture_docs.py`
- Updated `demos/README.md`
- Updated `docs/milestones/v0.90/DEMO_MATRIX_v0.90.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/demo_v090_architecture_document_generation.sh adl/tools/test_demo_v090_architecture_document_generation.sh` verified shell syntax.
  - `python3 -m py_compile adl/tools/validate_architecture_docs.py` verified validator syntax.
  - `python3 adl/tools/validate_architecture_docs.py` verified required docs, sections, evidence markers, diagram packet coverage, source comments, and leak scans.
  - `bash adl/tools/test_demo_v090_architecture_document_generation.sh` verified deterministic proof packet generation, manifest schema, classification, required artifacts, and leak-detection failures.
  - `git diff --check` verified whitespace sanity.
- Results: PASS.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2055__backlog-docs-tools-generate-adl-architecture-document/sip.md
- Output card: .adl/v0.90/tasks/issue-2055__backlog-docs-tools-generate-adl-architecture-document/sor.md
- Idempotency-Key: add-first-class-adl-architecture-packet-adl-v0-90-tasks-issue-2055-backlog-docs-tools-generate-adl-architecture-document-sip-md-adl-v0-90-tasks-issue-2055-backlog-docs-tools-generate-adl-architecture-document-sor-md