### PR TITLE
[v0.90.5][runtime] Honor ADL_TIMEOUT_SECS in Ollama HTTP provider

### DIFF
--- a/adl/src/provider/http_family.rs
+++ b/adl/src/provider/http_family.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 mod config;
 
 use config::{
-    auth_env_for, ollama_generate_endpoint, validate_http_credential_endpoint,
+    auth_env_for, cfg_u64_strict, ollama_generate_endpoint, validate_http_credential_endpoint,
     validate_vendor_credential_endpoint, vendor_endpoint, HttpAuth,
 };
 pub(crate) use config::{cfg_u64, timeout_secs};
@@ -409,11 +409,15 @@ impl OllamaHttpProvider {
         spec: &adl::ProviderSpec,
         target: &ProviderInvocationTargetV1,
     ) -> Result<Self> {
+        let timeout_secs = match cfg_u64_strict(&spec.config, "timeout_secs", "ollama")? {
+            Some(value) => value,
+            None => timeout_secs().map_err(|err| invalid_config("ollama", err.to_string()))?,
+        };
         Ok(Self {
             endpoint: ollama_generate_endpoint(spec)?,
             model: target.provider_model_id.clone(),
             temperature: super::local::cfg_f32(&spec.config, "temperature"),
-            timeout_secs: cfg_u64(&spec.config, "timeout_secs"),
+            timeout_secs: Some(timeout_secs),
         })
     }
 }

--- a/adl/src/provider/http_family/config.rs
+++ b/adl/src/provider/http_family/config.rs
@@ -212,3 +212,44 @@ pub(crate) fn cfg_u64(cfg: &HashMap<String, Value>, key: &str) -> Option<u64> {
         }
     })
 }
+
+pub(crate) fn cfg_u64_strict(
+    cfg: &HashMap<String, Value>,
+    key: &str,
+    provider_label: &str,
+) -> Result<Option<u64>> {
+    let invalid_value = || {
+        invalid_config(
+            provider_label,
+            format!("config.{key} must be a positive integer when provided"),
+        )
+    };
+    let Some(value) = cfg.get(key) else {
+        return Ok(None);
+    };
+
+    if let Some(u) = value.as_u64() {
+        return if u > 0 {
+            Ok(Some(u))
+        } else {
+            Err(invalid_value())
+        };
+    }
+    if let Some(i) = value.as_i64() {
+        return if i > 0 {
+            Ok(Some(i as u64))
+        } else {
+            Err(invalid_value())
+        };
+    }
+    if let Some(s) = value.as_str() {
+        let parsed = s.parse::<u64>().map_err(|_| invalid_value())?;
+        return if parsed > 0 {
+            Ok(Some(parsed))
+        } else {
+            Err(invalid_value())
+        };
+    }
+
+    Err(invalid_value())
+}

--- a/adl/src/provider/http_family/tests.rs
+++ b/adl/src/provider/http_family/tests.rs
@@ -123,6 +123,13 @@ fn ollama_provider_spec_with_base_url(base_url: &str) -> adl::ProviderSpec {
     }
 }
 
+fn restore_env_var(key: &str, previous: Option<std::ffi::OsString>) {
+    match previous {
+        Some(value) => env::set_var(key, value),
+        None => env::remove_var(key),
+    }
+}
+
 fn provider_spec(
     kind: &str,
     endpoint: &str,
@@ -263,6 +270,95 @@ fn ollama_http_provider_rejects_missing_response_text() {
     );
 
     let _ = handle.join();
+}
+
+#[test]
+fn ollama_http_provider_uses_adl_timeout_secs_when_config_missing() {
+    let _guard = env_lock();
+    let prev_timeout = env::var_os("ADL_TIMEOUT_SECS");
+    env::set_var("ADL_TIMEOUT_SECS", "321");
+
+    let spec = ollama_provider_spec_with_base_url("http://127.0.0.1:11434");
+    let target = provider_target("ollama", "http://127.0.0.1:11434".to_string(), "phi4-mini");
+    let provider = OllamaHttpProvider::from_target(&spec, &target).expect("provider");
+
+    restore_env_var("ADL_TIMEOUT_SECS", prev_timeout);
+
+    assert_eq!(provider.timeout_secs, Some(321));
+}
+
+#[test]
+fn ollama_http_provider_uses_default_timeout_when_env_missing() {
+    let _guard = env_lock();
+    let prev_timeout = env::var_os("ADL_TIMEOUT_SECS");
+    env::remove_var("ADL_TIMEOUT_SECS");
+
+    let spec = ollama_provider_spec_with_base_url("http://127.0.0.1:11434");
+    let target = provider_target("ollama", "http://127.0.0.1:11434".to_string(), "phi4-mini");
+    let provider = OllamaHttpProvider::from_target(&spec, &target).expect("provider");
+
+    restore_env_var("ADL_TIMEOUT_SECS", prev_timeout);
+
+    assert_eq!(provider.timeout_secs, Some(120));
+}
+
+#[test]
+fn ollama_http_provider_prefers_explicit_config_timeout_over_env() {
+    let _guard = env_lock();
+    let prev_timeout = env::var_os("ADL_TIMEOUT_SECS");
+    env::set_var("ADL_TIMEOUT_SECS", "321");
+
+    let mut spec = ollama_provider_spec_with_base_url("http://127.0.0.1:11434");
+    spec.config.insert("timeout_secs".to_string(), json!(17));
+    let target = provider_target("ollama", "http://127.0.0.1:11434".to_string(), "phi4-mini");
+    let provider = OllamaHttpProvider::from_target(&spec, &target).expect("provider");
+
+    restore_env_var("ADL_TIMEOUT_SECS", prev_timeout);
+
+    assert_eq!(provider.timeout_secs, Some(17));
+}
+
+#[test]
+fn ollama_http_provider_rejects_invalid_explicit_timeout() {
+    let _guard = env_lock();
+    let prev_timeout = env::var_os("ADL_TIMEOUT_SECS");
+    env::set_var("ADL_TIMEOUT_SECS", "321");
+
+    let mut spec = ollama_provider_spec_with_base_url("http://127.0.0.1:11434");
+    spec.config
+        .insert("timeout_secs".to_string(), json!("nope"));
+    let target = provider_target("ollama", "http://127.0.0.1:11434".to_string(), "phi4-mini");
+    let err = OllamaHttpProvider::from_target(&spec, &target)
+        .expect_err("invalid explicit timeout should fail");
+
+    restore_env_var("ADL_TIMEOUT_SECS", prev_timeout);
+
+    assert!(
+        err.to_string()
+            .contains("config.timeout_secs must be a positive integer"),
+        "{err:#}"
+    );
+}
+
+#[test]
+fn ollama_http_provider_rejects_zero_explicit_timeout() {
+    let _guard = env_lock();
+    let prev_timeout = env::var_os("ADL_TIMEOUT_SECS");
+    env::set_var("ADL_TIMEOUT_SECS", "321");
+
+    let mut spec = ollama_provider_spec_with_base_url("http://127.0.0.1:11434");
+    spec.config.insert("timeout_secs".to_string(), json!(0));
+    let target = provider_target("ollama", "http://127.0.0.1:11434".to_string(), "phi4-mini");
+    let err = OllamaHttpProvider::from_target(&spec, &target)
+        .expect_err("zero explicit timeout should fail");
+
+    restore_env_var("ADL_TIMEOUT_SECS", prev_timeout);
+
+    assert!(
+        err.to_string()
+            .contains("config.timeout_secs must be a positive integer"),
+        "{err:#}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #2673

## Summary
Fixed the Ollama HTTP provider timeout inheritance path so explicit positive
`config.timeout_secs` remains authoritative, malformed or zero explicit timeout
values fail fast, and otherwise the provider inherits `ADL_TIMEOUT_SECS` with
the existing default of 120 seconds.

## Artifacts
- `adl/src/provider/http_family.rs`
- `adl/src/provider/http_family/config.rs`
- `adl/src/provider/http_family/tests.rs`
- Local ignored output-card record at `.adl/v0.90.5/tasks/issue-2673__v0-90-5-runtime-honor-adl-timeout-secs-in-ollama-http-provider/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified Rust formatting for the bounded provider fix surface.
  - `cargo test --manifest-path adl/Cargo.toml ollama_http_provider -- --nocapture`
    Verified the focused Ollama HTTP provider surface and the new regression cases.
  - `bash adl/tools/validate_structured_prompt.sh --type sip --phase run --input .adl/v0.90.5/tasks/issue-2673__v0-90-5-runtime-honor-adl-timeout-secs-in-ollama-http-provider/sip.md`
    Verified the bound-state SIP after the editor normalization pass.
  - `git diff --check`
    Verified patch hygiene and whitespace correctness.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  /Users/daniel/git/agent-design-language/.adl/v0.90.5/tasks/issue-2673__v0-90-5-runtime-honor-adl-timeout-secs-in-ollama-http-provider/sip.md
- Output card: /Users/daniel/git/agent-design-language/.adl/v0.90.5/tasks/issue-2673__v0-90-5-runtime-honor-adl-timeout-secs-in-ollama-http-provider/sor.md
- Idempotency-Key: v0-90-5-runtime-honor-adl-timeout-secs-in-ollama-http-provider-adl-src-provider-http-family-rs-adl-src-provider-http-family-config-rs-adl-src-provider-http-family-tests-rs-users-daniel-git-agent-design-language-adl-v0-90-5-tasks-issue-2673-v0-90-5-runtime-honor-adl-timeout-secs-in-ollama-http-provider-sip-md-users-daniel-git-agent-design-language-adl-v0-90-5-tasks-issue-2673-v0-90-5-runtime-honor-adl-timeout-secs-in-ollama-http-provider-sor-md