### PR TITLE
[v0.90.4][backlog][process-tools] Enforce closeout at merge and merged-issue hygiene

### DIFF
--- a/adl/tools/README.md
+++ b/adl/tools/README.md
@@ -23,7 +23,7 @@ Keep behavioral and milestone narrative in canonical docs, not here.
 - `burst_worktree.sh`, `burst_continue.sh`: burst lane/worktree helpers.
 - `batched_checks.sh`, `preflight_review.sh`: quality/preflight checks, including the repo-code-review skill contract guard.
 - `check_issue_metadata_parity.sh`: canonical metadata parity audit for GitHub issue title/labels plus local `.adl` body/STP metadata identity.
-- `closeout_completed_issue_wave.sh`: bounded local catch-up helper that runs `pr closeout` across closed/completed issue bundles for a milestone version so local-only `.adl` truth can converge after merge or main sync.
+- `closeout_completed_issue_wave.sh`: bounded local catch-up helper that runs `pr closeout` across closed/completed issue bundles for a milestone version so local-only `.adl` truth can converge after merge or main sync; `--dry-run` or `--report-only` emits the merged-needs-closeout candidate set without mutation.
 - `check_milestone_closed_issue_sor_truth.sh`: milestone closed-issue bundle truth gate for local-only `.adl` task bundles; verifies canonical `stp.md`, `sip.md`, and final `sor.md` truth for closed/completed issues.
 - `enforce_coverage_gates.sh`: deterministic coverage threshold enforcement (workspace + per-file).
 - `clean_coverage_artifacts.sh`: removes local generated coverage summaries and loose LLVM profile shards after coverage/report runs.

--- a/adl/tools/closeout_completed_issue_wave.sh
+++ b/adl/tools/closeout_completed_issue_wave.sh
@@ -11,11 +11,14 @@ DRY_RUN=0
 usage() {
   cat <<'EOF'
 Usage:
-  closeout_completed_issue_wave.sh --version <v0.88> [--repo <owner/name>] [--issues <csv>] [--report <path>] [--dry-run]
+  closeout_completed_issue_wave.sh --version <v0.88> [--repo <owner/name>] [--issues <csv>] [--report <path>] [--dry-run|--report-only]
 
 Scans the local `.adl/<version>/tasks/` bundle set, finds GitHub issues that are
 already CLOSED/COMPLETED for that version, and runs `adl/tools/pr.sh closeout`
 for the matching local issue bundles.
+
+Use `--dry-run` or `--report-only` to emit a merged-needs-closeout candidate
+report without mutating local issue bundles.
 EOF
 }
 
@@ -59,18 +62,30 @@ write_report() {
   local path="$1"
   local mode="$2"
   local eligible_count="$3"
-  local normalized_count="$4"
-  local failed_count="$5"
-  local normalized_list="$6"
-  local failed_list="$7"
+  local candidate_count="$4"
+  local candidate_list="$5"
+  local normalized_count="$6"
+  local failed_count="$7"
+  local normalized_list="$8"
+  local failed_list="$9"
   mkdir -p "$(dirname "$path")"
   {
     echo "version: $VERSION"
     echo "repo: $REPO"
     echo "mode: $mode"
     echo "eligible_issues: $eligible_count"
+    echo "candidate_issues: $candidate_count"
     echo "normalized_issues: $normalized_count"
     echo "failed_issues: $failed_count"
+    echo "candidate_reason: closed/completed on GitHub and local closeout may still be pending"
+    echo "candidates:"
+    if [[ -n "$candidate_list" ]]; then
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && echo "  - $line"
+      done <<< "$candidate_list"
+    else
+      echo "  - none"
+    fi
     echo "normalized:"
     if [[ -n "$normalized_list" ]]; then
       while IFS= read -r line; do
@@ -97,6 +112,7 @@ while [[ $# -gt 0 ]]; do
     --issues) ISSUES_CSV="${2:-}"; shift 2 ;;
     --report) REPORT_PATH="${2:-}"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
+    --report-only) DRY_RUN=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown arg: $1" ;;
   esac
@@ -116,8 +132,8 @@ fi
 
 local_issues="$(collect_local_issues "$VERSION")"
 if [[ -z "$local_issues" ]]; then
-  write_report "$REPORT_PATH" "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" 0 0 0 "" ""
-  echo "PASS closeout_completed_issue_wave version=$VERSION eligible=0"
+  write_report "$REPORT_PATH" "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" 0 0 "" 0 0 "" ""
+  echo "PASS closeout_completed_issue_wave version=$VERSION candidates=0 normalized=0"
   exit 0
 fi
 
@@ -147,11 +163,12 @@ PY
 )"
 
 if [[ -z "$eligible_issues" ]]; then
-  write_report "$REPORT_PATH" "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" 0 0 0 "" ""
-  echo "PASS closeout_completed_issue_wave version=$VERSION eligible=0"
+  write_report "$REPORT_PATH" "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" 0 0 "" 0 0 "" ""
+  echo "PASS closeout_completed_issue_wave version=$VERSION candidates=0 normalized=0"
   exit 0
 fi
 
+candidate_list=""
 normalized_list=""
 failed_list=""
 normalized_count=0
@@ -161,9 +178,8 @@ trap 'rm -f "$report_log"' EXIT
 
 while IFS= read -r issue; do
   [[ -n "$issue" ]] || continue
+  candidate_list+="${issue}"$'\n'
   if [[ "$DRY_RUN" == "1" ]]; then
-    normalized_list+="${issue}"$'\n'
-    normalized_count=$((normalized_count + 1))
     continue
   fi
   if bash "$ROOT/adl/tools/pr.sh" closeout "$issue" --version "$VERSION" --no-fetch-issue >>"$report_log" 2>&1; then
@@ -180,6 +196,8 @@ write_report \
   "$REPORT_PATH" \
   "$([[ "$DRY_RUN" == "1" ]] && echo dry_run || echo apply)" \
   "$(printf '%s\n' "$eligible_issues" | sed '/^$/d' | wc -l | tr -d ' ')" \
+  "$(printf '%s\n' "$candidate_list" | sed '/^$/d' | wc -l | tr -d ' ')" \
+  "$candidate_list" \
   "$normalized_count" \
   "$failed_count" \
   "$normalized_list" \
@@ -189,4 +207,4 @@ if [[ "$failed_count" != "0" ]]; then
   die "failed to normalize $failed_count closed issue bundle(s); see $REPORT_PATH"
 fi
 
-echo "PASS closeout_completed_issue_wave version=$VERSION normalized=$normalized_count"
+echo "PASS closeout_completed_issue_wave version=$VERSION candidates=$(printf '%s\n' "$candidate_list" | sed '/^$/d' | wc -l | tr -d ' ') normalized=$normalized_count"

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -439,6 +439,8 @@ Good patterns:
   truthfulness
 - after merge or intentional closure is confirmed, `pr-closeout` finalizes the
   cards and prunes the worktree
+- a merged PR should be treated as `merged_needs_closeout`, not as already
+  closed out; the next lifecycle phase is still `pr-closeout`
 - if the issue closed without a PR because it was superseded, duplicated, or
   intentionally resolved without code publication, `pr-closeout` records that
   disposition and the relevant follow-on links before pruning
@@ -1084,6 +1086,7 @@ Use `pr-closeout` when:
 - the PR outcome is already known
 - publication and review are over
 - the remaining work is local workflow truth and cleanup
+- a PR has merged and the issue now needs truthful local finalization
 
 Do not use it for:
 
@@ -1139,10 +1142,25 @@ policy:
 
 - after `pr-janitor` confirms the PR has merged and there are no remaining
   blocker states
+- when workflow-conductor reports `merged_needs_closeout` and routes directly to
+  `pr-closeout`
 - after an intentionally closed PR where the issue still needs final truthful
   local cleanup
 - when the cards are complete but the worktree and root bundle still need final
   reconciliation
+
+### Merged-Issue Hygiene
+
+For milestone-level visibility, use:
+
+```bash
+bash adl/tools/closeout_completed_issue_wave.sh --version <milestone> --report-only --report <path>
+```
+
+This produces a local report of closed/completed issues whose local closeout may
+still be pending. Use it as the merged-needs-closeout visibility surface before
+or during release tail work, then run the same helper without `--report-only`
+to apply bounded closeout catch-up when appropriate.
 
 ### Caller Notes
 

--- a/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
+++ b/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
@@ -70,7 +70,13 @@ def evaluate(payload):
         skill_name = "none"
         continuation = "ask_operator"
         escalation_reason = "healthy_pr_waiting"
-    elif pr_state in ("merged", "intentionally_closed", "closed_no_pr", "superseded", "duplicate"):
+    elif pr_state == "merged":
+        detected_phase = "merged_needs_closeout"
+        selected_phase = "closeout"
+        skill_name = "pr-closeout"
+        continuation = "continue"
+        escalation_reason = "none"
+    elif pr_state in ("intentionally_closed", "closed_no_pr", "superseded", "duplicate"):
         detected_phase = "closed_out"
         selected_phase = "closeout"
         skill_name = "pr-closeout"

--- a/adl/tools/test_closeout_completed_issue_wave.sh
+++ b/adl/tools/test_closeout_completed_issue_wave.sh
@@ -48,9 +48,18 @@ EOF
 chmod +x "$BIN/gh"
 
 REPORT="$TMP/report.md"
+DRY_REPORT="$TMP/dry-report.md"
+(cd "$REPO" && PATH="$BIN:$PATH" bash ./adl/tools/closeout_completed_issue_wave.sh --version v0.88 --repo danielbaustin/agent-design-language --report "$DRY_REPORT" --report-only)
+
+grep -Fq 'candidate_issues: 1' "$DRY_REPORT"
+grep -Fq 'normalized_issues: 0' "$DRY_REPORT"
+grep -Fq 'candidates:' "$DRY_REPORT"
+grep -Fq '  - 100' "$DRY_REPORT"
+
 (cd "$REPO" && PATH="$BIN:$PATH" bash ./adl/tools/closeout_completed_issue_wave.sh --version v0.88 --repo danielbaustin/agent-design-language --report "$REPORT")
 
 grep -Fq 'closeout 100 --version v0.88 --no-fetch-issue' "$CLOSEOUT_LOG"
+grep -Fq 'candidate_issues: 1' "$REPORT"
 grep -Fq 'normalized_issues: 1' "$REPORT"
 grep -Fq 'failed_issues: 0' "$REPORT"
 

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -1088,6 +1088,8 @@ assert route_pr_blocked["workflow_state"]["blocker_class"] == "review_changes_re
 
 route_pr_merged = load("route_pr_merged.out.json")
 assert route_pr_merged["selected_skill"]["skill_name"] == "pr-closeout"
+assert route_pr_merged["workflow_state"]["detected_phase"] == "merged_needs_closeout"
+assert route_pr_merged["handoff_state"]["next_phase"] == "pr-closeout"
 
 route_pr_clean = load("route_pr_clean.out.json")
 assert route_pr_clean["selected_skill"]["skill_name"] == "none"

--- a/docs/templates/RELEASE_PLAN_TEMPLATE.md
+++ b/docs/templates/RELEASE_PLAN_TEMPLATE.md
@@ -20,6 +20,7 @@
   - any active milestone-specific gap/risk tracker
 - [ ] Gap analysis refreshed or explicitly confirmed still current
 - [ ] Closed-issue closeout pass refreshed so issue/card truth is not stale
+  - capture a merged-needs-closeout visibility report before apply mode when useful
 - [ ] Release-truth docs aligned:
   - `README.md`
   - `CHANGELOG.md`


### PR DESCRIPTION
Closes #2453

## Summary
Tightened post-merge closeout hygiene by naming merged PRs as a distinct merged-needs-closeout workflow state, making the closeout wave script report closeout candidates explicitly, and documenting the report-first release-tail usage in the operational guide and release template.

## Artifacts
- Updated workflow-conductor routing logic in `adl/tools/skills/workflow-conductor/scripts/select_next_skill.py`
- Updated closeout-wave helper in `adl/tools/closeout_completed_issue_wave.sh`
- Updated contract coverage in `adl/tools/test_workflow_conductor_skill_contracts.sh`
- Updated closeout-wave test coverage in `adl/tools/test_closeout_completed_issue_wave.sh`
- Updated operator docs in `adl/tools/README.md`
- Updated operational guide in `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- Updated release template in `docs/templates/RELEASE_PLAN_TEMPLATE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Proved the workflow-conductor contract still passes and that merged PRs are now named as merged-needs-closeout.
  - `bash adl/tools/test_closeout_completed_issue_wave.sh`
    Proved the merged-needs-closeout candidate report path and the apply path both behave truthfully.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2453__v0-90-4-backlog-enforce-closeout-at-merge-and-merged-issue-hygiene/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2453__v0-90-4-backlog-enforce-closeout-at-merge-and-merged-issue-hygiene/sor.md
- Idempotency-Key: v0-90-4-backlog-process-tools-enforce-closeout-at-merge-and-merged-issue-hygiene-adl-docs-adl-v0-90-4-tasks-issue-2453-v0-90-4-backlog-enforce-closeout-at-merge-and-merged-issue-hygiene-sip-md-adl-v0-90-4-tasks-issue-2453-v0-90-4-backlog-enforce-closeout-at-merge-and-merged-issue-hygiene-sor-md