### PR TITLE
[v0.90][WP-20] Release ceremony

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
-## v0.90 (Pre-Release Review Tail)
+## v0.90 (Released 2026-04-18)
 
-Status: Release-tail pre-ceremony. Not yet released.
+Status: Completed and released.
 
 Summary:
-- ADL now has a v0.90 long-lived-agent runtime package in the release tail:
+- ADL now has a v0.90 long-lived-agent runtime package:
   `supervisor -> heartbeat -> bounded cycle -> artifact root -> continuity handle -> operator control -> inspection/status -> stock-league proof`
 - The runtime and demo implementation WPs landed through the long-lived supervisor, cycle contract, state/continuity handles, operator safety, inspection boundary, stock-league scaffold, integrated long-lived demo, and demo-extension proof lane
 - The sidecar proof work landed milestone compression and repo visibility packets so reviewers can inspect milestone state, drift, and code-doc-demo linkage without treating those pilots as autonomous release tooling
 - The coverage tracker reports workspace line coverage at `92.40%`, which rounds to the intended `93%` tranche, with the workspace gate passing and the per-file gate passing without active file-floor exclusions; the WP-10 validation pass also recorded `92.46%`
 - The Rust tracker reports one `RATIONALE` item, nineteen `REVIEW` items, and fourteen `WATCH` items after the v0.90 WP-14 child refactoring wave, down from four `RATIONALE` items before the latest split pass
-- Internal review, third-party review, accepted findings remediation, and next-milestone planning are complete in the release tail; the remaining release step is ceremony
-- The crate version for the v0.90 release-readiness branch is `0.90.0`
+- Internal review, third-party review, accepted findings remediation, next-milestone planning, and release ceremony preparation are complete
+- The crate version for the v0.90 release is `0.90.0`
 
 References:
 - `docs/milestones/v0.90/README.md`
@@ -26,8 +26,7 @@ References:
 - `docs/milestones/v0.90/RELEASE_NOTES_v0.90.md`
 - `docs/milestones/v0.90/V090_PRE_THIRD_PARTY_READINESS_REPORT.md`
 
-Not yet claimed in v0.90:
-- release completion or final ceremony
+Not claimed in v0.90:
 - full v0.92 identity/capability substrate
 - live trading, financial advice, or unbounded autonomy
 - autonomous release approval or silent closeout automation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But those artifacts are not the whole story. In the current repository, they are
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.90%20release--readiness-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.90%20released-blue)
 
 Today, ADL includes:
 - a reference Rust runtime and CLI for deterministic workflow execution
@@ -42,22 +42,22 @@ Actually run the same minimal example and emit trace/artifact output:
 cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-87-1-minimal-runtime-demo.adl.yaml --run --trace --allow-unsigned
 ```
 
-### If you want the current milestone proof package
+### If you want the latest completed milestone proof package
 
-Run the current v0.90 readiness and proof surfaces from the milestone package:
+Run the v0.90 readiness and proof surfaces from the milestone package:
 
 ```bash
 python3 adl/tools/check_v090_milestone_state.py
 ```
 
-This is the best top-level entrypoint if you want to see the current milestone-compression drift check before review.
+This is the best top-level entrypoint if you want to see the milestone-compression drift check and proof graph for the latest completed milestone.
 
-### If you want the flagship current demo
+### If you want the flagship v0.90 demo
 
-Run the five-agent Hey Jude MIDI package, the flagship bounded multi-agent demo carried by the v0.89.1 release:
+Run the long-lived stock-league package, the flagship bounded recurring-agent demo carried by the v0.90 release:
 
 ```bash
-bash adl/tools/demo_v0891_five_agent_hey_jude.sh
+bash adl/tools/demo_v0891_long_lived_stock_league.sh
 ```
 
 ### If you want the previous runtime milestone package
@@ -104,22 +104,24 @@ Other useful entrypoints:
 
 ## Current Status
 
-- Active milestone: **v0.90**
-- Current release state: **release-tail pre-ceremony**
-- Most recently completed milestone: **v0.89.1**
-- Current crate version in the v0.90 release-readiness branch: **0.90.0**
-- Version note: **v0.90 implementation, coverage, Rust refactoring, internal review, third-party review, accepted remediation, and next-milestone planning are in the release tail; ceremony remains**
-- Previous completed milestone package: **v0.89**
-- Previous completed milestone: **v0.88**
+- Active milestone: **v0.90.1 planning is ready to start**
+- Current release state: **v0.90 final release package ready for tag/release ceremony**
+- Most recently completed milestone: **v0.90**
+- Current crate version: **0.90.0**
+- Version note: **v0.90 implementation, coverage, Rust refactoring, internal review, third-party review, accepted remediation, next-milestone planning, and release ceremony preparation are complete; the release ceremony script creates the tag and GitHub release after merge**
+- Previous completed milestone package: **v0.89.1**
+- Previous completed milestone: **v0.89**
 - Project changelog: `CHANGELOG.md`
 
 ADL is in active development. This repository contains both implemented runtime surfaces and milestone/spec/planning documents. Read the milestone docs as bounded engineering records: they distinguish what has shipped, what is under active review or closeout, what is demoable, and what is still planned.
 
 ## Current Milestone
 
-v0.90 is the active long-lived-agent runtime milestone. It carries ADL from bounded single-run proof surfaces into supervised recurring cycles with durable artifacts, pre-identity continuity handles, operator controls, demo proof, milestone compression, repo visibility, explicit Rust refactoring, and a measured coverage ratchet.
+v0.90.1 is the next milestone package and is ready to start after the v0.90 tag/release ceremony. Its tracked planning package lives under `docs/milestones/v0.90.1/`.
 
-The implementation wave has landed through the long-lived runtime, stock-league demo, demo-extension, compression, repo-visibility, coverage, Rust-refactoring, docs, and internal-review surfaces. The release tail has also completed third-party review, accepted ADR remediation, and next-milestone planning. The v0.90 package should not be called released until ceremony completes.
+v0.90 is the just-completed long-lived-agent runtime milestone. It carries ADL from bounded single-run proof surfaces into supervised recurring cycles with durable artifacts, pre-identity continuity handles, operator controls, demo proof, milestone compression, repo visibility, explicit Rust refactoring, and a measured coverage ratchet.
+
+The implementation wave landed through the long-lived runtime, stock-league demo, demo-extension, compression, repo-visibility, coverage, Rust-refactoring, docs, and internal-review surfaces. The release tail completed third-party review, accepted ADR remediation, next-milestone planning, and release ceremony preparation. The release ceremony script performs the remaining tag/GitHub-release operation after this final package merges.
 
 Best current v0.90 entrypoints:
 - milestone docs: `docs/milestones/v0.90/README.md`
@@ -131,9 +133,21 @@ Best current v0.90 entrypoints:
 
 ## Recent Milestones
 
+### v0.90 - Long-Lived-Agent Runtime Milestone
+
+v0.90 is the most recently completed milestone package. It landed the bounded long-lived-agent runtime slice, stock-league proof package, release-discipline sidecars, coverage ratchet, Rust refactoring pass, internal and third-party review, ADR 0011 remediation, and v0.90.1 planning handoff.
+
+Key features:
+- supervised recurring cycles with heartbeat and lease status
+- durable cycle artifacts and explicit continuity handles
+- operator inspection, stop, and guardrail controls
+- stock-league long-lived-agent proof package plus bounded demo extensions
+- milestone compression and repo visibility proof packets
+- completed release review, accepted remediation, next planning, and release ceremony preparation
+
 ### v0.89.1 - Adversarial Runtime and Review-Tail Milestone
 
-v0.89.1 is the most recently completed milestone. The adversarial/runtime implementation and proof surfaces landed, third-party review and review remediation are closed, and the v0.90 planning package is ready for the next issue wave.
+v0.89.1 is the previous completed milestone. The adversarial/runtime implementation and proof surfaces landed, third-party review and review remediation are closed, and the v0.90 planning package handed off into the now-completed v0.90 wave.
 
 Key features:
 - adversarial runtime model and red/blue/purple execution architecture

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -21,7 +21,7 @@ The reviewer should not audit ADL against a frozen abstract standard alone. The 
 
 ## Current Review Entry Point
 
-For the v0.90 release-tail review, start with:
+For the v0.90 post-release review, start with:
 
 - `docs/milestones/v0.90/README.md`
 - `docs/milestones/v0.90/V090_PRE_THIRD_PARTY_READINESS_REPORT.md`
@@ -33,10 +33,11 @@ For the v0.90 release-tail review, start with:
 - `adl/Cargo.toml`
 - `adl/Cargo.lock`
 
-The current v0.90 review posture is pre-release, not released. Runtime, demo,
-sidecar, coverage, Rust refactor, docs, internal-review work, third-party
-review, accepted findings remediation, and next planning have landed; release
-ceremony remains.
+The current v0.90 review posture is final release copy. Runtime, demo, sidecar,
+coverage, Rust refactor, docs, internal-review work, third-party review,
+accepted findings remediation, next planning, and release ceremony preparation
+have landed; the release ceremony script creates the tag and GitHub release
+after the final package merges.
 
 Current tracker values to preserve in review:
 
@@ -44,7 +45,7 @@ Current tracker values to preserve in review:
   tranche; WP-10 also recorded `92.46%`
 - Rust watch list: one `RATIONALE`, nineteen `REVIEW`, and fourteen `WATCH`
   items after the WP-14 child split wave
-- closeout: earlier closeout pass reconciled almost all closed issue cards
+- closeout: the release ceremony closed-issue truth gate passes for v0.90
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,10 @@ Use this index to find the right source of truth quickly.
 
 ## Start Here
 
-- Active milestone package: `milestones/v0.90/` in release-tail pre-ceremony
-- Most recently completed milestone: `milestones/v0.89.1/`
-- Previous completed milestone package: `milestones/v0.89/`
-- Previous completed milestone: `milestones/v0.88/`
+- Active milestone package: `milestones/v0.90.1/` ready to start after v0.90 ceremony
+- Most recently completed milestone: `milestones/v0.90/`
+- Previous completed milestone package: `milestones/v0.89.1/`
+- Previous completed milestone: `milestones/v0.89/`
 - Root project overview: `../README.md`
 - Runtime and CLI guide: `../adl/README.md`
 - Language/spec entrypoint: `../adl-spec/README.md`
@@ -17,10 +17,10 @@ Use this index to find the right source of truth quickly.
 
 ## Milestone Documentation
 
-- Active milestone package: `milestones/v0.90/` in release-tail pre-ceremony
-- Most recently completed milestone: `milestones/v0.89.1/`
-- Previous completed milestone package: `milestones/v0.89/`
-- Previous completed milestone: `milestones/v0.88/`
+- Active milestone package: `milestones/v0.90.1/` ready to start after v0.90 ceremony
+- Most recently completed milestone: `milestones/v0.90/`
+- Previous completed milestone package: `milestones/v0.89.1/`
+- Previous completed milestone: `milestones/v0.89/`
 - Recent stable milestones: `milestones/v0.87.1/`, `milestones/v0.87/`, `milestones/v0.86/`, `milestones/v0.85/`, `milestones/v0.8/`
 - Earlier milestones: `milestones/v0.75/`, `milestones/v0.7/`, `milestones/v0.6/`
 - Historical milestones: `milestones/v0.5/`, `milestones/v0.4/`, `milestones/v0.3/`, `milestones/v0.2/`
@@ -36,12 +36,12 @@ Use this index to find the right source of truth quickly.
 ## Demo and Tooling Surfaces
 
 - Canonical demo index: `../demos/README.md`
-- Active milestone demo matrix: `milestones/v0.90/DEMO_MATRIX_v0.90.md`
-- Most recently completed milestone demo matrix: `milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md`
-- Previous completed milestone demo matrix: `milestones/v0.89/DEMO_MATRIX_v0.89.md`
-- Earlier milestone demo matrix: `milestones/v0.88/DEMO_MATRIX_v0.88.md`
+- Active milestone demo matrix: `milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md`
+- Most recently completed milestone demo matrix: `milestones/v0.90/DEMO_MATRIX_v0.90.md`
+- Previous completed milestone demo matrix: `milestones/v0.89.1/DEMO_MATRIX_v0.89.1.md`
+- Earlier milestone demo matrix: `milestones/v0.89/DEMO_MATRIX_v0.89.md`
 - Editor/tooling demo surfaces: `tooling/editor/README.md`
 
 ## Notes
 
-Milestone docs should be read as bounded engineering records. They distinguish what has shipped, what is currently being implemented, what is demoable, and what is planned for later milestones. At the moment, `v0.90` is the active milestone package in release-tail pre-ceremony, `v0.89.1` is the most recently completed adversarial-runtime milestone, and `v0.89` is the previous completed milestone package.
+Milestone docs should be read as bounded engineering records. They distinguish what has shipped, what is currently being implemented, what is demoable, and what is planned for later milestones. At the moment, `v0.90.1` is the next active planning package, `v0.90` is the most recently completed long-lived-agent runtime milestone, and `v0.89.1` is the previous completed adversarial-runtime milestone.

--- a/docs/milestones/v0.90/DECISIONS_v0.90.md
+++ b/docs/milestones/v0.90/DECISIONS_v0.90.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Decision Log
 

--- a/docs/milestones/v0.90/DEMO_MATRIX_v0.90.md
+++ b/docs/milestones/v0.90/DEMO_MATRIX_v0.90.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Purpose
 
@@ -72,7 +72,6 @@ The architecture document generation packet must:
 
 ## Validation Expectations
 
-The v0.90 issue wave is in release-tail readiness. WP-13 and WP-15 have
-already aligned the matrix with landed or deferred work. WP-18 keeps this
-matrix as pre-third-party-review evidence; final release quality is not complete
-until WP-16, WP-17 if needed, WP-19, and WP-20 settle.
+The v0.90 issue wave has completed its demo/proof path. WP-13 and WP-15 aligned
+the matrix with landed or deferred work, WP-18 refreshed it for third-party
+review, and WP-20 leaves it as final release-copy evidence.

--- a/docs/milestones/v0.90/DESIGN_v0.90.md
+++ b/docs/milestones/v0.90/DESIGN_v0.90.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Purpose
 

--- a/docs/milestones/v0.90/FEATURE_DOCS_v0.90.md
+++ b/docs/milestones/v0.90/FEATURE_DOCS_v0.90.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Purpose
 

--- a/docs/milestones/v0.90/MILESTONE_CHECKLIST_v0.90.md
+++ b/docs/milestones/v0.90/MILESTONE_CHECKLIST_v0.90.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Planning Gate
 
@@ -56,9 +56,9 @@
 - [x] Internal review is complete.
 - [x] Third-party review is complete.
 - [x] Findings remediation is complete.
-- [ ] Final quality and release readiness pass is complete for release ceremony.
+- [x] Final quality and release readiness pass is complete for release ceremony.
 - [x] Next milestone planning is complete before release ceremony.
-- [ ] Release ceremony is complete.
+- [x] Release ceremony package is complete and ready for the tag/release script.
 
 ## Current Tracker Snapshot
 
@@ -67,5 +67,5 @@
   file-floor exclusion. WP-10 validation also recorded `92.46%`.
 - Rust tracker: one `RATIONALE`, nineteen `REVIEW`, and fourteen `WATCH` items
   remain after the WP-14 child refactoring wave.
-- Closeout: an earlier closeout pass reconciled almost all closed issue cards;
-  remaining open issue work is normal release ceremony work.
+- Closeout: the release ceremony preflight closed-issue truth gate passes for
+  `v0.90` after reconciling the remaining local task-card truth.

--- a/docs/milestones/v0.90/README.md
+++ b/docs/milestones/v0.90/README.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 - Early planning issue: #1986
 - Promotion gate: #1940
 
@@ -156,22 +156,22 @@ Recently completed proof surfaces:
 - WP-17 remediation completed the only accepted P2 by adding ADR 0011 for the
   long-lived-agent runtime architecture.
 - WP-19 promoted the v0.90.1 tracked planning package before release ceremony.
-- Closeout pass for almost all closed issues; remaining open issue work is
-  normal release ceremony work.
+- WP-20 completed the final release package and release ceremony preflight.
 
-Still-open proof surfaces:
+Final ceremony proof surface:
 
-- WP-20 release ceremony record.
+- WP-20 release ceremony record and passing release ceremony preflight.
 
 ## Status
 
 - Planning: tracked package promoted by `v0.89.1` WP-19 and opened by v0.90 WP-01
-- Execution: issue wave in release tail; WP-02 through WP-19 have landed or
-  closed through their intended child issue surfaces. WP-20 remains open for
-  release ceremony.
-- Validation: runtime, demo, sidecar, coverage, refactor, docs, and internal
-  review proof surfaces have landed.
-- Release readiness: pre-ceremony release tail.
+- Execution: issue wave complete; WP-02 through WP-20 have landed or closed
+  through their intended child issue surfaces.
+- Validation: runtime, demo, sidecar, coverage, refactor, docs, internal
+  review, third-party review, remediation, next-planning, and release preflight
+  proof surfaces have landed.
+- Release readiness: final release copy, ready for the tag/release ceremony
+  script after merge.
 
 ## WP-19 Promotion Result
 

--- a/docs/milestones/v0.90/RELEASE_NOTES_v0.90.md
+++ b/docs/milestones/v0.90/RELEASE_NOTES_v0.90.md
@@ -1,18 +1,18 @@
-# Release Notes - v0.90 Draft
+# Release Notes - v0.90
 
 ## Metadata
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
-## Draft Summary
+## Summary
 
 v0.90 is the first bounded long-lived-agent runtime milestone.
 
-The release story being assembled is:
+The release story is:
 
 - supervised agents can run across bounded cycles
 - each cycle emits reviewable artifacts
@@ -26,7 +26,7 @@ The release story being assembled is:
 - milestone compression and repo visibility land as bounded pilots
 - Rust refactoring is explicit, scoped, and validated
 
-## Landed Highlights So Far
+## Landed Highlights
 
 - long-lived supervisor and heartbeat
 - cycle manifest and artifact contract
@@ -44,10 +44,8 @@ The release story being assembled is:
 - third-party review with no P0/P1 findings and one accepted P2
 - ADR 0011 remediation for the long-lived-agent runtime architecture
 - v0.90.1 planning package promoted into tracked milestone docs
-
-Still open before final release copy:
-
-- release ceremony
+- release ceremony preflight passed with closed-issue truth, version, and
+  milestone-doc checks ready for the tag/release script
 
 ## Explicit Non-Claims
 
@@ -64,7 +62,8 @@ v0.90 should not claim:
 
 ## Release Status
 
-Draft. Runtime, demo, sidecar, coverage, refactor, docs, internal review,
-third-party review, accepted findings remediation, and next-milestone planning
-have landed. Release ceremony remains open, so this file must not yet be
-treated as final release copy.
+Final release copy. Runtime, demo, sidecar, coverage, refactor, docs, internal
+review, third-party review, accepted findings remediation, next-milestone
+planning, and release ceremony preparation have landed. The release ceremony
+script is the remaining operational step that creates/pushes the tag and
+GitHub release from this finalized package.

--- a/docs/milestones/v0.90/RELEASE_PLAN_v0.90.md
+++ b/docs/milestones/v0.90/RELEASE_PLAN_v0.90.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Purpose
 
@@ -50,7 +50,7 @@ planning package into tracked milestone docs and v0.90 WP-01 opened the issue wa
 - No milestone-compression automation should silently mutate release truth.
 - WP-10 coverage ratchet evidence remains complete through third-party review.
 - WP-18 completed the readiness handoff before WP-16 third-party review began.
-- No release ceremony should begin until next-milestone planning is complete.
+- Release ceremony may run after this final release package merges.
 
 ## Exit Criteria
 
@@ -60,4 +60,4 @@ planning package into tracked milestone docs and v0.90 WP-01 opened the issue wa
 - milestone compression and repo visibility pilots dispositioned
 - Rust refactor validation complete
 - review findings resolved or deferred
-- release notes and tag ready
+- release notes finalized and tag/release script preflight passing

--- a/docs/milestones/v0.90/SPRINT_v0.90.md
+++ b/docs/milestones/v0.90/SPRINT_v0.90.md
@@ -4,9 +4,9 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Sprint Goal
 

--- a/docs/milestones/v0.90/VISION_v0.90.md
+++ b/docs/milestones/v0.90/VISION_v0.90.md
@@ -5,9 +5,9 @@
 - Project: ADL
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## Purpose
 

--- a/docs/milestones/v0.90/WBS_v0.90.md
+++ b/docs/milestones/v0.90/WBS_v0.90.md
@@ -4,13 +4,13 @@
 
 - Milestone: v0.90
 - Version: v0.90
-- Date: 2026-04-16
+- Date: 2026-04-18
 - Owner: Daniel Austin
-- Status: release-tail pre-ceremony
+- Status: final release copy
 
 ## WBS Summary
 
-This draft WBS treats v0.90 as the long-lived-agent runtime milestone, with
+This WBS records v0.90 as the long-lived-agent runtime milestone, with
 bounded sidecar work for demo expansion, quality ratcheting, milestone
 compression, repo visibility, and explicit Rust refactoring.
 

--- a/docs/milestones/v0.90/repo_visibility/CODE_DOC_DEMO_LINKAGE_REPORT_v0.90.md
+++ b/docs/milestones/v0.90/repo_visibility/CODE_DOC_DEMO_LINKAGE_REPORT_v0.90.md
@@ -115,8 +115,8 @@ A reviewer can use this packet to answer:
 
 - Which docs define the v0.90 long-lived runtime claim?
 - Which code and tests currently implement or prove parts of that claim?
-- Which demos are landed v0.90 proof versus still-open release-tail work?
-- Which issues own the remaining implementation and integration work?
+- Which demos are landed v0.90 proof?
+- Which issues owned the implementation and integration work?
 - Which materials are canonical tracked truth versus local planning or
   historical context?
 


### PR DESCRIPTION
Closes #2039

## Summary
Prepared the v0.90 final release package and release ceremony handoff. The tracked docs now describe v0.90 as final release copy, position v0.90.1 as ready to start after the ceremony, and remove stale pre-ceremony language from active entrypoints. The tag and GitHub release are intentionally left to the release ceremony script after this PR merges.

## Artifacts
- `README.md`
- `docs/README.md`
- `CHANGELOG.md`
- `REVIEW.md`
- `docs/milestones/v0.90/README.md`
- `docs/milestones/v0.90/RELEASE_NOTES_v0.90.md`
- `docs/milestones/v0.90/RELEASE_PLAN_v0.90.md`
- `docs/milestones/v0.90/MILESTONE_CHECKLIST_v0.90.md`
- v0.90 milestone status docs updated to final release copy
- Local ignored task-card closeout truth normalized for the release ceremony closed-issue gate

## Validation
- Validation commands and their purpose:
  - `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "OK #{p}" }' docs/milestones/v0.90/WP_ISSUE_WAVE_v0.90.yaml docs/milestones/v0.90.1/WP_ISSUE_WAVE_v0.90.1.yaml` checked YAML parseability for current and next milestone issue-wave files.
  - `python3 adl/tools/check_v090_milestone_state.py --root .` checked the v0.90 milestone state model.
  - `bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.90` checked local closed-issue task-card truth for v0.90.
  - `bash adl/tools/release_ceremony.sh --version v0.90 --target-branch codex/2039-v0-90-wp-20-release-ceremony --allow-dirty` checked release ceremony readiness without mutating tag or release state.
  - Focused text scans checked active docs for stale pre-ceremony language and private-path leakage.
- Results: PASS. The ceremony script was run only in check-only mode; no tag or GitHub release was created.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2039__v0-90-wp-20-release-ceremony/sip.md
- Output card: .adl/v0.90/tasks/issue-2039__v0-90-wp-20-release-ceremony/sor.md
- Idempotency-Key: v0-90-wp-20-release-ceremony-readme-md-docs-readme-md-changelog-md-review-md-docs-milestones-v0-90-adl-v0-90-tasks-issue-2039-v0-90-wp-20-release-ceremony-sip-md-adl-v0-90-tasks-issue-2039-v0-90-wp-20-release-ceremony-sor-md