### PR TITLE
[v0.90.3][tools] Stop running full Rust tests twice in PR CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,10 @@ jobs:
         run: bash adl/tools/test_check_coverage_impact.sh
         working-directory: .
 
+      - name: path-policy PR-fast coverage contract
+        run: bash adl/tools/test_ci_path_policy.sh
+        working-directory: .
+
       - name: guardrail (no new legacy refs)
         run: bash adl/tools/check_no_new_legacy_swarm_refs.sh
         working-directory: .
@@ -98,8 +102,14 @@ jobs:
         run: bash tools/check_release_notes_commands.sh
 
       - name: test
-        if: steps.path-policy.outputs.rust_required == 'true'
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
         run: cargo test
+
+      - name: test covered by full coverage lane
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required == 'true'
+        run: |
+          echo "Skipping standalone cargo test because this event requires the full cargo-llvm-cov lane."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
 
       - name: Rust validation skipped by path policy
         if: steps.path-policy.outputs.rust_required != 'true'
@@ -143,28 +153,28 @@ jobs:
         working-directory: .
 
       - name: Install Rust toolchain
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: llvm-tools-preview
 
       - name: Rust cache
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           workspaces: |
             adl -> target
 
       - name: Install cargo-llvm-cov
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # cargo-llvm-cov
 
       - name: Coverage run and summary (json)
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         run: cargo llvm-cov --workspace --all-features --json --summary-only --output-path coverage-summary.json
 
       - name: Coverage-impact changed-source gate
-        if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true'
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true'
         env:
           PER_FILE_LINE_THRESHOLD: "80"
         run: |
@@ -175,8 +185,29 @@ jobs:
             --threshold "$PER_FILE_LINE_THRESHOLD"
         working-directory: .
 
+      - name: PR coverage-impact preflight
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
+        env:
+          PER_FILE_LINE_THRESHOLD: "80"
+        run: |
+          bash adl/tools/check_coverage_impact.sh \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --require-summary-for-risk \
+            --threshold "$PER_FILE_LINE_THRESHOLD"
+        working-directory: .
+
+      - name: Full coverage deferred by PR policy
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
+        run: |
+          echo "Full cargo-llvm-cov is deferred for this PR to avoid duplicate full test execution."
+          echo "This check ran the changed-source coverage-impact preflight instead."
+          echo "Full coverage remains required on push-to-main, nightly coverage ratchet, and fail-closed classification."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+        working-directory: .
+
       - name: Enforce coverage policy gates (workspace + per-file)
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         env:
           WORKSPACE_LINE_THRESHOLD: "90"
           PER_FILE_LINE_THRESHOLD: "80"
@@ -185,24 +216,24 @@ jobs:
           bash tools/enforce_coverage_gates.sh coverage-summary.json
 
       - name: Coverage (ADL Rust workspace lcov)
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Coverage summary (text)
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         run: cargo llvm-cov report --summary-only | tee coverage-summary.txt
 
       - name: Verify generated lcov file
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         run: test -s lcov.info && ls -l lcov.info
 
       - name: Verify lcov path from repository root
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         run: test -s adl/lcov.info && ls -l adl/lcov.info
         working-directory: .
 
       - name: Upload coverage artifact
-        if: steps.path-policy.outputs.coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adl-coverage-lcov
@@ -221,7 +252,7 @@ jobs:
         working-directory: .
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.path-policy.outputs.coverage_required == 'true'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.path-policy.outputs.full_coverage_required == 'true'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nightly-coverage-ratchet.yaml
+++ b/.github/workflows/nightly-coverage-ratchet.yaml
@@ -40,11 +40,11 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          cargo llvm-cov --summary-only | tee coverage-summary.txt
-          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
           cargo fmt --all -- --check
           cargo clippy --all-targets -- -D warnings
-          cargo test
+          cargo llvm-cov --summary-only | tee coverage-summary.txt
+          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
+          cargo test --doc
 
       - name: Build nightly report
         id: report

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -50,6 +50,7 @@ done
 bool_false=false
 rust_required="$bool_false"
 coverage_required="$bool_false"
+full_coverage_required="$bool_false"
 demo_smoke_required="$bool_false"
 fail_closed=false
 reason="path_policy_docs_or_tooling_only"
@@ -68,6 +69,7 @@ emit() {
 require_full_validation() {
   rust_required=true
   coverage_required=true
+  full_coverage_required=true
   demo_smoke_required=true
 }
 
@@ -93,7 +95,7 @@ else
           rust_required=true
           coverage_required=true
           demo_smoke_required=true
-          reason="runtime_or_rust_test_change_runs_full_validation"
+          reason="runtime_or_rust_test_change_runs_pr_fast_validation"
           ;;
         demos/*|adl/tools/demo_*|adl/tools/test_demo_*)
           demo_smoke_required=true
@@ -107,6 +109,7 @@ fi
 
 emit "rust_required" "$rust_required"
 emit "coverage_required" "$coverage_required"
+emit "full_coverage_required" "$full_coverage_required"
 emit "demo_smoke_required" "$demo_smoke_required"
 emit "fail_closed" "$fail_closed"
 emit "changed_count" "$changed_count"
@@ -115,6 +118,7 @@ emit "reason" "$reason"
 printf '\nChanged path policy: %s\n' "$reason"
 printf '  rust_required=%s\n' "$rust_required"
 printf '  coverage_required=%s\n' "$coverage_required"
+printf '  full_coverage_required=%s\n' "$full_coverage_required"
 printf '  demo_smoke_required=%s\n' "$demo_smoke_required"
 printf '  fail_closed=%s\n' "$fail_closed"
 printf '  changed_count=%s\n' "$changed_count"

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -3,8 +3,8 @@
 ## Purpose
 
 This guide explains how ADL operational skills should interpret PR validation
-after the v0.90.3 changed-path CI policy introduced stable check names with
-truthful skip behavior.
+after the v0.90.3 changed-path CI policy introduced stable check names, PR-fast
+Rust validation, and truthful skip/defer behavior.
 
 The source milestone policy is:
 
@@ -20,7 +20,12 @@ Skills must distinguish:
 - `docs_only_path_policy_skip`: docs, planning, or non-runtime tooling changed;
   expensive Rust, demo smoke, and coverage phases were explicitly skipped
 - `runtime_full_validation`: runtime, source, test, or demo-affecting surfaces
-  changed; Rust validation, demo smoke where required, and coverage gates ran
+  changed on a full-evidence event; Rust validation, demo smoke where required,
+  and full coverage gates ran
+- `runtime_pr_fast_validation`: runtime, source, test, or demo-affecting
+  surfaces changed on a pull request; Rust fmt, clippy, normal tests, demo
+  smoke where required, and coverage-impact preflight ran, while full
+  instrumented coverage was deferred to avoid a duplicate full test universe
 - `failed_closed_full_validation`: changed-path classification failed or was
   ambiguous; CI must require full validation instead of granting a waiver
 - `release_or_main_full_validation`: pushes to `main` and release evidence gates
@@ -41,6 +46,7 @@ It emits:
 
 - `rust_required`
 - `coverage_required`
+- `full_coverage_required`
 - `demo_smoke_required`
 - `fail_closed`
 - `changed_count`
@@ -57,20 +63,20 @@ or assembling release evidence:
 - A docs-only `adl-coverage` path-policy skip can be healthy for a PR, but it
   is not release coverage evidence.
 - A runtime/source/test/demo-affecting PR should not skip Rust validation,
-  demo smoke when required, or coverage gates.
+  demo smoke when required, or the PR coverage-impact preflight.
 - Rust source additions or heavy edits should run the coverage-impact preflight
-  before publication. This is an authoring-time early warning, not a replacement
-  for the full `adl-coverage` gate.
-- When `adl-coverage` runs, the JSON summary and changed-source impact gate
-  should execute before LCOV artifact generation. A coverage failure should
-  fail at the first reviewable policy gate instead of spending extra time
-  producing upload artifacts for a known-bad run.
+  before publication. On normal PRs, this is the fast `adl-coverage` lane rather
+  than a second full instrumented test run.
+- When `full_coverage_required=true`, the JSON summary and changed-source
+  impact gate should execute before LCOV artifact generation. A coverage
+  failure should fail at the first reviewable policy gate instead of spending
+  extra time producing upload artifacts for a known-bad run.
 - `fail_closed=true` means full validation is required; it is not an approved
   skip.
 - If the stable check result and changed files disagree, treat the PR as
   blocked or action-required until `pr-janitor` or a human resolves the
   discrepancy.
-- Do not claim "full coverage passed" unless the coverage-required lane ran
+- Do not claim "full coverage passed" unless the full coverage-required lane ran
   and produced coverage artifacts such as `coverage-summary.json`.
 - Do not treat a green `adl-coverage` check as sufficient release evidence
   unless the evidence shows the full coverage lane ran.
@@ -96,14 +102,34 @@ Observed:
 
 - `rust_required=true`
 - `coverage_required=true`
+- `full_coverage_required=false`
 - `demo_smoke_required=true` when demo surfaces changed
 
 Truthful interpretation:
 
-- Rust fmt, clippy, tests, demo smoke where applicable, and coverage gates are
-  expected.
-- A skipped coverage lane is a blocker unless there is an explicit policy
-  exception.
+- Rust fmt, clippy, tests, demo smoke where applicable, and the fast
+  coverage-impact preflight are expected.
+- Full instrumented coverage is intentionally deferred for the PR to avoid
+  running all tests twice.
+- The PR does not itself provide full release coverage evidence.
+
+### Full-Evidence Runtime Event
+
+Observed:
+
+- `rust_required=true`
+- `coverage_required=true`
+- `full_coverage_required=true`
+
+Truthful interpretation:
+
+- Standalone `cargo test` may be skipped because the full `cargo llvm-cov`
+  lane is the authoritative full test execution for that event.
+- A lightweight `cargo test --doc` check may still run to preserve doc-test
+  coverage without duplicating the whole suite.
+- Full coverage artifacts and policy gates are expected.
+- This lane can be cited as full coverage evidence when it produces
+  `coverage-summary.json`, `coverage-summary.txt`, and `lcov.info`.
 
 ### Failed-Closed Classification
 
@@ -127,5 +153,5 @@ Truthful interpretation:
 
 - Those checks support PR-level readiness for docs-only changes.
 - They do not satisfy release coverage gates. Release evidence needs full
-  validation from `main`, release ceremony, runtime PRs, or explicit coverage
-  artifacts produced by a full coverage lane.
+  validation from `main`, release ceremony, fail-closed full-validation events,
+  or explicit coverage artifacts produced by a full coverage lane.

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+POLICY="$ROOT_DIR/adl/tools/ci_path_policy.sh"
+
+assert_has() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fqx "$needle" <<<"$haystack"; then
+    echo "expected path-policy output to contain: $needle" >&2
+    echo "actual output:" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+(
+  cd "$tmp_dir"
+  git init -q
+  git config user.email "ci-path-policy@example.invalid"
+  git config user.name "CI Path Policy Test"
+
+  mkdir -p adl/src docs
+  printf 'pub fn baseline() -> bool { true }\n' > adl/src/lib.rs
+  printf '# baseline\n' > docs/readme.md
+  git add .
+  git commit -q -m baseline
+  base_sha="$(git rev-parse HEAD)"
+
+  printf '\nmore docs\n' >> docs/readme.md
+  git add docs/readme.md
+  git commit -q -m docs-change
+  docs_head="$(git rev-parse HEAD)"
+
+  docs_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$docs_head")"
+  assert_has "$docs_output" "rust_required=false"
+  assert_has "$docs_output" "coverage_required=false"
+  assert_has "$docs_output" "full_coverage_required=false"
+  assert_has "$docs_output" "demo_smoke_required=false"
+
+  git checkout -q -b runtime-change "$base_sha"
+  printf 'pub fn added_runtime() -> bool { true }\n' >> adl/src/lib.rs
+  git add adl/src/lib.rs
+  git commit -q -m runtime-change
+  runtime_head="$(git rev-parse HEAD)"
+
+  runtime_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$runtime_head")"
+  assert_has "$runtime_output" "rust_required=true"
+  assert_has "$runtime_output" "coverage_required=true"
+  assert_has "$runtime_output" "full_coverage_required=false"
+  assert_has "$runtime_output" "demo_smoke_required=true"
+  assert_has "$runtime_output" "reason=runtime_or_rust_test_change_runs_pr_fast_validation"
+
+  main_output="$("$POLICY" --event-name push)"
+  assert_has "$main_output" "rust_required=true"
+  assert_has "$main_output" "coverage_required=true"
+  assert_has "$main_output" "full_coverage_required=true"
+  assert_has "$main_output" "demo_smoke_required=true"
+  assert_has "$main_output" "reason=non_pull_request_event_runs_full_validation"
+
+  fail_closed_output="$("$POLICY" --event-name pull_request --base "" --head "$runtime_head")"
+  assert_has "$fail_closed_output" "rust_required=true"
+  assert_has "$fail_closed_output" "coverage_required=true"
+  assert_has "$fail_closed_output" "full_coverage_required=true"
+  assert_has "$fail_closed_output" "fail_closed=true"
+)
+
+echo "PASS: ci_path_policy PR-fast/full-coverage contract"

--- a/docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md
+++ b/docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md
@@ -6,7 +6,8 @@ Landed through tooling issue #2392.
 
 This note is for all ADL execution sessions working through the v0.90.3
 closeout tail. The goal is to keep PR checks truthful without forcing every
-docs-heavy or planning-heavy PR to wait for full Rust coverage.
+docs-heavy or planning-heavy PR to wait for full Rust coverage, and without
+making runtime PRs run the same full Rust test universe twice.
 
 ## Why This Changed
 
@@ -16,7 +17,10 @@ it became a blocker as v0.90.3 entered documentation, demo-matrix, review, and
 release-evidence work.
 
 The new workflow keeps the check names stable while using changed-path policy
-to decide whether expensive Rust phases are needed.
+to decide whether expensive Rust phases are needed. For normal runtime PRs, the
+workflow now runs one full normal Rust test pass plus a fast changed-source
+coverage-impact preflight. Full instrumented coverage remains the authoritative
+main/nightly/release evidence lane instead of duplicating every PR test run.
 
 ## Stable Check Names
 
@@ -40,6 +44,7 @@ For pull requests, it compares the PR base and head SHAs and emits:
 
 - `rust_required`
 - `coverage_required`
+- `full_coverage_required`
 - `demo_smoke_required`
 - `fail_closed`
 - `changed_count`
@@ -67,16 +72,23 @@ Runtime/source PRs:
 - run guardrails and contract checks
 - run Rust fmt, clippy, and full tests
 - run demo smoke
-- run full coverage and coverage gates
+- run the changed-source coverage-impact preflight in the stable
+  `adl-coverage` check
+- defer full instrumented coverage to main/nightly/release evidence unless the
+  path classifier fails closed
 
 Pushes to `main`:
 
 - run full validation and full coverage
+- avoid a second standalone full `cargo test` when the full coverage lane is
+  already executing the Rust test suite
 
 ## Coverage Behavior
 
-Coverage still runs for Rust/runtime changes. The workflow now avoids rerunning
-the workspace just to print the text summary. It generates:
+Coverage-impact preflight still runs for Rust/runtime PR changes. The workflow
+does not run a second full instrumented test universe for ordinary PRs.
+
+When `full_coverage_required=true`, full coverage generates:
 
 - `lcov.info`
 - `coverage-summary.json`
@@ -90,15 +102,24 @@ When working a docs-heavy closeout PR, do not panic if `adl-coverage` completes
 quickly with a skip message. That is expected when the PR does not touch Rust
 runtime or test surfaces.
 
-When working a runtime PR, expect full CI cost. Runtime/source changes still
-pay for full Rust validation and coverage.
+When working a runtime PR, expect Rust fmt, clippy, normal tests, demo smoke
+when required, and coverage-impact preflight. Do not cite the PR-fast coverage
+lane as full release coverage evidence.
+
+When working a main, nightly, release, or fail-closed event, expect full
+coverage. In those lanes, standalone `cargo test` may be skipped because
+`cargo llvm-cov` is the authoritative full test execution. A lightweight
+`cargo test --doc` check may still run to preserve doc-test coverage without
+duplicating the whole suite.
 
 When in doubt, check the `Classify changed paths` step in `adl-ci` or
 `adl-coverage`. Its `reason` field explains why a lane did or did not run.
 
 ## Non-Claims
 
-This policy does not remove release coverage gates. It only avoids paying for
-full coverage on PRs that cannot affect Rust runtime behavior. Release
-readiness, `main` pushes, and runtime/source changes still retain strong
-validation.
+This policy does not remove release coverage gates. It avoids duplicate full
+test execution on PRs while preserving release coverage gates on main, nightly,
+release, and fail-closed full-validation surfaces. Runtime/source PRs still
+retain strong validation through normal Rust tests plus coverage-impact
+preflight; they simply no longer run the whole test suite a second time under
+coverage instrumentation before merge.


### PR DESCRIPTION
Closes #2409

## Summary
Implemented a PR-fast/full-evidence split for Rust CI so ordinary runtime PRs
no longer run both standalone `cargo test` and a full instrumented
`cargo llvm-cov` test universe. Runtime PRs still run fmt, clippy, normal
tests, demo smoke when required, and the changed-source coverage-impact
preflight. Full coverage remains authoritative for push-to-main, nightly,
release, and fail-closed validation lanes.

## Artifacts
- `.github/workflows/ci.yaml`
- `.github/workflows/nightly-coverage-ratchet.yaml`
- `adl/tools/ci_path_policy.sh`
- `adl/tools/test_ci_path_policy.sh`
- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
- `docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/ci_path_policy.sh adl/tools/test_ci_path_policy.sh adl/tools/check_coverage_impact.sh adl/tools/test_check_coverage_impact.sh`: verified edited and related shell scripts parse.
  - `bash adl/tools/test_ci_path_policy.sh`: verified docs-only, runtime PR-fast, push-main, and fail-closed path-policy outputs.
  - `bash adl/tools/test_check_coverage_impact.sh`: verified the existing coverage-impact contract still passes.
  - `git diff --check`: verified no whitespace errors.
  - `bash tools/check_release_notes_commands.sh`: verified documented release-note command references still pass.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --require-summary-for-risk`: verified this tooling/docs change has no changed `adl/src` Rust coverage-impact surface.
  - `ruby -e 'require "yaml"; ...' .github/workflows/ci.yaml .github/workflows/nightly-coverage-ratchet.yaml`: verified edited workflow YAML parses.
- Results: PASS.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.3/tasks/issue-2409__v0-90-3-tools-stop-running-full-rust-tests-twice-in-pr-ci/sip.md
- Output card: .adl/v0.90.3/tasks/issue-2409__v0-90-3-tools-stop-running-full-rust-tests-twice-in-pr-ci/sor.md
- Idempotency-Key: v0-90-3-tools-stop-running-full-rust-tests-twice-in-pr-ci-github-workflows-ci-yaml-github-workflows-nightly-coverage-ratchet-yaml-adl-tools-ci-path-policy-sh-adl-tools-test-ci-path-policy-sh-adl-tools-skills-docs-ci-runtime-policy-guide-md-docs-milestones-v0-90-3-ci-runtime-policy-v0-90-3-md-adl-v0-90-3-tasks-issue-2409-v0-90-3-tools-stop-running-full-rust-tests-twice-in-pr-ci-sip-md-adl-v0-90-3-tasks-issue-2409-v0-90-3-tools-stop-running-full-rust-tests-twice-in-pr-ci-sor-md