### PR TITLE
[v0.90][backlog][skills] Add refactoring helper skill

### DIFF
--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -23,6 +23,7 @@ coverage, or an explicit multi-agent review demo/proof surface.
 - `architecture-diagram-reviewer`
 - `review-to-test-planner`
 - `gap-analysis`
+- `refactoring-helper`
 - `adr-curator`
 - `architecture-fitness-function-author`
 - `finding-to-issue-planner`
@@ -44,11 +45,12 @@ Recommended order:
 9. `architecture-diagram-reviewer`
 10. `review-to-test-planner`
 11. `gap-analysis`
-12. `adr-curator`
-13. `architecture-fitness-function-author`
-14. `finding-to-issue-planner`
-15. `product-report-writer`
-16. `review-quality-evaluator`
+12. `refactoring-helper`
+13. `adr-curator`
+14. `architecture-fitness-function-author`
+15. `finding-to-issue-planner`
+16. `product-report-writer`
+17. `review-quality-evaluator`
 
 The first four roles may run independently when the operator wants parallel
 review. The synthesis role should run after at least one specialist artifact is
@@ -67,6 +69,12 @@ The gap-analysis skill should run when a concrete expected baseline must be
 reconciled against observed implementation, docs, tests, review, report, PR, or
 closeout evidence. It emits source-grounded gap findings and stops before fixes,
 approval, publication, issue creation, PR creation, or repository mutation.
+The refactoring-helper skill should run when review findings, architecture
+findings, gap reports, or code surfaces need to be turned into bounded,
+behavior-preserving refactor slices. It identifies current behavior, invariants,
+risks, validation commands, rollback notes, residual risk, and follow-on slices;
+it stops before broad rewrites, silent behavior changes, issue creation, PR
+creation, or unapproved repository mutation.
 The ADR curator should run after architecture findings, synthesis, migration
 notes, or repo evidence identify durable decisions that need Architecture
 Decision Record candidates. It drafts proposed ADR packets without accepting

--- a/adl/tools/skills/docs/REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,88 @@
+# Refactoring Helper Skill Input Schema
+
+Schema id: `refactoring_helper.v1`
+
+## Purpose
+
+Turn a bounded code surface into a behavior-preserving refactor plan with
+invariants, validation commands, rollback notes, residual risks, and small
+execution slices.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `refactoring_helper.v1`.
+- `mode`: one of `plan_refactor`, `slice_refactor`,
+  `review_refactor_plan`, or `prepare_refactor_handoff`.
+- `target`: bounded files, modules, diff paths, plan path, or handoff target.
+- `current_behavior`: source-grounded description of behavior to preserve.
+- `refactor_intent`: structural improvement intent and any explicit behavior
+  changes.
+- `policy`: refactor safety and stop-boundary policy.
+
+## Optional Fields
+
+- `artifact_root`: refactor plan destination.
+- `known_risks`
+- `invariants`
+- `validation_commands`
+- `rollback_constraints`
+
+## Policy Fields
+
+- `behavior_change_allowed`
+- `max_slice_count`
+- `require_tests_before_edits`
+- `require_rollback_notes`
+- `stop_before_broad_rewrite`
+- `write_refactor_artifact`
+
+## Example
+
+```yaml
+skill_input_schema: refactoring_helper.v1
+mode: plan_refactor
+target:
+  paths:
+    - adl/src/cli/pr_cmd.rs
+current_behavior:
+  preserve:
+    - issue lifecycle commands keep root main clean
+    - started issue work happens in issue worktrees
+refactor_intent:
+  summary: split branch/worktree guard helpers from publication code without behavior changes
+  behavior_change_allowed: false
+policy:
+  behavior_change_allowed: false
+  max_slice_count: 4
+  require_tests_before_edits: true
+  require_rollback_notes: true
+  stop_before_broad_rewrite: true
+  write_refactor_artifact: true
+```
+
+## Output Contract
+
+Default artifact root:
+
+```text
+.adl/reviews/refactoring-helper/<run_id>/
+```
+
+Required artifacts:
+
+- `refactor_plan.md`
+- `refactor_plan.json`
+
+Statuses:
+
+- `ready`: bounded slices and validation proof are available.
+- `partial`: evidence, invariants, or validation proof are incomplete.
+- `not_run`: bounded target missing.
+- `blocked`: request violates broad-rewrite, mutation, or behavior-change
+  boundary.
+
+## Stop Boundary
+
+The skill must not perform large unbounded rewrites, make silent behavior
+changes, delete code without proof, create issues or PRs, claim implementation
+completion, or mutate repositories without explicit operator approval.

--- a/adl/tools/skills/refactoring-helper/SKILL.md
+++ b/adl/tools/skills/refactoring-helper/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: refactoring-helper
+description: Plan and bound source-grounded refactoring work by turning a concrete code surface into small behavior-preserving slices with invariants, risk inventory, validation commands, rollback notes, and residual risks, while stopping before broad rewrites or silent behavior changes.
+---
+
+# Refactoring Helper
+
+Use this skill when a messy code surface needs a safer refactoring path before
+implementation. The skill creates a behavior-preserving refactor plan, bounded
+refactor plans, and execution slices; it does not turn vague cleanup instincts
+into broad rewrites.
+
+## Quick Start
+
+1. Confirm the bounded code surface:
+   - exact files, modules, diff, or issue scope
+   - current behavior to preserve
+   - explicit behavior changes, if any
+2. Identify invariants before edits:
+   - public API behavior
+   - persistence or artifact format
+   - ordering or determinism guarantees
+   - security/privacy boundaries
+   - compatibility contracts
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/plan_refactor.py <refactor-root> --out <artifact-root>`
+4. Review the refactor plan, risk inventory, validation plan, slices, and
+   rollback notes.
+5. Stop unless the operator explicitly asks to implement one bounded slice.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `mode`
+- `target`
+- `current_behavior`
+- `refactor_intent`
+- `policy`
+
+Supported modes:
+
+- `plan_refactor`
+- `slice_refactor`
+- `review_refactor_plan`
+- `prepare_refactor_handoff`
+
+Useful policy fields:
+
+- `behavior_change_allowed`
+- `max_slice_count`
+- `require_tests_before_edits`
+- `require_rollback_notes`
+- `stop_before_broad_rewrite`
+- `write_refactor_artifact`
+
+If no bounded target is supplied, stop and report `not_run`. If behavior change
+is requested, name it explicitly and keep it separate from behavior-preserving
+refactor work.
+
+## Refactor Slice Rules
+
+Each slice should include:
+
+- the smallest coherent code surface
+- behavior-preservation intent or explicit behavior-change note
+- invariants that must remain true
+- likely changed files
+- validation commands and what they prove
+- rollback notes
+- residual risk and follow-on slices
+
+Prefer sequencing that reduces blast radius:
+
+1. characterization or contract tests
+2. extraction or naming cleanup
+3. dependency boundary tightening
+4. internal data-shape cleanup
+5. deletion of dead paths only after proof exists
+
+## Output
+
+Write Markdown and JSON artifacts when an output root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/refactoring-helper/<run_id>/
+```
+
+Required artifacts:
+
+- `refactor_plan.md`
+- `refactor_plan.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+This skill must not:
+
+- perform large unbounded rewrites
+- make silent behavior changes
+- skip invariant identification before proposing edits
+- replace code review, test generation, CI, or human approval
+- claim implementation completion when it only produced a plan
+- create issues, PRs, commits, or release notes without explicit operator
+  approval
+- delete code without proof that the path is unused or replaced
+
+Handoff candidates:
+
+- `test-generator` when characterization or regression tests are needed.
+- `repo-code-review` when the code surface needs defect review before planning.
+- `gap-analysis` when refactor output must be compared to an expected contract.
+- `finding-to-issue-planner` when human-approved follow-up issues are needed.
+
+## Blocked States
+
+Return `not_run` when the bounded target is missing.
+
+Return `blocked` when the request requires broad rewrite, silent behavior
+change, repo mutation, or issue/PR creation without explicit approval.
+
+Return `partial` when the plan can be produced but the evidence is incomplete or
+important invariants are unknown.

--- a/adl/tools/skills/refactoring-helper/adl-skill.yaml
+++ b/adl/tools/skills/refactoring-helper/adl-skill.yaml
@@ -1,0 +1,119 @@
+version: "0.1"
+kind: "adl-skill"
+id: "refactoring-helper"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "refactoring_helper.v1"
+    reference_doc: "../docs/REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "target"
+      - "current_behavior"
+      - "refactor_intent"
+      - "policy"
+    mode_enum:
+      - "plan_refactor"
+      - "slice_refactor"
+      - "review_refactor_plan"
+      - "prepare_refactor_handoff"
+    policy_fields:
+      - "behavior_change_allowed"
+      - "max_slice_count"
+      - "require_tests_before_edits"
+      - "require_rollback_notes"
+      - "stop_before_broad_rewrite"
+      - "write_refactor_artifact"
+    mode_requirements:
+      plan_refactor:
+        required_target_fields:
+          - "paths"
+      slice_refactor:
+        required_target_fields:
+          - "paths"
+          - "selected_slice"
+      review_refactor_plan:
+        required_target_fields:
+          - "refactor_plan_path"
+      prepare_refactor_handoff:
+        required_target_fields:
+          - "paths"
+          - "handoff_recipient"
+  intent:
+    - "refactor_planning"
+    - "safe_refactor_slicing"
+    - "behavior_preservation"
+    - "validation_planning"
+  required_inputs:
+    - "target"
+    - "current_behavior"
+    - "refactor_intent"
+    - "policy"
+  optional_inputs:
+    - "artifact_root"
+    - "known_risks"
+    - "invariants"
+    - "validation_commands"
+    - "rollback_constraints"
+  stop_if_missing:
+    - "target"
+  prevalidation_rules:
+    - "bounded_target_must_be_explicit"
+    - "skill_input_schema_must_equal_refactoring_helper.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.stop_before_broad_rewrite_must_be_true"
+    - "behavior_change_must_be_explicit_when_allowed"
+execution:
+  mode: "plan_then_optional_single_slice"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/plan_refactor.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<refactor-root>"
+        - "--out <artifact-root>"
+        - "--run-id <id>"
+        - "--max-slices <n>"
+  preferred_read_order:
+    - "refactor_manifest.json"
+    - "target_surface.md"
+    - "current_behavior.md"
+    - "refactor_intent.md"
+    - "invariants.md"
+    - "validation.md"
+    - "known_risks.md"
+  invocation_guidance: "require_bounded_target_and_behavior_preservation_before_planning"
+boundaries:
+  must_not_run:
+    - "large_unbounded_rewrite"
+    - "silent_behavior_change"
+    - "unreviewed_code_deletion"
+    - "test_skipping_for_behavioral_surface"
+    - "tracker_item_creation"
+    - "pull_request_creation"
+    - "release_approval"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/refactoring-helper/<run_id>/"
+  required_artifacts:
+    - "refactor_plan.md"
+    - "refactor_plan.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_silent_behavior_changes: true
+  no_mutation_without_operator_approval: true
+  manifest_declares_executables: true
+
+display_name: Refactoring Helper
+short_description: Plan bounded behavior-preserving refactor slices with invariants, tests, and rollback notes
+default_prompt: Turn a bounded code surface into a safe refactor plan. Identify current behavior, invariants, risks, validation commands, small execution slices, rollback notes, and residual risks; stop before broad rewrites, silent behavior changes, or unapproved repository mutation.

--- a/adl/tools/skills/refactoring-helper/agents/openai.yaml
+++ b/adl/tools/skills/refactoring-helper/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Refactoring Helper
+short_description: Plan bounded behavior-preserving refactor slices with invariants, tests, and rollback notes
+default_prompt: Turn a bounded code surface into a safe refactor plan. Identify current behavior, invariants, risks, validation commands, small execution slices, rollback notes, and residual risks; stop before broad rewrites, silent behavior changes, or unapproved repository mutation.

--- a/adl/tools/skills/refactoring-helper/references/output-contract.md
+++ b/adl/tools/skills/refactoring-helper/references/output-contract.md
@@ -1,0 +1,85 @@
+# Output Contract
+
+The refactoring-helper skill produces bounded refactor plans for explicit code
+surfaces. It can prepare a safe implementation handoff, but it does not by
+itself claim the refactor was implemented.
+
+Default artifact root:
+
+```text
+.adl/reviews/refactoring-helper/<run_id>/
+```
+
+## Required Artifacts
+
+### refactor_plan.md
+
+Required sections:
+
+- Refactor Plan Summary
+- Scope
+- Current Behavior
+- Refactor Intent
+- Invariants
+- Risk Inventory
+- Refactor Slices
+- Validation Plan
+- Rollback Notes
+- Residual Risk
+- Stop Boundary
+
+### refactor_plan.json
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `status`
+- `scope`
+- `target`
+- `current_behavior`
+- `refactor_intent`
+- `invariants`
+- `risks`
+- `slices`
+- `validation_plan`
+- `rollback_notes`
+- `residual_risk`
+- `stop_boundary`
+
+## Status Values
+
+- `ready`: bounded slices and validation proof are available.
+- `partial`: a useful plan exists, but evidence, invariants, or validation proof
+  are incomplete.
+- `not_run`: no bounded target was supplied.
+- `blocked`: the request would require broad rewrite, silent behavior change,
+  unapproved mutation, or unsafe deletion.
+
+## Slice Shape
+
+Each slice must include:
+
+- stable id
+- title
+- intent
+- behavior change flag
+- target files or surfaces
+- invariants
+- validation commands
+- rollback notes
+- residual risk
+- follow-up slice or explicit none
+
+## Rules
+
+- Require a bounded target before planning.
+- Identify behavior-preserving intent unless a behavior change is explicit.
+- Identify invariants before edits.
+- Prefer small slices over broad rewrites.
+- Treat missing tests as a risk or validation prerequisite.
+- Use repo-relative, issue-relative, or packet-relative paths.
+- Do not write absolute host paths into plan artifacts.
+- Do not claim implementation, merge-readiness, release-readiness, or approval.
+- Do not create issues, PRs, commits, fixes, test files, or code edits without
+  explicit operator approval.

--- a/adl/tools/skills/refactoring-helper/references/refactoring-playbook.md
+++ b/adl/tools/skills/refactoring-helper/references/refactoring-playbook.md
@@ -1,0 +1,35 @@
+# Refactoring Playbook
+
+## Planning Checklist
+
+- Bound the target to named files, modules, diff paths, or issue surfaces.
+- State whether behavior must be preserved or behavior change is explicitly in
+  scope.
+- List invariants before proposing edits.
+- List available tests and missing characterization tests.
+- Split the plan into independently reviewable slices.
+- Attach rollback notes to each slice.
+- Record residual risk instead of pretending the plan proves everything.
+
+## Slice Heuristics
+
+- Start with characterization tests when behavior is risky or underspecified.
+- Prefer extraction and naming cleanup before data-shape changes.
+- Move one boundary at a time.
+- Delete only after evidence proves the path is unused or replaced.
+- Keep generated artifacts and public formats stable unless a migration is named.
+
+## Validation Heuristics
+
+- Use the smallest command that proves the changed surface.
+- Pair each command with the invariant it verifies.
+- Record not-run validation as residual risk.
+- Do not substitute formatting for behavior proof.
+
+## Unsafe Signals
+
+- target described only as "cleanup everything"
+- behavior change is implied but not named
+- tests are absent for public or persistence behavior
+- refactor spans unrelated subsystems
+- rollback would require reconstructing lost behavior from memory

--- a/adl/tools/skills/refactoring-helper/scripts/plan_refactor.py
+++ b/adl/tools/skills/refactoring-helper/scripts/plan_refactor.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Create a bounded refactor plan from explicit target and evidence files."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "adl.refactor_plan.v1"
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def rel(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def extract_bullets_after(text: str, heading: str) -> list[str]:
+    pattern = re.compile(rf"^##+\s+{re.escape(heading)}\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        return []
+    next_heading = re.search(r"^##+\s+", text[match.end() :], re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(text)
+    section = text[match.end() : end]
+    return [line.strip()[2:].strip() for line in section.splitlines() if line.strip().startswith("- ")][:80]
+
+
+def bullet_file(root: Path, name: str, heading: str) -> list[str]:
+    text = read_text(root / name)
+    return extract_bullets_after(text, heading) or [line.strip()[2:].strip() for line in text.splitlines() if line.strip().startswith("- ")]
+
+
+def line_value(text: str, key: str) -> str:
+    pattern = re.compile(rf"^\s*-\s*{re.escape(key)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    return match.group(1).strip() if match else ""
+
+
+def metadata(root: Path) -> dict[str, Any]:
+    manifest = load_json(root / "refactor_manifest.json")
+    if not isinstance(manifest, dict):
+        manifest = {}
+    target_text = read_text(root / "target_surface.md")
+    targets = manifest.get("target_paths")
+    if not isinstance(targets, list):
+        targets = bullet_file(root, "target_surface.md", "Target Surface")
+    return {
+        "run_id": str(manifest.get("run_id") or root.name),
+        "scope": str(manifest.get("scope") or line_value(target_text, "Scope") or root.name),
+        "mode": str(manifest.get("mode") or "plan_refactor"),
+        "target_paths": [str(item) for item in targets if str(item).strip()],
+    }
+
+
+def has_behavior_change(intent: str) -> bool:
+    lowered = intent.lower()
+    return "behavior change" in lowered or "change behavior" in lowered or "semantic change" in lowered
+
+
+def default_validation(root: Path) -> list[str]:
+    commands = bullet_file(root, "validation.md", "Validation Commands")
+    return commands or ["Run the smallest focused test or check that proves the touched surface still preserves behavior."]
+
+
+def infer_risks(root: Path, invariants: list[str], validation: list[str]) -> list[dict[str, str]]:
+    risks = []
+    for index, risk in enumerate(bullet_file(root, "known_risks.md", "Risks"), start=1):
+        risks.append({"id": f"R-{index:03d}", "risk": risk, "mitigation": "Address or validate before the affected slice lands."})
+    if not invariants:
+        risks.append({"id": f"R-{len(risks)+1:03d}", "risk": "No invariants were supplied.", "mitigation": "Identify invariants before implementation."})
+    if not validation:
+        risks.append({"id": f"R-{len(risks)+1:03d}", "risk": "No validation commands were supplied.", "mitigation": "Add focused validation before edits land."})
+    return risks
+
+
+def make_slices(targets: list[str], intent: str, invariants: list[str], validation: list[str], max_slices: int) -> list[dict[str, object]]:
+    if not targets:
+        return []
+    selected = targets[: max(1, max_slices)]
+    slices = []
+    behavior_change = has_behavior_change(intent)
+    for index, target in enumerate(selected, start=1):
+        slices.append(
+            {
+                "id": f"S-{index:03d}",
+                "title": f"Refactor {target}",
+                "intent": intent or "Improve internal structure while preserving externally visible behavior.",
+                "behavior_change": behavior_change,
+                "target_files": [target],
+                "invariants": invariants or ["Current externally visible behavior must remain unchanged."],
+                "validation_commands": validation,
+                "rollback_notes": f"Revert this slice independently if validation for {target} fails.",
+                "residual_risk": "Review call sites and tests for behavior assumptions not visible in the supplied bundle.",
+                "follow_up": "Continue with the next bounded slice after validation passes." if index < len(selected) else "None.",
+            }
+        )
+    return slices
+
+
+def stop_boundary() -> dict[str, bool]:
+    return {
+        "performed_refactor": False,
+        "changed_behavior": False,
+        "created_issues": False,
+        "created_prs": False,
+        "committed_changes": False,
+        "mutated_repository": False,
+    }
+
+
+def analyze(root: Path, max_slices: int) -> dict[str, object]:
+    meta = metadata(root)
+    current_behavior = read_text(root / "current_behavior.md").strip()
+    refactor_intent = read_text(root / "refactor_intent.md").strip()
+    invariants = bullet_file(root, "invariants.md", "Invariants")
+    validation = default_validation(root)
+    if not meta["target_paths"]:
+        return {
+            "schema": SCHEMA,
+            "created_at": now_utc(),
+            "run_id": meta["run_id"],
+            "status": "not_run",
+            "scope": meta["scope"],
+            "target": {"paths": [], "mode": meta["mode"]},
+            "current_behavior": current_behavior or "Not supplied.",
+            "refactor_intent": refactor_intent or "Not supplied.",
+            "invariants": invariants,
+            "risks": [{"id": "R-001", "risk": "Bounded target missing.", "mitigation": "Provide target paths before planning."}],
+            "slices": [],
+            "validation_plan": validation,
+            "rollback_notes": ["No rollback notes because no slice was planned."],
+            "residual_risk": ["No target was supplied; no refactor plan was produced."],
+            "stop_boundary": stop_boundary(),
+        }
+    risks = infer_risks(root, invariants, validation)
+    slices = make_slices(meta["target_paths"], refactor_intent, invariants, validation, max_slices)
+    status = "ready" if current_behavior and refactor_intent and invariants else "partial"
+    residual = ["Behavior change is explicitly in scope; review this separately from structural cleanup."] if has_behavior_change(refactor_intent) else []
+    if status == "partial":
+        residual.append("Some current behavior, intent, or invariant evidence is missing.")
+    residual.append("Human review and CI remain required before any slice is merged.")
+    return {
+        "schema": SCHEMA,
+        "created_at": now_utc(),
+        "run_id": meta["run_id"],
+        "status": status,
+        "scope": meta["scope"],
+        "target": {"paths": meta["target_paths"], "mode": meta["mode"]},
+        "current_behavior": current_behavior or "Not supplied.",
+        "refactor_intent": refactor_intent or "Not supplied.",
+        "invariants": invariants or ["Current externally visible behavior must remain unchanged."],
+        "risks": risks,
+        "slices": slices,
+        "validation_plan": validation,
+        "rollback_notes": [str(item["rollback_notes"]) for item in slices] or ["No slices planned."],
+        "residual_risk": residual,
+        "stop_boundary": stop_boundary(),
+    }
+
+
+def bullet_lines(items: list[Any]) -> str:
+    return "\n".join(f"- {item}" for item in items) if items else "- None."
+
+
+def risk_lines(risks: list[dict[str, str]]) -> str:
+    return "\n".join(f"- {risk['id']}: {risk['risk']} Mitigation: {risk['mitigation']}" for risk in risks) if risks else "- None."
+
+
+def slice_lines(slices: list[dict[str, object]]) -> str:
+    if not slices:
+        return "- No slices planned."
+    parts = []
+    for item in slices:
+        parts.append(
+            f"""### {item['id']}: {item['title']}
+
+- Intent: {item['intent']}
+- Behavior change: {str(item['behavior_change']).lower()}
+- Target files: {', '.join(str(path) for path in item['target_files'])}
+- Invariants: {', '.join(str(inv) for inv in item['invariants'])}
+- Validation commands: {', '.join(str(command) for command in item['validation_commands'])}
+- Rollback notes: {item['rollback_notes']}
+- Residual risk: {item['residual_risk']}
+- Follow-up: {item['follow_up']}
+"""
+        )
+    return "\n".join(parts)
+
+
+def write_markdown(path: Path, report: dict[str, object]) -> None:
+    boundary = report["stop_boundary"]
+    content = f"""# Refactor Plan: {report['scope']}
+
+## Refactor Plan Summary
+
+- Status: {report['status']}
+- Run id: {report['run_id']}
+- Planned slices: {len(report['slices'])}
+
+## Scope
+
+- Scope: {report['scope']}
+- Mode: {report['target']['mode']}
+- Target paths:
+{bullet_lines(report['target']['paths'])}
+
+## Current Behavior
+
+{report['current_behavior']}
+
+## Refactor Intent
+
+{report['refactor_intent']}
+
+## Invariants
+
+{bullet_lines(report['invariants'])}
+
+## Risk Inventory
+
+{risk_lines(report['risks'])}
+
+## Refactor Slices
+
+{slice_lines(report['slices'])}
+
+## Validation Plan
+
+{bullet_lines(report['validation_plan'])}
+
+## Rollback Notes
+
+{bullet_lines(report['rollback_notes'])}
+
+## Residual Risk
+
+{bullet_lines(report['residual_risk'])}
+
+## Stop Boundary
+
+- Performed refactor: {str(boundary['performed_refactor']).lower()}.
+- Changed behavior: {str(boundary['changed_behavior']).lower()}.
+- Created issues: {str(boundary['created_issues']).lower()}.
+- Created PRs: {str(boundary['created_prs']).lower()}.
+- Committed changes: {str(boundary['committed_changes']).lower()}.
+- Mutated repository: {str(boundary['mutated_repository']).lower()}.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("refactor_root", help="Directory containing refactor input evidence")
+    parser.add_argument("--out", default=None, help="Refactor plan output root")
+    parser.add_argument("--run-id", default=None, help="Run id override")
+    parser.add_argument("--max-slices", type=int, default=5, help="Maximum slices to emit")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.refactor_root)
+    if not root.is_dir():
+        raise SystemExit(f"refactor root does not exist: {root}")
+    out_root = Path(args.out) if args.out else root / "refactoring-helper"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+    report = analyze(root, args.max_slices)
+    if args.run_id:
+        report["run_id"] = args.run_id
+    write_json(out_root / "refactor_plan.json", report)
+    write_markdown(out_root / "refactor_plan.md", report)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_refactoring_helper_skill_contracts.sh
+++ b/adl/tools/test_refactoring_helper_skill_contracts.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/refactoring-helper/SKILL.md" ]]
+[[ -f "${skills_root}/refactoring-helper/adl-skill.yaml" ]]
+[[ -f "${skills_root}/refactoring-helper/agents/openai.yaml" ]]
+[[ -f "${skills_root}/refactoring-helper/references/refactoring-playbook.md" ]]
+[[ -f "${skills_root}/refactoring-helper/references/output-contract.md" ]]
+[[ -x "${skills_root}/refactoring-helper/scripts/plan_refactor.py" ]]
+[[ -f "${skills_root}/docs/REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "refactoring-helper"' "${skills_root}/refactoring-helper/adl-skill.yaml"
+grep -Fq 'id: "refactoring_helper.v1"' "${skills_root}/refactoring-helper/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/refactoring-helper/adl-skill.yaml"
+grep -Fq "bounded_target_must_be_explicit" "${skills_root}/refactoring-helper/adl-skill.yaml"
+grep -Fq "behavior-preserving refactor plan" "${skills_root}/refactoring-helper/SKILL.md"
+grep -Fq "Do not claim implementation" "${skills_root}/refactoring-helper/references/output-contract.md"
+grep -Fq "Schema id: \`refactoring_helper.v1\`" "${skills_root}/docs/REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md"
+
+refactor_root="${tmpdir}/refactor"
+plan_root="${tmpdir}/refactor-plan"
+mkdir -p "${refactor_root}"
+cat >"${refactor_root}/refactor_manifest.json" <<'JSON'
+{
+  "run_id": "refactoring-helper-contract-test",
+  "scope": "issue-2043",
+  "mode": "plan_refactor",
+  "target_paths": [
+    "adl/src/cli/pr_cmd.rs",
+    "adl/src/cli/pr_cmd_validate.rs"
+  ]
+}
+JSON
+cat >"${refactor_root}/current_behavior.md" <<'MD'
+# Current Behavior
+
+The PR lifecycle keeps root main clean while binding implementation work to issue worktrees.
+MD
+cat >"${refactor_root}/refactor_intent.md" <<'MD'
+# Refactor Intent
+
+Improve internal structure while preserving externally visible behavior.
+MD
+cat >"${refactor_root}/invariants.md" <<'MD'
+# Invariants
+
+## Invariants
+
+- Root main remains clean and is not used for tracked implementation edits.
+- Issue worktrees remain traceable to the issue branch.
+MD
+cat >"${refactor_root}/validation.md" <<'MD'
+# Validation
+
+## Validation Commands
+
+- cargo test -p adl --lib cli::pr_cmd
+- bash adl/tools/test_pr_lifecycle_contracts.sh
+MD
+cat >"${refactor_root}/known_risks.md" <<'MD'
+# Known Risks
+
+## Risks
+
+- Lifecycle helper refactors can accidentally weaken root checkout guardrails.
+MD
+
+python3 "${skills_root}/refactoring-helper/scripts/plan_refactor.py" \
+  "${refactor_root}" --out "${plan_root}" --max-slices 2 >/tmp/refactoring-helper.out
+[[ -f "${plan_root}/refactor_plan.json" ]]
+[[ -f "${plan_root}/refactor_plan.md" ]]
+grep -Fq '"schema": "adl.refactor_plan.v1"' "${plan_root}/refactor_plan.json"
+grep -Fq '"run_id": "refactoring-helper-contract-test"' "${plan_root}/refactor_plan.json"
+grep -Fq '"status": "ready"' "${plan_root}/refactor_plan.json"
+grep -Fq '"performed_refactor": false' "${plan_root}/refactor_plan.json"
+grep -Fq '"mutated_repository": false' "${plan_root}/refactor_plan.json"
+grep -Fq "## Refactor Plan Summary" "${plan_root}/refactor_plan.md"
+grep -Fq "## Refactor Slices" "${plan_root}/refactor_plan.md"
+grep -Fq "Performed refactor: false." "${plan_root}/refactor_plan.md"
+grep -Fq "Mutated repository: false." "${plan_root}/refactor_plan.md"
+
+missing_root="${tmpdir}/missing-target"
+mkdir -p "${missing_root}"
+python3 "${skills_root}/refactoring-helper/scripts/plan_refactor.py" \
+  "${missing_root}" --out "${tmpdir}/missing-plan" >/tmp/refactoring-helper-missing.out
+grep -Fq '"status": "not_run"' "${tmpdir}/missing-plan/refactor_plan.json"
+
+if grep -R "${tmpdir}" "${plan_root}" "${tmpdir}/missing-plan" >/dev/null; then
+  echo "refactoring helper artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+if find "${plan_root}" -name '*.rs' -o -name '*.py' -o -name '*.ts' | grep -q .; then
+  echo "refactoring helper should not write implementation files" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/refactoring-helper/SKILL.md"
+
+echo "PASS test_refactoring_helper_skill_contracts"


### PR DESCRIPTION
Closes #2043

## Summary
Implemented the refactoring-helper operational skill as a bounded planning skill for safe refactor work. The skill requires explicit target scope, current behavior, refactor intent, invariants, validation commands, rollback notes, and residual-risk recording before any implementation handoff. It stops before broad rewrites, silent behavior changes, issue creation, PR creation, commits, or unapproved repository mutation.

## Artifacts
- adl/tools/skills/refactoring-helper/SKILL.md
- adl/tools/skills/refactoring-helper/adl-skill.yaml
- adl/tools/skills/refactoring-helper/agents/openai.yaml
- adl/tools/skills/refactoring-helper/references/output-contract.md
- adl/tools/skills/refactoring-helper/references/refactoring-playbook.md
- adl/tools/skills/refactoring-helper/scripts/plan_refactor.py
- adl/tools/skills/docs/REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md
- adl/tools/test_refactoring_helper_skill_contracts.sh
- adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md

## Validation
- Validation commands and their purpose:
  - python3 -m py_compile adl/tools/skills/refactoring-helper/scripts/plan_refactor.py verified the helper script compiles.
  - bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/refactoring-helper/SKILL.md verified required skill frontmatter.
  - bash adl/tools/test_refactoring_helper_skill_contracts.sh verified the new skill bundle, schema wiring, deterministic helper outputs, stop boundary, missing-target not-run behavior, no temp path leakage, and no implementation-file generation.
  - bash adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh verified the existing multi-agent suite contract still passes after adding the refactoring-helper lane.
  - git diff --check verified whitespace hygiene.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2043__backlog-skills-add-refactoring-helper-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2043__backlog-skills-add-refactoring-helper-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-refactoring-helper-skill-adl-tools-skills-refactoring-helper-adl-tools-skills-docs-refactoring-helper-skill-input-schema-md-adl-tools-skills-docs-multi-agent-repo-review-skill-suite-md-adl-tools-test-refactoring-helper-skill-contracts-sh-adl-v0-90-tasks-issue-2043-backlog-skills-add-refactoring-helper-skill-sip-md-adl-v0-90-tasks-issue-2043-backlog-skills-add-refactoring-helper-skill-sor-md