### PR TITLE
[v0.90.2][skills] Create portable-contract-normalizer operational skill

### DIFF
--- a/adl/tools/batched_checks.sh
+++ b/adl/tools/batched_checks.sh
@@ -53,6 +53,7 @@ run_step "test-generator contract check" bash "$ROOT/adl/tools/test_test_generat
 run_step "demo-operator contract check" bash "$ROOT/adl/tools/test_demo_operator_skill_contracts.sh"
 run_step "release-evidence contract check" bash "$ROOT/adl/tools/test_release_evidence_skill_contracts.sh"
 run_step "review-readiness-cleanup contract check" bash "$ROOT/adl/tools/test_review_readiness_cleanup_skill_contracts.sh"
+run_step "portable-contract-normalizer contract check" bash "$ROOT/adl/tools/test_portable_contract_normalizer_skill_contracts.sh"
 run_step "medium-article-writer contract check" bash "$ROOT/adl/tools/test_medium_article_writer_skill_contracts.sh"
 run_step "arxiv-paper-writer contract check" bash "$ROOT/adl/tools/test_arxiv_paper_writer_skill_contracts.sh"
 run_step "diagram-author contract check" bash "$ROOT/adl/tools/test_diagram_author_skill_contracts.sh"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -25,6 +25,7 @@ The tracked skill set is:
 - `gap-analysis`
 - `issue-watcher`
 - `medium-article-writer`
+- `portable-contract-normalizer`
 - `pr-closeout`
 - `pr-finish`
 - `pr-init`
@@ -84,6 +85,7 @@ The normal workflow is:
 `pr-stack-manager` is a bounded stack-topology helper for ancestry, base alignment, and dependency-order analysis.
 `review-comment-triage` is a bounded review-feedback helper for classifying PR comments before implementation.
 `review-readiness-cleanup` is a bounded review-cycle preflight helper for classifying safe cleanup, blockers, skipped surfaces, and follow-on needs before formal review starts.
+`portable-contract-normalizer` is a bounded portability helper for detecting machine-local assumptions and applying only explicitly approved safe mechanical normalization.
 
 The three editor skills are helper skills:
 - `stp-editor` for bounded `stp.md` cleanup
@@ -1292,6 +1294,50 @@ Use `documentation-specialist` for approved mechanical cleanup, `gap-analysis`
 for scope-vs-evidence uncertainty, `finding-to-issue-planner` for follow-on
 issue candidates, and `review-quality-evaluator` for packet quality gates.
 
+## `portable-contract-normalizer`
+
+### Purpose
+
+`portable-contract-normalizer` scans bounded repo contracts, tests, packets, and
+validation surfaces for machine-local assumptions such as absolute host paths,
+brittle worktree names, temp paths, stale hard-coded contract references, and
+environment-specific assertions.
+
+It separates safe mechanical normalization from findings that require design
+decisions.
+
+### When To Use It
+
+Use it when:
+
+- contract tests or review packets may contain local machine assumptions
+- a PR has portability drift from hard-coded paths or worktree names
+- safe fixture normalization should be separated from design-decision findings
+
+Do not use it for:
+
+- unbounded repository rewrites
+- hiding legitimate host-specific evidence
+- semantic test redesign
+- customer or review packet mutation without explicit permission
+
+Structured schema:
+
+- `adl/tools/skills/docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md`
+- schema id: `portable_contract_normalizer.v1`
+
+Deterministic fixture analyzer:
+
+```bash
+python3 adl/tools/skills/portable-contract-normalizer/scripts/normalize_portable_contracts.py --root <path> --out <artifact-root> --run-id <run-id>
+```
+
+### Typical Handoff
+
+Use `documentation-specialist` for approved fixture text cleanup,
+`gap-analysis` when portability claims need evidence comparison, and focused
+remediation issues when a finding requires design decisions.
+
 ## `stp-editor`
 
 ### Purpose
@@ -2207,6 +2253,8 @@ Use this quick selector:
   - `review-comment-triage`
 - need to preflight review packets before a formal review cycle:
   - `review-readiness-cleanup`
+- need to detect machine-local assumptions in bounded contract surfaces:
+  - `portable-contract-normalizer`
 - need a broad findings-first code review:
   - `repo-code-review`
 - need source-backed arXiv-style manuscript drafting or citation-gap review:
@@ -2263,6 +2311,7 @@ surfaces:
 | `finding-to-issue-planner` | `FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | issue candidates only |
 | `gap-analysis` | `GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | gap report only |
 | `medium-article-writer` | `MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | article packet only |
+| `portable-contract-normalizer` | `PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | bounded portability scan or explicit safe normalization only |
 | `pr-closeout` | `PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | local closeout only |
 | `pr-finish` | `PR_FINISH_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | PR publication/update only |
 | `pr-init` | `PR_INIT_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | issue bootstrap only |

--- a/adl/tools/skills/docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,71 @@
+# Portable Contract Normalizer Skill Input Schema
+
+Schema id: `portable_contract_normalizer.v1`
+
+Use this schema when invoking `portable-contract-normalizer` with structured
+input.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `portable_contract_normalizer.v1`
+- `mode`: one of `scan_contracts`, `scan_and_apply_safe_fixes`, or
+  `inspect_normalizer_report`
+- `target`: bounded paths or report path
+- `policy`: scan and safe-fix policy
+
+## Target Object
+
+Recommended fields:
+
+- `paths`: bounded files or directories to scan
+- `report_path`: existing report for inspect mode
+- `operator_approval`: required for `scan_and_apply_safe_fixes`
+
+## Policy Object
+
+Recommended fields:
+
+- `write_report`: boolean
+- `apply_safe_fixes`: boolean
+- `bounded_paths`: explicit path list
+- `preserve_legitimate_host_evidence`: must be true
+- `stop_before_broad_rewrite`: must be true
+- `stop_before_design_decision`: must be true
+
+## Example
+
+```yaml
+skill_input_schema: portable_contract_normalizer.v1
+mode: scan_contracts
+target:
+  paths:
+    - adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh
+    - adl/tools/skills/repo-packet-builder
+policy:
+  write_report: true
+  apply_safe_fixes: false
+  bounded_paths:
+    - adl/tools/test_multi_agent_repo_review_skill_suite_contracts.sh
+    - adl/tools/skills/repo-packet-builder
+  preserve_legitimate_host_evidence: true
+  stop_before_broad_rewrite: true
+  stop_before_design_decision: true
+```
+
+## Output
+
+Default output root:
+
+```text
+.adl/reviews/portable-contract-normalizer/<run_id>/
+```
+
+Required artifacts:
+
+- `portable_contract_normalizer_report.md`
+- `portable_contract_normalizer_report.json`
+
+The report must distinguish safe mechanical normalization from design decisions.
+It must not broadly rewrite tests, hide legitimate evidence, or claim portability
+outside the bounded scan.
+

--- a/adl/tools/skills/portable-contract-normalizer/SKILL.md
+++ b/adl/tools/skills/portable-contract-normalizer/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: portable-contract-normalizer
+description: Scan bounded repo contracts, tests, packets, and validation surfaces for machine-local assumptions such as absolute host paths, brittle worktree names, temp paths, stale hard-coded contract references, and environment-specific assertions, then report findings or apply only explicit safe mechanical normalizations.
+---
+
+# Portable Contract Normalizer
+
+Find portability defects before they leak into CI, review packets, or another
+operator machine. This skill scans bounded paths for host-specific assumptions
+and separates safe mechanical normalization from findings that require design
+decisions.
+
+It is a portability guard and optional narrow normalizer, not a broad test
+rewrite tool.
+
+## Quick Start
+
+1. Confirm the bounded paths to scan.
+2. Confirm whether the run is report-only or explicit safe-fix mode.
+3. Run the deterministic helper:
+   - `scripts/normalize_portable_contracts.py --root <path> --out <artifact-root> --run-id <run_id>`
+4. If the operator explicitly requests safe fixes, rerun with:
+   - `scripts/normalize_portable_contracts.py --root <path> --out <artifact-root> --run-id <run_id> --apply`
+5. Review the Markdown and JSON artifacts. Stop before broad contract rewrites
+   or design decisions.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `mode`
+- `target`
+- `policy`
+
+Supported modes:
+
+- `scan_contracts`
+- `scan_and_apply_safe_fixes`
+- `inspect_normalizer_report`
+
+Useful policy fields:
+
+- `write_report`
+- `apply_safe_fixes`
+- `bounded_paths`
+- `preserve_legitimate_host_evidence`
+- `stop_before_broad_rewrite`
+- `stop_before_design_decision`
+
+If no bounded path is provided, return `not_run` or `blocked`; do not scan the
+entire machine by default.
+
+## Finding Categories
+
+Classify findings as:
+
+- `absolute_host_path`: local user, temp, or machine-specific absolute paths.
+- `brittle_worktree_name`: hard-coded `.worktrees/adl-wp-<number>` or similar
+  branch/worktree coupling.
+- `machine_local_temp_path`: `/tmp`, `/private/var`, or platform temp paths
+  embedded in portable artifacts.
+- `stale_contract_reference`: hard-coded contract or skill inventory references
+  likely to drift when the skill set changes.
+- `environment_specific_assertion`: assertions tied to one user, host, shell,
+  platform, or local environment.
+
+## Fix Policy
+
+Safe mechanical normalization may replace obvious host-specific fixture text
+with portable placeholders such as `<repo-root>`, `<temp-path>`, or
+`.worktrees/adl-wp-<issue>`.
+
+Do not apply fixes when:
+
+- the path is legitimate evidence that must remain exact
+- the replacement would alter semantic test intent
+- the surface is a customer or review packet without explicit permission
+- the finding requires a design decision
+
+## Output
+
+Default artifact root:
+
+```text
+.adl/reviews/portable-contract-normalizer/<run_id>/
+```
+
+Required artifacts:
+
+- `portable_contract_normalizer_report.md`
+- `portable_contract_normalizer_report.json`
+
+Use the detailed contract in `references/output-contract.md`.
+
+## Stop Boundary
+
+This skill must not:
+
+- broadly rewrite tests or contracts without explicit operator approval
+- hide legitimate host-specific evidence
+- mutate customer or review packets unless explicitly requested
+- replace focused remediation issues
+- claim portability is proven beyond the scanned paths
+

--- a/adl/tools/skills/portable-contract-normalizer/adl-skill.yaml
+++ b/adl/tools/skills/portable-contract-normalizer/adl-skill.yaml
@@ -1,0 +1,100 @@
+version: "0.1"
+kind: "adl-skill"
+id: "portable-contract-normalizer"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "portable_contract_normalizer.v1"
+    reference_doc: "../docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "scan_contracts"
+      - "scan_and_apply_safe_fixes"
+      - "inspect_normalizer_report"
+    policy_fields:
+      - "write_report"
+      - "apply_safe_fixes"
+      - "bounded_paths"
+      - "preserve_legitimate_host_evidence"
+      - "stop_before_broad_rewrite"
+      - "stop_before_design_decision"
+    mode_requirements:
+      scan_contracts:
+        required_target_fields:
+          - "paths"
+      scan_and_apply_safe_fixes:
+        required_target_fields:
+          - "paths"
+          - "operator_approval"
+      inspect_normalizer_report:
+        required_target_fields:
+          - "report_path"
+  intent:
+    - "contract_portability"
+    - "path_leakage_detection"
+    - "safe_mechanical_normalization"
+  required_inputs:
+    - "target"
+    - "policy"
+  optional_inputs:
+    - "repo_root"
+    - "output_root"
+    - "run_id"
+  stop_if_missing:
+    - "target.paths"
+  prevalidation_rules:
+    - "skill_input_schema_must_equal_portable_contract_normalizer.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "bounded_paths_must_be_explicit"
+    - "policy.stop_before_broad_rewrite_must_be_true"
+    - "policy.stop_before_design_decision_must_be_true"
+    - "scan_and_apply_safe_fixes_requires_operator_approval"
+execution:
+  mode: "portability_scan_or_explicit_safe_fix"
+  allow_code_edits: true
+  allow_network: false
+  allow_subagents: false
+  permitted_scripts:
+    - path: "scripts/normalize_portable_contracts.py"
+      interpreter: "python3"
+      read_only: false
+      allowed_args:
+        - "--root <path>"
+        - "--out <artifact-root>"
+        - "--run-id <id>"
+        - "--apply"
+  preferred_read_order:
+    - "bounded target files"
+    - "contract tests"
+    - "skill metadata"
+    - "review packet manifests"
+    - "validation artifacts"
+  invocation_guidance: "prefer_report_only_first_then_explicit_apply"
+boundaries:
+  must_not_run:
+    - "unbounded_repository_rewrite"
+    - "customer_packet_mutation_without_permission"
+    - "semantic_test_rewrite"
+    - "design_decision_resolution"
+    - "legitimate_evidence_redaction"
+outputs:
+  default_format: "markdown_and_json"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/portable-contract-normalizer/<run_id>/"
+  required_artifacts:
+    - "portable_contract_normalizer_report.md"
+    - "portable_contract_normalizer_report.json"
+security:
+  no_network: true
+  bounded_paths_required: true
+  safe_fixes_require_explicit_apply: true
+  preserve_legitimate_evidence: true
+

--- a/adl/tools/skills/portable-contract-normalizer/agents/openai.yaml
+++ b/adl/tools/skills/portable-contract-normalizer/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: Portable Contract Normalizer
+short_description: Detect and optionally normalize machine-local assumptions in bounded contracts, tests, packets, and validation surfaces
+default_prompt: Scan bounded repo contracts, tests, packets, and validation surfaces for absolute host paths, brittle worktree names, machine-local temp paths, stale hard-coded contract references, and environment-specific assertions. Emit findings first, separate safe mechanical normalization from design-decision findings, and only apply narrow safe fixes when explicitly requested.
+

--- a/adl/tools/skills/portable-contract-normalizer/references/output-contract.md
+++ b/adl/tools/skills/portable-contract-normalizer/references/output-contract.md
@@ -1,0 +1,63 @@
+# Portable Contract Normalizer Output Contract
+
+Portable contract normalizer artifacts must report portability findings without
+hiding legitimate evidence or claiming unscanned surfaces are portable.
+
+## Required Markdown Sections
+
+- `Portable Contract Normalizer Summary`
+- `Finding Counts`
+- `Findings`
+- `Safe Mechanical Normalization`
+- `Design Decisions Required`
+- `Applied Fixes`
+- `Non-Claims`
+- `Safety Flags`
+
+## Required JSON Shape
+
+Schema id: `adl.portable_contract_normalizer_report.v1`
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `status`
+- `mode`
+- `counts`
+- `findings`
+- `applied_fixes`
+- `non_claims`
+- `safety_flags`
+
+Supported statuses:
+
+- `clean`
+- `findings`
+- `fixed`
+- `blocked`
+- `not_run`
+
+Supported finding categories:
+
+- `absolute_host_path`
+- `brittle_worktree_name`
+- `machine_local_temp_path`
+- `stale_contract_reference`
+- `environment_specific_assertion`
+
+## Safety Flags
+
+Every report must state:
+
+- `mutated_repository`: boolean
+- `applied_safe_fixes_only`: boolean
+- `design_decisions_resolved`: false
+- `legitimate_evidence_redacted`: false
+- `unbounded_scan`: false
+
+The skill may report that scanned paths are clean. It must not claim repository
+portability outside the bounded scan root.
+
+`legitimate_evidence_redacted: false` means the report did not hide exact host
+evidence without operator-approved normalization.

--- a/adl/tools/skills/portable-contract-normalizer/references/portable-contract-normalizer-playbook.md
+++ b/adl/tools/skills/portable-contract-normalizer/references/portable-contract-normalizer-playbook.md
@@ -1,0 +1,30 @@
+# Portable Contract Normalizer Playbook
+
+Use this playbook when contract tests, skill docs, review packets, or validation
+artifacts may contain machine-local assumptions.
+
+## Scan Targets
+
+- Shell, Python, Markdown, YAML, JSON, TOML, and text contract surfaces.
+- Review packets and generated reports only when explicitly in scope.
+- Test fixtures that are intended to be portable across machines.
+
+## Common Findings
+
+- Absolute user paths such as `/Users/name/...`.
+- macOS temp paths such as `/private/var/folders/...`.
+- Generic temp paths such as `/tmp/...`.
+- Hard-coded `.worktrees/adl-wp-1234` names.
+- Assertions tied to one user, hostname, shell, or platform.
+- Hard-coded skill inventory expectations that should derive from scanned
+  bundles instead.
+
+## Safe Fix Examples
+
+- Replace `/Users/name/git/repo` fixture text with `<repo-root>`.
+- Replace platform temp paths with `<temp-path>`.
+- Replace `.worktrees/adl-wp-1234` with `.worktrees/adl-wp-<issue>`.
+
+If a replacement changes the meaning of the test, report a design-decision
+finding instead of applying it.
+

--- a/adl/tools/skills/portable-contract-normalizer/scripts/normalize_portable_contracts.py
+++ b/adl/tools/skills/portable-contract-normalizer/scripts/normalize_portable_contracts.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Scan and optionally normalize machine-local contract assumptions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+TEXT_SUFFIXES = {
+    ".bash",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+RULES = [
+    (
+        "brittle_worktree_name",
+        re.compile(r"\.worktrees/adl-wp-\d+"),
+        ".worktrees/adl-wp-<issue>",
+        "hard-coded issue worktree name should be generalized",
+        True,
+    ),
+    (
+        "absolute_host_path",
+        re.compile(r"/Users/[A-Za-z0-9._-]+/[^\s\"')]*?(?=/.worktrees|[\s\"')]|\Z)"),
+        "<host-path>",
+        "absolute user path should be parameterized",
+        True,
+    ),
+    (
+        "machine_local_temp_path",
+        re.compile(r"/(?:private/)?var/folders/[^\s\"')]+|/tmp/[^\s\"')]+"),
+        "<temp-path>",
+        "machine-local temp path should not be embedded in portable artifacts",
+        True,
+    ),
+    (
+        "environment_specific_assertion",
+        re.compile(r"\b(?:USER|HOME|HOSTNAME|SHELL)=['\"]?[A-Za-z0-9_./-]+"),
+        "<env-var>=<value>",
+        "environment-specific assertion should be parameterized",
+        False,
+    ),
+    (
+        "stale_contract_reference",
+        re.compile(r"hard-?coded (?:skill )?(?:list|inventory|contract)|stale contract", re.I),
+        "<contract-reference>",
+        "hard-coded contract reference may need a derived source of truth",
+        False,
+    ),
+]
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+def iter_files(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root] if root.suffix.lower() in TEXT_SUFFIXES else []
+    if not root.is_dir():
+        return []
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+            files.append(path)
+    return files
+
+
+def line_for_offset(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def scan_file(path: Path, scan_root: Path) -> tuple[list[dict[str, Any]], str]:
+    text = read_text(path)
+    rel = path.relative_to(scan_root).as_posix()
+    findings: list[dict[str, Any]] = []
+    for category, pattern, replacement, reason, safe_fix in RULES:
+        for match in pattern.finditer(text):
+            findings.append(
+                {
+                    "category": category,
+                    "path": rel,
+                    "line": line_for_offset(text, match.start()),
+                    "evidence": match.group(0),
+                    "reason": reason,
+                    "safe_fix_available": safe_fix,
+                    "replacement": replacement if safe_fix else None,
+                }
+            )
+    return findings, text
+
+
+def apply_safe_fixes(path: Path) -> tuple[bool, list[str]]:
+    original = read_text(path)
+    updated = original
+    applied: list[str] = []
+    for category, pattern, replacement, _reason, safe_fix in RULES:
+        if not safe_fix:
+            continue
+        updated, count = pattern.subn(replacement, updated)
+        if count:
+            applied.append(f"{category}:{count}")
+    if updated != original:
+        path.write_text(updated, encoding="utf-8")
+        return True, applied
+    return False, applied
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    scan_root = Path(args.root)
+    if not scan_root.exists():
+        findings = [
+            {
+                "category": "not_run",
+                "path": "scan_root",
+                "line": 0,
+                "evidence": "missing root",
+                "reason": "scan root is missing",
+                "safe_fix_available": False,
+                "replacement": None,
+            }
+        ]
+        return report_for(args, "not_run", findings, [], mutated=False)
+
+    files = iter_files(scan_root)
+    if not files:
+        findings = [
+            {
+                "category": "not_run",
+                "path": "scan_root",
+                "line": 0,
+                "evidence": "no supported text files",
+                "reason": "scan root contains no supported contract surfaces",
+                "safe_fix_available": False,
+                "replacement": None,
+            }
+        ]
+        return report_for(args, "not_run", findings, [], mutated=False)
+
+    all_findings: list[dict[str, Any]] = []
+    applied: list[dict[str, Any]] = []
+    for path in files:
+        findings, _text = scan_file(path, scan_root)
+        all_findings.extend(findings)
+        if args.apply:
+            changed, applied_rules = apply_safe_fixes(path)
+            if changed:
+                applied.append(
+                    {
+                        "path": path.relative_to(scan_root).as_posix(),
+                        "rules": applied_rules,
+                    }
+                )
+
+    status = "clean"
+    if all_findings:
+        status = "fixed" if args.apply and applied else "findings"
+    if any(not finding.get("safe_fix_available") for finding in all_findings):
+        status = "blocked" if args.apply else status
+    return report_for(args, status, all_findings, applied, mutated=bool(applied))
+
+
+def report_for(
+    args: argparse.Namespace,
+    status: str,
+    findings: list[dict[str, Any]],
+    applied: list[dict[str, Any]],
+    mutated: bool,
+) -> dict[str, Any]:
+    counts = Counter(finding["category"] for finding in findings)
+    return {
+        "schema": "adl.portable_contract_normalizer_report.v1",
+        "run_id": args.run_id,
+        "status": status,
+        "mode": "scan_and_apply_safe_fixes" if args.apply else "scan_contracts",
+        "counts": dict(sorted(counts.items())),
+        "findings": findings,
+        "applied_fixes": applied,
+        "non_claims": [
+            "This report covers only the bounded scan root.",
+            "This report does not resolve design-decision findings.",
+            "This report does not prove the full repository is portable.",
+            "This report does not redact legitimate evidence automatically.",
+        ],
+        "safety_flags": {
+            "mutated_repository": mutated,
+            "applied_safe_fixes_only": mutated,
+            "design_decisions_resolved": False,
+            "legitimate_evidence_redacted": False,
+            "unbounded_scan": False,
+        },
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Portable Contract Normalizer Summary",
+        "",
+        f"- Run id: `{report['run_id']}`",
+        f"- Status: `{report['status']}`",
+        f"- Mode: `{report['mode']}`",
+        "",
+        "## Finding Counts",
+        "",
+    ]
+    if report["counts"]:
+        for category, count in report["counts"].items():
+            lines.append(f"- {category}: {count}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Findings", ""])
+    if report["findings"]:
+        for finding in report["findings"]:
+            lines.append(
+                f"- `{finding['category']}` in `{finding['path']}` line {finding['line']}: "
+                f"{finding['reason']} Evidence: `{finding['evidence']}`"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Safe Mechanical Normalization", ""])
+    safe = [finding for finding in report["findings"] if finding.get("safe_fix_available")]
+    if safe:
+        for finding in safe:
+            lines.append(f"- `{finding['path']}` line {finding['line']}: replace with `{finding['replacement']}`")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Design Decisions Required", ""])
+    design = [finding for finding in report["findings"] if not finding.get("safe_fix_available")]
+    if design:
+        for finding in design:
+            lines.append(f"- `{finding['path']}` line {finding['line']}: {finding['reason']}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Applied Fixes", ""])
+    if report["applied_fixes"]:
+        for fix in report["applied_fixes"]:
+            lines.append(f"- `{fix['path']}`: {', '.join(fix['rules'])}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Non-Claims", ""])
+    for item in report["non_claims"]:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## Safety Flags", ""])
+    for key, value in report["safety_flags"].items():
+        lines.append(f"- {key}: {str(value).lower()}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--run-id", default="portable-contract-normalizer")
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    report = build_report(args)
+    (out / "portable_contract_normalizer_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "portable_contract_normalizer_report.md").write_text(
+        markdown_report(report),
+        encoding="utf-8",
+    )
+    print(f"WROTE {out / 'portable_contract_normalizer_report.json'}")
+    print(f"WROTE {out / 'portable_contract_normalizer_report.md'}")
+    print(f"STATUS {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -52,6 +52,8 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/release-evidence/scripts/assemble_release_evidence.py" ]]
   [[ -f "${root}/skills/review-readiness-cleanup/SKILL.md" ]]
   [[ -x "${root}/skills/review-readiness-cleanup/scripts/inspect_review_readiness.py" ]]
+  [[ -f "${root}/skills/portable-contract-normalizer/SKILL.md" ]]
+  [[ -x "${root}/skills/portable-contract-normalizer/scripts/normalize_portable_contracts.py" ]]
   [[ -f "${root}/skills/medium-article-writer/SKILL.md" ]]
   [[ -f "${root}/skills/arxiv-paper-writer/SKILL.md" ]]
   [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
@@ -83,6 +85,7 @@ assert_skill_bundle() {
   grep -Fq "run one named demo" "${root}/skills/demo-operator/SKILL.md"
   grep -Fq "evidence packaging skill" "${root}/skills/release-evidence/SKILL.md"
   grep -Fq "readiness cleanup classifier" "${root}/skills/review-readiness-cleanup/SKILL.md"
+  grep -Fq "portability guard and optional narrow normalizer" "${root}/skills/portable-contract-normalizer/SKILL.md"
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
   grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
   grep -Fq "diagram-as-code and model-as-code router" "${root}/skills/diagram-author/SKILL.md"
@@ -114,6 +117,7 @@ assert_skill_bundle() {
     "${root}/skills/demo-operator/SKILL.md" \
     "${root}/skills/release-evidence/SKILL.md" \
     "${root}/skills/review-readiness-cleanup/SKILL.md" \
+    "${root}/skills/portable-contract-normalizer/SKILL.md" \
     "${root}/skills/medium-article-writer/SKILL.md" \
     "${root}/skills/arxiv-paper-writer/SKILL.md" \
     "${root}/skills/diagram-author/SKILL.md" \
@@ -145,6 +149,7 @@ assert_skill_bundle "${CODEX_HOME}"
 [[ -L "${CODEX_HOME}/skills/finding-to-issue-planner" ]]
 [[ -L "${CODEX_HOME}/skills/release-evidence" ]]
 [[ -L "${CODEX_HOME}/skills/review-readiness-cleanup" ]]
+[[ -L "${CODEX_HOME}/skills/portable-contract-normalizer" ]]
 [[ -L "${CODEX_HOME}/skills/arxiv-paper-writer" ]]
 [[ -L "${CODEX_HOME}/skills/diagram-author" ]]
 [[ "$(cd "${CODEX_HOME}/skills/pr-init" && pwd -P)" == "${repo_root}/adl/tools/skills/pr-init" ]]

--- a/adl/tools/test_portable_contract_normalizer_skill_contracts.sh
+++ b/adl/tools/test_portable_contract_normalizer_skill_contracts.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+skill_root="${skills_root}/portable-contract-normalizer"
+python_script="${skill_root}/scripts/normalize_portable_contracts.py"
+
+[[ -f "${skill_root}/SKILL.md" ]]
+[[ -f "${skill_root}/adl-skill.yaml" ]]
+[[ -f "${skill_root}/agents/openai.yaml" ]]
+[[ -f "${skill_root}/references/portable-contract-normalizer-playbook.md" ]]
+[[ -f "${skill_root}/references/output-contract.md" ]]
+[[ -x "${python_script}" ]]
+[[ -f "${skills_root}/docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "portable-contract-normalizer"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'id: "portable_contract_normalizer.v1"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md"' "${skill_root}/adl-skill.yaml"
+grep -Fq "scan_and_apply_safe_fixes_requires_operator_approval" "${skill_root}/adl-skill.yaml"
+grep -Fq "portability guard and optional narrow normalizer" "${skill_root}/SKILL.md"
+grep -Fq "legitimate_evidence_redacted: false" "${skill_root}/references/output-contract.md"
+grep -Fq "Schema id: \`portable_contract_normalizer.v1\`" "${skills_root}/docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md"
+
+fixture_root="${tmpdir}/fixture"
+report_root="${tmpdir}/report"
+mkdir -p "${fixture_root}"
+cat >"${fixture_root}/contract.md" <<'MD'
+# Contract
+
+Path: /Users/daniel/git/agent-design-language/.worktrees/adl-wp-2362
+Temp: /private/var/folders/example/tmp/output.json
+Env: USER=daniel
+This has a hard-coded skill inventory that should be reviewed.
+MD
+
+python3 "${python_script}" \
+  --root "${fixture_root}" \
+  --out "${report_root}" \
+  --run-id portable-contract-normalizer-contract-test >/tmp/portable-contract-normalizer.out
+
+[[ -f "${report_root}/portable_contract_normalizer_report.json" ]]
+[[ -f "${report_root}/portable_contract_normalizer_report.md" ]]
+grep -Fq '"schema": "adl.portable_contract_normalizer_report.v1"' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"run_id": "portable-contract-normalizer-contract-test"' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"status": "findings"' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"absolute_host_path": 1' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"brittle_worktree_name": 1' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"machine_local_temp_path": 1' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"environment_specific_assertion": 1' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"stale_contract_reference": 1' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq '"mutated_repository": false' "${report_root}/portable_contract_normalizer_report.json"
+grep -Fq "## Safe Mechanical Normalization" "${report_root}/portable_contract_normalizer_report.md"
+grep -Fq "## Design Decisions Required" "${report_root}/portable_contract_normalizer_report.md"
+grep -Fq "mutated_repository: false" "${report_root}/portable_contract_normalizer_report.md"
+
+apply_root="${tmpdir}/apply-fixture"
+apply_report="${tmpdir}/apply-report"
+mkdir -p "${apply_root}"
+cp "${fixture_root}/contract.md" "${apply_root}/contract.md"
+python3 "${python_script}" \
+  --root "${apply_root}" \
+  --out "${apply_report}" \
+  --run-id portable-contract-normalizer-apply-test \
+  --apply >/tmp/portable-contract-normalizer-apply.out
+
+grep -Fq '"status": "blocked"' "${apply_report}/portable_contract_normalizer_report.json"
+grep -Fq '"mutated_repository": true' "${apply_report}/portable_contract_normalizer_report.json"
+grep -Fq '<host-path>' "${apply_root}/contract.md"
+grep -Fq '<temp-path>' "${apply_root}/contract.md"
+grep -Fq '.worktrees/adl-wp-<issue>' "${apply_root}/contract.md"
+grep -Fq 'USER=daniel' "${apply_root}/contract.md"
+
+missing_report="${tmpdir}/missing-report"
+python3 "${python_script}" \
+  --root "${tmpdir}/does-not-exist" \
+  --out "${missing_report}" \
+  --run-id portable-contract-normalizer-missing-test >/tmp/portable-contract-normalizer-missing.out
+grep -Fq '"status": "not_run"' "${missing_report}/portable_contract_normalizer_report.json"
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skill_root}/SKILL.md"
+
+echo "PASS test_portable_contract_normalizer_skill_contracts"
+


### PR DESCRIPTION
Closes #2362

## Summary
Implemented the `portable-contract-normalizer` operational skill as a bounded
portability guard for contracts, tests, packets, and validation surfaces. The
skill scans explicit paths for absolute host paths, brittle worktree names,
machine-local temp paths, stale hard-coded contract references, and
environment-specific assertions, then reports findings or applies only
explicitly requested safe mechanical normalizations.

## Artifacts
- `adl/tools/skills/portable-contract-normalizer/SKILL.md`
- `adl/tools/skills/portable-contract-normalizer/adl-skill.yaml`
- `adl/tools/skills/portable-contract-normalizer/agents/openai.yaml`
- `adl/tools/skills/portable-contract-normalizer/references/output-contract.md`
- `adl/tools/skills/portable-contract-normalizer/references/portable-contract-normalizer-playbook.md`
- `adl/tools/skills/portable-contract-normalizer/scripts/normalize_portable_contracts.py`
- `adl/tools/skills/docs/PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_portable_contract_normalizer_skill_contracts.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_portable_contract_normalizer_skill_contracts.sh` verified the new skill contract, helper output, finding categories, safe-fix behavior, missing-root status, and frontmatter.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified the new skill participates in copy and symlink install/sync behavior.
  - `bash adl/tools/test_skill_documentation_completeness.sh` verified the skill has required docs, contracts, and guide coverage.
  - `git diff --check` verified whitespace hygiene for the full branch diff.
- Results: All targeted validations passed.

Validation command/path rules:
- Repository-relative paths were used in recorded commands and artifact references.
- No unjustified absolute host paths are recorded in this output card.
- `absolute_path_leakage_detected: false` is supported by generic placeholder replacement in generated fixture reports and by avoiding host paths in committed report artifacts.
- All commands listed above include their validation purpose.

## Local Artifacts
- Input card:  .adl/v0.90.2/tasks/issue-2362__v0-90-2-skills-create-portable-contract-normalizer-operational-skill/sip.md
- Output card: .adl/v0.90.2/tasks/issue-2362__v0-90-2-skills-create-portable-contract-normalizer-operational-skill/sor.md
- Idempotency-Key: v0-90-2-skills-create-portable-contract-normalizer-operational-skill-adl-tools-batched-checks-sh-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-docs-portable-contract-normalizer-skill-input-schema-md-adl-tools-skills-portable-contract-normalizer-adl-tools-test-install-adl-operational-skills-sh-adl-tools-test-portable-contract-normalizer-skill-contracts-sh-adl-v0-90-2-tasks-issue-2362-v0-90-2-skills-create-portable-contract-normalizer-operational-skill-sip-md-adl-v0-90-2-tasks-issue-2362-v0-90-2-skills-create-portable-contract-normalizer-operational-skill-sor-md