### PR TITLE
[v0.90.4][WP-20] Finalize ceremony closeout docs

### DIFF
--- a/docs/milestones/v0.90.4/END_OF_MILESTONE_REPORT_v0.90.4.md
+++ b/docs/milestones/v0.90.4/END_OF_MILESTONE_REPORT_v0.90.4.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Pre-ceremony closeout report for `v0.90.4`.
+Final end-of-milestone report for `v0.90.4`.
 
 The implementation wave, feature-proof coverage, internal review, third-party
-review, ADR remediation, and next-milestone handoff are complete. Only the
-release-ceremony step remains open.
+review, ADR remediation, next-milestone handoff, and release ceremony are
+complete.
 
 ## What v0.90.4 Delivered
 
@@ -77,9 +77,10 @@ The handoff remains clean:
 - future `WP-19` handoffs should include explicit ADL architecture-doc review
   and update when scope changes have architectural consequences
 
-## Remaining Open Step
+## Ceremony Result
 
-- `WP-20` / `#2440` release ceremony
+- `WP-20` / `#2440` release ceremony: complete
 
-At this point, the open work is release closure, not hidden implementation or
-architecture recovery.
+At milestone close, no hidden implementation or architecture recovery work
+remained inside `v0.90.4`; the remaining carry-forward is already placed
+explicitly into later milestones and backlog lanes.

--- a/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
+++ b/docs/milestones/v0.90.4/MILESTONE_CHECKLIST_v0.90.4.md
@@ -44,4 +44,4 @@
 - [x] Changelog, README, Cargo metadata, and milestone docs aligned.
 - [x] Architecture closeout entry reflects actual documentation delta status.
 - [x] End-of-milestone report written or refreshed.
-- [ ] Ceremony completed.
+- [x] Ceremony completed.

--- a/docs/milestones/v0.90.4/README.md
+++ b/docs/milestones/v0.90.4/README.md
@@ -2,20 +2,15 @@
 
 ## Status
 
-Active milestone package. v0.90.4 is the citizen economics and contract-market
+Closed milestone package. v0.90.4 is the citizen economics and contract-market
 substrate milestone. It was initially placed by planning issue #2271, polished
 for execution readiness by #2389, reviewed again during the v0.90.3 WP-19
-handoff pass, and opened by WP-01 as issue #2420 after the v0.90.3 release
-ceremony.
+handoff pass, opened by WP-01 as issue #2420 after the v0.90.3 release
+ceremony, and closed by WP-20 release ceremony issue #2440.
 
-During the live release tail, active crate and CLI version surfaces should read
-`0.90.4` even though the latest published release tag remains `v0.90.3` until
-v0.90.4 ceremony closes.
-
-The issue wave is now live as #2420 through #2440. WP-01 through WP-19 are
-closed, and only WP-20 release ceremony remains open as #2440. This package is
-no longer planning-only truth: it is the tracked execution map for the live
-v0.90.4 wave.
+The issue wave ran as #2420 through #2440, and all twenty work packages are now
+closed. This package is no longer planning-only truth or a live execution map;
+it is the final tracked milestone record for v0.90.4.
 
 ## Thesis
 
@@ -120,13 +115,13 @@ docs instead of generic implementation language.
 
 ## Issue Wave State
 
-The official v0.90.4 wave is live:
+The official v0.90.4 wave is closed:
 
 - WP-01 through WP-20 are #2420 through #2440
 - Sprint 1 (#2420 through #2424) is closed
 - Sprint 2 (#2425 through #2429) is closed
 - Sprint 3 (#2430 through #2434) is closed
-- Sprint 4 closeout is down to WP-20 (#2440) release ceremony only
+- Sprint 4 (#2435 through #2440) is closed
 
 WP-14A remained explicit as #2434 so demo/proof coverage did not disappear into
 review tail work, and its resulting proof status is now recorded in

--- a/docs/milestones/v0.90.4/RELEASE_NOTES_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_NOTES_v0.90.4.md
@@ -1,19 +1,19 @@
-# Release Notes - v0.90.4 Draft
+# Release Notes - v0.90.4
 
 ## Status
 
-Pre-ceremony release notes draft. The implementation, feature-proof coverage,
-internal review, external review, ADR 0014 remediation, and next-milestone
-handoff are complete; only WP-20 ceremony remains before release publication.
+Final release notes for v0.90.4. The implementation, feature-proof coverage,
+internal review, external review, ADR 0014 remediation, next-milestone
+handoff, and release ceremony are complete.
 
-## Draft Headline
+## Headline
 
-v0.90.4 introduces ADL's first bounded citizen economics and contract-market
+v0.90.4 introduced ADL's first bounded citizen economics and contract-market
 substrate: governed contracts, bids, evaluation, lifecycle authority,
 counterparty participation, delegation, fixture-backed execution, a reviewer-
 facing proof packet, and an explicit governed-tools handoff boundary.
 
-## Draft Highlights
+## Highlights
 
 - contract and bid schemas
 - evaluation and selection artifacts
@@ -27,7 +27,7 @@ facing proof packet, and an explicit governed-tools handoff boundary.
 - resource-stewardship bridge without payment rails
 - ADR 0014 contract-market architecture record
 
-## Draft Non-Claims
+## Non-Claims
 
 - v0.90.4 does not ship payment settlement.
 - v0.90.4 does not ship full inter-polis economics.
@@ -40,4 +40,4 @@ facing proof packet, and an explicit governed-tools handoff boundary.
 
 ## Release Note Rule
 
-At ceremony closeout, keep only landed evidence and any explicit deferrals.
+This final note keeps only landed evidence and explicit deferrals.

--- a/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
+++ b/docs/milestones/v0.90.4/RELEASE_PLAN_v0.90.4.md
@@ -8,7 +8,7 @@ schema, lifecycle, authority, fixture, runner, demo, and review-summary story.
 - Issue wave opened by WP-01 as #2420.
 - WP-02 through WP-14A are closed as #2421 through #2434.
 - WP-15 through WP-19 are closed as #2435 through #2439.
-- WP-20 release ceremony remains open as #2440.
+- WP-20 release ceremony is closed as #2440.
 - The tracked milestone package now records the live issue map and execution
   order.
 - Demo/proof coverage has been carried through WP-14A and is now recorded in
@@ -18,6 +18,9 @@ schema, lifecycle, authority, fixture, runner, demo, and review-summary story.
 - Active crate/package version-reporting surfaces should read `0.90.4` during
   the live release tail, even while the latest published tag remains `v0.90.3`
   until ceremony.
+
+The milestone release plan is now fully satisfied; this document remains as the
+record of the gates that were applied before ceremony closeout.
 
 ## Release Gates
 


### PR DESCRIPTION
Closes #2440
Closes #2564

## Summary
- finalize the remaining v0.90.4 ceremony-closeout wording across the five milestone release-tail docs
- mark the ceremony checklist/report/release notes as final instead of pre-ceremony
- restore clean main by moving the residue into a reviewable follow-up branch

## Validation
- git diff --check
- root main cleanup verified before publication