### PR TITLE
[v0.90.4][WP-13] Review summary shape

### DIFF
--- a/adl/tools/render_v0904_contract_market_summary.py
+++ b/adl/tools/render_v0904_contract_market_summary.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Render the v0.90.4 contract-market review summary example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+class RenderError(Exception):
+    """Stable renderer failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render the deterministic v0.90.4 contract-market review summary."
+    )
+    parser.add_argument(
+        "--seed",
+        default="demos/fixtures/contract_market/review_summary_seed.json",
+        help="Repo-relative path to the review summary seed.",
+    )
+    parser.add_argument(
+        "--review-bundle",
+        required=True,
+        help="Repo-relative path to the WP-12 review bundle artifact.",
+    )
+    parser.add_argument(
+        "--schema",
+        default="demos/fixtures/contract_market/review_summary_schema.json",
+        help="Repo-relative path to the review summary schema.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Repo-relative output path for the rendered Markdown summary.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise RenderError("missing_input", f"missing input: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RenderError("invalid_json", f"invalid json in {path}: {exc}") from exc
+
+
+def ensure(condition: bool, code: str, message: str) -> None:
+    if not condition:
+        raise RenderError(code, message)
+
+
+def bullet_lines(items: list[str]) -> list[str]:
+    return [f"- {item}" for item in items]
+
+
+def format_recorded_requirements(review_bundle: dict[str, Any]) -> list[str]:
+    requirements = review_bundle["tool_boundary"]["recorded_requirements"]
+    if not requirements:
+        return ["- none recorded"]
+    return [
+        "- "
+        + requirement["description"]
+        + f" (`{requirement['mode']}`, authority `{requirement['execution_authority']}`)"
+        for requirement in requirements
+    ]
+
+
+def render_summary(schema: dict[str, Any], seed: dict[str, Any], review_bundle: dict[str, Any]) -> str:
+    ensure(
+        schema.get("schema") == "adl.v0904.contract_market.review_summary_schema.v1",
+        "schema_mismatch",
+        "review summary schema mismatch",
+    )
+    ensure(
+        seed.get("schema") == "adl.v0904.contract_market.review_summary_seed.v1",
+        "seed_mismatch",
+        "review summary seed schema mismatch",
+    )
+    ensure(
+        review_bundle.get("schema") == "adl.v0904.contract_market.runner_review_bundle.v1",
+        "review_bundle_mismatch",
+        "review bundle schema mismatch",
+    )
+
+    labels = schema["labels"]
+    tool_language = schema["tool_language"]
+
+    artifact_items = list(seed["artifacts"]) + [
+        review_bundle["artifacts"]["transition_report"],
+        review_bundle["artifacts"]["negative_case_results"],
+    ]
+    participants = review_bundle["participants"]
+    considered_bids = ", ".join(participants["considered_bid_ids"])
+
+    lines = [
+        "# Contract-Market Review Summary",
+        "",
+        f"Schema: `{schema['schema']}`",
+        f"Summary ID: `{seed['summary_id']}`",
+        f"Claim boundary: {schema['claim_boundary']}",
+        "",
+        "## Scope",
+        f"{labels['proof']}: {seed['scope']}",
+        f"{labels['judgment']}: This is a bounded contract-market substrate proof, not a live market run or governed-tool execution proof.",
+        "",
+        "## Participants",
+        f"{labels['proof']}:",
+        f"- Issuer: `{participants['issuer']}`",
+        f"- Selected actor: `{participants['selected_actor']}`",
+        f"- Considered bids: {considered_bids}",
+        f"- Subcontracted actor: `{participants['subcontracted_actor']}`",
+        "",
+        "## Authority Basis",
+        f"{labels['proof']}: {seed['authority_basis']}",
+        f"{labels['judgment']}: Award, acceptance, and completion remain tied to explicit authority bases in the runner review bundle.",
+        "",
+        "## Bid Comparison",
+        f"{labels['proof']}: {seed['bid_comparison']}",
+        f"{labels['judgment']}: The runner confirms the selected path because stronger trace and delegation posture beat lower complexity alone while tool needs remain deferred.",
+        "",
+        "## Selection Rationale",
+        f"{labels['judgment']}: {seed['selection_rationale']}",
+        "",
+        "## Delegation",
+        f"{labels['proof']}: {seed['delegation']}",
+        f"{labels['judgment']}: Delegation stays bounded because inherited subcontract constraints preserve portable artifacts and no governed tool execution.",
+        "",
+        "## Artifacts",
+        f"{labels['proof']}:",
+        *bullet_lines([f"`{item}`" for item in artifact_items]),
+        "",
+        "## Trace",
+        f"{labels['proof']}: {seed['trace']}",
+        f"{labels['judgment']}: The review surface relies on explicit trace-linked lifecycle events rather than hidden state or model confidence.",
+        "",
+        "## Validation",
+        f"{labels['proof']}: {seed['validation']}",
+        f"{labels['non_claims']}:",
+        "- This summary does not claim payment settlement, pricing, tax handling, or legal enforcement.",
+        "- This summary does not claim governed tool execution.",
+        "",
+        "## Tool Requirements",
+        f"{labels['recorded']}:",
+        *format_recorded_requirements(review_bundle),
+        f"{labels['deferred']}:",
+        f"- {tool_language['recorded']}",
+        f"- {tool_language['denied']}",
+        f"- {tool_language['deferred']}",
+        "",
+        "## Caveats",
+        *bullet_lines(seed["caveats"]),
+        "",
+        "## Residual Risk",
+        f"{labels['residual_risk']}:",
+        *bullet_lines(seed["residual_risk"] + review_bundle["residual_risk"]),
+        "",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    seed = load_json(Path(args.seed))
+    review_bundle = load_json(Path(args.review_bundle))
+    schema = load_json(Path(args.schema))
+    out_path = Path(args.out)
+    try:
+        rendered = render_summary(schema, seed, review_bundle)
+    except RenderError as exc:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(f"render_failure: {exc.code}: {exc.message}\n")
+        print(f"contract_market_summary: fail [{exc.code}]")
+        return 1
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered)
+    print("contract_market_summary: pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_v0904_contract_market_summary.sh
+++ b/adl/tools/test_v0904_contract_market_summary.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-contract-market-summary.XXXXXX")"
+RUNNER_OUT_REL="$(basename "$TMP_DIR")/runner"
+RENDERED_ONE_REL="$(basename "$TMP_DIR")/rendered_one.md"
+RENDERED_TWO_REL="$(basename "$TMP_DIR")/rendered_two.md"
+RUNNER_OUT="$ROOT_DIR/$RUNNER_OUT_REL"
+RENDERED_ONE="$ROOT_DIR/$RENDERED_ONE_REL"
+RENDERED_TWO="$ROOT_DIR/$RENDERED_TWO_REL"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+python3 adl/tools/run_v0904_contract_market_runner.py --out "$RUNNER_OUT_REL"
+python3 adl/tools/render_v0904_contract_market_summary.py \
+  --review-bundle "$RUNNER_OUT_REL/review_bundle.json" \
+  --out "$RENDERED_ONE_REL"
+python3 adl/tools/render_v0904_contract_market_summary.py \
+  --review-bundle "$RUNNER_OUT_REL/review_bundle.json" \
+  --out "$RENDERED_TWO_REL"
+
+diff -u "$RENDERED_ONE" "$RENDERED_TWO"
+diff -u "$RENDERED_ONE" "demos/fixtures/contract_market/review_summary_example.md"
+
+python3 - "$RENDERED_ONE" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+
+required_headings = [
+    "## Scope",
+    "## Participants",
+    "## Authority Basis",
+    "## Bid Comparison",
+    "## Selection Rationale",
+    "## Delegation",
+    "## Artifacts",
+    "## Trace",
+    "## Validation",
+    "## Tool Requirements",
+    "## Caveats",
+    "## Residual Risk",
+]
+for heading in required_headings:
+    assert heading in text
+
+assert "Proof:" in text
+assert "Judgment:" in text
+assert "Non-claims:" in text
+assert "Residual risk:" in text
+assert "Governed tool execution is deferred to v0.90.5." in text
+assert "/Users/" not in text
+assert "/private/" not in text
+assert "/var/" not in text
+assert "file://" not in text
+PY
+
+echo "v0.90.4 contract-market summary smoke: pass"

--- a/demos/fixtures/contract_market/review_summary_example.md
+++ b/demos/fixtures/contract_market/review_summary_example.md
@@ -1,0 +1,69 @@
+# Contract-Market Review Summary
+
+Schema: `adl.v0904.contract_market.review_summary_schema.v1`
+Summary ID: `review-summary-seed-001`
+Claim boundary: Reviewer-facing summary for the bounded v0.90.4 contract-market substrate. This summary must distinguish proof from judgment, preserve warnings and non-claims, and avoid claiming governed tool execution or payment rails.
+
+## Scope
+Proof: One parent contract, two bids, one award, one bounded subcontract, one delegated output, and one completion path.
+Judgment: This is a bounded contract-market substrate proof, not a live market run or governed-tool execution proof.
+
+## Participants
+Proof:
+- Issuer: `citizen.market.issuer`
+- Selected actor: `citizen.contract.beta`
+- Considered bids: bid-alpha-001, bid-beta-001
+- Subcontracted actor: `counterparty.editorial.gamma`
+
+## Authority Basis
+Proof: Issuer awards, awarded actor accepts, delegated scope is bounded, and completion requires linked artifacts.
+Judgment: Award, acceptance, and completion remain tied to explicit authority bases in the runner review bundle.
+
+## Bid Comparison
+Proof: Bid beta is selected for stronger trace and delegation posture while keeping tool requirements deferred.
+Judgment: The runner confirms the selected path because stronger trace and delegation posture beat lower complexity alone while tool needs remain deferred.
+
+## Selection Rationale
+Judgment: Selection favors reviewable bounded delegation and trace quality over lower complexity alone.
+
+## Delegation
+Proof: Delegated scope remains smaller than the parent contract and requires explicit parent integration.
+Judgment: Delegation stays bounded because inherited subcontract constraints preserve portable artifacts and no governed tool execution.
+
+## Artifacts
+Proof:
+- `packet_manifest.json`
+- `evaluation.json`
+- `trace_bundle.json`
+- `parent_integration_output.json`
+- `completion_event.json`
+- `transition_report.json`
+- `negative_case_results.json`
+
+## Trace
+Proof: Every major lifecycle step links to a trace event and artifact ref in the trace bundle.
+Judgment: The review surface relies on explicit trace-linked lifecycle events rather than hidden state or model confidence.
+
+## Validation
+Proof: Packet is fixture-backed, portable, and does not grant governed tool authority.
+Non-claims:
+- This summary does not claim payment settlement, pricing, tax handling, or legal enforcement.
+- This summary does not claim governed tool execution.
+
+## Tool Requirements
+Recorded:
+- Would benefit from later governed search support. (`requirement_only`, authority `not_granted`)
+Denied / deferred:
+- Recorded tool requirements remain constraints only.
+- Any attempt to grant direct tool execution is denied in v0.90.4.
+- Governed tool execution is deferred to v0.90.5.
+
+## Caveats
+- This is a bounded fixture packet, not a live market run.
+- Tool requirements remain constraints only.
+
+## Residual Risk
+Residual risk:
+- Future governed-tool work may change how tool-dependent bids are evaluated.
+- Later milestones must decide governed tool authority before any tool-mediated execution can occur.
+- Later review layers must render a human-facing summary from the seeded review packet.

--- a/demos/fixtures/contract_market/review_summary_schema.json
+++ b/demos/fixtures/contract_market/review_summary_schema.json
@@ -1,0 +1,47 @@
+{
+  "schema": "adl.v0904.contract_market.review_summary_schema.v1",
+  "summary_schema_id": "contract-market-review-summary-v1",
+  "audience": "reviewer",
+  "section_order": [
+    "scope",
+    "participants",
+    "authority_basis",
+    "bid_comparison",
+    "selection_rationale",
+    "delegation",
+    "artifacts",
+    "trace",
+    "validation",
+    "tool_requirements",
+    "caveats",
+    "residual_risk"
+  ],
+  "required_sections": [
+    "scope",
+    "participants",
+    "authority_basis",
+    "bid_comparison",
+    "selection_rationale",
+    "delegation",
+    "artifacts",
+    "trace",
+    "validation",
+    "tool_requirements",
+    "caveats",
+    "residual_risk"
+  ],
+  "labels": {
+    "proof": "Proof",
+    "judgment": "Judgment",
+    "non_claims": "Non-claims",
+    "recorded": "Recorded",
+    "deferred": "Denied / deferred",
+    "residual_risk": "Residual risk"
+  },
+  "tool_language": {
+    "recorded": "Recorded tool requirements remain constraints only.",
+    "denied": "Any attempt to grant direct tool execution is denied in v0.90.4.",
+    "deferred": "Governed tool execution is deferred to v0.90.5."
+  },
+  "claim_boundary": "Reviewer-facing summary for the bounded v0.90.4 contract-market substrate. This summary must distinguish proof from judgment, preserve warnings and non-claims, and avoid claiming governed tool execution or payment rails."
+}


### PR DESCRIPTION
## Summary
- add the bounded review-summary schema, deterministic renderer, tracked example, and smoke test
- render the example from the WP-11 seed plus the WP-12 review bundle
- preserve proof/judgment/non-claim/residual-risk distinctions for later contract-market demos

Closes #2432