### PR TITLE
[v0.90][backlog][skills] Add use case writer skill

### DIFF
--- a/adl/tools/skills/docs/USE_CASE_WRITER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/USE_CASE_WRITER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,79 @@
+# Use Case Writer Skill Input Schema
+
+Schema id: `use_case_writer.v1`
+
+## Purpose
+
+Turn one declared source brief, issue, feature, demo, or milestone context into
+grounded use cases, actor flows, concrete scenarios, and acceptance-oriented
+examples without inventing product commitments or implementation status.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `use_case_writer.v1`.
+- `mode`: one of `write_prd_use_cases`, `write_issue_use_cases`,
+  `write_demo_use_cases`, or `write_milestone_use_cases`.
+- `source`: declared source brief, issue, demo plan, or milestone plan.
+- `audience`: target reader for the packet.
+- `policy`: source grounding and stop-boundary policy.
+
+## Optional Fields
+
+- `artifact_root`: use-case packet destination.
+- `actors`
+- `acceptance_hooks`
+- `non_goals`
+- `unsupported_assumptions`
+
+## Policy Fields
+
+- `source_required`
+- `unsupported_assumptions_policy`
+- `implementation_status_claims_allowed`
+- `issue_creation_allowed`
+- `write_use_case_artifact`
+- `stop_before_commitment`
+
+## Example
+
+```yaml
+skill_input_schema: use_case_writer.v1
+mode: write_demo_use_cases
+source:
+  demo_plan_path: docs/milestones/v0.90/features/STOCK_LEAGUE_DEMO.md
+audience: milestone reviewer
+policy:
+  source_required: true
+  unsupported_assumptions_policy: record_explicitly
+  implementation_status_claims_allowed: false
+  issue_creation_allowed: false
+  write_use_case_artifact: true
+  stop_before_commitment: true
+```
+
+## Output Contract
+
+Default artifact root:
+
+```text
+.adl/reviews/use-case-writer/<run_id>/
+```
+
+Required artifacts:
+
+- `use_case_packet.md`
+- `use_case_packet.json`
+
+Statuses:
+
+- `ready`: source-grounded actors, use cases, and acceptance hooks are present.
+- `partial`: packet is useful but needs human review for missing evidence.
+- `not_run`: declared source missing.
+- `blocked`: request violates product-commitment, implementation-claim,
+  issue-creation, PR-creation, publication, or mutation boundary.
+
+## Stop Boundary
+
+The skill must not create issues, create PRs, publish externally, claim
+implementation completion, replace implementation planning, or promote
+unsupported assumptions into requirements.

--- a/adl/tools/skills/use-case-writer/SKILL.md
+++ b/adl/tools/skills/use-case-writer/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: use-case-writer
+description: Turn one declared source brief, issue, feature, demo, or milestone context into grounded use-case packets with actors, goals, scenarios, success and failure flows, acceptance hooks, assumptions, unsupported assumptions, and non-goals without inventing product commitments or implementation status.
+---
+
+# Use Case Writer
+
+Use this skill when a product, runtime, demo, feature, or milestone idea needs a
+reviewable use-case packet. The skill writes source-grounded use cases; it does
+not invent roadmap commitments, implementation status, or requirements that are
+not supported by the supplied brief.
+
+## Quick Start
+
+1. Confirm the declared source:
+   - issue body
+   - feature brief
+   - product note
+   - demo plan
+   - milestone planning doc
+2. Identify the actors, user goals, system behavior, acceptance hooks, and
+   non-goals that are explicitly supported.
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/write_use_cases.py <use-case-root> --out <artifact-root>`
+4. Review unsupported assumptions before treating the packet as product truth.
+5. Stop before creating issues, PRs, implementation plans, or external claims.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `mode`
+- `source`
+- `audience`
+- `policy`
+
+Supported modes:
+
+- `write_prd_use_cases`
+- `write_issue_use_cases`
+- `write_demo_use_cases`
+- `write_milestone_use_cases`
+
+Useful policy fields:
+
+- `source_required`
+- `unsupported_assumptions_policy`
+- `implementation_status_claims_allowed`
+- `issue_creation_allowed`
+- `write_use_case_artifact`
+- `stop_before_commitment`
+
+If there is no declared source brief or issue context, stop and report
+`not_run`. Do not backfill missing product intent from plausible-sounding
+requirements.
+
+## Use Case Rules
+
+Each use case should distinguish:
+
+- actor
+- user goal
+- system behavior
+- trigger
+- preconditions
+- success flow
+- failure or edge flow
+- acceptance hooks
+- evidence source
+- non-goals
+- unsupported assumptions
+
+When source evidence is incomplete, record the unsupported assumption instead of
+silently turning it into a requirement.
+
+## Output
+
+Write Markdown and JSON artifacts when an output root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/use-case-writer/<run_id>/
+```
+
+Required artifacts:
+
+- `use_case_packet.md`
+- `use_case_packet.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+This skill must not:
+
+- create GitHub issues, PRs, commits, release notes, or implementation plans
+- claim implementation status unless the source explicitly proves it
+- invent product requirements, user personas, business commitments, timelines,
+  success metrics, or demos
+- convert unsupported assumptions into acceptance criteria
+- replace implementation planning, product approval, or milestone approval
+- publish externally without explicit approval
+
+Handoff candidates:
+
+- `finding-to-issue-planner` when human-approved issue candidates are needed.
+- `documentation-specialist` or docs authoring workflows when a packet should
+  become published documentation.
+- `gap-analysis` when a use-case packet must be checked against implementation
+  or milestone evidence.
+- `refactoring-helper` only when use cases expose code-structure follow-up that
+  needs bounded refactor planning.
+
+## Blocked States
+
+Return `not_run` when the source brief or issue context is missing.
+
+Return `blocked` when the requested output requires unsupported product
+commitments, implementation claims, issue creation, PR creation, publication, or
+repository mutation.
+
+Return `partial` when a packet can be produced but important actor, behavior, or
+acceptance evidence is missing.

--- a/adl/tools/skills/use-case-writer/adl-skill.yaml
+++ b/adl/tools/skills/use-case-writer/adl-skill.yaml
@@ -1,0 +1,117 @@
+version: "0.1"
+kind: "adl-skill"
+id: "use-case-writer"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "use_case_writer.v1"
+    reference_doc: "../docs/USE_CASE_WRITER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "source"
+      - "audience"
+      - "policy"
+    mode_enum:
+      - "write_prd_use_cases"
+      - "write_issue_use_cases"
+      - "write_demo_use_cases"
+      - "write_milestone_use_cases"
+    policy_fields:
+      - "source_required"
+      - "unsupported_assumptions_policy"
+      - "implementation_status_claims_allowed"
+      - "issue_creation_allowed"
+      - "write_use_case_artifact"
+      - "stop_before_commitment"
+    mode_requirements:
+      write_prd_use_cases:
+        required_source_fields:
+          - "brief_path"
+      write_issue_use_cases:
+        required_source_fields:
+          - "issue_ref"
+      write_demo_use_cases:
+        required_source_fields:
+          - "demo_plan_path"
+      write_milestone_use_cases:
+        required_source_fields:
+          - "milestone_plan_path"
+  intent:
+    - "use_case_authoring"
+    - "prd_examples"
+    - "issue_acceptance_examples"
+    - "demo_scenarios"
+    - "milestone_planning_examples"
+  required_inputs:
+    - "source"
+    - "audience"
+    - "policy"
+  optional_inputs:
+    - "artifact_root"
+    - "actors"
+    - "acceptance_hooks"
+    - "non_goals"
+    - "unsupported_assumptions"
+  stop_if_missing:
+    - "source"
+  prevalidation_rules:
+    - "declared_source_must_be_explicit"
+    - "skill_input_schema_must_equal_use_case_writer.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.source_required_must_be_true"
+    - "policy.stop_before_commitment_must_be_true"
+    - "implementation_status_claims_must_be_source_supported"
+execution:
+  mode: "source_grounded_authoring"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/write_use_cases.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "<use-case-root>"
+        - "--out <artifact-root>"
+        - "--run-id <id>"
+        - "--max-use-cases <n>"
+  preferred_read_order:
+    - "use_case_manifest.json"
+    - "source_brief.md"
+    - "actors.md"
+    - "goals.md"
+    - "system_behavior.md"
+    - "acceptance_hooks.md"
+    - "non_goals.md"
+    - "unsupported_assumptions.md"
+  invocation_guidance: "require_declared_source_before_writing_use_cases"
+boundaries:
+  must_not_run:
+    - "unsupported_requirement_invention"
+    - "implementation_status_claims_without_source"
+    - "tracker_item_creation"
+    - "pull_request_creation"
+    - "implementation_planning_takeover"
+    - "publication"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/use-case-writer/<run_id>/"
+  required_artifacts:
+    - "use_case_packet.md"
+    - "use_case_packet.json"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_unsupported_product_claims: true
+  no_mutation_without_operator_approval: true
+  manifest_declares_executables: true
+
+display_name: Use Case Writer
+short_description: Write source-grounded use-case packets without inventing product commitments
+default_prompt: Turn one declared source brief, issue, feature, demo, or milestone context into grounded use cases. Distinguish actors, user goals, system behavior, acceptance hooks, non-goals, assumptions, and unsupported assumptions; stop before issue creation, PR creation, publication, implementation planning, or unsupported product claims.

--- a/adl/tools/skills/use-case-writer/agents/openai.yaml
+++ b/adl/tools/skills/use-case-writer/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Use Case Writer
+short_description: Write source-grounded use-case packets without inventing product commitments
+default_prompt: Turn one declared source brief, issue, feature, demo, or milestone context into grounded use cases. Distinguish actors, user goals, system behavior, acceptance hooks, non-goals, assumptions, and unsupported assumptions; stop before issue creation, PR creation, publication, implementation planning, or unsupported product claims.

--- a/adl/tools/skills/use-case-writer/references/output-contract.md
+++ b/adl/tools/skills/use-case-writer/references/output-contract.md
@@ -1,0 +1,84 @@
+# Output Contract
+
+The use-case-writer skill produces source-grounded use-case packets from a
+declared brief, issue, feature, demo, or milestone context.
+
+Default artifact root:
+
+```text
+.adl/reviews/use-case-writer/<run_id>/
+```
+
+## Required Artifacts
+
+### use_case_packet.md
+
+Required sections:
+
+- Use Case Packet Summary
+- Source
+- Audience
+- Actors
+- Use Cases
+- Acceptance Hooks
+- Assumptions
+- Unsupported Assumptions
+- Non-goals
+- Stop Boundary
+
+### use_case_packet.json
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `status`
+- `source`
+- `audience`
+- `actors`
+- `use_cases`
+- `acceptance_hooks`
+- `assumptions`
+- `unsupported_assumptions`
+- `non_goals`
+- `stop_boundary`
+
+## Status Values
+
+- `ready`: packet is source-grounded and contains actors, use cases, and
+  acceptance hooks.
+- `partial`: packet is useful, but some actors, behavior, acceptance hooks, or
+  assumptions need human review.
+- `not_run`: no declared source was supplied.
+- `blocked`: the request requires unsupported product commitments,
+  implementation claims, issue creation, PR creation, publication, or repository
+  mutation.
+
+## Use Case Shape
+
+Each use case must include:
+
+- stable id
+- title
+- actor
+- user goal
+- system behavior
+- trigger
+- preconditions
+- success flow
+- failure or edge flow
+- acceptance hooks
+- evidence source
+- non-goals
+- unsupported assumptions
+
+## Rules
+
+- Require a declared source before writing.
+- Distinguish user goals, system behavior, acceptance hooks, and non-goals.
+- Flag unsupported assumptions instead of making them requirements.
+- Use repo-relative, issue-relative, or packet-relative paths.
+- Do not write absolute host paths into packet artifacts.
+- Do not claim implementation status unless source-supported.
+- Do not create issues, PRs, implementation plans, release notes, or external
+  publication artifacts.

--- a/adl/tools/skills/use-case-writer/references/use-case-writing-playbook.md
+++ b/adl/tools/skills/use-case-writer/references/use-case-writing-playbook.md
@@ -1,0 +1,28 @@
+# Use Case Writing Playbook
+
+## Source Grounding Checklist
+
+- Name the source brief, issue, feature, demo, or milestone context.
+- Extract actors from supplied text or mark them as assumptions.
+- Separate user goals from system behavior.
+- Convert acceptance criteria into acceptance hooks, not implementation plans.
+- Preserve non-goals and constraints.
+- Put uncertain product details into unsupported assumptions.
+
+## Useful Packet Shapes
+
+- PRD packet: product actors, goals, constraints, acceptance hooks, and open
+  assumptions.
+- Issue packet: one implementable scenario family tied to acceptance criteria.
+- Demo packet: operator/viewer flow, proof surface, happy path, and failure path.
+- Milestone packet: milestone-level actor flows and acceptance hooks without
+  claiming implementation completion.
+
+## Unsafe Signals
+
+- no declared source
+- invented personas or market claims
+- implementation status claimed from a planning doc alone
+- acceptance criteria created from unsupported assumptions
+- issue or PR creation requested without explicit operator approval
+- external publication or business claims requested without review

--- a/adl/tools/skills/use-case-writer/scripts/write_use_cases.py
+++ b/adl/tools/skills/use-case-writer/scripts/write_use_cases.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Create a source-grounded use-case packet from explicit brief files."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "adl.use_case_packet.v1"
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def rel(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def extract_bullets_after(text: str, heading: str) -> list[str]:
+    pattern = re.compile(rf"^##+\s+{re.escape(heading)}\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        return []
+    next_heading = re.search(r"^##+\s+", text[match.end() :], re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(text)
+    section = text[match.end() : end]
+    return [line.strip()[2:].strip() for line in section.splitlines() if line.strip().startswith("- ")][:80]
+
+
+def bullet_file(root: Path, name: str, heading: str) -> list[str]:
+    text = read_text(root / name)
+    return extract_bullets_after(text, heading) or [line.strip()[2:].strip() for line in text.splitlines() if line.strip().startswith("- ")]
+
+
+def line_value(text: str, key: str) -> str:
+    pattern = re.compile(rf"^\s*-\s*{re.escape(key)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(text)
+    return match.group(1).strip() if match else ""
+
+
+def metadata(root: Path) -> dict[str, str]:
+    manifest = load_json(root / "use_case_manifest.json")
+    if not isinstance(manifest, dict):
+        manifest = {}
+    source_text = read_text(root / "source_brief.md")
+    return {
+        "run_id": str(manifest.get("run_id") or root.name),
+        "mode": str(manifest.get("mode") or "write_prd_use_cases"),
+        "source_ref": str(manifest.get("source_ref") or line_value(source_text, "Source") or "source_brief.md"),
+        "audience": str(manifest.get("audience") or line_value(source_text, "Audience") or "reviewer"),
+    }
+
+
+def sentence_from(text: str, fallback: str) -> str:
+    cleaned = re.sub(r"\s+", " ", text).strip()
+    if not cleaned:
+        return fallback
+    match = re.search(r"(.+?[.!?])(?:\s|$)", cleaned)
+    return match.group(1) if match else cleaned[:180]
+
+
+def source_available(root: Path) -> bool:
+    return bool(read_text(root / "source_brief.md").strip() or load_json(root / "use_case_manifest.json"))
+
+
+def make_use_cases(
+    root: Path,
+    source_text: str,
+    actors: list[str],
+    goals: list[str],
+    behaviors: list[str],
+    acceptance: list[str],
+    non_goals: list[str],
+    unsupported: list[str],
+    max_use_cases: int,
+) -> list[dict[str, object]]:
+    if not actors and not goals and not behaviors:
+        return []
+    actors = actors or ["Primary user"]
+    goals = goals or [sentence_from(source_text, "Use the described capability successfully.")]
+    behaviors = behaviors or ["System behavior must follow the declared source without adding unsupported scope."]
+    acceptance = acceptance or ["Reviewer confirms the scenario is grounded in the declared source."]
+    use_cases = []
+    count = min(max_use_cases, max(len(goals), 1))
+    for index in range(count):
+        actor = actors[min(index, len(actors) - 1)]
+        goal = goals[min(index, len(goals) - 1)]
+        behavior = behaviors[min(index, len(behaviors) - 1)]
+        use_cases.append(
+            {
+                "id": f"UC-{index + 1:03d}",
+                "title": goal[:96],
+                "actor": actor,
+                "user_goal": goal,
+                "system_behavior": behavior,
+                "trigger": "Actor attempts the scenario described by the source brief.",
+                "preconditions": ["Declared source has been reviewed.", "No unsupported assumptions have been promoted to requirements."],
+                "success_flow": [
+                    "Actor starts from the declared context.",
+                    "System performs the source-supported behavior.",
+                    "Reviewer checks the acceptance hooks against the source.",
+                ],
+                "failure_or_edge_flow": [
+                    "If source evidence is missing, record an unsupported assumption instead of expanding scope.",
+                    "If behavior is not implemented, do not claim implementation status.",
+                ],
+                "acceptance_hooks": acceptance,
+                "evidence_source": "source_brief.md",
+                "non_goals": non_goals or ["Implementation planning is out of scope for this packet."],
+                "unsupported_assumptions": unsupported,
+            }
+        )
+    return use_cases
+
+
+def stop_boundary() -> dict[str, bool]:
+    return {
+        "created_issues": False,
+        "created_prs": False,
+        "claimed_implementation_complete": False,
+        "published_externally": False,
+        "mutated_repository": False,
+    }
+
+
+def analyze(root: Path, max_use_cases: int) -> dict[str, object]:
+    meta = metadata(root)
+    source_text = read_text(root / "source_brief.md")
+    actors = bullet_file(root, "actors.md", "Actors")
+    goals = bullet_file(root, "goals.md", "User Goals")
+    behaviors = bullet_file(root, "system_behavior.md", "System Behavior")
+    acceptance = bullet_file(root, "acceptance_hooks.md", "Acceptance Hooks")
+    non_goals = bullet_file(root, "non_goals.md", "Non-goals")
+    unsupported = bullet_file(root, "unsupported_assumptions.md", "Unsupported Assumptions")
+    assumptions = bullet_file(root, "assumptions.md", "Assumptions")
+    if not source_available(root):
+        return {
+            "schema": SCHEMA,
+            "created_at": now_utc(),
+            "run_id": meta["run_id"],
+            "status": "not_run",
+            "source": {"ref": "missing", "mode": meta["mode"]},
+            "audience": meta["audience"],
+            "actors": [],
+            "use_cases": [],
+            "acceptance_hooks": [],
+            "assumptions": [],
+            "unsupported_assumptions": ["Declared source brief or issue context is missing."],
+            "non_goals": ["No use-case packet was written because the source is missing."],
+            "stop_boundary": stop_boundary(),
+        }
+    use_cases = make_use_cases(root, source_text, actors, goals, behaviors, acceptance, non_goals, unsupported, max_use_cases)
+    status = "ready" if actors and goals and behaviors and acceptance else "partial"
+    unsupported_out = unsupported[:]
+    if not actors:
+        unsupported_out.append("Actors were not explicitly supplied; default actor labels require review.")
+    if not acceptance:
+        unsupported_out.append("Acceptance hooks were inferred as reviewer checks and require review.")
+    return {
+        "schema": SCHEMA,
+        "created_at": now_utc(),
+        "run_id": meta["run_id"],
+        "status": status,
+        "source": {"ref": meta["source_ref"], "mode": meta["mode"]},
+        "audience": meta["audience"],
+        "actors": actors or ["Primary user"],
+        "use_cases": use_cases,
+        "acceptance_hooks": acceptance or ["Reviewer confirms the scenario is grounded in the declared source."],
+        "assumptions": assumptions or ["Only source-supported goals and behavior should be treated as requirements."],
+        "unsupported_assumptions": unsupported_out,
+        "non_goals": non_goals or ["Implementation planning and tracker creation are out of scope."],
+        "stop_boundary": stop_boundary(),
+    }
+
+
+def bullet_lines(items: list[Any]) -> str:
+    return "\n".join(f"- {item}" for item in items) if items else "- None."
+
+
+def use_case_lines(use_cases: list[dict[str, object]]) -> str:
+    if not use_cases:
+        return "- No use cases written."
+    parts = []
+    for item in use_cases:
+        parts.append(
+            f"""### {item['id']}: {item['title']}
+
+- Actor: {item['actor']}
+- User goal: {item['user_goal']}
+- System behavior: {item['system_behavior']}
+- Trigger: {item['trigger']}
+- Preconditions: {', '.join(str(value) for value in item['preconditions'])}
+- Success flow: {'; '.join(str(value) for value in item['success_flow'])}
+- Failure or edge flow: {'; '.join(str(value) for value in item['failure_or_edge_flow'])}
+- Acceptance hooks: {', '.join(str(value) for value in item['acceptance_hooks'])}
+- Evidence source: {item['evidence_source']}
+- Non-goals: {', '.join(str(value) for value in item['non_goals'])}
+- Unsupported assumptions: {', '.join(str(value) for value in item['unsupported_assumptions']) if item['unsupported_assumptions'] else 'None.'}
+"""
+        )
+    return "\n".join(parts)
+
+
+def write_markdown(path: Path, report: dict[str, object]) -> None:
+    boundary = report["stop_boundary"]
+    content = f"""# Use Case Packet: {report['source']['ref']}
+
+## Use Case Packet Summary
+
+- Status: {report['status']}
+- Run id: {report['run_id']}
+- Use cases: {len(report['use_cases'])}
+
+## Source
+
+- Source ref: {report['source']['ref']}
+- Mode: {report['source']['mode']}
+
+## Audience
+
+- {report['audience']}
+
+## Actors
+
+{bullet_lines(report['actors'])}
+
+## Use Cases
+
+{use_case_lines(report['use_cases'])}
+
+## Acceptance Hooks
+
+{bullet_lines(report['acceptance_hooks'])}
+
+## Assumptions
+
+{bullet_lines(report['assumptions'])}
+
+## Unsupported Assumptions
+
+{bullet_lines(report['unsupported_assumptions'])}
+
+## Non-goals
+
+{bullet_lines(report['non_goals'])}
+
+## Stop Boundary
+
+- Created issues: {str(boundary['created_issues']).lower()}.
+- Created PRs: {str(boundary['created_prs']).lower()}.
+- Claimed implementation complete: {str(boundary['claimed_implementation_complete']).lower()}.
+- Published externally: {str(boundary['published_externally']).lower()}.
+- Mutated repository: {str(boundary['mutated_repository']).lower()}.
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("use_case_root", help="Directory containing use-case input evidence")
+    parser.add_argument("--out", default=None, help="Use-case packet output root")
+    parser.add_argument("--run-id", default=None, help="Run id override")
+    parser.add_argument("--max-use-cases", type=int, default=5, help="Maximum use cases to emit")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.use_case_root)
+    if not root.is_dir():
+        raise SystemExit(f"use-case root does not exist: {root}")
+    out_root = Path(args.out) if args.out else root / "use-case-writer"
+    if not out_root.is_absolute():
+        out_root = Path.cwd() / out_root
+    out_root.mkdir(parents=True, exist_ok=True)
+    report = analyze(root, args.max_use_cases)
+    if args.run_id:
+        report["run_id"] = args.run_id
+    write_json(out_root / "use_case_packet.json", report)
+    write_markdown(out_root / "use_case_packet.md", report)
+    print(out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_use_case_writer_skill_contracts.sh
+++ b/adl/tools/test_use_case_writer_skill_contracts.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/use-case-writer/SKILL.md" ]]
+[[ -f "${skills_root}/use-case-writer/adl-skill.yaml" ]]
+[[ -f "${skills_root}/use-case-writer/agents/openai.yaml" ]]
+[[ -f "${skills_root}/use-case-writer/references/use-case-writing-playbook.md" ]]
+[[ -f "${skills_root}/use-case-writer/references/output-contract.md" ]]
+[[ -x "${skills_root}/use-case-writer/scripts/write_use_cases.py" ]]
+[[ -f "${skills_root}/docs/USE_CASE_WRITER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "use-case-writer"' "${skills_root}/use-case-writer/adl-skill.yaml"
+grep -Fq 'id: "use_case_writer.v1"' "${skills_root}/use-case-writer/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/USE_CASE_WRITER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/use-case-writer/adl-skill.yaml"
+grep -Fq "declared_source_must_be_explicit" "${skills_root}/use-case-writer/adl-skill.yaml"
+grep -Fq "without inventing product commitments" "${skills_root}/use-case-writer/SKILL.md"
+grep -Fq "Flag unsupported assumptions" "${skills_root}/use-case-writer/references/output-contract.md"
+grep -Fq "Schema id: \`use_case_writer.v1\`" "${skills_root}/docs/USE_CASE_WRITER_SKILL_INPUT_SCHEMA.md"
+
+use_case_root="${tmpdir}/use-case"
+packet_root="${tmpdir}/use-case-packet"
+mkdir -p "${use_case_root}"
+cat >"${use_case_root}/use_case_manifest.json" <<'JSON'
+{
+  "run_id": "use-case-writer-contract-test",
+  "mode": "write_demo_use_cases",
+  "source_ref": "issue-2040",
+  "audience": "milestone reviewer"
+}
+JSON
+cat >"${use_case_root}/source_brief.md" <<'MD'
+# Source Brief
+
+- Source: issue-2040
+- Audience: milestone reviewer
+
+Write grounded use cases for a demo planning packet without creating issues or claiming implementation completion.
+MD
+cat >"${use_case_root}/actors.md" <<'MD'
+# Actors
+
+## Actors
+
+- Operator
+- Reviewer
+MD
+cat >"${use_case_root}/goals.md" <<'MD'
+# Goals
+
+## User Goals
+
+- Operator turns a demo idea into source-grounded scenarios.
+- Reviewer checks acceptance hooks without chasing implicit assumptions.
+MD
+cat >"${use_case_root}/system_behavior.md" <<'MD'
+# System Behavior
+
+## System Behavior
+
+- The skill emits actor flows, acceptance hooks, non-goals, and unsupported assumptions.
+- The skill keeps unsupported product claims out of the use-case packet.
+MD
+cat >"${use_case_root}/acceptance_hooks.md" <<'MD'
+# Acceptance Hooks
+
+## Acceptance Hooks
+
+- Packet names actors and user goals separately from system behavior.
+- Packet records unsupported assumptions instead of promoting them to requirements.
+MD
+cat >"${use_case_root}/non_goals.md" <<'MD'
+# Non-goals
+
+## Non-goals
+
+- Creating GitHub issues directly.
+- Replacing implementation planning.
+MD
+cat >"${use_case_root}/unsupported_assumptions.md" <<'MD'
+# Unsupported Assumptions
+
+## Unsupported Assumptions
+
+- Publication scope is not defined by the source brief.
+MD
+
+python3 "${skills_root}/use-case-writer/scripts/write_use_cases.py" \
+  "${use_case_root}" --out "${packet_root}" --max-use-cases 2 >/tmp/use-case-writer.out
+[[ -f "${packet_root}/use_case_packet.json" ]]
+[[ -f "${packet_root}/use_case_packet.md" ]]
+grep -Fq '"schema": "adl.use_case_packet.v1"' "${packet_root}/use_case_packet.json"
+grep -Fq '"run_id": "use-case-writer-contract-test"' "${packet_root}/use_case_packet.json"
+grep -Fq '"status": "ready"' "${packet_root}/use_case_packet.json"
+grep -Fq '"created_issues": false' "${packet_root}/use_case_packet.json"
+grep -Fq '"mutated_repository": false' "${packet_root}/use_case_packet.json"
+grep -Fq "## Use Case Packet Summary" "${packet_root}/use_case_packet.md"
+grep -Fq "## Unsupported Assumptions" "${packet_root}/use_case_packet.md"
+grep -Fq "Created issues: false." "${packet_root}/use_case_packet.md"
+grep -Fq "Mutated repository: false." "${packet_root}/use_case_packet.md"
+
+missing_root="${tmpdir}/missing-source"
+mkdir -p "${missing_root}"
+python3 "${skills_root}/use-case-writer/scripts/write_use_cases.py" \
+  "${missing_root}" --out "${tmpdir}/missing-packet" >/tmp/use-case-writer-missing.out
+grep -Fq '"status": "not_run"' "${tmpdir}/missing-packet/use_case_packet.json"
+
+if grep -R "${tmpdir}" "${packet_root}" "${tmpdir}/missing-packet" >/dev/null; then
+  echo "use-case writer artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+if find "${packet_root}" -name '*issue*.md' -o -name '*.rs' -o -name '*.py' | grep -q .; then
+  echo "use-case writer should not create issues or implementation files" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/use-case-writer/SKILL.md"
+
+export CODEX_HOME="${tmpdir}/codex-home"
+bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null
+[[ -f "${CODEX_HOME}/skills/use-case-writer/SKILL.md" ]]
+[[ -f "${CODEX_HOME}/skills/use-case-writer/adl-skill.yaml" ]]
+[[ -f "${CODEX_HOME}/skills/use-case-writer/agents/openai.yaml" ]]
+
+echo "PASS test_use_case_writer_skill_contracts"


### PR DESCRIPTION
Closes #2040

## Summary
Implemented the use-case-writer operational skill as a bounded authoring skill for turning declared product, runtime, demo, feature, issue, or milestone context into grounded use-case packets. The skill requires a declared source before writing, distinguishes actors, user goals, system behavior, acceptance hooks, non-goals, assumptions, and unsupported assumptions, and stops before issue creation, PR creation, publication, implementation planning, or unsupported product commitments.

## Artifacts
- adl/tools/skills/use-case-writer/SKILL.md
- adl/tools/skills/use-case-writer/adl-skill.yaml
- adl/tools/skills/use-case-writer/agents/openai.yaml
- adl/tools/skills/use-case-writer/references/output-contract.md
- adl/tools/skills/use-case-writer/references/use-case-writing-playbook.md
- adl/tools/skills/use-case-writer/scripts/write_use_cases.py
- adl/tools/skills/docs/USE_CASE_WRITER_SKILL_INPUT_SCHEMA.md
- adl/tools/test_use_case_writer_skill_contracts.sh

## Validation
- Validation commands and their purpose:
  - python3 -m py_compile adl/tools/skills/use-case-writer/scripts/write_use_cases.py verified the helper script compiles.
  - bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/use-case-writer/SKILL.md verified required skill frontmatter.
  - bash adl/tools/test_use_case_writer_skill_contracts.sh verified the new skill bundle, schema wiring, deterministic helper outputs, stop boundary, missing-source not-run behavior, no temp path leakage, no issue or implementation-file generation, frontmatter validity, and install/sync visibility.
  - git diff --check verified whitespace hygiene.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2040__backlog-skills-add-use-case-writer-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2040__backlog-skills-add-use-case-writer-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-use-case-writer-skill-adl-tools-skills-use-case-writer-adl-tools-skills-docs-use-case-writer-skill-input-schema-md-adl-tools-test-use-case-writer-skill-contracts-sh-adl-v0-90-tasks-issue-2040-backlog-skills-add-use-case-writer-skill-sip-md-adl-v0-90-tasks-issue-2040-backlog-skills-add-use-case-writer-skill-sor-md