### PR TITLE
[v0.90.4][backlog][tools] Decompose the slow pr finish test tranche

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
 
       - name: test
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
-        run: cargo nextest run --status-level all --final-status-level slow --slow-timeout 60s
+        run: cargo nextest run --status-level all --final-status-level slow
 
       - name: doc test
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -23,6 +23,10 @@ path = "src/bin/adl_remote.rs"
 # ordinary `cargo test` but remain covered by authoritative `--all-features`
 # lanes such as cargo-llvm-cov.
 slow-proof-tests = []
+# Heavy `pr finish` temp-repo publication and sync integration tests stay out
+# of ordinary `cargo test` but remain covered by authoritative `--all-features`
+# lanes such as cargo-llvm-cov.
+slow-finish-tests = []
 
 [dependencies]
 # CLI

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -73,12 +73,6 @@ use self::git_support::{
     has_uncommitted_or_untracked_changes, issue_create_repo, path_str, primary_checkout_root,
     repo_root, run_capture, run_capture_allow_failure, run_status, tracked_changes_status,
 };
-#[cfg(test)]
-use self::github::ensure_pr_closing_linkage;
-#[cfg(test)]
-use self::github::pr_has_closing_linkage;
-#[cfg(test)]
-use self::github::{current_pr_url, ensure_or_repair_pr_closing_linkage};
 use self::github::{
     ensure_issue_metadata_parity, format_open_pr_wave, gh_issue_create, gh_issue_edit_body,
     gh_issue_title, issue_version, unresolved_milestone_pr_wave,

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 mod branch_and_gitignore;
+#[cfg(feature = "slow-finish-tests")]
 mod canonical_surfaces;
+#[cfg(feature = "slow-finish-tests")]
 mod foreign_bundle;
+#[cfg(feature = "slow-finish-tests")]
 mod output_truth;
+#[cfg(feature = "slow-finish-tests")]
 mod sync_and_prompt;

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
@@ -85,6 +85,7 @@ fn real_pr_finish_rejects_primary_checkout_when_issue_branch_is_bound_elsewhere(
     assert!(err.contains(&worktree.display().to_string()));
 }
 
+#[cfg(feature = "slow-finish-tests")]
 #[test]
 fn real_pr_finish_rejects_main_and_reports_no_pr_when_only_local_bundle_sync_changes_exist() {
     let _guard = env_lock();
@@ -274,6 +275,7 @@ fn real_pr_finish_rejects_main_and_reports_no_pr_when_only_local_bundle_sync_cha
     assert!(bundle_sync_err.to_string().contains("Nothing to PR."));
 }
 
+#[cfg(feature = "slow-finish-tests")]
 #[test]
 fn real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag() {
     let _guard = env_lock();

--- a/adl/src/cli/tests/pr_cmd_inline/finish/mod.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/mod.rs
@@ -2,4 +2,5 @@ use super::*;
 
 mod arg_render;
 mod guardrails;
+#[cfg(feature = "slow-finish-tests")]
 mod publication;

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::cli::pr_cmd::github::{
+    current_pr_url, ensure_or_repair_pr_closing_linkage, ensure_pr_closing_linkage,
+    pr_has_closing_linkage,
+};
 
 #[test]
 fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd::github::current_pr_url;
 
 #[test]
 fn issue_create_repo_requires_github_origin_remote() {

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -24,9 +24,9 @@ def step_run(name: str) -> str:
     return match.group(1).strip()
 
 ordinary_test = step_run("test")
-if ordinary_test != "cargo nextest run --status-level all --final-status-level slow --slow-timeout 60s":
+if ordinary_test != "cargo nextest run --status-level all --final-status-level slow":
     raise SystemExit(
-        "ordinary adl-ci test lane must be 'cargo nextest run --status-level all --final-status-level slow --slow-timeout 60s' without --all-features; "
+        "ordinary adl-ci test lane must be 'cargo nextest run --status-level all --final-status-level slow' without --all-features; "
         f"found: {ordinary_test}"
     )
 

--- a/docs/milestones/v0.90.4/FINISH_TEST_TOPOLOGY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/FINISH_TEST_TOPOLOGY_v0.90.4.md
@@ -1,0 +1,67 @@
+# Finish Test Topology v0.90.4
+
+## Purpose
+
+Record how the `cli::pr_cmd::tests::finish` tranche is split so ordinary Rust
+validation stays fast without dropping publication and guardrail proof.
+
+## Problem
+
+The original finish tranche put almost every `pr finish` proof in the default
+test lane. Most of those tests:
+
+- create a temp repo
+- initialize git metadata and a bare `origin`
+- seed issue prompt / STP / SIP / SOR bundle fixtures
+- shell through the full `real_pr finish` control path
+
+That topology made a small number of finish tests dominate wall-clock time even
+when the changed surface had nothing to do with finish publication.
+
+## New Split
+
+Ordinary lane:
+
+- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
+- one bounded integration guardrail in
+  `adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs`
+  that proves finish refuses the wrong checkout when the issue branch is bound
+  elsewhere
+
+Slow finish lane behind `slow-finish-tests`:
+
+- `finish/publication.rs`
+- `finish/guardrails/canonical_surfaces.rs`
+- `finish/guardrails/foreign_bundle.rs`
+- `finish/guardrails/output_truth.rs`
+- `finish/guardrails/sync_and_prompt.rs`
+- the heavier `branch_and_gitignore` publication-style temp-repo cases
+
+## Runner Placement
+
+Ordinary `cargo test` / `cargo nextest`:
+
+- does not enable `slow-finish-tests`
+- keeps fast argument rendering and one representative bound-checkout guardrail
+
+Authoritative lanes:
+
+- use `--all-features`
+- continue to run the full slow finish tranche
+- preserve publication, canonical-surface, foreign-bundle, sync, and stale-SOR
+  proofs
+
+## Why This Shape
+
+This keeps one real finish integration proof in the fast lane so finish does
+not become purely unit-tested there, while moving the expensive temp-repo PR
+publication matrix into the same class of authoritative-only coverage used for
+other slow proof surfaces.
+
+## Non-claims
+
+- This split does not claim the slow finish tranche is fully optimized.
+- It only stops the ordinary lane from paying for every temp-repo finish
+  publication scenario by default.
+- Follow-on work can still convert individual slow finish cases into lighter
+  helper-level tests when that can be done without losing behavioral coverage.

--- a/docs/milestones/v0.90.4/README.md
+++ b/docs/milestones/v0.90.4/README.md
@@ -82,6 +82,8 @@ Out of scope:
 - Economics inheritance audit:
   ECONOMICS_INHERITANCE_AND_AUTHORITY_AUDIT_v0.90.4.md
 - CI runtime policy for execution sessions: CI_RUNTIME_POLICY_v0.90.4.md
+- Finish test topology for validation throughput:
+  FINISH_TEST_TOPOLOGY_v0.90.4.md
 - Feature index: FEATURE_DOCS_v0.90.4.md
 - WP execution readiness: WP_EXECUTION_READINESS_v0.90.4.md
 - Milestone checklist: MILESTONE_CHECKLIST_v0.90.4.md


### PR DESCRIPTION
Closes #2486

## Summary
Split the slow `pr finish` integration tranche into a fast ordinary lane and a
feature-gated slow lane. Ordinary Rust validation now keeps `arg_render` plus
one representative bound-checkout guardrail, while the temp-repo publication,
sync, canonical-surface, foreign-bundle, and stale-output-card proofs move
behind `slow-finish-tests` and stay covered by authoritative `--all-features`
lanes.

## Artifacts
- Code:
  - `adl/Cargo.toml`
  - `adl/src/cli/tests/pr_cmd_inline/finish/mod.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/guardrails.rs`
  - `adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs`
- Docs:
  - `docs/milestones/v0.90.4/FINISH_TEST_TOPOLOGY_v0.90.4.md`
  - `docs/milestones/v0.90.4/README.md`
- Generated runtime artifacts: not_applicable for this tooling task

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Verified formatting after the finish tranche split.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish -- --nocapture`
    Verified the ordinary finish lane now runs the fast finish slice only.
  - `cargo test --manifest-path adl/Cargo.toml --features slow-finish-tests cli::pr_cmd::tests::finish::publication::real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture`
    Verified the heavy finish tranche still runs correctly when explicitly enabled.
  - `git diff --check`
    Verified no formatting residue remained after edits.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2486__v0-90-4-backlog-tools-decompose-the-slow-pr-finish-test-tranche/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2486__v0-90-4-backlog-tools-decompose-the-slow-pr-finish-test-tranche/sor.md
- Idempotency-Key: v0-90-4-backlog-tools-decompose-the-slow-pr-finish-test-tranche-adl-cargo-toml-adl-src-cli-tests-pr-cmd-inline-finish-mod-rs-adl-src-cli-tests-pr-cmd-inline-finish-guardrails-rs-adl-src-cli-tests-pr-cmd-inline-finish-guardrails-branch-and-gitignore-rs-docs-milestones-v0-90-4-readme-md-docs-milestones-v0-90-4-finish-test-topology-v0-90-4-md-adl-v0-90-4-tasks-issue-2486-v0-90-4-backlog-tools-decompose-the-slow-pr-finish-test-tranche-sip-md-adl-v0-90-4-tasks-issue-2486-v0-90-4-backlog-tools-decompose-the-slow-pr-finish-test-tranche-sor-md