### PR TITLE
Tighten tracked review expectations

### DIFF
--- a/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
+++ b/docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md
@@ -319,6 +319,9 @@ Required outputs:
 
 - Findings-first internal review packet covering code, docs, demos, tests,
   issue truth, release boundaries, and proof claims.
+- Sprint-by-sprint code-review artifacts for Sprint 1, Sprint 2, and Sprint 3,
+  with WP-14A reviewed according to its actual status at review time rather
+  than silently treated as landed.
 - Documentation review artifact from `repo-review-docs` when any review scope
   touches documentation, review templates, release text, or claim-bearing
   project surfaces.
@@ -328,6 +331,10 @@ Required validation:
 
 - Review packet has exact scope, exact files, requested review questions, and
   severity rubric.
+- Direct code review against issue intent is included; high-level packet or docs
+  review is not a substitute for implementation review.
+- Sprint 1, Sprint 2, and Sprint 3 each record findings or explicit no-finding
+  disposition for the code reviewed.
 - Accepted findings are routed to WP-18 or explicitly dispositioned.
 - If documentation review was skipped, the skipped state and reason are explicit in
   the internal review artifact, include an owner, and carry a concrete follow-up.

--- a/docs/milestones/v0.90/DEMO_MATRIX_v0.90.md
+++ b/docs/milestones/v0.90/DEMO_MATRIX_v0.90.md
@@ -24,7 +24,7 @@ landed issue wave.
 | D5 | Stock league proof expansion | Selected demo extensions can add reviewer evidence without weakening the primary stock-league proof | `cargo run --manifest-path adl/Cargo.toml -- demo demo-k-v090-stock-league-proof-expansion --run --trace --out out --no-open` | selected-demo manifest, extension proof packet, evidence index, replay manifest, non-goals/deferrals, and extension safety scan | landed by `#2028` |
 | D6 | Repo visibility proof packet | ADL can map one milestone or feature slice from canonical docs to implementation, tests, demos, and review surfaces | `docs/milestones/v0.90/repo_visibility/` | manifest and code-doc-demo linkage report | landed by `#2031` |
 | D7 | Milestone compression pilot | ADL can detect milestone drift from canonical state without silently mutating release truth | `python3 adl/tools/check_v090_milestone_state.py` | canonical state file, drift-check output, and generated status summary | landed by `#2030` |
-| D8 | CodeBuddy multi-agent review showcase | ADL can present the CodeBuddy review-engine skill family as a product-style, packet-first repo review workflow without building the web app or mutating customer repos | `bash adl/tools/demo_v090_codebuddy_review_showcase.sh` | `artifacts/v090/codebuddy_review_showcase/run_manifest.json`, specialist reviews, redaction report, diagram artifacts, final report, and demo-operator classification | landed by `#2072`; review-quality dependency landed by `#2070` |
+| D8 | CodeBuddy multi-agent review showcase | ADL can present the CodeBuddy review-engine skill family as a product-style, packet-first repo review workflow, including a meticulous code-review lane, without building the web app or mutating customer repos | `bash adl/tools/demo_v090_codebuddy_review_showcase.sh` | `artifacts/v090/codebuddy_review_showcase/run_manifest.json`, specialist reviews, redaction report, diagram artifacts, final report, and demo-operator classification | landed by `#2072`; review-quality dependency landed by `#2070`; code-review hardening follow-up `#2545` |
 | D9 | ADL architecture document generation | ADL can maintain a source-grounded first-class architecture packet with diagrams, review automation, generation planning, candidate ADRs, and deterministic validation | `bash adl/tools/demo_v090_architecture_document_generation.sh` | `docs/architecture/`, `docs/architecture/diagrams/`, and `artifacts/v090/adl_architecture_document_generation/architecture_generation_manifest.json` | landed by `#2055` |
 
 ## Safety Rules
@@ -54,6 +54,8 @@ The CodeBuddy showcase packet must:
 
 - keep review packet construction, specialist review, diagram review, redaction,
   follow-through planning, and product-report writing as explicit lanes
+- include a meticulous code-review lane that engages directly with source files
+  and records file/path evidence plus line-level grounding when available
 - preserve severity, evidence, caveats, specialist disagreement, and residual
   risk in the final report
 - treat `review-quality-evaluator` as landed by `#2070`


### PR DESCRIPTION
## Summary

Tightens the tracked reviewer-facing docs so two expectations are now explicit:

1. `v0.90.4` `WP-16` internal review must include direct sprint-by-sprint code review against issue intent, not just packet/docs review.
2. The `v0.90` CodeBuddy showcase definition must include a meticulous code-review lane with file/path grounding and line-level evidence when available.

## Linked Issues

- refs #2436
- refs #2545

## What Changed

- updated `docs/milestones/v0.90.4/WP_EXECUTION_READINESS_v0.90.4.md`
- updated `docs/milestones/v0.90/DEMO_MATRIX_v0.90.md`

## Notes

- local `.adl` planning truth remains local and is intentionally not part of this PR
- this PR carries only tracked milestone/doc surfaces
