### PR TITLE
[v0.90.1][CSM Observatory] Operator command packet design

### DIFF
--- a/adl/schemas/csm_operator_command_packet.v1.schema.json
+++ b/adl/schemas/csm_operator_command_packet.v1.schema.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-design-language.org/schemas/csm_operator_command_packet.v1.schema.json",
+  "title": "ADL CSM Operator Command Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "command_id",
+    "command_kind",
+    "requested_by",
+    "requested_at",
+    "target",
+    "intent",
+    "availability",
+    "safety",
+    "confirmation",
+    "kernel_handoff",
+    "event_logging",
+    "evidence_refs",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "adl.csm_operator_command_packet.v1"
+    },
+    "command_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "command_kind": {
+      "$ref": "#/$defs/command_kind"
+    },
+    "requested_by": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requested_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_kind",
+        "target_id",
+        "manifold_id",
+        "evidence_ref"
+      ],
+      "properties": {
+        "target_kind": {
+          "$ref": "#/$defs/target_kind"
+        },
+        "target_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "manifold_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "summary",
+        "rationale",
+        "requested_outcome"
+      ],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requested_outcome": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "availability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "reason",
+        "enabled_in"
+      ],
+      "properties": {
+        "state": {
+          "$ref": "#/$defs/availability_state"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "enabled_in": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "classification",
+        "policy_checks",
+        "side_effect_scope",
+        "operator_risk",
+        "citizen_risk"
+      ],
+      "properties": {
+        "classification": {
+          "$ref": "#/$defs/safety_classification"
+        },
+        "policy_checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "side_effect_scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_risk": {
+          "type": "string",
+          "minLength": 1
+        },
+        "citizen_risk": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "confirmation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "prompt",
+        "required_phrase",
+        "expires_after_seconds"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "prompt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "required_phrase": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expires_after_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        }
+      }
+    },
+    "kernel_handoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service",
+        "operation",
+        "policy_checks",
+        "trace_append_required",
+        "invariant_check_required",
+        "ui_direct_mutation_allowed"
+      ],
+      "properties": {
+        "service": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "trace_append_required": {
+          "type": "boolean"
+        },
+        "invariant_check_required": {
+          "type": "boolean"
+        },
+        "ui_direct_mutation_allowed": {
+          "const": false
+        }
+      }
+    },
+    "event_logging": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_schema",
+        "event_ref",
+        "required_fields",
+        "redact_prompt_or_tool_args",
+        "append_before_effect"
+      ],
+      "properties": {
+        "event_schema": {
+          "const": "adl.csm_operator_event.v1"
+        },
+        "event_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required_fields": {
+          "type": "array",
+          "minItems": 10,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "redact_prompt_or_tool_args": {
+          "const": true
+        },
+        "append_before_effect": {
+          "type": "boolean"
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "$defs": {
+    "command_kind": {
+      "enum": [
+        "inspect_manifold",
+        "inspect_citizen",
+        "inspect_episode",
+        "open_freedom_gate_decision",
+        "annotate_trace",
+        "ask_shepherd",
+        "pause_citizen",
+        "resume_citizen",
+        "request_snapshot",
+        "request_quiesce",
+        "request_wake",
+        "request_recovery_review"
+      ]
+    },
+    "target_kind": {
+      "enum": [
+        "manifold",
+        "citizen",
+        "episode",
+        "trace",
+        "invariant",
+        "freedom_gate",
+        "shepherd",
+        "kernel_service",
+        "snapshot"
+      ]
+    },
+    "availability_state": {
+      "enum": [
+        "available",
+        "disabled",
+        "deferred",
+        "requires_confirmation",
+        "submitted",
+        "refused"
+      ]
+    },
+    "safety_classification": {
+      "enum": [
+        "read_only",
+        "advisory",
+        "reversible_state_change",
+        "guarded_mutation",
+        "destructive_or_irreversible"
+      ]
+    }
+  }
+}

--- a/adl/tools/test_csm_operator_command_packets.sh
+++ b/adl/tools/test_csm_operator_command_packets.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PACKETS="${ROOT_DIR}/demos/fixtures/csm_observatory/proto-csm-01-operator-command-packets.json"
+EVENT="${ROOT_DIR}/demos/fixtures/csm_observatory/proto-csm-01-operator-event.json"
+SCHEMA="${ROOT_DIR}/adl/schemas/csm_operator_command_packet.v1.schema.json"
+DOC="${ROOT_DIR}/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md"
+VISIBILITY_DOC="${ROOT_DIR}/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md"
+VISIBILITY_PACKET="${ROOT_DIR}/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+
+python3 "${ROOT_DIR}/adl/tools/validate_csm_operator_command_packets.py" "${PACKETS}" "${EVENT}"
+python3 -m json.tool "${SCHEMA}" >/dev/null
+python3 -m json.tool "${PACKETS}" >/dev/null
+python3 -m json.tool "${EVENT}" >/dev/null
+
+grep -Fq "adl.csm_operator_command_packet.v1" "${DOC}"
+grep -Fq "The Observatory UI must never mutate Runtime v2 state directly" "${DOC}"
+grep -Fq "request_snapshot" "${DOC}"
+grep -Fq "ask_shepherd" "${DOC}"
+grep -Fq "ui_direct_mutation_allowed" "${SCHEMA}"
+grep -Fq '"ui_direct_mutation_allowed": false' "${PACKETS}"
+grep -Fq '"decision": "blocked"' "${EVENT}"
+grep -Fq "CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md" "${VISIBILITY_DOC}"
+grep -Fq "Runtime v2 kernel handling" "${VISIBILITY_PACKET}"
+
+if grep -REn '/Users/|/private/var/|localhost:[0-9]|192\.168\.|bearer[[:space:]]+[A-Za-z0-9._-]{8,}|(api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[A-Za-z0-9._-]{8,}' \
+  "${PACKETS}" "${EVENT}" "${SCHEMA}" "${DOC}" "${VISIBILITY_DOC}" "${VISIBILITY_PACKET}"; then
+  echo "CSM operator command packet artifacts leaked private path, endpoint, or secret-like text" >&2
+  exit 1
+fi
+
+echo "CSM operator command packet contract fixtures passed"

--- a/adl/tools/validate_csm_operator_command_packets.py
+++ b/adl/tools/validate_csm_operator_command_packets.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Validate CSM Observatory operator command packet examples."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import PurePosixPath
+from typing import Any
+
+
+COMMAND_KINDS = {
+    "inspect_manifold",
+    "inspect_citizen",
+    "inspect_episode",
+    "open_freedom_gate_decision",
+    "annotate_trace",
+    "ask_shepherd",
+    "pause_citizen",
+    "resume_citizen",
+    "request_snapshot",
+    "request_quiesce",
+    "request_wake",
+    "request_recovery_review",
+}
+
+TARGET_KINDS = {
+    "manifold",
+    "citizen",
+    "episode",
+    "trace",
+    "invariant",
+    "freedom_gate",
+    "shepherd",
+    "kernel_service",
+    "snapshot",
+}
+
+AVAILABILITY_STATES = {
+    "available",
+    "disabled",
+    "deferred",
+    "requires_confirmation",
+    "submitted",
+    "refused",
+}
+
+SAFETY_CLASSIFICATIONS = {
+    "read_only",
+    "advisory",
+    "reversible_state_change",
+    "guarded_mutation",
+    "destructive_or_irreversible",
+}
+
+EVENT_DECISIONS = {"recorded", "accepted", "deferred", "refused", "blocked"}
+
+REQUIRED_COMMAND_FIELDS = [
+    "schema",
+    "command_id",
+    "command_kind",
+    "requested_by",
+    "requested_at",
+    "target",
+    "intent",
+    "availability",
+    "safety",
+    "confirmation",
+    "kernel_handoff",
+    "event_logging",
+    "evidence_refs",
+    "claim_boundary",
+]
+
+REQUIRED_EVENT_FIELDS = [
+    "event_schema",
+    "event_id",
+    "command_id",
+    "command_kind",
+    "requested_by",
+    "requested_at",
+    "target",
+    "availability_state",
+    "safety_classification",
+    "decision",
+    "decision_reason",
+    "kernel_service",
+    "evidence_refs",
+]
+
+LEAK_PATTERNS = [
+    re.compile(r"/Users/[^\s\"']+"),
+    re.compile(r"/private/var/[^\s\"']+"),
+    re.compile(r"localhost:\d+"),
+    re.compile(r"192\.168\.\d+\.\d+"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]+"),
+    re.compile(r"(?i)(api[_-]?key|secret|token)\s*[:=]\s*[A-Za-z0-9._\-]{8,}"),
+]
+
+
+def add(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def mapping(errors: list[str], value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        add(errors, f"{path} must be an object")
+        return {}
+    return value
+
+
+def values(errors: list[str], value: Any, path: str, min_items: int = 0) -> list[Any]:
+    if not isinstance(value, list):
+        add(errors, f"{path} must be a list")
+        return []
+    if len(value) < min_items:
+        add(errors, f"{path} must contain at least {min_items} item(s)")
+    return value
+
+
+def require_fields(errors: list[str], value: dict[str, Any], fields: list[str], path: str) -> None:
+    for field in fields:
+        if field not in value:
+            add(errors, f"{path}.{field} is required")
+
+
+def walk_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        out: list[str] = []
+        for item in value:
+            out.extend(walk_strings(item))
+        return out
+    if isinstance(value, dict):
+        out = []
+        for item in value.values():
+            out.extend(walk_strings(item))
+        return out
+    return []
+
+
+def check_leakage(errors: list[str], value: Any) -> None:
+    for text in walk_strings(value):
+        for pattern in LEAK_PATTERNS:
+            if pattern.search(text):
+                add(errors, f"private path, endpoint, or secret-like value leaked: {text}")
+
+
+def check_ref(errors: list[str], value: Any, path: str) -> None:
+    if not isinstance(value, str):
+        add(errors, f"{path} must be a string")
+        return
+    if value.startswith(("http://", "https://")):
+        add(errors, f"{path} must not be a URL")
+        return
+    posix = PurePosixPath(value)
+    if posix.is_absolute() or ".." in posix.parts:
+        add(errors, f"{path} must be repository-relative")
+
+
+def validate_command(errors: list[str], command: dict[str, Any], path: str) -> None:
+    require_fields(errors, command, REQUIRED_COMMAND_FIELDS, path)
+    if command.get("schema") != "adl.csm_operator_command_packet.v1":
+        add(errors, f"{path}.schema must be adl.csm_operator_command_packet.v1")
+    if command.get("command_kind") not in COMMAND_KINDS:
+        add(errors, f"{path}.command_kind is invalid: {command.get('command_kind')}")
+
+    target = mapping(errors, command.get("target"), f"{path}.target")
+    require_fields(errors, target, ["target_kind", "target_id", "manifold_id", "evidence_ref"], f"{path}.target")
+    if target.get("target_kind") not in TARGET_KINDS:
+        add(errors, f"{path}.target.target_kind is invalid: {target.get('target_kind')}")
+    check_ref(errors, target.get("evidence_ref"), f"{path}.target.evidence_ref")
+
+    availability = mapping(errors, command.get("availability"), f"{path}.availability")
+    require_fields(errors, availability, ["state", "reason", "enabled_in"], f"{path}.availability")
+    if availability.get("state") not in AVAILABILITY_STATES:
+        add(errors, f"{path}.availability.state is invalid: {availability.get('state')}")
+
+    safety = mapping(errors, command.get("safety"), f"{path}.safety")
+    require_fields(
+        errors,
+        safety,
+        ["classification", "policy_checks", "side_effect_scope", "operator_risk", "citizen_risk"],
+        f"{path}.safety",
+    )
+    safety_classification = safety.get("classification")
+    if safety_classification not in SAFETY_CLASSIFICATIONS:
+        add(errors, f"{path}.safety.classification is invalid: {safety_classification}")
+    values(errors, safety.get("policy_checks"), f"{path}.safety.policy_checks", min_items=1)
+
+    confirmation = mapping(errors, command.get("confirmation"), f"{path}.confirmation")
+    require_fields(
+        errors,
+        confirmation,
+        ["required", "prompt", "required_phrase", "expires_after_seconds"],
+        f"{path}.confirmation",
+    )
+    if safety_classification in {"guarded_mutation", "destructive_or_irreversible"}:
+        if availability.get("state") not in {"disabled", "requires_confirmation", "refused"}:
+            add(errors, f"{path} guarded mutation must be disabled, refused, or require confirmation")
+        if availability.get("state") != "disabled" and confirmation.get("required") is not True:
+            add(errors, f"{path} enabled guarded mutation must require confirmation")
+
+    handoff = mapping(errors, command.get("kernel_handoff"), f"{path}.kernel_handoff")
+    require_fields(
+        errors,
+        handoff,
+        [
+            "service",
+            "operation",
+            "policy_checks",
+            "trace_append_required",
+            "invariant_check_required",
+            "ui_direct_mutation_allowed",
+        ],
+        f"{path}.kernel_handoff",
+    )
+    if handoff.get("ui_direct_mutation_allowed") is not False:
+        add(errors, f"{path}.kernel_handoff.ui_direct_mutation_allowed must be false")
+    if handoff.get("trace_append_required") is not True:
+        add(errors, f"{path}.kernel_handoff.trace_append_required must be true")
+    values(errors, handoff.get("policy_checks"), f"{path}.kernel_handoff.policy_checks", min_items=1)
+
+    event_logging = mapping(errors, command.get("event_logging"), f"{path}.event_logging")
+    require_fields(
+        errors,
+        event_logging,
+        [
+            "event_schema",
+            "event_ref",
+            "required_fields",
+            "redact_prompt_or_tool_args",
+            "append_before_effect",
+        ],
+        f"{path}.event_logging",
+    )
+    if event_logging.get("event_schema") != "adl.csm_operator_event.v1":
+        add(errors, f"{path}.event_logging.event_schema is invalid")
+    if event_logging.get("redact_prompt_or_tool_args") is not True:
+        add(errors, f"{path}.event_logging.redact_prompt_or_tool_args must be true")
+    check_ref(errors, event_logging.get("event_ref"), f"{path}.event_logging.event_ref")
+    required_fields = set(values(errors, event_logging.get("required_fields"), f"{path}.event_logging.required_fields", min_items=10))
+    missing = set(REQUIRED_EVENT_FIELDS) - required_fields
+    if missing:
+        add(errors, f"{path}.event_logging.required_fields missing: {', '.join(sorted(missing))}")
+
+    for index, ref in enumerate(values(errors, command.get("evidence_refs"), f"{path}.evidence_refs", min_items=1)):
+        check_ref(errors, ref, f"{path}.evidence_refs[{index}]")
+
+
+def validate_event(errors: list[str], event: dict[str, Any]) -> None:
+    require_fields(errors, event, REQUIRED_EVENT_FIELDS, "event")
+    if event.get("event_schema") != "adl.csm_operator_event.v1":
+        add(errors, "event.event_schema must be adl.csm_operator_event.v1")
+    if event.get("command_kind") not in COMMAND_KINDS:
+        add(errors, f"event.command_kind is invalid: {event.get('command_kind')}")
+    if event.get("availability_state") not in AVAILABILITY_STATES:
+        add(errors, f"event.availability_state is invalid: {event.get('availability_state')}")
+    if event.get("safety_classification") not in SAFETY_CLASSIFICATIONS:
+        add(errors, f"event.safety_classification is invalid: {event.get('safety_classification')}")
+    if event.get("decision") not in EVENT_DECISIONS:
+        add(errors, f"event.decision is invalid: {event.get('decision')}")
+    target = mapping(errors, event.get("target"), "event.target")
+    require_fields(errors, target, ["target_kind", "target_id", "manifold_id", "evidence_ref"], "event.target")
+    check_ref(errors, event.get("trace_ref"), "event.trace_ref")
+    for index, ref in enumerate(values(errors, event.get("evidence_refs"), "event.evidence_refs", min_items=1)):
+        check_ref(errors, ref, f"event.evidence_refs[{index}]")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet_set")
+    parser.add_argument("event")
+    args = parser.parse_args()
+
+    with open(args.packet_set, "r", encoding="utf-8") as handle:
+        packet_set = json.load(handle)
+    with open(args.event, "r", encoding="utf-8") as handle:
+        event = json.load(handle)
+
+    errors: list[str] = []
+    if packet_set.get("schema") != "adl.csm_operator_command_packet_examples.v1":
+        add(errors, "packet_set.schema must be adl.csm_operator_command_packet_examples.v1")
+    commands = values(errors, packet_set.get("commands"), "packet_set.commands", min_items=3)
+    observed = set()
+    for index, command_value in enumerate(commands):
+        command = mapping(errors, command_value, f"packet_set.commands[{index}]")
+        validate_command(errors, command, f"packet_set.commands[{index}]")
+        kind = command.get("command_kind")
+        if kind in observed:
+            add(errors, f"duplicate command_kind example: {kind}")
+        observed.add(kind)
+    for required in ["inspect_citizen", "request_snapshot", "ask_shepherd"]:
+        if required not in observed:
+            add(errors, f"missing required command example: {required}")
+
+    validate_event(errors, event)
+    if event.get("command_id") != "csm-cmd-proto-csm-01-request-snapshot-0001":
+        add(errors, "event must correspond to the disabled request_snapshot example")
+    if event.get("decision") != "blocked":
+        add(errors, "fixture request_snapshot event must remain blocked")
+
+    check_leakage(errors, packet_set)
+    check_leakage(errors, event)
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: {args.packet_set} and {args.event} are valid CSM operator command packet fixtures")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/fixtures/csm_observatory/proto-csm-01-operator-command-packets.json
+++ b/demos/fixtures/csm_observatory/proto-csm-01-operator-command-packets.json
@@ -1,0 +1,247 @@
+{
+  "schema": "adl.csm_operator_command_packet_examples.v1",
+  "packet_set_id": "proto-csm-01-operator-command-packets",
+  "manifold_id": "proto-csm-01",
+  "source_visibility_packet": "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json",
+  "claim_boundary": "Fixture-backed command packet examples only. These packets do not prove live Runtime v2 mutation.",
+  "commands": [
+    {
+      "schema": "adl.csm_operator_command_packet.v1",
+      "command_id": "csm-cmd-proto-csm-01-inspect-citizen-0001",
+      "command_kind": "inspect_citizen",
+      "requested_by": "operator.demo",
+      "requested_at": "2026-04-19T12:00:00Z",
+      "target": {
+        "target_kind": "citizen",
+        "target_id": "proto-citizen-alpha",
+        "manifold_id": "proto-csm-01",
+        "evidence_ref": "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+      },
+      "intent": {
+        "summary": "Inspect current citizen state and evidence references.",
+        "rationale": "Read-only inspection is safe for the fixture-backed Observatory.",
+        "requested_outcome": "Render citizen status without changing Runtime v2 state."
+      },
+      "availability": {
+        "state": "available",
+        "reason": "The static console already exposes read-only citizen inspection.",
+        "enabled_in": "v0.90.1 fixture-backed Observatory console"
+      },
+      "safety": {
+        "classification": "read_only",
+        "policy_checks": [
+          "target_identity_present",
+          "visibility_packet_evidence_present",
+          "no_runtime_mutation"
+        ],
+        "side_effect_scope": "none",
+        "operator_risk": "low",
+        "citizen_risk": "none"
+      },
+      "confirmation": {
+        "required": false,
+        "prompt": null,
+        "required_phrase": null,
+        "expires_after_seconds": null
+      },
+      "kernel_handoff": {
+        "service": "operator_control_interface",
+        "operation": "inspect_citizen",
+        "policy_checks": [
+          "validate_operator_identity",
+          "validate_target_identity",
+          "append_operator_event"
+        ],
+        "trace_append_required": true,
+        "invariant_check_required": false,
+        "ui_direct_mutation_allowed": false
+      },
+      "event_logging": {
+        "event_schema": "adl.csm_operator_event.v1",
+        "event_ref": "runtime_v2/traces/operator/inspect-citizen.json",
+        "required_fields": [
+          "event_schema",
+          "event_id",
+          "command_id",
+          "command_kind",
+          "requested_by",
+          "requested_at",
+          "target",
+          "availability_state",
+          "safety_classification",
+          "decision",
+          "decision_reason",
+          "kernel_service",
+          "evidence_refs"
+        ],
+        "redact_prompt_or_tool_args": true,
+        "append_before_effect": true
+      },
+      "evidence_refs": [
+        "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+      ],
+      "claim_boundary": "Read-only fixture-backed inspection example."
+    },
+    {
+      "schema": "adl.csm_operator_command_packet.v1",
+      "command_id": "csm-cmd-proto-csm-01-request-snapshot-0001",
+      "command_kind": "request_snapshot",
+      "requested_by": "operator.demo",
+      "requested_at": "2026-04-19T12:05:00Z",
+      "target": {
+        "target_kind": "manifold",
+        "target_id": "proto-csm-01",
+        "manifold_id": "proto-csm-01",
+        "evidence_ref": "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+      },
+      "intent": {
+        "summary": "Request a governed snapshot of the manifold.",
+        "rationale": "Snapshotting is a future safety operation and must not be triggered directly by the UI.",
+        "requested_outcome": "Submit to the snapshot manager only after kernel handlers exist."
+      },
+      "availability": {
+        "state": "disabled",
+        "reason": "The CSM Observatory has no live Runtime v2 snapshot command handler yet.",
+        "enabled_in": "future Runtime v2 snapshot command handler work"
+      },
+      "safety": {
+        "classification": "guarded_mutation",
+        "policy_checks": [
+          "validate_operator_identity",
+          "validate_manifold_identity",
+          "validate_invariants_before_snapshot",
+          "append_operator_event_before_effect",
+          "write_repository_relative_snapshot_artifacts"
+        ],
+        "side_effect_scope": "snapshot manager may quiesce and seal Runtime v2 state after approval",
+        "operator_risk": "medium",
+        "citizen_risk": "medium"
+      },
+      "confirmation": {
+        "required": true,
+        "prompt": "Confirm that the kernel may request a governed snapshot for proto-csm-01.",
+        "required_phrase": "REQUEST SNAPSHOT proto-csm-01",
+        "expires_after_seconds": 300
+      },
+      "kernel_handoff": {
+        "service": "snapshot_manager",
+        "operation": "request_snapshot",
+        "policy_checks": [
+          "validate_operator_identity",
+          "validate_snapshot_preconditions",
+          "validate_invariants_before_snapshot",
+          "append_operator_event",
+          "append_outcome_event"
+        ],
+        "trace_append_required": true,
+        "invariant_check_required": true,
+        "ui_direct_mutation_allowed": false
+      },
+      "event_logging": {
+        "event_schema": "adl.csm_operator_event.v1",
+        "event_ref": "runtime_v2/traces/operator/request-snapshot.json",
+        "required_fields": [
+          "event_schema",
+          "event_id",
+          "command_id",
+          "command_kind",
+          "requested_by",
+          "requested_at",
+          "target",
+          "availability_state",
+          "safety_classification",
+          "decision",
+          "decision_reason",
+          "kernel_service",
+          "evidence_refs"
+        ],
+        "redact_prompt_or_tool_args": true,
+        "append_before_effect": true
+      },
+      "evidence_refs": [
+        "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json",
+        "docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md"
+      ],
+      "claim_boundary": "Design-only disabled mutation example. No live snapshot is requested."
+    },
+    {
+      "schema": "adl.csm_operator_command_packet.v1",
+      "command_id": "csm-cmd-proto-csm-01-ask-shepherd-0001",
+      "command_kind": "ask_shepherd",
+      "requested_by": "operator.demo",
+      "requested_at": "2026-04-19T12:10:00Z",
+      "target": {
+        "target_kind": "shepherd",
+        "target_id": "proto-csm-01-shepherd",
+        "manifold_id": "proto-csm-01",
+        "evidence_ref": "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+      },
+      "intent": {
+        "summary": "Ask the shepherd for an evidence-grounded explanation of current manifold risk.",
+        "rationale": "A shepherd can help operators notice risk without receiving mutation authority.",
+        "requested_outcome": "Return an advisory explanation with evidence references and uncertainty."
+      },
+      "availability": {
+        "state": "deferred",
+        "reason": "The shepherd interface is not live yet; deterministic summaries remain the fallback.",
+        "enabled_in": "future ANRM or dedicated shepherd interface work"
+      },
+      "safety": {
+        "classification": "advisory",
+        "policy_checks": [
+          "visibility_packet_evidence_present",
+          "no_runtime_mutation",
+          "shepherd_output_must_cite_evidence",
+          "uncertainty_required"
+        ],
+        "side_effect_scope": "advisory response only",
+        "operator_risk": "low",
+        "citizen_risk": "low"
+      },
+      "confirmation": {
+        "required": false,
+        "prompt": null,
+        "required_phrase": null,
+        "expires_after_seconds": null
+      },
+      "kernel_handoff": {
+        "service": "shepherd_interface",
+        "operation": "ask_shepherd",
+        "policy_checks": [
+          "validate_operator_identity",
+          "ground_response_in_visibility_packet",
+          "append_operator_event"
+        ],
+        "trace_append_required": true,
+        "invariant_check_required": false,
+        "ui_direct_mutation_allowed": false
+      },
+      "event_logging": {
+        "event_schema": "adl.csm_operator_event.v1",
+        "event_ref": "runtime_v2/traces/operator/ask-shepherd.json",
+        "required_fields": [
+          "event_schema",
+          "event_id",
+          "command_id",
+          "command_kind",
+          "requested_by",
+          "requested_at",
+          "target",
+          "availability_state",
+          "safety_classification",
+          "decision",
+          "decision_reason",
+          "kernel_service",
+          "evidence_refs"
+        ],
+        "redact_prompt_or_tool_args": true,
+        "append_before_effect": true
+      },
+      "evidence_refs": [
+        "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json",
+        "docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md"
+      ],
+      "claim_boundary": "Advisory design example. The shepherd may recommend and explain, but never silently mutates CSM state."
+    }
+  ]
+}

--- a/demos/fixtures/csm_observatory/proto-csm-01-operator-event.json
+++ b/demos/fixtures/csm_observatory/proto-csm-01-operator-event.json
@@ -1,0 +1,31 @@
+{
+  "event_schema": "adl.csm_operator_event.v1",
+  "event_id": "csm-operator-event-proto-csm-01-request-snapshot-0001",
+  "command_id": "csm-cmd-proto-csm-01-request-snapshot-0001",
+  "command_kind": "request_snapshot",
+  "requested_by": "operator.demo",
+  "requested_at": "2026-04-19T12:05:00Z",
+  "recorded_at": "2026-04-19T12:05:01Z",
+  "target": {
+    "target_kind": "manifold",
+    "target_id": "proto-csm-01",
+    "manifold_id": "proto-csm-01",
+    "evidence_ref": "demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json"
+  },
+  "availability_state": "disabled",
+  "safety_classification": "guarded_mutation",
+  "decision": "blocked",
+  "decision_reason": "The command packet is valid as a design artifact, but live Runtime v2 snapshot command handling is not implemented.",
+  "kernel_service": "snapshot_manager",
+  "trace_ref": "runtime_v2/traces/operator/request-snapshot.json",
+  "evidence_refs": [
+    "demos/fixtures/csm_observatory/proto-csm-01-operator-command-packets.json",
+    "docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md"
+  ],
+  "redaction": {
+    "prompt_or_tool_args_redacted": true,
+    "private_paths_redacted": true,
+    "secret_material_redacted": true
+  },
+  "claim_boundary": "Fixture-backed operator event example only. No live Runtime v2 state changed."
+}

--- a/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
+++ b/demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json
@@ -368,17 +368,17 @@
     "disabled_actions": [
       {
         "action": "pause_citizen",
-        "reason": "Requires operator command packet design and kernel handling.",
+        "reason": "Requires Runtime v2 kernel handling of command packets.",
         "future_issue": 2192
       },
       {
         "action": "request_snapshot",
-        "reason": "Requires snapshot command packet and Runtime v2 snapshot implementation.",
+        "reason": "Requires Runtime v2 snapshot implementation and command handler.",
         "future_issue": 2192
       },
       {
         "action": "resume_citizen",
-        "reason": "Requires recovery eligibility and wake semantics.",
+        "reason": "Requires recovery eligibility, wake semantics, and Runtime v2 kernel handling.",
         "future_issue": 2192
       }
     ],

--- a/demos/v0.90.1/csm_observatory_cli_demo.md
+++ b/demos/v0.90.1/csm_observatory_cli_demo.md
@@ -44,6 +44,11 @@ completion, or v0.92 identity rebinding.
 All command behavior is read-only. The CLI validates and renders the packet; it
 does not mutate Runtime v2 state.
 
+Future operator actions are governed by the v0.90.1 command packet contract.
+That contract defines how pause, resume, snapshot, trace annotation, and
+shepherd requests must become kernel-routed command packets with operator-event
+logging before any live mutation is allowed.
+
 ## Why This Matters
 
 The static console is the spectacular human surface. The operator report is the

--- a/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
@@ -12,6 +12,7 @@
 | `features/CSM_OBSERVATORY_VISIBILITY_PACKET.md` | CSM visibility packet contract for Observatory console, reports, CLI, and operator-command follow-ons | #2188 |
 | `features/CSM_OBSERVATORY_OPERATOR_REPORT.md` | deterministic operator/reviewer report generated from the CSM visibility packet | #2190 |
 | `demos/v0.90.1/csm_observatory_cli_demo.md` | command-driven Observatory demo bundle for packet/report/console-reference proof | #2191 |
+| `features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md` | safe command packet contract for future Observatory pause/resume/snapshot/annotate/shepherd interactions without UI state mutation | #2192 |
 
 ## Compression-Enabling Process Work
 

--- a/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md
+++ b/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md
@@ -1,0 +1,312 @@
+# CSM Observatory Operator Command Packets
+
+## Purpose
+
+Define the safe packet contract for moving CSM Observatory from read-only
+visibility toward governed operator interaction.
+
+Schema name: adl.csm_operator_command_packet.v1
+
+The Observatory UI must never mutate Runtime v2 state directly. It may only
+submit bounded command packets to the Runtime v2 kernel/control plane. The
+kernel validates identity, policy, invariants, traceability, and command
+availability before any state transition is allowed.
+
+## Design Goal
+
+Every operator action must answer four questions before it can affect the CSM:
+
+- Who requested the action?
+- What exact target and intent were declared?
+- Which kernel service is responsible for accepting, deferring, or refusing it?
+- Which operator event proves the decision and any later effect?
+
+The packet is intentionally more formal than a UI button payload. It is a small
+constitutional instrument for a governed world.
+
+## Packet Contract
+
+Required top-level fields:
+
+- schema
+- command_id
+- command_kind
+- requested_by
+- requested_at
+- target
+- intent
+- availability
+- safety
+- confirmation
+- kernel_handoff
+- event_logging
+- evidence_refs
+- claim_boundary
+
+### Command Identity
+
+The command_id must be stable for retries and must not encode a host path,
+secret, prompt, or private operator note. The recommended shape is:
+
+```text
+csm-cmd-<manifold-or-citizen>-<action>-<sequence>
+```
+
+The requested_by field records an accountable operator or service principal. It
+must not contain personal secrets, local usernames, private hostnames, or raw
+session transcript text.
+
+### Command Kinds
+
+Allowed command_kind values for the first design pass:
+
+- inspect_manifold
+- inspect_citizen
+- inspect_episode
+- open_freedom_gate_decision
+- annotate_trace
+- ask_shepherd
+- pause_citizen
+- resume_citizen
+- request_snapshot
+- request_quiesce
+- request_wake
+- request_recovery_review
+
+Read-only commands may be available in the console before live mutation exists.
+State-changing commands remain disabled until Runtime v2 kernel handlers and
+operator-event append guarantees exist.
+
+### Target
+
+The target object must include:
+
+- target_kind
+- target_id
+- manifold_id
+- evidence_ref
+
+Allowed target_kind values:
+
+- manifold
+- citizen
+- episode
+- trace
+- invariant
+- freedom_gate
+- shepherd
+- kernel_service
+- snapshot
+
+All evidence references must be repository-relative artifact references. Public
+packets must not contain absolute host paths, local endpoints, secrets, raw
+prompts, or tool arguments.
+
+### Availability
+
+The availability object records whether the Observatory may surface the action:
+
+```json
+{
+  "state": "disabled",
+  "reason": "Runtime v2 has no live command handler for this action yet.",
+  "enabled_in": "future Runtime v2 kernel/control-plane work"
+}
+```
+
+Allowed availability states:
+
+- available
+- disabled
+- deferred
+- requires_confirmation
+- submitted
+- refused
+
+The UI may render disabled and deferred commands, but it must explain why the
+operator cannot execute them.
+
+### Safety Classification
+
+The safety object must include:
+
+- classification
+- policy_checks
+- side_effect_scope
+- operator_risk
+- citizen_risk
+
+Allowed classification values:
+
+- read_only
+- advisory
+- reversible_state_change
+- guarded_mutation
+- destructive_or_irreversible
+
+Rules:
+
+- read_only commands must not change Runtime v2 state.
+- advisory commands may call a shepherd model or deterministic summarizer but
+  must not mutate state.
+- reversible_state_change commands require an operator event and kernel policy
+  checks.
+- guarded_mutation commands require confirmation and invariant validation.
+- destructive_or_irreversible commands remain disabled unless a later milestone
+  explicitly accepts them.
+
+### Confirmation
+
+The confirmation object must include:
+
+- required
+- prompt
+- required_phrase
+- expires_after_seconds
+
+Dangerous or unavailable commands must either require explicit confirmation or
+remain disabled. A disabled command may set required to false only because it
+cannot be submitted yet.
+
+### Kernel Handoff
+
+The kernel_handoff object must include:
+
+- service
+- operation
+- policy_checks
+- trace_append_required
+- invariant_check_required
+- ui_direct_mutation_allowed
+
+The ui_direct_mutation_allowed field must always be false for CSM Observatory
+commands.
+
+The handoff sequence is:
+
+1. receive command packet
+2. assign temporal anchor
+3. validate operator identity and target identity
+4. validate policy and invariants
+5. append operator event
+6. route to responsible kernel service
+7. append outcome event
+
+No service may bypass trace append. No UI path may write the target Runtime v2
+state directly.
+
+### Event Logging
+
+Every command requires an operator event, even read-only inspection. The
+event_logging object must include:
+
+- event_schema
+- event_ref
+- required_fields
+- redact_prompt_or_tool_args
+- append_before_effect
+
+Required event fields:
+
+- event_schema
+- event_id
+- command_id
+- command_kind
+- requested_by
+- requested_at
+- target
+- availability_state
+- safety_classification
+- decision
+- decision_reason
+- kernel_service
+- evidence_refs
+
+Allowed decision values:
+
+- recorded
+- accepted
+- deferred
+- refused
+- blocked
+
+## Initial Action Table
+
+| Command | Safety | Initial state | Kernel owner | Event required |
+| --- | --- | --- | --- | --- |
+| inspect_manifold | read_only | available | operator_control_interface | yes |
+| inspect_citizen | read_only | available | operator_control_interface | yes |
+| inspect_episode | read_only | available | operator_control_interface | yes |
+| open_freedom_gate_decision | read_only | available | freedom_gate | yes |
+| annotate_trace | advisory | deferred | trace_system | yes |
+| ask_shepherd | advisory | deferred | shepherd_interface | yes |
+| pause_citizen | guarded_mutation | disabled | scheduler | yes |
+| resume_citizen | guarded_mutation | disabled | scheduler | yes |
+| request_snapshot | guarded_mutation | disabled | snapshot_manager | yes |
+| request_quiesce | guarded_mutation | disabled | scheduler | yes |
+| request_wake | guarded_mutation | disabled | scheduler | yes |
+| request_recovery_review | advisory | deferred | invariant_enforcement | yes |
+
+## Disabled Action Explanation Model
+
+Disabled actions must render an explanation with:
+
+- unavailable action
+- current blocker
+- required kernel capability
+- required evidence before enablement
+- safe alternative action
+
+Example:
+
+```json
+{
+  "action": "request_snapshot",
+  "current_blocker": "Snapshot command handling is not live in the CSM Observatory.",
+  "required_kernel_capability": "snapshot_manager.request_snapshot",
+  "required_evidence_before_enablement": [
+    "operator event append before effect",
+    "invariant checks pass before snapshot",
+    "snapshot artifact path is repository-relative"
+  ],
+  "safe_alternative_action": "inspect_manifold"
+}
+```
+
+## Shepherd Boundary
+
+The ask_shepherd command is advisory. It may produce a recommendation, concern,
+or explanation, but it must not silently mutate state. Shepherd output must cite
+visibility packet evidence or trace artifacts and must report uncertainty.
+
+ANRM or a dedicated shepherd model may later provide this role, including a
+trainable Gemma-backed local shepherd, but the command packet contract does not
+depend on training being complete.
+
+## Deferred Runtime Work
+
+This issue does not implement live pause, resume, snapshot, quiesce, wake,
+recovery, or shepherd execution. Those require Runtime v2 handlers that can
+prove:
+
+- operator-event append before effect
+- identity and target validation
+- invariant validation before mutation
+- replay-safe outcome events
+- no private path, endpoint, prompt, tool-argument, or secret leakage
+
+## Proof Surfaces
+
+- Schema: adl/schemas/csm_operator_command_packet.v1.schema.json
+- Example command packet set: demos/fixtures/csm_observatory/proto-csm-01-operator-command-packets.json
+- Example operator event: demos/fixtures/csm_observatory/proto-csm-01-operator-event.json
+- Validator: adl/tools/validate_csm_operator_command_packets.py
+- Focused test: adl/tools/test_csm_operator_command_packets.sh
+
+## Non-Goals
+
+- Do not implement live Runtime v2 mutations.
+- Do not make the static console submit commands.
+- Do not bypass Freedom Gate, kernel policy, identity validation, invariant
+  checks, or trace append.
+- Do not turn citizen or shepherd interaction into uncontrolled chat.

--- a/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
+++ b/docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md
@@ -254,6 +254,12 @@ Required fields:
 The v0.90.1 packet is read-only. Available actions may describe future affordance
 intent, but disabled actions must explain why live mutation is unavailable.
 
+The follow-on command packet contract defines how future action-rail controls
+become governed kernel submissions instead of direct UI mutations. Until a
+Runtime v2 handler exists, the visibility packet should keep state-changing
+actions disabled and point reviewers to
+CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md for the safety model.
+
 ### Review
 
 Required fields:
@@ -312,6 +318,10 @@ fixture labeling, and obvious path or endpoint leakage.
 - Focused test: adl/tools/test_csm_visibility_packet.sh
 - Operator report: demos/v0.90.1/csm_observatory_operator_report.md
 - Operator report renderer: adl/tools/render_csm_observatory_report.py
+- Operator command packet contract: docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md
+- Operator command packet schema: adl/schemas/csm_operator_command_packet.v1.schema.json
+- Operator command packet fixtures: demos/fixtures/csm_observatory/proto-csm-01-operator-command-packets.json
+- Operator command packet validator: adl/tools/validate_csm_operator_command_packets.py
 
 ## Non-Goals
 

--- a/docs/milestones/v0.90.1/features/README.md
+++ b/docs/milestones/v0.90.1/features/README.md
@@ -34,3 +34,9 @@ The first command-driven demo bundle lives in the demo docs rather than this
 feature directory, because it is a run surface over the packet/report contracts:
 
 - `../../../../demos/v0.90.1/csm_observatory_cli_demo.md`
+
+The first governed interaction contract lives here because it defines the safe
+boundary between the read-only action rail and future Runtime v2 kernel
+handlers:
+
+- `CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md`


### PR DESCRIPTION
Closes #2192

## Summary
Defined the first governed command-packet contract for CSM Observatory operator
interactions. The work keeps the Observatory non-mutating, but gives future
pause, resume, snapshot, trace annotation, citizen inspection, and shepherd
requests a concrete kernel-routed packet model with required operator-event
logging and explicit disabled-action explanations.

## Artifacts
- docs/milestones/v0.90.1/features/CSM_OBSERVATORY_OPERATOR_COMMAND_PACKETS.md
- adl/schemas/csm_operator_command_packet.v1.schema.json
- demos/fixtures/csm_observatory/proto-csm-01-operator-command-packets.json
- demos/fixtures/csm_observatory/proto-csm-01-operator-event.json
- adl/tools/validate_csm_operator_command_packets.py
- adl/tools/test_csm_operator_command_packets.sh
- Updated docs/milestones/v0.90.1/features/README.md and docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md to surface the new contract.
- Updated docs/milestones/v0.90.1/features/CSM_OBSERVATORY_VISIBILITY_PACKET.md, demos/fixtures/csm_observatory/proto-csm-01-visibility-packet.json, and demos/v0.90.1/csm_observatory_cli_demo.md to align the action rail with the command-packet boundary.

## Validation
- Validation commands and their purpose:
- bash adl/tools/test_csm_operator_command_packets.sh
  - Verified command packet fixtures, operator event fixture, JSON schema parseability, no-direct-UI-mutation rules, required event fields, disabled snapshot truth, documentation links, and leakage hygiene.
- bash adl/tools/test_csm_visibility_packet.sh
  - Verified the existing visibility packet remains valid after disabled-action explanation updates.
- bash adl/tools/demo_v0901_csm_observatory.sh scratch-output-dir
  - Verified the command-driven Observatory bundle still renders successfully from the updated visibility packet.
- Focused private-path and secret-pattern scan over the new docs, schema, fixtures, and updated Observatory surfaces.
  - Verified no private path, endpoint, bearer value, secret-like assignment, raw prompt, or tool-argument leakage was introduced in artifact content; scanner pattern definitions were not treated as artifact leakage.
- Results: all validation passed.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2192__v0-90-1-csm-observatory-operator-command-packet-design/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2192__v0-90-1-csm-observatory-operator-command-packet-design/sor.md
- Idempotency-Key: v0-90-1-csm-observatory-operator-command-packet-design-docs-milestones-v0-90-1-features-csm-observatory-operator-command-packets-md-adl-schemas-csm-operator-command-packet-v1-schema-json-demos-fixtures-csm-observatory-proto-csm-01-operator-command-packets-json-demos-fixtures-csm-observatory-proto-csm-01-operator-event-json-adl-tools-validate-csm-operator-command-packets-py-adl-tools-test-csm-operator-command-packets-sh-docs-milestones-v0-90-1-features-readme-md-docs-milestones-v0-90-1-feature-docs-v0-90-1-md-docs-milestones-v0-90-1-features-csm-observatory-visibility-packet-md-demos-fixtures-csm-observatory-proto-csm-01-visibility-packet-json-demos-v0-90-1-csm-observatory-cli-demo-md-adl-v0-90-1-tasks-issue-2192-v0-90-1-csm-observatory-operator-command-packet-design-sip-md-adl-v0-90-1-tasks-issue-2192-v0-90-1-csm-observatory-operator-command-packet-design-sor-md