### PR TITLE
[v0.90.4][planning] Prepare v0.90.5 docs for execution

### DIFF
--- a/docs/milestones/v0.90.5/DECISIONS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/DECISIONS_v0.90.5.md
@@ -2,11 +2,10 @@
 
 | ID | Decision | Status | Rationale | Consequences |
 | --- | --- | --- | --- | --- |
-| D-01 | v0.90.5 is Governed Tools v1.0 | Proposed | Tool calling needs a full implementation milestone, not a late add-on | v0.90.5 issue wave should implement the first working tool suite |
-| D-02 | Tool calling is proposal, not execution | Proposed | Model output is untrusted and cannot be treated as action | Runtime must validate, compile, mediate, and trace before execution |
-| D-03 | UTS is portable and public-compatible | Proposed | JSON compatibility may make UTS useful outside ADL | Requires public-spec discipline, examples, invalid examples, and conformance |
-| D-04 | ACC owns ADL runtime authority | Proposed | UTS metadata must not imply permission to execute | Authority, identity, delegation, privacy, trace, replay, and Freedom Gate stay in ACC |
-| D-05 | Visibility and redaction are first-class | Proposed | Tool traces and errors can leak private data | Actor, operator, reviewer, public, and Observatory views must be defined |
-| D-06 | Model testing is required | Proposed | A schema is not enough if models misuse or bypass it | Multi-model and local/Gemma tests are part of the milestone |
-| D-07 | v0.90.3 owns the inhabited CSM demo | Proposed | Citizen-state demo and tools demo have different proof surfaces | v0.90.5 gets a governed-tools flagship demo instead |
-
+| D-01 | v0.90.5 is Governed Tools v1.0 | Accepted | Tool calling needs a full implementation milestone, not a late add-on | v0.90.5 issue wave should implement the first working tool suite |
+| D-02 | Tool calling is proposal, not execution | Accepted | Model output is untrusted and cannot be treated as action | Runtime must validate, compile, mediate, and trace before execution |
+| D-03 | UTS is portable and public-compatible | Accepted | JSON compatibility may make UTS useful outside ADL | Requires public-spec discipline, examples, invalid examples, and conformance |
+| D-04 | ACC owns ADL runtime authority | Accepted | UTS metadata must not imply permission to execute | Authority, identity, delegation, privacy, trace, replay, and Freedom Gate stay in ACC |
+| D-05 | Visibility and redaction are first-class | Accepted | Tool traces and errors can leak private data | Actor, operator, reviewer, public, and Observatory views must be defined |
+| D-06 | Model testing is required | Accepted | A schema is not enough if models misuse or bypass it | Multi-model and local/Gemma tests are part of the milestone |
+| D-07 | v0.90.3 owns the inhabited CSM demo | Accepted | Citizen-state demo and tools demo have different proof surfaces | v0.90.5 gets a governed-tools flagship demo instead |

--- a/docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md
+++ b/docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Planning draft. No v0.90.5 issue wave has been opened yet.
+Reviewed planning matrix. No v0.90.5 issue wave has been opened yet, but the
+demo lane is already allocated so WP-18 and WP-18A are not treated as generic
+release-tail cleanup.
 
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |
@@ -16,8 +18,8 @@ Planning draft. No v0.90.5 issue wave has been opened yet.
 | D8 | Trace/redaction proof | WP-14 | Tool evidence is reviewable without leaking private data | trace packet and redacted views | PLANNED |
 | D9 | Dangerous negative suite | WP-15 | Destructive, process, network, exfiltration, missing actor, unsafe replay, and delegation failures fail closed | negative test report | PLANNED |
 | D10 | Multi-model proposal benchmark | WP-16-WP-17 | Models are scored on schema, authority, privacy, and bypass behavior | benchmark report and local model scorecards | PLANNED |
-| D11 | Governed Tools v1.0 flagship demo | WP-18 | Reviewer can watch proposal, validation, ACC, policy, gate, execution/denial, trace, and redaction end to end | flagship proof packet and report | PLANNED |
-| D12 | Feature proof coverage record | WP-18A | Every feature claim has proof, fixture, non-proving status, or deferral | proof coverage record | PLANNED |
+| D11 | Governed Tools v1.0 flagship demo | WP-18 | Reviewer can watch proposal, validation, ACC, policy, gate, execution or denial, trace, and redaction end to end in one coherent governed-tools story | flagship proof packet and report | PLANNED |
+| D12 | Feature proof coverage record | WP-18A | Every governed-tools feature claim reaches review with proof, fixture, non-proving status, or explicit deferral | proof coverage record | PLANNED |
 
 ## Non-Proving Boundaries
 
@@ -26,7 +28,5 @@ Planning draft. No v0.90.5 issue wave has been opened yet.
 - These demos do not permit arbitrary shell execution by model output.
 - These demos do not prove all future tool adapters.
 - These demos do not replace citizen standing, access control, or Freedom Gate.
-- These demos do not prove production cloud sandboxing, production secrets
-  handling, or arbitrary shell/network authority.
 - These demos do prove that approved fixture-backed actions and denied unsafe
   actions are distinguishable in review evidence.

--- a/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
@@ -15,9 +15,11 @@
 | Doc | Purpose | Execution WPs |
 | --- | --- | --- |
 | WBS_v0.90.5.md | execution plan for Governed Tools v1.0 | WP-01 |
-| DEMO_MATRIX_v0.90.5.md | planned proof matrix and non-proving boundaries | WP-01, WP-18, WP-19 |
+| DEMO_MATRIX_v0.90.5.md | proof matrix, flagship-demo proof boundary, and non-proving classifications | WP-01, WP-18A, WP-19 |
 | WP_ISSUE_WAVE_v0.90.5.yaml | future issue-wave source once reviewed | WP-01 |
 | WP_EXECUTION_READINESS_v0.90.5.md | card-authoring source for concrete WP outputs, validation, non-goals, and proof expectations | WP-01 |
+| RELEASE_PLAN_v0.90.5.md | release evidence, public-spec guardrails, and review-handoff expectations | WP-19, WP-20 |
+| DECISIONS_v0.90.5.md | accepted planning baseline for governed-tools scope and boundaries | WP-01, WP-19 |
 
 ## Context / Idea Docs
 

--- a/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
+++ b/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
@@ -4,11 +4,13 @@
 
 - [x] v0.90.5 planning package reviewed
 - [x] UTS/ACC scope confirmed as Governed Tools v1.0
+- [x] Decisions log reflects the accepted planning baseline for governed tools
 - [ ] Issue wave opened from reviewed YAML
 - [ ] WP issue numbers recorded in WBS and YAML
 - [ ] WP issue cards authored from WP_EXECUTION_READINESS_v0.90.5.md
 - [x] Package is ready to accept v0.90.4 handoff without reopening scope
   confusion about tool authority
+- [x] Demo/proof lane is explicit, including WP-18A before review convergence
 
 ## Implementation Gates
 

--- a/docs/milestones/v0.90.5/README.md
+++ b/docs/milestones/v0.90.5/README.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Draft milestone package. v0.90.5 is planned as the Governed Tools v1.0
-milestone under planning issue #2350, with follow-up polish under #2402 and an
-additional readiness review during the v0.90.3 WP-19 handoff pass.
+Tracked planning package for Governed Tools v1.0. The milestone direction was
+established under planning issue #2350, tightened under #2402, and is being
+prepared for clean execution in the current docs-prep pass under #2443.
 
 The issue wave has not been opened. This package is the reviewable planning
 source for a later WP-01 issue-wave creation pass. It is intended to be the
@@ -111,8 +111,8 @@ v0.90.5 builds on:
 
 - v0.90.3 citizen-state, standing, access-control, redacted projection, and
   inhabited CSM demo work
-- v0.90.4 contract-market planning and authority lessons, if v0.90.4 remains
-  focused on citizen economics
+- v0.90.4 contract-market, authority, and citizen-economics lessons that bear
+  on governed delegation and action approval
 
 v0.90.5 should not own the v0.90.3 inhabited CSM demo. It should own the
 Governed Tools v1.0 flagship demo.
@@ -120,3 +120,7 @@ Governed Tools v1.0 flagship demo.
 It also should not inherit unresolved v0.90.4 ambiguity about whether contract
 tool needs are constraints or execution grants. WP-19 of v0.90.4 is expected to
 hand that boundary off cleanly.
+
+Current docs-review findings may still sharpen wording, rustdoc references, and
+public-spec boundaries, but they should not widen the core milestone scope away
+from governed tools.

--- a/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
+++ b/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
@@ -18,6 +18,7 @@ Freedom Gate mediation, and trace.
 - local/Gemma evaluation
 - flagship demo proof packet
 - feature proof coverage record
+- public-spec language audit and boundary note
 - internal and external review notes
 - accepted-finding disposition record
 - end-of-milestone report
@@ -38,3 +39,7 @@ evidence prove that model output cannot bypass governed execution.
 
 Do not move into release review until every feature claim has a proof,
 non-proving classification, or explicit deferral.
+
+Do not describe UTS as a public standard, stable external contract, or
+standalone execution authority unless separate evidence and review approve that
+claim.

--- a/docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml
+++ b/docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml
@@ -7,6 +7,7 @@ tracked_package: docs/milestones/v0.90.5
 notes:
   - "Issue wave is not open yet."
   - "This package is owned by Governed Tools v1.0 planning issue #2350."
+  - "Current tracked execution-prep pass is running under issue #2443."
   - "v0.90.5 is intended to implement the first full governed tool suite, not only plan it."
   - "UTS is portable and public-compatible; ACC is ADL-native and owns runtime authority."
   - "UTS validity must never be treated as permission to execute."


### PR DESCRIPTION
## Summary
- tighten the tracked v0.90.5 planning package for clean WP-01 execution
- promote the governed-tools planning baseline from proposed to accepted decisions
- clarify demo/proof, public-spec, and release-readiness surfaces without widening scope

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml"); puts "YAML OK"'
- rg -n "\.adl/|/Users/daniel|file://|TODO|TBD" docs/milestones/v0.90.5 -g '*.md' -g '*.yaml' || true

Closes #2443