### PR TITLE
[v0.90.3][skills] Integrate CI runtime policy into workflow skills

### DIFF
--- a/adl/tools/skills/demo-operator/SKILL.md
+++ b/adl/tools/skills/demo-operator/SKILL.md
@@ -88,6 +88,15 @@ Prefer:
 - bounded smoke command
 - one live-provider path only when explicitly allowed
 
+If the demo run is being interpreted alongside PR CI, use
+`adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`:
+- if `demo_smoke_required=false` and the PR is docs/planning/non-runtime only,
+  record a truthful demo-smoke skip instead of a failed demo
+- if demo code, fixtures, manifests, or demo-facing runtime behavior changed,
+  expect demo smoke or record an explicit operator deferral
+- do not treat a docs-only path-policy skip as proof that a changed demo still
+  works
+
 ### 4. Classify The Result
 
 Use one of:

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -1,0 +1,124 @@
+# CI Runtime Policy Guide For Operational Skills
+
+## Purpose
+
+This guide explains how ADL operational skills should interpret PR validation
+after the v0.90.3 changed-path CI policy introduced stable check names with
+truthful skip behavior.
+
+The source milestone policy is:
+
+- `docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md`
+
+## Core Rule
+
+`adl-ci` and `adl-coverage` remain stable required PR check names, but a green
+check does not always mean the same validation lane ran.
+
+Skills must distinguish:
+
+- `docs_only_path_policy_skip`: docs, planning, or non-runtime tooling changed;
+  expensive Rust, demo smoke, and coverage phases were explicitly skipped
+- `runtime_full_validation`: runtime, source, test, or demo-affecting surfaces
+  changed; Rust validation, demo smoke where required, and coverage gates ran
+- `failed_closed_full_validation`: changed-path classification failed or was
+  ambiguous; CI must require full validation instead of granting a waiver
+- `release_or_main_full_validation`: pushes to `main` and release evidence gates
+  require full validation regardless of PR-level skip behavior
+
+## Path-Policy Evidence
+
+When a skill needs to interpret a stable check, inspect the
+`Classify changed paths` step in `adl-ci` or `adl-coverage`.
+
+The classifier is:
+
+```bash
+adl/tools/ci_path_policy.sh
+```
+
+It emits:
+
+- `rust_required`
+- `coverage_required`
+- `demo_smoke_required`
+- `fail_closed`
+- `changed_count`
+- `reason`
+
+The `reason` field is the operator-facing explanation for why a lane ran or
+was skipped.
+
+## Skill Interpretation Rules
+
+Use these rules when choosing validation, publishing PR truth, monitoring CI,
+or assembling release evidence:
+
+- A docs-only `adl-coverage` path-policy skip can be healthy for a PR, but it
+  is not release coverage evidence.
+- A runtime/source/test/demo-affecting PR should not skip Rust validation,
+  demo smoke when required, or coverage gates.
+- `fail_closed=true` means full validation is required; it is not an approved
+  skip.
+- If the stable check result and changed files disagree, treat the PR as
+  blocked or action-required until `pr-janitor` or a human resolves the
+  discrepancy.
+- Do not claim "full coverage passed" unless the coverage-required lane ran
+  and produced coverage artifacts such as `coverage-summary.json`.
+- Do not treat a green `adl-coverage` check as sufficient release evidence
+  unless the evidence shows the full coverage lane ran.
+
+## Examples
+
+### Docs-Only PR
+
+Observed:
+
+- `adl-ci`: pass
+- `adl-coverage`: pass with explicit path-policy skip
+- `reason`: changed paths are docs/planning/non-runtime tooling only
+
+Truthful interpretation:
+
+- PR CI is healthy for the changed surface.
+- Rust coverage did not run and must not be cited as release coverage.
+
+### Runtime PR
+
+Observed:
+
+- `rust_required=true`
+- `coverage_required=true`
+- `demo_smoke_required=true` when demo surfaces changed
+
+Truthful interpretation:
+
+- Rust fmt, clippy, tests, demo smoke where applicable, and coverage gates are
+  expected.
+- A skipped coverage lane is a blocker unless there is an explicit policy
+  exception.
+
+### Failed-Closed Classification
+
+Observed:
+
+- `fail_closed=true`
+
+Truthful interpretation:
+
+- CI should require full validation.
+- Skills must not waive validation on the grounds that the path classifier was
+  uncertain.
+
+### Release Evidence
+
+Observed:
+
+- Several docs-only PRs have green `adl-coverage` checks with skip messages.
+
+Truthful interpretation:
+
+- Those checks support PR-level readiness for docs-only changes.
+- They do not satisfy release coverage gates. Release evidence needs full
+  validation from `main`, release ceremony, runtime PRs, or explicit coverage
+  artifacts produced by a full coverage lane.

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -87,6 +87,12 @@ The normal workflow is:
 `review-readiness-cleanup` is a bounded review-cycle preflight helper for classifying safe cleanup, blockers, skipped surfaces, and follow-on needs before formal review starts.
 `portable-contract-normalizer` is a bounded portability helper for detecting machine-local assumptions and applying only explicitly approved safe mechanical normalization.
 
+The PR lifecycle skills share the CI runtime interpretation policy in
+`adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`. Stable PR check names
+(`adl-ci` and `adl-coverage`) remain required, but skills must distinguish a
+docs-only path-policy skip from full runtime validation, failed-closed
+classification, and release/main full-validation evidence.
+
 The three editor skills are helper skills:
 - `stp-editor` for bounded `stp.md` cleanup
 - `sip-editor` for truthful `sip.md` cleanup

--- a/adl/tools/skills/issue-watcher/SKILL.md
+++ b/adl/tools/skills/issue-watcher/SKILL.md
@@ -93,6 +93,18 @@ Inspect where applicable:
 Use direct GitHub metadata or `gh` where available. Do not infer readiness only
 from stale local cards when live GitHub state is required.
 
+When watching PR checks, apply
+`adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`. Continue watching stable
+check names (`adl-ci` and `adl-coverage`), but classify their meaning through
+the CI lane when needed:
+- `healthy_with_path_policy_skip`
+- `healthy_with_full_runtime_validation`
+- `pending_stable_checks`
+- `blocked_failed_closed_or_unexpected_skip`
+
+If the path-policy lane is unclear, route to `pr-janitor` rather than claiming
+the PR is ready.
+
 ### 3. Classify The Result
 
 Use:
@@ -128,4 +140,3 @@ This skill must not:
 - collapse into `pr-janitor`, `pr-run`, or `pr-closeout`
 
 When ADL expects structured output, follow `references/output-contract.md`.
-

--- a/adl/tools/skills/pr-finish/SKILL.md
+++ b/adl/tools/skills/pr-finish/SKILL.md
@@ -82,6 +82,18 @@ Before closeout:
 - confirm the intended staged paths are explicit or deterministically derived
 - confirm validation claims in the output record are truthful
 
+When PR checks are used as validation evidence, apply
+`adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`:
+- `adl-ci` and `adl-coverage` are stable check names, not proof that every
+  expensive Rust phase ran
+- if coverage was skipped by path policy, record
+  `Coverage: skipped by path policy` plus the classifier `reason`
+- if full coverage ran, record the coverage artifact or gate evidence, such as
+  `coverage-summary.json`
+- do not claim full coverage from a green `adl-coverage` check unless the
+  coverage-required lane actually ran
+- do not cite docs-only PR-level coverage skips as release coverage evidence
+
 ### 3. Run Finish Through The Repo Control Plane
 
 Prefer repo-native finish commands rather than manual git/PR surgery.

--- a/adl/tools/skills/pr-janitor/SKILL.md
+++ b/adl/tools/skills/pr-janitor/SKILL.md
@@ -119,6 +119,22 @@ At minimum, inspect where applicable:
 - review status and blocking review findings
 - whether the branch is behind main or otherwise needs refresh
 
+When inspecting `adl-ci` or `adl-coverage`, use
+`adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md` and inspect the
+`Classify changed paths` step when a stable check is skipped, unexpectedly quick, or
+ambiguous. Record the classifier `reason` when it affects readiness.
+
+Healthy CI interpretation requires:
+- stable checks are green
+- the path-policy reason matches the PR's changed surface
+- docs-only or tooling-only skips are explicit and expected
+
+Blocked CI interpretation includes:
+- runtime, source, test, or demo-affecting changes skipped coverage or demo
+  smoke unexpectedly
+- `fail_closed=true` requires full validation
+- stable check results contradict the PR diff or the path-policy reason
+
 ### 3. Classify the Problem
 
 Distinguish among:

--- a/adl/tools/skills/pr-run/SKILL.md
+++ b/adl/tools/skills/pr-run/SKILL.md
@@ -204,6 +204,29 @@ Prefer:
 
 Do not run an oversized validation suite unless the changed surface truly requires it or the user asks for it.
 
+#### CI Runtime Policy
+
+Use `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md` when selecting and
+recording the validation lane.
+
+For docs, planning, and non-runtime tooling changes:
+- run focused docs, tooling, contract, path, and guardrail checks
+- record the lane as a docs-only or tooling-only path-policy validation surface
+- do not imply Rust coverage ran
+
+For runtime, source, test, or demo-affecting changes:
+- expect Rust fmt, clippy, tests, demo smoke when required, and coverage gates
+- treat a skipped `adl-coverage` lane as a blocker unless the path-policy
+  `reason` proves the PR is truly non-runtime
+
+For ambiguous changed-path classification:
+- fail closed to full validation or record an explicit operator deferral
+- do not use uncertainty as a validation waiver
+
+When recording execution truth, distinguish `docs_only_path_policy_skip`,
+`runtime_full_validation`, `failed_closed_full_validation`, and
+`release_or_main_full_validation`.
+
 ### 6. Update The Execution Record
 
 Update the output card or execution record truthfully:

--- a/adl/tools/skills/release-evidence/SKILL.md
+++ b/adl/tools/skills/release-evidence/SKILL.md
@@ -66,6 +66,26 @@ Classify the package as:
 Do not use `ready` as release approval. It only means the evidence packet itself
 is complete enough to review.
 
+## CI Runtime Evidence Boundary
+
+Apply `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md` when using PR checks
+as validation evidence.
+
+Docs-only PR-level `adl-coverage` skips can support PR readiness for docs,
+planning, or non-runtime tooling changes, but they do not satisfy release
+coverage gates. Release evidence must cite full validation from `main`, release
+ceremony, runtime PRs, or explicit coverage artifacts produced by a full
+coverage lane.
+
+Do not claim release coverage from:
+- a green `adl-coverage` check that skipped coverage by path policy
+- a docs-only PR that did not produce coverage artifacts
+- an ambiguous path classification that should have failed closed
+
+When coverage is claimed, preserve the evidence surface, such as
+`coverage-summary.json`, the coverage gate output, or the full-validation check
+run that produced the full coverage lane.
+
 ## Output
 
 Write Markdown and JSON artifacts when an output root is available.
@@ -101,4 +121,3 @@ Handoff candidates:
   candidates.
 - `demo-operator` when one missing proof surface needs a bounded demo run.
 - `pr-closeout` when merged issues need truthful local closeout.
-


### PR DESCRIPTION
Closes #2394

## Summary
Integrated the v0.90.3 CI runtime policy into the tracked ADL operational skill
family. The skill docs now distinguish stable PR check names from the actual CI
lane that ran, so agents do not overclaim full Rust validation or release
coverage from docs-only path-policy skips.

## Artifacts
- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/skills/pr-run/SKILL.md`
- `adl/tools/skills/pr-finish/SKILL.md`
- `adl/tools/skills/pr-janitor/SKILL.md`
- `adl/tools/skills/issue-watcher/SKILL.md`
- `adl/tools/skills/release-evidence/SKILL.md`
- `adl/tools/skills/demo-operator/SKILL.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/pr-run/SKILL.md adl/tools/skills/pr-finish/SKILL.md adl/tools/skills/pr-janitor/SKILL.md adl/tools/skills/issue-watcher/SKILL.md adl/tools/skills/release-evidence/SKILL.md adl/tools/skills/demo-operator/SKILL.md`
    verified touched skill frontmatter remains valid.
  - `bash adl/tools/test_install_adl_operational_skills.sh` verified the tracked
    operational skill bundle still installs and expected skill contracts remain
    present.
  - `bash adl/tools/test_issue_watcher_skill_contracts.sh` verified the
    issue-watcher contract remains valid.
  - `bash adl/tools/test_release_evidence_skill_contracts.sh` verified the
    release-evidence contract remains valid.
  - `bash adl/tools/test_demo_operator_skill_contracts.sh` verified the
    demo-operator contract remains valid.
  - `bash adl/tools/test_skill_documentation_completeness.sh` verified tracked
    skill documentation completeness.
  - Custom Python acceptance audit verified required CI-policy terms are present
    across the shared guide and touched skills.
  - `git diff --check` verified the patch has no whitespace errors.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.90.3/tasks/issue-2394__v0-90-3-skills-integrate-ci-runtime-policy/sip.md
- Output card: .adl/v0.90.3/tasks/issue-2394__v0-90-3-skills-integrate-ci-runtime-policy/sor.md
- Idempotency-Key: v0-90-3-skills-integrate-ci-runtime-policy-into-workflow-skills-adl-tools-skills-docs-ci-runtime-policy-guide-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-pr-run-skill-md-adl-tools-skills-pr-finish-skill-md-adl-tools-skills-pr-janitor-skill-md-adl-tools-skills-issue-watcher-skill-md-adl-tools-skills-release-evidence-skill-md-adl-tools-skills-demo-operator-skill-md-adl-v0-90-3-tasks-issue-2394-v0-90-3-skills-integrate-ci-runtime-policy-sip-md-adl-v0-90-3-tasks-issue-2394-v0-90-3-skills-integrate-ci-runtime-policy-sor-md