### PR TITLE
[v0-90-4][backlog][docs] Add rustdoc coverage for schema and advanced subsystems

### DIFF
--- a/adl/src/adl.rs
+++ b/adl/src/adl.rs
@@ -1,3 +1,7 @@
+//! ADL document model and public loader APIs.
+//!
+//! This module defines the top-level `AdlDoc` structure and re-exports the
+//! schema-facing types that back ADL YAML loading, validation, and execution.
 use anyhow::{Context, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -19,6 +23,8 @@ pub use types::*;
 /// MVP v0.1 supports:
 /// - providers, tools, agents, tasks
 /// - a single `run` with a workflow
+///
+/// Use this as the authoritative in-memory representation for ADL YAML input.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AdlDoc {
     pub version: String,
@@ -48,7 +54,11 @@ pub struct AdlDoc {
 }
 
 impl AdlDoc {
-    /// Load an ADL YAML document from a file path.
+    /// Load and validate an ADL document from a file path.
+    ///
+    /// This is the canonical bootstrap path for local execution and tests:
+    /// it merges nested includes, validates schema, parses typed objects, and
+    /// runs semantic validation.
     ///
     /// Loading order:
     /// 1. expands top-level `include` files with deterministic merge semantics

--- a/adl/src/adl/types.rs
+++ b/adl/src/adl/types.rs
@@ -1,3 +1,7 @@
+//! ADL schema surface types.
+//!
+//! These public Rust structs and enums define the material contract for providers,
+//! task/workflow execution shapes, and policy wiring used by runtime and tooling.
 use anyhow::{anyhow, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -194,6 +198,9 @@ pub struct RunSpec {
 }
 
 impl RunSpec {
+    /// Resolve the effective workflow from either `workflow_ref` or inline `workflow`.
+    ///
+    /// This helper enforces that only one workflow selector is used per run.
     pub fn resolve_workflow<'a>(&'a self, doc: &'a AdlDoc) -> Result<&'a WorkflowSpec> {
         if self.pattern_ref.is_some() {
             return Err(anyhow!(
@@ -215,6 +222,7 @@ impl RunSpec {
     }
 }
 
+/// Default run-level knobs applied when a workflow omits local settings.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct RunDefaults {
@@ -228,6 +236,7 @@ pub struct RunDefaults {
     pub max_concurrency: Option<usize>,
 }
 
+/// Root delegation policy for run-time permission checks.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct DelegationPolicySpec {
@@ -247,6 +256,7 @@ impl Default for DelegationPolicySpec {
     }
 }
 
+/// Rule entry for explicit allow/deny overrides.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct DelegationPolicyRuleSpec {
@@ -262,6 +272,7 @@ pub struct DelegationPolicyRuleSpec {
     pub require_approval: bool,
 }
 
+/// Supported kinds of action that can be delegated.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DelegationActionKind {
@@ -284,6 +295,7 @@ impl DelegationActionKind {
     }
 }
 
+/// Delegation rule effect used by policy evaluators.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DelegationRuleEffect {

--- a/adl/src/chronosense.rs
+++ b/adl/src/chronosense.rs
@@ -1,3 +1,5 @@
+//! Chronosense contracts for temporal reasoning, continuity, and cognition-like
+//! runtime semantics.
 pub const IDENTITY_PROFILE_SCHEMA: &str = "identity_profile.v1";
 pub const TEMPORAL_CONTEXT_SCHEMA: &str = "temporal_context.v1";
 pub const CHRONOSENSE_FOUNDATION_SCHEMA: &str = "chronosense_foundation.v1";

--- a/adl/src/chronosense/causality.rs
+++ b/adl/src/chronosense/causality.rs
@@ -1,3 +1,4 @@
+//! Chronosense temporal causality contracts.
 use serde::{Deserialize, Serialize};
 
 use super::TEMPORAL_CAUSALITY_EXPLANATION_SCHEMA;

--- a/adl/src/chronosense/commitments.rs
+++ b/adl/src/chronosense/commitments.rs
@@ -1,3 +1,4 @@
+//! Chronosense commitment and deadline contract definitions.
 use serde::{Deserialize, Serialize};
 
 use super::COMMITMENT_DEADLINE_SCHEMA;

--- a/adl/src/chronosense/continuity.rs
+++ b/adl/src/chronosense/continuity.rs
@@ -1,3 +1,4 @@
+//! Chronosense continuity and resumption semantics.
 use serde::{Deserialize, Serialize};
 
 use super::CONTINUITY_SEMANTICS_SCHEMA;

--- a/adl/src/chronosense/foundation.rs
+++ b/adl/src/chronosense/foundation.rs
@@ -1,3 +1,4 @@
+//! Chronosense identity and temporal foundation contracts.
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Datelike, FixedOffset, Offset, Timelike, Utc};
 use chrono_tz::Tz;

--- a/adl/src/chronosense/instinct.rs
+++ b/adl/src/chronosense/instinct.rs
@@ -1,3 +1,4 @@
+//! Chronosense instinct model contracts and review surfaces.
 use serde::{Deserialize, Serialize};
 
 use super::{INSTINCT_MODEL_SCHEMA, INSTINCT_RUNTIME_SURFACE_SCHEMA};

--- a/adl/src/chronosense/phi.rs
+++ b/adl/src/chronosense/phi.rs
@@ -1,3 +1,4 @@
+//! Chronosense phi-integration and metric contracts.
 use serde::{Deserialize, Serialize};
 
 use super::PHI_INTEGRATION_METRICS_SCHEMA;

--- a/adl/src/chronosense/policy_cost.rs
+++ b/adl/src/chronosense/policy_cost.rs
@@ -1,3 +1,4 @@
+//! Chronosense cost policy and review-surface contracts.
 use serde::{Deserialize, Serialize};
 
 use super::{

--- a/adl/src/chronosense/retrieval.rs
+++ b/adl/src/chronosense/retrieval.rs
@@ -1,3 +1,4 @@
+//! Chronosense temporal retrieval contracts.
 use serde::{Deserialize, Serialize};
 
 use super::TEMPORAL_QUERY_RETRIEVAL_SCHEMA;

--- a/adl/src/chronosense/temporal_schema.rs
+++ b/adl/src/chronosense/temporal_schema.rs
@@ -1,3 +1,4 @@
+//! Chronosense temporal schema contract definitions.
 use serde::{Deserialize, Serialize};
 
 use super::TEMPORAL_SCHEMA_V01;

--- a/adl/src/chronosense/tests.rs
+++ b/adl/src/chronosense/tests.rs
@@ -1,3 +1,4 @@
+//! Test helpers for chronosense fixtures.
 use super::*;
 use chrono::{TimeZone, Utc};
 use std::{

--- a/adl/src/godel/affect_slice.rs
+++ b/adl/src/godel/affect_slice.rs
@@ -1,7 +1,7 @@
 //! Gödel affect-slice experiments and persisted candidate selection contracts.
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use serde::{Deserialize, Serialize};
 
 use super::hypothesis::PersistedHypothesisArtifact;
 use super::policy::PersistedPolicyArtifact;

--- a/adl/src/godel/affect_slice.rs
+++ b/adl/src/godel/affect_slice.rs
@@ -1,6 +1,6 @@
+//! Gödel affect-slice experiments and persisted candidate selection contracts.
 use std::fs;
 use std::path::{Path, PathBuf};
-
 use serde::{Deserialize, Serialize};
 
 use super::hypothesis::PersistedHypothesisArtifact;

--- a/adl/src/godel/canonical_evidence.rs
+++ b/adl/src/godel/canonical_evidence.rs
@@ -1,3 +1,4 @@
+//! Canonical evidence artifacts and schema checks for Gödel.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/cross_workflow.rs
+++ b/adl/src/godel/cross_workflow.rs
@@ -1,3 +1,4 @@
+//! Cross-workflow handoff artifacts and policy propagation contracts.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/evaluation.rs
+++ b/adl/src/godel/evaluation.rs
@@ -1,3 +1,4 @@
+//! Evaluation contracts used by the Gödel experiment loop.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/experiment_record.rs
+++ b/adl/src/godel/experiment_record.rs
@@ -1,3 +1,4 @@
+//! Gödel experiment record model and canonicalization helpers.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/mod.rs
+++ b/adl/src/godel/mod.rs
@@ -1,3 +1,7 @@
+//! Gödel experiment runtime surface.
+//!
+//! This subsystem coordinates failure analysis, hypothesis generation, mutation,
+//! evaluation, and promotion artifacts for the ADL runtime feedback loop.
 pub mod affect_slice;
 pub mod canonical_evidence;
 pub mod cross_workflow;
@@ -13,14 +17,17 @@ pub mod stage_loop;
 pub mod surface_status;
 pub mod workflow_template;
 
+/// Primary execution stages and runner state types for the Gödel pipeline.
 pub use stage_loop::{
     GodelStage, GodelStageLoopExecutor, StageLoopConfig, StageLoopError, StageLoopInput,
     StageLoopPersistenceResult, StageLoopRun,
 };
+/// Runtime status contract emitted by the Gödel status check.
 pub use surface_status::{
     load_v08_surface_status, repo_root_from_manifest, GodelRuntimeSurfaceStatus,
     GODEL_RUNTIME_STATUS_VERSION,
 };
+/// Workflow template parser/validator for Gödel experiment orchestration.
 pub use workflow_template::{
     embedded_v08_workflow_template, parse_workflow_template, GodelWorkflowTemplate,
 };

--- a/adl/src/godel/mutation.rs
+++ b/adl/src/godel/mutation.rs
@@ -1,3 +1,4 @@
+//! Mutation artifact contracts and canonical mutation records.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/obsmem_index.rs
+++ b/adl/src/godel/obsmem_index.rs
@@ -1,3 +1,4 @@
+//! Observation-memory index contracts for Gödel surface lookup.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/policy.rs
+++ b/adl/src/godel/policy.rs
@@ -1,3 +1,4 @@
+//! Policy artifacts, comparisons, and schema boundaries for Gödel runs.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/prioritization.rs
+++ b/adl/src/godel/prioritization.rs
@@ -1,3 +1,4 @@
+//! Experiment prioritization inputs and persisted ranking records.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/promotion.rs
+++ b/adl/src/godel/promotion.rs
@@ -1,3 +1,4 @@
+//! Promotion decision helpers and persisted evaluation artifacts.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/stage_loop.rs
+++ b/adl/src/godel/stage_loop.rs
@@ -1,3 +1,4 @@
+//! Gödel stage-loop orchestration and persistence contracts.
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};

--- a/adl/src/godel/surface_status.rs
+++ b/adl/src/godel/surface_status.rs
@@ -1,3 +1,4 @@
+//! Gödel surface status probe for v0.8+ compatibility checks.
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/adl/src/godel/workflow_template.rs
+++ b/adl/src/godel/workflow_template.rs
@@ -1,3 +1,4 @@
+//! Static embedded workflow template parser for Gödel stage orchestration.
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 

--- a/adl/src/long_lived_agent.rs
+++ b/adl/src/long_lived_agent.rs
@@ -1,3 +1,4 @@
+//! Long-lived agent orchestration surfaces.
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use serde_json::{json, Value};

--- a/adl/src/long_lived_agent/inspection.rs
+++ b/adl/src/long_lived_agent/inspection.rs
@@ -1,3 +1,4 @@
+//! Inspection packet generation for long-lived agent cycles.
 use super::{
     ledger_cursor, load_spec, path_artifact_ref, status, status_path, LoadedAgentSpec,
     INSPECTION_PACKET_SCHEMA,

--- a/adl/src/long_lived_agent/schema.rs
+++ b/adl/src/long_lived_agent/schema.rs
@@ -1,3 +1,4 @@
+//! Schema version constants and defaults for the long-lived agent subsystem.
 pub(crate) const SPEC_SCHEMA: &str = "adl.long_lived_agent_spec.v1";
 pub(crate) const LEASE_SCHEMA: &str = "adl.long_lived_agent_lease.v1";
 pub(crate) const STATUS_SCHEMA: &str = "adl.long_lived_agent_status.v1";

--- a/adl/src/long_lived_agent/storage.rs
+++ b/adl/src/long_lived_agent/storage.rs
@@ -1,3 +1,4 @@
+//! Persistent storage helpers for long-lived agent state artifacts.
 use super::schema::OPERATOR_EVENT_SCHEMA;
 use super::types::{LeaseRecord, LoadedAgentSpec, StatusRecord, StopRecord};
 use anyhow::{Context, Result};

--- a/adl/src/long_lived_agent/tests.rs
+++ b/adl/src/long_lived_agent/tests.rs
@@ -1,3 +1,4 @@
+//! Integration tests for long-lived agent execution and artifact invariants.
 use super::*;
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/adl/src/long_lived_agent/types.rs
+++ b/adl/src/long_lived_agent/types.rs
@@ -1,8 +1,10 @@
+//! Serializable configuration and state types for long-lived agents.
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
 
+/// Parsed configuration for one long-lived agent instance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSpec {
     pub schema: String,
@@ -17,6 +19,7 @@ pub struct AgentSpec {
     pub memory: Value,
 }
 
+/// Workflow selection for a long-lived agent spec.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowSpec {
     pub kind: String,
@@ -28,6 +31,7 @@ pub struct WorkflowSpec {
     pub run_args: Value,
 }
 
+/// Heartbeat configuration for recurring cycle execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HeartbeatSpec {
     #[serde(default)]
@@ -38,6 +42,7 @@ pub struct HeartbeatSpec {
     pub stale_lease_after_secs: Option<u64>,
 }
 
+/// Finite state for a running long-lived agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStatusState {
@@ -50,6 +55,7 @@ pub enum AgentStatusState {
     Completed,
 }
 
+/// Active lease details for one cycle.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LeaseRecord {
     pub schema: String,
@@ -63,12 +69,14 @@ pub struct LeaseRecord {
     pub status: String,
 }
 
+/// Error payload for stop records in status and run history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatusError {
     pub class: String,
     pub message: String,
 }
 
+/// Canonical status checkpoint written during agent runs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatusRecord {
     pub schema: String,
@@ -87,6 +95,7 @@ pub struct StatusRecord {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Stop request artifact persisted by operator/API calls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StopRecord {
     pub schema: String,
@@ -99,6 +108,7 @@ pub struct StopRecord {
     pub requested_at: DateTime<Utc>,
 }
 
+/// Resolved and normalized spec plus state paths after loading.
 #[derive(Debug, Clone)]
 pub struct LoadedAgentSpec {
     pub spec: AgentSpec,
@@ -106,11 +116,13 @@ pub struct LoadedAgentSpec {
     pub state_root: PathBuf,
 }
 
+/// Tick execution options for one iteration.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TickOptions {
     pub recover_stale_lease: bool,
 }
 
+/// Runtime control options for agent execution loops.
 #[derive(Debug, Clone, Copy)]
 pub struct RunOptions {
     pub max_cycles: u64,
@@ -119,6 +131,7 @@ pub struct RunOptions {
     pub recover_stale_lease: bool,
 }
 
+/// Inspection options for selecting a specific cycle.
 #[derive(Debug, Clone, Default)]
 pub struct InspectOptions {
     pub cycle_id: Option<String>,

--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -1,3 +1,6 @@
+//! HTTP-based provider implementations and request transport helpers.
+//!
+//! Supports OpenAI, Anthropic, generic HTTP, and Ollama-HTTP style backends.
 use super::*;
 use std::thread;
 use std::time::Duration;
@@ -43,6 +46,7 @@ fn acquire_invocation_artifact_lock(path: &Path) -> std::io::Result<InvocationAr
     ))
 }
 
+/// Maximum number of provider error-body characters kept for inline request-failure messages.
 const MAX_PROVIDER_ERROR_BODY_BYTES: usize = 200;
 
 fn truncate_provider_body(text: &str) -> String {
@@ -240,6 +244,7 @@ fn extract_anthropic_output_text(json: &Value) -> Option<String> {
 }
 
 #[derive(Debug, Clone)]
+/// OpenAI-compatible provider backed by HTTP/requests API.
 pub struct OpenAiProvider {
     endpoint: String,
     auth_env: String,
@@ -249,6 +254,7 @@ pub struct OpenAiProvider {
 }
 
 impl OpenAiProvider {
+    /// Build an OpenAI provider from normalized invocation target.
     pub fn from_target(
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,
@@ -307,6 +313,7 @@ impl Provider for OpenAiProvider {
 }
 
 #[derive(Debug, Clone)]
+/// Anthropic-compatible provider using the messages API format.
 pub struct AnthropicProvider {
     endpoint: String,
     auth_env: String,
@@ -316,6 +323,7 @@ pub struct AnthropicProvider {
 }
 
 impl AnthropicProvider {
+    /// Build an Anthropic provider from normalized invocation target.
     pub fn from_target(
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,
@@ -378,6 +386,7 @@ impl Provider for AnthropicProvider {
 }
 
 #[derive(Debug, Clone)]
+/// Generic HTTP provider for configurable endpoint + optional bearer auth.
 pub struct HttpProvider {
     endpoint: String,
     auth: Option<HttpAuth>,
@@ -386,6 +395,7 @@ pub struct HttpProvider {
 }
 
 #[derive(Debug, Clone)]
+/// Ollama-specific HTTP provider with prompt/model serialization.
 pub struct OllamaHttpProvider {
     endpoint: String,
     model: String,
@@ -394,6 +404,7 @@ pub struct OllamaHttpProvider {
 }
 
 impl OllamaHttpProvider {
+    /// Build an Ollama HTTP provider from the normalized invocation target.
     pub fn from_target(
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,
@@ -447,6 +458,7 @@ impl Provider for OllamaHttpProvider {
 }
 
 impl HttpProvider {
+    /// Build an HTTP provider from an already-normalized invocation spec.
     pub fn from_spec(spec: &adl::ProviderSpec) -> Result<Self> {
         let target = provider_substrate::provider_invocation_target_v1(
             spec.id.as_deref().unwrap_or("<anonymous-provider>"),
@@ -456,6 +468,7 @@ impl HttpProvider {
         Self::from_target(spec, &target)
     }
 
+    /// Build a generic HTTP provider from the normalized invocation target.
     pub fn from_target(
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,

--- a/adl/src/provider/local.rs
+++ b/adl/src/provider/local.rs
@@ -1,12 +1,18 @@
+//! Local and CLI-backed provider implementations.
+//!
+//! Includes the mock test provider and local command-line Ollama adapter used for
+//! offline or deterministic integration behavior.
 use super::http_family::timeout_secs;
 use super::*;
 
 #[derive(Debug, Clone)]
+/// Deterministic local provider used by tests and local smoke flows.
 pub struct MockProvider {
     model: String,
 }
 
 impl MockProvider {
+    /// Build the mock provider from a normalized target.
     pub fn from_target(target: &ProviderInvocationTargetV1) -> Self {
         Self {
             model: target.model_ref.clone(),
@@ -15,6 +21,7 @@ impl MockProvider {
 }
 
 impl Provider for MockProvider {
+    /// Returns the input prompt unchanged for deterministic pass-through testing.
     fn complete(&self, prompt: &str) -> Result<String> {
         let _model = &self.model;
         Ok(prompt.to_string())
@@ -24,12 +31,14 @@ impl Provider for MockProvider {
 /// Ollama provider (blocking) using the local `ollama` CLI.
 /// This keeps v0.1 dependency-light and works well for local prototyping.
 #[derive(Debug, Clone)]
+/// Local Ollama provider backed by the `ollama` binary.
 pub struct OllamaProvider {
     pub model: String,
     pub temperature: Option<f32>,
 }
 
 impl OllamaProvider {
+    /// Build an Ollama provider from ADL spec and optional run-time model override.
     pub fn from_spec(spec: &adl::ProviderSpec, model_override: Option<&str>) -> Result<Self> {
         let target = provider_substrate::provider_invocation_target_v1(
             spec.id.as_deref().unwrap_or("<anonymous-provider>"),
@@ -39,6 +48,7 @@ impl OllamaProvider {
         Self::from_target(spec, &target)
     }
 
+    /// Build from a resolved invocation target after `provider_substrate` expansion.
     pub fn from_target(
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,
@@ -211,6 +221,7 @@ impl OllamaProvider {
 }
 
 impl Provider for OllamaProvider {
+    /// Execute a prompt through `ollama run` and return complete stdout text.
     fn complete(&self, prompt: &str) -> Result<String> {
         self.complete_streaming(prompt, None)
     }

--- a/adl/src/provider/mod.rs
+++ b/adl/src/provider/mod.rs
@@ -1,3 +1,7 @@
+//! Provider selection and execution entrypoints for ADL.
+//!
+//! This module selects among mock/HTTP/CLI provider implementations and exposes
+//! the minimal abstraction layer used by scheduler and remote-exec paths.
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
@@ -28,10 +32,13 @@ pub(crate) use profiles::{
     ANTHROPIC_VERSION, OPENAI_RESPONSES_ENDPOINT,
 };
 
-/// A minimal blocking provider interface for v0.1.
+/// A minimal blocking provider abstraction used by runtime execution paths.
 pub trait Provider: Send + Sync {
+    /// Run a single completion call and return output text.
     fn complete(&self, prompt: &str) -> Result<String>;
 
+    /// Optional streaming callback form; default implementation buffers internally
+    /// and emits progress via callback before returning the full output.
     fn complete_stream(&self, prompt: &str, on_chunk: &mut dyn FnMut(&str)) -> Result<String> {
         let out = self.complete(prompt)?;
         on_chunk(&out);
@@ -149,6 +156,7 @@ impl fmt::Display for ProviderError {
 
 impl StdError for ProviderError {}
 
+/// Validate and normalize an unsupported provider kind into a typed error.
 fn unknown_kind(kind: &str) -> anyhow::Error {
     ProviderError::unknown_kind(kind).into()
 }
@@ -204,7 +212,7 @@ pub fn stable_failure_kind(err: &anyhow::Error) -> Option<&'static str> {
     None
 }
 
-/// Factory: build a provider implementation from ADL ProviderSpec.
+/// Construct a provider implementation from a `ProviderSpec`.
 ///
 /// Expected schema (based on your compiler errors):
 /// ProviderSpec { kind, base_url, config }
@@ -219,6 +227,7 @@ pub fn build_provider(
     )
 }
 
+/// Build a provider with explicit identity and optional model override.
 pub fn build_provider_for_id(
     provider_id: &str,
     spec: &adl::ProviderSpec,

--- a/adl/src/provider/profiles.rs
+++ b/adl/src/provider/profiles.rs
@@ -1,5 +1,10 @@
+//! Provider profile presets and expansion helpers.
+//!
+//! This module maps profile names to deterministic provider defaults and expands
+//! ADL documents into explicit provider specs before execution.
 use super::*;
 
+/// Profile payload used by `provider_profile_registry`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ProviderProfilePreset {
     pub(crate) kind: &'static str,
@@ -10,6 +15,7 @@ pub(crate) struct ProviderProfilePreset {
 const HTTP_PROFILE_PLACEHOLDER_ENDPOINT: &str = "https://api.example.invalid/v1/complete";
 const INVALID_ENDPOINT_HOST_MARKER: &str = "example.invalid";
 
+/// Validate that a profile-provided endpoint is usable and non-placeholder.
 pub(crate) fn validate_profile_endpoint(
     provider_id: &str,
     profile_name: &str,
@@ -49,6 +55,7 @@ pub(crate) fn is_allowed_ollama_endpoint(endpoint: &str) -> bool {
 
 pub(crate) const OPENAI_RESPONSES_ENDPOINT: &str = "https://api.openai.com/v1/responses";
 pub(crate) const ANTHROPIC_MESSAGES_ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
+/// Canonical Anthropic API version used by the HTTP adapter.
 pub(crate) const ANTHROPIC_VERSION: &str = "2023-06-01";
 
 pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProfilePreset> {
@@ -147,6 +154,7 @@ pub(crate) fn provider_profile_registry() -> BTreeMap<&'static str, ProviderProf
     m
 }
 
+/// Return available profile names for validation and command completions.
 pub fn provider_profile_names() -> Vec<String> {
     provider_profile_registry()
         .keys()
@@ -154,6 +162,10 @@ pub fn provider_profile_names() -> Vec<String> {
         .collect()
 }
 
+/// Expand provider profiles in an ADL document into explicit concrete specs.
+///
+/// This is a bounded transform: it expands profile-only providers while keeping
+/// explicit `kind`/`base_url`/`default_model` usage unchanged.
 pub fn expand_provider_profiles(doc: &adl::AdlDoc) -> Result<adl::AdlDoc> {
     let registry = provider_profile_registry();
     let available = provider_profile_names().join(", ");

--- a/adl/src/remote_exec.rs
+++ b/adl/src/remote_exec.rs
@@ -1,3 +1,7 @@
+//! Remote execution protocol and transport adapter.
+//!
+//! This module owns the request/response contract for remote step execution and
+//! the local client/server behavior behind `/v1/execute`.
 use std::collections::HashMap;
 use std::io::Read;
 use std::time::Duration;
@@ -21,6 +25,7 @@ mod signing_support;
 mod types;
 
 pub const PROTOCOL_VERSION: &str = "0.1";
+/// Maximum accepted request body size for `/v1/execute`.
 const MAX_REQUEST_BYTES: usize = 5 * 1024 * 1024;
 const REMOTE_REQUEST_SIGNATURE_SCHEMA_V1: &str = "remote_request_signature.v1";
 const REMOTE_REQUEST_SIGNATURE_ALG_ED25519: &str = "ed25519";

--- a/adl/src/remote_exec/errors.rs
+++ b/adl/src/remote_exec/errors.rs
@@ -1,3 +1,4 @@
+//! Error surfaces and stability classifications for remote execution paths.
 use anyhow::Error;
 
 use super::REMOTE_REQUEST_SIGNATURE_ALG_ED25519;

--- a/adl/src/remote_exec/security.rs
+++ b/adl/src/remote_exec/security.rs
@@ -1,9 +1,14 @@
+//! Security-envelope validation for remote execution requests.
+//!
+//! This module validates signing/verification flags, path sandbox policy, and
+//! required key source constraints for inbound execute requests.
 use crate::sandbox;
 use crate::signing;
 
 use super::signing_support::verify_execute_request_signature_v1;
 use super::{ExecuteRequest, SecurityEnvelopeError};
 
+/// Validate the request security envelope before execution.
 pub fn validate_security_envelope(
     req: &ExecuteRequest,
 ) -> std::result::Result<(), SecurityEnvelopeError> {

--- a/adl/src/remote_exec/signing_support.rs
+++ b/adl/src/remote_exec/signing_support.rs
@@ -1,3 +1,7 @@
+//! Canonicalization and signing helpers for remote execute requests.
+//!
+//! These helpers centralize deterministic request encoding and optional signing
+//! from environment-provided private keys.
 use anyhow::{anyhow, Context, Result};
 use base64::Engine;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};

--- a/adl/src/remote_exec/types.rs
+++ b/adl/src/remote_exec/types.rs
@@ -2,8 +2,8 @@
 //!
 //! These serializable types are stable surfaces for API consumers and on-disk
 //! execution traces.
-use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use crate::adl;
 

--- a/adl/src/remote_exec/types.rs
+++ b/adl/src/remote_exec/types.rs
@@ -1,5 +1,8 @@
+//! Data contracts exchanged over the remote execution protocol.
+//!
+//! These serializable types are stable surfaces for API consumers and on-disk
+//! execution traces.
 use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use crate::adl;


### PR DESCRIPTION
Closes #2445

## Summary
Issue 2445 is docs-only. I added the remaining rustdoc coverage for schema and advanced subsystem public surfaces, including module-overview docs and targeted public-item docs in `adl/src/adl.rs`, `adl/src/adl/types.rs`, `adl/src/provider/*`, `adl/src/remote_exec/*`, `adl/src/godel/*`, `adl/src/chronosense/*`, and `adl/src/long_lived_agent/*`.

## Artifacts
- `adl/src/adl.rs`
- `adl/src/adl/types.rs`
- `adl/src/provider/http_family.rs`
- `adl/src/provider/local.rs`
- `adl/src/provider/mod.rs`
- `adl/src/provider/profiles.rs`
- `adl/src/remote_exec.rs`
- `adl/src/remote_exec/errors.rs`
- `adl/src/remote_exec/security.rs`
- `adl/src/remote_exec/signing_support.rs`
- `adl/src/remote_exec/types.rs`
- `adl/src/godel/affect_slice.rs`
- `adl/src/godel/canonical_evidence.rs`
- `adl/src/godel/cross_workflow.rs`
- `adl/src/godel/experiment_record.rs`
- `adl/src/godel/evaluation.rs`
- `adl/src/godel/mutation.rs`
- `adl/src/godel/obsmem_index.rs`
- `adl/src/godel/policy.rs`
- `adl/src/godel/prioritization.rs`
- `adl/src/godel/promotion.rs`
- `adl/src/godel/stage_loop.rs`
- `adl/src/godel/surface_status.rs`
- `adl/src/godel/workflow_template.rs`
- `adl/src/chronosense.rs`
- `adl/src/chronosense/causality.rs`
- `adl/src/chronosense/commitments.rs`
- `adl/src/chronosense/continuity.rs`
- `adl/src/chronosense/foundation.rs`
- `adl/src/chronosense/instinct.rs`
- `adl/src/chronosense/phi.rs`
- `adl/src/chronosense/policy_cost.rs`
- `adl/src/chronosense/retrieval.rs`
- `adl/src/chronosense/temporal_schema.rs`
- `adl/src/chronosense/tests.rs`
- `adl/src/long_lived_agent.rs`
- `adl/src/long_lived_agent/inspection.rs`
- `adl/src/long_lived_agent/schema.rs`
- `adl/src/long_lived_agent/storage.rs`
- `adl/src/long_lived_agent/tests.rs`
- `adl/src/long_lived_agent/types.rs`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.90.4/tasks/issue-2445__v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems/sor.md`
    Verified initial scaffold contract and lifecycle binding.
  - `bash adl/tools/pr.sh run 2445 --slug v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems --version v0.90.4`
    Bound execution and verified sip/sor contracts in both root and worktree paths.
  - `cargo doc --no-deps --manifest-path adl/Cargo.toml`
    Proved the crate still documents successfully after rustdoc edits.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.90.4/tasks/issue-2445__v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems/sor.md`
    Proved finished output-card schema and populated required fields.
- Results:
  - PASS
  - PASS
  - PASS
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2445__v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2445__v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems/sor.md
- Idempotency-Key: v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems-adl-src-adl-v0-90-4-tasks-issue-2445-v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems-sip-md-adl-v0-90-4-tasks-issue-2445-v0-90-4-backlog-docs-add-rustdoc-coverage-for-schema-and-advanced-subsystems-sor-md