### PR TITLE
[v0.90.3][tools] Reduce PR CI runtime for docs-heavy closeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   adl-ci:
     runs-on: ubuntu-latest
@@ -17,12 +21,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Classify changed paths
+        id: path-policy
+        run: |
+          bash adl/tools/ci_path_policy.sh \
+            --event-name "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --github-output "$GITHUB_OUTPUT"
+        working-directory: .
+
       - name: Install Rust toolchain
+        if: steps.path-policy.outputs.rust_required == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt, clippy, llvm-tools-preview
 
       - name: Rust cache
+        if: steps.path-policy.outputs.rust_required == 'true'
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           workspaces: |
@@ -67,19 +83,37 @@ jobs:
         working-directory: .
 
       - name: fmt
+        if: steps.path-policy.outputs.rust_required == 'true'
         run: cargo fmt --all -- --check
 
       - name: clippy
+        if: steps.path-policy.outputs.rust_required == 'true'
         run: cargo clippy --all-targets -- -D warnings
 
       - name: docs command check
         run: bash tools/check_release_notes_commands.sh
 
       - name: test
+        if: steps.path-policy.outputs.rust_required == 'true'
         run: cargo test
 
+      - name: Rust validation skipped by path policy
+        if: steps.path-policy.outputs.rust_required != 'true'
+        run: |
+          echo "Rust fmt/clippy/test skipped because changed paths do not touch Rust runtime or test surfaces."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+        working-directory: .
+
       - name: demo smoke (S-01..S-05)
+        if: steps.path-policy.outputs.demo_smoke_required == 'true'
         run: bash adl/tools/demo_smoke_v07_story.sh
+        working-directory: .
+
+      - name: Demo smoke skipped by path policy
+        if: steps.path-policy.outputs.demo_smoke_required != 'true'
+        run: |
+          echo "Demo smoke skipped because changed paths do not touch runtime or demo surfaces."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
         working-directory: .
 
   adl-coverage:
@@ -94,30 +128,47 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Classify changed paths
+        id: path-policy
+        run: |
+          bash adl/tools/ci_path_policy.sh \
+            --event-name "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --github-output "$GITHUB_OUTPUT"
+        working-directory: .
+
       - name: Install Rust toolchain
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: llvm-tools-preview
 
       - name: Rust cache
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           workspaces: |
             adl -> target
 
       - name: Install cargo-llvm-cov
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # cargo-llvm-cov
 
       - name: Coverage (swarm)
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
 
       - name: Coverage summary (json)
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
 
       - name: Coverage summary (text)
-        run: cargo llvm-cov --workspace --summary-only | tee coverage-summary.txt
+        if: steps.path-policy.outputs.coverage_required == 'true'
+        run: cargo llvm-cov report --summary-only | tee coverage-summary.txt
 
       - name: Enforce coverage policy gates (workspace + per-file)
+        if: steps.path-policy.outputs.coverage_required == 'true'
         env:
           WORKSPACE_LINE_THRESHOLD: "90"
           PER_FILE_LINE_THRESHOLD: "80"
@@ -126,13 +177,16 @@ jobs:
           bash tools/enforce_coverage_gates.sh coverage-summary.json
 
       - name: Verify generated lcov file
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: test -s lcov.info && ls -l lcov.info
 
       - name: Verify lcov path from repository root
+        if: steps.path-policy.outputs.coverage_required == 'true'
         run: test -s adl/lcov.info && ls -l adl/lcov.info
         working-directory: .
 
       - name: Upload coverage artifact
+        if: steps.path-policy.outputs.coverage_required == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adl-coverage-lcov
@@ -142,8 +196,16 @@ jobs:
             adl/coverage-summary.txt
           if-no-files-found: error
 
+      - name: Coverage skipped by path policy
+        if: steps.path-policy.outputs.coverage_required != 'true'
+        run: |
+          echo "Coverage skipped because changed paths do not touch Rust runtime or test surfaces."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "This keeps the adl-coverage check stable while avoiding full cargo-llvm-cov for docs/planning/tools-only PRs."
+        working-directory: .
+
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.path-policy.outputs.coverage_required == 'true'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+event_name="${GITHUB_EVENT_NAME:-}"
+base_sha=""
+head_sha=""
+github_output="${GITHUB_OUTPUT:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/ci_path_policy.sh [--event-name <name>] [--base <sha>] [--head <sha>] [--github-output <path>]
+
+Classifies changed paths for CI so docs/planning/tools-only PRs can skip
+expensive Rust test and coverage phases while runtime/source changes still run
+the full gates.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event-name)
+      event_name="${2:-}"
+      shift 2
+      ;;
+    --base)
+      base_sha="${2:-}"
+      shift 2
+      ;;
+    --head)
+      head_sha="${2:-}"
+      shift 2
+      ;;
+    --github-output)
+      github_output="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+bool_false=false
+rust_required="$bool_false"
+coverage_required="$bool_false"
+demo_smoke_required="$bool_false"
+fail_closed=false
+reason="path_policy_docs_or_tooling_only"
+changed_count=0
+changed_files=""
+
+emit() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value"
+  if [ -n "$github_output" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$github_output"
+  fi
+}
+
+require_full_validation() {
+  rust_required=true
+  coverage_required=true
+  demo_smoke_required=true
+}
+
+if [ "$event_name" != "pull_request" ]; then
+  require_full_validation
+  reason="non_pull_request_event_runs_full_validation"
+elif [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+  require_full_validation
+  fail_closed=true
+  reason="missing_pull_request_sha_runs_full_validation"
+else
+  changed_files="$(git diff --name-only "$base_sha" "$head_sha" 2>/dev/null || true)"
+  if [ -z "$changed_files" ]; then
+    require_full_validation
+    fail_closed=true
+    reason="empty_or_unavailable_diff_runs_full_validation"
+  else
+    changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
+    while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      case "$path" in
+        adl/src/*|adl/tests/*|adl/Cargo.toml|adl/Cargo.lock|adl/build.rs)
+          rust_required=true
+          coverage_required=true
+          demo_smoke_required=true
+          reason="runtime_or_rust_test_change_runs_full_validation"
+          ;;
+        demos/*|adl/tools/demo_*|adl/tools/test_demo_*)
+          demo_smoke_required=true
+          ;;
+      esac
+    done <<EOF
+$changed_files
+EOF
+  fi
+fi
+
+emit "rust_required" "$rust_required"
+emit "coverage_required" "$coverage_required"
+emit "demo_smoke_required" "$demo_smoke_required"
+emit "fail_closed" "$fail_closed"
+emit "changed_count" "$changed_count"
+emit "reason" "$reason"
+
+printf '\nChanged path policy: %s\n' "$reason"
+printf '  rust_required=%s\n' "$rust_required"
+printf '  coverage_required=%s\n' "$coverage_required"
+printf '  demo_smoke_required=%s\n' "$demo_smoke_required"
+printf '  fail_closed=%s\n' "$fail_closed"
+printf '  changed_count=%s\n' "$changed_count"

--- a/docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md
+++ b/docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md
@@ -1,0 +1,104 @@
+# CI Runtime Policy - v0.90.3
+
+## Status
+
+Landed through tooling issue #2392.
+
+This note is for all ADL execution sessions working through the v0.90.3
+closeout tail. The goal is to keep PR checks truthful without forcing every
+docs-heavy or planning-heavy PR to wait for full Rust coverage.
+
+## Why This Changed
+
+The previous PR workflow ran full `cargo test` and full `cargo llvm-cov` on
+every pull request. That was appropriate when most PRs touched runtime code, but
+it became a blocker as v0.90.3 entered documentation, demo-matrix, review, and
+release-evidence work.
+
+The new workflow keeps the check names stable while using changed-path policy
+to decide whether expensive Rust phases are needed.
+
+## Stable Check Names
+
+The required PR checks remain:
+
+- `adl-ci`
+- `adl-coverage`
+
+These jobs still appear on docs-only PRs. When expensive validation is not
+needed, the job records an explicit skip message instead of disappearing.
+
+## Path Policy
+
+The shared classifier is:
+
+```bash
+adl/tools/ci_path_policy.sh
+```
+
+For pull requests, it compares the PR base and head SHAs and emits:
+
+- `rust_required`
+- `coverage_required`
+- `demo_smoke_required`
+- `fail_closed`
+- `changed_count`
+- `reason`
+
+For non-PR events, including pushes to `main`, it runs full validation.
+
+If the diff cannot be determined, the policy fails closed and runs full
+validation.
+
+## What Runs
+
+Docs/planning/tools-only PRs:
+
+- run tooling sanity checks
+- run issue-linkage and legacy-reference guardrails
+- run operational-skill contract checks
+- run docs command checks
+- skip Rust fmt, clippy, full tests, demo smoke, and full coverage with an
+  explicit path-policy message
+
+Runtime/source PRs:
+
+- run tooling sanity checks
+- run guardrails and contract checks
+- run Rust fmt, clippy, and full tests
+- run demo smoke
+- run full coverage and coverage gates
+
+Pushes to `main`:
+
+- run full validation and full coverage
+
+## Coverage Behavior
+
+Coverage still runs for Rust/runtime changes. The workflow now avoids rerunning
+the workspace just to print the text summary. It generates:
+
+- `lcov.info`
+- `coverage-summary.json`
+- `coverage-summary.txt`
+
+from the coverage data produced by one coverage run.
+
+## Session Guidance
+
+When working a docs-heavy closeout PR, do not panic if `adl-coverage` completes
+quickly with a skip message. That is expected when the PR does not touch Rust
+runtime or test surfaces.
+
+When working a runtime PR, expect full CI cost. Runtime/source changes still
+pay for full Rust validation and coverage.
+
+When in doubt, check the `Classify changed paths` step in `adl-ci` or
+`adl-coverage`. Its `reason` field explains why a lane did or did not run.
+
+## Non-Claims
+
+This policy does not remove release coverage gates. It only avoids paying for
+full coverage on PRs that cannot affect Rust runtime behavior. Release
+readiness, `main` pushes, and runtime/source changes still retain strong
+validation.

--- a/docs/milestones/v0.90.3/README.md
+++ b/docs/milestones/v0.90.3/README.md
@@ -102,6 +102,7 @@ dependencies.
 - Redacted Observatory projection proof: `REDACTED_OBSERVATORY_PROJECTIONS_v0.90.3.md`
 - Standing and communication boundary proof: `STANDING_COMMUNICATION_BOUNDARY_v0.90.3.md`
 - Access-control semantics proof: `ACCESS_CONTROL_SEMANTICS_v0.90.3.md`
+- CI runtime policy for closeout sessions: `CI_RUNTIME_POLICY_v0.90.3.md`
 - WP execution readiness: `WP_EXECUTION_READINESS_v0.90.3.md`
 - Feature index: `FEATURE_DOCS_v0.90.3.md`
 - Milestone checklist: `MILESTONE_CHECKLIST_v0.90.3.md`


### PR DESCRIPTION
Closes #2392

## Summary
Implemented a path-aware CI policy for v0.90.3 closeout work. The workflow now keeps stable `adl-ci` and `adl-coverage` check names while skipping expensive Rust fmt/clippy/test, demo smoke, and full coverage for docs/planning/tools-only PRs that cannot affect Rust runtime behavior.

Runtime/source PRs, non-PR events, and unknown diffs still fail closed into full validation. The coverage workflow also avoids rerunning the whole workspace just to generate the text summary.

## Artifacts
- `.github/workflows/ci.yaml`
- `adl/tools/ci_path_policy.sh`
- `docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md`
- `docs/milestones/v0.90.3/README.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/ci_path_policy.sh`: verified the new classifier shell syntax.
  - `bash adl/tools/ci_path_policy.sh --event-name push`: verified non-PR events force full Rust, coverage, and demo validation.
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "yaml ok"'`: verified workflow YAML parses.
  - `git diff --check`: verified whitespace hygiene.
  - `bash -n adl/tools/*.sh`: verified repository shell tooling syntax.
  - `bash tools/check_release_notes_commands.sh` from `adl/`: verified release-note command references.
  - `bash adl/tools/check_no_new_legacy_swarm_refs.sh`: verified no new unintended legacy-name references.
  - `sh adl/tools/codex_pr.sh --help` and `sh adl/tools/codexw.sh --help`: verified helper usage surfaces still load.
  - Alternate-index path-policy replay with the final changed files: verified docs/tooling-only PR classification emits `rust_required=false`, `coverage_required=false`, `demo_smoke_required=false`, `fail_closed=false`, and `changed_count=4`.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/v0.90.3/tasks/issue-2392__v0-90-3-tools-reduce-pr-ci-runtime-for-docs-heavy-closeout/stp.md
- Output card: .adl/v0.90.3/tasks/issue-2392__v0-90-3-tools-reduce-pr-ci-runtime-for-docs-heavy-closeout/sor.md
- Idempotency-Key: v0-90-3-tools-reduce-pr-ci-runtime-for-docs-heavy-closeout-github-workflows-ci-yaml-adl-tools-ci-path-policy-sh-docs-milestones-v0-90-3-ci-runtime-policy-v0-90-3-md-docs-milestones-v0-90-3-readme-md-adl-v0-90-3-tasks-issue-2392-v0-90-3-tools-reduce-pr-ci-runtime-for-docs-heavy-closeout-stp-md-adl-v0-90-3-tasks-issue-2392-v0-90-3-tools-reduce-pr-ci-runtime-for-docs-heavy-closeout-sor-md