### PR TITLE
[v0.90.1][gap] Fix CSM Observatory operator report golden mismatch

### DIFF
--- a/demos/v0.90.1/csm_observatory_operator_report.md
+++ b/demos/v0.90.1/csm_observatory_operator_report.md
@@ -19,9 +19,9 @@ The manifold is initialized at tick 0. The kernel pulse is bounded_tick_complete
 - Snapshot restore must validate before active state is deferred (high); evidence: runtime_v2/rehydration_report.json.
 - Freedom Gate packet is fixture-only
 - Open Freedom Gate question: Which live Freedom Gate artifact path becomes canonical in v0.90.2?
-- Operator action pause_citizen remains disabled: Requires operator command packet design and kernel handling. Future issue: #2192.
-- Operator action request_snapshot remains disabled: Requires snapshot command packet and Runtime v2 snapshot implementation. Future issue: #2192.
-- Operator action resume_citizen remains disabled: Requires recovery eligibility and wake semantics. Future issue: #2192.
+- Operator action pause_citizen remains disabled: Requires Runtime v2 kernel handling of command packets. Future issue: #2192.
+- Operator action request_snapshot remains disabled: Requires Runtime v2 snapshot implementation and command handler. Future issue: #2192.
+- Operator action resume_citizen remains disabled: Requires recovery eligibility, wake semantics, and Runtime v2 kernel handling. Future issue: #2192.
 - Info: Freedom Gate docket is fixture-backed until live decision packets land.
 
 ## Manifold And Kernel
@@ -82,9 +82,9 @@ Available read-only actions:
 - open_freedom_gate_decision: available_in_console_prototype
 
 Disabled mutation actions:
-- pause_citizen: Requires operator command packet design and kernel handling.
-- request_snapshot: Requires snapshot command packet and Runtime v2 snapshot implementation.
-- resume_citizen: Requires recovery eligibility and wake semantics.
+- pause_citizen: Requires Runtime v2 kernel handling of command packets.
+- request_snapshot: Requires Runtime v2 snapshot implementation and command handler.
+- resume_citizen: Requires recovery eligibility, wake semantics, and Runtime v2 kernel handling.
 
 Required confirmations:
 - live mutation actions must remain disabled until command packets are routed through the kernel


### PR DESCRIPTION
Closes #2212

## Summary
Updated the v0.90.1 CSM Observatory operator report golden file so it matches the current report generator output after the operator command packet design wording changed disabled-action rationales.

## Artifacts
- Updated demos/v0.90.1/csm_observatory_operator_report.md.
- Created GitHub issue #2212 to capture the P1 gap-analysis finding.
- Preserved local lifecycle evidence for the issue worktree run.

## Validation
- Validation commands and their purpose:
  - bash adl/tools/test_demo_v0901_csm_observatory_operator_report.sh verified the CSM Observatory operator report generator and golden artifact match.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2212__fix-csm-observatory-operator-report-golden-mismatch/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2212__fix-csm-observatory-operator-report-golden-mismatch/sor.md
- Idempotency-Key: v0-90-1-gap-fix-csm-observatory-operator-report-golden-mismatch-demos-v0-90-1-csm-observatory-operator-report-md-adl-v0-90-1-tasks-issue-2212-fix-csm-observatory-operator-report-golden-mismatch-sip-md-adl-v0-90-1-tasks-issue-2212-fix-csm-observatory-operator-report-golden-mismatch-sor-md