### PR TITLE
[v0.90.1][backlog][tools] Create issue-watcher skill for dependency gates

### DIFF
--- a/adl/tools/skills/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,165 @@
+# Issue Watcher Skill Input Schema
+
+Schema id: `issue_watcher.v1`
+
+## Purpose
+
+Provide one structured invocation shape for the bounded `issue-watcher` skill.
+
+The skill observes one issue, PR, branch, or dependency gate during a wait window
+and reports whether the watched target is:
+
+- `ready`
+- `pending`
+- `blocked`
+- `action_required`
+- `merged`
+- `closed`
+
+It does not mutate issues, PRs, branches, cards, or implementation files.
+
+## Supported Modes
+
+- `watch_issue`
+- `watch_pr`
+- `watch_pr_url`
+- `watch_branch`
+- `watch_dependency_gate`
+
+## Top-Level Shape
+
+```yaml
+skill_input_schema: issue_watcher.v1
+mode: watch_issue | watch_pr | watch_pr_url | watch_branch | watch_dependency_gate
+repo_root: /absolute/path
+target:
+  issue_number: <u32 or null>
+  pr_number: <u32 or null>
+  pr_url: <url or null>
+  branch: <string or null>
+  dependency_issue_number: <u32 or null>
+  expected_state: <ready | merged | closed | any | null>
+  expected_checks:
+    - <check name>
+  dependency_notes:
+    - <string>
+policy:
+  allow_pr_inference: true | false
+  monitor_checks: true | false
+  monitor_merge_state: true | false
+  monitor_closure_state: true | false
+  route_blockers: true
+  stop_after_watch: true
+```
+
+## Mode Requirements
+
+### `watch_issue`
+
+Requires:
+
+- `target.issue_number`
+
+Use when:
+
+- the issue itself is the watched gate
+- linked PR inference is allowed and should be used only when unambiguous
+
+### `watch_pr`
+
+Requires:
+
+- `target.pr_number`
+
+Use when:
+
+- a PR number is the canonical watched target
+
+### `watch_pr_url`
+
+Requires:
+
+- `target.pr_url`
+
+Use when:
+
+- the operator supplied the PR URL rather than a number
+
+### `watch_branch`
+
+Requires:
+
+- `target.branch`
+
+Use when:
+
+- the branch is known and may map to one in-flight PR
+
+### `watch_dependency_gate`
+
+Requires:
+
+- `target.dependency_issue_number`
+
+Use when:
+
+- one issue or PR must finish before another issue may start
+
+## Policy Fields
+
+- `allow_pr_inference`
+  - required
+  - whether the skill may infer a linked PR from an issue or branch
+- `monitor_checks`
+  - required
+  - whether check status should be summarized
+- `monitor_merge_state`
+  - required
+  - whether mergeability/conflict status should be summarized
+- `monitor_closure_state`
+  - required
+  - whether issue/PR closure state should be inspected
+- `route_blockers`
+  - must be `true`
+  - the skill should recommend the next skill/operator action rather than repairing
+- `stop_after_watch`
+  - must be `true`
+  - the skill must stop after one observation pass
+
+## Example Invocation
+
+```yaml
+Use $issue-watcher at /Users/daniel/git/agent-design-language/adl/tools/skills/issue-watcher/SKILL.md with this validated input:
+
+skill_input_schema: issue_watcher.v1
+mode: watch_pr
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  issue_number: 2144
+  pr_number: 2180
+  pr_url: null
+  branch: null
+  dependency_issue_number: null
+  expected_state: merged
+  expected_checks:
+    - adl-ci
+    - adl-coverage
+  dependency_notes:
+    - WP-05 may start after WP-04 merges.
+policy:
+  allow_pr_inference: false
+  monitor_checks: true
+  monitor_merge_state: true
+  monitor_closure_state: true
+  route_blockers: true
+  stop_after_watch: true
+```
+
+## Notes
+
+- Watch exactly one primary target per invocation.
+- Use dependency notes only as context; do not convert them into multiple watch targets.
+- Route failed checks, conflicts, and requested review changes to `pr-janitor`.
+- Route missing or structurally unready lifecycle surfaces to `pr-ready` or `pr-init`.
+- Stop before mutating issue, PR, branch, worktree, or implementation state.
+

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -23,6 +23,7 @@ The tracked skill set is:
 - `documentation-specialist`
 - `finding-to-issue-planner`
 - `gap-analysis`
+- `issue-watcher`
 - `medium-article-writer`
 - `pr-closeout`
 - `pr-finish`
@@ -74,6 +75,7 @@ The normal workflow is:
 `arxiv-paper-writer` is a bounded helper skill for turning one concrete scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, or inventing citations.
 `diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
+`issue-watcher` is a bounded wait-window helper for watching one issue, PR, branch, or dependency gate and routing blockers without mutating state.
 
 The three editor skills are helper skills:
 - `stp-editor` for bounded `stp.md` cleanup
@@ -137,7 +139,6 @@ The general pattern is:
 
 ```yaml
 Use $<skill-name> at /Users/daniel/git/agent-design-language/adl/tools/skills/<skill-name>/SKILL.md with this validated input:
-
 skill_input_schema: <schema-id>
 mode: <mode>
 repo_root: /Users/daniel/git/agent-design-language
@@ -148,6 +149,44 @@ policy:
 ```
 
 For `pr-init`, the payload uses `issue:` instead of `target:`.
+
+### `issue-watcher`
+
+Use `issue-watcher` when:
+
+- one issue, PR, branch, or dependency gate should be observed during a wait window
+- the operator needs a clear ready, pending, blocked, merged, closed, or action-required classification
+- PR blockers should be routed to `pr-janitor` rather than repaired inside the watcher
+
+Do not use it for:
+
+- implementation work
+- CI repair
+- issue or PR mutation
+- merge, closeout, or long-running scheduler behavior
+
+Structured schema:
+
+- `adl/tools/skills/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md`
+- schema id: `issue_watcher.v1`
+
+Supported modes:
+
+- `watch_issue`
+- `watch_pr`
+- `watch_pr_url`
+- `watch_branch`
+- `watch_dependency_gate`
+
+Expected output includes:
+
+- target identity
+- observed issue/PR/check/merge state
+- dependency state
+- recommended handoff skill or operator action
+- actions taken and actions recommended
+
+It must stop before mutating issue, PR, branch, card, or implementation state.
 
 ## Core Model
 

--- a/adl/tools/skills/issue-watcher/SKILL.md
+++ b/adl/tools/skills/issue-watcher/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: issue-watcher
+description: Watch one issue, PR, branch, or dependency gate for readiness while work is waiting, classify the state, route PR blockers to pr-janitor, and stop before merge, closeout, or implementation.
+---
+
+# Issue Watcher
+
+This skill owns bounded wait-window monitoring for one workflow target.
+
+Its job is to:
+- inspect one issue, PR, branch, or dependency gate
+- classify whether the target is ready, pending, blocked, merged, closed, or action-required
+- identify the next lifecycle handoff without performing it silently
+- route PR check, conflict, or review blockers to `pr-janitor`
+- emit a concise watcher result and stop
+
+This is an observation and routing skill, not a repair or execution skill.
+
+## When To Use It
+
+Use this skill when:
+- a prerequisite issue or PR is waiting to merge before the next work item can start
+- the operator wants a watcher on a dependency gate during another task
+- an issue should be rechecked for readiness without opening the implementation lane
+- a PR's high-level state is needed, but detailed CI repair belongs to `pr-janitor`
+
+Do not use this skill for:
+- bootstrapping missing issue cards
+- implementing the issue
+- diagnosing and fixing failed PR checks directly
+- merging PRs, closing issues, or running closeout
+- long-running daemon or scheduler behavior outside the current invocation
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- one concrete primary target:
+  - `target.issue_number`
+  - `target.pr_number`
+  - `target.pr_url`
+  - `target.branch`
+  - `target.dependency_issue_number`
+
+Useful additional inputs:
+- `target.expected_state`
+- `target.expected_checks`
+- `target.dependency_notes`
+- `policy.monitor_checks`
+- `policy.monitor_merge_state`
+- `policy.monitor_closure_state`
+- `policy.allow_pr_inference`
+
+If no concrete primary target is present, stop and report `blocked`.
+
+## Quick Start
+
+1. Resolve exactly one primary watch target.
+2. Inspect the target's live state using GitHub or repo-native metadata.
+3. If watching an issue, inspect linked PRs only when inference is allowed and unambiguous.
+4. Classify the observed state.
+5. Recommend the next handoff.
+6. Stop without mutating issue, PR, branch, or implementation state.
+
+## Workflow
+
+### 1. Resolve The Target
+
+Prefer the most concrete selector supplied:
+1. explicit PR number
+2. explicit PR URL
+3. explicit issue number
+4. explicit branch
+5. explicit dependency issue number
+
+Exactly one primary target should drive the watch. A dependency list may be
+used as context, but it must not create multiple independent watch tasks in one
+invocation.
+
+If multiple primary targets disagree, report `blocked`.
+
+### 2. Inspect State
+
+Inspect where applicable:
+- issue open/closed state
+- issue labels, milestone, and dependency notes when relevant
+- linked PR state when inference is allowed
+- PR draft/open/merged/closed state
+- check summary
+- mergeability or conflict state
+- review state only at the high-level blocker/routing level
+
+Use direct GitHub metadata or `gh` where available. Do not infer readiness only
+from stale local cards when live GitHub state is required.
+
+### 3. Classify The Result
+
+Use:
+- `ready`
+  - the watched gate is satisfied and the next work item may proceed
+- `pending`
+  - the target is healthy but still waiting on checks, review, draft state, or merge
+- `blocked`
+  - the target is ambiguous, missing, conflicted, or requires human/process action
+- `action_required`
+  - a concrete next skill or operator action is needed
+- `merged`
+  - the watched PR has merged
+- `closed`
+  - the watched issue or PR is closed without being a merge-ready success path
+
+## Routing Rules
+
+- If a PR has failed checks, merge conflicts, or requested changes, route to `pr-janitor`.
+- If an issue is structurally unready, route to `pr-ready`.
+- If cards are missing, route to `pr-init`.
+- If the watched prerequisite is merged and the next issue is structurally ready, route to `pr-run`.
+- If the issue or PR outcome is settled and only lifecycle cleanup remains, route to `pr-closeout`.
+- If human review or explicit approval is needed, route to the operator.
+
+## Stop Boundary
+
+This skill must not:
+- modify source files, cards, issues, PRs, labels, branches, or worktrees
+- rerun or repair CI
+- merge, close, reopen, or mark PRs ready for review
+- create a long-running background loop
+- collapse into `pr-janitor`, `pr-run`, or `pr-closeout`
+
+When ADL expects structured output, follow `references/output-contract.md`.
+

--- a/adl/tools/skills/issue-watcher/adl-skill.yaml
+++ b/adl/tools/skills/issue-watcher/adl-skill.yaml
@@ -1,0 +1,122 @@
+version: "0.1"
+kind: "adl-skill"
+id: "issue-watcher"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "issue_watcher.v1"
+    reference_doc: "../docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "watch_issue"
+      - "watch_pr"
+      - "watch_pr_url"
+      - "watch_branch"
+      - "watch_dependency_gate"
+    policy_fields:
+      - "allow_pr_inference"
+      - "monitor_checks"
+      - "monitor_merge_state"
+      - "monitor_closure_state"
+      - "route_blockers"
+      - "stop_after_watch"
+    mode_requirements:
+      watch_issue:
+        required_target_fields:
+          - "issue_number"
+      watch_pr:
+        required_target_fields:
+          - "pr_number"
+      watch_pr_url:
+        required_target_fields:
+          - "pr_url"
+      watch_branch:
+        required_target_fields:
+          - "branch"
+      watch_dependency_gate:
+        required_target_fields:
+          - "dependency_issue_number"
+  intent:
+    - "issue_progress_watch"
+    - "dependency_gate_watch"
+    - "pr_high_level_readiness_watch"
+    - "workflow_handoff_routing"
+  required_inputs:
+    - "repo_root"
+  optional_inputs:
+    - "issue_number"
+    - "pr_number"
+    - "pr_url"
+    - "branch"
+    - "dependency_issue_number"
+    - "expected_state"
+    - "expected_checks"
+    - "dependency_notes"
+  stop_if_missing:
+    - "repo_root"
+  require_one_of:
+    - "issue_number"
+    - "pr_number"
+    - "pr_url"
+    - "branch"
+    - "dependency_issue_number"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_issue_watcher.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "exactly_one_primary_watch_target_should_drive_the_mode"
+    - "dependency_context_must_not_create_multiple_primary_targets"
+    - "policy.stop_after_watch_must_be_true"
+    - "policy.route_blockers_must_be_explicit"
+    - "pr_repair_must_route_to_pr_janitor"
+execution:
+  mode: "observe_and_route"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: true
+  preferred_model: "gpt-5.4"
+  preferred_reasoning_effort: "medium"
+  workflow_role: "wait_window_issue_and_dependency_gate_watcher"
+  stop_before:
+    - "issue_or_pr_mutation"
+    - "ci_repair"
+    - "implementation"
+    - "silent_merge"
+    - "silent_closeout"
+  preferred_path: "validated_structured_input_plus_live_github_state_plus_bounded_handoff"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/** watcher notes only when explicitly requested"
+  must_not_write:
+    - "main branch directly"
+    - "issue labels, issue state, or PR state"
+    - "implementation files"
+    - "task cards unless explicitly recording watcher notes"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-issue-watcher.md"
+  required_sections:
+    - "status"
+    - "target"
+    - "observed_state"
+    - "dependency_state"
+    - "handoff"
+    - "actions_taken"
+    - "actions_recommended"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  manifest_declares_executables: false
+

--- a/adl/tools/skills/issue-watcher/agents/openai.yaml
+++ b/adl/tools/skills/issue-watcher/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Issue Watcher"
+  short_description: "Watch issue and dependency gates"
+  default_prompt: "Use $issue-watcher to inspect one issue, PR, branch, or dependency gate, classify whether it is ready or blocked, route the next handoff, and stop without mutating state."
+

--- a/adl/tools/skills/issue-watcher/references/output-contract.md
+++ b/adl/tools/skills/issue-watcher/references/output-contract.md
@@ -1,0 +1,50 @@
+# Output Contract
+
+When ADL expects structured `issue-watcher` output, use this shape.
+
+```yaml
+status: ready | pending | blocked | action_required | merged | closed
+target:
+  issue_number: <u32 or null>
+  pr_number: <u32 or null>
+  pr_url: <url or null>
+  branch: <branch or null>
+  dependency_issue_number: <u32 or null>
+observed_state:
+  issue_state: open | closed | unknown | not_applicable
+  pr_state: draft | open | merged | closed | unknown | not_applicable
+  checks_state: pass | fail | pending | mixed | unknown | not_applicable
+  merge_state: clean | dirty | blocked | unknown | not_applicable
+dependency_state:
+  satisfied: true | false | unknown
+  blockers:
+    - <short blocker description>
+handoff:
+  next_skill: pr-init | pr-ready | pr-run | pr-janitor | pr-closeout | none
+  next_operator_action: <short action or null>
+  ready_for_next_work: true | false | unknown
+actions_taken:
+  - <inspection action>
+actions_recommended:
+  - <next action>
+notes:
+  - <optional bounded note>
+```
+
+## Rules
+
+- If `status: ready`, `handoff.ready_for_next_work` must be `true`.
+- If `status: pending`, the target must have no known hard blocker; it is still waiting on checks, review, draft state, merge, or closure.
+- If `status: action_required`, `handoff.next_skill` or `handoff.next_operator_action` must name the required next step.
+- If PR checks, conflicts, or requested changes are the blocker, `handoff.next_skill` must be `pr-janitor`.
+- If cards or workflow readiness are the blocker, route to `pr-init` or `pr-ready` rather than repairing inside this skill.
+- Do not claim `ready_for_next_work: true` when the watched prerequisite is still a draft PR, has failing checks, is ambiguous, or requires human approval.
+
+## Default Artifact Location
+
+When writing the watcher result to disk by default, use:
+
+```text
+.adl/reviews/<timestamp>-issue-watcher.md
+```
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,11 +8,12 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
   [[ -f "${root}/skills/workflow-conductor/SKILL.md" ]]
+  [[ -f "${root}/skills/issue-watcher/SKILL.md" ]]
   [[ -f "${root}/skills/pr-init/SKILL.md" ]]
   [[ -f "${root}/skills/pr-ready/SKILL.md" ]]
   [[ -f "${root}/skills/pr-run/SKILL.md" ]]
@@ -56,6 +57,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]
 
   grep -Fq "thin orchestrator" "${root}/skills/workflow-conductor/SKILL.md"
+  grep -Fq "Watch one issue, PR, branch, or dependency gate" "${root}/skills/issue-watcher/SKILL.md"
   grep -Fq "qualitative card review" "${root}/skills/pr-init/SKILL.md"
   grep -Fq "execution_readiness" "${root}/skills/pr-ready/references/output-contract.md"
   grep -Fq "perform the bounded implementation work" "${root}/skills/pr-run/SKILL.md"
@@ -84,6 +86,7 @@ assert_skill_bundle() {
 
   bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
     "${root}/skills/workflow-conductor/SKILL.md" \
+    "${root}/skills/issue-watcher/SKILL.md" \
     "${root}/skills/pr-init/SKILL.md" \
     "${root}/skills/pr-ready/SKILL.md" \
     "${root}/skills/pr-run/SKILL.md" \
@@ -120,6 +123,7 @@ export CODEX_HOME="${tmpdir}/codex-home-symlink"
 ADL_OPERATIONAL_SKILLS_INSTALL_MODE=symlink bash "${repo_root}/adl/tools/install_adl_operational_skills.sh" >/dev/null
 assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/pr-init" ]]
+[[ -L "${CODEX_HOME}/skills/issue-watcher" ]]
 [[ -L "${CODEX_HOME}/skills/pr-ready" ]]
 [[ -L "${CODEX_HOME}/skills/repo-packet-builder" ]]
 [[ -L "${CODEX_HOME}/skills/redaction-and-evidence-auditor" ]]
@@ -134,6 +138,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]
+[[ "$(cd "${CODEX_HOME}/skills/issue-watcher" && pwd -P)" == "${repo_root}/adl/tools/skills/issue-watcher" ]]
 
 malformed_root="${tmpdir}/malformed-skills"
 cp -R "${repo_root}/adl/tools/skills" "${malformed_root}"

--- a/adl/tools/test_issue_watcher_skill_contracts.sh
+++ b/adl/tools/test_issue_watcher_skill_contracts.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+
+[[ -f "${skills_root}/issue-watcher/SKILL.md" ]]
+[[ -f "${skills_root}/issue-watcher/adl-skill.yaml" ]]
+[[ -f "${skills_root}/issue-watcher/agents/openai.yaml" ]]
+[[ -f "${skills_root}/issue-watcher/references/output-contract.md" ]]
+[[ -f "${skills_root}/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "issue-watcher"' "${skills_root}/issue-watcher/adl-skill.yaml"
+grep -Fq 'id: "issue_watcher.v1"' "${skills_root}/issue-watcher/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md"' "${skills_root}/issue-watcher/adl-skill.yaml"
+grep -Fq "policy.stop_after_watch_must_be_true" "${skills_root}/issue-watcher/adl-skill.yaml"
+grep -Fq "pr_repair_must_route_to_pr_janitor" "${skills_root}/issue-watcher/adl-skill.yaml"
+grep -Fq "Watch one issue, PR, branch, or dependency gate" "${skills_root}/issue-watcher/SKILL.md"
+grep -Fq "route to \`pr-janitor\`" "${skills_root}/issue-watcher/SKILL.md"
+grep -Fq 'Schema id: `issue_watcher.v1`' "${skills_root}/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "watch_issue | watch_pr | watch_pr_url | watch_branch | watch_dependency_gate" "${skills_root}/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "route_blockers: true" "${skills_root}/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md"
+grep -Fq "handoff.next_skill" "${skills_root}/issue-watcher/references/output-contract.md"
+grep -Fq "If PR checks, conflicts, or requested changes are the blocker" "${skills_root}/issue-watcher/references/output-contract.md"
+grep -Fq "issue_watcher.v1" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/issue-watcher/SKILL.md"
+
+echo "PASS test_issue_watcher_skill_contracts"


### PR DESCRIPTION
Closes #2182

## Summary
Implemented a tracked `issue-watcher` operational skill for bounded wait-window monitoring of one issue, PR, branch, or dependency gate. The skill observes live workflow state, classifies readiness/blocker outcomes, routes PR blockers to `pr-janitor`, and stops before issue/PR mutation, implementation, merge, or closeout.

## Artifacts
- `adl/tools/skills/issue-watcher/SKILL.md`
- `adl/tools/skills/issue-watcher/adl-skill.yaml`
- `adl/tools/skills/issue-watcher/agents/openai.yaml`
- `adl/tools/skills/issue-watcher/references/output-contract.md`
- `adl/tools/skills/docs/ISSUE_WATCHER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_issue_watcher_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_issue_watcher_skill_contracts.sh` verified the new skill bundle, schema references, stop boundary, output contract, and `pr-janitor` routing rule.
  - `bash adl/tools/test_skill_documentation_completeness.sh` verified every tracked skill, including `issue-watcher`, has required bundle files, input schema docs, output contracts, and guide coverage.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified copy and symlink installation include the new `issue-watcher` skill and pass frontmatter validation.
- Results: PASS.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2182__create-issue-watcher-skill-for-dependency-gates/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2182__create-issue-watcher-skill-for-dependency-gates/sor.md
- Idempotency-Key: v0-90-1-backlog-tools-create-issue-watcher-skill-for-dependency-gates-adl-tools-skills-issue-watcher-adl-tools-skills-docs-issue-watcher-skill-input-schema-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-test-install-adl-operational-skills-sh-adl-tools-test-issue-watcher-skill-contracts-sh-adl-v0-90-1-tasks-issue-2182-create-issue-watcher-skill-for-dependency-gates-sip-md-adl-v0-90-1-tasks-issue-2182-create-issue-watcher-skill-for-dependency-gates-sor-md