### PR TITLE
Runtime v2 proof truth and command semantics

### DIFF
--- a/adl/src/cli/runtime_v2_cmd.rs
+++ b/adl/src/cli/runtime_v2_cmd.rs
@@ -13,6 +13,19 @@ pub(crate) fn real_runtime_v2(args: &[String]) -> Result<()> {
     real_runtime_v2_in_repo(args, &repo_root)
 }
 
+fn resolve_relative_output_path(
+    repo_root: &Path,
+    out_path: &PathBuf,
+    command: &str,
+) -> Result<PathBuf> {
+    if out_path.is_absolute() {
+        return Err(anyhow!(
+            "runtime-v2 {command} --out path must be repository-relative"
+        ));
+    }
+    Ok(repo_root.join(out_path))
+}
+
 fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
@@ -67,11 +80,7 @@ fn real_runtime_v2_operator_controls(repo_root: &Path, args: &[String]) -> Resul
         println!("{json}");
         return Ok(());
     };
-    let resolved = if out_path.is_absolute() {
-        out_path
-    } else {
-        repo_root.join(out_path)
-    };
+    let resolved = resolve_relative_output_path(repo_root, &out_path, "operator-controls")?;
     let Some(parent) = resolved.parent() else {
         return Err(anyhow!(
             "runtime-v2 operator-controls --out path must have a parent directory"
@@ -125,11 +134,7 @@ fn real_runtime_v2_security_boundary(repo_root: &Path, args: &[String]) -> Resul
         println!("{json}");
         return Ok(());
     };
-    let resolved = if out_path.is_absolute() {
-        out_path
-    } else {
-        repo_root.join(out_path)
-    };
+    let resolved = resolve_relative_output_path(repo_root, &out_path, "security-boundary")?;
     let Some(parent) = resolved.parent() else {
         return Err(anyhow!(
             "runtime-v2 security-boundary --out path must have a parent directory"
@@ -180,11 +185,7 @@ fn real_runtime_v2_foundation_demo(repo_root: &Path, args: &[String]) -> Result<
         println!("{}", to_string_pretty(&artifacts.proof_packet)?);
         return Ok(());
     };
-    let resolved = if out_path.is_absolute() {
-        out_path
-    } else {
-        repo_root.join(out_path)
-    };
+    let resolved = resolve_relative_output_path(repo_root, &out_path, "foundation-demo")?;
     fs::create_dir_all(&resolved).with_context(|| {
         format!(
             "failed to create Runtime v2 foundation demo root {}",
@@ -192,6 +193,9 @@ fn real_runtime_v2_foundation_demo(repo_root: &Path, args: &[String]) -> Result<
         )
     })?;
     artifacts.write_to_root(&resolved)?;
+    artifacts
+        .proof_packet
+        .validate_packaging_artifacts(&resolved)?;
     println!("RUNTIME_V2_FOUNDATION_DEMO_ROOT={}", resolved.display());
     Ok(())
 }
@@ -283,9 +287,8 @@ mod tests {
     }
 
     #[test]
-    fn runtime_v2_operator_controls_covers_stdout_help_and_absolute_output() {
+    fn runtime_v2_operator_controls_rejects_absolute_output() {
         let repo = temp_repo("operator-controls-branches");
-        let out_path = repo.join("absolute/operator_report.json");
 
         real_runtime_v2_in_repo(&["operator-controls".to_string()], &repo).expect("stdout report");
         real_runtime_v2_in_repo(
@@ -293,17 +296,20 @@ mod tests {
             &repo,
         )
         .expect("operator controls help");
-        real_runtime_v2_in_repo(
+        let err = real_runtime_v2_in_repo(
             &[
                 "operator-controls".to_string(),
                 "--out".to_string(),
-                out_path.to_string_lossy().to_string(),
+                repo.join("absolute/operator_report.json")
+                    .to_string_lossy()
+                    .to_string(),
             ],
             &repo,
         )
-        .expect("absolute output path");
-
-        assert!(out_path.is_file());
+        .expect_err("absolute output path should fail");
+        assert!(err
+            .to_string()
+            .contains("runtime-v2 operator-controls --out path must be repository-relative"));
 
         fs::remove_dir_all(repo).ok();
     }
@@ -365,9 +371,8 @@ mod tests {
     }
 
     #[test]
-    fn runtime_v2_security_boundary_covers_stdout_help_and_absolute_output() {
+    fn runtime_v2_security_boundary_rejects_absolute_output() {
         let repo = temp_repo("security-boundary-branches");
-        let out_path = repo.join("absolute/security_boundary.json");
 
         real_runtime_v2_in_repo(&["security-boundary".to_string()], &repo).expect("stdout proof");
         real_runtime_v2_in_repo(
@@ -375,17 +380,20 @@ mod tests {
             &repo,
         )
         .expect("security boundary help");
-        real_runtime_v2_in_repo(
+        let err = real_runtime_v2_in_repo(
             &[
                 "security-boundary".to_string(),
                 "--out".to_string(),
-                out_path.to_string_lossy().to_string(),
+                repo.join("absolute/security_boundary.json")
+                    .to_string_lossy()
+                    .to_string(),
             ],
             &repo,
         )
-        .expect("absolute output path");
-
-        assert!(out_path.is_file());
+        .expect_err("absolute output path should fail");
+        assert!(err
+            .to_string()
+            .contains("runtime-v2 security-boundary --out path must be repository-relative"));
 
         fs::remove_dir_all(repo).ok();
     }
@@ -425,9 +433,8 @@ mod tests {
     }
 
     #[test]
-    fn runtime_v2_foundation_demo_validates_stdout_help_and_errors() {
+    fn runtime_v2_foundation_demo_validates_stdout_help_and_output_path_rules() {
         let repo = temp_repo("foundation-demo-branches");
-        let out_dir = repo.join("absolute/foundation");
 
         real_runtime_v2_in_repo(&["foundation-demo".to_string()], &repo)
             .expect("stdout proof packet");
@@ -436,16 +443,20 @@ mod tests {
             &repo,
         )
         .expect("foundation demo help");
-        real_runtime_v2_in_repo(
+        let err = real_runtime_v2_in_repo(
             &[
                 "foundation-demo".to_string(),
                 "--out".to_string(),
-                out_dir.to_string_lossy().to_string(),
+                repo.join("absolute/foundation")
+                    .to_string_lossy()
+                    .to_string(),
             ],
             &repo,
         )
-        .expect("absolute output dir");
-        assert!(out_dir.join("runtime_v2/proof_packet.json").is_file());
+        .expect_err("absolute output dir should fail");
+        assert!(err
+            .to_string()
+            .contains("runtime-v2 foundation-demo --out path must be repository-relative"));
 
         let err = real_runtime_v2_in_repo(
             &["foundation-demo".to_string(), "--bogus".to_string()],

--- a/adl/src/runtime_v2/foundation.rs
+++ b/adl/src/runtime_v2/foundation.rs
@@ -221,6 +221,22 @@ impl RuntimeV2FoundationProofPacket {
                         .to_string(),
                 },
                 RuntimeV2FoundationArtifactRef {
+                    artifact_id: "active_citizen_index".to_string(),
+                    artifact_kind: "citizen_index".to_string(),
+                    schema_version: citizens.active_index.schema_version.clone(),
+                    path: citizens.active_index.index_path.clone(),
+                    source_wp: "WP-07".to_string(),
+                    proves: "active citizen index supports continuity and admission auditability".to_string(),
+                },
+                RuntimeV2FoundationArtifactRef {
+                    artifact_id: "pending_citizen_index".to_string(),
+                    artifact_kind: "citizen_index".to_string(),
+                    schema_version: citizens.pending_index.schema_version.clone(),
+                    path: citizens.pending_index.index_path.clone(),
+                    source_wp: "WP-07".to_string(),
+                    proves: "pending citizen index supports blocked reentry and wake readiness".to_string(),
+                },
+                RuntimeV2FoundationArtifactRef {
                     artifact_id: "snapshot_manifest".to_string(),
                     artifact_kind: "snapshot".to_string(),
                     schema_version: snapshot.snapshot.schema_version.clone(),
@@ -340,7 +356,12 @@ impl RuntimeV2FoundationProofPacket {
         validate_relative_path(&self.artifact_path, "foundation.artifact_path")?;
         validate_timestamp_marker(&self.generated_at_utc, "foundation.generated_at_utc")?;
         validate_foundation_artifact_refs(&self.integrated_artifacts)?;
-        validate_foundation_checks(&self.checks)?;
+        let artifact_paths = self
+            .integrated_artifacts
+            .iter()
+            .map(|artifact| artifact.path.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        validate_foundation_checks(&self.checks, &artifact_paths)?;
         if self.proof_claims.len() < 3 || self.non_claims.len() < 3 {
             return Err(anyhow!(
                 "Runtime v2 foundation proof packet must include explicit claims and non-claims"
@@ -362,6 +383,30 @@ impl RuntimeV2FoundationProofPacket {
             &self.artifact_path,
             self.to_pretty_json_bytes()?,
         )
+    }
+
+    pub fn validate_packaging_artifacts(&self, root: &Path) -> Result<()> {
+        for artifact in &self.integrated_artifacts {
+            let path = root.join(&artifact.path);
+            if !path.is_file() {
+                return Err(anyhow!(
+                    "Runtime v2 foundation proof artifact '{}' not found at {}",
+                    artifact.artifact_id,
+                    path.display()
+                ));
+            }
+        }
+        for check in &self.checks {
+            let path = root.join(&check.evidence_ref);
+            if !path.is_file() {
+                return Err(anyhow!(
+                    "Runtime v2 foundation proof check '{}' references missing evidence '{}'",
+                    check.check_id,
+                    check.evidence_ref
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -407,6 +452,7 @@ fn validate_foundation_artifact_kind(value: &str) -> Result<()> {
         | "kernel_registry"
         | "kernel_state"
         | "citizen_record"
+        | "citizen_index"
         | "snapshot"
         | "rehydration"
         | "invariant_violation"
@@ -416,7 +462,10 @@ fn validate_foundation_artifact_kind(value: &str) -> Result<()> {
     }
 }
 
-fn validate_foundation_checks(checks: &[RuntimeV2FoundationProofCheck]) -> Result<()> {
+fn validate_foundation_checks(
+    checks: &[RuntimeV2FoundationProofCheck],
+    artifact_paths: &std::collections::BTreeSet<String>,
+) -> Result<()> {
     let mut seen = std::collections::BTreeSet::new();
     for check in checks {
         normalize_id(check.check_id.clone(), "foundation.check_id")?;
@@ -427,6 +476,13 @@ fn validate_foundation_checks(checks: &[RuntimeV2FoundationProofCheck]) -> Resul
             ));
         }
         validate_relative_path(&check.evidence_ref, "foundation.check_evidence_ref")?;
+        if !artifact_paths.contains(&check.evidence_ref) {
+            return Err(anyhow!(
+                "Runtime v2 foundation proof check '{}' references '{}', which is not declared in integrated artifacts",
+                check.check_id,
+                check.evidence_ref
+            ));
+        }
         if !seen.insert(check.check_id.clone()) {
             return Err(anyhow!(
                 "Runtime v2 foundation proof packet contains duplicate check '{}'",

--- a/adl/src/runtime_v2/operator.rs
+++ b/adl/src/runtime_v2/operator.rs
@@ -32,13 +32,13 @@ impl RuntimeV2OperatorControlReport {
             kernel_loop_status: "operator_paused".to_string(),
             ..active_state.clone()
         };
-        let snapshotting_state = RuntimeV2OperatorControlState::from_parts(
+        let _snapshotting_state = RuntimeV2OperatorControlState::from_parts(
             "snapshotting",
             &kernel.state,
             citizens,
             Some(snapshot.snapshot.snapshot_id.clone()),
         );
-        let terminated_state = RuntimeV2OperatorControlState {
+        let _terminated_state = RuntimeV2OperatorControlState {
             manifold_lifecycle_state: "terminated".to_string(),
             kernel_loop_status: "operator_terminated".to_string(),
             active_citizen_count: 0,
@@ -79,21 +79,21 @@ impl RuntimeV2OperatorControlReport {
                     requested_by: "operator.cli".to_string(),
                     affected_service: "scheduler".to_string(),
                     pre_state: active_state.clone(),
-                    post_state: paused_state.clone(),
-                    outcome: "allowed".to_string(),
+                    post_state: active_state.clone(),
+                    outcome: "deferred".to_string(),
                     trace_event_ref: "runtime_v2/traces/operator/pause-manifold.json".to_string(),
-                    reason: "scheduler accepts a bounded operator pause before new episodes"
+                    reason: "pause command is deferred while kernel lifecycle gating is explicit"
                         .to_string(),
                 },
                 RuntimeV2OperatorCommandReport {
                     command: "resume_manifold".to_string(),
                     requested_by: "operator.cli".to_string(),
                     affected_service: "scheduler".to_string(),
-                    pre_state: paused_state,
-                    post_state: active_state.clone(),
-                    outcome: "allowed".to_string(),
+                    pre_state: paused_state.clone(),
+                    post_state: paused_state,
+                    outcome: "refused".to_string(),
                     trace_event_ref: "runtime_v2/traces/operator/resume-manifold.json".to_string(),
-                    reason: "invariant checks passed and the paused manifold may resume"
+                    reason: "invalid resume attempt is deferred until fresh invariant evidence exists"
                         .to_string(),
                 },
                 RuntimeV2OperatorCommandReport {
@@ -101,10 +101,10 @@ impl RuntimeV2OperatorControlReport {
                     requested_by: "operator.cli".to_string(),
                     affected_service: "snapshot_manager".to_string(),
                     pre_state: active_state.clone(),
-                    post_state: snapshotting_state,
-                    outcome: "allowed".to_string(),
+                    post_state: active_state.clone(),
+                    outcome: "deferred".to_string(),
                     trace_event_ref: "runtime_v2/traces/operator/request-snapshot.json".to_string(),
-                    reason: "snapshot manager can seal a bounded snapshot after invariants pass"
+                    reason: "snapshot command is deferred while live snapshot re-hydration policy is under v0.90.1 guard"
                         .to_string(),
                 },
                 RuntimeV2OperatorCommandReport {
@@ -124,12 +124,12 @@ impl RuntimeV2OperatorControlReport {
                     command: "terminate_manifold".to_string(),
                     requested_by: "operator.cli".to_string(),
                     affected_service: "resource_ledger".to_string(),
-                    pre_state: active_state,
-                    post_state: terminated_state,
-                    outcome: "allowed".to_string(),
+                    pre_state: active_state.clone(),
+                    post_state: active_state,
+                    outcome: "deferred".to_string(),
                     trace_event_ref: "runtime_v2/traces/operator/terminate-manifold.json"
                         .to_string(),
-                    reason: "resource ledger records bounded termination and release intent"
+                    reason: "termination is deferred until live deactivation policy is explicit"
                         .to_string(),
                 },
             ],

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -714,24 +714,28 @@ fn runtime_v2_operator_control_report_records_bounded_controls() {
     assert_eq!(report.commands.len(), 7);
     assert_eq!(report.commands[0].command, "inspect_manifold");
     assert_eq!(report.commands[2].command, "pause_manifold");
+    assert_eq!(report.commands[2].outcome, "deferred");
     assert_eq!(
         report.commands[2].post_state.manifold_lifecycle_state,
-        "paused"
+        "active"
     );
     assert_eq!(report.commands[3].command, "resume_manifold");
+    assert_eq!(report.commands[3].outcome, "refused");
     assert_eq!(
         report.commands[4].post_state.latest_snapshot_id.as_deref(),
-        Some("snapshot-0001")
+        None
     );
+    assert_eq!(report.commands[4].outcome, "deferred");
     assert_eq!(report.commands[5].command, "inspect_last_failures");
     assert!(report.commands[5]
         .trace_event_ref
         .contains("violation-0001"));
     assert_eq!(
         report.commands[6].post_state.manifold_lifecycle_state,
-        "terminated"
+        "active"
     );
-    assert_eq!(report.commands[6].post_state.active_citizen_count, 0);
+    assert_eq!(report.commands[6].outcome, "deferred");
+    assert_eq!(report.commands[6].post_state.active_citizen_count, 1);
 }
 
 #[test]
@@ -785,6 +789,7 @@ fn runtime_v2_operator_control_validation_rejects_unsafe_or_ambiguous_state() {
 
     let mut report = runtime_v2_operator_control_report_contract().expect("operator report");
     report.commands[2].post_state = report.commands[2].pre_state.clone();
+    report.commands[2].outcome = "allowed".to_string();
     assert!(report
         .validate()
         .expect_err("mutating command with unchanged state should fail")
@@ -792,6 +797,7 @@ fn runtime_v2_operator_control_validation_rejects_unsafe_or_ambiguous_state() {
         .contains("mutating control commands must change post_state"));
 
     let mut report = runtime_v2_operator_control_report_contract().expect("operator report");
+    report.commands[6].post_state.manifold_lifecycle_state = "terminated".to_string();
     report.commands[6].post_state.active_citizen_count = 1;
     assert!(report
         .validate()

--- a/adl/tests/fixtures/runtime_v2/operator/control_report.json
+++ b/adl/tests/fixtures/runtime_v2/operator/control_report.json
@@ -67,16 +67,16 @@
         "completed_through_event_sequence": 8
       },
       "post_state": {
-        "manifold_lifecycle_state": "paused",
-        "kernel_loop_status": "operator_paused",
+        "manifold_lifecycle_state": "active",
+        "kernel_loop_status": "bounded_tick_complete",
         "active_citizen_count": 1,
         "pending_citizen_count": 1,
         "latest_snapshot_id": null,
         "completed_through_event_sequence": 8
       },
-      "outcome": "allowed",
+      "outcome": "deferred",
       "trace_event_ref": "runtime_v2/traces/operator/pause-manifold.json",
-      "reason": "scheduler accepts a bounded operator pause before new episodes"
+      "reason": "pause command is deferred while kernel lifecycle gating is explicit"
     },
     {
       "command": "resume_manifold",
@@ -91,16 +91,16 @@
         "completed_through_event_sequence": 8
       },
       "post_state": {
-        "manifold_lifecycle_state": "active",
-        "kernel_loop_status": "bounded_tick_complete",
+        "manifold_lifecycle_state": "paused",
+        "kernel_loop_status": "operator_paused",
         "active_citizen_count": 1,
         "pending_citizen_count": 1,
         "latest_snapshot_id": null,
         "completed_through_event_sequence": 8
       },
-      "outcome": "allowed",
+      "outcome": "refused",
       "trace_event_ref": "runtime_v2/traces/operator/resume-manifold.json",
-      "reason": "invariant checks passed and the paused manifold may resume"
+      "reason": "invalid resume attempt is deferred until fresh invariant evidence exists"
     },
     {
       "command": "request_snapshot",
@@ -115,16 +115,16 @@
         "completed_through_event_sequence": 8
       },
       "post_state": {
-        "manifold_lifecycle_state": "snapshotting",
+        "manifold_lifecycle_state": "active",
         "kernel_loop_status": "bounded_tick_complete",
         "active_citizen_count": 1,
         "pending_citizen_count": 1,
-        "latest_snapshot_id": "snapshot-0001",
+        "latest_snapshot_id": null,
         "completed_through_event_sequence": 8
       },
-      "outcome": "allowed",
+      "outcome": "deferred",
       "trace_event_ref": "runtime_v2/traces/operator/request-snapshot.json",
-      "reason": "snapshot manager can seal a bounded snapshot after invariants pass"
+      "reason": "snapshot command is deferred while live snapshot re-hydration policy is under v0.90.1 guard"
     },
     {
       "command": "inspect_last_failures",
@@ -163,16 +163,16 @@
         "completed_through_event_sequence": 8
       },
       "post_state": {
-        "manifold_lifecycle_state": "terminated",
-        "kernel_loop_status": "operator_terminated",
-        "active_citizen_count": 0,
+        "manifold_lifecycle_state": "active",
+        "kernel_loop_status": "bounded_tick_complete",
+        "active_citizen_count": 1,
         "pending_citizen_count": 1,
-        "latest_snapshot_id": "snapshot-0001",
-        "completed_through_event_sequence": 14
+        "latest_snapshot_id": null,
+        "completed_through_event_sequence": 8
       },
-      "outcome": "allowed",
+      "outcome": "deferred",
       "trace_event_ref": "runtime_v2/traces/operator/terminate-manifold.json",
-      "reason": "resource ledger records bounded termination and release intent"
+      "reason": "termination is deferred until live deactivation policy is explicit"
     }
   ]
 }


### PR DESCRIPTION
Closes #2222

## Summary
- Updated runtime-v2 operator command semantics to reflect deferred/refused control behavior and unchanged post-states for mutating controls in this issue’s proof surface.
- Added repository-relative output-path enforcement for `runtime-v2` CLI subcommands and added packaging check for foundation proof packet artifacts.
- Synchronized runtime-v2 operator control fixture and CLI runtime-v2 command tests to match the new semantics.

## Artifacts
- `adl/src/runtime_v2/operator.rs`
- `adl/src/runtime_v2/foundation.rs`
- `adl/src/cli/runtime_v2_cmd.rs`
- `adl/src/runtime_v2/tests.rs`
- `adl/tests/fixtures/runtime_v2/operator/control_report.json`

## Validation
- Validation commands and their purpose:
- Results:

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.1/tasks/issue-2222__v0-90-1-wp-16-bundle-p1-runtime-v2-proof-truth-and-command-semantics/sip.md
- Output card: .adl/v0.90.1/tasks/issue-2222__v0-90-1-wp-16-bundle-p1-runtime-v2-proof-truth-and-command-semantics/sor.md
- Idempotency-Key: runtime-v2-proof-truth-and-command-semantics-adl-v0-90-1-tasks-issue-2222-v0-90-1-wp-16-bundle-p1-runtime-v2-proof-truth-and-command-semantics-sip-md-adl-v0-90-1-tasks-issue-2222-v0-90-1-wp-16-bundle-p1-runtime-v2-proof-truth-and-command-semantics-sor-md