### PR TITLE
[v0.90.4][backlog][tools] Reduce total validation wall time below 5 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,10 @@ jobs:
         run: bash adl/tools/test_ci_path_policy.sh
         working-directory: .
 
+      - name: PR-fast test lane contract
+        run: bash adl/tools/test_run_pr_fast_test_lane.sh
+        working-directory: .
+
       - name: guardrail (no new legacy refs)
         run: bash adl/tools/check_no_new_legacy_swarm_refs.sh
         working-directory: .
@@ -148,7 +152,8 @@ jobs:
 
       - name: test
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
-        run: cargo nextest run --status-level all --final-status-level slow
+        run: bash adl/tools/run_pr_fast_test_lane.sh --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}"
+        working-directory: .
 
       - name: doc test
         if: steps.path-policy.outputs.rust_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'

--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASE_SHA=""
+HEAD_SHA=""
+CHANGED_FILES_FILE=""
+GITHUB_OUTPUT_PATH=""
+PRINT_PLAN=false
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/run_pr_fast_test_lane.sh [options]
+
+Options:
+  --base <sha>                 Base revision for changed-file detection.
+  --head <sha>                 Head revision for changed-file detection.
+  --changed-files <file>       Explicit changed-file list for tests. Lines may be
+                               "path" or "STATUS<TAB>path".
+  --github-output <path>       Emit key=value outputs for GitHub Actions.
+  --print-plan                 Print the computed plan and exit.
+  -h, --help                   Show this help.
+
+This script selects the ordinary PR-fast non-coverage Rust test lane.
+It fails closed to the full nextest sweep unless every changed Rust surface
+maps to a bounded focused filter expression.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      BASE_SHA="${2:-}"
+      shift 2
+      ;;
+    --head)
+      HEAD_SHA="${2:-}"
+      shift 2
+      ;;
+    --changed-files)
+      CHANGED_FILES_FILE="${2:-}"
+      shift 2
+      ;;
+    --github-output)
+      GITHUB_OUTPUT_PATH="${2:-}"
+      shift 2
+      ;;
+    --print-plan)
+      PRINT_PLAN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+emit() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value"
+  if [ -n "$GITHUB_OUTPUT_PATH" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT_PATH"
+  fi
+}
+
+normalize_changed_rows() {
+  awk -F '\t' '
+    NF == 1 { print "M\t" $1; next }
+    $1 ~ /^R/ && NF >= 3 { print $1 "\t" $3; next }
+    NF >= 2 { print $1 "\t" $2; next }
+  '
+}
+
+changed_rows() {
+  if [ -n "$CHANGED_FILES_FILE" ]; then
+    cat "$CHANGED_FILES_FILE"
+    return
+  fi
+  if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+    echo "run_pr_fast_test_lane: --base and --head are required unless --changed-files is supplied" >&2
+    exit 2
+  fi
+  git -C "$ROOT_DIR" diff --name-status --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" 2>/dev/null \
+    || git -C "$ROOT_DIR" diff --name-status --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" 2>/dev/null \
+    || true
+}
+
+is_relevant_fast_lane_surface() {
+  local path="$1"
+  case "$path" in
+    adl/src/*.rs|adl/tests/*.rs|adl/build.rs|\
+    docs/default_workflow.md|\
+    docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_broad_rust_surface() {
+  local path="$1"
+  case "$path" in
+    adl/build.rs|\
+    adl/src/lib.rs|\
+    adl/src/main.rs|\
+    adl/src/adl.rs|\
+    adl/src/schema.rs|\
+    adl/src/providers.rs|\
+    adl/src/cli.rs|\
+    adl/src/demo.rs|\
+    adl/src/runtime_v2/mod.rs|\
+    adl/src/runtime_v2/validators.rs|\
+    adl/src/tests.rs|\
+    adl/tests/*)
+      return 0
+      ;;
+    */mod.rs)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+filter_token_for_path() {
+  local path="$1"
+  case "$path" in
+    adl/src/runtime_v2/*/*.rs|adl/src/runtime_v2/*/*/*.rs|adl/src/runtime_v2/*/*/*/*.rs)
+      return 1
+      ;;
+    adl/src/runtime_v2/tests/*)
+      basename "$path" .rs
+      return 0
+      ;;
+    adl/src/runtime_v2/[^/]*.rs)
+      basename "$path" .rs
+      return 0
+      ;;
+    adl/src/cli/tests/pr_cmd_inline/*/*|adl/src/cli/tests/pr_cmd_inline/*)
+      printf 'pr_cmd'
+      return 0
+      ;;
+    adl/src/cli/tests/tooling_cmd*|adl/src/cli/tooling_cmd*|adl/src/cli/tests/tooling_cmd/*)
+      printf 'tooling_cmd'
+      return 0
+      ;;
+    adl/src/cli/pr_cmd*|adl/src/cli/tests/pr_cmd*|adl/src/cli/pr_cmd/*)
+      printf 'pr_cmd'
+      return 0
+      ;;
+    docs/default_workflow.md|docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md)
+      printf 'pr_cmd'
+      return 0
+      ;;
+    adl/src/cli/*/*/*.rs|adl/src/cli/*/*/*/*.rs)
+      return 1
+      ;;
+    adl/src/cli/[^/]*.rs|adl/src/cli/[^/]*/[^/]*.rs)
+      basename "$path" .rs
+      return 0
+      ;;
+    adl/src/demo/*/*/*/*.rs|adl/src/demo/*/*/*/*/*.rs)
+      return 1
+      ;;
+    adl/src/bin/[^/]*.rs)
+      basename "$path" .rs
+      return 0
+      ;;
+    adl/src/demo/[^/]*.rs|adl/src/demo/[^/]*/[^/]*.rs|adl/src/demo/[^/]*/[^/]*/[^/]*.rs)
+      basename "$path" .rs
+      return 0
+      ;;
+    adl/src/*/*)
+      return 1
+      ;;
+    adl/src/[^/]*.rs)
+      basename "$path" .rs
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+build_filter_expression() {
+  python3 - "$@" <<'PY'
+import sys
+
+tokens = [token for token in sys.argv[1:] if token]
+if not tokens:
+    raise SystemExit(1)
+print(" or ".join(f"test({token})" for token in tokens))
+PY
+}
+
+token_already_seen() {
+  local needle="$1"
+  local token
+  for token in "${tokens[@]:-}"; do
+    if [ "$token" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+mode="full"
+reason="ordinary_pr_fast_lane_fails_closed_to_full_nextest"
+filter_tokens=""
+filter_expression=""
+rust_surface_count=0
+
+declare -a tokens=()
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  if ! is_relevant_fast_lane_surface "$path"; then
+    continue
+  fi
+  rust_surface_count=$((rust_surface_count + 1))
+  if is_broad_rust_surface "$path"; then
+    mode="full"
+    reason="broad_rust_surface_requires_full_nextest"
+    tokens=()
+    break
+  fi
+  if ! token="$(filter_token_for_path "$path")"; then
+    mode="full"
+    reason="unmapped_rust_surface_requires_full_nextest"
+    tokens=()
+    break
+  fi
+  if ! token_already_seen "$token"; then
+    tokens+=("$token")
+  fi
+done <<EOF
+$(changed_rows \
+  | normalize_changed_rows \
+  | awk -F '\t' 'NF >= 2 { print $2 }')
+EOF
+
+if [ "$rust_surface_count" -eq 0 ]; then
+  mode="full"
+  reason="no_relevant_rust_surface_detected_for_fast_lane"
+elif [ "${#tokens[@]}" -gt 0 ]; then
+  if [ "${#tokens[@]}" -le 4 ]; then
+    mode="focused"
+    reason="bounded_rust_surface_runs_focused_nextest"
+    filter_expression="$(build_filter_expression "${tokens[@]}")"
+    filter_tokens="$(printf '%s\n' "${tokens[@]}" | paste -sd, -)"
+  else
+    mode="full"
+    reason="too_many_focused_filters_require_full_nextest"
+  fi
+fi
+
+emit "mode" "$mode"
+emit "reason" "$reason"
+emit "rust_surface_count" "$rust_surface_count"
+emit "filter_tokens" "$filter_tokens"
+emit "filter_expression" "$filter_expression"
+
+if [ "$PRINT_PLAN" = true ]; then
+  exit 0
+fi
+
+cd "$ROOT_DIR/adl"
+
+if [ "$mode" = "focused" ]; then
+  echo "Running focused nextest lane: $filter_expression"
+  cargo nextest run --status-level all --final-status-level slow -E "$filter_expression"
+else
+  echo "Running full nextest lane: $reason"
+  cargo nextest run --status-level all --final-status-level slow
+fi

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -182,9 +182,12 @@ Observed:
 
 Truthful interpretation:
 
-- Rust fmt, clippy, broad non-coverage tests via `cargo nextest run`, doc
-  tests via `cargo test --doc`, demo smoke where applicable, and the fast
-  coverage-impact preflight are expected.
+- Rust fmt, clippy, doc tests via `cargo test --doc`, demo smoke where
+  applicable, and the fast coverage-impact preflight are expected.
+- The non-coverage `test` step now runs through
+  `adl/tools/run_pr_fast_test_lane.sh`. For bounded PRs, that runner may use a
+  focused `cargo nextest` expression. For broad or ambiguous PRs, it fails
+  closed to the full ordinary nextest sweep.
 - The ordinary PR lane must not re-enable heavyweight opt-in features such as
   `slow-proof-tests`; those stay reserved for dedicated heavy proof or
   authoritative coverage lanes.

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -24,9 +24,13 @@ def step_run(name: str) -> str:
     return match.group(1).strip()
 
 ordinary_test = step_run("test")
-if ordinary_test != "cargo nextest run --status-level all --final-status-level slow":
+expected_ordinary_test = (
+    'bash adl/tools/run_pr_fast_test_lane.sh --base "${{ github.event.pull_request.base.sha }}" '
+    '--head "${{ github.event.pull_request.head.sha }}"'
+)
+if ordinary_test != expected_ordinary_test:
     raise SystemExit(
-        "ordinary adl-ci test lane must be 'cargo nextest run --status-level all --final-status-level slow' without --all-features; "
+        "ordinary adl-ci test lane must run through the fail-closed PR-fast runner; "
         f"found: {ordinary_test}"
     )
 

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/run_pr_fast_test_lane.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_has() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fqx "$needle" <<<"$haystack"; then
+    echo "expected runner output to contain: $needle" >&2
+    echo "actual output:" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+focused_runtime="$TMP/focused_runtime.txt"
+printf 'M\tadl/src/runtime_v2/contract_schema.rs\n' >"$focused_runtime"
+focused_runtime_output="$(bash "$SCRIPT" --changed-files "$focused_runtime" --print-plan)"
+assert_has "$focused_runtime_output" "mode=focused"
+assert_has "$focused_runtime_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$focused_runtime_output" "filter_tokens=contract_schema"
+assert_has "$focused_runtime_output" "filter_expression=test(contract_schema)"
+
+focused_control_plane="$TMP/focused_control_plane.txt"
+printf 'M\tdocs/default_workflow.md\n' >"$focused_control_plane"
+focused_control_plane_output="$(bash "$SCRIPT" --changed-files "$focused_control_plane" --print-plan)"
+assert_has "$focused_control_plane_output" "mode=focused"
+assert_has "$focused_control_plane_output" "filter_tokens=pr_cmd"
+
+broad_runtime="$TMP/broad_runtime.txt"
+printf 'M\tadl/src/runtime_v2/mod.rs\n' >"$broad_runtime"
+broad_runtime_output="$(bash "$SCRIPT" --changed-files "$broad_runtime" --print-plan)"
+assert_has "$broad_runtime_output" "mode=full"
+assert_has "$broad_runtime_output" "reason=broad_rust_surface_requires_full_nextest"
+
+too_many="$TMP/too_many.txt"
+cat >"$too_many" <<'EOF'
+M	adl/src/runtime_v2/contract_schema.rs
+M	adl/src/runtime_v2/bid_schema.rs
+M	adl/src/runtime_v2/evaluation_selection.rs
+M	adl/src/runtime_v2/inheritance.rs
+M	adl/src/runtime_v2/gateway_policies.rs
+EOF
+too_many_output="$(bash "$SCRIPT" --changed-files "$too_many" --print-plan)"
+assert_has "$too_many_output" "mode=full"
+assert_has "$too_many_output" "reason=too_many_focused_filters_require_full_nextest"
+
+unmapped="$TMP/unmapped.txt"
+printf 'M\tadl/src/runtime_v2/subdir/nested.rs\n' >"$unmapped"
+unmapped_output="$(bash "$SCRIPT" --changed-files "$unmapped" --print-plan)"
+assert_has "$unmapped_output" "mode=full"
+assert_has "$unmapped_output" "reason=unmapped_rust_surface_requires_full_nextest"
+
+echo "PASS test_run_pr_fast_test_lane"

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -133,11 +133,14 @@ or ambiguous changes.
 
 For broad non-coverage Rust lanes, prefer `cargo nextest run` over raw
 `cargo test` when the lane is executing the whole runnable test graph rather
-than a narrow filtered proof. Keep `cargo llvm-cov` on its own coverage lanes,
-and preserve doc-test signal explicitly with `cargo test --doc` where needed.
-Do not add `--all-features` back onto the ordinary PR lane when opt-in heavy
-features such as `slow-proof-tests` are being used to keep proof-materialization
-surfaces out of routine validation.
+than a narrow filtered proof. The tracked CI workflow now routes ordinary PR
+test execution through `adl/tools/run_pr_fast_test_lane.sh`, which may use a
+focused `cargo nextest` expression for bounded changed surfaces and otherwise
+fails closed to the full ordinary nextest sweep. Keep `cargo llvm-cov` on its
+own coverage lanes, and preserve doc-test signal explicitly with
+`cargo test --doc` where needed. Do not add `--all-features` back onto the
+ordinary PR lane when opt-in heavy features such as `slow-proof-tests` are
+being used to keep proof-materialization surfaces out of routine validation.
 
 ### Issue-Class Validation Rule
 

--- a/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
@@ -24,6 +24,22 @@ and makes the full-coverage trigger explicit and reviewable:
 - pushes to `main`, nightly automation, and other non-PR events still run the
   authoritative full coverage workflow
 
+## Current Cost Center
+
+After the coverage split and slow-proof isolation landed, the ordinary PR path
+still had one obvious long pole: the non-coverage `adl-ci` test step.
+
+Observed on successful run `24903573520` for PR `#2517`:
+
+- `adl-ci`: about `13m17s`
+- `clippy`: about `66s`
+- `test`: about `10m37s`
+- `demo smoke`: about `43s`
+
+That run is important because it shows the remaining bottleneck was not the
+coverage lane. The ordinary `cargo nextest run` sweep itself was still too
+broad for bounded PRs.
+
 ## Stable Check Names
 
 The required PR checks remain:
@@ -120,6 +136,41 @@ Pushes to `main` and nightly coverage:
 - run full validation and full coverage
 - avoid a second standalone full `cargo test` when the full coverage lane is
   already executing the Rust test suite
+
+## Ordinary PR-Fast Test Runner
+
+The ordinary non-coverage test step now runs through:
+
+```bash
+adl/tools/run_pr_fast_test_lane.sh
+```
+
+This runner is intentionally conservative:
+
+- it computes the changed surface from the PR base/head SHAs
+- it uses a focused `cargo nextest` expression only when every changed fast-lane
+  surface maps to a bounded token set
+- it fails closed to the full ordinary nextest sweep when the change is broad,
+  ambiguous, or touches too many independently-filtered modules
+
+Focused fast-lane cases currently include bounded slices such as:
+
+- individual `runtime_v2` module files
+- bounded CLI command files
+- publication-control-plane docs that intentionally route to the `pr_cmd`
+  validation slice
+
+Fail-closed full-lane cases include:
+
+- broad entry surfaces such as `adl/src/lib.rs`, `adl/src/main.rs`,
+  `adl/src/runtime_v2/mod.rs`, and `adl/src/schema.rs`
+- test-harness and integration surfaces under `adl/tests/`
+- unmapped nested source paths
+- PRs that would need more than four focused test tokens
+
+The goal is not to guess. The goal is to use a smaller truthful lane when the
+changed surface is obvious and bounded, and otherwise keep the prior full
+ordinary lane.
 
 ## Coverage Behavior
 


### PR DESCRIPTION
Closes #2506

## Summary
- route the ordinary PR test step through a fail-closed PR-fast lane runner
- add a shell contract test for focused vs full-lane planning
- document the remaining adl-ci cost center and the new bounded fallback policy

## Validation
- bash adl/tools/test_run_pr_fast_test_lane.sh
- bash adl/tools/test_ci_runtime_contracts.sh
- bash adl/tools/test_ci_path_policy.sh
- bash -n adl/tools/run_pr_fast_test_lane.sh adl/tools/test_run_pr_fast_test_lane.sh adl/tools/test_ci_runtime_contracts.sh adl/tools/test_ci_path_policy.sh
- git diff --check