### PR TITLE
[backlog][skill] Harden operational workflow skills

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -78,6 +78,8 @@ The normal workflow is:
 `diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 `issue-watcher` is a bounded wait-window helper for watching one issue, PR, branch, or dependency gate and routing blockers without mutating state.
+`pr-stack-manager` is a bounded stack-topology helper for ancestry, base alignment, and dependency-order analysis.
+`review-comment-triage` is a bounded review-feedback helper for classifying PR comments before implementation.
 
 The three editor skills are helper skills:
 - `stp-editor` for bounded `stp.md` cleanup
@@ -1169,6 +1171,75 @@ Use `records-hygiene` when hygiene can be resolved by safe record repair.
 If the issue is ambiguous, unresolved, or not mechanically safe, use the output
 recommendations as a follow-on issue queue item and avoid scope expansion.
 
+Deterministic local analyzer:
+
+```bash
+python3 adl/tools/skills/records-hygiene/scripts/analyze_records_hygiene.py <target>
+```
+
+## `pr-stack-manager`
+
+### Purpose
+
+`pr-stack-manager` is a focused stack-maintenance skill for ADL issue branches
+and PR stacks. It inspects branch ancestry, expected PR bases, dependency
+edges, and merge-order risks without silently rebasing, retargeting, or merging.
+
+### When To Use It
+
+- when a dependent PR may have a stale base,
+- when merge order is unclear,
+- when stack truth in an issue record disagrees with GitHub or local git state,
+- before executing or finishing a PR that depends on another open PR.
+
+Structured schema:
+
+- `adl/tools/skills/docs/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md`
+- schema id: `pr_stack_manager.v1`
+
+Deterministic fixture analyzer:
+
+```bash
+python3 adl/tools/skills/pr-stack-manager/scripts/analyze_pr_stack.py <stack-packet>
+```
+
+### Typical Handoff
+
+Use `pr-stack-manager` for stack analysis and planning. Hand off PR-specific CI,
+conflict, or review blockers to `pr-janitor`. Do not perform branch mutation
+unless the operator explicitly authorizes a bounded stack action.
+
+## `review-comment-triage`
+
+### Purpose
+
+`review-comment-triage` classifies PR review comments into a bounded execution
+plan while preserving comment identity, file and line context, links,
+uncertainty, and current-issue scope.
+
+### When To Use It
+
+- before addressing mixed review feedback,
+- when comments may be stale, already fixed, or outside the current issue,
+- when review feedback needs follow-on issue planning rather than direct fixes.
+
+Structured schema:
+
+- `adl/tools/skills/docs/REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md`
+- schema id: `review_comment_triage.v1`
+
+Deterministic fixture analyzer:
+
+```bash
+python3 adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py <payload-path>
+```
+
+### Typical Handoff
+
+Use `pr-janitor` for actionable current-PR items, `github:gh-address-comments`
+for thread-resolution work, and `finding-to-issue-planner` when comments should
+become follow-on issue candidates.
+
 ## `stp-editor`
 
 ### Purpose
@@ -1995,6 +2066,10 @@ Use this quick selector:
   - `pr-closeout`
 - need to clean drifted lifecycle records before closeout or janitor handoff:
   - `records-hygiene`
+- need to inspect stacked PR topology or stale branch bases:
+  - `pr-stack-manager`
+- need to classify PR review comments before implementation:
+  - `review-comment-triage`
 - need a broad findings-first code review:
   - `repo-code-review`
 - need source-backed arXiv-style manuscript drafting or citation-gap review:
@@ -2057,6 +2132,7 @@ surfaces:
 | `pr-janitor` | `PR_JANITOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | in-flight PR monitoring or bounded repair |
 | `pr-ready` | `PR_READY_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | readiness diagnosis only |
 | `pr-run` | `PR_RUN_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | bounded issue execution only |
+| `pr-stack-manager` | `PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | stack topology analysis or bounded stack plan only |
 | `product-report-writer` | `PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | product report packet only |
 | `redaction-and-evidence-auditor` | `REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | safety audit only |
 | `review-comment-triage` | `REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review-comment triage only |

--- a/adl/tools/skills/pr-stack-manager/SKILL.md
+++ b/adl/tools/skills/pr-stack-manager/SKILL.md
@@ -111,6 +111,8 @@ Write structured findings and next-step recommendations to a bounded artifact.
 
 1. Resolve target identity and stack context.
 2. Run topology+base analysis.
+   - For fixture-backed analysis, use
+     `python3 adl/tools/skills/pr-stack-manager/scripts/analyze_pr_stack.py <stack-packet>`.
 3. Report `blocking` stack risks first.
 4. If `allow_mutation` is enabled and risks are unambiguous, apply bounded actions.
 5. Write residual recommendations and handoff state.

--- a/adl/tools/skills/pr-stack-manager/adl-skill.yaml
+++ b/adl/tools/skills/pr-stack-manager/adl-skill.yaml
@@ -100,6 +100,7 @@ execution:
     - "git branch --all --list"
     - "git log --oneline --decorate --graph"
     - "gh pr view --json number,baseRefName,headRefName,state,title"
+    - "python3 adl/tools/skills/pr-stack-manager/scripts/analyze_pr_stack.py <stack-packet>"
     - "adl/tools/pr.sh doctor --json"
   preferred_path: "target_issue_stack_then_local_and_remote_stack_surfaces"
   repair_policy: "plan_only_by_default_then_apply_only_when_explicitly_safe"
@@ -127,4 +128,4 @@ outputs:
 security:
   trusted_root_required: true
   deny_symlink_escape: true
-  manifest_declares_executables: false
+  manifest_declares_executables: true

--- a/adl/tools/skills/pr-stack-manager/scripts/analyze_pr_stack.py
+++ b/adl/tools/skills/pr-stack-manager/scripts/analyze_pr_stack.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def node_issue(node: dict) -> int | None:
+    value = node.get("issue_number")
+    return int(value) if value is not None else None
+
+
+def detect_cycles(nodes: list[dict]) -> bool:
+    graph = {node_issue(node): list(node.get("depends_on", [])) for node in nodes if node_issue(node) is not None}
+    visiting: set[int] = set()
+    visited: set[int] = set()
+
+    def visit(issue: int) -> bool:
+        if issue in visiting:
+            return True
+        if issue in visited:
+            return False
+        visiting.add(issue)
+        for dep in graph.get(issue, []):
+            if dep in graph and visit(dep):
+                return True
+        visiting.remove(issue)
+        visited.add(issue)
+        return False
+
+    return any(visit(issue) for issue in graph)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze a bounded ADL PR stack packet.")
+    parser.add_argument("payload_path", help="Path to a JSON stack packet.")
+    parser.add_argument("--out", help="Optional JSON output path.")
+    args = parser.parse_args()
+
+    payload_path = Path(args.payload_path)
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    nodes = payload.get("nodes", [])
+    known_issues = {node_issue(node) for node in nodes if node_issue(node) is not None}
+    findings: list[dict] = []
+    edges: list[dict] = []
+    planned_actions: list[dict] = []
+
+    for node in nodes:
+        issue = node_issue(node)
+        base_ref = node.get("base_ref")
+        expected_base = node.get("expected_base_ref")
+        depends_on = list(node.get("depends_on", []))
+
+        for dep in depends_on:
+            edges.append(
+                {
+                    "from_issue": issue,
+                    "to_issue": dep,
+                    "edge_type": "requires",
+                    "confidence": "high" if dep in known_issues else "medium",
+                }
+            )
+            if dep not in known_issues:
+                findings.append(
+                    {
+                        "severity": "warning",
+                        "area": "dependency_order",
+                        "message": f"Issue {issue} depends on missing issue {dep}",
+                        "evidence": {
+                            "summary": "Dependency is listed but no matching node exists in the stack packet.",
+                            "files": [payload_path.as_posix()],
+                            "refs": [f"#{issue}", f"#{dep}"],
+                        },
+                        "can_auto_fix": False,
+                    }
+                )
+
+        if expected_base and base_ref and expected_base != base_ref:
+            findings.append(
+                {
+                    "severity": "blocking",
+                    "area": "base_alignment",
+                    "message": f"Issue {issue} base {base_ref!r} does not match expected base {expected_base!r}",
+                    "evidence": {
+                        "summary": "PR base drift would make merge order or review diff misleading.",
+                        "files": [payload_path.as_posix()],
+                        "refs": [node.get("branch"), f"PR {node.get('pr_number')}"],
+                    },
+                    "can_auto_fix": False,
+                }
+            )
+            planned_actions.append(
+                {
+                    "type": "plan",
+                    "issue_number": issue,
+                    "action": "retarget_or_rebase_base",
+                    "command": None,
+                    "rationale": "Base alignment needs operator-confirmed stack maintenance.",
+                    "safe": False,
+                    "preconditions": ["operator confirms expected stack parent", "working tree is clean"],
+                }
+            )
+
+    cycle_detected = detect_cycles(nodes)
+    if cycle_detected:
+        findings.append(
+            {
+                "severity": "blocking",
+                "area": "stack_topology",
+                "message": "Dependency cycle detected in stack packet",
+                "evidence": {
+                    "summary": "A stack cycle prevents a deterministic merge order.",
+                    "files": [payload_path.as_posix()],
+                    "refs": [],
+                },
+                "can_auto_fix": False,
+            }
+        )
+
+    status = "blocked" if any(item["severity"] == "blocking" for item in findings) else (
+        "findings" if findings else "clean"
+    )
+    output = {
+        "schema_version": "pr_stack_manager.analysis.v1",
+        "status": status,
+        "target": payload.get("target", {}),
+        "dependency_graph": {
+            "root_issue": payload.get("root_issue"),
+            "nodes": nodes,
+            "edges": edges,
+            "cycle_detected": cycle_detected,
+        },
+        "findings": findings,
+        "planned_actions": planned_actions,
+        "validation_performed": ["analyze_pr_stack.py"],
+        "handoff_state": {
+            "ready_for_editor": bool(findings),
+            "ready_for_execution": status == "clean",
+            "ready_for_follow_on_implementation": bool(planned_actions),
+        },
+    }
+
+    rendered = json.dumps(output, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if status != "blocked" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/skills/records-hygiene/SKILL.md
+++ b/adl/tools/skills/records-hygiene/SKILL.md
@@ -68,6 +68,8 @@ Useful additional inputs:
 2. Read the authoritative surfaces for that target.
 3. Run deterministic drift detection for status, linkage, placeholder, IDs, and
    integration claims.
+   - For a deterministic local check, use
+     `python3 adl/tools/skills/records-hygiene/scripts/analyze_records_hygiene.py <target>`.
 4. Classify each finding as safe fix, skipped, or ambiguous.
 5. If `report_only` is false and the finding is safe/ambiguous-free,
    apply the repair.
@@ -152,4 +154,3 @@ Use `references/output-contract.md` and emit the structured shape described ther
 
 Artifact path pattern should be an `.adl/reviews` record under the active
 repository path.
-

--- a/adl/tools/skills/records-hygiene/adl-skill.yaml
+++ b/adl/tools/skills/records-hygiene/adl-skill.yaml
@@ -87,6 +87,7 @@ execution:
   preferred_commands:
     - "rg --files .adl"
     - "rg -n \"status|run_id|worktree_only|pr_open|issue|pr|integration\" .adl"
+    - "python3 adl/tools/skills/records-hygiene/scripts/analyze_records_hygiene.py <target>"
     - "git worktree list"
     - "adl/tools/pr.sh doctor --json"
   preferred_path: "target_issue_or_task_first_then_worktree_or_branch_bound_records"
@@ -116,4 +117,4 @@ outputs:
 security:
   trusted_root_required: true
   deny_symlink_escape: true
-  manifest_declares_executables: false
+  manifest_declares_executables: true

--- a/adl/tools/skills/records-hygiene/scripts/analyze_records_hygiene.py
+++ b/adl/tools/skills/records-hygiene/scripts/analyze_records_hygiene.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+ALLOWED_INTEGRATION_STATES = {"worktree_only", "pr_open", "merged", "closed_no_pr"}
+PLACEHOLDER_RE = re.compile(r"\b(?:TODO|TBD)\b|<[^>\n]+>|\bN/A\b")
+STATUS_RE = re.compile(r"^Status:\s*(?P<status>[A-Z_]+)\s*$", re.MULTILINE)
+INTEGRATION_RE = re.compile(r"^- Integration state:\s*(?P<state>\S+)\s*$", re.MULTILINE)
+
+
+def repo_relative(path: Path, root: Path | None) -> str:
+    if root:
+        try:
+            return path.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            pass
+    return path.as_posix()
+
+
+def iter_markdown(paths: list[Path]) -> list[Path]:
+    discovered: list[Path] = []
+    for path in paths:
+        if path.is_file():
+            discovered.append(path)
+        elif path.is_dir():
+            discovered.extend(sorted(path.rglob("*.md")))
+    return sorted(dict.fromkeys(discovered))
+
+
+def finding(severity: str, area: str, message: str, evidence: str, path: str) -> dict:
+    return {
+        "severity": severity,
+        "area": area,
+        "message": message,
+        "evidence": evidence,
+        "files": [path],
+        "can_auto_fix": False,
+    }
+
+
+def analyze_file(path: Path, root: Path | None) -> list[dict]:
+    text = path.read_text(encoding="utf-8")
+    rel = repo_relative(path, root)
+    findings: list[dict] = []
+
+    for match in INTEGRATION_RE.finditer(text):
+        state = match.group("state")
+        if state not in ALLOWED_INTEGRATION_STATES:
+            findings.append(
+                finding(
+                    "blocking",
+                    "integration_truth",
+                    f"Invalid integration state {state!r}",
+                    f"Allowed values: {', '.join(sorted(ALLOWED_INTEGRATION_STATES))}",
+                    rel,
+                )
+            )
+
+    status_match = STATUS_RE.search(text)
+    integration_match = INTEGRATION_RE.search(text)
+    if status_match and integration_match:
+        status = status_match.group("status")
+        integration = integration_match.group("state")
+        if status in {"NOT_STARTED", "IN_PROGRESS"} and integration in {"pr_open", "merged", "closed_no_pr"}:
+            findings.append(
+                finding(
+                    "warning",
+                    "status_drift",
+                    f"Lifecycle status {status!r} conflicts with integration state {integration!r}",
+                    "A post-run or integrated record should not retain a pre-run status without explanation.",
+                    rel,
+                )
+            )
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if PLACEHOLDER_RE.search(line):
+            findings.append(
+                finding(
+                    "warning",
+                    "placeholder_drift",
+                    "Placeholder-like text remains in a lifecycle record",
+                    f"line {line_no}: {line.strip()}",
+                    rel,
+                )
+            )
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze ADL lifecycle records for bounded truth drift.")
+    parser.add_argument("paths", nargs="+", help="Record files or directories to scan.")
+    parser.add_argument("--repo-root", help="Optional repository root for relative paths.")
+    parser.add_argument("--out", help="Optional JSON output path.")
+    args = parser.parse_args()
+
+    root = Path(args.repo_root).resolve() if args.repo_root else None
+    paths = [Path(item) for item in args.paths]
+    files = iter_markdown(paths)
+
+    all_findings: list[dict] = []
+    for path in files:
+        all_findings.extend(analyze_file(path, root))
+
+    blocking = any(item["severity"] == "blocking" for item in all_findings)
+    output = {
+        "schema_version": "records_hygiene.analysis.v1",
+        "status": "blocked" if blocking else ("findings" if all_findings else "clean"),
+        "scanned_files": [repo_relative(path, root) for path in files],
+        "counts": {
+            "files": len(files),
+            "findings": len(all_findings),
+            "blocking": sum(1 for item in all_findings if item["severity"] == "blocking"),
+            "warning": sum(1 for item in all_findings if item["severity"] == "warning"),
+        },
+        "findings": all_findings,
+        "safe_repairs_applied": [],
+        "validation_performed": ["analyze_records_hygiene.py"],
+        "handoff_state": {
+            "ready_for_editor": bool(all_findings),
+            "ready_for_execution": not blocking,
+            "ready_for_follow_on_implementation": blocking,
+        },
+    }
+
+    rendered = json.dumps(output, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if not blocking else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/skills/review-comment-triage/adl-skill.yaml
+++ b/adl/tools/skills/review-comment-triage/adl-skill.yaml
@@ -19,7 +19,7 @@ admission:
     mode_enum:
       - "triage_from_payload"
       - "triage_live_pr_comments"
-  policy_fields:
+    policy_fields:
       - "allow_network"
       - "stop_after_triage"
       - "max_blocking_items_before_operator"
@@ -83,3 +83,4 @@ security:
   trusted_root_required: true
   deny_symlink_escape: true
   no_live_github_mutation_without_explicit_permission: true
+  manifest_declares_executables: true

--- a/adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py
+++ b/adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py
@@ -7,11 +7,19 @@ from pathlib import Path
 
 CATEGORY_ORDER = [
     "actionable_now",
+    "blocked_or_operator_decision",
     "already_fixed",
     "stale_or_not_reproducible",
     "follow_on_issue_needed",
-    "blocked_or_operator_decision",
 ]
+
+HANDOFF_BY_CATEGORY = {
+    "actionable_now": "pr-janitor",
+    "blocked_or_operator_decision": "operator",
+    "already_fixed": "no_action",
+    "stale_or_not_reproducible": "no_action",
+    "follow_on_issue_needed": "finding-to-issue-planner",
+}
 
 
 def classify(comment):
@@ -78,6 +86,11 @@ def main():
         "counts": {category: len(items) for category, items in grouped.items()},
         "triage": grouped,
         "execution_order": CATEGORY_ORDER,
+        "recommended_handoffs": {
+            category: HANDOFF_BY_CATEGORY[category]
+            for category, items in grouped.items()
+            if items
+        },
         "mismatches": mismatches,
     }
 

--- a/adl/tools/test_pr_stack_manager_skill_contracts.sh
+++ b/adl/tools/test_pr_stack_manager_skill_contracts.sh
@@ -12,6 +12,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 [[ -f "${skills_root}/pr-stack-manager/agents/openai.yaml" ]]
 [[ -f "${skills_root}/pr-stack-manager/references/output-contract.md" ]]
 [[ -f "${skills_root}/pr-stack-manager/references/pr-stack-manager-playbook.md" ]]
+[[ -x "${skills_root}/pr-stack-manager/scripts/analyze_pr_stack.py" ]]
 [[ -f "${docs_root}/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq 'name: pr-stack-manager' "${skills_root}/pr-stack-manager/SKILL.md"
@@ -21,6 +22,57 @@ grep -Fq 'pr_stack_manager.v1' "${docs_root}/PR_STACK_MANAGER_SKILL_INPUT_SCHEMA
 grep -Fq "dependency_graph" "${skills_root}/pr-stack-manager/references/output-contract.md"
 grep -Fq "Repair Policy" "${skills_root}/pr-stack-manager/references/pr-stack-manager-playbook.md"
 grep -Fq "pr-stack-manager" "${docs_root}/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "analyze_pr_stack.py" "${skills_root}/pr-stack-manager/adl-skill.yaml"
+
+cat >"${tmpdir}/stack.json" <<'EOF'
+{
+  "root_issue": 2285,
+  "target": {
+    "issue_number": 2285
+  },
+  "nodes": [
+    {
+      "issue_number": 2283,
+      "branch": "codex/2283-records-hygiene",
+      "pr_number": 2301,
+      "state": "open",
+      "base_ref": "main",
+      "expected_base_ref": "main",
+      "depends_on": []
+    },
+    {
+      "issue_number": 2285,
+      "branch": "codex/2285-pr-stack-manager",
+      "pr_number": 2302,
+      "state": "open",
+      "base_ref": "main",
+      "expected_base_ref": "codex/2283-records-hygiene",
+      "depends_on": [2283]
+    }
+  ]
+}
+EOF
+
+if python3 "${skills_root}/pr-stack-manager/scripts/analyze_pr_stack.py" \
+  "${tmpdir}/stack.json" \
+  --out "${tmpdir}/pr-stack.out.json" >/dev/null 2>&1; then
+  echo "expected stack analyzer to report blocking base drift" >&2
+  exit 1
+fi
+
+python3 - "${tmpdir}/pr-stack.out.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["schema_version"] == "pr_stack_manager.analysis.v1"
+assert payload["status"] == "blocked"
+areas = {finding["area"] for finding in payload["findings"]}
+assert "base_alignment" in areas
+assert payload["dependency_graph"]["cycle_detected"] is False
+assert payload["planned_actions"][0]["action"] == "retarget_or_rebase_base"
+PY
 
 CODEX_HOME="${tmpdir}/codex-home" \
 ADL_OPERATIONAL_SKILLS_SOURCE_ROOT="${skills_root}" \

--- a/adl/tools/test_records_hygiene_skill_contracts.sh
+++ b/adl/tools/test_records_hygiene_skill_contracts.sh
@@ -12,6 +12,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 [[ -f "${skills_root}/records-hygiene/agents/openai.yaml" ]]
 [[ -f "${skills_root}/records-hygiene/references/output-contract.md" ]]
 [[ -f "${skills_root}/records-hygiene/references/records-hygiene-playbook.md" ]]
+[[ -x "${skills_root}/records-hygiene/scripts/analyze_records_hygiene.py" ]]
 [[ -f "${skills_root}/docs/RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq 'name: records-hygiene' "${skills_root}/records-hygiene/SKILL.md"
@@ -22,6 +23,40 @@ grep -Fq 'records_hygiene.v1' "${skills_root}/docs/RECORDS_HYGIENE_SKILL_INPUT_S
 grep -Fq "safe_repairs_applied" "${skills_root}/records-hygiene/references/output-contract.md"
 grep -Fq "records-hygiene" "${docs_root}/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq "placeholder" "${skills_root}/records-hygiene/references/records-hygiene-playbook.md"
+grep -Fq "analyze_records_hygiene.py" "${skills_root}/records-hygiene/adl-skill.yaml"
+
+cat >"${tmpdir}/sor.md" <<'EOF'
+Task ID: issue-9001
+Status: IN_PROGRESS
+
+## Main Repo Integration (REQUIRED)
+
+- Integration state: pr_ready
+- Result: TODO
+EOF
+
+if python3 "${skills_root}/records-hygiene/scripts/analyze_records_hygiene.py" \
+  --repo-root "${repo_root}" \
+  "${tmpdir}/sor.md" \
+  --out "${tmpdir}/records-hygiene.out.json" >/dev/null 2>&1; then
+  echo "expected records hygiene analyzer to report blocking findings" >&2
+  exit 1
+fi
+
+python3 - "${tmpdir}/records-hygiene.out.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["schema_version"] == "records_hygiene.analysis.v1"
+assert payload["status"] == "blocked"
+areas = {finding["area"] for finding in payload["findings"]}
+assert "integration_truth" in areas
+assert "placeholder_drift" in areas
+assert payload["counts"]["blocking"] >= 1
+assert payload["handoff_state"]["ready_for_editor"] is True
+PY
 
 CODEX_HOME="${tmpdir}/codex-home" \
 ADL_OPERATIONAL_SKILLS_SOURCE_ROOT="${skills_root}" \

--- a/adl/tools/test_review_comment_triage_skill_contracts.sh
+++ b/adl/tools/test_review_comment_triage_skill_contracts.sh
@@ -78,15 +78,17 @@ for name, expected in expected_counts.items():
         assert triage["counts"].get(category, 0) == count, (name, category, triage["counts"], expected)
     for required in {
         "actionable_now",
+        "blocked_or_operator_decision",
         "already_fixed",
         "stale_or_not_reproducible",
         "follow_on_issue_needed",
-        "blocked_or_operator_decision",
     }:
         assert required in triage["triage"], required
+    assert "recommended_handoffs" in triage
 
     if name == "actionable_comments.json":
         assert triage["counts"]["actionable_now"] > 0
+        assert triage["recommended_handoffs"]["actionable_now"] == "pr-janitor"
 PY
 
 bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \


### PR DESCRIPTION
Closes #2283
Closes #2284
Closes #2285

## Summary
Polished the existing operational-skill trio instead of recreating it. The
records-hygiene and pr-stack-manager skills now have executable deterministic
analyzers and contract tests that prove real detection behavior. The
review-comment-triage skill now emits recommended handoffs and has corrected
machine-readable policy metadata. The operator guide now documents all three
helpers with concrete analyzer commands.

This PR is intended to satisfy the hardening/polish intent behind issues
`#2283`, `#2284`, and `#2285`, which were retitled from creation work after the
audit found that the skills already existed from closed v0.90 issues.

## Artifacts
- `adl/tools/skills/records-hygiene/scripts/analyze_records_hygiene.py`
- `adl/tools/skills/pr-stack-manager/scripts/analyze_pr_stack.py`
- `adl/tools/skills/review-comment-triage/scripts/triage_review_comments.py`
- `adl/tools/skills/records-hygiene/SKILL.md`
- `adl/tools/skills/pr-stack-manager/SKILL.md`
- `adl/tools/skills/records-hygiene/adl-skill.yaml`
- `adl/tools/skills/pr-stack-manager/adl-skill.yaml`
- `adl/tools/skills/review-comment-triage/adl-skill.yaml`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/test_records_hygiene_skill_contracts.sh`
- `adl/tools/test_pr_stack_manager_skill_contracts.sh`
- `adl/tools/test_review_comment_triage_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_records_hygiene_skill_contracts.sh`: verified the
    records-hygiene bundle shape, install behavior, frontmatter, executable
    analyzer, and blocking detection of invalid integration state and
    placeholder drift.
  - `bash adl/tools/test_pr_stack_manager_skill_contracts.sh`: verified the
    pr-stack-manager bundle shape, install behavior, frontmatter, executable
    analyzer, base-drift detection, dependency graph output, and planned action
    output.
  - `bash adl/tools/test_review_comment_triage_skill_contracts.sh`: verified
    the review-comment triage fixtures, category counts, required buckets, and
    recommended handoff output.
  - `bash adl/tools/test_skill_documentation_completeness.sh`: verified the
    broader skill documentation matrix remains complete.
  - `git diff --check`: checked the tracked diff for whitespace errors.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.90.2/tasks/issue-2283__backlog-skill-create-records-hygiene-operational-skill/sip.md
- Output card: .adl/v0.90.2/tasks/issue-2283__backlog-skill-create-records-hygiene-operational-skill/sor.md
- Idempotency-Key: backlog-skill-harden-operational-workflow-skills-adl-tools-skills-records-hygiene-skill-md-adl-tools-skills-records-hygiene-adl-skill-yaml-adl-tools-skills-records-hygiene-scripts-analyze-records-hygiene-py-adl-tools-skills-pr-stack-manager-skill-md-adl-tools-skills-pr-stack-manager-adl-skill-yaml-adl-tools-skills-pr-stack-manager-scripts-analyze-pr-stack-py-adl-tools-skills-review-comment-triage-adl-skill-yaml-adl-tools-skills-review-comment-triage-scripts-triage-review-comments-py-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-test-records-hygiene-skill-contracts-sh-adl-tools-test-pr-stack-manager-skill-contracts-sh-adl-tools-test-review-comment-triage-skill-contracts-sh-adl-v0-90-2-tasks-issue-2283-backlog-skill-create-records-hygiene-operational-skill-sip-md-adl-v0-90-2-tasks-issue-2283-backlog-skill-create-records-hygiene-operational-skill-sor-md