### PR TITLE
[v0.90.2][planning] Insert WP-14A demo/proof lane

### DIFF
--- a/docs/milestones/v0.90.2/DEMO_MATRIX_v0.90.2.md
+++ b/docs/milestones/v0.90.2/DEMO_MATRIX_v0.90.2.md
@@ -3,7 +3,9 @@
 ## Status
 
 Issue wave open. Demo commands remain pending until the implementation WPs
-land, but every planned demo now has a mapped WP issue.
+land, but every planned demo now has a mapped WP issue. WP-14A #2301 owns the
+feature-by-feature demo/proof coverage pass before WP-15 docs and review
+convergence.
 
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |
@@ -17,6 +19,17 @@ land, but every planned demo now has a mapped WP issue.
 | D8 | Recovery versus quarantine | WP-11 #2255 / WP-12 #2256 | Runtime distinguishes safe resume from required quarantine | recovery eligibility model, recovery decisions, quarantine artifact | PARTIAL: WP-11 DECISION MODEL LANDED; WP-12 QUARANTINE ARTIFACT PLANNED |
 | D9 | Governed adversarial hook and hardening probes | WP-13 #2257 | One bounded adversarial scenario is contained under explicit operator rules, and duplicate activation, snapshot integrity, and replay-gap failures are detected and recorded | adversarial hook packet, rules of engagement, hardening proof packets | PLANNED |
 | D10 | Integrated first CSM run proof | WP-14 #2258 | Reviewer can inspect the first bounded CSM run and its failure-boundary evidence end to end | integrated CSM run packet, trace, Observatory report, hardening artifacts | PLANNED |
+| D11 | Feature proof coverage record | WP-14A #2301 | Every v0.90.2 feature claim has a runnable demo command, test-backed proof packet, fixture-backed artifact, documented non-proving status, or explicit deferral before review convergence | demo matrix update and feature proof coverage record | PLANNED |
+
+## Demo-Program Ownership
+
+- WP-13 owns the governed adversarial hook and hardening probes only.
+- WP-14 owns the integrated first CSM run proof packet.
+- WP-14A owns feature-by-feature demo/proof coverage across WP-03 through
+  WP-14.
+- WP-15 consumes the completed demo/proof coverage record during docs, quality,
+  and review convergence; it should not be the place where missing feature
+  demos are invented.
 
 ## Non-Proving Boundaries
 

--- a/docs/milestones/v0.90.2/MILESTONE_CHECKLIST_v0.90.2.md
+++ b/docs/milestones/v0.90.2/MILESTONE_CHECKLIST_v0.90.2.md
@@ -24,6 +24,7 @@
 - [ ] Governed adversarial hook complete with rules of engagement and evidence
 - [ ] Additional hardening probes complete
 - [ ] Integrated first CSM run demo implemented
+- [ ] WP-14A demo matrix and feature proof coverage completed before WP-15
 
 ## Truth And Safety
 
@@ -34,6 +35,7 @@
 - [ ] Governed adversarial hook remains bounded and operator-scoped
 - [ ] Security-boundary evidence is present and bounded
 - [ ] Recovery and quarantine outcomes are explicit
+- [ ] Every feature claim has a runnable demo, proof packet, fixture-backed artifact, non-proving status, or explicit deferral
 - [ ] Quality gate is green or exceptions are explicit
 
 ## Release

--- a/docs/milestones/v0.90.2/README.md
+++ b/docs/milestones/v0.90.2/README.md
@@ -3,12 +3,15 @@
 ## Status
 
 Active milestone package. v0.90.2 is open and the issue wave has been created
-as #2245-#2264 from the reviewed milestone package.
+as #2245-#2264 from the reviewed milestone package, with WP-14A added as
+#2301 to restore the explicit demo matrix and feature proof demo lane.
 
 Current execution state:
 
 - WP-01 is #2245 and finalizes this package after issue-wave creation.
 - WP-02 through WP-20 are #2246-#2264.
+- WP-14A is #2301 and owns feature-by-feature demo/proof coverage before
+  WP-15 docs and review convergence.
 - WP-02 provides the Runtime v2 inheritance and compression audit before
   runtime implementation widens.
 - WP-03 provides the code-backed CSM run packet contract and fixture definition
@@ -176,3 +179,13 @@ positive path requires a declared predecessor, validated rehydration, and a
 single active head; the negative path refuses ambiguous or duplicate-head
 recovery and hands evidence preservation to WP-12. This does not implement the
 quarantine state machine or widen into live Runtime v2 execution.
+
+## WP-14A Demo Program Gate
+
+WP-14A restores the standard ADL milestone pattern where feature-by-feature
+demo and proof coverage is explicit before docs/review convergence. WP-13 owns
+the governed adversarial hook, WP-14 owns the integrated first CSM run proof,
+and WP-14A verifies that each v0.90.2 feature claim has a runnable demo command,
+test-backed proof packet, fixture-backed artifact, documented non-proving
+status, or explicit deferral. WP-15 consumes that coverage record rather than
+inventing missing demos during review convergence.

--- a/docs/milestones/v0.90.2/SPRINT_v0.90.2.md
+++ b/docs/milestones/v0.90.2/SPRINT_v0.90.2.md
@@ -31,9 +31,11 @@ Observatory-visible evidence.
 - WP-12 #2256 quarantine state machine
 - WP-13 #2257 governed adversarial hook and hardening probes
 - WP-14 #2258 integrated first CSM run demo
+- WP-14A #2301 demo matrix and feature proof demos
 
 Exit when the first run has recovery/quarantine semantics, one bounded governed
-adversarial hook, concrete hardening probes, and one integrated proof packet.
+adversarial hook, concrete hardening probes, one integrated proof packet, and
+feature-by-feature demo/proof coverage ready for review convergence.
 
 ## Sprint 4 - Review And Release Tail
 

--- a/docs/milestones/v0.90.2/WBS_v0.90.2.md
+++ b/docs/milestones/v0.90.2/WBS_v0.90.2.md
@@ -22,7 +22,8 @@ contract before implementation begins.
 | WP-12 | #2256 | Quarantine state machine | Implement quarantine state and evidence preservation for unsafe recovery | quarantine artifact and tests | WP-11 |
 | WP-13 | #2257 | Governed adversarial hook and hardening probes | Add one bounded adversarial probe plus duplicate activation, snapshot integrity, and trace/replay gap negative probes | adversarial hook packet and hardening proof packets | WP-11, WP-12 |
 | WP-14 | #2258 | Integrated first CSM run demo | Produce one end-to-end first-run and hardening proof packet | integrated CSM run demo packet | WP-05-WP-13 |
-| WP-15 | #2259 | Docs, quality, and review convergence | Align feature docs, demo matrix, README, quality posture, and reviewer entry surfaces | coherent docs/review package and quality report | WP-14 |
+| WP-14A | #2301 | Demo matrix and feature proof demos | Restore the explicit milestone demo-program lane by verifying every feature claim has a runnable demo, proof packet, fixture-backed artifact, non-proving status, or explicit deferral | demo matrix update and feature proof coverage record | WP-03-WP-14 |
+| WP-15 | #2259 | Docs, quality, and review convergence | Align feature docs, demo matrix, README, quality posture, and reviewer entry surfaces after demo coverage is explicit | coherent docs/review package and quality report | WP-14A |
 | WP-16 | #2260 | Internal review | Review claims, artifacts, compression, quality, and boundaries | findings-first internal review packet | WP-15 |
 | WP-17 | #2261 | External / 3rd-party review | Execute external review against the stabilized v0.90.2 proof package | completed external review record | WP-16 |
 | WP-18 | #2262 | Review findings remediation | Fix accepted findings or defer explicitly with owner and rationale | patches, closure notes, and tracked deferrals | WP-16, WP-17 |
@@ -41,6 +42,8 @@ Compression target:
   contract is stable
 - WP-13 should stay bounded to one governed adversarial hook plus concrete
   hardening probes, not expand into a full security-ecology sprint
+- WP-14A restores the older milestone pattern where feature-by-feature
+  demo/proof coverage is created before docs/review convergence
 - WP-15 through WP-19 must preserve the v0.87.1 closeout pattern:
   docs/review convergence, internal review, external / 3rd-party review,
   findings remediation, next-milestone planning, then ceremony

--- a/docs/milestones/v0.90.2/WP_ISSUE_WAVE_v0.90.2.yaml
+++ b/docs/milestones/v0.90.2/WP_ISSUE_WAVE_v0.90.2.yaml
@@ -6,6 +6,7 @@ planning_source: docs/milestones/v0.90.2
 tracked_package: docs/milestones/v0.90.2
 notes:
   - "Issue wave is open as #2245-#2264."
+  - "WP-14A is open as #2301 to restore the explicit demo matrix and feature proof demo lane without renumbering WP-15 through WP-20."
   - "Do not claim first true Gödel-agent birthday in v0.90.2."
   - "Do not collapse v0.91 moral/emotional civilization or v0.92 birthday scope into v0.90.2."
   - "v0.90.2 is the first bounded CSM run milestone plus hardening around that run."
@@ -97,12 +98,18 @@ work_packages:
     queue: demo
     outcome: integrated CSM run demo packet
     depends_on: WP-05-WP-13
+  - wp: WP-14A
+    issue: 2301
+    title: Demo matrix and feature proof demos
+    queue: demo
+    outcome: demo matrix update and feature proof coverage record
+    depends_on: WP-03-WP-14
   - wp: WP-15
     issue: 2259
     title: Docs, quality, and review convergence
     queue: docs
     outcome: aligned docs, quality posture, demo matrix, README, and reviewer entry surfaces
-    depends_on: WP-14
+    depends_on: WP-14A
   - wp: WP-16
     issue: 2260
     title: Internal review

--- a/docs/milestones/v0.90.3/SPRINT_v0.90.3.md
+++ b/docs/milestones/v0.90.3/SPRINT_v0.90.3.md
@@ -33,15 +33,15 @@ continuity, and preserve evidence when continuity is ambiguous.
 Exit when reviewers can inspect a bounded citizen-state proof without raw
 private-state access and operators have a safe visibility path.
 
-## Sprint 4 - Challenge, Threat Model, Economics Boundary, Review, And Release
+## Sprint 4 - Challenge, Threat Model, Demo Proofs, Review, And Release
 
 - WP-15 continuity challenge and appeal flow
-- WP-16 citizen-state threat model
-- WP-17 economics placement decision
+- WP-16 citizen-state threat model and economics placement decision
+- WP-17 demo matrix and feature proof demos
 - WP-18 docs, quality, and review convergence
 - WP-19 internal and external review remediation
 - WP-20 release ceremony
 
-Exit when the package is reviewed, truth-aligned, and clearly hands full
-economics and contract-market work to v0.90.4 while preserving v0.91/v0.92
-boundaries.
+Exit when feature-by-feature proof coverage is explicit, the package is
+reviewed, truth-aligned, and clearly hands full economics and contract-market
+work to v0.90.4 while preserving v0.91/v0.92 boundaries.

--- a/docs/milestones/v0.90.3/WBS_v0.90.3.md
+++ b/docs/milestones/v0.90.3/WBS_v0.90.3.md
@@ -23,9 +23,9 @@ before implementation widens.
 | WP-13 | planned | Access-control semantics | Define who may inspect, decrypt, project, migrate, wake, quarantine, challenge, or appeal | authority matrix and access events | WP-10-WP-12 |
 | WP-14 | planned | Projection policy | Define private, citizen, operator, reviewer, public, and debug views | projection policy and leakage tests | WP-10, WP-13 |
 | WP-15 | planned | Continuity challenge and appeal flow | Implement due-process artifacts for challenged continuity | challenge/appeal schemas and freeze behavior | WP-07, WP-13 |
-| WP-16 | planned | Citizen-state threat model | Model threats before demo claims widen | threat model and negative-test candidates | WP-03-WP-15 |
-| WP-17 | planned | Economics placement decision | Decide if v0.90.3 needs a resource-stewardship bridge before v0.90.4 economics | short decision record | WP-02, WP-16 |
-| WP-18 | planned | Docs, quality, and review convergence | Align docs, quality posture, demo matrix, README, and reviewer entry surfaces | coherent docs/review package | WP-12-WP-17 |
+| WP-16 | planned | Citizen-state threat model and economics placement decision | Model threats before demo claims widen and decide whether v0.90.3 needs only a resource-stewardship bridge before v0.90.4 economics | threat model, negative-test candidates, and economics placement record | WP-03-WP-15 |
+| WP-17 | planned | Demo matrix and feature proof demos | Verify every citizen-state feature claim has a runnable demo, proof packet, fixture-backed artifact, non-proving status, or explicit deferral | demo matrix update and feature proof coverage record | WP-12-WP-16 |
+| WP-18 | planned | Docs, quality, and review convergence | Align docs, quality posture, README, reviewer entry surfaces, and the completed demo/proof coverage record | coherent docs/review package | WP-17 |
 | WP-19 | planned | Internal and external review remediation | Run reviews and fix or defer accepted findings | review packets and remediation notes | WP-18 |
 | WP-20 | planned | Release ceremony | Complete release closure and handoff | release notes, ceremony result, next-milestone handoff | WP-19 |
 
@@ -42,4 +42,5 @@ Compression must not skip:
 - challenge/appeal behavior
 - anti-equivocation negative tests
 - threat modeling
+- feature-by-feature demo/proof coverage before docs/review convergence
 - release-truth checks

--- a/docs/milestones/v0.90.3/WP_ISSUE_WAVE_v0.90.3.yaml
+++ b/docs/milestones/v0.90.3/WP_ISSUE_WAVE_v0.90.3.yaml
@@ -9,8 +9,9 @@ notes:
   - "This package was prepared during v0.90.2 by #2269."
   - "Do not claim first true Gödel-agent birthday in v0.90.3."
   - "Do not collapse v0.91 moral/emotional civilization or v0.92 birthday scope into v0.90.3."
-  - "Full economics and contract-market work belongs to tentative v0.90.4 / #2271 unless WP-17 accepts a narrow resource-stewardship bridge."
+  - "Full economics and contract-market work belongs to tentative v0.90.4 / #2271 unless WP-16 accepts a narrow resource-stewardship bridge."
   - "Use local-first sealed checkpoint semantics; cloud enclave backends are later options, not v0.90.3 dependencies."
+  - "Preserve an explicit demo matrix and feature proof demo WP before docs/review convergence."
 work_packages:
   - wp: WP-01
     issue: planned
@@ -104,22 +105,22 @@ work_packages:
     depends_on: WP-07, WP-13
   - wp: WP-16
     issue: planned
-    title: Citizen-state threat model
+    title: Citizen-state threat model and economics placement decision
     queue: review
-    outcome: threat model and negative-test candidates
+    outcome: threat model, negative-test candidates, and economics placement record
     depends_on: WP-03-WP-15
   - wp: WP-17
     issue: planned
-    title: Economics placement decision
-    queue: docs
-    outcome: resource-stewardship bridge decision or v0.90.4 deferral
-    depends_on: WP-02, WP-16
+    title: Demo matrix and feature proof demos
+    queue: demo
+    outcome: demo matrix update and feature proof coverage record
+    depends_on: WP-12-WP-16
   - wp: WP-18
     issue: planned
     title: Docs, quality, and review convergence
     queue: docs
     outcome: coherent docs/review package
-    depends_on: WP-12-WP-17
+    depends_on: WP-17
   - wp: WP-19
     issue: planned
     title: Internal and external review remediation

--- a/docs/milestones/v0.90.4/SPRINT_v0.90.4.md
+++ b/docs/milestones/v0.90.4/SPRINT_v0.90.4.md
@@ -26,14 +26,15 @@ Goal: prove that market state changes are authority-checked and traceable.
 - WP-12: Review summary shape
 - WP-13: Bounded contract-market demo
 - WP-14: Negative authority and trace cases
-- WP-15: Resource stewardship bridge
+- WP-15: Resource stewardship bridge and late authority boundary
+- WP-16: Demo matrix and feature proof demos
 
-Goal: produce one reviewer-visible market proof without payment rails.
+Goal: produce one reviewer-visible market proof without payment rails and
+verify feature-by-feature demo/proof coverage before review convergence.
 
 ## Sprint 4: Review And Release
 
-- WP-16: Docs, feature index, and demo matrix convergence
-- WP-17: Internal review
+- WP-17: Docs, quality, and review convergence
 - WP-18: External review and remediation
 - WP-19: Next milestone planning handoff
 - WP-20: Release ceremony

--- a/docs/milestones/v0.90.4/WBS_v0.90.4.md
+++ b/docs/milestones/v0.90.4/WBS_v0.90.4.md
@@ -22,9 +22,9 @@ runner and proof demo widen.
 | WP-12 | planned | Review summary shape | Produce reviewer-facing summaries of market execution and residual risk | summary schema and example | WP-10, WP-11 |
 | WP-13 | planned | Bounded contract-market demo | Prove the parent contract, bids, award, delegation, completion, and summary end to end | contract-market proof packet | WP-10-WP-12 |
 | WP-14 | planned | Negative authority and trace cases | Prove unauthorized transitions, invalid bids, unsupported delegation, and missing traces fail safely | negative test packet | WP-06-WP-13 |
-| WP-15 | planned | Resource stewardship bridge | Connect contract-market execution to compute, memory, attention, and bandwidth without payment rails | resource bridge decision and fixture | WP-13, WP-14 |
-| WP-16 | planned | Docs, feature index, and demo matrix convergence | Align docs, feature docs, demo matrix, and reviewer entry surfaces | coherent docs package | WP-03-WP-15 |
-| WP-17 | planned | Internal review | Review claims, authority boundaries, fixtures, and proof packets | findings-first internal review | WP-16 |
+| WP-15 | planned | Resource stewardship bridge and late authority boundary | Connect contract-market execution to compute, memory, attention, and bandwidth without payment rails, while preserving negative authority lessons | resource bridge decision, fixture, and boundary notes | WP-13, WP-14 |
+| WP-16 | planned | Demo matrix and feature proof demos | Verify every contract-market feature claim has a runnable demo, proof packet, fixture-backed artifact, non-proving status, or explicit deferral | demo matrix update and feature proof coverage record | WP-03-WP-15 |
+| WP-17 | planned | Docs, quality, and review convergence | Align docs, feature docs, reviewer entry surfaces, and the completed demo/proof coverage record | coherent docs package and review-ready surface | WP-16 |
 | WP-18 | planned | External review and remediation | Run external review and fix or defer accepted findings | review packet and remediation notes | WP-17 |
 | WP-19 | planned | Next milestone planning handoff | Prepare v0.91/v0.92/v0.90.5 or payment-lane handoff as appropriate | handoff docs and backlog updates | WP-18 |
 | WP-20 | planned | Release ceremony | Complete release closure | release notes, ceremony result, next handoff | WP-19 |
@@ -42,4 +42,5 @@ Compression must not skip:
 - unauthorized transition negative tests
 - delegation authority checks
 - review summary truth
+- feature-by-feature demo/proof coverage before docs/review convergence
 - release-truth checks

--- a/docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml
+++ b/docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml
@@ -10,6 +10,7 @@ notes:
   - "v0.90.4 consumes v0.90.3 citizen-state, standing, access-control, projection, and challenge/appeal authority."
   - "Do not claim payment settlement, Lightning, x402, or full inter-polis economics in v0.90.4 unless a later decision explicitly changes scope."
   - "Use fixture-first contract-market proof before any production economics claims."
+  - "Preserve an explicit demo matrix and feature proof demo WP before docs/review convergence."
 work_packages:
   - wp: WP-01
     issue: planned
@@ -97,21 +98,21 @@ work_packages:
     depends_on: WP-06-WP-13
   - wp: WP-15
     issue: planned
-    title: Resource stewardship bridge
+    title: Resource stewardship bridge and late authority boundary
     queue: docs
-    outcome: resource bridge decision and fixture
+    outcome: resource bridge decision, fixture, and boundary notes
     depends_on: WP-13, WP-14
   - wp: WP-16
     issue: planned
-    title: Docs, feature index, and demo matrix convergence
-    queue: docs
-    outcome: coherent docs package
+    title: Demo matrix and feature proof demos
+    queue: demo
+    outcome: demo matrix update and feature proof coverage record
     depends_on: WP-03-WP-15
   - wp: WP-17
     issue: planned
-    title: Internal review
-    queue: review
-    outcome: findings-first internal review
+    title: Docs, quality, and review convergence
+    queue: docs
+    outcome: coherent docs package and review-ready surface
     depends_on: WP-16
   - wp: WP-18
     issue: planned


### PR DESCRIPTION
Refs #2301

## Summary
This is a planning/issue-graph correction only. It does not claim that the WP-14A demos have been built.

This PR inserts WP-14A into the v0.90.2 milestone docs so the actual demo-building issue remains explicit and open. WP-14A owns feature-by-feature demo/proof coverage before WP-15 docs and review convergence. It also updates v0.90.3 and v0.90.4 planning so future milestones preserve a dedicated demo/proof lane before review convergence.

## What this changes
- Adds WP-14A #2301 to the v0.90.2 WBS, sprint plan, issue-wave YAML, README, checklist, and demo matrix.
- Makes WP-15 depend on WP-14A.
- Clarifies that WP-13 owns the governed adversarial hook, WP-14 owns the integrated first CSM run demo, and WP-14A owns feature-by-feature demo/proof coverage.
- Updates v0.90.3 and v0.90.4 planning to preserve an explicit demo/proof WP before docs/review convergence.

## What this does not do
- Does not build the WP-14A demos.
- Does not close #2301.
- Does not claim feature proof coverage is complete.
- Does not perform WP-15 convergence or review.

## Validation
- Text scan verified WP-14A and future demo/proof lane references.
- YAML parse verified the edited issue-wave files.
- git diff --check passed.
