### PR TITLE
[v0.90.1][WP-01] Issue wave and task cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ Other useful entrypoints:
 
 ## Current Status
 
-- Active milestone: **v0.90.1 planning is ready to start**
-- Current release state: **v0.90 final release package ready for tag/release ceremony**
+- Active milestone: **v0.90.1**
+- Current release state: **v0.90 released; v0.90.1 issue wave open**
 - Most recently completed milestone: **v0.90**
 - Current crate version: **0.90.0**
-- Version note: **v0.90 implementation, coverage, Rust refactoring, internal review, third-party review, accepted remediation, next-milestone planning, and release ceremony preparation are complete; the release ceremony script creates the tag and GitHub release after merge**
+- Version note: **v0.90 is tagged and released; v0.90.1 WP-01 opened the Runtime v2 foundation issue wave**
 - Previous completed milestone package: **v0.89.1**
 - Previous completed milestone: **v0.89**
 - Project changelog: `CHANGELOG.md`
@@ -117,11 +117,11 @@ ADL is in active development. This repository contains both implemented runtime 
 
 ## Current Milestone
 
-v0.90.1 is the next milestone package and is ready to start after the v0.90 tag/release ceremony. Its tracked planning package lives under `docs/milestones/v0.90.1/`.
+v0.90.1 is the active milestone package. Its issue wave is open, with WP-01 at #2141 and WP-02 through WP-20 at #2142 through #2160. The tracked planning package lives under `docs/milestones/v0.90.1/`.
 
 v0.90 is the just-completed long-lived-agent runtime milestone. It carries ADL from bounded single-run proof surfaces into supervised recurring cycles with durable artifacts, pre-identity continuity handles, operator controls, demo proof, milestone compression, repo visibility, explicit Rust refactoring, and a measured coverage ratchet.
 
-The implementation wave landed through the long-lived runtime, stock-league demo, demo-extension, compression, repo-visibility, coverage, Rust-refactoring, docs, and internal-review surfaces. The release tail completed third-party review, accepted ADR remediation, next-milestone planning, and release ceremony preparation. The release ceremony script performs the remaining tag/GitHub-release operation after this final package merges.
+The implementation wave landed through the long-lived runtime, stock-league demo, demo-extension, compression, repo-visibility, coverage, Rust-refactoring, docs, and internal-review surfaces. The release tail completed third-party review, accepted ADR remediation, next-milestone planning, and release ceremony.
 
 Best current v0.90 entrypoints:
 - milestone docs: `docs/milestones/v0.90/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Use this index to find the right source of truth quickly.
 
 ## Start Here
 
-- Active milestone package: `milestones/v0.90.1/` ready to start after v0.90 ceremony
+- Active milestone package: `milestones/v0.90.1/` with issue wave open
 - Most recently completed milestone: `milestones/v0.90/`
 - Previous completed milestone package: `milestones/v0.89.1/`
 - Previous completed milestone: `milestones/v0.89/`
@@ -17,7 +17,7 @@ Use this index to find the right source of truth quickly.
 
 ## Milestone Documentation
 
-- Active milestone package: `milestones/v0.90.1/` ready to start after v0.90 ceremony
+- Active milestone package: `milestones/v0.90.1/` with issue wave open
 - Most recently completed milestone: `milestones/v0.90/`
 - Previous completed milestone package: `milestones/v0.89.1/`
 - Previous completed milestone: `milestones/v0.89/`
@@ -44,4 +44,4 @@ Use this index to find the right source of truth quickly.
 
 ## Notes
 
-Milestone docs should be read as bounded engineering records. They distinguish what has shipped, what is currently being implemented, what is demoable, and what is planned for later milestones. At the moment, `v0.90.1` is the next active planning package, `v0.90` is the most recently completed long-lived-agent runtime milestone, and `v0.89.1` is the previous completed adversarial-runtime milestone.
+Milestone docs should be read as bounded engineering records. They distinguish what has shipped, what is currently being implemented, what is demoable, and what is planned for later milestones. At the moment, `v0.90.1` is the active Runtime v2 foundation milestone with its issue wave open, `v0.90` is the most recently completed long-lived-agent runtime milestone, and `v0.89.1` is the previous completed adversarial-runtime milestone.

--- a/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
+++ b/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planning draft. Demo commands are not final until implementation WPs land.
+Issue wave open. Demo commands are not final until implementation WPs land.
 
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
@@ -2,7 +2,7 @@
 
 ## Implementation-Facing Features
 
-| Feature Doc | Purpose | Candidate WPs |
+| Feature Doc | Purpose | WPs / Issues |
 | --- | --- | --- |
 | `features/RUNTIME_V2_FOUNDATION_PROTOTYPE.md` | end-to-end prototype boundary and proof packet | WP-05-WP-12 |
 | `features/MANIFOLD_AND_SNAPSHOT_CONTRACT.md` | manifold root, snapshot, and rehydration contract | WP-05, WP-08 |
@@ -12,12 +12,12 @@
 
 ## Compression-Enabling Process Work
 
-| Work Surface | Purpose | Candidate WPs |
+| Work Surface | Purpose | WPs / Issues |
 | --- | --- | --- |
-| WP issue-wave template and generator alignment | make v0.90.1 and v0.90.2 issue waves cheaper and less error-prone | WP-02 |
-| Worktree-first workflow hardening | prevent tracked root-checkout drift during compressed execution | WP-03 |
-| Compression-era execution policy | align skills, explicit-only subagents, validation profiles, and SOR evidence | WP-04 |
-| Release-evidence packet | assemble the final proof trail without release-tail archaeology | WP-19 |
+| WP issue-wave template and generator alignment | make v0.90.1 and v0.90.2 issue waves cheaper and less error-prone | WP-02 / #2142 |
+| Worktree-first workflow hardening | prevent tracked root-checkout drift during compressed execution | WP-03 / #2143 |
+| Compression-era execution policy | align skills, explicit-only subagents, validation profiles, and SOR evidence | WP-04 / #2144 |
+| Release-evidence packet | assemble the final proof trail without release-tail archaeology | WP-19 / #2159 |
 
 ## Context / Idea Docs
 

--- a/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
+++ b/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
@@ -3,8 +3,8 @@
 ## Planning
 
 - [x] Planning docs promoted into the tracked v0.90.1 milestone package
-- [ ] Issue wave opened from reviewed WP YAML
-- [ ] Scope boundary reviewed against v0.91 and v0.92
+- [x] Issue wave opened from reviewed WP YAML
+- [x] Scope boundary reviewed against v0.91 and v0.92
 
 ## Implementation
 

--- a/docs/milestones/v0.90.1/README.md
+++ b/docs/milestones/v0.90.1/README.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Tracked next-milestone planning package promoted during the v0.90 WP-19
-release-tail planning gate.
+Active milestone package. The issue wave is open and ready for Sprint 1
+execution.
 
-The package is ready for v0.90.1 issue-wave authoring after v0.90 release
-ceremony approval. It is not evidence that v0.90.1 implementation has started.
+WP-01 opened the v0.90.1 issue wave after the v0.90 release ceremony. WP-01 is
+#2141; WP-02 through WP-20 are #2142 through #2160.
 
 ## Thesis
 
@@ -74,12 +74,11 @@ Out of scope:
 
 ## Issue-Wave Rule
 
-After v0.90 release ceremony approval, v0.90.1 WP-01 should open the actual
-GitHub issue wave and author the task cards from this tracked package.
+WP-01 opened the actual GitHub issue wave and authored the local task cards
+from this tracked package.
 
-Do not treat the tracked package itself as an opened issue wave. The wave is
-not open until the WP-01 issue-creation step records real issue numbers and
-updates the YAML.
+The wave is now open. Treat WP_ISSUE_WAVE_v0.90.1.yaml as the issue-number
+source of truth for WP routing.
 
 ## Compression Rule
 

--- a/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
@@ -9,6 +9,8 @@ weakened release truth.
 
 ## Required Release Evidence
 
+- Opened issue wave with WP-01 as #2141 and WP-02 through WP-20 as #2142
+  through #2160
 - Integrated Runtime v2 proof packet
 - Compression-enablement proof for issue-wave generation, worktree-first
   execution, and current execution policy

--- a/docs/milestones/v0.90.1/SPRINT_v0.90.1.md
+++ b/docs/milestones/v0.90.1/SPRINT_v0.90.1.md
@@ -7,6 +7,8 @@
 - WP-03 worktree-first workflow hardening
 - WP-04 compression-era execution policy
 
+Opened issues: #2141 through #2144.
+
 Exit when the milestone can create issues, route worktrees, and apply compressed
 validation rules without relying on folklore or hand-repaired card drift.
 
@@ -16,6 +18,8 @@ validation rules without relying on folklore or hand-repaired card drift.
 - WP-06 kernel service loop
 - WP-07 provisional citizen records
 - WP-08 snapshot and rehydration
+
+Opened issues: #2145 through #2148.
 
 Exit when the repo has a concrete Runtime v2 root, bounded kernel loop,
 provisional citizen records, and a sleep/wake path with tests or proof
@@ -28,6 +32,8 @@ artifacts.
 - WP-11 security-boundary proof
 - WP-12 Runtime v2 demo
 
+Opened issues: #2149 through #2152.
+
 Exit when invariant rejection, operator intervention, one security boundary,
 and the integrated Runtime v2 proof packet are all reviewable.
 
@@ -38,6 +44,8 @@ and the integrated Runtime v2 proof packet are all reviewable.
 - WP-15 internal review
 - WP-16 remediation
 
+Opened issues: #2153 through #2156.
+
 Exit when the prototype can be reviewed end to end and accepted findings are
 fixed or explicitly deferred.
 
@@ -47,6 +55,8 @@ fixed or explicitly deferred.
 - WP-18 v0.91/v0.92 handoff
 - WP-19 release-evidence packet
 - WP-20 release ceremony
+
+Opened issues: #2157 through #2160.
 
 Exit when the milestone is truthful, releaseable, and does not steal later
 identity or moral/emotional scope.

--- a/docs/milestones/v0.90.1/WBS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/WBS_v0.90.1.md
@@ -6,28 +6,28 @@ The issue wave uses the standard 20-WP milestone shape, but it front-loads a
 short compression-enablement sprint before Runtime v2 coding begins. v0.90.1 is
 still a follow-on foundation slice, not a full major milestone.
 
-| WP | Title | Purpose | Primary Output | Depends On |
-| --- | --- | --- | --- | --- |
-| WP-01 | Issue wave and task cards | Open the v0.90.1 issue wave from this tracked planning package | GitHub issues, task cards, and issue-number mapping | v0.90 closeout |
-| WP-02 | Issue-wave template and generator alignment | Make the WP wave seed mechanically reusable for this and later milestones | aligned template/generator proof | WP-01 |
-| WP-03 | Worktree-first workflow hardening | Prevent tracked root-checkout drift before compressed execution starts | workflow guardrails and tests | WP-02 |
-| WP-04 | Compression-era execution policy | Align skills, subagent rules, validation profiles, and SOR evidence expectations | operator policy and validation guidance | WP-02, WP-03 |
-| WP-05 | Manifold contract | Define and implement the persistent manifold root | manifest, tests, docs | WP-04 |
-| WP-06 | Kernel service loop | Implement bounded kernel loop and service registry | loop artifact, service state, tests | WP-05 |
-| WP-07 | Provisional citizen records | Add provisional citizen record and lifecycle states | citizen records, validation | WP-05 |
-| WP-08 | Snapshot and rehydration | Persist and restore manifold/citizen state | snapshot, wake report, tests | WP-06, WP-07 |
-| WP-09 | Invariant violation artifacts | Emit reviewable invariant failure evidence | violation packet, negative tests | WP-06 |
-| WP-10 | Operator controls | Add inspect, pause, resume, terminate controls | operator report, CLI/demo hook | WP-06, WP-08 |
-| WP-11 | Security-boundary proof | Prove one rejected invalid action through kernel policy | security proof packet | WP-09, WP-10 |
-| WP-12 | Runtime v2 demo | Integrate the foundation prototype into one demo | bounded demo and proof packet | WP-05-WP-11 |
-| WP-13 | Runtime v2 docs pass | Align feature docs, demo matrix, and README | coherent docs package | WP-12 |
-| WP-14 | Quality and coverage gate | Run focused tests and quality posture | quality report | WP-12 |
-| WP-15 | Internal review | Review scope, claims, and proof surfaces | review report and findings | WP-13, WP-14 |
-| WP-16 | Review remediation | Fix accepted internal review findings | patches and closure notes | WP-15 |
-| WP-17 | Release readiness | Finalize release notes, checklist, and handoff | readiness packet | WP-16 |
-| WP-18 | v0.91/v0.92 handoff | Preserve moral/emotional and birthday boundaries | handoff doc | WP-17 |
-| WP-19 | Release-evidence packet | Assemble the proof trail across demos, quality, review, and readiness | release evidence packet | WP-17, WP-18 |
-| WP-20 | Release ceremony | Complete tag/release ceremony | release closure | WP-18, WP-19 |
+| WP | Issue | Title | Purpose | Primary Output | Depends On |
+| --- | --- | --- | --- | --- | --- |
+| WP-01 | #2141 | Issue wave and task cards | Open the v0.90.1 issue wave from this tracked planning package | GitHub issues, task cards, and issue-number mapping | v0.90 closeout |
+| WP-02 | #2142 | Issue-wave template and generator alignment | Make the WP wave seed mechanically reusable for this and later milestones | aligned template/generator proof | WP-01 |
+| WP-03 | #2143 | Worktree-first workflow hardening | Prevent tracked root-checkout drift before compressed execution starts | workflow guardrails and tests | WP-02 |
+| WP-04 | #2144 | Compression-era execution policy | Align skills, subagent rules, validation profiles, and SOR evidence expectations | operator policy and validation guidance | WP-02, WP-03 |
+| WP-05 | #2145 | Manifold contract | Define and implement the persistent manifold root | manifest, tests, docs | WP-04 |
+| WP-06 | #2146 | Kernel service loop | Implement bounded kernel loop and service registry | loop artifact, service state, tests | WP-05 |
+| WP-07 | #2147 | Provisional citizen records | Add provisional citizen record and lifecycle states | citizen records, validation | WP-05 |
+| WP-08 | #2148 | Snapshot and rehydration | Persist and restore manifold/citizen state | snapshot, wake report, tests | WP-06, WP-07 |
+| WP-09 | #2149 | Invariant violation artifacts | Emit reviewable invariant failure evidence | violation packet, negative tests | WP-06 |
+| WP-10 | #2150 | Operator controls | Add inspect, pause, resume, terminate controls | operator report, CLI/demo hook | WP-06, WP-08 |
+| WP-11 | #2151 | Security-boundary proof | Prove one rejected invalid action through kernel policy | security proof packet | WP-09, WP-10 |
+| WP-12 | #2152 | Runtime v2 demo | Integrate the foundation prototype into one demo | bounded demo and proof packet | WP-05-WP-11 |
+| WP-13 | #2153 | Runtime v2 docs pass | Align feature docs, demo matrix, and README | coherent docs package | WP-12 |
+| WP-14 | #2154 | Quality and coverage gate | Run focused tests and quality posture | quality report | WP-12 |
+| WP-15 | #2155 | Internal review | Review scope, claims, and proof surfaces | review report and findings | WP-13, WP-14 |
+| WP-16 | #2156 | Review remediation | Fix accepted internal review findings | patches and closure notes | WP-15 |
+| WP-17 | #2157 | Release readiness | Finalize release notes, checklist, and handoff | readiness packet | WP-16 |
+| WP-18 | #2158 | v0.91/v0.92 handoff | Preserve moral/emotional and birthday boundaries | handoff doc | WP-17 |
+| WP-19 | #2159 | Release-evidence packet | Assemble the proof trail across demos, quality, review, and readiness | release evidence packet | WP-17, WP-18 |
+| WP-20 | #2160 | Release ceremony | Complete tag/release ceremony | release closure | WP-18, WP-19 |
 
 ## Compression Candidate
 

--- a/docs/milestones/v0.90.1/WP_ISSUE_WAVE_v0.90.1.yaml
+++ b/docs/milestones/v0.90.1/WP_ISSUE_WAVE_v0.90.1.yaml
@@ -1,70 +1,132 @@
 milestone: v0.90.1
-status: tracked_planning_ready
-issue_wave_opened: false
+status: issue_wave_open
+issue_wave_opened: true
+owner_issue: 2141
 tracked_package: docs/milestones/v0.90.1
 notes:
   - "Tracked planning package promoted during v0.90 WP-19."
-  - "Create real issues only after v0.90 release ceremony approval."
+  - "v0.90.1 issue wave opened by WP-01 after the v0.90 release ceremony."
+  - "WP-01 is #2141; WP-02 through WP-20 are #2142 through #2160."
   - "Do not claim first true Gödel-agent birthday in v0.90.1."
   - "WP-02 through WP-04 intentionally front-load compression enablement before Runtime v2 coding."
 work_packages:
   - wp: WP-01
-    title: Open and author v0.90.1 issue wave
-    outcome: GitHub issues, task cards, and issue-number mapping
+    title: "[v0.90.1][WP-01] Issue wave and task cards"
+    queue: wp
+    issue: 2141
+    depends_on: ["v0.90 release ceremony"]
+    outcome: docs
   - wp: WP-02
-    title: Issue-wave template and generator alignment
-    outcome: reusable WP wave template and generator proof
+    title: "[v0.90.1][WP-02] Issue-wave template and generator alignment"
+    queue: tools
+    issue: 2142
+    depends_on: ["WP-01"]
+    outcome: docs
   - wp: WP-03
-    title: Worktree-first workflow hardening
-    outcome: guarded worktree-first execution path
+    title: "[v0.90.1][WP-03] Worktree-first workflow hardening"
+    queue: tools
+    issue: 2143
+    depends_on: ["WP-02"]
+    outcome: code
   - wp: WP-04
-    title: Compression-era execution policy
-    outcome: current operator policy for skills, validation, and evidence
+    title: "[v0.90.1][WP-04] Compression-era execution policy"
+    queue: docs
+    issue: 2144
+    depends_on: ["WP-02", "WP-03"]
+    outcome: docs
   - wp: WP-05
-    title: Runtime v2 manifold contract
-    outcome: persistent manifold manifest and validation
+    title: "[v0.90.1][WP-05] Runtime v2 manifold contract"
+    queue: runtime
+    issue: 2145
+    depends_on: ["WP-04"]
+    outcome: code
   - wp: WP-06
-    title: Kernel service loop
-    outcome: bounded kernel/service loop with traceable state
+    title: "[v0.90.1][WP-06] Kernel service loop"
+    queue: runtime
+    issue: 2146
+    depends_on: ["WP-05"]
+    outcome: code
   - wp: WP-07
-    title: Provisional citizen lifecycle
-    outcome: provisional citizen record and lifecycle state machine
+    title: "[v0.90.1][WP-07] Provisional citizen lifecycle"
+    queue: runtime
+    issue: 2147
+    depends_on: ["WP-05"]
+    outcome: code
   - wp: WP-08
-    title: Snapshot and rehydration
-    outcome: sleep/wake proof without duplicate activation
+    title: "[v0.90.1][WP-08] Snapshot and rehydration"
+    queue: runtime
+    issue: 2148
+    depends_on: ["WP-06", "WP-07"]
+    outcome: code
   - wp: WP-09
-    title: Invariant violation artifacts
-    outcome: rejected illegal state transition evidence
+    title: "[v0.90.1][WP-09] Invariant violation artifacts"
+    queue: runtime
+    issue: 2149
+    depends_on: ["WP-06"]
+    outcome: code
   - wp: WP-10
-    title: Operator controls
-    outcome: inspect, pause, resume, terminate proof surfaces
+    title: "[v0.90.1][WP-10] Operator controls"
+    queue: runtime
+    issue: 2150
+    depends_on: ["WP-06", "WP-08"]
+    outcome: code
   - wp: WP-11
-    title: Security-boundary proof
-    outcome: one invalid action rejected through kernel/policy path
+    title: "[v0.90.1][WP-11] Security-boundary proof"
+    queue: runtime
+    issue: 2151
+    depends_on: ["WP-09", "WP-10"]
+    outcome: code
   - wp: WP-12
-    title: Integrated Runtime v2 prototype demo
-    outcome: reviewer-facing end-to-end proof packet
+    title: "[v0.90.1][WP-12] Integrated Runtime v2 prototype demo"
+    queue: demo
+    issue: 2152
+    depends_on: ["WP-05", "WP-06", "WP-07", "WP-08", "WP-09", "WP-10", "WP-11"]
+    outcome: demo
   - wp: WP-13
-    title: Runtime v2 docs pass
-    outcome: aligned feature docs, demo matrix, and README
+    title: "[v0.90.1][WP-13] Runtime v2 docs pass"
+    queue: docs
+    issue: 2153
+    depends_on: ["WP-12"]
+    outcome: docs
   - wp: WP-14
-    title: Quality and coverage gate
-    outcome: truthful quality posture
+    title: "[v0.90.1][WP-14] Quality and coverage gate"
+    queue: wp
+    issue: 2154
+    depends_on: ["WP-12"]
+    outcome: tests
   - wp: WP-15
-    title: Internal review
-    outcome: findings-first internal review packet
+    title: "[v0.90.1][WP-15] Internal review"
+    queue: review
+    issue: 2155
+    depends_on: ["WP-13", "WP-14"]
+    outcome: review
   - wp: WP-16
-    title: Review remediation
-    outcome: accepted findings fixed or explicitly deferred
+    title: "[v0.90.1][WP-16] Review remediation"
+    queue: review
+    issue: 2156
+    depends_on: ["WP-15"]
+    outcome: code
   - wp: WP-17
-    title: Release readiness
-    outcome: release notes, checklist, and reviewer handoff
+    title: "[v0.90.1][WP-17] Release readiness"
+    queue: release
+    issue: 2157
+    depends_on: ["WP-16"]
+    outcome: docs
   - wp: WP-18
-    title: v0.91/v0.92 handoff
-    outcome: preserved moral/emotional and birthday boundaries
+    title: "[v0.90.1][WP-18] v0.91/v0.92 handoff"
+    queue: docs
+    issue: 2158
+    depends_on: ["WP-17"]
+    outcome: docs
   - wp: WP-19
-    title: Release-evidence packet
-    outcome: coherent proof trail across demos, quality, review, and readiness
+    title: "[v0.90.1][WP-19] Release-evidence packet"
+    queue: release
+    issue: 2159
+    depends_on: ["WP-17", "WP-18"]
+    outcome: docs
   - wp: WP-20
-    title: Release ceremony
-    outcome: v0.90.1 closed truthfully
+    title: "[v0.90.1][WP-20] Release ceremony"
+    queue: release
+    issue: 2160
+    depends_on: ["WP-18", "WP-19"]
+    outcome: release


### PR DESCRIPTION
Closes #2141

## Summary
Opened the v0.90.1 issue wave, created WP-01 through WP-20 in contiguous order, normalized the local lifecycle cards, and updated the tracked v0.90.1 milestone docs so the issue map is executable.

## Artifacts
- GitHub issues #2141 through #2160 for WP-01 through WP-20.
- Updated v0.90.1 issue-wave YAML with issue numbers, queues, dependencies, and outcomes.
- Updated v0.90.1 README, WBS, sprint, checklist, release-plan, feature-doc, and demo-matrix surfaces.
- Updated repository README and docs index so v0.90.1 is the active milestone and v0.90 is released.
- Local ignored task bundles under `.adl/v0.90.1/tasks` for issues #2141 through #2160.

## Validation
- Validation commands and their purpose:
  - `git status --short --branch` in the root checkout verified main stayed clean for tracked files.
  - `git status --short --branch` in the WP-01 worktree verified the tracked changes are confined to the issue branch.
  - `ruby -e 'require "yaml"; data=YAML.load_file("docs/milestones/v0.90.1/WP_ISSUE_WAVE_v0.90.1.yaml"); ...'` verified the issue wave YAML parses and maps to #2141 through #2160.
  - `rg` stale-wording scan verified docs no longer say the v0.90.1 issue wave is unopened.
  - `rg` private-path scan verified tracked docs do not leak local `.adl` planning paths or host paths.
  - `adl/tools/validate_structured_prompt.sh` loop verified all twenty local task-card bundles.
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2141__v0-90-1-wp-01-issue-wave-and-task-cards/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2141__v0-90-1-wp-01-issue-wave-and-task-cards/sor.md
- Idempotency-Key: v0-90-1-wp-01-issue-wave-and-task-cards-readme-md-docs-readme-md-docs-milestones-v0-90-1-adl-v0-90-1-tasks-issue-2141-v0-90-1-wp-01-issue-wave-and-task-cards-sip-md-adl-v0-90-1-tasks-issue-2141-v0-90-1-wp-01-issue-wave-and-task-cards-sor-md