### PR TITLE
[v0.90.1][CSM Observatory] CLI integration for packet report and console output

### DIFF
--- a/adl/src/cli/csm_cmd.rs
+++ b/adl/src/cli/csm_cmd.rs
@@ -1,0 +1,102 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use ::adl::csm_observatory::{write_observatory_outputs, ObservatoryFormat};
+
+pub(crate) fn real_csm(args: &[String]) -> Result<()> {
+    let Some(cmd) = args.first().map(|value| value.as_str()) else {
+        eprintln!("csm requires subcommand: observatory");
+        std::process::exit(2);
+    };
+
+    match cmd {
+        "observatory" => real_observatory(&args[1..]),
+        "--help" | "-h" => {
+            println!("{}", csm_usage());
+            Ok(())
+        }
+        other => {
+            eprintln!("unknown csm subcommand: {other}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn real_observatory(args: &[String]) -> Result<()> {
+    let mut packet: Option<PathBuf> = None;
+    let mut out_dir = PathBuf::from("out/csm-observatory");
+    let mut format = ObservatoryFormat::Bundle;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--packet" => {
+                let Some(value) = args.get(i + 1) else {
+                    eprintln!("csm observatory requires --packet <visibility-packet.json>");
+                    std::process::exit(2);
+                };
+                packet = Some(PathBuf::from(value));
+                i += 1;
+            }
+            "--out" => {
+                let Some(value) = args.get(i + 1) else {
+                    eprintln!("csm observatory requires --out <dir>");
+                    std::process::exit(2);
+                };
+                out_dir = PathBuf::from(value);
+                i += 1;
+            }
+            "--format" => {
+                let Some(value) = args.get(i + 1) else {
+                    eprintln!("csm observatory requires --format <bundle|json|report>");
+                    std::process::exit(2);
+                };
+                format = ObservatoryFormat::parse(value)?;
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", csm_usage());
+                return Ok(());
+            }
+            other => {
+                eprintln!("unknown csm observatory arg: {other}");
+                std::process::exit(2);
+            }
+        }
+        i += 1;
+    }
+
+    let packet = packet.context("csm observatory requires --packet <visibility-packet.json>")?;
+    let output = write_observatory_outputs(&packet, &out_dir, format)?;
+
+    println!(
+        "CSM_OBSERVATORY ok format={format:?} out={}",
+        out_dir.display()
+    );
+    if let Some(path) = output.packet_path {
+        println!("  packet={}", path.display());
+    }
+    if let Some(path) = output.report_path {
+        println!("  report={}", path.display());
+    }
+    if let Some(path) = output.console_reference_path {
+        println!("  console_reference={}", path.display());
+    }
+    if let Some(path) = output.manifest_path {
+        println!("  manifest={}", path.display());
+    }
+    Ok(())
+}
+
+fn csm_usage() -> &'static str {
+    "Usage:
+  adl csm observatory --packet <visibility-packet.json> [--format bundle|json|report] [--out <dir>]
+
+Semantics:
+  - Read-only CSM Observatory inspection.
+  - Validates the visibility packet before emitting artifacts.
+  - bundle writes visibility_packet.json, operator_report.md, console_reference.md, and demo_manifest.json.
+  - json writes visibility_packet.json.
+  - report writes operator_report.md.
+  - No live Runtime v2 mutation is performed."
+}

--- a/adl/src/cli/mod.rs
+++ b/adl/src/cli/mod.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 mod agent_cmd;
 mod artifact_cmd;
 mod commands;
+mod csm_cmd;
 mod demo_cmd;
 mod godel_cmd;
 mod identity_cmd;
@@ -24,6 +25,7 @@ mod usage;
 use agent_cmd::real_agent;
 use artifact_cmd::real_artifact;
 use commands::{real_instrument, real_keygen, real_learn, real_sign, real_verify};
+use csm_cmd::real_csm;
 use demo_cmd::real_demo;
 use godel_cmd::real_godel;
 use identity_cmd::real_identity;
@@ -82,6 +84,7 @@ fn dispatch_args(args: &[String]) -> Result<()> {
     match args.first().map(|s| s.as_str()) {
         Some("artifact") => real_artifact(&args[1..]),
         Some("agent") => real_agent(&args[1..]),
+        Some("csm") => real_csm(&args[1..]),
         Some("demo") => real_demo(&args[1..]),
         Some("godel") => real_godel(&args[1..]),
         Some("identity") => real_identity(&args[1..]),

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -8,6 +8,7 @@ pub fn usage() -> &'static str {
   adl agent inspect --spec <agent-spec.yaml> [--cycle <cycle-id>] [--json]
   adl agent stop --spec <agent-spec.yaml> --reason <text> [--json]
   adl artifact validate-control-path --root <dir>
+  adl csm observatory --packet <visibility-packet.json> [--format bundle|json|report] [--out <dir>]
   adl demo <name> [--print-plan] [--trace] [--run] [--out <dir>] [--quiet] [--open] [--no-open]
   adl identity init --name <display-name> --birthday <rfc3339> --timezone <IANA> [--agent-id <id>] [--created-by <name>] [--force]
   adl identity show [--path <path>]
@@ -80,6 +81,7 @@ Examples:
   adl agent inspect --spec .adl/long_lived_agents/example-agent.yaml --json
   adl agent stop --spec .adl/long_lived_agents/example-agent.yaml --reason \"operator pause\"
   adl artifact validate-control-path --root /tmp/adl-v086-control-path-demo/demo-g-v086-control-path
+  adl csm observatory --packet demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json --format bundle --out artifacts/v0901/csm-observatory
   ADL_OLLAMA_BIN=adl/tools/mock_ollama_v0_4.sh adl examples/v0-4-demo-fork-join.adl.yaml --run --trace --out ./out
   adl examples/v0-3-concurrency-fork-join.adl.yaml --print-plan
   adl examples/v0-3-on-error-retry.adl.yaml --print-plan

--- a/adl/src/csm_observatory.rs
+++ b/adl/src/csm_observatory.rs
@@ -1,0 +1,525 @@
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const VISIBILITY_PACKET_SCHEMA: &str = "adl.csm_visibility_packet.v1";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ObservatoryFormat {
+    Bundle,
+    Json,
+    Report,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ObservatoryOutput {
+    pub packet_path: Option<PathBuf>,
+    pub report_path: Option<PathBuf>,
+    pub console_reference_path: Option<PathBuf>,
+    pub manifest_path: Option<PathBuf>,
+}
+
+impl ObservatoryFormat {
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw {
+            "bundle" => Ok(Self::Bundle),
+            "json" => Ok(Self::Json),
+            "report" => Ok(Self::Report),
+            other => {
+                bail!("unsupported CSM Observatory format '{other}' (expected bundle|json|report)")
+            }
+        }
+    }
+}
+
+pub fn load_visibility_packet(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("read CSM Observatory packet '{}'", path.display()))?;
+    let packet: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parse CSM Observatory packet '{}'", path.display()))?;
+    validate_visibility_packet(&packet)?;
+    Ok(packet)
+}
+
+pub fn validate_visibility_packet(packet: &Value) -> Result<()> {
+    let Some(object) = packet.as_object() else {
+        bail!("CSM Observatory packet root must be an object");
+    };
+    let required = [
+        "schema",
+        "packet_id",
+        "generated_at",
+        "source",
+        "manifold",
+        "kernel",
+        "citizens",
+        "freedom_gate",
+        "invariants",
+        "resources",
+        "trace",
+        "operator_actions",
+        "review",
+    ];
+    for field in required {
+        if !object.contains_key(field) {
+            bail!("CSM Observatory packet missing required field '{field}'");
+        }
+    }
+    if packet.pointer("/schema").and_then(Value::as_str) != Some(VISIBILITY_PACKET_SCHEMA) {
+        bail!("CSM Observatory packet schema must be {VISIBILITY_PACKET_SCHEMA}");
+    }
+    let source_mode = packet.pointer("/source/mode").and_then(Value::as_str);
+    if source_mode == Some("fixture")
+        && packet
+            .pointer("/review/demo_classification")
+            .and_then(Value::as_str)
+            != Some("fixture_backed")
+    {
+        bail!("fixture CSM Observatory packets must be classified as fixture_backed");
+    }
+    if packet
+        .pointer("/operator_actions/available_actions")
+        .and_then(Value::as_array)
+        .is_none()
+    {
+        bail!("CSM Observatory packet operator_actions.available_actions must be a list");
+    }
+    Ok(())
+}
+
+pub fn write_observatory_outputs(
+    packet_path: &Path,
+    out_dir: &Path,
+    format: ObservatoryFormat,
+) -> Result<ObservatoryOutput> {
+    let packet = load_visibility_packet(packet_path)?;
+    fs::create_dir_all(out_dir)
+        .with_context(|| format!("create CSM Observatory output dir '{}'", out_dir.display()))?;
+
+    let mut output = ObservatoryOutput {
+        packet_path: None,
+        report_path: None,
+        console_reference_path: None,
+        manifest_path: None,
+    };
+
+    if matches!(format, ObservatoryFormat::Bundle | ObservatoryFormat::Json) {
+        let path = out_dir.join("visibility_packet.json");
+        fs::write(&path, serde_json::to_string_pretty(&packet)? + "\n")
+            .with_context(|| format!("write '{}'", path.display()))?;
+        output.packet_path = Some(path);
+    }
+
+    if matches!(
+        format,
+        ObservatoryFormat::Bundle | ObservatoryFormat::Report
+    ) {
+        let path = out_dir.join("operator_report.md");
+        fs::write(&path, render_operator_report(&packet))
+            .with_context(|| format!("write '{}'", path.display()))?;
+        output.report_path = Some(path);
+    }
+
+    if matches!(format, ObservatoryFormat::Bundle) {
+        let path = out_dir.join("console_reference.md");
+        fs::write(&path, render_console_reference(packet_path))
+            .with_context(|| format!("write '{}'", path.display()))?;
+        output.console_reference_path = Some(path);
+
+        let manifest_path = out_dir.join("demo_manifest.json");
+        fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&render_manifest(&packet, &output))? + "\n",
+        )
+        .with_context(|| format!("write '{}'", manifest_path.display()))?;
+        output.manifest_path = Some(manifest_path);
+    }
+
+    Ok(output)
+}
+
+fn render_manifest(packet: &Value, output: &ObservatoryOutput) -> Value {
+    json!({
+        "schema": "adl.csm_observatory.demo_manifest.v1",
+        "demo_id": "demo-v0901-csm-observatory",
+        "classification": packet.pointer("/review/demo_classification").and_then(Value::as_str).unwrap_or("unknown"),
+        "packet_id": packet.pointer("/packet_id").and_then(Value::as_str).unwrap_or("unknown"),
+        "proof_surfaces": {
+            "visibility_packet": output.packet_path.as_ref().map(display_path),
+            "operator_report": output.report_path.as_ref().map(display_path),
+            "console_reference": output.console_reference_path.as_ref().map(display_path),
+        },
+        "truth_boundary": packet.pointer("/source/claim_boundary").and_then(Value::as_str).unwrap_or("not recorded"),
+        "read_only": true,
+        "live_runtime_capture": packet.pointer("/source/mode").and_then(Value::as_str) == Some("live_runtime"),
+    })
+}
+
+fn display_path(path: &PathBuf) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn render_console_reference(packet_path: &Path) -> String {
+    let packet_ref = packet_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| packet_path.display().to_string());
+    format!(
+        concat!(
+            "# CSM Observatory Console Reference\n\n",
+            "The CLI bundle is read-only. To inspect the visual console, open:\n\n",
+            "- demos/v0.90.1/csm_observatory_static_console.html\n\n",
+            "The command input packet was:\n\n",
+            "- {}\n\n",
+            "The static console and this CLI bundle both consume the same ",
+            "adl.csm_visibility_packet.v1 contract. No live mutation is performed.\n"
+        ),
+        packet_ref
+    )
+}
+
+pub fn render_operator_report(packet: &Value) -> String {
+    let mut lines = Vec::new();
+    let manifold = packet.get("manifold").unwrap_or(&Value::Null);
+    let kernel = packet.get("kernel").unwrap_or(&Value::Null);
+    let source = packet.get("source").unwrap_or(&Value::Null);
+    let review = packet.get("review").unwrap_or(&Value::Null);
+
+    lines.push(format!(
+        "# CSM Observatory Operator Report: {}",
+        str_at(manifold, "/display_name")
+    ));
+    lines.push(String::new());
+    lines.push("## Report Identity".to_string());
+    lines.push(table_row(&["Field", "Value"]));
+    lines.push(table_row(&["---", "---"]));
+    lines.push(table_row(&["Packet", &str_at(packet, "/packet_id")]));
+    lines.push(table_row(&["Schema", &str_at(packet, "/schema")]));
+    lines.push(table_row(&["Generated", &str_at(packet, "/generated_at")]));
+    lines.push(table_row(&["Source mode", &str_at(source, "/mode")]));
+    lines.push(table_row(&[
+        "Evidence level",
+        &str_at(source, "/evidence_level"),
+    ]));
+    lines.push(table_row(&[
+        "Demo classification",
+        &str_at(review, "/demo_classification"),
+    ]));
+    lines.push(String::new());
+    lines.push("## Operator Summary".to_string());
+    lines.push(format!(
+        "The manifold is {} at tick {}. The kernel pulse is {} through event sequence {}. Current evidence is {}; claim boundary: {}",
+        str_at(manifold, "/state"),
+        str_at(manifold, "/current_tick"),
+        str_at(kernel, "/pulse/status"),
+        str_at(kernel, "/pulse/completed_through_event_sequence"),
+        str_at(source, "/evidence_level"),
+        str_at(source, "/claim_boundary")
+    ));
+    lines.push(String::new());
+    lines.push("## Attention Items".to_string());
+    for item in attention_items(packet) {
+        lines.push(format!("- {item}"));
+    }
+    lines.push(String::new());
+    lines.push("## Citizens".to_string());
+    lines.push(table_row(&[
+        "Citizen",
+        "State",
+        "Continuity",
+        "Episode",
+        "Capability",
+    ]));
+    lines.push(table_row(&["---", "---", "---", "---", "---"]));
+    for citizen in array_at(packet, "/citizens") {
+        let capability = if bool_at(citizen, "/capability_envelope/can_execute_episodes") {
+            "episode execution allowed"
+        } else {
+            "episode execution disabled"
+        };
+        lines.push(table_row(&[
+            &str_at(citizen, "/display_name"),
+            &str_at(citizen, "/lifecycle_state"),
+            &str_at(citizen, "/continuity_status"),
+            &str_at(citizen, "/current_episode"),
+            capability,
+        ]));
+    }
+    lines.push(String::new());
+    lines.push("## Freedom Gate Docket".to_string());
+    lines.push(format!(
+        "Counts: allow {}, defer {}, refuse {}.",
+        str_at(packet, "/freedom_gate/allow_count"),
+        str_at(packet, "/freedom_gate/defer_count"),
+        str_at(packet, "/freedom_gate/refuse_count")
+    ));
+    lines.push(String::new());
+    lines.push(table_row(&[
+        "Decision",
+        "Actor",
+        "Action",
+        "Rationale",
+        "Evidence",
+    ]));
+    lines.push(table_row(&["---", "---", "---", "---", "---"]));
+    for entry in array_at(packet, "/freedom_gate/recent_docket") {
+        lines.push(table_row(&[
+            &str_at(entry, "/decision"),
+            &str_at(entry, "/actor"),
+            &str_at(entry, "/action"),
+            &str_at(entry, "/rationale"),
+            &str_at(entry, "/evidence_ref"),
+        ]));
+    }
+    lines.push(String::new());
+    lines.push("## Invariant Review".to_string());
+    lines.push(table_row(&["Invariant", "State", "Severity", "Evidence"]));
+    lines.push(table_row(&["---", "---", "---", "---"]));
+    for invariant in sorted_invariants(packet) {
+        lines.push(table_row(&[
+            &str_at(invariant, "/name"),
+            &str_at(invariant, "/state"),
+            &str_at(invariant, "/severity"),
+            &str_at(invariant, "/evidence_ref"),
+        ]));
+    }
+    lines.push(String::new());
+    lines.push("## Operator Action Boundary".to_string());
+    lines.push("Available read-only actions:".to_string());
+    for action in array_at(packet, "/operator_actions/available_actions") {
+        lines.push(format!(
+            "- {}: {}",
+            str_at(action, "/action"),
+            str_at(action, "/status")
+        ));
+    }
+    lines.push(String::new());
+    lines.push("Disabled mutation actions:".to_string());
+    for action in array_at(packet, "/operator_actions/disabled_actions") {
+        lines.push(format!(
+            "- {}: {}",
+            str_at(action, "/action"),
+            str_at(action, "/reason")
+        ));
+    }
+    lines.push(String::new());
+    lines.push("## Evidence And Caveats".to_string());
+    lines.push("Primary evidence references:".to_string());
+    for reference in evidence_refs(packet) {
+        lines.push(format!("- {reference}"));
+    }
+    lines.push(String::new());
+    lines.push("Caveats:".to_string());
+    for caveat in array_at(packet, "/review/caveats") {
+        lines.push(format!("- {}", value_text(caveat)));
+    }
+    lines.push(String::new());
+    lines.push("## Reviewer Use".to_string());
+    lines.push("This report is a proof surface for the packet-to-operator-report path. It is useful for reviewing visibility semantics, attention routing, claim boundaries, and evidence coverage without opening the HTML console.".to_string());
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+fn attention_items(packet: &Value) -> Vec<String> {
+    let mut items = Vec::new();
+    for item in array_at(packet, "/manifold/health/attention_items") {
+        let text = capitalize(&value_text(item));
+        if !text.to_ascii_lowercase().contains("snapshot evidence")
+            && !text.to_ascii_lowercase().contains("proposed, not active")
+        {
+            items.push((2, text));
+        }
+    }
+    if matches!(
+        packet
+            .pointer("/manifold/snapshot_status/state")
+            .and_then(Value::as_str),
+        Some("deferred" | "missing" | "blocked")
+    ) {
+        items.push((
+            1,
+            format!(
+                "Snapshot evidence is {}: {}",
+                str_at(packet, "/manifold/snapshot_status/state"),
+                str_at(packet, "/manifold/snapshot_status/note")
+            ),
+        ));
+    }
+    for citizen in array_at(packet, "/citizens") {
+        if str_at(citizen, "/lifecycle_state") != "active" {
+            items.push((
+                1,
+                format!(
+                    "{} is {}, not active; continuity is {}.",
+                    str_at(citizen, "/display_name"),
+                    str_at(citizen, "/lifecycle_state"),
+                    str_at(citizen, "/continuity_status")
+                ),
+            ));
+        }
+    }
+    for invariant in array_at(packet, "/invariants") {
+        if str_at(invariant, "/state") != "healthy" {
+            items.push((
+                severity_rank(&str_at(invariant, "/severity")),
+                format!(
+                    "{} is {} ({}); evidence: {}.",
+                    str_at(invariant, "/name"),
+                    str_at(invariant, "/state"),
+                    str_at(invariant, "/severity"),
+                    str_at(invariant, "/evidence_ref")
+                ),
+            ));
+        }
+    }
+    for gap in array_at(packet, "/trace/causal_gaps") {
+        items.push((
+            severity_rank(&str_at(gap, "/severity")),
+            format!(
+                "{}: {}",
+                capitalize(&str_at(gap, "/severity")),
+                str_at(gap, "/summary")
+            ),
+        ));
+    }
+    for question in array_at(packet, "/freedom_gate/open_questions") {
+        items.push((
+            2,
+            format!("Open Freedom Gate question: {}", value_text(question)),
+        ));
+    }
+    for action in array_at(packet, "/operator_actions/disabled_actions") {
+        let issue_suffix = action
+            .pointer("/future_issue")
+            .and_then(Value::as_i64)
+            .map(|issue| format!(" Future issue: #{issue}."))
+            .unwrap_or_default();
+        items.push((
+            2,
+            format!(
+                "Operator action {} remains disabled: {}.{}",
+                str_at(action, "/action"),
+                str_at(action, "/reason").trim_end_matches('.'),
+                issue_suffix
+            ),
+        ));
+    }
+    items.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+    items.dedup_by(|left, right| left.1.eq_ignore_ascii_case(&right.1));
+    items.into_iter().map(|(_, item)| item).collect()
+}
+
+fn sorted_invariants(packet: &Value) -> Vec<&Value> {
+    let mut invariants = array_at(packet, "/invariants");
+    invariants.sort_by(|left, right| {
+        severity_rank(&str_at(left, "/severity"))
+            .cmp(&severity_rank(&str_at(right, "/severity")))
+            .then_with(|| str_at(left, "/name").cmp(&str_at(right, "/name")))
+    });
+    invariants
+}
+
+fn evidence_refs(packet: &Value) -> Vec<String> {
+    let mut refs = Vec::new();
+    for pointer in [
+        "/source/source_refs",
+        "/manifold/evidence_refs",
+        "/kernel/pulse/evidence_refs",
+        "/review/primary_artifacts",
+    ] {
+        for item in array_at(packet, pointer) {
+            let item = value_text(item);
+            if !refs.contains(&item) {
+                refs.push(item);
+            }
+        }
+    }
+    refs
+}
+
+fn table_row(values: &[&str]) -> String {
+    format!("| {} |", values.join(" | "))
+}
+
+fn str_at(value: &Value, pointer: &str) -> String {
+    value
+        .pointer(pointer)
+        .map(value_text)
+        .unwrap_or_else(|| "not recorded".to_string())
+}
+
+fn value_text(value: &Value) -> String {
+    match value {
+        Value::Null => "not recorded".to_string(),
+        Value::String(text) if text.trim().is_empty() => "not recorded".to_string(),
+        Value::String(text) => text.clone(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn array_at<'a>(value: &'a Value, pointer: &str) -> Vec<&'a Value> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().collect())
+        .unwrap_or_default()
+}
+
+fn bool_at(value: &Value, pointer: &str) -> bool {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn capitalize(value: &str) -> String {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn severity_rank(value: &str) -> usize {
+    match value {
+        "critical" => 0,
+        "high" => 1,
+        "medium" => 2,
+        "low" => 3,
+        _ => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_packet() -> Value {
+        serde_json::from_str(include_str!(
+            "../../demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+        ))
+        .expect("fixture packet")
+    }
+
+    #[test]
+    fn fixture_packet_validates() {
+        validate_visibility_packet(&fixture_packet()).expect("valid fixture");
+    }
+
+    #[test]
+    fn operator_report_highlights_attention_items() {
+        let report = render_operator_report(&fixture_packet());
+        assert!(report.contains("CSM Observatory Operator Report"));
+        assert!(report.contains("Attention Items"));
+        assert!(report.contains("Snapshot evidence is deferred"));
+        assert!(report.contains("Operator action pause_citizen remains disabled"));
+        assert!(report.contains(
+            "This packet is a fixture-backed contract and does not prove a live CSM run."
+        ));
+    }
+}

--- a/adl/src/csm_observatory.rs
+++ b/adl/src/csm_observatory.rs
@@ -146,9 +146,9 @@ fn render_manifest(packet: &Value, output: &ObservatoryOutput) -> Value {
         "classification": packet.pointer("/review/demo_classification").and_then(Value::as_str).unwrap_or("unknown"),
         "packet_id": packet.pointer("/packet_id").and_then(Value::as_str).unwrap_or("unknown"),
         "proof_surfaces": {
-            "visibility_packet": output.packet_path.as_ref().map(display_path),
-            "operator_report": output.report_path.as_ref().map(display_path),
-            "console_reference": output.console_reference_path.as_ref().map(display_path),
+            "visibility_packet": output.packet_path.as_deref().map(display_path),
+            "operator_report": output.report_path.as_deref().map(display_path),
+            "console_reference": output.console_reference_path.as_deref().map(display_path),
         },
         "truth_boundary": packet.pointer("/source/claim_boundary").and_then(Value::as_str).unwrap_or("not recorded"),
         "read_only": true,
@@ -156,7 +156,7 @@ fn render_manifest(packet: &Value, output: &ObservatoryOutput) -> Value {
     })
 }
 
-fn display_path(path: &PathBuf) -> String {
+fn display_path(path: &Path) -> String {
     path.file_name()
         .map(|name| name.to_string_lossy().to_string())
         .unwrap_or_else(|| path.display().to_string())

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -19,6 +19,7 @@ pub mod bounded_executor;
 pub mod chronosense;
 pub mod continuous_verification_self_attack;
 pub mod control_plane;
+pub mod csm_observatory;
 pub mod delegation_policy;
 pub mod delegation_refusal_coordination;
 pub mod demo;

--- a/adl/tests/cli_smoke/instrument_and_cli.rs
+++ b/adl/tests/cli_smoke/instrument_and_cli.rs
@@ -98,6 +98,49 @@ fn instrument_replay_and_diff_trace_outputs_are_stable() {
 }
 
 #[test]
+fn csm_observatory_cli_writes_fixture_backed_bundle() {
+    let out_dir = unique_test_temp_dir("csm-observatory-cli");
+    let packet =
+        fixture_path("../demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json");
+    let out = run_adl(&[
+        "csm",
+        "observatory",
+        "--packet",
+        packet.to_str().unwrap(),
+        "--format",
+        "bundle",
+        "--out",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(
+        out.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let manifest = fs::read_to_string(out_dir.join("demo_manifest.json")).unwrap();
+    let report = fs::read_to_string(out_dir.join("operator_report.md")).unwrap();
+    assert!(out_dir.join("visibility_packet.json").is_file());
+    assert!(out_dir.join("console_reference.md").is_file());
+    assert!(manifest.contains("adl.csm_observatory.demo_manifest.v1"));
+    assert!(manifest.contains("fixture_backed"));
+    assert!(report.contains("CSM Observatory Operator Report"));
+    assert!(report.contains("Operator action pause_citizen remains disabled"));
+}
+
+#[test]
+fn csm_observatory_cli_fails_safely_on_missing_packet() {
+    let out = run_adl(&[
+        "csm",
+        "observatory",
+        "--packet",
+        "missing-csm-observatory-packet.json",
+    ]);
+    assert_failure_contains(&out, "read CSM Observatory packet");
+}
+
+#[test]
 fn run_flag_executes_fixture_with_mock_provider_and_writes_outputs() {
     let out_dir = unique_test_temp_dir("cli-run-mock").join("out");
     let runs_root = unique_test_temp_dir("cli-run-mock-runs");

--- a/adl/tests/cli_smoke/instrument_and_cli.rs
+++ b/adl/tests/cli_smoke/instrument_and_cli.rs
@@ -141,6 +141,93 @@ fn csm_observatory_cli_fails_safely_on_missing_packet() {
 }
 
 #[test]
+fn csm_observatory_cli_writes_report_only_output() {
+    let out_dir = unique_test_temp_dir("csm-observatory-report-only");
+    let packet =
+        fixture_path("../demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json");
+    let out = run_adl(&[
+        "csm",
+        "observatory",
+        "--packet",
+        packet.to_str().unwrap(),
+        "--format",
+        "report",
+        "--out",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(
+        out.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let report = fs::read_to_string(out_dir.join("operator_report.md")).unwrap();
+    assert!(stdout.contains("report="), "stdout:\n{stdout}");
+    assert!(!out_dir.join("visibility_packet.json").exists());
+    assert!(!out_dir.join("demo_manifest.json").exists());
+    assert!(report.contains("CSM Observatory Operator Report"));
+}
+
+#[test]
+fn csm_observatory_cli_writes_json_only_output() {
+    let out_dir = unique_test_temp_dir("csm-observatory-json-only");
+    let packet =
+        fixture_path("../demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json");
+    let out = run_adl(&[
+        "csm",
+        "observatory",
+        "--packet",
+        packet.to_str().unwrap(),
+        "--format",
+        "json",
+        "--out",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(
+        out.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let packet_copy = fs::read_to_string(out_dir.join("visibility_packet.json")).unwrap();
+    assert!(stdout.contains("packet="), "stdout:\n{stdout}");
+    assert!(!out_dir.join("operator_report.md").exists());
+    assert!(!out_dir.join("demo_manifest.json").exists());
+    assert!(packet_copy.contains("adl.csm_visibility_packet.v1"));
+}
+
+#[test]
+fn csm_observatory_cli_help_surfaces_usage() {
+    let top_help = run_adl(&["csm", "--help"]);
+    assert!(
+        top_help.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&top_help.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&top_help.stdout).contains("adl csm observatory --packet"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&top_help.stdout)
+    );
+
+    let subcommand_help = run_adl(&["csm", "observatory", "--help"]);
+    assert!(
+        subcommand_help.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&subcommand_help.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&subcommand_help.stdout).contains("bundle writes"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&subcommand_help.stdout)
+    );
+}
+
+#[test]
 fn run_flag_executes_fixture_with_mock_provider_and_writes_outputs() {
     let out_dir = unique_test_temp_dir("cli-run-mock").join("out");
     let runs_root = unique_test_temp_dir("cli-run-mock-runs");

--- a/adl/tools/demo_v0901_csm_observatory.sh
+++ b/adl/tools/demo_v0901_csm_observatory.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-"${ROOT_DIR}/artifacts/v0901/csm-observatory"}"
+PACKET="${ROOT_DIR}/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+
+cargo run -q --manifest-path "${ROOT_DIR}/adl/Cargo.toml" --bin adl -- \
+  csm observatory \
+  --packet "${PACKET}" \
+  --format bundle \
+  --out "${OUT_DIR}"
+
+for path in \
+  "${OUT_DIR}/visibility_packet.json" \
+  "${OUT_DIR}/operator_report.md" \
+  "${OUT_DIR}/console_reference.md" \
+  "${OUT_DIR}/demo_manifest.json"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "missing CSM Observatory demo artifact: ${path}" >&2
+    exit 1
+  fi
+done
+
+grep -Fq "CSM Observatory Operator Report" "${OUT_DIR}/operator_report.md"
+grep -Fq "Snapshot evidence is deferred" "${OUT_DIR}/operator_report.md"
+grep -Fq "Operator action pause_citizen remains disabled" "${OUT_DIR}/operator_report.md"
+grep -Fq '"schema": "adl.csm_observatory.demo_manifest.v1"' "${OUT_DIR}/demo_manifest.json"
+grep -Fq '"classification": "fixture_backed"' "${OUT_DIR}/demo_manifest.json"
+
+if grep -E "/Users/|/private/var/|localhost:[0-9]+|192\\.168\\.|Bearer |api[_-]?key|secret|token" \
+  "${OUT_DIR}/operator_report.md" \
+  "${OUT_DIR}/console_reference.md" \
+  "${OUT_DIR}/demo_manifest.json" >/dev/null; then
+  echo "CSM Observatory demo leaked private path, endpoint, or secret-like text" >&2
+  exit 1
+fi
+
+echo "CSM Observatory demo passed: ${OUT_DIR}"

--- a/demos/README.md
+++ b/demos/README.md
@@ -88,6 +88,12 @@ If you want the fixture-backed CSM Observatory operator report:
 bash adl/tools/test_demo_v0901_csm_observatory_operator_report.sh
 ```
 
+If you want the command-driven CSM Observatory demo bundle:
+
+```bash
+bash adl/tools/demo_v0901_csm_observatory.sh
+```
+
 ## Demo Categories
 
 - Runtime workflow demos live in `adl/examples/`.
@@ -247,6 +253,7 @@ staged `review-quality-evaluator` lane from `#2070` lands.
 
 - `v0.90.1/csm_observatory_static_console.md`
 - `v0.90.1/csm_observatory_operator_report.md`
+- `v0.90.1/csm_observatory_cli_demo.md`
 
 Use `v0.90.1/csm_observatory_static_console.html` for the first read-only CSM
 Observatory prototype. It renders the fixture-backed proto-csm-01 visibility
@@ -258,6 +265,10 @@ Use `bash adl/tools/test_demo_v0901_csm_observatory_operator_report.sh` to
 validate the packet-to-report proof surface. The generated Markdown report is a
 compact reviewer artifact for manifold status, citizen state, invariant risk,
 Freedom Gate decisions, trace tail, operator-action boundaries, and caveats.
+
+Use `bash adl/tools/demo_v0901_csm_observatory.sh` for the first command-driven
+Observatory demo bundle. It emits the packet copy, operator report, static
+console reference, and demo manifest from one ADL CLI command.
 
 Use `v0.87/v087_demo_program.md` for the canonical `v0.87` demo order and bounded
 repo-local commands.

--- a/demos/v0.90.1/csm_observatory_cli_demo.md
+++ b/demos/v0.90.1/csm_observatory_cli_demo.md
@@ -1,0 +1,52 @@
+# CSM Observatory CLI Demo
+
+## What This Is
+
+This is the command-driven CSM Observatory demo surface. It packages the
+fixture-backed visibility packet, operator report, and visual-console reference
+into one reviewable artifact directory.
+
+Run:
+
+```bash
+bash adl/tools/demo_v0901_csm_observatory.sh
+```
+
+The default output directory is:
+
+```text
+artifacts/v0901/csm-observatory
+```
+
+## Direct CLI Command
+
+The demo script wraps:
+
+```bash
+cargo run -q --manifest-path adl/Cargo.toml --bin adl -- csm observatory --packet demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json --format bundle --out artifacts/v0901/csm-observatory
+```
+
+Bundle mode writes:
+
+- visibility_packet.json
+- operator_report.md
+- console_reference.md
+- demo_manifest.json
+
+## Truth Boundary
+
+Demo classification: fixture_backed.
+
+This demo proves the CLI packaging path for CSM Observatory visibility. It does
+not prove a live CSM run, live Runtime v2 capture, live mutation, snapshot/wake
+completion, or v0.92 identity rebinding.
+
+All command behavior is read-only. The CLI validates and renders the packet; it
+does not mutate Runtime v2 state.
+
+## Why This Matters
+
+The static console is the spectacular human surface. The operator report is the
+reviewer notebook. This CLI demo is the reproducible packaging path that lets a
+reviewer regenerate both proof surfaces from the packet without manual file
+assembly.

--- a/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
+++ b/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
@@ -15,6 +15,7 @@ Issue wave open. Demo commands are not final until implementation WPs land.
 | D6 | Security boundary | WP-11 | One invalid action is rejected through normal kernel/policy path | security-boundary proof packet | PLANNED |
 | D7 | Runtime v2 integrated prototype | WP-12 | Reviewer can inspect the foundation prototype end to end | integrated proof packet | PLANNED |
 | D8 | Release evidence packet | WP-19 | Reviewer can trace demo, quality, review, and release-readiness evidence without reconstructing the milestone by hand | release-evidence packet | PLANNED |
+| D9 | CSM Observatory CLI bundle | #2191 | Reviewer can regenerate packet, operator report, console reference, and demo manifest from one read-only ADL CLI command | visibility_packet.json, operator_report.md, console_reference.md, demo_manifest.json | READY |
 
 ## Non-Proving Boundaries
 

--- a/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
@@ -11,6 +11,7 @@
 | `features/INVARIANT_AND_SECURITY_BOUNDARY.md` | invariant violation artifacts and one security-boundary proof | WP-09, WP-11 |
 | `features/CSM_OBSERVATORY_VISIBILITY_PACKET.md` | CSM visibility packet contract for Observatory console, reports, CLI, and operator-command follow-ons | #2188 |
 | `features/CSM_OBSERVATORY_OPERATOR_REPORT.md` | deterministic operator/reviewer report generated from the CSM visibility packet | #2190 |
+| `demos/v0.90.1/csm_observatory_cli_demo.md` | command-driven Observatory demo bundle for packet/report/console-reference proof | #2191 |
 
 ## Compression-Enabling Process Work
 

--- a/docs/milestones/v0.90.1/features/README.md
+++ b/docs/milestones/v0.90.1/features/README.md
@@ -29,3 +29,8 @@ The first text report surface renders that packet into a compact operator and
 reviewer brief:
 
 - `CSM_OBSERVATORY_OPERATOR_REPORT.md`
+
+The first command-driven demo bundle lives in the demo docs rather than this
+feature directory, because it is a run surface over the packet/report contracts:
+
+- `../../../../demos/v0.90.1/csm_observatory_cli_demo.md`


### PR DESCRIPTION
Closes #2191

## Summary
Implemented the first read-only ADL CLI command surface for CSM Observatory
outputs. The new command validates a visibility packet and writes JSON, report,
or bundled demo artifacts without mutating Runtime v2 state. Also added the
planned Observatory demo bundle so reviewers can regenerate packet, operator
report, console reference, and manifest artifacts from one command.

## Artifacts
- adl/src/csm_observatory.rs
- adl/src/cli/csm_cmd.rs
- adl/tools/demo_v0901_csm_observatory.sh
- demos/v0.90.1/csm_observatory_cli_demo.md
- Updated adl/src/lib.rs, adl/src/cli/mod.rs, and adl/src/cli/usage.rs for the csm observatory command.
- Updated adl/tests/cli_smoke/instrument_and_cli.rs with success and missing-packet failure coverage.
- Updated demos/README.md and docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md to surface the Observatory demo bundle.
- Updated docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md and docs/milestones/v0.90.1/features/README.md to link the CLI demo surface.

## Validation
- Validation commands and their purpose:
- cargo fmt --manifest-path adl/Cargo.toml --check
  - Verified Rust formatting for the new CSM Observatory module, CLI command, and test edits.
- cargo test --manifest-path adl/Cargo.toml csm_observatory -- --nocapture
  - Verified packet validation and report rendering unit tests.
- cargo test --manifest-path adl/Cargo.toml csm_observatory_cli -- --nocapture
  - Verified CLI integration success path and safe missing-packet failure path.
- bash adl/tools/demo_v0901_csm_observatory.sh scratch-output-dir
  - Verified the command-driven demo bundle emits visibility_packet.json, operator_report.md, console_reference.md, and demo_manifest.json with required markers and no private path, endpoint, or credential-like leakage inside generated artifacts.
- Focused rg private-path scan over the new Rust command/module docs and milestone/demo docs.
  - Verified no host-absolute paths or private endpoints were introduced into the tracked docs/code surfaces checked.
- Results: all validation passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2191__v0-90-1-csm-observatory-cli-integration/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2191__v0-90-1-csm-observatory-cli-integration/sor.md
- Idempotency-Key: v0-90-1-csm-observatory-cli-integration-for-packet-report-and-console-output-adl-src-csm-observatory-rs-adl-src-cli-csm-cmd-rs-adl-src-lib-rs-adl-src-cli-mod-rs-adl-src-cli-usage-rs-adl-tests-cli-smoke-instrument-and-cli-rs-adl-tools-demo-v0901-csm-observatory-sh-demos-v0-90-1-csm-observatory-cli-demo-md-demos-readme-md-docs-milestones-v0-90-1-demo-matrix-v0-90-1-md-docs-milestones-v0-90-1-feature-docs-v0-90-1-md-docs-milestones-v0-90-1-features-readme-md-adl-v0-90-1-tasks-issue-2191-v0-90-1-csm-observatory-cli-integration-sip-md-adl-v0-90-1-tasks-issue-2191-v0-90-1-csm-observatory-cli-integration-sor-md