### PR TITLE
Backlog docs: add rustdoc coverage for runtime and control-plane surfaces

### DIFF
--- a/adl/src/control_plane.rs
+++ b/adl/src/control_plane.rs
@@ -1,6 +1,15 @@
+//! Workflow tooling helpers for ADL issue and worktree path resolution.
+//!
+//! This module converts issue identifiers into concrete task cards, branch names,
+//! and worktree checkout locations used across the ADL PR lifecycle.
+
 use anyhow::{anyhow, Result};
 use std::path::{Path, PathBuf};
 
+/// Canonical reference to an ADL issue and its workflow-local artifacts.
+///
+/// The helper exposes validated identifiers and deterministic path derivation for
+/// issue prompts, task bundles, and branch names.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IssueRef {
     issue_number: u32,
@@ -9,6 +18,11 @@ pub struct IssueRef {
 }
 
 impl IssueRef {
+    /// Build a validated `IssueRef` from user-supplied metadata.
+    ///
+    /// `scope` must be non-empty, and `slug` is normalized to a workflow-safe
+    /// form before being stored. The error contract is intentionally strict for
+    /// deterministic path construction.
     pub fn new(
         issue_number: u32,
         scope: impl Into<String>,
@@ -33,26 +47,32 @@ impl IssueRef {
         self.issue_number
     }
 
+    /// Return the issue scope token associated with this issue record.
     pub fn scope(&self) -> &str {
         &self.scope
     }
 
+    /// Return the normalized slug used in branch/task filenames.
     pub fn slug(&self) -> &str {
         &self.slug
     }
 
+    /// Return a zero-padded issue number, used for legacy ADL task directory names.
     pub fn padded_issue_number(&self) -> String {
         format!("{:04}", self.issue_number)
     }
 
+    /// Derive the standard `issue-xxxx` task identifier.
     pub fn task_issue_id(&self) -> String {
         format!("issue-{}", self.padded_issue_number())
     }
 
+    /// Return the canonical task bundle directory name used by the lifecycle tools.
     pub fn task_bundle_dir_name(&self) -> String {
         format!("{}__{}", self.task_issue_id(), self.slug)
     }
 
+    /// Resolve the source issue prompt path in the workflow scope.
     pub fn issue_prompt_path(&self, repo_root: &Path) -> PathBuf {
         repo_root
             .join(".adl")
@@ -97,6 +117,7 @@ impl IssueRef {
         format!("{prefix}/{}-{}", self.issue_number, self.slug)
     }
 
+    /// Return the default worktree directory for this issue.
     pub fn default_worktree_path(
         &self,
         primary_checkout_root: &Path,
@@ -117,6 +138,10 @@ impl IssueRef {
     }
 }
 
+/// Normalize a human-facing slug into a workflow-safe path segment.
+///
+/// The function keeps only lower-case alphanumerics and collapses all other
+/// characters to single dash separators, trimming leading/trailing separators.
 pub fn sanitize_slug(raw: impl AsRef<str>) -> String {
     let mut out = String::new();
     let mut last_was_dash = false;
@@ -176,6 +201,7 @@ pub fn resolve_primary_checkout_root(current_top: &Path, git_common_dir: Option<
     current_top.to_path_buf()
 }
 
+/// Resolve cards root from explicit override or default `.adl/cards`.
 pub fn resolve_cards_root(
     primary_checkout_root: &Path,
     cards_root_override: Option<&Path>,

--- a/adl/src/execute/mod.rs
+++ b/adl/src/execute/mod.rs
@@ -1,3 +1,8 @@
+//! Execution entrypoints and orchestration for resolved ADL run plans.
+//!
+//! Provides the public API for sequential and deterministic concurrent execution,
+//! resume handling, and step-level tracing/outputs.
+
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -62,6 +67,10 @@ pub fn execute_sequential(
     )
 }
 
+/// Execute a resolved plan with optional resume state.
+///
+/// This variant preserves deterministic execution semantics while allowing
+/// resumed runs to validate prior step completion state before continuing.
 pub fn execute_sequential_with_resume(
     resolved: &AdlResolved,
     tr: &mut Trace,

--- a/adl/src/execute/runner.rs
+++ b/adl/src/execute/runner.rs
@@ -1,3 +1,8 @@
+//! Core execution scheduling internals and delegation policy enforcement.
+//!
+//! This module implements deterministic setup, step execution dispatch, and
+//! delegation policy checks that produce stable execution outcomes.
+
 use super::*;
 
 use crate::bounded_executor;
@@ -24,6 +29,7 @@ pub(super) struct StepRunFailure {
 type StepJob = Box<dyn FnOnce() -> (String, Result<StepRunSuccess>) + Send>;
 
 pub const DELEGATION_POLICY_DENY_CODE: &str = "DELEGATION_POLICY_DENY";
+/// Error code used when an explicit approval decision is required.
 pub const DELEGATION_POLICY_APPROVAL_REQUIRED_CODE: &str = "DELEGATION_POLICY_APPROVAL_REQUIRED";
 
 #[derive(Debug)]
@@ -165,6 +171,7 @@ pub(super) fn effective_max_concurrency_with_source(
     Ok((max_parallel, source))
 }
 
+/// Return effective concurrency policy for the run when concurrent execution is in use.
 pub fn scheduler_policy_for_run(
     resolved: &AdlResolved,
 ) -> Result<Option<(usize, SchedulerPolicySource)>> {

--- a/adl/src/execute/state/contracts.rs
+++ b/adl/src/execute/state/contracts.rs
@@ -1,3 +1,8 @@
+//! Public contract types for execution phases, boundaries, and step artifacts.
+//!
+//! These APIs define trace-referenced lifecycle and boundary enums plus the
+//! execution result envelope used by tracing and resume flows.
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -7,6 +12,10 @@ use crate::sandbox;
 
 use super::{PauseState, RuntimeControlState, SteeringRecord};
 
+/// Resolve `@file:` inputs into in-memory, validated input values.
+///
+/// Inputs are loaded and normalized deterministically with explicit size limits
+/// and sandbox path checks.
 pub fn materialize_inputs(
     mut inputs: HashMap<String, String>,
     base_dir: &Path,
@@ -99,6 +108,7 @@ pub const MATERIALIZE_INPUT_MAX_FILE_BYTES: u64 = 512 * 1024;
 pub(crate) const DEFAULT_MAX_CONCURRENCY: usize = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Execution lifecycle markers emitted in traces.
 pub enum RuntimeLifecyclePhase {
     Init,
     Execute,
@@ -117,6 +127,7 @@ impl RuntimeLifecyclePhase {
     }
 }
 
+/// Runtime execution boundaries traversed during execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionBoundary {
     RuntimeInit,
@@ -138,6 +149,7 @@ impl ExecutionBoundary {
     }
 }
 
+/// Scheduler policy source used for concurrency selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchedulerPolicySource {
     WorkflowOverride,

--- a/adl/src/execute/state/mod.rs
+++ b/adl/src/execute/state/mod.rs
@@ -1,3 +1,5 @@
+//! Execution state model for deterministic workflow execution and resume control.
+
 mod contracts;
 mod policy;
 mod runtime_control;

--- a/adl/src/execute/state/policy.rs
+++ b/adl/src/execute/state/policy.rs
@@ -1,3 +1,5 @@
+//! Execution policy errors and stable classification codes.
+
 use super::super::DELEGATION_POLICY_DENY_CODE;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,6 +21,7 @@ pub struct ExecutionPolicyError {
 }
 
 impl ExecutionPolicyError {
+    /// Convert the error variant to a short stable error code.
     pub fn code(&self) -> &'static str {
         match self.kind {
             ExecutionPolicyErrorKind::Denied => DELEGATION_POLICY_DENY_CODE,
@@ -59,6 +62,7 @@ impl std::fmt::Display for ExecutionPolicyError {
 
 impl std::error::Error for ExecutionPolicyError {}
 
+/// Map execution policy errors to a stable failure classification.
 pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
     for cause in err.chain() {
         if cause.downcast_ref::<ExecutionPolicyError>().is_some() {

--- a/adl/src/execute/state/runtime_control.rs
+++ b/adl/src/execute/state/runtime_control.rs
@@ -1,3 +1,8 @@
+//! Runtime control surface used to derive bounded execution telemetry and routing state.
+//!
+/// Execution state is derived deterministically from step records and trace signals
+/// to provide machine-readable status and control diagnostics.
+
 use std::collections::HashSet;
 
 use crate::artifacts;
@@ -31,6 +36,7 @@ struct RuntimeSignalEvidence {
     scheduler_max_parallel_observed: usize,
 }
 
+/// Build a deterministic execution-control snapshot from step outputs and trace signals.
 pub fn derive_runtime_control_state(
     overall_status: &str,
     records: &[StepExecutionRecord],
@@ -104,6 +110,7 @@ fn collect_runtime_signal_evidence(
         scheduler_max_parallel_observed,
     }
 }
+
 
 fn compute_max_parallel_observed_from_trace(tr: &trace::Trace) -> usize {
     let mut active: HashSet<&str> = HashSet::new();
@@ -465,6 +472,7 @@ fn derive_agency_selection_state(
     }
 }
 
+/// Build the first-class instinctive control template used by downstream selection logic.
 pub fn select_instinct_runtime_candidate(
     selected_path: SelectedPath,
     dominant_instinct: DominantInstinct,

--- a/adl/src/execute/state/runtime_control.rs
+++ b/adl/src/execute/state/runtime_control.rs
@@ -2,7 +2,6 @@
 //!
 /// Execution state is derived deterministically from step records and trace signals
 /// to provide machine-readable status and control diagnostics.
-
 use std::collections::HashSet;
 
 use crate::artifacts;
@@ -110,7 +109,6 @@ fn collect_runtime_signal_evidence(
         scheduler_max_parallel_observed,
     }
 }
-
 
 fn compute_max_parallel_observed_from_trace(tr: &trace::Trace) -> usize {
     let mut active: HashSet<&str> = HashSet::new();

--- a/adl/src/execute/state/steering.rs
+++ b/adl/src/execute/state/steering.rs
@@ -1,8 +1,11 @@
+//! Resume steering model for execution pause and resume control state.
+
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
+/// Snapshot of a paused execution state and deferred continuation plan.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PauseState {
     pub paused_step_id: String,
@@ -13,6 +16,7 @@ pub struct PauseState {
     pub completed_outputs: HashMap<String, String>,
 }
 
+/// Mutable state persisted across resume attempts.
 #[derive(Debug, Clone, Default)]
 pub struct ResumeState {
     pub completed_step_ids: HashSet<String>,
@@ -21,6 +25,7 @@ pub struct ResumeState {
     pub steering_history: Vec<SteeringRecord>,
 }
 
+/// Declarative steering patch applied at the configured resume boundary.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct SteeringPatch {
@@ -34,6 +39,7 @@ pub struct SteeringPatch {
     pub remove_state: Vec<String>,
 }
 
+/// Applied steering operation record for deterministic audit trails.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct SteeringRecord {
@@ -51,6 +57,7 @@ pub struct SteeringRecord {
 pub const STEERING_PATCH_SCHEMA_VERSION: &str = "steering_patch.v1";
 pub const STEERING_APPLY_AT_RESUME_BOUNDARY: &str = "resume_boundary";
 
+/// Validate a steering patch for schema, application boundary, and basic key rules.
 pub fn validate_steering_patch(patch: &SteeringPatch) -> Result<()> {
     if patch.schema_version != STEERING_PATCH_SCHEMA_VERSION {
         return Err(anyhow!(
@@ -103,6 +110,7 @@ pub fn validate_steering_patch(patch: &SteeringPatch) -> Result<()> {
     Ok(())
 }
 
+/// Build a persisted steering record from an applied steering patch.
 pub fn steering_record_from_patch(
     sequence: u32,
     payload_fingerprint: String,
@@ -124,6 +132,7 @@ pub fn steering_record_from_patch(
     }
 }
 
+/// Apply a steering patch to resume state and record the resulting deterministic patch history.
 pub fn apply_steering_patch(
     resume: &mut ResumeState,
     patch: &SteeringPatch,

--- a/adl/src/instrumentation.rs
+++ b/adl/src/instrumentation.rs
@@ -1,3 +1,8 @@
+//! Trace instrumentation and replay normalization helpers.
+//!
+//! This module exposes graph exports, event formatting, and trace normalization
+//! utilities used by replay, diagnostics, and CI evidence generation.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
@@ -20,6 +25,7 @@ pub use trace_normalization::normalize_trace_events;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", deny_unknown_fields)]
+/// Stable, normalized event shape consumed by replay and diff tooling.
 pub enum TraceEventNormalized {
     LifecyclePhaseEntered {
         phase: String,
@@ -112,6 +118,7 @@ pub enum TraceEventNormalized {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Replay projection of step lifecycle ordering.
 pub struct TraceReplay {
     pub step_started_order: Vec<String>,
     pub step_finished_order: Vec<String>,
@@ -120,6 +127,7 @@ pub struct TraceReplay {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Diff of two execution plan or trace graphs.
 pub struct PlanDiff {
     pub added_nodes: Vec<String>,
     pub removed_nodes: Vec<String>,
@@ -128,6 +136,7 @@ pub struct PlanDiff {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Diff of two normalized trace traces.
 pub struct TraceDiff {
     pub changed_indices: Vec<usize>,
     pub left_only: Vec<String>,
@@ -158,6 +167,7 @@ impl std::fmt::Display for ReplayInvariantError {
 
 impl std::error::Error for ReplayInvariantError {}
 
+/// Activation-log wrapper version; kept stable for replay diff comparability.
 pub const ACTIVATION_LOG_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -177,6 +187,7 @@ struct ActivationLogArtifact {
     events: Vec<TraceEventNormalized>,
 }
 
+/// Serialize a raw trace into a canonical activation-log artifact on disk.
 pub fn write_trace_artifact(path: &Path, events: &[TraceEvent]) -> Result<()> {
     let normalized = normalize_trace_events(events);
     let artifact = ActivationLogArtifact {
@@ -194,6 +205,7 @@ pub fn write_trace_artifact(path: &Path, events: &[TraceEvent]) -> Result<()> {
         .with_context(|| format!("failed writing trace artifact '{}'", path.display()))
 }
 
+/// Classify a trace invariant error into a replay-facing failure code.
 pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
     for cause in err.chain() {
         if cause.downcast_ref::<ReplayInvariantError>().is_some() {
@@ -203,6 +215,7 @@ pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
     None
 }
 
+/// Load a normalized activation-log trace artifact for replay or validation.
 pub fn load_trace_artifact(path: &Path) -> Result<Vec<TraceEventNormalized>> {
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed reading trace artifact '{}'", path.display()))?;
@@ -261,6 +274,7 @@ pub fn load_trace_artifact(path: &Path) -> Result<Vec<TraceEventNormalized>> {
     }
 }
 
+/// Derive execution-order summaries from normalized event streams.
 pub fn replay_trace(events: &[TraceEventNormalized]) -> TraceReplay {
     let mut step_started_order = Vec::new();
     let mut step_finished_order = Vec::new();

--- a/adl/src/instrumentation/graph.rs
+++ b/adl/src/instrumentation/graph.rs
@@ -1,20 +1,25 @@
+//! Execution-plan graph projections used for trace and plan visualization.
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::execution_plan::ExecutionPlan;
 
+/// Node metadata for execution-plan exports.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GraphNode {
     pub id: String,
     pub save_as: Option<String>,
 }
 
+/// Directed edge payload for execution-plan dependency graphs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GraphEdge {
     pub from: String,
     pub to: String,
 }
 
+/// Full graph export used by DOT/JSON renderers.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GraphExport {
     pub workflow_kind: String,
@@ -52,11 +57,13 @@ pub fn export_graph(plan: &ExecutionPlan) -> GraphExport {
     }
 }
 
+/// Export graph data in deterministic JSON for replay and CI artifacts.
 pub fn export_graph_json(plan: &ExecutionPlan) -> Result<String> {
     let graph = export_graph(plan);
     serde_json::to_string_pretty(&graph).context("serialize graph json")
 }
 
+/// Export graph data to Graphviz DOT for quick structural inspection.
 pub fn export_graph_dot(plan: &ExecutionPlan) -> String {
     let graph = export_graph(plan);
     let mut out = String::new();

--- a/adl/src/instrumentation/trace_formatting.rs
+++ b/adl/src/instrumentation/trace_formatting.rs
@@ -1,5 +1,8 @@
+//! Deterministic formatting utilities for normalized instrumentation events.
+
 use super::TraceEventNormalized;
 
+/// Render one normalized event into a stable single-line string.
 pub fn format_normalized_event(ev: &TraceEventNormalized) -> String {
     match ev {
         TraceEventNormalized::LifecyclePhaseEntered { phase } => {

--- a/adl/src/instrumentation/trace_normalization.rs
+++ b/adl/src/instrumentation/trace_normalization.rs
@@ -1,6 +1,9 @@
+//! Mapping from runtime events to normalized replay events.
+
 use super::TraceEventNormalized;
 use crate::trace::TraceEvent;
 
+/// Normalize raw runtime trace events into replay-safe normalized events.
 pub fn normalize_trace_events(events: &[TraceEvent]) -> Vec<TraceEventNormalized> {
     events
         .iter()

--- a/adl/src/runtime_v2/access_control.rs
+++ b/adl/src/runtime_v2/access_control.rs
@@ -1,3 +1,9 @@
+//! Runtime-v2 access-control contracts and evidence artifacts.
+//!
+//! This module models authority boundaries for runtime services, action-level
+//! access decisions, and machine-readable proof artifacts used to validate denial
+//! and approval behavior in reviews.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/boot_admission.rs
+++ b/adl/src/runtime_v2/boot_admission.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 boot and admission artifacts.
+//!
+//! Defines the initial boot manifest, citizen roster, and admission trace
+//! contract records for CSM entry and readiness checks.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/challenge.rs
+++ b/adl/src/runtime_v2/challenge.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 continuity challenge and review pathways.
+//!
+//! This module covers challenge artifacts, freeze records, and appeal review
+//! structures used to reason about continuity transitions and risk control.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/citizen.rs
+++ b/adl/src/runtime_v2/citizen.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 citizen lifecycle contracts and index records.
+//!
+//! This module exposes canonical records for provisional citizens, lifecycle
+//! indices, and helper constructors used by higher-level runtime-v2 proofs.
+
 use super::*;
 impl RuntimeV2CitizenLifecycleArtifacts {
     pub fn prototype(manifold: &RuntimeV2ManifoldRoot) -> Result<Self> {

--- a/adl/src/runtime_v2/contracts.rs
+++ b/adl/src/runtime_v2/contracts.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 shared contract types and validation-facing structures.
+//!
+//! The public surface in this module is used as the typed backbone for
+//! manifold, kernel, snapshot, and citizen artifact contracts.
+
 use super::*;
 pub fn runtime_v2_manifold_contract() -> Result<RuntimeV2ManifoldRoot> {
     RuntimeV2ManifoldRoot::prototype("proto-csm-01")

--- a/adl/src/runtime_v2/csm_run.rs
+++ b/adl/src/runtime_v2/csm_run.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 CSM run packet contracts and policy checkpoints.
+//!
+//! Provides schema/version contracts for run manifests and related trace
+//! entries consumed by boot, manifold, and operator control checks.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/feature_proof_coverage.rs
+++ b/adl/src/runtime_v2/feature_proof_coverage.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 feature proof coverage artifacts.
+//!
+//! Defines explicit proof packets and coverage summaries used to represent
+//! feature-level verification outcomes in a replayable format.
+
 use super::*;
 
 pub const RUNTIME_V2_FEATURE_PROOF_COVERAGE_SCHEMA: &str = "runtime_v2.feature_proof_coverage.v2";

--- a/adl/src/runtime_v2/foundation.rs
+++ b/adl/src/runtime_v2/foundation.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 foundation proof packet assembly.
+//!
+//! Produces foundational proof artifacts and cross-subsystem checks used by WP-06/07/
+//! and adjacent Runtime-v2 milestone documentation flows.
+
 use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};

--- a/adl/src/runtime_v2/governed_episode.rs
+++ b/adl/src/runtime_v2/governed_episode.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 governed episode and bounded citizen participation model.
+//!
+//! This file documents episode-level manifests and behavior around lifecycle
+//! transitions subject to governance policies.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/hardening.rs
+++ b/adl/src/runtime_v2/hardening.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 hardening artifacts and checks.
+//!
+//! Captures explicit hardening evidence and structured outputs for hardening
+//! controls, constraints, and review-ready checkpoints.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/integrated_csm_run.rs
+++ b/adl/src/runtime_v2/integrated_csm_run.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 integrated CSM run artifacts and execution recorders.
+//!
+//! Defines the integrated contract surface used after candidate admission and
+//! before steady-state manifold and kernel operations.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/invariant.rs
+++ b/adl/src/runtime_v2/invariant.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 invariant definitions and proof records.
+//!
+//! Defines invariants, enforcement signals, and report shapes used to determine
+//! whether a run state remains acceptable to continue execution.
+
 use super::*;
 impl RuntimeV2InvariantViolationArtifact {
     pub fn duplicate_active_citizen_prototype(

--- a/adl/src/runtime_v2/invariant_contract.rs
+++ b/adl/src/runtime_v2/invariant_contract.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 invariant contract artifacts.
+//!
+//! Bundles invariant definitions, failure envelopes, and validation contracts
+//! used by the invariant-checking workflow.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/kernel_loop.rs
+++ b/adl/src/runtime_v2/kernel_loop.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 kernel loop contracts and service-loop state artifacts.
+//!
+//! Documents the public contract used by the service loop for service registry,
+//! execution state, and event tracking.
+
 use super::*;
 impl RuntimeV2KernelLoopArtifacts {
     pub fn prototype(manifold: &RuntimeV2ManifoldRoot) -> Result<Self> {

--- a/adl/src/runtime_v2/manifold.rs
+++ b/adl/src/runtime_v2/manifold.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 manifold and proof-surface contracts.
+//!
+//! This module defines manifold-root and manifold-linked proof artifacts that
+//! bind together kernel, citizens, invariants, and observability surfaces.
+
 use super::*;
 impl RuntimeV2ManifoldRoot {
     pub fn prototype(manifold_id: impl Into<String>) -> Result<Self> {

--- a/adl/src/runtime_v2/mod.rs
+++ b/adl/src/runtime_v2/mod.rs
@@ -1,3 +1,9 @@
+//! Runtime v2 public surface for core operational APIs and proof artifacts.
+//!
+//! This module groups the prototype runtime domain into smaller documented surfaces:
+//! manifold state, kernel control, citizen lifecycle, private-state pathways,
+//! and proof-bearing contracts used by downstream review tooling.
+
 mod access_control;
 mod boot_admission;
 mod challenge;

--- a/adl/src/runtime_v2/observatory.rs
+++ b/adl/src/runtime_v2/observatory.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 observatory data structures and projection artifacts.
+//!
+//! Provides types describing the observatory projection path and review-facing
+//! telemetry checkpoints for private-state and continuity operations.
+
 use std::path::Path;
 
 use crate::csm_observatory::{

--- a/adl/src/runtime_v2/observatory_flagship.rs
+++ b/adl/src/runtime_v2/observatory_flagship.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 flagship observatory contract and report artifacts.
+//!
+//! Captures flagship observatory surfaces used as a reduced proof set for
+//! review and cross-boundary integration checkpoints.
+
 use super::*;
 use std::collections::BTreeSet;
 use std::path::Path;

--- a/adl/src/runtime_v2/operator.rs
+++ b/adl/src/runtime_v2/operator.rs
@@ -1,3 +1,7 @@
+//! Runtime-v2 operator control and command artifacts.
+//! Exposes operator-facing proof artifacts, checks, and status surfaces used to
+//! assert bounded operator interventions.
+
 use super::*;
 impl RuntimeV2OperatorControlReport {
     pub fn prototype(

--- a/adl/src/runtime_v2/private_state.rs
+++ b/adl/src/runtime_v2/private_state.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state contract primitives.
+//!
+//! Describes private-state references, lifecycle metadata, and serialization-safe
+//! payloads for privacy-sensitive execution flow.
+
 use super::*;
 use sha2::{Digest, Sha256};
 

--- a/adl/src/runtime_v2/private_state_envelope.rs
+++ b/adl/src/runtime_v2/private_state_envelope.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state envelope validation and packaging.
+//!
+//! Defines the envelope structures used to encode private-state provenance and
+//! persistence boundaries across trace and snapshot operations.
+
 use super::*;
 use base64::Engine;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};

--- a/adl/src/runtime_v2/private_state_equivocation.rs
+++ b/adl/src/runtime_v2/private_state_equivocation.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state equivocation evidence.
+//!
+//! Covers evidence records and report artifacts for equivocation events and
+//! handling paths in replayable runtime proofs.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/private_state_lineage.rs
+++ b/adl/src/runtime_v2/private_state_lineage.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state lineage tracking.
+//!
+//! Documents lineage references and continuity chain metadata used to prove
+//! deterministic private-state evolution across state transitions.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/private_state_observatory.rs
+++ b/adl/src/runtime_v2/private_state_observatory.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state observatory contract and projections.
+//!
+//! Provides observability structures for private-state projection requests,
+//! snapshots, and proof-related checks.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/private_state_sanctuary.rs
+++ b/adl/src/runtime_v2/private_state_sanctuary.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state sanctuary and protection envelope.
+//!
+//! Defines sanctuary-boundary rules and records for sensitive continuity and
+//! continuity-state safety checks.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/private_state_sealing.rs
+++ b/adl/src/runtime_v2/private_state_sealing.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state sealing and transition contracts.
+//!
+//! Defines seal/unseal style records and transitions used to close or restore
+//! sensitive private-state operations in a reviewable manner.
+
 use super::*;
 use base64::Engine;
 use sha2::{Digest, Sha256};

--- a/adl/src/runtime_v2/private_state_witness.rs
+++ b/adl/src/runtime_v2/private_state_witness.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 private-state witness material and evidentiary hashes.
+//!
+//! Covers witness artifacts and witness-set validation used to support replayed
+//! continuity and private-state checks.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/quarantine.rs
+++ b/adl/src/runtime_v2/quarantine.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 quarantine and release surfaces.
+//!
+//! Provides quarantine packet contracts and release validation checks used to
+//! model temporarily constrained runtime behavior.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/recovery.rs
+++ b/adl/src/runtime_v2/recovery.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 recovery eligibility and rehydration surfaces.
+//!
+//! Documents recovery artifact contracts and constraints that gate resumed
+//! execution after invariant and continuity transitions.
+
 use std::path::Path;
 
 use super::*;

--- a/adl/src/runtime_v2/security.rs
+++ b/adl/src/runtime_v2/security.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 security-boundary contracts and operator refusal artifacts.
+//!
+//! Defines security-boundary proof packets and related invariants used by
+//! resume gating and operator control policy checks.
+
 use super::*;
 impl RuntimeV2SecurityBoundaryProofPacket {
     pub fn refused_resume_without_invariant_prototype(

--- a/adl/src/runtime_v2/snapshot.rs
+++ b/adl/src/runtime_v2/snapshot.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 snapshot and rehydration contracts.
+//!
+//! Captures canonical snapshot manifests and rehydration reports consumed by
+//! wake/resume workflows and snapshot validation.
+
 use super::*;
 impl RuntimeV2SnapshotAndRehydrationArtifacts {
     pub fn prototype(

--- a/adl/src/runtime_v2/standing.rs
+++ b/adl/src/runtime_v2/standing.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 standing classes and standing-policy evidence.
+//!
+//! Defines standing classifications, access rights examples, and negative-case
+//! fixtures for policy- and communication-focused controls.
+
 use super::*;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;

--- a/adl/src/runtime_v2/types.rs
+++ b/adl/src/runtime_v2/types.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 core schema types and shared artifact record graph.
+//!
+//! Holds the canonical type system for manifold, kernel, citizen, snapshot, and
+//! security-boundary records shared across Runtime-v2 public APIs.
+
 use serde::{Deserialize, Serialize};
 
 pub const RUNTIME_V2_MANIFOLD_SCHEMA: &str = "runtime_v2.manifold.v1";

--- a/adl/src/runtime_v2/validators.rs
+++ b/adl/src/runtime_v2/validators.rs
@@ -1,3 +1,8 @@
+//! Runtime-v2 shared validation helpers.
+//!
+//! Contains internal helpers used by runtime-v2 validation paths to enforce
+//! stable identifiers, lifecycle values, and repository-relative paths.
+
 use super::*;
 pub(crate) fn normalize_id(value: String, field: &str) -> Result<String> {
     let trimmed = value.trim();

--- a/adl/src/trace.rs
+++ b/adl/src/trace.rs
@@ -1,9 +1,19 @@
+//! Deterministic trace-event stream used across execution and replay tooling.
+//!
+//! `Trace` is the main in-memory event log for runtime execution, while
+//! `TraceEvent` captures concrete lifecycle, delegation, and step transitions
+//! used for artifact replay and audit.
+
 use std::collections::HashMap;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::adl::DelegationSpec;
 use crate::execute::{ExecutionBoundary, RuntimeLifecyclePhase};
 
+/// In-memory execution trace captured during runtime operation.
+///
+/// A `Trace` stores high-level lifecycle markers and step-level telemetry in an
+/// append-only sequence, including timings for replay-friendly review.
 #[derive(Debug, Clone)]
 pub struct Trace {
     pub run_id: String,
@@ -18,6 +28,10 @@ pub struct Trace {
 }
 
 #[derive(Debug, Clone)]
+/// Canonical trace event model emitted by runtime execution.
+///
+/// Variants are intentionally stable and replay-oriented. Additional variants
+/// should preserve naming conventions and include bounded human-readable fields.
 pub enum TraceEvent {
     LifecyclePhaseEntered {
         ts_ms: u128,
@@ -147,6 +161,7 @@ pub enum TraceEvent {
 }
 
 impl TraceEvent {
+    /// Convert an event to a short, stable summary string for logs and snapshots.
     pub fn summarize(&self) -> String {
         match self {
             TraceEvent::LifecyclePhaseEntered {
@@ -410,6 +425,10 @@ impl TraceEvent {
 }
 
 impl Trace {
+    /// Construct a new trace context for a run/workflow pair.
+    ///
+    /// `run_id` and `workflow_id` participate in replay artifact naming and
+    /// are emitted verbatim in trace output.
     pub fn new(
         run_id: impl Into<String>,
         workflow_id: impl Into<String>,
@@ -436,6 +455,7 @@ impl Trace {
             .unwrap_or(0)
     }
 
+    /// Record a phase transition in the runtime lifecycle.
     pub fn lifecycle_phase_entered(&mut self, phase: RuntimeLifecyclePhase) {
         let elapsed_ms = self.run_started_instant.elapsed().as_millis();
         let ts_ms = self.run_started_ms.saturating_add(elapsed_ms);
@@ -446,6 +466,7 @@ impl Trace {
         });
     }
 
+    /// Record a boundary transition such as runtime init, workflow call, or pause.
     pub fn execution_boundary_crossed(&mut self, boundary: ExecutionBoundary, state: &str) {
         let elapsed_ms = self.run_started_instant.elapsed().as_millis();
         let ts_ms = self.run_started_ms.saturating_add(elapsed_ms);
@@ -457,6 +478,7 @@ impl Trace {
         });
     }
 
+    /// Mark a step start with normalized actor/provider/task metadata.
     pub fn step_started(
         &mut self,
         step_id: &str,
@@ -649,6 +671,7 @@ impl Trace {
         });
     }
 
+    /// Record a terminal step result including success and duration.
     pub fn step_finished(&mut self, step_id: &str, success: bool) {
         let elapsed_ms = self.run_started_instant.elapsed().as_millis();
         let ts_ms = self.run_started_ms.saturating_add(elapsed_ms);
@@ -697,6 +720,7 @@ impl Trace {
         });
     }
 
+    /// Record final run completion.
     pub fn run_finished(&mut self, success: bool) {
         let elapsed_ms = self.run_started_instant.elapsed().as_millis();
         let ts_ms = self.run_started_ms.saturating_add(elapsed_ms);
@@ -707,10 +731,12 @@ impl Trace {
         });
     }
 
+    /// Return elapsed milliseconds from trace start to now.
     pub fn current_elapsed_ms(&self) -> u128 {
         self.run_started_instant.elapsed().as_millis()
     }
 
+    /// Return the current trace timestamp in wall-clock milliseconds.
     pub fn current_ts_ms(&self) -> u128 {
         self.run_started_ms
             .saturating_add(self.run_started_instant.elapsed().as_millis())


### PR DESCRIPTION
Closes #2444

## Summary
Ran a full rustdoc coverage pass across the requested Runtime-v2, control-plane,
execute, and trace/instrumentation surfaces. Added module docs for all required
runtime_v2 files in scope and added key API docs for core structs, enums, and entry
functions in `control_plane`, `trace`, `instrumentation`, and `execute`.

## Artifacts
- Updated runtime surface docs:
  - `adl/src/runtime_v2/mod.rs`
  - `adl/src/runtime_v2/access_control.rs`
  - `adl/src/runtime_v2/boot_admission.rs`
  - `adl/src/runtime_v2/challenge.rs`
  - `adl/src/runtime_v2/citizen.rs`
  - `adl/src/runtime_v2/contracts.rs`
  - `adl/src/runtime_v2/csm_run.rs`
  - `adl/src/runtime_v2/feature_proof_coverage.rs`
  - `adl/src/runtime_v2/foundation.rs`
  - `adl/src/runtime_v2/governed_episode.rs`
  - `adl/src/runtime_v2/hardening.rs`
  - `adl/src/runtime_v2/integrated_csm_run.rs`
  - `adl/src/runtime_v2/invariant.rs`
  - `adl/src/runtime_v2/invariant_contract.rs`
  - `adl/src/runtime_v2/kernel_loop.rs`
  - `adl/src/runtime_v2/manifold.rs`
  - `adl/src/runtime_v2/observatory.rs`
  - `adl/src/runtime_v2/observatory_flagship.rs`
  - `adl/src/runtime_v2/operator.rs`
  - `adl/src/runtime_v2/private_state.rs`
  - `adl/src/runtime_v2/private_state_envelope.rs`
  - `adl/src/runtime_v2/private_state_equivocation.rs`
  - `adl/src/runtime_v2/private_state_lineage.rs`
  - `adl/src/runtime_v2/private_state_observatory.rs`
  - `adl/src/runtime_v2/private_state_sanctuary.rs`
  - `adl/src/runtime_v2/private_state_sealing.rs`
  - `adl/src/runtime_v2/private_state_witness.rs`
  - `adl/src/runtime_v2/quarantine.rs`
  - `adl/src/runtime_v2/recovery.rs`
  - `adl/src/runtime_v2/security.rs`
  - `adl/src/runtime_v2/snapshot.rs`
  - `adl/src/runtime_v2/standing.rs`
  - `adl/src/runtime_v2/types.rs`
  - `adl/src/runtime_v2/validators.rs`
  - `adl/src/control_plane.rs`
  - `adl/src/trace.rs`
  - `adl/src/instrumentation.rs`
  - `adl/src/instrumentation/graph.rs`
  - `adl/src/instrumentation/trace_formatting.rs`
  - `adl/src/instrumentation/trace_normalization.rs`
  - `adl/src/execute/mod.rs`
  - `adl/src/execute/runner.rs`
  - `adl/src/execute/state/contracts.rs`
  - `adl/src/execute/state/mod.rs`
  - `adl/src/execute/state/policy.rs`
  - `adl/src/execute/state/runtime_control.rs`
  - `adl/src/execute/state/steering.rs`
- Output card file updated with validation and verification status.

## Validation
- Validation commands and their purpose:
  - `cargo doc --no-deps --manifest-path adl/Cargo.toml`: validated that generated rust docs succeed for the updated public API surfaces.
- Results: PASS; docs command completed successfully and wrote `adl/target/doc/adl/index.html`.

Validation command/path rules:
- No absolute paths were added to this output record.
- Commands are represented as repository-relative paths.
- `absolute_path_leakage_detected: false` confirmed by avoiding absolute host paths in records.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2444__v0-90-4-backlog-docs-add-rustdoc-coverage-for-runtime-and-control-plane-surfaces/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2444__v0-90-4-backlog-docs-add-rustdoc-coverage-for-runtime-and-control-plane-surfaces/sor.md
- Idempotency-Key: backlog-docs-add-rustdoc-coverage-for-runtime-and-control-plane-surfaces-adl-v0-90-4-tasks-issue-2444-v0-90-4-backlog-docs-add-rustdoc-coverage-for-runtime-and-control-plane-surfaces-sip-md-adl-v0-90-4-tasks-issue-2444-v0-90-4-backlog-docs-add-rustdoc-coverage-for-runtime-and-control-plane-surfaces-sor-md