### PR TITLE
[v0.90.5][coverage] Clear daily coverage blockers for 2026-04-28

### DIFF
--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -800,7 +800,12 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
         .expect("git branch")
         .success());
     assert!(Command::new("git")
-        .args(["init", "--bare", "-q", path_str(&origin).expect("origin path")])
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
         .current_dir(&repo)
         .status()
         .expect("git init bare")
@@ -823,7 +828,12 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
         .expect("git push")
         .success());
     assert!(Command::new("git")
-        .args(["checkout", "-q", "-b", "codex/1153-rust-finish-default-lane"])
+        .args([
+            "checkout",
+            "-q",
+            "-b",
+            "codex/1153-rust-finish-default-lane"
+        ])
         .current_dir(&repo)
         .status()
         .expect("git checkout")
@@ -944,12 +954,16 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
 
     let head_subject = run_capture(
         "git",
-        &["-C", path_str(&repo).expect("repo"), "log", "-1", "--format=%s"],
+        &[
+            "-C",
+            path_str(&repo).expect("repo"),
+            "log",
+            "-1",
+            "--format=%s",
+        ],
     )
     .expect("head subject");
-    assert!(head_subject.contains(
-        "[v0.86][tools] Rust finish default lane (Closes #1153)"
-    ));
+    assert!(head_subject.contains("[v0.86][tools] Rust finish default lane (Closes #1153)"));
     let gh_log = fs::read_to_string(&gh_log).expect("gh log");
     assert!(gh_log.contains("pr create"));
     assert!(gh_log.contains("pr view -R danielbaustin/agent-design-language"));

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::pr_cmd::finish_support::real_pr_finish;
 
 #[test]
 fn parse_finish_args_requires_title_and_accepts_finish_flags() {
@@ -754,4 +755,206 @@ fn finish_misc_helpers_cover_section_parsing_fingerprint_and_create_outcomes() {
         infer_required_outcome_type_for_create("track:roadmap,type:task", "[v0.89] Ship code"),
         "code"
     );
+}
+
+#[test]
+fn real_pr_finish_happy_path_is_covered_in_default_lane() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-finish-default-lane");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join(".gitignore"), ".adl/\n").expect("seed gitignore");
+    fs::create_dir_all(repo.join("adl/src")).expect("adl src");
+    fs::write(repo.join("adl/src/lib.rs"), "pub fn placeholder() {}\n").expect("write source");
+    assert!(Command::new("git")
+        .args(["add", ".gitignore", "adl/src/lib.rs"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args(["init", "--bare", "-q", path_str(&origin).expect("origin path")])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["checkout", "-q", "-b", "codex/1153-rust-finish-default-lane"])
+        .current_dir(&repo)
+        .status()
+        .expect("git checkout")
+        .success());
+
+    let issue_ref = IssueRef::new(
+        1153,
+        "v0.86".to_string(),
+        "rust-finish-default-lane".to_string(),
+    )
+    .expect("issue ref");
+    fs::create_dir_all(issue_ref.task_bundle_dir_path(&repo)).expect("bundle dir");
+    let stp = issue_ref.task_bundle_stp_path(&repo);
+    let input = issue_ref.task_bundle_input_path(&repo);
+    let output = issue_ref.task_bundle_output_path(&repo);
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish default lane");
+    fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
+    write_authored_sip(
+        &input,
+        &issue_ref,
+        "[v0.86][tools] Rust finish default lane",
+        "codex/1153-rust-finish-default-lane",
+        &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_completed_sor_fixture(&output, "codex/1153-rust-finish-default-lane");
+    fs::write(
+        repo.join("adl/src/lib.rs"),
+        "pub fn placeholder() {}\npub fn changed() {}\n",
+    )
+    .expect("write change");
+
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    let janitor_log = temp.join("janitor.log");
+    let closeout_log = temp.join("closeout.log");
+    let gh_path = bin_dir.join("gh");
+    let janitor_path = bin_dir.join("janitor");
+    let closeout_path = bin_dir.join("closeout");
+    write_executable(
+        &gh_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2 $3\" = 'repo view --json' ]; then\n  printf 'danielbaustin/agent-design-language\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr list' ]; then\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr create' ]; then\n  printf 'https://github.com/danielbaustin/agent-design-language/pull/1159\\n'\n  exit 0\nfi\nif [ \"$1 $2\" = 'pr view' ]; then\n  if printf '%s ' \"$@\" | grep -q 'closingIssuesReferences'; then\n    printf '1153\\n'\n  else\n    printf 'Closes #1153\\n'\n  fi\n  exit 0\nfi\nexit 1\n",
+            gh_log.display()
+        ),
+    );
+    write_executable(
+        &janitor_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            janitor_log.display()
+        ),
+    );
+    write_executable(
+        &closeout_path,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            closeout_log.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_janitor_cmd = env::var("ADL_PR_JANITOR_CMD").ok();
+    let old_janitor_disable = env::var("ADL_PR_JANITOR_DISABLE").ok();
+    let old_closeout_cmd = env::var("ADL_POST_MERGE_CLOSEOUT_CMD").ok();
+    let old_closeout_disable = env::var("ADL_POST_MERGE_CLOSEOUT_DISABLE").ok();
+    let prev_dir = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_PR_JANITOR_DISABLE", "0");
+        env::set_var("ADL_PR_JANITOR_CMD", &janitor_path);
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", "0");
+        env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", &closeout_path);
+    }
+    env::set_current_dir(&repo).expect("chdir");
+
+    let result = real_pr_finish(&[
+        "1153".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Rust finish default lane".to_string(),
+        "--paths".to_string(),
+        "adl".to_string(),
+        "--input".to_string(),
+        path_relative_to_repo(&repo, &input),
+        "--output".to_string(),
+        path_relative_to_repo(&repo, &output),
+        "--no-checks".to_string(),
+        "--no-open".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+        if let Some(value) = old_janitor_cmd {
+            env::set_var("ADL_PR_JANITOR_CMD", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_CMD");
+        }
+        if let Some(value) = old_janitor_disable {
+            env::set_var("ADL_PR_JANITOR_DISABLE", value);
+        } else {
+            env::remove_var("ADL_PR_JANITOR_DISABLE");
+        }
+        if let Some(value) = old_closeout_cmd {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_CMD", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_CMD");
+        }
+        if let Some(value) = old_closeout_disable {
+            env::set_var("ADL_POST_MERGE_CLOSEOUT_DISABLE", value);
+        } else {
+            env::remove_var("ADL_POST_MERGE_CLOSEOUT_DISABLE");
+        }
+    }
+
+    result.expect("real_pr_finish success");
+
+    let head_subject = run_capture(
+        "git",
+        &["-C", path_str(&repo).expect("repo"), "log", "-1", "--format=%s"],
+    )
+    .expect("head subject");
+    assert!(head_subject.contains(
+        "[v0.86][tools] Rust finish default lane (Closes #1153)"
+    ));
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(gh_log.contains("pr create"));
+    assert!(gh_log.contains("pr view -R danielbaustin/agent-design-language"));
+    let janitor_log = fs::read_to_string(&janitor_log).expect("janitor log");
+    let closeout_log = fs::read_to_string(&closeout_log).expect("closeout log");
+    assert!(janitor_log.contains("--issue 1153"));
+    assert!(closeout_log.contains("--issue 1153"));
 }

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -1,5 +1,9 @@
 use super::*;
-use crate::cli::pr_cmd::github::{current_pr_url, OpenPullRequest};
+use crate::cli::pr_cmd::github::{
+    current_pr_url, ensure_issue_metadata_parity, gh_issue_create, gh_issue_edit_body,
+    gh_issue_title, pr_has_closing_linkage, ensure_pr_closing_linkage,
+    ensure_or_repair_pr_closing_linkage, OpenPullRequest,
+};
 
 #[test]
 fn issue_create_repo_requires_github_origin_remote() {
@@ -597,6 +601,137 @@ fn ensure_issue_metadata_parity_errors_when_drift_remains_after_repair() {
     );
     assert!(gh_log.contains("issue edit 1153 -R owner/repo --add-label version:v0.87.1"));
     assert!(gh_log.contains("issue edit 1153 -R owner/repo --remove-label version:v0.86"));
+}
+
+#[test]
+fn github_issue_create_and_metadata_helpers_cover_direct_success_paths() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-github-helper-success");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    let title_state = temp.join("gh-title.txt");
+    let labels_state = temp.join("gh-labels.txt");
+    let body_state = temp.join("gh-body.txt");
+    fs::write(&title_state, "[tools] Metadata parity\n").expect("seed title");
+    fs::write(
+        &labels_state,
+        "track:roadmap\ntype:task\narea:tools\nversion:v0.86\n",
+    )
+    .expect("seed labels");
+    fs::write(&body_state, "initial body\n").expect("seed body");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nTITLE_FILE='{}'\nLABELS_FILE='{}'\nBODY_FILE='{}'\nif [[ \"$*\" == *\"issue create -R owner/repo --title [v0.87.1][tools] Metadata parity --body Seed body\"* ]]; then\n  printf 'https://github.com/owner/repo/issues/1153\\n'\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json title -q .title\"* ]]; then\n  cat \"$TITLE_FILE\"\n  exit 0\nfi\nif [[ \"$*\" == *\"issue view 1153 -R owner/repo --json labels -q .labels[].name\"* ]]; then\n  cat \"$LABELS_FILE\"\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity\"* ]]; then\n  printf '[v0.87.1][tools] Metadata parity\\n' > \"$TITLE_FILE\"\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo\"* && \"$*\" == *\"--add-label version:v0.87.1\"* ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.86\\nversion:v0.87.1\\n' > \"$LABELS_FILE\"\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo\"* && \"$*\" == *\"--remove-label version:v0.86\"* ]]; then\n  printf 'track:roadmap\\ntype:task\\narea:tools\\nversion:v0.87.1\\n' > \"$LABELS_FILE\"\n  exit 0\nfi\nif [[ \"$*\" == *\"issue edit 1153 -R owner/repo --body-file \"* ]]; then\n  body_file=\"${{@:$#}}\"\n  cat \"$body_file\" > \"$BODY_FILE\"\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            title_state.display(),
+            labels_state.display(),
+            body_state.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    let created = gh_issue_create(
+        "owner/repo",
+        "[v0.87.1][tools] Metadata parity",
+        "Seed body",
+        "track:roadmap,type:task,area:tools,version:v0.87.1",
+    )
+    .expect("issue create");
+    assert_eq!(created, "https://github.com/owner/repo/issues/1153");
+
+    ensure_issue_metadata_parity(
+        "owner/repo",
+        1153,
+        "[v0.87.1][tools] Metadata parity",
+        "track:roadmap,type:task,area:tools,version:v0.87.1",
+    )
+    .expect("metadata parity");
+    gh_issue_edit_body("owner/repo", 1153, "Refined issue body").expect("edit body");
+    assert_eq!(
+        gh_issue_title(1153, "owner/repo").expect("title"),
+        Some("[v0.87.1][tools] Metadata parity".to_string())
+    );
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(gh_log.contains(
+        "issue create -R owner/repo --title [v0.87.1][tools] Metadata parity --body Seed body"
+    ));
+    assert!(gh_log.contains("issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity"));
+    assert!(gh_log.contains("--add-label version:v0.87.1"));
+    assert!(gh_log.contains("--remove-label version:v0.86"));
+    assert_eq!(
+        fs::read_to_string(&body_state).expect("body state"),
+        "Refined issue body"
+    );
+}
+
+#[test]
+fn github_closing_linkage_helpers_cover_body_fallback_and_repair_paths() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-closing-linkage-helpers");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let gh_log = temp.join("gh.log");
+    let linkage_state = temp.join("closing-state.txt");
+    fs::write(&linkage_state, "body_only\n").expect("seed linkage state");
+    write_executable(
+        &bin_dir.join("gh"),
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nSTATE='{}'\nif [[ \"$*\" == *\"pr view -R owner/repo https://github.com/owner/repo/pull/1 --json closingIssuesReferences --jq .closingIssuesReferences[]?.number\"* ]]; then\n  if grep -q linked \"$STATE\"; then\n    printf '1153\\n'\n  fi\n  exit 0\nfi\nif [[ \"$*\" == *\"pr view -R owner/repo https://github.com/owner/repo/pull/1 --json body --jq .body\"* ]]; then\n  if grep -q body_only \"$STATE\"; then\n    printf 'Closes #1153\\n'\n  else\n    printf 'No close keyword present\\n'\n  fi\n  exit 0\nfi\nif [[ \"$*\" == *\"pr edit -R owner/repo https://github.com/owner/repo/pull/1 --body-file \"* ]]; then\n  printf 'linked\\n' > \"$STATE\"\n  exit 0\nfi\nexit 1\n",
+            gh_log.display(),
+            linkage_state.display()
+        ),
+    );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+
+    assert!(
+        pr_has_closing_linkage("owner/repo", "https://github.com/owner/repo/pull/1", 1153)
+            .expect("body fallback linkage")
+    );
+    ensure_pr_closing_linkage(
+        "owner/repo",
+        "https://github.com/owner/repo/pull/1",
+        1153,
+        false,
+    )
+    .expect("body fallback should satisfy close linkage");
+
+    fs::write(&linkage_state, "repair_needed\n").expect("reset linkage state");
+    let desired_body = temp.join("desired-body.md");
+    fs::write(&desired_body, "Closes #1153\n").expect("desired body");
+    assert!(
+        ensure_or_repair_pr_closing_linkage(
+            "owner/repo",
+            "https://github.com/owner/repo/pull/1",
+            1153,
+            false,
+            &desired_body,
+        )
+        .expect("repair linkage")
+    );
+
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log");
+    assert!(gh_log.contains("pr view -R owner/repo https://github.com/owner/repo/pull/1 --json closingIssuesReferences --jq .closingIssuesReferences[]?.number"));
+    assert!(gh_log.contains("pr view -R owner/repo https://github.com/owner/repo/pull/1 --json body --jq .body"));
+    assert!(gh_log.contains("pr edit -R owner/repo https://github.com/owner/repo/pull/1 --body-file"));
 }
 
 #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::cli::pr_cmd::github::{
-    current_pr_url, ensure_issue_metadata_parity, gh_issue_create, gh_issue_edit_body,
-    gh_issue_title, pr_has_closing_linkage, ensure_pr_closing_linkage,
-    ensure_or_repair_pr_closing_linkage, OpenPullRequest,
+    current_pr_url, ensure_issue_metadata_parity, ensure_or_repair_pr_closing_linkage,
+    ensure_pr_closing_linkage, gh_issue_create, gh_issue_edit_body, gh_issue_title,
+    pr_has_closing_linkage, OpenPullRequest,
 };
 
 #[test]
@@ -666,7 +666,9 @@ fn github_issue_create_and_metadata_helpers_cover_direct_success_paths() {
     assert!(gh_log.contains(
         "issue create -R owner/repo --title [v0.87.1][tools] Metadata parity --body Seed body"
     ));
-    assert!(gh_log.contains("issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity"));
+    assert!(
+        gh_log.contains("issue edit 1153 -R owner/repo --title [v0.87.1][tools] Metadata parity")
+    );
     assert!(gh_log.contains("--add-label version:v0.87.1"));
     assert!(gh_log.contains("--remove-label version:v0.86"));
     assert_eq!(
@@ -713,16 +715,14 @@ fn github_closing_linkage_helpers_cover_body_fallback_and_repair_paths() {
     fs::write(&linkage_state, "repair_needed\n").expect("reset linkage state");
     let desired_body = temp.join("desired-body.md");
     fs::write(&desired_body, "Closes #1153\n").expect("desired body");
-    assert!(
-        ensure_or_repair_pr_closing_linkage(
-            "owner/repo",
-            "https://github.com/owner/repo/pull/1",
-            1153,
-            false,
-            &desired_body,
-        )
-        .expect("repair linkage")
-    );
+    assert!(ensure_or_repair_pr_closing_linkage(
+        "owner/repo",
+        "https://github.com/owner/repo/pull/1",
+        1153,
+        false,
+        &desired_body,
+    )
+    .expect("repair linkage"));
 
     unsafe {
         env::set_var("PATH", old_path);
@@ -730,8 +730,12 @@ fn github_closing_linkage_helpers_cover_body_fallback_and_repair_paths() {
 
     let gh_log = fs::read_to_string(&gh_log).expect("gh log");
     assert!(gh_log.contains("pr view -R owner/repo https://github.com/owner/repo/pull/1 --json closingIssuesReferences --jq .closingIssuesReferences[]?.number"));
-    assert!(gh_log.contains("pr view -R owner/repo https://github.com/owner/repo/pull/1 --json body --jq .body"));
-    assert!(gh_log.contains("pr edit -R owner/repo https://github.com/owner/repo/pull/1 --body-file"));
+    assert!(gh_log.contains(
+        "pr view -R owner/repo https://github.com/owner/repo/pull/1 --json body --jq .body"
+    ));
+    assert!(
+        gh_log.contains("pr edit -R owner/repo https://github.com/owner/repo/pull/1 --body-file")
+    );
 }
 
 #[test]

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -4,7 +4,6 @@ use super::*;
 mod access_control;
 mod bid_schema;
 mod boot_admission;
-#[cfg(feature = "slow-proof-tests")]
 mod challenge;
 mod citizen_lifecycle;
 mod common;
@@ -26,7 +25,6 @@ mod invariant_violation;
 mod kernel_loop;
 mod manifold;
 mod observatory;
-#[cfg(feature = "slow-proof-tests")]
 mod observatory_flagship;
 mod operator_control;
 mod private_state;

--- a/adl/src/runtime_v2/tests/private_state_sealing.rs
+++ b/adl/src/runtime_v2/tests/private_state_sealing.rs
@@ -233,7 +233,6 @@ fn runtime_v2_private_state_sealing_payload_is_not_raw_json_or_canonical_bytes()
     assert_ne!(sealed_payload, canonical);
 }
 
-#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_private_state_sealing_write_to_root_materializes_fixtures() {
     let artifacts = runtime_v2_private_state_sealing_contract().expect("sealing artifacts");


### PR DESCRIPTION
## Summary
- move the challenge and observatory flagship runtime-v2 coverage modules into the default lane
- expose the private-state sealing write-to-root fixture test in the default lane
- add always-on CLI coverage tests for github issue metadata helpers, closing-linkage helpers, and the direct finish happy path

## Validation
- cargo llvm-cov --manifest-path adl/Cargo.toml --package adl --tests --json --summary-only --output-path /tmp/2638-runtime-cov.json -- runtime_v2_
- cargo llvm-cov --manifest-path adl/Cargo.toml --package adl --tests --json --summary-only --output-path /tmp/2638-cli3-cov.json -- cli::pr_cmd::tests
- cargo test --manifest-path adl/Cargo.toml github_issue_create_and_metadata_helpers_cover_direct_success_paths -- --nocapture
- cargo test --manifest-path adl/Cargo.toml github_closing_linkage_helpers_cover_body_fallback_and_repair_paths -- --nocapture
- cargo test --manifest-path adl/Cargo.toml real_pr_finish_happy_path_is_covered_in_default_lane -- --nocapture
- cargo test --manifest-path adl/Cargo.toml runtime_v2_continuity_challenge_ -- --nocapture
- cargo test --manifest-path adl/Cargo.toml runtime_v2_observatory_flagship_ -- --nocapture
- cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_sealing_write_to_root_materializes_fixtures -- --nocapture

## Coverage result
- adl/src/cli/pr_cmd/github.rs: 85.86%
- adl/src/cli/pr_cmd/finish_support.rs: 82.34%
- adl/src/runtime_v2/challenge.rs: 88.43%
- adl/src/runtime_v2/observatory_flagship.rs: 85.64%
- adl/src/runtime_v2/private_state_sealing.rs: 82.46%

Closes #2638