### PR TITLE
[v0.90][backlog][skills] Add PR stack manager skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -54,6 +54,7 @@ run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_mediu
 run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_paper_writer_skill_contracts.sh"
 run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_author_skill_contracts.sh"
 run_step "records-hygiene contract check" bash "$ROOT/adl/tools/test_records_hygiene_skill_contracts.sh"
+run_step "pr-stack-manager contract check" bash "$ROOT/adl/tools/test_pr_stack_manager_skill_contracts.sh"
 run_step "skill documentation completeness check" bash "$ROOT/adl/tools/test_skill_documentation_completeness.sh"
 run_step "tracked .adl issue-record residue guard" bash "$ROOT/adl/tools/check_no_tracked_adl_issue_record_residue.sh"
 echo "• Running adl checks (batched)…"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -30,6 +30,7 @@ The tracked skill set is:
 - `pr-janitor`
 - `pr-ready`
 - `pr-run`
+- `pr-stack-manager`
 - `product-report-writer`
 - `redaction-and-evidence-auditor`
 - `refactoring-helper`

--- a/adl/tools/skills/docs/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,93 @@
+# PR Stack Manager Skill Input Schema
+
+## Metadata
+- Feature Name: `PR Stack Manager Skill Input Schema`
+- Milestone Target: `v0.90`
+- Status: `proposed`
+- Owner: `Daniel Austin / Agent Logic`
+- Doc Role: `primary`
+- Supporting Docs: `adl/tools/skills/pr-stack-manager/SKILL.md`, `adl/tools/skills/pr-stack-manager/adl-skill.yaml`, `adl/tools/skills/pr-stack-manager/references/output-contract.md`
+- Proof Modes: `validation`, `records`
+
+## Purpose
+
+This schema defines the invocation contract for bounded PR stack management around ADL
+issue dependencies, base alignment, and merge-order safety.
+
+## Canonical Invocation
+
+```yaml
+skill_input_schema: pr_stack_manager.v1
+mode: analyze_issue | analyze_task_bundle | analyze_branch | analyze_worktree | repair_stack_plan | repair_stack_apply
+repo_root: /absolute/path/to/repo
+target:
+  issue_number: 2173
+  task_bundle_path: .adl/v0.90/tasks/issue-2173__backlog-skills-add-pr-stack-manager-skill
+  branch: codex/2173-backlog-skills-add-pr-stack-manager-skill
+  worktree_path: .worktrees/adl-wp-2173
+  slug: backlog-skills-add-pr-stack-manager-skill
+  version: v0.90
+  source_prompt_path: .adl/v0.90/bodies/issue-2173-backlog-skills-add-pr-stack-manager-skill.md
+  stp_path: .adl/v0.90/tasks/issue-2173__backlog-skills-add-pr-stack-manager-skill/stp.md
+  sip_path: .adl/v0.90/tasks/issue-2173__backlog-skills-add-pr-stack-manager-skill/sip.md
+  sor_path: .adl/v0.90/tasks/issue-2173__backlog-skills-add-pr-stack-manager-skill/sor.md
+policy:
+  dry_run: true | false
+  allow_mutation: true | false
+  max_stack_depth: <integer >=1>
+  include_follow_ons: true | false
+  base_alignment: true | false
+  max_findings_to_emit: <integer >=0>
+```
+
+## Required Fields
+
+- `skill_input_schema` must equal `pr_stack_manager.v1`.
+- `mode` must match one of:
+  - `analyze_issue`
+  - `analyze_task_bundle`
+  - `analyze_branch`
+  - `analyze_worktree`
+  - `repair_stack_plan`
+  - `repair_stack_apply`
+- `repo_root` must be absolute.
+- `target` must include exactly one primary mode field:
+  - `issue_number` for `analyze_issue` and repair modes,
+  - `task_bundle_path` for `analyze_task_bundle`,
+  - `branch` for `analyze_branch`,
+  - `worktree_path` for `analyze_worktree`.
+- `policy.dry_run` and `policy.allow_mutation` must be explicit.
+- `policy.max_stack_depth` must be a positive integer.
+- `policy.base_alignment` must be boolean.
+- `policy.max_findings_to_emit` must be nonnegative integer.
+
+## Optional Fields
+
+- `slug`, `version`, `source_prompt_path`, and explicit card paths can reduce inference.
+- `policy.include_follow_ons` controls explicit recommended follow-on issue output.
+
+## Mode Semantics
+
+### analyze_issue
+
+Resolve the issue centrally and audit all known issue-affiliated task and PR stack surfaces.
+
+### analyze_task_bundle
+
+Resolve from task bundle and validate outward to branch and PR metadata.
+
+### analyze_branch
+
+Resolve issue context from branch naming and bound task surfaces.
+
+### analyze_worktree
+
+Use worktree path as the concrete context and validate stack and dependency state.
+
+### repair_stack_plan
+
+Produce a strict, non-mutating remediation plan for stack/base misalignment.
+
+### repair_stack_apply
+
+Apply bounded stack remediation only when explicit safety policy is satisfied.

--- a/adl/tools/skills/pr-stack-manager/SKILL.md
+++ b/adl/tools/skills/pr-stack-manager/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: pr-stack-manager
+description: Analyze and manage PR stack topology, dependency order, and base alignment for ADL issue workflows in a bounded, reviewable way.
+---
+
+# PR Stack Manager
+
+This skill helps operators and automation reason about stacked PR execution safely.
+
+Its job is to:
+
+- inspect current PR/dependency topology for ADL issue workflows,
+- detect base drift and merge-order risks,
+- surface concrete recommendations for restack/rebase workflows only within the bounded target,
+- emit machine-readable state with optional, bounded mutation actions when explicitly requested.
+
+It is not a replacement for other lifecycle skills. It supports stack governance
+and truth recording around `pr-init`, `pr-run`, `pr-ready`, `pr-janitor`,
+and `pr-finish`.
+
+## Entry Conditions
+
+Use this skill when all of the following are true:
+
+- the target is an issue or bounded worktree with a concrete stack-relevant context,
+- the operator needs a deterministic stack assessment or bounded stack action plan,
+- the requested action is limited to PR ordering/dependency truth and bounded remediation.
+
+Use `pr-stack-manager` when:
+
+- dependent branches are expected but dependency edges are uncertain,
+- PR base branches drift from expected parent branches,
+- topological merge order appears to violate dependency intent,
+- worktree/branch/PR metadata in task artifacts and local git are out of sync.
+
+Do not use this skill for:
+
+- general workflow arbitration that should stay with lifecycle routing,
+- open-ended branch rewrites without explicit stack scope,
+- unrelated repo-wide PR cleanup not bound to an issue/worktree,
+- speculative dependency graph construction without evidence.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `issue_number`
+  - `task_bundle_path`
+  - `branch`
+  - `worktree_path`
+
+Useful additional inputs:
+
+- `slug`
+- `version`
+- explicit PR/task surfaces (`source_prompt_path`, `stp_path`, `sip_path`, `sor_path`)
+- `policy` (`mode`, `base_alignment`, `allow_mutation`, `dry_run`, `max_stack_depth`)
+
+## Workflow
+
+### 1. Resolve and Normalize the Target
+
+Use one primary target mode and bound metadata:
+
+1. `issue`/`task bundle`/`branch`/`worktree`
+2. issue artifacts (`source_prompt`, `stp`, `sip`, `sor`)
+3. local git branch and worktree topology
+4. GitHub PR metadata for stack-relevant issue branches
+
+### 2. Analyze Stack Topology
+
+Surface:
+
+- issue-to-branch binding and expected stack ancestry,
+- PR base relationships and whether bases still match expected dependency ordering,
+- dependent issue overlap (directly and transitively),
+- worktree-only vs open-pr state mismatch,
+- unresolved blockers (e.g., open dependency PRs, stale bases, missing proofs).
+
+### 3. Classify Risk and Action
+
+Use four risk levels:
+
+- `info`: low-risk visibility gaps
+- `warning`: non-blocking stack friction
+- `blocking`: incorrect execution/finish dependency truth
+- `error`: analysis or safety precondition failure
+
+Classify each action by:
+
+- deterministic and bounded mutation
+- ambiguous/human-review-needed
+- safe planning only
+
+### 4. Optional Bounded Mutation
+
+Mutation is allowed only if requested and bounded:
+
+- generate a dry-run plan,
+- reorder a documented dependency action sequence,
+- emit explicit commands to reopen/rebase/rebase-base where evidence is unambiguous,
+- never perform branch surgery without explicit safe mutation policy.
+
+### 5. Emit Contracted Output
+
+Write structured findings and next-step recommendations to a bounded artifact.
+
+## Quick Start
+
+1. Resolve target identity and stack context.
+2. Run topology+base analysis.
+3. Report `blocking` stack risks first.
+4. If `allow_mutation` is enabled and risks are unambiguous, apply bounded actions.
+5. Write residual recommendations and handoff state.
+
+## Workflow Boundaries
+
+Allowed writes are mechanical and bounded to the addressed issue surface.
+
+Stop before:
+
+- wide PR strategy changes,
+- milestone-level workflow redesign,
+- unrelated branch operations outside the target stack,
+- merge decisions outside scoped input.
+
+## Output
+
+Use `references/output-contract.md` and emit deterministic structured records that are
+machine-readable and reviewable before any merge-facing publication.

--- a/adl/tools/skills/pr-stack-manager/adl-skill.yaml
+++ b/adl/tools/skills/pr-stack-manager/adl-skill.yaml
@@ -1,0 +1,130 @@
+version: "0.1"
+kind: "adl-skill"
+id: "pr-stack-manager"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "pr_stack_manager.v1"
+    reference_doc: "../docs/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "analyze_issue"
+      - "analyze_task_bundle"
+      - "analyze_branch"
+      - "analyze_worktree"
+      - "repair_stack_plan"
+      - "repair_stack_apply"
+    policy_fields:
+      - "dry_run"
+      - "allow_mutation"
+      - "max_stack_depth"
+      - "include_follow_ons"
+      - "base_alignment"
+      - "max_findings_to_emit"
+    mode_requirements:
+      analyze_issue:
+        required_target_fields:
+          - "issue_number"
+      analyze_task_bundle:
+        required_target_fields:
+          - "task_bundle_path"
+      analyze_branch:
+        required_target_fields:
+          - "branch"
+      analyze_worktree:
+        required_target_fields:
+          - "worktree_path"
+      repair_stack_plan:
+        required_target_fields:
+          - "issue_number"
+      repair_stack_apply:
+        required_target_fields:
+          - "issue_number"
+  intent:
+    - "pr_stack_topology_management"
+    - "dependency_order_analysis"
+    - "base_drift_detection"
+    - "bounded_stack_repair_planning"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "issue_number"
+    - "task_bundle_path"
+    - "branch"
+    - "worktree_path"
+    - "slug"
+    - "version"
+    - "source_prompt_path"
+    - "stp_path"
+    - "sip_path"
+    - "sor_path"
+  stop_if_missing:
+    - "repo_root"
+  require_one_of:
+    - "issue_number"
+    - "task_bundle_path"
+    - "branch"
+    - "worktree_path"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_pr_stack_manager.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "policy.max_stack_depth_must_be_positive_integer"
+    - "policy.max_findings_to_emit_must_be_nonnegative_integer"
+    - "policy.dry_run_or_allow_mutation_must_be_boolean"
+    - "policy.base_alignment_must_be_boolean"
+    - "exactly_one_primary_target_should_drive_the_mode"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: true
+  allow_network: false
+  allow_subagents: false
+  parallelism_policy: "serial_by_issue_stack"
+  workflow_role: "pr_stack_manager"
+  stop_before:
+    - "pr_run"
+    - "pr_ready"
+    - "pr_finish"
+    - "pr_closeout"
+  preferred_commands:
+    - "git worktree list"
+    - "git branch --all --list"
+    - "git log --oneline --decorate --graph"
+    - "gh pr view --json number,baseRefName,headRefName,state,title"
+    - "adl/tools/pr.sh doctor --json"
+  preferred_path: "target_issue_stack_then_local_and_remote_stack_surfaces"
+  repair_policy: "plan_only_by_default_then_apply_only_when_explicitly_safe"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+    - "adl/tools/skills/pr-stack-manager/**"
+  must_not_write:
+    - "unrelated issue stacks"
+    - "unbounded branch operations"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "yaml"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-pr-stack-manager.md"
+  required_sections:
+    - "status"
+    - "target"
+    - "dependency_graph"
+    - "findings"
+    - "planned_actions"
+    - "validation_performed"
+    - "handoff_state"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false

--- a/adl/tools/skills/pr-stack-manager/agents/openai.yaml
+++ b/adl/tools/skills/pr-stack-manager/agents/openai.yaml
@@ -1,0 +1,5 @@
+display_name: PR Stack Manager
+short_description: Analyze PR stack ancestry, base drift, and bounded restack options for an issue and its dependent branches.
+default_prompt: >
+  Assess PR stack topology for the target issue/worktree, classify ordering risks,
+  and produce a machine-readable plan for safe bounded restack or dependency remediation.

--- a/adl/tools/skills/pr-stack-manager/references/output-contract.md
+++ b/adl/tools/skills/pr-stack-manager/references/output-contract.md
@@ -1,0 +1,74 @@
+# PR Stack Manager Output Contract
+
+Use this contract when the skill emits a machine-readable artifact.
+
+```yaml
+status: clean | findings | blocked | error
+target:
+  issue_number: <u32 or null>
+  task_bundle_path: <repo-relative-or-absolute path or null>
+  branch: <branch name or null>
+  worktree_path: <repo-relative-or-absolute path or null>
+  slug: <string or null>
+  version: <string or null>
+dependency_graph:
+  root_issue: <issue number or null>
+  nodes:
+    - issue_number: <u32 or null>
+      slug: <string or null>
+      branch: <string or null>
+      pr_number: <u32 or null>
+      state: <open|closed|unknown>
+      depends_on: [<issue numbers>]
+      base_ref: <branch or null>
+  edges:
+    - from_issue: <u32>
+      to_issue: <u32>
+      edge_type: requires | blocks | base_rebase_candidate
+      confidence: low | medium | high
+  cycle_detected: <true|false>
+findings:
+  - severity: info | warning | blocking | ambiguous
+    area: stack_topology | base_alignment | dependency_order | artifact_drift
+    message: <short finding text>
+    evidence:
+      summary: <short evidence summary>
+      files:
+        - <path>
+      refs:
+        - <issue, branch, or PR ref>
+    can_auto_fix: <true|false>
+planned_actions:
+  - type: plan | mutate
+    issue_number: <u32>
+    action: <action name>
+    command: <bounded command string or null>
+    rationale: <why this action is proposed>
+    safe: <true|false>
+    preconditions:
+      - <required condition>
+skip_list:
+  - <path>
+recommended_follow_ons:
+  - title: <follow-on issue candidate title>
+    rationale: <reason this should be handled separately>
+validation_performed:
+  - <validation command or check name>
+handoff_state:
+  ready_for_editor: <true|false>
+  ready_for_execution: <true|false>
+  ready_for_follow_on_implementation: <true|false>
+```
+
+## Rules
+
+- `status: clean` indicates no actionable `warning` or `blocking` findings.
+- `status: findings` means at least one actionable finding is present.
+- `status: blocked` means the stack cannot be safely assessed or repaired without
+  operator direction.
+- `status: error` means the skill could not complete analysis for safety reasons.
+- `planned_actions` entries with `type: mutate` must set `safe: true` only when
+  bounded, deterministic, and explicitly requested by policy.
+- `command` should be null for plan-only output.
+- If policy is dry-run or plan mode, mutation actions should remain explicit but not executed.
+- Do not include absolute host paths.

--- a/adl/tools/skills/pr-stack-manager/references/pr-stack-manager-playbook.md
+++ b/adl/tools/skills/pr-stack-manager/references/pr-stack-manager-playbook.md
@@ -1,0 +1,60 @@
+# PR Stack Manager Playbook
+
+## Detection Workflow
+
+1. Resolve the target issue/worktree or branch context.
+2. Read task surfaces and doctor state for the target:
+   - source prompt
+   - STP, SIP, SOR
+   - local worktree metadata
+   - PR metadata when available
+3. Build deterministic stack topology:
+   - branch ancestry from `codex/<issue>-...` naming
+   - dependency declarations from `depends_on`
+   - observed PR base chain from local and remote metadata
+4. Compare expected dependency graph with actual stack/base truth.
+5. Detect drift types:
+   - base drift (base branch no longer expected),
+   - ordering conflict (child branch claims dependency not present),
+   - stale dependency claim (depends_on references merged or missing nodes),
+   - open blocker risk (unmerged dependency PR still required).
+6. Emit findings with severity and deterministic evidence.
+7. Produce a plan-first repair list:
+   - safe ordering sequence,
+   - explicit prerequisite actions,
+   - mutation-safe command(s) only when requested and deterministic.
+
+## Planning Heuristics
+
+- Prefer no mutation when stack truth is contradictory or evidence is partial.
+- Prefer `status: blocked` only when an ambiguous parent/child dependency exists.
+- Treat missing issue intent as `ambiguous` rather than inventing order.
+- Never force branch surgery.
+- Never infer PR targets without explicit PR number + base evidence.
+
+## Repair Policy
+
+Mutation is allowed only in plan/apply modes and when:
+
+- dependency edges are explicit and unique,
+- base expectation can be proven from issue graph or direct evidence,
+- and actions are bounded to the target scope.
+
+Safe actions include:
+- emitting an execution-order plan,
+- annotating ordering recommendations on SOR/local surfaces,
+- preparing deterministic, scoped follow-up steps for follow-on PR stack execution.
+
+Unsafe actions include:
+- cross-stack forced rebases,
+- rewriting unrelated PRs,
+- changing issue intent or acceptance criteria,
+- silent branch deletion/recreation.
+
+## Validation
+
+Before finalizing, validate:
+- topology reconstruction is deterministic,
+- action list is scoped and bounded,
+- mutation commands are explicit and reversible where possible,
+- all emitted paths are repository-relative and non-absolute.

--- a/adl/tools/test_pr_stack_manager_skill_contracts.sh
+++ b/adl/tools/test_pr_stack_manager_skill_contracts.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+docs_root="${skills_root}/docs"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/pr-stack-manager/SKILL.md" ]]
+[[ -f "${skills_root}/pr-stack-manager/adl-skill.yaml" ]]
+[[ -f "${skills_root}/pr-stack-manager/agents/openai.yaml" ]]
+[[ -f "${skills_root}/pr-stack-manager/references/output-contract.md" ]]
+[[ -f "${skills_root}/pr-stack-manager/references/pr-stack-manager-playbook.md" ]]
+[[ -f "${docs_root}/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'name: pr-stack-manager' "${skills_root}/pr-stack-manager/SKILL.md"
+grep -Fq 'id: "pr-stack-manager"' "${skills_root}/pr-stack-manager/adl-skill.yaml"
+grep -Fq 'id: "pr_stack_manager.v1"' "${skills_root}/pr-stack-manager/adl-skill.yaml"
+grep -Fq 'pr_stack_manager.v1' "${docs_root}/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "dependency_graph" "${skills_root}/pr-stack-manager/references/output-contract.md"
+grep -Fq "Repair Policy" "${skills_root}/pr-stack-manager/references/pr-stack-manager-playbook.md"
+grep -Fq "pr-stack-manager" "${docs_root}/OPERATIONAL_SKILLS_GUIDE.md"
+
+CODEX_HOME="${tmpdir}/codex-home" \
+ADL_OPERATIONAL_SKILLS_SOURCE_ROOT="${skills_root}" \
+bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/tmp/pr-stack-manager-install.out
+[[ -f "${tmpdir}/codex-home/skills/pr-stack-manager/SKILL.md" ]]
+diff -q \
+  "${skills_root}/pr-stack-manager/SKILL.md" \
+  "${tmpdir}/codex-home/skills/pr-stack-manager/SKILL.md" >/dev/null
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/pr-stack-manager/SKILL.md"
+
+echo "PASS test_pr_stack_manager_skill_contracts"


### PR DESCRIPTION
Closes #2173

## Summary
- Added a bounded operational skill bundle for managing stacked PRs and dependent branch relationships (`pr-stack-manager`).
- Added source-grounded input schema and contract-test coverage for skill integrity.
- Integrated the new contract check into batched skill checks and validated run-bound issue state before finishing.

## Artifacts
- `adl/tools/skills/pr-stack-manager/SKILL.md`
- `adl/tools/skills/pr-stack-manager/adl-skill.yaml`
- `adl/tools/skills/pr-stack-manager/agents/openai.yaml`
- `adl/tools/skills/pr-stack-manager/references/output-contract.md`
- `adl/tools/skills/pr-stack-manager/references/pr-stack-manager-playbook.md`
- `adl/tools/skills/docs/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_pr_stack_manager_skill_contracts.sh`
- `adl/tools/batched_checks.sh`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh run 2173 --slug backlog-skills-add-pr-stack-manager-skill --version v0.90`: bind run context and initialize execution state.
  - `bash adl/tools/test_pr_stack_manager_skill_contracts.sh`: verify skill schema, files, and required playbook text.
  - `bash adl/tools/batched_checks.sh`: ensure the new check is part of standard batched verification.
  - `bash adl/tools/pr.sh doctor 2173 --slug backlog-skills-add-pr-stack-manager-skill --version v0.90 --mode full --json`: verify lifecycle state and readiness before finish.
- Results:
  - All targeted validation checks pass.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2173__backlog-skills-add-pr-stack-manager-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2173__backlog-skills-add-pr-stack-manager-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-pr-stack-manager-skill-adl-v0-90-tasks-issue-2173-backlog-skills-add-pr-stack-manager-skill-sip-md-adl-v0-90-tasks-issue-2173-backlog-skills-add-pr-stack-manager-skill-sor-md