### PR TITLE
[v0.90.3][docs] Refresh release truth surfaces after WP-19 merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable project-level changes are summarized here by milestone/release.
 
 Status: Issue wave opened on 2026-04-21. WP-01 is #2327, WP-02 through WP-14
 are #2328-#2340, WP-14A is #2341, and WP-15 through WP-20 are #2342-#2347.
-WP-01 through WP-14A have landed. WP-15 records the current
-quality/docs/reviewer-entry convergence surface, and WP-16 internal review is
-in progress with no P0/P1 blocker found in the citizen-state substrate.
+WP-01 through WP-19 have landed. WP-16 internal review closed with only minor
+internal cleanup, WP-17 external review closed with zero third-party findings,
+WP-18 closed by zero-finding disposition plus trivial follow-up #2415, WP-19
+completed the next-milestone handoff, and only WP-20 release ceremony remains.
 
 Planned scope:
 - v0.90.3 is the citizen-state substrate milestone.
@@ -23,6 +24,9 @@ Planned scope:
 - WP-15 adds `docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md` as the
   reviewer entry surface, records coverage/tracker truth, and keeps docs-only CI
   path-policy skips separate from full release coverage evidence.
+- WP-19 leaves the v0.90.4 economics package, the v0.90.5 governed-tools
+  package, and the downstream v0.91/v0.92 boundaries ready to start cleanly
+  after v0.90.3 ceremony.
 - The crate version is `0.90.3` for the active v0.90.3 development line.
 
 Not claimed in v0.90.3:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Other useful entrypoints:
 ## Current Status
 
 - Active milestone: **v0.90.3**
-- Current release state: **v0.90.3 is in release-tail convergence; WP-01 through WP-14A have landed, WP-15 carries quality/docs convergence, and WP-16 through WP-20 carry review/remediation/handoff/ceremony**
+- Current release state: **v0.90.3 has completed WP-01 through WP-19; WP-20 release ceremony is the only remaining tail step**
 - Most recently completed milestone: **v0.90.2**
 - Current crate version: **0.90.3**
 - Version note: **v0.90.3 is the active citizen-state substrate development line**
@@ -135,12 +135,14 @@ ADL is in active development. This repository contains both implemented runtime 
 v0.90.3 is the active citizen-state substrate milestone. Its tracked package
 lives under `docs/milestones/v0.90.3/`. The issue wave is open as #2327-#2347:
 WP-01 is #2327, WP-02 through WP-14 are #2328-#2340, WP-14A is #2341, and
-WP-15 through WP-20 are #2342-#2347. WP-01 through WP-14A have landed.
+WP-15 through WP-20 are #2342-#2347. WP-01 through WP-19 have landed, and only
+WP-20 release ceremony remains.
 
-The current reviewer entry surface is
-`docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md`. It records the WP-15
-quality/docs convergence posture, the landed feature-proof coverage record, and
-the no-P0/P1 internal-review posture before third-party review.
+The current release-tail entry surface is
+`docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md`. It records the landed
+feature-proof coverage record, closed internal review, clean third-party review
+result, accepted-finding disposition, completed next-milestone handoff, and the
+fact that v0.90.4 is ready to open immediately after ceremony.
 
 v0.90.3 should turn the bounded CSM run from v0.90.2 into safer citizen-state
 substrate work: canonical private state, signed envelopes, local-first sealing,

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -50,6 +50,7 @@ can survive code review, ops review, and postmortem analysis.
 The current repo truth is:
 - active milestone: `v0.90.3`
 - current crate version on the active release line: `0.90.3`
+- current release-tail state: `WP-20 ceremony remains; WP-19 handoff is complete`
 - most recently completed Runtime v2 foundation milestone package: `v0.90.1`
 - most recently completed long-lived runtime milestone package: `v0.90`
 - most recently completed adversarial-runtime milestone package before that: `v0.89.1`
@@ -66,7 +67,9 @@ That means the feature story should be read this way:
 - `v0.90.3` is the active citizen-state substrate band: private-state authority,
   signed envelopes, local sealing, lineage, witnesses, standing, access control,
   redacted projections, challenge/appeal, and the inhabited Observatory demo
-- `v0.90.4` through `v0.95` are the next planned capability bands
+- `v0.90.4` and `v0.90.5` are already prepared as the next immediate planning
+  packages after v0.90.3 ceremony
+- `v0.91` through `v0.95` are the later planned capability bands
 
 ## ADL at a Glance
 
@@ -339,12 +342,12 @@ citizen state and standing; it does not claim full identity, moral
 civilization, production citizenship, legal personhood, or complete
 constitutional authority.
 
-## Major Capability Bands Still to Come
+## Current And Upcoming Capability Bands
 
 ### v0.90.3 - Citizen State, Standing, And Private-State Substrate
 
-`v0.90.3` is expected to deepen citizen continuity after the first bounded CSM
-run:
+`v0.90.3` is the current closeout band. Its implementation and review tail have
+already landed through WP-19, leaving only ceremony:
 - private citizen-state format
 - signed envelopes and continuity witnesses
 - append-only lineage and anti-equivocation rules
@@ -352,6 +355,9 @@ run:
 - redacted Observatory projections
 - access-control semantics for who may inspect, project, wake, migrate, or
   challenge citizen state
+
+Its remaining release-tail work is ceremony and closeout, not more feature
+scope.
 
 ### v0.90.4 - Citizen Economics And Contract Markets
 


### PR DESCRIPTION
## Summary
- refresh the top-level README release-tail truth for v0.90.3
- update the changelog to reflect completed WP-16 through WP-19 status
- tighten the ADL feature list timing language so v0.90.3 closeout and v0.90.4/v0.90.5 readiness are described truthfully

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml"); puts "yaml ok"'
- manual consistency check against README, CHANGELOG, Cargo.toml, v0.90.4 wave YAML, and local backlog surfaces