### PR TITLE
[v0.90.1][WP-03] Worktree-first workflow hardening

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -370,7 +370,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
             queue: infer_workflow_queue(&title, &normalized_labels, None)
                 .ok_or_else(|| {
                     anyhow!(
-                        "start: missing or invalid workflow queue for issue #{}; add a canonical queue such as wp/tools/demo/docs/review/release before execution",
+                        "start: missing or invalid workflow queue for issue #{}; add a canonical queue such as wp/tools/runtime/demo/docs/review/release before execution",
                         parsed.issue
                     )
                 })?

--- a/adl/src/cli/pr_cmd_prompt.rs
+++ b/adl/src/cli/pr_cmd_prompt.rs
@@ -21,7 +21,9 @@ pub(crate) struct WorkflowQueueResolution {
     pub(crate) source: &'static str,
 }
 
-const VALID_WORKFLOW_QUEUES: &[&str] = &["wp", "tools", "demo", "docs", "review", "release"];
+const VALID_WORKFLOW_QUEUES: &[&str] = &[
+    "wp", "tools", "runtime", "demo", "docs", "review", "release",
+];
 
 #[cfg(test)]
 #[derive(Debug)]
@@ -280,6 +282,9 @@ pub(crate) fn infer_workflow_queue(
     }
     if lowered.contains("area:release") || lowered.contains("[release]") {
         return Some("release");
+    }
+    if lowered.contains("area:runtime") || lowered.contains("[runtime]") {
+        return Some("runtime");
     }
     None
 }

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -209,6 +209,18 @@ fn infer_workflow_queue_prefers_explicit_signals_and_tags() {
         infer_workflow_queue("[v0.88] Example", "", Some("review")),
         Some("review")
     );
+    assert_eq!(
+        infer_workflow_queue(
+            "[v0.90.1] Runtime substrate",
+            "track:roadmap,area:runtime",
+            None
+        ),
+        Some("runtime")
+    );
+    assert_eq!(
+        infer_workflow_queue("[v0.90.1] Runtime substrate", "", Some("runtime")),
+        Some("runtime")
+    );
     assert_eq!(infer_workflow_queue("No queue signals", "", None), None);
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -678,6 +678,21 @@ fn resolve_issue_prompt_workflow_queue_rejects_missing_and_uninferrable_queue() 
 }
 
 #[test]
+fn resolve_issue_prompt_workflow_queue_accepts_runtime_queue() {
+    let repo = unique_temp_dir("adl-pr-runtime-workflow-queue");
+    let prompt = repo.join("issue.md");
+    fs::write(
+        &prompt,
+        "---\nissue_card_schema: adl.issue.v1\nwp: \"WP-05\"\nqueue: \"runtime\"\nslug: \"runtime-queue\"\ntitle: \"[v0.90.1][WP-05] Runtime v2 manifold contract\"\nlabels:\n  - \"track:roadmap\"\n  - \"area:runtime\"\n  - \"version:v0.90.1\"\nissue_number: 2145\nstatus: \"active\"\naction: \"edit\"\ndepends_on: []\nmilestone_sprint: \"v0.90.1\"\nrequired_outcome_type:\n  - \"code\"\nrepo_inputs: []\ncanonical_files: []\ndemo_required: false\ndemo_names: []\nissue_graph_notes: []\npr_start:\n  enabled: false\n  slug: \"runtime-queue\"\n---\n\n# Runtime queue\n\n## Summary\nx\n## Goal\nx\n## Required Outcome\nx\n## Deliverables\nx\n## Acceptance Criteria\nx\n## Repo Inputs\nx\n## Dependencies\nx\n## Demo Expectations\nx\n## Non-goals\nx\n## Issue-Graph Notes\nx\n## Notes\nx\n## Tooling Notes\nx\n",
+    )
+    .expect("prompt");
+
+    let queue = resolve_issue_prompt_workflow_queue(&prompt).expect("runtime queue resolves");
+    assert_eq!(queue.queue, "runtime");
+    assert_eq!(queue.source, "explicit");
+}
+
+#[test]
 fn real_pr_start_rejects_missing_slug_or_empty_sanitized_title_in_no_fetch_mode() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-start-preconditions");


### PR DESCRIPTION
Closes #2143

## Summary
Added `runtime` as a first-class ADL workflow queue so v0.90.1 Runtime v2 WPs keep their intended fine-grained queue instead of falling back to the generic `wp` queue. The fix accepts explicit `queue: runtime` front matter, infers runtime queue from `area:runtime` or `[runtime]` signals, and updates the operator-facing queue error message.

## Artifacts
- `adl/src/cli/pr_cmd_prompt.rs`
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::basics::infer_workflow_queue_prefers_explicit_signals_and_tags -- --nocapture`
    - verifies workflow queue inference now accepts runtime signals without regressing existing queue signals.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::repo_helpers::resolve_issue_prompt_workflow_queue_accepts_runtime_queue -- --nocapture`
    - verifies explicit `queue: runtime` issue front matter resolves as an explicit workflow queue.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests -- --nocapture`
    - verifies the broader PR workflow command test slice still passes after adding the new canonical queue.
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check`
    - verifies final Rust formatting.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    - verifies the Rust changes introduce no clippy warnings across all targets.
  - `adl/tools/pr.sh doctor 2145 --json --slug v0-90-1-wp-05-runtime-v2-manifold-contract --version v0.90.1`
    - verifies WP-05 now reports `target_queue: runtime`, `target_queue_source: explicit`, and doctor `PASS`.
  - `for n in $(seq 2145 2151); do ... adl/tools/pr.sh doctor "$n" --json ...; done`
    - verifies WP-05 through WP-11 all report `target_queue: runtime` and doctor `PASS`.
- Results:
  - focused queue inference test: PASS, 1 passed and 0 failed
  - focused runtime front-matter test: PASS, 1 passed and 0 failed
  - broader PR workflow tests: PASS, 107 passed and 0 failed
  - final Rust formatting: PASS
  - clippy: PASS
  - WP-05 runtime queue doctor proof: PASS
  - WP-05 through WP-11 runtime queue doctor proof: PASS

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2143__v0-90-1-wp-03-worktree-first-workflow-hardening/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2143__v0-90-1-wp-03-worktree-first-workflow-hardening/sor.md
- Idempotency-Key: v0-90-1-wp-03-worktree-first-workflow-hardening-adl-src-cli-pr-cmd-prompt-rs-adl-src-cli-pr-cmd-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-src-cli-tests-pr-cmd-inline-repo-helpers-rs-adl-v0-90-1-tasks-issue-2143-v0-90-1-wp-03-worktree-first-workflow-hardening-sip-md-adl-v0-90-1-tasks-issue-2143-v0-90-1-wp-03-worktree-first-workflow-hardening-sor-md