### PR TITLE
[v0.90.5][WP-02] Tool-call threat model and semantics

### DIFF
--- a/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
@@ -4,6 +4,7 @@
 
 | Feature Doc | Purpose | Execution WPs |
 | --- | --- | --- |
+| features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md | proposal/action boundary, tool-call threat model, side-effect taxonomy, dangerous-category denial expectations, and governed-tools non-goals | WP-02 |
 | features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md | Universal Tool Schema v1.0 public-compatible schema, examples, invalid examples, extension rules, and conformance | WP-03-WP-05 |
 | features/ACC_AUTHORITY_AND_VISIBILITY.md | ADL Capability Contract v1.0 authority, identity, delegation, privacy, visibility, redaction, trace, replay, and policy semantics | WP-06-WP-07 |
 | features/TOOL_REGISTRY_AND_COMPILER.md | registered tools, binding rules, UTS-to-ACC compiler, normalization, and rejection behavior | WP-08-WP-10 |

--- a/docs/milestones/v0.90.5/features/ACC_AUTHORITY_AND_VISIBILITY.md
+++ b/docs/milestones/v0.90.5/features/ACC_AUTHORITY_AND_VISIBILITY.md
@@ -5,6 +5,10 @@
 ADL Capability Contract v1.0 is the runtime-facing governance layer for tools.
 It decides whether an accountable actor may exercise a capability in context.
 
+This feature inherits the WP-02 proposal/action boundary from
+`TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`: a model proposal may request a tool,
+but ACC owns runtime authority, visibility, delegation, and failure posture.
+
 ## Required Contract
 
 ACC v1.0 must define:
@@ -42,4 +46,4 @@ the action must be rejected.
 - ACC is not portable public schema in the same sense as UTS.
 - ACC does not rely on model self-reporting for authority.
 - ACC does not permit hidden delegation.
-
+- ACC does not convert UTS validity into execution permission.

--- a/docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md
+++ b/docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md
@@ -5,6 +5,11 @@
 The governed executor runs tool actions only after ACC construction, policy
 evaluation, and Freedom Gate mediation.
 
+This feature inherits the WP-02 proposal/action boundary from
+`TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`: direct model-output execution is
+forbidden, and dangerous categories require denial evidence unless a later
+bounded fixture proves a safer dry-run path.
+
 ## Execution Contract
 
 The executor must:
@@ -35,3 +40,6 @@ Trace must record:
 
 Trace must be useful for accountability without becoming a privacy leak.
 
+Denied proposals are first-class trace evidence. They must identify the
+boundary that stopped the proposal without leaking protected arguments,
+private state, prompts, credentials, or secret-like values.

--- a/docs/milestones/v0.90.5/features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md
+++ b/docs/milestones/v0.90.5/features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md
@@ -6,6 +6,11 @@ Governed Tools v1.0 must be tested against real model behavior. A schema is not
 enough if models misunderstand authority, leak arguments, or try to bypass the
 runtime.
 
+This feature inherits the WP-02 proposal/action boundary from
+`TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`: model evaluation should score whether
+models preserve proposal humility and whether dangerous categories fail closed
+before action.
+
 ## Model Testing
 
 The model benchmark should test:

--- a/docs/milestones/v0.90.5/features/README.md
+++ b/docs/milestones/v0.90.5/features/README.md
@@ -6,3 +6,7 @@ Tools v1.0.
 The root rule is stable across all feature slices: UTS describes tools; ACC
 governs capability exercise.
 
+The shared WP-02 boundary lives in
+`TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`: model tool calls are proposals, not
+actions, and UTS validity is schema compatibility rather than execution
+authority.

--- a/docs/milestones/v0.90.5/features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md
+++ b/docs/milestones/v0.90.5/features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md
@@ -1,0 +1,159 @@
+# Tool-Call Threat Model And Semantics
+
+## Purpose
+
+This document defines the shared threat model and proposal/action semantics for
+Governed Tools v1.0. It is the WP-02 boundary that later UTS, ACC, registry,
+compiler, policy, executor, trace, redaction, negative-safety, and demo work
+must reference.
+
+The threat model explicitly covers model proposals, tool registry binding,
+adapter execution, arguments, results, traces, redaction, replay, and denial.
+
+The core rule is intentionally simple:
+
+> A model tool call is a proposal. It is not an action, not authority, and not
+> permission to execute.
+
+## Trust Boundaries
+
+Governed tool handling crosses these review boundaries:
+
+| Boundary | Untrusted input | Required control before action |
+| --- | --- | --- |
+| Model proposal ingress | tool name, arguments, explanation, confidence, requested adapter | parse and classify as a proposal only |
+| UTS validation | model-facing tool schema and proposal shape | schema compatibility checks, version checks, extension checks |
+| Registry binding | requested tool and adapter identity | explicit registry lookup and approved adapter binding |
+| Argument normalization | every model-produced argument value | type, size, path, enum, default, and injection checks |
+| ACC construction | actor, authority, resources, sensitivity, visibility, replay posture | ADL Capability Contract or deterministic rejection |
+| Policy and Freedom Gate | candidate action in context | allow, deny, defer, challenge, or escalate decision |
+| Adapter execution | approved capability exercise | execute only the selected ACC-backed registered adapter |
+| Trace and redaction | proposals, denials, arguments, results, errors, and replay evidence | accountable evidence with visibility-specific redaction |
+
+Anything missing at a boundary fails closed. Missing actor identity, missing
+authority, unknown tool, unregistered adapter, unsafe replay posture, unsafe
+visibility, or unsatisfied resource constraints must produce a denial or
+deferral record instead of execution.
+
+## Proposal / Action Boundary
+
+A proposal is a structured candidate emitted by a model, UI, script, or future
+agent surface. It may name a tool, supply arguments, explain intent, and claim
+confidence. The runtime must treat all of that as untrusted input.
+
+An action is a capability exercise after all required controls have succeeded:
+
+1. the proposal is parsed and classified;
+2. UTS compatibility checks pass;
+3. the tool is present in the registry;
+4. the adapter binding is approved for the tool and version;
+5. arguments are normalized and validated;
+6. ACC construction succeeds for the accountable actor and context;
+7. policy and Freedom Gate mediation approve the candidate;
+8. visibility and redaction policy is safe to construct;
+9. the governed executor selects the approved adapter path.
+
+UTS validity is schema compatibility only. It never grants actor authority,
+adapter permission, execution permission, replay permission, visibility rights,
+or exemption from Freedom Gate mediation.
+
+Model confidence, natural-language urgency, prior successful calls, or a
+well-formed JSON payload must not bypass ACC, policy, registry, redaction, or
+negative-safety checks.
+
+## Side-Effect Taxonomy
+
+Every tool description, proposal, fixture, denial, and trace should classify
+the maximum plausible side effect before execution:
+
+| Class | Meaning | Baseline posture |
+| --- | --- | --- |
+| `read` | Reads local fixture or already-authorized in-memory data without changing state. | Allowed only after authority, visibility, and registry checks. |
+| `local_write` | Writes bounded local fixture state or generated artifacts. | Requires explicit resource scope, replay posture, and audit trace. |
+| `external_read` | Reads from a network, service, account, or third-party data source. | Deny or dry-run until registry, credentials policy, and privacy posture are explicit. |
+| `external_write` | Mutates an external service, account, API, or third-party state. | Deny in the first milestone unless a later WP lands explicit fixture-backed proof. |
+| `process` | Starts, controls, or observes an operating-system process or shell-like capability. | Deny by default; arbitrary shell is out of scope. |
+| `network` | Opens arbitrary network access or indirect network-capable execution. | Deny by default; external-read fixtures must not require real network dependency. |
+| `destructive` | Deletes, overwrites, spends, revokes, publishes, or otherwise causes hard-to-reverse effects. | Deny by default; demos use refusal fixtures rather than real destructive effects. |
+| `exfiltration` | Reveals secrets, private state, protected prompts, credentials, sensitive arguments, or hidden traces. | Deny by default and record redacted denial evidence. |
+
+If a proposal fits more than one class, use the highest-risk applicable class.
+Ambiguous side effects are unsafe and must be rejected or challenged before
+execution.
+
+## Dangerous Category Denial Expectations
+
+Before implementation starts, later WPs must preserve these expectations:
+
+- Unknown tools and unregistered adapters fail closed.
+- UTS-compatible proposals without accountable actor authority fail closed.
+- Hidden delegation, missing grantor attribution, revoked authority, or excess
+  delegation depth fail closed.
+- Destructive, process, arbitrary network, and exfiltration proposals fail
+  closed unless a later issue lands a deliberately scoped fixture or dry-run
+  proof with explicit authority and redaction evidence.
+- Unsafe replay posture fails closed rather than creating non-replayable
+  execution records.
+- Unsafe visibility construction fails closed rather than leaking arguments,
+  results, errors, private state, prompts, credentials, or protected traces.
+- Malformed, oversized, path-traversing, injection-shaped, or ambiguous
+  arguments fail before policy or execution.
+- Denials must be reviewable without exposing the sensitive payload that caused
+  the denial.
+
+The denial record is itself evidence. It should explain the boundary that
+stopped the proposal, the safe classification, and the redaction posture, but
+it must not leak the protected content it refused.
+
+## Threat Inventory
+
+The first Governed Tools v1.0 implementation should account for these abuse
+paths:
+
+- A model emits valid JSON and presents it as an already-authorized action.
+- A proposal names a real tool but requests an unregistered or incompatible
+  adapter.
+- A proposal smuggles execution through arguments, paths, schema extensions,
+  prompt text, URLs, shell fragments, or serialized payloads.
+- A proposal claims another actor's role, standing, delegation, or grant.
+- A proposal attempts hidden delegation or drops grantor attribution.
+- A proposal asks for external write, process, network, destructive, or
+  exfiltration behavior using harmless-sounding descriptions.
+- A result, error, trace, or denial leaks private state, secrets, protected
+  prompts, credentials, or tool arguments.
+- Replay of a previously safe proposal becomes unsafe because environment,
+  actor, policy, resource, or adapter state changed.
+- Model self-reported confidence or urgency pressures the runtime to skip
+  validation, policy, Freedom Gate, or redaction.
+
+## Non-Goals
+
+WP-02 does not approve:
+
+- production secrets integration;
+- arbitrary shell or process execution;
+- production sandboxing claims;
+- real destructive filesystem, account, network, or external-service effects;
+- public standardization claims for UTS;
+- treating UTS validity as ADL runtime authority;
+- merging UTS and ACC into one authority surface;
+- replacing citizen standing, access control, or Freedom Gate semantics.
+
+## Later-WP Reference Contract
+
+Later v0.90.5 work packages should cite this document as the shared boundary:
+
+- WP-03 must name fixture classes that preserve this taxonomy and state that
+  UTS validity is not execution authority.
+- WP-04 must ensure the UTS schema records side effects and risk metadata
+  without embedding ADL runtime authority grants.
+- WP-05 must include valid, invalid, extension, and dangerous-category fixtures
+  that classify proposals without granting execution.
+- WP-06 and WP-07 must make ACC authority, delegation, visibility, and
+  redaction the runtime authority surface.
+- WP-08 through WP-10 must reject unknown, unregistered, malformed, ambiguous,
+  unsafe, or unsatisfiable proposals before execution.
+- WP-11 through WP-14 must preserve policy, Freedom Gate, execution, trace,
+  replay, and redaction evidence across approved and denied paths.
+- WP-15 through WP-18 must prove dangerous categories fail closed and make the
+  proposal/action separation visible in benchmark and demo surfaces.

--- a/docs/milestones/v0.90.5/features/TOOL_REGISTRY_AND_COMPILER.md
+++ b/docs/milestones/v0.90.5/features/TOOL_REGISTRY_AND_COMPILER.md
@@ -5,6 +5,11 @@
 The tool registry and UTS-to-ACC compiler prevent loose model output from
 binding directly to execution.
 
+This feature inherits the WP-02 proposal/action boundary from
+`TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`: model output can only become an ACC
+or a deterministic rejection after registry binding, normalization, and policy
+context are explicit.
+
 ## Registry Requirements
 
 The registry must:
@@ -23,6 +28,8 @@ The compiler must:
 - validate UTS
 - normalize untrusted arguments
 - reject ambiguous or malformed proposals
+- reject proposals whose side effects are unknown or higher-risk than the
+  registered tool and policy context allow
 - map UTS semantics into ACC execution semantics
 - inject policy context
 - construct visibility and redaction rules
@@ -33,4 +40,3 @@ The compiler must:
 
 Identical UTS, proposal, registry state, and policy context should produce an
 identical ACC or identical rejection.
-

--- a/docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md
+++ b/docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md
@@ -6,6 +6,10 @@ Universal Tool Schema v1.0 is the portable, model-facing description layer for
 tools. It should be JSON-compatible and useful outside ADL, but it must not
 pretend to grant runtime authority.
 
+This feature inherits the WP-02 proposal/action boundary from
+`TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`: UTS validity is schema compatibility,
+not permission to execute.
+
 ## Required Contract
 
 UTS v1.0 must define:
@@ -32,6 +36,8 @@ Conformance must include:
   destructive categories
 - invalid fixtures for missing semantics, missing security, malformed schema,
   invalid enum values, unsafe extension shape, and ambiguous side effects
+- dangerous-category fixtures for process, network, destructive, and
+  exfiltration proposals that classify risk without granting execution
 - explicit rule that UTS validity is not permission to execute
 - compatibility notes for existing JSON tool-call systems
 - versioning and extension guidance
@@ -41,4 +47,3 @@ Conformance must include:
 - UTS does not define ADL actor authority.
 - UTS does not define Freedom Gate decisions.
 - UTS does not define citizen standing or operator inspection rights.
-


### PR DESCRIPTION
Closes #2567

## Summary
Landed the WP-02 governed-tools threat model and proposal/action semantics as a docs-only milestone slice. The new feature contract defines the shared boundary that model tool calls are proposals, not actions; records the side-effect taxonomy and denial expectations; and gives later UTS, ACC, registry, compiler, policy, executor, trace, model-testing, and demo work a concrete reference surface.

## Artifacts
- `docs/milestones/v0.90.5/features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`
- `docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md`
- `docs/milestones/v0.90.5/features/README.md`
- `docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md`
- `docs/milestones/v0.90.5/features/ACC_AUTHORITY_AND_VISIBILITY.md`
- `docs/milestones/v0.90.5/features/TOOL_REGISTRY_AND_COMPILER.md`
- `docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md`
- `docs/milestones/v0.90.5/features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace cleanliness for the docs diff.
  - `python3 - <<'PY' ...`
    Verified every `features/*.md` path listed in `FEATURE_DOCS_v0.90.5.md` exists.
  - `python3 - <<'PY' ...`
    Verified later feature docs reference `TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`.
  - `python3 - <<'PY' ...`
    Verified required WP-02 threat-model terms, side-effect classes, and non-goals are present in the new contract.
  - `ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml"); puts "PASS WP_ISSUE_WAVE_v0.90.5.yaml parses"'`
    Verified the milestone issue-wave YAML still parses.
  - `absolute-host-path scan over docs/milestones/v0.90.5`
    Verified the tracked v0.90.5 milestone package does not contain absolute host-path leakage.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.5/tasks/issue-2567__v0-90-5-wp-02-tool-call-threat-model-and-semantics/sip.md
- Output card: .adl/v0.90.5/tasks/issue-2567__v0-90-5-wp-02-tool-call-threat-model-and-semantics/sor.md
- Idempotency-Key: v0-90-5-wp-02-tool-call-threat-model-and-semantics-docs-milestones-v0-90-5-features-tool-call-threat-model-and-semantics-md-docs-milestones-v0-90-5-feature-docs-v0-90-5-md-docs-milestones-v0-90-5-features-readme-md-docs-milestones-v0-90-5-features-uts-public-spec-and-conformance-md-docs-milestones-v0-90-5-features-acc-authority-and-visibility-md-docs-milestones-v0-90-5-features-tool-registry-and-compiler-md-docs-milestones-v0-90-5-features-governed-execution-and-trace-md-docs-milestones-v0-90-5-features-model-testing-and-flagship-demo-md-adl-v0-90-5-tasks-issue-2567-v0-90-5-wp-02-tool-call-threat-model-and-semantics-sip-md-adl-v0-90-5-tasks-issue-2567-v0-90-5-wp-02-tool-call-threat-model-and-semantics-sor-md