### PR TITLE
[v0.90.4][backlog][tools] Make CI Rust linker acceleration path activate truthfully on GitHub runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,15 @@ jobs:
         with:
           tool: sccache
 
+      - name: Install lld
+        if: steps.path-policy.outputs.rust_required == 'true'
+        run: |
+          if ! command -v ld.lld >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y lld
+          fi
+          command -v ld.lld
+
       - name: Configure Rust acceleration
         if: steps.path-policy.outputs.rust_required == 'true'
         run: |
@@ -60,12 +69,12 @@ jobs:
           echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          if command -v ld.lld >/dev/null 2>&1; then
-            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
-            echo "RUST_LINK_ACCEL=lld" >> "$GITHUB_ENV"
-          else
-            echo "RUST_LINK_ACCEL=system-default" >> "$GITHUB_ENV"
+          if ! command -v ld.lld >/dev/null 2>&1; then
+            echo "::error::ld.lld is unavailable after the install step"
+            exit 1
           fi
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
+          echo "RUST_LINK_ACCEL=lld" >> "$GITHUB_ENV"
           sccache --zero-stats || true
 
       - name: tooling sanity (bash -n)
@@ -246,6 +255,15 @@ jobs:
         with:
           tool: sccache
 
+      - name: Install lld for coverage
+        if: steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true'
+        run: |
+          if ! command -v ld.lld >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y lld
+          fi
+          command -v ld.lld
+
       - name: Configure Rust acceleration for coverage
         if: steps.path-policy.outputs.full_coverage_required == 'true' || steps.coverage-impact.outputs.needs_fast_summary == 'true'
         run: |
@@ -253,12 +271,12 @@ jobs:
           echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          if command -v ld.lld >/dev/null 2>&1; then
-            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
-            echo "RUST_LINK_ACCEL=lld" >> "$GITHUB_ENV"
-          else
-            echo "RUST_LINK_ACCEL=system-default" >> "$GITHUB_ENV"
+          if ! command -v ld.lld >/dev/null 2>&1; then
+            echo "::error::ld.lld is unavailable after the install step"
+            exit 1
           fi
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
+          echo "RUST_LINK_ACCEL=lld" >> "$GITHUB_ENV"
           sccache --zero-stats || true
 
       - name: Install cargo-nextest for coverage

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -144,7 +144,8 @@ Current CI posture also includes bounded build acceleration:
 
 - `sccache` is installed in Rust lanes and wired through `RUSTC_WRAPPER`
 - `~/.cache/sccache` is persisted through the existing Rust cache action
-- `lld` is enabled only when `ld.lld` is available on the runner
+- `lld` is installed and asserted on GitHub-hosted Linux runners before Rust
+  acceleration is configured
 - CI logs emit `sccache --show-stats` so operators can tell whether compiler
   output reuse is actually happening
 
@@ -152,8 +153,8 @@ Skills should treat this as throughput infrastructure, not proof by itself:
 
 - a green run still needs the correct validation lane
 - cache hits are supporting evidence about efficiency, not correctness
-- missing `lld` is acceptable because the workflow falls back to the system
-  default linker rather than failing closed
+- missing `lld` after the install step is a CI failure because the workflow is
+  explicitly claiming linker acceleration on the hosted runner path
 
 ### Docs-Only PR
 

--- a/adl/tools/test_ci_cache_linker_contracts.sh
+++ b/adl/tools/test_ci_cache_linker_contracts.sh
@@ -15,7 +15,9 @@ required_fragments = [
     "tool: sccache",
     'echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"',
     'echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"',
-    "command -v ld.lld >/dev/null 2>&1",
+    'sudo apt-get install -y lld',
+    'command -v ld.lld',
+    'echo "::error::ld.lld is unavailable after the install step"',
     'echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"',
     'sccache --zero-stats || true',
     'sccache --show-stats || true',
@@ -30,8 +32,10 @@ if missing:
 
 for step in [
     "Install sccache",
+    "Install lld",
     "Configure Rust acceleration",
     "Install sccache for coverage",
+    "Install lld for coverage",
     "Configure Rust acceleration for coverage",
     "Rust acceleration stats",
     "Rust acceleration stats for coverage",

--- a/docs/milestones/v0.90.4/RUST_VALIDATION_ACCELERATION_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RUST_VALIDATION_ACCELERATION_v0.90.4.md
@@ -32,14 +32,15 @@ This issue implements three bounded changes:
 
 1. Install and enable `sccache` in both `adl-ci` and `adl-coverage`
 2. Persist `~/.cache/sccache` through the existing Rust cache action
-3. Enable `lld` opportunistically on Linux runners when `ld.lld` is present
+3. Install and assert `lld` on GitHub-hosted Linux runners
 
 Operational posture:
 
 - `RUSTC_WRAPPER=sccache` is set only in CI
 - `SCCACHE_DIR=$HOME/.cache/sccache` is persisted by `Swatinem/rust-cache`
-- `RUSTFLAGS=-C link-arg=-fuse-ld=lld` is set only when the runner actually
-  has `ld.lld`
+- `lld` is installed in CI before Rust acceleration is configured
+- `RUSTFLAGS=-C link-arg=-fuse-ld=lld` is set only after `ld.lld` is verified
+- the workflow fails closed if `ld.lld` is still unavailable after install
 - each job emits `sccache --show-stats` so operators can verify whether the
   cache is helping in practice
 
@@ -50,7 +51,8 @@ This is intentionally conservative.
 - It improves repeated CI compiles without forcing a host-specific local tool
   chain on every contributor.
 - It does not assume `mold` or another non-default linker is installed.
-- It keeps the repo portable by detecting `lld` instead of hard-requiring it.
+- It keeps the repo portable locally while making the hosted CI runner posture
+  deterministic.
 - It produces visible cache stats in the job logs so we can judge whether the
   posture is working.
 
@@ -83,9 +85,19 @@ That local setup remains optional and out of the tracked repo contract.
 
 ## Expected Outcome
 
-This issue does not claim a guaranteed sub-5-minute total validation wall time
-by itself. It should reduce repeated compile/link cost and make the remaining
-compile work more observable.
+The original opportunistic linker posture proved insufficient in practice:
+
+- successful run `24884703780` still logged `RUST_LINK_ACCEL=system-default`
+- `adl-coverage` rose from about `447s` baseline to about `600s`
+- `Coverage run and summary (json)` rose from about `409s` to about `555s`
+- `sccache` was active but only reached about `46.65%` Rust cache hit rate
+
+That evidence means cache help alone is not enough; the linker path must be
+truthful and active on the hosted runners.
+
+This issue still does not claim a guaranteed sub-5-minute total validation wall
+time by itself. It should make the linker posture truthful, reduce repeated
+compile/link cost, and make remaining compile work more observable.
 
 Success criteria for this posture:
 
@@ -93,4 +105,4 @@ Success criteria for this posture:
 - `sccache` stats appear in job logs
 - repeated runs have a chance to reuse compiler outputs instead of paying only
   target-directory cache restores
-- linker acceleration stays opportunistic rather than brittle
+- linker acceleration is truthfully active in CI rather than silently dormant


### PR DESCRIPTION
Closes #2512

## Summary
Replaced the dormant opportunistic `lld` path with a deterministic CI posture that installs `lld` on GitHub-hosted Linux runners, fails closed if the linker is still unavailable, and updates the workflow contract and operator docs to reflect that the linker path must now activate truthfully.

## Artifacts
- Updated workflow: `.github/workflows/ci.yaml`
- Updated workflow contract: `adl/tools/test_ci_cache_linker_contracts.sh`
- Updated operator guide: `adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md`
- Updated milestone evidence note: `docs/milestones/v0.90.4/RUST_VALIDATION_ACCELERATION_v0.90.4.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_ci_cache_linker_contracts.sh`
    Verified the new deterministic linker-install posture and supporting fragments are present.
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Verified the CI runtime contract still matches the expected lane behavior.
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "YAML_PARSE_OK"'`
    Verified workflow syntax.
  - `git diff --check`
    Verified clean patch formatting.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2512__v0-90-4-backlog-tools-make-ci-rust-linker-acceleration-path-activate-truthfully-on-github-runners/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2512__v0-90-4-backlog-tools-make-ci-rust-linker-acceleration-path-activate-truthfully-on-github-runners/sor.md
- Idempotency-Key: v0-90-4-backlog-tools-make-ci-rust-linker-acceleration-path-activate-truthfully-on-github-runners-github-workflows-ci-yaml-adl-tools-test-ci-cache-linker-contracts-sh-adl-tools-skills-docs-ci-runtime-policy-guide-md-docs-milestones-v0-90-4-rust-validation-acceleration-v0-90-4-md-adl-v0-90-4-tasks-issue-2512-v0-90-4-backlog-tools-make-ci-rust-linker-acceleration-path-activate-truthfully-on-github-runners-sip-md-adl-v0-90-4-tasks-issue-2512-v0-90-4-backlog-tools-make-ci-rust-linker-acceleration-path-activate-truthfully-on-github-runners-sor-md