### PR TITLE
[v0.90][WP-17] Fix CodeBuddy product-report layer

### DIFF
--- a/adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py
+++ b/adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py
@@ -43,17 +43,25 @@ def source_files(source: Path) -> list[Path]:
         return [source]
     if not source.is_dir():
         return []
-    preferred = [
-        source / "final_report.md",
-        source / "synthesis.md",
+    for synthesized in (
+        [source / "final_report.md"],
+        [source / "synthesis.md", source / "specialist_reviews" / "synthesis.md"],
+        [source / "product-report" / "codebuddy_product_report.md"],
+    ):
+        files = [path for path in synthesized if path.is_file()]
+        if files:
+            return files
+
+    specialist = [
         source / "specialist_reviews" / "code.md",
         source / "specialist_reviews" / "security.md",
         source / "specialist_reviews" / "tests.md",
         source / "specialist_reviews" / "docs.md",
         source / "specialist_reviews" / "architecture.md",
         source / "specialist_reviews" / "dependencies.md",
+        source / "specialist_reviews" / "dependency.md",
     ]
-    files = [path for path in preferred if path.is_file()]
+    files = [path for path in specialist if path.is_file()]
     if files:
         return files
     return sorted(source.rglob("*.md"))[:30]

--- a/adl/tools/skills/product-report-writer/scripts/write_product_report.py
+++ b/adl/tools/skills/product-report-writer/scripts/write_product_report.py
@@ -94,19 +94,37 @@ def role_from_path(path: Path, block: str) -> str:
     return "review"
 
 
+def first_existing(root: Path, candidates: list[str]) -> Path | None:
+    for rel in candidates:
+        path = root / rel
+        if path.is_file():
+            return path
+    return None
+
+
+def any_existing(root: Path, candidates: list[str]) -> bool:
+    return first_existing(root, candidates) is not None
+
+
 def finding_sources(root: Path) -> list[Path]:
-    preferred = [
-        root / "final_report.md",
-        root / "synthesis.md",
-        root / "specialist_reviews" / "synthesis.md",
+    for synthesized in (
+        [root / "final_report.md"],
+        [root / "synthesis.md", root / "specialist_reviews" / "synthesis.md"],
+    ):
+        found_synthesized = [path for path in synthesized if path.is_file()]
+        if found_synthesized:
+            return found_synthesized
+
+    specialist = [
         root / "specialist_reviews" / "code.md",
         root / "specialist_reviews" / "security.md",
         root / "specialist_reviews" / "tests.md",
         root / "specialist_reviews" / "docs.md",
         root / "specialist_reviews" / "architecture.md",
         root / "specialist_reviews" / "dependencies.md",
+        root / "specialist_reviews" / "dependency.md",
     ]
-    found = [path for path in preferred if path.is_file()]
+    found = [path for path in specialist if path.is_file()]
     if found:
         return found
     return sorted(root.rglob("*.md"))[:40]
@@ -195,17 +213,38 @@ def read_manifest(root: Path, repo_name_override: str | None) -> dict[str, objec
 
 def artifact_status(root: Path) -> dict[str, object]:
     return {
-        "redaction_report": (root / "redaction_report.md").is_file(),
-        "quality_evaluation": any(path.is_file() for path in [root / "quality_evaluation.md", root / "review_quality.md"]),
-        "diagram_manifest": any(path.is_file() for path in [root / "diagrams" / "diagram_manifest.md", root / "diagram_manifest.md"]),
-        "test_plan": any(path.is_file() for path in [root / "test_recommendations" / "test_gap_report.md", root / "review-to-test-plan" / "review_to_test_plan.md"]),
-        "issue_plan": any(path.is_file() for path in [root / "issue-planning" / "issue_candidates.md"]),
+        "redaction_report": any_existing(root, ["redaction_report.md", "redaction-audit/redaction_report.md"]),
+        "quality_evaluation": any_existing(
+            root,
+            [
+                "quality_evaluation.md",
+                "review_quality.md",
+                "quality-evaluation/review_quality_evaluation.md",
+            ],
+        ),
+        "diagram_manifest": any_existing(
+            root,
+            [
+                "diagrams/diagram_manifest.md",
+                "diagram_manifest.md",
+                "diagram-plan/repo_diagram_plan.md",
+            ],
+        ),
+        "test_plan": any_existing(
+            root,
+            [
+                "test_recommendations/test_gap_report.md",
+                "review-to-test-plan/review_to_test_plan.md",
+                "test-plan/review_to_test_plan.md",
+            ],
+        ),
+        "issue_plan": any_existing(root, ["issue-planning/issue_candidates.md", "issue-plan/issue_candidates.md"]),
     }
 
 
 def diagram_links(root: Path) -> list[str]:
     links: list[str] = []
-    for rel in ("diagrams/diagram_manifest.md", "diagram_manifest.md"):
+    for rel in ("diagrams/diagram_manifest.md", "diagram_manifest.md", "diagram-plan/repo_diagram_plan.md"):
         path = root / rel
         if path.is_file():
             links.append(rel)
@@ -216,6 +255,7 @@ def test_recommendations(root: Path) -> list[str]:
     paths = [
         root / "test_recommendations" / "test_gap_report.md",
         root / "review-to-test-plan" / "review_to_test_plan.md",
+        root / "test-plan" / "review_to_test_plan.md",
     ]
     found = [packet_relative(root, path) for path in paths if path.is_file()]
     return found or ["No test recommendation artifact found in packet."]
@@ -267,6 +307,7 @@ def build_report(root: Path, audience: str, repo_name_override: str | None) -> d
             "remediation_complete_claimed": False,
         },
         "scope": scope,
+        "artifact_status": artifacts,
         "top_findings": findings[:8],
         "architecture_summary": architecture_summary(findings, artifacts),
         "security_privacy_notes": security_privacy_notes(findings, artifacts, manifest),
@@ -308,9 +349,13 @@ def appendix(root: Path) -> list[str]:
         "synthesis.md",
         "redaction_report.md",
         "quality_evaluation.md",
+        "quality-evaluation/review_quality_evaluation.md",
         "diagrams/diagram_manifest.md",
+        "diagram-plan/repo_diagram_plan.md",
         "test_recommendations/test_gap_report.md",
+        "test-plan/review_to_test_plan.md",
         "issue-planning/issue_candidates.md",
+        "issue-plan/issue_candidates.md",
     ):
         if (root / rel).is_file():
             names.append(rel)
@@ -387,7 +432,7 @@ def write_markdown(path: Path, report: dict[str, object]) -> None:
 
 {numbered_lines(report['remediation_sequence'])}
 
-## Caveats And Residual Risks
+## Residual Risks
 
 {bullet_lines(report['residual_risks'])}
 

--- a/adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py
+++ b/adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py
@@ -105,23 +105,46 @@ def read_manifest(root: Path) -> dict[str, object]:
 
 
 def preferred_review_sources(root: Path) -> list[Path]:
-    preferred = [
-        root / "final_report.md",
-        root / "product-report" / "codebuddy_product_report.md",
-        root / "synthesis.md",
-        root / "specialist_reviews" / "synthesis.md",
+    for final_reports in (
+        [root / "final_report.md"],
+        [root / "product-report" / "codebuddy_product_report.md"],
+        [root / "synthesis.md", root / "specialist_reviews" / "synthesis.md"],
+    ):
+        found_final = [path for path in final_reports if path.is_file()]
+        if found_final:
+            return found_final
+
+    specialist = [
         root / "specialist_reviews" / "code.md",
         root / "specialist_reviews" / "security.md",
         root / "specialist_reviews" / "tests.md",
         root / "specialist_reviews" / "docs.md",
         root / "specialist_reviews" / "architecture.md",
         root / "specialist_reviews" / "dependencies.md",
+        root / "specialist_reviews" / "dependency.md",
         root / "redaction_report.md",
+        root / "redaction-audit" / "redaction_report.md",
     ]
-    found = [path for path in preferred if path.is_file()]
+    found = [path for path in specialist if path.is_file()]
     if found:
         return found
     return sorted(path for path in root.rglob("*.md") if "quality-evaluation" not in path.parts)[:50]
+
+
+def role_artifact_sources(root: Path) -> list[Path]:
+    preferred = [
+        root / "specialist_reviews" / "code.md",
+        root / "specialist_reviews" / "security.md",
+        root / "specialist_reviews" / "tests.md",
+        root / "specialist_reviews" / "docs.md",
+        root / "specialist_reviews" / "architecture.md",
+        root / "specialist_reviews" / "dependencies.md",
+        root / "specialist_reviews" / "dependency.md",
+        root / "architecture-review" / "architecture_review_scaffold.md",
+        root / "dependency-review" / "dependency_review_scaffold.md",
+    ]
+    found = [path for path in preferred if path.is_file()]
+    return found or preferred_review_sources(root)
 
 
 def all_review_text(root: Path) -> str:
@@ -211,13 +234,18 @@ def source_scope(root: Path) -> dict[str, object]:
 
 
 def role_coverage(root: Path, required_roles: list[str]) -> dict[str, object]:
-    sources = preferred_review_sources(root)
+    sources = role_artifact_sources(root)
     source_names = {packet_relative(root, path).lower() for path in sources}
     present: dict[str, bool] = {}
     for role in required_roles:
         role_l = role.lower()
+        aliases = {
+            "dependency": ["dependency", "dependencies"],
+            "dependencies": ["dependency", "dependencies"],
+        }.get(role_l, [role_l])
         present[role_l] = any(
-            f"/{role_l}.md" in f"/{name}" or role_l in read_text(path).lower().splitlines()[0:5]
+            any(f"/{alias}.md" in f"/{name}" or alias in name for alias in aliases)
+            or any(alias in "\n".join(read_text(path).lower().splitlines()[0:8]) for alias in aliases)
             for name, path in [(packet_relative(root, item).lower(), item) for item in sources]
         )
     missing = [role for role, exists in present.items() if not exists]

--- a/adl/tools/test_finding_to_issue_planner_skill_contracts.sh
+++ b/adl/tools/test_finding_to_issue_planner_skill_contracts.sh
@@ -70,6 +70,61 @@ if grep -R "${tmpdir}" "${out_root}" >/dev/null; then
   exit 1
 fi
 
+packet_root="${tmpdir}/packet"
+packet_out="${tmpdir}/packet-issue-plan"
+mkdir -p "${packet_root}/specialist_reviews"
+cat >"${packet_root}/specialist_reviews/code.md" <<'MARKDOWN'
+# Code Review
+
+## Findings
+
+### Finding C-001: [P1] Duplicate raw packet finding
+
+- Role: code
+- Affected path or artifact: adl/tools/report.sh
+- Evidence: raw specialist evidence.
+- Impact: duplicate raw finding.
+- Recommended action: use synthesis.
+MARKDOWN
+cat >"${packet_root}/specialist_reviews/security.md" <<'MARKDOWN'
+# Security Review
+
+## Findings
+
+### Finding S-002: [P2] Duplicate raw packet finding
+
+- Role: security
+- Affected path or artifact: adl/tools/report.sh
+- Evidence: raw specialist evidence.
+- Impact: duplicate raw finding.
+- Recommended action: use synthesis.
+MARKDOWN
+cat >"${packet_root}/specialist_reviews/synthesis.md" <<'MARKDOWN'
+# Review Synthesis
+
+## Findings
+
+### Finding SYN-001: [P1] Synthesis grouped packet finding
+
+- Role: synthesis
+- Confidence: high
+- Affected path or artifact: adl/tools/report.sh
+- Evidence: synthesis groups C-001 and S-002 into one remediation bucket.
+- Impact: downstream issue planning should not create one issue per raw specialist finding.
+- Recommended action: create one bounded issue from the synthesis bucket.
+- Validation or proof gap: rerun finding-to-issue planner contract tests.
+- Related findings: C-001, S-002
+MARKDOWN
+
+python3 "${skills_root}/finding-to-issue-planner/scripts/plan_review_issues.py" \
+  "${packet_root}" --out "${packet_out}" --tracker github >/tmp/finding-to-issue-planner-packet.out
+grep -Fq '"candidate_count": 1' "${packet_out}/issue_candidates.json"
+grep -Fq '"SYN-001"' "${packet_out}/issue_candidates.json"
+if grep -Fq '"C-001"' "${packet_out}/issue_candidates.json" || grep -Fq '"S-002"' "${packet_out}/issue_candidates.json"; then
+  echo "packet issue planning should prefer synthesis over duplicate specialist findings" >&2
+  exit 1
+fi
+
 bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
   "${skills_root}/finding-to-issue-planner/SKILL.md"
 

--- a/adl/tools/test_product_report_writer_skill_contracts.sh
+++ b/adl/tools/test_product_report_writer_skill_contracts.sh
@@ -25,7 +25,13 @@ grep -Fq "product-report-writer" "${skills_root}/docs/MULTI_AGENT_REPO_REVIEW_SK
 
 packet_root="${tmpdir}/packet"
 report_root="${tmpdir}/product-report"
-mkdir -p "${packet_root}/specialist_reviews" "${packet_root}/diagrams" "${packet_root}/test_recommendations"
+mkdir -p \
+  "${packet_root}/specialist_reviews" \
+  "${packet_root}/diagram-plan" \
+  "${packet_root}/test-plan" \
+  "${packet_root}/issue-plan" \
+  "${packet_root}/quality-evaluation" \
+  "${packet_root}/redaction-audit"
 cat >"${packet_root}/run_manifest.json" <<'JSON'
 {
   "schema": "codebuddy.repo_packet.run_manifest.v1",
@@ -88,16 +94,38 @@ cat >"${packet_root}/specialist_reviews/docs.md" <<'MD'
 - User/customer impact: reviewer handoff may overstate certainty.
 - Recommended action: surface missing gates in caveats.
 MD
-cat >"${packet_root}/redaction_report.md" <<'MD'
+cat >"${packet_root}/specialist_reviews/synthesis.md" <<'MD'
+# Review Synthesis
+
+## Findings
+
+### Finding SYN-001: [P1] Unsafe report overclaim path
+
+- Role: synthesis
+- Confidence: high
+- Affected path or artifact: adl/tools/report.sh
+- Evidence: specialist reviews C-001 and D-002 identify the same report-boundary failure.
+- Impact: customers may believe remediation or approval happened when it did not.
+- Recommended action: require explicit publication boundary language and surface supporting specialist evidence as related findings.
+- Validation or proof gap: rerun product-report and quality-evaluation contract tests.
+- Related findings: C-001, D-002
+MD
+cat >"${packet_root}/redaction-audit/redaction_report.md" <<'MD'
 # Redaction Report
 
 - Final publication status: partial.
 MD
-cat >"${packet_root}/diagrams/diagram_manifest.md" <<'MD'
-# Diagram Manifest
+cat >"${packet_root}/quality-evaluation/review_quality_evaluation.md" <<'MD'
+# Review Quality Evaluation
 MD
-cat >"${packet_root}/test_recommendations/test_gap_report.md" <<'MD'
-# Test Gap Report
+cat >"${packet_root}/diagram-plan/repo_diagram_plan.md" <<'MD'
+# Repo Diagram Plan
+MD
+cat >"${packet_root}/test-plan/review_to_test_plan.md" <<'MD'
+# Review To Test Plan
+MD
+cat >"${packet_root}/issue-plan/issue_candidates.md" <<'MD'
+# Issue Candidates
 MD
 
 python3 "${skills_root}/product-report-writer/scripts/write_product_report.py" \
@@ -107,15 +135,34 @@ python3 "${skills_root}/product-report-writer/scripts/write_product_report.py" \
 grep -Fq '"schema": "codebuddy.product_report.v1"' "${report_root}/codebuddy_product_report.json"
 grep -Fq '"repo_name": "example-repo"' "${report_root}/codebuddy_product_report.json"
 grep -Fq '"severity": "P1"' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"redaction_report": true' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"quality_evaluation": true' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"diagram_manifest": true' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"test_plan": true' "${report_root}/codebuddy_product_report.json"
+grep -Fq '"issue_plan": true' "${report_root}/codebuddy_product_report.json"
 grep -Fq '"published_by_skill": false' "${report_root}/codebuddy_product_report.json"
 grep -Fq '"approval_claimed": false' "${report_root}/codebuddy_product_report.json"
 grep -Fq '"remediation_complete_claimed": false' "${report_root}/codebuddy_product_report.json"
 grep -Fq "## Executive Summary" "${report_root}/codebuddy_product_report.md"
 grep -Fq "## Top Findings" "${report_root}/codebuddy_product_report.md"
-grep -Fq "## Caveats And Residual Risks" "${report_root}/codebuddy_product_report.md"
+grep -Fq "## Residual Risks" "${report_root}/codebuddy_product_report.md"
 grep -Fq "Approval claimed: false." "${report_root}/codebuddy_product_report.md"
 grep -Fq "Compliance claimed: false." "${report_root}/codebuddy_product_report.md"
 grep -Fq "Remediation complete claimed: false." "${report_root}/codebuddy_product_report.md"
+grep -Fq "Redaction report present." "${report_root}/codebuddy_product_report.md"
+if grep -Fq "Redaction report missing" "${report_root}/codebuddy_product_report.md"; then
+  echo "product report should discover redaction-audit/redaction_report.md" >&2
+  exit 1
+fi
+python3 - "${report_root}/codebuddy_product_report.json" <<'PY'
+import json
+import sys
+report = json.load(open(sys.argv[1], encoding="utf-8"))
+titles = [finding["title"] for finding in report["top_findings"]]
+assert titles == ["Unsafe report overclaim path"], titles
+assert report["top_findings"][0]["source_artifact"] == "specialist_reviews/synthesis.md"
+assert report["remediation_sequence"].count(report["remediation_sequence"][0]) == 1
+PY
 if grep -R "${tmpdir}" "${report_root}" >/dev/null; then
   echo "product report artifacts should not leak absolute temp paths" >&2
   exit 1

--- a/adl/tools/test_review_quality_evaluator_skill_contracts.sh
+++ b/adl/tools/test_review_quality_evaluator_skill_contracts.sh
@@ -90,6 +90,13 @@ cat >"${packet_root}/specialist_reviews/security.md" <<'MD'
 - Recommended action: require redaction status in the quality gate.
 - Validation or proof gap: verify customer-private output fails without redaction.
 MD
+cat >"${packet_root}/specialist_reviews/dependencies.md" <<'MD'
+# Dependency Review
+
+## Findings
+
+No dependency findings.
+MD
 cat >"${packet_root}/final_report.md" <<'MD'
 # CodeBuddy Review Report: example-repo
 
@@ -140,7 +147,7 @@ MD
 
 python3 "${skills_root}/review-quality-evaluator/scripts/evaluate_review_quality.py" \
   "${packet_root}" --out "${quality_root}" --publication-intent customer_private \
-  --required-role code --required-role security >/tmp/review-quality-evaluator.out
+  --required-role code --required-role security --required-role dependencies >/tmp/review-quality-evaluator.out
 [[ -f "${quality_root}/review_quality_evaluation.json" ]]
 [[ -f "${quality_root}/review_quality_evaluation.md" ]]
 grep -Fq '"schema": "codebuddy.review_quality_evaluation.v1"' "${quality_root}/review_quality_evaluation.json"
@@ -149,6 +156,18 @@ grep -Fq '"status": "pass"' "${quality_root}/review_quality_evaluation.json"
 grep -Fq '"publication_intent": "customer_private"' "${quality_root}/review_quality_evaluation.json"
 grep -Fq '"published_by_skill": false' "${quality_root}/review_quality_evaluation.json"
 grep -Fq '"approval_claimed": false' "${quality_root}/review_quality_evaluation.json"
+grep -Fq '"dependencies"' "${quality_root}/review_quality_evaluation.json"
+python3 - "${quality_root}/review_quality_evaluation.json" <<'PY'
+import json
+import sys
+evaluation = json.load(open(sys.argv[1], encoding="utf-8"))
+assert "dependencies" in evaluation["specialist_coverage"]["present_roles"]
+assert "dependencies" not in evaluation["specialist_coverage"]["missing_roles"]
+assert not [
+    warning for warning in evaluation["warnings"]
+    if warning.get("check") == "duplication"
+], evaluation["warnings"]
+PY
 grep -Fq "## Quality Gate Summary" "${quality_root}/review_quality_evaluation.md"
 grep -Fq "## Scorecard" "${quality_root}/review_quality_evaluation.md"
 grep -Fq "## Publication Boundary" "${quality_root}/review_quality_evaluation.md"
@@ -156,7 +175,7 @@ grep -Fq "## Publication Boundary" "${quality_root}/review_quality_evaluation.md
 rm "${packet_root}/redaction_report.md"
 python3 "${skills_root}/review-quality-evaluator/scripts/evaluate_review_quality.py" \
   "${packet_root}" --out "${quality_root}/fail" --publication-intent customer_private \
-  --required-role code --required-role security >/tmp/review-quality-evaluator-fail.out
+  --required-role code --required-role security --required-role dependencies >/tmp/review-quality-evaluator-fail.out
 grep -Fq '"status": "fail"' "${quality_root}/fail/review_quality_evaluation.json"
 grep -Fq '"check": "redaction"' "${quality_root}/fail/review_quality_evaluation.json"
 


### PR DESCRIPTION
Closes #2124

## Summary
Fixed the CodeBuddy review reporting layer so product reports and downstream review tools understand the v0.90 WP-15 packet shape. Product-report artifact discovery now recognizes sibling `redaction-audit`, `quality-evaluation`, `diagram-plan`, `test-plan`, and `issue-plan` directories. Finding extraction now prefers a single synthesized finding layer before falling back to raw specialist reviews, avoiding duplicate top-level findings and fragmented issue candidates. Review-quality role coverage now accepts `specialist_reviews/dependencies.md` without requiring the duplicate `dependency.md` compatibility artifact.

## Artifacts
- Updated `adl/tools/skills/product-report-writer/scripts/write_product_report.py`.
- Updated `adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py`.
- Updated `adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py`.
- Updated focused contract tests for product-report, review-quality, and finding-to-issue behavior.
- Local proof artifacts were generated under a temporary proof root; they are not tracked and are reproducible from the commands below.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_product_report_writer_skill_contracts.sh`: verifies product-report contract, sibling artifact discovery, synthesis-first top findings, no false redaction-missing language, and no temp-path leakage.
  - `bash adl/tools/test_review_quality_evaluator_skill_contracts.sh`: verifies quality-evaluator contract, dependency role detection from `dependencies.md`, no duplicate warnings for synthesized report input, and customer-private redaction failure behavior.
  - `bash adl/tools/test_finding_to_issue_planner_skill_contracts.sh`: verifies issue candidate grouping and synthesis-first packet issue planning.
  - `python3 adl/tools/skills/product-report-writer/scripts/write_product_report.py <local WP-15 packet copy> --out <proof product-report> --audience internal_review`: verifies the actual WP-15 packet shape no longer produces false missing-artifact claims.
  - `python3 adl/tools/skills/review-quality-evaluator/scripts/evaluate_review_quality.py <local WP-15 packet copy> --out <proof quality-evaluation> --publication-intent internal_review --required-role code --required-role security --required-role tests --required-role docs --required-role architecture --required-role dependencies`: verifies role coverage and duplicate-warning behavior against the regenerated report.
  - `python3 adl/tools/skills/finding-to-issue-planner/scripts/plan_review_issues.py <local WP-15 packet copy> --out <proof issue-plan> --tracker github`: verifies issue planning uses four synthesis-backed buckets instead of raw specialist fragmentation.
- Results: all focused contract tests passed; local WP-15 replay passed with all artifact-status booleans true, top findings sourced from `specialist_reviews/synthesis.md`, no dependency role gap, no duplicate warnings, and four synthesis-backed issue candidates.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2124__v0-90-wp-17-fix-codebuddy-product-report-layer/sip.md
- Output card: .adl/v0.90/tasks/issue-2124__v0-90-wp-17-fix-codebuddy-product-report-layer/sor.md
- Idempotency-Key: v0-90-wp-17-fix-codebuddy-product-report-layer-adl-tools-skills-finding-to-issue-planner-scripts-plan-review-issues-py-adl-tools-skills-product-report-writer-scripts-write-product-report-py-adl-tools-skills-review-quality-evaluator-scripts-evaluate-review-quality-py-adl-tools-test-finding-to-issue-planner-skill-contracts-sh-adl-tools-test-product-report-writer-skill-contracts-sh-adl-tools-test-review-quality-evaluator-skill-contracts-sh-adl-v0-90-tasks-issue-2124-v0-90-wp-17-fix-codebuddy-product-report-layer-sip-md-adl-v0-90-tasks-issue-2124-v0-90-wp-17-fix-codebuddy-product-report-layer-sor-md