### PR TITLE
[v0.90.3][WP-20] Release ceremony

### DIFF
--- a/docs/milestones/v0.90.3/MILESTONE_CHECKLIST_v0.90.3.md
+++ b/docs/milestones/v0.90.3/MILESTONE_CHECKLIST_v0.90.3.md
@@ -37,6 +37,7 @@
 - [x] Accepted review findings remediated or explicitly deferred
 - [x] Next-milestone planning and handoff complete
 - [x] Release notes describe actual shipped scope
+- [x] End-of-milestone report written or refreshed
 - [ ] Release ceremony preflight passes
 - [ ] Tag and release completed or blocked truthfully
 

--- a/docs/milestones/v0.90.3/RELEASE_PLAN_v0.90.3.md
+++ b/docs/milestones/v0.90.3/RELEASE_PLAN_v0.90.3.md
@@ -43,7 +43,7 @@ The release tail should follow the v0.87.1/v0.90.2 pattern:
 5. external / third-party review
 6. accepted finding remediation or explicit deferral
 7. next-milestone planning and handoff
-8. release notes and release evidence
+8. release notes, end-of-milestone report, and release evidence
 9. release ceremony
 
 ## Release Non-Claims

--- a/docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md
+++ b/docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md
@@ -126,23 +126,27 @@ This convergence pass used focused documentation and release-truth validation:
 
 ## Tracker Review
 
-- Coverage tracker: current tracked release surfaces still carry the active
-  coverage truth from the recent quality gate, with workspace line coverage at
-  `92.40%`, rounded to the intended `93%` tranche, and no active file-floor
-  exclusion documented. WP-15 did not rerun full coverage because this PR is a
-  docs/release-truth convergence pass; release evidence must still come from a
-  full coverage lane, a runtime PR, a main push, or ceremony validation.
+- Coverage tracker: the local tracker was refreshed on `2026-04-23` and now
+  records workspace line coverage at `90.72%` (`~91.00%` rounded). The
+  workspace gate still passes, and there is still no active file-floor
+  exclusion. WP-15 did not rerun full coverage because that issue was a
+  docs/release-truth convergence pass; the current ceremony surface should use
+  the refreshed tracker rather than the older `92.40%` snapshot.
 - CI runtime policy: #2392, #2394, #2406, and #2409 have landed the docs-heavy
   PR path policy, skill integration, coverage-impact preflight, and duplicate
   full-Rust-test reduction. Green `adl-ci` and `adl-coverage` checks on
   docs-only PRs can be healthy PR evidence, but they are not full release
   coverage evidence.
 - Gap status: the active gap risk before ceremony is no longer review-tail
-  findings. The remaining work is handoff truth and ceremony sequencing from
-  clean main.
-- Rust module watch: no new Rust refactoring scope is introduced by WP-15.
-  Runtime/source changes should still use the coverage-impact preflight before
-  PR publication.
+  findings. The remaining work is ceremony sequencing from clean main, not
+  unresolved review or closeout drift.
+- Rust module watch: the local watch list was refreshed from `main` at commit
+  `2c686ce5` on `2026-04-23 12:42:28 PDT`. There are still no `RATIONALE`-band
+  modules. The current watch posture is twenty-seven `REVIEW` items and twenty
+  `WATCH` items, with the largest module still below the `1500` LoC threshold.
+- Closed-issue truth: the v0.90.3 closeout wave is complete with `23` eligible
+  issues, `23` normalized issues, and `0` failures. WP-20 should treat
+  closeout normalization as complete ceremony input, not remaining tail work.
 
 ## Version Truth
 

--- a/docs/milestones/v0.90.3/WBS_v0.90.3.md
+++ b/docs/milestones/v0.90.3/WBS_v0.90.3.md
@@ -29,7 +29,7 @@ format and envelope before implementation widens.
 | WP-17 | #2344 | External / third-party review | Run bounded external review and record findings or zero-finding disposition | third-party review record | WP-16 |
 | WP-18 | #2345 | Review findings remediation | Fix accepted internal/external findings or defer explicitly with owner and rationale | remediation PRs or deferral records | WP-16, WP-17 |
 | WP-19 | #2346 | Next-milestone planning and handoff | Prepare v0.90.4/v0.91/v0.92 handoff and preserve later-scope boundaries before ceremony | next-milestone planning package and handoff notes | WP-18 |
-| WP-20 | #2347 | Release ceremony | Complete release closure and handoff | release notes, ceremony result, next-milestone handoff | WP-19 |
+| WP-20 | #2347 | Release ceremony | Complete release closure and handoff | release notes, ceremony result, end-of-milestone report, next-milestone handoff | WP-19 |
 
 ## Compression Candidate
 

--- a/docs/milestones/v0.90.3/WP_EXECUTION_READINESS_v0.90.3.md
+++ b/docs/milestones/v0.90.3/WP_EXECUTION_READINESS_v0.90.3.md
@@ -321,6 +321,7 @@ Required outputs:
 
 - release ceremony result
 - final release notes
+- end-of-milestone report
 - version/status truth confirmed
 - release closure note
 

--- a/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
+++ b/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
@@ -39,4 +39,5 @@
 - [ ] External review complete or explicitly waived.
 - [ ] Accepted findings fixed or dispositioned.
 - [ ] Changelog, README, Cargo metadata, and milestone docs aligned.
+- [ ] End-of-milestone report written or refreshed.
 - [ ] Ceremony completed.

--- a/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
@@ -23,6 +23,7 @@ The milestone is releasable when:
 - the feature proof coverage WP is complete before quality/docs convergence
 - internal and external review findings are fixed or dispositioned
 - release notes describe actual shipped scope
+- end-of-milestone report is written before ceremony
 
 ## Quality Bar
 

--- a/docs/milestones/v0.90.4/WBS_v0.90.4.md
+++ b/docs/milestones/v0.90.4/WBS_v0.90.4.md
@@ -29,7 +29,7 @@ fixtures, validators, and lifecycle before the runner and proof demo widen.
 | WP-17 | planned | External review | Run bounded external review and record findings or zero-finding disposition | third-party review record | WP-16 |
 | WP-18 | planned | Review findings remediation | Fix accepted internal/external findings or defer explicitly with owner and rationale | remediation PRs or deferral records | WP-16, WP-17 |
 | WP-19 | planned | Next milestone planning handoff | Prepare v0.90.5 governed-tools handoff plus v0.91/v0.92/payment-lane follow-ups as appropriate | handoff docs and backlog updates | WP-18 |
-| WP-20 | planned | Release ceremony | Complete release closure | release notes, ceremony result, next handoff | WP-19 |
+| WP-20 | planned | Release ceremony | Complete release closure | release notes, ceremony result, end-of-milestone report, next handoff | WP-19 |
 
 ## Compression Candidate
 

--- a/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
+++ b/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
@@ -367,6 +367,7 @@ Required validation:
 Required outputs:
 
 - Release notes updated from actual evidence.
+- End-of-milestone report written and stored in the local planning lane or other explicitly designated closeout surface.
 - Changelog, README, Cargo metadata, feature list, milestone checklist, review
   records, and issue closeout state aligned.
 - Ceremony script run using the milestone's accepted closeout pattern.

--- a/docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml
+++ b/docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml
@@ -145,5 +145,5 @@ work_packages:
     issue: planned
     title: Release ceremony
     queue: release
-    outcome: release notes, ceremony result, and next handoff
+    outcome: release notes, ceremony result, end-of-milestone report, and next handoff
     depends_on: WP-19

--- a/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
+++ b/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
@@ -38,6 +38,7 @@
 ## Release Gates
 
 - [ ] README, CHANGELOG, REVIEW, release notes, and release evidence aligned
+- [ ] end-of-milestone report written or refreshed
 - [ ] no stale version references
 - [ ] no local path leaks in tracked docs
 - [ ] release ceremony completed

--- a/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
+++ b/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
@@ -20,6 +20,7 @@ Freedom Gate mediation, and trace.
 - feature proof coverage record
 - internal and external review notes
 - accepted-finding disposition record
+- end-of-milestone report
 
 ## Release Risks
 

--- a/docs/milestones/v0.90.5/WBS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/WBS_v0.90.5.md
@@ -28,7 +28,7 @@ documentation-only planning lane.
 | WP-18 | planned | Governed Tools v1.0 flagship demo | Show proposal, validation, ACC, policy, gate, execution/denial, trace, and redaction | flagship demo proof packet | WP-13-WP-17 |
 | WP-18A | planned | Demo matrix and feature proof coverage | Verify every governed-tools claim has proof, fixture, non-proving status, or deferral before review convergence | demo matrix update and proof coverage record | WP-03-WP-18 |
 | WP-19 | planned | Quality, docs, review, and public-spec handoff | Align docs, conformance, feature docs, review packets, public-spec language, and accepted-finding routing | review-ready package and finding register | WP-18A |
-| WP-20 | planned | Release ceremony | Complete release closure and next handoff | release evidence and next handoff | WP-19 |
+| WP-20 | planned | Release ceremony | Complete release closure and next handoff | release evidence, end-of-milestone report, and next handoff | WP-19 |
 
 ## Compression Candidate
 

--- a/docs/milestones/v0.90.5/WP_EXECUTION_READINESS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/WP_EXECUTION_READINESS_v0.90.5.md
@@ -338,6 +338,7 @@ Required validation:
 Required outputs:
 
 - Release notes updated from actual evidence.
+- End-of-milestone report written and stored in the local planning lane or other explicitly designated closeout surface.
 - Changelog, README, Cargo metadata, feature list, milestone checklist, review
   records, and issue closeout state aligned.
 - Ceremony script run using the milestone's accepted closeout pattern.

--- a/docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml
+++ b/docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml
@@ -142,5 +142,5 @@ work_packages:
     issue: planned
     title: Release ceremony
     queue: release
-    outcome: release evidence and next handoff
+    outcome: release evidence, end-of-milestone report, and next handoff
     depends_on: WP-19

--- a/docs/templates/RELEASE_PLAN_TEMPLATE.md
+++ b/docs/templates/RELEASE_PLAN_TEMPLATE.md
@@ -10,6 +10,29 @@
 - Execute sections in order and capture links for each completed step.
 - Keep this doc focused on shipping mechanics; use release notes for narrative.
 - Mark blockers immediately; do not publish until gates pass.
+- Ceremony is a confirmation and publication phase, not a hidden implementation
+  phase.
+
+## 0) Release-Tail Convergence
+- [ ] Live trackers refreshed and reflected honestly:
+  - coverage/test tracker
+  - Rust module watch / refactoring tracker
+  - any active milestone-specific gap/risk tracker
+- [ ] Gap analysis refreshed or explicitly confirmed still current
+- [ ] Closed-issue closeout pass refreshed so issue/card truth is not stale
+- [ ] Release-truth docs aligned:
+  - `README.md`
+  - `CHANGELOG.md`
+  - `Cargo.toml`
+  - `REVIEW.md`
+  - feature list
+  - milestone checklist
+  - release plan
+  - release notes
+- [ ] Review artifacts collected and review disposition reflected truthfully
+- [ ] End-of-milestone report written or refreshed (`{{end_of_milestone_report_link}}`)
+- [ ] Next-milestone handoff prepared before ceremony starts
+- [ ] Any remaining work is either landed, explicitly deferred, or routed
 
 ## 1) Release Readiness
 - [ ] Milestone checklist complete (`{{milestone_checklist_link}}`)
@@ -41,6 +64,7 @@
 - [ ] Roadmap/status updated (`{{roadmap_update_link}}`)
 
 ## Exit Criteria
+- No hidden implementation or unresolved truth-maintenance work remains in the ceremony phase.
 - Tag and GitHub Release are published and accessible.
 - Verification completed with no unknown critical failures.
 - Communication links captured.


### PR DESCRIPTION
## What changed
- updated the v0.90.3 WP-20 release-tail surfaces so the ceremony now explicitly owns the end-of-milestone report
- refreshed v0.90.3 release readiness with the current tracker and closeout truth
- carried the end-of-milestone report requirement forward into the v0.90.4, v0.90.5, and release-plan template ceremony pattern

## Why it changed
- WP-20 needed to reflect the real ceremony inputs before closeout
- the test/coverage tracker, Rust watch tracker, and closeout wave are now finished and should be recorded truthfully instead of as in-progress tail work
- we want the end-of-milestone report to become a standard part of release ceremony going forward

## Impact
- v0.90.3 ceremony surfaces now point at the current release-tail truth
- the milestone checklist now records the report as complete
- future milestone packages now expect an end-of-milestone report during release ceremony

## Validation
- `git diff --check`
- YAML parse check for `docs/milestones/v0.90.4/WP_ISSUE_WAVE_v0.90.4.yaml`
- YAML parse check for `docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml`



Closes #2347
