### PR TITLE
[v0.90.4][review] Harden Sprint 1 proof identity and negative-case coverage

### DIFF
--- a/adl/src/runtime_v2/bid_schema.rs
+++ b/adl/src/runtime_v2/bid_schema.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeSet;
 
 pub const RUNTIME_V2_BID_ARTIFACT_SCHEMA: &str = "runtime_v2.bid_artifact.v1";
 pub const RUNTIME_V2_BID_NEGATIVE_CASES_SCHEMA: &str = "runtime_v2.bid_negative_cases.v1";
@@ -595,6 +596,25 @@ impl RuntimeV2BidNegativeCases {
         if self.required_negative_cases.len() != 7 {
             return Err(anyhow!(
                 "bid_negative_cases.required_negative_cases must contain seven required mutations"
+            ));
+        }
+        let actual_case_ids = self
+            .required_negative_cases
+            .iter()
+            .map(|case| case.case_id.as_str())
+            .collect::<BTreeSet<_>>();
+        let expected_case_ids = BTreeSet::from([
+            "ineligible-counterparty",
+            "late-bid",
+            "missing-commitments",
+            "missing-signature-requirements",
+            "missing-trace-requirements",
+            "tool-usage-outside-contract-constraints",
+            "wrong-contract-id",
+        ]);
+        if actual_case_ids != expected_case_ids {
+            return Err(anyhow!(
+                "bid_negative_cases.required_negative_cases must contain the required case-id set"
             ));
         }
         for case in &self.required_negative_cases {

--- a/adl/src/runtime_v2/contract_schema.rs
+++ b/adl/src/runtime_v2/contract_schema.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeSet;
 
 pub const RUNTIME_V2_CONTRACT_ARTIFACT_SCHEMA: &str = "runtime_v2.contract_artifact.v1";
 pub const RUNTIME_V2_CONTRACT_NEGATIVE_CASES_SCHEMA: &str = "runtime_v2.contract_negative_cases.v1";
@@ -431,6 +432,23 @@ impl RuntimeV2ContractNegativeCases {
         if self.required_negative_cases.len() != 5 {
             return Err(anyhow!(
                 "contract_negative_cases.required_negative_cases must contain five required mutations"
+            ));
+        }
+        let actual_case_ids = self
+            .required_negative_cases
+            .iter()
+            .map(|case| case.case_id.as_str())
+            .collect::<BTreeSet<_>>();
+        let expected_case_ids = BTreeSet::from([
+            "incomplete-evaluation-criteria",
+            "missing-authority-basis",
+            "missing-trace-requirements",
+            "tool-requirement-implies-direct-execution",
+            "unsupported-lifecycle-state",
+        ]);
+        if actual_case_ids != expected_case_ids {
+            return Err(anyhow!(
+                "contract_negative_cases.required_negative_cases must contain the required case-id set"
             ));
         }
         for case in &self.required_negative_cases {

--- a/adl/src/runtime_v2/evaluation_selection.rs
+++ b/adl/src/runtime_v2/evaluation_selection.rs
@@ -240,7 +240,7 @@ impl RuntimeV2EvaluationSelectionArtifact {
 
         let artifact = Self {
             schema_version: RUNTIME_V2_EVALUATION_SELECTION_SCHEMA.to_string(),
-            demo_id: "D3".to_string(),
+            demo_id: "D4".to_string(),
             wp_id: "WP-05".to_string(),
             evaluation_id: "selection-observatory-readiness-alpha".to_string(),
             artifact_path: RUNTIME_V2_EVALUATION_SELECTION_PATH.to_string(),
@@ -752,7 +752,7 @@ impl RuntimeV2SelectionNegativeCases {
         let proof = Self {
             schema_version: RUNTIME_V2_SELECTION_NEGATIVE_CASES_SCHEMA.to_string(),
             proof_id: "evaluation-selection-negative-cases".to_string(),
-            demo_id: "D3".to_string(),
+            demo_id: "D4".to_string(),
             artifact_path: RUNTIME_V2_SELECTION_NEGATIVE_CASES_PATH.to_string(),
             contract_ref: contract.artifact_path.clone(),
             valid_selection_ref: selection.artifact_path.clone(),
@@ -827,6 +827,21 @@ impl RuntimeV2SelectionNegativeCases {
         if self.required_negative_cases.len() != 3 {
             return Err(anyhow!(
                 "selection_negative_cases.required_negative_cases must contain three required mutations"
+            ));
+        }
+        let actual_case_ids = self
+            .required_negative_cases
+            .iter()
+            .map(|case| case.case_id.as_str())
+            .collect::<BTreeSet<_>>();
+        let expected_case_ids = BTreeSet::from([
+            "selected-bid-loses-mandatory-criterion",
+            "top-score-tie-without-rationale",
+            "unsupported-override-authority-shortcut",
+        ]);
+        if actual_case_ids != expected_case_ids {
+            return Err(anyhow!(
+                "selection_negative_cases.required_negative_cases must contain the required case-id set"
             ));
         }
         validate_nonempty_text(

--- a/adl/src/runtime_v2/tests/bid_schema.rs
+++ b/adl/src/runtime_v2/tests/bid_schema.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeSet;
 
 #[test]
 fn runtime_v2_bid_schema_contract_is_stable() {
@@ -9,6 +10,18 @@ fn runtime_v2_bid_schema_contract_is_stable() {
     assert_eq!(artifacts.valid_bids[0].demo_id, "D3");
     assert_eq!(artifacts.valid_bids[1].demo_id, "D3");
     assert_eq!(artifacts.negative_cases.required_negative_cases.len(), 7);
+    assert_eq!(
+        required_case_ids(&artifacts.negative_cases.required_negative_cases),
+        BTreeSet::from([
+            "ineligible-counterparty".to_string(),
+            "late-bid".to_string(),
+            "missing-commitments".to_string(),
+            "missing-signature-requirements".to_string(),
+            "missing-trace-requirements".to_string(),
+            "tool-usage-outside-contract-constraints".to_string(),
+            "wrong-contract-id".to_string(),
+        ])
+    );
 }
 
 #[test]
@@ -111,6 +124,20 @@ fn runtime_v2_bid_schema_rejects_invalid_bid_fixtures_for_expected_reasons() {
     }
 }
 
+#[test]
+fn runtime_v2_bid_schema_requires_named_negative_case_membership() {
+    let artifacts = runtime_v2_bid_schema_contract().expect("bid schema artifacts");
+    let mut invalid = artifacts.negative_cases.clone();
+    invalid.required_negative_cases[0] = invalid.required_negative_cases[6].clone();
+    invalid.required_negative_cases[0].case_id = "arbitrary-failing-case".to_string();
+
+    assert!(invalid
+        .validate_against(&artifacts.contract, &artifacts.valid_bids)
+        .expect_err("negative-case membership drift should fail")
+        .to_string()
+        .contains("must contain the required case-id set"));
+}
+
 #[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_bid_schema_write_to_root_materializes_fixtures() {
@@ -133,4 +160,8 @@ fn runtime_v2_bid_schema_write_to_root_materializes_fixtures() {
     }
 
     std::fs::remove_dir_all(root).expect("cleanup bid schema temp root");
+}
+
+fn required_case_ids(cases: &[RuntimeV2BidNegativeCase]) -> BTreeSet<String> {
+    cases.iter().map(|case| case.case_id.clone()).collect()
 }

--- a/adl/src/runtime_v2/tests/contract_schema.rs
+++ b/adl/src/runtime_v2/tests/contract_schema.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeSet;
 
 #[test]
 fn runtime_v2_contract_schema_contract_is_stable() {
@@ -15,6 +16,16 @@ fn runtime_v2_contract_schema_contract_is_stable() {
     assert_eq!(artifacts.contract.lifecycle_state, "bidding");
     assert_eq!(artifacts.contract.evaluation_criteria.len(), 3);
     assert_eq!(artifacts.negative_cases.required_negative_cases.len(), 5);
+    assert_eq!(
+        required_case_ids(&artifacts.negative_cases.required_negative_cases),
+        BTreeSet::from([
+            "incomplete-evaluation-criteria".to_string(),
+            "missing-authority-basis".to_string(),
+            "missing-trace-requirements".to_string(),
+            "tool-requirement-implies-direct-execution".to_string(),
+            "unsupported-lifecycle-state".to_string(),
+        ])
+    );
 }
 
 #[test]
@@ -93,6 +104,20 @@ fn runtime_v2_contract_schema_rejects_invalid_contract_fixtures_for_expected_rea
     }
 }
 
+#[test]
+fn runtime_v2_contract_schema_requires_named_negative_case_membership() {
+    let artifacts = runtime_v2_contract_schema_contract().expect("contract schema artifacts");
+    let mut invalid = artifacts.negative_cases.clone();
+    invalid.required_negative_cases[0] = invalid.required_negative_cases[4].clone();
+    invalid.required_negative_cases[0].case_id = "arbitrary-failing-case".to_string();
+
+    assert!(invalid
+        .validate_against(&artifacts.contract)
+        .expect_err("negative-case membership drift should fail")
+        .to_string()
+        .contains("must contain the required case-id set"));
+}
+
 #[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_contract_schema_write_to_root_materializes_fixtures() {
@@ -114,4 +139,8 @@ fn runtime_v2_contract_schema_write_to_root_materializes_fixtures() {
     }
 
     std::fs::remove_dir_all(root).expect("cleanup contract schema temp root");
+}
+
+fn required_case_ids(cases: &[RuntimeV2ContractNegativeCase]) -> BTreeSet<String> {
+    cases.iter().map(|case| case.case_id.clone()).collect()
 }

--- a/adl/src/runtime_v2/tests/evaluation_selection.rs
+++ b/adl/src/runtime_v2/tests/evaluation_selection.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeSet;
 
 #[test]
 fn runtime_v2_evaluation_selection_contract_is_stable() {
@@ -10,9 +11,17 @@ fn runtime_v2_evaluation_selection_contract_is_stable() {
         artifacts.selection.schema_version,
         RUNTIME_V2_EVALUATION_SELECTION_SCHEMA
     );
-    assert_eq!(artifacts.selection.demo_id, "D3");
+    assert_eq!(artifacts.selection.demo_id, "D4");
     assert_eq!(artifacts.selection.bid_evaluations.len(), 2);
     assert_eq!(artifacts.negative_cases.required_negative_cases.len(), 3);
+    assert_eq!(
+        required_case_ids(&artifacts.negative_cases.required_negative_cases),
+        BTreeSet::from([
+            "selected-bid-loses-mandatory-criterion".to_string(),
+            "top-score-tie-without-rationale".to_string(),
+            "unsupported-override-authority-shortcut".to_string(),
+        ])
+    );
     assert_eq!(
         artifacts.selection.recommendation.selected_bid_id,
         artifacts.valid_bids[0].bid_id
@@ -139,7 +148,7 @@ fn runtime_v2_evaluation_selection_write_to_root_materializes_fixtures() {
         RUNTIME_V2_SELECTION_NEGATIVE_CASES_PATH,
     ] {
         let text = std::fs::read_to_string(root.join(rel_path)).expect("artifact text");
-        assert!(text.contains("D3"));
+        assert!(text.contains("D4"));
         assert!(text.contains("selection"));
         assert!(!text.contains(root.to_string_lossy().as_ref()));
     }
@@ -269,4 +278,27 @@ fn runtime_v2_evaluation_selection_rejects_unnecessary_tie_breaks_and_negative_c
         .expect_err("negative case count drift should fail")
         .to_string()
         .contains("must contain three required mutations"));
+}
+
+#[test]
+fn runtime_v2_evaluation_selection_requires_named_negative_case_membership() {
+    let artifacts =
+        RuntimeV2EvaluationSelectionArtifacts::prototype().expect("evaluation selection");
+    let mut invalid = artifacts.negative_cases.clone();
+    invalid.required_negative_cases[0] = invalid.required_negative_cases[2].clone();
+    invalid.required_negative_cases[0].case_id = "arbitrary-failing-case".to_string();
+
+    assert!(invalid
+        .validate_against(
+            &artifacts.contract,
+            &artifacts.valid_bids,
+            &artifacts.selection
+        )
+        .expect_err("negative-case membership drift should fail")
+        .to_string()
+        .contains("must contain the required case-id set"));
+}
+
+fn required_case_ids(cases: &[RuntimeV2SelectionNegativeCase]) -> BTreeSet<String> {
+    cases.iter().map(|case| case.case_id.clone()).collect()
 }

--- a/adl/tests/fixtures/runtime_v2/contract_market/evaluation_selection.json
+++ b/adl/tests/fixtures/runtime_v2/contract_market/evaluation_selection.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "runtime_v2.evaluation_selection_artifact.v1",
-  "demo_id": "D3",
+  "demo_id": "D4",
   "wp_id": "WP-05",
   "evaluation_id": "selection-observatory-readiness-alpha",
   "artifact_path": "runtime_v2/contract_market/evaluation_selection.json",

--- a/adl/tests/fixtures/runtime_v2/contract_market/selection_negative_cases.json
+++ b/adl/tests/fixtures/runtime_v2/contract_market/selection_negative_cases.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "runtime_v2.selection_negative_cases.v1",
   "proof_id": "evaluation-selection-negative-cases",
-  "demo_id": "D3",
+  "demo_id": "D4",
   "artifact_path": "runtime_v2/contract_market/selection_negative_cases.json",
   "contract_ref": "runtime_v2/contract_market/parent_contract.json",
   "valid_selection_ref": "runtime_v2/contract_market/evaluation_selection.json",
@@ -12,7 +12,7 @@
       "expected_error_fragment": "selected bid must satisfy all mandatory criteria",
       "invalid_selection": {
         "schema_version": "runtime_v2.evaluation_selection_artifact.v1",
-        "demo_id": "D3",
+        "demo_id": "D4",
         "wp_id": "WP-05",
         "evaluation_id": "selection-observatory-readiness-alpha",
         "artifact_path": "runtime_v2/contract_market/evaluation_selection.json",
@@ -169,7 +169,7 @@
       "expected_error_fragment": "selection_recommendation.tie_break_rationale is required when top bids tie",
       "invalid_selection": {
         "schema_version": "runtime_v2.evaluation_selection_artifact.v1",
-        "demo_id": "D3",
+        "demo_id": "D4",
         "wp_id": "WP-05",
         "evaluation_id": "selection-observatory-readiness-alpha",
         "artifact_path": "runtime_v2/contract_market/evaluation_selection.json",
@@ -324,7 +324,7 @@
       "expected_error_fragment": "selection override rationale must not treat adapter availability, model confidence, or valid JSON as tool execution authority",
       "invalid_selection": {
         "schema_version": "runtime_v2.evaluation_selection_artifact.v1",
-        "demo_id": "D3",
+        "demo_id": "D4",
         "wp_id": "WP-05",
         "evaluation_id": "selection-observatory-readiness-alpha",
         "artifact_path": "runtime_v2/contract_market/evaluation_selection.json",


### PR DESCRIPTION
Closes #2557

## Summary
Implemented and verified the Sprint 1 proof-hardening surface for issue `#2557`. The branch aligns WP-05 evaluation artifacts to the milestone D4 identity and hardens contract, bid, and evaluation negative-case validators/tests so they require the named case-id sets rather than only counts and failing fragments.

## Artifacts
- Updated Runtime v2 proof code in `adl/src/runtime_v2/contract_schema.rs`, `adl/src/runtime_v2/bid_schema.rs`, and `adl/src/runtime_v2/evaluation_selection.rs`.
- Updated focused Runtime v2 tests in `adl/src/runtime_v2/tests/contract_schema.rs`, `adl/src/runtime_v2/tests/bid_schema.rs`, and `adl/src/runtime_v2/tests/evaluation_selection.rs`.
- Updated golden fixtures in `adl/tests/fixtures/runtime_v2/contract_market/evaluation_selection.json` and `adl/tests/fixtures/runtime_v2/contract_market/selection_negative_cases.json`.
- Generated local coverage summary at `adl/target/coverage-impact-summary.json`; this is a build artifact and is not a tracked deliverable.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh doctor 2557 --slug v0-90-4-review-harden-sprint-1-proof-identity-and-negative-case-coverage --version v0.90.4 --mode full --json`
    Confirmed `doctor_status: PASS`, `ready_status: PASS`, and the bound issue worktree `.worktrees/adl-wp-2557`.
  - `workflow-conductor route_issue for issue 2557`
    Confirmed lifecycle routing to `pr-run`.
  - `bash adl/tools/pr.sh run 2557 --slug v0-90-4-review-harden-sprint-1-proof-identity-and-negative-case-coverage --version v0.90.4`
    Confirmed branch/worktree binding and local STP/SIP/SOR cards.
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Formatted the touched Rust source and tests.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_contract_schema -- --nocapture`
    Verified the contract-schema proof surface, including named negative-case membership.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_bid_schema -- --nocapture`
    Verified the bid-schema proof surface, including named negative-case membership.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_evaluation_selection -- --nocapture`
    Verified the WP-05 evaluation-selection D4 identity and named negative-case membership.
  - `git diff --check`
    Verified the final diff had no whitespace errors.
  - `cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- runtime_v2_contract_schema runtime_v2_bid_schema runtime_v2_evaluation_selection`
    Generated coverage-impact summary evidence for the focused changed Rust surfaces.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified coverage-impact preflight passed for changed Rust source files.
- Results:
  - PASS
- Intentionally not run:
  - Full local Rust test cycle was not run because the issue is bounded to Sprint 1 Runtime v2 proof hardening; focused tests plus coverage-impact evidence prove the changed surface.
  - No standalone demo command was run because the issue prompt names the hardened Runtime v2 proof tests and corrected proof identity as the proof surface.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.4/tasks/issue-2557__v0-90-4-review-harden-sprint-1-proof-identity-and-negative-case-coverage/sip.md
- Output card: .adl/v0.90.4/tasks/issue-2557__v0-90-4-review-harden-sprint-1-proof-identity-and-negative-case-coverage/sor.md
- Idempotency-Key: v0-90-4-review-harden-sprint-1-proof-identity-and-negative-case-coverage-adl-src-runtime-v2-contract-schema-rs-adl-src-runtime-v2-bid-schema-rs-adl-src-runtime-v2-evaluation-selection-rs-adl-src-runtime-v2-tests-contract-schema-rs-adl-src-runtime-v2-tests-bid-schema-rs-adl-src-runtime-v2-tests-evaluation-selection-rs-adl-tests-fixtures-runtime-v2-contract-market-evaluation-selection-json-adl-tests-fixtures-runtime-v2-contract-market-selection-negative-cases-json-adl-v0-90-4-tasks-issue-2557-v0-90-4-review-harden-sprint-1-proof-identity-and-negative-case-coverage-sip-md-adl-v0-90-4-tasks-issue-2557-v0-90-4-review-harden-sprint-1-proof-identity-and-negative-case-coverage-sor-md