### PR TITLE
[v0.90.4][backlog][tools] Split heavyweight runtime_v2 proof tests from the default adl-ci lane

### DIFF
--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -19,6 +19,9 @@ name = "adl-remote"
 path = "src/bin/adl_remote.rs"
 
 [features]
+# Heavy runtime_v2 proof-materialization and CLI proof-smoke tests stay out of
+# ordinary `cargo test` but remain covered by authoritative `--all-features`
+# lanes such as cargo-llvm-cov.
 slow-proof-tests = []
 
 [dependencies]

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -18,6 +18,9 @@ path = "src/main.rs"
 name = "adl-remote"
 path = "src/bin/adl_remote.rs"
 
+[features]
+slow-proof-tests = []
+
 [dependencies]
 # CLI
 clap = { version = "4.5", features = ["derive"] }

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -1,8 +1,10 @@
 use super::*;
 
+#[cfg(feature = "slow-proof-tests")]
 mod access_control;
 mod bid_schema;
 mod boot_admission;
+#[cfg(feature = "slow-proof-tests")]
 mod challenge;
 mod citizen_lifecycle;
 mod common;
@@ -19,6 +21,7 @@ mod invariant_violation;
 mod kernel_loop;
 mod manifold;
 mod observatory;
+#[cfg(feature = "slow-proof-tests")]
 mod observatory_flagship;
 mod operator_control;
 mod private_state;

--- a/adl/src/runtime_v2/tests/bid_schema.rs
+++ b/adl/src/runtime_v2/tests/bid_schema.rs
@@ -111,6 +111,7 @@ fn runtime_v2_bid_schema_rejects_invalid_bid_fixtures_for_expected_reasons() {
     }
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_bid_schema_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_bid_schema_contract().expect("bid schema artifacts");

--- a/adl/src/runtime_v2/tests/boot_admission.rs
+++ b/adl/src/runtime_v2/tests/boot_admission.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -82,6 +84,7 @@ fn runtime_v2_csm_boot_admission_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_boot_admission_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-boot-admission");

--- a/adl/src/runtime_v2/tests/contract_schema.rs
+++ b/adl/src/runtime_v2/tests/contract_schema.rs
@@ -93,6 +93,7 @@ fn runtime_v2_contract_schema_rejects_invalid_contract_fixtures_for_expected_rea
     }
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_contract_schema_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_contract_schema_contract().expect("contract schema artifacts");

--- a/adl/src/runtime_v2/tests/csm_run_packet.rs
+++ b/adl/src/runtime_v2/tests/csm_run_packet.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -86,6 +88,7 @@ fn runtime_v2_csm_run_packet_contract_matches_golden_fixture() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_run_packet_contract_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-run-contract");

--- a/adl/src/runtime_v2/tests/freedom_gate_mediation.rs
+++ b/adl/src/runtime_v2/tests/freedom_gate_mediation.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -67,6 +69,7 @@ fn runtime_v2_csm_freedom_gate_mediation_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_freedom_gate_mediation_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-freedom-gate-mediation");

--- a/adl/src/runtime_v2/tests/governed_episode.rs
+++ b/adl/src/runtime_v2/tests/governed_episode.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -73,6 +75,7 @@ fn runtime_v2_csm_governed_episode_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_governed_episode_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-governed-episode");

--- a/adl/src/runtime_v2/tests/hardening.rs
+++ b/adl/src/runtime_v2/tests/hardening.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -107,6 +109,7 @@ fn runtime_v2_csm_hardening_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_hardening_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-hardening");

--- a/adl/src/runtime_v2/tests/integrated_csm_run.rs
+++ b/adl/src/runtime_v2/tests/integrated_csm_run.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -60,6 +62,7 @@ fn runtime_v2_csm_integrated_run_contract_matches_golden_fixture() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_integrated_run_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-integrated-run");

--- a/adl/src/runtime_v2/tests/invalid_action_rejection.rs
+++ b/adl/src/runtime_v2/tests/invalid_action_rejection.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -73,6 +75,7 @@ fn runtime_v2_csm_invalid_action_rejection_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_invalid_action_rejection_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-invalid-action-rejection");

--- a/adl/src/runtime_v2/tests/invariant_contract.rs
+++ b/adl/src/runtime_v2/tests/invariant_contract.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -74,6 +76,7 @@ fn runtime_v2_invariant_and_violation_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_invariant_and_violation_contract_writes_without_path_leakage() {
     let temp_root = unique_temp_path("wp04-contract");

--- a/adl/src/runtime_v2/tests/observatory.rs
+++ b/adl/src/runtime_v2/tests/observatory.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -43,6 +45,7 @@ fn runtime_v2_csm_observatory_contract_is_stable() {
         .contains("This is not the first true Godel-agent birthday."));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_observatory_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-observatory");

--- a/adl/src/runtime_v2/tests/operator_control.rs
+++ b/adl/src/runtime_v2/tests/operator_control.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -53,6 +55,7 @@ fn runtime_v2_operator_control_report_matches_golden_fixture() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_operator_control_report_writes_without_path_leakage() {
     let temp_root = unique_temp_path("operator-controls");

--- a/adl/src/runtime_v2/tests/private_state.rs
+++ b/adl/src/runtime_v2/tests/private_state.rs
@@ -137,6 +137,7 @@ fn runtime_v2_private_state_validation_rejects_missing_required_boundaries() {
         .contains("non-authority"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_write_to_root_materializes_authority_and_projection() {
     let artifacts = runtime_v2_private_state_contract().expect("private-state artifacts");

--- a/adl/src/runtime_v2/tests/private_state_envelope.rs
+++ b/adl/src/runtime_v2/tests/private_state_envelope.rs
@@ -176,6 +176,7 @@ fn runtime_v2_private_state_envelope_rejects_signature_and_trust_policy_drift() 
         .contains("missing negative case"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_envelope_write_to_root_materializes_fixtures() {
     let artifacts =

--- a/adl/src/runtime_v2/tests/private_state_equivocation.rs
+++ b/adl/src/runtime_v2/tests/private_state_equivocation.rs
@@ -186,6 +186,7 @@ fn runtime_v2_private_state_anti_equivocation_rejects_non_conflicting_claims() {
         .contains("must contain conflicting signed successors"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_anti_equivocation_write_to_root_materializes_fixtures() {
     let artifacts =

--- a/adl/src/runtime_v2/tests/private_state_lineage.rs
+++ b/adl/src/runtime_v2/tests/private_state_lineage.rs
@@ -205,6 +205,7 @@ fn runtime_v2_private_state_lineage_head_disagreement_enters_recovery_or_quarant
         .contains("reconstruct_from_ledger_or_quarantine"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_lineage_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_lineage_contract().expect("lineage artifacts");

--- a/adl/src/runtime_v2/tests/private_state_observatory.rs
+++ b/adl/src/runtime_v2/tests/private_state_observatory.rs
@@ -209,6 +209,7 @@ fn runtime_v2_private_state_observatory_rejects_public_overexposure_and_report_d
     .contains("must not claim raw private-state inspection"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_observatory_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_observatory_contract().expect("observatory artifacts");

--- a/adl/src/runtime_v2/tests/private_state_sanctuary.rs
+++ b/adl/src/runtime_v2/tests/private_state_sanctuary.rs
@@ -216,6 +216,7 @@ fn runtime_v2_private_state_sanctuary_operator_report_reviews_all_preserved_evid
         .contains("must review preserved evidence"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_sanctuary_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_sanctuary_contract().expect("sanctuary artifacts");

--- a/adl/src/runtime_v2/tests/private_state_sealing.rs
+++ b/adl/src/runtime_v2/tests/private_state_sealing.rs
@@ -233,6 +233,7 @@ fn runtime_v2_private_state_sealing_payload_is_not_raw_json_or_canonical_bytes()
     assert_ne!(sealed_payload, canonical);
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_sealing_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_sealing_contract().expect("sealing artifacts");

--- a/adl/src/runtime_v2/tests/private_state_witness.rs
+++ b/adl/src/runtime_v2/tests/private_state_witness.rs
@@ -201,6 +201,7 @@ fn runtime_v2_private_state_receipts_reject_leakage_and_missing_explanation() {
         .contains("must explain valid continuation"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_witness_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_witness_contract().expect("witness artifacts");

--- a/adl/src/runtime_v2/tests/quarantine.rs
+++ b/adl/src/runtime_v2/tests/quarantine.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -84,6 +86,7 @@ fn runtime_v2_csm_quarantine_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_quarantine_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-quarantine");

--- a/adl/src/runtime_v2/tests/recovery_eligibility.rs
+++ b/adl/src/runtime_v2/tests/recovery_eligibility.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -93,6 +95,7 @@ fn runtime_v2_csm_recovery_eligibility_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_recovery_eligibility_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-recovery-eligibility");

--- a/adl/src/runtime_v2/tests/security_boundary.rs
+++ b/adl/src/runtime_v2/tests/security_boundary.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -45,6 +47,7 @@ fn runtime_v2_security_boundary_proof_matches_golden_fixture() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_security_boundary_proof_writes_without_path_leakage() {
     let temp_root = unique_temp_path("security-boundary");

--- a/adl/src/runtime_v2/tests/standing.rs
+++ b/adl/src/runtime_v2/tests/standing.rs
@@ -184,6 +184,7 @@ fn runtime_v2_standing_rejects_naked_actor_effects() {
         .contains("naked actor must be rejected before effect"));
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_standing_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_standing_contract().expect("standing artifacts");

--- a/adl/src/runtime_v2/tests/wake_continuity.rs
+++ b/adl/src/runtime_v2/tests/wake_continuity.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "slow-proof-tests")]
 use super::common::unique_temp_path;
 use super::*;
+#[cfg(feature = "slow-proof-tests")]
 use std::fs;
 
 #[test]
@@ -78,6 +80,7 @@ fn runtime_v2_csm_wake_continuity_contract_matches_golden_fixtures() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_wake_continuity_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-wake-continuity");
@@ -111,6 +114,7 @@ fn runtime_v2_csm_wake_continuity_writes_without_path_leakage() {
     fs::remove_dir_all(temp_root).ok();
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_csm_wake_continuity_proof_standalone_writes_without_path_leakage() {
     let temp_root = unique_temp_path("csm-wake-proof-standalone");

--- a/adl/tests/cli_smoke/instrument_and_cli.rs
+++ b/adl/tests/cli_smoke/instrument_and_cli.rs
@@ -141,6 +141,7 @@ fn csm_observatory_cli_fails_safely_on_missing_packet() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_v0903_demo_stdout_uses_repo_relative_output_paths() {
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
@@ -88,6 +88,9 @@ Ordinary runtime/source PRs:
 - run tooling sanity checks
 - run guardrails and contract checks
 - run Rust fmt, clippy, and full tests
+- keep heavyweight `runtime_v2` proof-materialization tests and the explicit
+  CLI proof-smoke stdout test behind the `slow-proof-tests` feature so the
+  default `cargo test` lane stays bounded
 - run demo smoke when required
 - run the changed-source coverage-impact preflight in the stable
   `adl-coverage` check
@@ -110,6 +113,16 @@ Pushes to `main` and nightly coverage:
 
 Coverage-impact preflight still runs for Rust/runtime PR changes. The workflow
 does not run a second full instrumented test universe for ordinary PRs.
+
+The heavyweight `runtime_v2` proof-materialization tranche is intentionally
+classified separately from always-on contract checks:
+
+- default `adl-ci` runs `cargo test` without `slow-proof-tests`
+- authoritative `cargo llvm-cov --workspace --all-features` lanes still execute
+  that tranche
+
+That keeps ordinary PR validation fast without pretending those proof surfaces
+no longer matter.
 
 When `full_coverage_required=true`, full coverage generates:
 


### PR DESCRIPTION
Closes #2497

## Summary
- add a non-default `slow-proof-tests` feature for heavyweight runtime_v2 proof/demo tests
- remove the slow access_control/challenge/observatory_flagship modules from the default fast lane
- gate the long CLI demo-path hygiene proof test behind the same feature

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all
- cargo test --manifest-path adl/Cargo.toml runtime_v2_feature_proof_coverage_contract_is_stable -- --nocapture
- cargo test --manifest-path adl/Cargo.toml -- --list | rg "runtime_v2_access_control_contract_is_stable|runtime_v2_continuity_challenge_contract_is_stable|runtime_v2_observatory_flagship_contract_is_stable|runtime_v2_v0903_demo_stdout_uses_repo_relative_output_paths" || true
- cargo test --manifest-path adl/Cargo.toml --features slow-proof-tests -- --list | rg "runtime_v2_access_control_contract_is_stable|runtime_v2_continuity_challenge_contract_is_stable|runtime_v2_observatory_flagship_contract_is_stable|runtime_v2_v0903_demo_stdout_uses_repo_relative_output_paths"
- cargo test --manifest-path adl/Cargo.toml --features slow-proof-tests runtime_v2_access_control_contract_is_stable -- --nocapture
- git diff --check