### PR TITLE
[v0.90.4][backlog][tools] Tune Rust cache and linker strategy for validation throughput

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -373,12 +373,6 @@ jobs:
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.path-policy.outputs.full_coverage_required == 'true'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
-
-      - name: Rust acceleration stats for coverage
-        if: always() && (steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true')
-        run: |
-          echo "Linker mode: ${RUST_LINK_ACCEL:-unknown}"
-          sccache --show-stats || true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: adl/lcov.info
@@ -386,3 +380,9 @@ jobs:
           # Keep CI signal stable during transient Codecov outages; upload is informational.
           fail_ci_if_error: false
           verbose: true
+
+      - name: Rust acceleration stats for coverage
+        if: always() && (steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true')
+        run: |
+          echo "Linker mode: ${RUST_LINK_ACCEL:-unknown}"
+          sccache --show-stats || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,29 @@ jobs:
         with:
           workspaces: |
             adl -> target
+          cache-directories: |
+            ~/.cache/sccache
+
+      - name: Install sccache
+        if: steps.path-policy.outputs.rust_required == 'true'
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
+        with:
+          tool: sccache
+
+      - name: Configure Rust acceleration
+        if: steps.path-policy.outputs.rust_required == 'true'
+        run: |
+          mkdir -p "$HOME/.cache/sccache"
+          echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          if command -v ld.lld >/dev/null 2>&1; then
+            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
+            echo "RUST_LINK_ACCEL=lld" >> "$GITHUB_ENV"
+          else
+            echo "RUST_LINK_ACCEL=system-default" >> "$GITHUB_ENV"
+          fi
+          sccache --zero-stats || true
 
       - name: tooling sanity (bash -n)
         run: bash -n adl/tools/*.sh
@@ -105,6 +128,9 @@ jobs:
       - name: ci runtime contract check
         run: bash tools/test_ci_runtime_contracts.sh
 
+      - name: ci cache/linker contract check
+        run: bash tools/test_ci_cache_linker_contracts.sh
+
       - name: Install cargo-nextest
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
@@ -147,6 +173,12 @@ jobs:
           echo "Demo smoke skipped because changed paths do not touch runtime or demo surfaces."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
         working-directory: .
+
+      - name: Rust acceleration stats
+        if: always() && steps.path-policy.outputs.rust_required == 'true'
+        run: |
+          echo "Linker mode: ${RUST_LINK_ACCEL:-unknown}"
+          sccache --show-stats || true
 
   adl-coverage:
     runs-on: ubuntu-latest
@@ -201,10 +233,33 @@ jobs:
         with:
           workspaces: |
             adl -> target
+          cache-directories: |
+            ~/.cache/sccache
 
       - name: Install cargo-llvm-cov
         if: steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # cargo-llvm-cov
+
+      - name: Install sccache for coverage
+        if: steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true'
+        uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
+        with:
+          tool: sccache
+
+      - name: Configure Rust acceleration for coverage
+        if: steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true'
+        run: |
+          mkdir -p "$HOME/.cache/sccache"
+          echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          if command -v ld.lld >/dev/null 2>&1; then
+            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
+            echo "RUST_LINK_ACCEL=lld" >> "$GITHUB_ENV"
+          else
+            echo "RUST_LINK_ACCEL=system-default" >> "$GITHUB_ENV"
+          fi
+          sccache --zero-stats || true
 
       - name: Install cargo-nextest for coverage
         if: steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true'
@@ -318,6 +373,12 @@ jobs:
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.path-policy.outputs.full_coverage_required == 'true'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+
+      - name: Rust acceleration stats for coverage
+        if: always() && (steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true')
+        run: |
+          echo "Linker mode: ${RUST_LINK_ACCEL:-unknown}"
+          sccache --show-stats || true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: adl/lcov.info

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -10,6 +10,7 @@ skip/defer behavior.
 The source milestone policy is:
 
 - `docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md`
+- `docs/milestones/v0.90.4/RUST_VALIDATION_ACCELERATION_v0.90.4.md`
 
 ## Core Rule
 
@@ -136,6 +137,23 @@ When recording PR or output-card truth, say both:
 - what larger validation did not run and why that was acceptable
 
 ## Examples
+
+## Build Acceleration Posture
+
+Current CI posture also includes bounded build acceleration:
+
+- `sccache` is installed in Rust lanes and wired through `RUSTC_WRAPPER`
+- `~/.cache/sccache` is persisted through the existing Rust cache action
+- `lld` is enabled only when `ld.lld` is available on the runner
+- CI logs emit `sccache --show-stats` so operators can tell whether compiler
+  output reuse is actually happening
+
+Skills should treat this as throughput infrastructure, not proof by itself:
+
+- a green run still needs the correct validation lane
+- cache hits are supporting evidence about efficiency, not correctness
+- missing `lld` is acceptable because the workflow falls back to the system
+  default linker rather than failing closed
 
 ### Docs-Only PR
 

--- a/adl/tools/test_ci_cache_linker_contracts.sh
+++ b/adl/tools/test_ci_cache_linker_contracts.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/ci.yaml"
+
+python3 - "$WORKFLOW" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text()
+
+required_fragments = [
+    "cache-directories: |\n            ~/.cache/sccache",
+    "tool: sccache",
+    'echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"',
+    'echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"',
+    "command -v ld.lld >/dev/null 2>&1",
+    'echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"',
+    'sccache --zero-stats || true',
+    'sccache --show-stats || true',
+]
+
+missing = [frag for frag in required_fragments if frag not in workflow]
+if missing:
+    raise SystemExit(
+        "ci cache/linker posture drifted; missing workflow fragments:\n- "
+        + "\n- ".join(missing)
+    )
+
+for step in [
+    "Install sccache",
+    "Configure Rust acceleration",
+    "Install sccache for coverage",
+    "Configure Rust acceleration for coverage",
+    "Rust acceleration stats",
+    "Rust acceleration stats for coverage",
+]:
+    if f"- name: {step}" not in workflow:
+        raise SystemExit(f"missing workflow step: {step}")
+
+print("PASS test_ci_cache_linker_contracts")
+PY

--- a/docs/milestones/v0.90.4/README.md
+++ b/docs/milestones/v0.90.4/README.md
@@ -82,6 +82,8 @@ Out of scope:
 - Economics inheritance audit:
   ECONOMICS_INHERITANCE_AND_AUTHORITY_AUDIT_v0.90.4.md
 - CI runtime policy for execution sessions: CI_RUNTIME_POLICY_v0.90.4.md
+- Rust validation acceleration posture:
+  RUST_VALIDATION_ACCELERATION_v0.90.4.md
 - Finish test topology for validation throughput:
   FINISH_TEST_TOPOLOGY_v0.90.4.md
 - Feature index: FEATURE_DOCS_v0.90.4.md

--- a/docs/milestones/v0.90.4/RUST_VALIDATION_ACCELERATION_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RUST_VALIDATION_ACCELERATION_v0.90.4.md
@@ -1,0 +1,96 @@
+# Rust Validation Acceleration For v0.90.4
+
+## Purpose
+
+Record the bounded cache and linker posture chosen for the current Rust
+validation workflow so operators can understand what was changed, why it was
+changed, and what was intentionally left out.
+
+## Baseline
+
+Recent successful CI before this change showed that Rust validation was already
+down from the earlier 20-40 minute failure era, but compile-heavy steps still
+dominated the remaining wall time.
+
+Observed on successful run `24882019723`:
+
+- `adl-ci`: about `119s`
+- `adl-coverage`: about `447s`
+- `adl-coverage` step `Coverage run and summary (json)`: about `409s`
+
+Interpretation:
+
+- the remaining long pole is still compile-and-link work inside the full
+  coverage lane
+- both CI jobs perform Rust compilation on the same PR event
+- target-directory caching helps, but the workflow had no compiler-output cache
+  and no explicit linker acceleration posture
+
+## Chosen Improvements
+
+This issue implements three bounded changes:
+
+1. Install and enable `sccache` in both `adl-ci` and `adl-coverage`
+2. Persist `~/.cache/sccache` through the existing Rust cache action
+3. Enable `lld` opportunistically on Linux runners when `ld.lld` is present
+
+Operational posture:
+
+- `RUSTC_WRAPPER=sccache` is set only in CI
+- `SCCACHE_DIR=$HOME/.cache/sccache` is persisted by `Swatinem/rust-cache`
+- `RUSTFLAGS=-C link-arg=-fuse-ld=lld` is set only when the runner actually
+  has `ld.lld`
+- each job emits `sccache --show-stats` so operators can verify whether the
+  cache is helping in practice
+
+## Why This Shape
+
+This is intentionally conservative.
+
+- It improves repeated CI compiles without forcing a host-specific local tool
+  chain on every contributor.
+- It does not assume `mold` or another non-default linker is installed.
+- It keeps the repo portable by detecting `lld` instead of hard-requiring it.
+- It produces visible cache stats in the job logs so we can judge whether the
+  posture is working.
+
+## Explicit Rejections
+
+Rejected for this issue:
+
+- mandatory `mold`
+  Reason: not guaranteed on the GitHub-hosted runners we already use, and it
+  would widen infrastructure surface beyond a bounded tuning change.
+- tracked repo-global local linker config
+  Reason: local host assumptions should not silently become required checkout
+  state.
+- crate/workspace decomposition
+  Reason: that belongs to a different issue class and would be much larger than
+  cache/linker tuning.
+
+## Local Workflow Guidance
+
+The repo does not force local developers onto `sccache` or `lld`, but the CI
+choice is intentionally compatible with local opt-in use.
+
+If a local operator wants the same posture:
+
+- install `sccache`
+- set `RUSTC_WRAPPER=sccache`
+- optionally use `lld` when it is available on the local host
+
+That local setup remains optional and out of the tracked repo contract.
+
+## Expected Outcome
+
+This issue does not claim a guaranteed sub-5-minute total validation wall time
+by itself. It should reduce repeated compile/link cost and make the remaining
+compile work more observable.
+
+Success criteria for this posture:
+
+- CI stays green on the current workflow
+- `sccache` stats appear in job logs
+- repeated runs have a chance to reuse compiler outputs instead of paying only
+  target-directory cache restores
+- linker acceleration stays opportunistic rather than brittle


### PR DESCRIPTION
Closes #2487

## Summary
Implemented a bounded CI acceleration posture for Rust validation by adding
`sccache`, persisting its cache directory through the existing Rust cache
action, and enabling `lld` opportunistically when the GitHub runner provides
it. Added a workflow-contract test for the cache/linker posture and documented
the measured baseline plus explicit non-goals in the v0.90.4 milestone package.

## Artifacts
- `.github/workflows/ci.yaml`
- `adl/tools/test_ci_cache_linker_contracts.sh`
- `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
- `docs/milestones/v0.90.4/RUST_VALIDATION_ACCELERATION_v0.90.4.md`
- `docs/milestones/v0.90.4/README.md`

## Validation
- Validation commands and their purpose:
  - `GH_PAGER=cat gh run view 24882019723 --json jobs`
    Collected recent successful CI timing evidence for the acceleration note.
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Proved the CI runtime lane contract still holds.
  - `bash adl/tools/test_ci_cache_linker_contracts.sh`
    Proved the new cache/linker workflow posture is present.
  - `bash -n adl/tools/test_ci_cache_linker_contracts.sh`
    Proved the new shell script parses.
  - `bash -n adl/tools/*.sh`
    Proved the shell tooling surface remains syntactically valid.
  - `git diff --check`
    Proved the patch is whitespace-clean.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2487__v0-90-4-backlog-tools-tune-rust-cache-and-linker-strategy-for-validation-throughput/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2487__v0-90-4-backlog-tools-tune-rust-cache-and-linker-strategy-for-validation-throughput/sor.md
- Idempotency-Key: v0-90-4-backlog-tools-tune-rust-cache-and-linker-strategy-for-validation-throughput-github-workflows-ci-yaml-adl-tools-test-ci-cache-linker-contracts-sh-adl-tools-skills-docs-ci-runtime-policy-guide-md-docs-milestones-v0-90-4-readme-md-docs-milestones-v0-90-4-rust-validation-acceleration-v0-90-4-md-adl-v0-90-4-tasks-issue-2487-v0-90-4-backlog-tools-tune-rust-cache-and-linker-strategy-for-validation-throughput-sip-md-adl-v0-90-4-tasks-issue-2487-v0-90-4-backlog-tools-tune-rust-cache-and-linker-strategy-for-validation-throughput-sor-md