### PR TITLE
[v0.90.3][WP-19] Next-milestone planning and handoff

### DIFF
--- a/docs/milestones/v0.90.3/INTERNAL_REVIEW_v0.90.3.md
+++ b/docs/milestones/v0.90.3/INTERNAL_REVIEW_v0.90.3.md
@@ -32,8 +32,11 @@ and `WP-15` work:
   WP-14A feature-proof coverage.
 
 This report does not approve the release by itself. It says the internal review
-gate is healthy enough to hand to external review, remediation/deferral, next
-milestone handoff, and final ceremony.
+gate was healthy enough to hand to external review, remediation/deferral, next
+milestone handoff, and final ceremony. That later release-tail work has now
+confirmed the same direction: third-party review closed with no blocking
+findings, and the only small internal stdout-path hygiene item was fixed in
+#2415.
 
 ## Readiness Gate
 
@@ -42,9 +45,13 @@ At final refresh:
 - `WP-01` through `WP-14` were closed.
 - `WP-14A` (`#2341`) was closed at 2026-04-22T19:26:32Z.
 - `WP-15` (`#2342`) was closed at 2026-04-22T19:40:24Z.
-- `WP-16` (`#2343`) is the active internal-review PR.
-- `WP-17` through `WP-20` remain the third-party review, accepted-finding
-  remediation, next-milestone handoff, and release ceremony tail.
+- `WP-16` (`#2343`) closed and merged at 2026-04-22T19:58:27Z.
+- `WP-17` (`#2344`) closed after the third-party review reported no blocking
+  findings.
+- `WP-18` (`#2345`) closed by zero-finding disposition, with the small internal
+  stdout-path hygiene follow-up completed in `#2415`.
+- `WP-19` and `WP-20` remain the next-milestone handoff and release ceremony
+  tail.
 
 ## Findings
 
@@ -157,27 +164,26 @@ Not run:
   tracker truth and preserves release-tail coverage as a later ceremony or CI
   responsibility.
 
-## WP-18 Remediation Queue
+## WP-18 Remediation Outcome
 
-Recommended order:
+Outcome:
 
-1. Decide whether to add v0.90.3 demo wrapper scripts for feature-proof
-   coverage and Observatory flagship proof.
-2. Decide whether demo stdout should print repo-relative output roots or keep
-   absolute local roots as operator diagnostics.
-3. Preserve any new `WP-17` external-review findings separately so this
-   internal-review packet does not blur internal and external review evidence.
+1. Demo wrapper parity was left as optional later polish; it was not needed for
+   truthful proof or release readiness.
+2. Demo stdout path hygiene was accepted as the only concrete internal P3
+   follow-up and completed in `#2415`.
+3. `WP-17` external review produced no additional remediation bundle.
 
-## WP-17 Handoff
+## WP-17 Handoff And Result
 
-WP-17 can use this packet as final internal-review context. External review
-should recheck the D12 and D13 commands, confirm the two P3 notes are acceptable
-or routed to WP-18, and preserve any third-party findings as a separate review
-surface.
+WP-17 used this packet as final internal-review context. External review later
+closed with no blocking findings, so this internal packet remained the main
+source for the small P3 polish queue rather than becoming one half of a larger
+remediation story.
 
 ## Release-Tail Disposition
 
-Current assessment: ready for external review handoff. The v0.90.3
-implementation quality is high in the core citizen-state substrate, and the
-remaining internal-review notes are release-tail ergonomics and publication
-hygiene rather than missing core implementation.
+Current assessment: internal review is complete and later tail work confirmed
+its direction. The v0.90.3 implementation quality is high in the core
+citizen-state substrate, and the internal-review notes resolved as release-tail
+ergonomics rather than missing core implementation.

--- a/docs/milestones/v0.90.3/MILESTONE_CHECKLIST_v0.90.3.md
+++ b/docs/milestones/v0.90.3/MILESTONE_CHECKLIST_v0.90.3.md
@@ -32,11 +32,11 @@
 
 - [x] Docs, quality gate, and feature docs converge before internal review
 - [x] Demo matrix and feature proof coverage converge before internal review
-- [ ] Internal review complete
-- [ ] External / third-party review complete
-- [ ] Accepted review findings remediated or explicitly deferred
-- [ ] Next-milestone planning and handoff complete
-- [ ] Release notes describe actual shipped scope
+- [x] Internal review complete
+- [x] External / third-party review complete
+- [x] Accepted review findings remediated or explicitly deferred
+- [x] Next-milestone planning and handoff complete
+- [x] Release notes describe actual shipped scope
 - [ ] Release ceremony preflight passes
 - [ ] Tag and release completed or blocked truthfully
 

--- a/docs/milestones/v0.90.3/README.md
+++ b/docs/milestones/v0.90.3/README.md
@@ -8,8 +8,11 @@ WP-19 handoff pass (#2263).
 
 The issue wave is open as #2327-#2347. WP-01 is #2327, WP-02 through WP-14 are
 #2328-#2340, WP-14A is #2341, and WP-15 through WP-20 are #2342-#2347.
-WP-01 through WP-14A have landed. WP-15 records the quality, docs, and
-reviewer-entry convergence surface before the final review tail.
+WP-01 through WP-18 are now complete. WP-16 internal review closed with only
+minor P3 notes, WP-17 external review closed with no third-party findings, and
+WP-18 closed by truthful zero-finding disposition plus the small stdout-path
+hygiene follow-up #2415. WP-19 completes the next-milestone handoff package, so
+WP-20 release ceremony is the only remaining milestone-closeout step.
 
 ## Thesis
 

--- a/docs/milestones/v0.90.3/RELEASE_NOTES_v0.90.3.md
+++ b/docs/milestones/v0.90.3/RELEASE_NOTES_v0.90.3.md
@@ -2,17 +2,16 @@
 
 ## Status
 
-Draft release notes. Do not publish as shipped scope until the milestone closes.
-WP-15 has created the release-readiness reviewer entry surface after WP-14A
-landed feature-proof coverage. Internal review finalization, third-party
-review, remediation, handoff, and ceremony remain release-tail gates.
+Pre-ceremony release notes draft. The implementation, demo/proof, internal
+review, third-party review, and handoff passes are complete; only the WP-20
+ceremony remains before publication.
 
-## Planned Headline
+## Draft Headline
 
-v0.90.3 is planned to introduce the citizen-state substrate: a local-first,
-reviewable foundation for protected citizen continuity.
+v0.90.3 introduces the citizen-state substrate: a local-first, reviewable
+foundation for protected citizen continuity.
 
-## Planned Highlights
+## Draft Highlights
 
 - canonical private citizen-state format
 - signed state envelopes and local trust-root fixture
@@ -29,7 +28,7 @@ reviewable foundation for protected citizen continuity.
 - narrow economics placement decision for v0.90.4 handoff
 - inhabited CSM Observatory flagship proof demo
 
-## Planned Non-Claims
+## Draft Non-Claims
 
 - v0.90.3 does not birth the first true Gödel agent.
 - v0.90.3 does not complete moral/emotional civilization.
@@ -39,5 +38,4 @@ reviewable foundation for protected citizen continuity.
 
 ## Release Note Rule
 
-At closeout, replace planned language with actual shipped evidence. Delete any
-item that did not land or mark it explicitly as deferred.
+At ceremony closeout, keep only landed evidence and any explicit deferrals.

--- a/docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md
+++ b/docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md
@@ -2,17 +2,18 @@
 
 ## Status
 
-WP-15 pre-third-party-review convergence record.
+WP-19 handoff record, ready for WP-20 ceremony.
 
 This document is the reviewer entry surface for the v0.90.3 citizen-state
-substrate milestone after WP-14A feature-proof coverage and before the final
-third-party review tail. It records the current quality posture, review
-entrypoints, proof evidence, and release-tail gates.
+substrate milestone after the internal review, third-party review, and accepted
+finding disposition pass. It records the current quality posture, review
+entrypoints, proof evidence, and the final handoff and ceremony gates.
 
 Important boundary: WP-14A / #2341 has landed the final feature-proof coverage
-record. WP-15 aligns docs and quality truth, but it does not approve the
-release, replace internal review, replace third-party review, or close the
-release-tail remediation/handoff/ceremony gates.
+record. WP-15 aligned docs and quality truth, WP-16 and WP-17 closed the review
+passes, and WP-18 closed by zero-finding disposition plus the small internal
+stdout-path hygiene cleanup issue #2415. None of those steps approve the
+release by themselves; WP-19 and WP-20 still own final handoff and ceremony.
 
 ## Review Entry Points
 
@@ -39,17 +40,20 @@ release-tail remediation/handoff/ceremony gates.
 
 ## Current Issue State
 
-At WP-15 refresh:
+At WP-19 refresh:
 
 - WP-01 through WP-14A have landed.
 - WP-14A / #2341 landed the explicit demo-matrix and feature-proof coverage
   record.
 - WP-15 / #2342 records quality, documentation, and reviewer-entry convergence.
-- WP-16 internal review is in progress and has not identified a P0/P1 blocker
-  in the citizen-state substrate; any remaining internal-review items are
-  expected to be minor P2/P3 follow-ups or explicit deferrals.
-- WP-17 through WP-20 remain the third-party review, remediation, planning
-  handoff, and ceremony tail.
+- WP-16 / #2343 is closed. Internal review found no P0, P1, or P2 findings and
+  left only small P3 polish notes.
+- WP-17 / #2344 is closed. Third-party review reported no P0, P1, or P2
+  findings and no external remediation bundle was required.
+- WP-18 / #2345 is closed by truthful zero-finding disposition plus completion
+  of the small internal stdout-path hygiene follow-up #2415.
+- WP-19 / #2346 completed the next-milestone planning and handoff pass.
+- WP-20 / #2347 remains the final release ceremony.
 
 ## Landed Proof Surface
 
@@ -133,10 +137,9 @@ This convergence pass used focused documentation and release-truth validation:
   full-Rust-test reduction. Green `adl-ci` and `adl-coverage` checks on
   docs-only PRs can be healthy PR evidence, but they are not full release
   coverage evidence.
-- Gap status: the active gap risk before third-party review is not a missing
-  core runtime slice; it is release-tail truth. Internal review should preserve
-  any minor P2/P3 follow-ups or explicit deferrals without reopening the
-  completed WP-14A feature-proof coverage gate.
+- Gap status: the active gap risk before ceremony is no longer review-tail
+  findings. The remaining work is handoff truth and ceremony sequencing from
+  clean main.
 - Rust module watch: no new Rust refactoring scope is introduced by WP-15.
   Runtime/source changes should still use the coverage-impact preflight before
   PR publication.
@@ -146,9 +149,8 @@ This convergence pass used focused documentation and release-truth validation:
 - Active milestone: v0.90.3
 - Crate version: `0.90.3`
 - Most recently completed milestone: v0.90.2
-- Current release-tail stage: WP-15 convergence after WP-14A feature-proof
-  coverage, with WP-16 internal review finalization and WP-17 third-party review
-  next
+- Current release-tail stage: WP-20 ceremony after clean internal/external
+  review closure and completed next-milestone handoff
 
 Reviewers should treat any conflicting older crate-version statement or claim
 that v0.90.3 is still pre-issue-wave as stale release-truth drift.
@@ -167,13 +169,6 @@ v0.90.3 does not claim:
 
 ## Remaining Release-Tail Gates
 
-- WP-16 internal review must record final P0/P1/P2/P3 findings or explicit
-  no-finding statements; the current internal-review posture has no P0/P1
-  blocker in the citizen-state substrate.
-- WP-17 third-party review must archive review artifacts in the review
-  directory.
-- WP-18 must fix accepted findings or defer them with owner and rationale.
-- WP-19 must complete next-milestone planning and handoff before ceremony.
 - WP-20 release ceremony must run from clean main after all closeout PRs merge.
 
 ## WP-15 Disposition

--- a/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
+++ b/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
@@ -2,13 +2,14 @@
 
 ## Planning Readiness
 
-- [ ] v0.90.4 planning package reviewed.
+- [x] v0.90.4 planning package reviewed.
 - [ ] v0.90.4 issue wave opened from reviewed WP YAML.
 - [ ] WP issue numbers recorded in WBS and WP YAML.
 - [ ] WP issue cards authored from WP_EXECUTION_READINESS_v0.90.4.md.
-- [ ] v0.90.3 citizen-state dependency state confirmed.
-- [ ] Payment and inter-polis deferrals accepted or explicitly changed.
-- [ ] v0.90.5 governed-tools handoff boundary accepted.
+- [x] v0.90.3 citizen-state dependency state confirmed.
+- [x] Payment and inter-polis deferrals accepted or explicitly changed.
+- [x] v0.90.5 governed-tools handoff boundary accepted.
+- [x] No blocking carryover remains from the v0.90.3 review tail.
 
 ## Execution Readiness
 

--- a/docs/milestones/v0.90.4/README.md
+++ b/docs/milestones/v0.90.4/README.md
@@ -4,10 +4,13 @@
 
 Draft milestone package. v0.90.4 is planned as the citizen economics and
 contract-market substrate milestone. It was initially placed by planning issue
-#2271 and polished for execution readiness by #2389.
+#2271, polished for execution readiness by #2389, and reviewed again during the
+v0.90.3 WP-19 handoff pass.
 
 The issue wave has not been opened. This package is the reviewable planning
-source for a later WP-01 issue-wave creation pass.
+source for a later WP-01 issue-wave creation pass. The v0.90.3 review tail
+closed with no blocking carryover, so this package is intended to be ready for
+immediate WP-01 issue-wave creation after the v0.90.3 ceremony.
 
 ## Thesis
 
@@ -119,6 +122,10 @@ projection, challenge, appeal, and continuity semantics.
 
 If v0.90.3 defers a required authority surface, v0.90.4 should either narrow its
 proof to a fixture-backed boundary or delay the affected WP.
+
+The current handoff result is favorable: v0.90.3 closed internal review,
+third-party review, and accepted-finding disposition without any blocking
+economics-facing carryover.
 
 ## Handoff To v0.90.5
 

--- a/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
@@ -7,6 +7,8 @@ schema, lifecycle, authority, fixture, runner, demo, and review-summary story.
 
 The milestone is releasable when:
 
+- v0.90.3 closes with no blocking economics-facing carryover from its review
+  tail
 - v0.90.3 citizen-state dependencies are explicitly inherited or safely
   fixture-backed
 - contracts that mention tool-mediated work express tool needs as constraints,
@@ -39,3 +41,5 @@ The closeout should hand off:
 - any deferred authority or trace negative cases
 - v0.90.5 governed-tools follow-up for UTS, ACC, tool registry binding,
   executor authority, redaction, replay, denial records, and model testing
+- any contract-market requirement that recorded tool needs only as a constraint
+  and must be picked up by v0.90.5

--- a/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
+++ b/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
@@ -44,8 +44,10 @@ Required validation:
 
 - Check the issue wave matches WP ordering.
 - Check no WP body is generic or missing required outputs and validation.
-- Check planning docs contain no unresolved scaffold markers or local host
+- Check planning docs contain no unresolved template placeholders or local host
   paths.
+- Check the v0.90.3 handoff truth still shows no blocking carryover before
+  opening the wave.
 
 ## WP-02: Economics Inheritance And Authority Audit
 

--- a/docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml
+++ b/docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml
@@ -8,7 +8,9 @@ notes:
   - "Issue wave is not open yet."
   - "This package is owned by planning issue #2271."
   - "This package was polished for execution readiness by #2389."
+  - "This package was reviewed again during v0.90.3 WP-19 handoff."
   - "v0.90.4 consumes v0.90.3 citizen-state, standing, access-control, projection, and challenge/appeal authority."
+  - "v0.90.3 closed internal review, third-party review, and accepted-finding disposition without blocking economics-facing carryover."
   - "Do not claim payment settlement, Lightning, x402, or full inter-polis economics in v0.90.4 unless a later decision explicitly changes scope."
   - "Use fixture-first contract-market proof before any production economics claims."
   - "Preserve an explicit demo matrix and feature proof demo WP before docs/review convergence."
@@ -16,6 +18,7 @@ notes:
 card_update_rule:
   - "WP-01 must copy the relevant section from WP_EXECUTION_READINESS_v0.90.4.md into each issue body before implementation."
   - "Cards must include required outputs, required validation, source docs, non-goals, and demo/proof expectations."
+  - "WP-01 should confirm the v0.90.3 handoff still has no blocking carryover before opening the wave."
   - "No issue should claim implementation, review, payment, settlement, or release completion until evidence has landed and validated."
 work_packages:
   - wp: WP-01

--- a/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
+++ b/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
@@ -2,11 +2,13 @@
 
 ## Before Issue Wave
 
-- [ ] v0.90.5 planning package reviewed
-- [ ] UTS/ACC scope confirmed as Governed Tools v1.0
+- [x] v0.90.5 planning package reviewed
+- [x] UTS/ACC scope confirmed as Governed Tools v1.0
 - [ ] Issue wave opened from reviewed YAML
 - [ ] WP issue numbers recorded in WBS and YAML
 - [ ] WP issue cards authored from WP_EXECUTION_READINESS_v0.90.5.md
+- [x] Package is ready to accept v0.90.4 handoff without reopening scope
+  confusion about tool authority
 
 ## Implementation Gates
 

--- a/docs/milestones/v0.90.5/README.md
+++ b/docs/milestones/v0.90.5/README.md
@@ -3,10 +3,13 @@
 ## Status
 
 Draft milestone package. v0.90.5 is planned as the Governed Tools v1.0
-milestone under planning issue #2350, with follow-up polish under #2402.
+milestone under planning issue #2350, with follow-up polish under #2402 and an
+additional readiness review during the v0.90.3 WP-19 handoff pass.
 
 The issue wave has not been opened. This package is the reviewable planning
-source for a later WP-01 issue-wave creation pass.
+source for a later WP-01 issue-wave creation pass. It is intended to be the
+next immediately executable planning package after v0.90.4 closeout, not a
+half-managed later idea lane.
 
 ## Thesis
 
@@ -113,3 +116,7 @@ v0.90.5 builds on:
 
 v0.90.5 should not own the v0.90.3 inhabited CSM demo. It should own the
 Governed Tools v1.0 flagship demo.
+
+It also should not inherit unresolved v0.90.4 ambiguity about whether contract
+tool needs are constraints or execution grants. WP-19 of v0.90.4 is expected to
+hand that boundary off cleanly.

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -3,7 +3,9 @@
 ## Status
 
 Forward planning. v0.91 is not yet an active implementation milestone and has no
-final issue wave.
+final issue wave. Its boundary was rechecked during the v0.90.3 WP-19 handoff
+pass so it stays clearly downstream of the nearer v0.90.4 and v0.90.5
+milestones.
 
 ## Purpose
 
@@ -47,6 +49,9 @@ v0.91 depends on:
 
 - v0.90.3 citizen state, signed state envelopes, lineage, standing, access
   control, challenge, sanctuary, quarantine, and redacted projection surfaces
+- v0.90.4 only for any landed contract-market evidence that later moral review
+  needs to inspect; v0.91 should not absorb economics implementation as part of
+  moral governance
 - v0.90.5 governed tools only where tool-mediated moral evidence or refusal
   evidence depends on landed UTS, ACC, and tool-call trace
 - v0.92 as a downstream consumer of moral trace and wellbeing evidence for
@@ -75,6 +80,7 @@ v0.91 depends on:
 - Production moral agency.
 - Scalar karma, scalar happiness, or scoreboard framing.
 - Public exposure of private wellbeing diagnostics.
+- Replacing v0.90.4 economics or v0.90.5 governed-tool implementation.
 - Replacing v0.90.3 citizen-state/security work.
 - Replacing v0.92 identity and birthday semantics.
 

--- a/docs/milestones/v0.92/README.md
+++ b/docs/milestones/v0.92/README.md
@@ -3,7 +3,9 @@
 ## Status
 
 Forward planning. v0.92 is not yet an active implementation milestone and has
-no final issue wave.
+no final issue wave. Its boundary was rechecked during the v0.90.3 WP-19
+handoff pass so it stays about identity and birth rather than absorbing
+economics, governed tools, or constitutional citizenship prematurely.
 
 ## Purpose
 
@@ -45,6 +47,9 @@ v0.92 depends on:
 
 - v0.90.3 for citizen state, signed envelopes, lineage, continuity witnesses,
   standing, challenge, sanctuary, quarantine, and redacted projections
+- v0.90.4 only for any landed economic or contractual context that becomes part
+  of a later capability envelope; v0.92 must not absorb contract-market
+  implementation
 - v0.90.5 for governed-tool authority, UTS, ACC, and tool-call trace if
   capability envelopes include tool-mediated actions
 - v0.91 for moral trace, moral trajectory review, outcome linkage, wellbeing,


### PR DESCRIPTION
Closes #2346

## Summary
Completed the v0.90.3 next-milestone handoff pass. The current milestone docs
now reflect the closed WP-16/WP-17/WP-18 review tail truth, and the v0.90.4,
v0.90.5, v0.91, and v0.92 packages are tightened so the next milestones can
start immediately without cleanup drift.

## Artifacts
- Updated tracked milestone docs for v0.90.3, v0.90.4, v0.90.5, v0.91, and
  v0.92.

## Validation
- Validation commands and their purpose:
  - path/placeholder scan checked for host-path leakage and unresolved template
    placeholders.
  - markdown link check verified changed local document references resolve.
  - YAML parse verified the v0.90.4 issue-wave source still parses.
  - git diff --check verified patch hygiene.
  - git status --short --branch verified the intended docs-only changed-path set.
- Results: PASS.

## Local Artifacts
- Input card:  .adl/cards/2346/input_2346.md
- Output card: .adl/cards/2346/output_2346.md
- Idempotency-Key: v0-90-3-wp-19-next-milestone-planning-and-handoff-docs-milestones-v0-90-3-readme-md-docs-milestones-v0-90-3-milestone-checklist-v0-90-3-md-docs-milestones-v0-90-3-release-readiness-v0-90-3-md-docs-milestones-v0-90-3-release-notes-v0-90-3-md-docs-milestones-v0-90-3-internal-review-v0-90-3-md-docs-milestones-v0-90-4-readme-md-docs-milestones-v0-90-4-milestone-checklist-v0-90-4-md-docs-milestones-v0-90-4-release-plan-v0-90-4-md-docs-milestones-v0-90-4-wp-execution-readiness-v0-90-4-md-docs-milestones-v0-90-4-wp-issue-wave-v0-90-4-yaml-docs-milestones-v0-90-5-readme-md-docs-milestones-v0-90-5-milestone-checklist-v0-90-5-md-docs-milestones-v0-91-readme-md-docs-milestones-v0-92-readme-md-adl-cards-2346-input-2346-md-adl-cards-2346-output-2346-md