### PR TITLE
[v0.90.4][tools] Enforce repo-relative path boundaries in Sprint 3 contract-market Python tools

### DIFF
--- a/adl/tools/render_v0904_contract_market_summary.py
+++ b/adl/tools/render_v0904_contract_market_summary.py
@@ -18,6 +18,18 @@ class RenderError(Exception):
         self.message = message
 
 
+def resolve_repo_relative_path(raw: str, *, field: str) -> Path:
+    path = Path(raw)
+    if path.is_absolute():
+        raise RenderError("absolute_path_forbidden", f"{field} must be repo-relative: {raw}")
+    if any(part == ".." for part in path.parts):
+        raise RenderError(
+            "path_traversal_forbidden",
+            f"{field} must stay within repository root: {raw}",
+        )
+    return path
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Render the deterministic v0.90.4 contract-market review summary."
@@ -170,15 +182,22 @@ def render_summary(schema: dict[str, Any], seed: dict[str, Any], review_bundle: 
 
 def main() -> int:
     args = parse_args()
-    seed = load_json(Path(args.seed))
-    review_bundle = load_json(Path(args.review_bundle))
-    schema = load_json(Path(args.schema))
-    out_path = Path(args.out)
+    out_path: Path | None = None
     try:
+        seed_path = resolve_repo_relative_path(args.seed, field="--seed")
+        review_bundle_path = resolve_repo_relative_path(
+            args.review_bundle, field="--review-bundle"
+        )
+        schema_path = resolve_repo_relative_path(args.schema, field="--schema")
+        out_path = resolve_repo_relative_path(args.out, field="--out")
+        seed = load_json(seed_path)
+        review_bundle = load_json(review_bundle_path)
+        schema = load_json(schema_path)
         rendered = render_summary(schema, seed, review_bundle)
     except RenderError as exc:
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(f"render_failure: {exc.code}: {exc.message}\n")
+        if out_path is not None:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(f"render_failure: {exc.code}: {exc.message}\n")
         print(f"contract_market_summary: fail [{exc.code}]")
         return 1
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/adl/tools/run_v0904_contract_market_runner.py
+++ b/adl/tools/run_v0904_contract_market_runner.py
@@ -18,6 +18,18 @@ class RunnerError(Exception):
         self.message = message
 
 
+def resolve_repo_relative_path(raw: str, *, field: str) -> Path:
+    path = Path(raw)
+    if path.is_absolute():
+        raise RunnerError("absolute_path_forbidden", f"{field} must be repo-relative: {raw}")
+    if any(part == ".." for part in path.parts):
+        raise RunnerError(
+            "path_traversal_forbidden",
+            f"{field} must stay within repository root: {raw}",
+        )
+    return path
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run the bounded v0.90.4 contract-market fixture packet."
@@ -471,11 +483,15 @@ def build_runner_manifest(
 
 def main() -> int:
     args = parse_args()
-    fixture_root = Path(args.fixture_root)
-    negative_root = Path(args.negative_root)
-    out_root = Path(args.out)
-
+    out_root: Path | None = None
     try:
+        fixture_root = resolve_repo_relative_path(
+            args.fixture_root, field="--fixture-root"
+        )
+        negative_root = resolve_repo_relative_path(
+            args.negative_root, field="--negative-root"
+        )
+        out_root = resolve_repo_relative_path(args.out, field="--out")
         packet = validate_packet_root(fixture_root, negative_root)
         validate_contract(packet)
         transition_report = build_transition_report(packet)
@@ -505,13 +521,14 @@ def main() -> int:
         print("contract_market_runner: pass")
         return 0
     except RunnerError as exc:
-        payload = {
-            "schema": "adl.v0904.contract_market.runner_failure.v1",
-            "status": "failed",
-            "code": exc.code,
-            "message": exc.message,
-        }
-        write_json(out_root / "runner_failure.json", payload)
+        if out_root is not None:
+            payload = {
+                "schema": "adl.v0904.contract_market.runner_failure.v1",
+                "status": "failed",
+                "code": exc.code,
+                "message": exc.message,
+            }
+            write_json(out_root / "runner_failure.json", payload)
         print(f"contract_market_runner: fail [{exc.code}]")
         return 1
 

--- a/adl/tools/test_v0904_contract_market_runner.sh
+++ b/adl/tools/test_v0904_contract_market_runner.sh
@@ -5,8 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-contract-market-runner.XXXXXX")"
 OUT_ONE_REL="$(basename "$TMP_DIR")/run_one"
 OUT_TWO_REL="$(basename "$TMP_DIR")/run_two"
+TRAVERSAL_OUT_REL="../runner-escape-attempt"
 OUT_ONE="$ROOT_DIR/$OUT_ONE_REL"
 OUT_TWO="$ROOT_DIR/$OUT_TWO_REL"
+ABSOLUTE_OUT="/tmp/adl-contract-market-runner-absolute"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 cd "$ROOT_DIR"
@@ -61,5 +63,29 @@ for path in out.glob("*.json"):
     assert "tool_arguments" not in text
     assert "prompt text" not in text
 PY
+
+rm -rf "$ABSOLUTE_OUT"
+set +e
+ABSOLUTE_OUTPUT="$(
+  python3 adl/tools/run_v0904_contract_market_runner.py --out "$ABSOLUTE_OUT" 2>&1
+)"
+ABSOLUTE_STATUS=$?
+set -e
+
+test "$ABSOLUTE_STATUS" -eq 1
+[[ "$ABSOLUTE_OUTPUT" == *"contract_market_runner: fail [absolute_path_forbidden]"* ]]
+[[ "$ABSOLUTE_OUTPUT" != *"Traceback (most recent call last)"* ]]
+test ! -e "$ABSOLUTE_OUT"
+
+set +e
+TRAVERSAL_OUTPUT="$(
+  python3 adl/tools/run_v0904_contract_market_runner.py --out "$TRAVERSAL_OUT_REL" 2>&1
+)"
+TRAVERSAL_STATUS=$?
+set -e
+
+test "$TRAVERSAL_STATUS" -eq 1
+[[ "$TRAVERSAL_OUTPUT" == *"contract_market_runner: fail [path_traversal_forbidden]"* ]]
+[[ "$TRAVERSAL_OUTPUT" != *"Traceback (most recent call last)"* ]]
 
 echo "v0.90.4 contract-market runner smoke: pass"

--- a/adl/tools/test_v0904_contract_market_summary.sh
+++ b/adl/tools/test_v0904_contract_market_summary.sh
@@ -6,9 +6,11 @@ TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-contract-market-summary.XXXXXX")"
 RUNNER_OUT_REL="$(basename "$TMP_DIR")/runner"
 RENDERED_ONE_REL="$(basename "$TMP_DIR")/rendered_one.md"
 RENDERED_TWO_REL="$(basename "$TMP_DIR")/rendered_two.md"
+TRAVERSAL_RENDER_REL="../summary-escape-attempt.md"
 RUNNER_OUT="$ROOT_DIR/$RUNNER_OUT_REL"
 RENDERED_ONE="$ROOT_DIR/$RENDERED_ONE_REL"
 RENDERED_TWO="$ROOT_DIR/$RENDERED_TWO_REL"
+ABSOLUTE_RENDER="/tmp/adl-contract-market-summary-absolute.md"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 cd "$ROOT_DIR"
@@ -57,5 +59,35 @@ assert "/private/" not in text
 assert "/var/" not in text
 assert "file://" not in text
 PY
+
+rm -f "$ABSOLUTE_RENDER"
+set +e
+ABSOLUTE_OUTPUT="$(
+  python3 adl/tools/render_v0904_contract_market_summary.py \
+    --review-bundle "$RUNNER_OUT_REL/review_bundle.json" \
+    --out "$ABSOLUTE_RENDER" \
+    2>&1
+)"
+ABSOLUTE_STATUS=$?
+set -e
+
+test "$ABSOLUTE_STATUS" -eq 1
+[[ "$ABSOLUTE_OUTPUT" == *"contract_market_summary: fail [absolute_path_forbidden]"* ]]
+[[ "$ABSOLUTE_OUTPUT" != *"Traceback (most recent call last)"* ]]
+test ! -e "$ABSOLUTE_RENDER"
+
+set +e
+TRAVERSAL_OUTPUT="$(
+  python3 adl/tools/render_v0904_contract_market_summary.py \
+    --review-bundle "$RUNNER_OUT_REL/review_bundle.json" \
+    --out "$TRAVERSAL_RENDER_REL" \
+    2>&1
+)"
+TRAVERSAL_STATUS=$?
+set -e
+
+test "$TRAVERSAL_STATUS" -eq 1
+[[ "$TRAVERSAL_OUTPUT" == *"contract_market_summary: fail [path_traversal_forbidden]"* ]]
+[[ "$TRAVERSAL_OUTPUT" != *"Traceback (most recent call last)"* ]]
 
 echo "v0.90.4 contract-market summary smoke: pass"


### PR DESCRIPTION
Closes #2534

## Summary
Hardened the Sprint 3 contract-market Python runner and summary renderer so all operator-facing file arguments now enforce the same repo-relative boundary the D12 Rust CLI already claims. Absolute paths and `..` traversal attempts now fail deterministically with stable tool-shaped error codes and no out-of-repo writes.

## Artifacts
- Updated path-boundary enforcement in `adl/tools/run_v0904_contract_market_runner.py`
- Updated path-boundary enforcement in `adl/tools/render_v0904_contract_market_summary.py`
- Extended focused regression coverage in `adl/tools/test_v0904_contract_market_runner.sh`
- Extended focused regression coverage in `adl/tools/test_v0904_contract_market_summary.sh`
- Worktree execution record at `.adl/v0.90.4/tasks/issue-2534__v0-90-4-tools-enforce-repo-relative-path-boundaries-in-sprint-3-contract-market-python-tools/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/test_v0904_contract_market_runner.sh`
    Checked shell syntax for the focused runner regression harness.
  - `bash -n adl/tools/test_v0904_contract_market_summary.sh`
    Checked shell syntax for the focused summary regression harness.
  - `bash adl/tools/test_v0904_contract_market_runner.sh`
    Proved valid repo-relative runner execution still passes and invalid path arguments fail in a bounded tool-shaped way.
  - `bash adl/tools/test_v0904_contract_market_summary.sh`
    Proved valid repo-relative summary rendering still passes and invalid path arguments fail in a bounded tool-shaped way.
  - `git diff --check`
    Checked patch hygiene for the bounded tooling diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2534__v0-90-4-tools-enforce-repo-relative-path-boundaries-in-sprint-3-contract-market-python-tools/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2534__v0-90-4-tools-enforce-repo-relative-path-boundaries-in-sprint-3-contract-market-python-tools/sor.md
- Idempotency-Key: v0-90-4-tools-enforce-repo-relative-path-boundaries-in-sprint-3-contract-market-python-tools-adl-v0-90-4-tasks-issue-2534-v0-90-4-tools-enforce-repo-relative-path-boundaries-in-sprint-3-contract-market-python-tools-sip-md-adl-v0-90-4-tasks-issue-2534-v0-90-4-tools-enforce-repo-relative-path-boundaries-in-sprint-3-contract-market-python-tools-sor-md