### PR TITLE
[v0.90.4][backlog][ci] Add lightweight CI path for release-version-only Cargo surface changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,11 @@ jobs:
       - name: ci cache/linker contract check
         run: bash tools/test_ci_cache_linker_contracts.sh
 
+      - name: release version truth check
+        if: steps.path-policy.outputs.release_version_only == 'true'
+        run: bash adl/tools/check_release_version_surfaces.sh
+        working-directory: .
+
       - name: Install cargo-nextest
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
         uses: taiki-e/install-action@e5c52b603cc5f5e9b52b6a43afad8e9fe0527090 # install-action
@@ -162,8 +167,17 @@ jobs:
           echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
           echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
 
+      - name: release-version Rust lane replacement
+        if: steps.path-policy.outputs.release_version_only == 'true'
+        run: |
+          echo "Ordinary Rust fmt/clippy/test is replaced by the bounded release-version truth check for this PR."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
+        working-directory: .
+
       - name: Rust validation skipped by path policy
-        if: steps.path-policy.outputs.rust_required != 'true'
+        if: steps.path-policy.outputs.rust_required != 'true' && steps.path-policy.outputs.release_version_only != 'true'
         run: |
           echo "Rust fmt/clippy/test skipped because changed paths do not touch Rust runtime or test surfaces."
           echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"

--- a/adl/tools/check_release_version_surfaces.sh
+++ b/adl/tools/check_release_version_surfaces.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+manifest_version="$(
+  python3 - <<'PY'
+import pathlib
+import tomllib
+
+manifest = pathlib.Path("adl/Cargo.toml")
+data = tomllib.loads(manifest.read_text())
+print(data["package"]["version"])
+PY
+)"
+
+lock_version="$(
+  python3 - <<'PY'
+import pathlib
+import tomllib
+
+lock = pathlib.Path("adl/Cargo.lock")
+data = tomllib.loads(lock.read_text())
+for package in data.get("package", []):
+    if package.get("name") == "adl":
+        print(package["version"])
+        break
+else:
+    raise SystemExit("adl package entry missing from Cargo.lock")
+PY
+)"
+
+if [ "$manifest_version" != "$lock_version" ]; then
+  echo "release-version check: adl/Cargo.toml version $manifest_version does not match adl/Cargo.lock package version $lock_version" >&2
+  exit 1
+fi
+
+resolved_version="$(
+  cargo metadata --manifest-path adl/Cargo.toml --no-deps --format-version 1 \
+    | python3 -c 'import json, sys
+data = json.load(sys.stdin)
+for package in data["packages"]:
+    if package["name"] == "adl":
+        print(package["version"])
+        break
+else:
+    raise SystemExit("adl package missing from cargo metadata")'
+)"
+
+if [ "$resolved_version" != "$manifest_version" ]; then
+  echo "release-version check: cargo metadata resolved $resolved_version but manifest says $manifest_version" >&2
+  exit 1
+fi
+
+cli_version="$(cargo run -q --manifest-path adl/Cargo.toml -- --version)"
+if [ "$cli_version" != "$manifest_version" ]; then
+  echo "release-version check: CLI reports $cli_version but manifest says $manifest_version" >&2
+  exit 1
+fi
+
+echo "PASS release-version-surfaces manifest=$manifest_version lock=$lock_version cli=$cli_version"

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -57,6 +57,7 @@ rust_required="$bool_false"
 coverage_required="$bool_false"
 full_coverage_required="$bool_false"
 demo_smoke_required="$bool_false"
+release_version_only="$bool_false"
 fail_closed=false
 coverage_lane="skip"
 coverage_authority="not_required"
@@ -159,6 +160,141 @@ is_full_coverage_policy_surface() {
   return 1
 }
 
+is_release_truth_doc_surface() {
+  local path="$1"
+  case "$path" in
+    README.md|CHANGELOG.md|REVIEW.md|docs/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+cargo_manifest_package_version_only_change() {
+  python3 - "$base_sha" "$head_sha" <<'PY'
+import io
+import subprocess
+import sys
+import tomllib
+
+base, head = sys.argv[1], sys.argv[2]
+path = "adl/Cargo.toml"
+
+def load(rev: str):
+    try:
+        text = subprocess.check_output(
+            ["git", "show", f"{rev}:{path}"], text=True, stderr=subprocess.DEVNULL
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return tomllib.loads(text)
+
+before = load(base)
+after = load(head)
+if before is None or after is None:
+    raise SystemExit(1)
+
+before_pkg = dict(before.get("package", {}))
+after_pkg = dict(after.get("package", {}))
+before_version = before_pkg.pop("version", None)
+after_version = after_pkg.pop("version", None)
+
+before_norm = dict(before)
+after_norm = dict(after)
+before_norm["package"] = before_pkg
+after_norm["package"] = after_pkg
+
+if (
+    before_version
+    and after_version
+    and before_version != after_version
+    and before_norm == after_norm
+):
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+cargo_lock_adl_package_version_only_change() {
+  python3 - "$base_sha" "$head_sha" <<'PY'
+import subprocess
+import sys
+import tomllib
+
+base, head = sys.argv[1], sys.argv[2]
+path = "adl/Cargo.lock"
+
+def load(rev: str):
+    try:
+        text = subprocess.check_output(
+            ["git", "show", f"{rev}:{path}"], text=True, stderr=subprocess.DEVNULL
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return tomllib.loads(text)
+
+def normalize(data):
+    packages = []
+    changed_versions = []
+    for package in data.get("package", []):
+        pkg = dict(package)
+        if pkg.get("name") == "adl":
+            changed_versions.append(pkg.get("version"))
+            pkg.pop("version", None)
+        packages.append(pkg)
+    normalized = dict(data)
+    normalized["package"] = packages
+    return normalized, changed_versions
+
+before = load(base)
+after = load(head)
+if before is None or after is None:
+    raise SystemExit(1)
+
+before_norm, before_versions = normalize(before)
+after_norm, after_versions = normalize(after)
+
+if (
+    before_versions
+    and after_versions
+    and before_versions != after_versions
+    and before_norm == after_norm
+):
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+is_release_version_only_surface_change() {
+  local saw_manifest=false
+  local saw_lock=false
+  local path=""
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$path" in
+      adl/Cargo.toml)
+        saw_manifest=true
+        ;;
+      adl/Cargo.lock)
+        saw_lock=true
+        ;;
+      *)
+        if ! is_release_truth_doc_surface "$path"; then
+          return 1
+        fi
+        ;;
+    esac
+  done <<EOF
+$changed_files
+EOF
+
+  [ "$saw_manifest" = true ] || return 1
+  [ "$saw_lock" = true ] || return 1
+  cargo_manifest_package_version_only_change || return 1
+  cargo_lock_adl_package_version_only_change || return 1
+  return 0
+}
+
 line_count_for_path() {
   local path="$1"
   if [ -f "$path" ]; then
@@ -192,6 +328,10 @@ else
   else
     saw_pr_finish_control_plane=false
     changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
+    if is_release_version_only_surface_change; then
+      release_version_only=true
+      reason="release_version_only_cargo_surface_change_runs_lightweight_validation"
+    fi
     while IFS= read -r path; do
       [ -n "$path" ] || continue
       if is_pr_finish_control_plane_surface "$path"; then
@@ -201,6 +341,9 @@ else
       fi
       case "$path" in
         adl/src/*|adl/tests/*|adl/Cargo.toml|adl/Cargo.lock|adl/build.rs)
+          if [ "$release_version_only" = true ] && { [ "$path" = "adl/Cargo.toml" ] || [ "$path" = "adl/Cargo.lock" ]; }; then
+            continue
+          fi
           mark_pr_fast_coverage
           ;;
         demos/*|adl/tools/demo_*|adl/tools/test_demo_*)
@@ -232,6 +375,7 @@ emit "rust_required" "$rust_required"
 emit "coverage_required" "$coverage_required"
 emit "full_coverage_required" "$full_coverage_required"
 emit "demo_smoke_required" "$demo_smoke_required"
+emit "release_version_only" "$release_version_only"
 emit "fail_closed" "$fail_closed"
 emit "coverage_lane" "$coverage_lane"
 emit "coverage_authority" "$coverage_authority"
@@ -243,6 +387,7 @@ printf '  rust_required=%s\n' "$rust_required"
 printf '  coverage_required=%s\n' "$coverage_required"
 printf '  full_coverage_required=%s\n' "$full_coverage_required"
 printf '  demo_smoke_required=%s\n' "$demo_smoke_required"
+printf '  release_version_only=%s\n' "$release_version_only"
 printf '  fail_closed=%s\n' "$fail_closed"
 printf '  coverage_lane=%s\n' "$coverage_lane"
 printf '  coverage_authority=%s\n' "$coverage_authority"

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -26,6 +26,19 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
   mkdir -p adl/src docs
   printf 'pub fn baseline() -> bool { true }\n' > adl/src/lib.rs
+  cat > adl/Cargo.toml <<'EOF'
+[package]
+name = "adl"
+version = "0.90.3"
+edition = "2021"
+EOF
+  cat > adl/Cargo.lock <<'EOF'
+version = 4
+
+[[package]]
+name = "adl"
+version = "0.90.3"
+EOF
   printf '# baseline\n' > docs/readme.md
   git add .
   git commit -q -m baseline
@@ -41,8 +54,55 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$docs_output" "coverage_required=false"
   assert_has "$docs_output" "full_coverage_required=false"
   assert_has "$docs_output" "demo_smoke_required=false"
+  assert_has "$docs_output" "release_version_only=false"
   assert_has "$docs_output" "coverage_lane=skip"
   assert_has "$docs_output" "coverage_authority=not_required"
+
+  git checkout -q -b release-version-only "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+manifest = Path("adl/Cargo.toml")
+manifest.write_text(manifest.read_text().replace('version = "0.90.3"', 'version = "0.90.4"', 1))
+
+lock = Path("adl/Cargo.lock")
+lock.write_text(lock.read_text().replace('version = "0.90.3"', 'version = "0.90.4"', 1))
+
+doc = Path("docs/readme.md")
+doc.write_text(doc.read_text() + "\nrelease-truth update\n")
+PY
+  git add adl/Cargo.toml adl/Cargo.lock docs/readme.md
+  git commit -q -m release-version-only
+  release_version_head="$(git rev-parse HEAD)"
+
+  release_version_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$release_version_head" --ref "refs/pull/1/merge")"
+  assert_has "$release_version_output" "rust_required=false"
+  assert_has "$release_version_output" "coverage_required=false"
+  assert_has "$release_version_output" "full_coverage_required=false"
+  assert_has "$release_version_output" "demo_smoke_required=false"
+  assert_has "$release_version_output" "release_version_only=true"
+  assert_has "$release_version_output" "coverage_lane=skip"
+  assert_has "$release_version_output" "coverage_authority=not_required"
+  assert_has "$release_version_output" "reason=release_version_only_cargo_surface_change_runs_lightweight_validation"
+
+  git checkout -q -b cargo-structural-change "$base_sha"
+  cat >> adl/Cargo.toml <<'EOF'
+
+[features]
+example = []
+EOF
+  git add adl/Cargo.toml
+  git commit -q -m cargo-structural-change
+  cargo_structural_head="$(git rev-parse HEAD)"
+
+  cargo_structural_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$cargo_structural_head" --ref "refs/pull/1/merge")"
+  assert_has "$cargo_structural_output" "rust_required=true"
+  assert_has "$cargo_structural_output" "coverage_required=true"
+  assert_has "$cargo_structural_output" "full_coverage_required=false"
+  assert_has "$cargo_structural_output" "demo_smoke_required=true"
+  assert_has "$cargo_structural_output" "release_version_only=false"
+  assert_has "$cargo_structural_output" "coverage_lane=pr_fast"
+  assert_has "$cargo_structural_output" "coverage_authority=pr_changed_surface"
 
   git checkout -q -b runtime-change "$base_sha"
   printf 'pub fn added_runtime() -> bool { true }\n' >> adl/src/lib.rs
@@ -55,6 +115,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$runtime_output" "coverage_required=true"
   assert_has "$runtime_output" "full_coverage_required=false"
   assert_has "$runtime_output" "demo_smoke_required=true"
+  assert_has "$runtime_output" "release_version_only=false"
   assert_has "$runtime_output" "coverage_lane=pr_fast"
   assert_has "$runtime_output" "coverage_authority=pr_changed_surface"
   assert_has "$runtime_output" "reason=runtime_or_rust_test_change_runs_pr_fast_validation"
@@ -70,6 +131,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$new_runtime_file_output" "coverage_required=true"
   assert_has "$new_runtime_file_output" "full_coverage_required=false"
   assert_has "$new_runtime_file_output" "demo_smoke_required=true"
+  assert_has "$new_runtime_file_output" "release_version_only=false"
   assert_has "$new_runtime_file_output" "coverage_lane=pr_fast"
   assert_has "$new_runtime_file_output" "coverage_authority=pr_changed_surface"
   assert_has "$new_runtime_file_output" "reason=runtime_or_rust_test_change_runs_pr_fast_validation"
@@ -88,6 +150,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$finish_control_plane_output" "coverage_required=false"
   assert_has "$finish_control_plane_output" "full_coverage_required=false"
   assert_has "$finish_control_plane_output" "demo_smoke_required=false"
+  assert_has "$finish_control_plane_output" "release_version_only=false"
   assert_has "$finish_control_plane_output" "reason=publication_control_plane_change_runs_focused_rust_validation"
 
   git checkout -q -b policy-surface-change "$base_sha"
@@ -102,6 +165,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$policy_surface_output" "coverage_required=false"
   assert_has "$policy_surface_output" "full_coverage_required=true"
   assert_has "$policy_surface_output" "demo_smoke_required=false"
+  assert_has "$policy_surface_output" "release_version_only=false"
   assert_has "$policy_surface_output" "coverage_lane=authoritative_full"
   assert_has "$policy_surface_output" "coverage_authority=pr_policy_surface"
   assert_has "$policy_surface_output" "reason=coverage_policy_surface_change_runs_full_coverage"
@@ -111,6 +175,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$main_output" "coverage_required=true"
   assert_has "$main_output" "full_coverage_required=true"
   assert_has "$main_output" "demo_smoke_required=true"
+  assert_has "$main_output" "release_version_only=false"
   assert_has "$main_output" "coverage_lane=authoritative_full"
   assert_has "$main_output" "coverage_authority=push_main"
   assert_has "$main_output" "reason=push_main_runs_authoritative_full_coverage"
@@ -119,6 +184,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
   assert_has "$fail_closed_output" "rust_required=true"
   assert_has "$fail_closed_output" "coverage_required=true"
   assert_has "$fail_closed_output" "full_coverage_required=true"
+  assert_has "$fail_closed_output" "release_version_only=false"
   assert_has "$fail_closed_output" "fail_closed=true"
   assert_has "$fail_closed_output" "coverage_lane=authoritative_full"
   assert_has "$fail_closed_output" "coverage_authority=fail_closed"

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -37,6 +37,13 @@ if ordinary_doc_test != "cargo test --doc":
         f"found: {ordinary_doc_test}"
     )
 
+release_version_truth = step_run("release version truth check")
+if release_version_truth != "bash adl/tools/check_release_version_surfaces.sh":
+    raise SystemExit(
+        "release-version-only PRs must run the bounded release version truth check; "
+        f"found: {release_version_truth}"
+    )
+
 if "tool: nextest" not in workflow:
     raise SystemExit(
         "coverage lanes must install cargo-nextest before running cargo llvm-cov nextest"


### PR DESCRIPTION
## Summary
- add a conservative path-policy classification for release-version-only Cargo surface changes
- replace the ordinary Rust lane with a bounded release-version truth check for that case
- lock the new behavior into the CI contract tests

## Validation
- bash adl/tools/test_ci_path_policy.sh
- bash adl/tools/test_ci_runtime_contracts.sh
- bash adl/tools/check_release_version_surfaces.sh
- bash -n adl/tools/ci_path_policy.sh adl/tools/check_release_version_surfaces.sh adl/tools/test_ci_path_policy.sh adl/tools/test_ci_runtime_contracts.sh
- git diff --check

Closes #2520
