### PR TITLE
[v0.90][tests] Add focused coverage for adl/src/cli/godel_cmd.rs

### DIFF
--- a/adl/src/cli/tests/godel.rs
+++ b/adl/src/cli/tests/godel.rs
@@ -124,6 +124,42 @@ fn real_godel_affect_slice_rejects_missing_value_flags() {
 }
 
 #[test]
+fn real_godel_affect_slice_rejects_missing_required_args() {
+    let missing_initial = real_godel_affect_slice(&[
+        "--adapted-run-id".to_string(),
+        "run-b".to_string(),
+        "--godel-run-id".to_string(),
+        "run-c".to_string(),
+    ])
+    .expect_err("missing initial run id should fail");
+    assert!(missing_initial
+        .to_string()
+        .contains("godel affect-slice requires --initial-run-id <id>"));
+
+    let missing_adapted = real_godel_affect_slice(&[
+        "--initial-run-id".to_string(),
+        "run-a".to_string(),
+        "--godel-run-id".to_string(),
+        "run-c".to_string(),
+    ])
+    .expect_err("missing adapted run id should fail");
+    assert!(missing_adapted
+        .to_string()
+        .contains("godel affect-slice requires --adapted-run-id <id>"));
+
+    let missing_godel = real_godel_affect_slice(&[
+        "--initial-run-id".to_string(),
+        "run-a".to_string(),
+        "--adapted-run-id".to_string(),
+        "run-b".to_string(),
+    ])
+    .expect_err("missing godel run id should fail");
+    assert!(missing_godel
+        .to_string()
+        .contains("godel affect-slice requires --godel-run-id <id>"));
+}
+
+#[test]
 fn real_godel_affect_slice_persists_vertical_slice_artifact() {
     let base = std::env::temp_dir().join(format!("adl-godel-affect-slice-{}", std::process::id()));
     let aee_root = base.join("aee-runs");


### PR DESCRIPTION
Closes #2122

## Summary
Added a focused CLI regression test in `adl/src/cli/tests/godel.rs` to cover missing required-argument validation for `real_godel_affect_slice`.

The new test validates:

- `--initial-run-id` is required when other args are present.
- `--adapted-run-id` is required when other args are present.
- `--godel-run-id` is required when other args are present.

## Artifacts
- `.adl/v0.90/tasks/issue-2122__v0-90-tests-add-focused-coverage-for-adl-src-cli-godel-cmd-rs/sor.md` (updated with execution proof)
- `adl/src/cli/tests/godel.rs` (test addition)

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml real_godel_affect_slice_rejects_missing_required_args -- --nocapture`
    - Proves the new focused regression test and ensures error-path handling is covered for all three missing required args.
  - `cargo test --manifest-path adl/Cargo.toml real_godel_ -- --nocapture`
    - Proves the broader `godel` CLI test surface remains green after the change.
  - `cargo test --manifest-path adl/Cargo.toml real_godel_ -- --nocapture`
    - Replay run to confirm deterministic stability of test outcomes.
- Results:
  - First command: 1 passed, 0 failed.
  - Second command: 9 passed, 0 failed.
  - Replay command: 9 passed, 0 failed, same effective behavior and ordering.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2122__v0-90-tests-add-focused-coverage-for-adl-src-cli-godel-cmd-rs/sip.md
- Output card: .adl/v0.90/tasks/issue-2122__v0-90-tests-add-focused-coverage-for-adl-src-cli-godel-cmd-rs/sor.md
- Idempotency-Key: v0-90-tests-add-focused-coverage-for-adl-src-cli-godel-cmd-rs-adl-v0-90-tasks-issue-2122-v0-90-tests-add-focused-coverage-for-adl-src-cli-godel-cmd-rs-sip-md-adl-v0-90-tasks-issue-2122-v0-90-tests-add-focused-coverage-for-adl-src-cli-godel-cmd-rs-sor-md