### PR TITLE
[v0.90.1][WP-07] Provisional citizen lifecycle

### DIFF
--- a/adl/src/runtime_v2.rs
+++ b/adl/src/runtime_v2.rs
@@ -7,6 +7,8 @@ pub const RUNTIME_V2_MANIFOLD_SCHEMA: &str = "runtime_v2.manifold.v1";
 pub const RUNTIME_V2_KERNEL_SERVICE_REGISTRY_SCHEMA: &str = "runtime_v2.kernel.service_registry.v1";
 pub const RUNTIME_V2_KERNEL_SERVICE_STATE_SCHEMA: &str = "runtime_v2.kernel.service_state.v1";
 pub const RUNTIME_V2_KERNEL_LOOP_EVENT_SCHEMA: &str = "runtime_v2.kernel.service_loop_event.v1";
+pub const RUNTIME_V2_PROVISIONAL_CITIZEN_SCHEMA: &str = "runtime_v2.provisional_citizen.v1";
+pub const RUNTIME_V2_CITIZEN_REGISTRY_INDEX_SCHEMA: &str = "runtime_v2.citizen_registry_index.v1";
 pub const DEFAULT_MANIFOLD_ARTIFACT_PATH: &str = "runtime_v2/manifold.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -135,6 +137,62 @@ pub struct RuntimeV2KernelLoopArtifacts {
     pub state: RuntimeV2KernelServiceState,
     pub events: Vec<RuntimeV2KernelLoopEvent>,
     pub service_loop_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CitizenMemoryIdentityRefs {
+    pub memory_root_ref: String,
+    pub identity_profile_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CitizenPolicyBoundaryRefs {
+    pub policy_ref: String,
+    pub admission_trace_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ProvisionalCitizenRecord {
+    pub schema_version: String,
+    pub citizen_id: String,
+    pub display_name: String,
+    pub provisional_status: String,
+    pub lifecycle_state: String,
+    pub manifold_id: String,
+    pub record_path: String,
+    pub created_at_utc: String,
+    pub last_wake_at_utc: Option<String>,
+    pub memory_identity_refs: RuntimeV2CitizenMemoryIdentityRefs,
+    pub policy_boundary_refs: RuntimeV2CitizenPolicyBoundaryRefs,
+    pub rehydration_validation_ref: Option<String>,
+    pub termination_event_ref: Option<String>,
+    pub resources_released: bool,
+    pub can_execute_episodes: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CitizenRegistryEntry {
+    pub citizen_id: String,
+    pub lifecycle_state: String,
+    pub record_path: String,
+    pub can_execute_episodes: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CitizenRegistryIndex {
+    pub schema_version: String,
+    pub manifold_id: String,
+    pub registry_root: String,
+    pub index_kind: String,
+    pub index_path: String,
+    pub citizens: Vec<RuntimeV2CitizenRegistryEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeV2CitizenLifecycleArtifacts {
+    pub records: Vec<RuntimeV2ProvisionalCitizenRecord>,
+    pub active_index: RuntimeV2CitizenRegistryIndex,
+    pub pending_index: RuntimeV2CitizenRegistryIndex,
 }
 
 impl RuntimeV2ManifoldRoot {
@@ -437,6 +495,320 @@ impl RuntimeV2KernelLoopArtifacts {
     }
 }
 
+impl RuntimeV2CitizenLifecycleArtifacts {
+    pub fn prototype(manifold: &RuntimeV2ManifoldRoot) -> Result<Self> {
+        manifold.validate()?;
+        let records = vec![
+            RuntimeV2ProvisionalCitizenRecord {
+                schema_version: RUNTIME_V2_PROVISIONAL_CITIZEN_SCHEMA.to_string(),
+                citizen_id: "proto-citizen-alpha".to_string(),
+                display_name: "Prototype Citizen Alpha".to_string(),
+                provisional_status: "provisional".to_string(),
+                lifecycle_state: "active".to_string(),
+                manifold_id: manifold.manifold_id.clone(),
+                record_path: "runtime_v2/citizens/proto-citizen-alpha.json".to_string(),
+                created_at_utc: "not_started".to_string(),
+                last_wake_at_utc: None,
+                memory_identity_refs: RuntimeV2CitizenMemoryIdentityRefs {
+                    memory_root_ref: "runtime_v2/citizens/proto-citizen-alpha/memory".to_string(),
+                    identity_profile_ref: "runtime_v2/citizens/proto-citizen-alpha/identity.json"
+                        .to_string(),
+                },
+                policy_boundary_refs: RuntimeV2CitizenPolicyBoundaryRefs {
+                    policy_ref: "runtime_v2/citizens/proto-citizen-alpha/policy.json".to_string(),
+                    admission_trace_ref: "runtime_v2/traces/admission/proto-citizen-alpha.json"
+                        .to_string(),
+                },
+                rehydration_validation_ref: None,
+                termination_event_ref: None,
+                resources_released: false,
+                can_execute_episodes: true,
+            },
+            RuntimeV2ProvisionalCitizenRecord {
+                schema_version: RUNTIME_V2_PROVISIONAL_CITIZEN_SCHEMA.to_string(),
+                citizen_id: "proto-citizen-beta".to_string(),
+                display_name: "Prototype Citizen Beta".to_string(),
+                provisional_status: "provisional".to_string(),
+                lifecycle_state: "proposed".to_string(),
+                manifold_id: manifold.manifold_id.clone(),
+                record_path: "runtime_v2/citizens/proto-citizen-beta.json".to_string(),
+                created_at_utc: "not_started".to_string(),
+                last_wake_at_utc: None,
+                memory_identity_refs: RuntimeV2CitizenMemoryIdentityRefs {
+                    memory_root_ref: "runtime_v2/citizens/proto-citizen-beta/memory".to_string(),
+                    identity_profile_ref: "runtime_v2/citizens/proto-citizen-beta/identity.json"
+                        .to_string(),
+                },
+                policy_boundary_refs: RuntimeV2CitizenPolicyBoundaryRefs {
+                    policy_ref: "runtime_v2/citizens/proto-citizen-beta/policy.json".to_string(),
+                    admission_trace_ref: "runtime_v2/traces/admission/proto-citizen-beta.json"
+                        .to_string(),
+                },
+                rehydration_validation_ref: None,
+                termination_event_ref: None,
+                resources_released: false,
+                can_execute_episodes: false,
+            },
+        ];
+        let active_citizens = records
+            .iter()
+            .filter(|record| record.lifecycle_state == "active")
+            .map(RuntimeV2CitizenRegistryEntry::from_record)
+            .collect();
+        let pending_citizens = records
+            .iter()
+            .filter(|record| record.lifecycle_state != "active")
+            .map(RuntimeV2CitizenRegistryEntry::from_record)
+            .collect();
+        let active_index = RuntimeV2CitizenRegistryIndex {
+            schema_version: RUNTIME_V2_CITIZEN_REGISTRY_INDEX_SCHEMA.to_string(),
+            manifold_id: manifold.manifold_id.clone(),
+            registry_root: manifold.citizen_registry_refs.registry_root.clone(),
+            index_kind: "active".to_string(),
+            index_path: manifold.citizen_registry_refs.active_index.clone(),
+            citizens: active_citizens,
+        };
+        let pending_index = RuntimeV2CitizenRegistryIndex {
+            schema_version: RUNTIME_V2_CITIZEN_REGISTRY_INDEX_SCHEMA.to_string(),
+            manifold_id: manifold.manifold_id.clone(),
+            registry_root: manifold.citizen_registry_refs.registry_root.clone(),
+            index_kind: "pending".to_string(),
+            index_path: manifold.citizen_registry_refs.pending_index.clone(),
+            citizens: pending_citizens,
+        };
+        let artifacts = Self {
+            records,
+            active_index,
+            pending_index,
+        };
+        artifacts.validate()?;
+        Ok(artifacts)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        self.active_index.validate()?;
+        self.pending_index.validate()?;
+        if self.active_index.index_kind != "active" {
+            return Err(anyhow!("citizen active index must use index_kind active"));
+        }
+        if self.pending_index.index_kind != "pending" {
+            return Err(anyhow!("citizen pending index must use index_kind pending"));
+        }
+        if self.records.is_empty() {
+            return Err(anyhow!("citizen_lifecycle.records must not be empty"));
+        }
+        let mut all_ids = std::collections::BTreeSet::new();
+        let mut active_ids = std::collections::BTreeSet::new();
+        for record in &self.records {
+            record.validate()?;
+            if record.manifold_id != self.active_index.manifold_id
+                || record.manifold_id != self.pending_index.manifold_id
+            {
+                return Err(anyhow!(
+                    "citizen record manifold id must match registry index"
+                ));
+            }
+            if !all_ids.insert(record.citizen_id.clone()) {
+                return Err(anyhow!(
+                    "citizen_lifecycle.records contains duplicate citizen '{}'",
+                    record.citizen_id
+                ));
+            }
+            if record.lifecycle_state == "active" && !active_ids.insert(record.citizen_id.clone()) {
+                return Err(anyhow!(
+                    "citizen_lifecycle.records contains duplicate active citizen '{}'",
+                    record.citizen_id
+                ));
+            }
+        }
+        let active_entries = self
+            .records
+            .iter()
+            .filter(|record| record.lifecycle_state == "active")
+            .map(RuntimeV2CitizenRegistryEntry::from_record)
+            .collect::<Vec<_>>();
+        let pending_entries = self
+            .records
+            .iter()
+            .filter(|record| record.lifecycle_state != "active")
+            .map(RuntimeV2CitizenRegistryEntry::from_record)
+            .collect::<Vec<_>>();
+        if self.active_index.citizens != active_entries {
+            return Err(anyhow!(
+                "citizen active index must match active lifecycle records"
+            ));
+        }
+        if self.pending_index.citizens != pending_entries {
+            return Err(anyhow!(
+                "citizen pending index must match non-active lifecycle records"
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn record_pretty_json_bytes(record: &RuntimeV2ProvisionalCitizenRecord) -> Result<Vec<u8>> {
+        record.validate()?;
+        serde_json::to_vec_pretty(record).context("serialize provisional citizen record")
+    }
+
+    pub fn index_pretty_json_bytes(index: &RuntimeV2CitizenRegistryIndex) -> Result<Vec<u8>> {
+        index.validate()?;
+        serde_json::to_vec_pretty(index).context("serialize citizen registry index")
+    }
+
+    pub fn write_to_root(&self, root: impl AsRef<Path>) -> Result<()> {
+        let root = root.as_ref();
+        self.validate()?;
+        for record in &self.records {
+            write_relative(
+                root,
+                &record.record_path,
+                Self::record_pretty_json_bytes(record)?,
+            )?;
+        }
+        write_relative(
+            root,
+            &self.active_index.index_path,
+            Self::index_pretty_json_bytes(&self.active_index)?,
+        )?;
+        write_relative(
+            root,
+            &self.pending_index.index_path,
+            Self::index_pretty_json_bytes(&self.pending_index)?,
+        )?;
+        Ok(())
+    }
+}
+
+impl RuntimeV2ProvisionalCitizenRecord {
+    pub fn validate(&self) -> Result<()> {
+        if self.schema_version != RUNTIME_V2_PROVISIONAL_CITIZEN_SCHEMA {
+            return Err(anyhow!(
+                "unsupported Runtime v2 provisional citizen schema '{}'",
+                self.schema_version
+            ));
+        }
+        normalize_id(self.citizen_id.clone(), "citizen.citizen_id")?;
+        validate_display_name(&self.display_name, "citizen.display_name")?;
+        validate_provisional_status(&self.provisional_status)?;
+        validate_citizen_lifecycle_state(&self.lifecycle_state)?;
+        normalize_id(self.manifold_id.clone(), "citizen.manifold_id")?;
+        validate_relative_path(&self.record_path, "citizen.record_path")?;
+        validate_timestamp_marker(&self.created_at_utc, "citizen.created_at_utc")?;
+        if let Some(last_wake) = &self.last_wake_at_utc {
+            validate_timestamp_marker(last_wake, "citizen.last_wake_at_utc")?;
+        }
+        self.memory_identity_refs.validate()?;
+        self.policy_boundary_refs.validate()?;
+        if let Some(rehydration_ref) = &self.rehydration_validation_ref {
+            validate_relative_path(rehydration_ref, "citizen.rehydration_validation_ref")?;
+        }
+        if let Some(termination_ref) = &self.termination_event_ref {
+            validate_relative_path(termination_ref, "citizen.termination_event_ref")?;
+        }
+        let lifecycle_can_execute = self.lifecycle_state == "active";
+        if self.can_execute_episodes != lifecycle_can_execute {
+            return Err(anyhow!(
+                "citizen.can_execute_episodes must be true only for active citizens"
+            ));
+        }
+        if self.lifecycle_state == "waking" && self.rehydration_validation_ref.is_none() {
+            return Err(anyhow!(
+                "waking citizens must record rehydration validation before execution"
+            ));
+        }
+        if self.resources_released && self.termination_event_ref.is_none() {
+            return Err(anyhow!(
+                "citizen resources cannot be released before termination is recorded"
+            ));
+        }
+        if self.lifecycle_state == "rejected" && self.provisional_status != "rejected" {
+            return Err(anyhow!(
+                "rejected citizen lifecycle must use rejected provisional_status"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl RuntimeV2CitizenMemoryIdentityRefs {
+    pub fn validate(&self) -> Result<()> {
+        validate_relative_path(&self.memory_root_ref, "citizen.memory_root_ref")?;
+        validate_relative_path(&self.identity_profile_ref, "citizen.identity_profile_ref")
+    }
+}
+
+impl RuntimeV2CitizenPolicyBoundaryRefs {
+    pub fn validate(&self) -> Result<()> {
+        validate_relative_path(&self.policy_ref, "citizen.policy_ref")?;
+        validate_relative_path(&self.admission_trace_ref, "citizen.admission_trace_ref")
+    }
+}
+
+impl RuntimeV2CitizenRegistryEntry {
+    fn from_record(record: &RuntimeV2ProvisionalCitizenRecord) -> Self {
+        Self {
+            citizen_id: record.citizen_id.clone(),
+            lifecycle_state: record.lifecycle_state.clone(),
+            record_path: record.record_path.clone(),
+            can_execute_episodes: record.can_execute_episodes,
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        normalize_id(self.citizen_id.clone(), "citizen_index.citizen_id")?;
+        validate_citizen_lifecycle_state(&self.lifecycle_state)?;
+        validate_relative_path(&self.record_path, "citizen_index.record_path")?;
+        if self.can_execute_episodes != (self.lifecycle_state == "active") {
+            return Err(anyhow!(
+                "citizen index can_execute_episodes must match lifecycle state"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl RuntimeV2CitizenRegistryIndex {
+    pub fn validate(&self) -> Result<()> {
+        if self.schema_version != RUNTIME_V2_CITIZEN_REGISTRY_INDEX_SCHEMA {
+            return Err(anyhow!(
+                "unsupported Runtime v2 citizen registry index schema '{}'",
+                self.schema_version
+            ));
+        }
+        normalize_id(self.manifold_id.clone(), "citizen_index.manifold_id")?;
+        validate_relative_path(&self.registry_root, "citizen_index.registry_root")?;
+        validate_citizen_index_kind(&self.index_kind)?;
+        validate_relative_path(&self.index_path, "citizen_index.index_path")?;
+        if self.index_kind == "active" && self.citizens.is_empty() {
+            return Err(anyhow!(
+                "citizen_index.citizens must not be empty for active index"
+            ));
+        }
+        let mut ids = std::collections::BTreeSet::new();
+        for entry in &self.citizens {
+            entry.validate()?;
+            if !ids.insert(entry.citizen_id.clone()) {
+                return Err(anyhow!(
+                    "citizen_index.citizens contains duplicate citizen '{}'",
+                    entry.citizen_id
+                ));
+            }
+            if self.index_kind == "active" && entry.lifecycle_state != "active" {
+                return Err(anyhow!(
+                    "citizen active index must contain only active citizens"
+                ));
+            }
+            if self.index_kind == "pending" && entry.lifecycle_state == "active" {
+                return Err(anyhow!(
+                    "citizen pending index must not contain active citizens"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
 impl RuntimeV2KernelServiceRegistry {
     pub fn validate(&self) -> Result<()> {
         if self.schema_version != RUNTIME_V2_KERNEL_SERVICE_REGISTRY_SCHEMA {
@@ -709,6 +1081,42 @@ fn validate_service_lifecycle_state(value: &str, field: &str) -> Result<()> {
     }
 }
 
+fn validate_provisional_status(value: &str) -> Result<()> {
+    match value {
+        "provisional" | "admitted" | "rejected" => Ok(()),
+        other => Err(anyhow!("unsupported citizen.provisional_status '{other}'")),
+    }
+}
+
+fn validate_citizen_lifecycle_state(value: &str) -> Result<()> {
+    match value {
+        "proposed" | "admitted" | "active" | "paused" | "sleeping" | "waking" | "terminated"
+        | "rejected" => Ok(()),
+        other => Err(anyhow!("unsupported citizen.lifecycle_state '{other}'")),
+    }
+}
+
+fn validate_citizen_index_kind(value: &str) -> Result<()> {
+    match value {
+        "active" | "pending" => Ok(()),
+        other => Err(anyhow!("unsupported citizen_index.index_kind '{other}'")),
+    }
+}
+
+fn validate_display_name(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(anyhow!("{field} must not be empty"));
+    }
+    Ok(())
+}
+
+fn validate_timestamp_marker(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(anyhow!("{field} must not be empty"));
+    }
+    Ok(())
+}
+
 fn validate_required_kernel_services(
     services: &[RuntimeV2KernelServiceRegistration],
 ) -> Result<()> {
@@ -796,6 +1204,10 @@ pub fn runtime_v2_manifold_contract() -> Result<RuntimeV2ManifoldRoot> {
 
 pub fn runtime_v2_kernel_loop_contract() -> Result<RuntimeV2KernelLoopArtifacts> {
     RuntimeV2KernelLoopArtifacts::prototype(&runtime_v2_manifold_contract()?)
+}
+
+pub fn runtime_v2_citizen_lifecycle_contract() -> Result<RuntimeV2CitizenLifecycleArtifacts> {
+    RuntimeV2CitizenLifecycleArtifacts::prototype(&runtime_v2_manifold_contract()?)
 }
 
 #[cfg(test)]
@@ -1025,5 +1437,155 @@ mod tests {
             .expect_err("absolute path should fail")
             .to_string()
             .contains("repository-relative path"));
+    }
+
+    #[test]
+    fn runtime_v2_citizen_lifecycle_contract_matches_manifold_refs() {
+        let manifold = runtime_v2_manifold_contract().expect("manifold");
+        let citizens = RuntimeV2CitizenLifecycleArtifacts::prototype(&manifold).expect("citizens");
+
+        assert_eq!(citizens.active_index.manifold_id, manifold.manifold_id);
+        assert_eq!(citizens.pending_index.manifold_id, manifold.manifold_id);
+        assert_eq!(
+            citizens.active_index.registry_root,
+            manifold.citizen_registry_refs.registry_root
+        );
+        assert_eq!(
+            citizens.active_index.index_path,
+            manifold.citizen_registry_refs.active_index
+        );
+        assert_eq!(
+            citizens.pending_index.index_path,
+            manifold.citizen_registry_refs.pending_index
+        );
+        assert_eq!(citizens.records.len(), 2);
+        assert_eq!(citizens.active_index.citizens.len(), 1);
+        assert_eq!(citizens.pending_index.citizens.len(), 1);
+        assert!(citizens
+            .records
+            .iter()
+            .any(|record| record.lifecycle_state == "active" && record.can_execute_episodes));
+        assert!(citizens
+            .records
+            .iter()
+            .any(|record| record.lifecycle_state == "proposed" && !record.can_execute_episodes));
+    }
+
+    #[test]
+    fn runtime_v2_citizen_lifecycle_artifacts_match_golden_fixtures() {
+        let citizens = runtime_v2_citizen_lifecycle_contract().expect("citizens");
+        let alpha = citizens
+            .records
+            .iter()
+            .find(|record| record.citizen_id == "proto-citizen-alpha")
+            .expect("alpha");
+        let beta = citizens
+            .records
+            .iter()
+            .find(|record| record.citizen_id == "proto-citizen-beta")
+            .expect("beta");
+        let alpha_json = String::from_utf8(
+            RuntimeV2CitizenLifecycleArtifacts::record_pretty_json_bytes(alpha)
+                .expect("alpha json"),
+        )
+        .expect("utf8 alpha");
+        let beta_json = String::from_utf8(
+            RuntimeV2CitizenLifecycleArtifacts::record_pretty_json_bytes(beta).expect("beta json"),
+        )
+        .expect("utf8 beta");
+        let active_index_json = String::from_utf8(
+            RuntimeV2CitizenLifecycleArtifacts::index_pretty_json_bytes(&citizens.active_index)
+                .expect("active index json"),
+        )
+        .expect("utf8 active index");
+        let pending_index_json = String::from_utf8(
+            RuntimeV2CitizenLifecycleArtifacts::index_pretty_json_bytes(&citizens.pending_index)
+                .expect("pending index json"),
+        )
+        .expect("utf8 pending index");
+
+        assert_eq!(
+            alpha_json,
+            include_str!("../tests/fixtures/runtime_v2/citizens/proto-citizen-alpha.json")
+                .trim_end()
+        );
+        assert_eq!(
+            beta_json,
+            include_str!("../tests/fixtures/runtime_v2/citizens/proto-citizen-beta.json")
+                .trim_end()
+        );
+        assert_eq!(
+            active_index_json,
+            include_str!("../tests/fixtures/runtime_v2/citizens/active_index.json").trim_end()
+        );
+        assert_eq!(
+            pending_index_json,
+            include_str!("../tests/fixtures/runtime_v2/citizens/pending_index.json").trim_end()
+        );
+    }
+
+    #[test]
+    fn runtime_v2_citizen_lifecycle_writes_artifacts_without_path_leakage() {
+        let temp_root = unique_temp_path("citizens");
+        let citizens = runtime_v2_citizen_lifecycle_contract().expect("citizens");
+
+        citizens
+            .write_to_root(&temp_root)
+            .expect("write citizen artifacts");
+
+        let alpha_path = temp_root.join(&citizens.records[0].record_path);
+        let beta_path = temp_root.join(&citizens.records[1].record_path);
+        let active_index_path = temp_root.join(&citizens.active_index.index_path);
+        let pending_index_path = temp_root.join(&citizens.pending_index.index_path);
+        assert!(alpha_path.is_file());
+        assert!(beta_path.is_file());
+        assert!(active_index_path.is_file());
+        assert!(pending_index_path.is_file());
+
+        let alpha = fs::read_to_string(alpha_path).expect("alpha text");
+        let index = fs::read_to_string(active_index_path).expect("index text");
+        let temp_root_text = temp_root.to_string_lossy();
+        assert!(!alpha.contains(temp_root_text.as_ref()));
+        assert!(!index.contains(temp_root_text.as_ref()));
+        assert!(index.contains("\"index_kind\": \"active\""));
+        assert!(index.contains("\"citizens\""));
+
+        fs::remove_dir_all(temp_root).ok();
+    }
+
+    #[test]
+    fn runtime_v2_citizen_lifecycle_validation_rejects_unsafe_or_ambiguous_state() {
+        let mut citizens = runtime_v2_citizen_lifecycle_contract().expect("citizens");
+        citizens.records[1].citizen_id = "proto-citizen-alpha".to_string();
+        assert!(citizens
+            .validate()
+            .expect_err("duplicate citizen should fail")
+            .to_string()
+            .contains("duplicate citizen"));
+
+        let mut citizens = runtime_v2_citizen_lifecycle_contract().expect("citizens");
+        citizens.records[1].lifecycle_state = "paused".to_string();
+        citizens.records[1].can_execute_episodes = true;
+        assert!(citizens
+            .validate()
+            .expect_err("inactive executor should fail")
+            .to_string()
+            .contains("true only for active citizens"));
+
+        let mut citizens = runtime_v2_citizen_lifecycle_contract().expect("citizens");
+        citizens.records[1].lifecycle_state = "waking".to_string();
+        assert!(citizens
+            .validate()
+            .expect_err("waking without rehydration proof should fail")
+            .to_string()
+            .contains("rehydration validation"));
+
+        let mut citizens = runtime_v2_citizen_lifecycle_contract().expect("citizens");
+        citizens.records[1].resources_released = true;
+        assert!(citizens
+            .validate()
+            .expect_err("resource release without termination proof should fail")
+            .to_string()
+            .contains("before termination is recorded"));
     }
 }

--- a/adl/tests/fixtures/runtime_v2/citizens/active_index.json
+++ b/adl/tests/fixtures/runtime_v2/citizens/active_index.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "runtime_v2.citizen_registry_index.v1",
+  "manifold_id": "proto-csm-01",
+  "registry_root": "runtime_v2/citizens",
+  "index_kind": "active",
+  "index_path": "runtime_v2/citizens/active_index.json",
+  "citizens": [
+    {
+      "citizen_id": "proto-citizen-alpha",
+      "lifecycle_state": "active",
+      "record_path": "runtime_v2/citizens/proto-citizen-alpha.json",
+      "can_execute_episodes": true
+    }
+  ]
+}

--- a/adl/tests/fixtures/runtime_v2/citizens/pending_index.json
+++ b/adl/tests/fixtures/runtime_v2/citizens/pending_index.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "runtime_v2.citizen_registry_index.v1",
+  "manifold_id": "proto-csm-01",
+  "registry_root": "runtime_v2/citizens",
+  "index_kind": "pending",
+  "index_path": "runtime_v2/citizens/pending_index.json",
+  "citizens": [
+    {
+      "citizen_id": "proto-citizen-beta",
+      "lifecycle_state": "proposed",
+      "record_path": "runtime_v2/citizens/proto-citizen-beta.json",
+      "can_execute_episodes": false
+    }
+  ]
+}

--- a/adl/tests/fixtures/runtime_v2/citizens/proto-citizen-alpha.json
+++ b/adl/tests/fixtures/runtime_v2/citizens/proto-citizen-alpha.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "runtime_v2.provisional_citizen.v1",
+  "citizen_id": "proto-citizen-alpha",
+  "display_name": "Prototype Citizen Alpha",
+  "provisional_status": "provisional",
+  "lifecycle_state": "active",
+  "manifold_id": "proto-csm-01",
+  "record_path": "runtime_v2/citizens/proto-citizen-alpha.json",
+  "created_at_utc": "not_started",
+  "last_wake_at_utc": null,
+  "memory_identity_refs": {
+    "memory_root_ref": "runtime_v2/citizens/proto-citizen-alpha/memory",
+    "identity_profile_ref": "runtime_v2/citizens/proto-citizen-alpha/identity.json"
+  },
+  "policy_boundary_refs": {
+    "policy_ref": "runtime_v2/citizens/proto-citizen-alpha/policy.json",
+    "admission_trace_ref": "runtime_v2/traces/admission/proto-citizen-alpha.json"
+  },
+  "rehydration_validation_ref": null,
+  "termination_event_ref": null,
+  "resources_released": false,
+  "can_execute_episodes": true
+}

--- a/adl/tests/fixtures/runtime_v2/citizens/proto-citizen-beta.json
+++ b/adl/tests/fixtures/runtime_v2/citizens/proto-citizen-beta.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "runtime_v2.provisional_citizen.v1",
+  "citizen_id": "proto-citizen-beta",
+  "display_name": "Prototype Citizen Beta",
+  "provisional_status": "provisional",
+  "lifecycle_state": "proposed",
+  "manifold_id": "proto-csm-01",
+  "record_path": "runtime_v2/citizens/proto-citizen-beta.json",
+  "created_at_utc": "not_started",
+  "last_wake_at_utc": null,
+  "memory_identity_refs": {
+    "memory_root_ref": "runtime_v2/citizens/proto-citizen-beta/memory",
+    "identity_profile_ref": "runtime_v2/citizens/proto-citizen-beta/identity.json"
+  },
+  "policy_boundary_refs": {
+    "policy_ref": "runtime_v2/citizens/proto-citizen-beta/policy.json",
+    "admission_trace_ref": "runtime_v2/traces/admission/proto-citizen-beta.json"
+  },
+  "rehydration_validation_ref": null,
+  "termination_event_ref": null,
+  "resources_released": false,
+  "can_execute_episodes": false
+}

--- a/docs/milestones/v0.90.1/features/PROVISIONAL_CITIZEN_LIFECYCLE.md
+++ b/docs/milestones/v0.90.1/features/PROVISIONAL_CITIZEN_LIFECYCLE.md
@@ -30,12 +30,55 @@ Each provisional citizen should include:
 - memory/identity refs as placeholders or bounded handles
 - policy boundary refs
 
+## WP-07 Implementation Surface
+
+WP-07 adds the provisional citizen lifecycle contract to `adl/src/runtime_v2.rs`.
+
+The contract defines:
+
+- `RuntimeV2ProvisionalCitizenRecord`
+- `RuntimeV2CitizenMemoryIdentityRefs`
+- `RuntimeV2CitizenPolicyBoundaryRefs`
+- `RuntimeV2CitizenRegistryEntry`
+- `RuntimeV2CitizenRegistryIndex`
+- `RuntimeV2CitizenLifecycleArtifacts`
+
+The default prototype is available through
+`runtime_v2_citizen_lifecycle_contract()`. It consumes the WP-05 manifold
+citizen registry refs and emits reviewable citizen artifacts:
+
+- `runtime_v2/citizens/proto-citizen-alpha.json`
+- `runtime_v2/citizens/proto-citizen-beta.json`
+- `runtime_v2/citizens/active_index.json`
+- `runtime_v2/citizens/pending_index.json`
+
 ## Required Invariants
 
 - no duplicate active citizen id
 - inactive citizens cannot execute episodes
 - wake must pass rehydration validation
 - termination must be recorded before resources are released
+
+## Validation Contract
+
+The citizen lifecycle contract validates:
+
+- schema versions
+- repository-relative artifact paths
+- stable citizen and manifold ids
+- supported provisional statuses
+- supported lifecycle states
+- active-only episode execution
+- duplicate citizen rejection
+- active and pending index consistency
+- waking-state rehydration proof presence
+- termination proof before resource release
+
+The focused proof hook is:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml runtime_v2::tests::runtime_v2_citizen
+```
 
 ## Boundary
 


### PR DESCRIPTION
Closes #2147

## Summary
Implemented the WP-07 provisional citizen lifecycle contract for Runtime v2. The
branch now materializes provisional citizen records, active/pending citizen
indexes, lifecycle validation, golden fixtures, and reviewer-facing docs without
claiming true Godel-agent birthday or identity semantics.

## Artifacts
- `adl/src/runtime_v2.rs`: provisional citizen schemas, record/index structs,
  prototype artifact generation, path-safe writers, validation helpers, and
  focused tests.
- `adl/tests/fixtures/runtime_v2/citizens/proto-citizen-alpha.json`: active
  provisional citizen golden fixture.
- `adl/tests/fixtures/runtime_v2/citizens/proto-citizen-beta.json`: proposed
  provisional citizen golden fixture.
- `adl/tests/fixtures/runtime_v2/citizens/active_index.json`: active citizen
  index golden fixture.
- `adl/tests/fixtures/runtime_v2/citizens/pending_index.json`: pending citizen
  index golden fixture.
- `docs/milestones/v0.90.1/features/PROVISIONAL_CITIZEN_LIFECYCLE.md`: WP-07
  implementation surface, validation contract, artifacts, and proof hook.

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2::tests::runtime_v2_citizen`: proves the new citizen lifecycle contract, fixtures, write paths, and validation failures.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2::tests`: proves WP-07 did not regress the existing Runtime v2 manifold or kernel loop contracts.
  - `cargo check --manifest-path adl/Cargo.toml`: verifies the Rust crate compiles after adding the new citizen contract types.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: verifies committed Rust formatting.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`: verifies no clippy warnings across all targets.
- Results: PASS. All commands completed successfully.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2147__v0-90-1-wp-07-provisional-citizen-lifecycle/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2147__v0-90-1-wp-07-provisional-citizen-lifecycle/sor.md
- Idempotency-Key: v0-90-1-wp-07-provisional-citizen-lifecycle-adl-src-runtime-v2-rs-adl-tests-fixtures-runtime-v2-citizens-proto-citizen-alpha-json-adl-tests-fixtures-runtime-v2-citizens-proto-citizen-beta-json-adl-tests-fixtures-runtime-v2-citizens-active-index-json-adl-tests-fixtures-runtime-v2-citizens-pending-index-json-docs-milestones-v0-90-1-features-provisional-citizen-lifecycle-md-adl-v0-90-1-tasks-issue-2147-v0-90-1-wp-07-provisional-citizen-lifecycle-sip-md-adl-v0-90-1-tasks-issue-2147-v0-90-1-wp-07-provisional-citizen-lifecycle-sor-md