### PR TITLE
[v0.90.4][WP-14] Bounded contract-market demo and negative cases

### DIFF
--- a/adl/src/cli/runtime_v2_cmd.rs
+++ b/adl/src/cli/runtime_v2_cmd.rs
@@ -4,9 +4,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use ::adl::runtime_v2::{
-    runtime_v2_csm_integrated_run_contract, runtime_v2_feature_proof_coverage_contract,
-    runtime_v2_foundation_demo_contract, runtime_v2_observatory_flagship_contract,
-    runtime_v2_operator_control_report_contract, runtime_v2_security_boundary_proof_contract,
+    runtime_v2_contract_market_demo_contract, runtime_v2_csm_integrated_run_contract,
+    runtime_v2_feature_proof_coverage_contract, runtime_v2_foundation_demo_contract,
+    runtime_v2_observatory_flagship_contract, runtime_v2_operator_control_report_contract,
+    runtime_v2_security_boundary_proof_contract,
 };
 
 pub(crate) fn real_runtime_v2(args: &[String]) -> Result<()> {
@@ -30,7 +31,7 @@ fn resolve_relative_output_path(
 fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, observatory-flagship-demo, or feature-proof-coverage"
+            "runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, observatory-flagship-demo, contract-market-demo, or feature-proof-coverage"
         ));
     };
 
@@ -42,13 +43,14 @@ fn real_runtime_v2_in_repo(args: &[String], repo_root: &Path) -> Result<()> {
         "observatory-flagship-demo" => {
             real_runtime_v2_observatory_flagship_demo(repo_root, &args[1..])
         }
+        "contract-market-demo" => real_runtime_v2_contract_market_demo(repo_root, &args[1..]),
         "feature-proof-coverage" => real_runtime_v2_feature_proof_coverage(repo_root, &args[1..]),
         "--help" | "-h" | "help" => {
             println!("{}", super::usage::usage());
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, observatory-flagship-demo, or feature-proof-coverage)"
+            "unknown runtime-v2 subcommand '{subcommand}' (expected operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, observatory-flagship-demo, contract-market-demo, or feature-proof-coverage)"
         )),
     }
 }
@@ -358,6 +360,54 @@ fn real_runtime_v2_feature_proof_coverage(repo_root: &Path, args: &[String]) -> 
     Ok(())
 }
 
+fn real_runtime_v2_contract_market_demo(repo_root: &Path, args: &[String]) -> Result<()> {
+    let mut out_path: Option<PathBuf> = None;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                let Some(value) = args.get(i + 1) else {
+                    return Err(anyhow!(
+                        "runtime-v2 contract-market-demo requires --out <dir>"
+                    ));
+                };
+                out_path = Some(PathBuf::from(value));
+                i += 1;
+            }
+            "--help" | "-h" => {
+                println!("{}", super::usage::usage());
+                return Ok(());
+            }
+            other => {
+                return Err(anyhow!(
+                    "unknown arg for runtime-v2 contract-market-demo: {other}"
+                ))
+            }
+        }
+        i += 1;
+    }
+
+    let artifacts = runtime_v2_contract_market_demo_contract()?;
+    let Some(out_path) = out_path else {
+        println!("{}", to_string_pretty(&artifacts.proof_packet)?);
+        return Ok(());
+    };
+    let resolved = resolve_relative_output_path(repo_root, &out_path, "contract-market-demo")?;
+    fs::create_dir_all(&resolved).with_context(|| {
+        format!(
+            "failed to create Runtime v2 contract-market demo root {}",
+            resolved.display()
+        )
+    })?;
+    artifacts.write_to_root(&resolved)?;
+    println!("{}", contract_market_demo_stdout_line(&out_path));
+    println!();
+    println!("{}", artifacts.execution_summary()?);
+    println!();
+    println!("{}", artifacts.operator_report_markdown);
+    Ok(())
+}
+
 fn observatory_flagship_demo_stdout_line(out_path: &Path) -> String {
     format!(
         "RUNTIME_V2_OBSERVATORY_FLAGSHIP_DEMO_ROOT={}",
@@ -368,6 +418,13 @@ fn observatory_flagship_demo_stdout_line(out_path: &Path) -> String {
 fn feature_proof_coverage_stdout_line(out_path: &Path) -> String {
     format!(
         "RUNTIME_V2_FEATURE_PROOF_COVERAGE_PATH={}",
+        out_path.display()
+    )
+}
+
+fn contract_market_demo_stdout_line(out_path: &Path) -> String {
+    format!(
+        "RUNTIME_V2_CONTRACT_MARKET_DEMO_ROOT={}",
         out_path.display()
     )
 }
@@ -449,7 +506,7 @@ mod tests {
         let err = real_runtime_v2_in_repo(&[], &repo).expect_err("missing subcommand should fail");
         assert!(err
             .to_string()
-            .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, observatory-flagship-demo, or feature-proof-coverage"));
+            .contains("runtime-v2 requires a subcommand: operator-controls, security-boundary, foundation-demo, integrated-csm-run-demo, observatory-flagship-demo, contract-market-demo, or feature-proof-coverage"));
 
         let err = real_runtime_v2_in_repo(&["bogus".to_string()], &repo)
             .expect_err("unknown subcommand should fail");
@@ -934,6 +991,53 @@ mod tests {
     }
 
     #[test]
+    fn runtime_v2_contract_market_demo_validates_stdout_help_and_output_path_rules() {
+        let repo = temp_repo("contract-market-demo-branches");
+
+        real_runtime_v2_in_repo(&["contract-market-demo".to_string()], &repo)
+            .expect("stdout contract-market demo");
+        real_runtime_v2_in_repo(
+            &["contract-market-demo".to_string(), "--help".to_string()],
+            &repo,
+        )
+        .expect("contract-market demo help");
+        let err = real_runtime_v2_in_repo(
+            &[
+                "contract-market-demo".to_string(),
+                "--out".to_string(),
+                repo.join("absolute/contract-market-demo")
+                    .to_string_lossy()
+                    .to_string(),
+            ],
+            &repo,
+        )
+        .expect_err("absolute output path should fail");
+        assert!(err
+            .to_string()
+            .contains("runtime-v2 contract-market-demo --out path must be repository-relative"));
+
+        let err = real_runtime_v2_in_repo(
+            &["contract-market-demo".to_string(), "--bogus".to_string()],
+            &repo,
+        )
+        .expect_err("unknown arg should fail");
+        assert!(err
+            .to_string()
+            .contains("unknown arg for runtime-v2 contract-market-demo: --bogus"));
+
+        let err = real_runtime_v2_in_repo(
+            &["contract-market-demo".to_string(), "--out".to_string()],
+            &repo,
+        )
+        .expect_err("missing out value should fail");
+        assert!(err
+            .to_string()
+            .contains("runtime-v2 contract-market-demo requires --out <dir>"));
+
+        fs::remove_dir_all(repo).ok();
+    }
+
+    #[test]
     fn runtime_v2_demo_stdout_lines_preserve_requested_relative_paths() {
         let rel_root = PathBuf::from("target/v0903-path-hygiene-demo");
         let rel_file = rel_root.join("feature-proof-coverage.json");
@@ -942,11 +1046,11 @@ mod tests {
             .display()
             .to_string();
 
-        let d12_stdout = observatory_flagship_demo_stdout_line(&rel_root);
+        let d12_stdout = contract_market_demo_stdout_line(&rel_root);
         assert_eq!(
             d12_stdout,
             format!(
-                "RUNTIME_V2_OBSERVATORY_FLAGSHIP_DEMO_ROOT={}",
+                "RUNTIME_V2_CONTRACT_MARKET_DEMO_ROOT={}",
                 rel_root.display()
             )
         );

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -38,6 +38,7 @@ pub fn usage() -> &'static str {
   adl runtime-v2 foundation-demo [--out <dir>]
   adl runtime-v2 integrated-csm-run-demo [--out <dir>]
   adl runtime-v2 observatory-flagship-demo [--out <dir>]
+  adl runtime-v2 contract-market-demo [--out <dir>]
   adl runtime-v2 feature-proof-coverage [--out <path>]
   adl provider setup <family> [--out <dir>] [--force]
   adl pr create --title <title> [--slug <slug>] [--body <text> | --body-file <path>] [--labels <csv>] [--version <v>]
@@ -113,6 +114,7 @@ Examples:
   adl runtime-v2 foundation-demo --out artifacts/v0901/demo-l-v0901-runtime-v2-foundation
   adl runtime-v2 integrated-csm-run-demo --out artifacts/v0902/demo-d10-integrated-csm-run
   adl runtime-v2 observatory-flagship-demo --out artifacts/v0903/demo-d12-observatory-flagship
+  adl runtime-v2 contract-market-demo --out artifacts/v0904/demo-d12-contract-market
   adl runtime-v2 feature-proof-coverage --out artifacts/v0903/feature-proof-coverage.json
   adl provider setup chatgpt
   adl provider setup claude

--- a/adl/src/runtime_v2/contract_market_demo.rs
+++ b/adl/src/runtime_v2/contract_market_demo.rs
@@ -1,0 +1,1179 @@
+use super::*;
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+pub const RUNTIME_V2_CONTRACT_MARKET_PROOF_SCHEMA: &str =
+    "runtime_v2.contract_market_proof_packet.v1";
+pub const RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_SCHEMA: &str =
+    "runtime_v2.contract_market_negative_packet.v1";
+pub const RUNTIME_V2_CONTRACT_MARKET_PROOF_PATH: &str =
+    "runtime_v2/contract_market/proof_packet.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_OPERATOR_REPORT_PATH: &str =
+    "runtime_v2/contract_market/operator_report.md";
+pub const RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_PATH: &str =
+    "runtime_v2/contract_market/negative_test_packet.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_TRACE_REQUIREMENTS_PATH: &str =
+    "runtime_v2/contract_market/trace_requirements.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_REVIEW_SUMMARY_SEED_PATH: &str =
+    "runtime_v2/contract_market/review_summary_seed.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_BID_ALPHA_NOTES_PATH: &str =
+    "runtime_v2/contract_market/bid_alpha_notes.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_BID_BRAVO_NOTES_PATH: &str =
+    "runtime_v2/contract_market/bid_bravo_notes.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_BIDDING_WINDOW_NOTICE_PATH: &str =
+    "runtime_v2/contract_market/bidding_window_notice.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_SELECTION_RATIONALE_PATH: &str =
+    "runtime_v2/contract_market/selection_rationale.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_AWARD_RECORD_PATH: &str =
+    "runtime_v2/contract_market/award_record.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_ACCEPTANCE_RECORD_PATH: &str =
+    "runtime_v2/contract_market/acceptance_record.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_EXECUTION_READINESS_PATH: &str =
+    "runtime_v2/contract_market/execution_readiness.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH: &str =
+    "runtime_v2/contract_market/execution_trace.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_PACKET_PATH: &str =
+    "runtime_v2/contract_market/delegated_manifest_packet.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_TRACE_PATH: &str =
+    "runtime_v2/contract_market/delegated_manifest_trace.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_DELIVERABLE_MANIFEST_PATH: &str =
+    "runtime_v2/contract_market/deliverable_manifest.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_COMPLETION_RECORD_PATH: &str =
+    "runtime_v2/contract_market/completion_record.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_FAILURE_RECORD_PATH: &str =
+    "runtime_v2/contract_market/failure_record.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_CANCELLATION_RECORD_PATH: &str =
+    "runtime_v2/contract_market/cancellation_record.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_DISPUTE_OPENING_RECORD_PATH: &str =
+    "runtime_v2/contract_market/dispute_opening_record.json";
+pub const RUNTIME_V2_CONTRACT_MARKET_DISPUTE_RESOLUTION_PATH: &str =
+    "runtime_v2/contract_market/dispute_resolution.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ContractMarketNegativeCaseRef {
+    pub case_id: String,
+    pub category: String,
+    pub source_artifact_ref: String,
+    pub expected_error_fragment: String,
+    pub proof_purpose: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ContractMarketNegativePacket {
+    pub schema_version: String,
+    pub proof_id: String,
+    pub demo_id: String,
+    pub milestone: String,
+    pub artifact_path: String,
+    pub proof_packet_ref: String,
+    pub contract_ref: String,
+    pub required_negative_cases: Vec<RuntimeV2ContractMarketNegativeCaseRef>,
+    pub validation_commands: Vec<String>,
+    pub claim_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2ContractMarketProofPacket {
+    pub schema_version: String,
+    pub proof_id: String,
+    pub demo_id: String,
+    pub milestone: String,
+    pub artifact_path: String,
+    pub operator_report_ref: String,
+    pub negative_packet_ref: String,
+    pub contract_ref: String,
+    pub bid_refs: Vec<String>,
+    pub selection_ref: String,
+    pub transition_matrix_ref: String,
+    pub transition_authority_basis_ref: String,
+    pub lifecycle_state_machine_ref: String,
+    pub counterparty_model_ref: String,
+    pub delegation_refs: Vec<String>,
+    pub resource_bridge_ref: String,
+    pub successful_scenario_ref: String,
+    pub support_artifact_refs: Vec<String>,
+    pub validation_commands: Vec<String>,
+    pub reviewer_command: String,
+    pub proof_summary: String,
+    pub proof_classification: String,
+    pub non_claims: Vec<String>,
+    pub claim_boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeV2ContractMarketDemoArtifacts {
+    pub contract_schema: RuntimeV2ContractSchemaArtifacts,
+    pub bid_schema: RuntimeV2BidSchemaArtifacts,
+    pub selection: RuntimeV2EvaluationSelectionArtifacts,
+    pub transition_authority: RuntimeV2TransitionAuthorityArtifacts,
+    pub lifecycle: RuntimeV2ContractLifecycleArtifacts,
+    pub external_counterparty: RuntimeV2ExternalCounterpartyArtifacts,
+    pub delegation: RuntimeV2DelegationArtifacts,
+    pub resource_bridge: RuntimeV2ResourceStewardshipBridgeArtifact,
+    pub proof_packet: RuntimeV2ContractMarketProofPacket,
+    pub negative_packet: RuntimeV2ContractMarketNegativePacket,
+    pub operator_report_markdown: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeV2SupportArtifactFile {
+    path: String,
+    contents: Vec<u8>,
+}
+
+struct RuntimeV2ContractMarketProofContext<'a> {
+    contract_schema: &'a RuntimeV2ContractSchemaArtifacts,
+    bid_schema: &'a RuntimeV2BidSchemaArtifacts,
+    selection: &'a RuntimeV2EvaluationSelectionArtifacts,
+    transition_authority: &'a RuntimeV2TransitionAuthorityArtifacts,
+    lifecycle: &'a RuntimeV2ContractLifecycleArtifacts,
+    external_counterparty: &'a RuntimeV2ExternalCounterpartyArtifacts,
+    delegation: &'a RuntimeV2DelegationArtifacts,
+    resource_bridge: &'a RuntimeV2ResourceStewardshipBridgeArtifact,
+}
+
+impl RuntimeV2ContractMarketDemoArtifacts {
+    pub fn prototype() -> Result<Self> {
+        let contract_schema = runtime_v2_contract_schema_contract()?;
+        let bid_schema = runtime_v2_bid_schema_contract()?;
+        let selection = RuntimeV2EvaluationSelectionArtifacts::prototype()?;
+        let transition_authority = runtime_v2_transition_authority_model()?;
+        let lifecycle = runtime_v2_contract_lifecycle_state_model()?;
+        let external_counterparty = runtime_v2_external_counterparty_model()?;
+        let delegation = runtime_v2_delegation_subcontract_model()?;
+        let resource_bridge = runtime_v2_resource_stewardship_bridge()?;
+
+        let proof_context = RuntimeV2ContractMarketProofContext {
+            contract_schema: &contract_schema,
+            bid_schema: &bid_schema,
+            selection: &selection,
+            transition_authority: &transition_authority,
+            lifecycle: &lifecycle,
+            external_counterparty: &external_counterparty,
+            delegation: &delegation,
+            resource_bridge: &resource_bridge,
+        };
+
+        let proof_packet = RuntimeV2ContractMarketProofPacket::from_artifacts(&proof_context)?;
+        let negative_packet = RuntimeV2ContractMarketNegativePacket::from_artifacts(
+            &proof_packet,
+            &contract_schema.contract,
+            &bid_schema.negative_cases,
+            &transition_authority.negative_cases,
+            &external_counterparty.negative_cases,
+            &delegation.negative_cases,
+        )?;
+        let operator_report_markdown =
+            render_contract_market_operator_report(&proof_packet, &negative_packet)?;
+
+        let artifacts = Self {
+            contract_schema,
+            bid_schema,
+            selection,
+            transition_authority,
+            lifecycle,
+            external_counterparty,
+            delegation,
+            resource_bridge,
+            proof_packet,
+            negative_packet,
+            operator_report_markdown,
+        };
+        artifacts.validate()?;
+        Ok(artifacts)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        self.contract_schema.validate()?;
+        self.bid_schema.validate()?;
+        self.selection.validate()?;
+        self.transition_authority.validate()?;
+        self.lifecycle.validate()?;
+        self.external_counterparty.validate()?;
+        self.delegation.validate()?;
+        self.resource_bridge.validate()?;
+        self.proof_packet.validate_against(self)?;
+        self.negative_packet
+            .validate_against(&self.proof_packet, &self.contract_schema.contract)?;
+        validate_contract_market_operator_report(
+            &self.proof_packet,
+            &self.negative_packet,
+            &self.operator_report_markdown,
+        )
+    }
+
+    pub fn proof_packet_pretty_json_bytes(&self) -> Result<Vec<u8>> {
+        self.proof_packet.validate_against(self)?;
+        serde_json::to_vec_pretty(&self.proof_packet)
+            .context("serialize Runtime v2 contract-market proof packet")
+    }
+
+    pub fn negative_packet_pretty_json_bytes(&self) -> Result<Vec<u8>> {
+        self.negative_packet
+            .validate_against(&self.proof_packet, &self.contract_schema.contract)?;
+        serde_json::to_vec_pretty(&self.negative_packet)
+            .context("serialize Runtime v2 contract-market negative packet")
+    }
+
+    pub fn execution_summary(&self) -> Result<String> {
+        self.validate()?;
+        Ok(format!(
+            concat!(
+                "D12 bounded contract-market proof:\n",
+                "- proof packet: {}\n",
+                "- operator report: {}\n",
+                "- negative packet: {}\n",
+                "- selected bid: {}\n",
+                "- successful scenario: {}\n",
+                "- subcontract: {}\n",
+                "- parent integration: {}\n",
+                "- completion trace: {}\n"
+            ),
+            self.proof_packet.artifact_path,
+            self.proof_packet.operator_report_ref,
+            self.proof_packet.negative_packet_ref,
+            self.selection.selection.recommendation.selected_bid_ref,
+            self.proof_packet.successful_scenario_ref,
+            self.delegation.subcontract.artifact_path,
+            self.delegation.parent_integration.artifact_path,
+            RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH,
+        ))
+    }
+
+    pub fn write_to_root(&self, root: impl AsRef<Path>) -> Result<()> {
+        self.validate()?;
+        let root = root.as_ref();
+
+        self.contract_schema.write_to_root(root)?;
+        self.bid_schema.write_to_root(root)?;
+        self.selection.write_to_root(root)?;
+        self.transition_authority.write_to_root(root)?;
+        self.lifecycle.write_to_root(root)?;
+        self.external_counterparty.write_to_root(root)?;
+        self.delegation.write_to_root(root)?;
+        self.resource_bridge.write_to_root(root)?;
+
+        for file in self.support_artifact_files()? {
+            write_relative(root, &file.path, file.contents)?;
+        }
+        write_relative(
+            root,
+            RUNTIME_V2_CONTRACT_MARKET_OPERATOR_REPORT_PATH,
+            self.operator_report_markdown.as_bytes().to_vec(),
+        )?;
+        write_relative(
+            root,
+            RUNTIME_V2_CONTRACT_MARKET_PROOF_PATH,
+            self.proof_packet_pretty_json_bytes()?,
+        )?;
+        write_relative(
+            root,
+            RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_PATH,
+            self.negative_packet_pretty_json_bytes()?,
+        )?;
+        self.validate_bundle(root)
+    }
+
+    fn validate_bundle(&self, root: &Path) -> Result<()> {
+        let required_files = self
+            .proof_packet
+            .support_artifact_refs
+            .iter()
+            .chain([
+                &self.contract_schema.contract.artifact_path,
+                &self.bid_schema.valid_bids[0].artifact_path,
+                &self.bid_schema.valid_bids[1].artifact_path,
+                &self.selection.selection.artifact_path,
+                &self.transition_authority.matrix.artifact_path,
+                &self.transition_authority.authority_basis.artifact_path,
+                &self.lifecycle.state_machine.artifact_path,
+                &self.delegation.subcontract.artifact_path,
+                &self.delegation.delegated_output.artifact_path,
+                &self.delegation.parent_integration.artifact_path,
+                &self.resource_bridge.artifact_path,
+                &self.proof_packet.artifact_path,
+                &self.proof_packet.operator_report_ref,
+                &self.proof_packet.negative_packet_ref,
+            ])
+            .cloned()
+            .collect::<BTreeSet<_>>();
+
+        for rel_path in required_files {
+            if !root.join(&rel_path).is_file() {
+                return Err(anyhow!(
+                    "contract-market demo bundle missing required artifact {}",
+                    rel_path
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn support_artifact_files(&self) -> Result<Vec<RuntimeV2SupportArtifactFile>> {
+        let selected_bid = self
+            .bid_schema
+            .valid_bids
+            .iter()
+            .find(|bid| {
+                bid.artifact_path == self.selection.selection.recommendation.selected_bid_ref
+            })
+            .ok_or_else(|| anyhow!("selected bid ref must match a valid bid"))?;
+        let runner_up_bid = self
+            .bid_schema
+            .valid_bids
+            .iter()
+            .find(|bid| bid.artifact_path != selected_bid.artifact_path)
+            .ok_or_else(|| anyhow!("contract-market proof requires a runner-up bid"))?;
+
+        let make_json =
+            |path: &str, value: serde_json::Value| -> Result<RuntimeV2SupportArtifactFile> {
+                Ok(RuntimeV2SupportArtifactFile {
+                    path: path.to_string(),
+                    contents: serde_json::to_vec_pretty(&value)
+                        .with_context(|| format!("serialize support artifact {path}"))?,
+                })
+            };
+
+        Ok(vec![
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_TRACE_REQUIREMENTS_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_trace_requirements.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_TRACE_REQUIREMENTS_PATH,
+                    "contract_ref": self.contract_schema.contract.artifact_path,
+                    "trace_criteria": [
+                        {
+                            "criterion_id": "trace-integrity",
+                            "required_links": self.contract_schema.contract.trace_requirements,
+                            "review_boundary": "trace links must remain reviewer-visible and cannot silently widen authority"
+                        }
+                    ],
+                    "claim_boundary": "Trace requirements prove evidence linkage only; they do not grant execution authority, settlement, or hidden identity trust."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_REVIEW_SUMMARY_SEED_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_review_summary_seed.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_REVIEW_SUMMARY_SEED_PATH,
+                    "contract_ref": self.contract_schema.contract.artifact_path,
+                    "required_sections": [
+                        "scope",
+                        "participants",
+                        "authority_basis",
+                        "bid_comparison",
+                        "selection_rationale",
+                        "delegation",
+                        "artifacts",
+                        "trace",
+                        "validation",
+                        "caveats",
+                        "residual_risk"
+                    ],
+                    "tool_requirement_notice": "Review summary must record unmet tool needs and must not imply execution authority.",
+                    "claim_boundary": "This summary seed prepares reviewer-facing judgment language without claiming payment settlement, governed-tool execution, or production authority."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_BID_ALPHA_NOTES_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_bid_notes.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_BID_ALPHA_NOTES_PATH,
+                    "bid_ref": self.bid_schema.valid_bids[0].artifact_path,
+                    "reviewer_notes": [
+                        "Alpha preserves stronger trace continuity and lower bounded review burden.",
+                        "Tool requirement remains evidence-only and explicitly deferred."
+                    ]
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_BID_BRAVO_NOTES_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_bid_notes.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_BID_BRAVO_NOTES_PATH,
+                    "bid_ref": self.bid_schema.valid_bids[1].artifact_path,
+                    "reviewer_notes": [
+                        "Bravo remains admissible but ranks lower on bounded operator burden.",
+                        "Gateway review and valid formatting are not treated as tool execution authority."
+                    ]
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_BIDDING_WINDOW_NOTICE_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_notice.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_BIDDING_WINDOW_NOTICE_PATH,
+                    "contract_ref": self.contract_schema.contract.artifact_path,
+                    "notice_id": "bidding-open",
+                    "issued_by_actor_id": self.contract_schema.contract.issuer_actor_id,
+                    "summary": "Issuer opened the bounded bidding window for the observatory-readiness contract.",
+                    "claim_boundary": "Notice opens bidding only; it does not award, accept, or authorize tool execution."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_SELECTION_RATIONALE_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_selection_rationale.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_SELECTION_RATIONALE_PATH,
+                    "selection_ref": self.selection.selection.artifact_path,
+                    "selected_bid_ref": self.selection.selection.recommendation.selected_bid_ref,
+                    "runner_up_bid_ref": runner_up_bid.artifact_path,
+                    "rationale": self.selection.selection.recommendation.explanation,
+                    "tool_boundary_note": "Selection records tool requirements as deferred constraints, not execution grants."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_AWARD_RECORD_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_award_record.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_AWARD_RECORD_PATH,
+                    "contract_ref": self.contract_schema.contract.artifact_path,
+                    "selected_bid_ref": self.selection.selection.recommendation.selected_bid_ref,
+                    "selection_rationale_ref": repo_ref(RUNTIME_V2_CONTRACT_MARKET_SELECTION_RATIONALE_PATH, "selected-bid"),
+                    "award_status": "awarded",
+                    "claim_boundary": "Award records bounded bid selection only and does not authorize payment or governed tools."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_ACCEPTANCE_RECORD_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_acceptance_record.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_ACCEPTANCE_RECORD_PATH,
+                    "award_ref": repo_ref(RUNTIME_V2_CONTRACT_MARKET_AWARD_RECORD_PATH, "selected-bid"),
+                    "counterparty_ref": repo_ref(
+                        &self.external_counterparty.model.artifact_path,
+                        &self.external_counterparty.model.records[0].record_id,
+                    ),
+                    "accepted_bid_ref": selected_bid.artifact_path,
+                    "acceptance_status": "accepted",
+                    "claim_boundary": "Acceptance confirms the awarded counterparty remains inside reviewed trust and gateway limits."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_EXECUTION_READINESS_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_execution_readiness.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_EXECUTION_READINESS_PATH,
+                    "acceptance_ref": repo_ref(RUNTIME_V2_CONTRACT_MARKET_ACCEPTANCE_RECORD_PATH, "accepted-counterparty"),
+                    "readiness_status": "execution-cleared",
+                    "tool_execution_authority_granted": false,
+                    "required_reviews": [
+                        "trace linkage preserved",
+                        "delegated packaging remains parent-reviewed",
+                        "tool requirements remain deferred and non-executable"
+                    ],
+                    "claim_boundary": "Execution readiness clears bounded work only and explicitly refuses governed-tool authority."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_PACKET_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_delegated_manifest.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_PACKET_PATH,
+                    "subcontract_ref": self.delegation.subcontract.artifact_path,
+                    "delegated_output_ref": self.delegation.delegated_output.artifact_path,
+                    "entries": [
+                        {
+                            "artifact_ref": self.delegation.delegated_output.delivered_artifact_refs[0],
+                            "purpose": "trace-linked delegated manifest packet"
+                        }
+                    ]
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_TRACE_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_delegated_manifest_trace.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_TRACE_PATH,
+                    "parent_selection_ref": repo_ref(&self.selection.selection.artifact_path, "selected-bid"),
+                    "delegation_ref": repo_ref(&self.delegation.subcontract.artifact_path, "trace-manifest-scope"),
+                    "review_status": "parent_review_completed"
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_execution_trace.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH,
+                    "contract_ref": self.contract_schema.contract.artifact_path,
+                    "stages": [
+                        "award",
+                        "acceptance",
+                        "execution_readiness",
+                        "delegated_manifest_packaging",
+                        "parent_integration",
+                        "completion"
+                    ],
+                    "trace_links": [
+                        repo_ref(RUNTIME_V2_CONTRACT_MARKET_AWARD_RECORD_PATH, "selected-bid"),
+                        repo_ref(RUNTIME_V2_CONTRACT_MARKET_ACCEPTANCE_RECORD_PATH, "accepted-counterparty"),
+                        repo_ref(RUNTIME_V2_CONTRACT_MARKET_EXECUTION_READINESS_PATH, "execution-cleared"),
+                        repo_ref(&self.delegation.parent_integration.artifact_path, "delegated-review-approved"),
+                        repo_ref(RUNTIME_V2_CONTRACT_MARKET_COMPLETION_RECORD_PATH, "deliverables-accepted")
+                    ]
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_DELIVERABLE_MANIFEST_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_deliverable_manifest.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_DELIVERABLE_MANIFEST_PATH,
+                    "parent_integration_ref": self.delegation.parent_integration.artifact_path,
+                    "accepted_deliverables": self.delegation.parent_integration.accepted_deliverables,
+                    "artifact_refs": [
+                        self.delegation.delegated_output.artifact_path,
+                        self.delegation.parent_integration.artifact_path,
+                        self.resource_bridge.artifact_path
+                    ]
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_COMPLETION_RECORD_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_completion_record.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_COMPLETION_RECORD_PATH,
+                    "execution_trace_ref": repo_ref(RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH, "completion"),
+                    "deliverable_manifest_ref": RUNTIME_V2_CONTRACT_MARKET_DELIVERABLE_MANIFEST_PATH,
+                    "completion_status": "deliverables-accepted",
+                    "claim_boundary": "Completion records reviewable artifact acceptance only and does not imply settlement or commercial finality."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_FAILURE_RECORD_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_failure_record.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_FAILURE_RECORD_PATH,
+                    "execution_trace_ref": repo_ref(RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH, "failure"),
+                    "failure_status": "execution-failed",
+                    "preserved_evidence": [
+                        self.delegation.delegated_output.artifact_path
+                    ],
+                    "claim_boundary": "Failure preserves bounded evidence and does not imply retry economics or silent abandonment."
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_CANCELLATION_RECORD_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_cancellation_record.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_CANCELLATION_RECORD_PATH,
+                    "contract_ref": self.contract_schema.contract.artifact_path,
+                    "cancellation_status": "accepted-contract-cancelled",
+                    "cancellation_reason": "issuer halted execution before completion with reviewer-visible notice"
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_DISPUTE_OPENING_RECORD_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_dispute_opening_record.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_DISPUTE_OPENING_RECORD_PATH,
+                    "execution_trace_ref": repo_ref(RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH, "dispute"),
+                    "dispute_status": "dispute-opened",
+                    "dispute_reason": "reviewer-visible disagreement over delegated packaging completeness"
+                }),
+            )?,
+            make_json(
+                RUNTIME_V2_CONTRACT_MARKET_DISPUTE_RESOLUTION_PATH,
+                json!({
+                    "schema_version": "runtime_v2.contract_market_dispute_resolution.v1",
+                    "artifact_path": RUNTIME_V2_CONTRACT_MARKET_DISPUTE_RESOLUTION_PATH,
+                    "dispute_ref": repo_ref(RUNTIME_V2_CONTRACT_MARKET_DISPUTE_OPENING_RECORD_PATH, "dispute-opened"),
+                    "resolution_status": "completed-resolution",
+                    "resolution_summary": "Dispute resolved in favor of bounded completion after trace and deliverable review."
+                }),
+            )?,
+        ])
+    }
+}
+
+impl RuntimeV2ContractMarketProofPacket {
+    fn from_artifacts(context: &RuntimeV2ContractMarketProofContext<'_>) -> Result<Self> {
+        let packet = Self {
+            schema_version: RUNTIME_V2_CONTRACT_MARKET_PROOF_SCHEMA.to_string(),
+            proof_id: "d12-bounded-contract-market-proof-0001".to_string(),
+            demo_id: "D12".to_string(),
+            milestone: "v0.90.4".to_string(),
+            artifact_path: RUNTIME_V2_CONTRACT_MARKET_PROOF_PATH.to_string(),
+            operator_report_ref: RUNTIME_V2_CONTRACT_MARKET_OPERATOR_REPORT_PATH.to_string(),
+            negative_packet_ref: RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_PATH.to_string(),
+            contract_ref: context.contract_schema.contract.artifact_path.clone(),
+            bid_refs: context
+                .bid_schema
+                .valid_bids
+                .iter()
+                .map(|bid| bid.artifact_path.clone())
+                .collect(),
+            selection_ref: context.selection.selection.artifact_path.clone(),
+            transition_matrix_ref: context.transition_authority.matrix.artifact_path.clone(),
+            transition_authority_basis_ref: context
+                .transition_authority
+                .authority_basis
+                .artifact_path
+                .clone(),
+            lifecycle_state_machine_ref: context.lifecycle.state_machine.artifact_path.clone(),
+            counterparty_model_ref: context.external_counterparty.model.artifact_path.clone(),
+            delegation_refs: vec![
+                context.delegation.subcontract.artifact_path.clone(),
+                context.delegation.delegated_output.artifact_path.clone(),
+                context.delegation.parent_integration.artifact_path.clone(),
+            ],
+            resource_bridge_ref: context.resource_bridge.artifact_path.clone(),
+            successful_scenario_ref: repo_ref(
+                &context.lifecycle.state_machine.artifact_path,
+                "normal-completion",
+            ),
+            support_artifact_refs: vec![
+                RUNTIME_V2_CONTRACT_MARKET_TRACE_REQUIREMENTS_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_REVIEW_SUMMARY_SEED_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_BID_ALPHA_NOTES_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_BID_BRAVO_NOTES_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_BIDDING_WINDOW_NOTICE_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_SELECTION_RATIONALE_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_AWARD_RECORD_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_ACCEPTANCE_RECORD_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_EXECUTION_READINESS_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_EXECUTION_TRACE_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_PACKET_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_DELEGATED_MANIFEST_TRACE_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_DELIVERABLE_MANIFEST_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_COMPLETION_RECORD_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_FAILURE_RECORD_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_CANCELLATION_RECORD_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_DISPUTE_OPENING_RECORD_PATH.to_string(),
+                RUNTIME_V2_CONTRACT_MARKET_DISPUTE_RESOLUTION_PATH.to_string(),
+            ],
+            validation_commands: vec![
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_contract_market_demo -- --nocapture".to_string(),
+                "cargo run --manifest-path adl/Cargo.toml -- runtime-v2 contract-market-demo --out artifacts/v0904/demo-d12-contract-market".to_string(),
+                "git diff --check".to_string(),
+            ],
+            reviewer_command:
+                "adl runtime-v2 contract-market-demo --out artifacts/v0904/demo-d12-contract-market"
+                    .to_string(),
+            proof_summary:
+                "D12 proves one bounded contract-market path end to end: publish a parent contract, receive two bids, select and award one bidder, accept and review execution readiness, delegate one bounded packaging step, integrate delegated output, complete with reviewer-visible artifacts, and preserve explicit negative cases for unsafe variants."
+                    .to_string(),
+            proof_classification: "proving".to_string(),
+            non_claims: vec![
+                "does not prove payment settlement, Lightning, x402, banking, tax, or legal contracting".to_string(),
+                "does not grant governed-tool execution, UTS, ACC, or production tool authority".to_string(),
+                "does not redefine citizen standing, private-state authority, or access-control inheritance".to_string(),
+                "does not prove full economics, reputation markets, or inter-polis coordination".to_string(),
+                "does not prove production external-counterparty identity verification beyond bounded reviewed fixture records".to_string(),
+            ],
+            claim_boundary:
+                "This packet proves bounded contract-market mechanics only: contract, bids, selection, lifecycle authority, delegation, reviewed integration, completion, and reviewer-visible denials. It does not prove settlement, full economics, governed-tool execution authority, or wider identity/governance scope."
+                    .to_string(),
+        };
+        packet.validate_core_refs(context)?;
+        Ok(packet)
+    }
+
+    fn validate_against(&self, artifacts: &RuntimeV2ContractMarketDemoArtifacts) -> Result<()> {
+        let context = RuntimeV2ContractMarketProofContext {
+            contract_schema: &artifacts.contract_schema,
+            bid_schema: &artifacts.bid_schema,
+            selection: &artifacts.selection,
+            transition_authority: &artifacts.transition_authority,
+            lifecycle: &artifacts.lifecycle,
+            external_counterparty: &artifacts.external_counterparty,
+            delegation: &artifacts.delegation,
+            resource_bridge: &artifacts.resource_bridge,
+        };
+        self.validate_core_refs(&context)?;
+        if self.support_artifact_refs.len() < 12 {
+            return Err(anyhow!(
+                "contract_market_proof.support_artifact_refs must cover the D12 review spine"
+            ));
+        }
+        let unique = self.support_artifact_refs.iter().collect::<BTreeSet<_>>();
+        if unique.len() != self.support_artifact_refs.len() {
+            return Err(anyhow!(
+                "contract_market_proof.support_artifact_refs must not contain duplicates"
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_core_refs(&self, context: &RuntimeV2ContractMarketProofContext<'_>) -> Result<()> {
+        if self.schema_version != RUNTIME_V2_CONTRACT_MARKET_PROOF_SCHEMA {
+            return Err(anyhow!(
+                "unsupported contract_market_proof.schema_version '{}'",
+                self.schema_version
+            ));
+        }
+        if self.demo_id != "D12" {
+            return Err(anyhow!("contract_market_proof.demo_id must remain D12"));
+        }
+        if self.milestone != "v0.90.4" {
+            return Err(anyhow!(
+                "contract_market_proof.milestone must remain v0.90.4"
+            ));
+        }
+        validate_relative_path(&self.artifact_path, "contract_market_proof.artifact_path")?;
+        validate_relative_path(
+            &self.operator_report_ref,
+            "contract_market_proof.operator_report_ref",
+        )?;
+        validate_relative_path(
+            &self.negative_packet_ref,
+            "contract_market_proof.negative_packet_ref",
+        )?;
+        if self.contract_ref != context.contract_schema.contract.artifact_path {
+            return Err(anyhow!(
+                "contract_market_proof.contract_ref must bind the parent contract"
+            ));
+        }
+        if self.bid_refs
+            != context
+                .bid_schema
+                .valid_bids
+                .iter()
+                .map(|bid| bid.artifact_path.clone())
+                .collect::<Vec<_>>()
+        {
+            return Err(anyhow!(
+                "contract_market_proof.bid_refs must preserve the reviewed two-bid packet"
+            ));
+        }
+        if self.selection_ref != context.selection.selection.artifact_path {
+            return Err(anyhow!(
+                "contract_market_proof.selection_ref must bind the evaluation selection artifact"
+            ));
+        }
+        if self.transition_matrix_ref != context.transition_authority.matrix.artifact_path {
+            return Err(anyhow!(
+                "contract_market_proof.transition_matrix_ref must bind the transition matrix"
+            ));
+        }
+        if self.transition_authority_basis_ref
+            != context.transition_authority.authority_basis.artifact_path
+        {
+            return Err(anyhow!(
+                "contract_market_proof.transition_authority_basis_ref must bind the authority basis"
+            ));
+        }
+        if self.lifecycle_state_machine_ref != context.lifecycle.state_machine.artifact_path {
+            return Err(anyhow!(
+                "contract_market_proof.lifecycle_state_machine_ref must bind the lifecycle state machine"
+            ));
+        }
+        if self.counterparty_model_ref != context.external_counterparty.model.artifact_path {
+            return Err(anyhow!(
+                "contract_market_proof.counterparty_model_ref must bind the reviewed counterparty model"
+            ));
+        }
+        let expected_delegation_refs = vec![
+            context.delegation.subcontract.artifact_path.clone(),
+            context.delegation.delegated_output.artifact_path.clone(),
+            context.delegation.parent_integration.artifact_path.clone(),
+        ];
+        if self.delegation_refs != expected_delegation_refs {
+            return Err(anyhow!(
+                "contract_market_proof.delegation_refs must bind subcontract, delegated output, and parent integration"
+            ));
+        }
+        if self.resource_bridge_ref != context.resource_bridge.artifact_path {
+            return Err(anyhow!(
+                "contract_market_proof.resource_bridge_ref must bind the reviewed resource bridge"
+            ));
+        }
+        validate_repo_ref_with_fragment(
+            &self.successful_scenario_ref,
+            "contract_market_proof.successful_scenario_ref",
+        )?;
+        if reference_path(&self.successful_scenario_ref)
+            != context.lifecycle.state_machine.artifact_path
+        {
+            return Err(anyhow!(
+                "contract_market_proof.successful_scenario_ref must point at the lifecycle state machine"
+            ));
+        }
+        validate_relative_paths(
+            &self.support_artifact_refs,
+            "contract_market_proof.support_artifact_refs",
+        )?;
+        validate_nonempty_vec(
+            &self.validation_commands,
+            "contract_market_proof.validation_commands",
+        )?;
+        if !self
+            .validation_commands
+            .iter()
+            .any(|command| command.contains("runtime_v2_contract_market_demo"))
+        {
+            return Err(anyhow!(
+                "contract_market_proof.validation_commands must include the focused D12 test target"
+            ));
+        }
+        if !self.reviewer_command.contains("contract-market-demo") {
+            return Err(anyhow!(
+                "contract_market_proof.reviewer_command must use the bounded runtime-v2 contract-market-demo command"
+            ));
+        }
+        if self.proof_classification != "proving" {
+            return Err(anyhow!(
+                "contract_market_proof.proof_classification must remain proving"
+            ));
+        }
+        if !self
+            .proof_summary
+            .contains("bounded contract-market path end to end")
+        {
+            return Err(anyhow!(
+                "contract_market_proof.proof_summary must preserve the D12 end-to-end story"
+            ));
+        }
+        if self.non_claims.len() < 4 {
+            return Err(anyhow!(
+                "contract_market_proof.non_claims must preserve bounded non-goals"
+            ));
+        }
+        if !self.claim_boundary.contains("does not prove settlement")
+            || !self
+                .claim_boundary
+                .contains("governed-tool execution authority")
+        {
+            return Err(anyhow!(
+                "contract_market_proof.claim_boundary must preserve settlement and governed-tool non-claims"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl RuntimeV2ContractMarketNegativePacket {
+    fn from_artifacts(
+        proof_packet: &RuntimeV2ContractMarketProofPacket,
+        contract: &RuntimeV2ContractArtifact,
+        bid_negative_cases: &RuntimeV2BidNegativeCases,
+        transition_negative_cases: &RuntimeV2TransitionAuthorityNegativeCases,
+        external_negative_cases: &RuntimeV2ExternalCounterpartyNegativeCases,
+        delegation_negative_cases: &RuntimeV2DelegationNegativeCases,
+    ) -> Result<Self> {
+        let packet = Self {
+            schema_version: RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_SCHEMA.to_string(),
+            proof_id: "d12-bounded-contract-market-negative-packet-0001".to_string(),
+            demo_id: "D12".to_string(),
+            milestone: "v0.90.4".to_string(),
+            artifact_path: RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_PATH.to_string(),
+            proof_packet_ref: proof_packet.artifact_path.clone(),
+            contract_ref: contract.artifact_path.clone(),
+            required_negative_cases: vec![
+                negative_case_ref(
+                    "unauthorized-transition",
+                    "authority",
+                    repo_ref(&transition_negative_cases.artifact_path, "unauthorized_award"),
+                    "actor role not authorized",
+                    "award must fail when attempted by an unauthorized actor",
+                ),
+                negative_case_ref(
+                    "invalid-bid",
+                    "bid_validation",
+                    repo_ref(&bid_negative_cases.artifact_path, "wrong-contract-id"),
+                    "bid.target_contract_id must match the parent contract id",
+                    "bid validation must fail closed before award when the contract binding is wrong",
+                ),
+                negative_case_ref(
+                    "unsupported-delegation",
+                    "delegation",
+                    repo_ref(&delegation_negative_cases.artifact_path, "unsupported-subcontractor"),
+                    "subcontractor must reference a supported counterparty record",
+                    "delegation must remain inside the reviewed counterparty boundary",
+                ),
+                negative_case_ref(
+                    "revoked-counterparty",
+                    "counterparty",
+                    repo_ref(&external_negative_cases.artifact_path, "revoked-counterparty"),
+                    "revoked counterparty cannot participate",
+                    "revoked counterparties must not be able to accept or continue the contract path",
+                ),
+                negative_case_ref(
+                    "missing-trace-link",
+                    "trace",
+                    repo_ref(&delegation_negative_cases.artifact_path, "missing-parent-link"),
+                    "subcontract.parent_contract_ref must bind the parent contract",
+                    "delegation artifacts must preserve parent trace linkage and fail if that linkage drifts",
+                ),
+                negative_case_ref(
+                    "unauthorized-tool-execution-attempt",
+                    "governed_tool_boundary",
+                    repo_ref(
+                        &transition_negative_cases.artifact_path,
+                        "tool_execution_without_governed_authority",
+                    ),
+                    "missing governed-tool authority",
+                    "tool-mediated work must remain deferred unless a later milestone grants governed-tool authority",
+                ),
+            ],
+            validation_commands: vec![
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_contract_market_demo -- --nocapture".to_string(),
+                "cargo run --manifest-path adl/Cargo.toml -- runtime-v2 contract-market-demo --out artifacts/v0904/demo-d12-contract-market".to_string(),
+            ],
+            claim_boundary:
+                "This negative packet proves the bounded D12 demo fails closed on unsafe authority, bid, delegation, counterparty, trace, and governed-tool attempts; it does not implement enforcement beyond the reviewed fixture packet."
+                    .to_string(),
+        };
+        packet.validate_against(proof_packet, contract)?;
+        Ok(packet)
+    }
+
+    fn validate_against(
+        &self,
+        proof_packet: &RuntimeV2ContractMarketProofPacket,
+        contract: &RuntimeV2ContractArtifact,
+    ) -> Result<()> {
+        if self.schema_version != RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_SCHEMA {
+            return Err(anyhow!(
+                "unsupported contract_market_negative_packet.schema_version '{}'",
+                self.schema_version
+            ));
+        }
+        if self.demo_id != "D12" {
+            return Err(anyhow!(
+                "contract_market_negative_packet.demo_id must remain D12"
+            ));
+        }
+        if self.milestone != "v0.90.4" {
+            return Err(anyhow!(
+                "contract_market_negative_packet.milestone must remain v0.90.4"
+            ));
+        }
+        validate_relative_path(
+            &self.artifact_path,
+            "contract_market_negative_packet.artifact_path",
+        )?;
+        if self.proof_packet_ref != proof_packet.artifact_path {
+            return Err(anyhow!(
+                "contract_market_negative_packet.proof_packet_ref must bind the D12 proof packet"
+            ));
+        }
+        if self.contract_ref != contract.artifact_path {
+            return Err(anyhow!(
+                "contract_market_negative_packet.contract_ref must bind the parent contract"
+            ));
+        }
+        if self.required_negative_cases.len() != 6 {
+            return Err(anyhow!(
+                "contract_market_negative_packet.required_negative_cases must preserve the six required D12 denials"
+            ));
+        }
+        let actual_ids = self
+            .required_negative_cases
+            .iter()
+            .map(|case| case.case_id.as_str())
+            .collect::<BTreeSet<_>>();
+        let expected_ids = BTreeSet::from([
+            "unauthorized-transition",
+            "invalid-bid",
+            "unsupported-delegation",
+            "revoked-counterparty",
+            "missing-trace-link",
+            "unauthorized-tool-execution-attempt",
+        ]);
+        if actual_ids != expected_ids {
+            return Err(anyhow!(
+                "contract_market_negative_packet.required_negative_cases must preserve the reviewed D12 denial categories"
+            ));
+        }
+        for case in &self.required_negative_cases {
+            case.validate()?;
+        }
+        if !self
+            .validation_commands
+            .iter()
+            .any(|command| command.contains("runtime_v2_contract_market_demo"))
+        {
+            return Err(anyhow!(
+                "contract_market_negative_packet.validation_commands must include the focused D12 test target"
+            ));
+        }
+        if !self.claim_boundary.contains("fails closed") {
+            return Err(anyhow!(
+                "contract_market_negative_packet.claim_boundary must preserve fail-closed language"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl RuntimeV2ContractMarketNegativeCaseRef {
+    fn validate(&self) -> Result<()> {
+        normalize_id(
+            self.case_id.clone(),
+            "contract_market_negative_case.case_id",
+        )?;
+        normalize_id(
+            self.category.clone(),
+            "contract_market_negative_case.category",
+        )?;
+        validate_repo_ref_with_fragment(
+            &self.source_artifact_ref,
+            "contract_market_negative_case.source_artifact_ref",
+        )?;
+        validate_nonempty_text(
+            &self.expected_error_fragment,
+            "contract_market_negative_case.expected_error_fragment",
+        )?;
+        validate_nonempty_text(
+            &self.proof_purpose,
+            "contract_market_negative_case.proof_purpose",
+        )
+    }
+}
+
+fn negative_case_ref(
+    case_id: &str,
+    category: &str,
+    source_artifact_ref: String,
+    expected_error_fragment: &str,
+    proof_purpose: &str,
+) -> RuntimeV2ContractMarketNegativeCaseRef {
+    RuntimeV2ContractMarketNegativeCaseRef {
+        case_id: case_id.to_string(),
+        category: category.to_string(),
+        source_artifact_ref,
+        expected_error_fragment: expected_error_fragment.to_string(),
+        proof_purpose: proof_purpose.to_string(),
+    }
+}
+
+fn validate_repo_ref_with_fragment(value: &str, field: &str) -> Result<()> {
+    let (path, fragment) = value
+        .split_once('#')
+        .ok_or_else(|| anyhow!("{field} must contain a #fragment"))?;
+    validate_relative_path(path, field)?;
+    validate_nonempty_text(fragment, field)
+}
+
+fn reference_path(value: &str) -> &str {
+    value.split('#').next().unwrap_or(value)
+}
+
+fn validate_relative_paths(values: &[String], field: &str) -> Result<()> {
+    if values.is_empty() {
+        return Err(anyhow!("{field} must not be empty"));
+    }
+    for value in values {
+        validate_relative_path(value, field)?;
+    }
+    Ok(())
+}
+
+fn validate_nonempty_vec(values: &[String], field: &str) -> Result<()> {
+    if values.is_empty() {
+        return Err(anyhow!("{field} must not be empty"));
+    }
+    for value in values {
+        validate_nonempty_text(value, field)?;
+    }
+    Ok(())
+}
+
+fn render_contract_market_operator_report(
+    proof_packet: &RuntimeV2ContractMarketProofPacket,
+    negative_packet: &RuntimeV2ContractMarketNegativePacket,
+) -> Result<String> {
+    proof_packet
+        .support_artifact_refs
+        .iter()
+        .try_for_each(|path| {
+            validate_relative_path(path, "contract_market_report.support_artifact_ref")
+        })?;
+    Ok(format!(
+        concat!(
+            "# D12 Bounded Contract-Market Proof\n\n",
+            "## What This Proves\n\n",
+            "{}\n\n",
+            "## Successful Path\n\n",
+            "- parent contract published under explicit issuer authority\n",
+            "- two reviewed bids compared through mandatory criteria and bounded resource fit\n",
+            "- one bid awarded, accepted, delegated for one bounded packaging step, integrated, and completed\n",
+            "- trace bundle and review summary remain reviewer-visible\n",
+            "- tool requirements remain deferred and non-executable without governed-tool authority\n\n",
+            "## Review Surfaces\n\n",
+            "- proof packet: `{}`\n",
+            "- negative packet: `{}`\n",
+            "- contract: `{}`\n",
+            "- selection: `{}`\n",
+            "- lifecycle state machine: `{}`\n",
+            "- counterparty model: `{}`\n",
+            "- subcontract: `{}`\n",
+            "- parent integration: `{}`\n\n",
+            "## Negative Coverage\n\n",
+            "{}\n\n",
+            "## Non-Claims\n\n",
+            "{}\n\n",
+            "## Reviewer Command\n\n",
+            "`{}`\n"
+        ),
+        proof_packet.proof_summary,
+        proof_packet.artifact_path,
+        negative_packet.artifact_path,
+        proof_packet.contract_ref,
+        proof_packet.selection_ref,
+        proof_packet.lifecycle_state_machine_ref,
+        proof_packet.counterparty_model_ref,
+        proof_packet.delegation_refs[0],
+        proof_packet.delegation_refs[2],
+        negative_packet
+            .required_negative_cases
+            .iter()
+            .map(|case| format!(
+                "- `{}`: {} (`{}`)",
+                case.case_id, case.proof_purpose, case.expected_error_fragment
+            ))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        proof_packet
+            .non_claims
+            .iter()
+            .map(|line| format!("- {line}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        proof_packet.reviewer_command,
+    ))
+}
+
+fn validate_contract_market_operator_report(
+    proof_packet: &RuntimeV2ContractMarketProofPacket,
+    negative_packet: &RuntimeV2ContractMarketNegativePacket,
+    report: &str,
+) -> Result<()> {
+    for required in [
+        "D12 Bounded Contract-Market Proof",
+        "What This Proves",
+        "Successful Path",
+        "Negative Coverage",
+        "Non-Claims",
+        "tool requirements remain deferred and non-executable",
+    ] {
+        if !report.contains(required) {
+            return Err(anyhow!(
+                "contract-market operator report missing required text '{required}'"
+            ));
+        }
+    }
+    if !report.contains(&proof_packet.artifact_path) {
+        return Err(anyhow!(
+            "contract-market operator report must reference the D12 proof packet"
+        ));
+    }
+    if !report.contains(&negative_packet.artifact_path) {
+        return Err(anyhow!(
+            "contract-market operator report must reference the D12 negative packet"
+        ));
+    }
+    if report.contains("/Users/") || report.contains("/tmp/") {
+        return Err(anyhow!(
+            "contract-market operator report must not leak host-local absolute paths"
+        ));
+    }
+    Ok(())
+}
+
+fn repo_ref(path: &str, fragment: &str) -> String {
+    format!("{path}#{fragment}")
+}

--- a/adl/src/runtime_v2/contracts.rs
+++ b/adl/src/runtime_v2/contracts.rs
@@ -205,3 +205,8 @@ pub fn runtime_v2_observatory_flagship_contract() -> Result<RuntimeV2Observatory
     static ARTIFACTS: OnceCell<RuntimeV2ObservatoryFlagshipArtifacts> = OnceCell::new();
     cached_contract(&ARTIFACTS, RuntimeV2ObservatoryFlagshipArtifacts::prototype)
 }
+
+pub fn runtime_v2_contract_market_demo_contract() -> Result<RuntimeV2ContractMarketDemoArtifacts> {
+    static ARTIFACTS: OnceCell<RuntimeV2ContractMarketDemoArtifacts> = OnceCell::new();
+    cached_contract(&ARTIFACTS, RuntimeV2ContractMarketDemoArtifacts::prototype)
+}

--- a/adl/src/runtime_v2/mod.rs
+++ b/adl/src/runtime_v2/mod.rs
@@ -10,6 +10,7 @@ mod boot_admission;
 mod challenge;
 mod citizen;
 mod contract_lifecycle_state;
+mod contract_market_demo;
 mod contract_schema;
 mod contracts;
 mod csm_run;
@@ -62,6 +63,8 @@ pub use challenge::*;
 pub use citizen::*;
 #[allow(unused_imports)]
 pub use contract_lifecycle_state::*;
+#[allow(unused_imports)]
+pub use contract_market_demo::*;
 #[allow(unused_imports)]
 pub use contract_schema::*;
 #[allow(unused_imports)]

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -9,6 +9,7 @@ mod challenge;
 mod citizen_lifecycle;
 mod common;
 mod contract_lifecycle_state;
+mod contract_market_demo;
 mod contract_schema;
 mod csm_run_packet;
 mod delegation_subcontract;

--- a/adl/src/runtime_v2/tests/contract_market_demo.rs
+++ b/adl/src/runtime_v2/tests/contract_market_demo.rs
@@ -1,0 +1,107 @@
+use super::common::unique_temp_path;
+use super::*;
+use std::fs;
+use std::sync::OnceLock;
+
+fn contract_market_artifacts() -> &'static RuntimeV2ContractMarketDemoArtifacts {
+    static ARTIFACTS: OnceLock<RuntimeV2ContractMarketDemoArtifacts> = OnceLock::new();
+    ARTIFACTS.get_or_init(|| {
+        runtime_v2_contract_market_demo_contract().expect("contract-market demo artifacts")
+    })
+}
+
+#[test]
+fn runtime_v2_contract_market_demo_review_surfaces_are_stable() {
+    let artifacts = contract_market_artifacts();
+    artifacts.validate().expect("valid D12 artifacts");
+
+    assert_eq!(
+        artifacts.proof_packet.schema_version,
+        RUNTIME_V2_CONTRACT_MARKET_PROOF_SCHEMA
+    );
+    assert_eq!(artifacts.proof_packet.demo_id, "D12");
+    assert_eq!(artifacts.proof_packet.milestone, "v0.90.4");
+    assert_eq!(
+        artifacts.proof_packet.artifact_path,
+        "runtime_v2/contract_market/proof_packet.json"
+    );
+    assert_eq!(
+        artifacts.proof_packet.operator_report_ref,
+        "runtime_v2/contract_market/operator_report.md"
+    );
+    assert_eq!(artifacts.proof_packet.proof_classification, "proving");
+    assert_eq!(artifacts.proof_packet.bid_refs.len(), 2);
+    assert_eq!(artifacts.negative_packet.required_negative_cases.len(), 6);
+    assert!(artifacts
+        .proof_packet
+        .validation_commands
+        .iter()
+        .any(|command| command.contains("contract-market-demo")));
+    assert!(artifacts
+        .operator_report_markdown
+        .contains("D12 Bounded Contract-Market Proof"));
+    assert!(artifacts
+        .operator_report_markdown
+        .contains("tool requirements remain deferred and non-executable"));
+}
+
+#[test]
+fn runtime_v2_contract_market_negative_packet_preserves_required_denials() {
+    let packet = &contract_market_artifacts().negative_packet;
+    let ids = packet
+        .required_negative_cases
+        .iter()
+        .map(|case| case.case_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+
+    assert_eq!(
+        ids,
+        std::collections::BTreeSet::from([
+            "unauthorized-transition",
+            "invalid-bid",
+            "unsupported-delegation",
+            "revoked-counterparty",
+            "missing-trace-link",
+            "unauthorized-tool-execution-attempt",
+        ])
+    );
+}
+
+#[test]
+fn runtime_v2_contract_market_demo_writes_bundle_without_path_leakage() {
+    let root = unique_temp_path("contract-market-demo");
+    let artifacts = contract_market_artifacts();
+
+    artifacts
+        .write_to_root(&root)
+        .expect("write contract-market bundle");
+
+    for rel_path in [
+        RUNTIME_V2_CONTRACT_MARKET_PROOF_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_NEGATIVE_PACKET_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_OPERATOR_REPORT_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_REVIEW_SUMMARY_SEED_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_TRACE_REQUIREMENTS_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_SELECTION_RATIONALE_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_ACCEPTANCE_RECORD_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_EXECUTION_READINESS_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_DELIVERABLE_MANIFEST_PATH,
+        RUNTIME_V2_CONTRACT_MARKET_COMPLETION_RECORD_PATH,
+        RUNTIME_V2_PARENT_INTEGRATION_ARTIFACT_PATH,
+    ] {
+        assert!(root.join(rel_path).is_file(), "missing {rel_path}");
+    }
+
+    let proof_text =
+        fs::read_to_string(root.join(RUNTIME_V2_CONTRACT_MARKET_PROOF_PATH)).expect("proof text");
+    assert!(proof_text.contains("\"demo_id\": \"D12\""));
+    assert!(!proof_text.contains(root.to_string_lossy().as_ref()));
+
+    let report_text =
+        fs::read_to_string(root.join(RUNTIME_V2_CONTRACT_MARKET_OPERATOR_REPORT_PATH))
+            .expect("report text");
+    assert!(report_text.contains("Negative Coverage"));
+    assert!(!report_text.contains("/Users/"));
+
+    fs::remove_dir_all(root).ok();
+}


### PR DESCRIPTION
Closes #2433

## Summary
Implemented the D12 bounded contract-market proof surface for WP-14 in the bound worktree. The run added a new runtime-v2 contract-market demo artifact family, wired a `runtime-v2 contract-market-demo` CLI entrypoint plus usage/help coverage, added focused runtime tests, and verified one real demo bundle write with repository-relative stdout and no absolute-path leakage.

## Artifacts
- Runtime demo artifacts and validators in `adl/src/runtime_v2/contract_market_demo.rs`
- Runtime contract cache export in `adl/src/runtime_v2/contracts.rs`
- Runtime module/test wiring in `adl/src/runtime_v2/mod.rs` and `adl/src/runtime_v2/tests.rs`
- Focused runtime tests in `adl/src/runtime_v2/tests/contract_market_demo.rs`
- CLI entrypoint, stdout helper, and CLI tests in `adl/src/cli/runtime_v2_cmd.rs`
- CLI help/usage documentation in `adl/src/cli/usage.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_contract_market_demo -- --nocapture`
    Verified the new D12 runtime demo artifacts validate and the bundle write stays repository-relative.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_contract_market_demo_validates_stdout_help_and_output_path_rules -- --nocapture`
    Verified the new CLI entrypoint enforces help, relative `--out`, and argument rejection rules.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_dispatch_covers_help_and_subcommand_errors -- --nocapture`
    Verified top-level runtime-v2 dispatch/help text includes the new `contract-market-demo` subcommand.
  - `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 contract-market-demo --out tmp/contract-market-demo-proof`
    Verified one end-to-end demo bundle write, relative stdout marker, and reviewer-facing report output.
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Normalized formatting across the changed runtime and CLI surfaces.
  - `git diff --check`
    Verified no whitespace or patch-formatting defects remain in the worktree changes.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2433__v0-90-4-wp-14-bounded-contract-market-demo-and-negative-cases/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2433__v0-90-4-wp-14-bounded-contract-market-demo-and-negative-cases/sor.md
- Idempotency-Key: v0-90-4-wp-14-bounded-contract-market-demo-and-negative-cases-adl-src-cli-runtime-v2-cmd-rs-adl-src-cli-usage-rs-adl-src-runtime-v2-contracts-rs-adl-src-runtime-v2-mod-rs-adl-src-runtime-v2-tests-rs-adl-src-runtime-v2-contract-market-demo-rs-adl-src-runtime-v2-tests-contract-market-demo-rs-adl-v0-90-4-tasks-issue-2433-v0-90-4-wp-14-bounded-contract-market-demo-and-negative-cases-sip-md-adl-v0-90-4-tasks-issue-2433-v0-90-4-wp-14-bounded-contract-market-demo-and-negative-cases-sor-md