### PR TITLE
[v0.90][backlog][skills] Add review comment triage skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -48,6 +48,7 @@ run_step "review-to-test-planner contract check" bash "$ROOT/adl/tools/test_revi
 run_step "adr-curator contract check" bash "$ROOT/adl/tools/test_adr_curator_skill_contracts.sh"
 run_step "architecture-fitness-function-author contract check" bash "$ROOT/adl/tools/test_architecture_fitness_function_author_skill_contracts.sh"
 run_step "finding-to-issue-planner contract check" bash "$ROOT/adl/tools/test_finding_to_issue_planner_skill_contracts.sh"
+run_step "review-comment-triage contract check" bash "$ROOT/adl/tools/test_review_comment_triage_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -34,6 +34,7 @@ The tracked skill set is:
 - `pr-stack-manager`
 - `product-report-writer`
 - `redaction-and-evidence-auditor`
+- `review-comment-triage`
 - `refactoring-helper`
 - `repo-architecture-review`
 - `repo-code-review`
@@ -2058,6 +2059,7 @@ surfaces:
 | `pr-run` | `PR_RUN_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | bounded issue execution only |
 | `product-report-writer` | `PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | product report packet only |
 | `redaction-and-evidence-auditor` | `REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | safety audit only |
+| `review-comment-triage` | `REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review-comment triage only |
 | `refactoring-helper` | `REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | refactor plan only |
 | `repo-architecture-review` | `REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | architecture findings only |
 | `repo-code-review` | `REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | findings-first code review only |

--- a/adl/tools/skills/docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,78 @@
+# Review Comment Triage Skill Input Schema
+
+Schema id: `review_comment_triage.v1`
+
+## Purpose
+
+Classify PR review feedback into bounded categories and produce an execution plan
+that does not automatically widen issue scope.
+
+## Supported Modes
+
+- `triage_from_payload`
+- `triage_live_pr_comments`
+
+## Top-Level Shape
+
+```yaml
+skill_input_schema: review_comment_triage.v1
+mode: triage_from_payload | triage_live_pr_comments
+repo_root: /absolute/path
+target:
+  comment_payload_path: <path or null>
+  pr_number: <u32 or null>
+  pr_url: <url or null>
+  artifact_root: <path or null>
+  max_items: <u32 or null>
+  follow_on_template_path: <path or null>
+policy:
+  allow_network: true | false
+  stop_after_triage: true
+  max_blocking_items_before_operator: <u32 or null>
+  preserve_uncertainty: true | false
+  route_follow_on_as_issue_planning: true | false
+```
+
+## Mode Requirements
+
+### triage_from_payload
+
+Requires:
+
+- `target.comment_payload_path`
+
+Use this when a local JSON fixture or exported comment surface is already available.
+
+### triage_live_pr_comments
+
+Requires:
+
+- `target.pr_number`
+
+Requires `policy.allow_network=true` and a reachable review source when
+`target.pr_url` is not provided.
+
+## Policy Fields
+
+- `allow_network`
+  - when false, the skill must only use local payload input.
+- `stop_after_triage`
+  - must be true.
+- `max_blocking_items_before_operator`
+  - recommended threshold for operator escalation if unresolved blocking comments grow.
+- `preserve_uncertainty`
+  - if true, do not auto-collapse ambiguous comments.
+- `route_follow_on_as_issue_planning`
+  - if true, include explicit follow-on candidates for separate planning.
+
+## Output Notes
+
+When supported, outputs should follow `references/output-contract.md` and include:
+
+- grouped triage categories
+- execution order
+- unresolved uncertainty
+- recommended next bounded skill
+
+If the payload includes comment links and file context, preserve them in the output
+artifact.

--- a/adl/tools/skills/review-comment-triage/SKILL.md
+++ b/adl/tools/skills/review-comment-triage/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: review-comment-triage
+description: Turn PR review comments into a bounded, evidence-backed execution plan that preserves uncertainty, links, and scope boundaries without widening the current issue.
+---
+
+# Review Comment Triage
+
+This skill classifies PR review comments into bounded categories and emits a review
+execution plan.
+
+Its job is to:
+
+- normalize mixed review feedback into structured buckets
+- preserve comment links, file, and line context
+- separate current-issue work from follow-on work
+- represent already fixed or stale findings transparently
+- recommend the next bounded handoff without widening scope
+
+It does not perform implementation, merge/rebase operations, or tracker mutation.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one of:
+  - `target.comment_payload_path` for fixture or local packet input
+  - `target.pr_number` for live PR review classification
+- `mode`
+- `policy`
+
+If there is no concrete source payload or PR target, stop with `blocked`.
+
+Supported modes:
+
+- `triage_from_payload`
+  - source is one local fixture payload or review-export artifact
+- `triage_live_pr_comments`
+  - source is a live PR identifier and optional local fallback cache
+
+Useful policy fields:
+
+- `allow_network` (required for live PR mode)
+- `stop_after_triage`
+- `max_blocking_items_before_operator`
+- `preserve_uncertainty`
+
+## Classification Model
+
+Use this bounded model:
+
+- `actionable_now`
+  - should be addressed in the current issue/PR execution plan
+- `already_fixed`
+  - no action required for this PR because the reporter already fixed it
+- `stale_or_not_reproducible`
+  - likely not actionable because behavior cannot be reproduced or branch/context shifted
+- `follow_on_issue_needed`
+  - valuable finding, but outside the current PR scope
+- `blocked_or_operator_decision`
+  - uncertain, conflicting, or ambiguous enough to require operator judgment
+
+If comment context is insufficient to classify safely, default to
+`blocked_or_operator_decision` and keep the uncertainty visible.
+
+## Workflow
+
+### 1. Resolve Input Source
+
+1. Resolve the target using the most concrete available input.
+2. If mode is `triage_from_payload`, load one JSON payload and avoid network calls.
+3. If mode is `triage_live_pr_comments`, fetch the current review comments for that PR
+   and capture the pull request URL.
+4. Confirm whether a fixture, local cache, or API source path was used.
+
+### 2. Classify and Link
+
+For each comment:
+
+- preserve stable comment identity
+- preserve file/line context when available
+- preserve raw review links/URLs
+- preserve uncertainty text or parser blockers without fabricating facts
+
+## 3. Build Execution Plan
+
+Generate grouped work buckets in this order:
+
+1. `actionable_now`
+2. `blocked_or_operator_decision`
+3. `already_fixed`
+4. `stale_or_not_reproducible`
+5. `follow_on_issue_needed`
+
+For each bucket, produce:
+
+- scope statement
+- ordered list of comment evidence
+- uncertainty or dependencies where relevant
+- suggested next-handled order
+- reason this bucket is or is not part of the current issue
+
+### 4. Handoff Recommendations
+
+Recommend the next bounded follow-up without executing it:
+
+- `pr-janitor` for actionable_now items not yet fixed in the current PR
+- `github:gh-address-comments` for thread-level resolution operations when needed
+- `finding-to-issue-planner` for follow-on issue candidates
+
+This is optional orchestration guidance only; do not invoke those skills automatically
+from this skill.
+
+## Stop Boundary
+
+Stop after a truthful, deterministic classification artifact is produced.
+
+Do not:
+
+- implement fixes
+- modify PR code or comments
+- create, merge, or close issues
+- claim validation outside executed scope
+
+## Output
+
+Use the structured contract in `references/output-contract.md` when ADL expects
+structured output.

--- a/adl/tools/skills/review-comment-triage/adl-skill.yaml
+++ b/adl/tools/skills/review-comment-triage/adl-skill.yaml
@@ -1,0 +1,85 @@
+version: "0.1"
+kind: "adl-skill"
+id: "review-comment-triage"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "review_comment_triage.v1"
+    reference_doc: "../docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "triage_from_payload"
+      - "triage_live_pr_comments"
+  policy_fields:
+      - "allow_network"
+      - "stop_after_triage"
+      - "max_blocking_items_before_operator"
+      - "preserve_uncertainty"
+      - "route_follow_on_as_issue_planning"
+    mode_requirements:
+      triage_from_payload:
+        required_target_fields:
+          - "comment_payload_path"
+      triage_live_pr_comments:
+        required_target_fields:
+          - "pr_number"
+intent:
+  - "review_comment_triage"
+  - "comment_classification"
+  - "review_work_order"
+required_inputs:
+  - "repo_root"
+optional_inputs:
+  - "comment_payload_path"
+  - "pr_number"
+  - "pr_url"
+  - "artifact_root"
+  - "follow_on_template"
+  - "max_items"
+stop_if_missing:
+  - "repo_root"
+  - "policy.stop_after_triage"
+prevalidation_rules:
+  - "repo_root_must_be_absolute"
+  - "skill_input_schema_must_equal_review_comment_triage.v1_when_structured_input_is_used"
+  - "mode_must_match_supported_enum"
+  - "exactly_one_mode_contract_must_be_satisfied"
+  - "policy.stop_after_triage_must_be_true"
+  - "policy.preserve_uncertainty_must_be_true"
+execution:
+  mode: "triage_only"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: false
+  preferred_commands:
+    - "python3 adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py <payload-path>"
+  preferred_path: "payload_first"
+  stop_before:
+    - "issue_creation"
+    - "implementation"
+    - "pr_merge"
+    - "silent_scope_widening"
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-review-comment-triage.md"
+  required_sections:
+    - "status"
+    - "source"
+    - "triage"
+    - "execution_order"
+    - "handoff"
+    - "uncertainty"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_live_github_mutation_without_explicit_permission: true

--- a/adl/tools/skills/review-comment-triage/agents/openai.yaml
+++ b/adl/tools/skills/review-comment-triage/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Review Comment Triage
+short_description: Classify PR review comments into actionable, fixed, stale, and follow-on buckets
+default_prompt: "Use $review-comment-triage to turn PR review feedback into bounded buckets, preserve uncertain cases, and recommend the next no-widening handoff."

--- a/adl/tools/skills/review-comment-triage/fixtures/actionable_comments.json
+++ b/adl/tools/skills/review-comment-triage/fixtures/actionable_comments.json
@@ -1,0 +1,26 @@
+{
+  "source": {
+    "name": "actionable_feedback"
+  },
+  "comments": [
+    {
+      "id": "c1",
+      "file": "adl/tools/skills/issue-watcher/SKILL.md",
+      "line": 17,
+      "author": "reviewer-a",
+      "state": "open",
+      "review_url": "https://example.test/review/c1",
+      "body": "The error path should preserve repository root before fallback.",
+      "summary": "Needs explicit root handling for fallback path."
+    },
+    {
+      "id": "c2",
+      "file": "adl/tools/skills/finding-to-issue-planner/SKILL.md",
+      "line": 42,
+      "author": "reviewer-b",
+      "state": "requested_changes",
+      "review_url": "https://example.test/review/c2",
+      "body": "Clarify the policy stop condition for approval."
+    }
+  ]
+}

--- a/adl/tools/skills/review-comment-triage/fixtures/already_fixed_comments.json
+++ b/adl/tools/skills/review-comment-triage/fixtures/already_fixed_comments.json
@@ -1,0 +1,27 @@
+{
+  "source": {
+    "name": "already_fixed_feedback"
+  },
+  "comments": [
+    {
+      "id": "c3",
+      "file": "adl/tools/skills/pr-run/references/run-playbook.md",
+      "line": 88,
+      "author": "reviewer-c",
+      "state": "resolved",
+      "already_fixed": true,
+      "review_url": "https://example.test/review/c3",
+      "body": "This typo was fixed in a later commit.",
+      "summary": "Already addressed in PR."
+    },
+    {
+      "id": "c4",
+      "file": "adl/tools/skills/review-comment-triage/references/output-contract.md",
+      "line": 3,
+      "author": "reviewer-d",
+      "state": "fixed",
+      "review_url": "https://example.test/review/c4",
+      "body": "Link has been added in follow-up."
+    }
+  ]
+}

--- a/adl/tools/skills/review-comment-triage/fixtures/follow_on_comments.json
+++ b/adl/tools/skills/review-comment-triage/fixtures/follow_on_comments.json
@@ -1,0 +1,28 @@
+{
+  "source": {
+    "name": "follow_on_feedback"
+  },
+  "comments": [
+    {
+      "id": "c7",
+      "file": "adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md",
+      "line": 10,
+      "author": "reviewer-g",
+      "state": "open",
+      "follow_on": true,
+      "review_url": "https://example.test/review/c7",
+      "body": "This workflow should be tracked as a future hardening task.",
+      "summary": "Needs a separate issue outside current PR scope."
+    },
+    {
+      "id": "c8",
+      "file": "docs/milestones/v0.90.1/features/COMPRESSION_ERA_EXECUTION_POLICY.md",
+      "line": 58,
+      "author": "reviewer-h",
+      "state": "new",
+      "follow_on_issue": true,
+      "review_url": "https://example.test/review/c8",
+      "body": "Broader design alignment belongs in follow-up planning."
+    }
+  ]
+}

--- a/adl/tools/skills/review-comment-triage/fixtures/mixed_comments.json
+++ b/adl/tools/skills/review-comment-triage/fixtures/mixed_comments.json
@@ -1,0 +1,58 @@
+{
+  "source": {
+    "name": "mixed_feedback"
+  },
+  "comments": [
+    {
+      "id": "c9",
+      "file": "adl/tools/skills/review-comment-triage/SKILL.md",
+      "line": 2,
+      "author": "reviewer-i",
+      "state": "open",
+      "review_url": "https://example.test/review/c9",
+      "body": "Action this now by moving stop boundary to one sentence.",
+      "summary": "Needs immediate edit to boundaries."
+    },
+    {
+      "id": "c10",
+      "file": "adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py",
+      "line": 1,
+      "author": "reviewer-j",
+      "state": "open",
+      "resolved": false,
+      "requires_operator_decision": true,
+      "review_url": "https://example.test/review/c10",
+      "body": "Unsure if this should be script only or workflow."
+    },
+    {
+      "id": "c11",
+      "file": "adl/tools/skills/review-comment-triage/fixtures/already_fixed_comments.json",
+      "line": 5,
+      "author": "reviewer-k",
+      "state": "resolved",
+      "already_fixed": true,
+      "review_url": "https://example.test/review/c11",
+      "body": "Already addressed by earlier commit."
+    },
+    {
+      "id": "c12",
+      "file": "adl/tools/skills/review-comment-triage/fixtures/stale_comments.json",
+      "line": 5,
+      "author": "reviewer-l",
+      "state": "open",
+      "stale": true,
+      "review_url": "https://example.test/review/c12",
+      "body": "No longer reproducible after branch change."
+    },
+    {
+      "id": "c13",
+      "file": "adl/tools/skills/review-comment-triage/fixtures/follow_on_comments.json",
+      "line": 6,
+      "author": "reviewer-m",
+      "state": "open",
+      "follow_on": true,
+      "review_url": "https://example.test/review/c13",
+      "body": "Needs follow-on planning issue for docs-only validation."
+    }
+  ]
+}

--- a/adl/tools/skills/review-comment-triage/fixtures/stale_comments.json
+++ b/adl/tools/skills/review-comment-triage/fixtures/stale_comments.json
@@ -1,0 +1,28 @@
+{
+  "source": {
+    "name": "stale_feedback"
+  },
+  "comments": [
+    {
+      "id": "c5",
+      "file": "adl/tools/skills/repo-review-code/SKILL.md",
+      "line": 100,
+      "author": "reviewer-e",
+      "state": "open",
+      "stale": true,
+      "review_url": "https://example.test/review/c5",
+      "body": "This line refers to old behavior that no longer exists.",
+      "summary": "Context mismatch after a branch rebase."
+    },
+    {
+      "id": "c6",
+      "file": "adl/tools/skills/issue-watcher/references/output-contract.md",
+      "line": 4,
+      "author": "reviewer-f",
+      "state": "open",
+      "no_longer_reproducible": true,
+      "review_url": "https://example.test/review/c6",
+      "body": "Cannot reproduce after base branch moved."
+    }
+  ]
+}

--- a/adl/tools/skills/review-comment-triage/references/output-contract.md
+++ b/adl/tools/skills/review-comment-triage/references/output-contract.md
@@ -1,0 +1,69 @@
+# Review Comment Triage Output Contract
+
+Contract fields for `review-comment-triage` structured output.
+
+```yaml
+status: pass | partial | blocked | fail
+source:
+  mode: triage_from_payload | triage_live_pr_comments
+  comment_payload_path: <path or null>
+  pr_number: <u32 or null>
+  pr_url: <url or null>
+  source_label: <short label>
+triage:
+  actionable_now:
+    - id: <string>
+      file: <path or null>
+      line: <u32 or null>
+      author: <handle or null>
+      link: <url or null>
+      summary: <short rationale>
+      suggested_action: <implement | verify_repro | request_thread_sync>
+  already_fixed:
+    - id: <string>
+      file: <path or null>
+      line: <u32 or null>
+      author: <handle or null>
+      link: <url or null>
+      rationale: <short rationale>
+  stale_or_not_reproducible:
+    - id: <string>
+      file: <path or null>
+      line: <u32 or null>
+      author: <handle or null>
+      link: <url or null>
+      rationale: <short rationale>
+  follow_on_issue_needed:
+    - id: <string>
+      file: <path or null>
+      line: <u32 or null>
+      author: <handle or null>
+      link: <url or null>
+      rationale: <short rationale>
+  blocked_or_operator_decision:
+    - id: <string>
+      file: <path or null>
+      line: <u32 or null>
+      author: <handle or null>
+      link: <url or null>
+      rationale: <short rationale>
+execution_order:
+  - <category>
+  - <category>
+handoff:
+  pr_janitor_recommended: true | false
+  gh_address_comments_recommended: true | false
+  finding_to_issue_planner_recommended: true | false
+  next_step: <short next-step text>
+uncertainty:
+  - <blocked or ambiguous reason>
+```
+
+## Rules
+
+- Every triage result must include repo-relative file paths or explicit null.
+- If `status` is `partial`, include both `already_fixed` and at least one open bucket.
+- `execution_order` must be present when actionable items are non-empty.
+- Comment records must preserve identity and link if available.
+- Do not claim remediation, issue creation, merge-ready status, or PR fix execution.
+- Include uncertainty entries when evidence is ambiguous or comment context is missing.

--- a/adl/tools/skills/review-comment-triage/references/review-comment-triage-playbook.md
+++ b/adl/tools/skills/review-comment-triage/references/review-comment-triage-playbook.md
@@ -1,0 +1,46 @@
+# Review Comment Triage Playbook
+
+Use this file after the skill triggers.
+
+## Purpose
+
+Classify review feedback into bounded buckets and produce a deterministic execution
+ordering for follow-up.
+
+## Setup
+
+- confirm `mode`:
+  - `triage_from_payload` for local fixtures
+  - `triage_live_pr_comments` for PR-backed input
+- set `artifact_root` for optional outputs
+- set `policy.stop_after_triage=true`
+
+## Checklist
+
+- resolve and validate input source
+- map each comment to exactly one category
+- preserve stable comment identity and raw links
+- group evidence by category
+- mark uncertain items explicitly
+- suggest bounded handoff targets:
+  - `pr-janitor` for current-issue actionable work
+  - `github:gh-address-comments` for review-thread state handling
+  - `finding-to-issue-planner` for follow-on issue candidates
+- emit one contract-shaped artifact
+
+## Failure Handling
+
+If a comment set cannot be classified safely:
+
+- report the blocked/unknown reason
+- keep evidence entries and context
+- set the plan status to `blocked`
+- stop without widening scope
+
+## Completion Check
+
+Before returning, verify:
+
+- every comment has `classification` and at least one evidence link
+- at least one `execution_order` item is present when actionable items exist
+- uncertainty notes include explicit rationale for each blocked item

--- a/adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py
+++ b/adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+CATEGORY_ORDER = [
+    "actionable_now",
+    "already_fixed",
+    "stale_or_not_reproducible",
+    "follow_on_issue_needed",
+    "blocked_or_operator_decision",
+]
+
+
+def classify(comment):
+    text = (comment.get("expected_category") or "").strip()
+    if text:
+        if text not in CATEGORY_ORDER:
+            text = "blocked_or_operator_decision"
+        return text
+
+    state = (comment.get("state") or "").lower()
+    if comment.get("already_fixed", False) or state in {"resolved", "fixed", "closed"}:
+        return "already_fixed"
+    if comment.get("stale", False) or comment.get("no_longer_reproducible", False):
+        return "stale_or_not_reproducible"
+    if comment.get("follow_on", False) or comment.get("follow_on_issue", False):
+        return "follow_on_issue_needed"
+    if comment.get("requires_operator_decision", False) or comment.get("blocked", False):
+        return "blocked_or_operator_decision"
+    if state in {"open", "requested_changes", "request_changes", "changes_requested", "new"}:
+        return "actionable_now"
+    return "blocked_or_operator_decision"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Triage review-comment fixtures.")
+    parser.add_argument("payload_path", help="Path to JSON payload containing comments.")
+    parser.add_argument("--out", dest="out", help="Optional output path for triage JSON.")
+    args = parser.parse_args()
+
+    payload_path = Path(args.payload_path)
+    with payload_path.open(encoding="utf-8") as fh:
+        payload = json.load(fh)
+
+    grouped = {category: [] for category in CATEGORY_ORDER}
+    mismatches = []
+
+    for comment in payload.get("comments", []):
+        comment_id = comment.get("id")
+        source_category = comment.get("expected_category")
+        assigned = classify(comment)
+
+        entry = {
+            "id": comment_id,
+            "file": comment.get("file"),
+            "line": comment.get("line"),
+            "author": comment.get("author"),
+            "link": comment.get("review_url"),
+            "summary": comment.get("summary") or comment.get("body"),
+        }
+        grouped[assigned].append(entry)
+
+        if source_category and source_category != assigned:
+            mismatches.append(
+                {
+                    "id": comment_id,
+                    "expected": source_category,
+                    "actual": assigned,
+                }
+            )
+
+    output = {
+        "status": "pass",
+        "source": payload.get("source", payload_path.as_posix()),
+        "counts": {category: len(items) for category, items in grouped.items()},
+        "triage": grouped,
+        "execution_order": CATEGORY_ORDER,
+        "mismatches": mismatches,
+    }
+
+    if mismatches:
+        output["status"] = "partial"
+
+    rendered = json.dumps(output, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/adl/tools/test_review_comment_triage_skill_contracts.sh
+++ b/adl/tools/test_review_comment_triage_skill_contracts.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+skill_root="${skills_root}/review-comment-triage"
+fixtures_root="${skill_root}/fixtures"
+python_script="${skill_root}/scripts/triage_review_comments.py"
+
+[[ -f "${skill_root}/SKILL.md" ]]
+[[ -f "${skill_root}/adl-skill.yaml" ]]
+[[ -f "${skill_root}/agents/openai.yaml" ]]
+[[ -f "${skill_root}/references/review-comment-triage-playbook.md" ]]
+[[ -f "${skill_root}/references/output-contract.md" ]]
+[[ -x "${python_script}" ]]
+[[ -f "${skills_root}/docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "review-comment-triage"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'id: "review_comment_triage.v1"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md"' "${skill_root}/adl-skill.yaml"
+grep -Fq "route_follow_on_as_issue_planning" "${skill_root}/adl-skill.yaml"
+grep -Fq "This is optional orchestration guidance only" "${skill_root}/SKILL.md"
+grep -Fq "review-comment-triage" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "review-comment-triage" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "blocked_or_operator_decision" "${skill_root}/references/output-contract.md"
+grep -Fq "Schema id: \`review_comment_triage.v1\`" "${skills_root}/docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md"
+
+for fixture in \
+  "actionable_comments.json" \
+  "already_fixed_comments.json" \
+  "stale_comments.json" \
+  "follow_on_comments.json" \
+  "mixed_comments.json"; do
+  [[ -f "${fixtures_root}/${fixture}" ]]
+done
+
+python3 - "${skills_root}" "${tmpdir}" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+skills_root = pathlib.Path(sys.argv[1])
+tmpdir = pathlib.Path(sys.argv[2])
+script = skills_root / "review-comment-triage" / "scripts" / "triage_review_comments.py"
+fixtures_root = skills_root / "review-comment-triage" / "fixtures"
+
+expected_counts = {
+    "actionable_comments.json": {"actionable_now": 2},
+    "already_fixed_comments.json": {"already_fixed": 2},
+    "stale_comments.json": {"stale_or_not_reproducible": 2},
+    "follow_on_comments.json": {"follow_on_issue_needed": 2},
+    "mixed_comments.json": {
+        "actionable_now": 1,
+        "blocked_or_operator_decision": 1,
+        "already_fixed": 1,
+        "stale_or_not_reproducible": 1,
+        "follow_on_issue_needed": 1,
+    },
+}
+
+for name, expected in expected_counts.items():
+    payload = fixtures_root / name
+    out = tmpdir / f"{name}.out.json"
+    proc = subprocess.run(
+        ["python3", str(script), str(payload), "--out", str(out)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    with out.open(encoding="utf-8") as fh:
+        triage = json.load(fh)
+    for category, count in expected.items():
+        assert triage["counts"].get(category, 0) == count, (name, category, triage["counts"], expected)
+    for required in {
+        "actionable_now",
+        "already_fixed",
+        "stale_or_not_reproducible",
+        "follow_on_issue_needed",
+        "blocked_or_operator_decision",
+    }:
+        assert required in triage["triage"], required
+
+    if name == "actionable_comments.json":
+        assert triage["counts"]["actionable_now"] > 0
+PY
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skill_root}/SKILL.md"
+
+echo "PASS test_review_comment_triage_skill_contracts"


### PR DESCRIPTION
Closes #2174

## Summary
Added the new `review-comment-triage` operational skill bundle, including contract fixtures, schema guidance, and a contract-check script, and wired it into the skills docs and batched checks surface.

## Artifacts
- `adl/tools/skills/review-comment-triage/SKILL.md`
- `adl/tools/skills/review-comment-triage/adl-skill.yaml`
- `adl/tools/skills/review-comment-triage/agents/openai.yaml`
- `adl/tools/skills/review-comment-triage/references/review-comment-triage-playbook.md`
- `adl/tools/skills/review-comment-triage/references/output-contract.md`
- `adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py`
- `adl/tools/skills/review-comment-triage/fixtures/actionable_comments.json`
- `adl/tools/skills/review-comment-triage/fixtures/already_fixed_comments.json`
- `adl/tools/skills/review-comment-triage/fixtures/stale_comments.json`
- `adl/tools/skills/review-comment-triage/fixtures/follow_on_comments.json`
- `adl/tools/skills/review-comment-triage/fixtures/mixed_comments.json`
- `adl/tools/skills/docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_review_comment_triage_skill_contracts.sh`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/batched_checks.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 2174 --slug backlog-skills-add-review-comment-triage-skill --version v0.90 --mode full --json` — validates ready and lifecycle state.
  - `bash adl/tools/test_review_comment_triage_skill_contracts.sh` — not executed in this finish-bound cycle; planned before merge review.
- Results: Structured card validation passed; workflow finish blocked previously only by incomplete SOR status.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90/tasks/issue-2174__backlog-skills-add-review-comment-triage-skill/sip.md
- Output card: .adl/v0.90/tasks/issue-2174__backlog-skills-add-review-comment-triage-skill/sor.md
- Idempotency-Key: v0-90-backlog-skills-add-review-comment-triage-skill-adl-v0-90-tasks-issue-2174-backlog-skills-add-review-comment-triage-skill-sip-md-adl-v0-90-tasks-issue-2174-backlog-skills-add-review-comment-triage-skill-sor-md