### PR TITLE
[v0.90.4][backlog][tools] Adopt cargo-nextest for fast non-coverage Rust validation lanes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,14 +101,24 @@ jobs:
       - name: docs command check
         run: bash tools/check_release_notes_commands.sh
 
+      - name: Install cargo-nextest
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
+        with:
+          tool: nextest
+
       - name: test
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
-        run: cargo test
+        run: cargo nextest run --all-features
+
+      - name: doc test
+        if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
+        run: cargo test --doc --all-features
 
       - name: test covered by full coverage lane
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required == 'true'
         run: |
-          echo "Skipping standalone cargo test because this event requires the full cargo-llvm-cov lane."
+          echo "Skipping standalone cargo nextest/doc-test lane because this event requires the full cargo-llvm-cov lane."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
 
       - name: Rust validation skipped by path policy

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -390,6 +390,10 @@ fn finish_validation_guard(repo_root: &Path) -> Result<()> {
     run_status("bash", &[path_str(&tracked_residue_guard)?])
 }
 
+fn cargo_nextest_available() -> bool {
+    run_status_allow_failure("cargo", &["nextest", "--version"]).unwrap_or(false)
+}
+
 pub(super) fn select_finish_validation_mode(paths_csv: &str) -> Result<FinishValidationMode> {
     let paths = paths_csv
         .split(',')
@@ -469,7 +473,41 @@ pub(super) fn run_finish_validation_rust(
             "warnings",
         ],
     )?;
-    run_status("cargo", &["test", "--manifest-path", path_str(&manifest)?])?;
+    if cargo_nextest_available() {
+        run_status(
+            "cargo",
+            &[
+                "nextest",
+                "run",
+                "--manifest-path",
+                path_str(&manifest)?,
+                "--all-features",
+            ],
+        )?;
+    } else {
+        eprintln!(
+            "• cargo-nextest not available locally; falling back to cargo test for full local Rust validation."
+        );
+        run_status(
+            "cargo",
+            &[
+                "test",
+                "--manifest-path",
+                path_str(&manifest)?,
+                "--all-features",
+            ],
+        )?;
+    }
+    run_status(
+        "cargo",
+        &[
+            "test",
+            "--manifest-path",
+            path_str(&manifest)?,
+            "--doc",
+            "--all-features",
+        ],
+    )?;
     Ok(())
 }
 
@@ -485,7 +523,8 @@ pub(super) fn render_default_finish_validation(mode: FinishValidationMode) -> St
             "- bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk",
             "- cargo fmt",
             "- cargo clippy --all-targets -- -D warnings",
-            "- cargo test",
+            "- cargo nextest run --manifest-path adl/Cargo.toml --all-features (fallback: cargo test --manifest-path adl/Cargo.toml --all-features when cargo-nextest is unavailable locally)",
+            "- cargo test --manifest-path adl/Cargo.toml --doc --all-features",
         ]
         .join("\n"),
     }

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -104,6 +104,7 @@ fn render_pr_body_defaults_docs_only_validation_when_needed() {
     assert!(body.contains("bash adl/tools/check_no_tracked_adl_issue_record_residue.sh"));
     assert!(body.contains("git diff --check"));
     assert!(!body.contains("cargo clippy --all-targets -- -D warnings"));
+    assert!(!body.contains("cargo nextest run"));
     assert!(!body.contains("cargo test"));
 }
 
@@ -315,7 +316,55 @@ fn finish_helper_paths_cover_ahead_count_and_validation_modes() {
     let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
     assert!(cargo_calls.contains("fmt --manifest-path"));
     assert!(cargo_calls.contains("clippy --manifest-path"));
+    assert!(cargo_calls.contains("nextest --version"));
+    assert!(cargo_calls.contains("nextest run --manifest-path"));
     assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--doc --all-features"));
+}
+
+#[test]
+fn finish_full_rust_validation_falls_back_when_nextest_is_unavailable() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-nextest-fallback");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join("adl/tools")).expect("adl tools dir");
+    fs::write(
+        repo.join("adl/Cargo.toml"),
+        "[package]\nname='adl'\nversion='0.1.0'\n",
+    )
+    .expect("cargo toml");
+    write_executable(
+        &repo.join("adl/tools/check_no_tracked_adl_issue_record_residue.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    init_git_repo(&repo);
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let cargo_log = temp.join("cargo.log");
+    let cargo_path = bin_dir.join("cargo");
+    write_executable(
+        &cargo_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"${{1:-}}\" = 'nextest' ] && [ \"${{2:-}}\" = '--version' ]; then\n  exit 1\nfi\nexit 0\n",
+            cargo_log.display()
+        ),
+    );
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    run_finish_validation_rust(&repo, FinishValidationMode::FullRust).expect("full validation");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let cargo_calls = fs::read_to_string(&cargo_log).expect("cargo log");
+    assert!(cargo_calls.contains("nextest --version"));
+    assert!(!cargo_calls.contains("nextest run --manifest-path"));
+    assert!(cargo_calls.contains("test --manifest-path"));
+    assert!(cargo_calls.contains("--all-features"));
+    assert!(cargo_calls.contains("--doc --all-features"));
 }
 
 #[test]

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -153,7 +153,8 @@ Observed:
 
 Truthful interpretation:
 
-- Rust fmt, clippy, tests, demo smoke where applicable, and the fast
+- Rust fmt, clippy, broad non-coverage tests via `cargo nextest run`, doc
+  tests via `cargo test --doc`, demo smoke where applicable, and the fast
   coverage-impact preflight are expected.
 - Full instrumented coverage is intentionally deferred for the PR to avoid
   running all tests twice.

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -124,6 +124,11 @@ did run, and keep CI required before merge.
 Use full local validation for runtime, schema, security, release, broad tooling,
 or ambiguous changes.
 
+For broad non-coverage Rust lanes, prefer `cargo nextest run` over raw
+`cargo test` when the lane is executing the whole runnable test graph rather
+than a narrow filtered proof. Keep `cargo llvm-cov` on its own coverage lanes,
+and preserve doc-test signal explicitly with `cargo test --doc` where needed.
+
 ### Issue-Class Validation Rule
 
 Before choosing validation, classify the issue using the narrowest truthful


### PR DESCRIPTION
## Summary
- adopt `cargo nextest run` for broad non-coverage Rust test lanes
- keep `cargo llvm-cov` authoritative for coverage lanes
- preserve doc-test signal with explicit `cargo test --doc`

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all
- cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish::arg_render -- --nocapture
- git diff --check

Closes #2484