### PR TITLE
Add documentation specialist skill

### DIFF
--- a/adl/tools/skills/docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,90 @@
+# Documentation Specialist Skill Input Schema
+
+Schema id: `documentation_specialist.v1`
+
+This schema describes structured input for the `documentation-specialist` skill.
+The skill plans, writes, audits, repairs, or polishes bounded repository
+documentation from explicit source evidence and stops before publication,
+approval claims, ADR acceptance, or broad unbounded rewrites.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `documentation_specialist.v1`.
+- `mode`: one of the supported modes below.
+- `target`: bounded documentation target.
+- `source_packet`: evidence used to support factual claims.
+- `audience`: intended reader.
+- `policy`: edit, validation, and stop-boundary policy.
+
+## Supported Modes
+
+- `write_doc`: create a bounded documentation target.
+- `repair_doc`: fix stale, misleading, or incomplete documentation in a bounded
+  target.
+- `audit_doc`: produce findings or a handoff packet without editing by default.
+- `polish_doc`: improve readability while preserving facts and scope.
+- `plan_doc`: outline a future documentation target from source evidence.
+- `refresh_doc`: update a bounded doc after source evidence changes.
+- `handoff_packet`: emit a documentation packet for another skill or operator.
+
+## Target Fields
+
+- `path`: repository-relative target path when editing or auditing an existing
+  file.
+- `doc_type`: README, milestone, feature, ADR, demo, review, architecture,
+  onboarding, runbook, skill, or another explicit type.
+- `scope`: one bounded slice, path list, issue, PR, milestone, or review packet.
+- `write_intent`: edit_existing, create_new, audit_only, plan_only, or
+  handoff_only.
+
+## Source Packet Fields
+
+- `evidence_paths`: repository-relative paths that support factual claims.
+- `issues`: issue numbers or URLs used as intent evidence.
+- `prs`: PR numbers or URLs used as integration evidence.
+- `commands`: commands whose output or existence is relevant.
+- `known_gaps`: source gaps already known to the operator.
+- `assumptions`: assumptions that must stay labeled in output.
+
+## Audience Values
+
+Use an explicit value such as:
+
+- `operator`
+- `reviewer`
+- `new_contributor`
+- `maintainer`
+- `customer_private`
+- `public_candidate`
+
+## Policy Fields
+
+- `bounded_target_required`: must be true.
+- `source_evidence_required`: must be true.
+- `allow_repo_edits`: whether the skill may edit tracked docs.
+- `write_handoff_artifact`: whether to write a separate handoff packet.
+- `check_commands`: whether safe bounded commands should be checked.
+- `stop_before_publication`: must be true.
+- `stop_before_broad_rewrite`: must be true.
+
+## Output Contract
+
+When editing documentation, the skill reports:
+
+- target paths changed
+- source evidence used
+- claims clarified
+- assumptions and gaps surfaced
+- commands checked or skipped
+- validation result
+- residual risk
+
+When producing an artifact, use:
+
+- `references/output-contract.md`
+
+## Boundaries
+
+The skill must not publish externally, claim release approval, claim review
+approval, accept ADRs, create issues, open PRs, rewrite broad doc sets without
+an explicit bounded target, or present planned work as implemented behavior.

--- a/adl/tools/skills/documentation-specialist/SKILL.md
+++ b/adl/tools/skills/documentation-specialist/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: documentation-specialist
+description: Plan, write, audit, repair, or polish bounded repository documentation from explicit source evidence. Use when Codex needs to work on README, milestone, feature, ADR, demo, review, architecture, onboarding, runbook, or skill documentation while separating source-backed facts from recommendations and assumptions, flagging stale commands, overclaims, missing validation evidence, and stopping before publication or broad unbounded rewrites.
+---
+
+# Documentation Specialist
+
+Plan, write, audit, repair, or polish bounded repository documentation without
+turning docs work into unsupported storytelling.
+
+This skill is a documentation authoring and truth-boundary skill. It may edit
+bounded documentation targets when asked to write or repair docs. It may also
+produce a handoff packet when the requested output is planning, audit, or review
+only.
+
+## Quick Start
+
+1. Confirm the bounded documentation target:
+   - README or onboarding page
+   - milestone or feature document
+   - ADR or candidate ADR
+   - demo/runbook document
+   - review packet or report
+   - architecture packet
+   - skill documentation or input schema
+2. Confirm the source packet or evidence paths.
+3. Classify each claim as source-backed fact, assumption, recommendation, or
+   gap.
+4. Check for stale commands, broken paths, overclaims, missing validation
+   evidence, unclear audience, and unsafe publication language.
+5. Write or repair only the bounded target, or emit a documentation handoff
+   packet if edits are not requested.
+6. Record validation performed, validation not run, residual risk, and follow-up
+   gaps.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `mode`
+- `target`
+- `source_packet`
+- `audience`
+- `policy`
+
+Supported modes:
+
+- `write_doc`
+- `repair_doc`
+- `audit_doc`
+- `polish_doc`
+- `plan_doc`
+- `refresh_doc`
+- `handoff_packet`
+
+Useful policy fields:
+
+- `bounded_target_required`
+- `source_evidence_required`
+- `allow_repo_edits`
+- `write_handoff_artifact`
+- `check_commands`
+- `stop_before_publication`
+- `stop_before_broad_rewrite`
+
+If there is no bounded target or source evidence, stop with `blocked` rather
+than inventing repository behavior.
+
+## Workflow
+
+### 1. Establish Documentation Boundary
+
+Record:
+
+- target path or requested artifact
+- source evidence paths
+- intended audience
+- doc type
+- allowed edit scope
+- validation expectations
+- publication intent
+
+Do not infer a repo-wide rewrite from a broad docs request. Ask for or derive a
+bounded slice, then keep edits there.
+
+### 2. Build A Claim Ledger
+
+For the target doc, track:
+
+- source-backed facts
+- assumptions that must be labeled
+- recommendations that must not be presented as completed work
+- gaps where source evidence is missing
+- commands or paths that need validation
+- claims that depend on another issue, PR, demo, or reviewer decision
+
+Prefer deleting or qualifying unsupported claims over making them sound nicer.
+
+### 3. Write Or Repair The Doc
+
+Write for the declared audience:
+
+- operator docs should be direct, procedural, and command-truthful
+- reviewer docs should foreground scope, evidence, validation, and residual risk
+- architecture docs should separate current implementation from planned design
+- demo docs should state what the demo proves and does not prove
+- ADRs should separate proposed, accepted, superseded, and rejected decisions
+- skill docs should include entry conditions, required inputs, workflow, stop
+  boundary, outputs, blocked states, and handoffs
+
+Keep structure durable. Prefer short sections, explicit validation commands, and
+repo-relative paths.
+
+### 4. Validate Truthfully
+
+Use the smallest useful validation set:
+
+- check referenced files exist when possible
+- run documented commands only when safe and bounded
+- run Markdown or contract tests when the repo provides them
+- check generated docs for absolute host paths and secret markers when
+  publication is possible
+- verify diagram or demo links only when they are part of the bounded target
+
+If validation is not run, say why.
+
+### 5. Stop Boundary
+
+Stop after the bounded documentation edit, audit, or handoff packet.
+
+Do not:
+
+- publish externally
+- claim release approval
+- claim review approval
+- accept ADRs without human decision
+- create issues or PRs unless another lifecycle skill is explicitly invoked
+- rewrite broad doc sets without a bounded target
+- treat planned work as implemented work
+- hide stale commands, missing proof, or source gaps
+
+## Output
+
+When editing docs, report:
+
+- target paths changed
+- source evidence used
+- claims clarified
+- assumptions or gaps surfaced
+- commands checked
+- validation run or not run
+- residual risk
+
+When writing a handoff packet, use `references/output-contract.md`.
+
+## Handoffs
+
+- Use `repo-review-docs` when the task is review-only and findings-first.
+- Use `repo-architecture-review` when the problem is primarily architecture
+  structure, coupling, or lifecycle drift.
+- Use `diagram-author` when source-grounded diagrams are required.
+- Use `gap-analysis` when comparing expected baseline to observed evidence.
+- Use `product-report-writer` for customer-grade CodeBuddy report packaging.
+- Use `medium-article-writer` or `arxiv-paper-writer` for platform-specific
+  publication drafts.
+
+## Blocked States
+
+Return `blocked` when:
+
+- no bounded target is provided
+- no source evidence is available for factual claims
+- the user asks for publication, approval, compliance, or release readiness
+  claims without proof
+- the request would require broad repo mutation without an explicit scope
+- validation is required but unsafe or impossible in the current environment

--- a/adl/tools/skills/documentation-specialist/adl-skill.yaml
+++ b/adl/tools/skills/documentation-specialist/adl-skill.yaml
@@ -1,0 +1,131 @@
+version: "0.1"
+kind: "adl-skill"
+id: "documentation-specialist"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "documentation_specialist.v1"
+    reference_doc: "../docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "target"
+      - "source_packet"
+      - "audience"
+      - "policy"
+    mode_enum:
+      - "write_doc"
+      - "repair_doc"
+      - "audit_doc"
+      - "polish_doc"
+      - "plan_doc"
+      - "refresh_doc"
+      - "handoff_packet"
+    policy_fields:
+      - "bounded_target_required"
+      - "source_evidence_required"
+      - "allow_repo_edits"
+      - "write_handoff_artifact"
+      - "check_commands"
+      - "stop_before_publication"
+      - "stop_before_broad_rewrite"
+    mode_requirements:
+      write_doc:
+        required_target_fields:
+          - "target.path"
+          - "source_packet.evidence_paths"
+      repair_doc:
+        required_target_fields:
+          - "target.path"
+          - "source_packet.evidence_paths"
+      audit_doc:
+        required_target_fields:
+          - "target.path"
+      polish_doc:
+        required_target_fields:
+          - "target.path"
+      plan_doc:
+        required_target_fields:
+          - "target.doc_type"
+      refresh_doc:
+        required_target_fields:
+          - "target.path"
+          - "source_packet.evidence_paths"
+      handoff_packet:
+        required_target_fields:
+          - "target.doc_type"
+  intent:
+    - "documentation_authoring"
+    - "documentation_repair"
+    - "documentation_audit"
+    - "truth_boundary_review"
+    - "onboarding_docs"
+    - "milestone_docs"
+    - "architecture_docs"
+    - "demo_docs"
+    - "skill_docs"
+  required_inputs:
+    - "target"
+    - "source_packet"
+    - "audience"
+    - "policy"
+  optional_inputs:
+    - "output_root"
+    - "validation_commands"
+    - "claim_ledger"
+    - "existing_findings"
+    - "handoff_path"
+  stop_if_missing:
+    - "target"
+    - "source_packet"
+  prevalidation_rules:
+    - "skill_input_schema_must_equal_documentation_specialist.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.bounded_target_required_must_be_true"
+    - "policy.source_evidence_required_must_be_true"
+    - "policy.stop_before_publication_must_be_true"
+    - "policy.stop_before_broad_rewrite_must_be_true"
+execution:
+  mode: "bounded_docs"
+  allow_code_edits: false
+  allow_doc_edits: true
+  allow_network: false
+  allow_subagents: false
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+  validation_policy: "run_only_safe_bounded_doc_commands_and_record_skips"
+boundaries:
+  must_not_run:
+    - "external_publication"
+    - "release_approval"
+    - "review_approval"
+    - "compliance_claims"
+    - "adr_acceptance"
+    - "issue_creation"
+    - "pull_request_creation"
+    - "broad_repo_rewrite"
+    - "unsupported_behavior_claims"
+outputs:
+  default_format: "markdown_or_doc_edit_summary"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/docs/reviews/<run_id>-documentation-specialist.md"
+  required_sections:
+    - "documentation_scope"
+    - "source_evidence"
+    - "claim_ledger"
+    - "edits_or_recommendations"
+    - "validation"
+    - "residual_risk"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_external_publication: true
+  no_unbounded_doc_rewrite: true
+  manifest_declares_executables: false
+
+display_name: Documentation Specialist
+short_description: Plan, write, audit, and polish bounded repository documentation
+default_prompt: Plan, write, audit, or polish bounded repository documentation from explicit source evidence. Separate source-backed facts from recommendations and assumptions; flag stale commands, overclaims, missing validation evidence, and stop before publication or broad rewrites.

--- a/adl/tools/skills/documentation-specialist/agents/openai.yaml
+++ b/adl/tools/skills/documentation-specialist/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Documentation Specialist
+short_description: Plan, write, audit, and polish bounded repository documentation
+default_prompt: Plan, write, audit, or polish bounded repository documentation from explicit source evidence. Separate source-backed facts from recommendations and assumptions; flag stale commands, overclaims, missing validation evidence, and stop before publication or broad rewrites.

--- a/adl/tools/skills/documentation-specialist/references/output-contract.md
+++ b/adl/tools/skills/documentation-specialist/references/output-contract.md
@@ -1,0 +1,88 @@
+# Documentation Specialist Output Contract
+
+Use this contract for documentation handoff packets, documentation audits, and
+edit summaries.
+
+## Required Sections
+
+### Documentation Scope
+
+- Target path or artifact:
+- Documentation type:
+- Audience:
+- Mode:
+- Edit scope:
+- Publication attempted: true | false
+
+### Source Evidence
+
+- Evidence paths:
+- Commands or demos referenced:
+- Issues, PRs, or review artifacts referenced:
+- Evidence not available:
+
+### Claim Ledger
+
+Classify important claims as:
+
+- Source-backed fact:
+- Assumption:
+- Recommendation:
+- Gap or missing proof:
+- Planned but not implemented:
+
+Do not collapse assumptions or recommendations into facts.
+
+### Edits Or Recommendations
+
+For edits:
+
+- Paths changed:
+- Claims clarified:
+- Stale commands repaired:
+- Overclaims removed or qualified:
+- Missing validation evidence surfaced:
+
+For audit or planning:
+
+- Recommended changes:
+- Priority:
+- Rationale:
+- Blocking gaps:
+
+### Validation
+
+- Commands run:
+- Commands not run and why:
+- Paths checked:
+- Link or renderer checks:
+- Secret or host-path scan:
+- Result: pass | partial | fail | not_run
+
+### Residual Risk
+
+- Remaining uncertainty:
+- Human decisions required:
+- Follow-up skills recommended:
+- Publication blockers:
+
+## Guardrails
+
+The output must state:
+
+- Publication attempted: false, unless the user explicitly asked for an external
+  publication action and another authorized workflow performed it.
+- Release approval claimed: false.
+- Review approval claimed: false.
+- ADR accepted: false, unless a human decision explicitly accepted it.
+- Broad rewrite performed: false, unless the target scope explicitly allowed it.
+
+## Unsafe Output Patterns
+
+Do not write:
+
+- "This is release-ready" without release proof and human approval.
+- "The system does X" when evidence only shows planned behavior.
+- "All docs are updated" after touching only a bounded slice.
+- Absolute host paths in public docs.
+- Secret markers, prompt fragments, or private tool arguments.

--- a/adl/tools/test_documentation_specialist_skill_contracts.sh
+++ b/adl/tools/test_documentation_specialist_skill_contracts.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/documentation-specialist/SKILL.md" ]]
+[[ -f "${skills_root}/documentation-specialist/adl-skill.yaml" ]]
+[[ -f "${skills_root}/documentation-specialist/agents/openai.yaml" ]]
+[[ -f "${skills_root}/documentation-specialist/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'name: documentation-specialist' "${skills_root}/documentation-specialist/SKILL.md"
+grep -Fq 'id: "documentation-specialist"' "${skills_root}/documentation-specialist/adl-skill.yaml"
+grep -Fq 'id: "documentation_specialist.v1"' "${skills_root}/documentation-specialist/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md"' "${skills_root}/documentation-specialist/adl-skill.yaml"
+grep -Fq "policy.bounded_target_required_must_be_true" "${skills_root}/documentation-specialist/adl-skill.yaml"
+grep -Fq "policy.source_evidence_required_must_be_true" "${skills_root}/documentation-specialist/adl-skill.yaml"
+grep -Fq "policy.stop_before_publication_must_be_true" "${skills_root}/documentation-specialist/adl-skill.yaml"
+grep -Fq "policy.stop_before_broad_rewrite_must_be_true" "${skills_root}/documentation-specialist/adl-skill.yaml"
+grep -Fq "Plan, write, audit, repair, or polish bounded repository documentation" "${skills_root}/documentation-specialist/SKILL.md"
+grep -Fq "Classify each claim" "${skills_root}/documentation-specialist/SKILL.md"
+grep -Fq "Do not infer a repo-wide rewrite" "${skills_root}/documentation-specialist/SKILL.md"
+grep -Fq "Publication attempted: true | false" "${skills_root}/documentation-specialist/references/output-contract.md"
+grep -Fq "Release approval claimed: false." "${skills_root}/documentation-specialist/references/output-contract.md"
+grep -Fq "Schema id: \`documentation_specialist.v1\`" "${skills_root}/docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md"
+grep -Fq "README, milestone, feature, ADR, demo, review, architecture" "${skills_root}/docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md"
+grep -Fq "Documentation Specialist" "${skills_root}/documentation-specialist/agents/openai.yaml"
+
+if grep -R "${tmpdir}" \
+  "${skills_root}/documentation-specialist" \
+  "${skills_root}/docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md" >/dev/null; then
+  echo "documentation specialist skill should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+CODEX_HOME="${tmpdir}/codex-home" \
+ADL_OPERATIONAL_SKILLS_SOURCE_ROOT="${skills_root}" \
+bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/tmp/documentation-specialist-install.out
+[[ -f "${tmpdir}/codex-home/skills/documentation-specialist/SKILL.md" ]]
+[[ -f "${tmpdir}/codex-home/skills/documentation-specialist/adl-skill.yaml" ]]
+diff -q \
+  "${skills_root}/documentation-specialist/SKILL.md" \
+  "${tmpdir}/codex-home/skills/documentation-specialist/SKILL.md" >/dev/null
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/documentation-specialist/SKILL.md"
+
+echo "PASS test_documentation_specialist_skill_contracts"


### PR DESCRIPTION
Closes #2042

## Summary
Created the tracked `documentation-specialist` operational skill for bounded
repository documentation writing, repair, audit, polish, planning, refresh, and
handoff packets. The skill separates source-backed facts from assumptions,
recommendations, and gaps, and explicitly blocks publication, approval claims,
ADR acceptance, and broad unbounded rewrites.

## Artifacts
- `adl/tools/skills/documentation-specialist/SKILL.md`
- `adl/tools/skills/documentation-specialist/adl-skill.yaml`
- `adl/tools/skills/documentation-specialist/agents/openai.yaml`
- `adl/tools/skills/documentation-specialist/references/output-contract.md`
- `adl/tools/skills/docs/DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_documentation_specialist_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_documentation_specialist_skill_contracts.sh` verified required skill files, trigger metadata, structured contract fields, output contract guardrails, input schema markers, and install/sync visibility.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/documentation-specialist/SKILL.md` verified skill frontmatter.
  - `git diff --check` verified whitespace sanity.
  - Skill-creator `quick_validate.py` was attempted but not completed because the local Python environment lacks PyYAML.
- Results: PASS for repo-native validation; skill-creator quick validation not run due missing local `yaml` module.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2042__backlog-skills-add-documentation-specialist-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2042__backlog-skills-add-documentation-specialist-skill/sor.md
- Idempotency-Key: add-documentation-specialist-skill-adl-v0-90-tasks-issue-2042-backlog-skills-add-documentation-specialist-skill-sip-md-adl-v0-90-tasks-issue-2042-backlog-skills-add-documentation-specialist-skill-sor-md