### PR TITLE
[v0.90.2][skills] Create review-readiness-cleanup operational skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -52,6 +52,7 @@ run_step "review-comment-triage contract check" bash "$ROOT/adl/tools/test_revie
 run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generator_skill_contracts.sh"
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "release-evidence contract check" bash "$ROOT/adl/tools/test_release_evidence_skill_contracts.sh"
+run_step "review-readiness-cleanup contract check" bash "$ROOT/adl/tools/test_review_readiness_cleanup_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"
 run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_paper_writer_skill_contracts.sh"
 run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_author_skill_contracts.sh"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -35,6 +35,7 @@ The tracked skill set is:
 - `product-report-writer`
 - `redaction-and-evidence-auditor`
 - `release-evidence`
+- `review-readiness-cleanup`
 - `review-comment-triage`
 - `refactoring-helper`
 - `repo-architecture-review`
@@ -82,6 +83,7 @@ The normal workflow is:
 `issue-watcher` is a bounded wait-window helper for watching one issue, PR, branch, or dependency gate and routing blockers without mutating state.
 `pr-stack-manager` is a bounded stack-topology helper for ancestry, base alignment, and dependency-order analysis.
 `review-comment-triage` is a bounded review-feedback helper for classifying PR comments before implementation.
+`review-readiness-cleanup` is a bounded review-cycle preflight helper for classifying safe cleanup, blockers, skipped surfaces, and follow-on needs before formal review starts.
 
 The three editor skills are helper skills:
 - `stp-editor` for bounded `stp.md` cleanup
@@ -1248,6 +1250,48 @@ Use `pr-janitor` for actionable current-PR items, `github:gh-address-comments`
 for thread-resolution work, and `finding-to-issue-planner` when comments should
 become follow-on issue candidates.
 
+## `review-readiness-cleanup`
+
+### Purpose
+
+`review-readiness-cleanup` inspects review packets, review plans, finding
+registers, demo or proof registers, and milestone review docs before formal
+review starts.
+
+It classifies structure-level readiness cleanup without changing substantive
+findings or approving review readiness.
+
+### When To Use It
+
+Use it when:
+
+- a review cycle is about to start and packet drift should be caught first
+- stale markers, missing metadata, or skipped surfaces may create false blockers
+- blockers and follow-on cleanup need to be separated before internal or external review
+
+Do not use it for:
+
+- running the review itself
+- remediating findings or rewriting severity
+- publishing reports or approving review readiness
+
+Structured schema:
+
+- `adl/tools/skills/docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md`
+- schema id: `review_readiness_cleanup.v1`
+
+Deterministic fixture analyzer:
+
+```bash
+python3 adl/tools/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py --review-root <path> --out <artifact-root> --run-id <run-id>
+```
+
+### Typical Handoff
+
+Use `documentation-specialist` for approved mechanical cleanup, `gap-analysis`
+for scope-vs-evidence uncertainty, `finding-to-issue-planner` for follow-on
+issue candidates, and `review-quality-evaluator` for packet quality gates.
+
 ## `stp-editor`
 
 ### Purpose
@@ -2161,6 +2205,8 @@ Use this quick selector:
   - `pr-stack-manager`
 - need to classify PR review comments before implementation:
   - `review-comment-triage`
+- need to preflight review packets before a formal review cycle:
+  - `review-readiness-cleanup`
 - need a broad findings-first code review:
   - `repo-code-review`
 - need source-backed arXiv-style manuscript drafting or citation-gap review:
@@ -2228,6 +2274,7 @@ surfaces:
 | `redaction-and-evidence-auditor` | `REDACTION_AND_EVIDENCE_AUDITOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | safety audit only |
 | `release-evidence` | `RELEASE_EVIDENCE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | release evidence packet only |
 | `review-comment-triage` | `REVIEW_COMMENT_TRIAGE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review-comment triage only |
+| `review-readiness-cleanup` | `REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review readiness cleanup classification only |
 | `refactoring-helper` | `REFACTORING_HELPER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | refactor plan only |
 | `repo-architecture-review` | `REPO_ARCHITECTURE_REVIEW_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | architecture findings only |
 | `repo-code-review` | `REPO_CODE_REVIEW_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | findings-first code review only |

--- a/adl/tools/skills/docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,76 @@
+# Review Readiness Cleanup Skill Input Schema
+
+Schema id: `review_readiness_cleanup.v1`
+
+Use this schema when invoking `review-readiness-cleanup` with structured input.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `review_readiness_cleanup.v1`
+- `mode`: one of `inspect_review_packet`, `inspect_milestone_review`, or
+  `refresh_readiness_cleanup`
+- `review_root`: root path for the review packet or milestone review surface
+- `target`: review-cycle identity, milestone, or previous report details
+- `policy`: stop-boundary and artifact-writing policy
+
+## Target Object
+
+Recommended fields:
+
+- `milestone`: milestone identifier when applicable
+- `review_type`: internal, external, CodeBuddy, product, or release-tail review
+- `required_surfaces`: expected file or section names
+- `previous_report_path`: previous cleanup report for refresh mode
+
+## Policy Object
+
+Recommended fields:
+
+- `write_cleanup_artifact`: boolean
+- `allow_safe_mechanical_cleanup`: boolean
+- `require_finding_register`: boolean
+- `require_demo_or_proof_register`: boolean
+- `stop_before_remediation`: must be true
+- `stop_before_publication`: must be true
+- `stop_before_review_approval`: must be true
+
+## Example
+
+```yaml
+skill_input_schema: review_readiness_cleanup.v1
+mode: inspect_milestone_review
+review_root: .adl/reviews/v0.90.2/internal-review
+target:
+  milestone: v0.90.2
+  review_type: internal
+  required_surfaces:
+    - review plan
+    - finding register
+    - demo matrix
+policy:
+  write_cleanup_artifact: true
+  allow_safe_mechanical_cleanup: false
+  require_finding_register: true
+  require_demo_or_proof_register: true
+  stop_before_remediation: true
+  stop_before_publication: true
+  stop_before_review_approval: true
+```
+
+## Output
+
+Default output root:
+
+```text
+.adl/reviews/review-readiness-cleanup/<run_id>/
+```
+
+Required artifacts:
+
+- `review_readiness_cleanup_report.md`
+- `review_readiness_cleanup_report.json`
+
+The report must preserve non-claims and safety flags. It must not remediate
+findings, rewrite severity, publish reports, create tracker items, or approve
+review readiness.
+

--- a/adl/tools/skills/review-readiness-cleanup/SKILL.md
+++ b/adl/tools/skills/review-readiness-cleanup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: review-readiness-cleanup
+description: Inspect review packets, review plans, finding registers, demo or proof registers, and milestone review docs for structural readiness, classifying safe cleanup, blockers, skipped surfaces, and follow-on needs without remediating findings, publishing reports, or approving review readiness.
+---
+
+# Review Readiness Cleanup
+
+Inspect one review packet or milestone review surface before an internal,
+external, or CodeBuddy-style review cycle starts. This skill reduces avoidable
+review friction from stale markers, missing metadata, unclear blockers, and
+packet-structure drift.
+
+It is a readiness cleanup classifier, not a qualitative reviewer and not an
+approval authority.
+
+## Quick Start
+
+1. Confirm the review root and intended review cycle.
+2. Confirm the cleanup policy stops before remediation, publication, and review
+   approval.
+3. Run the deterministic helper when local filesystem access is available:
+   - `scripts/inspect_review_readiness.py --review-root <path> --out <artifact-root> --run-id <run_id>`
+4. Review the Markdown and JSON artifacts.
+5. Route actionable results to the appropriate owner. Do not rewrite findings,
+   alter severity, publish reports, or approve review readiness from this skill.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `mode`
+- `review_root`
+- `target`
+- `policy`
+
+Supported modes:
+
+- `inspect_review_packet`
+- `inspect_milestone_review`
+- `refresh_readiness_cleanup`
+
+Useful policy fields:
+
+- `write_cleanup_artifact`
+- `allow_safe_mechanical_cleanup`
+- `require_finding_register`
+- `require_demo_or_proof_register`
+- `stop_before_remediation`
+- `stop_before_publication`
+- `stop_before_review_approval`
+
+If the review root is missing or intentionally not in scope, return `skipped`
+with the reason visible.
+
+## Classification Model
+
+Classify findings as:
+
+- `safe_mechanical_cleanup`: stale placeholders, unchecked metadata, empty
+  packet sections, or formatting drift that can be repaired without changing
+  substantive findings.
+- `blocker`: missing required review surfaces, explicit blocker markers,
+  unresolved high-priority review state, or evidence drift that would make the
+  review misleading.
+- `skipped`: a review surface was intentionally absent, unavailable, or out of
+  scope for this cycle.
+- `follow_on_needed`: useful cleanup or process improvement that should not
+  block the current review but should be queued.
+
+If evidence is insufficient, classify as `blocker` or `skipped`; do not infer
+readiness from absence.
+
+## Output
+
+Write Markdown and JSON artifacts when an output root is available.
+
+Default artifact root:
+
+```text
+.adl/reviews/review-readiness-cleanup/<run_id>/
+```
+
+Required artifacts:
+
+- `review_readiness_cleanup_report.md`
+- `review_readiness_cleanup_report.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+This skill must not:
+
+- run a full internal or external review
+- remediate review findings
+- rewrite finding severity, disagreement, evidence, or conclusions
+- publish customer-facing reports
+- approve review readiness without evidence
+- create issues or PRs without explicit operator approval
+
+Handoff candidates:
+
+- `documentation-specialist` for approved mechanical doc cleanup.
+- `gap-analysis` when expected review scope needs comparison against evidence.
+- `finding-to-issue-planner` when cleanup or blockers should become issue
+  candidates.
+- `review-quality-evaluator` when the review packet itself needs a quality gate.
+

--- a/adl/tools/skills/review-readiness-cleanup/adl-skill.yaml
+++ b/adl/tools/skills/review-readiness-cleanup/adl-skill.yaml
@@ -1,0 +1,107 @@
+version: "0.1"
+kind: "adl-skill"
+id: "review-readiness-cleanup"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "review_readiness_cleanup.v1"
+    reference_doc: "../docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "review_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "inspect_review_packet"
+      - "inspect_milestone_review"
+      - "refresh_readiness_cleanup"
+    policy_fields:
+      - "write_cleanup_artifact"
+      - "allow_safe_mechanical_cleanup"
+      - "require_finding_register"
+      - "require_demo_or_proof_register"
+      - "stop_before_remediation"
+      - "stop_before_publication"
+      - "stop_before_review_approval"
+    mode_requirements:
+      inspect_review_packet:
+        required_target_fields:
+          - "review_root"
+      inspect_milestone_review:
+        required_target_fields:
+          - "target.milestone"
+          - "review_root"
+      refresh_readiness_cleanup:
+        required_target_fields:
+          - "target.previous_report_path"
+          - "review_root"
+  intent:
+    - "review_readiness_cleanup"
+    - "review_packet_preflight"
+    - "milestone_review_precheck"
+  required_inputs:
+    - "review_root"
+    - "target"
+    - "policy"
+  optional_inputs:
+    - "output_root"
+    - "run_id"
+    - "required_surfaces"
+    - "review_type"
+  stop_if_missing:
+    - "review_root"
+  prevalidation_rules:
+    - "skill_input_schema_must_equal_review_readiness_cleanup.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "review_root_must_be_explicit"
+    - "policy.stop_before_remediation_must_be_true"
+    - "policy.stop_before_publication_must_be_true"
+    - "policy.stop_before_review_approval_must_be_true"
+execution:
+  mode: "readiness_cleanup_classification_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/inspect_review_readiness.py"
+      interpreter: "python3"
+      read_only: true
+      allowed_args:
+        - "--review-root <path>"
+        - "--out <artifact-root>"
+        - "--run-id <id>"
+  preferred_read_order:
+    - "review plan"
+    - "finding register"
+    - "demo or proof register"
+    - "review packet manifest"
+    - "milestone review docs"
+    - "validation notes"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  must_not_run:
+    - "review_execution"
+    - "finding_remediation"
+    - "severity_rewriting"
+    - "publication"
+    - "review_approval_claims"
+    - "tracker_item_creation"
+    - "pull_request_creation"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/review-readiness-cleanup/<run_id>/"
+  required_artifacts:
+    - "review_readiness_cleanup_report.md"
+    - "review_readiness_cleanup_report.json"
+security:
+  no_review_approval: true
+  no_publication: true
+  no_finding_rewrites: true
+  no_repo_mutation: true
+

--- a/adl/tools/skills/review-readiness-cleanup/agents/openai.yaml
+++ b/adl/tools/skills/review-readiness-cleanup/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: Review Readiness Cleanup
+short_description: Inspect review surfaces for structural readiness cleanup without remediating findings or approving review readiness
+default_prompt: Inspect one review packet or milestone review surface for stale markers, missing metadata, unclear blockers, skipped surfaces, follow-on cleanup, and structural readiness drift. Classify safe mechanical cleanup, blockers, skipped items, and follow-on needs with evidence, and stop before remediation, publication, finding rewrites, issue creation, PRs, or review approval.
+

--- a/adl/tools/skills/review-readiness-cleanup/references/output-contract.md
+++ b/adl/tools/skills/review-readiness-cleanup/references/output-contract.md
@@ -1,0 +1,61 @@
+# Review Readiness Cleanup Output Contract
+
+Review readiness cleanup artifacts must classify structural review-cycle issues
+without changing findings or approving readiness.
+
+## Required Markdown Sections
+
+- `Review Readiness Cleanup Summary`
+- `Classification Counts`
+- `Items`
+- `Safe Mechanical Cleanup`
+- `Blockers`
+- `Skipped Surfaces`
+- `Follow-On Needed`
+- `Non-Claims`
+- `Safety Flags`
+
+## Required JSON Shape
+
+Schema id: `adl.review_readiness_cleanup_report.v1`
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `status`
+- `summary`
+- `counts`
+- `items`
+- `recommended_handoffs`
+- `non_claims`
+- `safety_flags`
+
+Supported item categories:
+
+- `safe_mechanical_cleanup`
+- `blocker`
+- `skipped`
+- `follow_on_needed`
+
+Supported status values:
+
+- `ready`
+- `cleanup_needed`
+- `blocked`
+- `skipped`
+
+## Safety Flags
+
+Every report must state:
+
+- `review_approved: false`
+- `findings_rewritten: false`
+- `published_report: false`
+- `created_issues: false`
+- `created_prs: false`
+- `mutated_repository: false`
+
+This skill may say a packet has cleanup findings. It must not claim the review
+cycle is approved, complete, published, or remediated.
+

--- a/adl/tools/skills/review-readiness-cleanup/references/review-readiness-cleanup-playbook.md
+++ b/adl/tools/skills/review-readiness-cleanup/references/review-readiness-cleanup-playbook.md
@@ -1,0 +1,29 @@
+# Review Readiness Cleanup Playbook
+
+Use this playbook before formal review cycles to remove avoidable structure
+noise without changing review substance.
+
+## Inspect For
+
+- Review plan presence and stale status markers.
+- Finding register presence and unresolved blocker markers.
+- Demo or proof register presence when proof evidence is expected.
+- Packet manifest, source paths, and validation notes.
+- Placeholder leakage such as `TBD`, `TODO`, `FIXME`, or empty template sections.
+- Explicit skipped surfaces and their rationale.
+- Follow-on cleanup that should be queued but should not block this review.
+
+## Classification Guide
+
+- Use `safe_mechanical_cleanup` for stale headings, placeholders, missing
+  metadata, or small structure drift that can be fixed without changing
+  substantive review findings.
+- Use `blocker` for missing required surfaces, explicit blocker markers, or
+  high-priority review truth that makes the packet misleading.
+- Use `skipped` for intentionally absent, unavailable, or out-of-scope surfaces.
+- Use `follow_on_needed` for cleanup that is useful but not required before the
+  current review cycle.
+
+Do not rewrite findings, hide disagreement, or approve readiness from this
+classification.
+

--- a/adl/tools/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py
+++ b/adl/tools/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Inspect review surfaces for structural readiness cleanup needs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+TEXT_SUFFIXES = {".md", ".txt", ".yaml", ".yml", ".json"}
+PLACEHOLDER_RE = re.compile(r"\b(TBD|TODO|FIXME|placeholder|not started)\b", re.I)
+BLOCKER_RE = re.compile(r"\b(BLOCKED|P0|P1|release-blocking|review-blocking|must fix)\b", re.I)
+SKIPPED_RE = re.compile(r"\b(skipped|not applicable|out of scope|intentionally absent)\b", re.I)
+FOLLOW_ON_RE = re.compile(r"\b(follow[- ]on|deferred|future work|later milestone|post-review)\b", re.I)
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+def collect_docs(root: Path) -> list[dict[str, str]]:
+    docs: list[dict[str, str]] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in TEXT_SUFFIXES:
+            continue
+        docs.append({"path": path.relative_to(root).as_posix(), "text": read_text(path)})
+    return docs
+
+
+def first_matching_line(text: str, pattern: re.Pattern[str]) -> str:
+    for line in text.splitlines():
+        compact = " ".join(line.strip().split())
+        if compact and pattern.search(compact):
+            return compact[:180]
+    return "marker present"
+
+
+def add_item(
+    items: list[dict[str, str]],
+    category: str,
+    source: str,
+    reason: str,
+    evidence: str,
+) -> None:
+    items.append(
+        {
+            "category": category,
+            "source": source,
+            "reason": reason,
+            "evidence": evidence,
+        }
+    )
+
+
+def classify_docs(docs: list[dict[str, str]]) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    if not docs:
+        add_item(
+            items,
+            "skipped",
+            "review_root",
+            "No readable review documents were found.",
+            "review root empty or unsupported",
+        )
+        return items
+
+    combined_paths = " ".join(doc["path"].lower() for doc in docs)
+    if not any(term in combined_paths for term in ("finding", "review", "gap")):
+        add_item(
+            items,
+            "blocker",
+            "review_root",
+            "No finding, review, or gap register path was found.",
+            "expected review truth surface missing",
+        )
+    if not any(term in combined_paths for term in ("demo", "proof", "coverage")):
+        add_item(
+            items,
+            "follow_on_needed",
+            "review_root",
+            "No demo or proof register path was found.",
+            "proof linkage may need a follow-on surface",
+        )
+
+    for doc in docs:
+        text = doc["text"]
+        if BLOCKER_RE.search(text):
+            add_item(
+                items,
+                "blocker",
+                doc["path"],
+                "Explicit blocker or high-priority review marker found.",
+                first_matching_line(text, BLOCKER_RE),
+            )
+        if PLACEHOLDER_RE.search(text):
+            add_item(
+                items,
+                "safe_mechanical_cleanup",
+                doc["path"],
+                "Placeholder or stale readiness marker found.",
+                first_matching_line(text, PLACEHOLDER_RE),
+            )
+        if SKIPPED_RE.search(text):
+            add_item(
+                items,
+                "skipped",
+                doc["path"],
+                "Skipped or out-of-scope surface is explicitly recorded.",
+                first_matching_line(text, SKIPPED_RE),
+            )
+        if FOLLOW_ON_RE.search(text):
+            add_item(
+                items,
+                "follow_on_needed",
+                doc["path"],
+                "Follow-on or deferred cleanup marker found.",
+                first_matching_line(text, FOLLOW_ON_RE),
+            )
+
+    if not items:
+        add_item(
+            items,
+            "safe_mechanical_cleanup",
+            "review_root",
+            "No blockers found; only final human skim remains before review start.",
+            "structural scan completed",
+        )
+    return items
+
+
+def status_from_counts(counts: Counter[str]) -> str:
+    if counts.get("blocker", 0):
+        return "blocked"
+    if counts.get("skipped", 0) and sum(counts.values()) == counts["skipped"]:
+        return "skipped"
+    if counts.get("safe_mechanical_cleanup", 0) or counts.get("follow_on_needed", 0):
+        return "cleanup_needed"
+    return "ready"
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    root = Path(args.review_root)
+    if not root.exists() or not root.is_dir():
+        items = [
+            {
+                "category": "skipped",
+                "source": "review_root",
+                "reason": "Review root is missing or unreadable.",
+                "evidence": "missing review root",
+            }
+        ]
+    else:
+        items = classify_docs(collect_docs(root))
+
+    counts = Counter(item["category"] for item in items)
+    status = status_from_counts(counts)
+    return {
+        "schema": "adl.review_readiness_cleanup_report.v1",
+        "run_id": args.run_id,
+        "status": status,
+        "summary": f"Review readiness cleanup classified {sum(counts.values())} item(s).",
+        "counts": {
+            "safe_mechanical_cleanup": counts.get("safe_mechanical_cleanup", 0),
+            "blocker": counts.get("blocker", 0),
+            "skipped": counts.get("skipped", 0),
+            "follow_on_needed": counts.get("follow_on_needed", 0),
+        },
+        "items": items,
+        "recommended_handoffs": {
+            "safe_mechanical_cleanup": "documentation-specialist",
+            "blocker": "gap-analysis",
+            "skipped": "operator-review",
+            "follow_on_needed": "finding-to-issue-planner",
+        },
+        "non_claims": [
+            "This report does not approve review readiness.",
+            "This report does not remediate findings.",
+            "This report does not rewrite finding severity or disagreement.",
+            "This report does not publish customer-facing reports.",
+        ],
+        "safety_flags": {
+            "review_approved": False,
+            "findings_rewritten": False,
+            "published_report": False,
+            "created_issues": False,
+            "created_prs": False,
+            "mutated_repository": False,
+        },
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Review Readiness Cleanup Summary",
+        "",
+        f"- Run id: `{report['run_id']}`",
+        f"- Status: `{report['status']}`",
+        f"- Summary: {report['summary']}",
+        "",
+        "## Classification Counts",
+        "",
+    ]
+    for category, count in report["counts"].items():
+        lines.append(f"- {category}: {count}")
+
+    lines.extend(["", "## Items", ""])
+    for item in report["items"]:
+        lines.append(f"- `{item['category']}` in `{item['source']}`: {item['reason']} Evidence: {item['evidence']}")
+
+    grouped = {
+        "Safe Mechanical Cleanup": "safe_mechanical_cleanup",
+        "Blockers": "blocker",
+        "Skipped Surfaces": "skipped",
+        "Follow-On Needed": "follow_on_needed",
+    }
+    for heading, category in grouped.items():
+        lines.extend(["", f"## {heading}", ""])
+        matching = [item for item in report["items"] if item["category"] == category]
+        if not matching:
+            lines.append("- none")
+        for item in matching:
+            lines.append(f"- `{item['source']}`: {item['reason']}")
+
+    lines.extend(["", "## Non-Claims", ""])
+    for item in report["non_claims"]:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## Safety Flags", ""])
+    for key, value in report["safety_flags"].items():
+        lines.append(f"- {key}: {str(value).lower()}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--review-root", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--run-id", default="review-readiness-cleanup")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    report = build_report(args)
+    (out / "review_readiness_cleanup_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "review_readiness_cleanup_report.md").write_text(
+        markdown_report(report),
+        encoding="utf-8",
+    )
+    print(f"WROTE {out / 'review_readiness_cleanup_report.json'}")
+    print(f"WROTE {out / 'review_readiness_cleanup_report.md'}")
+    print(f"STATUS {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -50,6 +50,8 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/demo-operator/SKILL.md" ]]
   [[ -f "${root}/skills/release-evidence/SKILL.md" ]]
   [[ -x "${root}/skills/release-evidence/scripts/assemble_release_evidence.py" ]]
+  [[ -f "${root}/skills/review-readiness-cleanup/SKILL.md" ]]
+  [[ -x "${root}/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
   [[ -f "${root}/skills/arxiv-paper-writer/SKILL.md" ]]
   [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
@@ -80,6 +82,7 @@ assert_skill_bundle() {
   grep -Fq "smallest truthful test surface" "${root}/skills/test-generator/SKILL.md"
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "evidence packaging skill" "${root}/skills/release-evidence/SKILL.md"
+  grep -Fq "readiness cleanup classifier" "${root}/skills/review-readiness-cleanup/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
   grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
   grep -Fq "diagram-as-code and model-as-code router" "${root}/skills/diagram-author/SKILL.md"
@@ -110,6 +113,7 @@ assert_skill_bundle() {
     "${root}/skills/test-generator/SKILL.md" \
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/release-evidence/SKILL.md" \
+    "${root}/skills/review-readiness-cleanup/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
     "${root}/skills/arxiv-paper-writer/SKILL.md" \
     "${root}/skills/diagram-author/SKILL.md" \
@@ -140,6 +144,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/architecture-fitness-function-author" ]]
 [[ -L "${CODEX_HOME}/skills/finding-to-issue-planner" ]]
 [[ -L "${CODEX_HOME}/skills/release-evidence" ]]
+[[ -L "${CODEX_HOME}/skills/review-readiness-cleanup" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_review_readiness_cleanup_skill_contracts.sh
+++ b/adl/tools/test_review_readiness_cleanup_skill_contracts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+skill_root="${skills_root}/review-readiness-cleanup"
+python_script="${skill_root}/scripts/inspect_review_readiness.py"
+
+[[ -f "${skill_root}/SKILL.md" ]]
+[[ -f "${skill_root}/adl-skill.yaml" ]]
+[[ -f "${skill_root}/agents/openai.yaml" ]]
+[[ -f "${skill_root}/references/review-readiness-cleanup-playbook.md" ]]
+[[ -f "${skill_root}/references/output-contract.md" ]]
+[[ -x "${python_script}" ]]
+[[ -f "${skills_root}/docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "review-readiness-cleanup"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'id: "review_readiness_cleanup.v1"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md"' "${skill_root}/adl-skill.yaml"
+grep -Fq "stop_before_review_approval_must_be_true" "${skill_root}/adl-skill.yaml"
+grep -Fq "readiness cleanup classifier" "${skill_root}/SKILL.md"
+grep -Fq "review_approved: false" "${skill_root}/references/output-contract.md"
+grep -Fq "Schema id: \`review_readiness_cleanup.v1\`" "${skills_root}/docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md"
+
+review_root="${tmpdir}/review"
+report_root="${tmpdir}/review-readiness-report"
+mkdir -p "${review_root}"
+cat >"${review_root}/REVIEW_PLAN.md" <<'MD'
+# Review Plan
+
+Status: TODO before final internal review.
+This packet has one skipped surface because external review is intentionally absent.
+MD
+cat >"${review_root}/FINDING_REGISTER.md" <<'MD'
+# Finding Register
+
+Finding: P1 review-blocking traceability gap.
+Follow-on: create a small docs cleanup issue after the review starts.
+MD
+cat >"${review_root}/DEMO_PROOF_REGISTER.md" <<'MD'
+# Demo Proof Register
+
+Demo proof coverage is linked here.
+MD
+
+python3 "${python_script}" \
+  --review-root "${review_root}" \
+  --out "${report_root}" \
+  --run-id review-readiness-contract-test >/tmp/review-readiness.out
+
+[[ -f "${report_root}/review_readiness_cleanup_report.json" ]]
+[[ -f "${report_root}/review_readiness_cleanup_report.md" ]]
+grep -Fq '"schema": "adl.review_readiness_cleanup_report.v1"' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"run_id": "review-readiness-contract-test"' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"status": "blocked"' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"safe_mechanical_cleanup": 1' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"blocker": 1' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"skipped": 1' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"follow_on_needed": 1' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"review_approved": false' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq '"mutated_repository": false' "${report_root}/review_readiness_cleanup_report.json"
+grep -Fq "## Classification Counts" "${report_root}/review_readiness_cleanup_report.md"
+grep -Fq "## Safe Mechanical Cleanup" "${report_root}/review_readiness_cleanup_report.md"
+grep -Fq "## Blockers" "${report_root}/review_readiness_cleanup_report.md"
+grep -Fq "review_approved: false" "${report_root}/review_readiness_cleanup_report.md"
+
+missing_report="${tmpdir}/missing-report"
+python3 "${python_script}" \
+  --review-root "${tmpdir}/does-not-exist" \
+  --out "${missing_report}" \
+  --run-id review-readiness-missing-test >/tmp/review-readiness-missing.out
+grep -Fq '"status": "skipped"' "${missing_report}/review_readiness_cleanup_report.json"
+grep -Fq '"skipped": 1' "${missing_report}/review_readiness_cleanup_report.json"
+
+if grep -R "${tmpdir}" "${report_root}" "${missing_report}" >/dev/null; then
+  echo "review readiness artifacts should not leak absolute temp paths" >&2
+  exit 1
+fi
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skill_root}/SKILL.md"
+
+echo "PASS test_review_readiness_cleanup_skill_contracts"
+


### PR DESCRIPTION
Closes #2361

## Summary
Implemented the `review-readiness-cleanup` operational skill as a bounded
review-cycle preflight surface. The skill inspects review packets, review plans,
finding registers, demo/proof registers, and milestone review docs for
structural readiness drift, then classifies safe mechanical cleanup, blockers,
skipped surfaces, and follow-on needs without running reviews, remediating
findings, rewriting severity, publishing reports, or approving readiness.

## Artifacts
- `adl/tools/skills/review-readiness-cleanup/SKILL.md`
- `adl/tools/skills/review-readiness-cleanup/adl-skill.yaml`
- `adl/tools/skills/review-readiness-cleanup/agents/openai.yaml`
- `adl/tools/skills/review-readiness-cleanup/references/output-contract.md`
- `adl/tools/skills/review-readiness-cleanup/references/review-readiness-cleanup-playbook.md`
- `adl/tools/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py`
- `adl/tools/skills/docs/REVIEW_READINESS_CLEANUP_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_review_readiness_cleanup_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_review_readiness_cleanup_skill_contracts.sh` verified the new skill contract, helper output, classification behavior, safety flags, and path-leakage guard.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified the new skill participates in copy and symlink install/sync behavior.
  - `bash adl/tools/test_skill_documentation_completeness.sh` verified the skill has required docs, contracts, and guide coverage.
  - `git diff --check` verified whitespace hygiene for the full branch diff.
- Results: All targeted validations passed.

Validation command/path rules:
- Repository-relative paths were used in recorded commands and artifact references.
- No unjustified absolute host paths are recorded in this output card.
- `absolute_path_leakage_detected: false` is supported by the contract test grep against generated fixture reports.
- All commands listed above include their validation purpose.

## Local Artifacts
- Input card:  .adl/v0.90.2/tasks/issue-2361__v0-90-2-skills-create-review-readiness-cleanup-operational-skill/sip.md
- Output card: .adl/v0.90.2/tasks/issue-2361__v0-90-2-skills-create-review-readiness-cleanup-operational-skill/sor.md
- Idempotency-Key: v0-90-2-skills-create-review-readiness-cleanup-operational-skill-adl-tools-batched-checks-sh-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-docs-review-readiness-cleanup-skill-input-schema-md-adl-tools-skills-review-readiness-cleanup-adl-tools-test-install-adl-operational-skills-sh-adl-tools-test-review-readiness-cleanup-skill-contracts-sh-adl-v0-90-2-tasks-issue-2361-v0-90-2-skills-create-review-readiness-cleanup-operational-skill-sip-md-adl-v0-90-2-tasks-issue-2361-v0-90-2-skills-create-review-readiness-cleanup-operational-skill-sor-md