### PR TITLE
[v0.90.3][tooling] Compact milestone dashboard UI

### DIFF
--- a/docs/tooling/milestone-dashboard/style.css
+++ b/docs/tooling/milestone-dashboard/style.css
@@ -16,11 +16,11 @@
   --warn-soft: rgba(138, 93, 19, 0.12);
   --unknown: #5f6472;
   --unknown-soft: rgba(95, 100, 114, 0.13);
-  --shadow: 0 24px 60px rgba(32, 30, 24, 0.08);
-  --radius-xl: 32px;
-  --radius-lg: 24px;
-  --radius-md: 16px;
-  --rail-width: 320px;
+  --shadow: 0 14px 34px rgba(32, 30, 24, 0.07);
+  --radius-xl: 24px;
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --rail-width: 268px;
   --sans: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
   --serif: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
 }
@@ -57,8 +57,8 @@ body::before {
   position: relative;
   display: grid;
   grid-template-columns: minmax(280px, var(--rail-width)) minmax(0, 1fr);
-  gap: 20px;
-  padding: 22px;
+  gap: 14px;
+  padding: 14px;
 }
 
 .rail,
@@ -72,16 +72,16 @@ body::before {
 .rail {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 24px;
+  gap: 12px;
+  padding: 16px;
   border-radius: var(--radius-xl);
-  min-height: calc(100svh - 44px);
+  min-height: calc(100svh - 28px);
   position: sticky;
-  top: 22px;
+  top: 14px;
 }
 
 .rail-block + .rail-block {
-  padding-top: 18px;
+  padding-top: 12px;
   border-top: 1px solid var(--line);
 }
 
@@ -89,7 +89,7 @@ body::before {
 .section-kicker,
 .rail-label {
   margin: 0 0 10px;
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--muted);
@@ -105,9 +105,9 @@ body::before {
 }
 
 .rail h1 {
-  font-size: clamp(2rem, 4vw, 3rem);
-  line-height: 0.96;
-  max-width: 9ch;
+  font-size: clamp(1.55rem, 2.4vw, 2.15rem);
+  line-height: 1;
+  max-width: 11ch;
 }
 
 .rail-copy,
@@ -130,10 +130,10 @@ body::before {
 .chip {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   border-radius: 999px;
-  padding: 8px 12px;
-  font-size: 0.88rem;
+  padding: 5px 9px;
+  font-size: 0.78rem;
   border: 1px solid var(--line-strong);
   background: rgba(255, 255, 255, 0.55);
 }
@@ -145,19 +145,19 @@ body::before {
 
 .meta-list {
   display: grid;
-  grid-template-columns: 96px 1fr;
-  gap: 8px 10px;
-  margin: 14px 0 0;
+  grid-template-columns: 76px 1fr;
+  gap: 5px 8px;
+  margin: 10px 0 0;
 }
 
 .meta-list dt {
-  font-size: 0.85rem;
+  font-size: 0.76rem;
   color: var(--muted);
 }
 
 .meta-list dd {
   margin: 0;
-  font-size: 0.94rem;
+  font-size: 0.82rem;
 }
 
 .bands-list,
@@ -167,7 +167,7 @@ body::before {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 10px;
+  gap: 7px;
 }
 
 .bands-list li,
@@ -175,7 +175,8 @@ body::before {
 .watchlist li {
   padding-left: 16px;
   position: relative;
-  line-height: 1.45;
+  line-height: 1.35;
+  font-size: 0.88rem;
 }
 
 .bands-list li::before,
@@ -184,42 +185,42 @@ body::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 0.55rem;
-  width: 7px;
-  height: 7px;
+  top: 0.48rem;
+  width: 6px;
+  height: 6px;
   border-radius: 999px;
   background: var(--accent);
 }
 
 .workspace {
   display: grid;
-  gap: 20px;
+  gap: 14px;
 }
 
 .workspace-header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
-  gap: 20px;
+  grid-template-columns: minmax(0, 0.85fr) minmax(320px, 1fr);
+  gap: 14px;
   align-items: end;
-  padding: 10px 8px 0;
+  padding: 4px 4px 0;
   animation: rise 500ms ease;
 }
 
 .workspace-header h2 {
-  font-size: clamp(2.2rem, 4vw, 3.8rem);
-  line-height: 0.95;
-  max-width: 12ch;
+  font-size: clamp(1.65rem, 3vw, 2.7rem);
+  line-height: 1;
+  max-width: 18ch;
 }
 
 .lede {
   margin: 0;
-  font-size: 1.02rem;
-  line-height: 1.6;
+  font-size: 0.94rem;
+  line-height: 1.42;
 }
 
 .surface {
   border-radius: var(--radius-lg);
-  padding: 22px;
+  padding: 15px;
   animation: rise 560ms ease both;
 }
 
@@ -227,7 +228,7 @@ body::before {
 .detail-grid,
 .signal-grid {
   display: grid;
-  gap: 20px;
+  gap: 14px;
 }
 
 .signal-grid {
@@ -246,19 +247,19 @@ body::before {
   display: flex;
   justify-content: space-between;
   align-items: start;
-  gap: 14px;
-  margin-bottom: 18px;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
 .metric-stack {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
-  margin-bottom: 22px;
+  gap: 8px;
+  margin-bottom: 12px;
 }
 
 .metric {
-  padding: 14px;
+  padding: 10px;
   border-radius: var(--radius-md);
   background: rgba(255, 255, 255, 0.62);
   border: 1px solid var(--line);
@@ -266,27 +267,27 @@ body::before {
 
 .metric-label {
   display: block;
-  margin-bottom: 6px;
-  font-size: 0.8rem;
+  margin-bottom: 4px;
+  font-size: 0.68rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--muted);
 }
 
 .metric strong {
-  font-size: 1.65rem;
+  font-size: 1.25rem;
   letter-spacing: -0.04em;
 }
 
 .metric span:last-child {
   display: block;
-  margin-top: 6px;
-  font-size: 0.92rem;
+  margin-top: 4px;
+  font-size: 0.78rem;
   color: var(--muted);
 }
 
 .progress-shell {
-  padding: 16px;
+  padding: 10px;
   border-radius: var(--radius-md);
   background: linear-gradient(135deg, rgba(47, 95, 133, 0.08), rgba(180, 79, 47, 0.08));
   border: 1px solid var(--line);
@@ -296,12 +297,13 @@ body::before {
   display: flex;
   justify-content: space-between;
   gap: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 7px;
+  font-size: 0.86rem;
 }
 
 .progress-track {
   overflow: hidden;
-  height: 13px;
+  height: 9px;
   border-radius: 999px;
   background: rgba(31, 35, 48, 0.08);
 }
@@ -319,7 +321,7 @@ body::before {
 }
 
 .signal-card {
-  padding: 18px;
+  padding: 12px;
   border-radius: var(--radius-lg);
   background: var(--paper);
   border: 1px solid var(--line);
@@ -329,7 +331,7 @@ body::before {
 
 .signal-card span {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 5px;
   color: var(--muted);
   font-size: 0.78rem;
   letter-spacing: 0.12em;
@@ -339,63 +341,65 @@ body::before {
 .signal-card strong {
   display: block;
   font-family: var(--serif);
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-size: clamp(1.35rem, 2vw, 1.9rem);
   letter-spacing: -0.04em;
 }
 
 .signal-card p {
-  margin: 8px 0 0;
+  margin: 5px 0 0;
   color: var(--muted);
-  line-height: 1.45;
+  line-height: 1.34;
+  font-size: 0.86rem;
 }
 
 .sprint-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px;
+  gap: 10px;
 }
 
 .lane-card {
-  padding: 18px;
+  padding: 12px;
   border-radius: var(--radius-md);
   background: rgba(255, 255, 255, 0.62);
   border: 1px solid var(--line);
   display: grid;
-  gap: 12px;
+  gap: 8px;
 }
 
 .lane-topline,
 .wp-topline {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
   align-items: start;
 }
 
 .lane-card h4,
 .wp-title {
   margin: 0;
-  font-size: 1.04rem;
+  font-size: 0.94rem;
 }
 
 .lane-card ul {
   margin: 0;
-  padding-left: 18px;
+  padding-left: 15px;
   color: var(--muted);
-  line-height: 1.55;
+  line-height: 1.35;
+  font-size: 0.84rem;
 }
 
 .toolbar {
   display: flex;
   flex-wrap: wrap;
   justify-content: end;
-  gap: 8px 12px;
+  gap: 6px 8px;
 }
 
 .chip-group {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
 }
 
 .chip {
@@ -417,13 +421,13 @@ body::before {
 .table-head,
 .wp-row {
   display: grid;
-  grid-template-columns: minmax(260px, 1.4fr) 140px 140px minmax(150px, 0.9fr) minmax(150px, 0.9fr) minmax(150px, 0.9fr);
-  gap: 14px;
+  grid-template-columns: minmax(220px, 1.35fr) 112px 112px minmax(130px, 0.85fr) minmax(130px, 0.85fr) minmax(130px, 0.85fr);
+  gap: 10px;
 }
 
 .table-head {
-  padding: 0 12px 12px;
-  font-size: 0.78rem;
+  padding: 0 8px 8px;
+  font-size: 0.68rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--muted);
@@ -431,11 +435,11 @@ body::before {
 
 .wp-list {
   display: grid;
-  gap: 10px;
+  gap: 7px;
 }
 
 .wp-row {
-  padding: 16px 12px;
+  padding: 10px 8px;
   border-radius: var(--radius-md);
   background: rgba(255, 255, 255, 0.62);
   border: 1px solid var(--line);
@@ -451,21 +455,22 @@ body::before {
 
 .wp-title-block {
   display: grid;
-  gap: 6px;
+  gap: 4px;
 }
 
 .wp-desc,
 .wp-meta {
   margin: 0;
-  line-height: 1.45;
+  line-height: 1.32;
+  font-size: 0.84rem;
 }
 
 .status-pill {
   display: inline-flex;
   width: fit-content;
-  padding: 6px 10px;
+  padding: 4px 8px;
   border-radius: 999px;
-  font-size: 0.8rem;
+  font-size: 0.72rem;
   font-weight: 700;
 }
 
@@ -504,9 +509,9 @@ body::before {
 .inline-pill {
   display: inline-flex;
   width: fit-content;
-  padding: 4px 8px;
+  padding: 3px 7px;
   border-radius: 999px;
-  font-size: 0.72rem;
+  font-size: 0.66rem;
   font-weight: 800;
   margin-right: 8px;
   text-transform: uppercase;
@@ -517,7 +522,7 @@ body::before {
 .issues-list,
 .review-list {
   display: grid;
-  gap: 12px;
+  gap: 8px;
 }
 
 .doc-item,
@@ -525,7 +530,7 @@ body::before {
 .review-item {
   display: grid;
   gap: 4px;
-  padding: 14px 16px;
+  padding: 10px 12px;
   border-radius: var(--radius-md);
   background: rgba(255, 255, 255, 0.62);
   border: 1px solid var(--line);
@@ -553,15 +558,16 @@ body::before {
   width: fit-content;
   max-width: 100%;
   overflow-wrap: anywhere;
-  padding: 6px 8px;
-  border-radius: 10px;
+  padding: 4px 7px;
+  border-radius: 8px;
   background: rgba(31, 35, 48, 0.07);
   color: var(--ink);
 }
 
 .review-item p {
-  margin: 6px 0 0;
-  line-height: 1.45;
+  margin: 4px 0 0;
+  line-height: 1.32;
+  font-size: 0.84rem;
 }
 
 .status-badge.status-active {
@@ -605,6 +611,12 @@ body::before {
     position: relative;
     top: 0;
     min-height: auto;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rail-brand {
+    grid-column: 1 / -1;
   }
 
   .hero-grid,
@@ -636,13 +648,17 @@ body::before {
 
 @media (max-width: 640px) {
   .app-shell {
-    padding: 14px;
+    padding: 10px;
   }
 
   .rail,
   .surface {
-    padding: 18px;
-    border-radius: 22px;
+    padding: 12px;
+    border-radius: 16px;
+  }
+
+  .rail {
+    grid-template-columns: 1fr;
   }
 
   .metric-stack {


### PR DESCRIPTION
Closes #2371

## Summary
Tightened the Milestone Compression Dashboard into a denser operator surface while preserving the read-only dashboard contract and the refreshed v0.90.3 dataset from #2370. The layout now uses a narrower rail, smaller cards, reduced radii/shadows, tighter typography, denser WP rows, and a more useful tablet/mobile rail arrangement.

## Artifacts
- `docs/tooling/milestone-dashboard/style.css`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_milestone_dashboard.sh`: verifies required dashboard sections, static renderer population, milestone consistency, stale dataset rejection, and private path/secret marker checks.
  - `git diff --check`: verifies the patch has no whitespace errors.
  - Local browser render: verified the compact layout is visually usable and still shows the key v0.90.3 operator surfaces.
- Results: PASS.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/cards/2371/input_2371.md
- Output card: .adl/cards/2371/output_2371.md
- Idempotency-Key: v0-90-3-tooling-compact-milestone-dashboard-ui-docs-tooling-milestone-dashboard-style-css-adl-cards-2371-input-2371-md-adl-cards-2371-output-2371-md