### PR TITLE
[v0.90.2][tools] Make issue-body authoring validator-ready

### DIFF
--- a/adl/src/cli/pr_cmd_cards.rs
+++ b/adl/src/cli/pr_cmd_cards.rs
@@ -153,7 +153,7 @@ pub(crate) fn validate_issue_body_for_create(
     body: &str,
 ) -> Result<()> {
     let init_template =
-        "docs/templates/PR_INIT_INVOCATION_TEMPLATE.md or an authored issue body file";
+        "docs/templates/PR_INIT_INVOCATION_TEMPLATE.md#canonical-authored-issue-body-scaffold or an authored issue body file";
     let probe_issue = 999_999;
     let probe_url = format!(
         "https://github.com/{}/issues/{probe_issue}",
@@ -162,13 +162,12 @@ pub(crate) fn validate_issue_body_for_create(
     let prompt =
         render_issue_prompt_from_body(probe_issue, slug, title, labels_csv, &probe_url, body);
     let temp = write_temp_markdown("issue_body_probe", &prompt)?;
-    validate_bootstrap_stp(repo_root, &temp)
-        .with_context(|| {
-            format!(
-                "create: issue body cannot satisfy source-prompt validation; provide an authored body or use {}",
-                init_template
-            )
-        })?;
+    if let Err(err) = validate_bootstrap_stp(repo_root, &temp) {
+        bail!(
+            "create: issue body cannot satisfy source-prompt validation: {err}; provide an authored body or use {}",
+            init_template
+        );
+    }
     if let Some(reason) = placeholder_issue_body_reason(body) {
         bail!(
             "create: issue body is still bootstrap stub content ({reason}); provide an authored body or use {}",
@@ -180,17 +179,33 @@ pub(crate) fn validate_issue_body_for_create(
 
 pub(crate) fn validate_bootstrap_stp(repo_root: &Path, path: &Path) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
-    run_status(
-        "bash",
-        &[
+    let output = Command::new("bash")
+        .args([
             path_str(&validator)?,
             "--type",
             "stp",
             "--input",
             path_str(path)?,
-        ],
-    )
-    .with_context(|| format!("init: stp failed validation: {}", path.display()))
+        ])
+        .output()
+        .with_context(|| "failed to spawn 'bash'")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("bash failed with status {:?}", output.status.code())
+        };
+        bail!(
+            "init: stp failed validation: {}: {}",
+            path.display(),
+            detail
+        );
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_ready_cards(

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -960,9 +960,15 @@ fn real_pr_create_rejects_issue_body_that_cannot_pass_source_prompt_validation()
     assert!(err
         .to_string()
         .contains("create: issue body cannot satisfy source-prompt validation"));
+    assert!(err.to_string().contains(
+        "missing required sections: Summary, Required Outcome, Deliverables, Acceptance Criteria"
+    ));
     assert!(err
         .to_string()
         .contains("docs/templates/PR_INIT_INVOCATION_TEMPLATE.md"));
+    assert!(err
+        .to_string()
+        .contains("#canonical-authored-issue-body-scaffold"));
 }
 
 #[test]

--- a/adl/src/cli/tooling_cmd/structured_prompt.rs
+++ b/adl/src/cli/tooling_cmd/structured_prompt.rs
@@ -267,6 +267,20 @@ pub(super) fn validate_prompt_spec(spec: &str) -> Result<()> {
     Ok(())
 }
 
+fn ensure_required_sections(text: &str, required_sections: &[&str]) -> Result<()> {
+    let missing = required_sections
+        .iter()
+        .copied()
+        .filter(|section| !markdown_has_heading(text, section))
+        .collect::<Vec<_>>();
+    ensure!(
+        missing.is_empty(),
+        "missing required sections: {}",
+        missing.join(", ")
+    );
+    Ok(())
+}
+
 pub(super) fn validate_stp_text(text: &str) -> Result<()> {
     let (fm_text, body_text) = split_front_matter(text)?;
     let fm_yaml: Value = serde_yaml::from_str(&fm_text)?;
@@ -274,25 +288,23 @@ pub(super) fn validate_stp_text(text: &str) -> Result<()> {
         .as_mapping()
         .ok_or_else(|| anyhow!("front matter must be a YAML mapping"))?;
 
-    for section in [
-        "Summary",
-        "Goal",
-        "Required Outcome",
-        "Deliverables",
-        "Acceptance Criteria",
-        "Repo Inputs",
-        "Dependencies",
-        "Demo Expectations",
-        "Non-goals",
-        "Issue-Graph Notes",
-        "Notes",
-        "Tooling Notes",
-    ] {
-        ensure!(
-            markdown_has_heading(&body_text, section),
-            "missing required section: {section}"
-        );
-    }
+    ensure_required_sections(
+        &body_text,
+        &[
+            "Summary",
+            "Goal",
+            "Required Outcome",
+            "Deliverables",
+            "Acceptance Criteria",
+            "Repo Inputs",
+            "Dependencies",
+            "Demo Expectations",
+            "Non-goals",
+            "Issue-Graph Notes",
+            "Notes",
+            "Tooling Notes",
+        ],
+    )?;
 
     ensure!(
         mapping_string(fm, "issue_card_schema").as_deref() == Some("adl.issue.v1"),
@@ -377,26 +389,24 @@ pub(super) fn validate_stp_text(text: &str) -> Result<()> {
 }
 
 pub(super) fn validate_sip_text(text: &str, path: &Path, phase: Option<&str>) -> Result<()> {
-    for section in [
-        "Goal",
-        "Required Outcome",
-        "Acceptance Criteria",
-        "Inputs",
-        "Target Files / Surfaces",
-        "Validation Plan",
-        "Demo / Proof Requirements",
-        "Constraints / Policies",
-        "System Invariants (must remain true)",
-        "Reviewer Checklist (machine-readable hints)",
-        "Non-goals / Out of scope",
-        "Notes / Risks",
-        "Instructions to the Agent",
-    ] {
-        ensure!(
-            markdown_has_heading(text, section),
-            "missing required section: {section}"
-        );
-    }
+    ensure_required_sections(
+        text,
+        &[
+            "Goal",
+            "Required Outcome",
+            "Acceptance Criteria",
+            "Inputs",
+            "Target Files / Surfaces",
+            "Validation Plan",
+            "Demo / Proof Requirements",
+            "Constraints / Policies",
+            "System Invariants (must remain true)",
+            "Reviewer Checklist (machine-readable hints)",
+            "Non-goals / Out of scope",
+            "Notes / Risks",
+            "Instructions to the Agent",
+        ],
+    )?;
     ensure!(
         valid_task_id(&markdown_field(text, "Task ID").unwrap_or_default()),
         "Task ID must match issue-0000"
@@ -480,12 +490,7 @@ pub(super) fn validate_sip_text(text: &str, path: &Path, phase: Option<&str>) ->
 }
 
 pub(super) fn validate_sor_text(text: &str, phase: Option<&str>) -> Result<()> {
-    for section in super::common::REQUIRED_OUTPUT_SECTIONS {
-        ensure!(
-            markdown_has_heading(text, section),
-            "missing required section: {section}"
-        );
-    }
+    ensure_required_sections(text, super::common::REQUIRED_OUTPUT_SECTIONS)?;
     ensure!(
         valid_task_id(&markdown_field(text, "Task ID").unwrap_or_default()),
         "Task ID must match issue-0000"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -650,6 +650,12 @@ single batch.
 Canonical template:
 - `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
 
+For authored issue bodies, use the canonical authored issue body scaffold in
+that template before calling `pr create --body`, `pr create --body-file`, or
+`pr-init` with `issue.body` / `issue.body_file`. The create path validates all
+required source-prompt sections up front and reports the complete missing
+section set in one failure.
+
 ```yaml
 Use $pr-init at /Users/daniel/git/agent-design-language/adl/tools/skills/pr-init/SKILL.md with this validated input:
 

--- a/adl/tools/skills/pr-init/SKILL.md
+++ b/adl/tools/skills/pr-init/SKILL.md
@@ -95,6 +95,11 @@ When the caller can provide structured input, prefer the tracked invocation
 template in:
 - `/Users/daniel/git/agent-design-language/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
 
+When the caller provides an authored issue body, require it to follow the
+canonical authored issue body scaffold in that template before running create.
+This avoids iterative one-section-at-a-time validation failures and keeps the
+GitHub issue body, source prompt, and bootstrap cards aligned from the start.
+
 If no slug is given, derive one from the title using the repo's normal slug rules.
 
 ## Quick Start
@@ -108,20 +113,22 @@ If no slug is given, derive one from the title using the repo's normal slug rule
    - aggregate completion outside the skill instead of asking one invocation to bootstrap many issues
 3. If using structured invocation, start from the canonical tracked template
    rather than writing the payload from scratch.
-4. Prefer the Rust-owned path when available.
-5. For new issues:
+4. If supplying an authored issue body, start from the canonical authored issue
+   body scaffold in the same template.
+5. Prefer the Rust-owned path when available.
+6. For new issues:
    - create the GitHub issue correctly
    - pass explicit repo-standard labels rather than relying on label inference
    - verify the created issue actually has the expected labels before continuing
    - ensure the canonical local source issue prompt and root bundle exist
-6. For existing issues:
+7. For existing issues:
    - run the bootstrap/init phase
    - seed the task-bundle `stp.md`
    - seed the initial `sip.md`
    - seed the initial `sor.md`
    - ensure canonical compatibility links exist when the repo expects them
-7. Validate the resulting surfaces mechanically.
-8. Emit a structured readiness result for qualitative card review and stop.
+8. Validate the resulting surfaces mechanically.
+9. Emit a structured readiness result for qualitative card review and stop.
 
 ## Workflow
 

--- a/adl/tools/test_structured_prompt_validation.sh
+++ b/adl/tools/test_structured_prompt_validation.sh
@@ -214,6 +214,44 @@ EOF
 "$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_valid.md"
 "$VALIDATOR" --type sor --phase bootstrap --input "$tmpdir/sor_valid.md"
 
+cat >"$tmpdir/stp_missing_multiple_sections.md" <<'EOF'
+---
+issue_card_schema: adl.issue.v1
+wp: "SUB-ISSUE"
+slug: "invalid-structured-task-prompt"
+title: "Invalid STP"
+labels:
+  - "track:roadmap"
+issue_number: 901
+status: "draft"
+action: "create"
+depends_on: []
+milestone_sprint: "Sprint 2"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "docs/tooling/prompt-spec.md"
+canonical_files: []
+demo_required: false
+demo_names: []
+issue_graph_notes: []
+pr_start:
+  enabled: false
+  slug: "invalid-structured-task-prompt"
+---
+
+# Issue Card
+
+## Goal
+x
+EOF
+
+if "$VALIDATOR" --type stp --input "$tmpdir/stp_missing_multiple_sections.md" >"$tmpdir/stp_missing_multiple_sections.out" 2>&1; then
+  echo "expected multi-section-missing STP to fail validation" >&2
+  exit 1
+fi
+grep -Fq "missing required sections: Summary, Required Outcome, Deliverables, Acceptance Criteria, Repo Inputs, Dependencies, Demo Expectations, Non-goals, Issue-Graph Notes, Notes, Tooling Notes" "$tmpdir/stp_missing_multiple_sections.out"
+
 cp "$tmpdir/sip_valid.md" "$tmpdir/sip_dot_version_valid.md"
 perl -0pi -e 's/Version: v0\.85/Version: v0.87.1/' "$tmpdir/sip_dot_version_valid.md"
 "$VALIDATOR" --type sip --phase bootstrap --input "$tmpdir/sip_dot_version_valid.md"

--- a/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
+++ b/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
@@ -66,6 +66,66 @@ Typical choices:
 - `policy.body_source: generated` when you want the control plane to generate the first readable body
 - `policy.label_source: explicit` for tracked issue creation
 
+If you provide an authored issue body with `issue.body` or `issue.body_file`,
+start from the scaffold below. The create path validates authored bodies against
+the source-prompt contract before it calls GitHub, so missing sections should be
+fixed in one pass instead of discovered one at a time.
+
+## Canonical Authored Issue Body Scaffold
+
+Use this shape for direct authored issue bodies passed to `pr create --body`,
+`pr create --body-file`, or `pr-init` `issue.body` / `issue.body_file`.
+
+```markdown
+## Summary
+
+Describe the bounded issue in one short paragraph.
+
+## Goal
+
+State the user-facing or operator-facing goal.
+
+## Required Outcome
+
+State the concrete outcome that must be true when this issue is complete.
+
+## Deliverables
+
+- List the expected code, docs, tests, demos, or records.
+
+## Acceptance Criteria
+
+- List the observable checks that prove the issue is complete.
+
+## Repo Inputs
+
+- List the files, docs, tools, or issue references that bound the work.
+
+## Dependencies
+
+- List blocking or related issues, or `none`.
+
+## Demo Expectations
+
+- State required demos or `none`.
+
+## Non-goals
+
+- List explicit out-of-scope work.
+
+## Issue-Graph Notes
+
+- Record dependency, split, supersession, or milestone-routing notes.
+
+## Notes
+
+- Add implementation notes, risks, or operator context.
+
+## Tooling Notes
+
+- Add workflow, validation, or closeout notes for the ADL control plane.
+```
+
 ### `bootstrap_existing_issue`
 
 Use when the GitHub issue already exists and only the local bootstrap surfaces must be created or reconciled.


### PR DESCRIPTION
Closes #2290

## Summary
Implemented validator-ready authored issue body support for `pr create` / `pr-init` paths. Authored bodies now get complete missing-section feedback in one validation pass, `pr create` preserves validator details in its error message, and the pr-init docs include a canonical copyable authored-body scaffold.

## Artifacts
- Updated source-prompt structured validation in `adl/src/cli/tooling_cmd/structured_prompt.rs`.
- Updated create-path validation surfacing in `adl/src/cli/pr_cmd_cards.rs`.
- Updated regression coverage in `adl/src/cli/tests/pr_cmd_inline/basics.rs` and `adl/tools/test_structured_prompt_validation.sh`.
- Added authored issue body scaffold guidance in `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`, `adl/tools/skills/pr-init/SKILL.md`, and `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_structured_prompt_validation.sh`: verifies complete structured prompts still pass and incomplete STPs report all missing required sections in one pass.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_rejects_issue_body_that_cannot_pass_source_prompt_validation -- --nocapture`: verifies invalid authored `pr create` bodies fail before GitHub creation and include the scaffold pointer plus aggregate missing-section detail.
  - `bash adl/tools/test_pr_init_skill_contracts.sh`: verifies pr-init skill/template contract remains intact.
  - `bash adl/tools/test_skill_documentation_completeness.sh`: verifies skill documentation completeness after guidance changes.
  - `bash adl/tools/test_pr_create.sh`: verifies PR-create shell surface still exposes expected help behavior.
  - `bash adl/tools/test_pr_init.sh`: verifies bootstrap/init script behavior remains intact.
  - `git diff --check`: verifies no whitespace errors.
- Results: PASS for all listed commands.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.2/tasks/issue-2290__make-issue-body-authoring-validator-ready/sip.md
- Output card: .adl/v0.90.2/tasks/issue-2290__make-issue-body-authoring-validator-ready/sor.md
- Idempotency-Key: v0-90-2-tools-make-issue-body-authoring-validator-ready-adl-v0-90-2-tasks-issue-2290-make-issue-body-authoring-validator-ready-sip-md-adl-v0-90-2-tasks-issue-2290-make-issue-body-authoring-validator-ready-sor-md