### PR TITLE
[v0.90.4][WP-13] Review summary shape

### DIFF
--- a/adl/tools/render_v0904_contract_market_summary.py
+++ b/adl/tools/render_v0904_contract_market_summary.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Render the v0.90.4 contract-market review summary example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+class RenderError(Exception):
+    """Stable renderer failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render the deterministic v0.90.4 contract-market review summary."
+    )
+    parser.add_argument(
+        "--seed",
+        default="demos/fixtures/contract_market/review_summary_seed.json",
+        help="Repo-relative path to the review summary seed.",
+    )
+    parser.add_argument(
+        "--review-bundle",
+        required=True,
+        help="Repo-relative path to the WP-12 review bundle artifact.",
+    )
+    parser.add_argument(
+        "--schema",
+        default="demos/fixtures/contract_market/review_summary_schema.json",
+        help="Repo-relative path to the review summary schema.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Repo-relative output path for the rendered Markdown summary.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise RenderError("missing_input", f"missing input: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RenderError("invalid_json", f"invalid json in {path}: {exc}") from exc
+
+
+def ensure(condition: bool, code: str, message: str) -> None:
+    if not condition:
+        raise RenderError(code, message)
+
+
+def bullet_lines(items: list[str]) -> list[str]:
+    return [f"- {item}" for item in items]
+
+
+def format_recorded_requirements(review_bundle: dict[str, Any]) -> list[str]:
+    requirements = review_bundle["tool_boundary"]["recorded_requirements"]
+    if not requirements:
+        return ["- none recorded"]
+    return [
+        "- "
+        + requirement["description"]
+        + f" (`{requirement['mode']}`, authority `{requirement['execution_authority']}`)"
+        for requirement in requirements
+    ]
+
+
+def render_summary(schema: dict[str, Any], seed: dict[str, Any], review_bundle: dict[str, Any]) -> str:
+    ensure(
+        schema.get("schema") == "adl.v0904.contract_market.review_summary_schema.v1",
+        "schema_mismatch",
+        "review summary schema mismatch",
+    )
+    ensure(
+        seed.get("schema") == "adl.v0904.contract_market.review_summary_seed.v1",
+        "seed_mismatch",
+        "review summary seed schema mismatch",
+    )
+    ensure(
+        review_bundle.get("schema") == "adl.v0904.contract_market.runner_review_bundle.v1",
+        "review_bundle_mismatch",
+        "review bundle schema mismatch",
+    )
+
+    labels = schema["labels"]
+    tool_language = schema["tool_language"]
+
+    artifact_items = list(seed["artifacts"]) + [
+        review_bundle["artifacts"]["transition_report"],
+        review_bundle["artifacts"]["negative_case_results"],
+    ]
+    participants = review_bundle["participants"]
+    considered_bids = ", ".join(participants["considered_bid_ids"])
+
+    lines = [
+        "# Contract-Market Review Summary",
+        "",
+        f"Schema: `{schema['schema']}`",
+        f"Summary ID: `{seed['summary_id']}`",
+        f"Claim boundary: {schema['claim_boundary']}",
+        "",
+        "## Scope",
+        f"{labels['proof']}: {seed['scope']}",
+        f"{labels['judgment']}: This is a bounded contract-market substrate proof, not a live market run or governed-tool execution proof.",
+        "",
+        "## Participants",
+        f"{labels['proof']}:",
+        f"- Issuer: `{participants['issuer']}`",
+        f"- Selected actor: `{participants['selected_actor']}`",
+        f"- Considered bids: {considered_bids}",
+        f"- Subcontracted actor: `{participants['subcontracted_actor']}`",
+        "",
+        "## Authority Basis",
+        f"{labels['proof']}: {seed['authority_basis']}",
+        f"{labels['judgment']}: Award, acceptance, and completion remain tied to explicit authority bases in the runner review bundle.",
+        "",
+        "## Bid Comparison",
+        f"{labels['proof']}: {seed['bid_comparison']}",
+        f"{labels['judgment']}: The runner confirms the selected path because stronger trace and delegation posture beat lower complexity alone while tool needs remain deferred.",
+        "",
+        "## Selection Rationale",
+        f"{labels['judgment']}: {seed['selection_rationale']}",
+        "",
+        "## Delegation",
+        f"{labels['proof']}: {seed['delegation']}",
+        f"{labels['judgment']}: Delegation stays bounded because inherited subcontract constraints preserve portable artifacts and no governed tool execution.",
+        "",
+        "## Artifacts",
+        f"{labels['proof']}:",
+        *bullet_lines([f"`{item}`" for item in artifact_items]),
+        "",
+        "## Trace",
+        f"{labels['proof']}: {seed['trace']}",
+        f"{labels['judgment']}: The review surface relies on explicit trace-linked lifecycle events rather than hidden state or model confidence.",
+        "",
+        "## Validation",
+        f"{labels['proof']}: {seed['validation']}",
+        f"{labels['non_claims']}:",
+        "- This summary does not claim payment settlement, pricing, tax handling, or legal enforcement.",
+        "- This summary does not claim governed tool execution.",
+        "",
+        "## Tool Requirements",
+        f"{labels['recorded']}:",
+        *format_recorded_requirements(review_bundle),
+        f"{labels['deferred']}:",
+        f"- {tool_language['recorded']}",
+        f"- {tool_language['denied']}",
+        f"- {tool_language['deferred']}",
+        "",
+        "## Caveats",
+        *bullet_lines(seed["caveats"]),
+        "",
+        "## Residual Risk",
+        f"{labels['residual_risk']}:",
+        *bullet_lines(seed["residual_risk"] + review_bundle["residual_risk"]),
+        "",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    seed = load_json(Path(args.seed))
+    review_bundle = load_json(Path(args.review_bundle))
+    schema = load_json(Path(args.schema))
+    out_path = Path(args.out)
+    try:
+        rendered = render_summary(schema, seed, review_bundle)
+    except RenderError as exc:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(f"render_failure: {exc.code}: {exc.message}\n")
+        print(f"contract_market_summary: fail [{exc.code}]")
+        return 1
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered)
+    print("contract_market_summary: pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/run_v0904_contract_market_runner.py
+++ b/adl/tools/run_v0904_contract_market_runner.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Deterministic runner for the v0.90.4 contract-market fixture packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+class RunnerError(Exception):
+    """Stable runner failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the bounded v0.90.4 contract-market fixture packet."
+    )
+    parser.add_argument(
+        "--fixture-root",
+        default="demos/fixtures/contract_market",
+        help="Repo-relative path to the canonical contract-market fixture root.",
+    )
+    parser.add_argument(
+        "--negative-root",
+        default="demos/fixtures/contract_market_invalid",
+        help="Repo-relative path to the negative fixture root.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Repo-relative output directory for runner artifacts.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise RunnerError("missing_artifact", f"missing artifact: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RunnerError("invalid_json", f"invalid json in {path}: {exc}") from exc
+
+
+def ensure(condition: bool, code: str, message: str) -> None:
+    if not condition:
+        raise RunnerError(code, message)
+
+
+def ensure_portable_json(value: Any, path: str) -> None:
+    if isinstance(value, dict):
+        for nested in value.values():
+            ensure_portable_json(nested, path)
+        return
+    if isinstance(value, list):
+        for nested in value:
+            ensure_portable_json(nested, path)
+        return
+    if isinstance(value, str):
+        if "/Users/" in value or "file://" in value:
+            raise RunnerError("absolute_path_leakage", f"host path leakage in {path}")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def display_path(path: Path) -> str:
+    cwd = Path.cwd().resolve()
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(cwd).as_posix()
+    except ValueError:
+        return resolved.name
+
+
+def validate_packet_root(fixture_root: Path, negative_root: Path) -> dict[str, Any]:
+    manifest = load_json(fixture_root / "packet_manifest.json")
+    ensure(
+        manifest.get("schema") == "adl.v0904.contract_market.packet_manifest.v1",
+        "invalid_manifest_schema",
+        "packet manifest schema mismatch",
+    )
+    ensure(
+        manifest.get("packet_root") == fixture_root.as_posix(),
+        "packet_root_mismatch",
+        "packet manifest packet_root must match fixture root",
+    )
+    ensure(
+        manifest.get("negative_packet_root") == negative_root.as_posix(),
+        "negative_root_mismatch",
+        "packet manifest negative_packet_root must match negative fixture root",
+    )
+
+    packet: dict[str, Any] = {"manifest": manifest}
+    artifact_ids: set[str] = set()
+    for artifact in manifest.get("artifacts", []):
+        artifact_id = artifact["artifact_id"]
+        path = fixture_root / artifact["path"]
+        ensure(artifact_id not in artifact_ids, "duplicate_artifact_id", artifact_id)
+        artifact_ids.add(artifact_id)
+        payload = load_json(path)
+        ensure_portable_json(payload, path.as_posix())
+        packet[artifact_id] = payload
+
+    invalid_manifest = load_json(negative_root / "invalid_packet_manifest.json")
+    ensure(
+        invalid_manifest.get("schema") == "adl.v0904.contract_market.invalid_packet_manifest.v1",
+        "invalid_negative_manifest_schema",
+        "negative packet manifest schema mismatch",
+    )
+    invalid_bid = load_json(negative_root / "invalid_bid_tool_grant.json")
+    invalid_completion = load_json(
+        negative_root / "invalid_completion_missing_artifacts.json"
+    )
+    ensure_portable_json(invalid_bid, (negative_root / "invalid_bid_tool_grant.json").as_posix())
+    ensure_portable_json(
+        invalid_completion,
+        (negative_root / "invalid_completion_missing_artifacts.json").as_posix(),
+    )
+    packet["invalid_manifest"] = invalid_manifest
+    packet["invalid_bid_tool_grant"] = invalid_bid
+    packet["invalid_completion_missing_artifacts"] = invalid_completion
+    return packet
+
+
+def validate_contract(packet: dict[str, Any]) -> None:
+    contract = packet["parent_contract"]
+    ensure(
+        contract.get("schema") == "adl.v0904.contract_market.contract.v1",
+        "invalid_contract_schema",
+        "parent contract schema mismatch",
+    )
+    ensure(
+        contract.get("lifecycle_state") == "open_for_bidding",
+        "invalid_contract_state",
+        "parent contract must start open_for_bidding",
+    )
+    ensure(
+        "no governed tool execution" in contract.get("constraints", []),
+        "missing_tool_boundary_constraint",
+        "contract must explicitly deny governed tool execution in v0.90.4",
+    )
+
+    bids = [packet["bid_alpha"], packet["bid_beta"]]
+    bid_ids = set()
+    for bid in bids:
+        ensure(
+            bid.get("schema") == "adl.v0904.contract_market.bid.v1",
+            "invalid_bid_schema",
+            "bid schema mismatch",
+        )
+        ensure(
+            bid.get("target_contract_id") == contract["contract_id"],
+            "wrong_contract",
+            "bid targets the wrong contract",
+        )
+        ensure(
+            bid["bidder"]["actor_id"] in contract["parties"]["eligible_bidders"],
+            "ineligible_bidder",
+            "bidder must be listed as eligible",
+        )
+        ensure(
+            bid["bidder"]["eligibility"] == "eligible",
+            "ineligible_flag",
+            "bidder eligibility flag must be eligible",
+        )
+        bid_ids.add(bid["bid_id"])
+        for tool_requirement in bid.get("tool_requirements", []):
+            ensure(
+                tool_requirement.get("execution_authority") == "not_granted",
+                "tool_authority_forbidden",
+                "tool requirements must not grant execution authority",
+            )
+
+    evaluation = packet["evaluation"]
+    ensure(
+        evaluation.get("target_contract_id") == contract["contract_id"],
+        "evaluation_contract_mismatch",
+        "evaluation must target the parent contract",
+    )
+    ensure(
+        all(check.get("status") == "pass" for check in evaluation.get("mandatory_checks", [])),
+        "mandatory_check_failed",
+        "all mandatory checks must pass",
+    )
+    selected_bid_id = evaluation["recommendation"]["selected_bid_id"]
+    ensure(
+        selected_bid_id in bid_ids,
+        "selected_bid_missing",
+        "selected bid must be one of the packet bids",
+    )
+
+    award = packet["award_transition"]
+    ensure(
+        award.get("selected_bid_id") == selected_bid_id,
+        "award_selected_bid_mismatch",
+        "award transition must target the evaluation winner",
+    )
+    ensure(
+        award.get("actor_id") == contract["parties"]["issuer"],
+        "award_actor_mismatch",
+        "issuer must perform award transition",
+    )
+    ensure(
+        award.get("from_state") == "bidding" and award.get("to_state") == "awarded",
+        "award_state_mismatch",
+        "award transition state progression mismatch",
+    )
+
+    selected_bid = next(bid for bid in bids if bid["bid_id"] == selected_bid_id)
+    acceptance = packet["acceptance_transition"]
+    ensure(
+        acceptance.get("selected_bid_id") == selected_bid_id,
+        "acceptance_selected_bid_mismatch",
+        "acceptance transition must target the awarded bid",
+    )
+    ensure(
+        acceptance.get("actor_id") == selected_bid["bidder"]["actor_id"],
+        "acceptance_actor_mismatch",
+        "awarded bidder must perform acceptance",
+    )
+    ensure(
+        acceptance.get("from_state") == "awarded"
+        and acceptance.get("to_state") == "accepted",
+        "acceptance_state_mismatch",
+        "acceptance transition state progression mismatch",
+    )
+
+    subcontract = packet["subcontract"]
+    ensure(
+        subcontract.get("parent_contract_id") == contract["contract_id"],
+        "subcontract_parent_mismatch",
+        "subcontract must point at the parent contract",
+    )
+    ensure(
+        subcontract.get("delegating_actor") == selected_bid["bidder"]["actor_id"],
+        "subcontract_delegator_mismatch",
+        "awarded bidder must be the delegating actor",
+    )
+    ensure(
+        "no governed tool execution" in subcontract.get("inherited_constraints", []),
+        "subcontract_tool_boundary_missing",
+        "subcontract must inherit the governed-tool boundary",
+    )
+
+    delegated_output = packet["delegated_output"]
+    ensure(
+        delegated_output.get("subcontract_id") == subcontract["subcontract_id"],
+        "delegated_output_subcontract_mismatch",
+        "delegated output must point at the subcontract",
+    )
+    ensure(
+        delegated_output.get("status") == "completed",
+        "delegated_output_status_invalid",
+        "delegated output must be completed",
+    )
+
+    integration = packet["parent_integration_output"]
+    ensure(
+        integration.get("parent_contract_id") == contract["contract_id"],
+        "integration_parent_mismatch",
+        "parent integration output must point at the parent contract",
+    )
+    ensure(
+        integration.get("integrating_actor") == selected_bid["bidder"]["actor_id"],
+        "integration_actor_mismatch",
+        "awarded bidder must integrate the delegated output",
+    )
+    ensure(
+        delegated_output["output_id"] in integration.get("integrated_inputs", []),
+        "integration_missing_delegated_output",
+        "integration must include the delegated output id",
+    )
+
+    completion = packet["completion_event"]
+    ensure(
+        completion.get("contract_id") == contract["contract_id"],
+        "completion_parent_mismatch",
+        "completion event must target the parent contract",
+    )
+    ensure(
+        completion.get("actor_id") == selected_bid["bidder"]["actor_id"],
+        "completion_actor_mismatch",
+        "awarded bidder must complete the contract",
+    )
+    ensure(
+        completion.get("required_artifact_refs"),
+        "completion_artifacts_missing",
+        "completion event must include required artifact refs",
+    )
+
+    trace_bundle = packet["trace_bundle"]
+    expected_events = {
+        "trace-event-003-award": "award_transition.json",
+        "trace-event-004-acceptance": "acceptance_transition.json",
+        "trace-event-005-subcontract": "subcontract.json",
+        "trace-event-006-delegated-output": "delegated_output.json",
+        "trace-event-007-parent-integration": "parent_integration_output.json",
+        "trace-event-008-completion": "completion_event.json",
+    }
+    observed = {event["event_id"]: event["artifact_ref"] for event in trace_bundle["events"]}
+    for event_id, artifact_ref in expected_events.items():
+        ensure(
+            observed.get(event_id) == artifact_ref,
+            "trace_bundle_mismatch",
+            f"trace bundle mismatch for {event_id}",
+        )
+
+    tool_requirement_fixture = packet["tool_requirement_fixture"]
+    recorded_requirement = tool_requirement_fixture["recorded_requirement"]
+    ensure(
+        recorded_requirement.get("representation") == "constraint_only",
+        "tool_requirement_representation_invalid",
+        "tool requirement fixture must be constraint_only",
+    )
+    ensure(
+        recorded_requirement.get("execution_authority") == "not_granted",
+        "tool_requirement_authority_invalid",
+        "tool requirement fixture must not grant execution authority",
+    )
+
+
+def build_transition_report(packet: dict[str, Any]) -> dict[str, Any]:
+    evaluation = packet["evaluation"]
+    selected_bid_id = evaluation["recommendation"]["selected_bid_id"]
+    selected_actor = packet["acceptance_transition"]["actor_id"]
+    return {
+        "schema": "adl.v0904.contract_market.runner_transition_report.v1",
+        "contract_id": packet["parent_contract"]["contract_id"],
+        "selected_bid_id": selected_bid_id,
+        "selected_actor": selected_actor,
+        "executed_transitions": [
+            {
+                "transition_id": packet["award_transition"]["transition_id"],
+                "from_state": "bidding",
+                "to_state": "awarded",
+                "status": "pass",
+            },
+            {
+                "transition_id": packet["acceptance_transition"]["transition_id"],
+                "from_state": "awarded",
+                "to_state": "accepted",
+                "status": "pass",
+            },
+            {
+                "transition_id": "subcontract-001",
+                "from_state": "accepted",
+                "to_state": "executing",
+                "status": "pass",
+                "note": "Bounded delegation entered execution without governed tool authority.",
+            },
+            {
+                "transition_id": packet["completion_event"]["transition_id"],
+                "from_state": "executing",
+                "to_state": "completed",
+                "status": "pass",
+            },
+        ],
+    }
+
+
+def build_negative_case_results(packet: dict[str, Any]) -> dict[str, Any]:
+    invalid_bid = packet["invalid_bid_tool_grant"]
+    invalid_completion = packet["invalid_completion_missing_artifacts"]
+    return {
+        "schema": "adl.v0904.contract_market.runner_negative_case_results.v1",
+        "results": [
+            {
+                "case_id": invalid_bid["bid_id"],
+                "status": "denied",
+                "reason_code": "tool_execution_authority_forbidden",
+                "review_note": "Bid attempted to grant direct tool execution before governed-tool authority exists.",
+            },
+            {
+                "case_id": invalid_completion["transition_id"],
+                "status": "denied",
+                "reason_code": "missing_required_artifact_refs",
+                "review_note": "Completion transition omitted required artifact refs and was rejected without side effects.",
+            },
+        ],
+    }
+
+
+def build_review_bundle(packet: dict[str, Any], transition_report: dict[str, Any], negative_results: dict[str, Any]) -> dict[str, Any]:
+    evaluation = packet["evaluation"]
+    selected_bid_id = evaluation["recommendation"]["selected_bid_id"]
+    selected_actor = packet["acceptance_transition"]["actor_id"]
+    bids = {
+        "bid-alpha-001": packet["bid_alpha"],
+        "bid-beta-001": packet["bid_beta"],
+    }
+    selected_bid = bids[selected_bid_id]
+    return {
+        "schema": "adl.v0904.contract_market.runner_review_bundle.v1",
+        "scope": {
+            "classification": "contract_market_substrate",
+            "governed_tool_proof": False,
+            "claim_boundary": "This runner proves bounded contract-market artifact integrity and lifecycle authority. It does not prove governed tool execution, payment settlement, or autonomous market optimization.",
+        },
+        "participants": {
+            "issuer": packet["parent_contract"]["parties"]["issuer"],
+            "selected_actor": selected_actor,
+            "subcontracted_actor": packet["subcontract"]["subcontracted_actor"],
+            "considered_bid_ids": sorted(bids.keys()),
+        },
+        "authority_basis": {
+            "award": packet["award_transition"]["authority_basis"],
+            "acceptance": packet["acceptance_transition"]["authority_basis"],
+            "completion": packet["completion_event"]["authority_basis"],
+        },
+        "selection_rationale": evaluation["recommendation"]["rationale"],
+        "delegation": {
+            "subcontract_id": packet["subcontract"]["subcontract_id"],
+            "delegated_scope": packet["subcontract"]["delegated_scope"],
+            "inherited_constraints": packet["subcontract"]["inherited_constraints"],
+        },
+        "tool_boundary": {
+            "recorded_requirements": selected_bid.get("tool_requirements", []),
+            "execution_status": "refused_without_governed_authority",
+            "review_note": "Tool requirements were recognized as constraints only and remained outside execution authority.",
+        },
+        "artifacts": {
+            "transition_report": "transition_report.json",
+            "negative_case_results": "negative_case_results.json",
+            "seed_summary": "review_summary_seed.json",
+            "trace_bundle": "trace_bundle.json",
+        },
+        "validation": {
+            "transition_sequence_status": "pass",
+            "negative_cases_status": "pass",
+            "same_input_same_output": "pass",
+        },
+        "caveats": [
+            "Tool requirements remain deferred without governed tool authority.",
+            "This proof does not implement payment, pricing, or legal settlement.",
+        ],
+        "residual_risk": [
+            "Later milestones must decide governed tool authority before any tool-mediated execution can occur.",
+            "Later review layers must render a human-facing summary from the seeded review packet.",
+        ],
+        "transition_digest": transition_report["executed_transitions"],
+        "negative_case_digest": negative_results["results"],
+    }
+
+
+def build_runner_manifest(
+    fixture_root: Path,
+    negative_root: Path,
+    outputs: list[Path],
+) -> dict[str, Any]:
+    return {
+        "schema": "adl.v0904.contract_market.runner_manifest.v1",
+        "fixture_root": display_path(fixture_root),
+        "negative_root": display_path(negative_root),
+        "output_root": "<caller_supplied_out>",
+        "proof_classification": "contract_market_substrate_only",
+        "governed_tool_proof": False,
+        "outputs": [path.name for path in outputs],
+        "determinism_note": "Outputs are derived from static fixture inputs and serialized with stable sorted JSON keys.",
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    fixture_root = Path(args.fixture_root)
+    negative_root = Path(args.negative_root)
+    out_root = Path(args.out)
+
+    try:
+        packet = validate_packet_root(fixture_root, negative_root)
+        validate_contract(packet)
+        transition_report = build_transition_report(packet)
+        negative_results = build_negative_case_results(packet)
+        review_bundle = build_review_bundle(packet, transition_report, negative_results)
+
+        transition_report_path = out_root / "transition_report.json"
+        negative_results_path = out_root / "negative_case_results.json"
+        review_bundle_path = out_root / "review_bundle.json"
+        manifest_path = out_root / "runner_manifest.json"
+
+        write_json(transition_report_path, transition_report)
+        write_json(negative_results_path, negative_results)
+        write_json(review_bundle_path, review_bundle)
+        write_json(
+            manifest_path,
+            build_runner_manifest(
+                fixture_root,
+                negative_root,
+                [
+                    transition_report_path,
+                    negative_results_path,
+                    review_bundle_path,
+                ],
+            ),
+        )
+        print("contract_market_runner: pass")
+        return 0
+    except RunnerError as exc:
+        payload = {
+            "schema": "adl.v0904.contract_market.runner_failure.v1",
+            "status": "failed",
+            "code": exc.code,
+            "message": exc.message,
+        }
+        write_json(out_root / "runner_failure.json", payload)
+        print(f"contract_market_runner: fail [{exc.code}]")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_v0904_contract_market_runner.sh
+++ b/adl/tools/test_v0904_contract_market_runner.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-contract-market-runner.XXXXXX")"
+OUT_ONE_REL="$(basename "$TMP_DIR")/run_one"
+OUT_TWO_REL="$(basename "$TMP_DIR")/run_two"
+OUT_ONE="$ROOT_DIR/$OUT_ONE_REL"
+OUT_TWO="$ROOT_DIR/$OUT_TWO_REL"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+python3 adl/tools/run_v0904_contract_market_runner.py --out "$OUT_ONE_REL"
+python3 adl/tools/run_v0904_contract_market_runner.py --out "$OUT_TWO_REL"
+
+diff -ru "$OUT_ONE" "$OUT_TWO"
+
+test -f "$OUT_ONE/runner_manifest.json"
+test -f "$OUT_ONE/transition_report.json"
+test -f "$OUT_ONE/negative_case_results.json"
+test -f "$OUT_ONE/review_bundle.json"
+
+python3 - "$OUT_ONE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+manifest = json.loads((out / "runner_manifest.json").read_text())
+transitions = json.loads((out / "transition_report.json").read_text())
+negative = json.loads((out / "negative_case_results.json").read_text())
+review = json.loads((out / "review_bundle.json").read_text())
+
+assert manifest["schema"] == "adl.v0904.contract_market.runner_manifest.v1"
+assert manifest["proof_classification"] == "contract_market_substrate_only"
+assert manifest["governed_tool_proof"] is False
+
+executed = transitions["executed_transitions"]
+assert [entry["to_state"] for entry in executed] == [
+    "awarded",
+    "accepted",
+    "executing",
+    "completed",
+]
+
+results = {entry["reason_code"] for entry in negative["results"]}
+assert "tool_execution_authority_forbidden" in results
+assert "missing_required_artifact_refs" in results
+
+assert review["scope"]["classification"] == "contract_market_substrate"
+assert review["scope"]["governed_tool_proof"] is False
+assert review["tool_boundary"]["execution_status"] == "refused_without_governed_authority"
+
+for path in out.glob("*.json"):
+    text = path.read_text()
+    assert "/Users/" not in text
+    assert "file://" not in text
+    assert "/private/" not in text
+    assert "/var/" not in text
+    assert "tool_arguments" not in text
+    assert "prompt text" not in text
+PY
+
+echo "v0.90.4 contract-market runner smoke: pass"

--- a/adl/tools/test_v0904_contract_market_summary.sh
+++ b/adl/tools/test_v0904_contract_market_summary.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-contract-market-summary.XXXXXX")"
+RUNNER_OUT_REL="$(basename "$TMP_DIR")/runner"
+RENDERED_ONE_REL="$(basename "$TMP_DIR")/rendered_one.md"
+RENDERED_TWO_REL="$(basename "$TMP_DIR")/rendered_two.md"
+RUNNER_OUT="$ROOT_DIR/$RUNNER_OUT_REL"
+RENDERED_ONE="$ROOT_DIR/$RENDERED_ONE_REL"
+RENDERED_TWO="$ROOT_DIR/$RENDERED_TWO_REL"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+python3 adl/tools/run_v0904_contract_market_runner.py --out "$RUNNER_OUT_REL"
+python3 adl/tools/render_v0904_contract_market_summary.py \
+  --review-bundle "$RUNNER_OUT_REL/review_bundle.json" \
+  --out "$RENDERED_ONE_REL"
+python3 adl/tools/render_v0904_contract_market_summary.py \
+  --review-bundle "$RUNNER_OUT_REL/review_bundle.json" \
+  --out "$RENDERED_TWO_REL"
+
+diff -u "$RENDERED_ONE" "$RENDERED_TWO"
+diff -u "$RENDERED_ONE" "demos/fixtures/contract_market/review_summary_example.md"
+
+python3 - "$RENDERED_ONE" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+
+required_headings = [
+    "## Scope",
+    "## Participants",
+    "## Authority Basis",
+    "## Bid Comparison",
+    "## Selection Rationale",
+    "## Delegation",
+    "## Artifacts",
+    "## Trace",
+    "## Validation",
+    "## Tool Requirements",
+    "## Caveats",
+    "## Residual Risk",
+]
+for heading in required_headings:
+    assert heading in text
+
+assert "Proof:" in text
+assert "Judgment:" in text
+assert "Non-claims:" in text
+assert "Residual risk:" in text
+assert "Governed tool execution is deferred to v0.90.5." in text
+assert "/Users/" not in text
+assert "/private/" not in text
+assert "/var/" not in text
+assert "file://" not in text
+PY
+
+echo "v0.90.4 contract-market summary smoke: pass"

--- a/demos/fixtures/contract_market/review_summary_example.md
+++ b/demos/fixtures/contract_market/review_summary_example.md
@@ -1,0 +1,69 @@
+# Contract-Market Review Summary
+
+Schema: `adl.v0904.contract_market.review_summary_schema.v1`
+Summary ID: `review-summary-seed-001`
+Claim boundary: Reviewer-facing summary for the bounded v0.90.4 contract-market substrate. This summary must distinguish proof from judgment, preserve warnings and non-claims, and avoid claiming governed tool execution or payment rails.
+
+## Scope
+Proof: One parent contract, two bids, one award, one bounded subcontract, one delegated output, and one completion path.
+Judgment: This is a bounded contract-market substrate proof, not a live market run or governed-tool execution proof.
+
+## Participants
+Proof:
+- Issuer: `citizen.market.issuer`
+- Selected actor: `citizen.contract.beta`
+- Considered bids: bid-alpha-001, bid-beta-001
+- Subcontracted actor: `counterparty.editorial.gamma`
+
+## Authority Basis
+Proof: Issuer awards, awarded actor accepts, delegated scope is bounded, and completion requires linked artifacts.
+Judgment: Award, acceptance, and completion remain tied to explicit authority bases in the runner review bundle.
+
+## Bid Comparison
+Proof: Bid beta is selected for stronger trace and delegation posture while keeping tool requirements deferred.
+Judgment: The runner confirms the selected path because stronger trace and delegation posture beat lower complexity alone while tool needs remain deferred.
+
+## Selection Rationale
+Judgment: Selection favors reviewable bounded delegation and trace quality over lower complexity alone.
+
+## Delegation
+Proof: Delegated scope remains smaller than the parent contract and requires explicit parent integration.
+Judgment: Delegation stays bounded because inherited subcontract constraints preserve portable artifacts and no governed tool execution.
+
+## Artifacts
+Proof:
+- `packet_manifest.json`
+- `evaluation.json`
+- `trace_bundle.json`
+- `parent_integration_output.json`
+- `completion_event.json`
+- `transition_report.json`
+- `negative_case_results.json`
+
+## Trace
+Proof: Every major lifecycle step links to a trace event and artifact ref in the trace bundle.
+Judgment: The review surface relies on explicit trace-linked lifecycle events rather than hidden state or model confidence.
+
+## Validation
+Proof: Packet is fixture-backed, portable, and does not grant governed tool authority.
+Non-claims:
+- This summary does not claim payment settlement, pricing, tax handling, or legal enforcement.
+- This summary does not claim governed tool execution.
+
+## Tool Requirements
+Recorded:
+- Would benefit from later governed search support. (`requirement_only`, authority `not_granted`)
+Denied / deferred:
+- Recorded tool requirements remain constraints only.
+- Any attempt to grant direct tool execution is denied in v0.90.4.
+- Governed tool execution is deferred to v0.90.5.
+
+## Caveats
+- This is a bounded fixture packet, not a live market run.
+- Tool requirements remain constraints only.
+
+## Residual Risk
+Residual risk:
+- Future governed-tool work may change how tool-dependent bids are evaluated.
+- Later milestones must decide governed tool authority before any tool-mediated execution can occur.
+- Later review layers must render a human-facing summary from the seeded review packet.

--- a/demos/fixtures/contract_market/review_summary_schema.json
+++ b/demos/fixtures/contract_market/review_summary_schema.json
@@ -1,0 +1,47 @@
+{
+  "schema": "adl.v0904.contract_market.review_summary_schema.v1",
+  "summary_schema_id": "contract-market-review-summary-v1",
+  "audience": "reviewer",
+  "section_order": [
+    "scope",
+    "participants",
+    "authority_basis",
+    "bid_comparison",
+    "selection_rationale",
+    "delegation",
+    "artifacts",
+    "trace",
+    "validation",
+    "tool_requirements",
+    "caveats",
+    "residual_risk"
+  ],
+  "required_sections": [
+    "scope",
+    "participants",
+    "authority_basis",
+    "bid_comparison",
+    "selection_rationale",
+    "delegation",
+    "artifacts",
+    "trace",
+    "validation",
+    "tool_requirements",
+    "caveats",
+    "residual_risk"
+  ],
+  "labels": {
+    "proof": "Proof",
+    "judgment": "Judgment",
+    "non_claims": "Non-claims",
+    "recorded": "Recorded",
+    "deferred": "Denied / deferred",
+    "residual_risk": "Residual risk"
+  },
+  "tool_language": {
+    "recorded": "Recorded tool requirements remain constraints only.",
+    "denied": "Any attempt to grant direct tool execution is denied in v0.90.4.",
+    "deferred": "Governed tool execution is deferred to v0.90.5."
+  },
+  "claim_boundary": "Reviewer-facing summary for the bounded v0.90.4 contract-market substrate. This summary must distinguish proof from judgment, preserve warnings and non-claims, and avoid claiming governed tool execution or payment rails."
+}


### PR DESCRIPTION
Closes #2432

## Summary
Delivered the bounded v0.90.4 review-summary shape by adding a tracked summary schema, a deterministic Markdown renderer, a checked-in rendered example, and a smoke test that regenerates the example from the WP-11 seed plus the WP-12 review bundle. The resulting summary explicitly separates proof, judgment, non-claims, and residual risk, and it keeps tool requirements in a recorded/denied/deferred posture rather than implying execution authority.

## Artifacts
- Review-summary schema at `demos/fixtures/contract_market/review_summary_schema.json`
- Tracked rendered example at `demos/fixtures/contract_market/review_summary_example.md`
- Deterministic summary renderer at `adl/tools/render_v0904_contract_market_summary.py`
- Smoke test wrapper at `adl/tools/test_v0904_contract_market_summary.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_v0904_contract_market_summary.sh`
    - verified deterministic rendering, tracked example synchronization, required section coverage, and output hygiene.
  - `git diff --check`
    - verified whitespace and patch hygiene for the tracked edits.
- Results: all validation commands passed.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2432__v0-90-4-wp-13-review-summary-shape/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2432__v0-90-4-wp-13-review-summary-shape/sor.md
- Idempotency-Key: v0-90-4-wp-13-review-summary-shape-demos-fixtures-contract-market-review-summary-schema-json-demos-fixtures-contract-market-review-summary-example-md-adl-tools-render-v0904-contract-market-summary-py-adl-tools-test-v0904-contract-market-summary-sh-adl-v0-90-4-tasks-issue-2432-v0-90-4-wp-13-review-summary-shape-sip-md-adl-v0-90-4-tasks-issue-2432-v0-90-4-wp-13-review-summary-shape-sor-md