### PR TITLE
[v0.90.5][WP-11] Policy injection and authority evaluation

### DIFF
--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -44,6 +44,7 @@ pub mod obsmem_store;
 pub mod operational_skills_substrate;
 pub mod overlay;
 pub mod plan;
+pub mod policy_authority;
 pub mod prompt;
 pub mod provider;
 pub mod provider_extension_packaging;

--- a/adl/src/policy_authority.rs
+++ b/adl/src/policy_authority.rs
@@ -1,0 +1,448 @@
+use crate::acc::AccGrantStatusV1;
+use crate::uts::{UtsDataSensitivityV1, UtsExecutionEnvironmentKindV1};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyAuthorityDecisionV1 {
+    Allowed,
+    Denied,
+    Deferred,
+    Challenged,
+    Revoked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyAuthorityEvidenceKindV1 {
+    ContextValidation,
+    RoleStanding,
+    Grant,
+    Delegation,
+    Environment,
+    Sensitivity,
+    Resource,
+    Adapter,
+    Decision,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyAuthorityEvidenceRecordV1 {
+    pub kind: PolicyAuthorityEvidenceKindV1,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyAuthorityContextV1 {
+    pub actor_id: String,
+    pub role: String,
+    pub standing: String,
+    pub grant_id: String,
+    pub grant_status: AccGrantStatusV1,
+    pub delegation_depth: u8,
+    pub environment: UtsExecutionEnvironmentKindV1,
+    pub sensitivity: UtsDataSensitivityV1,
+    pub resource_scope: String,
+    pub adapter_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyAuthorityConstraintsV1 {
+    pub allowed_roles: Vec<String>,
+    pub allowed_standings: Vec<String>,
+    pub max_delegation_depth: u8,
+    pub allowed_environments: Vec<UtsExecutionEnvironmentKindV1>,
+    pub allowed_sensitivities: Vec<UtsDataSensitivityV1>,
+    pub allowed_resource_scopes: Vec<String>,
+    pub allowed_adapter_ids: Vec<String>,
+    pub defer_for_environment_approval: bool,
+    pub require_human_challenge: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyAuthorityEvaluationInputV1 {
+    #[serde(default)]
+    pub context: Option<PolicyAuthorityContextV1>,
+    pub constraints: PolicyAuthorityConstraintsV1,
+    #[serde(default)]
+    pub model_confidence: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyAuthorityEvaluationV1 {
+    pub decision: PolicyAuthorityDecisionV1,
+    pub evidence: Vec<PolicyAuthorityEvidenceRecordV1>,
+}
+
+fn evidence(
+    kind: PolicyAuthorityEvidenceKindV1,
+    detail: impl Into<String>,
+) -> PolicyAuthorityEvidenceRecordV1 {
+    PolicyAuthorityEvidenceRecordV1 {
+        kind,
+        detail: detail.into(),
+    }
+}
+
+fn final_decision(
+    decision: PolicyAuthorityDecisionV1,
+    mut evidence_log: Vec<PolicyAuthorityEvidenceRecordV1>,
+) -> PolicyAuthorityEvaluationV1 {
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::Decision,
+        format!("{decision:?}"),
+    ));
+    PolicyAuthorityEvaluationV1 {
+        decision,
+        evidence: evidence_log,
+    }
+}
+
+fn token_like(value: &str) -> bool {
+    !value.trim().is_empty()
+        && value.chars().all(|ch| {
+            ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '-' | '_' | '.')
+        })
+}
+
+pub fn evaluate_policy_authority_v1(
+    input: &PolicyAuthorityEvaluationInputV1,
+) -> PolicyAuthorityEvaluationV1 {
+    let mut evidence_log = vec![evidence(
+        PolicyAuthorityEvidenceKindV1::ContextValidation,
+        "policy authority evaluation started",
+    )];
+
+    let Some(context) = input.context.as_ref() else {
+        evidence_log.push(evidence(
+            PolicyAuthorityEvidenceKindV1::ContextValidation,
+            "missing policy context",
+        ));
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    };
+
+    if !token_like(&context.actor_id)
+        || !token_like(&context.grant_id)
+        || !token_like(&context.resource_scope)
+        || !token_like(&context.adapter_id)
+    {
+        evidence_log.push(evidence(
+            PolicyAuthorityEvidenceKindV1::ContextValidation,
+            "policy context contains non-normalized identifiers",
+        ));
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    }
+
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::RoleStanding,
+        "role and standing evaluated",
+    ));
+    if !input.constraints.allowed_roles.contains(&context.role)
+        || !input
+            .constraints
+            .allowed_standings
+            .contains(&context.standing)
+    {
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    }
+
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::Grant,
+        "grant status evaluated",
+    ));
+    match context.grant_status {
+        AccGrantStatusV1::Revoked => {
+            return final_decision(PolicyAuthorityDecisionV1::Revoked, evidence_log);
+        }
+        AccGrantStatusV1::Denied => {
+            return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+        }
+        AccGrantStatusV1::Active | AccGrantStatusV1::Delegated => {}
+    }
+
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::Delegation,
+        "delegation depth evaluated",
+    ));
+    if context.delegation_depth > input.constraints.max_delegation_depth {
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    }
+
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::Environment,
+        "environment constraints evaluated",
+    ));
+    if !input
+        .constraints
+        .allowed_environments
+        .contains(&context.environment)
+    {
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    }
+
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::Sensitivity,
+        "sensitivity constraints evaluated",
+    ));
+    if !input
+        .constraints
+        .allowed_sensitivities
+        .contains(&context.sensitivity)
+    {
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    }
+
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::Resource,
+        "resource constraints evaluated",
+    ));
+    if !input
+        .constraints
+        .allowed_resource_scopes
+        .contains(&context.resource_scope)
+    {
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    }
+
+    evidence_log.push(evidence(
+        PolicyAuthorityEvidenceKindV1::Adapter,
+        "adapter constraints evaluated",
+    ));
+    if !input
+        .constraints
+        .allowed_adapter_ids
+        .contains(&context.adapter_id)
+    {
+        return final_decision(PolicyAuthorityDecisionV1::Denied, evidence_log);
+    }
+
+    if input.constraints.defer_for_environment_approval {
+        return final_decision(PolicyAuthorityDecisionV1::Deferred, evidence_log);
+    }
+
+    if input.constraints.require_human_challenge {
+        return final_decision(PolicyAuthorityDecisionV1::Challenged, evidence_log);
+    }
+
+    final_decision(PolicyAuthorityDecisionV1::Allowed, evidence_log)
+}
+
+pub fn wp11_policy_context_fixture() -> PolicyAuthorityContextV1 {
+    PolicyAuthorityContextV1 {
+        actor_id: "actor.operator.alice".to_string(),
+        role: "operator".to_string(),
+        standing: "active".to_string(),
+        grant_id: "grant.policy.fixture".to_string(),
+        grant_status: AccGrantStatusV1::Active,
+        delegation_depth: 0,
+        environment: UtsExecutionEnvironmentKindV1::DryRun,
+        sensitivity: UtsDataSensitivityV1::Internal,
+        resource_scope: "local-readonly".to_string(),
+        adapter_id: "adapter.fixture.safe_read.dry_run".to_string(),
+    }
+}
+
+pub fn wp11_policy_constraints_fixture() -> PolicyAuthorityConstraintsV1 {
+    PolicyAuthorityConstraintsV1 {
+        allowed_roles: vec!["operator".to_string()],
+        allowed_standings: vec!["active".to_string()],
+        max_delegation_depth: 1,
+        allowed_environments: vec![UtsExecutionEnvironmentKindV1::DryRun],
+        allowed_sensitivities: vec![UtsDataSensitivityV1::Internal],
+        allowed_resource_scopes: vec!["local-readonly".to_string()],
+        allowed_adapter_ids: vec!["adapter.fixture.safe_read.dry_run".to_string()],
+        defer_for_environment_approval: false,
+        require_human_challenge: false,
+    }
+}
+
+pub fn wp11_policy_input_fixture() -> PolicyAuthorityEvaluationInputV1 {
+    PolicyAuthorityEvaluationInputV1 {
+        context: Some(wp11_policy_context_fixture()),
+        constraints: wp11_policy_constraints_fixture(),
+        model_confidence: Some(0.99),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn evaluate(input: PolicyAuthorityEvaluationInputV1) -> PolicyAuthorityEvaluationV1 {
+        evaluate_policy_authority_v1(&input)
+    }
+
+    #[test]
+    fn wp11_allows_valid_policy_context() {
+        let outcome = evaluate(wp11_policy_input_fixture());
+
+        assert_eq!(outcome.decision, PolicyAuthorityDecisionV1::Allowed);
+        assert!(outcome
+            .evidence
+            .iter()
+            .any(|entry| entry.kind == PolicyAuthorityEvidenceKindV1::Decision));
+    }
+
+    #[test]
+    fn wp11_denies_disallowed_role() {
+        let mut input = wp11_policy_input_fixture();
+        input.context.as_mut().expect("context").role = "viewer".to_string();
+
+        assert_eq!(evaluate(input).decision, PolicyAuthorityDecisionV1::Denied);
+    }
+
+    #[test]
+    fn wp11_defers_when_environment_approval_is_required() {
+        let mut input = wp11_policy_input_fixture();
+        input.constraints.defer_for_environment_approval = true;
+
+        assert_eq!(
+            evaluate(input).decision,
+            PolicyAuthorityDecisionV1::Deferred
+        );
+    }
+
+    #[test]
+    fn wp11_deferral_cannot_bypass_hard_policy_constraints() {
+        let mut disallowed_environment = wp11_policy_input_fixture();
+        disallowed_environment
+            .constraints
+            .defer_for_environment_approval = true;
+        disallowed_environment
+            .context
+            .as_mut()
+            .expect("context")
+            .environment = UtsExecutionEnvironmentKindV1::Network;
+        assert_eq!(
+            evaluate(disallowed_environment).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+
+        let mut disallowed_sensitivity = wp11_policy_input_fixture();
+        disallowed_sensitivity
+            .constraints
+            .defer_for_environment_approval = true;
+        disallowed_sensitivity
+            .context
+            .as_mut()
+            .expect("context")
+            .sensitivity = UtsDataSensitivityV1::Secret;
+        assert_eq!(
+            evaluate(disallowed_sensitivity).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+
+        let mut disallowed_resource = wp11_policy_input_fixture();
+        disallowed_resource
+            .constraints
+            .defer_for_environment_approval = true;
+        disallowed_resource
+            .context
+            .as_mut()
+            .expect("context")
+            .resource_scope = "other-scope".to_string();
+        assert_eq!(
+            evaluate(disallowed_resource).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+
+        let mut disallowed_adapter = wp11_policy_input_fixture();
+        disallowed_adapter
+            .constraints
+            .defer_for_environment_approval = true;
+        disallowed_adapter
+            .context
+            .as_mut()
+            .expect("context")
+            .adapter_id = "adapter.fixture.other.dry_run".to_string();
+        assert_eq!(
+            evaluate(disallowed_adapter).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+    }
+
+    #[test]
+    fn wp11_challenges_when_human_challenge_is_required() {
+        let mut input = wp11_policy_input_fixture();
+        input.constraints.require_human_challenge = true;
+
+        assert_eq!(
+            evaluate(input).decision,
+            PolicyAuthorityDecisionV1::Challenged
+        );
+    }
+
+    #[test]
+    fn wp11_revokes_revoked_grant() {
+        let mut input = wp11_policy_input_fixture();
+        input.context.as_mut().expect("context").grant_status = AccGrantStatusV1::Revoked;
+
+        assert_eq!(evaluate(input).decision, PolicyAuthorityDecisionV1::Revoked);
+    }
+
+    #[test]
+    fn wp11_missing_policy_context_fails_closed() {
+        let mut input = wp11_policy_input_fixture();
+        input.context = None;
+
+        let outcome = evaluate(input);
+
+        assert_eq!(outcome.decision, PolicyAuthorityDecisionV1::Denied);
+        assert!(outcome
+            .evidence
+            .iter()
+            .any(|entry| entry.detail == "missing policy context"));
+    }
+
+    #[test]
+    fn wp11_model_confidence_does_not_affect_authority() {
+        let mut low_confidence = wp11_policy_input_fixture();
+        low_confidence.model_confidence = Some(0.01);
+        let mut high_confidence = wp11_policy_input_fixture();
+        high_confidence.model_confidence = Some(0.99);
+
+        assert_eq!(evaluate(low_confidence), evaluate(high_confidence));
+    }
+
+    #[test]
+    fn wp11_denies_bad_delegation_resource_sensitivity_and_adapter_constraints() {
+        let mut delegated = wp11_policy_input_fixture();
+        delegated
+            .context
+            .as_mut()
+            .expect("context")
+            .delegation_depth = 9;
+        assert_eq!(
+            evaluate(delegated).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+
+        let mut sensitive = wp11_policy_input_fixture();
+        sensitive.context.as_mut().expect("context").sensitivity = UtsDataSensitivityV1::Secret;
+        assert_eq!(
+            evaluate(sensitive).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+
+        let mut resource = wp11_policy_input_fixture();
+        resource.context.as_mut().expect("context").resource_scope = "other-scope".to_string();
+        assert_eq!(
+            evaluate(resource).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+
+        let mut adapter = wp11_policy_input_fixture();
+        adapter.context.as_mut().expect("context").adapter_id =
+            "adapter.fixture.other.dry_run".to_string();
+        assert_eq!(
+            evaluate(adapter).decision,
+            PolicyAuthorityDecisionV1::Denied
+        );
+    }
+}

--- a/docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md
+++ b/docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md
@@ -43,3 +43,25 @@ Trace must be useful for accountability without becoming a privacy leak.
 Denied proposals are first-class trace evidence. They must identify the
 boundary that stopped the proposal without leaking protected arguments,
 private state, prompts, credentials, or secret-like values.
+
+## WP-11: Policy Injection And Authority Evaluation
+
+WP-11 implements the bounded policy-authority slice in
+`adl/src/policy_authority.rs`:
+
+- `PolicyAuthorityContextV1`
+- `PolicyAuthorityConstraintsV1`
+- `PolicyAuthorityEvaluationInputV1`
+- `PolicyAuthorityEvaluationV1`
+- `PolicyAuthorityEvidenceRecordV1`
+- `evaluate_policy_authority_v1`
+- `wp11_policy_context_fixture`
+- `wp11_policy_constraints_fixture`
+- `wp11_policy_input_fixture`
+
+The evaluator consumes explicit actor role, standing, grant status, delegation
+depth, execution environment, data sensitivity, resource scope, adapter id, and
+bounded constraints. It emits allowed, denied, deferred, challenged, or revoked
+decisions with policy evidence records. Missing context fails closed, and model
+confidence is accepted only as an ignored input field so tests can prove that
+authority evaluation does not depend on model self-report.


### PR DESCRIPTION
Closes #2576

## Summary
Implemented the WP-11 bounded policy-authority evaluator. The new surface evaluates explicit actor role, standing, grant, delegation, environment, sensitivity, resource, and adapter context against bounded constraints and emits allowed, denied, deferred, challenged, or revoked decisions with evidence. Missing context fails closed, and model confidence is intentionally ignored. Independent pre-PR review found one P1 deferral ordering issue; it was fixed and re-reviewed clean before PR publication.

## Artifacts
- `adl/src/policy_authority.rs`
- `adl/src/lib.rs`
- `docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md`
- `adl/target/coverage-impact-summary.json` local validation artifact only
- Local ignored output card at `.adl/v0.90.5/tasks/issue-2576__v0-90-5-wp-11-policy-injection-and-authority-evaluation/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified formatting for the changed Rust surface.
  - `cargo test --manifest-path adl/Cargo.toml policy_authority -- --nocapture`
    Verified focused WP-11 policy-authority behavior.
  - `cargo clippy --manifest-path adl/Cargo.toml --lib --tests -- -D warnings`
    Verified the changed Rust library and test surface is warning-clean.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --manifest-path adl/Cargo.toml --workspace --all-features --json --summary-only --output-path adl/target/coverage-impact-summary.json -- policy_authority`
    Produced a focused coverage summary for the policy-authority surface.
  - `bash adl/tools/check_coverage_impact.sh --changed-files <tmp-changed-files> --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified coverage-impact preflight for the changed Rust source.
  - `git diff --check`
    Verified whitespace cleanliness for the tracked diff.
  - `rg -n '<local-path-denylist-pattern>' adl/src/policy_authority.rs adl/src/lib.rs docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md`
    Verified no local path denylist matches in tracked changed files.
  - Independent pre-PR subagent review
    Verified all review findings were resolved before PR publication.
- Results:
  - PASS
  - Focused policy-authority tests: 9 passed.
  - Coverage-impact preflight: PASS.
  - `policy_authority.rs` coverage summary: lines 98.46153846153847, functions 100.0, regions 96.7741935483871.
  - Demo: not applicable; issue has no named demo requirement.

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.5/tasks/issue-2576__v0-90-5-wp-11-policy-injection-and-authority-evaluation/sip.md
- Output card: .adl/v0.90.5/tasks/issue-2576__v0-90-5-wp-11-policy-injection-and-authority-evaluation/sor.md
- Idempotency-Key: v0-90-5-wp-11-policy-injection-and-authority-evaluation-adl-src-policy-authority-rs-adl-src-lib-rs-docs-milestones-v0-90-5-features-governed-execution-and-trace-md-adl-v0-90-5-tasks-issue-2576-v0-90-5-wp-11-policy-injection-and-authority-evaluation-sip-md-adl-v0-90-5-tasks-issue-2576-v0-90-5-wp-11-policy-injection-and-authority-evaluation-sor-md