### PR TITLE
Enforce post-merge issue worktree pruning

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -63,12 +63,14 @@ use self::finish_support::{
 #[cfg(test)]
 use self::git_support::commits_ahead_of_origin_main;
 #[cfg(test)]
+use self::git_support::has_uncommitted_changes;
+#[cfg(test)]
 use self::git_support::{branch_checked_out_worktree_path, infer_repo_from_remote};
 use self::git_support::{
     current_branch, default_repo, ensure_git_metadata_writable, ensure_local_branch_exists,
-    ensure_worktree_for_branch, fetch_origin_main_with_fallback, has_uncommitted_changes,
-    issue_create_repo, path_str, primary_checkout_root, repo_root, run_capture,
-    run_capture_allow_failure, run_status, tracked_changes_status,
+    ensure_worktree_for_branch, fetch_origin_main_with_fallback,
+    has_uncommitted_or_untracked_changes, issue_create_repo, path_str, primary_checkout_root,
+    repo_root, run_capture, run_capture_allow_failure, run_status, tracked_changes_status,
 };
 #[cfg(test)]
 use self::github::ensure_pr_closing_linkage;

--- a/adl/src/cli/pr_cmd/git_support.rs
+++ b/adl/src/cli/pr_cmd/git_support.rs
@@ -125,6 +125,20 @@ pub(super) fn has_uncommitted_changes(repo_root: &Path) -> Result<bool> {
     Ok(!(unstaged && staged))
 }
 
+pub(super) fn has_uncommitted_or_untracked_changes(repo_root: &Path) -> Result<bool> {
+    let status = run_capture(
+        "git",
+        &[
+            "-C",
+            path_str(repo_root)?,
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+        ],
+    )?;
+    Ok(!status.trim().is_empty())
+}
+
 pub(super) fn tracked_changes_status(repo_root: &Path) -> Result<String> {
     run_capture(
         "git",

--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -163,14 +163,33 @@ pub(super) fn closeout_closed_completed_issue_bundle(
     canonical_output: &Path,
 ) -> Result<()> {
     reconcile_closed_completed_issue_bundle(primary_root, issue_ref, canonical_output)?;
+    let worktree_path = issue_ref.default_worktree_path(
+        primary_root,
+        std::env::var_os("ADL_WORKTREE_ROOT")
+            .map(PathBuf::from)
+            .as_deref(),
+    );
+    if worktree_path.is_dir() && has_uncommitted_or_untracked_changes(&worktree_path)? {
+        let name = worktree_display_name(&worktree_path);
+        record_worktree_prune_result(canonical_output, &format!("blocked_dirty: retained {name}"))?;
+        replace_worktree_only_paths_remaining(
+            canonical_output,
+            &format!("issue worktree retained: {name}"),
+        )?;
+        bail!(
+            "closeout: refusing to prune dirty worktree '{}' because it contains staged, unstaged, or untracked changes",
+            worktree_path.display()
+        );
+    }
+    let prune_result = prune_issue_worktree(repo_root, primary_root, issue_ref)?;
+    record_worktree_prune_result(canonical_output, &prune_result.card_value())?;
     ensure_closed_completed_issue_bundle_truth(primary_root, issue_ref, canonical_output)
         .with_context(|| {
             format!(
                 "closeout: canonical closed-issue sor truth drift remains for issue #{}",
                 issue_ref.issue_number()
             )
-        })?;
-    prune_issue_worktree(repo_root, primary_root, issue_ref)
+        })
 }
 
 pub(super) fn ensure_closed_completed_issue_bundle_truth(
@@ -505,6 +524,39 @@ fn replace_first_prefixed_line(text: &mut String, prefix: &str, to: &str) {
     }
 }
 
+fn replace_or_insert_after_prefixed_line(
+    text: &mut String,
+    prefix: &str,
+    insert_prefix: &str,
+    to: &str,
+) {
+    let mut out = Vec::new();
+    let mut replaced = false;
+    let mut inserted = false;
+    for line in text.lines() {
+        if line.starts_with(insert_prefix) {
+            if !replaced {
+                out.push(to.to_string());
+                replaced = true;
+            }
+            continue;
+        }
+        out.push(line.to_string());
+        if !inserted && line.starts_with(prefix) && !replaced {
+            out.push(to.to_string());
+            inserted = true;
+            replaced = true;
+        }
+    }
+    if !replaced {
+        out.push(to.to_string());
+    }
+    *text = out.join("\n");
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+}
+
 pub(super) fn sync_completed_output_surfaces(
     repo_root: &Path,
     primary_root: &Path,
@@ -556,7 +608,56 @@ fn same_filesystem_target(left: &Path, right: &Path) -> Result<bool> {
     Ok(false)
 }
 
-fn prune_issue_worktree(repo_root: &Path, primary_root: &Path, issue_ref: &IssueRef) -> Result<()> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum IssueWorktreePruneResult {
+    Missing(String),
+    Pruned(String),
+}
+
+impl IssueWorktreePruneResult {
+    fn card_value(&self) -> String {
+        match self {
+            Self::Missing(name) => format!("skipped_missing: {name}"),
+            Self::Pruned(name) => format!("pruned: {name}"),
+        }
+    }
+}
+
+fn worktree_display_name(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| "issue worktree".to_string())
+}
+
+fn record_worktree_prune_result(path: &Path, result: &str) -> Result<()> {
+    let mut text = fs::read_to_string(path)?;
+    replace_or_insert_after_prefixed_line(
+        &mut text,
+        "- Worktree-only paths remaining:",
+        "- Worktree prune result:",
+        &format!("- Worktree prune result: {result}"),
+    );
+    fs::write(path, text)?;
+    Ok(())
+}
+
+fn replace_worktree_only_paths_remaining(path: &Path, value: &str) -> Result<()> {
+    let mut text = fs::read_to_string(path)?;
+    replace_first_prefixed_line(
+        &mut text,
+        "- Worktree-only paths remaining:",
+        &format!("- Worktree-only paths remaining: {value}"),
+    );
+    fs::write(path, text)?;
+    Ok(())
+}
+
+fn prune_issue_worktree(
+    repo_root: &Path,
+    primary_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<IssueWorktreePruneResult> {
     let worktree_path = issue_ref.default_worktree_path(
         primary_root,
         std::env::var_os("ADL_WORKTREE_ROOT")
@@ -564,11 +665,17 @@ fn prune_issue_worktree(repo_root: &Path, primary_root: &Path, issue_ref: &Issue
             .as_deref(),
     );
     if !worktree_path.is_dir() {
-        return Ok(());
+        println!(
+            "closeout: issue worktree already absent; prune not needed: {}",
+            worktree_path.display()
+        );
+        return Ok(IssueWorktreePruneResult::Missing(worktree_display_name(
+            &worktree_path,
+        )));
     }
-    if has_uncommitted_changes(&worktree_path)? {
+    if has_uncommitted_or_untracked_changes(&worktree_path)? {
         bail!(
-            "closeout: refusing to prune dirty worktree '{}'",
+            "closeout: refusing to prune dirty worktree '{}' because it contains staged, unstaged, or untracked changes",
             worktree_path.display()
         );
     }
@@ -591,7 +698,13 @@ fn prune_issue_worktree(repo_root: &Path, primary_root: &Path, issue_ref: &Issue
             path_str(&worktree_path)?,
         ],
     )?;
-    Ok(())
+    println!(
+        "closeout: pruned issue worktree: {}",
+        worktree_path.display()
+    );
+    Ok(IssueWorktreePruneResult::Pruned(worktree_display_name(
+        &worktree_path,
+    )))
 }
 
 #[cfg(test)]
@@ -1054,7 +1167,12 @@ mod tests {
         init_repo_with_origin(&repo, &origin);
         let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
 
-        prune_issue_worktree(&repo, &repo, &issue_ref).expect("missing worktree is fine");
+        let result =
+            prune_issue_worktree(&repo, &repo, &issue_ref).expect("missing worktree is fine");
+        assert_eq!(
+            result,
+            IssueWorktreePruneResult::Missing("adl-wp-1410".to_string())
+        );
     }
 
     #[test]
@@ -1085,5 +1203,39 @@ mod tests {
 
         prune_issue_worktree(&repo, &repo, &issue_ref).expect_err("dirty worktree rejected");
         assert!(worktree.is_dir());
+    }
+
+    #[test]
+    fn prune_issue_worktree_removes_clean_issue_worktree() {
+        let _guard = env_lock();
+        let temp = temp_dir("adl-pr-lifecycle-prune-clean");
+        let repo = temp.join("repo");
+        let origin = temp.join("origin.git");
+        init_repo_with_origin(&repo, &origin);
+        let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+        let worktree = issue_ref.default_worktree_path(&repo, None);
+
+        assert!(Command::new("git")
+            .args([
+                "-C",
+                path_str(&repo).expect("repo path"),
+                "worktree",
+                "add",
+                path_str(&worktree).expect("worktree path"),
+                "-b",
+                "codex/1410-canonical-slug",
+                "main",
+            ])
+            .status()
+            .expect("git worktree add")
+            .success());
+        assert!(worktree.is_dir());
+
+        let result = prune_issue_worktree(&repo, &repo, &issue_ref).expect("clean worktree pruned");
+        assert_eq!(
+            result,
+            IssueWorktreePruneResult::Pruned("adl-wp-1410".to_string())
+        );
+        assert!(!worktree.exists());
     }
 }

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
@@ -166,6 +166,7 @@ fn real_pr_closeout_reconciles_closed_completed_issue_bundle() {
     assert!(canonical_text.contains("- Integration state: merged"));
     assert!(canonical_text.contains("- Verification scope: main_repo"));
     assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
+    assert!(canonical_text.contains("- Worktree prune result: pruned: adl-wp-1596"));
     assert!(!worktree.exists());
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -953,5 +953,6 @@ verification_summary:
     assert!(canonical_text.contains("- Integration state: merged"));
     assert!(canonical_text.contains("- Verification scope: main_repo"));
     assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
+    assert!(canonical_text.contains("- Worktree prune result: pruned: adl-wp-1410"));
     assert!(!worktree.exists());
 }


### PR DESCRIPTION
Closes #2105

## Summary
Implemented safer post-merge closeout pruning for ADL issue worktrees. Closeout now treats untracked files as dirty residue, records the worktree prune outcome in the closed issue SOR, and preserves dirty worktrees with an explicit blocked result instead of silently deleting or pretending no residue remains.

## Artifacts
- Updated closeout pruning logic in `adl/src/cli/pr_cmd/lifecycle.rs`.
- Updated PR command helper imports in `adl/src/cli/pr_cmd.rs`.
- Updated git dirtiness detection in `adl/src/cli/pr_cmd/git_support.rs`.
- Added and tightened closeout/doctor regression assertions in `adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs` and `adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs`.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml prune_issue_worktree`
    - verified missing-worktree no-op, dirty-worktree refusal including untracked files, and clean-worktree removal behavior.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_closeout_reconciles_closed_completed_issue_bundle`
    - verified `pr closeout` reconciles a closed/completed issue, prunes the clean issue worktree, and records the prune result in the SOR.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree`
    - verified `pr doctor --mode full` routes closed/completed stale issue state through closeout reconciliation and records the prune result.
  - `cargo test --manifest-path adl/Cargo.toml finish_helper_paths_cover_nonempty_and_staged_checks`
    - verified the shared tracked-change helper still preserves finish behavior for ignored local-only `.adl` records.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_refuses_to_publish_local_only_bundle_without_tracked_changes`
    - verified `pr finish` still blocks local-only ignored bundle publication with the intended no-tracked-changes error.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_finish_updates_existing_pr_and_marks_ready`
    - verified `pr finish` still updates an existing PR after the closeout-specific residue helper split.
  - `git diff --check`
    - verified the patch has no whitespace errors.
  - `cargo test --manifest-path adl/Cargo.toml prune_issue_worktree real_pr_closeout_reconciles_closed_completed_issue_bundle real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree`
    - attempted a combined test invocation; cargo rejected the command because `cargo test` accepts only one test-name filter before `--`.
  - `adl/tools/pr.sh finish 2105 --title "Enforce post-merge issue worktree pruning" --output-card .adl/v0.90/tasks/issue-2105__v0-90-tools-enforce-post-merge-issue-worktree-pruning/sor.md`
    - attempted finish publication; full cargo validation failed because the first implementation changed a shared dirty-check helper used by finish tests.
- Results:
  - All valid focused validation commands passed after the helper split.
  - The invalid combined cargo invocation failed as expected due command syntax and was replaced by focused cargo test invocations.
  - The first `pr finish` attempt failed usefully, identified the shared-helper compatibility issue, and was followed by passing targeted regression tests for the affected finish paths.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2105__v0-90-tools-enforce-post-merge-issue-worktree-pruning/sip.md
- Output card: .adl/v0.90/tasks/issue-2105__v0-90-tools-enforce-post-merge-issue-worktree-pruning/sor.md
- Idempotency-Key: enforce-post-merge-issue-worktree-pruning-adl-v0-90-tasks-issue-2105-v0-90-tools-enforce-post-merge-issue-worktree-pruning-sip-md-adl-v0-90-tasks-issue-2105-v0-90-tools-enforce-post-merge-issue-worktree-pruning-sor-md