### PR TITLE
[v0.90.1][runtime] Continue splitting long_lived_agent.rs responsibilities

### DIFF
--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -1,18 +1,21 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
 mod schema;
+mod storage;
 mod types;
 
 use schema::*;
+use storage::*;
 use types::LedgerCursor;
 pub use types::{
     AgentSpec, AgentStatusState, HeartbeatSpec, InspectOptions, LeaseRecord, LoadedAgentSpec,
@@ -387,19 +390,6 @@ fn ensure_locked_spec(loaded: &LoadedAgentSpec) -> Result<()> {
             }),
         )?;
     }
-    Ok(())
-}
-
-fn ensure_jsonl_file(path: &Path) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed creating {}", parent.display()))?;
-    }
-    OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("failed ensuring jsonl file {}", path.display()))?;
     Ok(())
 }
 
@@ -1146,118 +1136,8 @@ fn provider_binding(loaded: &LoadedAgentSpec, cycle_id: &str, bound_at: DateTime
     })
 }
 
-fn read_status(loaded: &LoadedAgentSpec) -> Result<Option<StatusRecord>> {
-    read_json_optional(&status_path(loaded))
-}
-
-fn write_status(loaded: &LoadedAgentSpec, status: &StatusRecord) -> Result<()> {
-    write_json_pretty(&status_path(loaded), status)
-}
-
-fn read_lease(loaded: &LoadedAgentSpec) -> Result<Option<LeaseRecord>> {
-    read_json_optional(&lease_path(loaded))
-}
-
-fn read_stop(loaded: &LoadedAgentSpec) -> Result<Option<StopRecord>> {
-    read_json_optional(&stop_path(loaded))
-}
-
 fn lease_is_stale(lease: &LeaseRecord) -> bool {
     lease.status == "active" && lease.expires_at <= Utc::now()
-}
-
-fn remove_lease(loaded: &LoadedAgentSpec) -> Result<()> {
-    let path = lease_path(loaded);
-    match fs::remove_file(&path) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err).with_context(|| format!("failed removing lease {}", path.display())),
-    }
-}
-
-fn read_json_optional<T>(path: &Path) -> Result<Option<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    if !path.exists() {
-        return Ok(None);
-    }
-    let raw = fs::read_to_string(path)
-        .with_context(|| format!("failed reading json artifact {}", path.display()))?;
-    let value = serde_json::from_str(&raw)
-        .with_context(|| format!("failed parsing json artifact {}", path.display()))?;
-    Ok(Some(value))
-}
-
-fn read_json_required(path: &Path) -> Result<Value> {
-    let raw = fs::read_to_string(path)
-        .with_context(|| format!("failed reading json artifact {}", path.display()))?;
-    serde_json::from_str(&raw)
-        .with_context(|| format!("failed parsing json artifact {}", path.display()))
-}
-
-fn write_json_pretty<T>(path: &Path, value: &T) -> Result<()>
-where
-    T: Serialize,
-{
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed creating {}", parent.display()))?;
-    }
-    let file = File::create(path).with_context(|| format!("failed creating {}", path.display()))?;
-    serde_json::to_writer_pretty(&file, value)
-        .with_context(|| format!("failed writing {}", path.display()))?;
-    fs::OpenOptions::new()
-        .append(true)
-        .open(path)?
-        .write_all(b"\n")
-        .with_context(|| format!("failed finalizing {}", path.display()))?;
-    Ok(())
-}
-
-fn write_jsonl(path: &Path, values: &[Value]) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed creating {}", parent.display()))?;
-    }
-    let mut file =
-        File::create(path).with_context(|| format!("failed creating {}", path.display()))?;
-    for value in values {
-        serde_json::to_writer(&mut file, value)
-            .with_context(|| format!("failed writing {}", path.display()))?;
-        file.write_all(b"\n")
-            .with_context(|| format!("failed finalizing {}", path.display()))?;
-    }
-    Ok(())
-}
-
-fn append_jsonl(path: &Path, value: &Value) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed creating {}", parent.display()))?;
-    }
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("failed opening jsonl file {}", path.display()))?;
-    serde_json::to_writer(&mut file, value)
-        .with_context(|| format!("failed writing jsonl file {}", path.display()))?;
-    file.write_all(b"\n")
-        .with_context(|| format!("failed finalizing jsonl file {}", path.display()))?;
-    Ok(())
-}
-
-fn append_operator_event(loaded: &LoadedAgentSpec, event: &str, details: Value) -> Result<()> {
-    let record = json!({
-        "schema": OPERATOR_EVENT_SCHEMA,
-        "agent_instance_id": loaded.spec.agent_instance_id.clone(),
-        "event": event,
-        "at": Utc::now(),
-        "operator": "local",
-        "details": details
-    });
-    append_jsonl(&operator_events_path(loaded), &record)
 }
 
 fn inspect_cycle(loaded: &LoadedAgentSpec, cycle_id: &str) -> Result<Value> {
@@ -1661,46 +1541,6 @@ fn memory_namespace(loaded: &LoadedAgentSpec) -> String {
         .filter(|value| !value.trim().is_empty())
         .map(str::to_string)
         .unwrap_or_else(|| loaded.spec.agent_instance_id.clone())
-}
-
-fn cycles_dir(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("cycles")
-}
-
-fn locked_spec_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("agent_spec.locked.json")
-}
-
-fn continuity_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("continuity.json")
-}
-
-fn cycle_ledger_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("cycle_ledger.jsonl")
-}
-
-fn provider_binding_history_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("provider_binding_history.jsonl")
-}
-
-fn memory_index_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("memory_index.json")
-}
-
-fn operator_events_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("operator_events.jsonl")
-}
-
-fn status_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("status.json")
-}
-
-fn lease_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("lease.json")
-}
-
-fn stop_path(loaded: &LoadedAgentSpec) -> PathBuf {
-    loaded.state_root.join("stop.json")
 }
 
 fn hostname() -> String {

--- a/adl/src/long_lived_agent/storage.rs
+++ b/adl/src/long_lived_agent/storage.rs
@@ -1,0 +1,176 @@
+use super::schema::OPERATOR_EVENT_SCHEMA;
+use super::types::{LeaseRecord, LoadedAgentSpec, StatusRecord, StopRecord};
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub(super) fn cycles_dir(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("cycles")
+}
+
+pub(super) fn locked_spec_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("agent_spec.locked.json")
+}
+
+pub(super) fn continuity_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("continuity.json")
+}
+
+pub(super) fn cycle_ledger_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("cycle_ledger.jsonl")
+}
+
+pub(super) fn provider_binding_history_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("provider_binding_history.jsonl")
+}
+
+pub(super) fn memory_index_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("memory_index.json")
+}
+
+pub(super) fn operator_events_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("operator_events.jsonl")
+}
+
+pub(super) fn status_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("status.json")
+}
+
+pub(super) fn lease_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("lease.json")
+}
+
+pub(super) fn stop_path(loaded: &LoadedAgentSpec) -> PathBuf {
+    loaded.state_root.join("stop.json")
+}
+
+pub(super) fn ensure_jsonl_file(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating {}", parent.display()))?;
+    }
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed ensuring jsonl file {}", path.display()))?;
+    Ok(())
+}
+
+pub(super) fn read_status(loaded: &LoadedAgentSpec) -> Result<Option<StatusRecord>> {
+    read_json_optional(&status_path(loaded))
+}
+
+pub(super) fn write_status(loaded: &LoadedAgentSpec, status: &StatusRecord) -> Result<()> {
+    write_json_pretty(&status_path(loaded), status)
+}
+
+pub(super) fn read_lease(loaded: &LoadedAgentSpec) -> Result<Option<LeaseRecord>> {
+    read_json_optional(&lease_path(loaded))
+}
+
+pub(super) fn read_stop(loaded: &LoadedAgentSpec) -> Result<Option<StopRecord>> {
+    read_json_optional(&stop_path(loaded))
+}
+
+pub(super) fn remove_lease(loaded: &LoadedAgentSpec) -> Result<()> {
+    let path = lease_path(loaded);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("failed removing lease {}", path.display())),
+    }
+}
+
+pub(super) fn read_json_optional<T>(path: &Path) -> Result<Option<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed reading json artifact {}", path.display()))?;
+    let value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed parsing json artifact {}", path.display()))?;
+    Ok(Some(value))
+}
+
+pub(super) fn read_json_required(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed reading json artifact {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed parsing json artifact {}", path.display()))
+}
+
+pub(super) fn write_json_pretty<T>(path: &Path, value: &T) -> Result<()>
+where
+    T: Serialize,
+{
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating {}", parent.display()))?;
+    }
+    let file = File::create(path).with_context(|| format!("failed creating {}", path.display()))?;
+    serde_json::to_writer_pretty(&file, value)
+        .with_context(|| format!("failed writing {}", path.display()))?;
+    fs::OpenOptions::new()
+        .append(true)
+        .open(path)?
+        .write_all(b"\n")
+        .with_context(|| format!("failed finalizing {}", path.display()))?;
+    Ok(())
+}
+
+pub(super) fn write_jsonl(path: &Path, values: &[Value]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating {}", parent.display()))?;
+    }
+    let mut file =
+        File::create(path).with_context(|| format!("failed creating {}", path.display()))?;
+    for value in values {
+        serde_json::to_writer(&mut file, value)
+            .with_context(|| format!("failed writing {}", path.display()))?;
+        file.write_all(b"\n")
+            .with_context(|| format!("failed finalizing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+pub(super) fn append_jsonl(path: &Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating {}", parent.display()))?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed opening jsonl file {}", path.display()))?;
+    serde_json::to_writer(&mut file, value)
+        .with_context(|| format!("failed writing jsonl file {}", path.display()))?;
+    file.write_all(b"\n")
+        .with_context(|| format!("failed finalizing jsonl file {}", path.display()))?;
+    Ok(())
+}
+
+pub(super) fn append_operator_event(
+    loaded: &LoadedAgentSpec,
+    event: &str,
+    details: Value,
+) -> Result<()> {
+    let record = json!({
+        "schema": OPERATOR_EVENT_SCHEMA,
+        "agent_instance_id": loaded.spec.agent_instance_id.clone(),
+        "event": event,
+        "at": Utc::now(),
+        "operator": "local",
+        "details": details
+    });
+    append_jsonl(&operator_events_path(loaded), &record)
+}


### PR DESCRIPTION
Closes #2208

## Summary
Implemented a behavior-preserving long-lived-agent refactor by extracting the storage/path/persistence seam from `adl/src/long_lived_agent.rs` into `adl/src/long_lived_agent/storage.rs`. Public entrypoints, artifact paths, schema constants, status behavior, stop behavior, lease behavior, inspection behavior, and JSON/JSONL formatting remain unchanged.

Before/after line-count evidence:
- `adl/src/long_lived_agent.rs`: 1713 lines before, 1553 lines after.
- `adl/src/long_lived_agent/storage.rs`: new 176-line child module.

## Artifacts
- `adl/src/long_lived_agent.rs`: reduced parent module and wired in the new storage child module.
- `adl/src/long_lived_agent/storage.rs`: new focused storage/path/persistence helper module.
- `.adl/reviews/refactoring-helper/issue-2208/refactor_plan_manual.md`: local ignored bounded refactor plan used before moving code.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`: formatted Rust changes after the module extraction.
  - `cargo fmt --manifest-path adl/Cargo.toml -- --check`: verified Rust formatting remains clean.
  - `cargo test --manifest-path adl/Cargo.toml --test cli_smoke agent_run_writes_bounded_cycles_and_status -- --nocapture`: verified the CLI-facing long-lived-agent bounded-cycle smoke path still passes.
  - `cargo test --manifest-path adl/Cargo.toml long_lived_agent -- --nocapture`: verified the focused long-lived-agent behavior suite still passes after the storage extraction.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`: verified the new internal module boundary has no clippy or warning regressions.
  - `git diff --check`: verified tracked diff whitespace hygiene.
- Results: all listed validation commands passed after the test-only import repair.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2208__v0-90-1-runtime-continue-splitting-long-lived-agent-responsibilities/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2208__v0-90-1-runtime-continue-splitting-long-lived-agent-responsibilities/sor.md
- Idempotency-Key: v0-90-1-runtime-continue-splitting-long-lived-agent-rs-responsibilities-adl-src-long-lived-agent-rs-adl-src-long-lived-agent-storage-rs-adl-v0-90-1-tasks-issue-2208-v0-90-1-runtime-continue-splitting-long-lived-agent-responsibilities-sip-md-adl-v0-90-1-tasks-issue-2208-v0-90-1-runtime-continue-splitting-long-lived-agent-responsibilities-sor-md