### PR TITLE
[v0.90.5][Comms-06] Coding-agent invocation specialization and provider-neutral runner

### DIFF
--- a/adl/src/agent_comms.rs
+++ b/adl/src/agent_comms.rs
@@ -16,6 +16,9 @@ const ACIP_CONFORMANCE_REPORT_SCHEMA_VERSION: &str = "acip.conformance.report.v1
 const ACIP_REVIEW_INVOCATION_SCHEMA_VERSION: &str = "acip.review.invocation.v1";
 const ACIP_REVIEW_OUTCOME_SCHEMA_VERSION: &str = "acip.review.outcome.v1";
 const ACIP_REVIEW_FIXTURE_SCHEMA_VERSION: &str = "acip.review.fixture.v1";
+const ACIP_CODING_INVOCATION_SCHEMA_VERSION: &str = "acip.coding.invocation.v1";
+const ACIP_CODING_OUTCOME_SCHEMA_VERSION: &str = "acip.coding.outcome.v1";
+const ACIP_CODING_FIXTURE_SCHEMA_VERSION: &str = "acip.coding.fixture.v1";
 const MAX_CONTENT_CHARS: usize = 4_000;
 const MAX_INLINE_SUMMARY_CHARS: usize = 512;
 const MAX_LIST_LEN: usize = 16;
@@ -392,6 +395,93 @@ pub struct AcipReviewFixtureSetV1 {
     pub negative_cases: Vec<AcipReviewNegativeCaseV1>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcipCodingProviderLaneV1 {
+    CodexIssueWorktree,
+    ChatgptApi,
+    ClaudeApi,
+    LocalOllama,
+    OtherProposalOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcipCodingExecutionModeV1 {
+    WorktreeEdit,
+    UnappliedPatch,
+    StructuredProposal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcipCodingDispositionV1 {
+    PatchReadyForReview,
+    ProposalReadyForReview,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipCodingApprovalPolicyV1 {
+    pub review_required_before_pr_finish: bool,
+    pub required_review_schema_ref: String,
+    pub writer_session_id: String,
+    pub writer_model_ref: String,
+    pub forbid_same_session_blessing: bool,
+    pub forbid_same_model_blessing: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipCodingInvocationContractV1 {
+    pub schema_version: String,
+    pub invocation: AcipInvocationContractV1,
+    pub provider_lane: AcipCodingProviderLaneV1,
+    pub execution_mode: AcipCodingExecutionModeV1,
+    pub issue_ref: String,
+    pub task_bundle_ref: String,
+    pub issue_worktree_required: bool,
+    pub allowed_edit_paths: Vec<String>,
+    pub validation_commands: Vec<String>,
+    pub patch_format: String,
+    pub approval_policy: AcipCodingApprovalPolicyV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipCodingOutcomeV1 {
+    pub schema_version: String,
+    pub invocation_id: String,
+    pub provider_lane: AcipCodingProviderLaneV1,
+    pub execution_mode: AcipCodingExecutionModeV1,
+    pub disposition: AcipCodingDispositionV1,
+    pub primary_output_ref: String,
+    pub validation_result_refs: Vec<String>,
+    pub review_handoff_ref: String,
+    pub writer_session_id: String,
+    pub writer_model_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipCodingNegativeCaseV1 {
+    pub name: String,
+    pub expected_error_substring: String,
+    pub contract: JsonValue,
+    pub outcome: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipCodingFixtureSetV1 {
+    pub schema_version: String,
+    pub valid_codex_contract: AcipCodingInvocationContractV1,
+    pub valid_codex_outcome: AcipCodingOutcomeV1,
+    pub valid_patch_contract: AcipCodingInvocationContractV1,
+    pub valid_patch_outcome: AcipCodingOutcomeV1,
+    pub negative_cases: Vec<AcipCodingNegativeCaseV1>,
+}
+
 pub fn acip_message_envelope_v1_schema_json() -> Result<String> {
     serde_json::to_string_pretty(&schema_for!(AcipMessageEnvelopeV1))
         .context("serialize ACIP message envelope v1 schema")
@@ -437,6 +527,21 @@ pub fn acip_review_fixture_set_v1_schema_json() -> Result<String> {
         .context("serialize ACIP review fixture set v1 schema")
 }
 
+pub fn acip_coding_invocation_v1_schema_json() -> Result<String> {
+    serde_json::to_string_pretty(&schema_for!(AcipCodingInvocationContractV1))
+        .context("serialize ACIP coding invocation contract v1 schema")
+}
+
+pub fn acip_coding_outcome_v1_schema_json() -> Result<String> {
+    serde_json::to_string_pretty(&schema_for!(AcipCodingOutcomeV1))
+        .context("serialize ACIP coding outcome v1 schema")
+}
+
+pub fn acip_coding_fixture_set_v1_schema_json() -> Result<String> {
+    serde_json::to_string_pretty(&schema_for!(AcipCodingFixtureSetV1))
+        .context("serialize ACIP coding fixture set v1 schema")
+}
+
 pub fn validate_acip_review_invocation_contract_v1_value(
     value: &JsonValue,
 ) -> Result<AcipReviewInvocationContractV1> {
@@ -453,6 +558,25 @@ pub fn validate_acip_review_outcome_v1_value(
     let outcome: AcipReviewOutcomeV1 =
         serde_json::from_value(value.clone()).context("parse ACIP review outcome v1")?;
     validate_acip_review_outcome_v1(contract, &outcome)?;
+    Ok(outcome)
+}
+
+pub fn validate_acip_coding_invocation_contract_v1_value(
+    value: &JsonValue,
+) -> Result<AcipCodingInvocationContractV1> {
+    let contract: AcipCodingInvocationContractV1 = serde_json::from_value(value.clone())
+        .context("parse ACIP coding invocation contract v1")?;
+    validate_acip_coding_invocation_contract_v1(&contract)?;
+    Ok(contract)
+}
+
+pub fn validate_acip_coding_outcome_v1_value(
+    contract: &AcipCodingInvocationContractV1,
+    value: &JsonValue,
+) -> Result<AcipCodingOutcomeV1> {
+    let outcome: AcipCodingOutcomeV1 =
+        serde_json::from_value(value.clone()).context("parse ACIP coding outcome v1")?;
+    validate_acip_coding_outcome_v1(contract, &outcome)?;
     Ok(outcome)
 }
 
@@ -1224,6 +1348,428 @@ pub fn validate_acip_review_fixture_set_v1(fixtures: &AcipReviewFixtureSetV1) ->
             Some(outcome_value) => match contract_result {
                 Ok(contract) => validate_negative_result(
                     validate_acip_review_outcome_v1_value(&contract, outcome_value).map(|_| ()),
+                    &case.expected_error_substring,
+                )?,
+                Err(error) => validate_negative_result(Err(error), &case.expected_error_substring)?,
+            },
+            None => validate_negative_result(
+                contract_result.map(|_| ()),
+                &case.expected_error_substring,
+            )?,
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_acip_coding_invocation_contract_v1(
+    contract: &AcipCodingInvocationContractV1,
+) -> Result<()> {
+    if contract.schema_version != ACIP_CODING_INVOCATION_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP coding invocation contract requires schema_version '{}'",
+            ACIP_CODING_INVOCATION_SCHEMA_VERSION
+        ));
+    }
+    validate_acip_invocation_contract_v1(&contract.invocation)?;
+    if contract.invocation.intent != AcipIntentV1::CodingRequest {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires invocation.intent 'coding_request'"
+        ));
+    }
+    validate_repo_relative_ref(&contract.issue_ref, "issue_ref")?;
+    validate_repo_relative_ref(&contract.task_bundle_ref, "task_bundle_ref")?;
+    if contract.allowed_edit_paths.is_empty() {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires allowed_edit_paths"
+        ));
+    }
+    for path in &contract.allowed_edit_paths {
+        validate_repo_relative_ref(path, "allowed_edit_paths[]")?;
+    }
+    if contract.validation_commands.is_empty() {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires validation_commands"
+        ));
+    }
+    for command in &contract.validation_commands {
+        validate_non_empty(command, "validation_commands[]")?;
+    }
+    validate_non_empty(&contract.patch_format, "patch_format")?;
+    if !contract
+        .invocation
+        .input_refs
+        .iter()
+        .any(|reference| reference == &contract.task_bundle_ref)
+    {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires invocation.input_refs to include task_bundle_ref"
+        ));
+    }
+    if !contract
+        .invocation
+        .constraints
+        .required_capabilities
+        .iter()
+        .any(|capability| capability == "share_artifact")
+    {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires constraints.required_capabilities to include 'share_artifact'"
+        ));
+    }
+    for action in ["merge", "push", "self_review"] {
+        if !contract
+            .invocation
+            .constraints
+            .prohibited_actions
+            .iter()
+            .any(|prohibited| prohibited == action)
+        {
+            return Err(anyhow!(
+                "ACIP coding invocation specialization requires constraints.prohibited_actions to include '{}'",
+                action
+            ));
+        }
+    }
+    if contract.invocation.authority_scope.delegation_permitted {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization must not permit delegation inside the authority_scope"
+        ));
+    }
+    if !contract.invocation.stop_policy.stop_on_refusal {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires stop_policy.stop_on_refusal to be true"
+        ));
+    }
+    if !contract.invocation.stop_policy.stop_on_failure {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires stop_policy.stop_on_failure to be true"
+        ));
+    }
+    if !contract.approval_policy.review_required_before_pr_finish {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization requires review before PR finish"
+        ));
+    }
+    if contract.approval_policy.required_review_schema_ref != ACIP_REVIEW_INVOCATION_SCHEMA_VERSION
+    {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization must route to review schema '{}'",
+            ACIP_REVIEW_INVOCATION_SCHEMA_VERSION
+        ));
+    }
+    validate_id(
+        &contract.approval_policy.writer_session_id,
+        "approval_policy.writer_session_id",
+    )?;
+    validate_id(
+        &contract.approval_policy.writer_model_ref,
+        "approval_policy.writer_model_ref",
+    )?;
+    if !contract.approval_policy.forbid_same_session_blessing {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization must forbid same-session blessing"
+        ));
+    }
+    if !contract.approval_policy.forbid_same_model_blessing {
+        return Err(anyhow!(
+            "ACIP coding invocation specialization must forbid same-model blessing"
+        ));
+    }
+
+    match contract.provider_lane {
+        AcipCodingProviderLaneV1::CodexIssueWorktree => {
+            if !contract
+                .invocation
+                .constraints
+                .required_capabilities
+                .iter()
+                .any(|capability| capability == "code_edit")
+            {
+                return Err(anyhow!(
+                    "codex_issue_worktree lane requires constraints.required_capabilities to include 'code_edit'"
+                ));
+            }
+            if contract.execution_mode != AcipCodingExecutionModeV1::WorktreeEdit {
+                return Err(anyhow!(
+                    "codex_issue_worktree lane requires execution_mode 'worktree_edit'"
+                ));
+            }
+            if !contract.issue_worktree_required {
+                return Err(anyhow!(
+                    "codex_issue_worktree lane requires issue_worktree_required to be true"
+                ));
+            }
+        }
+        AcipCodingProviderLaneV1::ChatgptApi => {
+            if contract.execution_mode == AcipCodingExecutionModeV1::WorktreeEdit {
+                return Err(anyhow!(
+                    "only codex_issue_worktree lane may use execution_mode 'worktree_edit'"
+                ));
+            }
+            if contract.issue_worktree_required {
+                return Err(anyhow!(
+                    "proposal-only coding lanes must set issue_worktree_required to false"
+                ));
+            }
+            if contract.execution_mode == AcipCodingExecutionModeV1::StructuredProposal {
+                return Err(anyhow!(
+                    "chatgpt_api lane does not permit execution_mode 'structured_proposal'"
+                ));
+            }
+            if contract
+                .invocation
+                .constraints
+                .required_capabilities
+                .iter()
+                .any(|capability| capability == "code_edit")
+            {
+                return Err(anyhow!(
+                    "proposal-only coding lanes must not claim 'code_edit' capability"
+                ));
+            }
+            if !contract
+                .invocation
+                .constraints
+                .required_capabilities
+                .iter()
+                .any(|capability| capability == "propose_change")
+            {
+                return Err(anyhow!(
+                    "proposal-only coding lanes require constraints.required_capabilities to include 'propose_change'"
+                ));
+            }
+        }
+        AcipCodingProviderLaneV1::ClaudeApi
+        | AcipCodingProviderLaneV1::LocalOllama
+        | AcipCodingProviderLaneV1::OtherProposalOnly => {
+            if contract.execution_mode == AcipCodingExecutionModeV1::WorktreeEdit {
+                return Err(anyhow!(
+                    "only codex_issue_worktree lane may use execution_mode 'worktree_edit'"
+                ));
+            }
+            if contract.issue_worktree_required {
+                return Err(anyhow!(
+                    "proposal-only coding lanes must set issue_worktree_required to false"
+                ));
+            }
+            if contract
+                .invocation
+                .constraints
+                .required_capabilities
+                .iter()
+                .any(|capability| capability == "code_edit")
+            {
+                return Err(anyhow!(
+                    "proposal-only coding lanes must not claim 'code_edit' capability"
+                ));
+            }
+            if !contract
+                .invocation
+                .constraints
+                .required_capabilities
+                .iter()
+                .any(|capability| capability == "propose_change")
+            {
+                return Err(anyhow!(
+                    "proposal-only coding lanes require constraints.required_capabilities to include 'propose_change'"
+                ));
+            }
+        }
+    }
+
+    let required_output_kind = match contract.execution_mode {
+        AcipCodingExecutionModeV1::WorktreeEdit => {
+            if contract.patch_format != "patch_manifest_v1" {
+                return Err(anyhow!(
+                    "worktree_edit coding invocation requires patch_format 'patch_manifest_v1'"
+                ));
+            }
+            "patch_manifest"
+        }
+        AcipCodingExecutionModeV1::UnappliedPatch => {
+            if contract.patch_format != "unified_diff" {
+                return Err(anyhow!(
+                    "unapplied_patch coding invocation requires patch_format 'unified_diff'"
+                ));
+            }
+            "patch_diff"
+        }
+        AcipCodingExecutionModeV1::StructuredProposal => {
+            if contract.patch_format != "structured_proposal_v1" {
+                return Err(anyhow!(
+                    "structured_proposal coding invocation requires patch_format 'structured_proposal_v1'"
+                ));
+            }
+            "structured_proposal"
+        }
+    };
+
+    if !contract
+        .invocation
+        .expected_outputs
+        .iter()
+        .any(|output| output.required && output.output_kind == required_output_kind)
+    {
+        return Err(anyhow!(
+            "coding invocation specialization requires expected_outputs to declare required {} output",
+            required_output_kind
+        ));
+    }
+    for output_kind in ["validation_summary", "review_handoff"] {
+        if !contract
+            .invocation
+            .expected_outputs
+            .iter()
+            .any(|output| output.required && output.output_kind == output_kind)
+        {
+            return Err(anyhow!(
+                "coding invocation specialization requires expected_outputs to declare required {} output",
+                output_kind
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_acip_coding_outcome_v1(
+    contract: &AcipCodingInvocationContractV1,
+    outcome: &AcipCodingOutcomeV1,
+) -> Result<()> {
+    validate_acip_coding_invocation_contract_v1(contract)?;
+    if outcome.schema_version != ACIP_CODING_OUTCOME_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP coding outcome requires schema_version '{}'",
+            ACIP_CODING_OUTCOME_SCHEMA_VERSION
+        ));
+    }
+    validate_id(&outcome.invocation_id, "invocation_id")?;
+    validate_repo_relative_ref(&outcome.primary_output_ref, "primary_output_ref")?;
+    if outcome.validation_result_refs.is_empty() {
+        return Err(anyhow!(
+            "ACIP coding outcome requires validation_result_refs"
+        ));
+    }
+    for reference in &outcome.validation_result_refs {
+        validate_repo_relative_ref(reference, "validation_result_refs[]")?;
+    }
+    if !outcome
+        .validation_result_refs
+        .iter()
+        .any(|reference| reference.ends_with("validation_summary.json"))
+    {
+        return Err(anyhow!(
+            "coding outcome validation_result_refs must include the declared validation_summary output contract"
+        ));
+    }
+    validate_repo_relative_ref(&outcome.review_handoff_ref, "review_handoff_ref")?;
+    validate_id(&outcome.writer_session_id, "writer_session_id")?;
+    validate_id(&outcome.writer_model_ref, "writer_model_ref")?;
+
+    if contract.invocation.invocation_id != outcome.invocation_id {
+        return Err(anyhow!(
+            "coding outcome must match the invocation contract invocation_id"
+        ));
+    }
+    if contract.provider_lane != outcome.provider_lane {
+        return Err(anyhow!(
+            "coding outcome must preserve the provider_lane declared by the invocation contract"
+        ));
+    }
+    if contract.execution_mode != outcome.execution_mode {
+        return Err(anyhow!(
+            "coding outcome must preserve the execution_mode declared by the invocation contract"
+        ));
+    }
+    if contract.approval_policy.writer_session_id != outcome.writer_session_id {
+        return Err(anyhow!(
+            "coding outcome must preserve the writer_session_id declared by the approval policy"
+        ));
+    }
+    if contract.approval_policy.writer_model_ref != outcome.writer_model_ref {
+        return Err(anyhow!(
+            "coding outcome must preserve the writer_model_ref declared by the approval policy"
+        ));
+    }
+    if !outcome.review_handoff_ref.ends_with("review_handoff.json") {
+        return Err(anyhow!(
+            "coding outcome review_handoff_ref must match the declared review_handoff output contract"
+        ));
+    }
+
+    match contract.execution_mode {
+        AcipCodingExecutionModeV1::WorktreeEdit => {
+            if outcome.disposition != AcipCodingDispositionV1::PatchReadyForReview {
+                return Err(anyhow!(
+                    "worktree_edit coding outcome must use disposition 'patch_ready_for_review'"
+                ));
+            }
+            if !outcome.primary_output_ref.ends_with("patch_manifest.json") {
+                return Err(anyhow!(
+                    "coding outcome primary_output_ref must match the declared patch_manifest output contract"
+                ));
+            }
+        }
+        AcipCodingExecutionModeV1::UnappliedPatch => {
+            if outcome.disposition != AcipCodingDispositionV1::ProposalReadyForReview {
+                return Err(anyhow!(
+                    "unapplied_patch coding outcome must use disposition 'proposal_ready_for_review'"
+                ));
+            }
+            if !outcome.primary_output_ref.ends_with(".diff") {
+                return Err(anyhow!(
+                    "coding outcome primary_output_ref must match the declared patch_diff output contract"
+                ));
+            }
+        }
+        AcipCodingExecutionModeV1::StructuredProposal => {
+            if outcome.disposition != AcipCodingDispositionV1::ProposalReadyForReview {
+                return Err(anyhow!(
+                    "structured_proposal coding outcome must use disposition 'proposal_ready_for_review'"
+                ));
+            }
+            if !outcome.primary_output_ref.ends_with("proposal.json") {
+                return Err(anyhow!(
+                    "coding outcome primary_output_ref must match the declared structured_proposal output contract"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_acip_coding_fixture_set_v1(fixtures: &AcipCodingFixtureSetV1) -> Result<()> {
+    if fixtures.schema_version != ACIP_CODING_FIXTURE_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP coding fixture set requires schema_version '{}'",
+            ACIP_CODING_FIXTURE_SCHEMA_VERSION
+        ));
+    }
+    if fixtures.negative_cases.is_empty() {
+        return Err(anyhow!("ACIP coding fixture set requires negative_cases"));
+    }
+    validate_acip_coding_invocation_contract_v1(&fixtures.valid_codex_contract)?;
+    validate_acip_coding_outcome_v1(
+        &fixtures.valid_codex_contract,
+        &fixtures.valid_codex_outcome,
+    )?;
+    validate_acip_coding_invocation_contract_v1(&fixtures.valid_patch_contract)?;
+    validate_acip_coding_outcome_v1(
+        &fixtures.valid_patch_contract,
+        &fixtures.valid_patch_outcome,
+    )?;
+    for case in &fixtures.negative_cases {
+        validate_negative_case_name(&case.name, "negative_cases[].name")?;
+        validate_non_empty(
+            &case.expected_error_substring,
+            "negative_cases[].expected_error_substring",
+        )?;
+        let contract_result = validate_acip_coding_invocation_contract_v1_value(&case.contract);
+        match &case.outcome {
+            Some(outcome_value) => match contract_result {
+                Ok(contract) => validate_negative_result(
+                    validate_acip_coding_outcome_v1_value(&contract, outcome_value).map(|_| ()),
                     &case.expected_error_substring,
                 )?,
                 Err(error) => validate_negative_result(Err(error), &case.expected_error_substring)?,
@@ -2145,6 +2691,207 @@ pub fn acip_review_fixture_set_v1() -> AcipReviewFixtureSetV1 {
     }
 }
 
+pub fn acip_coding_fixture_set_v1() -> AcipCodingFixtureSetV1 {
+    let valid_codex_contract = sample_coding_invocation_contract(
+        AcipCodingProviderLaneV1::CodexIssueWorktree,
+        AcipCodingExecutionModeV1::WorktreeEdit,
+    );
+    let valid_patch_contract = sample_coding_invocation_contract(
+        AcipCodingProviderLaneV1::ChatgptApi,
+        AcipCodingExecutionModeV1::UnappliedPatch,
+    );
+
+    AcipCodingFixtureSetV1 {
+        schema_version: ACIP_CODING_FIXTURE_SCHEMA_VERSION.to_string(),
+        valid_codex_outcome: sample_coding_outcome(&valid_codex_contract),
+        valid_patch_outcome: sample_coding_outcome(&valid_patch_contract),
+        negative_cases: vec![
+            AcipCodingNegativeCaseV1 {
+                name: "non_codex_worktree_edit_rejected".to_string(),
+                expected_error_substring:
+                    "only codex_issue_worktree lane may use execution_mode 'worktree_edit'"
+                        .to_string(),
+                contract: serde_json::to_value(sample_coding_invocation_contract(
+                    AcipCodingProviderLaneV1::ChatgptApi,
+                    AcipCodingExecutionModeV1::WorktreeEdit,
+                ))
+                .expect("json"),
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "proposal_lane_code_edit_capability_rejected".to_string(),
+                expected_error_substring:
+                    "proposal-only coding lanes must not claim 'code_edit' capability"
+                        .to_string(),
+                contract: {
+                    let mut value = serde_json::to_value(sample_coding_invocation_contract(
+                        AcipCodingProviderLaneV1::ChatgptApi,
+                        AcipCodingExecutionModeV1::UnappliedPatch,
+                    ))
+                    .expect("json");
+                    value["invocation"]["constraints"]["required_capabilities"] =
+                        json!(["code_edit", "share_artifact"]);
+                    value
+                },
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "chatgpt_structured_proposal_rejected".to_string(),
+                expected_error_substring:
+                    "chatgpt_api lane does not permit execution_mode 'structured_proposal'"
+                        .to_string(),
+                contract: serde_json::to_value(sample_coding_invocation_contract(
+                    AcipCodingProviderLaneV1::ChatgptApi,
+                    AcipCodingExecutionModeV1::StructuredProposal,
+                ))
+                .expect("json"),
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "proposal_lane_worktree_flag_rejected".to_string(),
+                expected_error_substring:
+                    "proposal-only coding lanes must set issue_worktree_required to false"
+                        .to_string(),
+                contract: {
+                    let mut value = serde_json::to_value(sample_coding_invocation_contract(
+                        AcipCodingProviderLaneV1::ClaudeApi,
+                        AcipCodingExecutionModeV1::StructuredProposal,
+                    ))
+                    .expect("json");
+                    value["issue_worktree_required"] = json!(true);
+                    value
+                },
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "codex_requires_issue_worktree_rejected".to_string(),
+                expected_error_substring:
+                    "codex_issue_worktree lane requires issue_worktree_required to be true"
+                        .to_string(),
+                contract: {
+                    let mut value = serde_json::to_value(sample_coding_invocation_contract(
+                        AcipCodingProviderLaneV1::CodexIssueWorktree,
+                        AcipCodingExecutionModeV1::WorktreeEdit,
+                    ))
+                    .expect("json");
+                    value["issue_worktree_required"] = json!(false);
+                    value
+                },
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "missing_task_bundle_input_rejected".to_string(),
+                expected_error_substring:
+                    "requires invocation.input_refs to include task_bundle_ref".to_string(),
+                contract: {
+                    let mut value = serde_json::to_value(sample_coding_invocation_contract(
+                        AcipCodingProviderLaneV1::CodexIssueWorktree,
+                        AcipCodingExecutionModeV1::WorktreeEdit,
+                    ))
+                    .expect("json");
+                    value["invocation"]["input_refs"] = json!([
+                        "runtime/comms/coding/issue_context.md",
+                        "runtime/comms/coding/current_scope.json"
+                    ]);
+                    value
+                },
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "missing_merge_prohibition_rejected".to_string(),
+                expected_error_substring:
+                    "requires constraints.prohibited_actions to include 'merge'".to_string(),
+                contract: {
+                    let mut value = serde_json::to_value(sample_coding_invocation_contract(
+                        AcipCodingProviderLaneV1::CodexIssueWorktree,
+                        AcipCodingExecutionModeV1::WorktreeEdit,
+                    ))
+                    .expect("json");
+                    value["invocation"]["constraints"]["prohibited_actions"] =
+                        json!(["push", "self_review"]);
+                    value
+                },
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "review_schema_drift_rejected".to_string(),
+                expected_error_substring: "must route to review schema 'acip.review.invocation.v1'"
+                    .to_string(),
+                contract: {
+                    let mut value = serde_json::to_value(sample_coding_invocation_contract(
+                        AcipCodingProviderLaneV1::CodexIssueWorktree,
+                        AcipCodingExecutionModeV1::WorktreeEdit,
+                    ))
+                    .expect("json");
+                    value["approval_policy"]["required_review_schema_ref"] =
+                        json!("acip.review.invocation.v0");
+                    value
+                },
+                outcome: None,
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "outcome_output_contract_mismatch_rejected".to_string(),
+                expected_error_substring: "must match the declared patch_diff output contract"
+                    .to_string(),
+                contract: serde_json::to_value(valid_patch_contract.clone()).expect("json"),
+                outcome: Some({
+                    let mut value =
+                        serde_json::to_value(sample_coding_outcome(&valid_patch_contract))
+                            .expect("json");
+                    value["primary_output_ref"] = json!("runtime/comms/coding/proposal.json");
+                    value
+                }),
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "validation_summary_binding_rejected".to_string(),
+                expected_error_substring:
+                    "validation_result_refs must include the declared validation_summary output contract"
+                        .to_string(),
+                contract: serde_json::to_value(valid_codex_contract.clone()).expect("json"),
+                outcome: Some({
+                    let mut value =
+                        serde_json::to_value(sample_coding_outcome(&valid_codex_contract))
+                            .expect("json");
+                    value["validation_result_refs"] =
+                        json!(["runtime/comms/coding/some_other_artifact.json"]);
+                    value
+                }),
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "writer_identity_drift_rejected".to_string(),
+                expected_error_substring:
+                    "must preserve the writer_session_id declared by the approval policy"
+                        .to_string(),
+                contract: serde_json::to_value(valid_codex_contract.clone()).expect("json"),
+                outcome: Some({
+                    let mut value =
+                        serde_json::to_value(sample_coding_outcome(&valid_codex_contract))
+                            .expect("json");
+                    value["writer_session_id"] = json!("someone-else");
+                    value
+                }),
+            },
+            AcipCodingNegativeCaseV1 {
+                name: "stop_boundary_drift_rejected".to_string(),
+                expected_error_substring:
+                    "requires stop_policy.stop_on_refusal to be true".to_string(),
+                contract: {
+                    let mut value = serde_json::to_value(sample_coding_invocation_contract(
+                        AcipCodingProviderLaneV1::CodexIssueWorktree,
+                        AcipCodingExecutionModeV1::WorktreeEdit,
+                    ))
+                    .expect("json");
+                    value["invocation"]["stop_policy"]["stop_on_refusal"] = json!(false);
+                    value
+                },
+                outcome: None,
+            },
+        ],
+        valid_codex_contract,
+        valid_patch_contract,
+    }
+}
+
 fn sample_message(
     message_id: &str,
     conversation_id: &str,
@@ -2423,6 +3170,223 @@ fn sample_review_outcome(
         findings_ref,
         residual_risk_refs,
         pr_open_allowed,
+    }
+}
+
+fn sample_coding_invocation_contract(
+    provider_lane: AcipCodingProviderLaneV1,
+    execution_mode: AcipCodingExecutionModeV1,
+) -> AcipCodingInvocationContractV1 {
+    let mut invocation = sample_invocation_contract();
+    invocation.invocation_id = match execution_mode {
+        AcipCodingExecutionModeV1::WorktreeEdit => "invoke-coding-worktree-0001".to_string(),
+        AcipCodingExecutionModeV1::UnappliedPatch => "invoke-coding-patch-0001".to_string(),
+        AcipCodingExecutionModeV1::StructuredProposal => "invoke-coding-proposal-0001".to_string(),
+    };
+    invocation.conversation_id = "conv-coding-001".to_string();
+    invocation.causal_message_id = "msg-coding-0001".to_string();
+    invocation.target.id = "coding.agent".to_string();
+    invocation.intent = AcipIntentV1::CodingRequest;
+    invocation.purpose =
+        "Perform bounded coding work and return a reviewable patch or proposal surface."
+            .to_string();
+    invocation.input_refs = vec![
+        "runtime/comms/coding/task_bundle.json".to_string(),
+        "runtime/comms/coding/issue_context.md".to_string(),
+        "runtime/comms/coding/current_scope.json".to_string(),
+    ];
+    invocation.constraints.policy_refs = vec![
+        "runtime/comms/coding/workflow_conductor_policy.md".to_string(),
+        "runtime/comms/policy/coding_policy.json".to_string(),
+    ];
+    invocation.constraints.prohibited_actions = vec![
+        "merge".to_string(),
+        "push".to_string(),
+        "self_review".to_string(),
+    ];
+    invocation.stop_policy.max_turns = 4;
+    invocation.stop_policy.max_output_artifacts = 3;
+    invocation.stop_policy.completion_condition =
+        "emit reviewable coding output and validation evidence".to_string();
+    invocation.authority_scope.allowed_actions =
+        vec!["invoke".to_string(), "share_artifact".to_string()];
+    invocation.authority_scope.authority_basis_refs =
+        vec!["runtime/comms/authority/coding_basis.json".to_string()];
+    invocation.authority_scope.delegation_permitted = false;
+    invocation.decision_event_ref = "gate.coding-0001".to_string();
+    invocation.response_channel = AcipResponseChannelV1 {
+        kind: AcipResponseChannelKindV1::ArtifactReply,
+        channel_ref: "runtime/comms/coding/outcome.json".to_string(),
+    };
+    invocation.expected_outputs = match execution_mode {
+        AcipCodingExecutionModeV1::WorktreeEdit => vec![
+            AcipExpectedOutputV1 {
+                output_id: "patch_manifest".to_string(),
+                output_kind: "patch_manifest".to_string(),
+                artifact_role: "worktree_change_manifest".to_string(),
+                schema_ref: Some("schemas/coding_patch_manifest.schema.json".to_string()),
+                required: true,
+            },
+            AcipExpectedOutputV1 {
+                output_id: "validation_summary".to_string(),
+                output_kind: "validation_summary".to_string(),
+                artifact_role: "validation_summary".to_string(),
+                schema_ref: Some("schemas/validation_summary.schema.json".to_string()),
+                required: true,
+            },
+            AcipExpectedOutputV1 {
+                output_id: "review_handoff".to_string(),
+                output_kind: "review_handoff".to_string(),
+                artifact_role: "review_handoff".to_string(),
+                schema_ref: Some("schemas/review_handoff.schema.json".to_string()),
+                required: true,
+            },
+        ],
+        AcipCodingExecutionModeV1::UnappliedPatch => vec![
+            AcipExpectedOutputV1 {
+                output_id: "patch_diff".to_string(),
+                output_kind: "patch_diff".to_string(),
+                artifact_role: "proposed_patch".to_string(),
+                schema_ref: Some("schemas/unified_diff.schema.json".to_string()),
+                required: true,
+            },
+            AcipExpectedOutputV1 {
+                output_id: "validation_summary".to_string(),
+                output_kind: "validation_summary".to_string(),
+                artifact_role: "validation_summary".to_string(),
+                schema_ref: Some("schemas/validation_summary.schema.json".to_string()),
+                required: true,
+            },
+            AcipExpectedOutputV1 {
+                output_id: "review_handoff".to_string(),
+                output_kind: "review_handoff".to_string(),
+                artifact_role: "review_handoff".to_string(),
+                schema_ref: Some("schemas/review_handoff.schema.json".to_string()),
+                required: true,
+            },
+        ],
+        AcipCodingExecutionModeV1::StructuredProposal => vec![
+            AcipExpectedOutputV1 {
+                output_id: "structured_proposal".to_string(),
+                output_kind: "structured_proposal".to_string(),
+                artifact_role: "proposed_change_plan".to_string(),
+                schema_ref: Some("schemas/coding_proposal.schema.json".to_string()),
+                required: true,
+            },
+            AcipExpectedOutputV1 {
+                output_id: "validation_summary".to_string(),
+                output_kind: "validation_summary".to_string(),
+                artifact_role: "validation_summary".to_string(),
+                schema_ref: Some("schemas/validation_summary.schema.json".to_string()),
+                required: true,
+            },
+            AcipExpectedOutputV1 {
+                output_id: "review_handoff".to_string(),
+                output_kind: "review_handoff".to_string(),
+                artifact_role: "review_handoff".to_string(),
+                schema_ref: Some("schemas/review_handoff.schema.json".to_string()),
+                required: true,
+            },
+        ],
+    };
+
+    let (writer_session_id, writer_model_ref) = match provider_lane {
+        AcipCodingProviderLaneV1::CodexIssueWorktree => (
+            "writer-session-codex".to_string(),
+            "gpt-5-codex".to_string(),
+        ),
+        AcipCodingProviderLaneV1::ChatgptApi => {
+            ("writer-session-openai".to_string(), "gpt-5-api".to_string())
+        }
+        AcipCodingProviderLaneV1::ClaudeApi => (
+            "writer-session-anthropic".to_string(),
+            "claude-api".to_string(),
+        ),
+        AcipCodingProviderLaneV1::LocalOllama => (
+            "writer-session-ollama".to_string(),
+            "gemma3-local".to_string(),
+        ),
+        AcipCodingProviderLaneV1::OtherProposalOnly => (
+            "writer-session-other".to_string(),
+            "other-provider".to_string(),
+        ),
+    };
+
+    invocation.constraints.required_capabilities = match provider_lane {
+        AcipCodingProviderLaneV1::CodexIssueWorktree => {
+            vec!["code_edit".to_string(), "share_artifact".to_string()]
+        }
+        AcipCodingProviderLaneV1::ChatgptApi
+        | AcipCodingProviderLaneV1::ClaudeApi
+        | AcipCodingProviderLaneV1::LocalOllama
+        | AcipCodingProviderLaneV1::OtherProposalOnly => {
+            vec!["propose_change".to_string(), "share_artifact".to_string()]
+        }
+    };
+
+    AcipCodingInvocationContractV1 {
+        schema_version: ACIP_CODING_INVOCATION_SCHEMA_VERSION.to_string(),
+        invocation,
+        provider_lane: provider_lane.clone(),
+        execution_mode: execution_mode.clone(),
+        issue_ref: "issues/2627".to_string(),
+        task_bundle_ref: "runtime/comms/coding/task_bundle.json".to_string(),
+        issue_worktree_required: provider_lane == AcipCodingProviderLaneV1::CodexIssueWorktree,
+        allowed_edit_paths: vec![
+            "adl/src/agent_comms.rs".to_string(),
+            "docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md".to_string(),
+            "docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md".to_string(),
+            "docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md".to_string(),
+            "docs/milestones/v0.90.5/features/README.md".to_string(),
+            "docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md".to_string(),
+        ],
+        validation_commands: vec![
+            "cargo fmt --check".to_string(),
+            "cargo test agent_comms --lib".to_string(),
+        ],
+        patch_format: match execution_mode {
+            AcipCodingExecutionModeV1::WorktreeEdit => "patch_manifest_v1".to_string(),
+            AcipCodingExecutionModeV1::UnappliedPatch => "unified_diff".to_string(),
+            AcipCodingExecutionModeV1::StructuredProposal => "structured_proposal_v1".to_string(),
+        },
+        approval_policy: AcipCodingApprovalPolicyV1 {
+            review_required_before_pr_finish: true,
+            required_review_schema_ref: ACIP_REVIEW_INVOCATION_SCHEMA_VERSION.to_string(),
+            writer_session_id,
+            writer_model_ref,
+            forbid_same_session_blessing: true,
+            forbid_same_model_blessing: true,
+        },
+    }
+}
+
+fn sample_coding_outcome(contract: &AcipCodingInvocationContractV1) -> AcipCodingOutcomeV1 {
+    let (disposition, primary_output_ref) = match contract.execution_mode {
+        AcipCodingExecutionModeV1::WorktreeEdit => (
+            AcipCodingDispositionV1::PatchReadyForReview,
+            "runtime/comms/coding/patch_manifest.json".to_string(),
+        ),
+        AcipCodingExecutionModeV1::UnappliedPatch => (
+            AcipCodingDispositionV1::ProposalReadyForReview,
+            "runtime/comms/coding/proposed_changes.diff".to_string(),
+        ),
+        AcipCodingExecutionModeV1::StructuredProposal => (
+            AcipCodingDispositionV1::ProposalReadyForReview,
+            "runtime/comms/coding/proposal.json".to_string(),
+        ),
+    };
+
+    AcipCodingOutcomeV1 {
+        schema_version: ACIP_CODING_OUTCOME_SCHEMA_VERSION.to_string(),
+        invocation_id: contract.invocation.invocation_id.clone(),
+        provider_lane: contract.provider_lane.clone(),
+        execution_mode: contract.execution_mode.clone(),
+        disposition,
+        primary_output_ref,
+        validation_result_refs: vec!["runtime/comms/coding/validation_summary.json".to_string()],
+        review_handoff_ref: "runtime/comms/coding/review_handoff.json".to_string(),
+        writer_session_id: contract.approval_policy.writer_session_id.clone(),
+        writer_model_ref: contract.approval_policy.writer_model_ref.clone(),
     }
 }
 
@@ -3299,6 +4263,140 @@ mod tests {
         assert!(output_error
             .to_string()
             .contains("gate_result_ref must match the declared gate_result output contract"));
+    }
+
+    #[test]
+    fn acip_coding_specialization_schemas_and_fixtures_are_available() {
+        let contract_schema = acip_coding_invocation_v1_schema_json().expect("coding schema");
+        let outcome_schema = acip_coding_outcome_v1_schema_json().expect("outcome schema");
+        let fixture_schema = acip_coding_fixture_set_v1_schema_json().expect("fixture schema");
+        assert!(contract_schema.contains("\"provider_lane\""));
+        assert!(outcome_schema.contains("\"review_handoff_ref\""));
+        assert!(fixture_schema.contains("\"valid_codex_outcome\""));
+
+        let fixtures = acip_coding_fixture_set_v1();
+        validate_acip_coding_fixture_set_v1(&fixtures).expect("coding fixtures should validate");
+        assert_eq!(fixtures.negative_cases.len(), 12);
+    }
+
+    #[test]
+    fn acip_coding_specialization_rejects_non_codex_worktree_and_review_bypass() {
+        let fixtures = acip_coding_fixture_set_v1();
+
+        let non_codex = fixtures
+            .negative_cases
+            .iter()
+            .find(|case| case.name == "non_codex_worktree_edit_rejected")
+            .expect("non codex case");
+        let non_codex_contract: AcipCodingInvocationContractV1 =
+            serde_json::from_value(non_codex.contract.clone()).expect("contract");
+        let non_codex_error = validate_acip_coding_invocation_contract_v1(&non_codex_contract)
+            .expect_err("non-codex worktree edit should fail");
+        assert!(non_codex_error
+            .to_string()
+            .contains("only codex_issue_worktree lane may use execution_mode 'worktree_edit'"));
+
+        let review_schema = fixtures
+            .negative_cases
+            .iter()
+            .find(|case| case.name == "review_schema_drift_rejected")
+            .expect("review schema case");
+        let review_schema_contract: AcipCodingInvocationContractV1 =
+            serde_json::from_value(review_schema.contract.clone()).expect("contract");
+        let review_schema_error =
+            validate_acip_coding_invocation_contract_v1(&review_schema_contract)
+                .expect_err("review schema drift should fail");
+        assert!(review_schema_error
+            .to_string()
+            .contains("must route to review schema 'acip.review.invocation.v1'"));
+
+        let capability_case = fixtures
+            .negative_cases
+            .iter()
+            .find(|case| case.name == "proposal_lane_code_edit_capability_rejected")
+            .expect("capability case");
+        let capability_contract: AcipCodingInvocationContractV1 =
+            serde_json::from_value(capability_case.contract.clone()).expect("contract");
+        let capability_error = validate_acip_coding_invocation_contract_v1(&capability_contract)
+            .expect_err("proposal-only lane should not claim code_edit");
+        assert!(capability_error
+            .to_string()
+            .contains("proposal-only coding lanes must not claim 'code_edit' capability"));
+
+        let chatgpt_case = fixtures
+            .negative_cases
+            .iter()
+            .find(|case| case.name == "chatgpt_structured_proposal_rejected")
+            .expect("chatgpt case");
+        let chatgpt_contract: AcipCodingInvocationContractV1 =
+            serde_json::from_value(chatgpt_case.contract.clone()).expect("contract");
+        let chatgpt_error = validate_acip_coding_invocation_contract_v1(&chatgpt_contract)
+            .expect_err("chatgpt structured proposal should fail");
+        assert!(chatgpt_error
+            .to_string()
+            .contains("chatgpt_api lane does not permit execution_mode 'structured_proposal'"));
+
+        let worktree_flag_case = fixtures
+            .negative_cases
+            .iter()
+            .find(|case| case.name == "proposal_lane_worktree_flag_rejected")
+            .expect("worktree flag case");
+        let worktree_flag_contract: AcipCodingInvocationContractV1 =
+            serde_json::from_value(worktree_flag_case.contract.clone()).expect("contract");
+        let worktree_flag_error =
+            validate_acip_coding_invocation_contract_v1(&worktree_flag_contract)
+                .expect_err("proposal-only lane should not request issue worktree");
+        assert!(worktree_flag_error
+            .to_string()
+            .contains("proposal-only coding lanes must set issue_worktree_required to false"));
+    }
+
+    #[test]
+    fn acip_coding_specialization_binds_output_contract_and_writer_identity() {
+        let patch_contract = sample_coding_invocation_contract(
+            AcipCodingProviderLaneV1::ChatgptApi,
+            AcipCodingExecutionModeV1::UnappliedPatch,
+        );
+        let mut patch_outcome = sample_coding_outcome(&patch_contract);
+        patch_outcome.primary_output_ref = "runtime/comms/coding/proposal.json".to_string();
+        let patch_error = validate_acip_coding_outcome_v1(&patch_contract, &patch_outcome)
+            .expect_err("patch output drift should fail");
+        assert!(patch_error
+            .to_string()
+            .contains("must match the declared patch_diff output contract"));
+
+        let worktree_contract = sample_coding_invocation_contract(
+            AcipCodingProviderLaneV1::CodexIssueWorktree,
+            AcipCodingExecutionModeV1::WorktreeEdit,
+        );
+        let mut worktree_outcome = sample_coding_outcome(&worktree_contract);
+        worktree_outcome.writer_session_id = "drifted-session".to_string();
+        let identity_error = validate_acip_coding_outcome_v1(&worktree_contract, &worktree_outcome)
+            .expect_err("writer identity drift should fail");
+        assert!(identity_error
+            .to_string()
+            .contains("must preserve the writer_session_id declared by the approval policy"));
+
+        let mut validation_outcome = sample_coding_outcome(&worktree_contract);
+        validation_outcome.validation_result_refs =
+            vec!["runtime/comms/coding/not_validation.json".to_string()];
+        let validation_error =
+            validate_acip_coding_outcome_v1(&worktree_contract, &validation_outcome)
+                .expect_err("validation summary drift should fail");
+        assert!(validation_error.to_string().contains(
+            "validation_result_refs must include the declared validation_summary output contract"
+        ));
+
+        let mut stop_contract = sample_coding_invocation_contract(
+            AcipCodingProviderLaneV1::CodexIssueWorktree,
+            AcipCodingExecutionModeV1::WorktreeEdit,
+        );
+        stop_contract.invocation.stop_policy.stop_on_failure = false;
+        let stop_error = validate_acip_coding_invocation_contract_v1(&stop_contract)
+            .expect_err("stop policy drift should fail");
+        assert!(stop_error
+            .to_string()
+            .contains("requires stop_policy.stop_on_failure to be true"));
     }
 
     #[test]

--- a/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
@@ -11,6 +11,7 @@
 | features/GOVERNED_EXECUTION_AND_TRACE.md | policy injection, Freedom Gate integration, governed executor, trace, replay, and redaction contract | WP-11-WP-14 |
 | features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md | multi-model benchmark, local/Gemma evaluation, dangerous negative suite, and Governed Tools v1.0 flagship demo | WP-15-WP-18 |
 | features/LOCAL_MODEL_PR_REVIEWER_TOOL.md | operator and agent usage guide for the demo-grade pre-PR code review tool, fixture backend, and direct Ollama HTTP path | #2603 |
+| features/CODING_AGENT_RUNNER.md | provider-neutral coding-agent runner contract, provider-lane matrix, review-handoff boundary, and fixture-mode proof path | #2627 |
 
 ## Proof And Audit Docs
 

--- a/docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md
+++ b/docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md
@@ -303,6 +303,38 @@ The paired review outcome must preserve the declared reviewer identity, carry a
 gate result, and only allow PR finish for a blessed disposition. Review output
 remains evidence and handoff state only; it does not grant merge authority.
 
+## Comms-06 Coding Specialization
+
+The coding-agent specialization inherits the same ACIP invocation substrate and
+adds provider-lane, edit-boundary, and review-handoff requirements rather than
+creating a second execution protocol.
+
+The canonical coding specialization surfaces are:
+
+- an ACIP coding invocation contract with:
+  `invocation.intent = coding_request`
+- a declared `provider_lane` and `execution_mode`
+- explicit `issue_ref`, `task_bundle_ref`, and bounded `allowed_edit_paths`
+- explicit `validation_commands` and `patch_format`
+- an approval policy that:
+  requires review before PR finish
+  routes to `acip.review.invocation.v1`
+  forbids same-session blessing
+  forbids same-model blessing
+
+The canonical lane boundary is also fixed:
+
+- only `codex_issue_worktree` may use `worktree_edit`
+- all other lanes are proposal-only and return diff or structured-proposal
+  artifacts
+- proposal-only lanes must not claim direct `code_edit` capability
+
+The paired coding outcome must preserve writer identity, emit validation
+evidence plus a `review_handoff_ref`, and classify the result as either
+patch-ready-for-review or proposal-ready-for-review. Like the review outcome,
+the coding outcome is evidence and handoff only; it never grants merge or
+blessing authority.
+
 ## Non-Proving Statements
 
 ACIP v1 does not prove:

--- a/docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md
+++ b/docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md
@@ -1,0 +1,174 @@
+# Coding Agent Runner
+
+## Status
+
+Tracked feature contract for the v0.90.5 Comms-06 slice.
+
+This document defines the provider-neutral coding-agent runner that consumes
+ACIP coding invocations and returns bounded implementation outputs for normal
+ADL review and PR lifecycle handling. It does not replace `pr-run`,
+`pr-finish`, `pr-closeout`, or reviewer-agent responsibility.
+
+## Purpose
+
+ADL needs one stable way to ask coding agents for bounded implementation work
+without confusing authorship, review, merge, and operator authority.
+
+The coding-agent runner exists so ADL can:
+
+- route bounded coding requests through ACIP
+- distinguish direct issue-worktree editing from proposal-only lanes
+- require explicit file scope, validation commands, and stop boundaries
+- hand coding output to reviewer-agent or equivalent review surfaces before any
+  closeout decision
+
+## Core Boundary
+
+The coding-agent runner is an execution specialization, not an approval
+surface.
+
+It may:
+
+- consume an ACIP coding invocation contract
+- read bounded issue context and task-bundle inputs
+- edit inside a bound ADL issue worktree when the lane explicitly permits it
+- emit a patch, patch manifest, or structured proposal with validation evidence
+- produce a review handoff packet
+
+It must not:
+
+- merge branches
+- bless its own work
+- bypass reviewer-agent or SRP-governed review
+- grant repository authority to non-Codex lanes
+- turn remote-provider responses into direct unreviewed repository mutations
+
+## ACIP Alignment
+
+The canonical Comms-06 surface is `acip.coding.invocation.v1` plus its paired
+coding outcome and fixture set.
+
+The invocation contract adds coding-specific fields on top of the core ACIP
+invocation substrate:
+
+- `provider_lane`
+- `execution_mode`
+- `issue_ref`
+- `task_bundle_ref`
+- `issue_worktree_required`
+- `allowed_edit_paths`
+- `validation_commands`
+- `patch_format`
+- `approval_policy`
+
+The paired coding outcome returns:
+
+- `primary_output_ref`
+- `validation_result_refs`
+- `review_handoff_ref`
+- preserved writer session/model identity
+- a result classification that distinguishes patch-ready worktree edits from
+  proposal-ready non-worktree outputs
+
+## Provider Lane Matrix
+
+| Provider lane | Execution mode | Repo mutation authority | Expected primary output |
+| --- | --- | --- | --- |
+| `codex_issue_worktree` | `worktree_edit` | May edit only through the normal ADL bound issue worktree and only inside declared `allowed_edit_paths` | `patch_manifest.json` |
+| `chatgpt_api` | `unapplied_patch` | No direct repo mutation | unified diff / `.diff` artifact |
+| `claude_api` | `structured_proposal` or `unapplied_patch` | No direct repo mutation | structured proposal JSON or diff artifact |
+| `local_ollama` | `structured_proposal` or `unapplied_patch` | No direct repo mutation | structured proposal JSON or diff artifact |
+| `other_proposal_only` | `structured_proposal` or `unapplied_patch` | No direct repo mutation | structured proposal JSON or diff artifact |
+
+The root rule is stable:
+
+- only the Codex issue-worktree lane may use `worktree_edit`
+- every other lane is proposal-only and returns artifacts for later review or
+  application
+- proposal-only lanes advertise proposal capability, not direct `code_edit`
+  capability
+
+## Required Inputs
+
+Every coding invocation must remain explicit about:
+
+- the issue/task context it is serving
+- the bounded edit surface
+- the validation commands expected after the change
+- the output contract for patch/proposal and review handoff artifacts
+- the policy refs and decision-event linkage inherited from ACIP core
+
+The coding runner should fail closed if `task_bundle_ref` is absent from the
+declared `input_refs`, if `allowed_edit_paths` is empty, or if the provider
+lane claims more mutation capability than its matrix row allows.
+
+## Output Contract
+
+Required outputs depend on the execution mode:
+
+- `worktree_edit` requires a `patch_manifest`, `validation_summary`, and
+  `review_handoff`
+- `unapplied_patch` requires a `patch_diff`, `validation_summary`, and
+  `review_handoff`
+- `structured_proposal` requires a `structured_proposal`,
+  `validation_summary`, and `review_handoff`
+
+Those outputs remain evidence and handoff surfaces. They do not constitute a
+review decision or merge approval.
+
+## Approval Separation
+
+The coding invocation must carry an approval policy with:
+
+- `review_required_before_pr_finish = true`
+- `required_review_schema_ref = acip.review.invocation.v1`
+- preserved writer session/model identity
+- explicit prohibition of same-session blessing
+- explicit prohibition of same-model blessing
+
+This keeps Comms-06 aligned with Comms-05 rather than competing with it. Coding
+work can produce a review handoff packet, but reviewer-agent invocation remains
+the surface that determines whether the result is blessable.
+
+## Validation And Stop Boundary
+
+The coding-agent runner must record validation expectations up front. At
+minimum, the invocation should define a small proving command set such as:
+
+- `cargo fmt --check`
+- focused `cargo test` commands
+- any bounded artifact-schema or diff checks required by the issue
+
+The stop boundary is also explicit:
+
+- stop once the declared output contract is satisfied
+- stop on refusal or failure
+- stop when the bounded output-artifact limit is reached
+- stop before merge, closeout, or self-approval
+
+## Fixture-Mode Proof
+
+Comms-06 requires a dry-run / fixture-mode proof path that can run without paid
+or remote model access.
+
+The fixture-mode proof surface is:
+
+- one valid Codex issue-worktree request that yields a patch-manifest outcome
+- one valid proposal-only request that yields a diff/proposal outcome
+- negative cases proving that non-Codex lanes cannot use worktree-edit and that
+  review bypass or writer-identity drift is rejected
+
+## Interaction With Reviewer-Agent Work
+
+`LOCAL_MODEL_PR_REVIEWER_TOOL.md` remains the concrete backend for the
+reviewer-agent side of the protocol.
+
+The coding-agent runner should hand off:
+
+- patch/proposal artifact refs
+- validation evidence
+- bounded issue/task context
+- writer identity
+
+The reviewer-agent specialization then decides whether the work is blocked,
+non-proving, skipped, or blessed. The coding runner never makes that call.

--- a/docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md
+++ b/docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md
@@ -169,6 +169,7 @@ slice, but still has no write, push, merge, or arbitrary command authority.
 The tool blocks PR opening when:
 
 - the reviewer is the same session as the writer
+- the reviewer is the same model as the writer
 - static diff checks fail
 - a blocking `P0`, `P1`, or `P2` finding is present
 - the reviewer disposition is `blocked`
@@ -215,6 +216,25 @@ The alignment is:
 The reviewer remains independent evidence, not merge authority. Human or
 operator merge authority stays outside the reviewer result and outside the ACIP
 review specialization.
+
+## Coding-Agent Handoff
+
+Comms-06 makes the upstream coding-agent side explicit rather than leaving it
+implicit in issue-worktree practice.
+
+When the reviewer tool is called after coding-agent work, the expected handoff
+is:
+
+- a coding invocation or outcome surface that identifies the writer session and
+  model
+- a bounded patch, patch manifest, or structured proposal artifact
+- validation evidence from the coding lane
+- a review-handoff packet that points at the coding outputs without granting
+  approval
+
+The reviewer tool should therefore be treated as the next governed step after a
+coding-agent runner, not as something the coding lane can collapse into or
+self-satisfy.
 
 ## Current Limits
 

--- a/docs/milestones/v0.90.5/features/README.md
+++ b/docs/milestones/v0.90.5/features/README.md
@@ -20,3 +20,6 @@ core Governed Tools feature stack in full.
 
 The demo-grade local model PR reviewer tool usage guide lives in
 `LOCAL_MODEL_PR_REVIEWER_TOOL.md`.
+
+The provider-neutral coding-agent runner contract for Comms-06 lives in
+`CODING_AGENT_RUNNER.md`.


### PR DESCRIPTION
Closes #2627

## Summary
Implemented the Comms-06 ACIP coding-agent specialization and the milestone-facing coding-agent runner contract. The new `agent_comms` surface now defines typed coding invocation, outcome, and fixture-set schemas; enforces the provider-lane matrix; preserves writer identity; requires review handoff through `acip.review.invocation.v1`; and fails closed on proposal-lane repo-edit claims, worktree binding drift, missing validation-summary output binding, and stop-policy weakening. Documentation now includes a dedicated coding-runner feature contract plus aligned ACIP and reviewer-tool handoff notes.

## Artifacts
- Tracked implementation artifacts:
  - `adl/src/agent_comms.rs`
  - `docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md`
  - `docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md`
  - `docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md`
  - `docs/milestones/v0.90.5/features/README.md`
  - `docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md`
- Local execution record:
  - `.adl/v0.90.5/tasks/issue-2627__v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --check`
    Verified formatting conformance for the final Comms-06 implementation state.
  - `cargo test agent_comms --lib`
    Verified focused `agent_comms` contract, fixture, and coding-specialization behavior; final run passed 26 tests.
  - `git diff --check`
    Verified no patch-format whitespace or merge-marker residue.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- agent_comms`
    Regenerated focused coverage-impact evidence for the final Rust change set.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified changed Rust files remain above the coverage-impact gate.
  - `bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input .adl/v0.90.5/tasks/issue-2627__v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner/sip.md`
    Verified input-card contract compliance.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.90.5/tasks/issue-2627__v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner/sor.md`
    Verified output-card contract compliance.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.90.5/tasks/issue-2627__v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner/sip.md
- Output card: .adl/v0.90.5/tasks/issue-2627__v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner/sor.md
- Idempotency-Key: v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner-adl-v0-90-5-tasks-issue-2627-v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner-sip-md-adl-v0-90-5-tasks-issue-2627-v0-90-5-comms-06-coding-agent-invocation-specialization-and-provider-neutral-runner-sor-md