### PR TITLE
[v0.90][tests] Add focused coverage for adl/src/godel/stage_loop.rs

### DIFF
--- a/adl/src/godel/stage_loop.rs
+++ b/adl/src/godel/stage_loop.rs
@@ -913,4 +913,49 @@ mod tests {
             .expect_err("unsupported template stage must fail");
         assert!(err.to_string().contains("unsupported stage"));
     }
+
+    #[test]
+    fn stage_loop_input_evidence_refs_are_normalized_for_dedup_and_sort() {
+        let mut input = fixture_input();
+        input.evidence_refs = vec![
+            "runs/run-745-a/run_status.json".to_string(),
+            "runs/run-745-a/evidence/early.json".to_string(),
+            "runs/run-745-a/run_status.json".to_string(),
+            "runs/run-745-a/evidence/late.json".to_string(),
+        ];
+
+        assert_eq!(
+            input.normalized_evidence_refs(),
+            vec![
+                "runs/run-745-a/evidence/early.json".to_string(),
+                "runs/run-745-a/evidence/late.json".to_string(),
+                "runs/run-745-a/run_status.json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn stage_loop_execute_uses_normalized_evidence_refs_in_output_artifacts() {
+        let exec = GodelStageLoopExecutor::new(StageLoopConfig::default());
+        let mut input = fixture_input();
+        input.evidence_refs = vec![
+            "runs/run-745-a/run_status.json".to_string(),
+            "runs/run-745-a/evidence/repeated.json".to_string(),
+            "runs/run-745-a/evidence/repeated.json".to_string(),
+            "runs/run-745-a/activation_log.json".to_string(),
+        ];
+
+        let run = exec
+            .execute(&input)
+            .expect("normalized evidence refs should not fail");
+
+        assert_eq!(
+            run.record.evidence_refs,
+            vec![
+                "runs/run-745-a/activation_log.json".to_string(),
+                "runs/run-745-a/evidence/repeated.json".to_string(),
+                "runs/run-745-a/run_status.json".to_string(),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Closes #2121

## Summary
Added two focused tests in `adl/src/godel/stage_loop.rs` to lock down evidence-reference normalization behavior:
- Deduped/sorted evidence refs in input preprocessing.
- Evidence reference ordering and deduping in `StageLoopRun` output artifacts after execution.
These tests cover previously untested branches in evidence handling and keep the change scoped to `stage_loop.rs` tests only.

## Artifacts
- `.adl/v0.90/tasks/issue-2121__v0-90-tests-add-focused-coverage-for-adl-src-godel-stage-loop-rs/sor.md` (updated with completed execution record)
- `adl/src/godel/stage_loop.rs` (`mod tests` additions only)

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml stage_loop_ -- --nocapture` (proves all `stage_loop`-filtered tests, including two new tests, pass)
  - `cargo test --manifest-path adl/Cargo.toml stage_loop_ -- --nocapture` (second pass for replay confirmation)
- Results:
  - Second+ first pass: 10 tests passed, no failures.
  - Additional adjacent suite coverage during filtered run: `godel::godel_run_executes_bounded_stage_loop_and_persists_artifacts` passed.
  - No unexpected failures or fixture drift observed.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2121__v0-90-tests-add-focused-coverage-for-adl-src-godel-stage-loop-rs/sip.md
- Output card: .adl/v0.90/tasks/issue-2121__v0-90-tests-add-focused-coverage-for-adl-src-godel-stage-loop-rs/sor.md
- Idempotency-Key: v0-90-tests-add-focused-coverage-for-adl-src-godel-stage-loop-rs-adl-v0-90-tasks-issue-2121-v0-90-tests-add-focused-coverage-for-adl-src-godel-stage-loop-rs-sip-md-adl-v0-90-tasks-issue-2121-v0-90-tests-add-focused-coverage-for-adl-src-godel-stage-loop-rs-sor-md