### PR TITLE
[v0.90.1][WP-16] Record third-party review disposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable project-level changes are summarized here by milestone/release.
 ## v0.90.1 (Unreleased)
 
 Status: Active milestone; implementation/docs/quality work complete through
-WP-14, with WP-15/WP-15A/WP-16 review and remediation active before the
-WP-17 through WP-20 release tail.
+WP-14, internal and third-party review complete, and accepted WP-16 remediation
+bundles closed before the WP-17 through WP-20 release tail.
 
 Summary:
 - The v0.90.1 issue wave is open: WP-01 is #2141, WP-02 through WP-20 are
@@ -21,10 +21,10 @@ Summary:
   surfaces: visibility packet, operator report, CLI bundle, static console
   reference, and safe future command-packet design.
 - WP-13 aligned the review-facing docs, demo matrix, feature list, changelog,
-  README, and review guide; WP-14 established the quality gate; WP-15,
-  WP-15A, and WP-16 now carry the review/remediation band before WP-17 release
-  readiness, WP-18 v0.91/v0.92 handoff, WP-19 release evidence, and WP-20
-  release ceremony.
+  README, and review guide; WP-14 established the quality gate; WP-15 and
+  WP-15A completed internal and third-party review; the accepted WP-16
+  remediation bundles are closed before WP-17 release readiness, WP-18
+  v0.91/v0.92 handoff, WP-19 release evidence, and WP-20 release ceremony.
 - The crate version is `0.90.1` for the v0.90.1 release line.
 
 References:
@@ -34,6 +34,7 @@ References:
 - `docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md`
 - `docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md`
 - `docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md`
+- `docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md`
 - `docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md`
 - `docs/milestones/v0.90.1/RELEASE_NOTES_v0.90.1.md`
 - `docs/planning/ADL_FEATURE_LIST.md`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But those artifacts are not the whole story. In the current repository, they are
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.90%20released-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.90.1%20active-blue)
 
 Today, ADL includes:
 - a reference Rust runtime and CLI for deterministic workflow execution
@@ -105,7 +105,7 @@ Other useful entrypoints:
 ## Current Status
 
 - Active milestone: **v0.90.1**
-- Current release state: **v0.90 released; v0.90.1 issue wave open, implementation/docs/quality work complete through WP-14, review/remediation active in WP-15/WP-15A/WP-16**
+- Current release state: **v0.90 released; v0.90.1 issue wave open, implementation/docs/quality work complete through WP-14, internal and third-party review complete, accepted WP-16 remediation bundles closed**
 - Most recently completed milestone: **v0.90**
 - Current crate version: **0.90.1**
 - Version note: **v0.90.1 carries the active Runtime v2 foundation release line**
@@ -117,7 +117,7 @@ ADL is in active development. This repository contains both implemented runtime 
 
 ## Current Milestone
 
-v0.90.1 is the active milestone package. Its issue wave is open, with WP-01 at #2141, WP-02 through WP-20 at #2142 through #2160, and WP-15A third-party review at #2215. WP-01 through WP-14 are closed or in publication; WP-15 internal review, WP-15A third-party review, and WP-16 accepted-finding remediation are the active review-tail band before WP-17 release readiness, WP-18 v0.91/v0.92 handoff, WP-19 release-evidence packet, and WP-20 release ceremony. The tracked planning package lives under `docs/milestones/v0.90.1/`.
+v0.90.1 is the active milestone package. Its issue wave is open, with WP-01 at #2141, WP-02 through WP-20 at #2142 through #2160, and WP-15A third-party review at #2215. WP-01 through WP-15A are closed or complete, and the accepted WP-16 remediation bundles are closed before WP-17 release readiness, WP-18 v0.91/v0.92 handoff, WP-19 release-evidence packet, and WP-20 release ceremony. The tracked planning package lives under `docs/milestones/v0.90.1/`.
 
 v0.90 is the just-completed long-lived-agent runtime milestone. It carries ADL from bounded single-run proof surfaces into supervised recurring cycles with durable artifacts, pre-identity continuity handles, operator controls, demo proof, milestone compression, repo visibility, explicit Rust refactoring, and a measured coverage ratchet.
 

--- a/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
+++ b/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
@@ -31,8 +31,8 @@
 ## Release
 
 - [x] Internal review complete
-- [ ] Third-party review complete
-- [ ] Accepted internal and third-party findings remediated or explicitly deferred
+- [x] Third-party review complete
+- [x] Accepted internal and third-party findings remediated or explicitly deferred
 - [ ] Release notes describe landed work only
 - [ ] v0.91/v0.92 handoff preserves later scope
 - [ ] Release-evidence packet assembled

--- a/docs/milestones/v0.90.1/README.md
+++ b/docs/milestones/v0.90.1/README.md
@@ -2,19 +2,19 @@
 
 ## Status
 
-Active milestone package. The issue wave is open, WP-01 through WP-14 are
-closed or in publication, and the milestone now has review-facing docs plus a
-quality-gate proof surface before internal review, third-party review,
-remediation, and release tail.
+Active milestone package. The issue wave is open, WP-01 through WP-15A are
+closed or complete, the accepted WP-16 remediation bundles are closed, and the
+milestone is entering release-tail closeout.
 
 WP-01 opened the v0.90.1 issue wave after the v0.90 release ceremony. WP-01 is
 #2141; WP-02 through WP-20 are #2142 through #2160. WP-15A third-party review is
 #2215 and sits between internal review and remediation.
 
 The Runtime v2 implementation slice has now landed through WP-12, WP-13 aligned
-the docs package, and WP-14 defines the quality/coverage gate. Remaining work is
-review-tail work: WP-15 internal review, WP-15A third-party review, WP-16
-remediation, and WP-17 through WP-20 release closeout.
+the docs package, WP-14 defined the quality/coverage gate, WP-15 completed
+internal review, WP-15A completed third-party review, and the accepted WP-16
+remediation bundles are closed. Remaining work is WP-17 through WP-20 release
+closeout.
 
 ## Thesis
 
@@ -71,6 +71,7 @@ Out of scope:
 - Milestone checklist: `MILESTONE_CHECKLIST_v0.90.1.md`
 - Quality gate: `QUALITY_GATE_v0.90.1.md`
 - Internal review: `INTERNAL_REVIEW_v0.90.1.md`
+- Third-party review disposition: `THIRD_PARTY_REVIEW_v0.90.1.md`
 - Release plan: `RELEASE_PLAN_v0.90.1.md`
 - Release notes draft: `RELEASE_NOTES_v0.90.1.md`
 - Issue wave plan: `WP_ISSUE_WAVE_v0.90.1.yaml`

--- a/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
@@ -17,7 +17,8 @@ weakened release truth.
 - Demo matrix with every proof claim landed, skipped, or non-proving
 - Quality gate record: `QUALITY_GATE_v0.90.1.md` and
   `bash adl/tools/demo_v0901_quality_gate.sh`
-- Internal review, third-party review, and remediation record
+- Internal review, third-party review, and remediation record:
+  `INTERNAL_REVIEW_v0.90.1.md` and `THIRD_PARTY_REVIEW_v0.90.1.md`
 - WP-17 release-readiness packet and checklist
 - WP-18 v0.91/v0.92 handoff preserving moral/emotional and birthday/identity
   boundaries without claiming implementation of those later milestones

--- a/docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md
+++ b/docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md
@@ -1,0 +1,63 @@
+# Third-Party Review - v0.90.1
+
+## Metadata
+
+- Milestone: v0.90.1
+- Review lane: WP-15A
+- Review issue: #2215, closed as complete
+- Review materials: local v0.90.1 review archive
+- Remediation lane: WP-16 / #2156
+- Status: complete, with accepted findings remediated or routed to release tail
+
+## Summary
+
+The v0.90.1 third-party review found no P0 or P1 issues. It scored the
+milestone as ready after remediation bundles, with two P2 findings and one P3
+finding.
+
+The review confirmed the main milestone shape:
+
+- Runtime v2 foundation is substantial and reviewable.
+- CSM Observatory is useful and appropriately read-only or fixture-backed.
+- Compression enablement is real and does not replace review discipline.
+- Quality gate hardening is aligned with the milestone's release posture.
+- v0.90.1 does not overclaim first birthday, moral/emotional civilization, full
+  identity/capability rebinding, or cross-polis migration.
+
+## Findings And Disposition
+
+| Finding | Severity | Disposition |
+| --- | --- | --- |
+| README milestone badge still identified v0.90 as the released milestone | P2 | Fixed in WP-16 by changing the root README badge to v0.90.1 active. |
+| Third-party review handoff still described the remediation bundle state as draft/pending | P2 | Fixed locally in the review archive after #2221, #2222, #2224, and #2229 closed. The tracked release docs now point reviewers to this disposition record. |
+| D8 release-evidence packet remains planned | P3 | Explicitly deferred to WP-19, where the release-evidence packet belongs. This is normal release-tail work, not a WP-16 blocker. |
+
+## Remediation Bundle Closure
+
+The review findings were resolved through the accepted WP-16 remediation
+bundles:
+
+- #2221: quality gate and quality posture remediation
+- #2222: Runtime v2 proof truth and command semantics
+- #2224: CSM Observatory validation and report alignment
+- #2229: release docs routing and architecture truth
+
+Those bundle issues are closed. WP-17 through WP-20 remain responsible for
+release readiness, v0.91/v0.92 handoff, release-evidence assembly, and release
+ceremony.
+
+## Residual Release-Tail Work
+
+The third-party review did not add new release-blocking findings. Remaining
+release-tail work is procedural and evidentiary:
+
+- WP-17: release readiness
+- WP-18: v0.91/v0.92 handoff
+- WP-19: D8 release-evidence packet
+- WP-20: release ceremony
+
+## Non-Claims
+
+This disposition does not claim that v0.90.1 is already released. It records
+that WP-15A review is complete and that accepted review findings have either
+been fixed or routed to their planned release-tail work package.


### PR DESCRIPTION
## Summary

Closes #2156.

Records the v0.90.1 third-party review disposition after the review materials landed in the local review archive and the accepted WP-16 remediation bundles closed.

## Changes

- Updates the README milestone badge from v0.90 released to v0.90.1 active.
- Adds docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md.
- Marks third-party review complete and accepted findings remediated or deferred in the milestone checklist.
- Updates README, changelog, and release plan status language for the WP-17 through WP-20 release tail.

## Review Findings Addressed

- P2 README milestone badge not updated: fixed.
- P2 draft handoff state: local handoff finalized after #2221, #2222, #2224, and #2229 closed; tracked docs now record the disposition.
- P3 D8 release-evidence packet still planned: intentionally remains WP-19 release-tail work.

## Validation

- git diff --check
- stale-string scan for the old milestone badge and draft-handoff language in tracked release docs
- verified #2215 is closed as WP-15A complete
