### PR TITLE
[v0.90.3][observatory] Redesign the current Observatory demo

### DIFF
--- a/docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md
+++ b/docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md
@@ -5,12 +5,14 @@
 Planning/live-wave matrix. The v0.90.3 issue wave is open as #2327-#2347,
 with the explicit demo matrix and feature proof lane at WP-14A / #2341.
 
-The matrix has two layers:
+The matrix has three layers:
 
 - feature proof rows: D1 through D11 prove individual citizen-state safety,
   access, continuity, projection, and challenge surfaces
 - flagship demo row: D12 ties those proofs into one inhabited CSM Observatory
   scenario with agents inside the polis
+- design architecture row: D14 defines the room/lens/memory-dot architecture
+  that D12 should consume without treating design assets as runtime proof
 
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |
@@ -25,7 +27,7 @@ The matrix has two layers:
 | D9 | Redacted Observatory projection | WP-10 | Operators see continuity status without raw private state | projection schema, leakage tests, Observatory packet/report | PLANNED |
 | D10 | Standing, communication, and access boundary | WP-11 / WP-12 | Guests and service actors cannot silently acquire citizen rights or inspection access | standing events, access-denial events, communication examples | PLANNED |
 | D11 | Challenge, appeal, and threat review | WP-13 | A challenged wake or projection freezes destructive transition and preserves evidence, with threat-model coverage before demo claims widen | challenge artifact, appeal/review artifact, threat model, economics placement record | PLANNED |
-| D12 | Inhabited CSM Observatory flagship | WP-14 | Reviewer can inspect one bounded end-to-end citizen-state scenario with agents inside the polis rather than an empty artifact bundle | `OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md`, integrated proof packet, witness, receipt, redacted projection, access event, challenge/quarantine artifact, operator report | PLANNED |
+| D12 | Inhabited CSM Observatory flagship | WP-14 | Reviewer can inspect one bounded end-to-end citizen-state scenario through World / Reality, Operator / Governance, optional bounded Cognition / Internal State, and Corporate Investor fallback surfaces | `OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md`, `OBSERVATORY_UI_ARCHITECTURE_v0.90.3.md`, integrated proof packet, witness, receipt, redacted projection, access event, challenge/quarantine artifact, operator report | PLANNED |
 | D13 | Feature proof coverage record | WP-14A | Every v0.90.3 feature claim has a runnable demo, proof packet, fixture-backed artifact, non-proving status, or explicit deferral | feature proof coverage record and demo matrix update | PLANNED |
 | D14 | Observatory multimode UI architecture | WP-14A | The flagship Observatory demo has a reviewed room/lens/memory-dot architecture before demo redesign | `OBSERVATORY_UI_ARCHITECTURE_v0.90.3.md`, multimode mockup, Corporate Investor UI fallback rule | LANDED |
 
@@ -38,6 +40,9 @@ WP-14 / D12 should show an inhabited CSM:
 - service actor with bounded authority
 - operator with redacted visibility
 - challenged or quarantined transition when continuity or authority is unsafe
+- room traversal from World / Reality Mode into Operator / Governance Mode
+- optional Cognition / Internal State Mode only for bounded implemented signals
+- Corporate Investor UI fallback for demo continuity and investor-safe summary
 
 WP-14A / D13 should keep every feature proof row mapped to proof, fixture,
 non-proving status, or explicit deferral.

--- a/docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md
+++ b/docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md
@@ -5,6 +5,13 @@
 Planning/live-wave matrix. The v0.90.3 issue wave is open as #2327-#2347,
 with the explicit demo matrix and feature proof lane at WP-14A / #2341.
 
+The matrix has two layers:
+
+- feature proof rows: D1 through D11 prove individual citizen-state safety,
+  access, continuity, projection, and challenge surfaces
+- flagship demo row: D12 ties those proofs into one inhabited CSM Observatory
+  scenario with agents inside the polis
+
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |
 | D1 | Citizen-state inheritance audit | WP-02 | v0.90.3 targets actual v0.90.2 citizen, snapshot, wake, quarantine, and Observatory artifacts | `CITIZEN_STATE_INHERITANCE_AUDIT_v0.90.3.md`, unsafe-assumption list | LANDED |
@@ -18,9 +25,22 @@ with the explicit demo matrix and feature proof lane at WP-14A / #2341.
 | D9 | Redacted Observatory projection | WP-10 | Operators see continuity status without raw private state | projection schema, leakage tests, Observatory packet/report | PLANNED |
 | D10 | Standing, communication, and access boundary | WP-11 / WP-12 | Guests and service actors cannot silently acquire citizen rights or inspection access | standing events, access-denial events, communication examples | PLANNED |
 | D11 | Challenge, appeal, and threat review | WP-13 | A challenged wake or projection freezes destructive transition and preserves evidence, with threat-model coverage before demo claims widen | challenge artifact, appeal/review artifact, threat model, economics placement record | PLANNED |
-| D12 | Integrated citizen-state proof | WP-14 | Reviewer can inspect one bounded end-to-end citizen-state scenario | integrated proof packet, witness, receipt, projection, operator report | PLANNED |
+| D12 | Inhabited CSM Observatory flagship | WP-14 | Reviewer can inspect one bounded end-to-end citizen-state scenario with agents inside the polis rather than an empty artifact bundle | `OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md`, integrated proof packet, witness, receipt, redacted projection, access event, challenge/quarantine artifact, operator report | PLANNED |
 | D13 | Feature proof coverage record | WP-14A | Every v0.90.3 feature claim has a runnable demo, proof packet, fixture-backed artifact, non-proving status, or explicit deferral | feature proof coverage record and demo matrix update | PLANNED |
 | D14 | Observatory multimode UI architecture | WP-14A | The flagship Observatory demo has a reviewed room/lens/memory-dot architecture before demo redesign | `OBSERVATORY_UI_ARCHITECTURE_v0.90.3.md`, multimode mockup, Corporate Investor UI fallback rule | LANDED |
+
+## Flagship Demo Rule
+
+WP-14 / D12 should show an inhabited CSM:
+
+- citizen-like actor with continuity evidence
+- guest with no silent rights escalation
+- service actor with bounded authority
+- operator with redacted visibility
+- challenged or quarantined transition when continuity or authority is unsafe
+
+WP-14A / D13 should keep every feature proof row mapped to proof, fixture,
+non-proving status, or explicit deferral.
 
 ## Non-Proving Boundaries
 

--- a/docs/milestones/v0.90.3/OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md
+++ b/docs/milestones/v0.90.3/OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md
@@ -4,6 +4,11 @@
 
 Design/runbook note for the v0.90.3 inhabited CSM Observatory flagship demo.
 
+This runbook consumes the multimode UI architecture in
+`OBSERVATORY_UI_ARCHITECTURE_v0.90.3.md`. The demo is not only an inhabited
+story; it is the first planned traversal through the Observatory rooms, lenses,
+memory dots, and Corporate Investor UI fallback.
+
 ## Purpose
 
 The v0.90.3 demo matrix should not collapse into integration tests in disguise.
@@ -28,6 +33,48 @@ The demo shows one bounded local CSM scenario:
 The point is not to claim personhood. The point is to show the substrate in
 motion.
 
+## Observatory Rooms
+
+The demo should traverse rooms in this order:
+
+1. World / Reality Mode
+   - opens the demo on an inhabited polis rather than an artifact list
+   - shows citizen, guest, service actor, sanctuary/quarantine boundary,
+     resource weather, and trace routes
+   - uses lenses to make projection boundaries explicit
+
+2. Operator / Governance Mode
+   - follows one trace route into a Freedom Gate docket case
+   - shows allow, deny, defer, or challenge decisions as cases with evidence
+   - shows disabled unsafe actions with reasons
+
+3. Cognition / Internal State Mode
+   - optional in v0.90.3
+   - shows only bounded implemented signals such as coupling, coherence,
+     degraded state, or anomaly markers when evidence exists
+   - must not claim mature PHI, affect, instinct, or emotional substrate
+
+4. Corporate Investor UI fallback
+   - available through a visible operator control and keyboard shortcut
+   - useful when the multimode UI is too complex for the room or demo continuity
+     matters more than showing the full power-user surface
+   - switches presentation only, not evidence, trace, redaction, or authority
+
+The spaceship/art-deco design remains valuable as a power-user or fallback
+surface, but it should not be the default investor-facing path.
+
+## Walkthrough Sequence
+
+| Step | Room | Lens / Memory Dot | What The Reviewer Sees | Proof Boundary |
+| --- | --- | --- | --- | --- |
+| 1 | World / Reality Mode | triage overview | inhabited polis with citizen, guest, service actor, and protected boundary | design/demo projection, not live production UI |
+| 2 | World / Reality Mode | continuity lens | citizen worldline, witness, receipt, and trace route | continuity evidence without raw private state |
+| 3 | World / Reality Mode | quarantine lens | challenged or ambiguous transition enters sanctuary/quarantine | unsafe activation is blocked |
+| 4 | Operator / Governance Mode | quarantine review | Freedom Gate docket case with evidence, rationale, and next safe action | docket is audit surface, not unrestricted control |
+| 5 | Operator / Governance Mode | continuity proofs | disabled unsafe actions and allowed read-only review affordances | command authority remains policy-bound |
+| 6 | Cognition / Internal State Mode | anomaly watch | bounded coherence/coupling/degraded-state signal if implemented | no PHI, affect, or personhood claim |
+| 7 | Corporate Investor UI fallback | corporate investor view | calm art-deco summary for boardroom or constrained demo context | presentation fallback only |
+
 ## Actors
 
 | Actor | Role | What The Demo Shows |
@@ -49,6 +96,9 @@ motion.
 - challenge or quarantine artifact
 - operator report
 - feature proof coverage record
+- multimode UI architecture reference
+- lens and memory-dot sequence
+- Corporate Investor UI fallback note
 
 ## Demo Matrix Relationship
 
@@ -66,6 +116,30 @@ D12 is the flagship scenario. It ties the rows together so a reviewer can answer
 
 D13 remains the proof coverage record.
 
+D14 is the UI architecture design artifact. The flagship demo must consume D14
+but must not treat D14 as runtime proof.
+
+## Lenses And Memory Dots
+
+Minimum lenses:
+
+- public lens
+- operator lens
+- reviewer lens
+- continuity lens
+- quarantine lens
+
+Minimum memory dots:
+
+- triage overview
+- continuity proofs
+- quarantine review
+- anomaly watch if bounded evidence exists
+- corporate investor view
+
+Each lens must state what it shows, what it redacts, and what artifact supports
+the projection. Each memory dot must restore an authorized view only.
+
 ## Non-Proving Boundaries
 
 This demo does not prove:
@@ -77,6 +151,7 @@ This demo does not prove:
 - full contract-market economics
 - unrestricted operator control
 - production security or privacy hardening
+- mature PHI, affect, instinct, or emotional-substrate instrumentation
+- production UI readiness
 
 It proves a bounded local citizen-state safety and visibility story.
-

--- a/docs/milestones/v0.90.3/OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md
+++ b/docs/milestones/v0.90.3/OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md
@@ -1,0 +1,82 @@
+# Observatory Flagship Demo - v0.90.3
+
+## Status
+
+Design/runbook note for the v0.90.3 inhabited CSM Observatory flagship demo.
+
+## Purpose
+
+The v0.90.3 demo matrix should not collapse into integration tests in disguise.
+Feature proof rows remain necessary, but the flagship demo should make the CSM
+polis feel inhabited and governed.
+
+The demo principle is: no ship or walled town is anything if it is empty.
+
+## Demo Story
+
+The demo shows one bounded local CSM scenario:
+
+- a citizen-like actor has private state, signed continuity evidence, witness,
+  and receipt
+- a guest enters the polis but cannot silently acquire citizen rights
+- a service actor performs a bounded role without becoming a hidden social actor
+- an operator sees a redacted Observatory projection
+- an ambiguous or challenged transition enters sanctuary or quarantine
+- the Freedom Gate docket records allow, deny, defer, or challenge decisions
+- the timeline shows causal events without exposing raw private state
+
+The point is not to claim personhood. The point is to show the substrate in
+motion.
+
+## Actors
+
+| Actor | Role | What The Demo Shows |
+| --- | --- | --- |
+| Citizen-like actor | provisional governed identity | continuity, standing, private state projection, receipt |
+| Guest | default human/external entry mode | no silent rights escalation |
+| Service actor | bounded technical actor | authority without hidden citizenship |
+| Operator | accountable human operator | redacted visibility and disabled unsafe actions |
+| Challenged state or actor | ambiguity surface | quarantine/sanctuary rather than unsafe activation |
+
+## Required Artifacts
+
+- visibility or Observatory packet
+- witness
+- citizen receipt
+- redacted projection
+- standing or communication event
+- access approval or denial event
+- challenge or quarantine artifact
+- operator report
+- feature proof coverage record
+
+## Demo Matrix Relationship
+
+D1 through D11 remain feature proof rows. They prove individual surfaces.
+
+D12 is the flagship scenario. It ties the rows together so a reviewer can answer:
+
+- who is inside the CSM?
+- what state changed?
+- what evidence proves continuity?
+- who was allowed or denied access?
+- what did the Observatory show?
+- what did it intentionally hide?
+- what was quarantined or challenged?
+
+D13 remains the proof coverage record.
+
+## Non-Proving Boundaries
+
+This demo does not prove:
+
+- first true Gödel-agent birth
+- full personhood
+- full moral, emotional, kindness, or wellbeing substrate
+- complete migration or cross-polis continuity
+- full contract-market economics
+- unrestricted operator control
+- production security or privacy hardening
+
+It proves a bounded local citizen-state safety and visibility story.
+


### PR DESCRIPTION
Closes #2352

## Summary
Refreshed the v0.90.3 Observatory flagship demo plan after the multimode UI architecture landed in #2365.

The demo is now explicitly designed as an inhabited CSM traversal through:

- World / Reality Mode as the default opening view of the polis
- Operator / Governance Mode for Freedom Gate docket, trace, policy, and audit
- optional bounded Cognition / Internal State Mode only when implemented evidence exists
- Corporate Investor UI fallback for boardroom-safe demo continuity

This keeps the feature proof rows intact while making D12 a real flagship story instead of integration tests in disguise.

## Artifacts
- docs/milestones/v0.90.3/OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md
- docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md

## Validation
- git diff --check: passed.
- changed-doc scan for host paths, local .adl paths, stale markers, and pasted review emoji: passed.
- artifact existence checks for the demo runbook, demo matrix, and UI architecture doc: passed.
- bash adl/tools/pr.sh doctor 2352 --version v0.90.3 --json: passed with preflight_status PASS and ready_status PASS.

## Notes
- This PR does not implement the running UI.
- D12 now consumes D14 but does not treat D14 as runtime proof.
- The spaceship/art-deco design remains preserved as the Corporate Investor UI fallback, not the default investor-facing path.
