### PR TITLE
[v0.90.1][WP-20] Complete release ceremony prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
-## v0.90.1 (Unreleased)
+## v0.90.1 (Released 2026-04-20)
 
-Status: Active milestone; implementation, docs, quality, review, remediation,
-readiness, handoff, and release-evidence work are complete through WP-19. WP-20
-release ceremony remains.
+Status: Completed. Implementation, docs, quality, review, remediation,
+readiness, handoff, release evidence, and WP-20 release ceremony preflight are
+complete. Final tag/release publication runs from clean main after this closeout
+PR merges.
 
 Summary:
-- The v0.90.1 issue wave is open: WP-01 is #2141, WP-02 through WP-20 are
+- The v0.90.1 issue wave is complete: WP-01 is #2141, WP-02 through WP-20 are
   #2142 through #2160, and WP-15A third-party review is #2215.
 - The compression-enablement sprint landed first: issue-wave generation,
   worktree-first workflow hardening, and the compression-era execution policy.
@@ -24,8 +25,8 @@ Summary:
   README, and review guide; WP-14 established the quality gate; WP-15 and
   WP-15A completed internal and third-party review; the accepted WP-16
   remediation bundles are closed; WP-17 release readiness, WP-18 v0.91/v0.92
-  handoff, and WP-19 release evidence are assembled before WP-20 release
-  ceremony.
+  handoff, WP-19 release evidence, and WP-20 ceremony preflight completed the
+  release tail.
 - The crate version is `0.90.1` for the v0.90.1 release line.
 
 References:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But those artifacts are not the whole story. In the current repository, they are
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.90.1%20active-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.90.2%20planning-blue)
 
 Today, ADL includes:
 - a reference Rust runtime and CLI for deterministic workflow execution
@@ -104,11 +104,11 @@ Other useful entrypoints:
 
 ## Current Status
 
-- Active milestone: **v0.90.1**
-- Current release state: **v0.90 released; v0.90.1 issue wave open, release-tail docs complete through WP-19, WP-20 ceremony remains**
-- Most recently completed milestone: **v0.90**
+- Active milestone: **v0.90.2 planning**
+- Current release state: **v0.90.1 release ceremony preflight passed; final tag/release publication runs from clean main after merge**
+- Most recently completed milestone: **v0.90.1**
 - Current crate version: **0.90.1**
-- Version note: **v0.90.1 carries the active Runtime v2 foundation release line**
+- Version note: **v0.90.1 carries the completed Runtime v2 foundation release line**
 - Previous completed milestone package: **v0.89.1**
 - Previous completed milestone: **v0.89**
 - Project changelog: `CHANGELOG.md`
@@ -117,9 +117,11 @@ ADL is in active development. This repository contains both implemented runtime 
 
 ## Current Milestone
 
-v0.90.1 is the active milestone package. Its issue wave is open, with WP-01 at #2141, WP-02 through WP-20 at #2142 through #2160, and WP-15A third-party review at #2215. WP-01 through WP-19 are complete or represented by tracked release-tail docs; WP-20 release ceremony remains. The tracked planning package lives under `docs/milestones/v0.90.1/`.
+v0.90.2 is the active planning package for the first bounded CSM run and Runtime v2 hardening. Its tracked planning package lives under `docs/milestones/v0.90.2/`; the issue wave remains closed until v0.90.2 WP-01 promotion.
 
-v0.90 is the just-completed long-lived-agent runtime milestone. It carries ADL from bounded single-run proof surfaces into supervised recurring cycles with durable artifacts, pre-identity continuity handles, operator controls, demo proof, milestone compression, repo visibility, explicit Rust refactoring, and a measured coverage ratchet.
+v0.90.1 is the completed Runtime v2 foundation prototype milestone. Its issue wave opened with WP-01 at #2141, WP-02 through WP-20 at #2142 through #2160, and WP-15A third-party review at #2215. WP-20 release ceremony preflight passed, including the closed-issue SOR truth gate, and the final tag/release publication is the clean-main post-merge ceremony step. The tracked milestone package lives under `docs/milestones/v0.90.1/`.
+
+v0.90 is the previous long-lived-agent runtime milestone. It carries ADL from bounded single-run proof surfaces into supervised recurring cycles with durable artifacts, pre-identity continuity handles, operator controls, demo proof, milestone compression, repo visibility, explicit Rust refactoring, and a measured coverage ratchet.
 
 The implementation wave landed through the long-lived runtime, stock-league demo, demo-extension, compression, repo-visibility, coverage, Rust-refactoring, docs, and internal-review surfaces. The release tail completed third-party review, accepted ADR remediation, next-milestone planning, and release ceremony.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -21,7 +21,7 @@ The reviewer should not audit ADL against a frozen abstract standard alone. The 
 
 ## Current Review Entry Point
 
-For the active v0.90.1 review-remediation pass, start with:
+For the most recently completed v0.90.1 release package, start with:
 
 - `docs/milestones/v0.90.1/README.md`
 - `docs/milestones/v0.90.1/WBS_v0.90.1.md`
@@ -38,21 +38,19 @@ For the active v0.90.1 review-remediation pass, start with:
 - `adl/Cargo.toml`
 - `adl/Cargo.lock`
 
-The current v0.90.1 review posture is pre-release remediation copy. WP-01
-through WP-15A have produced the Runtime v2 foundation implementation,
-documentation package, quality evidence, internal review, and third-party review
-inputs. WP-16 remediation is being handled through bundled follow-up issues so
-the release can resolve review findings without paying one full issue ceremony
-per small defect.
+The current v0.90.1 review posture is final release copy. WP-01 through WP-20
+have produced the Runtime v2 foundation implementation, documentation package,
+quality evidence, internal review, third-party review, accepted remediation,
+release readiness, v0.91/v0.92 handoff, release evidence, and release ceremony
+preflight.
 
-The crate version is `0.90.1` for the active v0.90.1 release line. Reviewers
+The crate version is `0.90.1` for the completed v0.90.1 release line. Reviewers
 should treat any conflicting older version reference as a stale release-truth
 defect.
 
-Before a final third-party review or release-readiness review, verify that the
-accepted WP-16 remediation bundle PRs have merged, root main has been
-fast-forwarded by the operator, and the local third-party review handoff packet
-has been regenerated from the merged tree.
+Before tag/release publication, verify that the WP-20 closeout PR has merged,
+root main has been fast-forwarded by the operator, and the release ceremony
+script is run from clean main.
 
 For the most recently completed v0.90 post-release review, start with:
 

--- a/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
+++ b/docs/milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Issue wave open. Runtime v2 foundation, CSM Observatory implementation rows,
-quality evidence, review disposition, and release evidence have landed. WP-20
-release ceremony remains.
+Issue wave closed through WP-20. Runtime v2 foundation, CSM Observatory
+implementation rows, quality evidence, review disposition, release evidence,
+and release ceremony preflight have landed.
 
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
+++ b/docs/milestones/v0.90.1/MILESTONE_CHECKLIST_v0.90.1.md
@@ -36,4 +36,4 @@
 - [x] Release notes describe landed work only
 - [x] v0.91/v0.92 handoff preserves later scope
 - [x] Release-evidence packet assembled
-- [ ] Release ceremony complete
+- [x] Release ceremony preflight complete; final tag/release publication runs from clean main after merge

--- a/docs/milestones/v0.90.1/README.md
+++ b/docs/milestones/v0.90.1/README.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Active milestone package. The issue wave is open, WP-01 through WP-19 are
-complete or represented by tracked release-tail docs, and WP-20 release ceremony
-remains.
+Completed milestone package. The issue wave is closed through WP-20, the
+release-tail docs are complete, and release ceremony preflight passed. Final
+tag/release publication runs from clean main after the WP-20 closeout PR merges.
 
 WP-01 opened the v0.90.1 issue wave after the v0.90 release ceremony. WP-01 is
 #2141; WP-02 through WP-20 are #2142 through #2160. WP-15A third-party review is
@@ -13,8 +13,8 @@ WP-01 opened the v0.90.1 issue wave after the v0.90 release ceremony. WP-01 is
 The Runtime v2 implementation slice has now landed through WP-12, WP-13 aligned
 the docs package, WP-14 defined the quality/coverage gate, WP-15 completed
 internal review, WP-15A completed third-party review, the accepted WP-16
-remediation bundles are closed, and WP-17 through WP-19 release-tail docs are
-assembled. Remaining work is WP-20 release ceremony.
+remediation bundles are closed, WP-17 through WP-19 release-tail docs are
+assembled, and WP-20 release ceremony preflight passed.
 
 ## Thesis
 

--- a/docs/milestones/v0.90.1/RELEASE_EVIDENCE_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_EVIDENCE_v0.90.1.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 This packet is D8 in the v0.90.1 demo matrix. It gives reviewers one place to
-trace the milestone from claims to proof surfaces before WP-20 release ceremony.
+trace the milestone from claims to proof surfaces for WP-20 release ceremony.
 
 ## Milestone Claims
 
@@ -62,14 +62,13 @@ finding was D8 itself, which this packet resolves.
 
 ## Release Ceremony Input
 
-WP-20 should consume this packet as navigation evidence. It should not repeat
-the full review. The ceremony should confirm:
+WP-20 consumes this packet as navigation evidence. It should not repeat the full
+review. The ceremony preflight confirmed:
 
-- root main is fast-forwarded and clean
+- the WP-20 worktree is clean and based on the merged release-tail branch
 - release notes still match landed scope
-- checklist remains green except ceremony-only items
+- checklist records the WP-20 preflight state truthfully
 - Cargo.toml and Cargo.lock report 0.90.1
 - no release blocker has reappeared
 
-Once those checks pass, WP-20 may perform the normal tag and GitHub release
-ceremony.
+Final tag and GitHub release publication remain the clean-main post-merge step.

--- a/docs/milestones/v0.90.1/RELEASE_NOTES_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_NOTES_v0.90.1.md
@@ -28,7 +28,8 @@ v0.90.1 delivers the first bounded Runtime v2 foundation prototype.
 - WP-17 release readiness is recorded in RELEASE_READINESS_v0.90.1.md.
 - WP-18 v0.91/v0.92 handoff is recorded in V091_V092_HANDOFF_v0.90.1.md.
 - WP-19 release evidence is recorded in RELEASE_EVIDENCE_v0.90.1.md.
-- WP-20 remains responsible for release ceremony.
+- WP-20 release ceremony preflight passed, including the closed-issue SOR truth
+  gate across 54 closed v0.90.1 issues.
 
 ## Explicit Non-Claims
 
@@ -42,5 +43,5 @@ v0.90.1 delivers the first bounded Runtime v2 foundation prototype.
 
 ## Release Note Rule
 
-WP-20 may use this file as release-note input. Do not add aspirational claims
-or later-milestone scope during ceremony.
+This file is final release-note input for v0.90.1. Do not add aspirational
+claims or later-milestone scope during tag/release publication.

--- a/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
+++ b/docs/milestones/v0.90.1/RELEASE_PLAN_v0.90.1.md
@@ -26,6 +26,8 @@ weakened release truth.
   `V091_V092_HANDOFF_v0.90.1.md`
 - Release-evidence packet tying demos, quality, review, and readiness together:
   `RELEASE_EVIDENCE_v0.90.1.md`
+- WP-20 release ceremony preflight:
+  `bash adl/tools/release_ceremony.sh --version v0.90.1 --target-branch codex/2160-v0-90-1-wp-20-release-ceremony`
 - Release notes that do not overclaim birthday, moral/emotional civilization,
   complete migration, or red/blue ecology
 

--- a/docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md
+++ b/docs/milestones/v0.90.1/THIRD_PARTY_REVIEW_v0.90.1.md
@@ -42,22 +42,23 @@ bundles:
 - #2224: CSM Observatory validation and report alignment
 - #2229: release docs routing and architecture truth
 
-Those bundle issues are closed. WP-17 through WP-19 have now assembled release
-readiness, v0.91/v0.92 handoff, and release evidence. WP-20 remains responsible
-for release ceremony.
+Those bundle issues are closed. WP-17 through WP-19 assembled release
+readiness, v0.91/v0.92 handoff, and release evidence. WP-20 release ceremony
+preflight has passed.
 
 ## Residual Release-Tail Work
 
-The third-party review did not add new release-blocking findings. Remaining
-release-tail work is procedural and evidentiary:
+The third-party review did not add new release-blocking findings. Release-tail
+work is recorded as follows:
 
 - WP-17: release readiness, recorded in RELEASE_READINESS_v0.90.1.md
 - WP-18: v0.91/v0.92 handoff, recorded in V091_V092_HANDOFF_v0.90.1.md
 - WP-19: D8 release-evidence packet, recorded in RELEASE_EVIDENCE_v0.90.1.md
-- WP-20: release ceremony
+- WP-20: release ceremony preflight passed; final tag/release publication runs
+  from clean main after merge
 
 ## Non-Claims
 
-This disposition does not claim that v0.90.1 is already released. It records
-that WP-15A review is complete and that accepted review findings have either
-been fixed or routed to their planned release-tail work package.
+This disposition records that WP-15A review is complete and that accepted
+review findings have either been fixed or routed to their planned release-tail
+work package.

--- a/docs/milestones/v0.90.2/MILESTONE_CHECKLIST_v0.90.2.md
+++ b/docs/milestones/v0.90.2/MILESTONE_CHECKLIST_v0.90.2.md
@@ -38,8 +38,11 @@
 
 ## Release
 
+- [ ] Docs, quality, and reviewer entry surfaces converged
 - [ ] Internal review complete
+- [ ] External / 3rd-party review complete
 - [ ] Accepted findings remediated or explicitly deferred
 - [ ] Release notes describe landed work only
 - [ ] v0.91/v0.92 handoff preserves later scope
+- [ ] Next-milestone planning complete before release ceremony
 - [ ] Release ceremony complete

--- a/docs/milestones/v0.90.2/RELEASE_PLAN_v0.90.2.md
+++ b/docs/milestones/v0.90.2/RELEASE_PLAN_v0.90.2.md
@@ -22,7 +22,11 @@ and produced reviewable hardening evidence around that run.
 - duplicate activation, snapshot integrity, and replay-gap negative proofs
 - bounded security-boundary hardening proof
 - integrated first CSM run demo packet
-- internal review and remediation record
+- docs, quality, and reviewer-entry convergence record
+- internal review record
+- external / 3rd-party review record
+- accepted-findings remediation or explicit owner-bound deferral record
+- next-milestone planning and v0.91/v0.92 handoff record
 - release notes that do not overclaim birthday, moral/emotional civilization,
   complete migration, or red/blue ecology
 
@@ -35,7 +39,21 @@ and produced reviewable hardening evidence around that run.
 - Missing violation artifact proof
 - Missing recovery/quarantine distinction
 - Missing operator-review evidence
+- Missing internal or external review disposition
+- Missing accepted-finding remediation or explicit deferral
+- Missing next-milestone planning before ceremony
 - Failing required CI without explicit release-owner disposition
+
+## Closeout Order
+
+Use the v0.87.1 closeout pattern for v0.90.2:
+
+1. WP-15 docs, quality, and review convergence.
+2. WP-16 internal review.
+3. WP-17 external / 3rd-party review.
+4. WP-18 review findings remediation.
+5. WP-19 next-milestone planning and v0.91/v0.92 handoff.
+6. WP-20 release ceremony.
 
 ## Handoff
 

--- a/docs/milestones/v0.90.2/SPRINT_v0.90.2.md
+++ b/docs/milestones/v0.90.2/SPRINT_v0.90.2.md
@@ -35,12 +35,17 @@ adversarial hook, concrete hardening probes, and one integrated proof packet.
 
 ## Sprint 4 - Review And Release Tail
 
-- WP-15 docs pass
-- WP-16 quality and coverage gate
-- WP-17 internal review
-- WP-18 remediation
-- WP-19 release readiness and v0.91/v0.92 handoff
+- WP-15 docs, quality, and review convergence
+- WP-16 internal review
+- WP-17 external / 3rd-party review
+- WP-18 review findings remediation
+- WP-19 next milestone planning and v0.91/v0.92 handoff
 - WP-20 release ceremony
 
 Exit when the milestone is truthful, releaseable, and does not steal later
 identity or moral/emotional scope.
+
+Sprint 4 must follow the v0.87.1 closeout order exactly: convergence before
+internal review, internal review before external review, external review before
+remediation, remediation before next-milestone planning, and planning before
+the final release ceremony.

--- a/docs/milestones/v0.90.2/WBS_v0.90.2.md
+++ b/docs/milestones/v0.90.2/WBS_v0.90.2.md
@@ -22,11 +22,11 @@ contract before implementation begins.
 | WP-12 | Quarantine state machine | Implement quarantine state and evidence preservation for unsafe recovery | quarantine artifact and tests | WP-11 |
 | WP-13 | Governed adversarial hook and hardening probes | Add one bounded adversarial probe plus duplicate activation, snapshot integrity, and trace/replay gap negative probes | adversarial hook packet and hardening proof packets | WP-11, WP-12 |
 | WP-14 | Integrated first CSM run demo | Produce one end-to-end first-run and hardening proof packet | integrated CSM run demo packet | WP-05-WP-13 |
-| WP-15 | Runtime v2 first-run docs pass | Align feature docs, demo matrix, README, and Observatory claims | coherent docs package | WP-14 |
-| WP-16 | Quality and coverage gate | Run focused tests and quality posture | quality report | WP-14 |
-| WP-17 | Internal review | Review claims, artifacts, compression, and boundaries | findings-first review packet | WP-15, WP-16 |
-| WP-18 | Review remediation | Fix accepted findings or defer explicitly | patches and closure notes | WP-17 |
-| WP-19 | Release readiness and v0.91/v0.92 handoff | Finalize release notes, checklist, reviewer handoff, and later-boundary inheritance | readiness and handoff packet | WP-18 |
+| WP-15 | Docs, quality, and review convergence | Align feature docs, demo matrix, README, quality posture, and reviewer entry surfaces | coherent docs/review package and quality report | WP-14 |
+| WP-16 | Internal review | Review claims, artifacts, compression, quality, and boundaries | findings-first internal review packet | WP-15 |
+| WP-17 | External / 3rd-party review | Execute external review against the stabilized v0.90.2 proof package | completed external review record | WP-16 |
+| WP-18 | Review findings remediation | Fix accepted findings or defer explicitly with owner and rationale | patches, closure notes, and tracked deferrals | WP-16, WP-17 |
+| WP-19 | Next milestone planning | Finalize v0.91/v0.92 handoff and next-milestone planning before release closeout | next-milestone planning and handoff packet | WP-18 |
 | WP-20 | Release ceremony | Complete tag/release ceremony | release closure | WP-19 |
 
 ## Compression Candidate
@@ -41,5 +41,6 @@ Compression target:
   contract is stable
 - WP-13 should stay bounded to one governed adversarial hook plus concrete
   hardening probes, not expand into a full security-ecology sprint
-- WP-15 through WP-19 should consume continuously maintained evidence rather
-  than rediscovering the milestone at the end
+- WP-15 through WP-19 must preserve the v0.87.1 closeout pattern:
+  docs/review convergence, internal review, external / 3rd-party review,
+  findings remediation, next-milestone planning, then ceremony

--- a/docs/milestones/v0.90.2/WP_ISSUE_WAVE_v0.90.2.yaml
+++ b/docs/milestones/v0.90.2/WP_ISSUE_WAVE_v0.90.2.yaml
@@ -10,6 +10,7 @@ notes:
   - "v0.90.2 is the first bounded CSM run milestone plus hardening around that run."
   - "Preserve one distinct governed adversarial hook in WP-13 without turning v0.90.2 into the full security ecology."
   - "Apply v0.90.1 compression rules: generated issue wave, worktree-first execution, validation profiles, and continuously maintained evidence."
+  - "Preserve the v0.87.1 closeout pattern: docs/review convergence, internal review, external / 3rd-party review, remediation, next-milestone planning, release ceremony."
 work_packages:
   - wp: WP-01
     title: Promote and finalize v0.90.2 milestone package
@@ -54,20 +55,20 @@ work_packages:
     title: Integrated first CSM run demo
     outcome: integrated CSM run demo packet
   - wp: WP-15
-    title: Runtime v2 first-run docs pass
-    outcome: aligned feature docs, demo matrix, and README
+    title: Docs, quality, and review convergence
+    outcome: aligned docs, quality posture, demo matrix, README, and reviewer entry surfaces
   - wp: WP-16
-    title: Quality and coverage gate
-    outcome: truthful quality posture
-  - wp: WP-17
     title: Internal review
     outcome: findings-first internal review packet
+  - wp: WP-17
+    title: External / 3rd-party review
+    outcome: completed external review record
   - wp: WP-18
-    title: Review remediation
-    outcome: accepted findings fixed or explicitly deferred
+    title: Review findings remediation
+    outcome: accepted findings fixed or explicitly deferred with owner and rationale
   - wp: WP-19
-    title: Release readiness and v0.91/v0.92 handoff
-    outcome: release notes, checklist, reviewer handoff, and preserved later boundaries
+    title: Next milestone planning and v0.91/v0.92 handoff
+    outcome: next-milestone planning package, release notes, checklist, reviewer handoff, and preserved later boundaries
   - wp: WP-20
     title: Release ceremony
     outcome: v0.90.2 closed truthfully


### PR DESCRIPTION
## Summary

Closes #2160.

Completes the v0.90.1 WP-20 release ceremony preparation and leaves the final tag/release publication as the clean-main post-merge step.

## Changes

- Updates README, CHANGELOG, REVIEW.md, and v0.90.1 milestone docs so v0.90.1 is represented as complete through WP-20 preflight.
- Records that the release ceremony preflight passed, including the closed-issue SOR truth gate across 54 closed v0.90.1 issues.
- Confirms Cargo.toml and Cargo.lock are at 0.90.1.
- Folds in the v0.90.2 planning correction so its closeout tail follows the v0.87.1 pattern: docs/review convergence, internal review, external / 3rd-party review, remediation, next-milestone planning, release ceremony.

## Validation

- bash adl/tools/release_ceremony.sh --version v0.90.1 --target-branch codex/2160-v0-90-1-wp-20-release-ceremony
- bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.90.1
- git diff --check HEAD~2..HEAD
- Cargo.toml and Cargo.lock version scan for 0.90.1
- local path leakage scan across README, CHANGELOG, REVIEW.md, and v0.90.1/v0.90.2 milestone docs

## Post-merge operator step

After merge, fast-forward clean main and run the mutating release ceremony step from main as appropriate: create/push tag and create/publish the GitHub release.