### PR TITLE
[planning] Stage Python elimination across future milestones

### DIFF
--- a/docs/milestones/v0.90.5/DECISIONS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/DECISIONS_v0.90.5.md
@@ -9,3 +9,4 @@
 | D-05 | Visibility and redaction are first-class | Accepted | Tool traces and errors can leak private data | Actor, operator, reviewer, public, and Observatory views must be defined |
 | D-06 | Model testing is required | Accepted | A schema is not enough if models misuse or bypass it | Multi-model and local/Gemma tests are part of the milestone |
 | D-07 | v0.90.3 owns the inhabited CSM demo | Accepted | Citizen-state demo and tools demo have different proof surfaces | v0.90.5 gets a governed-tools flagship demo instead |
+| D-08 | Python elimination is a cross-milestone burn-down, not a dedicated `v0.90.5` gate | Accepted | A single rewrite milestone would stall roadmap delivery and consume too much issue, review, and CI ceremony | `v0.90.5` stays Governed Tools v1.0 while each later milestone reserves bounded Python-reduction capacity |

--- a/docs/milestones/v0.90.5/README.md
+++ b/docs/milestones/v0.90.5/README.md
@@ -11,6 +11,22 @@ source for a later WP-01 issue-wave creation pass. It is intended to be the
 next immediately executable planning package after v0.90.4 closeout, not a
 half-managed later idea lane.
 
+## Parallel Python Reduction Tranche
+
+v0.90.5 should remain Governed Tools v1.0. It should not be repurposed into a
+stop-the-world Python rewrite gate.
+
+Instead, the milestone should reserve a small bounded Python-reduction tranche
+alongside the main governed-tools work. The cross-milestone policy is recorded
+in [Python Elimination Staged Plan](../../planning/PYTHON_ELIMINATION_STAGED_PLAN.md).
+
+The expected `v0.90.5` Python tranche is:
+
+- freeze and no-new-tracked-Python discipline
+- inventory and disposition truth surface
+- one high-leverage Rust port or delete wave for a coherent Python tooling
+  family
+
 ## Thesis
 
 v0.90.5 should make tools a first-class governed ADL primitive.

--- a/docs/milestones/v0.90.5/WBS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/WBS_v0.90.5.md
@@ -30,6 +30,21 @@ documentation-only planning lane.
 | WP-19 | planned | Quality, docs, review, and public-spec handoff | Align docs, conformance, feature docs, review packets, public-spec language, and accepted-finding routing | review-ready package and finding register | WP-18A |
 | WP-20 | planned | Release ceremony | Complete release closure and next handoff | release evidence, end-of-milestone report, and next handoff | WP-19 |
 
+## Parallel Python Reduction Tranche
+
+v0.90.5 should reserve bounded capacity for Python elimination without turning
+the milestone into a Python-only rewrite band. The cross-milestone program is
+recorded in [Python Elimination Staged Plan](../../planning/PYTHON_ELIMINATION_STAGED_PLAN.md).
+
+Recommended `v0.90.5` tranche:
+
+- freeze and no-new-tracked-Python rule
+- Python inventory and disposition truth surface
+- one coherent high-leverage Rust port or deletion wave
+
+Exact issue selection should happen at issue-wave time based on the current
+Python inventory, milestone pressure, and what can be finished truthfully.
+
 ## Compression Candidate
 
 The milestone can compress after UTS, ACC, fixtures, and compiler contracts are

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -59,6 +59,19 @@ v0.91 depends on:
 - v0.93 as a downstream consumer of moral evidence for constitutional
   citizenship, polis governance, social cognition, and review institutions
 
+## Parallel Python Reduction Tranche
+
+v0.91 should preserve room for a bounded Python-reduction tranche alongside the
+moral-governance milestone. The cross-milestone rule is recorded in
+[Python Elimination Staged Plan](../../planning/PYTHON_ELIMINATION_STAGED_PLAN.md).
+
+The likely `v0.91` tranche is:
+
+- validators and renderers that still sit in Python
+- proof and review surfaces used in milestone or release truth
+- one coherent family that reduces Python dependence in review and evidence
+  flow
+
 ## Scope Summary
 
 ### In scope

--- a/docs/milestones/v0.92/README.md
+++ b/docs/milestones/v0.92/README.md
@@ -57,6 +57,19 @@ v0.92 depends on:
 - v0.93 as a downstream consumer of identity evidence for constitutional
   citizenship and polis governance
 
+## Parallel Python Reduction Tranche
+
+v0.92 should also carry a bounded Python-reduction tranche. The cross-milestone
+rule is recorded in
+[Python Elimination Staged Plan](../../planning/PYTHON_ELIMINATION_STAGED_PLAN.md).
+
+The likely `v0.92` tranche is:
+
+- provider mocks and adapter cleanup
+- bridge or protocol leftovers that still sit in Python
+- edge-surface deletion or Rust replacement that is easier to finish after the
+  earlier control-plane waves land
+
 ## Scope Summary
 
 ### In scope

--- a/docs/milestones/v0.93/README.md
+++ b/docs/milestones/v0.93/README.md
@@ -43,6 +43,18 @@ v0.93 depends on:
 - v0.90.4 and v0.90.5 only where economics or governed-tool authority has
   landed before v0.93
 
+## Parallel Python Reduction Tranche
+
+v0.93 should preserve room for the final Python-burn-down tranche if the
+footprint has not already reached zero. The cross-milestone rule is recorded in
+[Python Elimination Staged Plan](../../planning/PYTHON_ELIMINATION_STAGED_PLAN.md).
+
+The likely `v0.93` tranche is:
+
+- remaining low-count helpers and odd one-off scripts
+- CI zero-tracked-Python enforcement if the footprint is already near zero
+- parity audit and final cleanup rather than another large migration wave
+
 ## Scope Summary
 
 ### In scope

--- a/docs/planning/PYTHON_ELIMINATION_STAGED_PLAN.md
+++ b/docs/planning/PYTHON_ELIMINATION_STAGED_PLAN.md
@@ -1,0 +1,181 @@
+# Python Elimination Staged Plan
+
+Date: 2026-04-24
+
+## Decision
+
+ADL should not turn Python elimination into a single dedicated milestone gate.
+
+That shape would:
+
+- stall milestone delivery too hard
+- consume too much issue and review ceremony
+- amplify CI frustration and rate-limit burn during a period when the roadmap
+  still needs to ship meaningful work
+- increase the risk that the migration itself becomes destabilizing
+
+Instead, `v0.90.5` should remain Governed Tools v1.0, and Python elimination
+should become a managed cross-milestone burn-down program.
+
+## Program Rule
+
+From `v0.90.5` forward:
+
+- every milestone should carry a small bounded Python-reduction tranche
+- every tranche should delete or replace a coherent family of Python surfaces
+- no new tracked Python should be added unless explicitly waived
+- the tracked Python file and LOC counts should trend downward every milestone
+
+This keeps product momentum while still reducing structural risk.
+
+## Budget Rule
+
+Recommended budget:
+
+- normal milestone: `2` to `4` Python-reduction WPs
+- heavy feature milestone: `1` to `2` Python-reduction WPs
+- lighter planning or docs milestone: up to `4` or `5` if capacity exists
+
+Python elimination should normally stay under about `15%` to `25%` of a
+milestone unless a specific emergency requires more.
+
+## Migration Rule
+
+For each Python tranche:
+
+- prefer porting or deleting a whole surface family, not random files
+- prefer delete-or-collapse over literal transliteration
+- require parity proof only for live behavior that still matters
+- if a Python file is stale, remove it instead of honoring it with a Rust twin
+
+## Milestone Allocation
+
+### v0.90.5
+
+Primary milestone:
+
+- Governed Tools v1.0
+
+Python tranche:
+
+- freeze and no-new-Python rule
+- inventory and disposition truth surface
+- one high-leverage tooling family
+
+Goal:
+
+- start the burn-down without letting it dominate the milestone
+
+### v0.90.6
+
+Primary milestone:
+
+- follow-on governed-tools or adjacent runtime work
+
+Python tranche:
+
+- biggest control-plane Python families that still remain
+
+Goal:
+
+- remove the most structurally dangerous Python first
+
+### v0.91
+
+Primary milestone:
+
+- moral governance and wellbeing foundations
+
+Python tranche:
+
+- validators, renderers, and proof surfaces used by milestone and review flow
+
+Goal:
+
+- stop relying on Python for proof and release truth
+
+### v0.92
+
+Primary milestone:
+
+- identity, memory grounding, and birthday
+
+Python tranche:
+
+- provider mocks, adapters, bridge cleanup, and odd edge surfaces
+
+Goal:
+
+- finish the weird families that are easy to leave behind
+
+### v0.93
+
+Primary milestone:
+
+- constitutional citizenship, ToM, reputation, and polis governance
+
+Python tranche:
+
+- remaining low-count leftovers
+- CI zero-Python gate if the footprint is already near zero
+
+Goal:
+
+- make zero tracked Python realistic without delaying the social stack
+
+### v0.94
+
+Primary milestone:
+
+- publication, review hardening, and broader polish bands
+
+Python tranche:
+
+- final cleanup only if needed
+
+Goal:
+
+- Python count should be zero by or before here
+
+## Surface Priority
+
+Migrate by structural risk, not by raw file count alone:
+
+1. workflow and control-plane skill scripts
+2. repo packet and review planning
+3. review-quality and report assembly
+4. validators and renderers used in milestone or release truth
+5. demo runners and benchmark helpers
+6. provider mocks and adapters
+7. fixture protocols and tiny leftovers
+
+## Milestone-Level Success Metric
+
+Each milestone should record:
+
+- tracked Python file count at start
+- tracked Python file count at end
+- tracked Python LOC at start
+- tracked Python LOC at end
+- which Python families were eliminated or reduced
+- which families remain
+
+If a milestone does not reduce the Python footprint, that should be explicit and
+justified.
+
+## Working Policy
+
+Effective policy recommendation:
+
+- do not add new tracked Python by default
+- if a temporary Python exception is truly needed, it must name:
+  - owner
+  - rationale
+  - removal milestone
+- default answer remains Rust first
+
+## Bottom Line
+
+Python elimination is important, but it should behave like a managed
+debt-retirement program inside the roadmap, not like a milestone that eclipses
+the roadmap.

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -10,6 +10,9 @@ Active planning docs:
 
 - `ADL_FEATURE_LIST.md` - full feature list, current status, implemented gaps,
   and target completion milestones through `v0.95`
+- `PYTHON_ELIMINATION_STAGED_PLAN.md` - cross-milestone staged reduction plan
+  for retiring tracked Python without turning the roadmap into a stop-the-world
+  rewrite
 - `ROADMAP_RUNTIME_V2_AND_BIRTHDAY_BOUNDARY.md` - cross-milestone Runtime v2,
   v0.91 moral/emotional, and v0.92 birthday boundary roadmap
 


### PR DESCRIPTION
## Summary

Stage Python elimination as a cross-milestone burn-down instead of turning v0.90.5 into a stop-the-world gate milestone.

## What changed

- add a tracked cross-milestone Python elimination plan under docs/planning
- keep v0.90.5 as Governed Tools v1.0
- add bounded Python-reduction tranche language to v0.90.5, v0.91, v0.92, and v0.93 milestone docs
- record the governing decision in the v0.90.5 decisions log
- update the planning index so the staged plan is part of the tracked planning surface

## Why

A single Python rewrite milestone would consume too much ceremony, CI time, and roadmap momentum. This keeps product work moving while still forcing the Python footprint down every milestone.

## Validation

- git diff --check
- tracked-doc scan for stray local .adl path leakage on the changed surfaces

## Notes

This PR is planning truth only. It does not start the Python conversion work itself.