### PR TITLE
[v0.90][tools] Allow closed_no_pr closeout truth in issue automation

### DIFF
--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -210,14 +210,8 @@ pub(super) fn ensure_closed_completed_issue_bundle_truth(
         mismatches.push("missing canonical sor.md".to_string());
     } else {
         let text = fs::read_to_string(canonical_output)?;
+        let integration_state = line_value_after_prefix(&text, "- Integration state:");
         check_required_field(&text, "Status:", "DONE", "SOR Status", &mut mismatches);
-        check_required_field(
-            &text,
-            "- Integration state:",
-            "merged",
-            "SOR Integration state",
-            &mut mismatches,
-        );
         check_required_field(
             &text,
             "- Verification scope:",
@@ -225,6 +219,22 @@ pub(super) fn ensure_closed_completed_issue_bundle_truth(
             "SOR Verification scope",
             &mut mismatches,
         );
+        match integration_state.as_deref() {
+            Some("merged") => (),
+            Some("closed_no_pr") => {
+                check_required_field(
+                    &text,
+                    "Branch:",
+                    "retrospective-no-branch",
+                    "SOR Branch for closed_no_pr",
+                    &mut mismatches,
+                );
+            }
+            Some(value) => mismatches.push(format!(
+                "SOR Integration state expected 'merged' or 'closed_no_pr' but found '{value}'"
+            )),
+            None => mismatches.push("SOR Integration state is missing".to_string()),
+        }
         check_required_field(
             &text,
             "- Worktree-only paths remaining:",
@@ -297,6 +307,13 @@ fn check_required_field(
         )),
         None => mismatches.push(format!("{} is missing", label)),
     }
+}
+
+fn line_value_after_prefix(text: &str, prefix: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        line.strip_prefix(prefix)
+            .map(|value| value.trim().to_string())
+    })
 }
 
 fn matching_task_bundle_dirs(repo_root: &Path, issue_ref: &IssueRef) -> Result<Vec<PathBuf>> {
@@ -1066,7 +1083,9 @@ mod tests {
         let rendered = err.to_string();
         assert!(rendered.contains("canonical closed-issue sor truth drift"));
         assert!(rendered.contains("SOR Status expected 'DONE' but found 'IN_PROGRESS'"));
-        assert!(rendered.contains("SOR Integration state expected 'merged' but found 'pr_open'"));
+        assert!(rendered.contains(
+            "SOR Integration state expected 'merged' or 'closed_no_pr' but found 'pr_open'"
+        ));
         assert!(
             rendered.contains("SOR Verification scope expected 'main_repo' but found 'worktree'")
         );

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs
@@ -171,6 +171,186 @@ fn real_pr_closeout_reconciles_closed_completed_issue_bundle() {
 }
 
 #[test]
+fn real_pr_closeout_reconciles_closed_no_pr_issue_bundle() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-closeout-no-pr");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "closeout no-pr\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref =
+        IssueRef::new(1597, "v0.87.1", "v0-87-1-tools-closeout-no-pr-truth").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.87.1][tools] Closeout no-pr truth");
+    real_pr(&[
+        "init".to_string(),
+        "1597".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--title".to_string(),
+        "[v0.87.1][tools] Closeout no-pr truth".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let sip_path = issue_ref.task_bundle_input_path(&repo);
+    write_authored_sip(
+        &sip_path,
+        &issue_ref,
+        "[v0.87.1][tools] Closeout no-pr truth",
+        "codex/1597-v0-87-1-tools-closeout-no-pr-truth",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    let sor_path = issue_ref.task_bundle_output_path(&repo);
+    write_completed_sor_fixture(&sor_path, "codex/1597-v0-87-1-tools-closeout-no-pr-truth");
+    let sor_text = fs::read_to_string(&sor_path).expect("read sor fixture");
+    let sor_text = sor_text
+        .replace(
+            "- Integration state: pr_open",
+            "- Integration state: closed_no_pr",
+        )
+        .replace(
+            "Branch: codex/1597-v0-87-1-tools-closeout-no-pr-truth",
+            "Branch: retrospective-no-branch",
+        );
+    fs::write(&sor_path, sor_text).expect("write closed no-pr sor");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "codex/1597-v0-87-1-tools-closeout-no-pr-truth",
+            path_str(&worktree).expect("worktree path"),
+            "origin/main",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git worktree add")
+        .success());
+    assert!(
+        worktree.is_dir(),
+        "closeout no-pr fixture worktree should exist"
+    );
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$1 $2 $3 $4\" == \"issue view 1597 -R\" ]]; then\n  echo '{\"state\":\"CLOSED\",\"stateReason\":\"COMPLETED\"}'\n  exit 0\nfi\nexit 1\n",
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var(
+            "PATH",
+            format!(
+                "{}:{}",
+                gh_path.parent().expect("gh path").display(),
+                old_path
+            ),
+        );
+    }
+
+    let closeout = real_pr(&[
+        "closeout".to_string(),
+        "1597".to_string(),
+        "--slug".to_string(),
+        issue_ref.slug().to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.87.1".to_string(),
+    ]);
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    closeout.expect("closeout closed no-pr issue");
+
+    let canonical_text = fs::read_to_string(&sor_path).expect("read canonical sor");
+    assert!(canonical_text.contains("Status: DONE"));
+    assert!(canonical_text.contains("Branch: retrospective-no-branch"));
+    assert!(canonical_text.contains("- Integration state: closed_no_pr"));
+    assert!(canonical_text.contains("- Verification scope: main_repo"));
+    assert!(canonical_text.contains("- Worktree-only paths remaining: none"));
+    assert!(!worktree.exists());
+}
+
+#[test]
 fn real_pr_closeout_refuses_issue_that_is_not_completed() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-closeout-refuse");


### PR DESCRIPTION
Closes #2133

## Summary
Updated closeout truth handling to accept completed issue bundles with `closed_no_pr` when they are truthful umbrella/no-direct-PR completions, while preserving strict existing merged-closeout checks.

## Artifacts
- `adl/src/cli/pr_cmd/lifecycle.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle/closeout.rs`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type stp --input .adl/v0.90/bodies/issue-2133-v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation.md`
  - `bash adl/tools/validate_structured_prompt.sh --type stp --input .adl/v0.90/tasks/issue-2133__v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation/stp.md`
  - `bash adl/tools/validate_structured_prompt.sh --type sor --input .worktrees/adl-wp-2133/.adl/v0.90/tasks/issue-2133__v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation/sor.md`
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2133__v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation/sip.md
- Output card: .adl/v0.90/tasks/issue-2133__v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation/sor.md
- Idempotency-Key: v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation-adl-v0-90-tasks-issue-2133-v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation-sip-md-adl-v0-90-tasks-issue-2133-v0-90-tools-allow-closed-no-pr-closeout-truth-in-issue-automation-sor-md