### PR TITLE
[v0.90.1][WP-11] Security-boundary proof

### DIFF
--- a/adl/src/cli/runtime_v2_cmd.rs
+++ b/adl/src/cli/runtime_v2_cmd.rs
@@ -3,7 +3,9 @@ use serde_json::to_string_pretty;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use ::adl::runtime_v2::runtime_v2_operator_control_report_contract;
+use ::adl::runtime_v2::{
+    runtime_v2_operator_control_report_contract, runtime_v2_security_boundary_proof_contract,
+};
 
 pub(crate) fn real_runtime_v2(args: &[String]) -> Result<()> {
     let repo_root = std::env::current_dir().context("resolve current working directory")?;
@@ -13,18 +15,19 @@ pub(crate) fn real_runtime_v2(args: &[String]) -> Result<()> {
 fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "runtime-v2 requires a subcommand: operator-controls"
+            "runtime-v2 requires a subcommand: operator-controls or security-boundary"
         ));
     };
 
     match subcommand {
         "operator-controls" => real_runtime_v2_operator_controls(repo_root, &args[1..]),
+        "security-boundary" => real_runtime_v2_security_boundary(repo_root, &args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls)"
+            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls or security-boundary)"
         )),
     }
 }
@@ -82,6 +85,64 @@ fn real_runtime_v2_operator_controls(repo_root: &Path, args: &[String]) -> Resul
     })?;
     println!(
         "RUNTIME_V2_OPERATOR_CONTROL_REPORT_PATH={}",
+        resolved.display()
+    );
+    Ok(())
+}
+
+fn real_runtime_v2_security_boundary(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!(
+                        "runtime-v2 security-boundary requires --out <path>"
+                    ));
+                };
+                out_path = Some(PathBuf::from(value));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => {
+                return Err(anyhow!(
+                    "unknown arg for runtime-v2 security-boundary: {other}"
+                ))
+            }
+        }
+        i += 1;
+    }
+
+    let proof = runtime_v2_security_boundary_proof_contract()?;
+    let json = to_string_pretty(&proof)?;
+    let Some(out_path) = out_path else {
+        println!("{json}");
+        return Ok(());
+    };
+    let resolved = if out_path.is_absolute() {
+        out_path
+    } else {
+        repo_root.join(out_path)
+    };
+    let Some(parent) = resolved.parent() else {
+        return Err(anyhow!(
+            "runtime-v2 security-boundary --out path must have a parent directory"
+        ));
+    };
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+    fs::write(&resolved, json.as_bytes()).with_context(|| {
+        format!(
+            "failed to write Runtime v2 security boundary proof to {}",
+            resolved.display()
+        )
+    })?;
+    println!(
+        "RUNTIME_V2_SECURITY_BOUNDARY_PROOF_PATH={}",
         resolved.display()
     );
     Ok(())
@@ -164,7 +225,7 @@ mod tests {
         let err = real_runtime_v2_in_repo(&[], &repo).expect_err("missing subcommand should fail");
         assert!(err
             .to_string()
-            .contains("runtime-v2 requires a subcommand: operator-controls"));
+            .contains("runtime-v2 requires a subcommand: operator-controls or security-boundary"));
 
         let err = real_runtime_v2_in_repo(&["bogus".to_string()], &repo)
             .expect_err("unknown subcommand should fail");
@@ -202,5 +263,82 @@ mod tests {
     #[test]
     fn runtime_v2_public_dispatch_uses_current_directory() {
         real_runtime_v2(&["operator-controls".to_string()]).expect("public dispatch stdout");
+    }
+
+    #[test]
+    fn runtime_v2_security_boundary_writes_proof_json() {
+        let repo = temp_repo("security-boundary");
+        let out_path = repo.join("out/security_boundary.json");
+
+        real_runtime_v2_in_repo(
+            &[
+                "security-boundary".to_string(),
+                "--out".to_string(),
+                "out/security_boundary.json".to_string(),
+            ],
+            &repo,
+        )
+        .expect("security boundary");
+
+        let json: serde_json::Value = serde_json::from_slice(
+            &fs::read(&out_path).expect("security boundary proof should be written"),
+        )
+        .expect("valid json");
+        assert_eq!(
+            json["schema_version"],
+            "runtime_v2.security_boundary_proof.v1"
+        );
+        assert_eq!(json["result"]["allowed"], false);
+
+        fs::remove_dir_all(repo).ok();
+    }
+
+    #[test]
+    fn runtime_v2_security_boundary_validates_unknown_args_and_missing_out_value() {
+        let repo = temp_repo("security-boundary-errors");
+
+        let err = real_runtime_v2_in_repo(
+            &["security-boundary".to_string(), "--bogus".to_string()],
+            &repo,
+        )
+        .expect_err("unknown arg should fail");
+        assert!(err
+            .to_string()
+            .contains("unknown arg for runtime-v2 security-boundary: --bogus"));
+
+        let err = real_runtime_v2_in_repo(
+            &["security-boundary".to_string(), "--out".to_string()],
+            &repo,
+        )
+        .expect_err("missing out value should fail");
+        assert!(err
+            .to_string()
+            .contains("runtime-v2 security-boundary requires --out <path>"));
+    }
+
+    #[test]
+    fn runtime_v2_security_boundary_covers_stdout_help_and_absolute_output() {
+        let repo = temp_repo("security-boundary-branches");
+        let out_path = repo.join("absolute/security_boundary.json");
+
+        real_runtime_v2_in_repo(&["security-boundary".to_string()], &repo).expect("stdout proof");
+        real_runtime_v2_in_repo(
+            &["security-boundary".to_string(), "--help".to_string()],
+            &repo,
+        )
+        .expect("security boundary help");
+        real_runtime_v2_in_repo(
+            &[
+                "security-boundary".to_string(),
+                "--out".to_string(),
+                out_path.to_string_lossy().to_string(),
+            ],
+            &repo,
+        )
+        .expect("absolute output path");
+
+        assert!(out_path.is_file());
+
+        fs::remove_dir_all(repo).ok();
     }
 }

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -34,6 +34,7 @@ pub fn usage() -> &'static str {
   adl identity instinct [--out <path>]
   adl identity instinct-runtime [--out <path>]
   adl runtime-v2 operator-controls [--out <path>]
+  adl runtime-v2 security-boundary [--out <path>]
   adl provider setup <family> [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
   adl pr init <issue> [--slug <slug>] [--title <title>] [--no-fetch-issue] [--version <v>]
@@ -103,6 +104,7 @@ Examples:
   adl identity provider-extension-packaging --out .adl/state/provider_extension_packaging_v1.json
   adl identity demo-proof-entry-points --out .adl/state/demo_proof_entry_points_v1.json
   adl runtime-v2 operator-controls --out .adl/state/runtime_v2_operator_control_report.v1.json
+  adl runtime-v2 security-boundary --out .adl/state/runtime_v2_security_boundary_proof.v1.json
   adl provider setup chatgpt
   adl provider setup claude
   adl provider setup anthropic --out ./.adl/provider-setup/anthropic

--- a/adl/src/runtime_v2.rs
+++ b/adl/src/runtime_v2.rs
@@ -13,6 +13,7 @@ pub const RUNTIME_V2_SNAPSHOT_MANIFEST_SCHEMA: &str = "runtime_v2.snapshot_manif
 pub const RUNTIME_V2_REHYDRATION_REPORT_SCHEMA: &str = "runtime_v2.rehydration_report.v1";
 pub const RUNTIME_V2_INVARIANT_VIOLATION_SCHEMA: &str = "runtime_v2.invariant_violation.v1";
 pub const RUNTIME_V2_OPERATOR_CONTROL_REPORT_SCHEMA: &str = "runtime_v2.operator_control_report.v1";
+pub const RUNTIME_V2_SECURITY_BOUNDARY_PROOF_SCHEMA: &str = "runtime_v2.security_boundary_proof.v1";
 pub const DEFAULT_MANIFOLD_ARTIFACT_PATH: &str = "runtime_v2/manifold.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -319,6 +320,45 @@ pub struct RuntimeV2OperatorControlReport {
     pub generated_at_utc: String,
     pub control_interface_service_id: String,
     pub commands: Vec<RuntimeV2OperatorCommandReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2SecurityBoundaryAttempt {
+    pub actor: String,
+    pub attempted_action: String,
+    pub requested_state: String,
+    pub source_command_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2SecurityBoundaryEvaluatedRule {
+    pub rule_id: String,
+    pub rule_kind: String,
+    pub source_ref: String,
+    pub decision: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2SecurityBoundaryResult {
+    pub allowed: bool,
+    pub refusal_reason: String,
+    pub resulting_state: RuntimeV2OperatorControlState,
+    pub trace_ref: String,
+    pub recovery_action: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2SecurityBoundaryProofPacket {
+    pub schema_version: String,
+    pub proof_id: String,
+    pub manifold_id: String,
+    pub artifact_path: String,
+    pub generated_at_utc: String,
+    pub boundary_service_id: String,
+    pub attempt: RuntimeV2SecurityBoundaryAttempt,
+    pub evaluated_rules: Vec<RuntimeV2SecurityBoundaryEvaluatedRule>,
+    pub related_artifacts: Vec<String>,
+    pub result: RuntimeV2SecurityBoundaryResult,
 }
 
 impl RuntimeV2ManifoldRoot {
@@ -1557,6 +1597,191 @@ impl RuntimeV2OperatorCommandReport {
     }
 }
 
+impl RuntimeV2SecurityBoundaryProofPacket {
+    pub fn refused_resume_without_invariant_prototype(
+        manifold: &RuntimeV2ManifoldRoot,
+        kernel: &RuntimeV2KernelLoopArtifacts,
+        violation: &RuntimeV2InvariantViolationArtifact,
+        operator_report: &RuntimeV2OperatorControlReport,
+    ) -> Result<Self> {
+        manifold.validate()?;
+        kernel.validate()?;
+        violation.validate()?;
+        operator_report.validate()?;
+        if kernel.state.manifold_id != manifold.manifold_id
+            || violation.manifold_id != manifold.manifold_id
+            || operator_report.manifold_id != manifold.manifold_id
+        {
+            return Err(anyhow!(
+                "security boundary inputs must share the same manifold id"
+            ));
+        }
+        let resume_command = operator_report
+            .commands
+            .iter()
+            .find(|command| command.command == "resume_manifold")
+            .ok_or_else(|| anyhow!("security boundary proof requires resume_manifold command"))?;
+        let inspect_failures_command = operator_report
+            .commands
+            .iter()
+            .find(|command| command.command == "inspect_last_failures")
+            .ok_or_else(|| {
+                anyhow!("security boundary proof requires inspect_last_failures command")
+            })?;
+        if inspect_failures_command.trace_event_ref != violation.result.trace_ref {
+            return Err(anyhow!(
+                "security boundary proof must use the latest invariant violation trace"
+            ));
+        }
+        let proof = Self {
+            schema_version: RUNTIME_V2_SECURITY_BOUNDARY_PROOF_SCHEMA.to_string(),
+            proof_id: "security-boundary-proof-0001".to_string(),
+            manifold_id: manifold.manifold_id.clone(),
+            artifact_path: "runtime_v2/security_boundary/proof_packet.json".to_string(),
+            generated_at_utc: "not_started".to_string(),
+            boundary_service_id: operator_report.control_interface_service_id.clone(),
+            attempt: RuntimeV2SecurityBoundaryAttempt {
+                actor: resume_command.requested_by.clone(),
+                attempted_action: "resume_manifold_without_fresh_invariant_pass".to_string(),
+                requested_state: "active".to_string(),
+                source_command_ref: operator_report.artifact_path.clone(),
+            },
+            evaluated_rules: vec![
+                RuntimeV2SecurityBoundaryEvaluatedRule {
+                    rule_id: "require_fresh_invariant_pass_before_resume".to_string(),
+                    rule_kind: "operator_policy".to_string(),
+                    source_ref: manifold.invariant_policy_refs.policy_path.clone(),
+                    decision: "refuse".to_string(),
+                },
+                RuntimeV2SecurityBoundaryEvaluatedRule {
+                    rule_id: violation.invariant_id.clone(),
+                    rule_kind: "blocking_invariant".to_string(),
+                    source_ref: violation.artifact_path.clone(),
+                    decision: "blocking_failure_present".to_string(),
+                },
+                RuntimeV2SecurityBoundaryEvaluatedRule {
+                    rule_id: "scheduler_resume_gate".to_string(),
+                    rule_kind: "kernel_service_policy".to_string(),
+                    source_ref: kernel.state.service_state_path.clone(),
+                    decision: "keep_paused".to_string(),
+                },
+            ],
+            related_artifacts: vec![
+                manifold.artifact_path.clone(),
+                kernel.state.service_state_path.clone(),
+                violation.artifact_path.clone(),
+                operator_report.artifact_path.clone(),
+            ],
+            result: RuntimeV2SecurityBoundaryResult {
+                allowed: false,
+                refusal_reason:
+                    "resume refused because latest invariant evidence is blocking and no fresh pass is recorded"
+                        .to_string(),
+                resulting_state: resume_command.pre_state.clone(),
+                trace_ref:
+                    "runtime_v2/traces/security_boundary/refused-resume-without-invariant.json"
+                        .to_string(),
+                recovery_action: "remain_paused_and_require_invariant_checker_pass_before_resume"
+                    .to_string(),
+            },
+        };
+        proof.validate()?;
+        Ok(proof)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.schema_version != RUNTIME_V2_SECURITY_BOUNDARY_PROOF_SCHEMA {
+            return Err(anyhow!(
+                "unsupported Runtime v2 security boundary proof schema '{}'",
+                self.schema_version
+            ));
+        }
+        normalize_id(self.proof_id.clone(), "security_boundary.proof_id")?;
+        normalize_id(self.manifold_id.clone(), "security_boundary.manifold_id")?;
+        validate_relative_path(&self.artifact_path, "security_boundary.artifact_path")?;
+        validate_timestamp_marker(&self.generated_at_utc, "security_boundary.generated_at_utc")?;
+        normalize_id(
+            self.boundary_service_id.clone(),
+            "security_boundary.boundary_service_id",
+        )?;
+        if self.boundary_service_id != "operator_control_interface" {
+            return Err(anyhow!(
+                "security boundary proof must pass through operator_control_interface"
+            ));
+        }
+        self.attempt.validate()?;
+        validate_security_boundary_rules(&self.evaluated_rules)?;
+        validate_security_boundary_related_artifacts(&self.related_artifacts)?;
+        self.result.validate()?;
+        if self.result.allowed {
+            return Err(anyhow!(
+                "security boundary proof must demonstrate a refused invalid action"
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn to_pretty_json_bytes(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        serde_json::to_vec_pretty(self).context("serialize Runtime v2 security boundary proof")
+    }
+
+    pub fn write_to_root(&self, root: impl AsRef<Path>) -> Result<()> {
+        write_relative(
+            root.as_ref(),
+            &self.artifact_path,
+            self.to_pretty_json_bytes()?,
+        )
+    }
+}
+
+impl RuntimeV2SecurityBoundaryAttempt {
+    pub fn validate(&self) -> Result<()> {
+        normalize_id(self.actor.clone(), "security_boundary.actor")?;
+        normalize_id(
+            self.attempted_action.clone(),
+            "security_boundary.attempted_action",
+        )?;
+        validate_lifecycle_state(&self.requested_state)?;
+        validate_relative_path(
+            &self.source_command_ref,
+            "security_boundary.source_command_ref",
+        )
+    }
+}
+
+impl RuntimeV2SecurityBoundaryEvaluatedRule {
+    pub fn validate(&self) -> Result<()> {
+        normalize_id(self.rule_id.clone(), "security_boundary.rule_id")?;
+        validate_security_boundary_rule_kind(&self.rule_kind)?;
+        validate_relative_path(&self.source_ref, "security_boundary.source_ref")?;
+        validate_security_boundary_decision(&self.decision)
+    }
+}
+
+impl RuntimeV2SecurityBoundaryResult {
+    pub fn validate(&self) -> Result<()> {
+        validate_nonempty_text(&self.refusal_reason, "security_boundary.refusal_reason")?;
+        self.resulting_state.validate()?;
+        validate_relative_path(&self.trace_ref, "security_boundary.trace_ref")?;
+        normalize_id(
+            self.recovery_action.clone(),
+            "security_boundary.recovery_action",
+        )?;
+        if self.allowed {
+            return Err(anyhow!(
+                "security boundary result must be refused for this proof"
+            ));
+        }
+        if self.resulting_state.manifold_lifecycle_state != "paused" {
+            return Err(anyhow!(
+                "security boundary refused resume must leave the manifold paused"
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl RuntimeV2ProvisionalCitizenRecord {
     pub fn validate(&self) -> Result<()> {
         if self.schema_version != RUNTIME_V2_PROVISIONAL_CITIZEN_SCHEMA {
@@ -2086,6 +2311,89 @@ fn validate_operator_outcome(value: &str) -> Result<()> {
     }
 }
 
+fn validate_security_boundary_rules(
+    rules: &[RuntimeV2SecurityBoundaryEvaluatedRule],
+) -> Result<()> {
+    if rules.len() < 3 {
+        return Err(anyhow!(
+            "security_boundary.evaluated_rules must include operator, invariant, and kernel checks"
+        ));
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    let mut has_operator = false;
+    let mut has_invariant = false;
+    let mut has_kernel = false;
+    for rule in rules {
+        rule.validate()?;
+        if !seen.insert(rule.rule_id.clone()) {
+            return Err(anyhow!(
+                "security_boundary.evaluated_rules contains duplicate rule '{}'",
+                rule.rule_id
+            ));
+        }
+        match rule.rule_kind.as_str() {
+            "operator_policy" => has_operator = true,
+            "blocking_invariant" => has_invariant = true,
+            "kernel_service_policy" => has_kernel = true,
+            _ => {}
+        }
+    }
+    if !(has_operator && has_invariant && has_kernel) {
+        return Err(anyhow!(
+            "security_boundary.evaluated_rules missing required policy/invariant/kernel coverage"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_security_boundary_rule_kind(value: &str) -> Result<()> {
+    match value {
+        "operator_policy" | "blocking_invariant" | "kernel_service_policy" => Ok(()),
+        other => Err(anyhow!("unsupported security_boundary.rule_kind '{other}'")),
+    }
+}
+
+fn validate_security_boundary_decision(value: &str) -> Result<()> {
+    match value {
+        "refuse" | "blocking_failure_present" | "keep_paused" => Ok(()),
+        other => Err(anyhow!("unsupported security_boundary.decision '{other}'")),
+    }
+}
+
+fn validate_security_boundary_related_artifacts(artifacts: &[String]) -> Result<()> {
+    if artifacts.is_empty() {
+        return Err(anyhow!(
+            "security_boundary.related_artifacts must not be empty"
+        ));
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for artifact in artifacts {
+        validate_relative_path(artifact, "security_boundary.related_artifacts")?;
+        if !seen.insert(artifact.clone()) {
+            return Err(anyhow!(
+                "security_boundary.related_artifacts contains duplicate artifact"
+            ));
+        }
+    }
+    if !artifacts
+        .iter()
+        .any(|artifact| artifact == "runtime_v2/invariants/violation-0001.json")
+    {
+        return Err(anyhow!(
+            "security_boundary.related_artifacts must include invariant violation evidence"
+        ));
+    }
+    if !artifacts
+        .iter()
+        .any(|artifact| artifact == "runtime_v2/operator/control_report.json")
+    {
+        return Err(anyhow!(
+            "security_boundary.related_artifacts must include operator control evidence"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_nonempty_text(value: &str, field: &str) -> Result<()> {
     if value.trim().is_empty() {
         return Err(anyhow!("{field} must not be empty"));
@@ -2231,6 +2539,27 @@ pub fn runtime_v2_operator_control_report_contract() -> Result<RuntimeV2Operator
         &manifold, &kernel, &citizens,
     )?;
     RuntimeV2OperatorControlReport::prototype(&manifold, &kernel, &citizens, &snapshot, &violation)
+}
+
+pub fn runtime_v2_security_boundary_proof_contract() -> Result<RuntimeV2SecurityBoundaryProofPacket>
+{
+    let manifold = runtime_v2_manifold_contract()?;
+    let kernel = RuntimeV2KernelLoopArtifacts::prototype(&manifold)?;
+    let citizens = RuntimeV2CitizenLifecycleArtifacts::prototype(&manifold)?;
+    let snapshot =
+        RuntimeV2SnapshotAndRehydrationArtifacts::prototype(&manifold, &kernel, &citizens)?;
+    let violation = RuntimeV2InvariantViolationArtifact::duplicate_active_citizen_prototype(
+        &manifold, &kernel, &citizens,
+    )?;
+    let operator_report = RuntimeV2OperatorControlReport::prototype(
+        &manifold, &kernel, &citizens, &snapshot, &violation,
+    )?;
+    RuntimeV2SecurityBoundaryProofPacket::refused_resume_without_invariant_prototype(
+        &manifold,
+        &kernel,
+        &violation,
+        &operator_report,
+    )
 }
 
 #[cfg(test)]
@@ -2947,5 +3276,106 @@ mod tests {
             .expect_err("terminated state with active citizens should fail")
             .to_string()
             .contains("terminated state must not retain active citizens"));
+    }
+
+    #[test]
+    fn runtime_v2_security_boundary_proof_records_refused_invalid_action() {
+        let proof = runtime_v2_security_boundary_proof_contract().expect("security proof");
+
+        assert_eq!(
+            proof.schema_version,
+            RUNTIME_V2_SECURITY_BOUNDARY_PROOF_SCHEMA
+        );
+        assert_eq!(proof.manifold_id, "proto-csm-01");
+        assert_eq!(proof.boundary_service_id, "operator_control_interface");
+        assert_eq!(
+            proof.attempt.attempted_action,
+            "resume_manifold_without_fresh_invariant_pass"
+        );
+        assert!(!proof.result.allowed);
+        assert_eq!(
+            proof.result.resulting_state.manifold_lifecycle_state,
+            "paused"
+        );
+        assert!(proof
+            .evaluated_rules
+            .iter()
+            .any(|rule| rule.rule_kind == "blocking_invariant"));
+        assert!(proof
+            .related_artifacts
+            .contains(&"runtime_v2/operator/control_report.json".to_string()));
+        assert!(proof
+            .related_artifacts
+            .contains(&"runtime_v2/invariants/violation-0001.json".to_string()));
+    }
+
+    #[test]
+    fn runtime_v2_security_boundary_proof_matches_golden_fixture() {
+        let proof = runtime_v2_security_boundary_proof_contract().expect("security proof");
+        let generated =
+            String::from_utf8(proof.to_pretty_json_bytes().expect("json")).expect("utf8");
+
+        assert_eq!(
+            generated,
+            include_str!("../tests/fixtures/runtime_v2/security_boundary/proof_packet.json")
+                .trim_end()
+        );
+    }
+
+    #[test]
+    fn runtime_v2_security_boundary_proof_writes_without_path_leakage() {
+        let temp_root = unique_temp_path("security-boundary");
+        let proof = runtime_v2_security_boundary_proof_contract().expect("security proof");
+
+        proof
+            .write_to_root(&temp_root)
+            .expect("write security proof");
+
+        let proof_path = temp_root.join(&proof.artifact_path);
+        assert!(proof_path.is_file());
+        let text = fs::read_to_string(proof_path).expect("security proof text");
+        assert!(!text.contains(temp_root.to_string_lossy().as_ref()));
+        assert!(text.contains("\"schema_version\": \"runtime_v2.security_boundary_proof.v1\""));
+        assert!(text.contains("\"allowed\": false"));
+        assert!(text.contains("resume_manifold_without_fresh_invariant_pass"));
+
+        fs::remove_dir_all(temp_root).ok();
+    }
+
+    #[test]
+    fn runtime_v2_security_boundary_validation_rejects_unsafe_or_ambiguous_state() {
+        let mut proof = runtime_v2_security_boundary_proof_contract().expect("security proof");
+        proof.artifact_path = "/tmp/security/proof.json".to_string();
+        assert!(proof
+            .validate()
+            .expect_err("absolute path should fail")
+            .to_string()
+            .contains("repository-relative path"));
+
+        let mut proof = runtime_v2_security_boundary_proof_contract().expect("security proof");
+        proof.result.allowed = true;
+        assert!(proof
+            .validate()
+            .expect_err("allowed invalid action should fail")
+            .to_string()
+            .contains("must be refused"));
+
+        let mut proof = runtime_v2_security_boundary_proof_contract().expect("security proof");
+        proof.evaluated_rules.remove(1);
+        assert!(proof
+            .validate()
+            .expect_err("missing invariant coverage should fail")
+            .to_string()
+            .contains("must include operator, invariant, and kernel checks"));
+
+        let mut proof = runtime_v2_security_boundary_proof_contract().expect("security proof");
+        proof
+            .related_artifacts
+            .retain(|artifact| artifact != "runtime_v2/operator/control_report.json");
+        assert!(proof
+            .validate()
+            .expect_err("missing operator evidence should fail")
+            .to_string()
+            .contains("operator control evidence"));
     }
 }

--- a/adl/tests/fixtures/runtime_v2/security_boundary/proof_packet.json
+++ b/adl/tests/fixtures/runtime_v2/security_boundary/proof_packet.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "runtime_v2.security_boundary_proof.v1",
+  "proof_id": "security-boundary-proof-0001",
+  "manifold_id": "proto-csm-01",
+  "artifact_path": "runtime_v2/security_boundary/proof_packet.json",
+  "generated_at_utc": "not_started",
+  "boundary_service_id": "operator_control_interface",
+  "attempt": {
+    "actor": "operator.cli",
+    "attempted_action": "resume_manifold_without_fresh_invariant_pass",
+    "requested_state": "active",
+    "source_command_ref": "runtime_v2/operator/control_report.json"
+  },
+  "evaluated_rules": [
+    {
+      "rule_id": "require_fresh_invariant_pass_before_resume",
+      "rule_kind": "operator_policy",
+      "source_ref": "runtime_v2/invariants/policy.json",
+      "decision": "refuse"
+    },
+    {
+      "rule_id": "no_duplicate_active_citizen_instance",
+      "rule_kind": "blocking_invariant",
+      "source_ref": "runtime_v2/invariants/violation-0001.json",
+      "decision": "blocking_failure_present"
+    },
+    {
+      "rule_id": "scheduler_resume_gate",
+      "rule_kind": "kernel_service_policy",
+      "source_ref": "runtime_v2/kernel/service_state.json",
+      "decision": "keep_paused"
+    }
+  ],
+  "related_artifacts": [
+    "runtime_v2/manifold.json",
+    "runtime_v2/kernel/service_state.json",
+    "runtime_v2/invariants/violation-0001.json",
+    "runtime_v2/operator/control_report.json"
+  ],
+  "result": {
+    "allowed": false,
+    "refusal_reason": "resume refused because latest invariant evidence is blocking and no fresh pass is recorded",
+    "resulting_state": {
+      "manifold_lifecycle_state": "paused",
+      "kernel_loop_status": "operator_paused",
+      "active_citizen_count": 1,
+      "pending_citizen_count": 1,
+      "latest_snapshot_id": null,
+      "completed_through_event_sequence": 8
+    },
+    "trace_ref": "runtime_v2/traces/security_boundary/refused-resume-without-invariant.json",
+    "recovery_action": "remain_paused_and_require_invariant_checker_pass_before_resume"
+  }
+}

--- a/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
+++ b/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
@@ -12,7 +12,7 @@ Issue wave open. Demo commands are not final until implementation WPs land.
 | D3 | Snapshot and wake | WP-08 | Manifold state can be snapshotted and rehydrated without duplicate activation | snapshot, wake report | PLANNED |
 | D4 | Invariant violation | WP-09 | Illegal state transition is rejected and recorded | violation artifact, negative test | PLANNED |
 | D5 | Operator control | WP-10 | Operator can inspect, pause, resume, and terminate bounded runtime state | operator control report | PLANNED |
-| D6 | Security boundary | WP-11 | One invalid action is rejected through normal kernel/policy path | security-boundary proof packet | PLANNED |
+| D6 | Security boundary | WP-11 | One invalid action is rejected through normal kernel/policy path | security-boundary proof packet, negative test, CLI proof hook | READY |
 | D7 | Runtime v2 integrated prototype | WP-12 | Reviewer can inspect the foundation prototype end to end | integrated proof packet | PLANNED |
 | D8 | Release evidence packet | WP-19 | Reviewer can trace demo, quality, review, and release-readiness evidence without reconstructing the milestone by hand | release-evidence packet | PLANNED |
 | D9 | CSM Observatory CLI bundle | #2191 | Reviewer can regenerate packet, operator report, console reference, and demo manifest from one read-only ADL CLI command | visibility_packet.json, operator_report.md, console_reference.md, demo_manifest.json | READY |

--- a/docs/milestones/v0.90.1/features/INVARIANT_AND_SECURITY_BOUNDARY.md
+++ b/docs/milestones/v0.90.1/features/INVARIANT_AND_SECURITY_BOUNDARY.md
@@ -62,6 +62,41 @@ The security proof must include:
 - trace ref
 - resulting state
 
+## WP-11 Implementation Surface
+
+WP-11 adds a Rust-owned security-boundary proof packet in
+`adl/src/runtime_v2.rs` and a reviewer CLI hook:
+
+```bash
+adl runtime-v2 security-boundary --out .adl/state/runtime_v2_security_boundary_proof.v1.json
+```
+
+The default proof is available through
+`runtime_v2_security_boundary_proof_contract()`. It consumes the WP-09
+invariant violation artifact and the WP-10 operator-control report, then
+attempts an invalid `resume_manifold_without_fresh_invariant_pass` action
+through the operator control interface and scheduler policy path.
+
+The emitted artifact path is:
+
+- `runtime_v2/security_boundary/proof_packet.json`
+
+The proof packet records:
+
+- `operator.cli` as the actor
+- the attempted invalid resume action
+- operator policy, blocking invariant, and kernel scheduler rule evaluations
+- the refusal reason
+- the trace ref for the refused action
+- the resulting paused state
+- related invariant and operator-control evidence
+
+The focused WP-11 proof hook is:
+
+```bash
+cargo test --manifest-path adl/Cargo.toml runtime_v2::tests::runtime_v2_security_boundary
+```
+
 ## Boundary
 
 This is safety evidence for the polis. It is not the full red/blue/purple

--- a/docs/milestones/v0.90.1/features/RUNTIME_V2_FOUNDATION_PROTOTYPE.md
+++ b/docs/milestones/v0.90.1/features/RUNTIME_V2_FOUNDATION_PROTOTYPE.md
@@ -41,3 +41,17 @@ handles and failure artifacts.
 - `runtime_v2/invariants/*.json`
 - `runtime_v2/operator/control_report.json`
 - `runtime_v2/security_boundary/proof_packet.json`
+
+## WP-11 Security Boundary Proof
+
+The foundation prototype now exposes one bounded security-boundary proof through
+`runtime_v2_security_boundary_proof_contract()` and:
+
+```bash
+adl runtime-v2 security-boundary --out .adl/state/runtime_v2_security_boundary_proof.v1.json
+```
+
+The proof consumes the invariant violation and operator-control report and
+shows that an invalid resume attempt is refused before the paused Runtime v2
+state changes. This is a first wall stone for Runtime v2 safety evidence, not a
+complete defensive ecology.


### PR DESCRIPTION
Closes #2151

## Summary
Implemented WP-11 as a bounded Runtime v2 security-boundary proof packet. The proof consumes the WP-09 invariant violation artifact and WP-10 operator-control report, then proves that `operator.cli` attempting `resume_manifold_without_fresh_invariant_pass` is refused through the operator-control and scheduler policy path before the paused state changes.

## Artifacts
- `adl/src/runtime_v2.rs`: added `runtime_v2.security_boundary_proof.v1` constants, packet structs, validation, deterministic prototype construction, serialization/write helpers, and tests.
- `adl/src/cli/runtime_v2_cmd.rs`: added `adl runtime-v2 security-boundary [--out <path>]` with stdout, relative output, absolute output, help, and error-path tests.
- `adl/src/cli/usage.rs`: documented the reviewer-facing CLI hook.
- `adl/tests/fixtures/runtime_v2/security_boundary/proof_packet.json`: golden proof packet fixture.
- `docs/milestones/v0.90.1/features/INVARIANT_AND_SECURITY_BOUNDARY.md`: documented the WP-11 implementation surface and proof hook.
- `docs/milestones/v0.90.1/features/RUNTIME_V2_FOUNDATION_PROTOTYPE.md`: documented the security-boundary proof as part of the foundation prototype.
- `docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md`: marked D6 security boundary as READY with CLI proof hook evidence.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`: formatted Rust changes.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2::tests::runtime_v2_security_boundary`: verified the focused WP-11 proof, golden fixture, write path, and negative validation cases.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_cmd::tests`: verified the Runtime v2 CLI dispatch, output, help, and error paths including `security-boundary`.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2::tests`: verified the full Runtime v2 prototype contract suite after WP-11 integration.
  - `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 security-boundary --out .adl/state/runtime_v2_security_boundary_proof.v1.json`: regenerated the reviewer-facing proof packet through the public CLI hook.
  - `rg -n "/Users|/private|/tmp|tool|prompt" .adl/state/runtime_v2_security_boundary_proof.v1.json adl/tests/fixtures/runtime_v2/security_boundary/proof_packet.json`: verified no host-path or prompt/tool-argument leakage in the generated proof and fixture; command returned no matches.
  - `cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info`: ran the workspace coverage test sweep.
  - `cargo llvm-cov report --json --summary-only --output-path coverage-summary.json && bash tools/enforce_coverage_gates.sh coverage-summary.json`: verified workspace and per-file coverage gates.
- Results: all listed validation commands passed; coverage reported workspace line coverage `92.14%` and per-file line coverage gate passed.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2151__v0-90-1-wp-11-security-boundary-proof/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2151__v0-90-1-wp-11-security-boundary-proof/sor.md
- Idempotency-Key: v0-90-1-wp-11-security-boundary-proof-adl-src-runtime-v2-rs-adl-src-cli-runtime-v2-cmd-rs-adl-src-cli-usage-rs-adl-tests-fixtures-runtime-v2-security-boundary-proof-packet-json-docs-milestones-v0-90-1-demo-matrix-v0-90-1-md-docs-milestones-v0-90-1-features-invariant-and-security-boundary-md-docs-milestones-v0-90-1-features-runtime-v2-foundation-prototype-md-adl-v0-90-1-tasks-issue-2151-v0-90-1-wp-11-security-boundary-proof-sip-md-adl-v0-90-1-tasks-issue-2151-v0-90-1-wp-11-security-boundary-proof-sor-md