### PR TITLE
[v0.90.5][demo] Local model PR reviewer agent

### DIFF
--- a/adl/src/cli/tests/open_usage.rs
+++ b/adl/src/cli/tests/open_usage.rs
@@ -115,3 +115,14 @@ fn usage_mentions_v0_4_and_legacy_examples() {
     assert!(text.contains("examples/adl-0.1.yaml"));
     assert!(text.contains("--allow-unsigned"));
 }
+
+#[test]
+fn code_review_filter_covers_global_usage_entry() {
+    let text = usage();
+    assert!(text.contains("adl tooling <card-prompt|code-review|lint-prompt-spec"));
+    assert!(text.contains(
+        "adl tooling code-review --out artifacts/reviews/pr-review --backend fixture --visibility packet-only"
+    ));
+    assert!(text.contains("adl pr finish <issue> --title <title>"));
+    assert!(text.contains("adl runtime-v2 contract-market-demo"));
+}

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -75,7 +75,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
 fn tooling_usage() -> &'static str {
     "adl tooling card-prompt --issue <number> [--out <path>]\n\
 adl tooling card-prompt --input <path> [--out <path>]\n\
-adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility packet-only|read-only-repo] [--base <ref>] [--head <ref>] [--issue <number>] [--writer-session <id>] [--reviewer-session <id>] [--model <name>] [--allow-live-ollama] [--ollama-url <url>] [--fixture-case clean|blocked]\n\
+adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility packet-only|read-only-repo] [--base <ref>] [--head <ref>] [--issue <number>] [--writer-session <id>] [--reviewer-session <id>] [--model <name>] [--allow-live-ollama] [--ollama-url <url>] [--timeout-secs <n>] [--include-working-tree] [--fixture-case clean|blocked]\n\
 adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\
 adl tooling lint-prompt-spec --issue <number>\n\
 adl tooling lint-prompt-spec --input <path>\n\

--- a/adl/src/cli/tooling_cmd.rs
+++ b/adl/src/cli/tooling_cmd.rs
@@ -2,6 +2,8 @@ use anyhow::{anyhow, Result};
 
 #[path = "tooling_cmd/card_prompt.rs"]
 mod card_prompt;
+#[path = "tooling_cmd/code_review.rs"]
+mod code_review;
 #[path = "tooling_cmd/common.rs"]
 mod common;
 #[path = "tooling_cmd/markdown.rs"]
@@ -16,6 +18,7 @@ mod structured_prompt;
 mod wp_issue_wave;
 
 use card_prompt::real_card_prompt;
+use code_review::real_code_review;
 use review_contract::{real_verify_repo_review_contract, real_verify_review_output_provenance};
 use review_surface::{real_review_card_surface, real_review_runtime_surface};
 use structured_prompt::{real_lint_prompt_spec, real_validate_structured_prompt};
@@ -45,12 +48,13 @@ use structured_prompt::{
 pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|arg| arg.as_str()) else {
         return Err(anyhow!(
-            "tooling requires a subcommand: card-prompt | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
+            "tooling requires a subcommand: card-prompt | code-review | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave"
         ));
     };
 
     match subcommand {
         "card-prompt" => real_card_prompt(&args[1..]),
+        "code-review" => real_code_review(&args[1..]),
         "generate-wp-issue-wave" => real_generate_wp_issue_wave(&args[1..]),
         "lint-prompt-spec" => real_lint_prompt_spec(&args[1..]),
         "validate-structured-prompt" => real_validate_structured_prompt(&args[1..]),
@@ -63,7 +67,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
             Ok(())
         }
         _ => Err(anyhow!(
-            "unknown tooling subcommand '{subcommand}' (expected card-prompt | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave)"
+            "unknown tooling subcommand '{subcommand}' (expected card-prompt | code-review | lint-prompt-spec | validate-structured-prompt | review-card-surface | review-runtime-surface | verify-review-output-provenance | verify-repo-review-contract | generate-wp-issue-wave)"
         )),
     }
 }
@@ -71,6 +75,7 @@ pub(crate) fn real_tooling(args: &[String]) -> Result<()> {
 fn tooling_usage() -> &'static str {
     "adl tooling card-prompt --issue <number> [--out <path>]\n\
 adl tooling card-prompt --input <path> [--out <path>]\n\
+adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility packet-only|read-only-repo] [--base <ref>] [--head <ref>] [--issue <number>] [--writer-session <id>] [--reviewer-session <id>] [--model <name>] [--allow-live-ollama] [--ollama-url <url>] [--fixture-case clean|blocked]\n\
 adl tooling generate-wp-issue-wave --version <version> [--wbs <path>] [--sprint <path>] [--out <path>]\n\
 adl tooling lint-prompt-spec --issue <number>\n\
 adl tooling lint-prompt-spec --input <path>\n\

--- a/adl/src/cli/tooling_cmd/code_review.rs
+++ b/adl/src/cli/tooling_cmd/code_review.rs
@@ -1,0 +1,909 @@
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::Digest;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use super::common::{contains_absolute_host_path_in_text, repo_root};
+use super::tooling_usage;
+
+const PACKET_SCHEMA: &str = "adl.pr_review_packet.v1";
+const RESULT_SCHEMA: &str = "adl.pr_review_result.v1";
+const GATE_SCHEMA: &str = "adl.pr_review_gate.v1";
+const SUMMARY_SCHEMA: &str = "adl.pr_review_run_summary.v1";
+
+#[derive(Debug)]
+struct CodeReviewArgs {
+    out: PathBuf,
+    backend: ReviewerBackend,
+    visibility_mode: VisibilityMode,
+    base_ref: String,
+    head_ref: String,
+    issue_number: Option<u32>,
+    writer_session: String,
+    reviewer_session: Option<String>,
+    model: Option<String>,
+    allow_live_ollama: bool,
+    ollama_url: String,
+    fixture_case: FixtureCase,
+    max_diff_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ReviewerBackend {
+    Fixture,
+    Ollama,
+}
+
+impl ReviewerBackend {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Fixture => "fixture",
+            Self::Ollama => "ollama",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum VisibilityMode {
+    PacketOnly,
+    ReadOnlyRepo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FixtureCase {
+    Clean,
+    Blocked,
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewPacket {
+    schema_version: &'static str,
+    issue_number: Option<u32>,
+    branch: String,
+    base_ref: String,
+    head_ref: String,
+    visibility_mode: VisibilityMode,
+    changed_files: Vec<String>,
+    diff_summary: DiffSummary,
+    focused_diff_hunks: Vec<DiffHunk>,
+    validation_evidence: Vec<ValidationEvidence>,
+    static_analysis_evidence: Vec<ValidationEvidence>,
+    repo_slice_manifest: RepoSliceManifest,
+    review_scope: String,
+    non_scope: Vec<String>,
+    known_risks: Vec<String>,
+    redaction_status: RedactionStatus,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffSummary {
+    files_changed: usize,
+    max_diff_bytes: usize,
+    truncated_hunks: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffHunk {
+    file: String,
+    diff_excerpt: String,
+    truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidationEvidence {
+    command: String,
+    status: String,
+    summary: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RepoSliceManifest {
+    read_only: bool,
+    write_allowed: bool,
+    tool_execution_allowed: bool,
+    files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactionStatus {
+    absolute_host_paths_present: bool,
+    secret_like_values_present: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReviewResult {
+    schema_version: String,
+    review_id: String,
+    reviewer_backend: String,
+    reviewer_model: String,
+    reviewer_session: String,
+    writer_session: String,
+    same_session_as_writer: bool,
+    visibility_mode: VisibilityMode,
+    repo_access: RepoAccess,
+    packet_id: String,
+    static_analysis_summary: Vec<String>,
+    findings: Vec<ReviewFinding>,
+    disposition: ReviewDisposition,
+    residual_risk: Vec<String>,
+    validation_claims: Vec<String>,
+    non_claims: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RepoAccess {
+    read_only: bool,
+    write_allowed: bool,
+    tool_execution_allowed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReviewFinding {
+    title: String,
+    priority: String,
+    file: String,
+    line: Option<u32>,
+    body: String,
+    evidence: Vec<String>,
+    heuristic_ids: Vec<String>,
+    confidence: String,
+    blocking: bool,
+    suggested_fix_scope: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ReviewDisposition {
+    Blessed,
+    Blocked,
+    NonProving,
+    Skipped,
+}
+
+#[derive(Debug, Serialize)]
+struct GateResult {
+    schema_version: &'static str,
+    gate_disposition: String,
+    pr_open_allowed: bool,
+    reasons: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RunSummary {
+    schema_version: &'static str,
+    packet_path: String,
+    result_path: String,
+    gate_path: String,
+    backend: String,
+    visibility_mode: VisibilityMode,
+    pr_open_allowed: bool,
+}
+
+pub(super) fn real_code_review(args: &[String]) -> Result<()> {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "help" | "--help" | "-h"))
+    {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+
+    let args = parse_args(args)?;
+    fs::create_dir_all(&args.out).context("create code-review output directory")?;
+
+    let root = repo_root()?;
+    let packet = build_packet(&root, &args)?;
+    let packet_id = packet_id(&packet);
+    let result = run_reviewer(&args, &packet, &packet_id)?;
+    let gate = evaluate_gate(&result, &packet);
+
+    let packet_path = args.out.join("review_packet.json");
+    let result_path = args.out.join("review_result.json");
+    let gate_path = args.out.join("gate_result.json");
+    let summary_path = args.out.join("run_summary.json");
+
+    write_json(&packet_path, &packet)?;
+    write_json(&result_path, &result)?;
+    write_json(&gate_path, &gate)?;
+    write_json(
+        &summary_path,
+        &RunSummary {
+            schema_version: SUMMARY_SCHEMA,
+            packet_path: "review_packet.json".to_string(),
+            result_path: "review_result.json".to_string(),
+            gate_path: "gate_result.json".to_string(),
+            backend: args.backend.as_str().to_string(),
+            visibility_mode: args.visibility_mode,
+            pr_open_allowed: gate.pr_open_allowed,
+        },
+    )?;
+
+    println!(
+        "CODE_REVIEW_GATE={} OUT={}",
+        gate.gate_disposition,
+        args.out.display()
+    );
+    Ok(())
+}
+
+fn parse_args(args: &[String]) -> Result<CodeReviewArgs> {
+    let mut parsed = CodeReviewArgs {
+        out: PathBuf::new(),
+        backend: ReviewerBackend::Fixture,
+        visibility_mode: VisibilityMode::PacketOnly,
+        base_ref: "origin/main".to_string(),
+        head_ref: "HEAD".to_string(),
+        issue_number: None,
+        writer_session: std::env::var("CODEX_SESSION_ID")
+            .unwrap_or_else(|_| "unknown-writer-session".to_string()),
+        reviewer_session: None,
+        model: None,
+        allow_live_ollama: false,
+        ollama_url: std::env::var("OLLAMA_HOST")
+            .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string()),
+        fixture_case: FixtureCase::Clean,
+        max_diff_bytes: 12_000,
+    };
+
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                parsed.out = PathBuf::from(value_arg(args, i, "--out")?);
+                i += 1;
+            }
+            "--backend" => {
+                parsed.backend = parse_backend(value_arg(args, i, "--backend")?)?;
+                i += 1;
+            }
+            "--visibility" => {
+                parsed.visibility_mode = parse_visibility(value_arg(args, i, "--visibility")?)?;
+                i += 1;
+            }
+            "--base" => {
+                parsed.base_ref = value_arg(args, i, "--base")?.to_string();
+                i += 1;
+            }
+            "--head" => {
+                parsed.head_ref = value_arg(args, i, "--head")?.to_string();
+                i += 1;
+            }
+            "--issue" => {
+                parsed.issue_number = Some(
+                    value_arg(args, i, "--issue")?
+                        .parse()
+                        .map_err(|_| anyhow!("invalid --issue value"))?,
+                );
+                i += 1;
+            }
+            "--writer-session" => {
+                parsed.writer_session = value_arg(args, i, "--writer-session")?.to_string();
+                i += 1;
+            }
+            "--reviewer-session" => {
+                parsed.reviewer_session =
+                    Some(value_arg(args, i, "--reviewer-session")?.to_string());
+                i += 1;
+            }
+            "--model" => {
+                parsed.model = Some(value_arg(args, i, "--model")?.to_string());
+                i += 1;
+            }
+            "--allow-live-ollama" => parsed.allow_live_ollama = true,
+            "--ollama-url" => {
+                parsed.ollama_url = value_arg(args, i, "--ollama-url")?.to_string();
+                i += 1;
+            }
+            "--fixture-case" => {
+                parsed.fixture_case = parse_fixture_case(value_arg(args, i, "--fixture-case")?)?;
+                i += 1;
+            }
+            "--max-diff-bytes" => {
+                parsed.max_diff_bytes = value_arg(args, i, "--max-diff-bytes")?
+                    .parse()
+                    .map_err(|_| anyhow!("invalid --max-diff-bytes value"))?;
+                i += 1;
+            }
+            other => bail!("unknown arg for tooling code-review: {other}"),
+        }
+        i += 1;
+    }
+
+    ensure!(!parsed.out.as_os_str().is_empty(), "missing --out <dir>");
+    ensure!(
+        !parsed.writer_session.trim().is_empty(),
+        "--writer-session must not be empty"
+    );
+    ensure!(
+        parsed.max_diff_bytes >= 256,
+        "--max-diff-bytes must be at least 256"
+    );
+    Ok(parsed)
+}
+
+fn value_arg<'a>(args: &'a [String], index: usize, flag: &str) -> Result<&'a str> {
+    args.get(index + 1)
+        .map(|value| value.as_str())
+        .ok_or_else(|| anyhow!("missing value for {flag}"))
+}
+
+fn parse_backend(raw: &str) -> Result<ReviewerBackend> {
+    match raw {
+        "fixture" => Ok(ReviewerBackend::Fixture),
+        "ollama" | "gemma4_local" => Ok(ReviewerBackend::Ollama),
+        other => bail!("unsupported code-review backend '{other}'"),
+    }
+}
+
+fn parse_visibility(raw: &str) -> Result<VisibilityMode> {
+    match raw {
+        "packet-only" | "packet_only" => Ok(VisibilityMode::PacketOnly),
+        "read-only-repo" | "read_only_repo" => Ok(VisibilityMode::ReadOnlyRepo),
+        other => bail!("unsupported visibility mode '{other}'"),
+    }
+}
+
+fn parse_fixture_case(raw: &str) -> Result<FixtureCase> {
+    match raw {
+        "clean" => Ok(FixtureCase::Clean),
+        "blocked" => Ok(FixtureCase::Blocked),
+        other => bail!("unsupported fixture case '{other}'"),
+    }
+}
+
+fn build_packet(root: &Path, args: &CodeReviewArgs) -> Result<ReviewPacket> {
+    let branch = git_output(root, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .unwrap_or_else(|_| "unknown".to_string());
+    let changed_files = changed_files(root, &args.base_ref, &args.head_ref)?;
+    let focused_diff_hunks = diff_hunks(root, args, &changed_files)?;
+    let truncated_hunks = focused_diff_hunks.iter().any(|hunk| hunk.truncated);
+    let static_analysis_evidence = static_evidence(root, args);
+    let packet_text = serde_json::to_string(&focused_diff_hunks).unwrap_or_default();
+    let redaction_status = RedactionStatus {
+        absolute_host_paths_present: contains_absolute_host_path_in_text(&packet_text),
+        secret_like_values_present: false,
+    };
+    Ok(ReviewPacket {
+        schema_version: PACKET_SCHEMA,
+        issue_number: args.issue_number,
+        branch,
+        base_ref: args.base_ref.clone(),
+        head_ref: args.head_ref.clone(),
+        visibility_mode: args.visibility_mode,
+        changed_files: changed_files.clone(),
+        diff_summary: DiffSummary {
+            files_changed: changed_files.len(),
+            max_diff_bytes: args.max_diff_bytes,
+            truncated_hunks,
+        },
+        focused_diff_hunks,
+        validation_evidence: Vec::new(),
+        static_analysis_evidence,
+        repo_slice_manifest: RepoSliceManifest {
+            read_only: args.visibility_mode == VisibilityMode::ReadOnlyRepo,
+            write_allowed: false,
+            tool_execution_allowed: false,
+            files: changed_files,
+        },
+        review_scope: "review changed files, diff hunks, static evidence, and issue/card context for correctness, safety, tests, docs, and ADL lifecycle risks".to_string(),
+        non_scope: vec![
+            "do not edit files".to_string(),
+            "do not claim merge authority".to_string(),
+            "do not claim validation that is not present in the packet".to_string(),
+        ],
+        known_risks: vec![
+            "packet-only mode may miss surrounding-code context not included in focused hunks".to_string(),
+        ],
+        redaction_status,
+    })
+}
+
+fn changed_files(root: &Path, base: &str, head: &str) -> Result<Vec<String>> {
+    let mut files = BTreeSet::new();
+    if let Ok(output) = git_output(root, &["diff", "--name-only", &format!("{base}...{head}")]) {
+        files.extend(
+            output
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string),
+        );
+    }
+    if let Ok(output) = git_output(root, &["diff", "--name-only"]) {
+        files.extend(
+            output
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string),
+        );
+    }
+    Ok(files.into_iter().collect())
+}
+
+fn diff_hunks(root: &Path, args: &CodeReviewArgs, files: &[String]) -> Result<Vec<DiffHunk>> {
+    let mut hunks = Vec::new();
+    for file in files.iter().take(40) {
+        let diff = git_output(root, &["diff", "--", file])
+            .ok()
+            .filter(|text| !text.trim().is_empty())
+            .or_else(|| {
+                git_output(
+                    root,
+                    &[
+                        "diff",
+                        &format!("{}...{}", args.base_ref, args.head_ref),
+                        "--",
+                        file,
+                    ],
+                )
+                .ok()
+            })
+            .unwrap_or_default();
+        let (diff_excerpt, truncated) = truncate(&diff, args.max_diff_bytes);
+        hunks.push(DiffHunk {
+            file: file.clone(),
+            diff_excerpt,
+            truncated,
+        });
+    }
+    Ok(hunks)
+}
+
+fn static_evidence(root: &Path, args: &CodeReviewArgs) -> Vec<ValidationEvidence> {
+    let mut evidence = Vec::new();
+    evidence.push(command_evidence(
+        root,
+        &["diff", "--check"],
+        "working tree whitespace check",
+    ));
+    evidence.push(command_evidence(
+        root,
+        &[
+            "diff",
+            "--check",
+            &format!("{}...{}", args.base_ref, args.head_ref),
+        ],
+        "committed diff whitespace check",
+    ));
+    evidence
+}
+
+fn command_evidence(root: &Path, git_args: &[&str], label: &str) -> ValidationEvidence {
+    let output = Command::new("git")
+        .args(git_args)
+        .current_dir(root)
+        .output();
+    match output {
+        Ok(output) if output.status.success() => ValidationEvidence {
+            command: format!("git {}", git_args.join(" ")),
+            status: "PASS".to_string(),
+            summary: label.to_string(),
+        },
+        Ok(output) => ValidationEvidence {
+            command: format!("git {}", git_args.join(" ")),
+            status: "FAIL".to_string(),
+            summary: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        },
+        Err(err) => ValidationEvidence {
+            command: format!("git {}", git_args.join(" ")),
+            status: "SKIPPED".to_string(),
+            summary: format!("{label}: {err}"),
+        },
+    }
+}
+
+fn run_reviewer(
+    args: &CodeReviewArgs,
+    packet: &ReviewPacket,
+    packet_id: &str,
+) -> Result<ReviewResult> {
+    match args.backend {
+        ReviewerBackend::Fixture => Ok(fixture_review(args, packet, packet_id)),
+        ReviewerBackend::Ollama => ollama_review(args, packet, packet_id),
+    }
+}
+
+fn fixture_review(args: &CodeReviewArgs, packet: &ReviewPacket, packet_id: &str) -> ReviewResult {
+    let reviewer_session = args
+        .reviewer_session
+        .clone()
+        .unwrap_or_else(|| "fixture-reviewer-session".to_string());
+    let same_session = reviewer_session == args.writer_session;
+    let mut findings = Vec::new();
+    let mut disposition = ReviewDisposition::Blessed;
+    if args.fixture_case == FixtureCase::Blocked {
+        disposition = ReviewDisposition::Blocked;
+        findings.push(ReviewFinding {
+            title: "Fixture blocking finding".to_string(),
+            priority: "P2".to_string(),
+            file: packet
+                .changed_files
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string()),
+            line: Some(1),
+            body: "Fixture backend intentionally produced a blocking finding for gate testing."
+                .to_string(),
+            evidence: vec!["fixture:blocked-case".to_string()],
+            heuristic_ids: vec!["C1".to_string(), "T7".to_string()],
+            confidence: "high".to_string(),
+            blocking: true,
+            suggested_fix_scope: "fixture_only".to_string(),
+        });
+    }
+    if same_session {
+        disposition = ReviewDisposition::NonProving;
+    }
+    review_result(
+        args,
+        packet,
+        packet_id,
+        ReviewResultParts {
+            reviewer_session,
+            reviewer_model: args
+                .model
+                .clone()
+                .unwrap_or_else(|| "fixture-reviewer-v1".to_string()),
+            same_session,
+            disposition,
+            findings,
+            residual_risk: vec![
+                "fixture backend does not perform semantic model review".to_string()
+            ],
+        },
+    )
+}
+
+struct ReviewResultParts {
+    reviewer_session: String,
+    reviewer_model: String,
+    same_session: bool,
+    disposition: ReviewDisposition,
+    findings: Vec<ReviewFinding>,
+    residual_risk: Vec<String>,
+}
+
+fn skipped_review_result(
+    args: &CodeReviewArgs,
+    packet: &ReviewPacket,
+    packet_id: &str,
+    reviewer_session: String,
+    model: String,
+    residual_risk: String,
+) -> ReviewResult {
+    review_result(
+        args,
+        packet,
+        packet_id,
+        ReviewResultParts {
+            same_session: reviewer_session == args.writer_session,
+            reviewer_session,
+            reviewer_model: model,
+            disposition: ReviewDisposition::Skipped,
+            findings: Vec::new(),
+            residual_risk: vec![residual_risk],
+        },
+    )
+}
+
+fn ollama_review(
+    args: &CodeReviewArgs,
+    packet: &ReviewPacket,
+    packet_id: &str,
+) -> Result<ReviewResult> {
+    let reviewer_session = args
+        .reviewer_session
+        .clone()
+        .unwrap_or_else(|| "ollama-reviewer-session".to_string());
+    let model = args
+        .model
+        .clone()
+        .unwrap_or_else(|| "gemma4:latest".to_string());
+    if !args.allow_live_ollama {
+        return Ok(skipped_review_result(
+            args,
+            packet,
+            packet_id,
+            reviewer_session.clone(),
+            model,
+            "live Ollama review requires --allow-live-ollama".to_string(),
+        ));
+    }
+
+    let prompt = reviewer_prompt(packet);
+    let endpoint = ollama_generate_url(&args.ollama_url)?;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()
+        .context("build Ollama HTTP client")?;
+    let response = client
+        .post(endpoint)
+        .header("Content-Type", "application/json")
+        .json(&serde_json::json!({
+            "model": model,
+            "prompt": prompt,
+            "stream": false
+        }))
+        .send();
+    let text = match response {
+        Ok(resp) if resp.status().is_success() => resp
+            .json::<Value>()
+            .context("parse Ollama response JSON")?
+            .get("response")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string(),
+        Ok(resp) => {
+            return Ok(skipped_review_result(
+                args,
+                packet,
+                packet_id,
+                reviewer_session.clone(),
+                model,
+                format!("Ollama returned HTTP {}", resp.status()),
+            ));
+        }
+        Err(err) => {
+            return Ok(skipped_review_result(
+                args,
+                packet,
+                packet_id,
+                reviewer_session.clone(),
+                model,
+                format!("Ollama unavailable: {err}"),
+            ));
+        }
+    };
+
+    let parsed = parse_model_review_json(&text);
+    let (disposition, findings, residual) = match parsed {
+        Some((disposition, findings)) => (disposition, findings, Vec::new()),
+        None => (
+            ReviewDisposition::NonProving,
+            Vec::new(),
+            vec![
+                "Ollama response was not valid normalized review JSON".to_string(),
+                truncate(&text, 800).0,
+            ],
+        ),
+    };
+    Ok(review_result(
+        args,
+        packet,
+        packet_id,
+        ReviewResultParts {
+            same_session: reviewer_session == args.writer_session,
+            reviewer_session,
+            reviewer_model: model,
+            disposition,
+            findings,
+            residual_risk: residual,
+        },
+    ))
+}
+
+fn review_result(
+    args: &CodeReviewArgs,
+    packet: &ReviewPacket,
+    packet_id: &str,
+    parts: ReviewResultParts,
+) -> ReviewResult {
+    ReviewResult {
+        schema_version: RESULT_SCHEMA.to_string(),
+        review_id: format!("review-{}", packet_id),
+        reviewer_backend: args.backend.as_str().to_string(),
+        reviewer_model: parts.reviewer_model,
+        reviewer_session: parts.reviewer_session,
+        writer_session: args.writer_session.clone(),
+        same_session_as_writer: parts.same_session,
+        visibility_mode: args.visibility_mode,
+        repo_access: RepoAccess {
+            read_only: args.visibility_mode == VisibilityMode::ReadOnlyRepo,
+            write_allowed: false,
+            tool_execution_allowed: false,
+        },
+        packet_id: packet_id.to_string(),
+        static_analysis_summary: packet
+            .static_analysis_evidence
+            .iter()
+            .map(|item| format!("{}: {}", item.status, item.command))
+            .collect(),
+        findings: parts.findings,
+        disposition: parts.disposition,
+        residual_risk: parts.residual_risk,
+        validation_claims: Vec::new(),
+        non_claims: vec![
+            "review result is not merge authority".to_string(),
+            "reviewer did not execute repository writes".to_string(),
+        ],
+    }
+}
+
+fn evaluate_gate(result: &ReviewResult, packet: &ReviewPacket) -> GateResult {
+    let mut reasons = Vec::new();
+    if result.same_session_as_writer {
+        reasons.push("reviewer session matches writer session".to_string());
+    }
+    if packet
+        .static_analysis_evidence
+        .iter()
+        .any(|item| item.status == "FAIL")
+    {
+        reasons.push("static analysis evidence contains failures".to_string());
+    }
+    for finding in &result.findings {
+        if finding.blocking && matches!(finding.priority.as_str(), "P0" | "P1" | "P2") {
+            reasons.push(format!(
+                "blocking {} finding: {}",
+                finding.priority, finding.title
+            ));
+        }
+    }
+    if result.disposition == ReviewDisposition::Blocked {
+        reasons.push("review disposition is blocked".to_string());
+    }
+    if result.disposition == ReviewDisposition::Skipped {
+        reasons
+            .push("review disposition is skipped; operator waiver is not implemented".to_string());
+    }
+    if result.disposition == ReviewDisposition::NonProving {
+        reasons.push(
+            "review disposition is non_proving; operator waiver is not implemented".to_string(),
+        );
+    }
+    let pr_open_allowed = reasons.is_empty() && result.disposition == ReviewDisposition::Blessed;
+    let gate_disposition = if pr_open_allowed {
+        "allow_with_evidence"
+    } else {
+        "block_pr_open"
+    };
+    GateResult {
+        schema_version: GATE_SCHEMA,
+        gate_disposition: gate_disposition.to_string(),
+        pr_open_allowed,
+        reasons,
+    }
+}
+
+fn reviewer_prompt(packet: &ReviewPacket) -> String {
+    format!(
+        "You are an ADL code reviewer. Review this bounded packet fairly and meticulously. Return only JSON matching schema_version adl.pr_review_result.v1 with fields disposition (blessed|blocked|non_proving), findings array, and residual_risk array. Packet:\n{}",
+        serde_json::to_string_pretty(packet).unwrap_or_default()
+    )
+}
+
+fn parse_model_review_json(raw: &str) -> Option<(ReviewDisposition, Vec<ReviewFinding>)> {
+    let cleaned = raw
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+    let value: Value = serde_json::from_str(cleaned).ok()?;
+    let disposition = match value.get("disposition")?.as_str()? {
+        "blessed" => ReviewDisposition::Blessed,
+        "blocked" => ReviewDisposition::Blocked,
+        "non_proving" => ReviewDisposition::NonProving,
+        "skipped" => ReviewDisposition::Skipped,
+        _ => return None,
+    };
+    let findings = value
+        .get("findings")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| ReviewFinding {
+                    title: item
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Untitled model finding")
+                        .to_string(),
+                    priority: item
+                        .get("priority")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("P3")
+                        .to_string(),
+                    file: item
+                        .get("file")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string(),
+                    line: item.get("line").and_then(|v| v.as_u64()).map(|v| v as u32),
+                    body: item
+                        .get("body")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    evidence: string_array(item.get("evidence")),
+                    heuristic_ids: string_array(item.get("heuristic_ids")),
+                    confidence: item
+                        .get("confidence")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("medium")
+                        .to_string(),
+                    blocking: item
+                        .get("blocking")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
+                    suggested_fix_scope: item
+                        .get("suggested_fix_scope")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("issue_local")
+                        .to_string(),
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Some((disposition, findings))
+}
+
+fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(ToString::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn ollama_generate_url(raw: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(raw).context("parse Ollama URL")?;
+    let path = url.path().trim_end_matches('/');
+    if !path.ends_with("/api/generate") {
+        url.set_path("/api/generate");
+    }
+    Ok(url.to_string())
+}
+
+fn packet_id(packet: &ReviewPacket) -> String {
+    let seed = format!(
+        "{}:{}:{}:{}",
+        packet.issue_number.unwrap_or_default(),
+        packet.branch,
+        packet.changed_files.len(),
+        packet.diff_summary.truncated_hunks
+    );
+    let digest = sha2::Sha256::digest(seed.as_bytes());
+    format!("{:x}", digest)[..16].to_string()
+}
+
+fn truncate(text: &str, max_bytes: usize) -> (String, bool) {
+    if text.len() <= max_bytes {
+        return (text.to_string(), false);
+    }
+    let end = text
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .chain(std::iter::once(text.len()))
+        .take_while(|idx| *idx <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    (text[..end].to_string(), true)
+}
+
+fn git_output(root: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git").args(args).current_dir(root).output()?;
+    if !output.status.success() {
+        bail!("git command failed: git {}", args.join(" "));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    fs::write(path, bytes)?;
+    Ok(())
+}

--- a/adl/src/cli/tooling_cmd/code_review.rs
+++ b/adl/src/cli/tooling_cmd/code_review.rs
@@ -29,6 +29,8 @@ struct CodeReviewArgs {
     model: Option<String>,
     allow_live_ollama: bool,
     ollama_url: String,
+    timeout_secs: u64,
+    include_working_tree: bool,
     fixture_case: FixtureCase,
     max_diff_bytes: usize,
 }
@@ -248,6 +250,8 @@ fn parse_args(args: &[String]) -> Result<CodeReviewArgs> {
         allow_live_ollama: false,
         ollama_url: std::env::var("OLLAMA_HOST")
             .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string()),
+        timeout_secs: 120,
+        include_working_tree: false,
         fixture_case: FixtureCase::Clean,
         max_diff_bytes: 12_000,
     };
@@ -297,8 +301,15 @@ fn parse_args(args: &[String]) -> Result<CodeReviewArgs> {
                 i += 1;
             }
             "--allow-live-ollama" => parsed.allow_live_ollama = true,
+            "--include-working-tree" => parsed.include_working_tree = true,
             "--ollama-url" => {
                 parsed.ollama_url = value_arg(args, i, "--ollama-url")?.to_string();
+                i += 1;
+            }
+            "--timeout-secs" => {
+                parsed.timeout_secs = value_arg(args, i, "--timeout-secs")?
+                    .parse()
+                    .map_err(|_| anyhow!("invalid --timeout-secs value"))?;
                 i += 1;
             }
             "--fixture-case" => {
@@ -324,6 +335,10 @@ fn parse_args(args: &[String]) -> Result<CodeReviewArgs> {
     ensure!(
         parsed.max_diff_bytes >= 256,
         "--max-diff-bytes must be at least 256"
+    );
+    ensure!(
+        (1..=900).contains(&parsed.timeout_secs),
+        "--timeout-secs must be between 1 and 900"
     );
     Ok(parsed)
 }
@@ -361,7 +376,7 @@ fn parse_fixture_case(raw: &str) -> Result<FixtureCase> {
 fn build_packet(root: &Path, args: &CodeReviewArgs) -> Result<ReviewPacket> {
     let branch = git_output(root, &["rev-parse", "--abbrev-ref", "HEAD"])
         .unwrap_or_else(|_| "unknown".to_string());
-    let changed_files = changed_files(root, &args.base_ref, &args.head_ref)?;
+    let changed_files = changed_files(root, args)?;
     let focused_diff_hunks = diff_hunks(root, args, &changed_files)?;
     let truncated_hunks = focused_diff_hunks.iter().any(|hunk| hunk.truncated);
     let static_analysis_evidence = static_evidence(root, args);
@@ -405,9 +420,16 @@ fn build_packet(root: &Path, args: &CodeReviewArgs) -> Result<ReviewPacket> {
     })
 }
 
-fn changed_files(root: &Path, base: &str, head: &str) -> Result<Vec<String>> {
+fn changed_files(root: &Path, args: &CodeReviewArgs) -> Result<Vec<String>> {
     let mut files = BTreeSet::new();
-    if let Ok(output) = git_output(root, &["diff", "--name-only", &format!("{base}...{head}")]) {
+    if let Ok(output) = git_output(
+        root,
+        &[
+            "diff",
+            "--name-only",
+            &format!("{}...{}", args.base_ref, args.head_ref),
+        ],
+    ) {
         files.extend(
             output
                 .lines()
@@ -416,7 +438,8 @@ fn changed_files(root: &Path, base: &str, head: &str) -> Result<Vec<String>> {
                 .map(str::to_string),
         );
     }
-    if let Ok(output) = git_output(root, &["diff", "--name-only"]) {
+    if args.include_working_tree {
+        let output = git_output(root, &["diff", "--name-only"])?;
         files.extend(
             output
                 .lines()
@@ -431,22 +454,26 @@ fn changed_files(root: &Path, base: &str, head: &str) -> Result<Vec<String>> {
 fn diff_hunks(root: &Path, args: &CodeReviewArgs, files: &[String]) -> Result<Vec<DiffHunk>> {
     let mut hunks = Vec::new();
     for file in files.iter().take(40) {
-        let diff = git_output(root, &["diff", "--", file])
-            .ok()
-            .filter(|text| !text.trim().is_empty())
-            .or_else(|| {
-                git_output(
-                    root,
-                    &[
-                        "diff",
-                        &format!("{}...{}", args.base_ref, args.head_ref),
-                        "--",
-                        file,
-                    ],
-                )
+        let diff = if args.include_working_tree {
+            git_output(root, &["diff", "--", file])
                 .ok()
-            })
-            .unwrap_or_default();
+                .filter(|text| !text.trim().is_empty())
+        } else {
+            None
+        }
+        .or_else(|| {
+            git_output(
+                root,
+                &[
+                    "diff",
+                    &format!("{}...{}", args.base_ref, args.head_ref),
+                    "--",
+                    file,
+                ],
+            )
+            .ok()
+        })
+        .unwrap_or_default();
         let (diff_excerpt, truncated) = truncate(&diff, args.max_diff_bytes);
         hunks.push(DiffHunk {
             file: file.clone(),
@@ -459,11 +486,13 @@ fn diff_hunks(root: &Path, args: &CodeReviewArgs, files: &[String]) -> Result<Ve
 
 fn static_evidence(root: &Path, args: &CodeReviewArgs) -> Vec<ValidationEvidence> {
     let mut evidence = Vec::new();
-    evidence.push(command_evidence(
-        root,
-        &["diff", "--check"],
-        "working tree whitespace check",
-    ));
+    if args.include_working_tree {
+        evidence.push(command_evidence(
+            root,
+            &["diff", "--check"],
+            "working tree whitespace check",
+        ));
+    }
     evidence.push(command_evidence(
         root,
         &[
@@ -621,7 +650,7 @@ fn ollama_review(
     let prompt = reviewer_prompt(packet);
     let endpoint = ollama_generate_url(&args.ollama_url)?;
     let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(120))
+        .timeout(Duration::from_secs(args.timeout_secs))
         .build()
         .context("build Ollama HTTP client")?;
     let response = client
@@ -666,7 +695,7 @@ fn ollama_review(
 
     let parsed = parse_model_review_json(&text);
     let (disposition, findings, residual) = match parsed {
-        Some((disposition, findings)) => (disposition, findings, Vec::new()),
+        Some((disposition, findings)) => normalize_model_review(disposition, findings),
         None => (
             ReviewDisposition::NonProving,
             Vec::new(),
@@ -776,7 +805,7 @@ fn evaluate_gate(result: &ReviewResult, packet: &ReviewPacket) -> GateResult {
 
 fn reviewer_prompt(packet: &ReviewPacket) -> String {
     format!(
-        "You are an ADL code reviewer. Review this bounded packet fairly and meticulously. Return only JSON matching schema_version adl.pr_review_result.v1 with fields disposition (blessed|blocked|non_proving), findings array, and residual_risk array. Packet:\n{}",
+        "You are an ADL code reviewer. Review this bounded packet fairly and meticulously. Return only JSON matching schema_version adl.pr_review_result.v1 with fields disposition (blessed|blocked|non_proving), findings array, and residual_risk array. Findings are only actionable risks, bugs, regressions, missing tests, security issues, or misleading documentation. Do not put praise, confirmations, or already-correct behavior in findings. If you include a finding, every finding must include a specific title, priority (P0|P1|P2|P3), file, body, evidence array, heuristic_ids array, confidence, blocking, and suggested_fix_scope. Do not include placeholder, empty, or non-actionable findings. Packet:\n{}",
         serde_json::to_string_pretty(packet).unwrap_or_default()
     )
 }
@@ -847,6 +876,69 @@ fn parse_model_review_json(raw: &str) -> Option<(ReviewDisposition, Vec<ReviewFi
     Some((disposition, findings))
 }
 
+fn normalize_model_review(
+    disposition: ReviewDisposition,
+    findings: Vec<ReviewFinding>,
+) -> (ReviewDisposition, Vec<ReviewFinding>, Vec<String>) {
+    let mut malformed = Vec::new();
+    for (idx, finding) in findings.iter().enumerate() {
+        let label = format!("finding {}", idx + 1);
+        if finding.title.trim().is_empty() || finding.title == "Untitled model finding" {
+            malformed.push(format!("{label} is missing a specific title"));
+        }
+        if !matches!(finding.priority.as_str(), "P0" | "P1" | "P2" | "P3") {
+            malformed.push(format!(
+                "{label} has unsupported priority '{}'",
+                finding.priority
+            ));
+        }
+        if finding.file.trim().is_empty() || finding.file == "unknown" {
+            malformed.push(format!("{label} is missing a specific file"));
+        }
+        if finding.body.trim().is_empty() {
+            malformed.push(format!("{label} is missing an explanatory body"));
+        }
+        if finding.evidence.is_empty()
+            || finding
+                .evidence
+                .iter()
+                .any(|evidence| evidence.trim().is_empty())
+        {
+            malformed.push(format!("{label} is missing concrete evidence"));
+        }
+        if finding.confidence.trim().is_empty() {
+            malformed.push(format!("{label} is missing confidence"));
+        }
+        if finding.suggested_fix_scope.trim().is_empty() {
+            malformed.push(format!("{label} is missing suggested_fix_scope"));
+        }
+        if is_non_actionable_fix_scope(&finding.suggested_fix_scope) {
+            malformed.push(format!(
+                "{label} is non-actionable praise or confirmation, not a review finding"
+            ));
+        }
+    }
+
+    if malformed.is_empty() {
+        return (disposition, findings, Vec::new());
+    }
+
+    let mut residual_risk = vec!["model review output contained malformed findings".to_string()];
+    residual_risk.extend(malformed);
+    (ReviewDisposition::NonProving, findings, residual_risk)
+}
+
+fn is_non_actionable_fix_scope(raw: &str) -> bool {
+    let normalized = raw.trim().to_ascii_lowercase();
+    normalized == "none"
+        || normalized == "n/a"
+        || normalized == "not applicable"
+        || normalized.starts_with("none.")
+        || normalized.starts_with("no fix")
+        || normalized.starts_with("no change")
+        || normalized.starts_with("no action")
+}
+
 fn string_array(value: Option<&Value>) -> Vec<String> {
     value
         .and_then(|v| v.as_array())
@@ -906,4 +998,331 @@ fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
     let bytes = serde_json::to_vec_pretty(value)?;
     fs::write(path, bytes)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_args() -> CodeReviewArgs {
+        CodeReviewArgs {
+            out: PathBuf::from("artifacts/review"),
+            backend: ReviewerBackend::Fixture,
+            visibility_mode: VisibilityMode::PacketOnly,
+            base_ref: "origin/main".to_string(),
+            head_ref: "HEAD".to_string(),
+            issue_number: Some(2603),
+            writer_session: "writer".to_string(),
+            reviewer_session: Some("reviewer".to_string()),
+            model: None,
+            allow_live_ollama: false,
+            ollama_url: "http://127.0.0.1:11434".to_string(),
+            timeout_secs: 120,
+            include_working_tree: false,
+            fixture_case: FixtureCase::Clean,
+            max_diff_bytes: 12_000,
+        }
+    }
+
+    fn test_packet() -> ReviewPacket {
+        ReviewPacket {
+            schema_version: PACKET_SCHEMA,
+            issue_number: Some(2603),
+            branch: "codex/test".to_string(),
+            base_ref: "origin/main".to_string(),
+            head_ref: "HEAD".to_string(),
+            visibility_mode: VisibilityMode::PacketOnly,
+            changed_files: vec!["docs/example.md".to_string()],
+            diff_summary: DiffSummary {
+                files_changed: 1,
+                max_diff_bytes: 12_000,
+                truncated_hunks: false,
+            },
+            focused_diff_hunks: vec![DiffHunk {
+                file: "docs/example.md".to_string(),
+                diff_excerpt: "+example".to_string(),
+                truncated: false,
+            }],
+            validation_evidence: Vec::new(),
+            static_analysis_evidence: Vec::new(),
+            repo_slice_manifest: RepoSliceManifest {
+                read_only: false,
+                write_allowed: false,
+                tool_execution_allowed: false,
+                files: vec!["docs/example.md".to_string()],
+            },
+            review_scope: "test review scope".to_string(),
+            non_scope: vec!["do not edit files".to_string()],
+            known_risks: Vec::new(),
+            redaction_status: RedactionStatus {
+                absolute_host_paths_present: false,
+                secret_like_values_present: false,
+            },
+        }
+    }
+
+    #[test]
+    fn parse_args_preserves_backend_after_out_and_accepts_timeout() {
+        let args = vec![
+            "--out".to_string(),
+            "artifacts/review".to_string(),
+            "--backend".to_string(),
+            "ollama".to_string(),
+            "--timeout-secs".to_string(),
+            "240".to_string(),
+            "--include-working-tree".to_string(),
+        ];
+        let parsed = parse_args(&args).expect("args should parse");
+        assert_eq!(parsed.backend, ReviewerBackend::Ollama);
+        assert_eq!(parsed.timeout_secs, 240);
+        assert!(parsed.include_working_tree);
+    }
+
+    #[test]
+    fn parse_args_excludes_working_tree_by_default() {
+        let args = vec!["--out".to_string(), "artifacts/review".to_string()];
+        let parsed = parse_args(&args).expect("args should parse");
+        assert!(!parsed.include_working_tree);
+    }
+
+    #[test]
+    fn parse_args_rejects_invalid_values_and_missing_required_out() {
+        assert!(parse_args(&["--backend".to_string(), "bad".to_string()]).is_err());
+        assert!(parse_args(&[
+            "--out".to_string(),
+            "artifacts/review".to_string(),
+            "--visibility".to_string(),
+            "bad".to_string(),
+        ])
+        .is_err());
+        assert!(parse_args(&[
+            "--out".to_string(),
+            "artifacts/review".to_string(),
+            "--fixture-case".to_string(),
+            "bad".to_string(),
+        ])
+        .is_err());
+        assert!(parse_args(&[
+            "--out".to_string(),
+            "artifacts/review".to_string(),
+            "--timeout-secs".to_string(),
+            "0".to_string(),
+        ])
+        .is_err());
+        assert!(parse_args(&[
+            "--out".to_string(),
+            "artifacts/review".to_string(),
+            "--max-diff-bytes".to_string(),
+            "255".to_string(),
+        ])
+        .is_err());
+        assert!(parse_args(&["--writer-session".to_string(), "".to_string()]).is_err());
+        assert!(parse_args(&["--out".to_string()]).is_err());
+        assert!(parse_args(&["--unknown".to_string()]).is_err());
+    }
+
+    #[test]
+    fn fixture_review_covers_blocked_and_same_session_paths() {
+        let packet = test_packet();
+        let packet_id = "packet-id";
+
+        let mut blocked_args = test_args();
+        blocked_args.fixture_case = FixtureCase::Blocked;
+        let blocked = fixture_review(&blocked_args, &packet, packet_id);
+        assert_eq!(blocked.disposition, ReviewDisposition::Blocked);
+        assert_eq!(blocked.findings.len(), 1);
+
+        let mut same_session_args = test_args();
+        same_session_args.reviewer_session = Some("writer".to_string());
+        let same_session = fixture_review(&same_session_args, &packet, packet_id);
+        assert_eq!(same_session.disposition, ReviewDisposition::NonProving);
+        assert!(same_session.same_session_as_writer);
+    }
+
+    #[test]
+    fn ollama_without_live_returns_skipped_blocker() {
+        let mut args = test_args();
+        args.backend = ReviewerBackend::Ollama;
+        args.model = Some("gemma4:test".to_string());
+        let packet = test_packet();
+        let result = ollama_review(&args, &packet, "packet-id").expect("skipped review");
+        assert_eq!(result.disposition, ReviewDisposition::Skipped);
+        let gate = evaluate_gate(&result, &packet);
+        assert!(!gate.pr_open_allowed);
+        assert!(gate.reasons.iter().any(|reason| reason.contains("skipped")));
+    }
+
+    #[test]
+    fn evaluate_gate_covers_static_failure_and_blocking_finding() {
+        let mut packet = test_packet();
+        packet.static_analysis_evidence.push(ValidationEvidence {
+            command: "git diff --check".to_string(),
+            status: "FAIL".to_string(),
+            summary: "whitespace error".to_string(),
+        });
+        let mut result = review_result(
+            &test_args(),
+            &packet,
+            "packet-id",
+            ReviewResultParts {
+                reviewer_session: "reviewer".to_string(),
+                reviewer_model: "fixture".to_string(),
+                same_session: false,
+                disposition: ReviewDisposition::Blessed,
+                findings: vec![ReviewFinding {
+                    title: "Blocking issue".to_string(),
+                    priority: "P2".to_string(),
+                    file: "docs/example.md".to_string(),
+                    line: Some(1),
+                    body: "A concrete problem exists.".to_string(),
+                    evidence: vec!["path:docs/example.md".to_string()],
+                    heuristic_ids: vec!["T1".to_string()],
+                    confidence: "high".to_string(),
+                    blocking: true,
+                    suggested_fix_scope: "issue_local".to_string(),
+                }],
+                residual_risk: Vec::new(),
+            },
+        );
+        result.same_session_as_writer = true;
+        let gate = evaluate_gate(&result, &packet);
+        assert!(!gate.pr_open_allowed);
+        assert!(gate
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("static analysis")));
+        assert!(gate
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("blocking P2 finding")));
+        assert!(gate
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("matches writer session")));
+    }
+
+    #[test]
+    fn parse_model_review_json_accepts_fenced_json_and_filters_string_arrays() {
+        let raw = r#"```json
+{
+  "disposition": "blocked",
+  "findings": [
+    {
+      "title": "Missing evidence",
+      "priority": "P3",
+      "file": "docs/example.md",
+      "line": 12,
+      "body": "The example references a fact without evidence.",
+      "evidence": ["path:docs/example.md", 42],
+      "heuristic_ids": ["D1", false],
+      "confidence": "medium",
+      "blocking": false,
+      "suggested_fix_scope": "issue_local"
+    }
+  ]
+}
+```"#;
+        let (disposition, findings) = parse_model_review_json(raw).expect("parse review json");
+        assert_eq!(disposition, ReviewDisposition::Blocked);
+        assert_eq!(findings[0].evidence, vec!["path:docs/example.md"]);
+        assert_eq!(findings[0].heuristic_ids, vec!["D1"]);
+        assert_eq!(findings[0].line, Some(12));
+        assert!(parse_model_review_json("{not-json").is_none());
+        assert!(parse_model_review_json(r#"{"disposition":"unexpected"}"#).is_none());
+    }
+
+    #[test]
+    fn helpers_cover_url_normalization_prompt_and_unicode_truncation() {
+        assert_eq!(
+            ollama_generate_url("http://127.0.0.1:11434").expect("url"),
+            "http://127.0.0.1:11434/api/generate"
+        );
+        assert_eq!(
+            ollama_generate_url("http://127.0.0.1:11434/api/generate").expect("url"),
+            "http://127.0.0.1:11434/api/generate"
+        );
+        assert!(ollama_generate_url("not a url").is_err());
+
+        let prompt = reviewer_prompt(&test_packet());
+        assert!(prompt.contains("actionable risks"));
+        assert!(prompt.contains("adl.pr_review_result.v1"));
+
+        let (truncated, was_truncated) = truncate("éclair", 3);
+        assert!(was_truncated);
+        assert_eq!(truncated, "éc");
+    }
+
+    #[test]
+    fn normalize_model_review_rejects_placeholder_findings() {
+        let finding = ReviewFinding {
+            title: "Untitled model finding".to_string(),
+            priority: "P3".to_string(),
+            file: "unknown".to_string(),
+            line: None,
+            body: String::new(),
+            evidence: Vec::new(),
+            heuristic_ids: Vec::new(),
+            confidence: "medium".to_string(),
+            blocking: false,
+            suggested_fix_scope: "issue_local".to_string(),
+        };
+
+        let (disposition, findings, residual) =
+            normalize_model_review(ReviewDisposition::Blessed, vec![finding]);
+        assert_eq!(disposition, ReviewDisposition::NonProving);
+        assert_eq!(findings.len(), 1);
+        assert!(residual
+            .iter()
+            .any(|risk| risk.contains("malformed findings")));
+        assert!(residual
+            .iter()
+            .any(|risk| risk.contains("missing concrete evidence")));
+    }
+
+    #[test]
+    fn normalize_model_review_rejects_praise_as_findings() {
+        let finding = ReviewFinding {
+            title: "Correctly separates proposal and execution".to_string(),
+            priority: "P3".to_string(),
+            file: "docs/example.md".to_string(),
+            line: None,
+            body: "The change correctly preserves the intended safety boundary.".to_string(),
+            evidence: vec!["diff excerpt".to_string()],
+            heuristic_ids: vec!["ADL-REVIEW".to_string()],
+            confidence: "high".to_string(),
+            blocking: false,
+            suggested_fix_scope: "None. This is already correct.".to_string(),
+        };
+
+        let (disposition, findings, residual) =
+            normalize_model_review(ReviewDisposition::Blessed, vec![finding]);
+        assert_eq!(disposition, ReviewDisposition::NonProving);
+        assert_eq!(findings.len(), 1);
+        assert!(residual
+            .iter()
+            .any(|risk| risk.contains("non-actionable praise")));
+    }
+
+    #[test]
+    fn normalize_model_review_accepts_specific_evidenced_finding() {
+        let finding = ReviewFinding {
+            title: "Missing reviewer evidence link".to_string(),
+            priority: "P3".to_string(),
+            file: "docs/example.md".to_string(),
+            line: Some(12),
+            body: "The review packet mentions a follow-up but does not link the evidence."
+                .to_string(),
+            evidence: vec!["path:docs/example.md".to_string()],
+            heuristic_ids: vec!["C1".to_string()],
+            confidence: "medium".to_string(),
+            blocking: false,
+            suggested_fix_scope: "issue_local".to_string(),
+        };
+
+        let (disposition, findings, residual) =
+            normalize_model_review(ReviewDisposition::Blessed, vec![finding]);
+        assert_eq!(disposition, ReviewDisposition::Blessed);
+        assert_eq!(findings.len(), 1);
+        assert!(residual.is_empty());
+    }
 }

--- a/adl/src/cli/tooling_cmd/common.rs
+++ b/adl/src/cli/tooling_cmd/common.rs
@@ -171,7 +171,22 @@ pub(super) fn contains_absolute_host_path_in_text(text: &str) -> bool {
     ["/Users/", "/home/", "/tmp/", "/var/folders/"]
         .iter()
         .any(|needle| text.contains(needle))
-        || text.contains(":\\")
+        || contains_windows_absolute_path(text)
+}
+
+fn contains_windows_absolute_path(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.windows(3).enumerate().any(|(idx, window)| {
+        let drive = window[0].is_ascii_alphabetic();
+        let colon = window[1] == b':';
+        let slash = matches!(window[2], b'\\' | b'/');
+        let boundary = idx == 0
+            || matches!(
+                bytes[idx - 1],
+                b' ' | b'\n' | b'\r' | b'\t' | b'"' | b'\'' | b'(' | b'['
+            );
+        drive && colon && slash && boundary
+    })
 }
 
 pub(super) fn contains_secret_like_token(text: &str) -> bool {

--- a/adl/src/cli/tooling_cmd/tests/common_helpers.rs
+++ b/adl/src/cli/tooling_cmd/tests/common_helpers.rs
@@ -187,3 +187,38 @@ fn common_helpers_cover_safety_and_path_branches() {
     assert!(ensure_no_absolute_host_path(&clean, "sip").is_ok());
     assert!(ensure_no_absolute_host_path(&abs, "sip").is_err());
 }
+
+#[test]
+fn code_review_filter_covers_common_helpers_for_fast_coverage_lane() {
+    let repo = TempRepo::new("code-review-common");
+    let clean = repo.write_rel("safe.md", "safe relative/path content\n");
+    let secret = repo.write_rel("secret.md", "token ghs_secretvalue\n");
+    let host = repo.write_rel("host.md", "/tmp/adl-private\n");
+
+    assert!(is_repo_relative("docs/milestones/v0.90.5/features/demo.md"));
+    assert!(!is_repo_relative("/Users/daniel/demo.md"));
+    assert_eq!(normalize_issue("2603").expect("issue"), 2603);
+    assert!(normalize_issue("not-an-issue").is_err());
+    assert!(valid_reference("https://example.com/review"));
+    assert!(valid_reference("docs/milestones/v0.90.5/features/demo.md"));
+    assert!(contains_secret_like_token("prefix gho_secretvalue suffix"));
+    assert!(!contains_secret_like_token("ordinary-token"));
+    assert!(contains_absolute_host_path_in_text("C:\\Users\\reviewer"));
+    assert!(contains_absolute_host_path_in_text("D:/workspace/reviewer"));
+    assert!(!contains_absolute_host_path_in_text(
+        "json field with escaped colon \":\\n\""
+    ));
+
+    ensure_file(&clean, "clean").expect("clean file");
+    assert!(ensure_no_disallowed_content(&clean, "clean").is_ok());
+    assert!(ensure_no_disallowed_content(&secret, "secret").is_err());
+    assert!(ensure_no_absolute_host_path(&clean, "clean").is_ok());
+    assert!(ensure_no_absolute_host_path(&host, "host").is_err());
+
+    let abs = absolutize(&clean).expect("absolute");
+    assert!(abs.is_absolute());
+    assert_eq!(
+        repo_relative_display(repo.path(), &clean).expect("relative"),
+        "safe.md"
+    );
+}

--- a/adl/src/cli/tooling_cmd/tests/common_helpers.rs
+++ b/adl/src/cli/tooling_cmd/tests/common_helpers.rs
@@ -107,6 +107,11 @@ fn common_helpers_cover_argument_and_content_guards() {
     assert!(contains_secret_like_token("ghs_1234567890"));
     assert!(!contains_secret_like_token("mask sk_short"));
     assert!(contains_absolute_host_path_in_text("/tmp/example"));
+    assert!(contains_absolute_host_path_in_text("C:\\Users\\example"));
+    assert!(contains_absolute_host_path_in_text("D:/workspace/example"));
+    assert!(!contains_absolute_host_path_in_text(
+        "ordinary JSON diff text with \":\\n\" escaped line endings"
+    ));
     assert!(!contains_absolute_host_path_in_text("relative/path"));
 
     assert!(is_repo_review_finding_title("1. [P2] Useful finding"));
@@ -152,6 +157,8 @@ fn common_helpers_cover_safety_and_path_branches() {
     assert!(contains_absolute_host_path_in_text(
         "/Users/example/project"
     ));
+    assert!(contains_absolute_host_path_in_text("C:\\Users\\example"));
+    assert!(!contains_absolute_host_path_in_text("field:\\nvalue"));
     assert!(!contains_absolute_host_path_in_text("relative/path"));
     assert!(contains_secret_like_token("prefix sk-abcdefgh suffix"));
     assert!(contains_secret_like_token("ghp_exampletoken"));

--- a/adl/src/cli/tooling_cmd/tests/common_helpers.rs
+++ b/adl/src/cli/tooling_cmd/tests/common_helpers.rs
@@ -2,7 +2,7 @@ use super::support::*;
 use super::*;
 
 #[test]
-fn helper_validators_cover_expected_shapes() {
+fn code_review_filter_covers_helper_validators_expected_shapes() {
     assert!(is_repo_relative("docs/tooling/prompt-spec.md"));
     assert!(!is_repo_relative("/Users/daniel/file"));
     assert!(valid_task_id("issue-1374"));
@@ -63,7 +63,7 @@ fn helper_validators_cover_expected_shapes() {
 }
 
 #[test]
-fn common_helpers_cover_argument_and_content_guards() {
+fn code_review_filter_covers_common_helpers_argument_and_content_guards() {
     let repo = TempRepo::new("common");
     let clean = repo.write_rel("clean.txt", "safe text");
     let secret = repo.write_rel("secret.txt", "token gho_1234567890");
@@ -108,10 +108,6 @@ fn common_helpers_cover_argument_and_content_guards() {
     assert!(!contains_secret_like_token("mask sk_short"));
     assert!(contains_absolute_host_path_in_text("/tmp/example"));
     assert!(contains_absolute_host_path_in_text("C:\\Users\\example"));
-    assert!(contains_absolute_host_path_in_text("D:/workspace/example"));
-    assert!(!contains_absolute_host_path_in_text(
-        "ordinary JSON diff text with \":\\n\" escaped line endings"
-    ));
     assert!(!contains_absolute_host_path_in_text("relative/path"));
 
     assert!(is_repo_review_finding_title("1. [P2] Useful finding"));
@@ -123,7 +119,7 @@ fn common_helpers_cover_argument_and_content_guards() {
 }
 
 #[test]
-fn common_mapping_helpers_cover_yaml_access_patterns() {
+fn code_review_filter_covers_common_mapping_helpers_yaml_access_patterns() {
     let mapping: Mapping = serde_yaml::from_str(
         r#"
 flag: true
@@ -150,7 +146,7 @@ items:
 }
 
 #[test]
-fn common_helpers_cover_safety_and_path_branches() {
+fn code_review_filter_covers_common_helpers_safety_and_path_branches() {
     let root = repo_root_for_tests();
     let nested = root.join("adl/src/cli/tooling_cmd.rs");
 
@@ -158,7 +154,6 @@ fn common_helpers_cover_safety_and_path_branches() {
         "/Users/example/project"
     ));
     assert!(contains_absolute_host_path_in_text("C:\\Users\\example"));
-    assert!(!contains_absolute_host_path_in_text("field:\\nvalue"));
     assert!(!contains_absolute_host_path_in_text("relative/path"));
     assert!(contains_secret_like_token("prefix sk-abcdefgh suffix"));
     assert!(contains_secret_like_token("ghp_exampletoken"));
@@ -204,10 +199,6 @@ fn code_review_filter_covers_common_helpers_for_fast_coverage_lane() {
     assert!(contains_secret_like_token("prefix gho_secretvalue suffix"));
     assert!(!contains_secret_like_token("ordinary-token"));
     assert!(contains_absolute_host_path_in_text("C:\\Users\\reviewer"));
-    assert!(contains_absolute_host_path_in_text("D:/workspace/reviewer"));
-    assert!(!contains_absolute_host_path_in_text(
-        "json field with escaped colon \":\\n\""
-    ));
 
     ensure_file(&clean, "clean").expect("clean file");
     assert!(ensure_no_disallowed_content(&clean, "clean").is_ok());

--- a/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
+++ b/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
@@ -191,6 +191,20 @@ fn code_review_ollama_without_live_gate_records_skipped_blocker() {
 }
 
 #[test]
+fn code_review_filter_covers_tooling_dispatch_help_and_errors() {
+    assert!(real_tooling(&["help".to_string()]).is_ok());
+    assert!(real_tooling(&["--help".to_string()]).is_ok());
+    assert!(real_tooling(&["code-review".to_string(), "--help".to_string()]).is_ok());
+
+    let missing = real_tooling(&["code-review".to_string()]).expect_err("missing out");
+    assert!(missing.to_string().contains("missing --out"));
+
+    let unknown = real_tooling(&["unknown-code-review-subcommand".to_string()])
+        .expect_err("unknown subcommand");
+    assert!(unknown.to_string().contains("unknown tooling subcommand"));
+}
+
+#[test]
 fn tooling_dispatch_accepts_help_and_rejects_unknown_subcommands() {
     assert!(real_tooling(&["help".to_string()]).is_ok());
     assert!(real_tooling(&["--help".to_string()]).is_ok());

--- a/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
+++ b/adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs
@@ -24,6 +24,8 @@ fn tooling_dispatch_and_help_paths_cover_public_entrypoint() {
     assert!(real_tooling(&[]).is_err());
     real_tooling(&["help".to_string()]).expect("help should succeed");
     assert!(real_tooling(&["unknown".to_string()]).is_err());
+    real_tooling(&["code-review".to_string(), "--help".to_string()])
+        .expect("code-review help should succeed without --out");
 
     real_tooling(&[
         "card-prompt".to_string(),
@@ -34,6 +36,25 @@ fn tooling_dispatch_and_help_paths_cover_public_entrypoint() {
     ])
     .expect("card-prompt dispatch should succeed");
     assert!(prompt_out.is_file());
+
+    let code_review_out = repo.path().join("code-review-clean");
+    real_tooling(&[
+        "code-review".to_string(),
+        "--out".to_string(),
+        code_review_out.to_string_lossy().to_string(),
+        "--backend".to_string(),
+        "fixture".to_string(),
+        "--visibility".to_string(),
+        "packet-only".to_string(),
+        "--writer-session".to_string(),
+        "writer-a".to_string(),
+        "--reviewer-session".to_string(),
+        "reviewer-a".to_string(),
+    ])
+    .expect("code-review fixture dispatch should succeed");
+    assert!(code_review_out.join("review_packet.json").is_file());
+    assert!(code_review_out.join("review_result.json").is_file());
+    assert!(code_review_out.join("gate_result.json").is_file());
 
     let wbs = repo.write_rel(
         ".tmp/tooling_cmd_tests/wbs.md",
@@ -103,6 +124,70 @@ fn tooling_dispatch_and_help_paths_cover_public_entrypoint() {
         review.to_string_lossy().to_string(),
     ])
     .expect("repo review contract dispatch should succeed");
+}
+
+#[test]
+fn code_review_fixture_backend_writes_blocking_gate_artifacts() {
+    let repo = TempRepo::new("code-review");
+    let out = repo.path().join("blocked");
+    real_tooling(&[
+        "code-review".to_string(),
+        "--out".to_string(),
+        out.to_string_lossy().to_string(),
+        "--backend".to_string(),
+        "fixture".to_string(),
+        "--fixture-case".to_string(),
+        "blocked".to_string(),
+        "--visibility".to_string(),
+        "read-only-repo".to_string(),
+        "--writer-session".to_string(),
+        "writer-session".to_string(),
+        "--reviewer-session".to_string(),
+        "reviewer-session".to_string(),
+    ])
+    .expect("blocked fixture review should write artifacts");
+
+    let gate: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out.join("gate_result.json")).expect("gate"))
+            .expect("gate json");
+    assert_eq!(gate["schema_version"], "adl.pr_review_gate.v1");
+    assert_eq!(gate["pr_open_allowed"], false);
+
+    let result: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out.join("review_result.json")).expect("result"))
+            .expect("result json");
+    assert_eq!(result["visibility_mode"], "read_only_repo");
+    assert_eq!(result["repo_access"]["write_allowed"], false);
+    assert_eq!(result["repo_access"]["tool_execution_allowed"], false);
+}
+
+#[test]
+fn code_review_ollama_without_live_gate_records_skipped_blocker() {
+    let repo = TempRepo::new("code-review-ollama-skip");
+    let out = repo.path().join("ollama-skip");
+    real_tooling(&[
+        "code-review".to_string(),
+        "--out".to_string(),
+        out.to_string_lossy().to_string(),
+        "--backend".to_string(),
+        "ollama".to_string(),
+        "--model".to_string(),
+        "gemma4:latest".to_string(),
+        "--writer-session".to_string(),
+        "writer-session".to_string(),
+        "--reviewer-session".to_string(),
+        "ollama-reviewer".to_string(),
+    ])
+    .expect("ollama skip should still write artifacts");
+
+    let gate: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out.join("gate_result.json")).expect("gate"))
+            .expect("gate json");
+    assert_eq!(gate["pr_open_allowed"], false);
+    assert!(gate["reasons"][0]
+        .as_str()
+        .expect("reason")
+        .contains("skipped"));
 }
 
 #[test]

--- a/adl/src/cli/usage.rs
+++ b/adl/src/cli/usage.rs
@@ -56,7 +56,7 @@ pub fn usage() -> &'static str {
   adl sign <adl.yaml> --key <private_key_path> [--key-id <id>] [--out <signed_file>]
   adl instrument <graph|replay|replay-bundle|diff-plan|diff-trace|trace-schema|validate-trace-v1|provider-substrate|provider-substrate-schema> ...
   adl learn export --format <jsonl|bundle-v1|trace-bundle-v2> [--runs-dir <dir>] [--run-id <id> ...] --out <path>
-  adl tooling <card-prompt|lint-prompt-spec|validate-structured-prompt|review-card-surface|review-runtime-surface|verify-review-output-provenance|verify-repo-review-contract> ...
+  adl tooling <card-prompt|code-review|lint-prompt-spec|validate-structured-prompt|review-card-surface|review-runtime-surface|verify-review-output-provenance|verify-repo-review-contract> ...
   adl verify <adl.yaml> [--key <public_key_path>]
 
 Options:
@@ -139,6 +139,7 @@ Examples:
   adl learn export --format trace-bundle-v2 --runs-dir .adl/trace-archive --out /tmp/archived-trace-bundle
   adl tooling lint-prompt-spec --issue 761
   adl tooling card-prompt --issue 761 --out /tmp/issue-761.prompt.md
+  adl tooling code-review --out artifacts/reviews/pr-review --backend fixture --visibility packet-only
   adl verify /tmp/signed.adl.yaml --key ./.keys/ed25519-public.b64"
 }
 

--- a/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
@@ -10,6 +10,7 @@
 | features/TOOL_REGISTRY_AND_COMPILER.md | registered tools, binding rules, UTS-to-ACC compiler, normalization, and rejection behavior | WP-08-WP-10 |
 | features/GOVERNED_EXECUTION_AND_TRACE.md | policy injection, Freedom Gate integration, governed executor, trace, replay, and redaction contract | WP-11-WP-14 |
 | features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md | multi-model benchmark, local/Gemma evaluation, dangerous negative suite, and Governed Tools v1.0 flagship demo | WP-15-WP-18 |
+| features/LOCAL_MODEL_PR_REVIEWER_TOOL.md | operator and agent usage guide for the demo-grade pre-PR code review tool, fixture backend, and direct Ollama HTTP path | #2603 |
 
 ## Proof And Audit Docs
 

--- a/docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md
+++ b/docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md
@@ -1,0 +1,174 @@
+# Local Model PR Reviewer Tool
+
+## Status
+
+Initial working demo/tool surface for issue `#2603`.
+
+This tool is designed for coding agents to request a bounded code review before
+opening a PR. It is still a demo-grade surface, but it is operational: it builds
+a review packet, runs a reviewer backend, writes normalized artifacts, and emits
+a gate result.
+
+## Command
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- tooling code-review \
+  --out artifacts/v0905/local-model-pr-reviewer-fixture \
+  --backend fixture \
+  --visibility read-only-repo \
+  --issue 2603 \
+  --writer-session codex-writer \
+  --reviewer-session fixture-reviewer
+```
+
+The command writes:
+
+- `review_packet.json`
+- `review_result.json`
+- `gate_result.json`
+- `run_summary.json`
+
+The gate result is the file an agent should inspect before opening a PR.
+
+## Fixture Review
+
+Use fixture mode when you want a deterministic proof path or when no live model
+is available:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- tooling code-review \
+  --out artifacts/reviews/current \
+  --backend fixture \
+  --visibility read-only-repo \
+  --issue <issue-number> \
+  --writer-session <writer-session-id> \
+  --reviewer-session fixture-reviewer
+```
+
+Expected success signal:
+
+```text
+CODE_REVIEW_GATE=allow_with_evidence
+```
+
+To prove the blocking path:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- tooling code-review \
+  --out artifacts/reviews/blocked-fixture \
+  --backend fixture \
+  --fixture-case blocked \
+  --visibility read-only-repo \
+  --issue <issue-number> \
+  --writer-session <writer-session-id> \
+  --reviewer-session fixture-reviewer
+```
+
+Expected blocking signal:
+
+```text
+CODE_REVIEW_GATE=block_pr_open
+```
+
+## Ollama / Gemma4 Review
+
+The Ollama backend calls the Ollama HTTP API directly. It does not require a new
+Ollama-specific CLI wrapper.
+
+By default, live Ollama review is gated off. Running without
+`--allow-live-ollama` records an explicit skipped-review blocker:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- tooling code-review \
+  --out artifacts/reviews/ollama-skip \
+  --backend ollama \
+  --visibility packet-only \
+  --issue <issue-number> \
+  --writer-session <writer-session-id> \
+  --reviewer-session ollama-reviewer \
+  --model gemma4:latest
+```
+
+Expected signal:
+
+```text
+CODE_REVIEW_GATE=block_pr_open
+```
+
+To run a live local model review:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- tooling code-review \
+  --out artifacts/reviews/ollama-live \
+  --backend ollama \
+  --visibility packet-only \
+  --issue <issue-number> \
+  --writer-session <writer-session-id> \
+  --reviewer-session ollama-reviewer \
+  --model gemma4:latest \
+  --allow-live-ollama
+```
+
+The default Ollama endpoint is:
+
+```text
+http://127.0.0.1:11434/api/generate
+```
+
+Set a different local endpoint with either:
+
+```bash
+OLLAMA_HOST=http://127.0.0.1:11434
+```
+
+or:
+
+```bash
+--ollama-url http://127.0.0.1:11434
+```
+
+## Visibility Modes
+
+`packet-only` gives the reviewer only the bounded review packet. This is safer
+and works better for constrained local models, but it is weaker review evidence.
+
+`read-only-repo` records that the reviewer may inspect the bounded repository
+slice, but still has no write, push, merge, or arbitrary command authority.
+
+## Gate Policy
+
+The tool blocks PR opening when:
+
+- the reviewer is the same session as the writer
+- static diff checks fail
+- a blocking `P0`, `P1`, or `P2` finding is present
+- the reviewer disposition is `blocked`
+- the reviewer disposition is `skipped`
+- the reviewer disposition is `non_proving`
+
+Only `blessed` review with no blocking reasons produces:
+
+```text
+CODE_REVIEW_GATE=allow_with_evidence
+```
+
+This is review evidence only. Human/operator merge authority remains outside
+the tool.
+
+## Agent Workflow
+
+1. Finish the code change in the issue worktree.
+2. Run the normal issue validation commands.
+3. Run `adl tooling code-review`.
+4. Inspect `gate_result.json`.
+5. If `pr_open_allowed` is `false`, fix or route the finding before PR creation.
+6. If `pr_open_allowed` is `true`, continue to `pr finish`.
+
+## Current Limits
+
+- The fixture backend proves artifact shape and gate behavior, not semantic code
+  review quality.
+- Ollama output must return parseable normalized JSON to become proving review
+  evidence; otherwise the result is `non_proving`.
+- Packet compression is simple and may need improvement for large diffs.
+- Operator-waiver handling is intentionally not implemented in this first demo.

--- a/docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md
+++ b/docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md
@@ -106,6 +106,7 @@ cargo run --manifest-path adl/Cargo.toml -- tooling code-review \
   --writer-session <writer-session-id> \
   --reviewer-session ollama-reviewer \
   --model gemma4:latest \
+  --timeout-secs 240 \
   --allow-live-ollama
 ```
 
@@ -125,6 +126,34 @@ or:
 
 ```bash
 --ollama-url http://127.0.0.1:11434
+```
+
+Use `--timeout-secs <n>` for larger remote models. The default timeout is 120
+seconds; the accepted range is 1 to 900 seconds.
+
+## Diff Scope
+
+By default, the packet contains only the requested committed diff:
+
+```text
+--base <ref> --head <ref>
+```
+
+This keeps historical PR reviews and merge-commit reviews from accidentally
+absorbing unrelated local edits in the reviewer worktree.
+
+Use `--include-working-tree` only when the reviewer intentionally needs to
+inspect uncommitted local edits before they are committed:
+
+```bash
+cargo run --manifest-path adl/Cargo.toml -- tooling code-review \
+  --out artifacts/reviews/current-uncommitted \
+  --backend fixture \
+  --base origin/main \
+  --head HEAD \
+  --include-working-tree \
+  --writer-session <writer-session-id> \
+  --reviewer-session fixture-reviewer
 ```
 
 ## Visibility Modes
@@ -170,5 +199,11 @@ the tool.
   review quality.
 - Ollama output must return parseable normalized JSON to become proving review
   evidence; otherwise the result is `non_proving`.
+- Ollama findings must include concrete title, file, body, evidence,
+  confidence, and suggested fix scope. Placeholder or empty findings are treated
+  as `non_proving`, even when the model says `blessed`.
+- Findings must be actionable risks or defects. Positive observations,
+  confirmations, and `None`/`no action` fix scopes are treated as
+  `non_proving` because they are not review findings.
 - Packet compression is simple and may need improvement for large diffs.
 - Operator-waiver handling is intentionally not implemented in this first demo.

--- a/docs/milestones/v0.90.5/features/README.md
+++ b/docs/milestones/v0.90.5/features/README.md
@@ -10,3 +10,6 @@ The shared WP-02 boundary lives in
 `TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md`: model tool calls are proposals, not
 actions, and UTS validity is schema compatibility rather than execution
 authority.
+
+The demo-grade local model PR reviewer tool usage guide lives in
+`LOCAL_MODEL_PR_REVIEWER_TOOL.md`.

--- a/docs/milestones/v0.90.5/ideas/LOCAL_MODEL_PR_REVIEWER_AGENT_DESIGN.md
+++ b/docs/milestones/v0.90.5/ideas/LOCAL_MODEL_PR_REVIEWER_AGENT_DESIGN.md
@@ -1,0 +1,351 @@
+# Local Model PR Reviewer Agent Design
+
+## Status
+
+Design draft for issue `#2603`.
+
+This document defines the intended pre-PR review gate for the local model PR
+reviewer demo. The implementation target is an agent-callable ADL code-review
+tool, not only a static demo packet.
+
+## Purpose
+
+ADL should be able to call an independent reviewer tool after an execution agent has
+finished code changes and local validation, but before a PR is opened. If the
+reviewer reports actionable blocking findings, the execution session should fix
+them and run the review gate again before publication.
+
+The reviewer may be a local model such as Gemma4, another Codex session, ChatGPT,
+Claude, or a deterministic fixture backend. The reviewer must not be the same
+session that wrote the code.
+
+The first operational surface is:
+
+```text
+adl tooling code-review --out <dir> [--backend fixture|ollama] [--visibility packet-only|read-only-repo]
+```
+
+The fixture backend is deterministic and always available. The Ollama backend
+calls the Ollama HTTP API directly via `/api/generate`; it does not require a new
+Ollama-specific CLI wrapper.
+
+## Desired Lifecycle Placement
+
+The target hook is the end of the `pr run` / beginning of `pr finish` boundary:
+
+1. Execution agent completes the bounded issue work in the issue worktree.
+2. Execution agent runs the issue validation set and records results.
+3. ADL builds a PR-review packet from the worktree diff, cards, source prompt,
+   validation evidence, and explicit scope.
+4. ADL invokes the external reviewer backend through a review skill contract.
+5. ADL normalizes and validates reviewer output.
+6. If there are blocking findings, the PR is not opened.
+7. Execution agent fixes accepted findings and repeats validation plus review.
+8. Only after the review gate is clean, skipped by explicit operator policy, or
+   classified non-proving with operator acceptance may `pr finish` open the PR.
+
+This makes the reviewer a pre-publication quality gate, not a merge authority.
+
+## Reviewer Visibility Tiers
+
+The reviewer should support two visibility tiers.
+
+### Tier 1: Packet-Only Review
+
+Packet-only review is the deterministic baseline. The reviewer receives only the
+bounded packet fields described below: issue context, cards, changed files, diff
+hunks, selected excerpts, validation evidence, static analyzer evidence, scope,
+and known risks.
+
+This tier is best for:
+
+- fixture-backed proof paths
+- small local models with limited context
+- provider-gated or privacy-sensitive environments
+- deterministic artifact-shape testing
+
+Packet-only review is safer and more portable, but it is weaker evidence. The
+reviewer cannot inspect surrounding code, call sites, hidden invariants, or
+tests that were not included in the packet.
+
+### Tier 2: Read-Only Repo Review
+
+Read-only repo review is the stronger target for real use. The reviewer receives
+the packet plus bounded read-only access to the issue worktree or a review packet
+root that mirrors the relevant repository slice.
+
+Allowed:
+
+- read files
+- inspect surrounding code and tests
+- inspect manifests, schemas, fixtures, and docs relevant to the diff
+- cite evidence from the repository slice
+
+Forbidden:
+
+- edit files
+- stage, commit, push, merge, or open PRs
+- run arbitrary commands outside ADL-mediated static-analysis lanes
+- claim validation that ADL did not supply
+
+The result artifact must record which tier was used:
+
+```json
+{
+  "visibility_mode": "packet_only|read_only_repo",
+  "repo_access": {
+    "read_only": true,
+    "write_allowed": false,
+    "tool_execution_allowed": false
+  }
+}
+```
+
+Gate policy should treat packet-only blessings as weaker evidence than
+read-only-repo blessings. A packet-only `blessed` result may support PR opening
+for small or fixture-scoped changes, but higher-risk runtime changes should
+prefer read-only repo review or an explicit operator waiver.
+
+## Non-Negotiable Boundaries
+
+- The reviewer backend cannot push, commit, merge, edit files, or run unbounded
+  tools.
+- The reviewer backend cannot claim tests passed unless ADL supplied validation
+  evidence.
+- The reviewer backend cannot broaden issue scope without routing that concern
+  as follow-up work.
+- The reviewer backend must identify itself by backend, model, and session or
+  invocation id where available.
+- The reviewer backend must be distinct from the writing session.
+- Human/operator authority remains responsible for final merge decisions.
+
+## Review Packet
+
+The packet should be compact, reproducible, and safe to hand to different
+reviewer backends.
+
+Required fields:
+
+- `schema_version`
+- `visibility_mode`
+- `issue_number`
+- `issue_title`
+- `source_prompt_excerpt`
+- `stp_excerpt`
+- `sip_excerpt`
+- `sor_excerpt`
+- `branch`
+- `base_ref`
+- `head_ref`
+- `changed_files`
+- `diff_summary`
+- `focused_diff_hunks`
+- `validation_evidence`
+- `static_analysis_evidence`
+- `repo_slice_manifest`
+- `review_scope`
+- `non_scope`
+- `known_risks`
+- `redaction_status`
+
+The packet should avoid full unbounded repository dumps, secrets, raw prompts,
+credentials, private state, and unrelated history.
+
+When `visibility_mode` is `read_only_repo`, the packet should include a bounded
+repo slice manifest that names allowed roots or files. The reviewer may inspect
+only that slice unless the operator explicitly widens scope.
+
+## Static Analyzer Lane
+
+Static analysis should run before semantic model review so the model reviews
+both the code and machine-check evidence.
+
+Repository-native analyzers available now:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --doc`
+- focused `cargo test` or `cargo nextest` for changed Rust surfaces
+- `cargo llvm-cov` or the repository coverage-impact lane when required by path
+  policy
+- `git diff --check`
+- `bash adl/tools/validate_structured_prompt.sh ...` for card and prompt
+  surfaces
+- `bash adl/tools/test_check_coverage_impact.sh`
+- `bash adl/tools/test_run_authoritative_coverage_lane.sh`
+- demo or review-packet validators under `adl/tools/validate_*.py` when the
+  changed surface is one of those demos or packets
+
+Optional analyzers to evaluate later:
+
+- `cargo audit` for Rust dependency vulnerability checks
+- `cargo deny` for license, advisory, and duplicate dependency policy
+- `typos` for typo detection in docs and code
+- `semgrep` for repository-specific security and correctness patterns
+- `shellcheck` for shell scripts
+- `cargo machete` or `cargo udeps` for unused dependency cleanup
+
+Optional analyzers should not be treated as required until the repository has
+configuration, installation guidance, and acceptance rules for them.
+
+## ADL Review Heuristics Integration
+
+The reviewer should consume the ADL review heuristics as a rule taxonomy:
+
+- functional correctness: `F1-F10`
+- security and safety: `S1-S10`
+- code quality and maintainability: `Q1-Q10`
+- architecture and system alignment: `A1-A10`
+- performance and efficiency: `P1-P10`
+- testing and verification: `T1-T10`
+- AI-specific risks: `AI1-AI10`
+- ADL-specific review discipline: `C1-C10`
+
+The first implementation can embed this taxonomy as a static prompt/rubric. A
+later implementation can compile the rules into machine-readable YAML and route
+each rule as `static`, `pattern`, `semantic`, or `hybrid`.
+
+## Reviewer Skill Contract
+
+All reviewer backends must use the same normalized output shape:
+
+```json
+{
+  "schema_version": "adl.pr_review_result.v1",
+  "review_id": "string",
+  "reviewer_backend": "fixture|gemma4_local|codex|chatgpt|claude",
+  "reviewer_model": "string",
+  "reviewer_session": "string",
+  "writer_session": "string",
+  "same_session_as_writer": false,
+  "visibility_mode": "packet_only|read_only_repo",
+  "repo_access": {
+    "read_only": true,
+    "write_allowed": false,
+    "tool_execution_allowed": false
+  },
+  "packet_id": "string",
+  "static_analysis_summary": [],
+  "findings": [],
+  "disposition": "blessed|blocked|non_proving|skipped",
+  "residual_risk": [],
+  "validation_claims": [],
+  "non_claims": []
+}
+```
+
+Finding fields:
+
+- `title`
+- `priority`
+- `file`
+- `line`
+- `body`
+- `evidence`
+- `heuristic_ids`
+- `confidence`
+- `blocking`
+- `suggested_fix_scope`
+
+The normalizer must reject reviewer output that lacks evidence for blocking
+findings, claims unavailable validation, marks `same_session_as_writer` as true,
+or attempts to request write or merge authority.
+
+## Backend Modes
+
+### Fixture
+
+The fixture backend proves packet and artifact shape deterministically. It
+should include one no-findings path and one blocking-finding path.
+
+### Gemma4 Local
+
+Gemma4 is the flagship local-model path. It should receive the same packet and
+produce the same normalized artifact. The first implementation should call the
+Ollama API directly:
+
+```text
+POST http://127.0.0.1:11434/api/generate
+```
+
+`OLLAMA_HOST` or an explicit tool argument may select another trusted local
+endpoint. Missing local model availability should be classified as `skipped`,
+not as proof failure, unless the operator explicitly asks for a required live
+run.
+
+### Codex, ChatGPT, Claude
+
+Hosted or separate-agent reviewers are comparative backends. They must be
+operator-gated when credentials, cost, network, or provider availability are
+involved. They must still use the same packet and output schema.
+
+## Two-Agent Adversarial Mode
+
+The demo should support a panel mode:
+
+- Blessing reviewer: evaluates whether the PR has enough evidence to publish.
+- Adversarial reviewer: searches for correctness, security, proof, test, docs,
+  and lifecycle blockers.
+- Reconciler: deduplicates findings, records disagreement, and emits a final
+  panel disposition.
+
+Panel dispositions:
+
+- `panel_blessed`
+- `panel_blocked`
+- `panel_split`
+- `panel_non_proving`
+- `panel_skipped`
+
+The panel is not allowed to override the evidence rules. A blessing reviewer can
+only bless from packet evidence, and an adversarial reviewer can only block from
+packet evidence.
+
+## Freedom Gate Policy
+
+Initial gate policy:
+
+- Block PR opening on any `P0`, `P1`, or `P2` finding marked `blocking`.
+- Block PR opening when the reviewer output is malformed or same-session.
+- Block PR opening when required static analysis failed.
+- Prefer read-only repo review for runtime, security, schema, lifecycle, or
+  broad refactor changes. Packet-only blessing for those changes requires an
+  explicit operator waiver or a follow-up read-only review.
+- Permit PR opening with explicit residual risk for non-blocking `P3+` findings
+  if the execution SOR records them.
+- Permit `skipped` only when provider unavailability, operator policy, or
+  fixture-only mode is explicitly recorded.
+
+The gate result is merge-readiness evidence only. It is not merge approval.
+
+## Demo Proof Path
+
+Minimum proving path:
+
+1. Build a fixture PR review packet.
+2. Run static analyzer simulation or bounded local analyzer evidence.
+3. Run fixture reviewer in no-findings mode.
+4. Run fixture reviewer in blocking-finding mode.
+5. Validate normalized review artifacts in packet-only mode.
+6. Run a read-only repo review fixture over a bounded repo slice manifest.
+7. Run two-agent panel reconciliation over fixture outputs.
+8. Emit a run summary that classifies which live backends ran, skipped, or were
+   unavailable.
+
+Optional live path:
+
+1. Run the same packet through direct Ollama HTTP with `gemma4_local` when
+   available.
+2. Optionally run through `codex`, `chatgpt`, or `claude` when operator-gated.
+3. Compare dispositions without claiming provider ranking.
+
+## Open Design Questions
+
+- Whether the pre-PR hook lives inside `pr finish` initially or as an explicit
+  `adl pr review-gate` command that `pr finish` can call.
+- Whether the static analyzer lane should fail closed by default for Rust source
+  changes or inherit the existing CI runtime path policy.
+- How much diff context a local model can review reliably before packet
+  compression becomes necessary.
+- How strongly `pr finish` should enforce this tool once it has enough
+  production mileage.

--- a/docs/milestones/v0.90.5/ideas/README.md
+++ b/docs/milestones/v0.90.5/ideas/README.md
@@ -8,6 +8,7 @@ Current tracked idea notes:
 
 - `TOOLS_ARE_GOVERNED_CAPABILITIES.md`
 - `GEMMA4_UTS_ACC_MODEL_BENCHMARK_PLAN.md`
+- `LOCAL_MODEL_PR_REVIEWER_AGENT_DESIGN.md`
 - `TEST_RUNTIME_REDUCTION_PLAN_v0.90.5.md`
 
 The milestone-root pointer for the runtime-reduction/get-well work is


### PR DESCRIPTION
Closes #2603

## Summary
Implemented the local model PR reviewer agent demo as a working agent-callable `adl tooling code-review` surface. The current work establishes the pre-PR review-gate design, reviewer independence boundary, two-tier visibility model, static-analysis evidence lane, backend-neutral reviewer contract, ADL review-heuristics integration, documentation for coding-session use, deterministic fixture mode, gated direct Ollama HTTP mode, corrected committed-diff scoping, model-output normalization, and live Gemma4 smoke-test evidence against closed WP-02.

## Artifacts
- Tracked design doc: `docs/milestones/v0.90.5/ideas/LOCAL_MODEL_PR_REVIEWER_AGENT_DESIGN.md`
- Usage guide: `docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md`
- Feature docs index updates: `docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md`, `docs/milestones/v0.90.5/features/README.md`
- Code-review tooling module: `adl/src/cli/tooling_cmd/code_review.rs`
- Tooling dispatch update: `adl/src/cli/tooling_cmd.rs`
- Focused dispatch tests: `adl/src/cli/tooling_cmd/tests/tooling_dispatch.rs`
- Shared redaction helper tests: `adl/src/cli/tooling_cmd/tests/common_helpers.rs`
- Demo artifact set: `artifacts/v0905/local-model-pr-reviewer-fixture/`
- Demo artifact set: `artifacts/v0905/local-model-pr-reviewer-ollama-skip/`
- WP-02 corrected fixture artifact set: `artifacts/v0905/local-model-pr-reviewer-wp02-fixture-corrected/`
- WP-02 live Gemma4 comparison artifacts:
  - `artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-e2b-live-actionable-normalized/`
  - `artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-e4b-live-corrected/`
  - `artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-26b-remote-live-corrected/`
  - `artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-31b-remote-live-corrected/`
- Updated ideas index: `docs/milestones/v0.90.5/ideas/README.md`
- Updated issue source prompt: `.adl/v0.90.5/bodies/issue-2603-v0-90-5-demo-local-model-pr-reviewer-agent.md`
- Updated task/input/output cards: `.adl/v0.90.5/tasks/issue-2603__v0-90-5-demo-local-model-pr-reviewer-agent/`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml tooling_cmd::tests::tooling_dispatch -- --nocapture`
    Verified the new `code-review` tooling dispatch path, fixture success artifact generation, and blocked-gate artifact generation.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-fixture --backend fixture --visibility read-only-repo --issue 2603 --writer-session codex-writer --reviewer-session fixture-reviewer`
    Verified the working fixture demo path and produced packet/result/gate/run-summary artifacts.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-ollama-skip --backend ollama --visibility packet-only --issue 2603 --writer-session codex-writer --reviewer-session ollama-reviewer --model gemma4:latest`
    Verified the direct-Ollama backend skip path remains explicit and blocks PR opening without `--allow-live-ollama`.
  - `bash adl/tools/validate_structured_prompt.sh --type stp --phase run --input .adl/v0.90.5/tasks/issue-2603__v0-90-5-demo-local-model-pr-reviewer-agent/stp.md`
    Verified STP contract compliance after design updates.
  - `bash adl/tools/validate_structured_prompt.sh --type sip --phase run --input .adl/v0.90.5/tasks/issue-2603__v0-90-5-demo-local-model-pr-reviewer-agent/sip.md`
    Verified SIP contract compliance after design updates.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase run --input .adl/v0.90.5/tasks/issue-2603__v0-90-5-demo-local-model-pr-reviewer-agent/sor.md`
    Verified SOR contract compliance after correcting this record.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --help`
    Verified coding-session usage discovery for the new reviewer tool.
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified Rust formatting after reviewer hardening.
  - `cargo test --manifest-path adl/Cargo.toml tooling_cmd:: -- --nocapture`
    Verified the tooling command slice, including reviewer argument parsing, gate behavior, redaction helper tests, and model-output normalization.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the hardened reviewer implementation has no clippy warnings.
  - `cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json`
    Produced the required coverage-impact summary for the changed Rust surfaces.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified the changed Rust source files satisfy the coverage-impact preflight.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-wp02-fixture-corrected --backend fixture --visibility packet-only --base '953e913f^1' --head '953e913f^2' --issue 2567 --writer-session codex-wp02-writer --reviewer-session fixture-wp02-reviewer-corrected`
    Verified corrected historical PR packet scoping for WP-02 with exactly 8 changed files and no redaction hits.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-e2b-live-actionable-normalized --backend ollama --visibility packet-only --base '953e913f^1' --head '953e913f^2' --issue 2567 --writer-session codex-wp02-writer --reviewer-session gemma4-e2b-wp02-reviewer-actionable-normalized --model gemma4:e2b --allow-live-ollama`
    Verified small local Gemma4 output is blocked as `non_proving` when it proposes findings without concrete evidence.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-e4b-live-corrected --backend ollama --visibility packet-only --base '953e913f^1' --head '953e913f^2' --issue 2567 --writer-session codex-wp02-writer --reviewer-session gemma4-e4b-wp02-reviewer-corrected --model gemma4:e4b --allow-live-ollama`
    Verified local Gemma4 e4b can bless the corrected WP-02 packet with no findings.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-26b-remote-live-corrected --backend ollama --visibility packet-only --base '953e913f^1' --head '953e913f^2' --issue 2567 --writer-session codex-wp02-writer --reviewer-session remote-gemma4-26b-wp02-reviewer-corrected --model gemma4:26b --ollama-url 'http://192.168.68.73:11434' --timeout-secs 240 --allow-live-ollama`
    Verified remote Gemma4 26b can bless the corrected WP-02 packet with no findings.
  - `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-wp02-gemma4-31b-remote-live-corrected --backend ollama --visibility packet-only --base '953e913f^1' --head '953e913f^2' --issue 2567 --writer-session codex-wp02-writer --reviewer-session remote-gemma4-31b-wp02-reviewer-corrected --model gemma4:31b --ollama-url 'http://192.168.68.73:11434' --timeout-secs 240 --allow-live-ollama`
    Verified remote Gemma4 31b can bless the corrected WP-02 packet with no findings.
  - `git diff --check`
    Verified the tracked worktree diff has no whitespace errors.
- Results:
  - focused Rust tooling dispatch tests: PASS
  - fixture code-review demo: PASS, gate disposition `allow_with_evidence`
  - Ollama skipped code-review demo: PASS, gate disposition `block_pr_open`
  - code-review help path: PASS
  - corrected WP-02 fixture packet: PASS, exactly 8 files, no redaction hits
  - local Gemma4 e2b WP-02 review: PASS as a negative-control run, gate disposition `block_pr_open` due `non_proving`
  - local Gemma4 e4b WP-02 review: PASS, gate disposition `allow_with_evidence`
  - remote Gemma4 26b WP-02 review: PASS, gate disposition `allow_with_evidence`
  - remote Gemma4 31b WP-02 review: PASS, gate disposition `allow_with_evidence`
  - diff whitespace check: PASS
  - clippy all-targets: PASS
  - coverage-impact summary generation: PASS
  - coverage-impact preflight: PASS
  - STP: PASS
  - SIP: PASS
  - SOR: PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.5/tasks/issue-2603__v0-90-5-demo-local-model-pr-reviewer-agent/sip.md
- Output card: .adl/v0.90.5/tasks/issue-2603__v0-90-5-demo-local-model-pr-reviewer-agent/sor.md
- Idempotency-Key: v0-90-5-demo-local-model-pr-reviewer-agent-adl-src-cli-tests-open-usage-rs-adl-src-cli-tooling-cmd-tests-common-helpers-rs-adl-src-cli-tooling-cmd-tests-tooling-dispatch-rs-adl-v0-90-5-tasks-issue-2603-v0-90-5-demo-local-model-pr-reviewer-agent-sip-md-adl-v0-90-5-tasks-issue-2603-v0-90-5-demo-local-model-pr-reviewer-agent-sor-md