### PR TITLE
[v0.90.5][publication] Draft Determinism in the ADL Runtime first manuscript packet

### DIFF
--- a/demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_manuscript_packet.md
+++ b/demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_manuscript_packet.md
@@ -1,0 +1,221 @@
+# Manuscript Packet: Determinism in the ADL Runtime
+
+## Metadata
+
+- Skill mode: `draft_from_source_packet`
+- Issue: `#2641`
+- Source packet: `demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_source_packet.md`
+- Status: first serious draft for internal review
+- Submission state: not submitted; not publication-ready
+
+## Working Title
+
+**Determinism in the ADL Runtime: Execution Truth for Reviewable Agent Systems**
+
+## Alternate Titles
+
+1. Determinism in the ADL Runtime
+2. Execution Truth, Replay Posture, and Reviewability in ADL
+3. Why ADL Treats Determinism as a Trust Primitive
+
+## Abstract
+
+AI and agent systems often fail not only because of incorrect outputs, but
+because their execution cannot be reconstructed clearly enough for review.
+Agent Design Language (ADL) addresses this by treating determinism as a trust
+primitive rather than a secondary optimization. In the current repository, ADL
+uses deterministic plan compilation, explicit scheduler and dependency
+semantics, structured traces, deterministic artifact paths, bounded provider
+and remote-execution contracts, and explicit control-plane closeout records to
+make execution legible. This paper explains what determinism means in ADL, why
+it matters for runtime trust, and where the boundary lies between deterministic
+structure and stochastic model behavior. The claim is not that ADL offers
+perfect replay or formal proof of correctness. The claim is that ADL provides a
+substantially stronger execution-truth substrate than prompt-only orchestration
+by ensuring that what happened can be inspected, challenged, and debugged as
+repository evidence.
+
+## Draft
+
+### 1. Why Determinism Matters In Agent Systems
+
+Determinism matters in ordinary software because reproducibility improves
+debugging, testing, and operational trust. It matters even more in agent
+systems because those systems are often asked to reason, delegate, and call
+tools in ways that are difficult to inspect after the fact. If the structure of
+execution is unstable, then the surrounding review and governance claims become
+unstable too.
+
+Many contemporary agent workflows still depend on hidden orchestration logic:
+prompt ordering, implicit retries, undeclared fallback behavior, or manual
+operator interpretation of what probably happened. This creates a familiar
+failure pattern. A result may appear useful, but the team still cannot explain
+the run with enough precision to know whether the success is durable, whether
+the failure can be reproduced, or whether a later regression has occurred.
+
+ADL treats this as a systems problem, not merely a modeling problem. The system
+must make execution legible. Determinism, in this context, is not an aesthetic
+preference. It is part of the trust boundary between the runtime and the people
+who must review it.
+
+### 2. What ADL Means By Determinism
+
+ADL does not use the word determinism to mean that every token emitted by every
+model backend is guaranteed to be identical forever. That would be both
+unrealistic and, in many practical settings, false. Instead, ADL's
+determinism claim is layered.
+
+At the structural level, the same schema-valid documents and configuration
+should compile into the same plan. Dependency resolution, rejection of invalid
+graphs, step identity, scheduler ordering rules, artifact layout, and control
+surfaces should remain stable for identical inputs. The runtime should not
+silently improvise orchestration logic.
+
+At the review level, major control transitions should be explicit. If retries,
+failures, delegation decisions, or policy boundaries occur, they should become
+trace-visible and artifact-visible rather than living only in hidden runtime
+state.
+
+At the control-plane level, determinism also means that issue intent, execution
+packet, validation, and closeout records stay aligned. A merged PR with stale
+cards is a truth failure even if the code compiles. ADL therefore extends the
+determinism story beyond the runner into the surrounding lifecycle that tells a
+reviewer what happened.
+
+### 3. Deterministic Planning And Bounded Execution
+
+ADL grounds its determinism posture in the execution plan. Providers, agents,
+tasks, workflows, and steps are parsed into typed structures. The planner then
+builds an acyclic execution graph whose dependencies and order are explicit.
+Duplicate step ids, duplicate saved-state keys, unknown saved-state references,
+self-dependencies, and cycles are rejected before runtime execution begins.
+
+This is not a small detail. It means that the runtime starts from a known,
+checkable structure rather than from a prompt narrative about structure. The
+runtime can then apply explicit scheduler semantics, including ready-step
+ordering rules and bounded concurrency behavior, without leaving the reviewer to
+guess why one step happened before another.
+
+The accepted determinism ADR makes this concrete: ready-step ordering is
+lexicographic by full step id, plan generation is deterministic for
+canonicalized inputs, and bounded execution preserves stable output ordering.
+These are intentionally engineering-facing guarantees. They sacrifice some
+throughput opportunism in exchange for a more stable debugging and review
+surface.
+
+### 4. Trace And Artifacts As Execution Truth
+
+Determinism would be of limited value if the system did not expose what it was
+doing. That is why ADL treats trace and artifact surfaces as part of the same
+truth model. Trace is not a narrative convenience layered on afterward. It is a
+structured record of lifecycle, scheduling, control decisions, and execution
+events. Artifacts carry the heavier payload truth referenced by trace.
+
+This division is deliberate. Trace alone cannot reconstruct all payloads.
+Artifacts alone cannot explain causality. Together they form the reconstruction
+surface that reviewers, operators, and later automation can use to understand a
+run.
+
+The most important consequence is epistemic rather than aesthetic: if a
+reviewer must infer a major transition, the truth surface is incomplete. ADL's
+trace architecture therefore aims to preserve explicit lifecycle boundaries,
+decision visibility, provider attribution, stable artifact references, and
+deterministic structural ordering.
+
+### 5. Determinism Beyond The Runner
+
+One of ADL's more unusual claims is that runtime determinism is undermined if
+the surrounding control plane is sloppy. A build may produce stable artifacts,
+yet still leave the project in a non-reconstructable state if issue closure,
+validation records, or worktree cleanup are ambiguous.
+
+That is why the ADL control plane uses STP, SIP, and SOR as canonical packet
+surfaces and enforces an issue -> worktree -> validation -> PR -> closeout
+lifecycle. The output record must say what was run, what was intentionally not
+run, what artifacts exist, and what integration state is real. The closeout
+stage then reconciles GitHub state, local cards, and worktree cleanup.
+
+This is an important extension of the determinism concept. ADL does not treat
+execution truth as something that ends when the binary exits. It treats the
+whole bounded engineering path as part of the proof surface. If the runtime is
+deterministic but the review records drift, then the system has still failed to
+be fully trustworthy.
+
+### 6. Replay, Security, And Bounded Trust
+
+ADL also links determinism to replay posture and security posture. Replay in
+ADL is not framed as a magical guarantee that every external dependency will
+always behave identically. Instead, it is framed as a disciplined attempt to
+make structure, references, artifacts, and trust boundaries explicit enough
+that a run can be reconstructed credibly.
+
+This is why provider identity is kept separate from transport identity and why
+bounded remote execution surfaces preserve local scheduler ownership. It is why
+write-path validation and signing surfaces matter. It is why absolute host-path
+leakage and undeclared side effects are treated as violations of the review
+surface.
+
+The security story fits naturally into the same frame. A system under
+adversarial pressure cannot rely on hand-wavy narratives about what probably
+happened. It needs attributable, traceable, policy-bounded runtime behavior.
+Determinism does not solve security on its own, but it provides a substrate on
+which security review becomes materially more credible.
+
+### 7. What ADL Does Not Claim
+
+This paper must stay disciplined about its boundary. ADL does not claim formal
+verification of the full runtime. It does not claim that all provider outputs
+are semantically identical under replay. It does not claim that every later
+milestone layer is fully deterministic in the strongest mathematical sense. Nor
+does it claim superiority over every competing framework without a comparison
+study.
+
+What it does claim is that determinism in agent systems is most valuable when
+it is connected to review. Stable plan generation, bounded scheduler behavior,
+explicit traces, deterministic artifact roots, and truthful closeout records
+make a system more inspectable, more debuggable, and easier to trust than one
+that leaves orchestration hidden.
+
+### 8. Conclusion
+
+In ADL, determinism is not a boast about perfection. It is a design discipline
+for making runtime behavior legible enough to review. The runtime compiles
+structured inputs into stable execution plans. The scheduler applies explicit
+ordering and bounded concurrency rules. Trace and artifacts preserve the causal
+record. The control plane extends truthfulness into validation, PR, and
+closeout surfaces. Together, these choices turn determinism into a practical
+trust primitive for agent systems.
+
+That is the real contribution of the ADL runtime. It does not ask reviewers to
+believe a story about what happened. It tries to leave behind enough structured
+evidence that the story can be checked.
+
+## Claim Boundary Report
+
+| Claim | Label | Notes |
+| --- | --- | --- |
+| ADL treats deterministic planning and ordering as an accepted runtime contract. | SUPPORTED | Grounded in ADR 0001 and architecture docs. |
+| Trace and artifacts together provide the execution-truth surface. | SUPPORTED | Grounded in trace and architecture docs. |
+| Control-plane closeout truth is part of the determinism story. | SUPPORTED | Grounded in workflow and architecture docs. |
+| ADL offers perfect replay of all runs including stochastic model outputs. | REMOVE_OR_WEAKEN | Unsupported and too strong. |
+| ADL is formally verified. | REMOVE_OR_WEAKEN | Unsupported. |
+| ADL is more deterministic than all alternatives. | NEEDS_CITATION | Comparative evidence required. |
+
+## Citation Gap Report
+
+No external citations are invented in this packet. Before public submission, the
+paper still needs related work on:
+
+- deterministic workflow and orchestration systems
+- replay and provenance systems
+- reproducibility/debugging literature
+- adjacent agent runtime and orchestration platforms
+
+## Reviewer Questions
+
+1. Should this paper include one concrete end-to-end example of a run packet
+   and closeout record, or keep the first draft more architectural?
+2. Is the control-plane extension of determinism persuasive, or does it need a
+   shorter, sharper argument?
+3. Should the final title stay narrow on runtime determinism, or mention
+   execution truth explicitly?

--- a/demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_review_note.md
+++ b/demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_review_note.md
@@ -1,0 +1,49 @@
+# Review Note: Determinism in the ADL Runtime
+
+## Status
+
+This first draft is ready for internal review.
+
+It is not yet ready for external publication.
+
+## What The Draft Does Well
+
+- It defines determinism in a bounded, credible way instead of making impossible
+  claims about perfect replay.
+- It ties deterministic runtime behavior to trace, artifacts, and closeout
+  truth, which is a real ADL differentiator.
+- It explains why determinism matters specifically for agent systems rather than
+  treating it as generic runtime hygiene.
+
+## Main Remaining Gaps
+
+### 1. External related work is still absent
+
+The paper needs a later comparison pass against workflow engines, replay and
+provenance systems, and adjacent agent-orchestration frameworks.
+
+### 2. A compact worked example would improve it
+
+One short issue/run/trace/artifact/closeout example would help readers
+understand why ADL's determinism claim is practical rather than merely
+architectural.
+
+### 3. The control-plane argument should be checked for clarity
+
+The idea that determinism extends into issue/PR/closeout truth is important,
+but it may be new enough to readers that it benefits from one cleaner example
+or figure.
+
+## Recommended Next Revision Pass
+
+1. add 4-8 external citations
+2. add one worked runtime-plus-closeout example
+3. add one small figure showing plan -> execution -> trace/artifact -> review
+4. run one overclaim pass on replay language
+
+## Publication Boundary
+
+- submitted: no
+- author-approved: no
+- citation-complete: no
+- initial-review-ready: yes

--- a/demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_source_packet.md
+++ b/demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_source_packet.md
@@ -1,0 +1,175 @@
+# Source Packet: Determinism in the ADL Runtime
+
+## Metadata
+
+- Packet: `determinism_in_the_adl_runtime_source_packet`
+- Intended paper: `Determinism in the ADL Runtime`
+- Issue: `#2641`
+- Status: draft input for initial manuscript review
+- Publication state: not submitted; not publication-ready
+
+## Purpose
+
+Provide one bounded source packet for a focused paper on why ADL treats
+determinism, replayability, and execution truth as part of the runtime contract
+rather than as implementation polish.
+
+## Core Thesis
+
+ADL treats determinism as a trust primitive. The system's value does not come
+only from producing outputs. It comes from producing outputs through explicit
+plans, bounded scheduler semantics, trace-visible decisions, deterministic
+artifact paths, and closeout records that make the run reconstructable enough
+for review and debugging.
+
+## Target Reader
+
+- systems and runtime engineers
+- people skeptical of agent systems because they are difficult to audit
+- reviewers interested in trust, replay, provenance, and bounded operational
+  claims
+
+## Primary Source Surfaces
+
+### `docs/adr/0001-determinism.md`
+
+Supported facts:
+
+- deterministic execution semantics are an accepted architecture decision
+- ready-step ordering is lexicographic by full step id
+- plan generation is deterministic for canonicalized inputs
+- determinism is justified by reproducibility, debugging, and trust
+
+### `README.md`
+
+Supported facts:
+
+- ADL is described as a deterministic orchestration system
+- explicit contracts, bounded runtime behavior, and repository-visible proof
+  are central project claims
+- trace events, run manifests, and replay-friendly artifact roots are part of
+  the current system story
+
+### `adl/README.md`
+
+Supported facts:
+
+- the Rust runtime resolves documents into deterministic execution plans
+- the runtime has explicit semantics for concurrency, retries, failures,
+  signing, tracing, and bounded remote execution
+- run artifacts are stable and replay-friendly
+- deterministic execution is the foundation on which later runtime layers build
+
+### `docs/architecture/ADL_ARCHITECTURE.md`
+
+Supported facts:
+
+- workflows are compiled into explicit execution plans before execution
+- duplicate ids, cycles, and invalid saved-state references are rejected before
+  runtime
+- execution records lifecycle phases, scheduling policy, step events,
+  delegation, failures, and completion
+- traces and artifacts are treated as truth-bearing runtime evidence
+- STP/SIP/SOR and worktree/PR lifecycle are part of the truth model
+
+### `docs/architecture/TRACE_SYSTEM_ARCHITECTURE.md`
+
+Supported facts:
+
+- trace is execution truth, not after-the-fact logging
+- structured trace plus artifacts form the reconstruction surface
+- deterministic structural ordering is one of the core guarantees
+- review fails if major control transitions must be inferred
+
+### `docs/default_workflow.md`
+
+Supported facts:
+
+- ADL's default workflow couples deterministic lifecycle steps with explicit
+  validation and output records
+- replay/security/artifact sections are required in the output-card contract
+- docs-only and focused validation must be recorded truthfully rather than
+  hidden under generic test claims
+
+### `docs/planning/ADL_FEATURE_LIST.md`
+
+Supported facts:
+
+- deterministic workflow execution is an implemented baseline
+- run artifacts and replay-oriented inspection are implemented baseline
+  capabilities
+- control-plane lifecycle, review surfaces, and milestone proof packages are
+  part of the current repo truth
+
+### `docs/milestones/v0.87/README.md`, `docs/milestones/v0.87/RELEASE_NOTES_v0.87.md`
+
+Supported facts:
+
+- trace became a first-class substrate surface for reconstruction-oriented
+  execution truth
+- provider, shared memory, skills, and control-plane work were aligned around
+  the trace/review/documentation truth model
+
+### `docs/milestones/v0.87.1/features/LOCAL_RUNTIME_RESILIENCE.md`
+
+Supported facts:
+
+- runtime resilience depends on durable execution truth
+- resilience is not independent of artifact and trace discipline
+
+### `docs/milestones/v0.90/README.md` and later milestone docs
+
+Supported facts:
+
+- later runtime layers deepen determinism by extending artifact, continuity,
+  observability, and review surfaces
+- long-lived runtime work preserves bounded cycle truth rather than replacing
+  it with opaque daemon behavior
+
+## Allowed Claims
+
+| Claim | Status | Evidence |
+| --- | --- | --- |
+| ADL treats determinism as a runtime contract rather than an implementation accident. | SUPPORTED | `docs/adr/0001-determinism.md`; `adl/README.md`; architecture docs |
+| Plan compilation, scheduling, trace ordering, and artifact structure are designed to be stable and reviewable. | SUPPORTED | `docs/adr/0001-determinism.md`; `docs/architecture/ADL_ARCHITECTURE.md`; `docs/architecture/TRACE_SYSTEM_ARCHITECTURE.md` |
+| Closeout truth is part of runtime trust because stale records undermine reconstruction. | SUPPORTED | `docs/default_workflow.md`; `docs/architecture/ADL_ARCHITECTURE.md`; review docs |
+| ADL offers perfect replay or formal proof of correctness. | REMOVE_OR_WEAKEN | Not supported by current repo evidence |
+| Every provider interaction is fully deterministic at the semantic output level. | REMOVE_OR_WEAKEN | Model/provider stochasticity remains bounded but not eliminated |
+| ADL's determinism posture is stronger than all competing systems. | NEEDS_EVIDENCE | No comparative study in this packet |
+
+## Important Framing Constraints
+
+- The paper should emphasize that ADL's determinism is bounded and layered.
+- It should distinguish deterministic structure from stochastic model contents.
+- It should explain why reviewability and artifact truth matter more than
+  inflated claims of absolute replay.
+- It should connect runtime determinism to the control plane and closeout truth.
+
+## Citation And Evidence Gaps
+
+- related work on deterministic workflow engines and replayable execution
+- provenance and artifact-traceability literature
+- systems/debugging literature around reproducibility and operational truth
+- comparison to other orchestration or agent frameworks, if desired later
+
+## Recommended Section Order
+
+1. Why determinism matters for agent systems
+2. What ADL means by determinism
+3. Deterministic planning and bounded execution
+4. Trace and artifacts as execution truth
+5. Determinism beyond the runner: control-plane and closeout truth
+6. Security, trust, and bounded replay claims
+7. Limits and future work
+
+## Non-Goals
+
+- formal-methods proof paper
+- complete survey of replay systems
+- public submission packet
+- broader ADL architecture paper replacement
+
+## Boundary
+
+This packet is for internal drafting and review. It is not a submission package
+and does not certify publication readiness.


### PR DESCRIPTION
Closes #2641

## Summary
Drafted the first serious `Determinism in the ADL Runtime` manuscript packet
as a tracked reviewable surface, together with a source packet and reviewer note
grounded in current runtime, trace, architecture, workflow, and milestone docs.

## Artifacts
- `demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_source_packet.md`
- `demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_manuscript_packet.md`
- `demos/v0.90.5/publication/determinism_in_the_adl_runtime/determinism_in_the_adl_runtime_review_note.md`
- updated execution record at `.adl/v0.90.5/tasks/issue-2641__v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type stp --phase bootstrap --input .adl/v0.90.5/tasks/issue-2641__v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet/stp.md`
    Verified the task prompt card still satisfies the structured contract.
  - `bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input .adl/v0.90.5/tasks/issue-2641__v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet/sip.md`
    Verified the input card still satisfies the structured contract for this worktree run.
  - `git diff --check`
    Verified the new manuscript packet files are patch-clean.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.5/tasks/issue-2641__v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet/sip.md
- Output card: .adl/v0.90.5/tasks/issue-2641__v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet/sor.md
- Idempotency-Key: v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet-demos-v0-90-5-publication-determinism-in-the-adl-runtime-adl-v0-90-5-tasks-issue-2641-v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet-sip-md-adl-v0-90-5-tasks-issue-2641-v0-90-5-publication-draft-determinism-in-the-adl-runtime-first-manuscript-packet-sor-md