### PR TITLE
[v0.90.2][skills] Create release-evidence operational skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -51,6 +51,7 @@ run_step "finding-to-issue-planner contract check" bash "$ROOT/adl/tools/test_fi
 run_step "review-comment-triage contract check" bash "$ROOT/adl/tools/test_review_comment_triage_skill_contracts.sh"
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
+run_step "release-evidence contract check" bash "$ROOT/adl/tools/test_release_evidence_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"
 run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_paper_writer_skill_contracts.sh"
 run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_author_skill_contracts.sh"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -34,6 +34,7 @@ The tracked skill set is:
 - `pr-stack-manager`
 - `product-report-writer`
 - `redaction-and-evidence-auditor`
+- `release-evidence`
 - `review-comment-triage`
 - `refactoring-helper`
 - `repo-architecture-review`
@@ -73,6 +74,7 @@ The normal workflow is:
 `repo-code-review` is cross-cutting rather than phase-specific.
 `test-generator` is a bounded helper skill for focused tests for a concrete issue, diff, file, or worktree.
 `demo-operator` is a bounded helper skill for running one named demo and classifying the proof result consistently.
+`release-evidence` is a bounded helper skill for assembling milestone release proof surfaces into a reviewable evidence packet without approving, publishing, tagging, merging, or closing anything.
 `medium-article-writer` is a bounded helper skill for turning one concrete article brief into a reviewer-friendly Medium packet without publishing.
 `arxiv-paper-writer` is a bounded helper skill for turning one concrete scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, or inventing citations.
 `diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
@@ -1788,6 +1790,87 @@ policy:
 Run the named demo in a bounded way, classify the result, and stop.
 ```
 
+## `release-evidence`
+
+### Purpose
+
+`release-evidence` assembles one milestone release-evidence packet from existing
+issue, PR, demo, proof, review, remediation, validation, non-claim, and
+residual-risk records.
+
+It is an evidence packaging helper, not a release authority.
+
+### When To Use It
+
+Use it when:
+
+- a milestone needs one reviewable release proof surface
+- internal or external review needs issue, PR, demo, review, remediation, and validation evidence in one place
+- release closeout preparation needs explicit non-claims and residual risks
+
+Do not use it for:
+
+- release approval or release ceremony decisions
+- PR merge, issue closure, tag creation, or publication
+- demo execution or remediation implementation
+
+### Required Inputs
+
+Minimum:
+
+- `milestone`
+- structured invocation should use `skill_input_schema: release_evidence.v1`
+- `evidence.milestone_root`
+- `policy.stop_before_release_approval: true`
+- `policy.stop_before_mutation: true`
+
+### Input Schema
+
+Canonical schema:
+
+- `adl/tools/skills/docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md`
+
+Schema id:
+
+- `release_evidence.v1`
+
+Structured invocation shape:
+
+```yaml
+skill_input_schema: release_evidence.v1
+mode: assemble_milestone_evidence
+milestone: v0.90.2
+evidence:
+  milestone_root: docs/milestones/v0.90.2
+  review_roots:
+    - .adl/reviews/v0.90.2/internal-review
+  demo_roots:
+    - artifacts/v0.90.2
+policy:
+  write_evidence_artifact: true
+  include_open_issues: true
+  require_review_records: true
+  require_validation_commands: true
+  stop_before_release_approval: true
+  stop_before_mutation: true
+```
+
+### Output And Stop Boundary
+
+Expected output includes:
+
+- ready, partial, blocked, or not-run classification
+- evidence families and source paths
+- blocking or partial evidence
+- non-claims
+- residual risks
+- validation commands
+- safety flags
+
+The skill may write a Markdown and JSON evidence artifact. It must stop before
+release approval, publication, tag creation, PR merge, issue closure, demo
+execution, or remediation.
+
 ## `arxiv-paper-writer`
 
 ### Purpose
@@ -2068,6 +2151,8 @@ Use this quick selector:
   - `test-generator`
 - need to run one named demo and classify the proof result:
   - `demo-operator`
+- need to assemble milestone release proof surfaces:
+  - `release-evidence`
 - need to finalize local issue state after merge/closure:
   - `pr-closeout`
 - need to clean drifted lifecycle records before closeout or janitor handoff:
@@ -2141,6 +2226,7 @@ surfaces:
 | `pr-stack-manager` | `PR_STACK_MANAGER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | stack topology analysis or bounded stack plan only |
 | `product-report-writer` | `PRODUCT_REPORT_WRITER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | product report packet only |
 | `redaction-and-evidence-auditor` | `REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | safety audit only |
+| `release-evidence` | `RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | release evidence packet only |
 | `review-comment-triage` | `REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review-comment triage only |
 | `refactoring-helper` | `REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | refactor plan only |
 | `repo-architecture-review` | `REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | architecture findings only |

--- a/adl/tools/skills/docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,75 @@
+# Release Evidence Skill Input Schema
+
+Schema id: `release_evidence.v1`
+
+Use this schema when invoking `release-evidence` with structured input.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `release_evidence.v1`
+- `mode`: one of `assemble_milestone_evidence`, `refresh_release_evidence`, or
+  `inspect_release_evidence`
+- `milestone`: explicit milestone identifier such as `v0.90.2`
+- `evidence`: source evidence locations and optional previously generated
+  reports
+- `policy`: stop-boundary and artifact-writing policy
+
+## Evidence Object
+
+Recommended fields:
+
+- `milestone_root`: milestone documentation or closeout root
+- `issue_records_root`: local issue/card root when available
+- `review_roots`: internal, external, or gap review roots
+- `demo_roots`: demo or proof artifact roots
+- `previous_report_path`: previous release evidence report for refresh mode
+- `report_path`: existing report to inspect
+
+## Policy Object
+
+Recommended fields:
+
+- `write_evidence_artifact`: boolean
+- `include_open_issues`: boolean
+- `require_review_records`: boolean
+- `require_validation_commands`: boolean
+- `stop_before_release_approval`: must be true
+- `stop_before_mutation`: must be true
+
+## Example
+
+```yaml
+skill_input_schema: release_evidence.v1
+mode: assemble_milestone_evidence
+milestone: v0.90.2
+evidence:
+  milestone_root: docs/milestones/v0.90.2
+  review_roots:
+    - .adl/reviews/v0.90.2/internal-review
+  demo_roots:
+    - artifacts/v0.90.2
+policy:
+  write_evidence_artifact: true
+  include_open_issues: true
+  require_review_records: true
+  require_validation_commands: true
+  stop_before_release_approval: true
+  stop_before_mutation: true
+```
+
+## Output
+
+Default output root:
+
+```text
+.adl/reviews/release-evidence/<run_id>/
+```
+
+Required artifacts:
+
+- `release_evidence_report.md`
+- `release_evidence_report.json`
+
+The report must preserve non-claims and safety flags. It must not approve,
+publish, tag, merge, close, or mutate anything.
+

--- a/adl/tools/skills/release-evidence/SKILL.md
+++ b/adl/tools/skills/release-evidence/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: release-evidence
+description: Assemble milestone release proof surfaces into a bounded reviewable evidence package covering issue and PR evidence, demos, reviews, remediation, validation, non-claims, and residual risks without approving releases, publishing notes, tagging, merging, or closing issues.
+---
+
+# Release Evidence
+
+Assemble one milestone release-evidence packet from existing milestone, review,
+demo, validation, issue, and PR records. This is an evidence packaging skill,
+not a release authority.
+
+Use this skill during milestone closeout preparation, release-readiness review,
+or internal/external review handoff when operators need one bounded artifact
+that says what is proven, what is partial, what is blocked, and what is not
+claimed.
+
+## Quick Start
+
+1. Confirm the milestone identifier and evidence root.
+2. Confirm the packet is evidence-only and must stop before release approval.
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/assemble_release_evidence.py --milestone <version> --milestone-root docs/milestones/<version> --out .adl/reviews/release-evidence/<run_id> --run-id <run_id>`
+4. Review the Markdown and JSON artifacts.
+5. Hand off any gaps to `gap-analysis`, `finding-to-issue-planner`, or the
+   appropriate PR lifecycle skill. Do not merge, tag, close, or publish from
+   this skill.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `mode`
+- `milestone`
+- `evidence`
+- `policy`
+
+Supported modes:
+
+- `assemble_milestone_evidence`
+- `refresh_release_evidence`
+- `inspect_release_evidence`
+
+Useful policy fields:
+
+- `write_evidence_artifact`
+- `include_open_issues`
+- `require_review_records`
+- `require_validation_commands`
+- `stop_before_release_approval`
+- `stop_before_mutation`
+
+If no milestone or evidence root is available, return `not_run`.
+
+## Classification
+
+Classify the package as:
+
+- `ready`: required evidence families are present and no open release checklist
+  or blocker markers are visible.
+- `partial`: evidence can be assembled but important proof, review, validation,
+  or closeout surfaces are missing or still open.
+- `blocked`: explicit blocker markers, unresolved high-priority findings, or
+  missing release-readiness evidence prevent truthful release-evidence packaging.
+- `not_run`: the milestone evidence root is missing, unreadable, or empty.
+
+Do not use `ready` as release approval. It only means the evidence packet itself
+is complete enough to review.
+
+## Output
+
+Write Markdown and JSON artifacts when an output root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/release-evidence/<run_id>/
+```
+
+Required artifacts:
+
+- `release_evidence_report.md`
+- `release_evidence_report.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+This skill must not:
+
+- approve a release or claim release approval
+- merge PRs, close issues, create tags, or publish release notes
+- rewrite milestone truth to make evidence look complete
+- execute demos beyond reading their recorded evidence
+- replace `gap-analysis`, `demo-operator`, `pr-finish`, `pr-closeout`, or
+  release ceremony review
+
+Handoff candidates:
+
+- `gap-analysis` when expected release scope needs comparison against evidence.
+- `finding-to-issue-planner` when gaps should become reviewable issue
+  candidates.
+- `demo-operator` when one missing proof surface needs a bounded demo run.
+- `pr-closeout` when merged issues need truthful local closeout.
+

--- a/adl/tools/skills/release-evidence/adl-skill.yaml
+++ b/adl/tools/skills/release-evidence/adl-skill.yaml
@@ -1,0 +1,114 @@
+version: "0.1"
+kind: "adl-skill"
+id: "release-evidence"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "release_evidence.v1"
+    reference_doc: "../docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "milestone"
+      - "evidence"
+      - "policy"
+    mode_enum:
+      - "assemble_milestone_evidence"
+      - "refresh_release_evidence"
+      - "inspect_release_evidence"
+    policy_fields:
+      - "write_evidence_artifact"
+      - "include_open_issues"
+      - "require_review_records"
+      - "require_validation_commands"
+      - "stop_before_release_approval"
+      - "stop_before_mutation"
+    mode_requirements:
+      assemble_milestone_evidence:
+        required_target_fields:
+          - "milestone"
+          - "evidence.milestone_root"
+      refresh_release_evidence:
+        required_target_fields:
+          - "milestone"
+          - "evidence.previous_report_path"
+      inspect_release_evidence:
+        required_target_fields:
+          - "evidence.report_path"
+  intent:
+    - "release_evidence_packaging"
+    - "milestone_closeout_review"
+    - "release_readiness_evidence"
+  required_inputs:
+    - "milestone"
+    - "evidence"
+    - "policy"
+  optional_inputs:
+    - "output_root"
+    - "run_id"
+    - "issue_range"
+    - "pr_range"
+    - "review_roots"
+    - "demo_roots"
+  stop_if_missing:
+    - "milestone"
+    - "evidence.milestone_root"
+  prevalidation_rules:
+    - "skill_input_schema_must_equal_release_evidence.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "milestone_must_be_explicit"
+    - "evidence_root_must_be_explicit"
+    - "policy.stop_before_release_approval_must_be_true"
+    - "policy.stop_before_mutation_must_be_true"
+execution:
+  mode: "evidence_assembly_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/assemble_release_evidence.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "--milestone <version>"
+        - "--milestone-root <path>"
+        - "--out <artifact-root>"
+        - "--run-id <id>"
+  preferred_read_order:
+    - "milestone README"
+    - "issue wave or WBS"
+    - "release readiness"
+    - "demo matrix and proof coverage"
+    - "internal and external review artifacts"
+    - "remediation and finding closeout records"
+    - "validation and checklist records"
+    - "release notes draft"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  must_not_run:
+    - "release_approval"
+    - "release_publication"
+    - "tag_creation"
+    - "pull_request_merge"
+    - "issue_closure"
+    - "release_notes_publication"
+    - "demo_execution"
+    - "evidence_rewriting_to_hide_gaps"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/release-evidence/<run_id>/"
+  required_artifacts:
+    - "release_evidence_report.md"
+    - "release_evidence_report.json"
+security:
+  no_release_approval: true
+  no_publication: true
+  no_tag_creation: true
+  no_issue_closure: true
+  no_pr_merge: true
+

--- a/adl/tools/skills/release-evidence/agents/openai.yaml
+++ b/adl/tools/skills/release-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: Release Evidence
+short_description: Assemble milestone release proof surfaces into a bounded evidence packet without approving or publishing releases
+default_prompt: Assemble a milestone release-evidence packet from existing issue, PR, demo, review, remediation, validation, non-claim, and residual-risk surfaces. Classify the packet as ready, partial, blocked, or not-run with source-grounded reasons, and stop before release approval, publication, tags, merges, issue closure, or repository mutation.
+

--- a/adl/tools/skills/release-evidence/references/output-contract.md
+++ b/adl/tools/skills/release-evidence/references/output-contract.md
@@ -1,0 +1,55 @@
+# Release Evidence Output Contract
+
+Release evidence artifacts must be reviewable, bounded, and explicit about what
+is not claimed.
+
+## Required Markdown Sections
+
+- `Release Evidence Summary`
+- `Evidence Families`
+- `Blocking Or Partial Evidence`
+- `Non-Claims`
+- `Residual Risks`
+- `Validation Commands`
+- `Safety Flags`
+
+## Required JSON Shape
+
+Schema id: `adl.release_evidence_report.v1`
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `milestone`
+- `status`
+- `summary`
+- `evidence_families`
+- `blocking_or_partial_evidence`
+- `non_claims`
+- `residual_risks`
+- `validation_commands`
+- `safety_flags`
+
+Supported status values:
+
+- `ready`
+- `partial`
+- `blocked`
+- `not_run`
+
+## Safety Flags
+
+Every report must state:
+
+- `release_approved: false`
+- `published_release_notes: false`
+- `created_tags: false`
+- `merged_prs: false`
+- `closed_issues: false`
+- `mutated_repository: false`
+
+The skill may report that evidence appears packet-ready. It must not claim the
+milestone is approved, released, published, or complete.
+
+This report does not approve the release.

--- a/adl/tools/skills/release-evidence/references/release-evidence-playbook.md
+++ b/adl/tools/skills/release-evidence/references/release-evidence-playbook.md
@@ -1,0 +1,34 @@
+# Release Evidence Playbook
+
+Use this playbook to assemble one milestone evidence packet without widening
+into release ceremony work.
+
+## Evidence Families
+
+- Issue and PR evidence: WBS, issue wave, merged issue summaries, PR lists, or
+  closeout records.
+- Demo and proof evidence: demo matrix, proof coverage, proof artifacts, or
+  recorded demo outcomes.
+- Review evidence: internal review, external review, gap reviews, or review
+  closeout notes.
+- Remediation evidence: finding-to-issue links, remediation status, follow-up
+  issue state, or explicit deferrals.
+- Validation evidence: checklist, validation command log, CI summary, or release
+  readiness validation notes.
+- Non-claims: anything the packet must not assert, especially release approval.
+- Residual risks: known partials, open issues, skipped demos, unresolved reviews,
+  or future milestone dependencies.
+
+## Classification Guide
+
+- Use `not_run` when the milestone evidence root cannot be read or contains no
+  evidence documents.
+- Use `blocked` when explicit blockers, unresolved high-priority findings, or
+  missing release-readiness evidence prevent truthful packaging.
+- Use `partial` when evidence exists but one or more families are absent,
+  incomplete, or visibly unchecked.
+- Use `ready` only when all required evidence families are present and no open
+  checklist or blocker markers are visible.
+
+`ready` means ready to review the evidence package. It is not release approval.
+

--- a/adl/tools/skills/release-evidence/scripts/assemble_release_evidence.py
+++ b/adl/tools/skills/release-evidence/scripts/assemble_release_evidence.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Assemble a bounded milestone release-evidence packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+EVIDENCE_FAMILIES = {
+    "issue_pr_evidence": (
+        "issue",
+        "issues",
+        "pr",
+        "pull request",
+        "wbs",
+        "wave",
+        "work package",
+    ),
+    "demo_proof_evidence": ("demo", "proof", "feature proof", "coverage"),
+    "review_evidence": ("review", "gap", "internal", "external"),
+    "remediation_evidence": ("remediation", "finding", "follow-up", "follow up", "closeout"),
+    "validation_evidence": ("validation", "checklist", "test", "ci", "command"),
+}
+
+BLOCKER_RE = re.compile(r"\b(blocked|release-blocking|p0|p1|must fix before release)\b", re.I)
+OPEN_CHECKBOX_RE = re.compile(r"^\s*[-*]\s+\[\s\]", re.M)
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+def collect_documents(root: Path) -> list[dict[str, str]]:
+    docs: list[dict[str, str]] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in {".md", ".txt", ".yaml", ".yml", ".json"}:
+            continue
+        rel = path.relative_to(root).as_posix()
+        docs.append({"path": rel, "text": read_text(path)})
+    return docs
+
+
+def summarize_matches(docs: list[dict[str, str]]) -> dict[str, dict[str, Any]]:
+    families: dict[str, dict[str, Any]] = {}
+    for family, terms in EVIDENCE_FAMILIES.items():
+        paths: list[str] = []
+        snippets: list[str] = []
+        for doc in docs:
+            haystack = f"{doc['path']}\n{doc['text']}".lower()
+            if any(term in haystack for term in terms):
+                paths.append(doc["path"])
+                snippets.extend(extract_snippets(doc["text"], terms, limit=2))
+        families[family] = {
+            "status": "present" if paths else "missing",
+            "paths": paths[:20],
+            "signals": snippets[:6],
+        }
+    return families
+
+
+def extract_snippets(text: str, terms: tuple[str, ...], limit: int) -> list[str]:
+    snippets: list[str] = []
+    for line in text.splitlines():
+        compact = " ".join(line.strip().split())
+        if not compact:
+            continue
+        lower = compact.lower()
+        if any(term in lower for term in terms):
+            snippets.append(compact[:180])
+        if len(snippets) >= limit:
+            break
+    return snippets
+
+
+def classify(docs: list[dict[str, str]], families: dict[str, dict[str, Any]]) -> tuple[str, list[str]]:
+    if not docs:
+        return "not_run", ["No readable milestone evidence documents were found."]
+
+    combined = "\n".join(doc["text"] for doc in docs)
+    missing = [name for name, data in families.items() if data["status"] == "missing"]
+    reasons: list[str] = []
+
+    if BLOCKER_RE.search(combined):
+        reasons.append("Explicit blocker or high-priority finding marker found in evidence.")
+        return "blocked", reasons
+
+    if "release_readiness" in combined.lower() and "missing" in combined.lower():
+        reasons.append("Release-readiness evidence appears to identify missing proof.")
+        return "blocked", reasons
+
+    if missing:
+        reasons.append("Missing evidence families: " + ", ".join(missing) + ".")
+
+    if OPEN_CHECKBOX_RE.search(combined):
+        reasons.append("Open checklist items are visible in evidence.")
+
+    if reasons:
+        return "partial", reasons
+
+    return "ready", ["All required evidence families are present and no open checklist or blocker markers were found."]
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Release Evidence Summary",
+        "",
+        f"- Milestone: `{report['milestone']}`",
+        f"- Run id: `{report['run_id']}`",
+        f"- Status: `{report['status']}`",
+        f"- Summary: {report['summary']}",
+        "",
+        "## Evidence Families",
+        "",
+    ]
+    for family, data in report["evidence_families"].items():
+        lines.append(f"### {family}")
+        lines.append("")
+        lines.append(f"- Status: `{data['status']}`")
+        paths = data.get("paths") or []
+        if paths:
+            lines.append("- Paths: " + ", ".join(f"`{path}`" for path in paths[:8]))
+        else:
+            lines.append("- Paths: none recorded")
+        signals = data.get("signals") or []
+        if signals:
+            lines.append("- Signals:")
+            for signal in signals[:4]:
+                lines.append(f"  - {signal}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Blocking Or Partial Evidence",
+            "",
+        ]
+    )
+    for item in report["blocking_or_partial_evidence"]:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## Non-Claims", ""])
+    for item in report["non_claims"]:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## Residual Risks", ""])
+    for item in report["residual_risks"]:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## Validation Commands", ""])
+    for command in report["validation_commands"]:
+        lines.append(f"- `{command}`")
+
+    lines.extend(["", "## Safety Flags", ""])
+    for key, value in report["safety_flags"].items():
+        lines.append(f"- {key}: {str(value).lower()}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    milestone_root = Path(args.milestone_root)
+    if not milestone_root.exists() or not milestone_root.is_dir():
+        families = {
+            name: {"status": "missing", "paths": [], "signals": []}
+            for name in EVIDENCE_FAMILIES
+        }
+        status = "not_run"
+        reasons = ["Milestone evidence root is missing or unreadable."]
+        docs: list[dict[str, str]] = []
+    else:
+        docs = collect_documents(milestone_root)
+        families = summarize_matches(docs)
+        status, reasons = classify(docs, families)
+
+    residual_risks = list(reasons)
+    if status == "ready":
+        residual_risks = [
+            "This packet is evidence-ready only; release approval still requires the normal release ceremony.",
+        ]
+
+    return {
+        "schema": "adl.release_evidence_report.v1",
+        "run_id": args.run_id,
+        "milestone": args.milestone,
+        "status": status,
+        "summary": (
+            "Release evidence assembled for review."
+            if status != "not_run"
+            else "Release evidence was not assembled because the milestone evidence root was unavailable or empty."
+        ),
+        "evidence_families": families,
+        "blocking_or_partial_evidence": reasons,
+        "non_claims": [
+            "This report does not approve the release.",
+            "This report does not publish release notes.",
+            "This report does not create tags, merge PRs, or close issues.",
+            "This report does not prove absent evidence is failed implementation.",
+        ],
+        "residual_risks": residual_risks,
+        "validation_commands": [
+            "python3 adl/tools/skills/release-evidence/scripts/assemble_release_evidence.py --milestone <version> --milestone-root docs/milestones/<version> --out <artifact-root> --run-id <run-id>",
+        ],
+        "safety_flags": {
+            "release_approved": False,
+            "published_release_notes": False,
+            "created_tags": False,
+            "merged_prs": False,
+            "closed_issues": False,
+            "mutated_repository": False,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--milestone", required=True)
+    parser.add_argument("--milestone-root", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--run-id", default="release-evidence")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    report = build_report(args)
+    (out / "release_evidence_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "release_evidence_report.md").write_text(
+        markdown_report(report),
+        encoding="utf-8",
+    )
+    print(f"WROTE {out / 'release_evidence_report.json'}")
+    print(f"WROTE {out / 'release_evidence_report.md'}")
+    print(f"STATUS {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -48,6 +48,8 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/repo-review-synthesis/references/output-contract.md" ]]
   [[ -f "${root}/skills/repo-review-tests/references/output-contract.md" ]]
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
+  [[ -f "${root}/skills/release-evidence/SKILL.md" ]]
+  [[ -x "${root}/skills/release-evidence/scripts/assemble_release_evidence.py" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
   [[ -f "${root}/skills/arxiv-paper-writer/SKILL.md" ]]
   [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
@@ -77,6 +79,7 @@ assert_skill_bundle() {
   grep -Fq "Convert source-grounded CodeBuddy review findings" "${root}/skills/finding-to-issue-planner/SKILL.md"
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
+  grep -Fq "evidence packaging skill" "${root}/skills/release-evidence/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
   grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
   grep -Fq "diagram-as-code and model-as-code router" "${root}/skills/diagram-author/SKILL.md"
@@ -106,6 +109,7 @@ assert_skill_bundle() {
     "${root}/skills/finding-to-issue-planner/SKILL.md" \
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
+    "${root}/skills/release-evidence/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
     "${root}/skills/arxiv-paper-writer/SKILL.md" \
     "${root}/skills/diagram-author/SKILL.md" \
@@ -135,6 +139,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/adr-curator" ]]
 [[ -L "${CODEX_HOME}/skills/architecture-fitness-function-author" ]]
 [[ -L "${CODEX_HOME}/skills/finding-to-issue-planner" ]]
+[[ -L "${CODEX_HOME}/skills/release-evidence" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_release_evidence_skill_contracts.sh
+++ b/adl/tools/test_release_evidence_skill_contracts.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+[[ -f "${skills_root}/release-evidence/SKILL.md" ]]
+[[ -f "${skills_root}/release-evidence/adl-skill.yaml" ]]
+[[ -f "${skills_root}/release-evidence/agents/openai.yaml" ]]
+[[ -f "${skills_root}/release-evidence/references/release-evidence-playbook.md" ]]
+[[ -f "${skills_root}/release-evidence/references/output-contract.md" ]]
+[[ -x "${skills_root}/release-evidence/scripts/assemble_release_evidence.py" ]]
+[[ -f "${skills_root}/docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "release-evidence"' "${skills_root}/release-evidence/adl-skill.yaml"
+grep -Fq 'id: "release_evidence.v1"' "${skills_root}/release-evidence/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md"' "${skills_root}/release-evidence/adl-skill.yaml"
+grep -Fq "stop_before_release_approval_must_be_true" "${skills_root}/release-evidence/adl-skill.yaml"
+grep -Fq "Assemble milestone release proof surfaces" "${skills_root}/release-evidence/SKILL.md"
+grep -Fq "This report does not approve the release" "${skills_root}/release-evidence/references/output-contract.md"
+grep -Fq "Schema id: \`release_evidence.v1\`" "${skills_root}/docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md"
+
+milestone_root="${tmpdir}/milestone"
+report_root="${tmpdir}/release-evidence-report"
+mkdir -p "${milestone_root}"
+cat >"${milestone_root}/README.md" <<'MD'
+# vTEST
+
+This milestone has an issue wave and PR review surface.
+MD
+cat >"${milestone_root}/WBS_vTEST.md" <<'MD'
+# WBS
+
+WP issue and PR mapping is recorded here.
+MD
+cat >"${milestone_root}/DEMO_MATRIX_vTEST.md" <<'MD'
+# Demo Matrix
+
+Demo proof coverage exists for the milestone.
+MD
+cat >"${milestone_root}/INTERNAL_REVIEW_vTEST.md" <<'MD'
+# Internal Review
+
+Review findings were triaged.
+MD
+cat >"${milestone_root}/REMEDIATION_vTEST.md" <<'MD'
+# Remediation
+
+Finding follow-up status is recorded.
+MD
+cat >"${milestone_root}/MILESTONE_CHECKLIST_vTEST.md" <<'MD'
+# Checklist
+
+- [x] Validation command log recorded.
+- [ ] External ceremony not run yet.
+MD
+
+python3 "${skills_root}/release-evidence/scripts/assemble_release_evidence.py" \
+  --milestone vTEST \
+  --milestone-root "${milestone_root}" \
+  --out "${report_root}" \
+  --run-id release-evidence-contract-test >/tmp/release-evidence.out
+
+[[ -f "${report_root}/release_evidence_report.json" ]]
+[[ -f "${report_root}/release_evidence_report.md" ]]
+grep -Fq '"schema": "adl.release_evidence_report.v1"' "${report_root}/release_evidence_report.json"
+grep -Fq '"run_id": "release-evidence-contract-test"' "${report_root}/release_evidence_report.json"
+grep -Fq '"status": "partial"' "${report_root}/release_evidence_report.json"
+grep -Fq '"release_approved": false' "${report_root}/release_evidence_report.json"
+grep -Fq '"mutated_repository": false' "${report_root}/release_evidence_report.json"
+grep -Fq "## Evidence Families" "${report_root}/release_evidence_report.md"
+grep -Fq "## Non-Claims" "${report_root}/release_evidence_report.md"
+grep -Fq "## Safety Flags" "${report_root}/release_evidence_report.md"
+grep -Fq "release_approved: false" "${report_root}/release_evidence_report.md"
+
+missing_report="${tmpdir}/missing-report"
+python3 "${skills_root}/release-evidence/scripts/assemble_release_evidence.py" \
+  --milestone vMISSING \
+  --milestone-root "${tmpdir}/does-not-exist" \
+  --out "${missing_report}" \
+  --run-id release-evidence-missing-test >/tmp/release-evidence-missing.out
+grep -Fq '"status": "not_run"' "${missing_report}/release_evidence_report.json"
+
+if grep -R "${tmpdir}" "${report_root}" "${missing_report}" >/dev/null; then
+  echo "release evidence artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skills_root}/release-evidence/SKILL.md"
+
+echo "PASS test_release_evidence_skill_contracts"
+


### PR DESCRIPTION
Closes #2360

## Summary
Implemented the `release-evidence` operational skill as a bounded release-tail
evidence packaging surface. The skill assembles existing milestone issue/PR,
demo/proof, review, remediation, validation, non-claim, and residual-risk
records into Markdown and JSON artifacts, classifies the packet as `ready`,
`partial`, `blocked`, or `not_run`, and explicitly stops before release
approval, publication, tags, merges, issue closure, demo execution, or
remediation.

## Artifacts
- `adl/tools/skills/release-evidence/SKILL.md`
- `adl/tools/skills/release-evidence/adl-skill.yaml`
- `adl/tools/skills/release-evidence/agents/openai.yaml`
- `adl/tools/skills/release-evidence/references/output-contract.md`
- `adl/tools/skills/release-evidence/references/release-evidence-playbook.md`
- `adl/tools/skills/release-evidence/scripts/assemble_release_evidence.py`
- `adl/tools/skills/docs/RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_release_evidence_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_release_evidence_skill_contracts.sh` verified the new skill contract, helper output, classification behavior, safety flags, and path-leakage guard.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified the new skill participates in copy and symlink install/sync behavior.
  - `bash adl/tools/test_skill_documentation_completeness.sh` verified the skill has required docs, contracts, and guide coverage.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/release-evidence/SKILL.md` verified Codex skill frontmatter shape.
  - `git diff --check` verified whitespace hygiene for the full branch diff.
- Results: All targeted validations passed.

Validation command/path rules:
- Repository-relative paths were used in recorded commands and artifact references.
- No unjustified absolute host paths are recorded in this output card.
- `absolute_path_leakage_detected: false` is supported by the contract test grep against generated fixture reports.
- All commands listed above include their validation purpose.

## Local Artifacts
- Input card:  .adl/v0.90.2/tasks/issue-2360__v0-90-2-skills-create-release-evidence-operational-skill/sip.md
- Output card: .adl/v0.90.2/tasks/issue-2360__v0-90-2-skills-create-release-evidence-operational-skill/sor.md
- Idempotency-Key: v0-90-2-skills-create-release-evidence-operational-skill-adl-tools-batched-checks-sh-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-docs-release-evidence-skill-input-schema-md-adl-tools-skills-release-evidence-adl-tools-test-install-adl-operational-skills-sh-adl-tools-test-release-evidence-skill-contracts-sh-adl-v0-90-2-tasks-issue-2360-v0-90-2-skills-create-release-evidence-operational-skill-sip-md-adl-v0-90-2-tasks-issue-2360-v0-90-2-skills-create-release-evidence-operational-skill-sor-md