### PR TITLE
[v0.90.4][backlog][review] Make documentation and doc review first-class in CodeBuddy and ADL review flow

### DIFF
--- a/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
+++ b/adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md
@@ -53,8 +53,13 @@ Recommended order:
 17. `review-quality-evaluator`
 
 The first four roles may run independently when the operator wants parallel
-review. The synthesis role should run after at least one specialist artifact is
-available, and ideally after all required roles have reported.
+review. The suite treats documentation review as required for all internal and
+external review packets unless a lane is explicitly skipped.
+
+For this suite, the synthesis role must run after at least one specialist
+artifact is available, and ideally after all required roles have reported.
+When a required role is intentionally skipped, record an explicit skip reason,
+the owner of that skip decision, and a follow-up path in the synthesis record.
 The diagram planner should normally run after packet building and after the
 specialist artifacts that may propose diagram work. It emits bounded task briefs
 for `diagram-author`; it is not itself a review or diagram-authoring lane.
@@ -183,7 +188,8 @@ Each specialist artifact should use this shape:
 - `repo-review-code` must include `reviewed_surfaces` and code-risk residuals.
 - `repo-review-security` must include `trust_boundaries` and asset/attacker notes when relevant.
 - `repo-review-tests` must include a `missing_proof_map` when coverage gaps are found.
-- `repo-review-docs` must include `commands_or_claims_checked` when docs make runnable claims.
+- `repo-review-docs` must include `documentation_objects` for the bounded scope,
+  and `commands_or_claims_checked` when docs make runnable claims.
 - `repo-architecture-review` must include an `architecture_map`, candidate diagram tasks, candidate ADRs, and candidate fitness functions.
 - `repo-dependency-review` must include a `dependency_surface_map`, candidate supply-chain findings, candidate dependency test gaps, and candidate license review notes.
 
@@ -217,6 +223,10 @@ Each specialist artifact should use this shape:
 - Docs: present | missing | skipped
 - Architecture: present | missing | skipped
 - Dependency: present | missing | skipped
+
+Use `docs: skipped` only when the lane was intentionally skipped, with a
+named rationale and a follow-up owner captured in `Residual Risk` or
+`Recommended Follow-up Issues`.
 
 ## Dedupe Notes
 - <what was merged and why>

--- a/adl/tools/skills/repo-review-docs/SKILL.md
+++ b/adl/tools/skills/repo-review-docs/SKILL.md
@@ -68,6 +68,17 @@ Use the shared suite contract in
 `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md` when ADL expects
 a structured artifact.
 
+## Required Review Outputs
+
+For each scoped review packet, this specialist is expected to identify and list:
+- documentation objects inspected (for example schemas, skills, manifests,
+  runbooks, demos, and release surfaces),
+- evidence for each major claim that is checked, and
+- skipped-object rationale when a bounded docs lane is intentionally not run.
+
+All doc findings must preserve severity and role ownership exactly as discovered,
+matching the severity framing used by other lanes.
+
 ## Stop Boundary
 
 Stop after producing the docs-review artifact.

--- a/adl/tools/skills/repo-review-docs/references/output-contract.md
+++ b/adl/tools/skills/repo-review-docs/references/output-contract.md
@@ -11,11 +11,15 @@ Default `repo-review-docs` artifacts are Markdown review packets with these sect
 
 ## Findings
 - <priority>: <title>
+  Severity: <P0 | P1 | P2 | P3>
   File: <repo-relative path or none>
   Role: docs
   Scenario: <trigger or review condition>
   Impact: <behavioral consequence>
   Evidence: <specific code/doc/test/config observation>
+
+## Documentation Objects
+- <bounded object> (`schema` | `skill` | `review artifact` | `demo` | `guide` | `runbook` | `release note`)
 
 ## Commands Or Claims Checked
 - <bounded list or explicit none>
@@ -25,6 +29,12 @@ Default `repo-review-docs` artifacts are Markdown review packets with these sect
 
 ## Residual Risk
 - <what this role did not inspect or could not prove>
+
+If no docs review was performed, write `Documentation Review: skipped`.
+State skip reason, owner, and follow-up action in `Residual Risk`.
+
+If findings are found, preserve the same severity framing used by other
+specialist lanes and call out any disagreement from synthesis or peer artifacts.
 ```
 
 ## Rules

--- a/adl/tools/skills/repo-review-synthesis/references/output-contract.md
+++ b/adl/tools/skills/repo-review-synthesis/references/output-contract.md
@@ -17,6 +17,7 @@ Default `repo-review-synthesis` artifacts are Markdown review packets with these
 
 ## Findings
 - <priority>: <title>
+  Severity: <P0 | P1 | P2 | P3>
   Source Roles: <role list>
   File: <repo-relative path or none>
   Scenario: <trigger or review condition>
@@ -30,6 +31,10 @@ Default `repo-review-synthesis` artifacts are Markdown review packets with these
 - Docs: present | missing | skipped
 - Architecture: present | missing | skipped
 - Dependency: present | missing | skipped
+
+`Docs` must be `present`, `missing`, or `skipped`. If `skipped`, include a skip
+reason, owner, and follow-up owner in `Residual Risk` and a concrete follow-up
+issue candidate unless the skip was pre-approved.
 
 ## Dedupe Notes
 - <dedupe decision or explicit none>

--- a/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
+++ b/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
@@ -312,6 +312,9 @@ Required outputs:
 
 - Findings-first internal review packet covering code, docs, demos, tests,
   issue truth, release boundaries, and proof claims.
+- Documentation review artifact from `repo-review-docs` when any review scope
+  touches documentation, review templates, release text, or claim-bearing
+  project surfaces.
 - Findings register and proof register.
 
 Required validation:
@@ -319,6 +322,8 @@ Required validation:
 - Review packet has exact scope, exact files, requested review questions, and
   severity rubric.
 - Accepted findings are routed to WP-18 or explicitly dispositioned.
+- If documentation review was skipped, the skipped state and reason are explicit in
+  the internal review artifact, include an owner, and carry a concrete follow-up.
 
 ## WP-17: External Review
 


### PR DESCRIPTION
Closes #2446

## Summary
Made docs and review-surface process updates in tracked ADL workflow docs so
documentation review is explicit, first-class, and skip-governed for internal
review outputs.

## Artifacts
- Local ignored issue-worktree record updates:
  - `.adl/v0.90.4/tasks/issue-2446__v0-90-4-backlog-review-make-documentation-and-doc-review-first-class-in-codebuddy-and-adl-review-flow/stp.md`
- Tracked implementation artifacts:
  - `adl/tools/skills/docs/MULTI_AGENT_REPO_REVIEW_SKILL_SUITE.md`
  - `adl/tools/skills/repo-review-docs/SKILL.md`
  - `adl/tools/skills/repo-review-docs/references/output-contract.md`
  - `adl/tools/skills/repo-review-synthesis/references/output-contract.md`
  - `docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.90.4/tasks/issue-2446__v0-90-4-backlog-review-make-documentation-and-doc-review-first-class-in-codebuddy-and-adl-review-flow/sor.md`
    Verified bootstrap SOR contract compliance for the local output scaffold.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2446__v0-90-4-backlog-review-make-documentation-and-doc-review-first-class-in-codebuddy-and-adl-review-flow/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2446__v0-90-4-backlog-review-make-documentation-and-doc-review-first-class-in-codebuddy-and-adl-review-flow/sor.md
- Idempotency-Key: v0-90-4-backlog-review-make-documentation-and-doc-review-first-class-in-codebuddy-and-adl-review-flow-adl-v0-90-4-tasks-issue-2446-v0-90-4-backlog-review-make-documentation-and-doc-review-first-class-in-codebuddy-and-adl-review-flow-sip-md-adl-v0-90-4-tasks-issue-2446-v0-90-4-backlog-review-make-documentation-and-doc-review-first-class-in-codebuddy-and-adl-review-flow-sor-md