### PR TITLE
[v0.90.4][release] Update ADL crate/package version surfaces to 0.90.4 before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
-## v0.90.3 (In development)
+## v0.90.4 (In development)
+
+Status: v0.90.4 is the active citizen economics and contract-market milestone.
+The issue wave is open as #2420-#2440, and the active crate/package version
+surface is now `0.90.4` for the live development line even though the latest
+released tag remains v0.90.3 until v0.90.4 closes.
+
+Scope note:
+- This entry is intentionally minimal during the live issue wave.
+- Detailed milestone scope, proof expectations, and release-tail truth live in
+  `docs/milestones/v0.90.4/`.
+
+## v0.90.3 (Released 2026-04-23)
 
 Status: Issue wave opened on 2026-04-21. WP-01 is #2327, WP-02 through WP-14
 are #2328-#2340, WP-14A is #2341, and WP-15 through WP-20 are #2342-#2347.
@@ -27,7 +39,7 @@ Planned scope:
 - WP-19 leaves the v0.90.4 economics package, the v0.90.5 governed-tools
   package, and the downstream v0.91/v0.92 boundaries ready to start cleanly
   after v0.90.3 ceremony.
-- The crate version is `0.90.3` for the active v0.90.3 development line.
+- The crate version is `0.90.3` for the released v0.90.3 line.
 
 Not claimed in v0.90.3:
 - first true Gödel-agent birthday

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Other useful entrypoints:
 - Active milestone: **v0.90.4**
 - Current release state: **v0.90.3 is released; v0.90.4 is open as issue wave #2420-#2440**
 - Most recently completed milestone: **v0.90.3**
-- Current crate version: **0.90.3**
+- Current crate version: **0.90.4**
 - Version note: **v0.90.4 is the active citizen economics and contract-market development line**
 - Previous completed milestone package: **v0.90.2**
 - Previous completed milestone: **v0.90.1**
@@ -137,8 +137,9 @@ milestone. Its tracked package lives under `docs/milestones/v0.90.4/`. The
 issue wave is open as #2420-#2440: WP-01 is #2420, WP-02 through WP-14 are
 #2421-#2433, WP-14A is #2434, and WP-15 through WP-20 are #2435-#2440.
 
-v0.90.3 is now the most recently completed citizen-state milestone and the
-current released crate line remains 0.90.3 until v0.90.4 closes.
+v0.90.3 is now the most recently completed citizen-state milestone. The latest
+released tag remains v0.90.3, while the active development crate line is now
+0.90.4 for the open v0.90.4 milestone.
 
 The current release-tail entry surface is
 `docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md`. It records the landed

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.90.3"
+version = "0.90.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.90.3"
+version = "0.90.4"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"

--- a/docs/milestones/v0.90.4/README.md
+++ b/docs/milestones/v0.90.4/README.md
@@ -8,6 +8,10 @@ for execution readiness by #2389, reviewed again during the v0.90.3 WP-19
 handoff pass, and opened by WP-01 as issue #2420 after the v0.90.3 release
 ceremony.
 
+During the live release tail, active crate and CLI version surfaces should read
+`0.90.4` even though the latest published release tag remains `v0.90.3` until
+v0.90.4 ceremony closes.
+
 The issue wave is now open as #2420 through #2440. This package is no longer
 planning-only truth: it is the tracked execution map for the live v0.90.4 wave.
 

--- a/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
@@ -9,6 +9,9 @@ schema, lifecycle, authority, fixture, runner, demo, and review-summary story.
 - WP-02 through WP-20 are open as #2421 through #2440.
 - The tracked milestone package now records the live issue map and execution
   order.
+- Active crate/package version-reporting surfaces should read `0.90.4` during
+  the live release tail, even while the latest published tag remains `v0.90.3`
+  until ceremony.
 
 ## Release Gates
 


### PR DESCRIPTION
## Summary
- update the ADL crate and lockfile version surfaces from 0.90.3 to 0.90.4
- align reviewer-visible root and milestone release surfaces with the live v0.90.4 development line
- keep the change bounded to version-surface truth, not broader release churn

## Validation
- cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1 | ruby -rjson -e 'j=JSON.parse(STDIN.read); puts j["packages"].find{|p| p["name"]=="adl"}["version"]'
- cargo run -q --manifest-path adl/Cargo.toml -- --version
- cargo test --manifest-path adl/Cargo.toml top_level_version_flag_is_handled_before_workflow_dispatch -- --nocapture
- git diff --check

Closes #2504