### PR TITLE
[v0.90.4][backlog][tools] Restore focused pr finish validation and stop duplicate local full-Rust validation

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -54,8 +54,9 @@ use self::finish_support::{
     extra_pr_body_looks_like_issue_template, extract_markdown_section, finish_changed_paths,
     finish_inputs_fingerprint, issue_bundle_issue_number_from_repo_relative,
     render_default_finish_validation, render_pr_body, run_finish_validation_rust,
-    select_finish_validation_mode, stage_selected_paths_rust, staged_diff_is_empty,
+    select_finish_validation_plan, stage_selected_paths_rust, staged_diff_is_empty,
     staged_gitignore_change_present, tracked_issue_surface_paths, FinishValidationMode,
+    FinishValidationPlan,
 };
 use self::finish_support::{
     ensure_nonempty_file_path, validate_completed_sor, write_temp_markdown,

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -103,9 +103,9 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         })?;
     }
 
-    let finish_validation_mode = select_finish_validation_mode(&parsed.paths)?;
+    let finish_validation_plan = select_finish_validation_plan(&parsed.paths)?;
     if !parsed.no_checks {
-        run_finish_validation_rust(&repo_root, finish_validation_mode)?;
+        run_finish_validation_rust(&repo_root, &finish_validation_plan)?;
     }
 
     stage_selected_paths_rust(&repo_root, &parsed.paths)?;
@@ -133,7 +133,7 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     let default_validation = if parsed.no_checks {
         None
     } else {
-        Some(render_default_finish_validation(finish_validation_mode))
+        Some(render_default_finish_validation(&finish_validation_plan))
     };
     let fingerprint = finish_inputs_fingerprint(
         &parsed.title,
@@ -381,7 +381,14 @@ pub(super) fn validate_completed_sor(repo_root: &Path, output_path: &Path) -> Re
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FinishValidationMode {
     DocsOnly,
+    FocusedLocalCiGated,
     FullRust,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct FinishValidationPlan {
+    pub mode: FinishValidationMode,
+    pub commands: Vec<String>,
 }
 
 fn finish_validation_guard(repo_root: &Path) -> Result<()> {
@@ -390,7 +397,7 @@ fn finish_validation_guard(repo_root: &Path) -> Result<()> {
     run_status("bash", &[path_str(&tracked_residue_guard)?])
 }
 
-pub(super) fn select_finish_validation_mode(paths_csv: &str) -> Result<FinishValidationMode> {
+pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishValidationPlan> {
     let paths = paths_csv
         .split(',')
         .map(str::trim)
@@ -400,9 +407,58 @@ pub(super) fn select_finish_validation_mode(paths_csv: &str) -> Result<FinishVal
         bail!("finish: --paths resolved to empty");
     }
     if paths.iter().all(|path| finish_path_is_docs_only(path)) {
-        return Ok(FinishValidationMode::DocsOnly);
+        return Ok(FinishValidationPlan {
+            mode: FinishValidationMode::DocsOnly,
+            commands: vec![
+                "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+                "git diff --check".to_string(),
+            ],
+        });
     }
-    Ok(FinishValidationMode::FullRust)
+    if paths
+        .iter()
+        .all(|path| finish_path_is_focused_local_ci_gated(path))
+    {
+        let mut commands = vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "git diff --check".to_string(),
+        ];
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_pr_finish_rust_focused_validation(path))
+        {
+            commands.push("cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string());
+            commands.push(
+                "cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish".to_string(),
+            );
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_coverage_tooling_focused_validation(path))
+        {
+            commands.push("bash adl/tools/test_check_coverage_impact.sh".to_string());
+        }
+        if paths
+            .iter()
+            .any(|path| finish_path_needs_ci_policy_focused_validation(path))
+        {
+            commands.push("bash adl/tools/test_ci_path_policy.sh".to_string());
+        }
+        return Ok(FinishValidationPlan {
+            mode: FinishValidationMode::FocusedLocalCiGated,
+            commands,
+        });
+    }
+    Ok(FinishValidationPlan {
+        mode: FinishValidationMode::FullRust,
+        commands: vec![
+            "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+            "bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk".to_string(),
+            "cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string(),
+            "cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings".to_string(),
+            "cargo test --manifest-path adl/Cargo.toml".to_string(),
+        ],
+    })
 }
 
 fn finish_path_is_docs_only(path: &str) -> bool {
@@ -420,13 +476,100 @@ fn finish_path_is_docs_only(path: &str) -> bool {
             .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
 }
 
+fn finish_path_is_focused_local_ci_gated(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        ".github/workflows/ci.yaml"
+            | "docs/default_workflow.md"
+            | "docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md"
+            | "adl/src/cli/pr_cmd.rs"
+            | "adl/tools/check_coverage_impact.sh"
+            | "adl/tools/test_check_coverage_impact.sh"
+            | "adl/tools/ci_path_policy.sh"
+            | "adl/tools/test_ci_path_policy.sh"
+            | "adl/src/cli/pr_cmd/finish_support.rs"
+    ) || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/finish/")
+}
+
+fn finish_path_needs_pr_finish_rust_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    trimmed == "adl/src/cli/pr_cmd.rs"
+        || trimmed == "adl/src/cli/pr_cmd/finish_support.rs"
+        || trimmed.starts_with("adl/src/cli/tests/pr_cmd_inline/finish/")
+}
+
+fn finish_path_needs_coverage_tooling_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        ".github/workflows/ci.yaml"
+            | "adl/tools/check_coverage_impact.sh"
+            | "adl/tools/test_check_coverage_impact.sh"
+    )
+}
+
+fn finish_path_needs_ci_policy_focused_validation(path: &str) -> bool {
+    let trimmed = path.trim().trim_matches('/');
+    matches!(
+        trimmed,
+        ".github/workflows/ci.yaml"
+            | "adl/tools/ci_path_policy.sh"
+            | "adl/tools/test_ci_path_policy.sh"
+    )
+}
+
 pub(super) fn run_finish_validation_rust(
     repo_root: &Path,
-    mode: FinishValidationMode,
+    plan: &FinishValidationPlan,
 ) -> Result<()> {
     finish_validation_guard(repo_root)?;
-    if mode == FinishValidationMode::DocsOnly {
+    if plan.mode == FinishValidationMode::DocsOnly {
         run_status("git", &["-C", path_str(repo_root)?, "diff", "--check"])?;
+        return Ok(());
+    }
+
+    if plan.mode == FinishValidationMode::FocusedLocalCiGated {
+        run_status("git", &["-C", path_str(repo_root)?, "diff", "--check"])?;
+        let manifest = repo_root.join("adl/Cargo.toml");
+        for command in &plan.commands {
+            match command.as_str() {
+                "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh" => {}
+                "git diff --check" => {}
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check" => {
+                    run_status(
+                        "cargo",
+                        &[
+                            "fmt",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "--all",
+                            "--check",
+                        ],
+                    )?;
+                }
+                "cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish" => {
+                    run_status(
+                        "cargo",
+                        &[
+                            "test",
+                            "--manifest-path",
+                            path_str(&manifest)?,
+                            "cli::pr_cmd::tests::finish",
+                        ],
+                    )?;
+                }
+                "bash adl/tools/test_check_coverage_impact.sh" => {
+                    let script = repo_root.join("adl/tools/test_check_coverage_impact.sh");
+                    run_status("bash", &[path_str(&script)?])?;
+                }
+                "bash adl/tools/test_ci_path_policy.sh" => {
+                    let script = repo_root.join("adl/tools/test_ci_path_policy.sh");
+                    run_status("bash", &[path_str(&script)?])?;
+                }
+                other => bail!("finish: unsupported focused validation command '{other}'"),
+            }
+        }
         return Ok(());
     }
 
@@ -473,22 +616,12 @@ pub(super) fn run_finish_validation_rust(
     Ok(())
 }
 
-pub(super) fn render_default_finish_validation(mode: FinishValidationMode) -> String {
-    match mode {
-        FinishValidationMode::DocsOnly => [
-            "- bash adl/tools/check_no_tracked_adl_issue_record_residue.sh",
-            "- git diff --check",
-        ]
-        .join("\n"),
-        FinishValidationMode::FullRust => [
-            "- bash adl/tools/check_no_tracked_adl_issue_record_residue.sh",
-            "- bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk",
-            "- cargo fmt",
-            "- cargo clippy --all-targets -- -D warnings",
-            "- cargo test",
-        ]
-        .join("\n"),
-    }
+pub(super) fn render_default_finish_validation(plan: &FinishValidationPlan) -> String {
+    plan.commands
+        .iter()
+        .map(|command| format!("- {command}"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 pub(super) fn ensure_issue_surfaces_are_local_only(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -44,9 +44,16 @@ fn render_pr_body_uses_output_sections_and_rejects_issue_template_text() {
         &input,
         &output,
         Some("extra notes"),
-        Some(&render_default_finish_validation(
-            FinishValidationMode::FullRust,
-        )),
+        Some(&render_default_finish_validation(&FinishValidationPlan {
+            mode: FinishValidationMode::FullRust,
+            commands: vec![
+                "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+                "bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk".to_string(),
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string(),
+                "cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings".to_string(),
+                "cargo test --manifest-path adl/Cargo.toml".to_string(),
+            ],
+        })),
         "fp-123",
         &temp,
     )
@@ -65,9 +72,16 @@ fn render_pr_body_uses_output_sections_and_rejects_issue_template_text() {
         &input,
         &output,
         Some("issue_card_schema: adl.issue.v1"),
-        Some(&render_default_finish_validation(
-            FinishValidationMode::FullRust,
-        )),
+        Some(&render_default_finish_validation(&FinishValidationPlan {
+            mode: FinishValidationMode::FullRust,
+            commands: vec![
+                "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+                "bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk".to_string(),
+                "cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string(),
+                "cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings".to_string(),
+                "cargo test --manifest-path adl/Cargo.toml".to_string(),
+            ],
+        })),
         "fp-123",
         &temp,
     )
@@ -93,9 +107,13 @@ fn render_pr_body_defaults_docs_only_validation_when_needed() {
         &input,
         &output,
         None,
-        Some(&render_default_finish_validation(
-            FinishValidationMode::DocsOnly,
-        )),
+        Some(&render_default_finish_validation(&FinishValidationPlan {
+            mode: FinishValidationMode::DocsOnly,
+            commands: vec![
+                "bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string(),
+                "git diff --check".to_string(),
+            ],
+        })),
         "fp-123",
         &temp,
     )
@@ -293,21 +311,32 @@ fn finish_helper_paths_cover_ahead_count_and_validation_modes() {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
     }
     assert_eq!(
-        select_finish_validation_mode("docs,README.md").expect("docs-only mode"),
+        select_finish_validation_plan("docs,README.md")
+            .expect("docs-only plan")
+            .mode,
         FinishValidationMode::DocsOnly
     );
-    run_finish_validation_rust(&repo, FinishValidationMode::DocsOnly)
-        .expect("docs-only validation");
+    run_finish_validation_rust(
+        &repo,
+        &select_finish_validation_plan("docs,README.md").expect("docs-only plan"),
+    )
+    .expect("docs-only validation");
     assert!(
         !cargo_log.exists(),
         "docs-only validation should not invoke cargo"
     );
 
     assert_eq!(
-        select_finish_validation_mode("adl,docs").expect("full-rust mode"),
+        select_finish_validation_plan("adl,docs")
+            .expect("full-rust plan")
+            .mode,
         FinishValidationMode::FullRust
     );
-    run_finish_validation_rust(&repo, FinishValidationMode::FullRust).expect("full validation");
+    run_finish_validation_rust(
+        &repo,
+        &select_finish_validation_plan("adl,docs").expect("full-rust plan"),
+    )
+    .expect("full validation");
     unsafe {
         env::set_var("PATH", old_path);
     }
@@ -316,6 +345,107 @@ fn finish_helper_paths_cover_ahead_count_and_validation_modes() {
     assert!(cargo_calls.contains("fmt --manifest-path"));
     assert!(cargo_calls.contains("clippy --manifest-path"));
     assert!(cargo_calls.contains("test --manifest-path"));
+}
+
+#[test]
+fn finish_validation_plan_supports_focused_local_ci_gated_mode() {
+    let plan = select_finish_validation_plan(
+        "adl/src/cli/pr_cmd/finish_support.rs,adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs,.github/workflows/ci.yaml,adl/tools/check_coverage_impact.sh,adl/tools/ci_path_policy.sh",
+    )
+    .expect("focused plan");
+
+    assert_eq!(plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/check_no_tracked_adl_issue_record_residue.sh".to_string()));
+    assert!(plan.commands.contains(&"git diff --check".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"cargo fmt --manifest-path adl/Cargo.toml --all --check".to_string()));
+    assert!(plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish".to_string()
+    ));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_check_coverage_impact.sh".to_string()));
+    assert!(plan
+        .commands
+        .contains(&"bash adl/tools/test_ci_path_policy.sh".to_string()));
+    assert!(!plan
+        .commands
+        .iter()
+        .any(|command| command.contains("cargo clippy")));
+}
+
+#[test]
+fn finish_helper_paths_run_focused_local_ci_gated_validation() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-focused-validation");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::create_dir_all(repo.join("adl/src/cli/tests/pr_cmd_inline/finish"))
+        .expect("finish tests dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_check_coverage_impact.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' coverage >> \"$FOCUSED_LOG\"\n",
+    );
+    write_executable(
+        &repo.join("adl/tools/test_ci_path_policy.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' path-policy >> \"$FOCUSED_LOG\"\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let focused_log = temp.join("focused.log");
+    let cargo_path = bin_dir.join("cargo");
+    write_executable(
+        &cargo_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_focused_log = env::var("FOCUSED_LOG").ok();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("FOCUSED_LOG", &focused_log);
+    }
+
+    let plan = select_finish_validation_plan(
+        "adl/src/cli/pr_cmd/finish_support.rs,.github/workflows/ci.yaml,adl/tools/check_coverage_impact.sh,adl/tools/ci_path_policy.sh",
+    )
+    .expect("focused plan");
+    assert_eq!(plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    run_finish_validation_rust(&repo, &plan).expect("focused validation");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    match old_focused_log {
+        Some(value) => unsafe { env::set_var("FOCUSED_LOG", value) },
+        None => unsafe { env::remove_var("FOCUSED_LOG") },
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("fmt --manifest-path"));
+    assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(!cargo_calls.contains("clippy --manifest-path"));
+
+    let focused_calls = fs::read_to_string(&focused_log).expect("focused log");
+    assert!(focused_calls.contains("coverage"));
+    assert!(focused_calls.contains("path-policy"));
 }
 
 #[test]

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -99,6 +99,20 @@ is_production_rust_source() {
   return 1
 }
 
+is_pr_finish_control_plane_surface() {
+  local path="$1"
+  case "$path" in
+    adl/src/cli/pr_cmd.rs|\
+    adl/src/cli/pr_cmd/finish_support.rs|\
+    adl/src/cli/tests/pr_cmd_inline/finish/*|\
+    docs/default_workflow.md|\
+    docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 is_full_coverage_policy_surface() {
   local path="$1"
   case "$path" in
@@ -143,9 +157,15 @@ else
     fail_closed=true
     reason="empty_or_unavailable_diff_runs_full_validation"
   else
+    saw_pr_finish_control_plane=false
     changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
     while IFS= read -r path; do
       [ -n "$path" ] || continue
+      if is_pr_finish_control_plane_surface "$path"; then
+        rust_required=true
+        saw_pr_finish_control_plane=true
+        continue
+      fi
       case "$path" in
         adl/src/*|adl/tests/*|adl/Cargo.toml|adl/Cargo.lock|adl/build.rs)
           rust_required=true
@@ -170,6 +190,12 @@ EOF
     done <<EOF
 $changed_rows
 EOF
+    if [ "$saw_pr_finish_control_plane" = true ] \
+      && [ "$coverage_required" != true ] \
+      && [ "$full_coverage_required" != true ] \
+      && [ "$demo_smoke_required" != true ]; then
+      reason="publication_control_plane_change_runs_focused_rust_validation"
+    fi
   fi
 fi
 

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -68,6 +68,22 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$new_runtime_file_output" "demo_smoke_required=true"
   assert_has "$new_runtime_file_output" "reason=runtime_or_rust_test_change_runs_pr_fast_validation"
 
+  git checkout -q -b finish-control-plane "$base_sha"
+  mkdir -p adl/src/cli/pr_cmd adl/src/cli/tests/pr_cmd_inline/finish docs/milestones/v0.90/milestone_compression
+  printf 'pub fn finish_support() -> bool { true }\n' > adl/src/cli/pr_cmd/finish_support.rs
+  printf 'use super::*;\n#[test]\nfn finish_path_is_stable() {}\n' > adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+  printf '# workflow\n' > docs/default_workflow.md
+  git add adl/src/cli/pr_cmd/finish_support.rs adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs docs/default_workflow.md
+  git commit -q -m finish-control-plane
+  finish_control_plane_head="$(git rev-parse HEAD)"
+
+  finish_control_plane_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$finish_control_plane_head")"
+  assert_has "$finish_control_plane_output" "rust_required=true"
+  assert_has "$finish_control_plane_output" "coverage_required=false"
+  assert_has "$finish_control_plane_output" "full_coverage_required=false"
+  assert_has "$finish_control_plane_output" "demo_smoke_required=false"
+  assert_has "$finish_control_plane_output" "reason=publication_control_plane_change_runs_focused_rust_validation"
+
   git checkout -q -b policy-surface-change "$base_sha"
   mkdir -p adl/tools
   printf '#!/usr/bin/env bash\nprintf policy\n' > adl/tools/enforce_coverage_gates.sh

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -121,6 +121,13 @@ when focused local checks directly prove the changed surface. The output record
 must say that full local validation was not run, list the focused commands that
 did run, and keep CI required before merge.
 
+Current implementation is intentionally narrower than the general policy: the
+focused `pr finish` lane currently applies only to docs-only paths and a
+bounded publication-control-plane slice (`pr_cmd`, `finish_support`, inline finish tests,
+CI path-policy / coverage-impact scripts, and the matching workflow/docs
+surfaces). Other changes still escalate to full local validation until more
+focused lanes are explicitly implemented and tested.
+
 Use full local validation for runtime, schema, security, release, broad tooling,
 or ambiguous changes.
 

--- a/docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md
+++ b/docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md
@@ -56,8 +56,9 @@ Required local evidence:
 
 ### FOCUSED_LOCAL_CI_GATED
 
-Use this profile only for low-risk docs/static-tooling work where the changed
-surface is narrow and easy to validate directly.
+Use this profile only for low-risk docs/static-tooling or explicitly bounded
+publication-control-plane work where the changed surface is narrow and easy to
+validate directly.
 
 Eligible examples:
 
@@ -66,6 +67,17 @@ Eligible examples:
 - static browser copy or validation text
 - small shell helper docs/tests where behavior is covered by a focused script
 - review packet or process docs with deterministic grep-style guardrails
+- `pr finish` publication-control-plane surfaces currently limited to:
+  - `adl/src/cli/pr_cmd.rs`
+  - `adl/src/cli/pr_cmd/finish_support.rs`
+  - `adl/src/cli/tests/pr_cmd_inline/finish/**`
+  - `.github/workflows/ci.yaml`
+  - `adl/tools/check_coverage_impact.sh`
+  - `adl/tools/test_check_coverage_impact.sh`
+  - `adl/tools/ci_path_policy.sh`
+  - `adl/tools/test_ci_path_policy.sh`
+  - `docs/default_workflow.md`
+  - `docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md`
 
 Required local evidence:
 
@@ -84,6 +96,18 @@ Required SOR wording:
 - CI requirement: required before merge
 - rationale: one sentence explaining why focused validation is safe for this
   issue
+
+Current implementation note:
+
+- the focused `pr finish` lane is intentionally narrow rather than generic
+- when those publication-control-plane surfaces are the only changed paths, the
+  local finish validator may run targeted commands such as:
+  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
+  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish`
+  - `bash adl/tools/test_check_coverage_impact.sh`
+  - `bash adl/tools/test_ci_path_policy.sh`
+- if the changed paths fall outside that bounded set, `pr finish` must
+  escalate back to `FULL_LOCAL`
 
 ### ESCALATE_TO_FULL
 


### PR DESCRIPTION
Closes #2479

## Summary
Restored a truthful middle `pr finish` validation lane by replacing the old `DocsOnly` vs `FullRust` split with an explicit validation plan. The new `FocusedLocalCiGated` mode now covers a bounded publication-control-plane surface, runs exact focused commands for that surface, and keeps broader or riskier changes escalated to full local Rust validation.

## Artifacts
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `docs/default_workflow.md`
- `docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md`
- `.adl/v0.90.4/tasks/issue-2479__v0-90-4-backlog-tools-restore-focused-pr-finish-validation-and-stop-duplicate-local-full-rust-validation/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Ensured the new finish-plan logic, tests, and docs edits are rustfmt-clean.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish -- --nocapture`
    Proved the new focused validation lane and the existing finish publication/guardrail behavior together on the real inline finish suite.
  - `git diff --check`
    Ensured the tracked patch contains no whitespace, conflict-marker, or malformed-hunk residue.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2479__v0-90-4-backlog-tools-restore-focused-pr-finish-validation-and-stop-duplicate-local-full-rust-validation/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2479__v0-90-4-backlog-tools-restore-focused-pr-finish-validation-and-stop-duplicate-local-full-rust-validation/sor.md
- Idempotency-Key: v0-90-4-backlog-tools-restore-focused-pr-finish-validation-and-stop-duplicate-local-full-rust-validation-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-default-workflow-md-docs-milestones-v0-90-milestone-compression-finish-validation-profiles-v0-90-md-adl-v0-90-4-tasks-issue-2479-v0-90-4-backlog-tools-restore-focused-pr-finish-validation-and-stop-duplicate-local-full-rust-validation-sip-md-adl-v0-90-4-tasks-issue-2479-v0-90-4-backlog-tools-restore-focused-pr-finish-validation-and-stop-duplicate-local-full-rust-validation-sor-md