### PR TITLE
[v0.90.4][backlog][tests] Classify and relocate slow proof tests out of the default PR lane

### DIFF
--- a/adl/src/runtime_v2/tests/access_control.rs
+++ b/adl/src/runtime_v2/tests/access_control.rs
@@ -20,6 +20,7 @@ fn runtime_v2_access_control_contract_is_stable() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_access_control_serializes_and_matches_golden_fixtures() {
     let artifacts = runtime_v2_access_control_contract().expect("access artifacts");
     let matrix_json = String::from_utf8(
@@ -173,6 +174,7 @@ fn runtime_v2_access_control_rejects_unsafe_event_mutations() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_access_control_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_access_control_contract().expect("access artifacts");
     let root = common::unique_temp_path("access-control-write");

--- a/adl/src/runtime_v2/tests/contract_lifecycle_state.rs
+++ b/adl/src/runtime_v2/tests/contract_lifecycle_state.rs
@@ -20,6 +20,7 @@ fn runtime_v2_contract_lifecycle_state_machine_is_stable() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_contract_lifecycle_state_machine_matches_golden_fixture() {
     let artifacts =
         runtime_v2_contract_lifecycle_state_model().expect("contract lifecycle artifacts");
@@ -41,6 +42,7 @@ fn runtime_v2_contract_lifecycle_state_machine_matches_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_contract_lifecycle_negative_cases_match_golden_fixture() {
     let artifacts =
         runtime_v2_contract_lifecycle_state_model().expect("contract lifecycle artifacts");
@@ -134,6 +136,7 @@ fn runtime_v2_contract_lifecycle_negative_cases_require_full_terminal_reopen_mat
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_contract_lifecycle_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_contract_lifecycle_state_model().expect("contract lifecycle artifacts");

--- a/adl/src/runtime_v2/tests/delegation_subcontract.rs
+++ b/adl/src/runtime_v2/tests/delegation_subcontract.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::path::PathBuf;
 
 #[test]
 fn runtime_v2_delegation_subcontract_artifacts_are_stable() {
@@ -21,6 +20,7 @@ fn runtime_v2_delegation_subcontract_artifacts_are_stable() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_delegation_subcontract_matches_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -42,6 +42,7 @@ fn runtime_v2_delegation_subcontract_matches_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_delegated_output_matches_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -61,6 +62,7 @@ fn runtime_v2_delegated_output_matches_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_parent_integration_matches_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -80,6 +82,7 @@ fn runtime_v2_parent_integration_matches_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_delegation_negative_cases_match_golden_fixture() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");
@@ -327,6 +330,7 @@ fn runtime_v2_delegation_subcontract_rejects_subcontractor_outside_runner_up_bas
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_delegation_subcontract_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_delegation_subcontract_model().expect("delegation subcontract artifacts");

--- a/adl/src/runtime_v2/tests/evaluation_selection.rs
+++ b/adl/src/runtime_v2/tests/evaluation_selection.rs
@@ -20,6 +20,7 @@ fn runtime_v2_evaluation_selection_contract_is_stable() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_evaluation_selection_matches_golden_fixture() {
     let artifacts =
         RuntimeV2EvaluationSelectionArtifacts::prototype().expect("evaluation selection");
@@ -41,6 +42,7 @@ fn runtime_v2_evaluation_selection_matches_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_selection_negative_cases_match_golden_fixture() {
     let artifacts =
         RuntimeV2EvaluationSelectionArtifacts::prototype().expect("evaluation selection");
@@ -122,6 +124,7 @@ fn runtime_v2_evaluation_selection_does_not_treat_tool_availability_as_authority
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_evaluation_selection_write_to_root_materializes_fixtures() {
     let artifacts =
         RuntimeV2EvaluationSelectionArtifacts::prototype().expect("evaluation selection");

--- a/adl/src/runtime_v2/tests/external_counterparty.rs
+++ b/adl/src/runtime_v2/tests/external_counterparty.rs
@@ -623,6 +623,7 @@ fn runtime_v2_external_counterparty_helper_validators_cover_remaining_variants()
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_external_counterparty_model_matches_golden_fixture() {
     let artifacts =
         runtime_v2_external_counterparty_model().expect("external counterparty artifacts");
@@ -660,6 +661,7 @@ fn runtime_v2_external_counterparty_negative_cases_match_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_external_counterparty_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_external_counterparty_model().expect("external counterparty artifacts");

--- a/adl/src/runtime_v2/tests/resource_stewardship_bridge.rs
+++ b/adl/src/runtime_v2/tests/resource_stewardship_bridge.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::path::PathBuf;
 
 #[test]
 fn runtime_v2_resource_stewardship_bridge_is_stable() {
@@ -20,6 +19,7 @@ fn runtime_v2_resource_stewardship_bridge_is_stable() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_resource_stewardship_bridge_matches_golden_fixture() {
     let artifact =
         runtime_v2_resource_stewardship_bridge().expect("resource stewardship bridge artifact");
@@ -158,6 +158,7 @@ fn runtime_v2_resource_stewardship_bridge_rejects_policy_and_authority_drift() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_resource_stewardship_bridge_write_to_root_materializes_fixture() {
     let artifact =
         runtime_v2_resource_stewardship_bridge().expect("resource stewardship bridge artifact");

--- a/adl/src/runtime_v2/tests/transition_authority.rs
+++ b/adl/src/runtime_v2/tests/transition_authority.rs
@@ -16,6 +16,7 @@ fn runtime_v2_transition_authority_contract_is_stable() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_transition_authority_matrix_matches_golden_fixture() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");
@@ -32,6 +33,7 @@ fn runtime_v2_transition_authority_matrix_matches_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_transition_authority_basis_matches_golden_fixture() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");
@@ -53,6 +55,7 @@ fn runtime_v2_transition_authority_basis_matches_golden_fixture() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_transition_authority_negative_cases_match_golden_fixture() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");
@@ -141,6 +144,7 @@ fn runtime_v2_transition_authority_records_governed_tool_boundary() {
 }
 
 #[test]
+#[cfg(feature = "slow-proof-tests")]
 fn runtime_v2_transition_authority_write_to_root_materializes_fixtures() {
     let artifacts =
         runtime_v2_transition_authority_model().expect("transition authority artifacts");

--- a/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
@@ -187,6 +187,11 @@ The heavyweight `runtime_v2` proof-materialization tranche is intentionally
 classified separately from always-on contract checks:
 
 - default `adl-ci` runs `cargo test` without `slow-proof-tests`
+- large multi-artifact runtime_v2 golden-packet parity checks and
+  `write_to_root` materialization proofs for access control, contract
+  lifecycle, delegation subcontract, evaluation selection, external
+  counterparty, resource stewardship bridge, and transition authority now live
+  behind that same `slow-proof-tests` feature
 - authoritative `cargo llvm-cov --workspace --all-features` lanes still execute
   that tranche
 


### PR DESCRIPTION
## Summary
- move the slowest remaining ungated runtime_v2 packet-parity and write-to-root proof tests behind `slow-proof-tests`
- keep the semantic contract-stability checks in the default ordinary PR lane
- document the relocated tranche in the v0.90.4 CI runtime policy

## Validation
- cargo test --manifest-path adl/Cargo.toml runtime_v2_access_control -- --list
- cargo test --manifest-path adl/Cargo.toml runtime_v2_access_control --features slow-proof-tests -- --list
- cargo test --manifest-path adl/Cargo.toml runtime_v2_delegation_subcontract -- --list
- cargo test --manifest-path adl/Cargo.toml runtime_v2_delegation_subcontract --features slow-proof-tests -- --list
- cargo test --manifest-path adl/Cargo.toml runtime_v2_access_control_contract_is_stable -- --exact
- cargo test --manifest-path adl/Cargo.toml runtime_v2_delegation_subcontract_artifacts_are_stable -- --exact
- git diff --check

Closes #2537
