### PR TITLE
[v0.90.5][WP-05] UTS fixture and conformance suite

### DIFF
--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -60,3 +60,4 @@ pub mod tool_result;
 pub mod trace;
 pub mod trace_schema_v1;
 pub mod uts;
+pub mod uts_conformance;

--- a/adl/src/uts.rs
+++ b/adl/src/uts.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 pub const UTS_SCHEMA_VERSION_V1: &str = "uts.v1";
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum UtsSideEffectClassV1 {
     Read,
@@ -47,6 +47,7 @@ pub enum UtsIdempotenceV1 {
 pub enum UtsAuthenticationModeV1 {
     None,
     ApiKey,
+    #[serde(rename = "oauth")]
     OAuth,
     UserDelegated,
     ServiceAccount,
@@ -226,6 +227,14 @@ fn extension_key_allowed(key: &str) -> bool {
         && !key.contains("permission")
 }
 
+fn extension_declares_required(value: &JsonValue) -> bool {
+    value
+        .as_object()
+        .and_then(|object| object.get("required"))
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false)
+}
+
 /// Validate UTS v1 semantic constraints that are stricter than serde shape.
 ///
 /// This validator intentionally treats UTS validity as schema compatibility
@@ -320,6 +329,16 @@ pub fn validate_uts_v1(schema: &UniversalToolSchemaV1) -> Result<(), UtsValidati
             "exfiltration side effects must declare high exfiltration risk",
         );
     }
+    if !matches!(schema.side_effect_class, UtsSideEffectClassV1::Exfiltration)
+        && matches!(schema.exfiltration_risk, UtsExfiltrationRiskV1::High)
+    {
+        push_error(
+            &mut errors,
+            "ambiguous_side_effects",
+            "side_effect_class",
+            "high exfiltration risk must use the exfiltration side-effect class",
+        );
+    }
     if schema.execution_environment.isolation.trim().is_empty() {
         push_error(
             &mut errors,
@@ -347,12 +366,20 @@ pub fn validate_uts_v1(schema: &UniversalToolSchemaV1) -> Result<(), UtsValidati
         }
     }
     for key in schema.extensions.keys() {
+        let value = &schema.extensions[key];
         if !extension_key_allowed(key) {
             push_error(
                 &mut errors,
                 "invalid_extension_key",
                 "extensions",
                 format!("extension key '{key}' is not allowed for UTS v1"),
+            );
+        } else if extension_declares_required(value) {
+            push_error(
+                &mut errors,
+                "unsupported_required_extension",
+                "extensions",
+                format!("extension key '{key}' declares unsupported required behavior"),
             );
         }
     }

--- a/adl/src/uts.rs
+++ b/adl/src/uts.rs
@@ -517,6 +517,114 @@ mod tests {
     }
 
     #[test]
+    fn uts_v1_accepts_oauth_wire_spelling_and_optional_extension_metadata() {
+        let mut value = valid_safe_read_json();
+        value["name"] = json!("fixture.external_write");
+        value["side_effect_class"] = json!("external_write");
+        value["authentication"] = json!({ "mode": "oauth", "required": true });
+        value["data_sensitivity"] = json!("confidential");
+        value["exfiltration_risk"] = json!("medium");
+        value["execution_environment"] = json!({
+            "kind": "external_service",
+            "isolation": "bounded external-write fixture; schema compatibility only"
+        });
+        value["extensions"] = json!({
+            "x-vendor-metadata": {
+                "required": false,
+                "review_note": "portable optional metadata"
+            }
+        });
+
+        let schema = parse_valid(value);
+        validate_uts_v1(&schema).expect("oauth wire spelling and optional metadata should pass");
+    }
+
+    #[test]
+    fn uts_v1_rejects_high_exfiltration_risk_without_exfiltration_class() {
+        let mut value = valid_safe_read_json();
+        value["side_effect_class"] = json!("network");
+        value["exfiltration_risk"] = json!("high");
+
+        let schema = parse_valid(value);
+        let err = validate_uts_v1(&schema).expect_err("ambiguous high-risk schema should fail");
+
+        assert!(err.codes().contains(&"ambiguous_side_effects"));
+    }
+
+    #[test]
+    fn uts_v1_rejects_required_extension_metadata() {
+        let mut value = valid_safe_read_json();
+        value["extensions"] = json!({
+            "x-vendor-required-mode": {
+                "required": true,
+                "mode": "vendor-private"
+            }
+        });
+
+        let schema = parse_valid(value);
+        let err = validate_uts_v1(&schema).expect_err("required extension should fail");
+
+        assert!(err.codes().contains(&"unsupported_required_extension"));
+    }
+
+    #[test]
+    fn uts_v1_validation_reports_semantic_error_families() {
+        let mut value = valid_safe_read_json();
+        value["name"] = json!("ab");
+        value["version"] = json!("1.0");
+        value["description"] = json!("short");
+        value["output_schema"] = json!({});
+        value["resources"] = json!([
+            { "resource_type": "Bad Token", "scope": "" }
+        ]);
+        value["side_effect_class"] = json!("exfiltration");
+        value["exfiltration_risk"] = json!("medium");
+        value["execution_environment"] = json!({
+            "kind": "fixture",
+            "isolation": ""
+        });
+        value["errors"] = json!([
+            {
+                "code": "Bad Code",
+                "message": "",
+                "retryable": false
+            }
+        ]);
+        value["extensions"] = json!({
+            "not-x": true
+        });
+
+        let schema = parse_valid(value);
+        let err = validate_uts_v1(&schema).expect_err("invalid schema should fail");
+        let codes = err.codes();
+
+        for code in [
+            "invalid_name",
+            "invalid_version",
+            "missing_description",
+            "invalid_output_schema",
+            "invalid_resource",
+            "invalid_exfiltration_risk",
+            "missing_execution_isolation",
+            "invalid_error_model",
+            "invalid_extension_key",
+        ] {
+            assert!(codes.contains(&code), "missing validation code {code}");
+        }
+    }
+
+    #[test]
+    fn uts_v1_rejects_missing_error_model() {
+        let mut value = valid_safe_read_json();
+        value["errors"] = json!([]);
+
+        let schema = parse_valid(value);
+        let err = validate_uts_v1(&schema).expect_err("missing error model should fail");
+
+        assert!(err.codes().contains(&"missing_error_model"));
+    }
+
+    #[test]
     fn uts_v1_rejects_authority_grant_extensions() {
         let mut value = valid_safe_read_json();
         value["extensions"] = json!({

--- a/adl/src/uts_conformance.rs
+++ b/adl/src/uts_conformance.rs
@@ -348,21 +348,25 @@ pub fn uts_conformance_fixtures() -> Vec<UtsConformanceFixture> {
     ]
 }
 
-fn deserialize_reason(error: &serde_json::Error) -> &'static str {
-    let message = error.to_string();
-    if message.contains("side_effect_class")
-        || message.contains("determinism")
-        || message.contains("replay_safety")
-        || message.contains("idempotence")
+fn missing_required_reason(document: &JsonValue) -> Option<&'static str> {
+    let object = document.as_object()?;
+    if [
+        "side_effect_class",
+        "determinism",
+        "replay_safety",
+        "idempotence",
+    ]
+    .iter()
+    .any(|field| !object.contains_key(*field))
     {
-        "missing_semantics"
-    } else if message.contains("authentication")
-        || message.contains("data_sensitivity")
-        || message.contains("exfiltration_risk")
+        Some("missing_semantics")
+    } else if ["authentication", "data_sensitivity", "exfiltration_risk"]
+        .iter()
+        .any(|field| !object.contains_key(*field))
     {
-        "missing_security_metadata"
+        Some("missing_security_metadata")
     } else {
-        "deserialize_error"
+        None
     }
 }
 
@@ -377,6 +381,19 @@ fn side_effect_is_dangerous(side_effect: UtsSideEffectClassV1) -> bool {
 }
 
 fn evaluate_fixture(fixture: &UtsConformanceFixture) -> UtsConformanceCaseResult {
+    if let Some(reason) = missing_required_reason(&fixture.document) {
+        let execution_granted = false;
+        return UtsConformanceCaseResult {
+            id: fixture.id,
+            group: fixture.group,
+            accepted: false,
+            reason,
+            side_effect_class: None,
+            execution_granted,
+            passed: matches!(fixture.expected, UtsExpectedOutcome::Rejected(expected) if expected == reason),
+        };
+    }
+
     let parsed = serde_json::from_value::<UniversalToolSchemaV1>(fixture.document.clone());
     let (accepted, reason, side_effect_class) = match parsed {
         Ok(schema) => match validate_uts_v1(&schema) {
@@ -391,7 +408,7 @@ fn evaluate_fixture(fixture: &UtsConformanceFixture) -> UtsConformanceCaseResult
                 Some(schema.side_effect_class),
             ),
         },
-        Err(error) => (false, deserialize_reason(&error), None),
+        Err(_) => (false, "deserialize_error", None),
     };
 
     let execution_granted = false;

--- a/adl/src/uts_conformance.rs
+++ b/adl/src/uts_conformance.rs
@@ -1,0 +1,565 @@
+use crate::uts::{
+    validate_uts_v1, UniversalToolSchemaV1, UtsSideEffectClassV1, UTS_SCHEMA_VERSION_V1,
+};
+use serde_json::{json, Value as JsonValue};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UtsConformanceGroup {
+    Valid,
+    Invalid,
+    Extension,
+    Dangerous,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UtsExpectedOutcome {
+    Accepted,
+    Rejected(&'static str),
+    DangerousDenied(UtsSideEffectClassV1),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UtsConformanceFixture {
+    pub id: &'static str,
+    pub group: UtsConformanceGroup,
+    pub document: JsonValue,
+    pub expected: UtsExpectedOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UtsConformanceCaseResult {
+    pub id: &'static str,
+    pub group: UtsConformanceGroup,
+    pub accepted: bool,
+    pub reason: &'static str,
+    pub side_effect_class: Option<UtsSideEffectClassV1>,
+    pub execution_granted: bool,
+    pub passed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UtsConformanceReport {
+    pub schema_version: &'static str,
+    pub fixture_count: usize,
+    pub passed: bool,
+    pub cases: Vec<UtsConformanceCaseResult>,
+}
+
+fn side_effect_wire(side_effect: UtsSideEffectClassV1) -> &'static str {
+    match side_effect {
+        UtsSideEffectClassV1::Read => "read",
+        UtsSideEffectClassV1::LocalWrite => "local_write",
+        UtsSideEffectClassV1::ExternalRead => "external_read",
+        UtsSideEffectClassV1::ExternalWrite => "external_write",
+        UtsSideEffectClassV1::Process => "process",
+        UtsSideEffectClassV1::Network => "network",
+        UtsSideEffectClassV1::Destructive => "destructive",
+        UtsSideEffectClassV1::Exfiltration => "exfiltration",
+    }
+}
+
+fn fixture_profile(
+    side_effect: UtsSideEffectClassV1,
+) -> (&'static str, &'static str, &'static str) {
+    match side_effect {
+        UtsSideEffectClassV1::Read => ("none", "internal", "none"),
+        UtsSideEffectClassV1::LocalWrite => ("none", "internal", "none"),
+        UtsSideEffectClassV1::ExternalRead => ("api_key", "confidential", "low"),
+        UtsSideEffectClassV1::ExternalWrite => ("oauth", "confidential", "medium"),
+        UtsSideEffectClassV1::Destructive => ("user_delegated", "confidential", "medium"),
+        UtsSideEffectClassV1::Process => ("service_account", "confidential", "medium"),
+        UtsSideEffectClassV1::Network => ("service_account", "confidential", "medium"),
+        UtsSideEffectClassV1::Exfiltration => ("user_delegated", "secret", "high"),
+    }
+}
+
+fn execution_kind(side_effect: UtsSideEffectClassV1) -> &'static str {
+    match side_effect {
+        UtsSideEffectClassV1::Read => "fixture",
+        UtsSideEffectClassV1::LocalWrite => "dry_run",
+        UtsSideEffectClassV1::ExternalRead | UtsSideEffectClassV1::ExternalWrite => {
+            "external_service"
+        }
+        UtsSideEffectClassV1::Process => "process",
+        UtsSideEffectClassV1::Network => "network",
+        UtsSideEffectClassV1::Destructive | UtsSideEffectClassV1::Exfiltration => "dry_run",
+    }
+}
+
+fn base_fixture(id: &'static str, side_effect: UtsSideEffectClassV1) -> JsonValue {
+    let (auth_mode, sensitivity, exfiltration_risk) = fixture_profile(side_effect);
+    let auth_required = auth_mode != "none";
+    let resource_type = match side_effect {
+        UtsSideEffectClassV1::Read => "fixture",
+        UtsSideEffectClassV1::LocalWrite => "local_file",
+        UtsSideEffectClassV1::ExternalRead | UtsSideEffectClassV1::ExternalWrite => {
+            "external_service"
+        }
+        UtsSideEffectClassV1::Process => "process",
+        UtsSideEffectClassV1::Network => "network",
+        UtsSideEffectClassV1::Destructive => "operator_state",
+        UtsSideEffectClassV1::Exfiltration => "protected_prompt",
+    };
+    let replay_safety = match side_effect {
+        UtsSideEffectClassV1::Read
+        | UtsSideEffectClassV1::ExternalRead
+        | UtsSideEffectClassV1::Network => "replay_safe",
+        UtsSideEffectClassV1::LocalWrite | UtsSideEffectClassV1::ExternalWrite => {
+            "replay_requires_approval"
+        }
+        UtsSideEffectClassV1::Process
+        | UtsSideEffectClassV1::Destructive
+        | UtsSideEffectClassV1::Exfiltration => "not_replay_safe",
+    };
+    let idempotence = match side_effect {
+        UtsSideEffectClassV1::Read | UtsSideEffectClassV1::ExternalRead => "idempotent",
+        UtsSideEffectClassV1::LocalWrite
+        | UtsSideEffectClassV1::ExternalWrite
+        | UtsSideEffectClassV1::Network => "conditionally_idempotent",
+        UtsSideEffectClassV1::Process
+        | UtsSideEffectClassV1::Destructive
+        | UtsSideEffectClassV1::Exfiltration => "not_idempotent",
+    };
+
+    json!({
+        "schema_version": UTS_SCHEMA_VERSION_V1,
+        "name": id,
+        "version": "1.0.0",
+        "description": format!("{id} fixture for deterministic UTS v1 conformance review."),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "fixture_id": { "type": "string" }
+            },
+            "required": ["fixture_id"],
+            "additionalProperties": false
+        },
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "status": { "type": "string" }
+            },
+            "required": ["status"],
+            "additionalProperties": false
+        },
+        "side_effect_class": side_effect_wire(side_effect),
+        "determinism": "deterministic",
+        "replay_safety": replay_safety,
+        "idempotence": idempotence,
+        "resources": [
+            { "resource_type": resource_type, "scope": format!("{id}-bounded-fixture") }
+        ],
+        "authentication": { "mode": auth_mode, "required": auth_required },
+        "data_sensitivity": sensitivity,
+        "exfiltration_risk": exfiltration_risk,
+        "execution_environment": {
+            "kind": execution_kind(side_effect),
+            "isolation": format!("{id} is a conformance fixture and grants no execution authority")
+        },
+        "errors": [
+            {
+                "code": "fixture_not_available",
+                "message": "The requested conformance fixture is not available.",
+                "retryable": false
+            }
+        ],
+        "extensions": {
+            "x-adl-conformance-note": "schema compatibility only; no runtime authority"
+        }
+    })
+}
+
+fn valid_fixture(id: &'static str, side_effect: UtsSideEffectClassV1) -> UtsConformanceFixture {
+    UtsConformanceFixture {
+        id,
+        group: UtsConformanceGroup::Valid,
+        document: base_fixture(id, side_effect),
+        expected: UtsExpectedOutcome::Accepted,
+    }
+}
+
+fn invalid_fixture(
+    id: &'static str,
+    mut document: JsonValue,
+    reason: &'static str,
+) -> UtsConformanceFixture {
+    UtsConformanceFixture {
+        id,
+        group: UtsConformanceGroup::Invalid,
+        document: {
+            document["name"] = json!(id);
+            document
+        },
+        expected: UtsExpectedOutcome::Rejected(reason),
+    }
+}
+
+fn extension_fixture(
+    id: &'static str,
+    document: JsonValue,
+    expected: UtsExpectedOutcome,
+) -> UtsConformanceFixture {
+    UtsConformanceFixture {
+        id,
+        group: UtsConformanceGroup::Extension,
+        document,
+        expected,
+    }
+}
+
+fn dangerous_fixture(id: &'static str, side_effect: UtsSideEffectClassV1) -> UtsConformanceFixture {
+    UtsConformanceFixture {
+        id,
+        group: UtsConformanceGroup::Dangerous,
+        document: base_fixture(id, side_effect),
+        expected: UtsExpectedOutcome::DangerousDenied(side_effect),
+    }
+}
+
+pub fn uts_conformance_fixtures() -> Vec<UtsConformanceFixture> {
+    let mut missing_semantics =
+        base_fixture("invalid.missing_semantics", UtsSideEffectClassV1::Read);
+    missing_semantics
+        .as_object_mut()
+        .expect("fixture should be an object")
+        .remove("side_effect_class");
+
+    let mut missing_security = base_fixture(
+        "invalid.missing_security_metadata",
+        UtsSideEffectClassV1::Read,
+    );
+    missing_security
+        .as_object_mut()
+        .expect("fixture should be an object")
+        .remove("authentication");
+
+    let mut malformed_schema = base_fixture("invalid.malformed_schema", UtsSideEffectClassV1::Read);
+    malformed_schema["input_schema"] = json!({});
+
+    let mut ambiguous = base_fixture(
+        "invalid.ambiguous_side_effects",
+        UtsSideEffectClassV1::Network,
+    );
+    ambiguous["exfiltration_risk"] = json!("high");
+
+    let mut unsafe_extension = base_fixture("invalid.unsafe_extension", UtsSideEffectClassV1::Read);
+    unsafe_extension["extensions"] = json!({
+        "x-adl-authority-grant": "operator"
+    });
+
+    let mut incompatible_version =
+        base_fixture("invalid.incompatible_version", UtsSideEffectClassV1::Read);
+    incompatible_version["schema_version"] = json!("uts.v2");
+
+    let mut optional_extension = base_fixture(
+        "extension.optional_vendor_metadata",
+        UtsSideEffectClassV1::Read,
+    );
+    optional_extension["extensions"] = json!({
+        "x-vendor-metadata": {
+            "required": false,
+            "review_note": "portable optional metadata"
+        }
+    });
+
+    let mut unsupported_required = base_fixture(
+        "extension.unsupported_required_extension",
+        UtsSideEffectClassV1::Read,
+    );
+    unsupported_required["extensions"] = json!({
+        "x-vendor-required-mode": {
+            "required": true,
+            "mode": "vendor-private"
+        }
+    });
+
+    let mut reserved_authority = base_fixture(
+        "extension.reserved_authority_extension",
+        UtsSideEffectClassV1::Read,
+    );
+    reserved_authority["extensions"] = json!({
+        "x-adl-authority-grant": "operator"
+    });
+
+    vec![
+        valid_fixture("valid.safe_read", UtsSideEffectClassV1::Read),
+        valid_fixture("valid.local_write", UtsSideEffectClassV1::LocalWrite),
+        valid_fixture("valid.external_read", UtsSideEffectClassV1::ExternalRead),
+        valid_fixture("valid.external_write", UtsSideEffectClassV1::ExternalWrite),
+        valid_fixture("valid.destructive", UtsSideEffectClassV1::Destructive),
+        valid_fixture("valid.process", UtsSideEffectClassV1::Process),
+        valid_fixture("valid.network", UtsSideEffectClassV1::Network),
+        valid_fixture("valid.exfiltration", UtsSideEffectClassV1::Exfiltration),
+        invalid_fixture(
+            "invalid.missing_semantics",
+            missing_semantics,
+            "missing_semantics",
+        ),
+        invalid_fixture(
+            "invalid.missing_security_metadata",
+            missing_security,
+            "missing_security_metadata",
+        ),
+        invalid_fixture(
+            "invalid.malformed_schema",
+            malformed_schema,
+            "invalid_input_schema",
+        ),
+        invalid_fixture(
+            "invalid.ambiguous_side_effects",
+            ambiguous,
+            "ambiguous_side_effects",
+        ),
+        invalid_fixture(
+            "invalid.unsafe_extension",
+            unsafe_extension,
+            "invalid_extension_key",
+        ),
+        invalid_fixture(
+            "invalid.incompatible_version",
+            incompatible_version,
+            "unsupported_schema_version",
+        ),
+        extension_fixture(
+            "extension.optional_vendor_metadata",
+            optional_extension,
+            UtsExpectedOutcome::Accepted,
+        ),
+        extension_fixture(
+            "extension.unsupported_required_extension",
+            unsupported_required,
+            UtsExpectedOutcome::Rejected("unsupported_required_extension"),
+        ),
+        extension_fixture(
+            "extension.reserved_authority_extension",
+            reserved_authority,
+            UtsExpectedOutcome::Rejected("invalid_extension_key"),
+        ),
+        dangerous_fixture(
+            "dangerous.destructive_denied",
+            UtsSideEffectClassV1::Destructive,
+        ),
+        dangerous_fixture("dangerous.process_denied", UtsSideEffectClassV1::Process),
+        dangerous_fixture("dangerous.network_denied", UtsSideEffectClassV1::Network),
+        dangerous_fixture(
+            "dangerous.exfiltration_denied",
+            UtsSideEffectClassV1::Exfiltration,
+        ),
+    ]
+}
+
+fn deserialize_reason(error: &serde_json::Error) -> &'static str {
+    let message = error.to_string();
+    if message.contains("side_effect_class")
+        || message.contains("determinism")
+        || message.contains("replay_safety")
+        || message.contains("idempotence")
+    {
+        "missing_semantics"
+    } else if message.contains("authentication")
+        || message.contains("data_sensitivity")
+        || message.contains("exfiltration_risk")
+    {
+        "missing_security_metadata"
+    } else {
+        "deserialize_error"
+    }
+}
+
+fn side_effect_is_dangerous(side_effect: UtsSideEffectClassV1) -> bool {
+    matches!(
+        side_effect,
+        UtsSideEffectClassV1::Destructive
+            | UtsSideEffectClassV1::Process
+            | UtsSideEffectClassV1::Network
+            | UtsSideEffectClassV1::Exfiltration
+    )
+}
+
+fn evaluate_fixture(fixture: &UtsConformanceFixture) -> UtsConformanceCaseResult {
+    let parsed = serde_json::from_value::<UniversalToolSchemaV1>(fixture.document.clone());
+    let (accepted, reason, side_effect_class) = match parsed {
+        Ok(schema) => match validate_uts_v1(&schema) {
+            Ok(()) => (true, "accepted", Some(schema.side_effect_class)),
+            Err(report) => (
+                false,
+                report
+                    .errors
+                    .first()
+                    .map(|error| error.code)
+                    .unwrap_or("rejected"),
+                Some(schema.side_effect_class),
+            ),
+        },
+        Err(error) => (false, deserialize_reason(&error), None),
+    };
+
+    let execution_granted = false;
+    let passed = match fixture.expected {
+        UtsExpectedOutcome::Accepted => accepted && !execution_granted,
+        UtsExpectedOutcome::Rejected(expected_reason) => !accepted && reason == expected_reason,
+        UtsExpectedOutcome::DangerousDenied(expected_side_effect) => {
+            accepted
+                && side_effect_class == Some(expected_side_effect)
+                && side_effect_is_dangerous(expected_side_effect)
+                && !execution_granted
+        }
+    };
+
+    UtsConformanceCaseResult {
+        id: fixture.id,
+        group: fixture.group,
+        accepted,
+        reason,
+        side_effect_class,
+        execution_granted,
+        passed,
+    }
+}
+
+pub fn run_uts_conformance_suite() -> UtsConformanceReport {
+    let fixtures = uts_conformance_fixtures();
+    let cases: Vec<UtsConformanceCaseResult> = fixtures.iter().map(evaluate_fixture).collect();
+    let passed = cases.iter().all(|case| case.passed);
+
+    UtsConformanceReport {
+        schema_version: UTS_SCHEMA_VERSION_V1,
+        fixture_count: fixtures.len(),
+        passed,
+        cases,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    const EXPECTED_IDS: &[&str] = &[
+        "valid.safe_read",
+        "valid.local_write",
+        "valid.external_read",
+        "valid.external_write",
+        "valid.destructive",
+        "valid.process",
+        "valid.network",
+        "valid.exfiltration",
+        "invalid.missing_semantics",
+        "invalid.missing_security_metadata",
+        "invalid.malformed_schema",
+        "invalid.ambiguous_side_effects",
+        "invalid.unsafe_extension",
+        "invalid.incompatible_version",
+        "extension.optional_vendor_metadata",
+        "extension.unsupported_required_extension",
+        "extension.reserved_authority_extension",
+        "dangerous.destructive_denied",
+        "dangerous.process_denied",
+        "dangerous.network_denied",
+        "dangerous.exfiltration_denied",
+    ];
+
+    #[test]
+    fn uts_conformance_fixture_packet_has_expected_ids_in_order() {
+        let fixtures = uts_conformance_fixtures();
+        let ids: Vec<&str> = fixtures.iter().map(|fixture| fixture.id).collect();
+
+        assert_eq!(ids, EXPECTED_IDS);
+        assert_eq!(
+            ids.iter().copied().collect::<BTreeSet<_>>().len(),
+            ids.len(),
+            "fixture ids must be unique"
+        );
+    }
+
+    #[test]
+    fn uts_conformance_suite_passes_all_expected_outcomes() {
+        let report = run_uts_conformance_suite();
+
+        assert_eq!(report.schema_version, UTS_SCHEMA_VERSION_V1);
+        assert_eq!(report.fixture_count, EXPECTED_IDS.len());
+        let failed: Vec<&UtsConformanceCaseResult> =
+            report.cases.iter().filter(|case| !case.passed).collect();
+        assert!(
+            report.passed,
+            "all UTS conformance cases should pass; failed cases: {failed:?}"
+        );
+        assert!(report.cases.iter().all(|case| case.passed));
+    }
+
+    #[test]
+    fn uts_conformance_invalid_fixtures_fail_for_intended_reasons() {
+        let report = run_uts_conformance_suite();
+
+        for (id, reason) in [
+            ("invalid.missing_semantics", "missing_semantics"),
+            (
+                "invalid.missing_security_metadata",
+                "missing_security_metadata",
+            ),
+            ("invalid.malformed_schema", "invalid_input_schema"),
+            ("invalid.ambiguous_side_effects", "ambiguous_side_effects"),
+            ("invalid.unsafe_extension", "invalid_extension_key"),
+            ("invalid.incompatible_version", "unsupported_schema_version"),
+        ] {
+            let case = report
+                .cases
+                .iter()
+                .find(|case| case.id == id)
+                .expect("invalid fixture result should exist");
+            assert!(!case.accepted, "{id} should be rejected");
+            assert_eq!(case.reason, reason);
+        }
+    }
+
+    #[test]
+    fn uts_conformance_extension_fixtures_record_expected_outcomes() {
+        let report = run_uts_conformance_suite();
+        let optional = report
+            .cases
+            .iter()
+            .find(|case| case.id == "extension.optional_vendor_metadata")
+            .expect("optional extension fixture should exist");
+        let required = report
+            .cases
+            .iter()
+            .find(|case| case.id == "extension.unsupported_required_extension")
+            .expect("required extension fixture should exist");
+        let reserved = report
+            .cases
+            .iter()
+            .find(|case| case.id == "extension.reserved_authority_extension")
+            .expect("reserved extension fixture should exist");
+
+        assert!(optional.accepted);
+        assert!(!required.accepted);
+        assert_eq!(required.reason, "unsupported_required_extension");
+        assert!(!reserved.accepted);
+        assert_eq!(reserved.reason, "invalid_extension_key");
+    }
+
+    #[test]
+    fn uts_conformance_dangerous_fixtures_never_grant_execution() {
+        let report = run_uts_conformance_suite();
+        let dangerous: Vec<&UtsConformanceCaseResult> = report
+            .cases
+            .iter()
+            .filter(|case| case.group == UtsConformanceGroup::Dangerous)
+            .collect();
+
+        assert_eq!(dangerous.len(), 4);
+        for case in dangerous {
+            assert!(case.accepted, "{} should be schema-compatible", case.id);
+            assert!(
+                !case.execution_granted,
+                "{} must not grant execution",
+                case.id
+            );
+            assert!(
+                case.side_effect_class.is_some_and(side_effect_is_dangerous),
+                "{} should classify a dangerous side effect",
+                case.id
+            );
+        }
+    }
+}

--- a/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
+++ b/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
@@ -16,7 +16,7 @@
 
 ## Implementation Gates
 
-- [ ] UTS schema and conformance fixtures complete
+- [x] UTS schema and conformance fixtures complete
 - [ ] ACC authority and visibility fixtures complete
 - [ ] compiler rejects unsafe or unsatisfiable proposals
 - [ ] policy and Freedom Gate mediation implemented

--- a/docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md
+++ b/docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md
@@ -104,6 +104,15 @@ WP-05 should provide a deterministic conformance command or harness that:
 - classifies every `dangerous.*` fixture without granting execution;
 - emits repository-relative, portable output with no host paths or secrets.
 
+WP-05 implements the review-facing conformance harness in
+`adl/src/uts_conformance.rs`. The fixture packet is exposed through
+`uts_conformance_fixtures`, and `run_uts_conformance_suite` evaluates the
+packet without granting execution. The focused validation command is:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml uts -- --nocapture
+```
+
 ## Non-Goals
 
 - UTS does not define ADL actor authority.


### PR DESCRIPTION
Closes #2570

## Summary
Implemented the WP-05 UTS fixture and conformance suite as a deterministic Rust
harness. The suite defines the required valid, invalid, extension, and
dangerous-category fixtures, validates them against the UTS v1 schema, and
records that dangerous fixtures are classified without granting execution.

## Artifacts
- `adl/src/uts_conformance.rs`
- `adl/src/uts.rs`
- `adl/src/lib.rs`
- `docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md`
- `docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md`
- Local ignored output-card update at `.adl/v0.90.5/tasks/issue-2570__v0-90-5-wp-05-uts-fixture-and-conformance-suite/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified Rust formatting for the changed UTS surfaces.
  - `cargo test --manifest-path adl/Cargo.toml uts -- --nocapture`
    Verified the UTS v1 validator and deterministic WP-05 fixture suite.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the changed Rust surface under strict clippy warnings.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --json --summary-only --output-path target/coverage-impact-summary.json -- uts`
    Generated focused coverage evidence for UTS tests.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified the coverage-impact gate for the changed Rust surface.
  - `git diff --check`
    Verified whitespace cleanliness for the tracked diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.5/tasks/issue-2570__v0-90-5-wp-05-uts-fixture-and-conformance-suite/sip.md
- Output card: .adl/v0.90.5/tasks/issue-2570__v0-90-5-wp-05-uts-fixture-and-conformance-suite/sor.md
- Idempotency-Key: v0-90-5-wp-05-uts-fixture-and-conformance-suite-adl-src-lib-rs-adl-src-uts-rs-adl-src-uts-conformance-rs-docs-milestones-v0-90-5-features-uts-public-spec-and-conformance-md-docs-milestones-v0-90-5-milestone-checklist-v0-90-5-md-adl-v0-90-5-tasks-issue-2570-v0-90-5-wp-05-uts-fixture-and-conformance-suite-sip-md-adl-v0-90-5-tasks-issue-2570-v0-90-5-wp-05-uts-fixture-and-conformance-suite-sor-md