### PR TITLE
[v0.90.4][tools] Make WP-13 contract-market summary renderer fail in bounded tool-shaped ways

### DIFF
--- a/adl/tools/render_v0904_contract_market_summary.py
+++ b/adl/tools/render_v0904_contract_market_summary.py
@@ -170,11 +170,11 @@ def render_summary(schema: dict[str, Any], seed: dict[str, Any], review_bundle: 
 
 def main() -> int:
     args = parse_args()
-    seed = load_json(Path(args.seed))
-    review_bundle = load_json(Path(args.review_bundle))
-    schema = load_json(Path(args.schema))
     out_path = Path(args.out)
     try:
+        seed = load_json(Path(args.seed))
+        review_bundle = load_json(Path(args.review_bundle))
+        schema = load_json(Path(args.schema))
         rendered = render_summary(schema, seed, review_bundle)
     except RenderError as exc:
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/adl/tools/test_v0904_contract_market_summary.sh
+++ b/adl/tools/test_v0904_contract_market_summary.sh
@@ -6,9 +6,15 @@ TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-contract-market-summary.XXXXXX")"
 RUNNER_OUT_REL="$(basename "$TMP_DIR")/runner"
 RENDERED_ONE_REL="$(basename "$TMP_DIR")/rendered_one.md"
 RENDERED_TWO_REL="$(basename "$TMP_DIR")/rendered_two.md"
+MISSING_RENDER_REL="$(basename "$TMP_DIR")/rendered_missing.md"
+INVALID_REVIEW_REL="$(basename "$TMP_DIR")/invalid_review_bundle.json"
+INVALID_RENDER_REL="$(basename "$TMP_DIR")/rendered_invalid.md"
 RUNNER_OUT="$ROOT_DIR/$RUNNER_OUT_REL"
 RENDERED_ONE="$ROOT_DIR/$RENDERED_ONE_REL"
 RENDERED_TWO="$ROOT_DIR/$RENDERED_TWO_REL"
+MISSING_RENDER="$ROOT_DIR/$MISSING_RENDER_REL"
+INVALID_REVIEW="$ROOT_DIR/$INVALID_REVIEW_REL"
+INVALID_RENDER="$ROOT_DIR/$INVALID_RENDER_REL"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 cd "$ROOT_DIR"
@@ -57,5 +63,37 @@ assert "/private/" not in text
 assert "/var/" not in text
 assert "file://" not in text
 PY
+
+set +e
+MISSING_OUTPUT="$(
+  python3 adl/tools/render_v0904_contract_market_summary.py \
+    --review-bundle "$(basename "$TMP_DIR")/does_not_exist.json" \
+    --out "$MISSING_RENDER_REL" \
+    2>&1
+)"
+MISSING_STATUS=$?
+set -e
+
+test "$MISSING_STATUS" -eq 1
+[[ "$MISSING_OUTPUT" == *"contract_market_summary: fail [missing_input]"* ]]
+[[ "$MISSING_OUTPUT" != *"Traceback (most recent call last)"* ]]
+grep -F "render_failure: missing_input:" "$MISSING_RENDER"
+
+printf '{ invalid json }\n' > "$INVALID_REVIEW"
+
+set +e
+INVALID_OUTPUT="$(
+  python3 adl/tools/render_v0904_contract_market_summary.py \
+    --review-bundle "$INVALID_REVIEW_REL" \
+    --out "$INVALID_RENDER_REL" \
+    2>&1
+)"
+INVALID_STATUS=$?
+set -e
+
+test "$INVALID_STATUS" -eq 1
+[[ "$INVALID_OUTPUT" == *"contract_market_summary: fail [invalid_json]"* ]]
+[[ "$INVALID_OUTPUT" != *"Traceback (most recent call last)"* ]]
+grep -F "render_failure: invalid_json:" "$INVALID_RENDER"
 
 echo "v0.90.4 contract-market summary smoke: pass"


### PR DESCRIPTION
Closes #2533

## Summary
Moved WP-13 summary-renderer input loading under the renderer's guarded failure contract so missing or malformed input files now produce stable bounded `render_failure` output instead of raw Python tracebacks. Added focused regression coverage to the existing contract-market summary smoke test for both missing-input and invalid-JSON failure paths.

## Artifacts
- Updated renderer failure-path handling in `adl/tools/render_v0904_contract_market_summary.py`
- Extended focused tool regression coverage in `adl/tools/test_v0904_contract_market_summary.sh`
- Worktree execution record at `.adl/v0.90.4/tasks/issue-2533__v0-90-4-tools-make-wp-13-contract-market-summary-renderer-fail-in-bounded-tool-shaped-ways/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/test_v0904_contract_market_summary.sh`
    Checked shell syntax for the focused contract-market summary regression harness.
  - `bash adl/tools/test_v0904_contract_market_summary.sh`
    Proved the renderer still matches the canonical summary example on the happy path and now handles missing / invalid input files through the stable bounded failure contract.
  - `git diff --check`
    Checked for whitespace and patch hygiene problems in the bounded tooling diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2533__v0-90-4-tools-make-wp-13-contract-market-summary-renderer-fail-in-bounded-tool-shaped-ways/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2533__v0-90-4-tools-make-wp-13-contract-market-summary-renderer-fail-in-bounded-tool-shaped-ways/sor.md
- Idempotency-Key: v0-90-4-tools-make-wp-13-contract-market-summary-renderer-fail-in-bounded-tool-shaped-ways-adl-v0-90-4-tasks-issue-2533-v0-90-4-tools-make-wp-13-contract-market-summary-renderer-fail-in-bounded-tool-shaped-ways-sip-md-adl-v0-90-4-tasks-issue-2533-v0-90-4-tools-make-wp-13-contract-market-summary-renderer-fail-in-bounded-tool-shaped-ways-sor-md