### PR TITLE
[v0.90.4][WP-19] Record next milestone handoff

### DIFF
--- a/docs/milestones/v0.90.4/NEXT_MILESTONE_HANDOFF_v0.90.4.md
+++ b/docs/milestones/v0.90.4/NEXT_MILESTONE_HANDOFF_v0.90.4.md
@@ -1,0 +1,89 @@
+# Next Milestone Handoff - v0.90.4
+
+## Purpose
+
+Record the clean next-milestone handoff for `v0.90.4` without inventing a loose
+backlog lane.
+
+`v0.90.4` delivered the bounded contract-market and resource-stewardship slice.
+The remaining carry-forward work is milestone placement for already-planned
+later bands, not leftover economics debt.
+
+## Zero-Leftover Result
+
+- There is no open carry-forward issue backlog from `v0.90.4`.
+- No unresolved `v0.90.4` contract-market finding is being parked as a vague
+  later fix.
+- All discovered follow-on scope is either:
+  - already completed inside `v0.90.4`, or
+  - explicitly placed into later milestone boundaries.
+
+## v0.90.5 Placement
+
+`v0.90.5` is the immediate follow-on for governed tools.
+
+It inherits the `v0.90.4` rule that contract and bid tool needs are
+constraints, resource estimates, adapter expectations, or evidence requirements,
+not execution grants.
+
+`v0.90.5` owns:
+
+- UTS public compatibility and conformance
+- ACC authority, visibility, delegation, and privacy
+- tool registry binding
+- UTS-to-ACC compilation
+- governed executor behavior
+- tool-call denial, replay, and redaction evidence
+- model proposal testing and the flagship governed-tools proof
+
+## v0.91 Placement
+
+`v0.91` remains the moral-governance and wellbeing milestone.
+
+Nothing in `v0.90.4` moves economics implementation, payment rails, or contract
+execution leftovers into `v0.91`. It should consume only already-landed
+citizen-state and governed-tools evidence where later moral review needs it.
+
+## v0.92 Placement
+
+`v0.92` remains the identity, continuity, and first true birthday milestone.
+
+It may later consume landed contract or tool-governance context as evidence
+inside capability envelopes, but it does not inherit unresolved `v0.90.4`
+market implementation work.
+
+## v0.93 Placement
+
+`v0.93` remains the constitutional citizenship, social-cognition, and
+polis-governance milestone.
+
+That means the reputation boundary and social-cognition lane belong there, not
+as a leftover `v0.90.4` economics problem.
+
+## Non-Goals Stay Non-Goals
+
+The following were explicit `v0.90.4` non-goals and should stay that way unless
+some later milestone deliberately plans them from scratch:
+
+- payment settlement
+- Lightning, x402, stablecoins, banking, invoicing, and tax
+- production contract/legal/billing boundaries
+- inter-polis economics and exchange
+- later accounting or economic-memory expansion
+
+They are not active `v0.90.4` leftovers, and this handoff does not create a new
+economics roadmap commitment for them.
+
+## Non-Reduction Rule
+
+This handoff does not reduce `v0.90.5`, `v0.91`, `v0.92`, or `v0.93`.
+
+It preserves:
+
+- `v0.90.5` as Governed Tools v1.0
+- `v0.91` as moral governance and wellbeing
+- `v0.92` as identity, continuity, and birthday
+- `v0.93` as constitutional citizenship, reputation boundary, and polis
+  governance
+
+The handoff result is a clean milestone chain, not a new backlog.

--- a/docs/milestones/v0.90.4/README.md
+++ b/docs/milestones/v0.90.4/README.md
@@ -98,6 +98,7 @@ Out of scope:
 - Milestone checklist: MILESTONE_CHECKLIST_v0.90.4.md
 - Release plan: RELEASE_PLAN_v0.90.4.md
 - Release notes draft: RELEASE_NOTES_v0.90.4.md
+- Next-milestone handoff: NEXT_MILESTONE_HANDOFF_v0.90.4.md
 - Issue wave: WP_ISSUE_WAVE_v0.90.4.yaml
 
 ## Execution Rule
@@ -165,3 +166,7 @@ v0.90.4 should record tool needs as contract constraints and review evidence.
 v0.90.5 owns the governed tool layer: UTS, ACC, tool registry binding,
 capability compilation, Freedom Gate mediation for tool use, executor behavior,
 redaction, replay, denial records, and multi-model tool-call testing.
+
+WP-19 records the clean handoff in NEXT_MILESTONE_HANDOFF_v0.90.4.md. The
+result is zero leftover issue backlog from `v0.90.4`; all carry-forward scope is
+explicitly milestone-placed.

--- a/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
@@ -48,16 +48,17 @@ release must say so plainly.
 
 ## Handoff
 
-The closeout should hand off:
+The closeout should record a zero-leftover handoff:
 
-- payment-settlement options, if still relevant
-- reputation and economic memory follow-ons
-- inter-polis economics follow-ons
-- production contract/legal/billing boundaries
-- any deferred authority or trace negative cases
+- no open carry-forward issue backlog from `v0.90.4`
 - v0.90.5 governed-tools follow-up for UTS, ACC, tool registry binding,
   executor authority, redaction, replay, denial records, and model testing
 - any contract-market requirement that recorded tool needs only as a constraint
   and must be picked up by v0.90.5
-- whether the canonical architecture packet changed and was updated, or was explicitly
-  reviewed as unchanged with a tracked owner and rationale.
+- payment, legal/billing, and inter-polis items remain explicit non-goals
+  unless some later milestone deliberately plans them from scratch
+- whether the canonical architecture packet changed and was updated, or was
+  explicitly reviewed as unchanged with a tracked owner and rationale
+
+The detailed handoff record should live in
+`NEXT_MILESTONE_HANDOFF_v0.90.4.md`.

--- a/docs/milestones/v0.90.5/README.md
+++ b/docs/milestones/v0.90.5/README.md
@@ -3,8 +3,9 @@
 ## Status
 
 Tracked planning package for Governed Tools v1.0. The milestone direction was
-established under planning issue #2350, tightened under #2402, and is being
-prepared for clean execution in the current docs-prep pass under #2443.
+established under planning issue #2350, tightened under #2402, prepared for
+clean execution under #2443, and re-affirmed as the immediate governed-tools
+follow-on during the `v0.90.4` WP-19 handoff pass under #2439.
 
 The issue wave has not been opened. This package is the reviewable planning
 source for a later WP-01 issue-wave creation pass. It is intended to be the
@@ -136,6 +137,10 @@ Governed Tools v1.0 flagship demo.
 It also should not inherit unresolved v0.90.4 ambiguity about whether contract
 tool needs are constraints or execution grants. WP-19 of v0.90.4 is expected to
 hand that boundary off cleanly.
+
+That handoff is now clean: `v0.90.4` leaves no loose issue backlog here. It
+hands off only the governed-tool authority lane that contracts and bids were
+explicitly not allowed to absorb.
 
 Current docs-review findings may still sharpen wording, rustdoc references, and
 public-spec boundaries, but they should not widen the core milestone scope away

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -3,9 +3,9 @@
 ## Status
 
 Forward planning. v0.91 is not yet an active implementation milestone and has no
-final issue wave. Its boundary was rechecked during the v0.90.3 WP-19 handoff
-pass so it stays clearly downstream of the nearer v0.90.4 and v0.90.5
-milestones.
+final issue wave. Its boundary was rechecked during the v0.90.3 and v0.90.4
+WP-19 handoff passes so it stays clearly downstream of the nearer v0.90.4 and
+v0.90.5 milestones without absorbing their implementation leftovers.
 
 ## Purpose
 

--- a/docs/milestones/v0.92/README.md
+++ b/docs/milestones/v0.92/README.md
@@ -3,9 +3,10 @@
 ## Status
 
 Forward planning. v0.92 is not yet an active implementation milestone and has
-no final issue wave. Its boundary was rechecked during the v0.90.3 WP-19
-handoff pass so it stays about identity and birth rather than absorbing
-economics, governed tools, or constitutional citizenship prematurely.
+no final issue wave. Its boundary was rechecked during the v0.90.3 and v0.90.4
+WP-19 handoff passes so it stays about identity and birth rather than
+absorbing economics, governed tools, or constitutional citizenship
+prematurely.
 
 ## Purpose
 

--- a/docs/milestones/v0.93/README.md
+++ b/docs/milestones/v0.93/README.md
@@ -3,7 +3,9 @@
 ## Status
 
 Forward planning. v0.93 is not yet an active implementation milestone and has
-no final issue wave.
+no final issue wave. Its boundary was rechecked during the `v0.90.4` WP-19
+handoff pass so reputation and social-cognition work stay here instead of
+turning into loose `v0.90.4` follow-on debt.
 
 ## Purpose
 

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -164,7 +164,7 @@ ADL already provides a serious platform baseline:
 | Identity, capability, names, and continuity substrate | Planned | `v0.92` identity, continuity, and birthday allocation plan | `v0.92` |
 | First true Gödel-agent birthday | Planned | `v0.92` identity, continuity, and birthday allocation plan plus Runtime v2 birthday boundary roadmap | `v0.92` |
 | Governance, delegation, IAM, social contract | Planned | `v0.93` constitutional citizenship and polis-governance allocation plan | `v0.93` |
-| Economics, accounting, and payment substrate | Planned | `docs/milestones/v0.90.4` citizen economics and contract-market planning | `v0.90.4` |
+| Bounded contract-market and resource-stewardship bridge | Implemented baseline | `docs/milestones/v0.90.4` contract-market docs, proof coverage, and demo matrix | Complete bounded baseline for the economics slice actually planned in `v0.90.4` |
 | Distributed execution integration | Partially implemented | cluster groundwork plus planning docs | `v0.94` / `v0.95` |
 | Demo catalog and polished MVP walkthrough | Partially implemented | milestone demo matrices and reviewer packages | `v0.95` |
 | Control-plane Rust migration / tooling hardening | Partially implemented | mixed Rust/shell control plane and active tooling hardening | `v0.95` |
@@ -191,12 +191,12 @@ has already landed, is landing now, or has explicitly placed on the path to the
 | `v0.90.1` | Runtime v2 foundation, manifold/snapshot contracts, kernel/control-plane boundaries, provisional citizens, invariant/security-boundary proof, CSM Observatory visibility packet, static console, operator report, CLI bundle, command-packet design, ANRM shepherd experiments, third-party review as WP-15A, Aptitude Atlas planning, and CodeBuddy product-lane planning. |
 | `v0.90.2` | Runtime v2 hardening, expanded invariants, violation artifacts, recovery/quarantine, operator review surfaces, stronger security-boundary evidence, CSM Observatory integration, and first meaningful CSM-run preparation. |
 | `v0.90.3` | Citizen state security, standing, canonical private-state authority, signed envelopes, local sealing, append-only lineage, continuity witnesses/receipts, anti-equivocation, sanctuary/quarantine, access control, redacted projections, challenge/appeal/threat-model evidence, inhabited Observatory flagship demo, and forward planning for later governance prerequisites. |
-| `v0.90.4` | Citizen economics and contract-market planning/implementation lane, with resource stewardship carried forward from v0.90.3. |
+| `v0.90.4` | Bounded contract-market and resource-stewardship bridge, with explicit deferral of payment rails, legal/billing, inter-polis economics, and governed-tool authority. |
 | `v0.90.5` | Governed Tools v1.0: Universal Tool Schema, ADL Capability Contract, capability-to-tool binding, policy enforcement, audit, privacy, and model compatibility proof. |
 | `v0.91` | Wellbeing and happiness, affect, kindness, humor, moral cognition, and the evaluation surfaces needed for emotionally and normatively legible agents. |
 | `v0.92` | Identity-bearing agent substrate, stable names, model/provider capability contracts, continuity across runs, memory grounding, witnesses, receipts, and the first true Gödel-agent birthday. |
 | `v0.93` | Governance, delegation, IAM, social contract, policy/constitutional surfaces, rights/duties, and accountable multi-agent society boundaries. |
-| `v0.94` | Economics/payment work if promoted into a full milestone package, distributed-substrate integration, cross-band convergence, and dependency closure. |
+| `v0.94` | Distributed-substrate integration, cross-band convergence, and dependency closure if promoted into a full milestone package. |
 | `v0.95` | MVP convergence, polished demo catalog, coherent reviewer/customer walkthrough, control-plane/tooling hardening, feature freeze, and the 1.0 scope boundary. |
 
 ## Implemented Platform Highlights


### PR DESCRIPTION
Closes #2439

## Summary
- record the v0.90.4 next-milestone handoff as a zero-leftover closeout for the bounded contract-market and resource-stewardship slice
- reaffirm v0.90.5, v0.91, v0.92, and v0.93 milestone boundaries without deleting or collapsing future planned work
- update the global feature list so v0.90.4 is recorded as a completed bounded economics baseline rather than unfinished carry-forward debt

## Validation
- git diff --check
- manual host-path leakage scan on touched handoff docs
- bash adl/tools/validate_structured_prompt.sh --type sor --input .adl/v0.90.4/tasks/issue-2439__v0-90-4-wp-19-next-milestone-planning-handoff/sor.md

## Notes
- docs-only issue; no full Rust test cycle was run by design