### PR TITLE
[v0.90.4][runtime] Enforce required denial coverage membership in external counterparty negative cases

### DIFF
--- a/adl/src/runtime_v2/external_counterparty.rs
+++ b/adl/src/runtime_v2/external_counterparty.rs
@@ -703,6 +703,7 @@ impl RuntimeV2ExternalCounterpartyNegativeCases {
         }
 
         let mut seen_cases = BTreeSet::new();
+        let expected_case_ids = expected_external_counterparty_negative_case_ids();
         for case in &self.required_negative_cases {
             case.validate()?;
             if !seen_cases.insert(case.case_id.clone()) {
@@ -725,6 +726,11 @@ impl RuntimeV2ExternalCounterpartyNegativeCases {
                     err
                 ));
             }
+        }
+        if seen_cases != expected_case_ids {
+            return Err(anyhow!(
+                "external_counterparty_negative_cases must preserve the reviewed denial coverage membership"
+            ));
         }
         Ok(())
     }
@@ -987,6 +993,19 @@ fn validate_counterparty_actions(values: &[String]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn expected_external_counterparty_negative_case_ids() -> BTreeSet<String> {
+    [
+        "mismatched-assurance-claim",
+        "mismatched-revocation-claim",
+        "missing-gateway",
+        "private-state-inspection-attempt",
+        "tool-mediated-action-outside-allowed-scope",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
 fn validate_human_action_mode(value: &str) -> Result<()> {

--- a/adl/src/runtime_v2/tests/external_counterparty.rs
+++ b/adl/src/runtime_v2/tests/external_counterparty.rs
@@ -390,6 +390,57 @@ fn runtime_v2_external_counterparty_negative_cases_and_attempts_reject_remaining
     };
     assert!(artifacts_validation_err(duplicate_case_artifacts).contains("contains duplicate case"));
 
+    let mut missing_required_case = artifacts.negative_cases.clone();
+    missing_required_case.required_negative_cases.pop();
+    missing_required_case.required_negative_cases.push(RuntimeV2ExternalCounterpartyNegativeCase {
+        case_id: "duplicate-tool-denial-shape".to_string(),
+        counterparty_id: artifacts.model.records[0].counterparty_id.clone(),
+        attempted_action: "request_tool_review".to_string(),
+        attempted_assurance_class: artifacts.model.records[0].assurance_class.clone(),
+        sponsor_ref: artifacts.model.records[0].sponsor_ref.clone(),
+        gateway_ref: artifacts.model.records[0].gateway_ref.clone(),
+        revocation_status: artifacts.model.records[0].revocation_status.clone(),
+        private_state_access_requested: false,
+        requested_tool_capability: Some("trace_projection".to_string()),
+        human_action_mode: "trace_mediated_external_participation".to_string(),
+        expected_error_fragment:
+            "tool-mediated action is outside allowed scope for external counterparties".to_string(),
+        reviewable_evidence_ref:
+            "runtime_v2/contract_market/selection_negative_cases.json#unsupported-override-authority-shortcut"
+                .to_string(),
+    });
+    let missing_required_case_artifacts = RuntimeV2ExternalCounterpartyArtifacts {
+        model: artifacts.model.clone(),
+        negative_cases: missing_required_case,
+    };
+    assert!(artifacts_validation_err(missing_required_case_artifacts)
+        .contains("must preserve the reviewed denial coverage membership"));
+
+    let mut substituted_case = artifacts.negative_cases.clone();
+    substituted_case.required_negative_cases[2] = RuntimeV2ExternalCounterpartyNegativeCase {
+        case_id: "substituted-tool-denial-shape".to_string(),
+        counterparty_id: artifacts.model.records[0].counterparty_id.clone(),
+        attempted_action: "request_tool_review".to_string(),
+        attempted_assurance_class: artifacts.model.records[0].assurance_class.clone(),
+        sponsor_ref: artifacts.model.records[0].sponsor_ref.clone(),
+        gateway_ref: artifacts.model.records[0].gateway_ref.clone(),
+        revocation_status: artifacts.model.records[0].revocation_status.clone(),
+        private_state_access_requested: false,
+        requested_tool_capability: Some("trace_projection".to_string()),
+        human_action_mode: "trace_mediated_external_participation".to_string(),
+        expected_error_fragment:
+            "tool-mediated action is outside allowed scope for external counterparties".to_string(),
+        reviewable_evidence_ref:
+            "runtime_v2/contract_market/selection_negative_cases.json#unsupported-override-authority-shortcut"
+                .to_string(),
+    };
+    let substituted_case_artifacts = RuntimeV2ExternalCounterpartyArtifacts {
+        model: artifacts.model.clone(),
+        negative_cases: substituted_case,
+    };
+    assert!(artifacts_validation_err(substituted_case_artifacts)
+        .contains("must preserve the reviewed denial coverage membership"));
+
     let mut bad_case_artifacts = artifacts.clone();
     bad_case_artifacts.negative_cases.required_negative_cases[0].human_action_mode =
         "unsupported_mode".to_string();


### PR DESCRIPTION
Closes #2527

## Summary
Implemented the bounded WP-08 review hardening fix so the external-counterparty negative-case validator now requires the reviewed denial membership set instead of accepting any five unique failing cases.

## Artifacts
- `adl/src/runtime_v2/external_counterparty.rs`
- `adl/src/runtime_v2/tests/external_counterparty.rs`
- local execution record at `.adl/v0.90.4/tasks/issue-2527__v0-90-4-runtime-enforce-required-denial-coverage-membership-in-external-counterparty-negative-cases/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_external_counterparty -- --nocapture`
    Proved the external-counterparty negative-case validator now rejects missing or substituted reviewed denial categories while keeping the reviewed packet stable.
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Formatted the touched runtime-v2 implementation and focused regression test file.
  - `cargo clippy --manifest-path adl/Cargo.toml --tests -- -D warnings`
    Checked the touched Rust runtime/test surface for warnings that would fail CI.
  - `git diff --check`
    Checked the current diff for whitespace and patch hygiene issues.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase completed --input .adl/v0.90.4/tasks/issue-2527__v0-90-4-runtime-enforce-required-denial-coverage-membership-in-external-counterparty-negative-cases/sor.md`
    Verifies this completed execution record stays within the structured SOR contract.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2527__v0-90-4-runtime-enforce-required-denial-coverage-membership-in-external-counterparty-negative-cases/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2527__v0-90-4-runtime-enforce-required-denial-coverage-membership-in-external-counterparty-negative-cases/sor.md
- Idempotency-Key: v0-90-4-runtime-enforce-required-denial-coverage-membership-in-external-counterparty-negative-cases-adl-src-runtime-v2-external-counterparty-rs-adl-src-runtime-v2-tests-external-counterparty-rs-adl-v0-90-4-tasks-issue-2527-v0-90-4-runtime-enforce-required-denial-coverage-membership-in-external-counterparty-negative-cases-sip-md-adl-v0-90-4-tasks-issue-2527-v0-90-4-runtime-enforce-required-denial-coverage-membership-in-external-counterparty-negative-cases-sor-md