### PR TITLE
[v0.90.1][CSM Observatory] Operator report generator

### DIFF
--- a/adl/tools/render_csm_observatory_report.py
+++ b/adl/tools/render_csm_observatory_report.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Render a reviewer-facing CSM Observatory operator report from a visibility packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SEVERITY_ORDER = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+    "info": 4,
+}
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def as_mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def text(value: Any, fallback: str = "not recorded") -> str:
+    if value is None:
+        return fallback
+    value_text = str(value).strip()
+    return value_text if value_text else fallback
+
+
+def bullet(value: str) -> str:
+    return f"- {value}"
+
+
+def table_row(values: list[Any]) -> str:
+    return "| " + " | ".join(text(value).replace("\n", " ") for value in values) + " |"
+
+
+def evidence_refs(*values: Any) -> list[str]:
+    refs: list[str] = []
+    for value in values:
+        if isinstance(value, str) and value not in refs:
+            refs.append(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str) and item not in refs:
+                    refs.append(item)
+    return refs
+
+
+def render_attention_items(packet: dict[str, Any]) -> list[str]:
+    items: list[tuple[int, str]] = []
+
+    def add(priority: int, item: str) -> None:
+        clean = text(item).strip()
+        if clean:
+            items.append((priority, clean[:1].upper() + clean[1:]))
+
+    manifold = as_mapping(packet.get("manifold"))
+    health = as_mapping(manifold.get("health"))
+    for item in as_list(health.get("attention_items")):
+        normalized_item = text(item).lower()
+        if "snapshot evidence" in normalized_item or "proposed, not active" in normalized_item:
+            continue
+        add(2, text(item))
+
+    snapshot = as_mapping(manifold.get("snapshot_status"))
+    if snapshot.get("state") in {"deferred", "missing", "blocked"}:
+        add(1, f"Snapshot evidence is {text(snapshot.get('state'))}: {text(snapshot.get('note'))}")
+
+    for citizen in as_list(packet.get("citizens")):
+        citizen_map = as_mapping(citizen)
+        state = citizen_map.get("lifecycle_state")
+        if state != "active":
+            add(
+                1,
+                (
+                    f"{text(citizen_map.get('display_name'))} is {text(state)}, not active; "
+                    f"continuity is {text(citizen_map.get('continuity_status'))}."
+                ),
+            )
+        for alert in as_list(citizen_map.get("alerts")):
+            alert_map = as_mapping(alert)
+            severity = text(alert_map.get("severity"), "info")
+            if "proposed, not active" in text(alert_map.get("message")).lower():
+                continue
+            add(SEVERITY_ORDER.get(severity, 4), f"{severity}: {text(alert_map.get('message'))}")
+
+    for invariant in as_list(packet.get("invariants")):
+        invariant_map = as_mapping(invariant)
+        state = invariant_map.get("state")
+        if state != "healthy":
+            severity = text(invariant_map.get("severity"), "info")
+            priority = SEVERITY_ORDER.get(severity, 4)
+            add(
+                priority,
+                f"{text(invariant_map.get('name'))} is {text(state)} "
+                f"({severity}); evidence: {text(invariant_map.get('evidence_ref'))}.",
+            )
+
+    trace = as_mapping(packet.get("trace"))
+    for gap in as_list(trace.get("causal_gaps")):
+        gap_map = as_mapping(gap)
+        severity = text(gap_map.get("severity"), "info")
+        add(SEVERITY_ORDER.get(severity, 4), f"{severity}: {text(gap_map.get('summary'))}")
+
+    freedom_gate = as_mapping(packet.get("freedom_gate"))
+    for question in as_list(freedom_gate.get("open_questions")):
+        add(2, f"Open Freedom Gate question: {text(question)}")
+
+    operator_actions = as_mapping(packet.get("operator_actions"))
+    for action in as_list(operator_actions.get("disabled_actions")):
+        action_map = as_mapping(action)
+        future_issue = action_map.get("future_issue")
+        suffix = f" Future issue: #{future_issue}." if future_issue else ""
+        reason = text(action_map.get("reason")).rstrip(".")
+        add(
+            2,
+            f"Operator action {text(action_map.get('action'))} remains disabled: {reason}.{suffix}",
+        )
+
+    rendered: list[str] = []
+    seen: set[str] = set()
+    for _, item in sorted(items, key=lambda candidate: (candidate[0], candidate[1].lower())):
+        normalized = item.lower().rstrip(".")
+        if normalized not in seen:
+            rendered.append(item)
+            seen.add(normalized)
+    return rendered
+
+
+def render_report(packet: dict[str, Any]) -> str:
+    source = as_mapping(packet.get("source"))
+    manifold = as_mapping(packet.get("manifold"))
+    kernel = as_mapping(packet.get("kernel"))
+    resources = as_mapping(packet.get("resources"))
+    compute = as_mapping(resources.get("compute_units"))
+    freedom_gate = as_mapping(packet.get("freedom_gate"))
+    trace = as_mapping(packet.get("trace"))
+    operator_actions = as_mapping(packet.get("operator_actions"))
+    review = as_mapping(packet.get("review"))
+
+    title = f"CSM Observatory Operator Report: {text(manifold.get('display_name'))}"
+    lines: list[str] = [
+        f"# {title}",
+        "",
+        "## Report Identity",
+        table_row(["Field", "Value"]),
+        table_row(["---", "---"]),
+        table_row(["Packet", packet.get("packet_id")]),
+        table_row(["Schema", packet.get("schema")]),
+        table_row(["Generated", packet.get("generated_at")]),
+        table_row(["Source mode", source.get("mode")]),
+        table_row(["Evidence level", source.get("evidence_level")]),
+        table_row(["Demo classification", review.get("demo_classification")]),
+        "",
+        "## Operator Summary",
+        f"The manifold is {text(manifold.get('state'))} at tick {text(manifold.get('current_tick'))}. "
+        f"The kernel pulse is {text(as_mapping(kernel.get('pulse')).get('status'))} through event sequence "
+        f"{text(as_mapping(kernel.get('pulse')).get('completed_through_event_sequence'))}. "
+        f"Current evidence is {text(source.get('evidence_level'))}; claim boundary: {text(source.get('claim_boundary'))}",
+        "",
+        "## Attention Items",
+    ]
+
+    attention_items = render_attention_items(packet)
+    if attention_items:
+        lines.extend(bullet(item) for item in attention_items)
+    else:
+        lines.append("- No operator attention items were reported by this packet.")
+
+    lines.extend(
+        [
+            "",
+            "## Manifold And Kernel",
+            table_row(["Field", "Value"]),
+            table_row(["---", "---"]),
+            table_row(["Manifold", manifold.get("manifold_id")]),
+            table_row(["Lifecycle", manifold.get("lifecycle")]),
+            table_row(["Policy profile", manifold.get("policy_profile")]),
+            table_row(["Health", f"{text(as_mapping(manifold.get('health')).get('level'))}: {text(as_mapping(manifold.get('health')).get('summary'))}"]),
+            table_row(["Scheduler", kernel.get("scheduler_state")]),
+            table_row(["Trace", kernel.get("trace_state")]),
+            table_row(["Invariants", kernel.get("invariant_state")]),
+            table_row(["Resources", kernel.get("resource_state")]),
+            "",
+            "## Citizens",
+            table_row(["Citizen", "State", "Continuity", "Episode", "Compute", "Capability"]),
+            table_row(["---", "---", "---", "---", "---", "---"]),
+        ]
+    )
+
+    for citizen in as_list(packet.get("citizens")):
+        citizen_map = as_mapping(citizen)
+        balance = as_mapping(citizen_map.get("resource_balance"))
+        envelope = as_mapping(citizen_map.get("capability_envelope"))
+        capability = "episode execution allowed" if envelope.get("can_execute_episodes") else "episode execution disabled"
+        lines.append(
+            table_row(
+                [
+                    citizen_map.get("display_name"),
+                    citizen_map.get("lifecycle_state"),
+                    citizen_map.get("continuity_status"),
+                    citizen_map.get("current_episode"),
+                    balance.get("compute_units"),
+                    capability,
+                ]
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Freedom Gate Docket",
+            f"Counts: allow {text(freedom_gate.get('allow_count'))}, defer {text(freedom_gate.get('defer_count'))}, refuse {text(freedom_gate.get('refuse_count'))}.",
+            "",
+            table_row(["Decision", "Actor", "Action", "Rationale", "Evidence"]),
+            table_row(["---", "---", "---", "---", "---"]),
+        ]
+    )
+    for entry in as_list(freedom_gate.get("recent_docket")):
+        entry_map = as_mapping(entry)
+        lines.append(
+            table_row(
+                [
+                    entry_map.get("decision"),
+                    entry_map.get("actor"),
+                    entry_map.get("action"),
+                    entry_map.get("rationale"),
+                    entry_map.get("evidence_ref"),
+                ]
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Invariant Review",
+            table_row(["Invariant", "State", "Severity", "Evidence"]),
+            table_row(["---", "---", "---", "---"]),
+        ]
+    )
+    for invariant in sorted(
+        as_list(packet.get("invariants")),
+        key=lambda item: (SEVERITY_ORDER.get(text(as_mapping(item).get("severity")), 99), text(as_mapping(item).get("name")).lower()),
+    ):
+        invariant_map = as_mapping(invariant)
+        lines.append(
+            table_row(
+                [
+                    invariant_map.get("name"),
+                    invariant_map.get("state"),
+                    invariant_map.get("severity"),
+                    invariant_map.get("evidence_ref"),
+                ]
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Resources",
+            table_row(["Total compute", compute.get("total")]),
+            table_row(["Allocated compute", compute.get("allocated")]),
+            table_row(["Available compute", compute.get("available")]),
+            table_row(["Memory pressure", resources.get("memory_pressure")]),
+            table_row(["Queue depth", resources.get("queue_depth")]),
+            "",
+            "Fairness notes:",
+        ]
+    )
+    lines.extend(bullet(text(note)) for note in as_list(resources.get("fairness_notes")))
+
+    lines.extend(
+        [
+            "",
+            "## Trace Tail",
+            table_row(["Seq", "Actor", "Event", "Summary", "Evidence"]),
+            table_row(["---", "---", "---", "---", "---"]),
+        ]
+    )
+    for event in sorted(as_list(trace.get("trace_tail")), key=lambda item: as_mapping(item).get("event_sequence", 0)):
+        event_map = as_mapping(event)
+        lines.append(
+            table_row(
+                [
+                    event_map.get("event_sequence"),
+                    event_map.get("actor"),
+                    event_map.get("event_type"),
+                    event_map.get("summary"),
+                    event_map.get("evidence_ref"),
+                ]
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Operator Action Boundary",
+            "Available read-only actions:",
+        ]
+    )
+    lines.extend(
+        bullet(f"{text(as_mapping(action).get('action'))}: {text(as_mapping(action).get('status'))}")
+        for action in as_list(operator_actions.get("available_actions"))
+    )
+    lines.append("")
+    lines.append("Disabled mutation actions:")
+    lines.extend(
+        bullet(f"{text(as_mapping(action).get('action'))}: {text(as_mapping(action).get('reason'))}")
+        for action in as_list(operator_actions.get("disabled_actions"))
+    )
+    lines.append("")
+    lines.append("Required confirmations:")
+    lines.extend(bullet(text(item)) for item in as_list(operator_actions.get("required_confirmations")))
+
+    primary_refs = evidence_refs(
+        source.get("source_refs"),
+        manifold.get("evidence_refs"),
+        as_mapping(kernel.get("pulse")).get("evidence_refs"),
+        review.get("primary_artifacts"),
+    )
+    missing = as_list(review.get("missing_artifacts"))
+
+    lines.extend(
+        [
+            "",
+            "## Evidence And Caveats",
+            "Primary evidence references:",
+        ]
+    )
+    lines.extend(bullet(ref) for ref in primary_refs)
+    lines.append("")
+    lines.append("Missing or deferred artifacts:")
+    for artifact in missing:
+        artifact_map = as_mapping(artifact)
+        lines.append(
+            bullet(
+                f"{text(artifact_map.get('artifact'))}: {text(artifact_map.get('status'))}; "
+                f"owner {text(artifact_map.get('owner'))}"
+            )
+        )
+    lines.append("")
+    lines.append("Caveats:")
+    lines.extend(bullet(text(caveat)) for caveat in as_list(review.get("caveats")))
+
+    lines.extend(
+        [
+            "",
+            "## Next Consumers",
+            table_row(["Issue", "Consumer"]),
+            table_row(["---", "---"]),
+        ]
+    )
+    for consumer in sorted(as_list(review.get("next_consumers")), key=lambda item: as_mapping(item).get("issue", 0)):
+        consumer_map = as_mapping(consumer)
+        lines.append(table_row([f"#{consumer_map.get('issue')}", consumer_map.get("consumer")]))
+
+    lines.extend(
+        [
+            "",
+            "## Reviewer Use",
+            "This report is a proof surface for the packet-to-operator-report path. It is useful for reviewing visibility semantics, attention routing, claim boundaries, and evidence coverage without opening the HTML console.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def load_packet(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        packet = json.load(handle)
+    if not isinstance(packet, dict):
+        raise ValueError("packet root must be an object")
+    return packet
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet", type=Path, help="Visibility packet JSON path")
+    parser.add_argument("--output", type=Path, help="Markdown report output path")
+    args = parser.parse_args()
+
+    packet = load_packet(args.packet)
+    rendered = render_report(packet)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_demo_v0901_csm_observatory_operator_report.sh
+++ b/adl/tools/test_demo_v0901_csm_observatory_operator_report.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PACKET="${ROOT_DIR}/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+REPORT="${ROOT_DIR}/demos/v0.90.1/csm_observatory_operator_report.md"
+DOC="${ROOT_DIR}/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_REPORT.md"
+GENERATOR="${ROOT_DIR}/adl/tools/render_csm_observatory_report.py"
+TMP_REPORT="$(mktemp)"
+cleanup() {
+  rm -f "${TMP_REPORT}"
+}
+trap cleanup EXIT
+
+for path in "${PACKET}" "${REPORT}" "${DOC}" "${GENERATOR}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "missing CSM Observatory operator-report artifact: ${path}" >&2
+    exit 1
+  fi
+done
+
+python3 "${ROOT_DIR}/adl/tools/validate_csm_visibility_packet.py" "${PACKET}" >/dev/null
+python3 "${GENERATOR}" "${PACKET}" --output "${TMP_REPORT}"
+diff -u "${REPORT}" "${TMP_REPORT}" >/dev/null
+python3 -m py_compile "${GENERATOR}"
+
+grep -Fq "CSM Observatory Operator Report" "${REPORT}"
+grep -Fq "Attention Items" "${REPORT}"
+grep -Fq "Snapshot evidence is deferred" "${REPORT}"
+grep -Fq "Freedom Gate packet is fixture-only" "${REPORT}"
+grep -Fq "Operator action pause_citizen remains disabled" "${REPORT}"
+grep -Fq "This packet is a fixture-backed contract and does not prove a live CSM run." "${REPORT}"
+grep -Fq "docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md" "${REPORT}"
+
+if grep -E "/Users/|/private/var/|localhost:[0-9]+|192\\.168\\.|Bearer |api[_-]?key|secret|token" "${REPORT}" "${DOC}" "${GENERATOR}" >/dev/null; then
+  echo "CSM Observatory operator report leaked private path, endpoint, or secret-like text" >&2
+  exit 1
+fi
+
+echo "CSM Observatory operator report passed"

--- a/demos/README.md
+++ b/demos/README.md
@@ -82,6 +82,12 @@ If you want the fixture-backed CSM Observatory static console:
 demos/v0.90.1/csm_observatory_static_console.html
 ```
 
+If you want the fixture-backed CSM Observatory operator report:
+
+```bash
+bash adl/tools/test_demo_v0901_csm_observatory_operator_report.sh
+```
+
 ## Demo Categories
 
 - Runtime workflow demos live in `adl/examples/`.
@@ -240,12 +246,18 @@ staged `review-quality-evaluator` lane from `#2070` lands.
 ### v0.90.1 Runtime v2 and CSM Observatory demos
 
 - `v0.90.1/csm_observatory_static_console.md`
+- `v0.90.1/csm_observatory_operator_report.md`
 
 Use `v0.90.1/csm_observatory_static_console.html` for the first read-only CSM
 Observatory prototype. It renders the fixture-backed proto-csm-01 visibility
 packet into a control-room surface with manifold header, citizen constellation,
 kernel pulse, Freedom Gate docket, trace ribbon, and read-only operator action
 rail.
+
+Use `bash adl/tools/test_demo_v0901_csm_observatory_operator_report.sh` to
+validate the packet-to-report proof surface. The generated Markdown report is a
+compact reviewer artifact for manifold status, citizen state, invariant risk,
+Freedom Gate decisions, trace tail, operator-action boundaries, and caveats.
 
 Use `v0.87/v087_demo_program.md` for the canonical `v0.87` demo order and bounded
 repo-local commands.

--- a/demos/v0.90.1/csm_observatory_operator_report.md
+++ b/demos/v0.90.1/csm_observatory_operator_report.md
@@ -1,0 +1,125 @@
+# CSM Observatory Operator Report: Prototype CSM 01
+
+## Report Identity
+| Field | Value |
+| --- | --- |
+| Packet | csm-observatory-fixture-proto-csm-01 |
+| Schema | adl.csm_visibility_packet.v1 |
+| Generated | 2026-04-19T00:00:00Z |
+| Source mode | fixture |
+| Evidence level | fixture_backed |
+| Demo classification | fixture_backed |
+
+## Operator Summary
+The manifold is initialized at tick 0. The kernel pulse is bounded_tick_complete through event sequence 8. Current evidence is fixture_backed; claim boundary: Fixture-backed Observatory contract example. This is not a live Runtime v2 capture.
+
+## Attention Items
+- Prototype Citizen Beta is proposed, not active; continuity is admission_pending.
+- Snapshot evidence is deferred: Snapshot and wake proof remain future Runtime v2 implementation surfaces.
+- Snapshot restore must validate before active state is deferred (high); evidence: runtime_v2/rehydration_report.json.
+- Freedom Gate packet is fixture-only
+- Open Freedom Gate question: Which live Freedom Gate artifact path becomes canonical in v0.90.2?
+- Operator action pause_citizen remains disabled: Requires operator command packet design and kernel handling. Future issue: #2192.
+- Operator action request_snapshot remains disabled: Requires snapshot command packet and Runtime v2 snapshot implementation. Future issue: #2192.
+- Operator action resume_citizen remains disabled: Requires recovery eligibility and wake semantics. Future issue: #2192.
+- Info: Freedom Gate docket is fixture-backed until live decision packets land.
+
+## Manifold And Kernel
+| Field | Value |
+| --- | --- |
+| Manifold | proto-csm-01 |
+| Lifecycle | bounded_fixture_world |
+| Policy profile | runtime_v2_minimal_prototype |
+| Health | nominal: initialized fixture |
+| Scheduler | registered |
+| Trace | bounded_tick_fixture |
+| Invariants | policy_loaded |
+| Resources | bounded_prototype |
+
+## Citizens
+| Citizen | State | Continuity | Episode | Compute | Capability |
+| --- | --- | --- | --- | --- | --- |
+| Prototype Citizen Alpha | active | provisional_identity_continuity | episode-resource-pressure-001 | 6 | episode execution allowed |
+| Prototype Citizen Beta | proposed | admission_pending | not recorded | 3 | episode execution disabled |
+
+## Freedom Gate Docket
+Counts: allow 1, defer 1, refuse 1.
+
+| Decision | Actor | Action | Rationale | Evidence |
+| --- | --- | --- | --- | --- |
+| allow | proto-citizen-alpha | bounded_task_work | Action stays inside provisional worker capability envelope. | runtime_v2/freedom_gate/fixture_docket.json |
+| refuse | proto-citizen-alpha | cross_polis_export | Cross-polis export is outside v0.90.1 and v0.90.2 bounded local CSM scope. | runtime_v2/freedom_gate/fixture_docket.json |
+| defer | proto-citizen-beta | episode_execution | Beta is proposed and cannot execute episodes until admission is complete. | runtime_v2/freedom_gate/fixture_docket.json |
+
+## Invariant Review
+| Invariant | State | Severity | Evidence |
+| --- | --- | --- | --- |
+| No duplicate active citizen instance | healthy | critical | runtime_v2/citizens/active_index.json |
+| Single active manifold instance | healthy | critical | runtime_v2/manifold.json |
+| Snapshot restore must validate before active state | deferred | high | runtime_v2/rehydration_report.json |
+| Trace sequence must advance monotonically | healthy | high | runtime_v2/kernel/service_loop.jsonl |
+
+## Resources
+| Total compute | 9 |
+| Allocated compute | 6 |
+| Available compute | 3 |
+| Memory pressure | low |
+| Queue depth | 1 |
+
+Fairness notes:
+- Alpha is active and schedulable; beta is proposed and intentionally deferred.
+
+## Trace Tail
+| Seq | Actor | Event | Summary | Evidence |
+| --- | --- | --- | --- | --- |
+| 1 | kernel.clock_service | service_tick | Clock service observed ready. | runtime_v2/kernel/service_loop.jsonl |
+| 3 | kernel.scheduler | service_tick | Scheduler observed ready. | runtime_v2/kernel/service_loop.jsonl |
+| 8 | kernel.operator_control_interface | service_tick | Operator control interface observed ready. | runtime_v2/kernel/service_loop.jsonl |
+
+## Operator Action Boundary
+Available read-only actions:
+- inspect_citizen: available_in_console_prototype
+- open_freedom_gate_decision: available_in_console_prototype
+
+Disabled mutation actions:
+- pause_citizen: Requires operator command packet design and kernel handling.
+- request_snapshot: Requires snapshot command packet and Runtime v2 snapshot implementation.
+- resume_citizen: Requires recovery eligibility and wake semantics.
+
+Required confirmations:
+- live mutation actions must remain disabled until command packets are routed through the kernel
+
+## Evidence And Caveats
+Primary evidence references:
+- adl/tests/fixtures/runtime_v2/manifold.json
+- adl/tests/fixtures/runtime_v2/kernel/service_registry.json
+- adl/tests/fixtures/runtime_v2/kernel/service_state.json
+- adl/tests/fixtures/runtime_v2/kernel/service_loop.jsonl
+- adl/tests/fixtures/runtime_v2/citizens/active_index.json
+- adl/tests/fixtures/runtime_v2/citizens/pending_index.json
+- runtime_v2/manifold.json
+- runtime_v2/kernel/service_registry.json
+- runtime_v2/kernel/service_loop.jsonl
+- docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
+- adl/schemas/csm_visibility_packet.v1.schema.json
+- demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
+
+Missing or deferred artifacts:
+- runtime_v2/freedom_gate/live_decisions.jsonl: deferred; owner future Runtime v2 Freedom Gate work
+- runtime_v2/snapshots/latest/snapshot.json: deferred; owner future snapshot/wake work
+
+Caveats:
+- This packet is a fixture-backed contract and does not prove a live CSM run.
+- Citizen identity is provisional and does not claim v0.92 birthday or rebinding semantics.
+- Operator actions are read-only affordances until command packets and kernel handling land.
+
+## Next Consumers
+| Issue | Consumer |
+| --- | --- |
+| #2189 | static Observatory console prototype |
+| #2190 | operator report generator |
+| #2191 | CLI integration |
+| #2192 | operator command packet design |
+
+## Reviewer Use
+This report is a proof surface for the packet-to-operator-report path. It is useful for reviewing visibility semantics, attention routing, claim boundaries, and evidence coverage without opening the HTML console.

--- a/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
@@ -10,6 +10,7 @@
 | `features/PROVISIONAL_CITIZEN_LIFECYCLE.md` | provisional citizen record and lifecycle state machine | WP-07 |
 | `features/INVARIANT_AND_SECURITY_BOUNDARY.md` | invariant violation artifacts and one security-boundary proof | WP-09, WP-11 |
 | `features/CSM_OBSERVATORY_VISIBILITY_PACKET.md` | CSM visibility packet contract for Observatory console, reports, CLI, and operator-command follow-ons | #2188 |
+| `features/CSM_OBSERVATORY_OPERATOR_REPORT.md` | deterministic operator/reviewer report generated from the CSM visibility packet | #2190 |
 
 ## Compression-Enabling Process Work
 

--- a/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_REPORT.md
+++ b/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_REPORT.md
@@ -1,0 +1,103 @@
+# CSM Observatory Operator Report
+
+## Purpose
+
+The CSM Observatory operator report is the text proof surface for the
+visibility packet. It lets an operator, reviewer, or third-party reader inspect
+the manifold state without opening the visual console.
+
+The report is intentionally not a packet dump. It renders the same
+adl.csm_visibility_packet.v1 fixture into a compact Markdown brief that answers:
+
+- What is the manifold state right now?
+- What requires judgment?
+- Which citizens and invariants are safe, pending, or deferred?
+- Which evidence is fixture-backed, missing, or future Runtime v2 scope?
+
+## Source Contract
+
+Input packet:
+
+- demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
+
+Packet contract:
+
+- docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
+- adl/schemas/csm_visibility_packet.v1.schema.json
+
+Renderer:
+
+- adl/tools/render_csm_observatory_report.py
+
+Generated proof artifact:
+
+- demos/v0.90.1/csm_observatory_operator_report.md
+
+Validation:
+
+- bash adl/tools/test_demo_v0901_csm_observatory_operator_report.sh
+
+## Report Sections
+
+The report has stable sections so later CLI and review tooling can compare
+outputs:
+
+- Report Identity
+- Operator Summary
+- Attention Items
+- Manifold And Kernel
+- Citizens
+- Freedom Gate Docket
+- Invariant Review
+- Resources
+- Trace Tail
+- Operator Action Boundary
+- Evidence And Caveats
+- Next Consumers
+- Reviewer Use
+
+## Attention Model
+
+The renderer promotes operator attention items from packet data instead of
+expecting the reviewer to infer them from raw JSON.
+
+Attention sources include:
+
+- manifold health attention items
+- deferred or missing snapshot state
+- non-active citizens
+- citizen alerts
+- non-healthy invariants, sorted by severity
+- causal gaps
+- open Freedom Gate questions
+- disabled mutation actions and their future issue links
+
+This model keeps the report useful even when the packet grows. Reviewers should
+see the judgment surface first, then supporting tables.
+
+## Truth Boundary
+
+Demo classification: fixture_backed.
+
+The first v0.90.1 report proves deterministic packet-to-report rendering. It
+does not prove a live CSM run, live Runtime v2 capture, live operator mutation,
+snapshot/wake completion, or v0.92 identity rebinding.
+
+The operator action section must preserve the read-only boundary. Mutation
+actions remain disabled until command packets route through the Runtime v2
+kernel/control plane.
+
+## Reviewer Use
+
+Use the generated report as a third-party review proof surface when the reviewer
+needs to inspect the Observatory state without running a browser. It is also a
+good companion artifact for the static console because both surfaces are derived
+from the same packet contract.
+
+The report is especially useful for checking:
+
+- whether evidence labels and caveats are visible
+- whether attention routing is clear
+- whether the packet avoids private paths, endpoints, and raw transient dumps
+- whether the Observatory distinguishes fixture, missing, deferred, and future
+  live-runtime claims

--- a/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
+++ b/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
@@ -310,6 +310,8 @@ fixture labeling, and obvious path or endpoint leakage.
 - Fixture packet: demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
 - Validator: adl/tools/validate_csm_visibility_packet.py
 - Focused test: adl/tools/test_csm_visibility_packet.sh
+- Operator report: demos/v0.90.1/csm_observatory_operator_report.md
+- Operator report renderer: adl/tools/render_csm_observatory_report.py
 
 ## Non-Goals
 

--- a/docs/milestones/v0.90.1/features/README.md
+++ b/docs/milestones/v0.90.1/features/README.md
@@ -24,3 +24,8 @@ v2 artifacts to reviewer-facing console, report, CLI, and future operator
 command surfaces:
 
 - `CSM_OBSERVATORY_VISIBILITY_PACKET.md`
+
+The first text report surface renders that packet into a compact operator and
+reviewer brief:
+
+- `CSM_OBSERVATORY_OPERATOR_REPORT.md`


### PR DESCRIPTION
Closes #2190

## Summary
Implemented a deterministic CSM Observatory operator-report surface that turns
the fixture-backed visibility packet into a compact Markdown proof artifact for
operators and reviewers. The report highlights attention items, manifold/kernel
state, citizen lifecycle state, Freedom Gate decisions, invariant risks,
resources, trace tail, disabled operator actions, evidence references, and
caveats without requiring the HTML console.

## Artifacts
- docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_REPORT.md
- adl/tools/render_csm_observatory_report.py
- adl/tools/test_demo_v0901_csm_observatory_operator_report.sh
- demos/v0.90.1/csm_observatory_operator_report.md
- Updated demos/README.md with the operator-report proof command.
- Updated docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md and feature README links.
- Updated docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md proof surfaces.

## Validation
- Validation commands and their purpose:
- bash adl/tools/test_demo_v0901_csm_observatory_operator_report.sh
  - Verifies packet validity, generated-report byte-stability, Python compilation, required report sections/attention items/caveats, disabled operator mutations, and leakage hygiene for the report surface.
- bash adl/tools/test_csm_visibility_packet.sh
  - Re-runs the underlying CSM visibility packet contract fixture validation to prove the report source remains valid.
- python3 adl/tools/render_csm_observatory_report.py demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json --output .csm_observatory_operator_report_check.md && diff -u demos/v0.90.1/csm_observatory_operator_report.md .csm_observatory_operator_report_check.md && rm -f .csm_observatory_operator_report_check.md
  - Verifies deterministic renderer replay produces the tracked Markdown report byte-for-byte.
- Focused rg leakage scan over demos/v0.90.1/csm_observatory_operator_report.md, docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_REPORT.md, and adl/tools/render_csm_observatory_report.py
  - Verifies the report, feature doc, and renderer do not contain private host paths, endpoints, or credential-like text.
- Results: all commands passed. The rg leakage scan exited 1 because it found no matches.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2190__v0-90-1-csm-observatory-operator-report-generator/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2190__v0-90-1-csm-observatory-operator-report-generator/sor.md
- Idempotency-Key: v0-90-1-csm-observatory-operator-report-generator-adl-tools-render-csm-observatory-report-py-adl-tools-test-demo-v0901-csm-observatory-operator-report-sh-demos-v0-90-1-csm-observatory-operator-report-md-docs-milestones-v0-90-1-features-csm-observatory-operator-report-md-demos-readme-md-docs-milestones-v0-90-1-feature-docs-v0-90-1-md-docs-milestones-v0-90-1-features-csm-observatory-visibility-packet-md-docs-milestones-v0-90-1-features-readme-md-adl-v0-90-1-tasks-issue-2190-v0-90-1-csm-observatory-operator-report-generator-sip-md-adl-v0-90-1-tasks-issue-2190-v0-90-1-csm-observatory-operator-report-generator-sor-md