### PR TITLE
[v0.90.4][backlog][coverage] Resolve daily coverage blockers for 2026-04-24

### DIFF
--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::cli::pr_cmd::github::{
-    current_pr_url, ensure_or_repair_pr_closing_linkage, ensure_pr_closing_linkage,
-    pr_has_closing_linkage,
+    attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
+    ensure_or_repair_pr_closing_linkage, ensure_pr_closing_linkage, pr_has_closing_linkage,
 };
 
 #[test]
@@ -872,4 +872,192 @@ fn ensure_or_repair_pr_closing_linkage_repairs_live_pr_body() {
     assert!(repaired.contains("Closes #1153"));
     let gh_calls = fs::read_to_string(&gh_log).expect("read gh log");
     assert!(gh_calls.contains("pr edit -R danielbaustin/agent-design-language https://github.com/danielbaustin/agent-design-language/pull/1159 --body-file"));
+}
+
+#[test]
+fn ensure_pr_closing_linkage_errors_when_pr_body_has_no_issue_reference() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-missing-linkage");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_path = bin_dir.join("gh");
+    write_executable(
+        &gh_path,
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    exit 0\n  fi\n  if printf '%s ' \"$@\" | grep -q ' --json body '; then\n    printf 'Refs #9999\\n'\n    exit 0\n  fi\nfi\nexit 1\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let err = ensure_pr_closing_linkage(
+        "danielbaustin/agent-design-language",
+        "https://github.com/danielbaustin/agent-design-language/pull/1159",
+        1153,
+        false,
+    )
+    .expect_err("missing linkage should fail");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(err
+        .to_string()
+        .contains("missing closing linkage to issue #1153"));
+}
+
+#[test]
+fn ensure_or_repair_pr_closing_linkage_is_noop_when_no_close_is_set() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-no-close");
+    let body_file = temp.join("desired.md");
+    fs::write(&body_file, "Refs #1153\n").expect("body");
+
+    let repaired = ensure_or_repair_pr_closing_linkage(
+        "danielbaustin/agent-design-language",
+        "https://github.com/danielbaustin/agent-design-language/pull/1159",
+        1153,
+        true,
+        &body_file,
+    )
+    .expect("no-close should skip linkage repair");
+
+    assert!(!repaired);
+}
+
+#[test]
+fn ensure_or_repair_pr_closing_linkage_is_noop_when_linkage_already_exists() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-linkage-already-present");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1153\\n'\n    exit 0\n  fi\n  if printf '%s ' \"$@\" | grep -q ' --json body '; then\n    printf 'Closes #1153\\n'\n    exit 0\n  fi\nfi\nif [ \"$1 $2\" = 'pr edit' ]; then\n  exit 99\nfi\nexit 1\n",
+            gh_log.display()
+        ),
+    );
+    let body_file = temp.join("desired.md");
+    fs::write(&body_file, "Closes #1153\n").expect("body");
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let repaired = ensure_or_repair_pr_closing_linkage(
+        "danielbaustin/agent-design-language",
+        "https://github.com/danielbaustin/agent-design-language/pull/1159",
+        1153,
+        false,
+        &body_file,
+    )
+    .expect("existing linkage should not require repair");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(!repaired);
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(!gh_log.contains("pr edit -R"));
+}
+
+#[test]
+fn attach_pr_janitor_reports_failure_output() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-attach-janitor-failure");
+    let repo = temp.join("repo");
+    let tools_dir = repo.join("adl/tools");
+    fs::create_dir_all(&tools_dir).expect("tools dir");
+    write_executable(
+        &tools_dir.join("attach_pr_janitor.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'janitor stdout'\necho 'janitor stderr' >&2\nexit 17\n",
+    );
+
+    let old_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
+    unsafe {
+        env::remove_var("ADL_PR_JANITOR_CMD");
+        env::set_var("ADL_PR_JANITOR_DISABLE", "0");
+    }
+
+    let err = attach_pr_janitor(
+        &repo,
+        "owner/repo",
+        1153,
+        "codex/1153-rust-finish-test",
+        "https://github.com/owner/repo/pull/1159",
+        "draft",
+    )
+    .expect_err("failing janitor helper should bubble up");
+
+    unsafe {
+        if let Some(value) = old_disable {
+            env::set_var("ADL_PR_JANITOR_DISABLE", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
+        if let Some(value) = old_cmd {
+            env::set_var("ADL_PR_JANITOR_CMD", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_CMD");
+        }
+    }
+
+    let message = err.to_string();
+    assert!(message.contains("PR janitor auto-attach failed"));
+    assert!(message.contains("janitor stderr"));
+    assert!(message.contains("stdout: janitor stdout"));
+}
+
+#[test]
+fn attach_post_merge_closeout_reports_failure_output() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-attach-closeout-failure");
+    let repo = temp.join("repo");
+    let tools_dir = repo.join("adl/tools");
+    fs::create_dir_all(&tools_dir).expect("tools dir");
+    write_executable(
+        &tools_dir.join("attach_post_merge_closeout.sh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'closeout stdout'\necho 'closeout stderr' >&2\nexit 18\n",
+    );
+
+    let old_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
+    let old_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    unsafe {
+        env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
+    }
+
+    let err = attach_post_merge_closeout(
+        &repo,
+        "owner/repo",
+        1153,
+        "codex/1153-rust-finish-test",
+        "https://github.com/owner/repo/pull/1159",
+    )
+    .expect_err("failing closeout helper should bubble up");
+
+    unsafe {
+        if let Some(value) = old_disable {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_DISABLE");
+        }
+        if let Some(value) = old_cmd {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
+        }
+    }
+
+    let message = err.to_string();
+    assert!(message.contains("post-merge closeout auto-attach failed"));
+    assert!(message.contains("closeout stderr"));
+    assert!(message.contains("stdout: closeout stdout"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -285,13 +285,9 @@ fn unresolved_milestone_pr_wave_filters_by_version_queue_and_excluded_branch() {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
     }
 
-    let prs = unresolved_milestone_pr_wave(
-        "danielbaustin/agent-design-language",
-        "v0.90.4",
-        "wp",
-        None,
-    )
-    .expect("runtime wave");
+    let prs =
+        unresolved_milestone_pr_wave("danielbaustin/agent-design-language", "v0.90.4", "wp", None)
+            .expect("runtime wave");
 
     unsafe {
         env::set_var("PATH", old_path);

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -255,7 +255,7 @@ fn unresolved_milestone_pr_wave_filters_by_version_queue_and_excluded_branch() {
     fs::create_dir_all(&bin_dir).expect("bin dir");
     write_executable(
         &bin_dir.join("gh"),
-        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'pr list' ]; then\n  cat <<'EOF'\n[\n  {\n    \"number\": 101,\n    \"title\": \"[v0.90.4][WP-15] Quality gate, docs, and review convergence\",\n    \"url\": \"https://example.invalid/pr/101\",\n    \"headRefName\": \"codex/2435-v0-90-4-wp-15-quality-gate-docs-and-review-convergence\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": true\n  },\n  {\n    \"number\": 102,\n    \"title\": \"[v0.90.4][WP-02] Economics inheritance and authority audit\",\n    \"url\": \"https://example.invalid/pr/102\",\n    \"headRefName\": \"codex/2421-v0-90-4-wp-02-economics-inheritance-and-authority-audit\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": false\n  },\n  {\n    \"number\": 103,\n    \"title\": \"[v0.90.3][WP-15] Older milestone tail\",\n    \"url\": \"https://example.invalid/pr/103\",\n    \"headRefName\": \"codex/old-tail\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": false\n  },\n  {\n    \"number\": 104,\n    \"title\": \"[v0.90.4][WP-15] Wrong base\",\n    \"url\": \"https://example.invalid/pr/104\",\n    \"headRefName\": \"codex/wrong-base\",\n    \"baseRefName\": \"release\",\n    \"isDraft\": false\n  }\n]\nEOF\n  exit 0\nfi\nexit 1\n",
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'pr list' ]; then\n  cat <<'EOF'\n[\n  {\n    \"number\": 101,\n    \"title\": \"[v0.90.4][docs] Quality gate, docs, and review convergence\",\n    \"url\": \"https://example.invalid/pr/101\",\n    \"headRefName\": \"codex/2435-v0-90-4-wp-15-quality-gate-docs-and-review-convergence\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": true\n  },\n  {\n    \"number\": 102,\n    \"title\": \"[v0.90.4][WP-02] Runtime economics inheritance and authority audit\",\n    \"url\": \"https://example.invalid/pr/102\",\n    \"headRefName\": \"codex/2421-v0-90-4-wp-02-economics-inheritance-and-authority-audit\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": false\n  },\n  {\n    \"number\": 103,\n    \"title\": \"[v0.90.3][WP-15] Older milestone tail\",\n    \"url\": \"https://example.invalid/pr/103\",\n    \"headRefName\": \"codex/old-tail\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": false\n  },\n  {\n    \"number\": 104,\n    \"title\": \"[v0.90.4][WP-15] Wrong base\",\n    \"url\": \"https://example.invalid/pr/104\",\n    \"headRefName\": \"codex/wrong-base\",\n    \"baseRefName\": \"release\",\n    \"isDraft\": false\n  }\n]\nEOF\n  exit 0\nfi\nexit 1\n",
     );
 
     let old_path = env::var("PATH").unwrap_or_default();
@@ -288,7 +288,7 @@ fn unresolved_milestone_pr_wave_filters_by_version_queue_and_excluded_branch() {
     let prs = unresolved_milestone_pr_wave(
         "danielbaustin/agent-design-language",
         "v0.90.4",
-        "runtime",
+        "wp",
         None,
     )
     .expect("runtime wave");
@@ -299,7 +299,7 @@ fn unresolved_milestone_pr_wave_filters_by_version_queue_and_excluded_branch() {
 
     assert_eq!(prs.len(), 1);
     assert_eq!(prs[0].number, 102);
-    assert_eq!(prs[0].queue.as_deref(), Some("runtime"));
+    assert_eq!(prs[0].queue.as_deref(), Some("wp"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::cli::pr_cmd::github::current_pr_url;
+use crate::cli::pr_cmd::github::{current_pr_url, OpenPullRequest};
 
 #[test]
 fn issue_create_repo_requires_github_origin_remote() {
@@ -248,6 +248,83 @@ fn issue_version_prefers_labels_and_falls_back_to_title() {
 }
 
 #[test]
+fn unresolved_milestone_pr_wave_filters_by_version_queue_and_excluded_branch() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-unresolved-wave");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    write_executable(
+        &bin_dir.join("gh"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'pr list' ]; then\n  cat <<'EOF'\n[\n  {\n    \"number\": 101,\n    \"title\": \"[v0.90.4][WP-15] Quality gate, docs, and review convergence\",\n    \"url\": \"https://example.invalid/pr/101\",\n    \"headRefName\": \"codex/2435-v0-90-4-wp-15-quality-gate-docs-and-review-convergence\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": true\n  },\n  {\n    \"number\": 102,\n    \"title\": \"[v0.90.4][WP-02] Economics inheritance and authority audit\",\n    \"url\": \"https://example.invalid/pr/102\",\n    \"headRefName\": \"codex/2421-v0-90-4-wp-02-economics-inheritance-and-authority-audit\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": false\n  },\n  {\n    \"number\": 103,\n    \"title\": \"[v0.90.3][WP-15] Older milestone tail\",\n    \"url\": \"https://example.invalid/pr/103\",\n    \"headRefName\": \"codex/old-tail\",\n    \"baseRefName\": \"main\",\n    \"isDraft\": false\n  },\n  {\n    \"number\": 104,\n    \"title\": \"[v0.90.4][WP-15] Wrong base\",\n    \"url\": \"https://example.invalid/pr/104\",\n    \"headRefName\": \"codex/wrong-base\",\n    \"baseRefName\": \"release\",\n    \"isDraft\": false\n  }\n]\nEOF\n  exit 0\nfi\nexit 1\n",
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let prs = unresolved_milestone_pr_wave(
+        "danielbaustin/agent-design-language",
+        "v0.90.4",
+        "docs",
+        Some("codex/2435-v0-90-4-wp-15-quality-gate-docs-and-review-convergence"),
+    )
+    .expect("wave");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert!(
+        prs.is_empty(),
+        "excluded docs branch should leave no matching PRs"
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let prs = unresolved_milestone_pr_wave(
+        "danielbaustin/agent-design-language",
+        "v0.90.4",
+        "runtime",
+        None,
+    )
+    .expect("runtime wave");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].number, 102);
+    assert_eq!(prs[0].queue.as_deref(), Some("runtime"));
+}
+
+#[test]
+fn format_open_pr_wave_marks_draft_and_unknown_queue() {
+    let mut pr = OpenPullRequest {
+        number: 101,
+        title: "[v0.90.4][WP-15] Quality gate, docs, and review convergence".to_string(),
+        url: "https://example.invalid/pr/101".to_string(),
+        head_ref_name: "codex/2435-v0-90-4-wp-15-quality-gate-docs-and-review-convergence"
+            .to_string(),
+        base_ref_name: "main".to_string(),
+        is_draft: true,
+        queue: Some("docs".to_string()),
+    };
+    let rendered = format_open_pr_wave(&[pr.clone()]);
+    assert!(rendered.contains("#101 [draft] [queue=docs]"));
+    assert!(rendered.contains("https://example.invalid/pr/101"));
+
+    pr.queue = None;
+    pr.is_draft = false;
+    let rendered = format_open_pr_wave(&[pr]);
+    assert!(rendered.contains("#101 [ready] [queue=unknown]"));
+}
+
+#[test]
 fn ensure_source_issue_prompt_replaces_existing_bootstrap_stub_when_github_body_is_authored() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-replace-bootstrap-stub");
@@ -442,6 +519,61 @@ fn real_pr_init_repairs_missing_version_metadata_on_github_issue() {
         gh_log.contains("issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity")
     );
     assert!(gh_log.contains("issue edit 1153 -R owner/repo --add-label version:v0.87.1"));
+}
+
+#[test]
+fn ensure_issue_metadata_parity_errors_when_drift_remains_after_repair() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-metadata-parity-drift-remains");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    let title_state = temp.join("gh-title.txt");
+    let labels_state = temp.join("gh-labels.txt");
+    fs::write(&title_state, "[tools] Metadata parity\n").expect("seed title");
+    fs::write(
+        &labels_state,
+        "track:roadmap\ntype:task\narea:tools\nversion:v0.86\n",
+    )
+    .expect("seed labels");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nTITLE_FILE='{}'\nLABELS_FILE='{}'\nread_title() {{ cat \"$TITLE_FILE\"; }}\nread_labels() {{ cat \"$LABELS_FILE\"; }}\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json title -q .title\"* ]]; then\n  read_title\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json labels -q .labels[].name\"* ]]; then\n  read_labels\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity\"* ]]; then\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo\"* && \"$*\" == *\"--add-label version:v0.87.1\"* ]]; then\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo\"* && \"$*\" == *\"--remove-label version:v0.86\"* ]]; then\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            title_state.display(),
+            labels_state.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let err = ensure_issue_metadata_parity(
+        "owner/repo",
+        1153,
+        "[v0.87.1][tools] Metadata parity",
+        "track:roadmap,type:task,area:tools,version:v0.87.1",
+    )
+    .expect_err("drift should remain when gh edits are ineffective");
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let message = err.to_string();
+    assert!(
+        message.contains("title mismatch after metadata parity enforcement")
+            || message.contains("metadata drift remains after parity enforcement")
+    );
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(
+        gh_log.contains("issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity")
+    );
+    assert!(gh_log.contains("issue edit 1153 -R owner/repo --add-label version:v0.87.1"));
+    assert!(gh_log.contains("issue edit 1153 -R owner/repo --remove-label version:v0.86"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #2526

## Summary
- add focused coverage tests for PR helper failure and no-op paths that were still lightly exercised
- cover metadata parity drift failure, existing-closing-linkage no-op, and janitor/closeout auto-attach failure reporting
- keep the fix bounded to the control-plane helpers instead of chasing stale runtime blocker signals

## Validation
- cargo fmt --manifest-path adl/Cargo.toml
- cargo test --manifest-path adl/Cargo.toml ensure_issue_metadata_parity_errors_when_drift_remains_after_repair -- --nocapture
- cargo test --manifest-path adl/Cargo.toml ensure_or_repair_pr_closing_linkage_is_noop_when_linkage_already_exists -- --nocapture
- cargo test --manifest-path adl/Cargo.toml attach_pr_janitor_reports_failure_output -- --nocapture
- cargo test --manifest-path adl/Cargo.toml attach_post_merge_closeout_reports_failure_output -- --nocapture

## Notes
- I did not run the full Rust cycle because this issue is a focused coverage backfill for specific helper branches, not a broad runtime change.
- The daily blocker report that spawned this work was partly stale; the landed tests target the still-real CLI/control-plane gaps.
