### PR TITLE
[v0.90.4][backlog][tools] Split ordinary Rust fallback validation into bounded families

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -23,8 +23,10 @@ Options:
   -h, --help                   Show this help.
 
 This script selects the ordinary PR-fast non-coverage Rust test lane.
-It fails closed to the full nextest sweep unless every changed Rust surface
-maps to a bounded focused filter expression.
+It prefers:
+  1. focused nextest filters for small, precisely-mapped changes
+  2. bounded family filters for broader-but-still-bounded changes
+  3. the full nextest sweep only for broad or ambiguous changes
 USAGE
 }
 
@@ -218,6 +220,25 @@ filter_token_for_path() {
   return 1
 }
 
+family_token_for_path() {
+  local path="$1"
+  case "$path" in
+    adl/src/runtime_v2/*)
+      printf 'runtime_v2'
+      return 0
+      ;;
+    adl/src/cli/*)
+      printf 'cli'
+      return 0
+      ;;
+    adl/src/demo/*)
+      printf 'demo'
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 build_filter_expression() {
   python3 - "$@" <<'PY'
 import sys
@@ -240,13 +261,28 @@ token_already_seen() {
   return 1
 }
 
+family_token_already_seen() {
+  local needle="$1"
+  local token
+  for token in "${family_tokens[@]:-}"; do
+    if [ "$token" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 mode="full"
 reason="ordinary_pr_fast_lane_fails_closed_to_full_nextest"
 filter_tokens=""
 filter_expression=""
 rust_surface_count=0
+all_paths_have_precise_token=true
+all_paths_have_family_token=true
+classification_locked=false
 
 declare -a tokens=()
+declare -a family_tokens=()
 
 while IFS= read -r path; do
   [ -n "$path" ] || continue
@@ -257,17 +293,24 @@ while IFS= read -r path; do
   if is_broad_rust_surface "$path"; then
     mode="full"
     reason="broad_rust_surface_requires_full_nextest"
+    classification_locked=true
     tokens=()
+    family_tokens=()
     break
   fi
-  if ! token="$(filter_token_for_path "$path")"; then
-    mode="full"
-    reason="unmapped_rust_surface_requires_full_nextest"
-    tokens=()
-    break
+  if token="$(filter_token_for_path "$path")"; then
+    if ! token_already_seen "$token"; then
+      tokens+=("$token")
+    fi
+  else
+    all_paths_have_precise_token=false
   fi
-  if ! token_already_seen "$token"; then
-    tokens+=("$token")
+  if family_token="$(family_token_for_path "$path")"; then
+    if ! family_token_already_seen "$family_token"; then
+      family_tokens+=("$family_token")
+    fi
+  else
+    all_paths_have_family_token=false
   fi
 done <<EOF
 $(changed_rows \
@@ -275,19 +318,39 @@ $(changed_rows \
   | awk -F '\t' 'NF >= 2 { print $2 }')
 EOF
 
-if [ "$rust_surface_count" -eq 0 ]; then
+if [ "$classification_locked" = true ]; then
+  :
+elif [ "$rust_surface_count" -eq 0 ]; then
   mode="full"
   reason="no_relevant_rust_surface_detected_for_fast_lane"
-elif [ "${#tokens[@]}" -gt 0 ]; then
+elif [ "$all_paths_have_precise_token" = true ] && [ "${#tokens[@]}" -gt 0 ]; then
   if [ "${#tokens[@]}" -le 4 ]; then
     mode="focused"
     reason="bounded_rust_surface_runs_focused_nextest"
     filter_expression="$(build_filter_expression "${tokens[@]}")"
     filter_tokens="$(printf '%s\n' "${tokens[@]}" | paste -sd, -)"
+  elif [ "$all_paths_have_family_token" = true ] && [ "${#family_tokens[@]}" -gt 0 ] && [ "${#family_tokens[@]}" -le 3 ]; then
+    mode="family"
+    reason="bounded_rust_surface_runs_family_nextest"
+    filter_expression="$(build_filter_expression "${family_tokens[@]}")"
+    filter_tokens="$(printf '%s\n' "${family_tokens[@]}" | paste -sd, -)"
   else
     mode="full"
     reason="too_many_focused_filters_require_full_nextest"
   fi
+elif [ "$all_paths_have_family_token" = true ] && [ "${#family_tokens[@]}" -gt 0 ]; then
+  if [ "${#family_tokens[@]}" -le 3 ]; then
+    mode="family"
+    reason="bounded_family_surface_runs_family_nextest"
+    filter_expression="$(build_filter_expression "${family_tokens[@]}")"
+    filter_tokens="$(printf '%s\n' "${family_tokens[@]}" | paste -sd, -)"
+  else
+    mode="full"
+    reason="too_many_family_filters_require_full_nextest"
+  fi
+else
+  mode="full"
+  reason="unmapped_rust_surface_requires_full_nextest"
 fi
 
 emit "mode" "$mode"
@@ -302,8 +365,8 @@ fi
 
 cd "$ROOT_DIR/adl"
 
-if [ "$mode" = "focused" ]; then
-  echo "Running focused nextest lane: $filter_expression"
+if [ "$mode" = "focused" ] || [ "$mode" = "family" ]; then
+  echo "Running $mode nextest lane: $filter_expression"
   cargo nextest run --status-level all --final-status-level slow -E "$filter_expression"
 else
   echo "Running full nextest lane: $reason"

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -74,13 +74,39 @@ M	adl/src/runtime_v2/inheritance.rs
 M	adl/src/runtime_v2/gateway_policies.rs
 EOF
 too_many_output="$(bash "$SCRIPT" --changed-files "$too_many" --print-plan)"
-assert_has "$too_many_output" "mode=full"
-assert_has "$too_many_output" "reason=too_many_focused_filters_require_full_nextest"
+assert_has "$too_many_output" "mode=family"
+assert_has "$too_many_output" "reason=bounded_rust_surface_runs_family_nextest"
+assert_has "$too_many_output" "filter_tokens=runtime_v2"
+assert_has "$too_many_output" "filter_expression=test(runtime_v2)"
 
 unmapped="$TMP/unmapped.txt"
 printf 'M\tadl/src/runtime_v2/subdir/nested.rs\n' >"$unmapped"
 unmapped_output="$(bash "$SCRIPT" --changed-files "$unmapped" --print-plan)"
-assert_has "$unmapped_output" "mode=full"
-assert_has "$unmapped_output" "reason=unmapped_rust_surface_requires_full_nextest"
+assert_has "$unmapped_output" "mode=family"
+assert_has "$unmapped_output" "reason=bounded_family_surface_runs_family_nextest"
+assert_has "$unmapped_output" "filter_tokens=runtime_v2"
+assert_has "$unmapped_output" "filter_expression=test(runtime_v2)"
+
+mixed_family="$TMP/mixed_family.txt"
+cat >"$mixed_family" <<'EOF'
+M	adl/src/runtime_v2/subdir/nested.rs
+M	adl/src/cli/identity_cmd/dispatch.rs
+EOF
+mixed_family_output="$(bash "$SCRIPT" --changed-files "$mixed_family" --print-plan)"
+assert_has "$mixed_family_output" "mode=family"
+assert_has "$mixed_family_output" "reason=bounded_family_surface_runs_family_nextest"
+assert_has "$mixed_family_output" "filter_tokens=runtime_v2,cli"
+assert_has "$mixed_family_output" "filter_expression=test(runtime_v2) or test(cli)"
+
+too_many_families="$TMP/too_many_families.txt"
+cat >"$too_many_families" <<'EOF'
+M	adl/src/runtime_v2/subdir/nested.rs
+M	adl/src/cli/subdir/nested.rs
+M	adl/src/demo/subdir/nested.rs
+M	adl/src/unknown.rs
+EOF
+too_many_families_output="$(bash "$SCRIPT" --changed-files "$too_many_families" --print-plan)"
+assert_has "$too_many_families_output" "mode=full"
+assert_has "$too_many_families_output" "reason=unmapped_rust_surface_requires_full_nextest"
 
 echo "PASS test_run_pr_fast_test_lane"

--- a/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
@@ -148,10 +148,12 @@ adl/tools/run_pr_fast_test_lane.sh
 This runner is intentionally conservative:
 
 - it computes the changed surface from the PR base/head SHAs
-- it uses a focused `cargo nextest` expression only when every changed fast-lane
-  surface maps to a bounded token set
-- it fails closed to the full ordinary nextest sweep when the change is broad,
-  ambiguous, or touches too many independently-filtered modules
+- it uses a focused `cargo nextest` expression when every changed fast-lane
+  surface maps to a small bounded token set
+- it uses a bounded family `cargo nextest` expression when the change is still
+  reviewably scoped but too broad for tiny token-by-token filtering
+- it fails closed to the full ordinary nextest sweep only when the change is
+  broad, ambiguous, or crosses too many fallback families
 
 Focused fast-lane cases currently include bounded slices such as:
 
@@ -166,13 +168,21 @@ Focused fast-lane cases currently include bounded slices such as:
 - publication-control-plane docs that intentionally route to the `pr_cmd`
   validation slice
 
+Bounded family fallback cases now include broader-but-still-reviewable slices
+such as:
+
+- nested or multi-module `runtime_v2` changes that can run through the
+  `runtime_v2` family lane
+- nested or mixed CLI changes that can run through the `cli` family lane
+- bounded demo-surface changes that can run through the `demo` family lane
+
 Fail-closed full-lane cases include:
 
 - broad entry surfaces such as `adl/src/lib.rs`, `adl/src/main.rs`,
   `adl/src/runtime_v2/mod.rs`, and `adl/src/schema.rs`
 - test-harness and integration surfaces under `adl/tests/`
-- unmapped nested source paths
-- PRs that would need more than four focused test tokens
+- truly unmapped source paths outside the known fallback families
+- PRs that would cross more than three fallback families
 
 The goal is not to guess. The goal is to use a smaller truthful lane when the
 changed surface is obvious and bounded, and otherwise keep the prior full


### PR DESCRIPTION
## Summary
- split the ordinary PR-fast Rust runner into `focused`, `family`, and `full` modes
- route bounded-but-broader runtime, CLI, and demo changes into family filters instead of defaulting straight to full nextest
- add shell contract coverage and document the new fallback model in the v0.90.4 CI runtime policy

## Validation
- bash adl/tools/test_run_pr_fast_test_lane.sh
- bash -n adl/tools/run_pr_fast_test_lane.sh adl/tools/test_run_pr_fast_test_lane.sh
- git diff --check

Closes #2536
