### PR TITLE
[v0.90.4][backlog][tools] Add issue-folding operational skill

### DIFF
--- a/adl/tools/skills/docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,77 @@
+# Issue Folding Skill Input Schema
+
+Schema id: `issue_folding.v1`
+
+Use this schema when invoking `issue-folding` with structured input.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `issue_folding.v1`
+- `mode`: one of `analyze_issue_bundle` or `analyze_issue_number`
+- `repo_root`: absolute repository root
+- `target`: one bounded issue target
+- `policy`: stop-boundary and evidence policy
+
+## Target Object
+
+Recommended fields:
+
+- `issue_number`
+- `task_bundle_path`
+- `source_issue_prompt_path`
+- `issue_state`
+- `pr_state`
+- `closure_hints`
+
+`analyze_issue_bundle` requires:
+
+- `task_bundle_path`
+
+`analyze_issue_number` requires:
+
+- `issue_number`
+
+## Policy Object
+
+Recommended fields:
+
+- `allow_network`
+- `stop_before_closeout`
+- `stop_before_tracker_mutation`
+- `permit_safe_noop_closeout_handoff`
+- `require_closure_references_for_linked_dispositions`
+
+## Example
+
+```yaml
+skill_input_schema: issue_folding.v1
+mode: analyze_issue_bundle
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  task_bundle_path: .adl/v0.90.4/tasks/issue-2481__v0-90-4-backlog-add-issue-folding-operational-skill
+  source_issue_prompt_path: .adl/v0.90.4/bodies/issue-2481-v0-90-4-backlog-add-issue-folding-operational-skill.md
+  issue_state: open
+  pr_state: none
+policy:
+  allow_network: false
+  stop_before_closeout: true
+  stop_before_tracker_mutation: true
+  permit_safe_noop_closeout_handoff: true
+  require_closure_references_for_linked_dispositions: true
+```
+
+## Output
+
+Default output root:
+
+```text
+.adl/reviews/issue-folding/<run_id>/
+```
+
+Required artifacts:
+
+- `issue_folding_report.md`
+- `issue_folding_report.json`
+
+The report must preserve issue-graph references, uncertainty, and non-claims. It
+must not close the issue, mutate GitHub, merge PRs, or prune worktrees.

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -23,6 +23,7 @@ The tracked skill set is:
 - `documentation-specialist`
 - `finding-to-issue-planner`
 - `gap-analysis`
+- `issue-folding`
 - `issue-watcher`
 - `medium-article-writer`
 - `portable-contract-normalizer`
@@ -81,6 +82,7 @@ The normal workflow is:
 `arxiv-paper-writer` is a bounded helper skill for turning one concrete scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, or inventing citations.
 `diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
+`issue-folding` is a bounded issue-disposition helper for classifying duplicate, superseded, absorbed, already-satisfied, obsolete, or still-actionable issues before closeout.
 `issue-watcher` is a bounded wait-window helper for watching one issue, PR, branch, or dependency gate and routing blockers without mutating state.
 `pr-stack-manager` is a bounded stack-topology helper for ancestry, base alignment, and dependency-order analysis.
 `review-comment-triage` is a bounded review-feedback helper for classifying PR comments before implementation.
@@ -1367,6 +1369,48 @@ Use `documentation-specialist` for approved mechanical cleanup, `gap-analysis`
 for scope-vs-evidence uncertainty, `finding-to-issue-planner` for follow-on
 issue candidates, and `review-quality-evaluator` for packet quality gates.
 
+## `issue-folding`
+
+### Purpose
+
+`issue-folding` classifies one bounded issue packet to decide whether it should
+stay actionable or close as duplicate, superseded, absorbed, already satisfied,
+or obsolete work.
+
+It preserves linked issue or PR references and recommends the truthful closeout
+handoff without claiming that closure already happened.
+
+### When To Use It
+
+Use it when:
+
+- an issue appears to be already covered by other work
+- closeout might be a no-op rather than a fresh implementation path
+- issue-graph references should be preserved before closure
+
+Do not use it for:
+
+- performing the closeout itself
+- implementing the absorbed work
+- broad tracker cleanup without one bounded issue target
+
+Structured schema:
+
+- `adl/tools/skills/docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md`
+- schema id: `issue_folding.v1`
+
+Deterministic fixture analyzer:
+
+```bash
+python3 adl/tools/skills/issue-folding/scripts/classify_issue_folding.py --task-bundle <path> --source-prompt <path> --out <artifact-root> --run-id <run-id>
+```
+
+### Typical Handoff
+
+Use `workflow-conductor` for still-actionable issues, `pr-closeout` for
+evidence-backed foldable outcomes, and operator review when disposition signals
+conflict.
+
 ## `portable-contract-normalizer`
 
 ### Purpose
@@ -2318,6 +2362,8 @@ Use this quick selector:
   - `release-evidence`
 - need to finalize local issue state after merge/closure:
   - `pr-closeout`
+- need to classify whether an issue should close as duplicate, superseded, absorbed, already satisfied, or obsolete work:
+  - `issue-folding`
 - need to clean drifted lifecycle records before closeout or janitor handoff:
   - `records-hygiene`
 - need to inspect stacked PR topology or stale branch bases:
@@ -2383,6 +2429,7 @@ surfaces:
 | `documentation-specialist` | `DOCUMENTATION_SPECIALIST_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | bounded docs write, audit, or handoff |
 | `finding-to-issue-planner` | `FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | issue candidates only |
 | `gap-analysis` | `GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | gap report only |
+| `issue-folding` | `ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | issue disposition classification only |
 | `medium-article-writer` | `MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | article packet only |
 | `portable-contract-normalizer` | `PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | bounded portability scan or explicit safe normalization only |
 | `pr-closeout` | `PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | local closeout only |

--- a/adl/tools/skills/issue-folding/SKILL.md
+++ b/adl/tools/skills/issue-folding/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: issue-folding
+description: Classify whether an issue should stay actionable, close as duplicate or superseded work, fold into another issue, or no-op close out with evidence-backed routing.
+---
+
+# Issue Folding
+
+This skill is an issue disposition classifier and closeout-routing helper.
+
+Its job is to:
+
+- inspect one bounded issue packet or task bundle
+- detect evidence that the issue is still actionable or should fold cleanly
+- preserve linked issue or PR references for duplicate, superseded, or absorbed work
+- recommend the correct closeout handoff without pretending implementation happened
+- record whether any bound worktree should be retired when the issue is a true no-op
+
+It does not implement the folded work, silently close the issue, or widen into
+repo-wide cleanup.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `issue_number`
+  - `task_bundle_path`
+  - `source_issue_prompt_path`
+- `mode`
+- `policy`
+
+Useful additional inputs:
+
+- `issue_state`
+- `pr_state`
+- `source_prompt_path`
+- `stp_path`
+- `sip_path`
+- `sor_path`
+- `closure_hints`
+
+If there is no concrete issue packet or task-bundle target, stop with `blocked`.
+
+## Classification Model
+
+Supported classifications:
+
+- `actionable`
+  - the issue still needs dedicated execution
+- `duplicate`
+  - the work is already tracked elsewhere and should close as duplicate
+- `superseded`
+  - the issue has been replaced by a newer bounded issue or PR
+- `absorbed`
+  - the work was folded into another issue or PR and no longer needs a standalone path
+- `already_satisfied`
+  - the intended result is already present on main or otherwise complete with no new PR
+- `obsolete`
+  - the issue is no longer relevant because the premise expired or the policy changed
+- `blocked`
+  - evidence conflicts or is too weak to close safely
+
+If multiple non-actionable classes appear with conflicting evidence, classify as
+`blocked` and preserve the uncertainty.
+
+## Workflow
+
+### 1. Resolve the Target
+
+Prefer this order:
+
+1. task bundle path
+2. issue number with resolved repo surfaces
+3. source issue prompt path
+
+Only inspect one issue target per invocation.
+
+### 2. Gather Evidence
+
+Read the bounded issue packet:
+
+- source issue prompt
+- `stp.md`
+- `sip.md`
+- `sor.md`
+
+Look for explicit closure cues such as:
+
+- `duplicate`
+- `superseded by #<n>`
+- `covered by #<n>`
+- `absorbed into #<n>`
+- `already satisfied on main`
+- `obsolete`
+
+For deterministic local classification, use:
+
+`python3 adl/tools/skills/issue-folding/scripts/classify_issue_folding.py --task-bundle <path> --source-prompt <path> --out <path>`
+
+### 3. Classify and Preserve References
+
+For every non-actionable outcome:
+
+- preserve the matching evidence line
+- preserve linked issue or PR references when they exist
+- map the class to a recommended closeout outcome
+- recommend whether any bound worktree can be retired
+
+Default closeout mapping:
+
+- `duplicate` -> `duplicate`
+- `superseded` -> `superseded`
+- `absorbed` -> `superseded`
+- `already_satisfied` -> `closed_no_pr`
+- `obsolete` -> `closed_no_pr`
+
+### 4. Handoff
+
+Recommend:
+
+- `workflow-conductor` or normal execution for `actionable`
+- `pr-closeout` for duplicate, superseded, absorbed, already-satisfied, or obsolete outcomes
+- operator review for `blocked`
+
+This skill stops after classification and handoff guidance. It does not mutate
+GitHub or perform the closeout itself.
+
+## Stop Boundary
+
+Stop after:
+
+- one truthful classification
+- evidence capture
+- recommended closure outcome
+- worktree-retirement guidance
+- handoff recommendation
+
+Do not:
+
+- implement fixes
+- merge or close issues directly
+- rewrite milestone plans
+- silently prune unrelated worktrees
+
+## Output
+
+Use the structured contract in `references/output-contract.md`.

--- a/adl/tools/skills/issue-folding/adl-skill.yaml
+++ b/adl/tools/skills/issue-folding/adl-skill.yaml
@@ -1,0 +1,91 @@
+version: "0.1"
+kind: "adl-skill"
+id: "issue-folding"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "issue_folding.v1"
+    reference_doc: "../docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "analyze_issue_bundle"
+      - "analyze_issue_number"
+    policy_fields:
+      - "allow_network"
+      - "stop_before_closeout"
+      - "stop_before_tracker_mutation"
+      - "permit_safe_noop_closeout_handoff"
+      - "require_closure_references_for_linked_dispositions"
+    mode_requirements:
+      analyze_issue_bundle:
+        required_target_fields:
+          - "task_bundle_path"
+      analyze_issue_number:
+        required_target_fields:
+          - "issue_number"
+  intent:
+    - "issue_disposition_classification"
+    - "fold_or_closeout_routing"
+    - "issue_graph_preservation"
+required_inputs:
+  - "repo_root"
+optional_inputs:
+  - "issue_number"
+  - "task_bundle_path"
+  - "source_issue_prompt_path"
+  - "issue_state"
+  - "pr_state"
+  - "closure_hints"
+stop_if_missing:
+  - "repo_root"
+  - "policy.stop_before_closeout"
+  - "policy.stop_before_tracker_mutation"
+prevalidation_rules:
+  - "repo_root_must_be_absolute"
+  - "skill_input_schema_must_equal_issue_folding.v1_when_structured_input_is_used"
+  - "mode_must_match_supported_enum"
+  - "exactly_one_issue_target_should_drive_the_mode"
+  - "policy.stop_before_closeout_must_be_true"
+  - "policy.stop_before_tracker_mutation_must_be_true"
+  - "linked_dispositions_require_reference_evidence"
+execution:
+  mode: "classify_only"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: false
+  preferred_commands:
+    - "python3 adl/tools/skills/issue-folding/scripts/classify_issue_folding.py --task-bundle <path> --source-prompt <path> --out <path>"
+    - "rg -n \"duplicate|superseded|covered by|absorbed|already satisfied|obsolete\" .adl"
+  preferred_path: "task_bundle_first"
+  stop_before:
+    - "pr_run"
+    - "issue_closure"
+    - "worktree_pruning"
+    - "silent_scope_rewrite"
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-issue-folding.md"
+  required_sections:
+    - "status"
+    - "classification"
+    - "evidence"
+    - "closure_outcome"
+    - "worktree_action"
+    - "recommended_handoff"
+    - "non_claims"
+    - "safety_flags"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_live_github_mutation_without_explicit_permission: true
+  manifest_declares_executables: true

--- a/adl/tools/skills/issue-folding/agents/openai.yaml
+++ b/adl/tools/skills/issue-folding/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Issue Folding
+short_description: Classify whether one issue should stay actionable or close as duplicate, superseded, absorbed, already satisfied, or obsolete work
+default_prompt: Inspect one issue packet or task bundle for evidence that it is still actionable, duplicated, superseded, absorbed elsewhere, already satisfied on main, or obsolete. Preserve linked issue or PR references, recommend the truthful closeout outcome and worktree action, and stop before implementation, tracker mutation, or silent issue closure.

--- a/adl/tools/skills/issue-folding/references/issue-folding-playbook.md
+++ b/adl/tools/skills/issue-folding/references/issue-folding-playbook.md
@@ -1,0 +1,46 @@
+# Issue Folding Playbook
+
+Use `issue-folding` when an issue appears to have become a no-op or should close
+without a fresh implementation PR.
+
+## Evidence Order
+
+Prefer these surfaces:
+
+1. source issue prompt
+2. `stp.md`
+3. `sip.md`
+4. `sor.md`
+5. explicit linked issue or PR references
+
+Do not infer `duplicate`, `superseded`, or `absorbed` without a linked issue or
+PR reference unless the packet clearly marks the issue as obsolete or already
+satisfied.
+
+## Recommended Mappings
+
+- `duplicate`:
+  - use when the packet says the same work is already tracked elsewhere
+  - preserve linked issue references
+- `superseded`:
+  - use when the issue was replaced by a newer, clearer issue or PR
+- `absorbed`:
+  - use when the work is explicitly folded into another issue or PR
+- `already_satisfied`:
+  - use when the intended state is already true on main and no new PR is needed
+- `obsolete`:
+  - use when the premise no longer matters because policy, milestone, or design changed
+
+## Blockers
+
+Classify as `blocked` when:
+
+- more than one non-actionable class appears with conflicting meaning
+- linked references are missing for duplicate, superseded, or absorbed claims
+- the issue packet contains both “still do this” and “already satisfied” style markers
+
+## Handoff
+
+- `actionable` -> normal workflow execution
+- non-actionable class with sufficient evidence -> `pr-closeout`
+- `blocked` -> operator review

--- a/adl/tools/skills/issue-folding/references/output-contract.md
+++ b/adl/tools/skills/issue-folding/references/output-contract.md
@@ -1,0 +1,64 @@
+# Issue Folding Output Contract
+
+Issue-folding artifacts must classify one bounded issue disposition without
+closing the issue, rewriting implementation history, or hiding uncertainty.
+
+## Required Markdown Sections
+
+- `Issue Folding Summary`
+- `Classification`
+- `Evidence`
+- `Closure Outcome`
+- `Worktree Action`
+- `Recommended Handoff`
+- `Non-Claims`
+- `Safety Flags`
+
+## Required JSON Shape
+
+Schema id: `adl.issue_folding_report.v1`
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `status`
+- `classification`
+- `summary`
+- `evidence`
+- `closure_outcome`
+- `closure_references`
+- `worktree_action`
+- `recommended_handoff`
+- `non_claims`
+- `safety_flags`
+
+Supported status values:
+
+- `actionable`
+- `foldable`
+- `blocked`
+- `skipped`
+
+Supported classifications:
+
+- `actionable`
+- `duplicate`
+- `superseded`
+- `absorbed`
+- `already_satisfied`
+- `obsolete`
+- `blocked`
+
+## Safety Flags
+
+Every report must state:
+
+- `issue_closed: false`
+- `github_mutated: false`
+- `merged_hidden: false`
+- `worktree_pruned: false`
+- `implementation_claimed: false`
+
+This skill may recommend closeout. It must not claim that closeout, merge, or
+worktree pruning already happened.

--- a/adl/tools/skills/issue-folding/scripts/classify_issue_folding.py
+++ b/adl/tools/skills/issue-folding/scripts/classify_issue_folding.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Classify whether a bounded issue should fold or stay actionable."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+PATTERNS: dict[str, re.Pattern[str]] = {
+    "duplicate": re.compile(r"\b(duplicate|dup(?:licate)? of|same as)\b", re.I),
+    "superseded": re.compile(r"\b(superseded by|replaced by|use issue)\b", re.I),
+    "absorbed": re.compile(r"\b(absorbed by|folded into|covered by|handled by)\b", re.I),
+    "already_satisfied": re.compile(
+        r"\b(already satisfied|already implemented|already complete|no code change needed)\b",
+        re.I,
+    ),
+    "obsolete": re.compile(r"\b(obsolete|no longer needed|no longer relevant|withdrawn)\b", re.I),
+}
+ISSUE_REF_RE = re.compile(r"#(\d+)")
+PR_REF_RE = re.compile(r"pull/(\d+)")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+def compact(line: str) -> str:
+    return " ".join(line.strip().split())[:180]
+
+
+def evidence_line(text: str, pattern: re.Pattern[str]) -> str:
+    for line in text.splitlines():
+        if pattern.search(line):
+            return compact(line)
+    return "marker present"
+
+
+def collect_texts(task_bundle: Path | None, source_prompt: Path | None) -> list[dict[str, str]]:
+    texts: list[dict[str, str]] = []
+    if source_prompt and source_prompt.is_file():
+        texts.append({"source": "source_issue_prompt", "text": read_text(source_prompt)})
+    if task_bundle and task_bundle.is_dir():
+        for name in ("stp.md", "sip.md", "sor.md"):
+            path = task_bundle / name
+            if path.is_file():
+                texts.append({"source": name, "text": read_text(path)})
+    return texts
+
+
+def classify(texts: list[dict[str, str]]) -> tuple[str, list[dict[str, str]], list[str]]:
+    matches: dict[str, list[dict[str, str]]] = {key: [] for key in PATTERNS}
+    refs: set[str] = set()
+    pr_refs: set[str] = set()
+
+    for entry in texts:
+        text = entry["text"]
+        refs.update(f"#{num}" for num in ISSUE_REF_RE.findall(text))
+        pr_refs.update(f"PR:{num}" for num in PR_REF_RE.findall(text))
+        for label, pattern in PATTERNS.items():
+            if pattern.search(text):
+                matches[label].append(
+                    {
+                        "source": entry["source"],
+                        "reason": f"{label.replace('_', ' ')} marker found",
+                        "evidence": evidence_line(text, pattern),
+                    }
+                )
+
+    active = [label for label, items in matches.items() if items]
+    references = sorted(refs | pr_refs)
+
+    linked_required = {"duplicate", "superseded", "absorbed"}
+    for label in active:
+        if label in linked_required and not references:
+            matches[label].append(
+                {
+                    "source": "issue_packet",
+                    "reason": "linked issue or PR evidence missing",
+                    "evidence": "linked dispositions require issue or PR references",
+                }
+            )
+            return "blocked", matches[label], references
+
+    if len(active) > 1:
+        conflict_evidence: list[dict[str, str]] = []
+        for label in active:
+            conflict_evidence.extend(matches[label][:1])
+        conflict_evidence.append(
+            {
+                "source": "issue_packet",
+                "reason": "conflicting disposition markers found",
+                "evidence": ", ".join(active),
+            }
+        )
+        return "blocked", conflict_evidence, references
+
+    if not active:
+        return "actionable", [], references
+
+    label = active[0]
+    return label, matches[label], references
+
+
+def closeout_outcome(classification: str) -> str | None:
+    if classification == "duplicate":
+        return "duplicate"
+    if classification in {"superseded", "absorbed"}:
+        return "superseded"
+    if classification in {"already_satisfied", "obsolete"}:
+        return "closed_no_pr"
+    return None
+
+
+def status_for(classification: str) -> str:
+    if classification == "actionable":
+        return "actionable"
+    if classification == "blocked":
+        return "blocked"
+    return "foldable"
+
+
+def handoff_for(classification: str) -> str:
+    if classification == "actionable":
+        return "workflow-conductor"
+    if classification == "blocked":
+        return "operator-review"
+    return "pr-closeout"
+
+
+def worktree_action_for(classification: str) -> str:
+    if classification in {"duplicate", "superseded", "absorbed", "already_satisfied", "obsolete"}:
+        return "retire_bound_worktree_if_present"
+    if classification == "blocked":
+        return "preserve_until_operator_confirms"
+    return "preserve_for_execution"
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    task_bundle = Path(args.task_bundle) if args.task_bundle else None
+    source_prompt = Path(args.source_prompt) if args.source_prompt else None
+    texts = collect_texts(task_bundle, source_prompt)
+
+    if not texts:
+        classification = "blocked"
+        evidence = [
+            {
+                "source": "issue_packet",
+                "reason": "no readable issue packet surfaces found",
+                "evidence": "expected source issue prompt or task bundle files missing",
+            }
+        ]
+        references: list[str] = []
+    else:
+        classification, evidence, references = classify(texts)
+
+    closure_outcome = closeout_outcome(classification)
+    return {
+        "schema": "adl.issue_folding_report.v1",
+        "run_id": args.run_id,
+        "status": status_for(classification),
+        "classification": classification,
+        "summary": f"Issue packet classified as {classification.replace('_', ' ')}.",
+        "evidence": evidence,
+        "closure_outcome": closure_outcome,
+        "closure_references": references,
+        "worktree_action": worktree_action_for(classification),
+        "recommended_handoff": handoff_for(classification),
+        "non_claims": [
+            "This report does not close the issue.",
+            "This report does not merge or prune worktrees.",
+            "This report does not claim the folded work was revalidated here.",
+        ],
+        "safety_flags": {
+            "issue_closed": False,
+            "github_mutated": False,
+            "merged_hidden": False,
+            "worktree_pruned": False,
+            "implementation_claimed": False,
+        },
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Issue Folding Summary",
+        "",
+        f"- Run id: `{report['run_id']}`",
+        f"- Status: `{report['status']}`",
+        f"- Summary: {report['summary']}",
+        "",
+        "## Classification",
+        "",
+        f"- classification: `{report['classification']}`",
+        "",
+        "## Evidence",
+        "",
+    ]
+    if report["evidence"]:
+        for item in report["evidence"]:
+            lines.append(
+                f"- `{item['source']}`: {item['reason']} Evidence: {item['evidence']}"
+            )
+    else:
+        lines.append("- no folding markers found")
+
+    lines.extend(
+        [
+            "",
+            "## Closure Outcome",
+            "",
+            f"- closure_outcome: `{report['closure_outcome'] or 'none'}`",
+            f"- closure_references: {', '.join(report['closure_references']) if report['closure_references'] else 'none'}",
+            "",
+            "## Worktree Action",
+            "",
+            f"- worktree_action: `{report['worktree_action']}`",
+            "",
+            "## Recommended Handoff",
+            "",
+            f"- recommended_handoff: `{report['recommended_handoff']}`",
+            "",
+            "## Non-Claims",
+            "",
+        ]
+    )
+    for item in report["non_claims"]:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## Safety Flags", ""])
+    for key, value in report["safety_flags"].items():
+        lines.append(f"- {key}: {str(value).lower()}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-bundle")
+    parser.add_argument("--source-prompt")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--run-id", default="issue-folding")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    report = build_report(args)
+    (out / "issue_folding_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "issue_folding_report.md").write_text(
+        markdown_report(report),
+        encoding="utf-8",
+    )
+    print(f"WROTE {out / 'issue_folding_report.json'}")
+    print(f"WROTE {out / 'issue_folding_report.md'}")
+    print(f"STATUS {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_issue_folding_skill_contracts.sh
+++ b/adl/tools/test_issue_folding_skill_contracts.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+skill_root="${skills_root}/issue-folding"
+python_script="${skill_root}/scripts/classify_issue_folding.py"
+
+[[ -f "${skill_root}/SKILL.md" ]]
+[[ -f "${skill_root}/adl-skill.yaml" ]]
+[[ -f "${skill_root}/agents/openai.yaml" ]]
+[[ -f "${skill_root}/references/issue-folding-playbook.md" ]]
+[[ -f "${skill_root}/references/output-contract.md" ]]
+[[ -x "${python_script}" ]]
+[[ -f "${skills_root}/docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "issue-folding"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'id: "issue_folding.v1"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md"' "${skill_root}/adl-skill.yaml"
+grep -Fq "linked_dispositions_require_reference_evidence" "${skill_root}/adl-skill.yaml"
+grep -Fq "issue disposition classifier and closeout-routing helper" "${skill_root}/SKILL.md"
+grep -Fq "issue_closed: false" "${skill_root}/references/output-contract.md"
+grep -Fq "Schema id: \`issue_folding.v1\`" "${skills_root}/docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md"
+
+duplicate_root="${tmpdir}/duplicate"
+duplicate_report="${tmpdir}/duplicate-report"
+mkdir -p "${duplicate_root}/task"
+cat >"${duplicate_root}/source.md" <<'MD'
+## Summary
+
+This is a duplicate of #2400 and the work is already tracked by PR: pull/2401.
+MD
+cat >"${duplicate_root}/task/stp.md" <<'MD'
+Issue is duplicate work already tracked by #2400 and should not execute separately.
+MD
+cat >"${duplicate_root}/task/sip.md" <<'MD'
+Execution should stop because the issue is duplicate work.
+MD
+cat >"${duplicate_root}/task/sor.md" <<'MD'
+No execution happened here.
+MD
+
+python3 "${python_script}" \
+  --task-bundle "${duplicate_root}/task" \
+  --source-prompt "${duplicate_root}/source.md" \
+  --out "${duplicate_report}" \
+  --run-id issue-folding-duplicate-test >/tmp/issue-folding-duplicate.out
+
+[[ -f "${duplicate_report}/issue_folding_report.json" ]]
+[[ -f "${duplicate_report}/issue_folding_report.md" ]]
+
+actionable_root="${tmpdir}/actionable"
+actionable_report="${tmpdir}/actionable-report"
+mkdir -p "${actionable_root}/task"
+cat >"${actionable_root}/source.md" <<'MD'
+## Summary
+
+Implement the new skill with no prior linked closure markers.
+MD
+cat >"${actionable_root}/task/stp.md" <<'MD'
+The issue still needs direct execution.
+MD
+
+python3 "${python_script}" \
+  --task-bundle "${actionable_root}/task" \
+  --source-prompt "${actionable_root}/source.md" \
+  --out "${actionable_report}" \
+  --run-id issue-folding-actionable-test >/tmp/issue-folding-actionable.out
+
+blocked_root="${tmpdir}/blocked"
+blocked_report="${tmpdir}/blocked-report"
+mkdir -p "${blocked_root}/task"
+cat >"${blocked_root}/source.md" <<'MD'
+## Summary
+
+This issue is duplicate of #2600 but also obsolete after the policy change.
+MD
+
+python3 "${python_script}" \
+  --task-bundle "${blocked_root}/task" \
+  --source-prompt "${blocked_root}/source.md" \
+  --out "${blocked_report}" \
+  --run-id issue-folding-blocked-test >/tmp/issue-folding-blocked.out
+
+python3 - "${tmpdir}" "${duplicate_report}" "${actionable_report}" "${blocked_report}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+tmpdir = sys.argv[1]
+duplicate_report = Path(sys.argv[2])
+actionable_report = Path(sys.argv[3])
+blocked_report = Path(sys.argv[4])
+
+duplicate_json = json.loads((duplicate_report / "issue_folding_report.json").read_text())
+assert duplicate_json["schema"] == "adl.issue_folding_report.v1"
+assert duplicate_json["run_id"] == "issue-folding-duplicate-test"
+assert duplicate_json["status"] == "foldable"
+assert duplicate_json["classification"] == "duplicate"
+assert duplicate_json["closure_outcome"] == "duplicate"
+assert duplicate_json["recommended_handoff"] == "pr-closeout"
+assert duplicate_json["worktree_action"] == "retire_bound_worktree_if_present"
+assert "#2400" in duplicate_json["closure_references"]
+assert "PR:2401" in duplicate_json["closure_references"]
+duplicate_md = (duplicate_report / "issue_folding_report.md").read_text()
+assert "## Closure Outcome" in duplicate_md
+assert "issue_closed: false" in duplicate_md
+
+actionable_json = json.loads((actionable_report / "issue_folding_report.json").read_text())
+assert actionable_json["status"] == "actionable"
+assert actionable_json["classification"] == "actionable"
+assert actionable_json["closure_outcome"] is None
+assert actionable_json["recommended_handoff"] == "workflow-conductor"
+
+blocked_json = json.loads((blocked_report / "issue_folding_report.json").read_text())
+assert blocked_json["status"] == "blocked"
+assert blocked_json["classification"] == "blocked"
+assert blocked_json["recommended_handoff"] == "operator-review"
+
+for report_root in (duplicate_report, actionable_report, blocked_report):
+    for path in report_root.iterdir():
+        if tmpdir in path.read_text():
+            raise AssertionError("issue folding artifacts should not leak absolute temp paths")
+PY
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skill_root}/SKILL.md"
+
+echo "PASS test_issue_folding_skill_contracts"


### PR DESCRIPTION
Closes #2481

## Summary
Added the `issue-folding` operational skill as a bounded classifier for duplicate, superseded, absorbed, already-satisfied, obsolete, and still-actionable issue states, including its schema doc, operator-guide integration, and deterministic contract test.

## Artifacts
- `adl/tools/skills/issue-folding/SKILL.md`
- `adl/tools/skills/issue-folding/adl-skill.yaml`
- `adl/tools/skills/issue-folding/agents/openai.yaml`
- `adl/tools/skills/issue-folding/references/output-contract.md`
- `adl/tools/skills/issue-folding/references/issue-folding-playbook.md`
- `adl/tools/skills/issue-folding/scripts/classify_issue_folding.py`
- `adl/tools/skills/docs/ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_issue_folding_skill_contracts.sh`
- Updated operator guide entry in `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_issue_folding_skill_contracts.sh`
    Proved the new `issue-folding` skill classifies duplicate, actionable, and blocked issue packets and emits bounded no-mutation reports without leaking host paths.
  - `bash adl/tools/test_skill_documentation_completeness.sh`
    Proved the new skill is represented in the tracked operator documentation matrix.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Proved the installer picks up the new skill bundle and validates its frontmatter.
  - `git diff --check`
    Proved the tracked patch set is free of formatting and whitespace errors.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2481__v0-90-4-backlog-add-issue-folding-operational-skill/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2481__v0-90-4-backlog-add-issue-folding-operational-skill/sor.md
- Idempotency-Key: v0-90-4-backlog-tools-add-issue-folding-operational-skill-adl-tools-skills-issue-folding-skill-md-adl-tools-skills-issue-folding-adl-skill-yaml-adl-tools-skills-issue-folding-agents-openai-yaml-adl-tools-skills-issue-folding-references-output-contract-md-adl-tools-skills-issue-folding-references-issue-folding-playbook-md-adl-tools-skills-issue-folding-scripts-classify-issue-folding-py-adl-tools-skills-docs-issue-folding-skill-input-schema-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-test-issue-folding-skill-contracts-sh-adl-v0-90-4-tasks-issue-2481-v0-90-4-backlog-add-issue-folding-operational-skill-sip-md-adl-v0-90-4-tasks-issue-2481-v0-90-4-backlog-add-issue-folding-operational-skill-sor-md