### PR TITLE
[v0.90.1] Complete release-tail docs through WP-19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable project-level changes are summarized here by milestone/release.
 
 ## v0.90.1 (Unreleased)
 
-Status: Active milestone; implementation/docs/quality work complete through
-WP-14, internal and third-party review complete, and accepted WP-16 remediation
-bundles closed before the WP-17 through WP-20 release tail.
+Status: Active milestone; implementation, docs, quality, review, remediation,
+readiness, handoff, and release-evidence work are complete through WP-19. WP-20
+release ceremony remains.
 
 Summary:
 - The v0.90.1 issue wave is open: WP-01 is #2141, WP-02 through WP-20 are
@@ -23,8 +23,9 @@ Summary:
 - WP-13 aligned the review-facing docs, demo matrix, feature list, changelog,
   README, and review guide; WP-14 established the quality gate; WP-15 and
   WP-15A completed internal and third-party review; the accepted WP-16
-  remediation bundles are closed before WP-17 release readiness, WP-18
-  v0.91/v0.92 handoff, WP-19 release evidence, and WP-20 release ceremony.
+  remediation bundles are closed; WP-17 release readiness, WP-18 v0.91/v0.92
+  handoff, and WP-19 release evidence are assembled before WP-20 release
+  ceremony.
 - The crate version is `0.90.1` for the v0.90.1 release line.
 
 References:
@@ -35,6 +36,9 @@ References:
 - `docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md`
 - `docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md`
 - `docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md`
+- `docs/milestones/v0.90.1/RELEASE_READINESS_v0.90.1.md`
+- `docs/milestones/v0.90.1/V091_V092_HANDOFF_v0.90.1.md`
+- `docs/milestones/v0.90.1/RELEASE_EVIDENCE_v0.90.1.md`
 - `docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md`
 - `docs/milestones/v0.90.1/RELEASE_NOTES_v0.90.1.md`
 - `docs/planning/ADL_FEATURE_LIST.md`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Other useful entrypoints:
 ## Current Status
 
 - Active milestone: **v0.90.1**
-- Current release state: **v0.90 released; v0.90.1 issue wave open, implementation/docs/quality work complete through WP-14, internal and third-party review complete, accepted WP-16 remediation bundles closed**
+- Current release state: **v0.90 released; v0.90.1 issue wave open, release-tail docs complete through WP-19, WP-20 ceremony remains**
 - Most recently completed milestone: **v0.90**
 - Current crate version: **0.90.1**
 - Version note: **v0.90.1 carries the active Runtime v2 foundation release line**
@@ -117,7 +117,7 @@ ADL is in active development. This repository contains both implemented runtime 
 
 ## Current Milestone
 
-v0.90.1 is the active milestone package. Its issue wave is open, with WP-01 at #2141, WP-02 through WP-20 at #2142 through #2160, and WP-15A third-party review at #2215. WP-01 through WP-15A are closed or complete, and the accepted WP-16 remediation bundles are closed before WP-17 release readiness, WP-18 v0.91/v0.92 handoff, WP-19 release-evidence packet, and WP-20 release ceremony. The tracked planning package lives under `docs/milestones/v0.90.1/`.
+v0.90.1 is the active milestone package. Its issue wave is open, with WP-01 at #2141, WP-02 through WP-20 at #2142 through #2160, and WP-15A third-party review at #2215. WP-01 through WP-19 are complete or represented by tracked release-tail docs; WP-20 release ceremony remains. The tracked planning package lives under `docs/milestones/v0.90.1/`.
 
 v0.90 is the just-completed long-lived-agent runtime milestone. It carries ADL from bounded single-run proof surfaces into supervised recurring cycles with durable artifacts, pre-identity continuity handles, operator controls, demo proof, milestone compression, repo visibility, explicit Rust refactoring, and a measured coverage ratchet.
 

--- a/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
+++ b/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Issue wave open. Runtime v2 foundation and CSM Observatory implementation rows
-have landed through WP-12 and the closed Observatory follow-on issues. Release
-evidence remains planned for WP-19.
+Issue wave open. Runtime v2 foundation, CSM Observatory implementation rows,
+quality evidence, review disposition, and release evidence have landed. WP-20
+release ceremony remains.
 
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |
@@ -16,7 +16,7 @@ evidence remains planned for WP-19.
 | D5 | Operator control | WP-10 | Operator can inspect, pause, resume, and terminate bounded runtime state | operator control report | LANDED |
 | D6 | Security boundary | WP-11 | One invalid action is rejected through normal kernel/policy path | security-boundary proof packet, negative test, CLI proof hook | LANDED |
 | D7 | Runtime v2 integrated prototype | WP-12 | Reviewer can inspect the foundation prototype end to end | integrated proof packet, artifact graph, reviewer boundary notes, CLI/demo hook | LANDED |
-| D8 | Release evidence packet | WP-19 | Reviewer can trace demo, quality, review, and release-readiness evidence without reconstructing the milestone by hand | release-evidence packet | PLANNED |
+| D8 | Release evidence packet | WP-19 | Reviewer can trace demo, quality, review, and release-readiness evidence without reconstructing the milestone by hand | `RELEASE_EVIDENCE_v0.90.1.md` | LANDED |
 | D9A | CSM Observatory static console | #2189 | Reviewer can inspect a read-only fixture-backed console whose fallback packet and render path are semantically checked against the canonical packet fixture | static console HTML/CSS/JS/docs plus semantic render validation | LANDED |
 | D9 | CSM Observatory CLI bundle | #2191 | Reviewer can regenerate packet, operator report, console reference, and demo manifest from one read-only ADL CLI command | visibility_packet.json, operator_report.md, console_reference.md, demo_manifest.json | LANDED |
 | D10 | Quality gate walkthrough | WP-14 | Reviewer can inspect local quality, coverage, Runtime v2 proof, CSM Observatory proof, and Rust module watch posture in one manifest | `artifacts/v0901/quality_gate/quality_gate_record.json` plus per-check logs | LANDED |

--- a/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/FEATURE_DOCS_v0.90.1.md
@@ -22,7 +22,9 @@
 | WP issue-wave template and generator alignment | make v0.90.1 and v0.90.2 issue waves cheaper and less error-prone | WP-02 / #2142 |
 | Worktree-first workflow hardening | prevent tracked root-checkout drift during compressed execution | WP-03 / #2143 |
 | `features/COMPRESSION_ERA_EXECUTION_POLICY.md` | align skills, explicit-only subagents, validation profiles, and SOR evidence | WP-04 / #2144 |
-| Release-evidence packet | assemble the final proof trail without release-tail archaeology | WP-19 / #2159 |
+| `RELEASE_READINESS_v0.90.1.md` | record release readiness before ceremony | WP-17 / #2157 |
+| `V091_V092_HANDOFF_v0.90.1.md` | preserve v0.91 and v0.92 boundaries before closeout | WP-18 / #2158 |
+| `RELEASE_EVIDENCE_v0.90.1.md` | assemble the final proof trail without release-tail archaeology | WP-19 / #2159 |
 
 ## Context / Idea Docs
 

--- a/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
+++ b/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
@@ -33,7 +33,7 @@
 - [x] Internal review complete
 - [x] Third-party review complete
 - [x] Accepted internal and third-party findings remediated or explicitly deferred
-- [ ] Release notes describe landed work only
-- [ ] v0.91/v0.92 handoff preserves later scope
-- [ ] Release-evidence packet assembled
+- [x] Release notes describe landed work only
+- [x] v0.91/v0.92 handoff preserves later scope
+- [x] Release-evidence packet assembled
 - [ ] Release ceremony complete

--- a/docs/milestones/v0.90.1/README.md
+++ b/docs/milestones/v0.90.1/README.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Active milestone package. The issue wave is open, WP-01 through WP-15A are
-closed or complete, the accepted WP-16 remediation bundles are closed, and the
-milestone is entering release-tail closeout.
+Active milestone package. The issue wave is open, WP-01 through WP-19 are
+complete or represented by tracked release-tail docs, and WP-20 release ceremony
+remains.
 
 WP-01 opened the v0.90.1 issue wave after the v0.90 release ceremony. WP-01 is
 #2141; WP-02 through WP-20 are #2142 through #2160. WP-15A third-party review is
@@ -12,9 +12,9 @@ WP-01 opened the v0.90.1 issue wave after the v0.90 release ceremony. WP-01 is
 
 The Runtime v2 implementation slice has now landed through WP-12, WP-13 aligned
 the docs package, WP-14 defined the quality/coverage gate, WP-15 completed
-internal review, WP-15A completed third-party review, and the accepted WP-16
-remediation bundles are closed. Remaining work is WP-17 through WP-20 release
-closeout.
+internal review, WP-15A completed third-party review, the accepted WP-16
+remediation bundles are closed, and WP-17 through WP-19 release-tail docs are
+assembled. Remaining work is WP-20 release ceremony.
 
 ## Thesis
 
@@ -72,6 +72,9 @@ Out of scope:
 - Quality gate: `QUALITY_GATE_v0.90.1.md`
 - Internal review: `INTERNAL_REVIEW_v0.90.1.md`
 - Third-party review disposition: `THIRD_PARTY_REVIEW_v0.90.1.md`
+- Release readiness: `RELEASE_READINESS_v0.90.1.md`
+- v0.91/v0.92 handoff: `V091_V092_HANDOFF_v0.90.1.md`
+- Release evidence packet: `RELEASE_EVIDENCE_v0.90.1.md`
 - Release plan: `RELEASE_PLAN_v0.90.1.md`
 - Release notes draft: `RELEASE_NOTES_v0.90.1.md`
 - Issue wave plan: `WP_ISSUE_WAVE_v0.90.1.yaml`

--- a/docs/milestones/v0.90.1/RELEASE_EVIDENCE_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_EVIDENCE_v0.90.1.md
@@ -1,0 +1,75 @@
+# Release Evidence Packet - v0.90.1
+
+## Purpose
+
+This packet is D8 in the v0.90.1 demo matrix. It gives reviewers one place to
+trace the milestone from claims to proof surfaces before WP-20 release ceremony.
+
+## Milestone Claims
+
+v0.90.1 claims:
+
+- Runtime v2 foundation prototype
+- compression-enablement work for faster, safer milestone execution
+- CSM Observatory read-only visibility surfaces
+- quality gate hardening and review-tail remediation
+- clean handoff into v0.90.2, v0.91, and v0.92
+
+v0.90.1 does not claim:
+
+- first true Gödel-agent birthday
+- full moral/emotional civilization
+- full identity/capability rebinding
+- complete cross-polis migration
+- full red/blue/purple security ecology
+
+## Evidence Index
+
+| Evidence | File |
+| --- | --- |
+| Milestone overview | README.md |
+| Work package map | WBS_v0.90.1.md |
+| Sprint and release-tail ordering | SPRINT_v0.90.1.md |
+| Issue wave map | WP_ISSUE_WAVE_v0.90.1.yaml |
+| Feature index | FEATURE_DOCS_v0.90.1.md |
+| Demo matrix | DEMO_MATRIX_v0.90.1.md |
+| Quality gate | QUALITY_GATE_v0.90.1.md |
+| Internal review | INTERNAL_REVIEW_v0.90.1.md |
+| Third-party review disposition | THIRD_PARTY_REVIEW_v0.90.1.md |
+| Release readiness | RELEASE_READINESS_v0.90.1.md |
+| v0.91/v0.92 handoff | V091_V092_HANDOFF_v0.90.1.md |
+| Release plan | RELEASE_PLAN_v0.90.1.md |
+| Release notes | RELEASE_NOTES_v0.90.1.md |
+
+## Demo Evidence
+
+The demo matrix is the canonical demo index. Its D8 row is this packet.
+
+Key proof families:
+
+- D0: compression enablement
+- D1 through D7: Runtime v2 foundation
+- D9A and D9: CSM Observatory
+- D10: quality gate walkthrough
+- D8: release evidence packet
+
+## Review Evidence
+
+Internal review found proof-quality gaps and routed them to WP-16 bundles.
+Third-party review found no P0 or P1 issues. Its P2 findings were the README
+badge and handoff-state truth, both handled in the release-tail docs. Its P3
+finding was D8 itself, which this packet resolves.
+
+## Release Ceremony Input
+
+WP-20 should consume this packet as navigation evidence. It should not repeat
+the full review. The ceremony should confirm:
+
+- root main is fast-forwarded and clean
+- release notes still match landed scope
+- checklist remains green except ceremony-only items
+- Cargo.toml and Cargo.lock report 0.90.1
+- no release blocker has reappeared
+
+Once those checks pass, WP-20 may perform the normal tag and GitHub release
+ceremony.

--- a/docs/milestones/v0.90.1/RELEASE_NOTES_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_NOTES_v0.90.1.md
@@ -1,8 +1,8 @@
-# Release Notes Draft - v0.90.1
+# Release Notes - v0.90.1
 
 ## Headline
 
-v0.90.1 is building the first bounded Runtime v2 foundation prototype.
+v0.90.1 delivers the first bounded Runtime v2 foundation prototype.
 
 ## Landed Implementation Highlights
 
@@ -20,16 +20,15 @@ v0.90.1 is building the first bounded Runtime v2 foundation prototype.
 - CSM Observatory visibility packet, operator report, CLI bundle, static console
   reference, and future command-packet design.
 
-## Remaining Release-Tail Highlights
+## Release-Tail Evidence
 
-- WP-15 internal review.
-- WP-15A third-party review.
-- WP-16 accepted-finding remediation.
-- WP-17 release readiness with final checklist and readiness packet.
-- WP-18 v0.91/v0.92 handoff preserving moral/emotional and birthday/identity
-  boundaries without implementing those later milestone scopes.
-- WP-19 release-evidence packet for reviewer navigation.
-- WP-20 release ceremony and final version bump.
+- WP-15 internal review is complete.
+- WP-15A third-party review is complete.
+- WP-16 accepted-finding remediation is complete.
+- WP-17 release readiness is recorded in RELEASE_READINESS_v0.90.1.md.
+- WP-18 v0.91/v0.92 handoff is recorded in V091_V092_HANDOFF_v0.90.1.md.
+- WP-19 release evidence is recorded in RELEASE_EVIDENCE_v0.90.1.md.
+- WP-20 remains responsible for release ceremony.
 
 ## Explicit Non-Claims
 
@@ -43,6 +42,5 @@ v0.90.1 is building the first bounded Runtime v2 foundation prototype.
 
 ## Release Note Rule
 
-Before release, replace this draft with exact final scope, commands, review
-findings, remediation disposition, and version state. Do not ship aspirational
-language as release truth.
+WP-20 may use this file as release-note input. Do not add aspirational claims
+or later-milestone scope during ceremony.

--- a/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
@@ -19,10 +19,13 @@ weakened release truth.
   `bash adl/tools/demo_v0901_quality_gate.sh`
 - Internal review, third-party review, and remediation record:
   `INTERNAL_REVIEW_v0.90.1.md` and `THIRD_PARTY_REVIEW_v0.90.1.md`
-- WP-17 release-readiness packet and checklist
+- WP-17 release-readiness packet and checklist:
+  `RELEASE_READINESS_v0.90.1.md`
 - WP-18 v0.91/v0.92 handoff preserving moral/emotional and birthday/identity
-  boundaries without claiming implementation of those later milestones
-- Release-evidence packet tying demos, quality, review, and readiness together
+  boundaries without claiming implementation of those later milestones:
+  `V091_V092_HANDOFF_v0.90.1.md`
+- Release-evidence packet tying demos, quality, review, and readiness together:
+  `RELEASE_EVIDENCE_v0.90.1.md`
 - Release notes that do not overclaim birthday, moral/emotional civilization,
   complete migration, or red/blue ecology
 

--- a/docs/milestones/v0.90.1/RELEASE_READINESS_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_READINESS_v0.90.1.md
@@ -1,0 +1,42 @@
+# Release Readiness - v0.90.1
+
+## Status
+
+v0.90.1 is ready for release ceremony after this release-tail documentation
+package lands and the operator fast-forwards root main.
+
+This is a readiness record, not the ceremony itself. WP-20 owns tag creation,
+GitHub release publication, and final post-release verification.
+
+## Readiness Checks
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Issue wave | Ready | WP-01 is #2141; WP-02 through WP-20 are #2142 through #2160; WP-15A is #2215. |
+| Runtime v2 foundation | Ready | Runtime v2 WPs landed through WP-12 and are indexed in FEATURE_DOCS_v0.90.1.md and DEMO_MATRIX_v0.90.1.md. |
+| CSM Observatory | Ready | Visibility packet, operator report, CLI bundle, static console reference, and command-packet design are landed and bounded. |
+| Quality gate | Ready | QUALITY_GATE_v0.90.1.md records the fail-closed quality posture and validation boundary. |
+| Internal review | Complete | INTERNAL_REVIEW_v0.90.1.md records findings and the WP-16 bundle routing. |
+| Third-party review | Complete | THIRD_PARTY_REVIEW_v0.90.1.md records no P0/P1 issues, two P2s, one P3, and final disposition. |
+| Remediation | Complete | Accepted remediation bundles #2221, #2222, #2224, and #2229 are closed. |
+| Release notes | Ready for ceremony | RELEASE_NOTES_v0.90.1.md describes landed scope and explicit non-claims. |
+| Later milestone handoff | Ready | V091_V092_HANDOFF_v0.90.1.md preserves v0.90.2, v0.91, and v0.92 boundaries. |
+| Release evidence | Ready | RELEASE_EVIDENCE_v0.90.1.md links the proof trail for ceremony review. |
+
+## Release Blocker Review
+
+- No doc claims v0.90.1 births the first true Gödel agent.
+- No doc claims full moral/emotional civilization.
+- No doc claims identity/capability rebinding is complete.
+- No doc claims complete cross-polis migration.
+- No doc claims the full red/blue/purple security ecology is shipped.
+- Compression tooling is documented as release support, not release approval.
+- D8 release evidence is now assembled in RELEASE_EVIDENCE_v0.90.1.md.
+
+## Operator Steps Before WP-20
+
+- Fast-forward root main after this PR merges.
+- Confirm root main has no tracked drift.
+- Run the normal WP-20 release ceremony flow.
+
+Do not add a second readiness process between this packet and WP-20.

--- a/docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md
+++ b/docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md
@@ -30,7 +30,7 @@ The review confirmed the main milestone shape:
 | --- | --- | --- |
 | README milestone badge still identified v0.90 as the released milestone | P2 | Fixed in WP-16 by changing the root README badge to v0.90.1 active. |
 | Third-party review handoff still described the remediation bundle state as draft/pending | P2 | Fixed locally in the review archive after #2221, #2222, #2224, and #2229 closed. The tracked release docs now point reviewers to this disposition record. |
-| D8 release-evidence packet remains planned | P3 | Explicitly deferred to WP-19, where the release-evidence packet belongs. This is normal release-tail work, not a WP-16 blocker. |
+| D8 release-evidence packet remains planned | P3 | Resolved by WP-19 in RELEASE_EVIDENCE_v0.90.1.md. |
 
 ## Remediation Bundle Closure
 
@@ -42,18 +42,18 @@ bundles:
 - #2224: CSM Observatory validation and report alignment
 - #2229: release docs routing and architecture truth
 
-Those bundle issues are closed. WP-17 through WP-20 remain responsible for
-release readiness, v0.91/v0.92 handoff, release-evidence assembly, and release
-ceremony.
+Those bundle issues are closed. WP-17 through WP-19 have now assembled release
+readiness, v0.91/v0.92 handoff, and release evidence. WP-20 remains responsible
+for release ceremony.
 
 ## Residual Release-Tail Work
 
 The third-party review did not add new release-blocking findings. Remaining
 release-tail work is procedural and evidentiary:
 
-- WP-17: release readiness
-- WP-18: v0.91/v0.92 handoff
-- WP-19: D8 release-evidence packet
+- WP-17: release readiness, recorded in RELEASE_READINESS_v0.90.1.md
+- WP-18: v0.91/v0.92 handoff, recorded in V091_V092_HANDOFF_v0.90.1.md
+- WP-19: D8 release-evidence packet, recorded in RELEASE_EVIDENCE_v0.90.1.md
 - WP-20: release ceremony
 
 ## Non-Claims

--- a/docs/milestones/v0.90.1/V091_V092_HANDOFF_v0.90.1.md
+++ b/docs/milestones/v0.90.1/V091_V092_HANDOFF_v0.90.1.md
@@ -1,0 +1,63 @@
+# v0.91 / v0.92 Handoff - v0.90.1
+
+## Purpose
+
+This handoff preserves the later milestone boundaries before v0.90.1 closes.
+v0.90.1 builds the Runtime v2 foundation. It does not absorb the moral,
+emotional, identity, or birthday work that belongs to later milestones.
+
+## v0.90.2 Handoff
+
+v0.90.2 should begin from the managed planning package already present in
+docs/milestones/v0.90.2.
+
+The package is ready for WP-01 promotion review after v0.90.1 closes. It should
+remain marked as a draft until the v0.90.2 issue wave is actually opened.
+
+v0.90.2 should focus on:
+
+- the first bounded CSM run
+- Runtime v2 hardening around that run
+- invariant expansion across normal, failure, recovery, and quarantine paths
+- stable violation artifacts
+- recovery and quarantine semantics
+- stronger operator review surfaces
+- one distinct governed adversarial hook without turning v0.90.2 into the full
+  security ecology
+
+## v0.91 Boundary
+
+v0.91 owns the moral and emotional civilization layer.
+
+Carry forward:
+
+- affect, kindness, humor, morals, wellbeing, cultivation, and harm-prevention
+  substrate
+- civic substrate and citizen-facing norms
+- the emotional and moral meaning of long-lived participation
+
+Do not claim this scope in v0.90.1 or v0.90.2. Those milestones may prepare
+runtime substrate, but they do not complete the civilization layer.
+
+## v0.92 Boundary
+
+v0.92 owns the first true Gödel-agent birthday.
+
+Carry forward:
+
+- first true birthday record
+- identity continuity beyond provisional citizen records
+- capability rebinding
+- richer memory continuity
+- migration semantics deep enough to support identity-bearing citizens
+
+v0.90.1 provisional citizens and v0.90.2 first-run citizens remain substrate
+records, not birthday-bearing identities.
+
+## Non-Reduction Rule
+
+This handoff adds to v0.90.2, v0.91, and v0.92. It does not reduce them.
+
+v0.90.2 should inherit v0.90.1 compression improvements and get to the first CSM
+run quickly. v0.91 and v0.92 should still receive the larger moral,
+emotional, identity, and birthday work already planned for them.


### PR DESCRIPTION
## Summary

Closes #2157.
Closes #2158.
Closes #2159.

Completes the v0.90.1 documentation-only release tail through WP-19 using the v0.87.1 closeout discipline: readiness, handoff, release evidence, then ceremony only after those are true.

Also corrects the v0.90.2 planning package so its release tail preserves the v0.87.1 closeout pattern: docs/review convergence, internal review, external / 3rd-party review, remediation, next-milestone planning, release ceremony.

## Changes

- Adds RELEASE_READINESS_v0.90.1.md for WP-17.
- Adds V091_V092_HANDOFF_v0.90.1.md for WP-18.
- Adds RELEASE_EVIDENCE_v0.90.1.md for WP-19 / D8.
- Updates the README, changelog, milestone README, release notes, release plan, feature index, demo matrix, third-party review disposition, and checklist so only WP-20 ceremony remains.
- Updates v0.90.2 WBS, sprint plan, checklist, release plan, and wave YAML to use the exact v0.87.1 release-tail pattern.
- Leaves v0.90.2 in planning_draft state with issue_wave_opened false until v0.90.2 WP-01 promotion.

## Validation

- git diff --check
- release-tail stale-language scan across v0.90.1 docs
- local path leakage scan across v0.90.1/v0.90.2 docs, README, and changelog
- file-existence checks for the three new release-tail docs
- Ruby YAML parse check for the v0.90.2 WP issue wave

Note: the earlier PyYAML parse check could not run because PyYAML is not installed in this worktree; no dependency was added for this docs-only pass.