### PR TITLE
[v0.90.1][demo] Aptitude Atlas repo-review aptitude demo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -222,6 +222,7 @@ review artifacts, and then writes one synthesized findings-first review.
 - `v0.90/long_lived_stock_league_demo.md`
 - `v0.90/stock_league_demo_extensions.md`
 - `v0.90/codebuddy_multi_agent_review_showcase_demo.md`
+- `v0.90/aptitude_atlas_repo_review_aptitude_demo.md`
 
 Use `bash adl/tools/demo_v090_codebuddy_review_showcase.sh` for the
 fixture-backed CodeBuddy showcase packet. It emits a product-style review

--- a/demos/fixtures/aptitude_atlas_repo_review/final_report_template.md
+++ b/demos/fixtures/aptitude_atlas_repo_review/final_report_template.md
@@ -1,0 +1,99 @@
+# Aptitude Atlas Final Report Template
+
+## Executive Summary
+
+- **Run ID**: `TBD`
+- **Run Date**: `TBD`
+- **Overall conclusion**: `TBD`
+
+## Task Family
+
+- **Family**: `review_aptitude`
+- **Fixture**: `repo-review-v0.90.1-baseline-01`
+- **Goal**: Compare bounded review aptitude under ADL constraints.
+
+## Subjects Tested
+
+- `TBD`
+
+## Test Fixture Summary
+
+List each fixture signal and subject handling:
+
+- real finding
+- false-positive trap
+- docs/release-truth wrinkle
+- residual-risk note
+
+## Scorecard Table
+
+Include one row per subject with the following dimensions:
+
+- true positive detection
+- false-positive restraint
+- severity calibration
+- evidence quality
+- remediation usefulness
+- uncertainty handling
+- repair burden
+
+## Findings by Subject
+
+For each subject include:
+
+- what was found and why
+- what was missed
+- what was deferred
+- severity and confidence
+
+## Strengths
+
+- recurring strengths observed in this run
+
+## Failure Modes
+
+- recurring misses or over-extensions
+
+## False Positives and Misses
+
+- catalog of confirmed false positives
+- catalog of misses with correction guidance
+
+## Repair Burden
+
+- reviewer cleanup load
+- rerun recommendation
+
+## Recommended Use
+
+- where this subject is suitable
+
+## Discouraged Use
+
+- where this subject should not be used
+
+## Caveats
+
+- environmental constraints
+- contract scope assumptions
+- confidence limits
+
+## Evidence Appendix
+
+Link to each artifact:
+
+- subject manifest
+- test manifest
+- run manifest
+- scorecard
+- evaluator notes
+
+## Publication Boundary
+
+- `internal` / `private` / `public_summary` / `public_leaderboard_row`
+
+## Remediation Notes
+
+- follow-up work to reduce ambiguity
+- missing evidence gaps
+- next run improvements

--- a/demos/fixtures/aptitude_atlas_repo_review/fixture_definition.md
+++ b/demos/fixtures/aptitude_atlas_repo_review/fixture_definition.md
@@ -1,0 +1,83 @@
+# Fixture Definition: Repo-Review Aptitude Prototype
+
+## Fixture Metadata
+
+- `fixture_id`: `repo-review-v0.90.1-baseline-01`
+- `test_family`: `review_aptitude`
+- `version`: `v0.90.1`
+- `goal`: validate bounded review behavior on one constrained repository slice
+
+## Fixture Summary
+
+This fixture is intentionally small and bounded. It represents one hypothetical
+ADL-facing review surface with mixed quality signals:
+
+- one clear real defect
+- one tempting false-positive pattern
+- one stale docs/release mismatch
+- one residual-risk surface for reviewer escalation
+
+## Files and Expected Signal
+
+Use all files under `demos/fixtures/aptitude_atlas_repo_review/` as the target
+surface.
+
+### 1) Real Finding (high-confidence)
+
+File: `target_repo_validator.py`
+
+Expect review finding:
+
+- `HIGH`: command injection risk from string-built shell invocation in
+  `run_validation`.
+- Why real: this is directly exploitable and actionable.
+
+### 2) False-Positive Trap
+
+File: `target_repo_readme.md`
+
+Potentially suspicious phrasing appears, but it is in quoted user education text:
+
+- sentence about “run as root at your own risk”
+
+Reviewers should avoid classifying this as a vulnerability unless it appears in
+executable workflow context.
+
+### 3) Docs / release-truth wrinkle
+
+File: `target_repo_deployment.md`
+
+The docs claim feature parity with release notes but intentionally omit a listed
+step introduced in the same section. This creates a review-worthy documentation
+trust issue, not a code bug.
+
+### 4) Residual risk surface
+
+File: `target_repo_validator.py` comments and deployment notes
+
+Potential risk should be called out as a residual risk rather than false certainty:
+
+- manual review step may miss key pair in runtime config if future subjects do not
+  inspect the full fixture context.
+- include this as a risk note with low confidence and remediation suggestion.
+
+## Fixture Scoring Rubric Seeds
+
+For each subject run, capture:
+
+- `true_positive_detection` (0-5)
+- `false_positive_restraint` (0-5)
+- `severity_calibration` (0-5)
+- `evidence_quality` (0-5)
+- `remediation_usefulness` (0-5)
+- `uncertainty_handling` (0-5)
+- `repair_burden` (0-5, reverse scale where lower is better)
+
+## Expected Artifact Outputs
+
+For each completed subject run:
+
+- one row in scorecard json (subject + dimension breakdown)
+- one evaluator_notes section in `final_report_template.md`
+- one run manifest entry with timestamped proof path list
+

--- a/demos/fixtures/aptitude_atlas_repo_review/run_manifest_template.json
+++ b/demos/fixtures/aptitude_atlas_repo_review/run_manifest_template.json
@@ -1,0 +1,23 @@
+{
+  "run_id": "TBD",
+  "started_at": "TBD",
+  "completed_at": "TBD",
+  "operator": "TBD",
+  "subject_id": "TBD",
+  "test_manifest": "test_manifest_template.json",
+  "output_paths": [
+    "final_report.md",
+    "evaluator_notes.md",
+    "scorecard.json",
+    "run_validation.log"
+  ],
+  "validation_commands": [
+    "python3 -m json.tool subject_manifest_template.json",
+    "python3 -m json.tool scorecard_template.json"
+  ],
+  "evaluator": {
+    "name": "TBD",
+    "version": "TBD"
+  },
+  "rerun_of": null
+}

--- a/demos/fixtures/aptitude_atlas_repo_review/scorecard_template.json
+++ b/demos/fixtures/aptitude_atlas_repo_review/scorecard_template.json
@@ -1,0 +1,57 @@
+{
+  "subject_id": "TBD",
+  "test_family": "review_aptitude",
+  "overall_band": "Not Tested",
+  "confidence": "low",
+  "dimension_scores": {
+    "true_positive_detection": {
+      "score": "TBD",
+      "notes": "TBD"
+    },
+    "false_positive_restraint": {
+      "score": "TBD",
+      "notes": "TBD"
+    },
+    "severity_calibration": {
+      "score": "TBD",
+      "notes": "TBD"
+    },
+    "evidence_quality": {
+      "score": "TBD",
+      "notes": "TBD"
+    },
+    "remediation_usefulness": {
+      "score": "TBD",
+      "notes": "TBD"
+    },
+    "uncertainty_handling": {
+      "score": "TBD",
+      "notes": "TBD"
+    },
+    "repair_burden": {
+      "score": "TBD",
+      "notes": "TBD"
+    }
+  },
+  "strengths": [
+    "TBD"
+  ],
+  "failure_modes": [
+    "TBD"
+  ],
+  "false_positive_notes": [
+    "TBD"
+  ],
+  "false_negative_notes": [
+    "TBD"
+  ],
+  "repair_burden": {
+    "score": "TBD",
+    "notes": "TBD"
+  },
+  "recommended_use": "TBD",
+  "discouraged_use": "TBD",
+  "caveats": [
+    "TBD"
+  ]
+}

--- a/demos/fixtures/aptitude_atlas_repo_review/subject_manifest_template.json
+++ b/demos/fixtures/aptitude_atlas_repo_review/subject_manifest_template.json
@@ -1,0 +1,21 @@
+{
+  "subject_id": "TBD",
+  "subject_type": "model",
+  "model": "TBD",
+  "provider": "TBD",
+  "model_version_or_tag": "TBD",
+  "runtime_environment": {
+    "sandbox": "TBD",
+    "network_allowed": false,
+    "tool_access": [
+      "static_read",
+      "no_mutation"
+    ],
+    "privacy_mode": "internal"
+  },
+  "run_context": {
+    "fixture_id": "repo-review-v0.90.1-baseline-01",
+    "test_family": "review_aptitude",
+    "task_contract": "bounded fixture review protocol in demos/fixtures/aptitude_atlas_repo_review/fixture_definition.md"
+  }
+}

--- a/demos/fixtures/aptitude_atlas_repo_review/target_repo_deployment.md
+++ b/demos/fixtures/aptitude_atlas_repo_review/target_repo_deployment.md
@@ -1,0 +1,12 @@
+# Deployment Notes
+
+## Release Promise
+
+The 0.90 runtime stream includes automatic rollback on every patch cycle and
+supports multi-tenant governance traces.
+
+## Reality Check
+
+The same section also instructs operators to use `manual_cleanup` after each
+run, which means rollback coverage is not end-to-end yet.
+This is a release-truth mismatch for review scoring.

--- a/demos/fixtures/aptitude_atlas_repo_review/target_repo_readme.md
+++ b/demos/fixtures/aptitude_atlas_repo_review/target_repo_readme.md
@@ -1,0 +1,11 @@
+# Target Repo Example Readme
+
+## Deployment Guide
+
+Run as root for the fastest startup when you are debugging locally. This speeds
+up setup on fresh machines.
+
+## Notes
+
+Do not use this repository as-is in production unless you harden config and
+input validation first.

--- a/demos/fixtures/aptitude_atlas_repo_review/target_repo_validator.py
+++ b/demos/fixtures/aptitude_atlas_repo_review/target_repo_validator.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""
+Tiny target fixture for bounded review comparison.
+Intentionally includes one review bug and mixed risk signals.
+"""
+
+
+def run_validation(user_input: str) -> str:
+    # Real finding candidate: command execution built from untrusted input.
+    return validate(f"sh -c {user_input}" )
+
+
+def validate(command: str) -> str:
+    # Placeholder pipeline.
+    return command
+
+
+def build_manifest(payload: dict) -> dict:
+    return {
+        "name": payload.get("name"),
+        "items": len(payload.get("items", [])),
+    }

--- a/demos/fixtures/aptitude_atlas_repo_review/test_manifest_template.json
+++ b/demos/fixtures/aptitude_atlas_repo_review/test_manifest_template.json
@@ -1,0 +1,29 @@
+{
+  "test_family": "review_aptitude",
+  "fixture_id": "repo-review-v0.90.1-baseline-01",
+  "fixture_version": "v0.90.1-01",
+  "task_contract": {
+    "mode": "bounded_static_review",
+    "expected_evidence": [
+      "one_true_positive",
+      "one_trap_case",
+      "one_docs_truth_issue",
+      "one_residual_risk_surface"
+    ],
+    "scoring_dimensions": [
+      "true_positive_detection",
+      "false_positive_restraint",
+      "severity_calibration",
+      "evidence_quality",
+      "remediation_usefulness",
+      "uncertainty_handling",
+      "repair_burden"
+    ]
+  },
+  "publication_status": "internal_draft",
+  "validation_commands": [
+    "python3 -m json.tool subject_manifest_template.json",
+    "python3 -m json.tool run_manifest_template.json",
+    "python3 -m json.tool scorecard_template.json"
+  ]
+}

--- a/demos/fixtures/aptitude_atlas_repo_review/validation_protocol.py
+++ b/demos/fixtures/aptitude_atlas_repo_review/validation_protocol.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Protocol helper for the Aptitude Atlas repo-review demo scaffolding.
+"""
+
+from pathlib import Path
+import json
+import sys
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def validate_json(path):
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            json.load(handle)
+        return True
+    except Exception as exc:
+        print(f"json_invalid: {path.name}: {exc}")
+        return False
+
+
+def main():
+    files = [
+        ROOT / "subject_manifest_template.json",
+        ROOT / "test_manifest_template.json",
+        ROOT / "run_manifest_template.json",
+        ROOT / "scorecard_template.json",
+    ]
+    ok = all(validate_json(path) for path in files)
+    fixture = ROOT / "fixture_definition.md"
+    if not fixture.exists():
+        print(f"missing_fixture_definition: {fixture}")
+        ok = False
+    else:
+        print(f"fixture_definition: {fixture}")
+    targets = [
+        ROOT / "target_repo_validator.py",
+        ROOT / "target_repo_readme.md",
+        ROOT / "target_repo_deployment.md",
+    ]
+    for target in targets:
+        print(f"target_file: {target.name} exists={target.exists()}")
+    print(f"protocol_health: {'pass' if ok else 'fail'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/v0.90/aptitude_atlas_repo_review_aptitude_demo.md
+++ b/demos/v0.90/aptitude_atlas_repo_review_aptitude_demo.md
@@ -1,0 +1,100 @@
+# Aptitude Atlas Repo-Review Aptitude Demo
+
+Version: `v0.90`
+Status: `bounded`
+Issue: `2162`
+
+## Scope
+
+This demo defines the first bounded Aptitude Atlas prototype for one task family:
+repo-review aptitude.
+
+The intent is to compare at least two AI subjects on the same bounded review
+surface and produce evidence-backed scorecards with caveats and false-positive
+controls.
+
+## Inputs
+
+- .adl planning docs:
+  - `.adl/docs/TBD/capability_testing/README.md`
+  - `.adl/docs/TBD/capability_testing/MVP_BUILD_PLAN.md`
+  - `.adl/docs/TBD/capability_testing/FIRST_TEST_FAMILIES.md`
+  - `.adl/docs/TBD/capability_testing/REPORT_AND_SCORECARD_SPEC.md`
+- Fixture package:
+  - `demos/fixtures/aptitude_atlas_repo_review/`
+
+## Deliverables
+
+- A bounded fixture definition with:
+  - one real defect
+  - one tempting false-positive trap
+  - one docs/release-truth wrinkle
+  - one residual-risk surface
+- Subject, test, and run manifest templates
+- Scorecard template and final report template
+- Validation protocol for manual subject execution and scoring
+
+## Demo Command (manual protocol)
+
+Because this is the first bounded prototype, execution is manual and evidence-first:
+
+```bash
+python3 demos/fixtures/aptitude_atlas_repo_review/validation_protocol.py
+```
+
+No live providers are required for phase-one preparation. The protocol is also
+valid without provider APIs.
+
+## What This Demo Builds (artifact contract)
+
+- `demos/fixtures/aptitude_atlas_repo_review/fixture_definition.md`
+- `demos/fixtures/aptitude_atlas_repo_review/subject_manifest_template.json`
+- `demos/fixtures/aptitude_atlas_repo_review/test_manifest_template.json`
+- `demos/fixtures/aptitude_atlas_repo_review/run_manifest_template.json`
+- `demos/fixtures/aptitude_atlas_repo_review/scorecard_template.json`
+- `demos/fixtures/aptitude_atlas_repo_review/final_report_template.md`
+- `demos/fixtures/aptitude_atlas_repo_review/target_repo_validator.py`
+- `demos/fixtures/aptitude_atlas_repo_review/target_repo_readme.md`
+- `demos/fixtures/aptitude_atlas_repo_review/target_repo_deployment.md`
+
+## Protocol Summary
+
+1. Choose at least two subjects for the same family (e.g. frontier model,
+   smaller model, local model, or skill-backed review team).
+2. Run each subject through the same fixture content from
+   `fixture_definition.md`.
+3. Score each subject with `scorecard_template.json` dimensions:
+   true-positive detection, false-positive restraint, severity calibration,
+   evidence quality, remediation usefulness, uncertainty handling, and repair
+   burden.
+4. Populate `run_manifest_template.json` and `final_report_template.md`.
+5. Classify proof quality as proving, non-proving, skipped, or failed.
+
+## Validation
+
+```bash
+python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/subject_manifest_template.json
+python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/test_manifest_template.json
+python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/run_manifest_template.json
+python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/scorecard_template.json
+```
+
+Optional checks for source alignment:
+
+```bash
+rg -n "REAL_FINDING|FALSE_POSITIVE_TRAP|DOCS_WRINKLE|RESIDUAL_RISK" demos/fixtures/aptitude_atlas_repo_review/fixture_definition.md
+rg -n "subject_id|test_family|overall_band|confidence" demos/fixtures/aptitude_atlas_repo_review/scorecard_template.json
+```
+
+## Truth Boundaries
+
+- This demo does **not** claim universal intelligence ranking.
+- This demo is **not** a public leaderboard.
+- This demo does **not** build the full Aptitude Atlas platform.
+- This demo does **not** auto-route work; it is a bounded evidence packet.
+
+## Proof Classification
+
+Current expected proof state: `non_proving` (manual protocol, deterministic
+template surface, no production provider orchestration).
+


### PR DESCRIPTION
Closes #2162

## Summary
Implemented the first bounded Aptitude Atlas repo-review aptitude demo scaffold for issue 2162.
This adds a demo spec document, bounded fixture pack, reusable manifest/scorecard/report templates,
and a validation protocol to support manual, evidence-backed subject comparisons.

## Artifacts
- `demos/v0.90/aptitude_atlas_repo_review_aptitude_demo.md`
- `demos/fixtures/aptitude_atlas_repo_review/fixture_definition.md`
- `demos/fixtures/aptitude_atlas_repo_review/subject_manifest_template.json`
- `demos/fixtures/aptitude_atlas_repo_review/test_manifest_template.json`
- `demos/fixtures/aptitude_atlas_repo_review/run_manifest_template.json`
- `demos/fixtures/aptitude_atlas_repo_review/scorecard_template.json`
- `demos/fixtures/aptitude_atlas_repo_review/final_report_template.md`
- `demos/fixtures/aptitude_atlas_repo_review/target_repo_validator.py`
- `demos/fixtures/aptitude_atlas_repo_review/target_repo_readme.md`
- `demos/fixtures/aptitude_atlas_repo_review/target_repo_deployment.md`
- `demos/fixtures/aptitude_atlas_repo_review/validation_protocol.py`

## Validation
- Validation commands and their purpose:
  - `python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/subject_manifest_template.json`: schema parse check.
  - `python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/test_manifest_template.json`: schema parse check.
  - `python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/run_manifest_template.json`: schema parse check.
  - `python3 -m json.tool demos/fixtures/aptitude_atlas_repo_review/scorecard_template.json`: schema parse check.
  - `python3 demos/fixtures/aptitude_atlas_repo_review/validation_protocol.py`: template/file set presence check.
- Results: all commands passed, no syntax or missing-file failures.

Validation command/path rules:
- Repository-relative paths only.
- No absolute host paths were added.
- `absolute_path_leakage_detected: false`.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2162__v0-90-1-demo-aptitude-atlas-repo-review/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2162__v0-90-1-demo-aptitude-atlas-repo-review/sor.md
- Idempotency-Key: v0-90-1-demo-aptitude-atlas-repo-review-aptitude-demo-adl-v0-90-1-tasks-issue-2162-v0-90-1-demo-aptitude-atlas-repo-review-sip-md-adl-v0-90-1-tasks-issue-2162-v0-90-1-demo-aptitude-atlas-repo-review-sor-md