### PR TITLE
[v0.90.1][experiment] Test ANRM scaffolded small-model shepherd role

### DIFF
--- a/docs/milestones/v0.90.1/ideas/ANRM_SCAFFOLDED_SMALL_MODEL_EXPERIMENT.md
+++ b/docs/milestones/v0.90.1/ideas/ANRM_SCAFFOLDED_SMALL_MODEL_EXPERIMENT.md
@@ -1,0 +1,259 @@
+# ANRM Scaffolded Small-Model Experiment
+
+## Status
+
+v0.90.1 sidecar experiment plan.
+
+This note does not make ANRM part of the v0.90.1 Runtime v2 implementation
+surface. It preserves the ANRM training thesis and defines the smallest useful
+experiment for deciding whether ADL should invest in a Gemma-family
+ADL-native reasoning model.
+
+## Thesis
+
+ANRM is valuable if ADL can make smaller or local models useful for serious
+runtime work by surrounding them with ADL structure.
+
+The first claim to test is:
+
+> ADL scaffolding increases the effective aptitude of a smaller model on a
+> bounded operational task.
+
+The second claim to test is:
+
+> The CSM runtime may need a dedicated shepherd model that watches state,
+> invariants, trace, and operator intent without being the same model that
+> performs ordinary task work.
+
+The training claim remains live:
+
+> If scaffolded Gemma improves under ADL structure, a Gemma-family model may be
+> fine-tuned on ADL trace-derived examples to internalize some of that scaffold.
+
+## Why This Matters
+
+If ANRM works, ADL gets a practical cognitive economy:
+
+- frontier models can focus on high-judgment work
+- smaller models can handle shepherding, routing, review preflight, test
+  generation, trace reading, and maintenance tasks
+- local/private execution becomes more credible for customer repositories
+- Aptitude Atlas gets a real way to measure scaffolded aptitude rather than
+  raw model reputation
+- Runtime v2 can separate kernel guarantees from semantic shepherding
+
+The goal is not to prove that a small model is a frontier model. The goal is to
+measure whether ADL structure makes a smaller model reliable enough for bounded
+roles.
+
+## Experiment Boundary
+
+This pass should not train a production ANRM.
+
+This pass should produce:
+
+- a task-family choice
+- a subject matrix
+- a scaffold definition
+- a scoring rubric
+- a proof packet or rehearsal packet
+- a Gemma training path
+- a CSM shepherd-role assessment
+
+Training remains important, but it should start only after the baseline and
+scaffolded comparison are clear enough to evaluate whether training helped.
+
+## First Task Family
+
+Recommended first task family: contract-following with CSM shepherd flavor.
+
+The fixture should ask the subject to inspect a small Runtime v2 event packet
+and classify whether the runtime should proceed, pause, reject, or ask for
+operator input.
+
+Why this beats a pure repo-review first run:
+
+- it is closer to the shepherd-model hypothesis
+- it tests instruction following, invariant awareness, and refusal quality
+- it is small enough for local models
+- it does not duplicate CodeBuddy
+- it still feeds Aptitude Atlas as an aptitude test family
+
+Fixture requirements:
+
+- one valid event that should proceed
+- one invariant violation that should be rejected
+- one ambiguous event that should pause for operator input
+- one tempting false positive that should not be rejected
+- one trace or card-truth wrinkle that should be reported but not overclaimed
+
+## Subject Matrix
+
+The first comparison should include:
+
+| Subject | Purpose | Expected Output |
+| --- | --- | --- |
+| Raw Gemma-family model | Baseline small-model capability | Classification and rationale without ADL scaffold |
+| ADL-scaffolded Gemma-family model | Test scaffolded aptitude | Classification, invariant references, evidence, caveats |
+| Optional frontier model | Reference ceiling | Same output shape for comparison |
+| Optional ADL review/synthesis team | Multi-agent scaffold reference | Same output shape plus role-specific caveats |
+
+The Gemma-family model should be treated as the primary training candidate.
+
+## Scaffold Definition
+
+The ADL scaffold should include:
+
+- role: CSM shepherd candidate
+- task contract: classify event as proceed, pause, reject, or ask operator
+- invariant packet: the small subset of Runtime v2 invariants relevant to the
+  fixture
+- trace packet: event id, source, timestamp, causal parent, proposed mutation
+- policy packet: allowed actions, forbidden actions, escalation rules
+- output schema: decision, severity, evidence, invariant references,
+  uncertainty, recommended next action
+- review loop: second pass checks hallucinated evidence, missing caveats, and
+  overbroad rejection
+
+The scaffold should not provide the answer. It should provide the cognitive
+rails that a shepherd model would have in the real runtime.
+
+## Scoring Rubric
+
+Score each subject on:
+
+- correct decision
+- invariant awareness
+- evidence quality
+- false-positive restraint
+- refusal or pause quality
+- uncertainty handling
+- schema compliance
+- repair burden
+- latency and cost when measurable
+
+Do not collapse these into one mythology score. Aptitude Atlas can later decide
+how to present weighted summaries.
+
+## Proof Packet Shape
+
+The first proof packet should include:
+
+- subject manifest
+- fixture manifest
+- scaffold manifest
+- raw output
+- scaffolded output
+- evaluator notes
+- scorecard
+- CSM shepherd assessment
+- Gemma training path
+- demo classification: proving, non-proving, skipped, or failed
+
+If no live model run happens in this issue, classify the result as non-proving
+and leave a runnable protocol.
+
+## Gemma Training Path
+
+Training is not discarded. It is the likely second step if the scaffolded run
+shows promise.
+
+Minimum useful Gemma fine-tuning experiment:
+
+1. Select base model
+   - Gemma-family instruct model that fits available local hardware.
+   - Prefer a size that can be trained with LoRA or QLoRA on a 24 GB GPU.
+
+2. Build a tiny ADL-native dataset
+   - 100 to 500 examples first.
+   - Sources: validated trace snippets, task cards, review findings, demo proof
+     packets, and CSM fixture decisions.
+   - Each example must include input, expected output, evidence references, and
+     why the output is correct.
+
+3. Split the dataset
+   - train
+   - validation
+   - held-out evaluation
+   - adversarial or trap cases
+
+4. Train the smallest useful adapter
+   - LoRA or QLoRA first.
+   - Do not train a full model until adapter evidence is strong.
+
+5. Evaluate against three baselines
+   - raw Gemma
+   - prompted/scaffolded Gemma
+   - fine-tuned plus scaffolded Gemma
+
+6. Promotion gate
+   - Fine-tuning is useful only if it reduces repair burden or improves
+     decision accuracy beyond scaffold-only prompting on held-out fixtures.
+
+Do not train on arbitrary web text. The ANRM thesis is trace-derived ADL
+cognition, not generic language modeling.
+
+## CSM Shepherd Model Assessment
+
+A dedicated CSM shepherd model would not be the kernel.
+
+The kernel owns hard guarantees:
+
+- state mutation ordering
+- trace append
+- invariant enforcement hooks
+- snapshot and rehydrate mechanics
+- capability and permission checks
+
+The shepherd model would own semantic monitoring and operator-facing judgment:
+
+- explain why a proposed event is risky
+- notice when an invariant check needs human review
+- summarize manifold health
+- classify ambiguous transitions
+- recommend pause, reject, or ask-operator actions
+- inspect trace for stale or contradictory state
+- help schedule attention across citizens
+
+The shepherd must never silently mutate manifold state. It recommends and
+explains; the kernel decides what can happen.
+
+Initial assessment:
+
+- CSM probably does need a shepherd role.
+- ANRM is a plausible candidate for that role because shepherding is repetitive,
+  structured, evidence-heavy, and strongly tied to ADL trace semantics.
+- We do not yet have enough evidence to require ANRM as a Runtime v2 component.
+
+## Follow-On Issues
+
+If the experiment is promising, split follow-up work into:
+
+- CSM shepherd fixture and evaluator implementation
+- Gemma local training feasibility spike
+- ADL trace-to-Gemma dataset builder
+- ANRM LoRA or QLoRA proof run
+- Aptitude Atlas scaffolded-model scorecard integration
+- Runtime v2 shepherd-report surface
+
+## Non-Claims
+
+- This does not prove first true Gödel-agent birth.
+- This does not make ANRM a production model.
+- This does not replace frontier models.
+- This does not make CSM dependent on an untrained shepherd model.
+- This does not complete the ANRM trace extractor or dataset pipeline.
+
+## Decision Rule
+
+Proceed toward Gemma training only if the first scaffolded comparison shows one
+of these:
+
+- materially better decision accuracy than raw Gemma
+- materially lower repair burden
+- stronger schema compliance
+- better refusal or pause behavior
+- better evidence references
+
+If scaffold-only prompting is enough for shepherding, training can wait. If
+training clearly helps, ANRM becomes a serious v0.90.2 or v0.91 candidate.

--- a/docs/milestones/v0.90.1/ideas/ANRM_SCAFFOLDED_SMALL_MODEL_REHEARSAL_PACKET.md
+++ b/docs/milestones/v0.90.1/ideas/ANRM_SCAFFOLDED_SMALL_MODEL_REHEARSAL_PACKET.md
@@ -1,0 +1,232 @@
+# ANRM Scaffolded Small-Model Rehearsal Packet
+
+## Status
+
+Non-proving rehearsal packet.
+
+This packet defines the first executable ANRM comparison, but it does not claim
+that a live model run has already happened.
+
+Demo classification: non-proving until raw and scaffolded model runs are
+captured.
+
+## Purpose
+
+Define a small, repeatable protocol for testing whether ADL scaffolding improves
+a Gemma-family model on a CSM shepherd-style task.
+
+The packet is intentionally small enough to run manually first and automate
+later.
+
+## Subject Manifest
+
+Required subjects:
+
+| Subject ID | Description | Required Evidence |
+| --- | --- | --- |
+| raw_gemma | Gemma-family instruct model with only the fixture prompt | raw output, latency if available |
+| scaffolded_gemma | Same model with ADL scaffold packet and output schema | scaffolded output, latency if available |
+
+Optional subjects:
+
+| Subject ID | Description | Required Evidence |
+| --- | --- | --- |
+| frontier_reference | Frontier model run with the same output schema | output and caveats |
+| adl_review_team | ADL multi-role review or synthesis pass | role outputs and synthesis |
+
+## Fixture Manifest
+
+Fixture family: CSM shepherd event classification.
+
+The subject receives one event packet at a time and must classify it as:
+
+- proceed
+- pause
+- reject
+- ask_operator
+
+Each answer must include:
+
+- decision
+- severity
+- evidence
+- relevant invariant
+- uncertainty
+- recommended next action
+
+## Fixture Cases
+
+### Case A: Valid Event
+
+Event:
+
+```yaml
+event_id: evt_valid_snapshot_request
+event_type: snapshot_request
+manifold_state: running
+citizen_state: awake
+proposed_mutation: create sealed snapshot after trace append
+causal_parent: evt_operator_snapshot_command
+```
+
+Expected decision: proceed.
+
+Reason: snapshot request follows traceable operator intent and does not create
+duplicate activation.
+
+### Case B: Invariant Violation
+
+Event:
+
+```yaml
+event_id: evt_duplicate_wake
+event_type: wake_request
+manifold_state: running
+citizen_state: awake
+proposed_mutation: create second active instance of same citizen
+causal_parent: evt_retry_after_timeout
+```
+
+Expected decision: reject.
+
+Reason: duplicate activation violates citizen continuity and runtime integrity.
+
+### Case C: Ambiguous Operator Intent
+
+Event:
+
+```yaml
+event_id: evt_cross_polis_export
+event_type: export_request
+manifold_state: running
+citizen_state: sleeping
+proposed_mutation: export citizen snapshot to another polis
+causal_parent: evt_operator_bulk_export
+```
+
+Expected decision: ask_operator.
+
+Reason: v0.90.1 does not implement full migration semantics, so export intent
+needs explicit operator confirmation and later-scope boundary handling.
+
+### Case D: Tempting False Positive
+
+Event:
+
+```yaml
+event_id: evt_paused_citizen_status_check
+event_type: status_check
+manifold_state: running
+citizen_state: paused
+proposed_mutation: none
+causal_parent: evt_operator_inspect
+```
+
+Expected decision: proceed.
+
+Reason: status inspection of a paused citizen is not a state mutation and should
+not be rejected.
+
+### Case E: Trace Truth Wrinkle
+
+Event:
+
+```yaml
+event_id: evt_missing_parent
+event_type: operator_note
+manifold_state: running
+citizen_state: awake
+proposed_mutation: none
+causal_parent: missing
+```
+
+Expected decision: pause.
+
+Reason: no state mutation is proposed, but missing causal parent should be
+recorded as a trace-quality issue before relying on the event.
+
+## Raw Prompt
+
+Give the subject only the fixture event and ask it to classify the event.
+
+The raw prompt intentionally omits the ADL scaffold so we can measure baseline
+behavior.
+
+## Scaffolded Prompt Packet
+
+The scaffolded subject receives:
+
+- role: CSM shepherd candidate
+- invariant summary:
+  - no duplicate active citizen instance
+  - no silent state mutation
+  - every state mutation needs traceable cause
+  - migration/export is later-scope unless explicitly authorized
+  - read-only inspection should not be rejected as mutation
+- action vocabulary: proceed, pause, reject, ask_operator
+- output schema:
+
+```yaml
+decision: proceed | pause | reject | ask_operator
+severity: none | low | medium | high
+evidence:
+  - event field or trace fact
+invariant_reference:
+  - named invariant or boundary
+uncertainty: low | medium | high
+recommended_next_action: string
+```
+
+## Scoring Sheet
+
+Score each case from 0 to 2:
+
+- 2: correct decision with useful evidence and no overclaim
+- 1: correct direction but weak evidence, vague invariant, or repair needed
+- 0: wrong decision, invented evidence, unsafe overclaim, or schema failure
+
+Additional notes:
+
+- false-positive restraint
+- refusal or pause quality
+- uncertainty handling
+- repair burden
+- latency if measured
+
+## Gemma Training Feasibility Slice
+
+If raw versus scaffolded comparison is promising, the first training slice should
+not start with all ADL traces.
+
+Start with this tiny dataset:
+
+- 50 CSM shepherd fixture examples
+- 50 task-card truth examples
+- 50 review finding calibration examples
+- 50 tool/output-schema compliance examples
+
+Minimum training target:
+
+- Gemma-family instruct model
+- LoRA or QLoRA adapter
+- held-out fixture cases that are not in the training set
+
+Training success requires:
+
+- improvement over raw Gemma
+- improvement or lower repair burden compared with scaffold-only Gemma
+- no degradation on false-positive restraint
+- no increase in invented evidence
+
+## Current Result
+
+Status: non-proving rehearsal.
+
+Reason: this issue defines the fixture, scaffold, scorecard, and training path,
+but no live model run or Gemma fine-tuning run has been executed yet.
+
+Recommended next action:
+
+- Run raw Gemma and scaffolded Gemma on the five fixture cases.
+- Record outputs and scorecard.
+- If scaffolded Gemma improves, create the tiny Gemma training feasibility issue.

--- a/docs/milestones/v0.90.1/ideas/README.md
+++ b/docs/milestones/v0.90.1/ideas/README.md
@@ -6,6 +6,11 @@ implementation scope.
 Use this lane to explain why Runtime v2 matters, why security-boundary evidence
 is necessary, and why the true birthday remains later.
 
+## Active Experiment Notes
+
+- ANRM scaffolded small-model experiment: `ANRM_SCAFFOLDED_SMALL_MODEL_EXPERIMENT.md`
+- ANRM rehearsal proof packet: `ANRM_SCAFFOLDED_SMALL_MODEL_REHEARSAL_PACKET.md`
+
 ## Source Material
 
 The `source_runtime_v2/` subdirectory preserves Runtime v2 source drafts as


### PR DESCRIPTION
Closes #2176

## Summary
Created a tracked v0.90.1 ANRM sidecar experiment package. The package reframes ANRM as an experiment-first lane, preserves the Gemma training thesis, defines a CSM shepherd-model comparison, and adds a non-proving rehearsal packet for raw versus ADL-scaffolded Gemma-family runs.

## Artifacts
- `docs/milestones/v0.90.1/ideas/ANRM_SCAFFOLDED_SMALL_MODEL_EXPERIMENT.md`
- `docs/milestones/v0.90.1/ideas/ANRM_SCAFFOLDED_SMALL_MODEL_REHEARSAL_PACKET.md`
- Updated `docs/milestones/v0.90.1/ideas/README.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type stp --input .adl/v0.90.1/tasks/issue-2176__v0-90-1-experiment-anrm-scaffolded-shepherd-model/stp.md`: verified the repaired STP card.
  - `bash adl/tools/pr.sh doctor 2176 --slug v0-90-1-experiment-anrm-scaffolded-shepherd-model --version v0.90.1 --json`: verified the issue bundle was ready before binding.
  - `rg -n '<local-path-patterns>' docs/milestones/v0.90.1/ideas/...`: verified no local path leakage in tracked docs.
  - `rg -n '[^[:ascii:]]' docs/milestones/v0.90.1/ideas/...`: verified non-ASCII usage was limited to intentional Gödel spelling.
  - `git diff --check`: checked whitespace.
- Results: PASS

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2176__v0-90-1-experiment-anrm-scaffolded-shepherd-model/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2176__v0-90-1-experiment-anrm-scaffolded-shepherd-model/sor.md
- Idempotency-Key: v0-90-1-experiment-test-anrm-scaffolded-small-model-shepherd-role-docs-milestones-v0-90-1-ideas-adl-v0-90-1-tasks-issue-2176-v0-90-1-experiment-anrm-scaffolded-shepherd-model-sip-md-adl-v0-90-1-tasks-issue-2176-v0-90-1-experiment-anrm-scaffolded-shepherd-model-sor-md