### PR TITLE
[v0.90.4][WP-20] Release ceremony

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,27 @@ All notable project-level changes are summarized here by milestone/release.
 ## v0.90.4 (In development)
 
 Status: v0.90.4 is the active citizen economics and contract-market milestone.
-The issue wave is open as #2420-#2440, and the active crate/package version
+The issue wave opened as #2420-#2440; WP-15 through WP-19 are now closed, WP-20
+release ceremony remains open as #2440, and the active crate/package version
 surface is now `0.90.4` for the live development line even though the latest
 released tag remains v0.90.3 until v0.90.4 closes.
 
 Scope note:
-- This entry is intentionally minimal during the live issue wave.
+- This entry is intentionally bounded during the live release tail.
 - Detailed milestone scope, proof expectations, and release-tail truth live in
   `docs/milestones/v0.90.4/`.
+- ADR 0014 now records the contract-market architecture boundary for the
+  milestone.
 
 ## v0.90.3 (Released 2026-04-23)
 
-Status: Issue wave opened on 2026-04-21. WP-01 is #2327, WP-02 through WP-14
-are #2328-#2340, WP-14A is #2341, and WP-15 through WP-20 are #2342-#2347.
-WP-01 through WP-19 have landed. WP-16 internal review closed with only minor
-internal cleanup, WP-17 external review closed with zero third-party findings,
-WP-18 closed by zero-finding disposition plus trivial follow-up #2415, WP-19
-completed the next-milestone handoff, and only WP-20 release ceremony remains.
+Status: Released. The issue wave opened on 2026-04-21 as #2327-#2347 and is now
+fully closed. Internal review, external review, accepted-finding disposition,
+next-milestone handoff, and release ceremony are complete.
 
-Planned scope:
+Scope:
 - v0.90.3 is the citizen-state substrate milestone.
-- The milestone should turn v0.90.2 bounded CSM run evidence into protected
+- The milestone turned v0.90.2 bounded CSM run evidence into protected
   continuity substrate work: canonical private state, signed envelopes,
   local-first sealing, append-only lineage, continuity witnesses and receipts,
   anti-equivocation, sanctuary/quarantine behavior, redacted Observatory

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Other useful entrypoints:
 ## Current Status
 
 - Active milestone: **v0.90.4**
-- Current release state: **v0.90.3 is released; v0.90.4 is open as issue wave #2420-#2440**
+- Current release state: **v0.90.3 is released; v0.90.4 has only WP-20 (#2440) remaining in the release tail**
 - Most recently completed milestone: **v0.90.3**
 - Current crate version: **0.90.4**
 - Version note: **v0.90.4 is the active citizen economics and contract-market development line**
@@ -134,22 +134,24 @@ ADL is in active development. This repository contains both implemented runtime 
 
 v0.90.4 is the active citizen economics and contract-market substrate
 milestone. Its tracked package lives under `docs/milestones/v0.90.4/`. The
-issue wave is open as #2420-#2440: WP-01 is #2420, WP-02 through WP-14 are
-#2421-#2433, WP-14A is #2434, and WP-15 through WP-20 are #2435-#2440.
+issue wave opened as #2420-#2440: WP-01 is #2420, WP-02 through WP-14 are
+#2421-#2433, WP-14A is #2434, WP-15 through WP-19 are now closed as
+#2435-#2439, and WP-20 release ceremony remains open as #2440.
 
 v0.90.3 is now the most recently completed citizen-state milestone. The latest
 released tag remains v0.90.3, while the active development crate line is now
 0.90.4 for the open v0.90.4 milestone.
 
 The current release-tail entry surface is
-`docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md`. It records the landed
-feature-proof coverage record, closed internal review, clean third-party review
-result, accepted-finding disposition, completed next-milestone handoff, and the
-fact that v0.90.4 is ready to open immediately after ceremony.
+`docs/milestones/v0.90.4/README.md`. It records the landed feature-proof
+coverage record, closed internal review, completed third-party review, ADR 0014
+architecture remediation, completed next-milestone handoff, and the fact that
+only ceremony remains open.
 
-v0.90.3 should turn the bounded CSM run from v0.90.2 into safer citizen-state
-substrate work: canonical private state, signed envelopes, local-first sealing,
-append-only lineage, continuity witnesses and receipts, anti-equivocation,
+v0.90.3 is the most recently released citizen-state milestone. It turned the
+bounded CSM run from v0.90.2 into safer citizen-state substrate work:
+canonical private state, signed envelopes, local-first sealing, append-only
+lineage, continuity witnesses and receipts, anti-equivocation,
 sanctuary/quarantine behavior, redacted Observatory projections, standing and
 access-control semantics, challenge/appeal flow, threat modeling, and one
 integrated citizen-state proof demo. It does not claim first true Gödel-agent

--- a/docs/milestones/v0.90.4/ADL_v0.90.4_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.90.4/ADL_v0.90.4_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -7,16 +7,13 @@
 - Review issue: `#2437`
 - Review materials: `docs/reviews/v0.90.4/external/`
 - Remediation lane: `WP-18` / `#2438`
-- Status: handoff prepared, external review pending
+- Status: external review complete; accepted finding remediated
 
 ## Summary
 
-This document is the tracked third-party review handoff surface for `v0.90.4`.
-
-It does not claim the external review has already happened. It records the
-bounded review scope, non-claims, expected artifact locations, and finding
-routing so an outside reviewer can evaluate the contract-market milestone
-without reconstructing the whole issue wave manually.
+This document began as the tracked third-party review handoff surface for
+`v0.90.4`. The external review is now complete, so this file also records the
+review outcome and the routing/remediation result.
 
 The intended review target is the bounded `v0.90.4` contract-market and
 resource-stewardship slice:
@@ -49,20 +46,11 @@ Primary review questions:
 The review should use the prepared handoff packet under
 `docs/reviews/v0.90.4/external/README.md` as the detailed entry surface.
 
-## Expected Imported Artifacts
+## Imported Review Artifacts
 
-Imported third-party review artifacts should be stored under
-`docs/reviews/v0.90.4/external/`, not loose project-root or milestone-root
-locations.
-
-Expected imported surfaces:
+Tracked review summary:
 
 - `docs/reviews/v0.90.4/external/EXTERNAL_REVIEW_SUMMARY.md`
-- `docs/reviews/v0.90.4/external/EXTERNAL_REVIEW_FULL_ARTIFACT.md`
-
-If the reviewer delivers another bounded format such as PDF, keep the summary
-in that directory and store the full artifact beside it with a stable,
-descriptive filename.
 
 ## Finding Routing Rule
 
@@ -71,6 +59,12 @@ descriptive filename.
   silence.
 - Findings that would widen `v0.90.4` beyond its bounded scope should be marked
   as non-blocking follow-on considerations rather than hidden release blockers.
+
+## Review Outcome
+
+- Overall result: ready after one P2 architecture remediation
+- Accepted finding: add ADR 0014 for the v0.90.4 contract-market architecture
+- Remediation result: completed in `WP-18` / `#2438`
 
 ## Non-Claims
 
@@ -86,5 +80,5 @@ This handoff does not claim that `v0.90.4` ships:
 
 ## Current Disposition
 
-Current disposition: ready for third-party review handoff, not yet a completed
-third-party review record.
+Current disposition: completed third-party review with one accepted P2 finding,
+now remediated by ADR 0014.

--- a/docs/milestones/v0.90.4/END_OF_MILESTONE_REPORT_v0.90.4.md
+++ b/docs/milestones/v0.90.4/END_OF_MILESTONE_REPORT_v0.90.4.md
@@ -1,0 +1,85 @@
+# End Of Milestone Report - v0.90.4
+
+## Status
+
+Pre-ceremony closeout report for `v0.90.4`.
+
+The implementation wave, feature-proof coverage, internal review, third-party
+review, ADR remediation, and next-milestone handoff are complete. Only the
+release-ceremony step remains open.
+
+## What v0.90.4 Delivered
+
+`v0.90.4` delivered ADL's first bounded citizen economics and contract-market
+substrate:
+
+- economics inheritance and authority audit from `v0.90.3`
+- contract schema
+- bid schema
+- evaluation and selection model
+- transition authority model
+- contract lifecycle state
+- external counterparty boundary
+- delegation and subcontract model
+- resource-stewardship bridge
+- contract-market fixture set
+- deterministic contract-market runner
+- reviewer-facing summary surfaces
+- bounded contract-market proof and negative packet
+- explicit feature-proof coverage through `WP-14A`
+
+## Review Result
+
+- Internal review: complete (`WP-16` / `#2436`)
+- External review: complete (`WP-17` / `#2437`)
+- Accepted findings remediation: complete (`WP-18` / `#2438`)
+
+The third-party review found one accepted P2 item:
+
+- missing ADR 0014 for the contract-market architecture
+
+That finding is now closed by:
+
+- `docs/adr/0014-contract-market-architecture.md`
+
+## Architecture Outcome
+
+Architecture outcome for `v0.90.4`: `architecture-update`
+
+The milestone did not remain architecture-neutral. It now has an accepted ADR
+for the contract-market substrate, explicitly grounded in:
+
+- contract and bid artifacts
+- evaluation and transition authority
+- external counterparty boundaries
+- delegation/subcontract parent responsibility
+- resource-stewardship bridge semantics
+- the governed-tools handoff boundary to `v0.90.5`
+
+## Scope Discipline Held
+
+`v0.90.4` still does not claim:
+
+- payment settlement
+- Lightning, x402, banking, invoicing, tax, or legal-contracting rails
+- full inter-polis economics
+- production counterparty identity/compliance systems
+- Governed Tools v1.0, UTS, ACC, registry binding, or executor authority
+- `v0.91` or `v0.92` completion
+
+## Handoff Result
+
+The handoff remains clean:
+
+- no vague leftover `v0.90.4` economics debt is being parked into later work
+- `v0.90.5` remains the governed-tools milestone
+- `v0.91`, `v0.92`, and `v0.93` remain intact rather than reduced or rewritten
+- future `WP-19` handoffs should include explicit ADL architecture-doc review
+  and update when scope changes have architectural consequences
+
+## Remaining Open Step
+
+- `WP-20` / `#2440` release ceremony
+
+At this point, the open work is release closure, not hidden implementation or
+architecture recovery.

--- a/docs/milestones/v0.90.4/FEATURE_DOCS_v0.90.4.md
+++ b/docs/milestones/v0.90.4/FEATURE_DOCS_v0.90.4.md
@@ -18,6 +18,9 @@
 | WBS_v0.90.4.md | opened execution map for the contract-market substrate milestone | WP-01 / #2420 |
 | DEMO_MATRIX_v0.90.4.md | live proof matrix and non-proving boundaries | WP-01 / #2420, WP-14 / #2433, WP-14A / #2434 |
 | FEATURE_PROOF_COVERAGE_v0.90.4.md | reviewer map from every D1-D13 claim to its landed proof home and explicit non-proving governed-tool handoff boundary | WP-14A / #2434 |
+| ../../adr/0014-contract-market-architecture.md | accepted architecture record for the bounded contract-market substrate and governed-tools handoff boundary | WP-18 / #2438 |
+| ../../reviews/v0.90.4/external/EXTERNAL_REVIEW_SUMMARY.md | tracked third-party review result and accepted-finding summary | WP-17 / #2437 |
+| END_OF_MILESTONE_REPORT_v0.90.4.md | closeout summary of landed scope, review outcome, ADR remediation, and carry-forward placement | WP-20 / #2440 |
 | WP_ISSUE_WAVE_v0.90.4.yaml | opened issue-wave source of truth with real issue numbers | WP-01 / #2420 |
 | WP_EXECUTION_READINESS_v0.90.4.md | card-authoring source for concrete WP outputs and validation | WP-01 / #2420 |
 

--- a/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
+++ b/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
@@ -28,20 +28,20 @@
 ## Review Readiness
 
 - [x] Demo matrix reflects actual proof status.
-- [ ] Feature docs match implemented artifacts.
-- [ ] Review summary artifact is truthful and reviewer-facing.
-- [ ] Architecture summary and no-change declaration in closeout reviewed.
-- [ ] Negative authority and trace cases are recorded.
-- [ ] Tool-mediated contract requirements are marked as constraints, not tool
+- [x] Feature docs match implemented artifacts.
+- [x] Review summary artifact is truthful and reviewer-facing.
+- [x] Architecture summary and change declaration in closeout reviewed.
+- [x] Negative authority and trace cases are recorded.
+- [x] Tool-mediated contract requirements are marked as constraints, not tool
   execution proof.
 - [x] Release notes avoid aspirational shipped language until closeout.
 
 ## Release Readiness
 
-- [ ] Internal review complete.
-- [ ] External review complete or explicitly waived.
-- [ ] Accepted findings fixed or dispositioned.
-- [ ] Changelog, README, Cargo metadata, and milestone docs aligned.
-- [ ] Architecture closeout entry reflects actual documentation delta status.
-- [ ] End-of-milestone report written or refreshed.
+- [x] Internal review complete.
+- [x] External review complete or explicitly waived.
+- [x] Accepted findings fixed or dispositioned.
+- [x] Changelog, README, Cargo metadata, and milestone docs aligned.
+- [x] Architecture closeout entry reflects actual documentation delta status.
+- [x] End-of-milestone report written or refreshed.
 - [ ] Ceremony completed.

--- a/docs/milestones/v0.90.4/NEXT_MILESTONE_HANDOFF_v0.90.4.md
+++ b/docs/milestones/v0.90.4/NEXT_MILESTONE_HANDOFF_v0.90.4.md
@@ -87,3 +87,10 @@ It preserves:
   governance
 
 The handoff result is a clean milestone chain, not a new backlog.
+
+## Future WP-19 Rule
+
+Future WP-19 handoffs should include an explicit ADL architecture-doc review and
+update pass when milestone scope changes have architectural consequences. The
+architecture narrative should move forward with next-milestone planning rather
+than waiting to surface only during late review or release-tail remediation.

--- a/docs/milestones/v0.90.4/README.md
+++ b/docs/milestones/v0.90.4/README.md
@@ -12,9 +12,9 @@ During the live release tail, active crate and CLI version surfaces should read
 `0.90.4` even though the latest published release tag remains `v0.90.3` until
 v0.90.4 ceremony closes.
 
-The issue wave is now live as #2420 through #2440. WP-01 through WP-14A are
-closed, and Sprint 4 remains active as WP-15 through WP-20. This package is no
-longer planning-only truth: it is the tracked execution map for the live
+The issue wave is now live as #2420 through #2440. WP-01 through WP-19 are
+closed, and only WP-20 release ceremony remains open as #2440. This package is
+no longer planning-only truth: it is the tracked execution map for the live
 v0.90.4 wave.
 
 ## Thesis
@@ -99,7 +99,9 @@ Out of scope:
 - Milestone checklist: MILESTONE_CHECKLIST_v0.90.4.md
 - Release plan: RELEASE_PLAN_v0.90.4.md
 - Release notes draft: RELEASE_NOTES_v0.90.4.md
+- End-of-milestone report: END_OF_MILESTONE_REPORT_v0.90.4.md
 - Third-party review handoff: ADL_v0.90.4_THIRD_PARTY_REVIEW_HANDOFF.md
+- External review summary: ../../reviews/v0.90.4/external/EXTERNAL_REVIEW_SUMMARY.md
 - Next-milestone handoff: NEXT_MILESTONE_HANDOFF_v0.90.4.md
 - Issue wave: WP_ISSUE_WAVE_v0.90.4.yaml
 
@@ -124,7 +126,7 @@ The official v0.90.4 wave is live:
 - Sprint 1 (#2420 through #2424) is closed
 - Sprint 2 (#2425 through #2429) is closed
 - Sprint 3 (#2430 through #2434) is closed
-- Sprint 4 (#2435 through #2440) is the remaining open release-tail tranche
+- Sprint 4 closeout is down to WP-20 (#2440) release ceremony only
 
 WP-14A remained explicit as #2434 so demo/proof coverage did not disappear into
 review tail work, and its resulting proof status is now recorded in

--- a/docs/milestones/v0.90.4/RELEASE_NOTES_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_NOTES_v0.90.4.md
@@ -2,17 +2,18 @@
 
 ## Status
 
-Draft only. Do not ship these notes until v0.90.4 closeout replaces planned
-language with actual release evidence.
+Pre-ceremony release notes draft. The implementation, feature-proof coverage,
+internal review, external review, ADR 0014 remediation, and next-milestone
+handoff are complete; only WP-20 ceremony remains before release publication.
 
-## Planned Headline
+## Draft Headline
 
-v0.90.4 is planned to introduce ADL's first citizen economics and contract-market
+v0.90.4 introduces ADL's first bounded citizen economics and contract-market
 substrate: governed contracts, bids, evaluation, lifecycle authority,
-counterparty participation, delegation, fixture-backed execution, and a bounded
-reviewable market proof.
+counterparty participation, delegation, fixture-backed execution, a reviewer-
+facing proof packet, and an explicit governed-tools handoff boundary.
 
-## Planned Highlights
+## Draft Highlights
 
 - contract and bid schemas
 - evaluation and selection artifacts
@@ -24,14 +25,19 @@ reviewable market proof.
 - bounded contract-market demo
 - negative authority and trace cases
 - resource-stewardship bridge without payment rails
+- ADR 0014 contract-market architecture record
 
-## Planned Non-Claims
+## Draft Non-Claims
 
-- v0.90.4 is not planned to ship payment settlement.
-- v0.90.4 is not planned to ship full inter-polis economics.
-- v0.90.4 is not planned to redefine citizen standing or private-state
+- v0.90.4 does not ship payment settlement.
+- v0.90.4 does not ship full inter-polis economics.
+- v0.90.4 does not redefine citizen standing or private-state
   authority.
-- v0.90.4 is not planned to ship Governed Tools v1.0, UTS, ACC, or production
+- v0.90.4 does not ship Governed Tools v1.0, UTS, ACC, or production
   tool-call execution authority.
-- v0.90.4 is not planned to ship production legal contracting, billing, tax, or
+- v0.90.4 does not ship production legal contracting, billing, tax, or
   counterparty identity verification.
+
+## Release Note Rule
+
+At ceremony closeout, keep only landed evidence and any explicit deferrals.

--- a/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
@@ -7,11 +7,14 @@ schema, lifecycle, authority, fixture, runner, demo, and review-summary story.
 
 - Issue wave opened by WP-01 as #2420.
 - WP-02 through WP-14A are closed as #2421 through #2434.
-- WP-15 through WP-20 remain open as #2435 through #2440.
+- WP-15 through WP-19 are closed as #2435 through #2439.
+- WP-20 release ceremony remains open as #2440.
 - The tracked milestone package now records the live issue map and execution
   order.
 - Demo/proof coverage has been carried through WP-14A and is now recorded in
   DEMO_MATRIX_v0.90.4.md.
+- Third-party review is complete with one accepted P2 architecture finding, and
+  ADR 0014 now records the contract-market architecture remediation.
 - Active crate/package version-reporting surfaces should read `0.90.4` during
   the live release tail, even while the latest published tag remains `v0.90.3`
   until ceremony.

--- a/docs/reviews/v0.90.4/external/EXTERNAL_REVIEW_SUMMARY.md
+++ b/docs/reviews/v0.90.4/external/EXTERNAL_REVIEW_SUMMARY.md
@@ -1,0 +1,52 @@
+# External Review Summary - v0.90.4
+
+## Status
+
+Completed third-party review result for the bounded `v0.90.4` contract-market
+milestone.
+
+## Outcome
+
+- Overall grade: `A+ (98/100)`
+- Historical recommendation: ready after ADR 0014 creation
+- Findings: `0 P0`, `0 P1`, `1 P2`
+
+## Accepted Finding
+
+The one accepted finding was architectural documentation drift:
+
+- missing `ADR 0014` for the contract-market architecture
+
+The review concluded that the implementation, proof packet, demo coverage,
+scope discipline, and release-boundary story were otherwise strong.
+
+## Remediation
+
+The accepted finding was remediated in `WP-18` / `#2438` by adding:
+
+- `docs/adr/0014-contract-market-architecture.md`
+
+That ADR records:
+
+- contract schema and bid-evaluation architecture
+- lifecycle and transition authority boundaries
+- external counterparty and delegation/subcontract boundaries
+- resource-stewardship bridge semantics
+- the governed-tools handoff to `v0.90.5`
+
+## Non-Claims Preserved
+
+The review outcome did not ask `v0.90.4` to widen into:
+
+- payment settlement
+- Lightning, x402, banking, invoicing, tax, or legal rails
+- full inter-polis economics
+- Governed Tools v1.0, UTS, ACC, registry binding, or executor authority
+- `v0.91` or `v0.92` scope
+
+## Release-Tail Meaning
+
+The review result means the milestone is architecturally and implementation-wise
+sound at the bounded `v0.90.4` level once ADR 0014 exists. After that
+remediation, the remaining work belongs to normal release-tail alignment and
+ceremony rather than hidden architecture repair.

--- a/docs/reviews/v0.90.4/external/README.md
+++ b/docs/reviews/v0.90.4/external/README.md
@@ -5,7 +5,7 @@
 - Milestone: `v0.90.4`
 - Review lane: `WP-17`
 - Review issue: `#2437`
-- Status: handoff prepared, external review pending
+- Status: external review complete; see `EXTERNAL_REVIEW_SUMMARY.md`
 - Prior review input: `docs/milestones/v0.90.4/INTERNAL_REVIEW_v0.90.4.md` if and when it lands, plus the WP-16 internal review plan used to prepare this packet
 - Remediation lane: `WP-18` / `#2438`
 
@@ -97,14 +97,9 @@ This review should not treat any of the following as shipped `v0.90.4` scope:
 Imported review artifacts for this lane should stay under this directory, not
 loose milestone or project-root locations.
 
-Expected imported artifacts when the review arrives:
+Tracked review artifact:
 
 - `docs/reviews/v0.90.4/external/EXTERNAL_REVIEW_SUMMARY.md`
-- `docs/reviews/v0.90.4/external/EXTERNAL_REVIEW_FULL_ARTIFACT.md`
-
-If the external reviewer delivers another bounded format such as PDF, keep the
-summary in this directory and store the full artifact beside it with a stable,
-descriptive filename.
 
 ## Finding Routing Rule
 
@@ -117,5 +112,5 @@ descriptive filename.
 
 ## Current State
 
-This packet is the prepared handoff surface only. It does not claim the
-external review has already happened.
+This packet remains the bounded entry surface, but the external review itself is
+now complete. The tracked result lives in `EXTERNAL_REVIEW_SUMMARY.md`.


### PR DESCRIPTION
Closes #2440

## Summary
- refresh the v0.90.4 release-tail docs to reflect the real closed/open wave state
- add the end-of-milestone report and tracked external-review summary
- record the ADR 0014 remediation and future WP-19 architecture-doc rule

## Validation
- git diff --check
- host-path and .adl leakage scan across touched release-tail docs
- v0.90.5 package spot-check for issue-wave/features/ideas readiness