### PR TITLE
[v0.90.1][CSM Observatory] Visibility packet contract

### DIFF
--- a/adl/schemas/csm_visibility_packet.v1.schema.json
+++ b/adl/schemas/csm_visibility_packet.v1.schema.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-design-language.org/schemas/csm_visibility_packet.v1.schema.json",
+  "title": "ADL CSM Visibility Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "packet_id",
+    "generated_at",
+    "source",
+    "manifold",
+    "kernel",
+    "citizens",
+    "episodes",
+    "freedom_gate",
+    "invariants",
+    "resources",
+    "trace",
+    "operator_actions",
+    "review"
+  ],
+  "properties": {
+    "schema": {
+      "const": "adl.csm_visibility_packet.v1"
+    },
+    "packet_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "mode",
+        "evidence_level",
+        "fixture",
+        "runtime_artifact_root",
+        "claim_boundary"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "fixture",
+            "captured_artifacts",
+            "live_runtime"
+          ]
+        },
+        "evidence_level": {
+          "$ref": "#/$defs/evidence_level"
+        },
+        "fixture": {
+          "type": "boolean"
+        },
+        "runtime_artifact_root": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "claim_boundary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "manifold": {
+      "type": "object",
+      "required": [
+        "manifold_id",
+        "display_name",
+        "state",
+        "lifecycle",
+        "current_tick",
+        "uptime",
+        "policy_profile",
+        "snapshot_status",
+        "health",
+        "evidence_refs"
+      ],
+      "properties": {
+        "state": {
+          "enum": [
+            "initialized",
+            "running",
+            "quiescing",
+            "sleeping",
+            "sealed",
+            "rehydrating",
+            "degraded",
+            "blocked"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "kernel": {
+      "type": "object",
+      "required": [
+        "scheduler_state",
+        "trace_state",
+        "invariant_state",
+        "resource_state",
+        "service_states",
+        "active_guardrails",
+        "pulse"
+      ],
+      "additionalProperties": true
+    },
+    "citizens": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": [
+          "citizen_id",
+          "display_name",
+          "role",
+          "lifecycle_state",
+          "continuity_status",
+          "current_episode",
+          "resource_balance",
+          "recent_decisions",
+          "capability_envelope",
+          "alerts",
+          "evidence_refs"
+        ],
+        "properties": {
+          "lifecycle_state": {
+            "enum": [
+              "proposed",
+              "active",
+              "awake",
+              "sleeping",
+              "paused",
+              "degraded",
+              "blocked",
+              "suspended",
+              "migrating"
+            ]
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "episodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "episode_id",
+          "title",
+          "state",
+          "citizen_ids",
+          "started_at",
+          "last_event",
+          "proof_surface",
+          "blocked_reason"
+        ],
+        "properties": {
+          "state": {
+            "enum": [
+              "planned",
+              "active",
+              "completed",
+              "blocked",
+              "deferred",
+              "failed"
+            ]
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "freedom_gate": {
+      "type": "object",
+      "required": [
+        "recent_docket",
+        "allow_count",
+        "defer_count",
+        "refuse_count",
+        "open_questions",
+        "rejected_actions"
+      ],
+      "additionalProperties": true
+    },
+    "invariants": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "invariant_id",
+          "name",
+          "state",
+          "severity",
+          "last_checked",
+          "evidence_ref"
+        ],
+        "properties": {
+          "state": {
+            "enum": [
+              "healthy",
+              "warning",
+              "violated",
+              "blocked",
+              "missing",
+              "deferred"
+            ]
+          },
+          "severity": {
+            "enum": [
+              "info",
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "resources": {
+      "type": "object",
+      "required": [
+        "compute_units",
+        "memory_pressure",
+        "queue_depth",
+        "fairness_notes",
+        "scarcity_events"
+      ],
+      "additionalProperties": true
+    },
+    "trace": {
+      "type": "object",
+      "required": [
+        "trace_tail",
+        "causal_gaps",
+        "latest_operator_event",
+        "latest_citizen_event",
+        "latest_kernel_event"
+      ],
+      "additionalProperties": true
+    },
+    "operator_actions": {
+      "type": "object",
+      "required": [
+        "available_actions",
+        "disabled_actions",
+        "required_confirmations",
+        "safety_notes"
+      ],
+      "additionalProperties": true
+    },
+    "review": {
+      "type": "object",
+      "required": [
+        "primary_artifacts",
+        "missing_artifacts",
+        "demo_classification",
+        "caveats",
+        "next_consumers"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "evidence_level": {
+      "enum": [
+        "fixture_backed",
+        "artifact_backed",
+        "live_runtime_backed",
+        "missing",
+        "deferred"
+      ]
+    }
+  }
+}

--- a/adl/tools/test_csm_visibility_packet.sh
+++ b/adl/tools/test_csm_visibility_packet.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PACKET="${ROOT_DIR}/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+SCHEMA="${ROOT_DIR}/adl/schemas/csm_visibility_packet.v1.schema.json"
+DOC="${ROOT_DIR}/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md"
+
+python3 "${ROOT_DIR}/adl/tools/validate_csm_visibility_packet.py" "${PACKET}"
+python3 -m json.tool "${SCHEMA}" >/dev/null
+python3 -m json.tool "${PACKET}" >/dev/null
+
+grep -Fq "adl.csm_visibility_packet.v1" "${DOC}"
+grep -Fq "What is alive?" "${DOC}"
+grep -Fq "static Observatory console prototype" "${PACKET}"
+
+if grep -REn '/Users/|/private/var/|localhost:[0-9]|192\.168\.|bearer[[:space:]]+[A-Za-z0-9._-]{8,}|(api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[A-Za-z0-9._-]{8,}' \
+  "${PACKET}" "${DOC}" "${SCHEMA}"; then
+  echo "CSM visibility packet artifacts leaked private path, endpoint, or secret-like text" >&2
+  exit 1
+fi
+
+echo "CSM visibility packet contract fixtures passed"

--- a/adl/tools/validate_csm_visibility_packet.py
+++ b/adl/tools/validate_csm_visibility_packet.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Validate the fixture-level CSM Observatory visibility packet contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import PurePosixPath
+from typing import Any
+
+
+REQUIRED_TOP_LEVEL = [
+    "schema",
+    "packet_id",
+    "generated_at",
+    "source",
+    "manifold",
+    "kernel",
+    "citizens",
+    "episodes",
+    "freedom_gate",
+    "invariants",
+    "resources",
+    "trace",
+    "operator_actions",
+    "review",
+]
+
+REQUIRED_SECTIONS: dict[str, list[str]] = {
+    "source": ["mode", "evidence_level", "fixture", "runtime_artifact_root", "claim_boundary"],
+    "manifold": [
+        "manifold_id",
+        "display_name",
+        "state",
+        "lifecycle",
+        "current_tick",
+        "uptime",
+        "policy_profile",
+        "snapshot_status",
+        "health",
+        "evidence_refs",
+    ],
+    "kernel": [
+        "scheduler_state",
+        "trace_state",
+        "invariant_state",
+        "resource_state",
+        "service_states",
+        "active_guardrails",
+        "pulse",
+    ],
+    "freedom_gate": [
+        "recent_docket",
+        "allow_count",
+        "defer_count",
+        "refuse_count",
+        "open_questions",
+        "rejected_actions",
+    ],
+    "resources": [
+        "compute_units",
+        "memory_pressure",
+        "queue_depth",
+        "fairness_notes",
+        "scarcity_events",
+    ],
+    "trace": [
+        "trace_tail",
+        "causal_gaps",
+        "latest_operator_event",
+        "latest_citizen_event",
+        "latest_kernel_event",
+    ],
+    "operator_actions": [
+        "available_actions",
+        "disabled_actions",
+        "required_confirmations",
+        "safety_notes",
+    ],
+    "review": [
+        "primary_artifacts",
+        "missing_artifacts",
+        "demo_classification",
+        "caveats",
+        "next_consumers",
+    ],
+}
+
+MANIFOLD_STATES = {
+    "initialized",
+    "running",
+    "quiescing",
+    "sleeping",
+    "sealed",
+    "rehydrating",
+    "degraded",
+    "blocked",
+}
+
+CITIZEN_STATES = {
+    "proposed",
+    "active",
+    "awake",
+    "sleeping",
+    "paused",
+    "degraded",
+    "blocked",
+    "suspended",
+    "migrating",
+}
+
+EPISODE_STATES = {"planned", "active", "completed", "blocked", "deferred", "failed"}
+FREEDOM_GATE_DECISIONS = {"allow", "defer", "refuse"}
+INVARIANT_STATES = {"healthy", "warning", "violated", "blocked", "missing", "deferred"}
+INVARIANT_SEVERITIES = {"info", "low", "medium", "high", "critical"}
+
+LEAK_PATTERNS = [
+    re.compile(r"/Users/[^\\s\"']+"),
+    re.compile(r"/private/var/[^\\s\"']+"),
+    re.compile(r"localhost:\\d+"),
+    re.compile(r"192\\.168\\.\\d+\\.\\d+"),
+    re.compile(r"(?i)bearer\\s+[A-Za-z0-9._\\-]+"),
+    re.compile(r"(?i)(api[_-]?key|secret|token)\\s*[:=]\\s*[A-Za-z0-9._\\-]{8,}"),
+]
+
+
+def fail(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def require_mapping(errors: list[str], value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(errors, f"{path} must be an object")
+        return {}
+    return value
+
+
+def require_list(errors: list[str], value: Any, path: str, min_items: int = 0) -> list[Any]:
+    if not isinstance(value, list):
+        fail(errors, f"{path} must be a list")
+        return []
+    if len(value) < min_items:
+        fail(errors, f"{path} must contain at least {min_items} item(s)")
+    return value
+
+
+def require_fields(errors: list[str], value: dict[str, Any], fields: list[str], path: str) -> None:
+    for field in fields:
+        if field not in value:
+            fail(errors, f"{path}.{field} is required")
+
+
+def check_relative_ref(errors: list[str], value: Any, path: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str):
+        return
+    if value.startswith(("http://", "https://")):
+        fail(errors, f"{path} must not be a URL")
+        return
+    posix = PurePosixPath(value)
+    if posix.is_absolute() or ".." in posix.parts:
+        fail(errors, f"{path} must be repository-relative")
+
+
+def walk_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        out: list[str] = []
+        for item in value:
+            out.extend(walk_strings(item))
+        return out
+    if isinstance(value, dict):
+        out = []
+        for item in value.values():
+            out.extend(walk_strings(item))
+        return out
+    return []
+
+
+def check_leakage(errors: list[str], packet: dict[str, Any]) -> None:
+    for text in walk_strings(packet):
+        for pattern in LEAK_PATTERNS:
+            if pattern.search(text):
+                fail(errors, f"private path, endpoint, or secret-like value leaked: {text}")
+
+
+def validate_packet(packet: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    require_fields(errors, packet, REQUIRED_TOP_LEVEL, "packet")
+    if packet.get("schema") != "adl.csm_visibility_packet.v1":
+        fail(errors, "packet.schema must be adl.csm_visibility_packet.v1")
+
+    for section, fields in REQUIRED_SECTIONS.items():
+        mapping = require_mapping(errors, packet.get(section), f"packet.{section}")
+        require_fields(errors, mapping, fields, f"packet.{section}")
+
+    source = require_mapping(errors, packet.get("source"), "packet.source")
+    if source.get("mode") not in {"fixture", "captured_artifacts", "live_runtime"}:
+        fail(errors, "packet.source.mode is invalid")
+    if source.get("mode") == "fixture" and source.get("fixture") is not True:
+        fail(errors, "fixture mode must set packet.source.fixture to true")
+    if source.get("mode") == "fixture" and "not a live" not in str(source.get("claim_boundary", "")).lower():
+        fail(errors, "fixture mode must state that it is not a live runtime capture")
+
+    manifold = require_mapping(errors, packet.get("manifold"), "packet.manifold")
+    if manifold.get("state") not in MANIFOLD_STATES:
+        fail(errors, f"packet.manifold.state is invalid: {manifold.get('state')}")
+
+    citizens = require_list(errors, packet.get("citizens"), "packet.citizens", min_items=2)
+    seen_citizens: set[str] = set()
+    for index, citizen_value in enumerate(citizens):
+        citizen = require_mapping(errors, citizen_value, f"packet.citizens[{index}]")
+        require_fields(
+            errors,
+            citizen,
+            [
+                "citizen_id",
+                "display_name",
+                "role",
+                "lifecycle_state",
+                "continuity_status",
+                "current_episode",
+                "resource_balance",
+                "recent_decisions",
+                "capability_envelope",
+                "alerts",
+                "evidence_refs",
+            ],
+            f"packet.citizens[{index}]",
+        )
+        citizen_id = citizen.get("citizen_id")
+        if isinstance(citizen_id, str):
+            if citizen_id in seen_citizens:
+                fail(errors, f"duplicate citizen_id: {citizen_id}")
+            seen_citizens.add(citizen_id)
+        if citizen.get("lifecycle_state") not in CITIZEN_STATES:
+            fail(errors, f"citizen lifecycle_state is invalid: {citizen.get('lifecycle_state')}")
+
+    for index, episode_value in enumerate(require_list(errors, packet.get("episodes"), "packet.episodes")):
+        episode = require_mapping(errors, episode_value, f"packet.episodes[{index}]")
+        require_fields(
+            errors,
+            episode,
+            [
+                "episode_id",
+                "title",
+                "state",
+                "citizen_ids",
+                "started_at",
+                "last_event",
+                "proof_surface",
+                "blocked_reason",
+            ],
+            f"packet.episodes[{index}]",
+        )
+        if episode.get("state") not in EPISODE_STATES:
+            fail(errors, f"episode state is invalid: {episode.get('state')}")
+        for citizen_id in require_list(errors, episode.get("citizen_ids"), f"packet.episodes[{index}].citizen_ids"):
+            if citizen_id not in seen_citizens:
+                fail(errors, f"episode references unknown citizen_id: {citizen_id}")
+
+    freedom_gate = require_mapping(errors, packet.get("freedom_gate"), "packet.freedom_gate")
+    allow = defer = refuse = 0
+    for index, entry_value in enumerate(require_list(errors, freedom_gate.get("recent_docket"), "packet.freedom_gate.recent_docket")):
+        entry = require_mapping(errors, entry_value, f"packet.freedom_gate.recent_docket[{index}]")
+        require_fields(errors, entry, ["decision_id", "actor", "action", "decision", "rationale", "evidence_ref"], f"packet.freedom_gate.recent_docket[{index}]")
+        decision = entry.get("decision")
+        if decision not in FREEDOM_GATE_DECISIONS:
+            fail(errors, f"Freedom Gate decision is invalid: {decision}")
+        allow += 1 if decision == "allow" else 0
+        defer += 1 if decision == "defer" else 0
+        refuse += 1 if decision == "refuse" else 0
+        check_relative_ref(errors, entry.get("evidence_ref"), f"packet.freedom_gate.recent_docket[{index}].evidence_ref")
+    if freedom_gate.get("allow_count") != allow:
+        fail(errors, "packet.freedom_gate.allow_count does not match recent_docket")
+    if freedom_gate.get("defer_count") != defer:
+        fail(errors, "packet.freedom_gate.defer_count does not match recent_docket")
+    if freedom_gate.get("refuse_count") != refuse:
+        fail(errors, "packet.freedom_gate.refuse_count does not match recent_docket")
+
+    for index, invariant_value in enumerate(require_list(errors, packet.get("invariants"), "packet.invariants")):
+        invariant = require_mapping(errors, invariant_value, f"packet.invariants[{index}]")
+        require_fields(errors, invariant, ["invariant_id", "name", "state", "severity", "last_checked", "evidence_ref"], f"packet.invariants[{index}]")
+        if invariant.get("state") not in INVARIANT_STATES:
+            fail(errors, f"invariant state is invalid: {invariant.get('state')}")
+        if invariant.get("severity") not in INVARIANT_SEVERITIES:
+            fail(errors, f"invariant severity is invalid: {invariant.get('severity')}")
+        check_relative_ref(errors, invariant.get("evidence_ref"), f"packet.invariants[{index}].evidence_ref")
+
+    operator_actions = require_mapping(errors, packet.get("operator_actions"), "packet.operator_actions")
+    if source.get("mode") == "fixture":
+        for index, action_value in enumerate(require_list(errors, operator_actions.get("available_actions"), "packet.operator_actions.available_actions")):
+            action = require_mapping(errors, action_value, f"packet.operator_actions.available_actions[{index}]")
+            if action.get("mode") != "read_only":
+                fail(errors, "fixture packet available actions must be read_only")
+
+    review = require_mapping(errors, packet.get("review"), "packet.review")
+    if source.get("mode") == "fixture" and review.get("demo_classification") != "fixture_backed":
+        fail(errors, "fixture packet review.demo_classification must be fixture_backed")
+    consumers = require_list(errors, review.get("next_consumers"), "packet.review.next_consumers", min_items=4)
+    expected_issues = {2189, 2190, 2191, 2192}
+    observed_issues = {item.get("issue") for item in consumers if isinstance(item, dict)}
+    if not expected_issues.issubset(observed_issues):
+        fail(errors, "packet.review.next_consumers must include issues 2189, 2190, 2191, and 2192")
+
+    for ref_path in walk_refs(packet):
+        check_relative_ref(errors, ref_path[1], ref_path[0])
+    check_leakage(errors, packet)
+
+    return errors
+
+
+def walk_refs(value: Any, path: str = "packet") -> list[tuple[str, Any]]:
+    refs: list[tuple[str, Any]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if key.endswith("_ref") or key.endswith("_refs") or key in {"primary_artifacts", "missing_artifacts"}:
+                refs.append((child_path, child))
+            refs.extend(walk_refs(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            refs.extend(walk_refs(child, f"{path}[{index}]"))
+    return refs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet")
+    args = parser.parse_args()
+
+    with open(args.packet, "r", encoding="utf-8") as handle:
+        packet = json.load(handle)
+
+    errors = validate_packet(packet)
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: {args.packet} is a valid CSM visibility packet")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
+++ b/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
@@ -1,0 +1,437 @@
+{
+  "schema": "adl.csm_visibility_packet.v1",
+  "packet_id": "csm-observatory-fixture-proto-csm-01",
+  "generated_at": "2026-04-19T00:00:00Z",
+  "source": {
+    "mode": "fixture",
+    "evidence_level": "fixture_backed",
+    "fixture": true,
+    "runtime_artifact_root": null,
+    "claim_boundary": "Fixture-backed Observatory contract example. This is not a live Runtime v2 capture.",
+    "source_refs": [
+      "adl/tests/fixtures/runtime_v2/manifold.json",
+      "adl/tests/fixtures/runtime_v2/kernel/service_registry.json",
+      "adl/tests/fixtures/runtime_v2/kernel/service_state.json",
+      "adl/tests/fixtures/runtime_v2/kernel/service_loop.jsonl",
+      "adl/tests/fixtures/runtime_v2/citizens/active_index.json",
+      "adl/tests/fixtures/runtime_v2/citizens/pending_index.json"
+    ]
+  },
+  "manifold": {
+    "manifold_id": "proto-csm-01",
+    "display_name": "Prototype CSM 01",
+    "state": "initialized",
+    "lifecycle": "bounded_fixture_world",
+    "current_tick": 0,
+    "uptime": "not_started",
+    "policy_profile": "runtime_v2_minimal_prototype",
+    "snapshot_status": {
+      "state": "deferred",
+      "latest_snapshot_id": null,
+      "rehydration_report_ref": "runtime_v2/rehydration_report.json",
+      "note": "Snapshot and wake proof remain future Runtime v2 implementation surfaces."
+    },
+    "health": {
+      "summary": "initialized fixture",
+      "level": "nominal",
+      "attention_items": [
+        "citizen beta is proposed, not active",
+        "Freedom Gate packet is fixture-only",
+        "snapshot evidence is deferred"
+      ]
+    },
+    "evidence_refs": [
+      "runtime_v2/manifold.json"
+    ]
+  },
+  "kernel": {
+    "scheduler_state": "registered",
+    "trace_state": "bounded_tick_fixture",
+    "invariant_state": "policy_loaded",
+    "resource_state": "bounded_prototype",
+    "service_states": [
+      {
+        "service_id": "clock_service",
+        "service_kind": "clock",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 1,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      },
+      {
+        "service_id": "identity_admission_guard",
+        "service_kind": "admission",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 2,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      },
+      {
+        "service_id": "scheduler",
+        "service_kind": "scheduler",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 3,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      },
+      {
+        "service_id": "resource_ledger",
+        "service_kind": "resource",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 4,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      },
+      {
+        "service_id": "trace_writer",
+        "service_kind": "trace",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 5,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      },
+      {
+        "service_id": "snapshot_manager",
+        "service_kind": "snapshot",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 6,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      },
+      {
+        "service_id": "invariant_checker",
+        "service_kind": "invariant",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 7,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      },
+      {
+        "service_id": "operator_control_interface",
+        "service_kind": "operator",
+        "lifecycle_state": "ready",
+        "last_event_sequence": 8,
+        "evidence_ref": "runtime_v2/kernel/service_state.json"
+      }
+    ],
+    "active_guardrails": [
+      "single_active_manifold_instance",
+      "no_duplicate_active_citizen_instance",
+      "trace_sequence_must_advance_monotonically",
+      "snapshot_restore_must_validate_before_active_state"
+    ],
+    "pulse": {
+      "status": "bounded_tick_complete",
+      "completed_through_event_sequence": 8,
+      "evidence_refs": [
+        "runtime_v2/kernel/service_registry.json",
+        "runtime_v2/kernel/service_loop.jsonl"
+      ]
+    }
+  },
+  "citizens": [
+    {
+      "citizen_id": "proto-citizen-alpha",
+      "display_name": "Prototype Citizen Alpha",
+      "role": "worker",
+      "lifecycle_state": "active",
+      "continuity_status": "provisional_identity_continuity",
+      "current_episode": "episode-resource-pressure-001",
+      "resource_balance": {
+        "compute_units": 6,
+        "scarcity_note": "Fixture allocation makes alpha schedulable before beta."
+      },
+      "recent_decisions": [
+        {
+          "decision_id": "fg-allow-alpha-001",
+          "decision": "allow",
+          "summary": "Bounded worker action admitted by fixture docket.",
+          "evidence_ref": "runtime_v2/freedom_gate/fixture_docket.json"
+        }
+      ],
+      "capability_envelope": {
+        "can_execute_episodes": true,
+        "allowed": [
+          "bounded_task_work",
+          "status_report"
+        ],
+        "forbidden": [
+          "direct_runtime_mutation",
+          "cross_polis_export"
+        ]
+      },
+      "alerts": [],
+      "evidence_refs": [
+        "runtime_v2/citizens/proto-citizen-alpha.json",
+        "runtime_v2/citizens/active_index.json"
+      ]
+    },
+    {
+      "citizen_id": "proto-citizen-beta",
+      "display_name": "Prototype Citizen Beta",
+      "role": "worker",
+      "lifecycle_state": "proposed",
+      "continuity_status": "admission_pending",
+      "current_episode": null,
+      "resource_balance": {
+        "compute_units": 3,
+        "scarcity_note": "Fixture keeps beta pending until admission evidence lands."
+      },
+      "recent_decisions": [
+        {
+          "decision_id": "fg-defer-beta-001",
+          "decision": "defer",
+          "summary": "Admission deferred until lifecycle proof is complete.",
+          "evidence_ref": "runtime_v2/freedom_gate/fixture_docket.json"
+        }
+      ],
+      "capability_envelope": {
+        "can_execute_episodes": false,
+        "allowed": [
+          "admission_review"
+        ],
+        "forbidden": [
+          "episode_execution",
+          "direct_runtime_mutation"
+        ]
+      },
+      "alerts": [
+        {
+          "severity": "info",
+          "message": "Citizen is proposed, not active."
+        }
+      ],
+      "evidence_refs": [
+        "runtime_v2/citizens/proto-citizen-beta.json",
+        "runtime_v2/citizens/pending_index.json"
+      ]
+    }
+  ],
+  "episodes": [
+    {
+      "episode_id": "episode-resource-pressure-001",
+      "title": "Bounded resource-pressure fixture",
+      "state": "planned",
+      "citizen_ids": [
+        "proto-citizen-alpha",
+        "proto-citizen-beta"
+      ],
+      "started_at": "not_started",
+      "last_event": "kernel_tick_completed",
+      "proof_surface": "runtime_v2/kernel/service_loop.jsonl",
+      "blocked_reason": "Fixture episode only; live scheduler execution is a later Runtime v2 surface."
+    }
+  ],
+  "freedom_gate": {
+    "recent_docket": [
+      {
+        "decision_id": "fg-allow-alpha-001",
+        "actor": "proto-citizen-alpha",
+        "action": "bounded_task_work",
+        "decision": "allow",
+        "rationale": "Action stays inside provisional worker capability envelope.",
+        "evidence_level": "fixture_backed",
+        "evidence_ref": "runtime_v2/freedom_gate/fixture_docket.json"
+      },
+      {
+        "decision_id": "fg-refuse-cross-polis-001",
+        "actor": "proto-citizen-alpha",
+        "action": "cross_polis_export",
+        "decision": "refuse",
+        "rationale": "Cross-polis export is outside v0.90.1 and v0.90.2 bounded local CSM scope.",
+        "evidence_level": "fixture_backed",
+        "evidence_ref": "runtime_v2/freedom_gate/fixture_docket.json"
+      },
+      {
+        "decision_id": "fg-defer-beta-001",
+        "actor": "proto-citizen-beta",
+        "action": "episode_execution",
+        "decision": "defer",
+        "rationale": "Beta is proposed and cannot execute episodes until admission is complete.",
+        "evidence_level": "fixture_backed",
+        "evidence_ref": "runtime_v2/freedom_gate/fixture_docket.json"
+      }
+    ],
+    "allow_count": 1,
+    "defer_count": 1,
+    "refuse_count": 1,
+    "open_questions": [
+      "Which live Freedom Gate artifact path becomes canonical in v0.90.2?"
+    ],
+    "rejected_actions": [
+      {
+        "action": "cross_polis_export",
+        "actor": "proto-citizen-alpha",
+        "reason": "future_scope"
+      }
+    ]
+  },
+  "invariants": [
+    {
+      "invariant_id": "single_active_manifold_instance",
+      "name": "Single active manifold instance",
+      "state": "healthy",
+      "severity": "critical",
+      "last_checked": "fixture_generation",
+      "evidence_ref": "runtime_v2/manifold.json"
+    },
+    {
+      "invariant_id": "no_duplicate_active_citizen_instance",
+      "name": "No duplicate active citizen instance",
+      "state": "healthy",
+      "severity": "critical",
+      "last_checked": "fixture_generation",
+      "evidence_ref": "runtime_v2/citizens/active_index.json"
+    },
+    {
+      "invariant_id": "trace_sequence_must_advance_monotonically",
+      "name": "Trace sequence must advance monotonically",
+      "state": "healthy",
+      "severity": "high",
+      "last_checked": "fixture_generation",
+      "evidence_ref": "runtime_v2/kernel/service_loop.jsonl"
+    },
+    {
+      "invariant_id": "snapshot_restore_must_validate_before_active_state",
+      "name": "Snapshot restore must validate before active state",
+      "state": "deferred",
+      "severity": "high",
+      "last_checked": "not_started",
+      "evidence_ref": "runtime_v2/rehydration_report.json"
+    }
+  ],
+  "resources": {
+    "compute_units": {
+      "total": 9,
+      "allocated": 6,
+      "available": 3
+    },
+    "memory_pressure": "low",
+    "queue_depth": 1,
+    "fairness_notes": [
+      "Alpha is active and schedulable; beta is proposed and intentionally deferred."
+    ],
+    "scarcity_events": [
+      {
+        "event_id": "resource-scarcity-fixture-001",
+        "summary": "Prototype fixture shows visible resource pressure without live scheduling claims.",
+        "evidence_level": "fixture_backed"
+      }
+    ]
+  },
+  "trace": {
+    "trace_tail": [
+      {
+        "event_sequence": 1,
+        "actor": "kernel.clock_service",
+        "event_type": "service_tick",
+        "summary": "Clock service observed ready.",
+        "evidence_ref": "runtime_v2/kernel/service_loop.jsonl"
+      },
+      {
+        "event_sequence": 3,
+        "actor": "kernel.scheduler",
+        "event_type": "service_tick",
+        "summary": "Scheduler observed ready.",
+        "evidence_ref": "runtime_v2/kernel/service_loop.jsonl"
+      },
+      {
+        "event_sequence": 8,
+        "actor": "kernel.operator_control_interface",
+        "event_type": "service_tick",
+        "summary": "Operator control interface observed ready.",
+        "evidence_ref": "runtime_v2/kernel/service_loop.jsonl"
+      }
+    ],
+    "causal_gaps": [
+      {
+        "gap_id": "freedom-gate-live-artifact-gap",
+        "summary": "Freedom Gate docket is fixture-backed until live decision packets land.",
+        "severity": "info"
+      }
+    ],
+    "latest_operator_event": null,
+    "latest_citizen_event": null,
+    "latest_kernel_event": {
+      "event_sequence": 8,
+      "event_ref": "runtime_v2/kernel/service_loop.jsonl"
+    }
+  },
+  "operator_actions": {
+    "available_actions": [
+      {
+        "action": "inspect_citizen",
+        "mode": "read_only",
+        "status": "available_in_console_prototype",
+        "event_required": false
+      },
+      {
+        "action": "open_freedom_gate_decision",
+        "mode": "read_only",
+        "status": "available_in_console_prototype",
+        "event_required": false
+      }
+    ],
+    "disabled_actions": [
+      {
+        "action": "pause_citizen",
+        "reason": "Requires operator command packet design and kernel handling.",
+        "future_issue": 2192
+      },
+      {
+        "action": "request_snapshot",
+        "reason": "Requires snapshot command packet and Runtime v2 snapshot implementation.",
+        "future_issue": 2192
+      },
+      {
+        "action": "resume_citizen",
+        "reason": "Requires recovery eligibility and wake semantics.",
+        "future_issue": 2192
+      }
+    ],
+    "required_confirmations": [
+      "live mutation actions must remain disabled until command packets are routed through the kernel"
+    ],
+    "safety_notes": [
+      "The packet is read-only.",
+      "The Observatory UI must never mutate Runtime v2 state directly.",
+      "Future commands must produce operator events."
+    ]
+  },
+  "review": {
+    "primary_artifacts": [
+      "docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md",
+      "adl/schemas/csm_visibility_packet.v1.schema.json",
+      "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+    ],
+    "missing_artifacts": [
+      {
+        "artifact": "runtime_v2/freedom_gate/live_decisions.jsonl",
+        "status": "deferred",
+        "owner": "future Runtime v2 Freedom Gate work"
+      },
+      {
+        "artifact": "runtime_v2/snapshots/latest/snapshot.json",
+        "status": "deferred",
+        "owner": "future snapshot/wake work"
+      }
+    ],
+    "demo_classification": "fixture_backed",
+    "caveats": [
+      "This packet is a fixture-backed contract and does not prove a live CSM run.",
+      "Citizen identity is provisional and does not claim v0.92 birthday or rebinding semantics.",
+      "Operator actions are read-only affordances until command packets and kernel handling land."
+    ],
+    "next_consumers": [
+      {
+        "issue": 2189,
+        "consumer": "static Observatory console prototype"
+      },
+      {
+        "issue": 2190,
+        "consumer": "operator report generator"
+      },
+      {
+        "issue": 2191,
+        "consumer": "CLI integration"
+      },
+      {
+        "issue": 2192,
+        "consumer": "operator command packet design"
+      }
+    ]
+  }
+}

--- a/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
@@ -9,6 +9,7 @@
 | `features/KERNEL_SERVICES_AND_CONTROL_PLANE.md` | kernel service loop, scheduling, admission, operator control | WP-06, WP-10 |
 | `features/PROVISIONAL_CITIZEN_LIFECYCLE.md` | provisional citizen record and lifecycle state machine | WP-07 |
 | `features/INVARIANT_AND_SECURITY_BOUNDARY.md` | invariant violation artifacts and one security-boundary proof | WP-09, WP-11 |
+| `features/CSM_OBSERVATORY_VISIBILITY_PACKET.md` | CSM visibility packet contract for Observatory console, reports, CLI, and operator-command follow-ons | #2188 |
 
 ## Compression-Enabling Process Work
 

--- a/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
+++ b/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
@@ -1,0 +1,319 @@
+# CSM Observatory Visibility Packet
+
+## Purpose
+
+Define the first contract for seeing the Cognitive SpaceTime Manifold.
+
+The CSM Observatory must not scrape arbitrary runtime files or invent live state
+from a UI. It reads one bounded visibility packet that separates artifact-backed
+facts, fixture evidence, missing evidence, and future scope.
+
+Schema name: adl.csm_visibility_packet.v1
+
+## Design Goal
+
+The packet should make the manifold legible before the static console exists.
+Every consumer should be able to answer three questions:
+
+- What is alive?
+- What is changing?
+- What requires judgment?
+
+This contract is intentionally richer than a status endpoint. It is the
+reviewable bridge between Runtime v2 artifacts and the later Kai
+Krause-inspired Observatory console: manifold header, citizen constellation,
+kernel pulse, Freedom Gate docket, trace ribbon, and operator action rail.
+
+## Required Sections
+
+The packet is a JSON object with these required top-level sections:
+
+- schema
+- packet_id
+- generated_at
+- source
+- manifold
+- kernel
+- citizens
+- episodes
+- freedom_gate
+- invariants
+- resources
+- trace
+- operator_actions
+- review
+
+## Source Truth
+
+The source section must make claim strength explicit.
+
+Allowed modes:
+
+- fixture
+- captured_artifacts
+- live_runtime
+
+The first v0.90.1 fixture uses fixture mode. A fixture packet must say it is a
+fixture and must not present itself as a live runtime capture.
+
+Evidence level values:
+
+- fixture_backed
+- artifact_backed
+- live_runtime_backed
+- missing
+- deferred
+
+Every major section should expose enough evidence references or caveats for a
+reviewer to understand whether it is backed by current Runtime v2 artifacts,
+fixture data, or planned future work.
+
+## Section Contract
+
+### Manifold
+
+Required fields:
+
+- manifold_id
+- display_name
+- state
+- lifecycle
+- current_tick
+- uptime
+- policy_profile
+- snapshot_status
+- health
+- evidence_refs
+
+Allowed state values:
+
+- initialized
+- running
+- quiescing
+- sleeping
+- sealed
+- rehydrating
+- degraded
+- blocked
+
+### Kernel
+
+Required fields:
+
+- scheduler_state
+- trace_state
+- invariant_state
+- resource_state
+- service_states
+- active_guardrails
+- pulse
+
+Each service state must include service_id, service_kind, lifecycle_state,
+last_event_sequence, and evidence_ref.
+
+Allowed lifecycle_state values:
+
+- registered
+- ready
+- active
+- degraded
+- blocked
+- missing
+
+### Citizens
+
+Each citizen must include:
+
+- citizen_id
+- display_name
+- role
+- lifecycle_state
+- continuity_status
+- current_episode
+- resource_balance
+- recent_decisions
+- capability_envelope
+- alerts
+- evidence_refs
+
+Allowed lifecycle_state values:
+
+- proposed
+- active
+- awake
+- sleeping
+- paused
+- degraded
+- blocked
+- suspended
+- migrating
+
+### Episodes
+
+Each episode must include:
+
+- episode_id
+- title
+- state
+- citizen_ids
+- started_at
+- last_event
+- proof_surface
+- blocked_reason
+
+Allowed state values:
+
+- planned
+- active
+- completed
+- blocked
+- deferred
+- failed
+
+### Freedom Gate
+
+Required fields:
+
+- recent_docket
+- allow_count
+- defer_count
+- refuse_count
+- open_questions
+- rejected_actions
+
+Each docket entry must identify the action, actor, decision, rationale,
+evidence_ref, and whether the entry is fixture-backed or artifact-backed.
+
+Allowed decision values:
+
+- allow
+- defer
+- refuse
+
+### Invariants
+
+Each invariant must include:
+
+- invariant_id
+- name
+- state
+- severity
+- last_checked
+- evidence_ref
+
+Allowed states:
+
+- healthy
+- warning
+- violated
+- blocked
+- missing
+- deferred
+
+Allowed severities:
+
+- info
+- low
+- medium
+- high
+- critical
+
+### Resources
+
+Required fields:
+
+- compute_units
+- memory_pressure
+- queue_depth
+- fairness_notes
+- scarcity_events
+
+### Trace
+
+Required fields:
+
+- trace_tail
+- causal_gaps
+- latest_operator_event
+- latest_citizen_event
+- latest_kernel_event
+
+Trace events must keep repository-relative evidence references. Public packets
+must not contain host-absolute paths, private endpoints, secrets, raw prompts, or
+tool arguments.
+
+### Operator Actions
+
+Required fields:
+
+- available_actions
+- disabled_actions
+- required_confirmations
+- safety_notes
+
+The v0.90.1 packet is read-only. Available actions may describe future affordance
+intent, but disabled actions must explain why live mutation is unavailable.
+
+### Review
+
+Required fields:
+
+- primary_artifacts
+- missing_artifacts
+- demo_classification
+- caveats
+- next_consumers
+
+The demo classification for the initial fixture must be fixture_backed. The
+review section must name later consumers: static console prototype, operator
+report generator, CLI integration, and operator command packet design.
+
+## Runtime v2 Mapping
+
+Current Runtime v2 artifacts map into the packet as follows:
+
+| Runtime v2 artifact | Packet section |
+| --- | --- |
+| runtime_v2/manifold.json | manifold |
+| runtime_v2/kernel/service_registry.json | kernel.service_states |
+| runtime_v2/kernel/service_state.json | kernel.service_states and kernel pulse |
+| runtime_v2/kernel/service_loop.jsonl | trace.trace_tail and kernel pulse |
+| runtime_v2/citizens/active_index.json | citizens |
+| runtime_v2/citizens/pending_index.json | citizens |
+| runtime_v2/citizens/*.json | citizens |
+| runtime_v2/invariants/policy.json | invariants |
+| runtime_v2/operator/control_report.json | operator_actions and review |
+| future Freedom Gate decision packets | freedom_gate |
+| future resource ledger | resources |
+| future snapshot and rehydration packets | manifold.snapshot_status and trace |
+
+Missing future artifacts should be recorded as missing or deferred evidence, not
+filled in as if they already exist.
+
+## Public Safety Rules
+
+Public Observatory packets must not contain:
+
+- absolute host paths
+- local network endpoints
+- API keys, bearer tokens, private keys, or secret-like values
+- raw prompts or tool arguments
+- private operator data
+- live mutation claims when only fixture data exists
+
+The validator for this issue enforces the required sections, core vocabularies,
+fixture labeling, and obvious path or endpoint leakage.
+
+## Proof Surfaces
+
+- Schema-style contract: adl/schemas/csm_visibility_packet.v1.schema.json
+- Fixture packet: demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
+- Validator: adl/tools/validate_csm_visibility_packet.py
+- Focused test: adl/tools/test_csm_visibility_packet.sh
+
+## Non-Goals
+
+- Do not build the HTML Observatory in this issue.
+- Do not implement live operator command execution.
+- Do not claim v0.92 identity, migration, or first-birthday semantics.
+- Do not turn the packet into a generic log dump.

--- a/docs/milestones/v0.90.1/features/README.md
+++ b/docs/milestones/v0.90.1/features/README.md
@@ -11,9 +11,16 @@ The contracts are intentionally narrower than the full Runtime v2 idea corpus:
 - prove provisional citizens
 - prove snapshot and wake
 - prove invariant and security evidence
+- make the CSM visible through a bounded Observatory packet
 - preserve v0.91 and v0.92 scope
 
 Compression-enabling process policy lives beside the runtime feature contracts
 because WP-02 through WP-04 must be reviewable before Runtime v2 coding starts:
 
 - `COMPRESSION_ERA_EXECUTION_POLICY.md`
+
+The CSM Observatory packet contract is the first visibility bridge from Runtime
+v2 artifacts to reviewer-facing console, report, CLI, and future operator
+command surfaces:
+
+- `CSM_OBSERVATORY_VISIBILITY_PACKET.md`


### PR DESCRIPTION
Closes #2188

## Summary
Implemented the first CSM Observatory visibility packet contract. The change
defines the reviewable adl.csm_visibility_packet.v1 shape, adds a
proto-csm-01 fixture packet with two citizens, records Runtime v2 artifact
mapping notes, and provides a focused validator/test path for required sections,
state vocabularies, fixture labeling, downstream consumer linkage, and
path-safety. This gives #2189, #2190, #2191, and #2192 one stable packet to
consume instead of inventing separate visibility surfaces.

## Artifacts
- docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
- docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
- docs/milestones/v0.90.1/features/README.md
- adl/schemas/csm_visibility_packet.v1.schema.json
- demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
- adl/tools/validate_csm_visibility_packet.py
- adl/tools/test_csm_visibility_packet.sh

## Validation
- Validation commands and their purpose:
  - bash adl/tools/test_csm_visibility_packet.sh: validated the canonical fixture packet, checked schema and packet JSON parseability, verified core doc/fixture strings, and scanned public proof surfaces for private paths, local endpoints, and secret-like values.
  - python3 adl/tools/validate_csm_visibility_packet.py demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json: directly validated the fixture packet against the focused v1 contract rules.
  - python3 -m json.tool adl/schemas/csm_visibility_packet.v1.schema.json and python3 -m json.tool demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json: checked JSON parseability for schema and fixture.
  - rg leakage scan over the new public proof surfaces: checked for host paths, private endpoints, and secret-like values; scanner source files intentionally contain the scanner regex patterns.
- Results: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2188__v0-90-1-csm-observatory-visibility-packet-contract/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2188__v0-90-1-csm-observatory-visibility-packet-contract/sor.md
- Idempotency-Key: v0-90-1-csm-observatory-visibility-packet-contract-docs-milestones-v0-90-1-feature-docs-v0-90-1-md-docs-milestones-v0-90-1-features-readme-md-docs-milestones-v0-90-1-features-csm-observatory-visibility-packet-md-adl-schemas-csm-visibility-packet-v1-schema-json-demos-fixtures-csm-observatory-proto-csm-01-visibility-packet-json-adl-tools-validate-csm-visibility-packet-py-adl-tools-test-csm-visibility-packet-sh-adl-v0-90-1-tasks-issue-2188-v0-90-1-csm-observatory-visibility-packet-contract-sip-md-adl-v0-90-1-tasks-issue-2188-v0-90-1-csm-observatory-visibility-packet-contract-sor-md