### PR TITLE
[v0.90.4][backlog][tools] Add issue-splitter operational skill

### DIFF
--- a/adl/tools/skills/docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,76 @@
+# Issue Splitter Skill Input Schema
+
+Schema id: `issue_splitter.v1`
+
+Use this schema when invoking `issue-splitter` with structured input.
+
+## Required Top-Level Fields
+
+- `skill_input_schema`: must be `issue_splitter.v1`
+- `mode`: one of `analyze_issue_bundle` or `analyze_issue_number`
+- `repo_root`: absolute repository root
+- `target`: one bounded issue target
+- `policy`: stop-boundary and split-planning policy
+
+## Target Object
+
+Recommended fields:
+
+- `issue_number`
+- `task_bundle_path`
+- `source_issue_prompt_path`
+- `issue_title`
+- `split_policy`
+- `current_scope_preference`
+
+`analyze_issue_bundle` requires:
+
+- `task_bundle_path`
+
+`analyze_issue_number` requires:
+
+- `issue_number`
+
+## Policy Object
+
+Recommended fields:
+
+- `stop_before_tracker_mutation`
+- `stop_before_card_mutation`
+- `allow_follow_on_issue_drafts`
+- `max_follow_on_count`
+- `preserve_issue_graph_links`
+
+## Example
+
+```yaml
+skill_input_schema: issue_splitter.v1
+mode: analyze_issue_bundle
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  task_bundle_path: .adl/v0.90.4/tasks/issue-2480__v0-90-4-backlog-add-issue-splitter-operational-skill
+  source_issue_prompt_path: .adl/v0.90.4/bodies/issue-2480-v0-90-4-backlog-add-issue-splitter-operational-skill.md
+  issue_title: "[v0.90.4][backlog][tools] Add issue-splitter operational skill"
+policy:
+  stop_before_tracker_mutation: true
+  stop_before_card_mutation: true
+  allow_follow_on_issue_drafts: true
+  max_follow_on_count: 2
+  preserve_issue_graph_links: true
+```
+
+## Output
+
+Default output root:
+
+```text
+.adl/reviews/issue-splitter/<run_id>/
+```
+
+Required artifacts:
+
+- `issue_splitter_report.md`
+- `issue_splitter_report.json`
+
+The report must preserve issue-graph notes, split rationale, and non-claims. It
+must not create tracker items, rewrite cards, or claim the scope already changed.

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -24,6 +24,7 @@ The tracked skill set is:
 - `finding-to-issue-planner`
 - `gap-analysis`
 - `issue-folding`
+- `issue-splitter`
 - `issue-watcher`
 - `medium-article-writer`
 - `portable-contract-normalizer`
@@ -83,6 +84,7 @@ The normal workflow is:
 `diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
 `issue-folding` is a bounded issue-disposition helper for classifying duplicate, superseded, absorbed, already-satisfied, obsolete, or still-actionable issues before closeout.
+`issue-splitter` is a bounded issue-scope helper for deciding whether one issue should stay intact, split now, defer splitting, or stop for operator review.
 `issue-watcher` is a bounded wait-window helper for watching one issue, PR, branch, or dependency gate and routing blockers without mutating state.
 `pr-stack-manager` is a bounded stack-topology helper for ancestry, base alignment, and dependency-order analysis.
 `review-comment-triage` is a bounded review-feedback helper for classifying PR comments before implementation.
@@ -1411,6 +1413,49 @@ Use `workflow-conductor` for still-actionable issues, `pr-closeout` for
 evidence-backed foldable outcomes, and operator review when disposition signals
 conflict.
 
+## `issue-splitter`
+
+### Purpose
+
+`issue-splitter` inspects one bounded issue packet and decides whether the issue
+should stay intact, split into follow-on work now, defer splitting, or stop for
+operator review.
+
+It preserves concern-bucket rationale, proposed follow-ons, and issue-graph
+links without mutating the tracker.
+
+### When To Use It
+
+Use it when:
+
+- an issue mixes multiple concern families or follow-on hints
+- scope drift should be turned into explicit split planning
+- current-scope narrowing should be reasoned about before touching cards
+
+Do not use it for:
+
+- automatic issue creation
+- silent card rewrites
+- broad milestone decomposition
+
+Structured schema:
+
+- `adl/tools/skills/docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md`
+- schema id: `issue_splitter.v1`
+
+Deterministic fixture analyzer:
+
+```bash
+python3 adl/tools/skills/issue-splitter/scripts/plan_issue_split.py --task-bundle <path> --source-prompt <path> --out <artifact-root> --run-id <run-id>
+```
+
+### Typical Handoff
+
+Use `workflow-conductor` when the issue should stay intact,
+`finding-to-issue-planner` or approved issue-creation flow for split-now or
+defer outcomes, and operator review when the packet contains conflicting split
+signals.
+
 ## `portable-contract-normalizer`
 
 ### Purpose
@@ -2364,6 +2409,8 @@ Use this quick selector:
   - `pr-closeout`
 - need to classify whether an issue should close as duplicate, superseded, absorbed, already satisfied, or obsolete work:
   - `issue-folding`
+- need to decide whether one issue should stay intact or split into follow-on work:
+  - `issue-splitter`
 - need to clean drifted lifecycle records before closeout or janitor handoff:
   - `records-hygiene`
 - need to inspect stacked PR topology or stale branch bases:
@@ -2430,6 +2477,7 @@ surfaces:
 | `finding-to-issue-planner` | `FINDING_TO_ISSUE_PLANNER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | issue candidates only |
 | `gap-analysis` | `GAP_ANALYSIS_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | gap report only |
 | `issue-folding` | `ISSUE_FOLDING_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | issue disposition classification only |
+| `issue-splitter` | `ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | issue split planning only |
 | `medium-article-writer` | `MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | article packet only |
 | `portable-contract-normalizer` | `PORTABLE_CONTRACT_NORMALIZER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | bounded portability scan or explicit safe normalization only |
 | `pr-closeout` | `PR_CLOSEOUT_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | local closeout only |

--- a/adl/tools/skills/issue-splitter/SKILL.md
+++ b/adl/tools/skills/issue-splitter/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: issue-splitter
+description: Classify whether one issue should stay intact, split into bounded follow-ons, defer splitting, or stop for operator judgment while preserving issue-graph and card truth.
+---
+
+# Issue Splitter
+
+This skill is a bounded issue split planner.
+
+Its job is to:
+
+- inspect one issue packet for mixed or drifting scope
+- detect concern buckets that may deserve separate follow-on issues
+- recommend whether to keep the issue intact, split now, defer, or block
+- preserve rationale and issue-graph notes for any proposed split
+- narrow the current issue scope in recommendations without mutating the tracker
+
+It does not create tracker items automatically, rewrite milestone plans, or
+perform implementation work.
+
+## Required Inputs
+
+At minimum, gather:
+
+- `repo_root`
+- one concrete target:
+  - `issue_number`
+  - `task_bundle_path`
+  - `source_issue_prompt_path`
+- `mode`
+- `policy`
+
+Useful additional inputs:
+
+- `issue_title`
+- `split_policy`
+- `current_scope_preference`
+- `target_tracker_style`
+- `max_follow_on_count`
+
+If there is no concrete issue packet or task bundle, stop with `blocked`.
+
+## Classification Model
+
+Supported classifications:
+
+- `keep_as_is`
+  - the issue is cohesive enough to stay intact
+- `split_now`
+  - the issue has multiple concern buckets and should split into follow-ons now
+- `defer`
+  - the issue may eventually split, but evidence is too weak or current work should stay together for now
+- `blocked`
+  - the packet contains conflicting split signals or insufficient structure
+
+## Workflow
+
+### 1. Resolve the Target
+
+Prefer this order:
+
+1. task bundle path
+2. issue number with resolved repo surfaces
+3. source issue prompt path
+
+Only inspect one issue target per invocation.
+
+### 2. Extract Concern Buckets
+
+Read the bounded issue packet:
+
+- source issue prompt
+- `stp.md`
+- `sip.md`
+- `sor.md` when relevant
+
+Bucket candidate lines by explicit prefixes or obvious keywords such as:
+
+- `runtime`
+- `tooling`
+- `docs`
+- `tests`
+- `review`
+- `release`
+- `security`
+- `process`
+
+For deterministic local planning, use:
+
+`python3 adl/tools/skills/issue-splitter/scripts/plan_issue_split.py --task-bundle <path> --source-prompt <path> --out <path>`
+
+### 3. Decide Keep, Split, Defer, or Block
+
+Split now when:
+
+- the packet clearly mixes multiple concern buckets
+- there is explicit split or follow-on language
+- proposed child issues can be stated without losing traceability
+
+Keep as-is when:
+
+- the issue stays mostly within one coherent bucket
+- secondary tasks are normal proof/doc/test support rather than separate issue-worthy work
+
+Defer when:
+
+- multiple buckets exist but current evidence is weak or sequencing argues for a later split
+
+Block when:
+
+- the packet says both “must stay together” and “split now”
+- the issue lacks enough structure to narrow current scope safely
+
+### 4. Emit Split Plan
+
+For `split_now` or `defer`, emit:
+
+- current issue scope recommendation
+- proposed follow-on buckets
+- candidate follow-on titles
+- issue-graph notes for `split_from` / `follow_on_to`
+- rationale and uncertainty
+
+### 5. Handoff
+
+Recommend:
+
+- `workflow-conductor` for `keep_as_is`
+- `finding-to-issue-planner` or `pr-init` after approval for concrete follow-on issue creation
+- `stp-editor` / `sip-editor` when the current issue cards need narrowing after a split decision
+- operator review for `blocked`
+
+This skill stops after the split plan. It does not create the follow-on issues
+itself.
+
+## Stop Boundary
+
+Stop after:
+
+- one truthful classification
+- concern-bucket evidence
+- recommended current-scope narrowing
+- proposed follow-ons
+- issue-graph guidance
+
+Do not:
+
+- mutate GitHub issues
+- silently rewrite the current issue cards
+- open follow-on PRs
+- absorb unrelated milestone planning
+
+## Output
+
+Use the structured contract in `references/output-contract.md`.

--- a/adl/tools/skills/issue-splitter/adl-skill.yaml
+++ b/adl/tools/skills/issue-splitter/adl-skill.yaml
@@ -1,0 +1,92 @@
+version: "0.1"
+kind: "adl-skill"
+id: "issue-splitter"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "issue_splitter.v1"
+    reference_doc: "../docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "analyze_issue_bundle"
+      - "analyze_issue_number"
+    policy_fields:
+      - "stop_before_tracker_mutation"
+      - "stop_before_card_mutation"
+      - "allow_follow_on_issue_drafts"
+      - "max_follow_on_count"
+      - "preserve_issue_graph_links"
+    mode_requirements:
+      analyze_issue_bundle:
+        required_target_fields:
+          - "task_bundle_path"
+      analyze_issue_number:
+        required_target_fields:
+          - "issue_number"
+  intent:
+    - "issue_scope_classification"
+    - "issue_split_planning"
+    - "follow_on_issue_planning"
+required_inputs:
+  - "repo_root"
+optional_inputs:
+  - "issue_number"
+  - "task_bundle_path"
+  - "source_issue_prompt_path"
+  - "issue_title"
+  - "split_policy"
+  - "current_scope_preference"
+stop_if_missing:
+  - "repo_root"
+  - "policy.stop_before_tracker_mutation"
+  - "policy.stop_before_card_mutation"
+prevalidation_rules:
+  - "repo_root_must_be_absolute"
+  - "skill_input_schema_must_equal_issue_splitter.v1_when_structured_input_is_used"
+  - "mode_must_match_supported_enum"
+  - "exactly_one_issue_target_should_drive_the_mode"
+  - "policy.stop_before_tracker_mutation_must_be_true"
+  - "policy.stop_before_card_mutation_must_be_true"
+  - "policy.max_follow_on_count_must_be_positive_integer_when_present"
+execution:
+  mode: "plan_only"
+  allow_code_edits: false
+  allow_network: false
+  allow_subagents: false
+  preferred_commands:
+    - "python3 adl/tools/skills/issue-splitter/scripts/plan_issue_split.py --task-bundle <path> --source-prompt <path> --out <path>"
+    - "rg -n \"follow-on|split|separate issue|must stay together|defer\" .adl"
+  preferred_path: "task_bundle_first"
+  stop_before:
+    - "issue_creation"
+    - "card_rewrite"
+    - "pr_run"
+    - "silent_scope_fragmentation"
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-issue-splitter.md"
+  required_sections:
+    - "status"
+    - "classification"
+    - "concern_buckets"
+    - "current_scope_recommendation"
+    - "proposed_follow_ons"
+    - "issue_graph_notes"
+    - "recommended_handoff"
+    - "non_claims"
+    - "safety_flags"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true
+  no_live_tracker_mutation_without_explicit_permission: true
+  manifest_declares_executables: true

--- a/adl/tools/skills/issue-splitter/agents/openai.yaml
+++ b/adl/tools/skills/issue-splitter/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Issue Splitter
+short_description: Classify whether one issue should stay intact, split into follow-ons, defer, or stop for operator judgment
+default_prompt: Inspect one issue packet or task bundle for mixed or drifting scope. Detect concern buckets, decide whether the issue should stay intact, split now, defer, or stop as blocked, and emit current-scope guidance plus follow-on issue candidates without mutating the tracker or rewriting cards automatically.

--- a/adl/tools/skills/issue-splitter/references/issue-splitter-playbook.md
+++ b/adl/tools/skills/issue-splitter/references/issue-splitter-playbook.md
@@ -1,0 +1,49 @@
+# Issue Splitter Playbook
+
+Use `issue-splitter` when an issue looks too broad, mixes multiple concern
+families, or contains explicit follow-on planning hints.
+
+## Evidence Order
+
+Prefer these surfaces:
+
+1. source issue prompt
+2. `stp.md`
+3. `sip.md`
+4. `sor.md` when it already records deferred work
+
+## Concern Buckets
+
+Prefer explicit bucket prefixes when they exist, such as:
+
+- `runtime:`
+- `tooling:`
+- `docs:`
+- `tests:`
+- `review:`
+- `release:`
+- `security:`
+- `process:`
+
+Fallback keyword bucketing is acceptable, but if the packet is too vague,
+classify `blocked` rather than inventing clean split boundaries.
+
+## Classification Heuristics
+
+- `keep_as_is`
+  - one dominant bucket
+  - supporting docs/tests remain normal proof work
+- `split_now`
+  - multiple strong buckets and explicit split/follow-on language
+  - clean child issue titles can be proposed without losing traceability
+- `defer`
+  - mixed buckets exist but the split should wait
+- `blocked`
+  - packet says both “must stay together” and “split now”
+  - current issue scope cannot be narrowed safely
+
+## Handoff
+
+- `keep_as_is` -> normal workflow execution
+- `split_now` or `defer` -> `finding-to-issue-planner`, `pr-init`, or operator approval path
+- `blocked` -> operator review

--- a/adl/tools/skills/issue-splitter/references/output-contract.md
+++ b/adl/tools/skills/issue-splitter/references/output-contract.md
@@ -1,0 +1,55 @@
+# Issue Splitter Output Contract
+
+Issue-splitter artifacts must plan one bounded split decision without creating
+follow-on issues, mutating cards, or hiding uncertainty.
+
+## Required Markdown Sections
+
+- `Issue Splitter Summary`
+- `Classification`
+- `Concern Buckets`
+- `Current Scope Recommendation`
+- `Proposed Follow-Ons`
+- `Issue Graph Notes`
+- `Recommended Handoff`
+- `Non-Claims`
+- `Safety Flags`
+
+## Required JSON Shape
+
+Schema id: `adl.issue_splitter_report.v1`
+
+Required top-level fields:
+
+- `schema`
+- `run_id`
+- `status`
+- `classification`
+- `summary`
+- `concern_buckets`
+- `current_scope_recommendation`
+- `proposed_follow_ons`
+- `issue_graph_notes`
+- `recommended_handoff`
+- `non_claims`
+- `safety_flags`
+
+Supported status values:
+
+- `keep_as_is`
+- `split_now`
+- `defer`
+- `blocked`
+
+## Safety Flags
+
+Every report must state:
+
+- `issues_created: false`
+- `cards_mutated: false`
+- `tracker_mutated: false`
+- `scope_silently_rewritten: false`
+- `implementation_claimed: false`
+
+This skill may recommend split actions. It must not claim that the split or
+follow-on issue creation already happened.

--- a/adl/tools/skills/issue-splitter/scripts/plan_issue_split.py
+++ b/adl/tools/skills/issue-splitter/scripts/plan_issue_split.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Plan whether a bounded issue should split into follow-on issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SPLIT_RE = re.compile(r"\b(split|follow[- ]on|separate issue|later issue|spin out)\b", re.I)
+KEEP_RE = re.compile(r"\b(must stay together|keep intact|single issue)\b", re.I)
+DEFER_RE = re.compile(r"\b(defer|later pass|wait until|after .* proves out)\b", re.I)
+
+BUCKETS: dict[str, tuple[str, ...]] = {
+    "runtime": ("runtime", "executor", "classifier", "engine"),
+    "tooling": ("tooling", "tool", "cli", "automation"),
+    "docs": ("docs", "documentation", "guide", "schema"),
+    "tests": ("test", "tests", "contract test", "coverage"),
+    "review": ("review", "reviewer", "triage", "findings"),
+    "release": ("release", "closeout", "milestone", "ceremony"),
+    "security": ("security", "privacy", "secret", "redaction"),
+    "process": ("process", "workflow", "policy", "issue graph"),
+}
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+def collect_texts(task_bundle: Path | None, source_prompt: Path | None) -> list[dict[str, str]]:
+    texts: list[dict[str, str]] = []
+    if source_prompt and source_prompt.is_file():
+        texts.append({"source": "source_issue_prompt", "text": read_text(source_prompt)})
+    if task_bundle and task_bundle.is_dir():
+        for name in ("stp.md", "sip.md", "sor.md"):
+            path = task_bundle / name
+            if path.is_file():
+                texts.append({"source": name, "text": read_text(path)})
+    return texts
+
+
+def candidate_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw in text.splitlines():
+        line = " ".join(raw.strip().split())
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith(("-", "*")) or ":" in line or len(line.split()) > 3:
+            lines.append(line[:220])
+    return lines
+
+
+def bucket_for_line(line: str) -> str:
+    lowered = line.lower().lstrip("-* ").strip()
+    for bucket, keywords in BUCKETS.items():
+        if lowered.startswith(f"{bucket}:"):
+            return bucket
+        if any(keyword in lowered for keyword in keywords):
+            return bucket
+    return "general"
+
+
+def classify(texts: list[dict[str, str]]) -> dict[str, Any]:
+    bucket_items: dict[str, list[dict[str, str]]] = defaultdict(list)
+    split_markers: list[dict[str, str]] = []
+    keep_markers: list[dict[str, str]] = []
+    defer_markers: list[dict[str, str]] = []
+
+    for entry in texts:
+        for line in candidate_lines(entry["text"]):
+            bucket = bucket_for_line(line)
+            bucket_items[bucket].append({"source": entry["source"], "evidence": line})
+            if SPLIT_RE.search(line):
+                split_markers.append({"source": entry["source"], "evidence": line})
+            if KEEP_RE.search(line):
+                keep_markers.append({"source": entry["source"], "evidence": line})
+            if DEFER_RE.search(line):
+                defer_markers.append({"source": entry["source"], "evidence": line})
+
+    non_general = {k: v for k, v in bucket_items.items() if k != "general" and v}
+    sorted_buckets = sorted(non_general.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+
+    if split_markers and keep_markers:
+        classification = "blocked"
+    elif len(sorted_buckets) <= 1:
+        classification = "keep_as_is"
+    elif defer_markers:
+        classification = "defer"
+    elif split_markers or len(sorted_buckets) >= 3:
+        classification = "split_now"
+    else:
+        classification = "defer"
+
+    primary_bucket = sorted_buckets[0][0] if sorted_buckets else "general"
+    proposed_follow_ons = []
+    if classification in {"split_now", "defer"}:
+        for bucket, items in sorted_buckets[1:3]:
+            proposed_follow_ons.append(
+                {
+                    "bucket": bucket,
+                    "candidate_title": f"Follow-on: {bucket} scope from current issue",
+                    "rationale": items[0]["evidence"],
+                    "issue_graph_link": f"split_from_current_issue::{bucket}",
+                }
+            )
+
+    issue_graph_notes = []
+    if classification in {"split_now", "defer"}:
+        issue_graph_notes.append(f"retain_current_scope::{primary_bucket}")
+        issue_graph_notes.extend(item["issue_graph_link"] for item in proposed_follow_ons)
+
+    current_scope = {
+        "primary_bucket": primary_bucket,
+        "rationale": (
+            sorted_buckets[0][1][0]["evidence"] if sorted_buckets else "no strong split markers found"
+        ),
+    }
+
+    return {
+        "classification": classification,
+        "concern_buckets": {
+            bucket: [item["evidence"] for item in items[:3]]
+            for bucket, items in sorted(bucket_items.items())
+            if items
+        },
+        "current_scope_recommendation": current_scope,
+        "proposed_follow_ons": proposed_follow_ons,
+        "issue_graph_notes": issue_graph_notes,
+    }
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    task_bundle = Path(args.task_bundle) if args.task_bundle else None
+    source_prompt = Path(args.source_prompt) if args.source_prompt else None
+    texts = collect_texts(task_bundle, source_prompt)
+
+    if not texts:
+        classification = "blocked"
+        concern_buckets = {}
+        current_scope = {
+            "primary_bucket": "unknown",
+            "rationale": "expected source issue prompt or task bundle files missing",
+        }
+        proposed_follow_ons = []
+        issue_graph_notes = []
+    else:
+        result = classify(texts)
+        classification = result["classification"]
+        concern_buckets = result["concern_buckets"]
+        current_scope = result["current_scope_recommendation"]
+        proposed_follow_ons = result["proposed_follow_ons"]
+        issue_graph_notes = result["issue_graph_notes"]
+
+    summary = {
+        "keep_as_is": "Issue packet remains cohesive enough to stay intact.",
+        "split_now": "Issue packet should split into bounded follow-on work now.",
+        "defer": "Issue packet shows split pressure, but the split should wait.",
+        "blocked": "Issue packet has conflicting or insufficient split signals.",
+    }[classification]
+
+    return {
+        "schema": "adl.issue_splitter_report.v1",
+        "run_id": args.run_id,
+        "status": classification,
+        "classification": classification,
+        "summary": summary,
+        "concern_buckets": concern_buckets,
+        "current_scope_recommendation": current_scope,
+        "proposed_follow_ons": proposed_follow_ons,
+        "issue_graph_notes": issue_graph_notes,
+        "recommended_handoff": (
+            "workflow-conductor"
+            if classification == "keep_as_is"
+            else "operator-review"
+            if classification == "blocked"
+            else "finding-to-issue-planner"
+        ),
+        "non_claims": [
+            "This report does not create follow-on issues.",
+            "This report does not rewrite the current issue cards.",
+            "This report does not claim implementation scope already changed.",
+        ],
+        "safety_flags": {
+            "issues_created": False,
+            "cards_mutated": False,
+            "tracker_mutated": False,
+            "scope_silently_rewritten": False,
+            "implementation_claimed": False,
+        },
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Issue Splitter Summary",
+        "",
+        f"- Run id: `{report['run_id']}`",
+        f"- Status: `{report['status']}`",
+        f"- Summary: {report['summary']}",
+        "",
+        "## Classification",
+        "",
+        f"- classification: `{report['classification']}`",
+        "",
+        "## Concern Buckets",
+        "",
+    ]
+    if report["concern_buckets"]:
+        for bucket, items in report["concern_buckets"].items():
+            lines.append(f"- `{bucket}`")
+            for item in items:
+                lines.append(f"  - {item.lstrip('- ').strip()}")
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Current Scope Recommendation",
+            "",
+            f"- primary_bucket: `{report['current_scope_recommendation']['primary_bucket']}`",
+            f"- rationale: {report['current_scope_recommendation']['rationale']}",
+            "",
+            "## Proposed Follow-Ons",
+            "",
+        ]
+    )
+    if report["proposed_follow_ons"]:
+        for item in report["proposed_follow_ons"]:
+            lines.append(
+                f"- `{item['bucket']}` -> {item['candidate_title']} ({item['issue_graph_link']})"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Issue Graph Notes", ""])
+    if report["issue_graph_notes"]:
+        for note in report["issue_graph_notes"]:
+            lines.append(f"- {note}")
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Recommended Handoff",
+            "",
+            f"- recommended_handoff: `{report['recommended_handoff']}`",
+            "",
+            "## Non-Claims",
+            "",
+        ]
+    )
+    for item in report["non_claims"]:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## Safety Flags", ""])
+    for key, value in report["safety_flags"].items():
+        lines.append(f"- {key}: {str(value).lower()}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-bundle")
+    parser.add_argument("--source-prompt")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--run-id", default="issue-splitter")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    report = build_report(args)
+    (out / "issue_splitter_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "issue_splitter_report.md").write_text(
+        markdown_report(report),
+        encoding="utf-8",
+    )
+    print(f"WROTE {out / 'issue_splitter_report.json'}")
+    print(f"WROTE {out / 'issue_splitter_report.md'}")
+    print(f"STATUS {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_issue_splitter_skill_contracts.sh
+++ b/adl/tools/test_issue_splitter_skill_contracts.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+skills_root="${repo_root}/adl/tools/skills"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+skill_root="${skills_root}/issue-splitter"
+python_script="${skill_root}/scripts/plan_issue_split.py"
+
+[[ -f "${skill_root}/SKILL.md" ]]
+[[ -f "${skill_root}/adl-skill.yaml" ]]
+[[ -f "${skill_root}/agents/openai.yaml" ]]
+[[ -f "${skill_root}/references/issue-splitter-playbook.md" ]]
+[[ -f "${skill_root}/references/output-contract.md" ]]
+[[ -x "${python_script}" ]]
+[[ -f "${skills_root}/docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md" ]]
+
+grep -Fq 'id: "issue-splitter"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'id: "issue_splitter.v1"' "${skill_root}/adl-skill.yaml"
+grep -Fq 'reference_doc: "../docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md"' "${skill_root}/adl-skill.yaml"
+grep -Fq "policy.stop_before_card_mutation_must_be_true" "${skill_root}/adl-skill.yaml"
+grep -Fq "bounded issue split planner" "${skill_root}/SKILL.md"
+grep -Fq "issues_created: false" "${skill_root}/references/output-contract.md"
+grep -Fq "Schema id: \`issue_splitter.v1\`" "${skills_root}/docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md"
+
+python3 - "${tmpdir}" "${python_script}" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+tmpdir = Path(sys.argv[1])
+python_script = Path(sys.argv[2])
+
+
+def run_case(name: str, source_text: str, stp_text: str = ""):
+    root = tmpdir / name
+    report = tmpdir / f"{name}-report"
+    (root / "task").mkdir(parents=True)
+    (root / "source.md").write_text(source_text, encoding="utf-8")
+    if stp_text:
+        (root / "task" / "stp.md").write_text(stp_text, encoding="utf-8")
+    subprocess.run(
+        [
+            "python3",
+            str(python_script),
+            "--task-bundle",
+            str(root / "task"),
+            "--source-prompt",
+            str(root / "source.md"),
+            "--out",
+            str(report),
+            "--run-id",
+            f"issue-splitter-{name}-test",
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    return report
+
+
+split_report = run_case(
+    "split",
+    """## Summary
+
+- runtime: implement the split classifier
+- docs: add a new operator guide section
+- release: create a release-tail follow-on issue
+- review: split the review-lane hardening into a follow-on issue
+""",
+    "review: split this concern into a later issue after the core classifier lands.\n",
+)
+split_json = json.loads((split_report / "issue_splitter_report.json").read_text(encoding="utf-8"))
+assert split_json["status"] == "split_now"
+assert split_json["classification"] == "split_now"
+assert split_json["recommended_handoff"] == "finding-to-issue-planner"
+assert split_json["proposed_follow_ons"]
+assert any(item["bucket"] == "docs" for item in split_json["proposed_follow_ons"])
+split_md = (split_report / "issue_splitter_report.md").read_text(encoding="utf-8")
+assert "## Proposed Follow-Ons" in split_md
+assert "issues_created: false" in split_md
+
+keep_report = run_case(
+    "keep",
+    """## Summary
+
+- tooling: add the split-planning helper
+- tooling: document invocation and stop boundary
+- tooling: add one deterministic contract test
+""",
+)
+keep_json = json.loads((keep_report / "issue_splitter_report.json").read_text(encoding="utf-8"))
+assert keep_json["status"] == "keep_as_is"
+assert keep_json["classification"] == "keep_as_is"
+assert keep_json["recommended_handoff"] == "workflow-conductor"
+assert not keep_json["proposed_follow_ons"]
+
+defer_report = run_case(
+    "defer",
+    """## Summary
+
+- tooling: implement the helper
+- docs: add the later documentation pass
+- docs: defer the documentation split until after the helper proves out
+""",
+)
+defer_json = json.loads((defer_report / "issue_splitter_report.json").read_text(encoding="utf-8"))
+assert defer_json["status"] == "defer"
+assert defer_json["classification"] == "defer"
+
+blocked_report = run_case(
+    "blocked",
+    """## Summary
+
+- runtime: split this into a follow-on issue now
+- process: this must stay together as a single issue
+""",
+)
+blocked_json = json.loads((blocked_report / "issue_splitter_report.json").read_text(encoding="utf-8"))
+assert blocked_json["status"] == "blocked"
+assert blocked_json["classification"] == "blocked"
+assert blocked_json["recommended_handoff"] == "operator-review"
+
+for report_root in (split_report, keep_report, defer_report, blocked_report):
+    for path in report_root.iterdir():
+        if str(tmpdir) in path.read_text(encoding="utf-8"):
+            raise AssertionError("issue splitter artifacts should not leak absolute temp paths")
+PY
+
+bash "${repo_root}/adl/tools/validate_skill_frontmatter.sh" \
+  "${skill_root}/SKILL.md"
+
+echo "PASS test_issue_splitter_skill_contracts"


### PR DESCRIPTION
Closes #2480

## Summary
Added the `issue-splitter` operational skill as a bounded split planner for keep-as-is, split-now, defer, and blocked issue-scope decisions, including its schema doc, operator-guide integration, deterministic planner script, and contract test.

## Artifacts
- `adl/tools/skills/issue-splitter/SKILL.md`
- `adl/tools/skills/issue-splitter/adl-skill.yaml`
- `adl/tools/skills/issue-splitter/agents/openai.yaml`
- `adl/tools/skills/issue-splitter/references/output-contract.md`
- `adl/tools/skills/issue-splitter/references/issue-splitter-playbook.md`
- `adl/tools/skills/issue-splitter/scripts/plan_issue_split.py`
- `adl/tools/skills/docs/ISSUE_SPLITTER_SKILL_INPUT_SCHEMA.md`
- `adl/tools/test_issue_splitter_skill_contracts.sh`
- Updated operator guide entry in `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_issue_splitter_skill_contracts.sh`
    Proved the new `issue-splitter` skill classifies split-now, keep-as-is, defer, and blocked issue packets and emits bounded no-mutation split plans without leaking host paths.
  - `bash adl/tools/test_skill_documentation_completeness.sh`
    Proved the new skill is represented in the tracked operator documentation matrix.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Proved the installer picks up the new skill bundle and validates its frontmatter.
  - `git diff --check`
    Proved the tracked patch set is free of formatting and whitespace errors.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2480__v0-90-4-backlog-add-issue-splitter-operational-skill/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2480__v0-90-4-backlog-add-issue-splitter-operational-skill/sor.md
- Idempotency-Key: v0-90-4-backlog-tools-add-issue-splitter-operational-skill-adl-tools-skills-issue-splitter-skill-md-adl-tools-skills-issue-splitter-adl-skill-yaml-adl-tools-skills-issue-splitter-agents-openai-yaml-adl-tools-skills-issue-splitter-references-output-contract-md-adl-tools-skills-issue-splitter-references-issue-splitter-playbook-md-adl-tools-skills-issue-splitter-scripts-plan-issue-split-py-adl-tools-skills-docs-issue-splitter-skill-input-schema-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-test-issue-splitter-skill-contracts-sh-adl-v0-90-4-tasks-issue-2480-v0-90-4-backlog-add-issue-splitter-operational-skill-sip-md-adl-v0-90-4-tasks-issue-2480-v0-90-4-backlog-add-issue-splitter-operational-skill-sor-md