### PR TITLE
[v0.90.3][WP-18][review] Normalize D12/D13 demo stdout path hygiene

### DIFF
--- a/adl/src/cli/runtime_v2_cmd.rs
+++ b/adl/src/cli/runtime_v2_cmd.rs
@@ -307,7 +307,10 @@ fn real_runtime_v2_observatory_flagship_demo(repo_root: &Path, args: &[String]) 
     artifacts.write_to_root(&resolved)?;
     println!(
         "RUNTIME_V2_OBSERVATORY_FLAGSHIP_DEMO_ROOT={}",
-        resolved.display()
+        out_path
+            .as_ref()
+            .expect("resolved D12 output path should preserve requested --out")
+            .display()
     );
     println!();
     println!("{}", artifacts.execution_summary()?);
@@ -352,7 +355,7 @@ fn real_runtime_v2_feature_proof_coverage(repo_root: &Path, args: &[String]) -> 
     packet.write_to_path(&resolved)?;
     println!(
         "RUNTIME_V2_FEATURE_PROOF_COVERAGE_PATH={}",
-        resolved.display()
+        out_path.display()
     );
     Ok(())
 }

--- a/adl/tests/cli_smoke/instrument_and_cli.rs
+++ b/adl/tests/cli_smoke/instrument_and_cli.rs
@@ -141,6 +141,73 @@ fn csm_observatory_cli_fails_safely_on_missing_packet() {
 }
 
 #[test]
+fn runtime_v2_v0903_demo_stdout_uses_repo_relative_output_paths() {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let rel_root = PathBuf::from(format!("target/v0903-path-hygiene-{unique}"));
+    let cwd = std::env::current_dir()
+        .expect("current dir")
+        .display()
+        .to_string();
+
+    let d13_rel = rel_root.join("feature-proof-coverage.json");
+    let d13 = run_adl(&[
+        "runtime-v2",
+        "feature-proof-coverage",
+        "--out",
+        d13_rel.to_str().unwrap(),
+    ]);
+    assert!(
+        d13.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&d13.stdout),
+        String::from_utf8_lossy(&d13.stderr)
+    );
+    let d13_stdout = String::from_utf8_lossy(&d13.stdout);
+    assert!(
+        d13_stdout.contains(&format!(
+            "RUNTIME_V2_FEATURE_PROOF_COVERAGE_PATH={}",
+            d13_rel.display()
+        )),
+        "stdout:\n{d13_stdout}"
+    );
+    assert!(
+        !d13_stdout.contains(&cwd),
+        "D13 stdout should not expose absolute repo root:\n{d13_stdout}"
+    );
+
+    let d12_rel = rel_root.join("observatory-flagship");
+    let d12 = run_adl(&[
+        "runtime-v2",
+        "observatory-flagship-demo",
+        "--out",
+        d12_rel.to_str().unwrap(),
+    ]);
+    assert!(
+        d12.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&d12.stdout),
+        String::from_utf8_lossy(&d12.stderr)
+    );
+    let d12_stdout = String::from_utf8_lossy(&d12.stdout);
+    assert!(
+        d12_stdout.contains(&format!(
+            "RUNTIME_V2_OBSERVATORY_FLAGSHIP_DEMO_ROOT={}",
+            d12_rel.display()
+        )),
+        "stdout:\n{d12_stdout}"
+    );
+    assert!(
+        !d12_stdout.contains(&cwd),
+        "D12 stdout should not expose absolute repo root:\n{d12_stdout}"
+    );
+
+    fs::remove_dir_all(rel_root).ok();
+}
+
+#[test]
 fn csm_observatory_cli_rejects_packets_missing_episodes() {
     let packet = csm_packet_with("missing-episodes", |packet| {
         packet.as_object_mut().unwrap().remove("episodes");


### PR DESCRIPTION
Closes #2415

## Summary
Issue 2415 corrected the reviewer-facing stdout for the v0.90.3 D12 and D13 runtime-v2 demos. The demo commands still resolve repo-relative `--out` paths to filesystem paths for writing, but stdout now reports the caller-provided repo-relative output paths instead of leaking the local checkout root.

## Artifacts
- Updated CLI behavior in `adl/src/cli/runtime_v2_cmd.rs`.
- Added CLI smoke coverage in `adl/tests/cli_smoke/instrument_and_cli.rs`.
- Generated local verification artifacts and stdout captures under `.adl/reviews/v0.90.3/wp18/issue-2415/after/` for manual proof only; these are ignored local review artifacts and are not part of the tracked PR payload.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`: formatted the Rust changes.
  - `git diff --check`: verified the patch has no whitespace errors.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_v0903_demo_stdout_uses_repo_relative_output_paths -- --nocapture`: verified the new CLI smoke test for D12/D13 stdout path hygiene.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_feature_proof_coverage -- --nocapture`: verified existing D13 feature-proof coverage tests still pass.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_observatory_flagship -- --nocapture`: verified existing D12 observatory flagship tests still pass.
  - `cargo run --manifest-path adl/Cargo.toml --quiet -- runtime-v2 feature-proof-coverage --out .adl/reviews/v0.90.3/wp18/issue-2415/after/feature-proof-coverage.json`: generated D13 proof output and verified stdout reports the repo-relative path.
  - `cargo run --manifest-path adl/Cargo.toml --quiet -- runtime-v2 observatory-flagship-demo --out .adl/reviews/v0.90.3/wp18/issue-2415/after/observatory-flagship`: generated D12 proof output and verified stdout reports the repo-relative root.
  - `bash -lc 'HOST_ROOT="$HOME"; TMP_ROOT="${TMPDIR:-__NO_TMP_ROOT__}"; rg -n "(${HOST_ROOT}/|${TMP_ROOT}|OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|\\bsk-[A-Za-z0-9]{20,}\\b)" .adl/reviews/v0.90.3/wp18/issue-2415/after/stdout-d12.txt .adl/reviews/v0.90.3/wp18/issue-2415/after/stdout-d13.txt .adl/reviews/v0.90.3/wp18/issue-2415/after adl/src/cli/runtime_v2_cmd.rs adl/tests/cli_smoke/instrument_and_cli.rs docs/milestones/v0.90.3 || true'`: scanned stdout captures, generated local proof artifacts, touched code, and v0.90.3 milestone docs for host-path and obvious secret leakage.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.90.3/tasks/issue-2415__v0-90-3-wp-18-normalize-d12-d13-demo-stdout-path-hygiene/sor.md`: verified the completed output card contract.
- Results: all validation commands passed; the leakage scan returned no matches.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.3/tasks/issue-2415__v0-90-3-wp-18-normalize-d12-d13-demo-stdout-path-hygiene/sip.md
- Output card: .adl/v0.90.3/tasks/issue-2415__v0-90-3-wp-18-normalize-d12-d13-demo-stdout-path-hygiene/sor.md
- Idempotency-Key: v0-90-3-wp-18-review-normalize-d12-d13-demo-stdout-path-hygiene-adl-src-cli-runtime-v2-cmd-rs-adl-tests-cli-smoke-instrument-and-cli-rs-adl-v0-90-3-tasks-issue-2415-v0-90-3-wp-18-normalize-d12-d13-demo-stdout-path-hygiene-sip-md-adl-v0-90-3-tasks-issue-2415-v0-90-3-wp-18-normalize-d12-d13-demo-stdout-path-hygiene-sor-md