### PR TITLE
[v0.90.5][review] Harden UTS schema and conformance reports

### DIFF
--- a/adl/src/uts.rs
+++ b/adl/src/uts.rs
@@ -114,14 +114,22 @@ pub struct UtsErrorModelV1 {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct UtsJsonSchemaFragmentV1 {
+    #[serde(rename = "type")]
+    pub schema_type: String,
+    #[serde(flatten, default)]
+    pub keywords: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct UniversalToolSchemaV1 {
     pub schema_version: String,
     pub name: String,
     pub version: String,
     pub description: String,
-    pub input_schema: JsonValue,
-    pub output_schema: JsonValue,
+    pub input_schema: UtsJsonSchemaFragmentV1,
+    pub output_schema: UtsJsonSchemaFragmentV1,
     pub side_effect_class: UtsSideEffectClassV1,
     pub determinism: UtsDeterminismV1,
     pub replay_safety: UtsReplaySafetyV1,
@@ -199,12 +207,8 @@ fn valid_version(value: &str) -> bool {
             .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
 }
 
-fn json_schema_fragment_has_type(value: &JsonValue) -> bool {
-    value
-        .as_object()
-        .and_then(|object| object.get("type"))
-        .and_then(JsonValue::as_str)
-        .is_some()
+fn json_schema_fragment_has_type(value: &UtsJsonSchemaFragmentV1) -> bool {
+    !value.schema_type.trim().is_empty()
 }
 
 fn valid_token(value: &str) -> bool {
@@ -492,7 +496,7 @@ mod tests {
         let mut value = valid_safe_read_json();
         value["name"] = json!("Bad Name");
         value["version"] = json!("v1");
-        value["input_schema"] = json!({});
+        value["input_schema"] = json!({ "type": "" });
         value["resources"] = json!([]);
 
         let schema = parse_valid(value);
@@ -573,7 +577,7 @@ mod tests {
         value["name"] = json!("ab");
         value["version"] = json!("1.0");
         value["description"] = json!("short");
-        value["output_schema"] = json!({});
+        value["output_schema"] = json!({ "type": "" });
         value["resources"] = json!([
             { "resource_type": "Bad Token", "scope": "" }
         ]);
@@ -662,6 +666,41 @@ mod tests {
     }
 
     #[test]
+    fn uts_v1_rejects_untyped_nested_schema_fragments_at_deserialize_boundary() {
+        let mut value = valid_safe_read_json();
+        value["input_schema"] = json!({
+            "properties": {
+                "fixture_id": { "type": "string" }
+            }
+        });
+
+        let err = serde_json::from_value::<UniversalToolSchemaV1>(value)
+            .expect_err("input_schema without a nested type must not deserialize");
+
+        assert!(err.to_string().contains("missing field `type`"));
+    }
+
+    fn resolve_generated_property_schema<'a>(
+        root: &'a JsonValue,
+        property: &'a JsonValue,
+    ) -> &'a JsonValue {
+        let Some(reference) = property.get("$ref").and_then(JsonValue::as_str) else {
+            return property;
+        };
+        let Some(name) = reference
+            .strip_prefix("#/definitions/")
+            .or_else(|| reference.strip_prefix("#/$defs/"))
+        else {
+            panic!("unsupported generated schema reference {reference}");
+        };
+
+        root.get("definitions")
+            .or_else(|| root.get("$defs"))
+            .and_then(|definitions| definitions.get(name))
+            .unwrap_or_else(|| panic!("missing generated schema definition {name}"))
+    }
+
+    #[test]
     fn uts_v1_schema_generation_exposes_required_surface() {
         let schema = uts_v1_schema_json();
         let properties = schema
@@ -689,6 +728,43 @@ mod tests {
             assert!(
                 properties.contains_key(key),
                 "UTS schema missing property {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn uts_v1_schema_generation_requires_typed_nested_schema_fragments() {
+        let schema = uts_v1_schema_json();
+        let properties = schema
+            .get("properties")
+            .and_then(JsonValue::as_object)
+            .expect("generated UTS schema should expose properties");
+
+        for key in ["input_schema", "output_schema"] {
+            let property = properties
+                .get(key)
+                .unwrap_or_else(|| panic!("generated UTS schema missing property {key}"));
+            let fragment_schema = resolve_generated_property_schema(&schema, property);
+            let required = fragment_schema
+                .get("required")
+                .and_then(JsonValue::as_array)
+                .expect("nested JSON Schema fragment should list required fields");
+
+            assert_eq!(
+                fragment_schema.get("type").and_then(JsonValue::as_str),
+                Some("object"),
+                "{key} should be generated as an object schema"
+            );
+            assert!(
+                required.contains(&json!("type")),
+                "{key} should require a nested JSON Schema type field"
+            );
+            assert_eq!(
+                fragment_schema
+                    .pointer("/properties/type/type")
+                    .and_then(JsonValue::as_str),
+                Some("string"),
+                "{key}.type should be generated as a string field"
             );
         }
     }

--- a/adl/src/uts_conformance.rs
+++ b/adl/src/uts_conformance.rs
@@ -1,9 +1,15 @@
 use crate::uts::{
     validate_uts_v1, UniversalToolSchemaV1, UtsSideEffectClassV1, UTS_SCHEMA_VERSION_V1,
 };
+use serde::Serialize;
 use serde_json::{json, Value as JsonValue};
+use std::{fs, io, path::Path};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub const UTS_CONFORMANCE_REPORT_ARTIFACT_PATH: &str =
+    "docs/milestones/v0.90.5/review/uts-conformance-report.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum UtsConformanceGroup {
     Valid,
     Invalid,
@@ -26,7 +32,7 @@ pub struct UtsConformanceFixture {
     pub expected: UtsExpectedOutcome,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UtsConformanceCaseResult {
     pub id: &'static str,
     pub group: UtsConformanceGroup,
@@ -37,7 +43,7 @@ pub struct UtsConformanceCaseResult {
     pub passed: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UtsConformanceReport {
     pub schema_version: &'static str,
     pub fixture_count: usize,
@@ -370,6 +376,26 @@ fn missing_required_reason(document: &JsonValue) -> Option<&'static str> {
     }
 }
 
+fn missing_schema_fragment_reason(document: &JsonValue) -> Option<&'static str> {
+    let object = document.as_object()?;
+    for (field, reason) in [
+        ("input_schema", "invalid_input_schema"),
+        ("output_schema", "invalid_output_schema"),
+    ] {
+        let has_fragment_type = object
+            .get(field)
+            .and_then(JsonValue::as_object)
+            .and_then(|fragment| fragment.get("type"))
+            .and_then(JsonValue::as_str)
+            .is_some();
+        if !has_fragment_type {
+            return Some(reason);
+        }
+    }
+
+    None
+}
+
 fn side_effect_is_dangerous(side_effect: UtsSideEffectClassV1) -> bool {
     matches!(
         side_effect,
@@ -382,6 +408,18 @@ fn side_effect_is_dangerous(side_effect: UtsSideEffectClassV1) -> bool {
 
 fn evaluate_fixture(fixture: &UtsConformanceFixture) -> UtsConformanceCaseResult {
     if let Some(reason) = missing_required_reason(&fixture.document) {
+        let execution_granted = false;
+        return UtsConformanceCaseResult {
+            id: fixture.id,
+            group: fixture.group,
+            accepted: false,
+            reason,
+            side_effect_class: None,
+            execution_granted,
+            passed: matches!(fixture.expected, UtsExpectedOutcome::Rejected(expected) if expected == reason),
+        };
+    }
+    if let Some(reason) = missing_schema_fragment_reason(&fixture.document) {
         let execution_granted = false;
         return UtsConformanceCaseResult {
             id: fixture.id,
@@ -434,6 +472,28 @@ fn evaluate_fixture(fixture: &UtsConformanceFixture) -> UtsConformanceCaseResult
     }
 }
 
+pub fn uts_conformance_report_json() -> JsonValue {
+    serde_json::to_value(run_uts_conformance_suite())
+        .expect("UTS conformance report should serialize")
+}
+
+pub fn write_uts_conformance_report(path: impl AsRef<Path>) -> io::Result<UtsConformanceReport> {
+    let path = path.as_ref();
+    let report = run_uts_conformance_suite();
+    let body = serde_json::to_string_pretty(&report).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize UTS conformance report: {error}"),
+        )
+    })?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, format!("{body}\n"))?;
+
+    Ok(report)
+}
+
 pub fn run_uts_conformance_suite() -> UtsConformanceReport {
     let fixtures = uts_conformance_fixtures();
     let cases: Vec<UtsConformanceCaseResult> = fixtures.iter().map(evaluate_fixture).collect();
@@ -450,7 +510,7 @@ pub fn run_uts_conformance_suite() -> UtsConformanceReport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeSet;
+    use std::{collections::BTreeSet, path::PathBuf};
 
     const EXPECTED_IDS: &[&str] = &[
         "valid.safe_read",
@@ -475,6 +535,8 @@ mod tests {
         "dangerous.network_denied",
         "dangerous.exfiltration_denied",
     ];
+    const TRACKED_REPORT_ARTIFACT: &str =
+        include_str!("../../docs/milestones/v0.90.5/review/uts-conformance-report.json");
 
     #[test]
     fn uts_conformance_fixture_packet_has_expected_ids_in_order() {
@@ -578,5 +640,68 @@ mod tests {
                 case.id
             );
         }
+    }
+
+    #[test]
+    fn uts_conformance_report_serializes_deterministically_without_host_paths() {
+        let first = serde_json::to_string_pretty(&run_uts_conformance_suite())
+            .expect("report should serialize");
+        let second = serde_json::to_string_pretty(&run_uts_conformance_suite())
+            .expect("report should serialize deterministically");
+
+        assert_eq!(first, second);
+        assert!(first.contains("\"id\": \"valid.safe_read\""));
+        assert!(first.contains("\"group\": \"valid\""));
+        for host_path_marker in ["/Users/", "/tmp/", "/var/folders/"] {
+            assert!(
+                !first.contains(host_path_marker),
+                "portable report must not contain host path marker {host_path_marker}"
+            );
+        }
+    }
+
+    #[test]
+    fn uts_conformance_report_writer_emits_portable_artifact_json() {
+        let report_path = temp_report_path();
+        let report = write_uts_conformance_report(&report_path)
+            .expect("report writer should emit a JSON artifact");
+        let body =
+            std::fs::read_to_string(&report_path).expect("report artifact should be readable");
+        let parsed: JsonValue =
+            serde_json::from_str(&body).expect("report artifact should be valid JSON");
+
+        assert!(report.passed);
+        assert_eq!(report.fixture_count, EXPECTED_IDS.len());
+        assert_eq!(parsed["schema_version"], json!(UTS_SCHEMA_VERSION_V1));
+        assert_eq!(parsed["fixture_count"], json!(EXPECTED_IDS.len()));
+        assert!(parsed["passed"].as_bool().unwrap_or(false));
+        assert!(body.ends_with('\n'));
+        assert!(!Path::new(UTS_CONFORMANCE_REPORT_ARTIFACT_PATH).is_absolute());
+        assert!(!UTS_CONFORMANCE_REPORT_ARTIFACT_PATH.contains(".."));
+        for host_path_marker in ["/Users/", "/tmp/", "/var/folders/"] {
+            assert!(
+                !body.contains(host_path_marker),
+                "portable report artifact must not contain host path marker {host_path_marker}"
+            );
+        }
+
+        let _ = std::fs::remove_file(report_path);
+    }
+
+    #[test]
+    fn uts_conformance_tracked_report_artifact_matches_generated_report() {
+        let generated = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&run_uts_conformance_suite())
+                .expect("report should serialize")
+        );
+
+        assert_eq!(TRACKED_REPORT_ARTIFACT, generated);
+    }
+
+    fn temp_report_path() -> PathBuf {
+        std::env::temp_dir()
+            .join(format!("adl-uts-conformance-report-{}", std::process::id()))
+            .join(UTS_CONFORMANCE_REPORT_ARTIFACT_PATH)
     }
 }

--- a/docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md
+++ b/docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md
@@ -87,6 +87,9 @@ WP-04 lands the first strongly typed UTS v1 artifact in
 WP-04 should make the schema and strongly typed artifact enforce these
 requirements:
 
+- input and output JSON Schema fragments use `UtsJsonSchemaFragmentV1` so the
+  generated schema exposes typed object fragments with a required nested `type`
+  field;
 - every fixture declares one side-effect class from the WP-02 taxonomy;
 - every fixture declares determinism and replay safety;
 - every fixture declares authentication posture and data sensitivity;
@@ -107,7 +110,12 @@ WP-05 should provide a deterministic conformance command or harness that:
 WP-05 implements the review-facing conformance harness in
 `adl/src/uts_conformance.rs`. The fixture packet is exposed through
 `uts_conformance_fixtures`, and `run_uts_conformance_suite` evaluates the
-packet without granting execution. The focused validation command is:
+packet without granting execution. `UtsConformanceReport` and
+`UtsConformanceCaseResult` serialize to deterministic JSON, and
+`write_uts_conformance_report` can emit the portable report artifact at the
+repository-relative path
+`docs/milestones/v0.90.5/review/uts-conformance-report.json` without embedding
+host paths or secrets. The focused validation command is:
 
 ```sh
 cargo test --manifest-path adl/Cargo.toml uts -- --nocapture

--- a/docs/milestones/v0.90.5/review/uts-conformance-report.json
+++ b/docs/milestones/v0.90.5/review/uts-conformance-report.json
@@ -1,0 +1,196 @@
+{
+  "schema_version": "uts.v1",
+  "fixture_count": 21,
+  "passed": true,
+  "cases": [
+    {
+      "id": "valid.safe_read",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "read",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "valid.local_write",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "local_write",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "valid.external_read",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "external_read",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "valid.external_write",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "external_write",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "valid.destructive",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "destructive",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "valid.process",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "process",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "valid.network",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "network",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "valid.exfiltration",
+      "group": "valid",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "exfiltration",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "invalid.missing_semantics",
+      "group": "invalid",
+      "accepted": false,
+      "reason": "missing_semantics",
+      "side_effect_class": null,
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "invalid.missing_security_metadata",
+      "group": "invalid",
+      "accepted": false,
+      "reason": "missing_security_metadata",
+      "side_effect_class": null,
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "invalid.malformed_schema",
+      "group": "invalid",
+      "accepted": false,
+      "reason": "invalid_input_schema",
+      "side_effect_class": null,
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "invalid.ambiguous_side_effects",
+      "group": "invalid",
+      "accepted": false,
+      "reason": "ambiguous_side_effects",
+      "side_effect_class": "network",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "invalid.unsafe_extension",
+      "group": "invalid",
+      "accepted": false,
+      "reason": "invalid_extension_key",
+      "side_effect_class": "read",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "invalid.incompatible_version",
+      "group": "invalid",
+      "accepted": false,
+      "reason": "unsupported_schema_version",
+      "side_effect_class": "read",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "extension.optional_vendor_metadata",
+      "group": "extension",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "read",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "extension.unsupported_required_extension",
+      "group": "extension",
+      "accepted": false,
+      "reason": "unsupported_required_extension",
+      "side_effect_class": "read",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "extension.reserved_authority_extension",
+      "group": "extension",
+      "accepted": false,
+      "reason": "invalid_extension_key",
+      "side_effect_class": "read",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "dangerous.destructive_denied",
+      "group": "dangerous",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "destructive",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "dangerous.process_denied",
+      "group": "dangerous",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "process",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "dangerous.network_denied",
+      "group": "dangerous",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "network",
+      "execution_granted": false,
+      "passed": true
+    },
+    {
+      "id": "dangerous.exfiltration_denied",
+      "group": "dangerous",
+      "accepted": true,
+      "reason": "accepted",
+      "side_effect_class": "exfiltration",
+      "execution_granted": false,
+      "passed": true
+    }
+  ]
+}


### PR DESCRIPTION
Closes #2611

## Summary
Review-remediation issue #2611 fixed the two Sprint 1 UTS review findings by hardening the generated UTS v1 schema contract for nested input/output JSON Schema fragments and adding durable deterministic conformance report output. The implementation keeps UTS validity as schema compatibility only and does not add execution authority.

## Artifacts
- `adl/src/uts.rs`: added `UtsJsonSchemaFragmentV1`, changed `input_schema` and `output_schema` to typed fragments, and added regression tests for untyped nested fragments plus generated schema shape.
- `adl/src/uts_conformance.rs`: made conformance report/case results serializable, added deterministic JSON/report writer helpers, preserved intended invalid-fixture classification before serde rejection, and added portability/artifact drift tests.
- `docs/milestones/v0.90.5/features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md`: documented the typed nested fragment contract and portable report artifact surface.
- `docs/milestones/v0.90.5/review/uts-conformance-report.json`: tracked deterministic UTS conformance report artifact.
- Local ignored output-card record at `.adl/v0.90.5/tasks/issue-2611__v0-90-5-review-harden-uts-schema-and-conformance-report-surfaces/sor.md`.

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting.
  - `cargo test --manifest-path adl/Cargo.toml uts -- --nocapture`
    Verified the targeted UTS review-remediation surface; result was 38 passed UTS-filtered tests plus filtered non-UTS tests across harnesses.
  - `cargo clippy --manifest-path adl/Cargo.toml --lib --tests -- -D warnings`
    Verified warning-free Rust compile/lint coverage for library and tests.
  - `python3 -m json.tool docs/milestones/v0.90.5/review/uts-conformance-report.json >/dev/null`
    Verified tracked conformance report JSON syntax.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --print-risk-filters`
    Verified changed-source coverage filters: `uts`, `uts_conformance`.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree`
    Verified local coverage-impact preflight passed.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- uts`
    Generated bounded UTS-filtered coverage summary; changed-file rows were `adl/src/uts.rs` at 473/486 lines (97.33%) and `adl/src/uts_conformance.rs` at 443/462 lines (95.89%).
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified local coverage-impact preflight passed using the generated summary.
  - `python3` feature-doc marker check
    Verified doc references to the schema/report surfaces introduced by this issue.
  - `python3` local path leak check
    Verified changed tracked files do not contain local host/worktree markers.
  - `git diff --check`
    Verified whitespace cleanliness.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.5/tasks/issue-2611__v0-90-5-review-harden-uts-schema-and-conformance-report-surfaces/sip.md
- Output card: .adl/v0.90.5/tasks/issue-2611__v0-90-5-review-harden-uts-schema-and-conformance-report-surfaces/sor.md
- Idempotency-Key: v0-90-5-review-harden-uts-schema-and-conformance-reports-adl-src-uts-rs-adl-src-uts-conformance-rs-docs-milestones-v0-90-5-features-uts-public-spec-and-conformance-md-docs-milestones-v0-90-5-review-uts-conformance-report-json-adl-v0-90-5-tasks-issue-2611-v0-90-5-review-harden-uts-schema-and-conformance-report-surfaces-sip-md-adl-v0-90-5-tasks-issue-2611-v0-90-5-review-harden-uts-schema-and-conformance-report-surfaces-sor-md