### PR TITLE
[v0.90.3][tools] Add fast coverage-impact preflight for Rust PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,10 @@ jobs:
         run: sh adl/tools/codexw.sh --help
         working-directory: .
 
+      - name: coverage-impact preflight contract
+        run: bash adl/tools/test_check_coverage_impact.sh
+        working-directory: .
+
       - name: guardrail (no new legacy refs)
         run: bash adl/tools/check_no_new_legacy_swarm_refs.sh
         working-directory: .
@@ -155,7 +159,7 @@ jobs:
         if: steps.path-policy.outputs.coverage_required == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # cargo-llvm-cov
 
-      - name: Coverage (swarm)
+      - name: Coverage (ADL Rust workspace)
         if: steps.path-policy.outputs.coverage_required == 'true'
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,17 +159,21 @@ jobs:
         if: steps.path-policy.outputs.coverage_required == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # cargo-llvm-cov
 
-      - name: Coverage (ADL Rust workspace)
+      - name: Coverage run and summary (json)
         if: steps.path-policy.outputs.coverage_required == 'true'
-        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --all-features --json --summary-only --output-path coverage-summary.json
 
-      - name: Coverage summary (json)
-        if: steps.path-policy.outputs.coverage_required == 'true'
-        run: cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
-
-      - name: Coverage summary (text)
-        if: steps.path-policy.outputs.coverage_required == 'true'
-        run: cargo llvm-cov report --summary-only | tee coverage-summary.txt
+      - name: Coverage-impact changed-source gate
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true'
+        env:
+          PER_FILE_LINE_THRESHOLD: "80"
+        run: |
+          bash adl/tools/check_coverage_impact.sh \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --summary adl/coverage-summary.json \
+            --threshold "$PER_FILE_LINE_THRESHOLD"
+        working-directory: .
 
       - name: Enforce coverage policy gates (workspace + per-file)
         if: steps.path-policy.outputs.coverage_required == 'true'
@@ -179,6 +183,14 @@ jobs:
         run: |
           set -eu
           bash tools/enforce_coverage_gates.sh coverage-summary.json
+
+      - name: Coverage (ADL Rust workspace lcov)
+        if: steps.path-policy.outputs.coverage_required == 'true'
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Coverage summary (text)
+        if: steps.path-policy.outputs.coverage_required == 'true'
+        run: cargo llvm-cov report --summary-only | tee coverage-summary.txt
 
       - name: Verify generated lcov file
         if: steps.path-policy.outputs.coverage_required == 'true'

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -431,6 +431,22 @@ pub(super) fn run_finish_validation_rust(
     }
 
     let manifest = repo_root.join("adl/Cargo.toml");
+    let coverage_impact = repo_root.join("adl/tools/check_coverage_impact.sh");
+    let coverage_summary = repo_root.join("adl/target/coverage-impact-summary.json");
+    if coverage_impact.is_file() {
+        run_status(
+            "bash",
+            &[
+                path_str(&coverage_impact)?,
+                "--base",
+                "origin/main",
+                "--include-working-tree",
+                "--summary",
+                path_str(&coverage_summary)?,
+                "--require-summary-for-risk",
+            ],
+        )?;
+    }
     run_status(
         "cargo",
         &[
@@ -466,6 +482,7 @@ pub(super) fn render_default_finish_validation(mode: FinishValidationMode) -> St
         .join("\n"),
         FinishValidationMode::FullRust => [
             "- bash adl/tools/check_no_tracked_adl_issue_record_residue.sh",
+            "- bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk",
             "- cargo fmt",
             "- cargo clippy --all-targets -- -D warnings",
             "- cargo test",

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+BASE="origin/main"
+HEAD="HEAD"
+INCLUDE_WORKTREE=false
+SUMMARY=""
+CHANGED_FILES_FILE=""
+THRESHOLD="${PER_FILE_LINE_THRESHOLD:-80}"
+LARGE_FILE_LINES="${COVERAGE_IMPACT_LARGE_FILE_LINES:-200}"
+LARGE_FILE_DELTA="${COVERAGE_IMPACT_LARGE_FILE_DELTA:-80}"
+REQUIRE_SUMMARY_FOR_RISK=false
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/check_coverage_impact.sh [options]
+
+Options:
+  --base <rev>                    Base revision for changed-file detection.
+  --head <rev>                    Head revision for changed-file detection.
+  --include-working-tree          Compare base against the current working tree.
+  --summary <coverage-summary>    cargo llvm-cov JSON summary to check.
+  --changed-files <file>          Explicit changed-file list for tests. Lines may be
+                                  "path" or "STATUS<TAB>path".
+  --threshold <percent>           Per-file line threshold. Defaults to PER_FILE_LINE_THRESHOLD or 80.
+  --require-summary-for-risk      Fail when risky changed Rust files lack summary evidence.
+  -h, --help                      Show this help.
+
+This is a fast authoring-time guard. It does not replace the full GitHub
+adl-coverage job; it catches likely per-file coverage failures before PR
+publication when Rust source files are added or heavily changed.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      BASE="${2:-}"
+      shift 2
+      ;;
+    --head)
+      HEAD="${2:-}"
+      shift 2
+      ;;
+    --include-working-tree)
+      INCLUDE_WORKTREE=true
+      shift
+      ;;
+    --summary)
+      SUMMARY="${2:-}"
+      shift 2
+      ;;
+    --changed-files)
+      CHANGED_FILES_FILE="${2:-}"
+      shift 2
+      ;;
+    --threshold)
+      THRESHOLD="${2:-}"
+      shift 2
+      ;;
+    --require-summary-for-risk)
+      REQUIRE_SUMMARY_FOR_RISK=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$BASE" ]; then
+  echo "coverage-impact: --base cannot be empty" >&2
+  exit 2
+fi
+
+changed_rows() {
+  if [ -n "$CHANGED_FILES_FILE" ]; then
+    cat "$CHANGED_FILES_FILE"
+    return
+  fi
+  if [ "$INCLUDE_WORKTREE" = true ]; then
+    git -C "$ROOT" diff --name-status --diff-filter=ACMR "$BASE" -- 2>/dev/null || true
+    return
+  fi
+  git -C "$ROOT" diff --name-status --diff-filter=ACMR "$BASE...$HEAD" -- 2>/dev/null || \
+    git -C "$ROOT" diff --name-status --diff-filter=ACMR "$BASE" "$HEAD" -- 2>/dev/null || true
+}
+
+normalize_changed_path() {
+  awk -F '\t' '
+    NF == 1 { print "M\t" $1; next }
+    $1 ~ /^R/ && NF >= 3 { print $1 "\t" $3; next }
+    NF >= 2 { print $1 "\t" $2; next }
+  '
+}
+
+changed_source_rows="$(
+  changed_rows \
+    | normalize_changed_path \
+    | awk -F '\t' '$2 ~ /^adl\/src\/.*\.rs$/ { print $1 "\t" $2 }'
+)"
+
+if [ -z "$changed_source_rows" ]; then
+  echo "Coverage-impact preflight: no changed adl/src Rust files."
+  exit 0
+fi
+
+line_count_for_path() {
+  local path="$1"
+  if [ -f "$ROOT/$path" ]; then
+    wc -l <"$ROOT/$path" | tr -d ' '
+  else
+    echo 0
+  fi
+}
+
+changed_line_delta_for_path() {
+  local path="$1"
+  if [ -n "$CHANGED_FILES_FILE" ]; then
+    echo 0
+    return
+  fi
+  local out
+  if [ "$INCLUDE_WORKTREE" = true ]; then
+    out="$(git -C "$ROOT" diff --numstat "$BASE" -- "$path" 2>/dev/null || true)"
+  else
+    out="$(git -C "$ROOT" diff --numstat "$BASE...$HEAD" -- "$path" 2>/dev/null || true)"
+  fi
+  if [ -z "$out" ]; then
+    echo 0
+    return
+  fi
+  echo "$out" | awk '($1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/) { total += $1 + $2 } END { print total + 0 }'
+}
+
+candidate_filter_for_path() {
+  local path="$1"
+  basename "$path" .rs
+}
+
+risk_rows=""
+while IFS=$'\t' read -r status path; do
+  [ -n "$path" ] || continue
+  lines="$(line_count_for_path "$path")"
+  delta="$(changed_line_delta_for_path "$path")"
+  reason=""
+  case "$status" in
+    A*) reason="new Rust source file" ;;
+  esac
+  if [ -z "$reason" ] && [ "$lines" -ge "$LARGE_FILE_LINES" ] && [ "$delta" -ge "$LARGE_FILE_DELTA" ]; then
+    reason="large Rust source file with ${delta} changed lines"
+  fi
+  if [ -n "$reason" ]; then
+    risk_rows="${risk_rows}${status}"$'\t'"${path}"$'\t'"${lines}"$'\t'"${delta}"$'\t'"${reason}"$'\n'
+  fi
+done <<EOF
+$changed_source_rows
+EOF
+
+if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required when --summary is supplied." >&2
+    exit 1
+  fi
+  failures=""
+  missing=""
+  while IFS=$'\t' read -r _status path; do
+    [ -n "$path" ] || continue
+    row="$(jq -r --arg path "$path" '
+      [
+        .data[].files[]
+        | {
+            filename: (
+              .filename
+              | gsub("\\\\"; "/")
+              | sub("^/home/runner/work/[^/]+/[^/]+/"; "")
+              | sub("^/__w/[^/]+/[^/]+/"; "")
+              | sub("^[A-Za-z]:/a/[^/]+/[^/]+/"; "")
+            ),
+            covered: (.summary.lines.covered // 0),
+            count: (.summary.lines.count // 0)
+          }
+        | select(.filename == $path or .filename == ("/" + $path) or (.filename | endswith("/" + $path)))
+      ]
+      | if length == 0 then empty else
+          {
+            covered: (map(.covered) | add),
+            count: (map(.count) | add)
+          }
+          | .percent = (if .count == 0 then 0 else (.covered * 100.0 / .count) end)
+          | [.covered, .count, .percent]
+          | @tsv
+        end
+    ' "$SUMMARY")"
+    if [ -z "$row" ]; then
+      missing="${missing}  - ${path} (no coverage row in ${SUMMARY})"$'\n'
+      continue
+    fi
+    pct="$(printf '%s\n' "$row" | awk -F '\t' '{ printf "%.2f", $3 + 0 }')"
+    covered_count="$(printf '%s\n' "$row" | awk -F '\t' '{ printf "%s/%s", $1, $2 }')"
+    if ! awk -v pct="$pct" -v threshold="$THRESHOLD" 'BEGIN { exit ((pct + 0) < (threshold + 0)) ? 0 : 1 }'; then
+      continue
+    fi
+    failures="${failures}  - ${path} (${covered_count}, ${pct}% < ${THRESHOLD}%)"$'\n'
+  done <<EOF
+$changed_source_rows
+EOF
+
+  if [ -n "$missing" ] || [ -n "$failures" ]; then
+    echo "Coverage-impact preflight failed for changed Rust source files:"
+    [ -z "$missing" ] || printf '%s' "$missing"
+    [ -z "$failures" ] || printf '%s' "$failures"
+    echo "Full adl-coverage remains authoritative; fix or add focused tests before publication."
+    exit 1
+  fi
+  echo "Coverage-impact preflight passed for changed Rust source files using ${SUMMARY}."
+  exit 0
+fi
+
+if [ "$REQUIRE_SUMMARY_FOR_RISK" = true ] && [ -n "$risk_rows" ]; then
+  echo "Coverage-impact preflight needs coverage evidence for risky changed Rust source files:"
+  while IFS=$'\t' read -r _status path lines delta reason; do
+    [ -n "$path" ] || continue
+    filter="$(candidate_filter_for_path "$path")"
+    echo "  - ${path} (${reason}; ${lines} lines, ${delta} changed)"
+    echo "    next action: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- ${filter}"
+  done <<EOF
+$risk_rows
+EOF
+  echo "Then rerun: bash adl/tools/check_coverage_impact.sh --base ${BASE} --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk"
+  exit 1
+fi
+
+echo "Coverage-impact preflight passed: no risky changed Rust source files require local summary evidence."

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -58,6 +58,9 @@ or assembling release evidence:
   is not release coverage evidence.
 - A runtime/source/test/demo-affecting PR should not skip Rust validation,
   demo smoke when required, or coverage gates.
+- Rust source additions or heavy edits should run the coverage-impact preflight
+  before publication. This is an authoring-time early warning, not a replacement
+  for the full `adl-coverage` gate.
 - `fail_closed=true` means full validation is required; it is not an approved
   skip.
 - If the stable check result and changed files disagree, treat the PR as

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -61,6 +61,10 @@ or assembling release evidence:
 - Rust source additions or heavy edits should run the coverage-impact preflight
   before publication. This is an authoring-time early warning, not a replacement
   for the full `adl-coverage` gate.
+- When `adl-coverage` runs, the JSON summary and changed-source impact gate
+  should execute before LCOV artifact generation. A coverage failure should
+  fail at the first reviewable policy gate instead of spending extra time
+  producing upload artifacts for a known-bad run.
 - `fail_closed=true` means full validation is required; it is not an approved
   skip.
 - If the stable check result and changed files disagree, treat the PR as

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SCRIPT="$ROOT/adl/tools/check_coverage_impact.sh"
+
+make_summary() {
+  local path="$1"
+  local covered="$2"
+  local count="$3"
+  local out="$4"
+  cat >"$out" <<EOF
+{
+  "data": [
+    {
+      "files": [
+        {
+          "filename": "$path",
+          "summary": {
+            "lines": {
+              "covered": $covered,
+              "count": $count
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+docs_only="$TMP/docs_only.txt"
+printf 'M\tdocs/milestones/v0.90.3/README.md\n' >"$docs_only"
+bash "$SCRIPT" --changed-files "$docs_only" --require-summary-for-risk >/dev/null
+
+changed="$TMP/changed.txt"
+printf 'A\tadl/src/runtime_v2/new_large_surface.rs\n' >"$changed"
+if bash "$SCRIPT" --changed-files "$changed" --require-summary-for-risk >/tmp/coverage-impact-missing.out 2>&1; then
+  echo "expected risky changed source without summary to fail" >&2
+  exit 1
+fi
+grep -F "Coverage-impact preflight needs coverage evidence" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
+
+low_summary="$TMP/low-summary.json"
+make_summary "adl/src/runtime_v2/new_large_surface.rs" 77 100 "$low_summary"
+if bash "$SCRIPT" --changed-files "$changed" --summary "$low_summary" >/tmp/coverage-impact-low.out 2>&1; then
+  echo "expected below-threshold changed source to fail" >&2
+  exit 1
+fi
+grep -F "77.00% < 80%" /tmp/coverage-impact-low.out >/dev/null
+
+missing_summary="$TMP/missing-row-summary.json"
+make_summary "adl/src/runtime_v2/other.rs" 100 100 "$missing_summary"
+if bash "$SCRIPT" --changed-files "$changed" --summary "$missing_summary" >/tmp/coverage-impact-missing-row.out 2>&1; then
+  echo "expected missing coverage row for changed source to fail" >&2
+  exit 1
+fi
+grep -F "no coverage row" /tmp/coverage-impact-missing-row.out >/dev/null
+
+passing_summary="$TMP/passing-summary.json"
+make_summary "/private/tmp/repo/adl/src/runtime_v2/new_large_surface.rs" 88 100 "$passing_summary"
+bash "$SCRIPT" --changed-files "$changed" --summary "$passing_summary" >/tmp/coverage-impact-pass.out
+grep -F "Coverage-impact preflight passed" /tmp/coverage-impact-pass.out >/dev/null
+
+echo "PASS test_check_coverage_impact"


### PR DESCRIPTION
Closes #2406

## Summary
Implemented a fast coverage-impact preflight for Rust source changes so large new
or heavily changed `adl/src/**/*.rs` files get an authoring-time risk signal
before PR publication. The new guard checks changed Rust source files against a
supplied `cargo llvm-cov` summary when available, fails with actionable local
coverage commands when risky files lack evidence, and is now invoked by full
Rust `pr finish` validation. The stale GitHub Actions step label `Coverage
(swarm)` was renamed to current ADL terminology, and the coverage lane now
emits/enforces JSON summary gates before producing LCOV upload artifacts.

## Artifacts
- `adl/tools/check_coverage_impact.sh`
- `adl/tools/test_check_coverage_impact.sh`
- `.github/workflows/ci.yaml`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/check_coverage_impact.sh adl/tools/test_check_coverage_impact.sh`: verified shell syntax for the new guard and test.
  - `bash adl/tools/test_check_coverage_impact.sh`: verified the new coverage-impact contract behavior.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`: verified this issue's current diff does not require local coverage summary evidence.
  - `bash -n adl/tools/*.sh`: verified repo shell-tool syntax after adding the new scripts.
  - `cargo fmt --manifest-path adl/Cargo.toml --all -- --check`: verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render -- --nocapture`: verified the previously failing finish-rendering slice.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::guardrails -- --nocapture`: verified finish guardrail behavior after the hook change.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish -- --nocapture`: verified the full finish test namespace.
  - `cargo llvm-cov report --help`: verified the workflow's post-gate LCOV report command is available.
- Results: PASS for all listed checks.

## Local Artifacts
- Input card:  .adl/v0.90.3/tasks/issue-2406__v0-90-3-tools-add-fast-coverage-impact-preflight-for-rust-prs/sip.md
- Output card: .adl/v0.90.3/tasks/issue-2406__v0-90-3-tools-add-fast-coverage-impact-preflight-for-rust-prs/sor.md
- Idempotency-Key: v0-90-3-tools-add-fast-coverage-impact-preflight-for-rust-prs-github-workflows-ci-yaml-adl-src-cli-pr-cmd-finish-support-rs-adl-tools-skills-docs-ci-runtime-policy-guide-md-adl-tools-check-coverage-impact-sh-adl-tools-test-check-coverage-impact-sh-adl-v0-90-3-tasks-issue-2406-v0-90-3-tools-add-fast-coverage-impact-preflight-for-rust-prs-sip-md-adl-v0-90-3-tasks-issue-2406-v0-90-3-tools-add-fast-coverage-impact-preflight-for-rust-prs-sor-md