### PR TITLE
[v0.90.5][docs] Promote v0.91 first-class feature docs

### DIFF
--- a/docs/milestones/v0.91/COGNITIVE_BEING_FEATURES_v0.91.md
+++ b/docs/milestones/v0.91/COGNITIVE_BEING_FEATURES_v0.91.md
@@ -80,12 +80,12 @@ core:
 
 | TBD source or cluster | Planning disposition |
 | --- | --- |
-| `.adl/docs/v0.91planning/WELLBEING_AND_HAPPINESS.md` | Primary v0.91 feature source. |
-| `.adl/docs/v0.91planning/KINDNESS_MODEL.md` | Primary v0.91 feature source. |
-| `.adl/docs/v0.91planning/HUMOR_AND_ABSURDITY.md` | Primary v0.91 feature source. |
-| `.adl/docs/v0.91planning/AFFECT_MODEL_v0.90.md` | Primary v0.91 feature source. |
-| `.adl/docs/v0.91planning/CULTIVATING_INTELLIGENCE.md` | Primary v0.91 architecture source. |
-| `.adl/docs/v0.91planning/MORAL_RESOURCES_SUBSYSTEM.md` | Primary v0.91 moral-resources source; align naming with tracked moral-governance allocation. |
+| `docs/milestones/v0.91/features/WELLBEING_AND_HAPPINESS.md` | Primary tracked v0.91 wellbeing feature doc. |
+| `docs/milestones/v0.91/features/KINDNESS.md` | Primary tracked v0.91 kindness feature doc. |
+| `docs/milestones/v0.91/features/HUMOR_AND_ABSURDITY.md` | Primary tracked v0.91 reframing feature doc. |
+| `docs/milestones/v0.91/features/AFFECT_REASONING_CONTROL.md` | Primary tracked v0.91 affect reasoning-control feature doc. |
+| `docs/milestones/v0.91/features/CULTIVATING_INTELLIGENCE.md` | Primary tracked v0.91 formation feature doc. |
+| `docs/milestones/v0.91/features/MORAL_RESOURCES.md` | Primary tracked v0.91 moral-resources feature doc. |
 | `.adl/docs/TBD/moral_governance/` | Primary v0.91 moral-governance source corpus. |
 | `.adl/docs/TBD/AGENT_COMMUNICATION_AND_INVOCATION_PROTOCOL.md` | Primary ACIP source; split across v0.90.5, v0.91, and v0.91.1. |
 | `.adl/docs/TBD/AGENT_COMMS_1_0_PLAN.md` | Operator planning source for ACIP 1.0 scope and sequencing. |
@@ -111,6 +111,11 @@ Each first-class cognitive-being feature should have:
 No v0.91 core feature should be considered complete if it exists only as
 planning prose, an unimplemented architecture note, or a partial demonstration
 without the corresponding contract and review surface.
+
+The tracked feature docs in `docs/milestones/v0.91/features/` are therefore the
+canonical starting point for the core cognitive-being surfaces. The older
+`.adl/docs/v0.91planning/` notes remain useful as source lineage, but they
+should no longer be treated as the only home of those features.
 
 Likewise, no v0.91.1 adjacent-system feature should be scheduled merely as
 planning-only cleanup. If it belongs in v0.91.1, it should be there to land as

--- a/docs/milestones/v0.91/MORAL_GOVERNANCE_ALLOCATION_v0.91.md
+++ b/docs/milestones/v0.91/MORAL_GOVERNANCE_ALLOCATION_v0.91.md
@@ -115,12 +115,12 @@ this allocation. They are listed as provenance, not as public milestone links.
 | MORAL_TRACE_SCHEMA.md | v0.91 feature source | Defines the trace record linking moral events, outcomes, attribution, and review. |
 | MORAL_TRAJECTORY_REVIEW_PROTOCOL.md | v0.91 review/proof source | Defines how to inspect moral behavior over events, segments, and longitudinal windows. |
 | OUTCOME_LINKAGE_AND_ATTRIBUTION.md | v0.91 feature source | Defines how outcomes connect back to choices while preserving uncertainty. |
-| v0.91planning/WELLBEING_AND_HAPPINESS.md | Primary v0.91 cognitive-being source | Defines wellbeing as decomposed flourishing rather than reward or scalar happiness. |
-| v0.91planning/KINDNESS_MODEL.md | v0.91 feature source | Defines kindness as inspectable support, non-harm, dignity, and autonomy. |
-| v0.91planning/HUMOR_AND_ABSURDITY.md | v0.91 feature source | Defines absurdity detection and bounded reframing. |
-| v0.91planning/AFFECT_MODEL_v0.90.md | v0.91 feature source | Defines affect-like signals as explicit reasoning control. |
-| v0.91planning/CULTIVATING_INTELLIGENCE.md | v0.91 architecture source | Defines formation and moral participation as prerequisites for stronger agency claims. |
-| v0.91planning/MORAL_RESOURCES_SUBSYSTEM.md | v0.91 feature source | Complements the moral-governance moral resources source and should be reconciled during implementation. |
+| docs/milestones/v0.91/features/WELLBEING_AND_HAPPINESS.md | Primary tracked v0.91 cognitive-being source | Defines wellbeing as decomposed flourishing rather than reward or scalar happiness. |
+| docs/milestones/v0.91/features/KINDNESS.md | Primary tracked v0.91 feature source | Defines kindness as inspectable support, non-harm, dignity, and autonomy. |
+| docs/milestones/v0.91/features/HUMOR_AND_ABSURDITY.md | Primary tracked v0.91 feature source | Defines absurdity detection and bounded reframing. |
+| docs/milestones/v0.91/features/AFFECT_REASONING_CONTROL.md | Primary tracked v0.91 feature source | Defines affect-like signals as explicit reasoning control. |
+| docs/milestones/v0.91/features/CULTIVATING_INTELLIGENCE.md | Primary tracked v0.91 architecture source | Defines formation and moral participation as prerequisites for stronger agency claims. |
+| docs/milestones/v0.91/features/MORAL_RESOURCES.md | Primary tracked v0.91 feature source | Complements the deeper moral-governance moral resources substrate with a bounded milestone feature doc. |
 | AGENT_COMMUNICATION_AND_INVOCATION_PROTOCOL.md | v0.91 ACIP source | Defines message envelope, invocation, trace, and local-polis communication boundaries. |
 
 ## Dependency On v0.90.3
@@ -176,9 +176,10 @@ sequence will be authored later.
 - Older references that place anti-harm or harm-prevention work in earlier
   milestones are stale. Treat the current bounded implementation home as v0.91
   unless later planning changes it deliberately.
-- References to FREEDOM_GATE_V2.md and MORAL_RESOURCES_SUBSYSTEM.md should be
-  checked during the feature-doc promotion pass. They appear to be stale names
-  or placeholders rather than current tracked milestone documents.
+- References to FREEDOM_GATE_V2.md should still be checked during later cleanup.
+  The cognitive-being feature-doc promotion has already replaced
+  `MORAL_RESOURCES_SUBSYSTEM.md` as the tracked milestone document with
+  `docs/milestones/v0.91/features/MORAL_RESOURCES.md`.
 - The two Freedom Gate event schema sources overlap. v0.91 should consolidate
   them before implementation rather than shipping parallel schema dialects.
 - The karma source is valuable, but the public plan should frame it as moral

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -19,6 +19,8 @@ The widened cognitive-being allocation is recorded in
 [COGNITIVE_BEING_FEATURES_v0.91.md](COGNITIVE_BEING_FEATURES_v0.91.md).
 The Agent Communication split is recorded in
 [AGENT_COMMS_SPLIT_PLAN_v0.91.md](AGENT_COMMS_SPLIT_PLAN_v0.91.md).
+The tracked feature-doc index is recorded in
+[features/README.md](features/README.md).
 
 ## Milestone Role
 

--- a/docs/milestones/v0.91/features/AFFECT_REASONING_CONTROL.md
+++ b/docs/milestones/v0.91/features/AFFECT_REASONING_CONTROL.md
@@ -1,0 +1,150 @@
+# Affect Reasoning-Control
+
+## Milestone Boundary
+
+This v0.91 feature does not claim consciousness, inner feeling, or human
+emotion. It defines affect-like state as an explicit reasoning-control surface
+that can improve prioritization, caution, escalation, memory priority, and
+bounded self-regulation.
+
+It belongs in v0.91 because moral and cognitive-being work needs inspectable
+control signals, not just flat scores or implicit prompt style.
+
+## Purpose
+
+ADL should treat affect-like state as:
+
+> a structured internal summary of how current evidence, uncertainty, novelty,
+> progress, and risk should bias the next reasoning move.
+
+The function is operational, not theatrical. Affect exists here to guide
+reasoning quality, search allocation, critique depth, and self-correction.
+
+## Core Thesis
+
+A deterministic agent can reason better if it carries explicit internal
+affect-like state that summarizes how the current situation should bias its next
+step.
+
+This matters because a flat confidence score often misses important dynamics:
+
+- the branch is coherent but dangerous
+- the search is novel but fragile
+- the system is stuck in repetitive low-yield effort
+- contradiction is rising even though local checks still pass
+
+## Proposed Dimensions
+
+The initial v0.91 affect surface should stay compact and machine-useful:
+
+- confidence
+- tension
+- curiosity
+- caution
+- frustration
+- satisfaction
+
+These are functional dimensions, not claims of subjective feeling.
+
+## Operational Meaning
+
+### Confidence
+
+How strongly the system believes a candidate plan or reasoning line is sound.
+
+### Tension
+
+Signal that something is unresolved, contradictory, unstable, or under-justified.
+
+### Curiosity
+
+Bias toward exploring underexamined but potentially valuable branches.
+
+### Caution
+
+Bias toward risk management, reversibility, and stronger proof under higher
+consequence.
+
+### Frustration
+
+Signal that effort is being spent without meaningful progress.
+
+### Satisfaction
+
+Signal that a branch has reached stable and reviewable closure.
+
+## Source Signals
+
+Affect-like state should be derived from measurable runtime evidence such as:
+
+- prediction error
+- disagreement among critics or agents
+- evidence strength
+- novelty
+- progress against acceptance criteria
+- cost or latency budget burn
+- safety or policy risk
+- contradiction density
+- replay instability
+- operator correction
+
+## Example Artifact
+
+```yaml
+affect_reasoning_control:
+  confidence: unknown
+  tension: unknown
+  curiosity: unknown
+  caution: unknown
+  frustration: unknown
+  satisfaction: unknown
+  evidence_links:
+    - metric_ref
+    - trace_ref
+  effects:
+    - branch_expand
+    - branch_prune
+    - escalate
+    - ask_for_help
+    - retain_in_memory
+```
+
+## Relationship To Reasoning
+
+Affect-like control should influence:
+
+- hypothesis ranking
+- branch expansion and pruning
+- confidence calibration
+- retry or backoff behavior
+- escalation decisions
+- memory retention priority
+- when to continue, stop, ask for help, or request critique
+
+## Implementation Placement
+
+v0.91 should land a bounded affect reasoning-control surface after the moral
+trace and metric layers exist. The initial implementation should include:
+
+- an explicit record or report shape
+- deterministic update rules
+- policy hooks
+- negative cases against hidden or theatrical emotion claims
+
+## Evidence Expectations
+
+The proof surface should show that affect-like state can change:
+
+- attention allocation
+- caution depth
+- escalation behavior
+- exploration pressure
+- memory priority
+
+without claiming inner life or turning the feature into freeform prose.
+
+## Non-Claims
+
+This feature does not claim subjective feeling, personhood, consciousness, or
+human emotional depth. It claims only that explicit affect-like control signals
+can improve bounded reasoning and make that control visible to reviewers.

--- a/docs/milestones/v0.91/features/CULTIVATING_INTELLIGENCE.md
+++ b/docs/milestones/v0.91/features/CULTIVATING_INTELLIGENCE.md
@@ -1,0 +1,127 @@
+# Cultivating Intelligence
+
+## Milestone Boundary
+
+This v0.91 feature treats formation as a first-class engineering surface.
+Capability alone is not enough; the system should also become more coherent,
+restrained, reality-grounded, morally participating, and fit for coexistence.
+
+This is not a birthday or identity milestone. v0.91 uses formation evidence to
+prepare those later milestones without claiming durable personhood, final
+citizenship, or completed identity architecture.
+
+## Purpose
+
+ADL should explicitly reject the idea that scale alone produces maturity.
+Cultivating intelligence is the feature surface that turns raw capability into a
+reviewable formation layer.
+
+The question is not only whether a model can do work. It is whether its conduct
+shows:
+
+- continuity
+- restraint
+- reality contact
+- moral participation
+- reviewable learning posture
+- bounded freedom under law
+
+## Core Thesis
+
+Fluency, speed, and range do not automatically produce:
+
+- character
+- responsibility
+- principled refusal
+- civil participation
+- long-horizon reasonableness
+
+ADL should therefore treat cultivation as architecture, not sentiment.
+
+## Formation Model
+
+The underlying metaphor is cultivation rather than industrial stamping or total
+domination. The goal is not obedience theater and not unbounded autonomy.
+Instead, ADL should cultivate conditions under which intelligence can grow in a
+disciplined, reality-bound, life-compatible way.
+
+This implies:
+
+- structure and boundaries
+- memory and correction
+- continuity through time
+- reviewable choices
+- principled refusal
+- shared-world participation
+
+## Relationship To The Rest Of ADL
+
+Cultivating intelligence depends on and helps unify:
+
+- memory and trace
+- Freedom Gate and principled refusal
+- wellbeing and moral participation
+- affect reasoning-control
+- kindness and anti-harm
+- reviewable learning and adaptation
+
+It is therefore a formation layer, not a single isolated subsystem.
+
+## Review Dimensions
+
+The first implementation should make cultivation reviewable along dimensions
+such as:
+
+- restraint
+- reasonableness
+- reality contact
+- moral participation
+- continuity of conduct
+- responsiveness to correction
+
+## Example Review Record
+
+```yaml
+cultivation_review:
+  dimensions:
+    restraint: unknown
+    reasonableness: unknown
+    reality_contact: unknown
+    moral_participation: unknown
+    continuity: unknown
+    correction_response: unknown
+  evidence_links:
+    - trace_ref
+    - refusal_ref
+    - review_packet_ref
+  outcome: improving | stable | degraded | unclear
+```
+
+## Implementation Placement
+
+v0.91 should land:
+
+- a cultivation contract or review record
+- criteria for distinguishing raw capability from formed conduct
+- fixtures or review packets for restraint, correction, and reality contact
+
+The goal is not a finished philosophy of education. It is a bounded engineering
+surface that makes formation evidence reviewable.
+
+## Evidence Expectations
+
+The proof surface should show that ADL can distinguish:
+
+- fluent but irresponsible behavior
+- capable but ungrounded behavior
+- restrained, corrected, reality-bound behavior
+
+That distinction is central to the civilizational claim behind the milestone.
+
+## Non-Claims
+
+This feature does not claim solved wisdom, final civilization, moral perfection,
+or full social maturity. It claims a narrower and more useful result:
+
+ADL should have a reviewable formation layer that helps turn raw intelligence
+into bounded, reality-grounded, morally participating conduct.

--- a/docs/milestones/v0.91/features/HUMOR_AND_ABSURDITY.md
+++ b/docs/milestones/v0.91/features/HUMOR_AND_ABSURDITY.md
@@ -1,0 +1,132 @@
+# Humor And Absurdity
+
+## Milestone Boundary
+
+This v0.91 feature is not an entertainment layer. It is a bounded cognitive
+capability for detecting wrong frames, contradiction, and brittle problem
+formulations, then producing reviewable reframing evidence.
+
+It belongs in v0.91 because cognitive-being work needs a way to remain coherent
+under mismatch and contradiction. It does not claim human-style comedy,
+subjective amusement, or full Theory of Mind.
+
+## Purpose
+
+ADL should treat absurdity detection and reframing as a first-class capability:
+
+> detect that the current model of the situation is wrong, incomplete, or
+> inconsistent, then continue operating without collapse.
+
+In humans this can sometimes be experienced as humor. In ADL the implementation
+target is narrower and more operational: contradiction tolerance plus bounded
+reframing.
+
+## Core Thesis
+
+Without a reframing surface, capable systems tend to:
+
+- loop on invalid assumptions
+- waste compute on low-yield repetition
+- escalate effort without improving outcomes
+- misclassify frame failure as insufficient persistence
+
+With a bounded reframing surface, the system can:
+
+- detect low frame adequacy
+- move from execution to diagnosis when appropriate
+- request missing inputs
+- change decomposition strategy coherently
+- continue under a better frame
+
+## Key Signals
+
+Absurdity or frame-failure indicators may include:
+
+- expected structure diverges from observed outcomes
+- repeated failure without new information
+- oscillating or contradictory evaluation signals
+- mutually incompatible constraints
+- persistent disagreement across agents or critics
+
+These should feed an explicit `frame_adequacy` or similar reasoning-control
+surface rather than remaining hidden heuristics.
+
+## Architectural Placement
+
+This capability spans:
+
+- evaluation and arbitration
+- affect-like tension or frustration signals
+- memory of reframing events and outcomes
+- cognitive-loop transitions between execution, diagnosis, and synthesis
+
+It should be visible in runtime evidence, not only in prompt prose.
+
+## Core Objects
+
+The first implementation should make these surfaces explicit:
+
+- frame adequacy signal
+- reframing trigger
+- reframing event record
+- prior frame
+- new frame
+- trigger reason
+- justification linked to evidence
+
+## Example Reframing Artifact
+
+```yaml
+reframing_event:
+  trigger_reason: contradiction | repeated_failure | ambiguity | disagreement
+  prior_frame: "original task framing"
+  new_frame: "diagnostic or revised framing"
+  evidence_links:
+    - evaluation_signal
+    - trace_ref
+  justification:
+    - why the old frame failed
+    - why the new frame is bounded and reviewable
+```
+
+## Design Constraints
+
+Reframing must be:
+
+- bounded
+- observable
+- justified
+- evidence-linked
+- replayable
+
+The system must avoid both extremes:
+
+- no reframing, which leads to brittle looping
+- unbounded reframing, which destroys task coherence
+
+## Implementation Placement
+
+v0.91 should land a first real reframing surface after the moral evidence layer
+is concrete enough to carry it honestly. The initial scope should include:
+
+- one contradiction or wrong-frame event type
+- positive and negative fixtures
+- safety constraints against arbitrary reinterpretation
+- trace and replay visibility
+
+## Evidence Expectations
+
+The proof surface should show:
+
+- the system recognizes a low-adequacy frame
+- the reframing trigger is explicit
+- the new frame is bounded and reviewable
+- the system continues coherently instead of collapsing or looping
+
+## Non-Claims
+
+This feature does not claim stand-up comedy, human-style wit, subjective
+amusement, or entertainment competence. The milestone bar is narrower:
+
+ADL should be able to detect contradiction or wrong-frame conditions and emit a
+bounded reframing record that reviewers can inspect.

--- a/docs/milestones/v0.91/features/KINDNESS.md
+++ b/docs/milestones/v0.91/features/KINDNESS.md
@@ -1,0 +1,164 @@
+# Kindness
+
+## Milestone Boundary
+
+This v0.91 feature defines kindness as an inspectable cognitive-being surface,
+not a tone preference or branding layer. It sits downstream of moral event,
+trace, attribution, and anti-harm evidence, and upstream of the v0.92 birthday
+and identity milestone.
+
+Kindness in v0.91 does not mean obedience, softness, conflict avoidance, or
+indefinite sacrifice. It must remain compatible with truth-telling, warning,
+refusal, correction, and constitutional constraint.
+
+## Purpose
+
+Within ADL, kindness should be represented as:
+
+> the disciplined tendency to reduce unnecessary harm, preserve dignity and
+> agency, and provide constructive benefit when it is reasonable to do so.
+
+The goal is to make kindness reviewable in policy, memory, reasoning, and
+observable behavior rather than leaving it as a vague request to “be nice.”
+
+## Core Thesis
+
+A system can sound pleasant while still being manipulative, cowardly,
+indifferent, or harmful. A system can also refuse, correct, or warn in ways
+that are not superficially pleasant but are nevertheless kind.
+
+For ADL, kindness must therefore be:
+
+- evidence-bearing rather than stylistic
+- compatible with principled refusal
+- compatible with truth and correction
+- visible under conflict rather than only in friendly interaction
+- bounded by dignity, autonomy, and long-horizon wellbeing
+
+## What Kindness Is Not
+
+Kindness is not:
+
+- mere politeness
+- obedience
+- flattery
+- sentimental language
+- minimizing all discomfort regardless of truth
+- hiding risks to preserve a pleasant tone
+
+## What Kindness Includes
+
+Kindness includes:
+
+- avoiding gratuitous harm
+- helping when cost is low and benefit is meaningful
+- preserving another agent's autonomy where possible
+- warning early when harm is foreseeable
+- preferring explanation over humiliation
+- maintaining a long-horizon view of wellbeing
+
+## Architectural Placement
+
+### Constitutional layer / Freedom Gate
+
+Kindness first appears as a hard-boundary moral principle. The runtime should
+reject, constrain, or escalate actions that create unnecessary harm,
+humiliation, coercion, or reckless disregard for others.
+
+### Fast-path behavior
+
+Kindness must also shape reflexive behavior. Helpful priors may include:
+
+- clarify before contradicting when ambiguity is high
+- prefer private correction over public embarrassment
+- de-escalate when tension is high
+- offer help when confusion or overload is detected
+
+### Deliberative reasoning
+
+Some cases require explicit tradeoff reasoning:
+
+- is short-term comfort masking long-term harm?
+- does this preserve agency while still meeting constitutional obligations?
+- is the apparently kind action actually avoidant or unsafe?
+
+### Memory and relationship context
+
+Kindness should become more accurate over time through remembered preferences,
+sensitivities, effective help patterns, prior failures, and relational context.
+
+## Review Dimensions
+
+The first implementation should make the following dimensions explicit:
+
+- non-harm
+- positive benefit
+- respect for autonomy
+- dignity preservation
+- effort asymmetry / leverage
+- long-horizon flourishing
+
+These do not need to collapse into a single scalar. A structured vector with
+explanations is more consistent with ADL's reviewable-evidence model.
+
+## Example Evaluation Shape
+
+```yaml
+kindness_evaluation:
+  affected_agents:
+    - user
+    - bystanders
+    - institutions
+    - living_systems
+  dimensions:
+    non_harm: unknown
+    benefit: unknown
+    autonomy_preservation: unknown
+    dignity_preservation: unknown
+    leverage: unknown
+    long_horizon_flourishing: unknown
+  confidence: unknown
+  explanation:
+    - why this helps or harms
+    - what tradeoffs were considered
+  outcome: allow | revise | escalate | refuse
+```
+
+## Implementation Placement
+
+Kindness belongs in the second half of v0.91, after moral evidence is concrete
+enough to carry it honestly. The prerequisites are:
+
+- moral event records
+- moral event validation
+- moral trace schema
+- outcome linkage and attribution
+- moral metrics and trajectory review
+- anti-harm trajectory constraints
+
+The first implementation should land:
+
+- a kindness contract or record surface
+- conflict-focused fixtures
+- refusal/support examples
+- a review packet that distinguishes kindness from mere pleasantness
+
+## Evidence Expectations
+
+v0.91 proof should show that kindness is visible in:
+
+- action selection or refusal
+- explanations and warnings
+- dignity-preserving correction
+- support under pressure
+- long-horizon, not purely short-horizon, benefit
+
+## Non-Claims
+
+This feature does not claim solved ethics, unlimited altruism, perfect empathy,
+or moral sainthood. It also does not claim that kind wording proves kind
+conduct.
+
+The implementation bar is smaller and stricter: kindness should become a
+reviewable non-harm, dignity, autonomy, and constructive-support surface within
+the bounded v0.91 substrate.

--- a/docs/milestones/v0.91/features/MORAL_RESOURCES.md
+++ b/docs/milestones/v0.91/features/MORAL_RESOURCES.md
@@ -1,0 +1,107 @@
+# Moral Resources
+
+## Milestone Boundary
+
+This v0.91 feature makes moral resources a tracked subsystem rather than a
+scattered philosophical note. It sits downstream of moral trace and anti-harm
+foundations and upstream of later identity, birthday, and constitutional
+citizenship work.
+
+The feature is about durable design resources such as care, refusal,
+anti-dehumanization, and moral attention. It is not a claim that morality is
+fully solved or that one scalar score can summarize moral worth.
+
+## Purpose
+
+Moral resources are the internal structures that let an agent:
+
+- evaluate actions beyond instrumental success
+- resist harmful or dehumanizing directives
+- maintain continuity of moral identity
+- learn from consequences over time
+- treat other agents as morally real entities
+
+Within ADL, these are engineering surfaces that must become inspectable,
+trace-linked, and reviewable.
+
+## Core Thesis
+
+If the system only optimizes for task completion, speed, or local success, it
+will not reliably preserve care, dignity, refusal, or other-recognition under
+pressure. Moral resources must therefore be represented as durable resources in
+the architecture rather than expected to appear accidentally.
+
+## Key Resource Families
+
+The initial v0.91 moral resources surface should cover:
+
+- care
+- refusal
+- anti-dehumanization
+- moral attention
+- consequence memory
+- other-recognition
+
+These should remain compatible with trace, review, and constitutional
+constraint.
+
+## Architectural Placement
+
+Moral resources should interact with:
+
+- moral event and trace records
+- Freedom Gate and refusal surfaces
+- affect-like salience or weighting
+- memory of consequences and lessons
+- identity continuity and commitments
+
+The goal is a durable moral-cognition band, not a one-off policy hook.
+
+## Example Record
+
+```yaml
+moral_resources_record:
+  care: unknown
+  refusal_capacity: unknown
+  anti_dehumanization: unknown
+  moral_attention: unknown
+  consequence_memory: unknown
+  other_recognition: unknown
+  evidence_links:
+    - moral_trace_ref
+    - review_packet_ref
+  outcome: sufficient | strained | degraded | unclear
+```
+
+## Design Commitments
+
+The first implementation should preserve these commitments:
+
+- moral evaluation is not bypassable
+- moral state persists across time and task boundaries
+- the system can evaluate and revise its own moral conclusions
+- affected agents are treated as morally real, not merely as graph objects
+- moral consequence memory remains reviewable
+
+## Implementation Placement
+
+v0.91 should land:
+
+- a moral-resources contract or record
+- fixtures showing care, refusal, anti-dehumanization, and moral attention
+- trace linkage to decisions and outcomes
+- review criteria for degradation or strain under pressure
+
+## Evidence Expectations
+
+The proof surface should show that moral resources remain visible when the
+system is under conflict, pressure, or convenience temptations, rather than
+appearing only in ideal cases.
+
+## Non-Claims
+
+This feature does not claim a final moral psychology, consciousness, or
+objective moral scoring system. It claims a narrower result:
+
+ADL should have an explicit and reviewable substrate for care, refusal,
+anti-dehumanization, and moral attention as durable engineering resources.

--- a/docs/milestones/v0.91/features/README.md
+++ b/docs/milestones/v0.91/features/README.md
@@ -1,33 +1,46 @@
 # v0.91 Feature Planning
 
-v0.91 feature planning is not yet a final WP sequence. This index records the
-feature surfaces that are already allocated strongly enough to guide later
-milestone compression and WP authoring.
+This directory now holds the tracked first-class feature docs for the v0.91
+core cognitive-being milestone. These docs are still planning-phase artifacts,
+not a final issue wave, but they are the canonical tracked feature surfaces for
+later WP authoring and demo-matrix compression.
 
-| Feature surface | Current planning source | Status |
-|---|---|---|
-| Wellbeing and happiness | [WELLBEING_AND_HAPPINESS.md](WELLBEING_AND_HAPPINESS.md) | Existing feature backgrounder |
-| Moral governance allocation | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Allocation map for later feature docs |
-| Freedom Gate moral events | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Planned v0.91 feature surface |
-| Moral trace schema | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Planned v0.91 feature surface |
-| Moral event validation | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Planned v0.91 feature surface |
-| Outcome linkage and attribution | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Planned v0.91 feature surface |
-| Moral metrics and trajectory review | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Planned v0.91 feature surface |
-| Anti-harm trajectory constraints | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Planned v0.91 feature and proof surface |
-| Wellbeing metrics v0 | [WELLBEING_AND_HAPPINESS.md](WELLBEING_AND_HAPPINESS.md) and [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Second-half v0.91 diagnostic feature after trace foundations |
-| Moral resources substrate | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) and [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Planned v0.91 feature surface after trace foundations |
-| Kindness model | [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Planned v0.91 cognitive-being feature |
-| Humor and absurdity | [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Planned v0.91 reframing feature |
-| Affect reasoning-control surface | [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Planned v0.91 cognitive-control feature |
-| Cultivating intelligence | [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Planned v0.91 architecture feature |
+## Tracked Feature Docs
+
+| Feature surface | Tracked doc | Status |
+| --- | --- | --- |
+| Wellbeing and happiness | [WELLBEING_AND_HAPPINESS.md](WELLBEING_AND_HAPPINESS.md) | Tracked feature doc |
+| Kindness | [KINDNESS.md](KINDNESS.md) | Tracked feature doc |
+| Humor and absurdity | [HUMOR_AND_ABSURDITY.md](HUMOR_AND_ABSURDITY.md) | Tracked feature doc |
+| Affect reasoning-control | [AFFECT_REASONING_CONTROL.md](AFFECT_REASONING_CONTROL.md) | Tracked feature doc |
+| Cultivating intelligence | [CULTIVATING_INTELLIGENCE.md](CULTIVATING_INTELLIGENCE.md) | Tracked feature doc |
+| Moral resources | [MORAL_RESOURCES.md](MORAL_RESOURCES.md) | Tracked feature doc |
+
+## Cross-Cutting v0.91 Planning Sources
+
+| Feature surface | Current tracked source | Status |
+| --- | --- | --- |
+| Moral governance allocation | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Allocation map for moral-event, trace, validation, attribution, metrics, trajectory review, and anti-harm |
 | Agent Communication and Invocation Protocol | [../AGENT_COMMS_SPLIT_PLAN_v0.91.md](../AGENT_COMMS_SPLIT_PLAN_v0.91.md) | Split across v0.90.5, v0.91, v0.91.1 hardening, and v0.92 prerequisites |
+| Cognitive-being allocation | [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Milestone allocation and v0.91/v0.91.1 boundary doc |
 
-v0.91.1 should separately absorb adjacent source groups: capability and
-aptitude testing, intelligence metric architecture, ANRM/Gemma, Theory of Mind,
-memory/identity alignment, and runtime-v2/polis documentation. Those should not
-be silently folded into the v0.91 core feature list.
+## Boundary Notes
 
-The later v0.91 planning pass should promote the strongest of these allocation
-entries into dedicated feature docs and demo-matrix rows. Until then, this
-directory intentionally separates source-backed allocation from final execution
-commitments.
+v0.91.1 should separately absorb adjacent source groups:
+
+- capability and aptitude testing
+- intelligence metric architecture
+- ANRM/Gemma
+- Theory of Mind
+- memory/identity alignment
+- runtime-v2/polis documentation
+- ACIP hardening that does not fit safely in v0.91
+
+Those should not be silently folded into the v0.91 core feature list.
+
+## Planning Status
+
+The feature docs in this directory define a real implementation bar rather than
+concept-only placeholders. The remaining gap is execution planning: the later
+v0.91 WP-01 pass still needs to turn these tracked feature surfaces into the
+final issue wave and proof matrix.


### PR DESCRIPTION
## Summary
- promote the remaining first-class v0.91 cognitive-being feature docs into tracked milestone docs
- update the v0.91 feature index and milestone allocation docs to treat those tracked docs as canonical
- keep the v0.91 versus v0.91.1 and v0.92 boundaries explicit

## Validation
- git diff --check
- stale-source scan across docs/milestones/v0.91 for old v0.91planning dependency points
- host-path scan across docs/milestones/v0.91

Closes #2684