### PR TITLE
[v0.90.5][publication] Draft Godel Agents and the Godel-Hadamard-Bayes Algorithm first manuscript packet

### DIFF
--- a/demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_manuscript_packet.md
+++ b/demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_manuscript_packet.md
@@ -1,0 +1,181 @@
+# Manuscript Packet: Godel Agents and the Godel-Hadamard-Bayes Algorithm
+
+## Metadata
+
+- Skill mode: `draft_from_source_packet`
+- Issue: `#2656`
+- Source packet: `demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_source_packet.md`
+- Status: first serious draft for internal review
+- Submission state: not submitted; not publication-ready
+
+## Working Title
+
+**Godel Agents and the Godel-Hadamard-Bayes Algorithm**
+
+## Abstract
+
+The phrase "Gödel agent" is often used loosely, which makes it difficult to
+separate bounded engineering substance from recursive-self-improvement
+rhetoric. Agent Design Language (ADL) now has enough structure to narrow that
+discussion. This paper focuses on one specific contribution: the
+Godel-Hadamard-Bayes (GHB) loop as a bounded algorithmic pattern for reflective
+cognition. The loop can be described as an expansion-exploration-compression
+cycle over cognitive state. Gödel expands representation when the current
+structure is inadequate, Hadamard explores and reshapes candidate structure,
+and Bayes compresses again through evaluation, selection, and persistence. The
+paper argues that GHB should be understood not as a proof of unconstrained
+self-improvement, but as a serious runtime pattern for turning failure,
+hypothesis generation, exploration, evaluation, and memory-worthy persistence
+into inspectable cognitive control surfaces.
+
+## Draft
+
+### 1. Why The Godel-Agent Story Needs A Narrower Paper
+
+The broader Godel-agent story in ADL is architectural. It explains how bounded
+reflective adaptation becomes credible once convergence, experiment records,
+memory participation, and continuity surfaces are made explicit. That broader
+paper is necessary, but it leaves a second question open: what is the loop
+itself?
+
+If Godel-agent language is going to survive review, it cannot remain only a
+banner over many related capabilities. It needs a narrower algorithmic account.
+The Godel-Hadamard-Bayes loop is the best candidate for that account in the
+current repository.
+
+This paper therefore does less than the architecture paper and more than a
+label. It isolates the loop and describes what it is doing.
+
+### 2. The GHB Loop In Exact Terms
+
+At a high level, GHB is a bounded cycle for dealing with inadequate current
+structure. The system notices that the present framing, branch set, or
+candidate explanation is not good enough. It then does three things.
+
+First, it expands. New possibilities, decompositions, reframings, or missing
+explanatory structures are introduced.
+
+Second, it explores. Those possibilities are traversed, reshaped, compared, and
+recombined under bounded reasoning patterns.
+
+Third, it compresses. The resulting space is evaluated, weaker structures are
+discarded, and a more useful representation is preserved for future reasoning.
+
+This is already enough to distinguish GHB from both naive search and generic
+"reflection" language. GHB is a disciplined way of revising cognitive state.
+
+### 3. Gödel As Expansion
+
+The Gödel role is the introduction of new structure when the current one is
+incomplete. In practical terms, this includes hypothesis generation,
+decomposition, reframing, contradiction recognition, and the discovery that the
+current problem representation cannot support good progress.
+
+This matters because many failures are not failures of effort but failures of
+representation. A system can work very hard inside the wrong structure. The
+Gödel step is the permissioned expansion that says the structure itself may
+need to change.
+
+That is why Gödel belongs at the front of the loop. Without structured
+expansion, the rest of the process becomes local optimization inside a bad
+space.
+
+### 4. Hadamard As Exploration And Transformation
+
+The Hadamard role is not merely branching. It is the geometry of cognition
+inside the newly expanded or revised space. Candidate structures are compared,
+reshaped, debated, refined, and recombined. Possibilities gain motion rather
+than remaining static options on a list.
+
+In ADL terms, this is where reasoning patterns matter most. Fork-join
+structures, debate patterns, iterative refinement, hypothesis trees, or
+counterfactual development can all instantiate the Hadamard phase.
+
+The key point is that Hadamard gives the loop a disciplined method for
+inspecting alternative structure rather than jumping prematurely from expansion
+to choice.
+
+### 5. Bayes As Compression And Selection
+
+The Bayes role is where the space contracts again. Candidate structures are
+evaluated, weaker lines are rejected, surviving lines are weighted or
+synthesized, and some result becomes fit to persist into future reasoning,
+memory, or action.
+
+Bayes is therefore not just "belief update" in the abstract. In this bounded
+algorithmic reading, it is the stage at which the expanded and explored space
+is made tractable again. The problem is not solved by expansion alone. It is
+solved when useful structure survives compression.
+
+This is the point at which GHB most clearly overlaps with state-space
+compression language. The loop does not merely think. It progressively
+constructs and selects more useful macrostates.
+
+### 6. Trace, Memory, And Bounded Continuation
+
+An algorithm paper on GHB still needs to say what happens after one cycle. A
+selected structure must not disappear immediately if the loop is to matter as a
+runtime pattern. This is where ADL's trace, memory, and bounded continuation
+surfaces become relevant.
+
+Trace allows the system and reviewer to see how the structure emerged. Memory
+allows the compressed result to participate in later cognition. Bounded
+continuation means the next cycle is not automatic; it depends on convergence
+signals, policy allowance, and the quality of the currently surviving
+representation.
+
+These surfaces keep GHB from collapsing into invisible latent drift. They make
+the loop inspectable and therefore operationally meaningful.
+
+### 7. What GHB Does Not Prove
+
+This paper should be explicit about its non-claims. GHB is not yet a formally
+proven optimal algorithm. ADL has not shown that the loop guarantees success,
+global convergence, or safe open-ended self-improvement. The current repository
+supports a bounded algorithmic interpretation, not a theorem of recursive
+agency.
+
+That limitation is not a weakness in the paper. It is part of what makes the
+claim serious. A bounded loop with explicit non-claims is more valuable than an
+inflated theory that cannot survive inspection.
+
+### 8. Conclusion
+
+The contribution of GHB is that it gives ADL a coherent loop for dealing with
+inadequate structure. It expands, explores, and compresses cognitive state in a
+way that can be connected to trace, memory, evaluation, and governed
+persistence. That is enough to justify treating GHB as a real algorithmic
+surface inside ADL.
+
+The paper therefore does not ask reviewers to believe in magical
+self-improvement. It asks them to inspect a bounded reflective-control loop
+whose roles are clear, whose artifacts can be named, and whose claims can be
+kept within runtime truth.
+
+## Claim Boundary Report
+
+| Claim | Label | Notes |
+| --- | --- | --- |
+| GHB is a coherent bounded algorithmic pattern inside ADL cognition. | SUPPORTED | grounded in GHB/SSC concept docs and the broader Godel-agent packet |
+| GHB decomposes into expansion, exploration, and compression roles. | SUPPORTED | directly grounded in the concept document |
+| GHB is formally proven or optimal. | REMOVE_OR_WEAKEN | not supported |
+| GHB guarantees recursive self-improvement. | REMOVE_OR_WEAKEN | not supported |
+| GHB is a useful runtime pattern for reflective control. | SUPPORTED | bounded architectural claim supported by repo surfaces |
+
+## Citation Gap Report
+
+No external citations are invented in this packet. Before public submission, the
+paper still needs exact support for:
+
+- any neighboring self-modifying-agent or reflective-agent literature
+- SSC references where the mapping is stated or compared
+- any scholarly positioning around Bayesian or search terminology
+
+## Reviewer Questions
+
+1. Should this paper include a compact pseudo-trace or example loop in the next
+   revision so the algorithm is more concrete?
+2. Does the paper stay sufficiently distinct from `Godel Agents and ADL`, or
+   does it still repeat too much architecture framing?
+3. Should the title keep "Gödel agents" in front, or should the algorithm name
+   lead more strongly?

--- a/demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_review_note.md
+++ b/demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_review_note.md
@@ -1,0 +1,47 @@
+# Review Note: Godel Agents and the Godel-Hadamard-Bayes Algorithm
+
+## Status
+
+This first draft is ready for internal review.
+
+It is not yet ready for external publication.
+
+## What The Draft Does Well
+
+- It gives the GHB loop a focused home separate from the broader Godel-agent
+  architecture paper.
+- It clearly separates algorithmic roles from unsupported stronger claims.
+- It explains why expansion, exploration, and compression are the core shape of
+  the loop.
+
+## Main Remaining Gaps
+
+### 1. It needs exact citation positioning
+
+The draft is currently grounded in repo truth, but public submission will need
+precise scholarly neighbors so novelty and lineage claims stay disciplined.
+
+### 2. It wants one compact pseudo-trace or worked example
+
+A tiny example showing inadequacy -> expansion -> exploration -> compression ->
+persisted result would make the algorithm much more tangible.
+
+### 3. The overlap boundary with the broader Godel paper will need review
+
+The current draft is distinct enough for internal review, but it should be
+checked carefully so the two papers do not become redundant.
+
+## Recommended Next Revision Pass
+
+1. add exact citations and positioning
+2. add one compact algorithm example or pseudo-trace
+3. reduce any repeated architecture background that properly belongs only in
+   the broader Godel paper
+4. review the title and novelty-language strength
+
+## Publication Boundary
+
+- submitted: no
+- author-approved: no
+- citation-complete: no
+- initial-review-ready: yes

--- a/demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_source_packet.md
+++ b/demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_source_packet.md
@@ -1,0 +1,164 @@
+# Source Packet: Godel Agents and the Godel-Hadamard-Bayes Algorithm
+
+## Metadata
+
+- Issue: `#2656`
+- Paper mode: `first_draft_from_bounded_repo_sources`
+- Intended output: reviewable manuscript packet, not publication-ready copy
+- Submission state: not submitted; not publication-ready
+
+## Proposed Working Title
+
+**Godel Agents and the Godel-Hadamard-Bayes Algorithm**
+
+Alternate subtitle direction:
+
+**A Bounded Expansion-Exploration-Compression Loop for Reflective Cognition**
+
+## Core Thesis
+
+The Godel-Hadamard-Bayes (GHB) loop deserves its own focused paper because it
+is more than a label for reflective adaptation. It is the clearest candidate
+algorithmic pattern inside ADL for turning inadequacy signals into new
+structure, exploring that structure under bounded reasoning, and then
+compressing the resulting space through evaluation, selection, and persistence.
+
+This paper should not claim that GHB is already a formally proven optimal
+algorithm. It should claim something narrower and stronger: ADL already has a
+coherent bounded algorithmic pattern that can be described as an
+expansion-exploration-compression loop over cognitive state.
+
+## Why This Paper Exists
+
+`Godel Agents and ADL` is the broader architecture paper. It explains the
+runtime, evidence, memory, convergence, and continuity surfaces that make the
+adaptive story credible.
+
+This follow-on paper should do something different:
+
+- isolate the GHB loop itself
+- explain its exact internal roles
+- describe how it relates to SSC and reflective learning
+- clarify what is algorithmic versus what remains architectural or aspirational
+
+That narrower treatment gives the publication program one paper that can discuss
+the algorithmic shape of ADL cognition without having to re-explain the whole
+platform every time.
+
+## Bounded Repo Evidence
+
+### 1. GHB and SSC concept document
+
+Source:
+
+- `docs/milestones/v0.89/ideas/GHB_ALGORITHM_AND_STATE_SPACE_COMPRESSION.md`
+
+Key usable facts:
+
+- GHB is described as ADL's core mechanism for online, recursive state space
+  compression.
+- The document explicitly maps GHB to SSC:
+  - Gödel = expansion
+  - Hadamard = transformation/exploration
+  - Bayes = compression/selection
+- It explains GHB as recursive state-space compression over time and as a
+  bounded recursive control system rather than a simple pipeline.
+- It names specific reasoning-pattern families that can instantiate the loop.
+
+### 2. Godel-agent architecture manuscript
+
+Source:
+
+- `demos/v0.90.5/publication/godel_agents_and_adl/godel_agents_and_adl_manuscript_packet.md`
+
+Key usable facts:
+
+- The broader Godel-agent line is about bounded reflective adaptation, not
+  unconstrained recursive self-improvement.
+- Failure, hypothesis generation, mutations, evaluation, adoption, memory
+  participation, and bounded continuation are already treated as runtime
+  surfaces in the larger paper.
+- This focused paper should reuse that bounded posture while narrowing down to
+  the algorithmic loop itself.
+
+### 3. Learning-model v2 reflective-learning layer
+
+Source:
+
+- `.adl/docs/TBD/learning_model/ADL_LEARNING_MODEL_v2.md`
+
+Key usable facts:
+
+- GHB/reflective learning is explicitly named as an ADL learning mode.
+- Reflective learning includes hypothesis generation, reframing, Bayesian
+  updating, trace-driven refinement, and improved use of skills and memory.
+- The learning model explicitly frames this as governed cognition over trace,
+  memory, hypotheses, outcomes, and revision.
+
+### 4. SSC/ADL problem-solving packet
+
+Source:
+
+- `demos/v0.90.5/publication/state_space_compression_adl_problem_solving/state_space_compression_adl_problem_solving_manuscript_packet.md`
+
+Key usable facts:
+
+- The GHB loop can be framed as an operational macrostate-management pattern
+  inside ADL problem solving.
+- This paper should stay narrower than the SSC/ADL paper and focus on the loop
+  mechanics rather than the whole problem-solving theory.
+
+## Allowed Claims
+
+- GHB is a coherent bounded algorithmic pattern inside ADL cognition.
+- The three roles of GHB can be described as expansion, exploration, and
+  compression.
+- GHB helps explain how ADL turns inadequacy signals into revisable cognitive
+  structure.
+- The loop is better treated as a bounded reflective-control pattern than as a
+  claim of unconstrained self-improvement.
+
+## Claims Requiring Careful Wording
+
+- statements that GHB is novel in a fully established scholarly sense
+- statements that GHB is optimal
+- statements that GHB has already been empirically validated across many model
+  families or workloads
+- any statement that GHB by itself solves alignment, personhood, or general
+  intelligence
+
+## Claims To Exclude
+
+- GHB is formally proven
+- ADL has solved recursive self-improvement
+- GHB guarantees convergence in all cases
+- GHB is the unique correct cognition algorithm
+
+## Likely Outline
+
+1. Why the broader Godel-agent story needs an algorithm paper
+2. The GHB loop in exact terms
+3. Gödel as expansion
+4. Hadamard as exploration and transformation
+5. Bayes as compression and selection
+6. Trace, memory, and bounded continuation
+7. Failure modes and non-claims
+8. Conclusion
+
+## Citation Posture
+
+No external citations are invented in this packet.
+
+Before public submission, the paper still needs exact support for:
+
+- any Gödel-agent or self-modifying-agent neighbors if comparison is made
+- SSC references where the mapping is explicitly discussed
+- Bayesian or search-related neighbors if the paper uses those terms in a
+  scholarly positioning section
+
+## Reviewer Risks
+
+- The paper can easily overclaim novelty unless it stays bounded.
+- It must not repeat too much of `Godel Agents and ADL`.
+- It needs one compact example or pseudo-trace in a later revision pass to show
+  the loop concretely.


### PR DESCRIPTION
Closes #2656

## Summary
Drafted the first serious `Godel Agents and the Godel-Hadamard-Bayes
Algorithm` manuscript packet as a tracked reviewable surface, together with a
source packet and reviewer note grounded in current GHB/SSC concept docs, the
broader Godel-agent architecture packet, reflective-learning docs, and the new
SSC/ADL problem-solving packet.

## Artifacts
- `demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_source_packet.md`
- `demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_manuscript_packet.md`
- `demos/v0.90.5/publication/godel_agents_ghb_algorithm/godel_agents_ghb_algorithm_review_note.md`
- updated execution record at `.adl/v0.90.5/tasks/issue-2656__v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/validate_structured_prompt.sh --type stp --phase bootstrap --input .adl/v0.90.5/tasks/issue-2656__v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet/stp.md`
    Verified the task prompt card still satisfies the structured contract.
  - `bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input .adl/v0.90.5/tasks/issue-2656__v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet/sip.md`
    Verified the input card still satisfies the structured contract for this
    issue bundle.
  - `git -C .worktrees/adl-wp-2656 diff --check`
    Verified the new manuscript packet files are patch-clean.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.90.5/tasks/issue-2656__v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet/sor.md`
    Verified the updated output record still satisfies the structured contract.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  /Users/daniel/git/agent-design-language/.adl/v0.90.5/tasks/issue-2656__v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet/sip.md
- Output card: /Users/daniel/git/agent-design-language/.adl/v0.90.5/tasks/issue-2656__v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet/sor.md
- Idempotency-Key: v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet-demos-v0-90-5-publication-godel-agents-ghb-algorithm-users-daniel-git-agent-design-language-adl-v0-90-5-tasks-issue-2656-v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet-sip-md-users-daniel-git-agent-design-language-adl-v0-90-5-tasks-issue-2656-v0-90-5-publication-draft-godel-agents-and-the-godel-hadamard-bayes-algorithm-first-manuscript-packet-sor-md