### PR TITLE
[v0.90][backlog][skills] Add records-hygiene skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -53,6 +53,7 @@ run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"
 run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_paper_writer_skill_contracts.sh"
 run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_author_skill_contracts.sh"
+run_step "records-hygiene contract check" bash "$ROOT/adl/tools/test_records_hygiene_skill_contracts.sh"
 run_step "skill documentation completeness check" bash "$ROOT/adl/tools/test_skill_documentation_completeness.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
 echo "• Running adl checks (batched)…"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -43,6 +43,7 @@ The tracked skill set is:
 - `repo-review-security`
 - `repo-review-synthesis`
 - `repo-review-tests`
+- `records-hygiene`
 - `review-quality-evaluator`
 - `review-to-test-planner`
 - `sip-editor`
@@ -1043,6 +1044,44 @@ policy:
 - use `stp-editor`, `sip-editor`, or `sor-editor` only when the closeout
   blocker is card-local rather than closure-state ambiguity
 
+## `records-hygiene`
+
+### Purpose
+
+`records-hygiene` is a focused workflow-maintenance skill for ADL task-record truth.
+
+It scans STP, SIP, and SOR for stale or contradictory lifecycle fields, PR/worktree
+claims, placeholder leakage, and integration wording drift, then returns a bounded
+machine-readable artifact.
+
+### When To Use It
+
+- before `pr-finish` or `pr-closeout` when records look stale,
+- when the issue has already been run and the output card claims look inconsistent,
+- when a concrete issue, task bundle, branch, or worktree target needs bounded hygiene.
+
+### Required Inputs
+
+Minimum:
+
+- `repo_root`
+- one of:
+  - `issue_number`
+  - `task_bundle_path`
+  - `branch`
+  - `worktree_path`
+
+Structured schema:
+
+- `adl/tools/skills/docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md`
+- schema id: `records_hygiene.v1`
+
+### Typical Handoff
+
+Use `records-hygiene` when hygiene can be resolved by safe record repair.
+If the issue is ambiguous, unresolved, or not mechanically safe, use the output
+recommendations as a follow-on issue queue item and avoid scope expansion.
+
 ## `stp-editor`
 
 ### Purpose
@@ -1867,6 +1906,8 @@ Use this quick selector:
   - `demo-operator`
 - need to finalize local issue state after merge/closure:
   - `pr-closeout`
+- need to clean drifted lifecycle records before closeout or janitor handoff:
+  - `records-hygiene`
 - need a broad findings-first code review:
   - `repo-code-review`
 - need source-backed arXiv-style manuscript drafting or citation-gap review:
@@ -1942,6 +1983,7 @@ surfaces:
 | `repo-review-security` | `REPO_REVIEW_SECURITY_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | security findings only |
 | `repo-review-synthesis` | `REPO_REVIEW_SYNTHESIS_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | severity-preserving synthesis only |
 | `repo-review-tests` | `REPO_REVIEW_TESTS_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | test-quality findings only |
+| `records-hygiene` | `RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | hygiene findings and follow-on recommendations only |
 | `review-quality-evaluator` | `REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review-quality evaluation only |
 | `review-to-test-planner` | `REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | test-generation handoff plan only |
 | `sip-editor` | `SIP_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | SIP normalization only |

--- a/adl/tools/skills/docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,88 @@
+# Records Hygiene Skill Input Schema
+
+## Metadata
+- Feature Name: `Records Hygiene Skill Input Schema`
+- Milestone Target: `v0.90`
+- Status: `proposed`
+- Owner: `Daniel Austin / Agent Logic`
+- Doc Role: `primary`
+- Supporting Docs: `adl/tools/skills/records-hygiene/SKILL.md`, `adl/tools/skills/records-hygiene/adl-skill.yaml`, `adl/tools/skills/records-hygiene/references/output-contract.md`
+- Proof Modes: `validation`, `records`
+
+## Purpose
+
+This schema defines the invocation contract for bounded record-truth hygiene.
+
+The skill is intended to stay mechanical and deterministic:
+- inspect a single issue/task/worktree target,
+- emit machine-readable findings,
+- apply only narrow safe fixes when explicitly allowed,
+- recommend follow-on work where ambiguity or tooling gaps remain.
+
+## Canonical Invocation
+
+```yaml
+skill_input_schema: records_hygiene.v1
+mode: analyze_issue | analyze_task_bundle | analyze_branch | analyze_worktree
+repo_root: /absolute/path/to/repo
+target:
+  issue_number: 2172
+  task_bundle_path: .adl/v0.90/tasks/issue-2172__backlog-skills-add-records-hygiene-skill
+  branch: codex/2172-backlog-skills-add-records-hygiene-skill
+  worktree_path: .worktrees/adl-wp-2172
+  slug: backlog-skills-add-records-hygiene-skill
+  version: v0.90
+  source_prompt_path: .adl/v0.90/bodies/issue-2172-backlog-skills-add-records-hygiene-skill.md
+  stp_path: .adl/v0.90/tasks/issue-2172__backlog-skills-add-records-hygiene-skill/stp.md
+  sip_path: .adl/v0.90/tasks/issue-2172__backlog-skills-add-records-hygiene-skill/sip.md
+  sor_path: .adl/v0.90/tasks/issue-2172__backlog-skills-add-records-hygiene-skill/sor.md
+policy:
+  report_only: true | false
+  apply_safe_repairs: true | false
+  include_follow_on_issues: true | false
+  max_findings_to_emit: <integer >=0>
+  stop_after_analysis: true
+```
+
+## Required Fields
+
+- `skill_input_schema` must equal `records_hygiene.v1`.
+- `mode` must be one of:
+  - `analyze_issue`
+  - `analyze_task_bundle`
+  - `analyze_branch`
+  - `analyze_worktree`
+- `repo_root` must be absolute.
+- `target` must include exactly one primary mode field:
+  - `issue_number` for `analyze_issue`
+  - `task_bundle_path` for `analyze_task_bundle`
+  - `branch` for `analyze_branch`
+  - `worktree_path` for `analyze_worktree`
+- `policy.stop_after_analysis` must be `true`.
+- `policy.report_only` and `policy.apply_safe_repairs` are mutually constrained:
+  - if `report_only` is `true`, do not apply safe repairs.
+  - if `apply_safe_repairs` is `true`, ensure explicit bounded safety proof for each proposed change.
+
+## Optional Fields
+
+- slug/version and explicit surface paths may be supplied to reduce inference risk.
+- `policy.max_findings_to_emit` defaults to emitting all boundedly discoverable findings.
+- `policy.include_follow_on_issues` enables explicit tooling-gap itemization.
+
+## Mode Semantics
+
+### analyze_issue
+
+Resolve the issue centrally and analyze all known issue-affiliated task surfaces.
+
+### analyze_task_bundle
+
+Resolve from task-bundle path and validate outward to issue/branch/worktree surfaces.
+
+### analyze_branch
+
+Resolve issue context from branch naming and validate the bound task surfaces.
+
+### analyze_worktree
+
+Use the worktree as the concrete target and validate its task surfaces and bound metadata.

--- a/adl/tools/skills/records-hygiene/SKILL.md
+++ b/adl/tools/skills/records-hygiene/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: records-hygiene
+description: Scan ADL lifecycle records for truth drift, report bounded machine-readable findings, and optionally apply narrow safe repairs.
+---
+
+# Records Hygiene
+
+This skill owns scoped hygiene for ADL lifecycle records across STP, SIP, SOR,
+and related workflow evidence.
+
+Its job is to:
+
+- detect common record-truth drift (status, linkage, placeholder, ID, and integration-state drift)
+- classify each finding by safety and ambiguity
+- emit structured evidence and repair recommendations in a machine-readable shape
+- apply only narrow, deterministic safe fixes when explicitly allowed
+- recommend follow-on issues when the drift signals tooling gaps
+
+This skill is a focused helper. It does not replace editor skills when the fix is
+qualitative, and it does not expand into broader repo cleanup beyond the bounded
+target.
+
+## Entry Conditions
+
+Use this skill when all of the following are true:
+
+- you have a concrete target (issue, task bundle, or worktree)
+- the request is to perform record truth hygiene, not general code implementation
+- the caller wants machine-readable output (or reviewable remediation steps)
+
+Use `records-hygiene` when:
+
+- `status` fields appear stale for completed, closed, or merged issues
+- `worktree_only`/`pr_open` state fields conflict with actual repo state
+- placeholder values remain in tracked cards
+- PR/issue links or run IDs drift across paired lifecycle surfaces
+- a safe, local mechanical correction is desired before broader remediation
+
+Do not use this skill for:
+
+- speculative issue edits without any bounded target
+- broad workflow orchestration that should stay with `workflow-conductor`
+- broad one-off documentation cleanup outside the bound task bundle
+- open-ended truth inference that requires human arbitration
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `issue_number`
+  - `task_bundle_path`
+  - `branch`
+  - `worktree_path`
+
+Useful additional inputs:
+
+- `slug`
+- `version`
+- explicit target surfaces (`source_prompt_path`, `stp_path`, `sip_path`, `sor_path`)
+- `policy` (`report_only`, `apply_safe_repairs`, `include_follow_on_issues`,
+  `stop_after_analysis`)
+
+## Quick Start
+
+1. Resolve the issue identity and concrete target first.
+2. Read the authoritative surfaces for that target.
+3. Run deterministic drift detection for status, linkage, placeholder, IDs, and
+   integration claims.
+4. Classify each finding as safe fix, skipped, or ambiguous.
+5. If `report_only` is false and the finding is safe/ambiguous-free,
+   apply the repair.
+6. Emit a structured result with recommendations for remaining work.
+
+## Workflow
+
+### 1. Resolve and Normalize the Target
+
+Prefer concrete target mode order:
+
+1. issue number
+2. task bundle path
+3. worktree path
+4. branch
+
+Only repair within that issue scope. Do not infer a different issue unless the
+bound data is unambiguous.
+
+### 2. Drift Detection
+
+Detect all of these classes:
+
+- lifecycle-status drift
+  - `status` in STP/SIP/SOR indicates completion while other records imply work is
+    still active
+  - stale `NOT_STARTED`/`IN_PROGRESS` on completed outputs
+- PR/worktree state drift
+  - `worktree_only`/`pr_open` flags out of sync with real branch-worktree evidence
+- linkage drift
+  - missing or mismatched PR/issue link in SOR execution sections
+- placeholder drift
+  - `TODO`, `TBD`, `<RUN_ID>`, `<timestamp>`, `N/A` used in finalized fields
+- identity drift
+  - run IDs, issue IDs, or branch names that disagree across task-card surfaces
+- integration truth drift
+  - claims that artifact is in main repository while only worktree copy exists
+
+### 3. Safe Fixes vs Ambiguity
+
+Safe fixes are only those that are mechanical and unambiguous:
+
+- replacing known placeholder markers in clearly bounded non-assertive fields
+- normalizing list/order of evidence fields where provenance is deterministic
+- back-filling missing worktree path in record surfaces when the target worktree is
+  uniquely resolved
+- replacing stale run-id fields with deterministic values from already bound evidence
+
+Treat these as ambiguous and report for operator follow-up:
+
+- mixed status signals across card and PR/tooling states
+- uncertain scope intent in acceptance criteria
+- open PR-state questions where closed/open claims conflict across stale sources
+
+### 4. Reporting and Handoffs
+
+Output must include:
+
+- machine-readable finding list with severity and area
+- safe fixes applied
+- skipped files
+- ambiguity list with recommended review inputs
+- follow-on issues for process/tooling gaps
+- handoff guidance (operator or editor skill)
+
+This skill should stop before repository-wide planning changes.
+
+## Workflow Boundaries
+
+Allowed writes are mechanical and bounded to the addressed issue surfaces.
+
+Stop before:
+
+- broad code or docs reimplementation
+- workflow-wide milestone edits
+- PR merge or closeout decisions
+- creation of follow-on implementation work that should be a sibling issue
+
+## Output
+
+Use `references/output-contract.md` and emit the structured shape described there.
+
+Artifact path pattern should be an `.adl/reviews` record under the active
+repository path.
+

--- a/adl/tools/skills/records-hygiene/adl-skill.yaml
+++ b/adl/tools/skills/records-hygiene/adl-skill.yaml
@@ -1,0 +1,119 @@
+version: "0.1"
+kind: "adl-skill"
+id: "records-hygiene"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "records_hygiene.v1"
+    reference_doc: "../docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "analyze_issue"
+      - "analyze_task_bundle"
+      - "analyze_branch"
+      - "analyze_worktree"
+    policy_fields:
+      - "report_only"
+      - "apply_safe_repairs"
+      - "include_follow_on_issues"
+      - "max_findings_to_emit"
+      - "stop_after_analysis"
+    mode_requirements:
+      analyze_issue:
+        required_target_fields:
+          - "issue_number"
+      analyze_task_bundle:
+        required_target_fields:
+          - "task_bundle_path"
+      analyze_branch:
+        required_target_fields:
+          - "branch"
+      analyze_worktree:
+        required_target_fields:
+          - "worktree_path"
+  intent:
+    - "lifecycle_record_hygiene"
+    - "record_drift_detection"
+    - "safe_record_repair"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "issue_number"
+    - "task_bundle_path"
+    - "branch"
+    - "worktree_path"
+    - "slug"
+    - "version"
+    - "source_prompt_path"
+    - "stp_path"
+    - "sip_path"
+    - "sor_path"
+  stop_if_missing:
+    - "repo_root"
+  require_one_of:
+    - "issue_number"
+    - "task_bundle_path"
+    - "branch"
+    - "worktree_path"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_records_hygiene.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "exactly_one_primary_target_should_drive_the_mode"
+    - "policy.stop_after_analysis_must_be_true"
+    - "policy.max_findings_to_emit_must_be_nonnegative_integer"
+    - "paths_must_identify_only_one_intended_target_context"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: true
+  allow_network: false
+  allow_subagents: false
+  parallelism_policy: "parallel_across_distinct_issues_only"
+  workflow_role: "records_hygiene"
+  stop_before:
+    - "pr_run"
+    - "pr_ready"
+    - "pr_closeout"
+    - "pr_finish"
+  preferred_commands:
+    - "rg --files .adl"
+    - "rg -n \"status|run_id|worktree_only|pr_open|issue|pr|integration\" .adl"
+    - "git worktree list"
+    - "adl/tools/pr.sh doctor --json"
+  preferred_path: "target_issue_or_task_first_then_worktree_or_branch_bound_records"
+  repair_policy: "apply_only_mechanical_non_ambiguous_fixes_for_bound_target"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+  must_not_write:
+    - "unrelated task bundles"
+    - "workflow orchestration artifacts outside the target"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "yaml"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-records-hygiene.md"
+  required_sections:
+    - "status"
+    - "target"
+    - "findings"
+    - "safe_repairs_applied"
+    - "skipped_files"
+    - "ambiguous_findings"
+    - "recommended_follow_ons"
+    - "validation_performed"
+    - "handoff_state"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/records-hygiene/agents/openai.yaml
+++ b/adl/tools/skills/records-hygiene/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Records Hygiene
+short_description: Detect lifecycle-record drift and optionally apply safe bounded corrections
+default_prompt: Inspect task bundle record surfaces for stale lifecycle state, placeholders, drift, and integration truth; emit structured findings, safe repairs, and follow-ons.

--- a/adl/tools/skills/records-hygiene/references/output-contract.md
+++ b/adl/tools/skills/records-hygiene/references/output-contract.md
@@ -1,0 +1,54 @@
+# Records-Hygiene Output Contract
+
+Use this contract whenever the skill emits a machine-readable artifact.
+
+```yaml
+status: clean | findings | blocked | error
+target:
+  issue_number: <u32 or null>
+  task_bundle_path: <repo-relative-or-absolute path or null>
+  branch: <branch name or null>
+  worktree_path: <repo-relative-or-absolute path or null>
+  version: <string or null>
+findings:
+  - severity: info | warning | blocking | ambiguous
+    area: status_drift | linkage_drift | placeholder_drift | identity_drift | integration_truth
+    message: <short finding text>
+    evidence: <short evidence summary>
+    files:
+      - <path>
+    can_auto_fix: true | false
+safe_repairs_applied:
+  - file: <path>
+    action: <repair action name>
+    previous: <previous value>
+    updated: <updated value>
+skipped_files:
+  - <path>
+ambiguous_findings:
+  - area: <area>
+    reason: <why a human decision is required>
+    files:
+      - <path>
+recommended_follow_ons:
+  - title: <follow-on issue candidate title>
+    rationale: <reason this should be handled as a separate issue>
+validation_performed:
+  - <validation command or check name>
+handoff_state:
+  ready_for_editor: true | false
+  ready_for_execution: true | false
+  ready_for_follow_on_implementation: true | false
+```
+
+## Output Rules
+
+- `status: clean` means no findings with `severity: blocking`.
+- `status: findings` means actionable findings exist with at least one non-ambiguous finding.
+- `status: blocked` means no safe pass is possible without operator input.
+- `status: error` means the analyzer itself could not complete safely.
+- `can_auto_fix` must be true only when the change is deterministic and mechanically safe.
+- `safe_repairs_applied` may only include files under the resolved target scope.
+- Do not include absolute host paths.
+- `ambiguous_findings` entries should have explicit follow-on guidance and must not include fabricated edits.
+- If `policy.report_only` is true, `safe_repairs_applied` must be empty.

--- a/adl/tools/skills/records-hygiene/references/records-hygiene-playbook.md
+++ b/adl/tools/skills/records-hygiene/references/records-hygiene-playbook.md
@@ -1,0 +1,54 @@
+# Records-Hygiene Playbook
+
+This playbook is the bounded operational algorithm for detecting and optionally
+repairing ADL lifecycle record drift.
+
+## Algorithm
+
+1. Resolve the target issue context.
+2. Load these surfaces when present:
+   - source prompt
+   - STP
+   - SIP
+   - SOR
+   - worktree-local STP/SIP/SOR if bound
+   - worktree path
+3. Build a deterministic normalized evidence map:
+   - issue number and slug
+   - branch/worktree pairing
+   - status states (`NOT_STARTED`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`)
+   - PR metadata claims
+   - run IDs and evidence IDs
+   - integration wording (`worktree_only`, `pr_open`, `main_repo`)
+4. Run drift checks:
+   - stale completion state check
+   - stale placeholder check
+   - PR/worktree drift check
+   - linkage drift check
+   - identity drift check
+   - integration truth check
+5. Classify each finding:
+   - `info` for low-impact cleanup hints
+   - `warning` for non-blocking hygiene debt
+   - `blocking` when execution/finish truth is materially wrong
+   - `ambiguous` when human arbitration is needed
+6. Apply safe fixes only when each fix:
+   - has explicit deterministic replacement
+   - is one of the supported safe fix types
+   - is bounded to the resolved target surface
+7. Emit contract artifact and follow-on recommendations.
+
+## Supported Safe Fix Types
+
+- Replace placeholder markers in bounded fields that are explicitly machine-determined.
+- Drop duplicate placeholder entries already covered by a live value.
+- Backfill run ID where all targets resolve to one canonical value.
+- Align integration wording when worktree-bound status is now proven by branch/worktree inspection.
+
+## Explicitly Unsupported Actions
+
+- Adding or inferring issue intent, acceptance criteria, or implementation scope.
+- Expanding into unbounded repo cleanup.
+- Rewriting completed or historical records without explicit permission from a bounded target.
+- Guessing issue intent from partial context.
+- Modifying files outside the issue task bundle and worktree scope.

--- a/adl/tools/test_records_hygiene_skill_contracts.sh
+++ b/adl/tools/test_records_hygiene_skill_contracts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+docs_root="${skills_root}/docs"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/records-hygiene/SKILL.md" ]]
+[[ -f "${skills_root}/records-hygiene/adl-skill.yaml" ]]
+[[ -f "${skills_root}/records-hygiene/agents/openai.yaml" ]]
+[[ -f "${skills_root}/records-hygiene/references/output-contract.md" ]]
+[[ -f "${skills_root}/records-hygiene/references/records-hygiene-playbook.md" ]]
+[[ -f "${skills_root}/docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'name: records-hygiene' "${skills_root}/records-hygiene/SKILL.md"
+grep -Fq 'id: "records-hygiene"' "${skills_root}/records-hygiene/adl-skill.yaml"
+grep -Fq 'id: "records_hygiene.v1"' "${skills_root}/records-hygiene/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md"' "${skills_root}/records-hygiene/adl-skill.yaml"
+grep -Fq 'records_hygiene.v1' "${skills_root}/docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md"
+grep -Fq "safe_repairs_applied" "${skills_root}/records-hygiene/references/output-contract.md"
+grep -Fq "records-hygiene" "${docs_root}/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "placeholder" "${skills_root}/records-hygiene/references/records-hygiene-playbook.md"
+
+CODEX_HOME="${tmpdir}/codex-home" \
+ADL_OPERATIONAL_SKILLS_SOURCE_ROOT="${skills_root}" \
+bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/tmp/records-hygiene-install.out
+[[ -f "${tmpdir}/codex-home/skills/records-hygiene/SKILL.md" ]]
+diff -q \
+  "${skills_root}/records-hygiene/SKILL.md" \
+  "${tmpdir}/codex-home/skills/records-hygiene/SKILL.md" >/dev/null
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/records-hygiene/SKILL.md"
+
+echo "PASS test_records_hygiene_skill_contracts"


### PR DESCRIPTION
Closes #2172

## Summary
Added a new operational skill bundle `records-hygiene` for bounded ADL task-record hygiene analysis, created schema and contract test coverage, and wired it into the skill-checking and skills documentation surfaces so it can be discovered and installed through existing runtime mechanisms.

## Artifacts
- `adl/tools/skills/records-hygiene/SKILL.md`
- `adl/tools/skills/records-hygiene/adl-skill.yaml`
- `adl/tools/skills/records-hygiene/agents/openai.yaml`
- `adl/tools/skills/records-hygiene/references/output-contract.md`
- `adl/tools/skills/records-hygiene/references/records-hygiene-playbook.md`
- `adl/tools/skills/docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_records_hygiene_skill_contracts.sh`
- `adl/tools/batched_checks.sh`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_records_hygiene_skill_contracts.sh`: validates presence of required skill files, schema tokens, install parity, and frontmatter constraints for records-hygiene.
  - `bash adl/tools/pr.sh doctor 2172 --slug backlog-skills-add-records-hygiene-skill --version v0.90 --mode full --json`: verifies lifecycle state and branch/worktree binding.
  - `bash -x adl/tools/test_records_hygiene_skill_contracts.sh`: isolated command-level failure point and ensured the script exits successfully.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/bodies/issue-2172-backlog-skills-add-records-hygiene-skill.md
- Output card: .adl/v0.90/tasks/issue-2172__backlog-skills-add-records-hygiene-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-records-hygiene-skill-adl-tools-skills-records-hygiene-adl-tools-skills-docs-adl-tools-test-records-hygiene-skill-contracts-sh-adl-tools-batched-checks-sh-adl-v0-90-bodies-issue-2172-backlog-skills-add-records-hygiene-skill-md-adl-v0-90-tasks-issue-2172-backlog-skills-add-records-hygiene-skill-sor-md