### PR TITLE
[v0.90.4][ci] Profile and reduce authoritative coverage base cost

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -306,9 +306,7 @@ jobs:
 
       - name: Coverage run and summary (json)
         if: steps.path-policy.outputs.full_coverage_required == 'true'
-        run: |
-          cargo llvm-cov nextest --workspace --all-features --status-level all --final-status-level slow --no-report
-          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
+        run: bash adl/tools/run_authoritative_coverage_lane.sh --authority "${{ steps.path-policy.outputs.coverage_authority }}" --event-name "${{ github.event_name }}"
 
       - name: PR fast coverage summary (json)
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.coverage-impact.outputs.needs_fast_summary == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,6 +326,16 @@ jobs:
             --threshold "$PER_FILE_LINE_THRESHOLD"
         working-directory: .
 
+      - name: Full workspace gate deferred for bounded authoritative policy PR
+        if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_authority == 'pr_policy_surface_tooling_only'
+        run: |
+          echo "Workspace coverage gate and lcov artifact generation are deferred for tooling-only policy PRs."
+          echo "This PR ran the bounded authoritative coverage pass plus changed-source coverage-impact validation."
+          echo "Full workspace coverage gating remains required on push-to-main, fail-closed events, and mixed runtime-plus-policy PRs."
+          echo "Policy reason: ${{ steps.path-policy.outputs.reason }}"
+          echo "Coverage lane: ${{ steps.path-policy.outputs.coverage_lane }}"
+          echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
+
       - name: PR coverage-impact preflight
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true'
         env:
@@ -359,7 +369,7 @@ jobs:
         working-directory: .
 
       - name: Enforce coverage policy gates (workspace + per-file)
-        if: steps.path-policy.outputs.full_coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         env:
           WORKSPACE_LINE_THRESHOLD: "90"
           PER_FILE_LINE_THRESHOLD: "80"
@@ -368,24 +378,24 @@ jobs:
           bash tools/enforce_coverage_gates.sh coverage-summary.json
 
       - name: Coverage (ADL Rust workspace lcov)
-        if: steps.path-policy.outputs.full_coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Coverage summary (text)
-        if: steps.path-policy.outputs.full_coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: cargo llvm-cov report --summary-only | tee coverage-summary.txt
 
       - name: Verify generated lcov file
-        if: steps.path-policy.outputs.full_coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: test -s lcov.info && ls -l lcov.info
 
       - name: Verify lcov path from repository root
-        if: steps.path-policy.outputs.full_coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: test -s adl/lcov.info && ls -l adl/lcov.info
         working-directory: .
 
       - name: Upload coverage artifact
-        if: steps.path-policy.outputs.full_coverage_required == 'true'
+        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adl-coverage-lcov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Coverage run and summary (json)
         if: steps.path-policy.outputs.full_coverage_required == 'true'
-        run: bash adl/tools/run_authoritative_coverage_lane.sh --authority "${{ steps.path-policy.outputs.coverage_authority }}" --event-name "${{ github.event_name }}"
+        run: bash tools/run_authoritative_coverage_lane.sh --authority "${{ steps.path-policy.outputs.coverage_authority }}" --event-name "${{ github.event_name }}"
 
       - name: PR fast coverage summary (json)
         if: github.event_name == 'pull_request' && steps.path-policy.outputs.coverage_required == 'true' && steps.path-policy.outputs.full_coverage_required != 'true' && steps.coverage-impact.outputs.needs_fast_summary == 'true'

--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -103,10 +103,12 @@ mark_pr_fast_coverage() {
 }
 
 mark_policy_surface_full_coverage() {
+  local authority="$1"
+  local reason_value="$2"
   full_coverage_required=true
   coverage_lane="authoritative_full"
-  coverage_authority="pr_policy_surface"
-  reason="coverage_policy_surface_change_runs_full_coverage"
+  coverage_authority="$authority"
+  reason="$reason_value"
 }
 
 normalize_changed_rows() {
@@ -356,7 +358,15 @@ EOF
     while IFS=$'\t' read -r _status path; do
       [ -n "$path" ] || continue
       if is_full_coverage_policy_surface "$path"; then
-        mark_policy_surface_full_coverage
+        if [ "$coverage_required" = true ] || [ "$demo_smoke_required" = true ]; then
+          mark_policy_surface_full_coverage \
+            "pr_policy_surface_runtime_mixed" \
+            "coverage_policy_surface_change_with_runtime_surface_runs_full_coverage"
+        else
+          mark_policy_surface_full_coverage \
+            "pr_policy_surface_tooling_only" \
+            "coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+        fi
         continue
       fi
     done <<EOF

--- a/adl/tools/run_authoritative_coverage_lane.sh
+++ b/adl/tools/run_authoritative_coverage_lane.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ADL_DIR="$ROOT_DIR/adl"
+PRINT_PLAN=false
+AUTHORITY="push_main"
+EVENT_NAME="push"
+MODE="full_authoritative_all_features"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/run_authoritative_coverage_lane.sh [--print-plan] [--authority <authority>] [--event-name <name>]
+
+Run the authoritative coverage lane in one bounded pass per event:
+- full authoritative all-features coverage on push/main and other full-evidence events
+- bounded workspace coverage on tooling-only policy pull requests
+
+The run always emits one final coverage summary report.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --print-plan)
+      PRINT_PLAN=true
+      shift
+      ;;
+    --authority)
+      AUTHORITY="${2:-}"
+      shift 2
+      ;;
+    --event-name)
+      EVENT_NAME="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$EVENT_NAME" = "pull_request" ] && [ "$AUTHORITY" = "pr_policy_surface_tooling_only" ]; then
+  MODE="bounded_policy_surface_pr"
+fi
+
+if [ "$PRINT_PLAN" = true ]; then
+  printf 'authority=%s\n' "$AUTHORITY"
+  printf 'event_name=%s\n' "$EVENT_NAME"
+  printf 'mode=%s\n' "$MODE"
+  if [ "$MODE" = "full_authoritative_all_features" ]; then
+    printf 'features=all_features\n'
+    printf 'workspace=full\n'
+  else
+    printf 'features=default\n'
+    printf 'workspace=bounded_policy_surface\n'
+  fi
+  exit 0
+fi
+
+cd "$ADL_DIR"
+
+if [ "$MODE" = "full_authoritative_all_features" ]; then
+  echo "Authoritative coverage mode: full_authoritative_all_features"
+  echo "Features: all_features"
+  cargo llvm-cov nextest \
+    --workspace \
+    --all-features \
+    --status-level all \
+    --final-status-level slow \
+    --no-report
+else
+  echo "Authoritative coverage mode: bounded_policy_surface_pr"
+  echo "Features: default"
+  echo "Full authoritative all-features proof remains reserved for push-to-main and mixed runtime policy changes."
+  cargo llvm-cov nextest \
+    --workspace \
+    --status-level all \
+    --final-status-level slow \
+    --no-report
+fi
+
+cargo llvm-cov report --json --summary-only --output-path coverage-summary.json

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -226,6 +226,13 @@ PR also changes runtime or demo-affecting surfaces, the authority upgrades to
 `pr_policy_surface_runtime_mixed` and the full all-features authoritative lane
 still runs.
 
+Tooling-only policy-surface PRs should still run changed-source coverage-impact
+validation from the generated `coverage-summary.json`, but they should not be
+described as having passed the full workspace coverage gate or produced full
+release-evidence LCOV artifacts. Those remain reserved for full-evidence
+authorities such as `push_main`, `fail_closed`, and mixed runtime-plus-policy
+governance changes.
+
 ### Failed-Closed Classification
 
 Observed:

--- a/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
+++ b/adl/tools/skills/docs/CI_RUNTIME_POLICY_GUIDE.md
@@ -77,9 +77,11 @@ or assembling release evidence:
 - Ordinary Rust source additions and edits should run the coverage-impact
   preflight before publication. On normal PRs, this is the fast
   `adl-coverage` lane rather than a second full instrumented test run.
-- PRs that change explicit coverage-governance surfaces should run full
-  coverage even when they are otherwise tooling-focused. The trigger is
-  policy-surface based, not size- or novelty-based.
+- PRs that change explicit coverage-governance surfaces should still run the
+  authoritative coverage lane. Tooling-only policy PRs may use the bounded
+  authoritative workspace pass, while mixed runtime-plus-policy PRs still run
+  the full all-features lane. The trigger is policy-surface based, not size-
+  or novelty-based.
 - When `full_coverage_required=true`, the JSON summary and changed-source
   impact gate should execute before LCOV artifact generation. A coverage
   failure should fail at the first reviewable policy gate instead of spending
@@ -203,23 +205,26 @@ Observed:
 - `coverage_required=true`
 - `full_coverage_required=true`
 - `coverage_lane=authoritative_full`
-- `coverage_authority=push_main`, `pr_policy_surface`, or another
-  authoritative trigger
+- `coverage_authority=push_main`, `pr_policy_surface_tooling_only`,
+  `pr_policy_surface_runtime_mixed`, or another authoritative trigger
 
 Truthful interpretation:
 
-- Standalone `cargo test` may be skipped because the full `cargo llvm-cov`
-  lane is the authoritative full test execution for that event.
+- Standalone `cargo test` may be skipped because the authoritative
+  `cargo llvm-cov` lane is the relevant Rust test execution for that event.
 - A lightweight `cargo test --doc` check may still run to preserve doc-test
   coverage without duplicating the whole suite.
 - Full coverage artifacts and policy gates are expected.
 - This lane can be cited as full coverage evidence when it produces
   `coverage-summary.json`, `coverage-summary.txt`, and `lcov.info`.
 
-For a policy-surface PR, `rust_required` and `demo_smoke_required` may stay
-false if the changed paths are tooling-only, but `full_coverage_required=true`
-still means the authoritative full coverage lane must run because the PR is
-modifying coverage governance itself.
+For a tooling-only policy-surface PR, `rust_required` and `demo_smoke_required`
+may stay false while `full_coverage_required=true` still means the
+authoritative coverage lane must run. In that bounded case, the PR uses one
+workspace `cargo llvm-cov nextest` pass without `--all-features`. If the same
+PR also changes runtime or demo-affecting surfaces, the authority upgrades to
+`pr_policy_surface_runtime_mixed` and the full all-features authoritative lane
+still runs.
 
 ### Failed-Closed Classification
 

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -167,8 +167,25 @@ EOF
   assert_has "$policy_surface_output" "demo_smoke_required=false"
   assert_has "$policy_surface_output" "release_version_only=false"
   assert_has "$policy_surface_output" "coverage_lane=authoritative_full"
-  assert_has "$policy_surface_output" "coverage_authority=pr_policy_surface"
-  assert_has "$policy_surface_output" "reason=coverage_policy_surface_change_runs_full_coverage"
+  assert_has "$policy_surface_output" "coverage_authority=pr_policy_surface_tooling_only"
+  assert_has "$policy_surface_output" "reason=coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+
+  git checkout -q -b runtime-policy-surface-change "$base_sha"
+  mkdir -p adl/tools
+  printf '#!/usr/bin/env bash\nprintf policy\n' > adl/tools/enforce_coverage_gates.sh
+  printf 'pub fn runtime_with_policy() -> bool { true }\n' >> adl/src/lib.rs
+  git add adl/tools/enforce_coverage_gates.sh adl/src/lib.rs
+  git commit -q -m runtime-policy-surface-change
+  runtime_policy_surface_head="$(git rev-parse HEAD)"
+
+  runtime_policy_surface_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$runtime_policy_surface_head" --ref "refs/pull/1/merge")"
+  assert_has "$runtime_policy_surface_output" "rust_required=true"
+  assert_has "$runtime_policy_surface_output" "coverage_required=true"
+  assert_has "$runtime_policy_surface_output" "full_coverage_required=true"
+  assert_has "$runtime_policy_surface_output" "demo_smoke_required=true"
+  assert_has "$runtime_policy_surface_output" "coverage_lane=authoritative_full"
+  assert_has "$runtime_policy_surface_output" "coverage_authority=pr_policy_surface_runtime_mixed"
+  assert_has "$runtime_policy_surface_output" "reason=coverage_policy_surface_change_with_runtime_surface_runs_full_coverage"
 
   main_output="$("$POLICY" --event-name push --ref "refs/heads/main")"
   assert_has "$main_output" "rust_required=true"

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -4,12 +4,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/ci.yaml"
 
-python3 - "$WORKFLOW" <<'PY'
+python3 - "$WORKFLOW" "$ROOT_DIR/adl/tools/test_run_authoritative_coverage_lane.sh" <<'PY'
 import pathlib
 import re
 import sys
 
 workflow = pathlib.Path(sys.argv[1]).read_text()
+runner_test = pathlib.Path(sys.argv[2])
 
 def step_run(name: str) -> str:
     pattern = re.compile(
@@ -54,17 +55,19 @@ if "tool: nextest" not in workflow:
     )
 
 expected_coverage = (
-    "cargo llvm-cov nextest --workspace --all-features --status-level all "
-    "--final-status-level slow --no-report"
+    'bash adl/tools/run_authoritative_coverage_lane.sh --authority "${{ steps.path-policy.outputs.coverage_authority }}" '
+    '--event-name "${{ github.event_name }}"'
 )
-if expected_coverage not in workflow:
+coverage_step = step_run("Coverage run and summary (json)")
+if coverage_step != expected_coverage:
     raise SystemExit(
-        "authoritative coverage lane must run through cargo llvm-cov nextest with slow markers"
+        "authoritative coverage lane must route through the bounded runner; "
+        f"found: {coverage_step}"
     )
 
-if "cargo llvm-cov report --json --summary-only --output-path coverage-summary.json" not in workflow:
+if not runner_test.exists():
     raise SystemExit(
-        "coverage lanes must emit coverage-summary.json via cargo llvm-cov report after nextest execution"
+        "authoritative coverage runner contract test must exist"
     )
 
 print("PASS test_ci_runtime_contracts")

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -55,7 +55,7 @@ if "tool: nextest" not in workflow:
     )
 
 expected_coverage = (
-    'bash adl/tools/run_authoritative_coverage_lane.sh --authority "${{ steps.path-policy.outputs.coverage_authority }}" '
+    'bash tools/run_authoritative_coverage_lane.sh --authority "${{ steps.path-policy.outputs.coverage_authority }}" '
     '--event-name "${{ github.event_name }}"'
 )
 coverage_step = step_run("Coverage run and summary (json)")

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -24,6 +24,18 @@ def step_run(name: str) -> str:
         raise SystemExit(f"missing workflow step: {name}")
     return match.group(1).strip()
 
+def step_if(name: str) -> str:
+    pattern = re.compile(
+        rf"^\s*-\s+name:\s+{re.escape(name)}\s*$"
+        rf"(?:\n^\s+.*$)*?"
+        rf"\n^\s+if:\s+(.+)$",
+        re.MULTILINE,
+    )
+    match = pattern.search(workflow)
+    if not match:
+        raise SystemExit(f"missing workflow if condition for step: {name}")
+    return match.group(1).strip()
+
 ordinary_test = step_run("test")
 expected_ordinary_test = (
     'bash adl/tools/run_pr_fast_test_lane.sh --base "${{ github.event.pull_request.base.sha }}" '
@@ -68,6 +80,14 @@ if coverage_step != expected_coverage:
 if not runner_test.exists():
     raise SystemExit(
         "authoritative coverage runner contract test must exist"
+    )
+
+gate_if = step_if("Enforce coverage policy gates (workspace + per-file)")
+expected_gate_fragment = "steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'"
+if expected_gate_fragment not in gate_if:
+    raise SystemExit(
+        "workspace coverage gate must defer for tooling-only policy authoritative PRs; "
+        f"found: {gate_if}"
     )
 
 print("PASS test_ci_runtime_contracts")

--- a/adl/tools/test_run_authoritative_coverage_lane.sh
+++ b/adl/tools/test_run_authoritative_coverage_lane.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+plan="$(bash "$ROOT_DIR/adl/tools/run_authoritative_coverage_lane.sh" --print-plan)"
+
+for required in \
+  "authority=push_main" \
+  "event_name=push" \
+  "mode=full_authoritative_all_features" \
+  "features=all_features" \
+  "workspace=full"
+do
+  if ! grep -F "$required" <<<"$plan" >/dev/null 2>&1; then
+    echo "missing authoritative coverage plan token: $required" >&2
+    exit 1
+  fi
+done
+
+policy_plan="$(bash "$ROOT_DIR/adl/tools/run_authoritative_coverage_lane.sh" --authority pr_policy_surface_tooling_only --event-name pull_request --print-plan)"
+
+for required in \
+  "authority=pr_policy_surface_tooling_only" \
+  "event_name=pull_request" \
+  "mode=bounded_policy_surface_pr" \
+  "features=default" \
+  "workspace=bounded_policy_surface"
+do
+  if ! grep -F "$required" <<<"$policy_plan" >/dev/null 2>&1; then
+    echo "missing policy-surface authoritative coverage plan token: $required" >&2
+    exit 1
+  fi
+done
+
+runtime_policy_plan="$(bash "$ROOT_DIR/adl/tools/run_authoritative_coverage_lane.sh" --authority pr_policy_surface_runtime_mixed --event-name pull_request --print-plan)"
+
+for required in \
+  "authority=pr_policy_surface_runtime_mixed" \
+  "event_name=pull_request" \
+  "mode=full_authoritative_all_features" \
+  "features=all_features" \
+  "workspace=full"
+do
+  if ! grep -F "$required" <<<"$runtime_policy_plan" >/dev/null 2>&1; then
+    echo "missing mixed policy-surface authoritative coverage plan token: $required" >&2
+    exit 1
+  fi
+done
+
+echo "PASS test_run_authoritative_coverage_lane"

--- a/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
@@ -135,6 +135,9 @@ Coverage-policy-sensitive PRs:
 - tooling-only policy PRs run one bounded workspace `cargo llvm-cov nextest`
   pass on the PR so they stop paying the full all-features governance tax on
   every iteration
+- tooling-only policy PRs still run the changed-source coverage-impact check,
+  but they defer the full workspace `90%` gate and LCOV artifact path because
+  those belong to the full-evidence lane
 - mixed runtime-plus-policy PRs still run the full all-features authoritative
   coverage lane
 

--- a/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
+++ b/docs/milestones/v0.90.4/CI_RUNTIME_POLICY_v0.90.4.md
@@ -20,7 +20,9 @@ The v0.90.4 policy keeps the stable check names, keeps PR validation truthful,
 and makes the full-coverage trigger explicit and reviewable:
 
 - ordinary runtime/test PRs run the fast PR validation path
-- coverage-policy-sensitive PRs still fail closed into the full coverage lane
+- coverage-policy-sensitive PRs still enter the authoritative coverage lane,
+  but tooling-only policy PRs use one bounded authoritative pass while mixed
+  runtime-plus-policy PRs still fail closed into the full all-features lane
 - pushes to `main`, nightly automation, and other non-PR events still run the
   authoritative full coverage workflow
 
@@ -128,8 +130,13 @@ Ordinary runtime/source PRs:
 Coverage-policy-sensitive PRs:
 
 - run the same base validation as other relevant PRs
-- run full coverage because the PR changes the rules or enforcement surfaces
-  that govern coverage itself
+- run the authoritative coverage lane because the PR changes the rules or
+  enforcement surfaces that govern coverage itself
+- tooling-only policy PRs run one bounded workspace `cargo llvm-cov nextest`
+  pass on the PR so they stop paying the full all-features governance tax on
+  every iteration
+- mixed runtime-plus-policy PRs still run the full all-features authoritative
+  coverage lane
 
 Pushes to `main` and nightly coverage:
 
@@ -223,8 +230,10 @@ smoke when required, and coverage-impact preflight. Do not cite the PR-fast
 coverage lane as full release coverage evidence.
 
 When working a PR that changes coverage governance or coverage tooling, expect
-the full coverage lane. That slower path is intentional because the PR is
-changing how coverage trust is enforced.
+the authoritative coverage lane. Tooling-only policy PRs now use one bounded
+authoritative workspace pass; mixed runtime-plus-policy PRs still take the full
+all-features lane because they are changing both governance and executable
+runtime surfaces.
 
 When working a `main`, nightly, release, or fail-closed event, expect full
 coverage. In those lanes, standalone `cargo test` may be skipped because
@@ -241,5 +250,5 @@ not run.
 
 This policy does not lower coverage thresholds or weaken release governance. It
 keeps ordinary bounded Rust PRs on the fast truthful path while preserving full
-coverage for `main`, nightly, release, fail-closed events, and PRs that modify
-coverage governance itself.
+all-features coverage for `main`, nightly, release, fail-closed events, and
+mixed runtime-plus-policy governance changes.


### PR DESCRIPTION
## Summary
- profile the remaining authoritative coverage bottleneck on current main rather than the stalled split branch
- add a bounded authoritative coverage runner so tooling-only policy PRs stop paying the full all-features governance tax
- preserve full all-features authoritative coverage for push-to-main, fail-closed events, and mixed runtime-plus-policy PRs

## Validation
- bash adl/tools/test_ci_path_policy.sh
- bash adl/tools/test_run_authoritative_coverage_lane.sh
- bash adl/tools/test_ci_runtime_contracts.sh
- bash -n adl/tools/run_authoritative_coverage_lane.sh adl/tools/test_run_authoritative_coverage_lane.sh adl/tools/ci_path_policy.sh adl/tools/test_ci_path_policy.sh adl/tools/test_ci_runtime_contracts.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "YAML_PARSE_OK"'
- git diff --check

Closes #2551