### PR TITLE
[v0.90.4][backlog][tools] Split PR coverage from authoritative main/nightly full coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
             --event-name "${{ github.event_name }}" \
             --base "${{ github.event.pull_request.base.sha }}" \
             --head "${{ github.event.pull_request.head.sha }}" \
+            --ref "${{ github.ref }}" \
             --github-output "$GITHUB_OUTPUT"
         working-directory: .
 
@@ -110,12 +111,16 @@ jobs:
         run: |
           echo "Skipping standalone cargo test because this event requires the full cargo-llvm-cov lane."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
 
       - name: Rust validation skipped by path policy
         if: steps.path-policy.outputs.rust_required != 'true'
         run: |
           echo "Rust fmt/clippy/test skipped because changed paths do not touch Rust runtime or test surfaces."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
         working-directory: .
 
       - name: demo smoke (S-01..S-05)
@@ -149,6 +154,7 @@ jobs:
             --event-name "${{ github.event_name }}" \
             --base "${{ github.event.pull_request.base.sha }}" \
             --head "${{ github.event.pull_request.head.sha }}" \
+            --ref "${{ github.ref }}" \
             --github-output "$GITHUB_OUTPUT"
         working-directory: .
 
@@ -236,6 +242,8 @@ jobs:
           echo "This check ran the changed-source coverage-impact preflight instead."
           echo "Full coverage remains required on push-to-main, nightly coverage ratchet, and fail-closed classification."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
         working-directory: .
 
       - name: Enforce coverage policy gates (workspace + per-file)
@@ -281,6 +289,8 @@ jobs:
           echo "Coverage skipped because changed paths do not touch Rust runtime or test surfaces."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
           echo "This keeps the adl-coverage check stable while avoiding full cargo-llvm-cov for docs/planning/tools-only PRs."
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
         working-directory: .
 
       - name: Upload coverage to Codecov

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -4,12 +4,13 @@ set -euo pipefail
 event_name="${GITHUB_EVENT_NAME:-}"
 base_sha=""
 head_sha=""
+ref_name="${GITHUB_REF:-}"
 github_output="${GITHUB_OUTPUT:-}"
 
 usage() {
   cat <<'USAGE'
 Usage:
-  adl/tools/ci_path_policy.sh [--event-name <name>] [--base <sha>] [--head <sha>] [--github-output <path>]
+  adl/tools/ci_path_policy.sh [--event-name <name>] [--base <sha>] [--head <sha>] [--ref <ref>] [--github-output <path>]
 
 Classifies changed paths for CI so docs/planning/tools-only PRs can skip
 expensive Rust test and coverage phases while runtime/source changes still run
@@ -29,6 +30,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --head)
       head_sha="${2:-}"
+      shift 2
+      ;;
+    --ref)
+      ref_name="${2:-}"
       shift 2
       ;;
     --github-output)
@@ -53,6 +58,8 @@ coverage_required="$bool_false"
 full_coverage_required="$bool_false"
 demo_smoke_required="$bool_false"
 fail_closed=false
+coverage_lane="skip"
+coverage_authority="not_required"
 reason="path_policy_docs_or_tooling_only"
 changed_count=0
 changed_files=""
@@ -74,6 +81,31 @@ require_full_validation() {
   coverage_required=true
   full_coverage_required=true
   demo_smoke_required=true
+}
+
+mark_authoritative_full_coverage() {
+  local authority="$1"
+  local reason_value="$2"
+  require_full_validation
+  coverage_lane="authoritative_full"
+  coverage_authority="$authority"
+  reason="$reason_value"
+}
+
+mark_pr_fast_coverage() {
+  rust_required=true
+  coverage_required=true
+  demo_smoke_required=true
+  coverage_lane="pr_fast"
+  coverage_authority="pr_changed_surface"
+  reason="runtime_or_rust_test_change_runs_pr_fast_validation"
+}
+
+mark_policy_surface_full_coverage() {
+  full_coverage_required=true
+  coverage_lane="authoritative_full"
+  coverage_authority="pr_policy_surface"
+  reason="coverage_policy_surface_change_runs_full_coverage"
 }
 
 normalize_changed_rows() {
@@ -129,29 +161,27 @@ changed_line_delta_for_path() {
 }
 
 if [ "$event_name" != "pull_request" ]; then
-  require_full_validation
-  reason="non_pull_request_event_runs_full_validation"
+  if [ "$event_name" = "push" ] && [ "$ref_name" = "refs/heads/main" ]; then
+    mark_authoritative_full_coverage "push_main" "push_main_runs_authoritative_full_coverage"
+  else
+    mark_authoritative_full_coverage "non_pr_event" "non_pull_request_event_runs_full_validation"
+  fi
 elif [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
-  require_full_validation
   fail_closed=true
-  reason="missing_pull_request_sha_runs_full_validation"
+  mark_authoritative_full_coverage "fail_closed" "missing_pull_request_sha_runs_full_validation"
 else
   changed_rows="$(git diff --name-status --diff-filter=ACMR "$base_sha" "$head_sha" 2>/dev/null | normalize_changed_rows || true)"
   changed_files="$(printf '%s\n' "$changed_rows" | awk -F '\t' 'NF >= 2 { print $2 }')"
   if [ -z "$changed_rows" ]; then
-    require_full_validation
     fail_closed=true
-    reason="empty_or_unavailable_diff_runs_full_validation"
+    mark_authoritative_full_coverage "fail_closed" "empty_or_unavailable_diff_runs_full_validation"
   else
     changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
     while IFS= read -r path; do
       [ -n "$path" ] || continue
       case "$path" in
         adl/src/*|adl/tests/*|adl/Cargo.toml|adl/Cargo.lock|adl/build.rs)
-          rust_required=true
-          coverage_required=true
-          demo_smoke_required=true
-          reason="runtime_or_rust_test_change_runs_pr_fast_validation"
+          mark_pr_fast_coverage
           ;;
         demos/*|adl/tools/demo_*|adl/tools/test_demo_*)
           demo_smoke_required=true
@@ -163,8 +193,7 @@ EOF
     while IFS=$'\t' read -r _status path; do
       [ -n "$path" ] || continue
       if is_full_coverage_policy_surface "$path"; then
-        full_coverage_required=true
-        reason="coverage_policy_surface_change_runs_full_coverage"
+        mark_policy_surface_full_coverage
         continue
       fi
     done <<EOF
@@ -178,6 +207,8 @@ emit "coverage_required" "$coverage_required"
 emit "full_coverage_required" "$full_coverage_required"
 emit "demo_smoke_required" "$demo_smoke_required"
 emit "fail_closed" "$fail_closed"
+emit "coverage_lane" "$coverage_lane"
+emit "coverage_authority" "$coverage_authority"
 emit "changed_count" "$changed_count"
 emit "reason" "$reason"
 
@@ -187,4 +218,6 @@ printf '  coverage_required=%s\n' "$coverage_required"
 printf '  full_coverage_required=%s\n' "$full_coverage_required"
 printf '  demo_smoke_required=%s\n' "$demo_smoke_required"
 printf '  fail_closed=%s\n' "$fail_closed"
+printf '  coverage_lane=%s\n' "$coverage_lane"
+printf '  coverage_authority=%s\n' "$coverage_authority"
 printf '  changed_count=%s\n' "$changed_count"

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -50,11 +50,19 @@ It emits:
 - `full_coverage_required`
 - `demo_smoke_required`
 - `fail_closed`
+- `coverage_lane`
+- `coverage_authority`
 - `changed_count`
 - `reason`
 
-The `reason` field is the operator-facing explanation for why a lane ran or
-was skipped.
+The stable interpretation order is:
+
+1. `coverage_lane`
+2. `coverage_authority`
+3. `reason`
+
+`reason` remains the human-facing explanation, while `coverage_lane` and
+`coverage_authority` make the event/risk split machine-readable.
 
 ## Skill Interpretation Rules
 
@@ -149,6 +157,8 @@ Observed:
 - `rust_required=true`
 - `coverage_required=true`
 - `full_coverage_required=false`
+- `coverage_lane=pr_fast`
+- `coverage_authority=pr_changed_surface`
 - `demo_smoke_required=true` when demo surfaces changed
 
 Truthful interpretation:
@@ -166,6 +176,9 @@ Observed:
 - `rust_required=true`
 - `coverage_required=true`
 - `full_coverage_required=true`
+- `coverage_lane=authoritative_full`
+- `coverage_authority=push_main`, `pr_policy_surface`, or another
+  authoritative trigger
 
 Truthful interpretation:
 
@@ -187,6 +200,8 @@ modifying coverage governance itself.
 Observed:
 
 - `fail_closed=true`
+- `coverage_lane=authoritative_full`
+- `coverage_authority=fail_closed`
 
 Truthful interpretation:
 

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -36,11 +36,13 @@ trap 'rm -rf "$tmp_dir"' EXIT
   git commit -q -m docs-change
   docs_head="$(git rev-parse HEAD)"
 
-  docs_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$docs_head")"
+  docs_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$docs_head" --ref "refs/pull/1/merge")"
   assert_has "$docs_output" "rust_required=false"
   assert_has "$docs_output" "coverage_required=false"
   assert_has "$docs_output" "full_coverage_required=false"
   assert_has "$docs_output" "demo_smoke_required=false"
+  assert_has "$docs_output" "coverage_lane=skip"
+  assert_has "$docs_output" "coverage_authority=not_required"
 
   git checkout -q -b runtime-change "$base_sha"
   printf 'pub fn added_runtime() -> bool { true }\n' >> adl/src/lib.rs
@@ -48,11 +50,13 @@ trap 'rm -rf "$tmp_dir"' EXIT
   git commit -q -m runtime-change
   runtime_head="$(git rev-parse HEAD)"
 
-  runtime_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$runtime_head")"
+  runtime_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$runtime_head" --ref "refs/pull/1/merge")"
   assert_has "$runtime_output" "rust_required=true"
   assert_has "$runtime_output" "coverage_required=true"
   assert_has "$runtime_output" "full_coverage_required=false"
   assert_has "$runtime_output" "demo_smoke_required=true"
+  assert_has "$runtime_output" "coverage_lane=pr_fast"
+  assert_has "$runtime_output" "coverage_authority=pr_changed_surface"
   assert_has "$runtime_output" "reason=runtime_or_rust_test_change_runs_pr_fast_validation"
 
   git checkout -q -b new-runtime-file "$base_sha"
@@ -61,11 +65,13 @@ trap 'rm -rf "$tmp_dir"' EXIT
   git commit -q -m new-runtime-file
   new_runtime_file_head="$(git rev-parse HEAD)"
 
-  new_runtime_file_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$new_runtime_file_head")"
+  new_runtime_file_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$new_runtime_file_head" --ref "refs/pull/1/merge")"
   assert_has "$new_runtime_file_output" "rust_required=true"
   assert_has "$new_runtime_file_output" "coverage_required=true"
   assert_has "$new_runtime_file_output" "full_coverage_required=false"
   assert_has "$new_runtime_file_output" "demo_smoke_required=true"
+  assert_has "$new_runtime_file_output" "coverage_lane=pr_fast"
+  assert_has "$new_runtime_file_output" "coverage_authority=pr_changed_surface"
   assert_has "$new_runtime_file_output" "reason=runtime_or_rust_test_change_runs_pr_fast_validation"
 
   git checkout -q -b policy-surface-change "$base_sha"
@@ -75,25 +81,31 @@ trap 'rm -rf "$tmp_dir"' EXIT
   git commit -q -m policy-surface-change
   policy_surface_head="$(git rev-parse HEAD)"
 
-  policy_surface_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$policy_surface_head")"
+  policy_surface_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$policy_surface_head" --ref "refs/pull/1/merge")"
   assert_has "$policy_surface_output" "rust_required=false"
   assert_has "$policy_surface_output" "coverage_required=false"
   assert_has "$policy_surface_output" "full_coverage_required=true"
   assert_has "$policy_surface_output" "demo_smoke_required=false"
+  assert_has "$policy_surface_output" "coverage_lane=authoritative_full"
+  assert_has "$policy_surface_output" "coverage_authority=pr_policy_surface"
   assert_has "$policy_surface_output" "reason=coverage_policy_surface_change_runs_full_coverage"
 
-  main_output="$("$POLICY" --event-name push)"
+  main_output="$("$POLICY" --event-name push --ref "refs/heads/main")"
   assert_has "$main_output" "rust_required=true"
   assert_has "$main_output" "coverage_required=true"
   assert_has "$main_output" "full_coverage_required=true"
   assert_has "$main_output" "demo_smoke_required=true"
-  assert_has "$main_output" "reason=non_pull_request_event_runs_full_validation"
+  assert_has "$main_output" "coverage_lane=authoritative_full"
+  assert_has "$main_output" "coverage_authority=push_main"
+  assert_has "$main_output" "reason=push_main_runs_authoritative_full_coverage"
 
-  fail_closed_output="$("$POLICY" --event-name pull_request --base "" --head "$runtime_head")"
+  fail_closed_output="$("$POLICY" --event-name pull_request --base "" --head "$runtime_head" --ref "refs/pull/1/merge")"
   assert_has "$fail_closed_output" "rust_required=true"
   assert_has "$fail_closed_output" "coverage_required=true"
   assert_has "$fail_closed_output" "full_coverage_required=true"
   assert_has "$fail_closed_output" "fail_closed=true"
+  assert_has "$fail_closed_output" "coverage_lane=authoritative_full"
+  assert_has "$fail_closed_output" "coverage_authority=fail_closed"
 )
 
 echo "PASS: ci_path_policy PR-fast/full-coverage contract"

--- a/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
@@ -49,10 +49,22 @@ For pull requests, it compares the PR base and head SHAs and emits:
 - `full_coverage_required`
 - `demo_smoke_required`
 - `fail_closed`
+- `coverage_lane`
+- `coverage_authority`
 - `changed_count`
 - `reason`
 
 For non-PR events, including pushes to `main`, it runs full validation.
+
+Interpretation order:
+
+1. `coverage_lane`
+2. `coverage_authority`
+3. `reason`
+
+`reason` remains the human-facing explanation, while `coverage_lane` and
+`coverage_authority` make the authoritative-vs-fast coverage split explicit for
+skills and operators.
 
 If the diff cannot be determined, the policy fails closed and runs full
 validation.
@@ -136,7 +148,9 @@ coverage. In those lanes, standalone `cargo test` may be skipped because
 duplicating the whole suite.
 
 When in doubt, check the `Classify changed paths` step in `adl-ci` or
-`adl-coverage`. Its `reason` field explains why a lane did or did not run.
+`adl-coverage`. Read `coverage_lane` first, `coverage_authority` second, and
+then use `reason` as the human-readable explanation for why a lane did or did
+not run.
 
 ## Non-Claims
 


### PR DESCRIPTION
## Summary
- make the PR-fast vs authoritative-full coverage split machine-readable
- expose stable `coverage_lane` and `coverage_authority` outputs
- keep check names stable while making their meaning easier to interpret

## Validation
- bash adl/tools/test_ci_path_policy.sh
- bash -n adl/tools/ci_path_policy.sh
- git diff --check

Closes #2485