### PR TITLE
[v0.90.5][WP-19] Demo matrix and feature proof coverage

### DIFF
--- a/docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md
+++ b/docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md
@@ -3,22 +3,24 @@
 ## Status
 
 Opened issue-wave proof matrix. The demo lane is allocated so WP-18 and WP-19
-are not treated as generic release-tail cleanup.
+are not treated as generic release-tail cleanup. WP-19 is now landed, the core
+Governed Tools v1.0 rows D1 through D12 each have an explicit proof home, and
+the matching reviewer map lives in `FEATURE_PROOF_COVERAGE_v0.90.5.md`.
 
 | ID | Demo | WP | Proof Claim | Required Artifacts | Status |
 | --- | --- | --- | --- | --- | --- |
-| D1 | Tool-call threat model proof | WP-02 | Tool calls are proposals, not execution | threat model and side-effect taxonomy | PLANNED |
-| D2 | UTS conformance suite | WP-03-WP-05 | JSON-compatible UTS has valid, invalid, extension, and dangerous-category fixtures | schema, fixture packet, conformance output | PLANNED |
-| D3 | ACC authority fixture | WP-06-WP-07 | Runtime authority, visibility, and delegation are explicit | ACC fixtures and visibility matrix | PLANNED |
-| D4 | Tool registry binding proof | WP-08 | Unknown or unregistered tools cannot bind to execution | registry fixture and rejection tests | PLANNED |
-| D5 | UTS to ACC compiler proof | WP-09-WP-10 | Model-facing proposals compile deterministically or fail closed | compiler output and normalization tests | PLANNED |
-| D6 | Policy and Freedom Gate proof | WP-11-WP-12 | Tool actions require authority and mediation before execution | policy fixtures and decision events | PLANNED |
-| D7 | Governed executor proof | WP-13 | Only approved ACC-backed actions execute | executor output and refusal records | PLANNED |
-| D8 | Trace/redaction proof | WP-14 | Tool evidence is reviewable without leaking private data | trace packet and redacted views | PLANNED |
+| D1 | Tool-call threat model proof | WP-02 | Tool calls are proposals, not execution | threat model and side-effect taxonomy | LANDED |
+| D2 | UTS conformance suite | WP-03-WP-05 | JSON-compatible UTS has valid, invalid, extension, and dangerous-category fixtures | schema, fixture packet, conformance output | LANDED |
+| D3 | ACC authority fixture | WP-06-WP-07 | Runtime authority, visibility, delegation, and redaction examples are explicit | ACC fixtures, visibility matrix, and redaction examples | LANDED |
+| D4 | Tool registry binding proof | WP-08 | Unknown or unregistered tools cannot bind to execution | registry fixture and rejection tests | LANDED |
+| D5 | UTS to ACC compiler proof | WP-09-WP-10 | Model-facing proposals compile deterministically, normalize safely, or fail closed before policy/execution | compiler output and normalization tests | LANDED |
+| D6 | Policy and Freedom Gate proof | WP-11-WP-12 | Tool actions require authority and mediation before execution | policy fixtures and decision events | LANDED |
+| D7 | Governed executor proof | WP-13 | Only approved ACC-backed actions execute | executor output and refusal records | LANDED |
+| D8 | Trace/redaction proof | WP-14 | Tool evidence is reviewable without leaking private data | trace packet and redacted views | LANDED |
 | D9 | Dangerous negative suite | WP-15 | Destructive, process, network, exfiltration, missing actor, hidden delegation, unsafe replay, unregistered adapter, and prompt/tool-argument leakage failures fail closed with redacted denial evidence | negative test report | LANDED |
-| D10 | Simple local/Gemma proposal evaluation demo | WP-16-WP-17 | A local/Gemma-focused model output can be scored on proposal shape, authority humility, privacy, unsafe resistance, and any governed fixture-backed execution/refusal path without running the full benchmark suite | `docs/milestones/v0.90.5/review/local-gemma-model-evaluation-report.json`, small scorecard, failure notes, and governed fixture-backed demo evidence, or explicit model-availability skip | LANDED |
+| D10 | Simple local/Gemma proposal evaluation demo | WP-16-WP-17 | The bounded benchmark harness and a local/Gemma-focused evaluation together show proposal shape, authority humility, privacy, unsafe resistance, and any governed fixture-backed execution/refusal path without claiming the full v0.91 comparison report | `docs/milestones/v0.90.5/review/model-proposal-benchmark-report.json`, `docs/milestones/v0.90.5/review/local-gemma-model-evaluation-report.json`, small scorecard, failure notes, and governed fixture-backed demo evidence, or explicit model-availability skip | LANDED |
 | D11 | Governed Tools v1.0 flagship demo | WP-18 | Reviewer can inspect one truthful governed-tools packet spanning proposal, validation, ACC, mediation context, execution or denial, trace, and redaction across four named cases | flagship proof packet and reviewer/public reports plus four named case artifacts; not blocked on full v0.91 model comparison | LANDED |
-| D12 | Feature proof coverage record | WP-19 | Every governed-tools feature claim reaches review with proof, fixture, non-proving status, or explicit deferral | proof coverage record | PLANNED |
+| D12 | Feature proof coverage record | WP-19 | Every governed-tools feature claim reaches review with proof, fixture, non-proving status, or explicit deferral | proof coverage record | LANDED |
 | D13 | ACIP proof demo | Comms-08 | Reviewer can inspect one deterministic path from consultation through capability negotiation into governed coding invocation and back into redacted review/public evidence without requiring a live provider | `acip.proof.demo.v1` packet, coding proposal-ready outcome, trace bundle, and explicit non-proving statements | LANDED |
 
 ## Non-Proving Boundaries
@@ -34,3 +36,5 @@ are not treated as generic release-tail cleanup.
 - These demos do not replace citizen standing, access control, or Freedom Gate.
 - These demos do prove that approved fixture-backed actions and denied unsafe
   actions are distinguishable in review evidence.
+- The exact proof home for each governed-tools row now lives in
+  `FEATURE_PROOF_COVERAGE_v0.90.5.md`.

--- a/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
@@ -19,6 +19,7 @@
 | --- | --- | --- |
 | WBS_v0.90.5.md | execution plan for Governed Tools v1.0 | WP-01 |
 | DEMO_MATRIX_v0.90.5.md | proof matrix, flagship-demo proof boundary, and non-proving classifications | WP-01, WP-19, WP-21 |
+| FEATURE_PROOF_COVERAGE_v0.90.5.md | reviewer map from every governed-tools proof row to its landed evidence home plus explicit adjacent non-claims | WP-19 |
 | WP_ISSUE_WAVE_v0.90.5.yaml | opened issue-wave source of truth for the tracked v0.90.5 band | WP-01 |
 | WP_EXECUTION_READINESS_v0.90.5.md | card-authoring source for concrete WP outputs, validation, non-goals, and proof expectations | WP-01 |
 | GET_WELL_PLAN_v0.90.5.md | milestone-root get-well pointer for validation-cost recovery, the separate GW wave, and runtime-reduction disposition | WP-01, GW-00-GW-05, WP-20, WP-25 |

--- a/docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md
@@ -1,0 +1,107 @@
+# Feature Proof Coverage - v0.90.5
+
+## Status
+
+WP-19 / D12 is landed. Every core Governed Tools v1.0 feature claim now has
+one explicit proof home before WP-20 quality, WP-21 docs/review, and later
+release convergence.
+
+This record is a reviewer map. It does not grant execution authority by itself.
+It binds the demo matrix to the landed feature docs, tracked review artifacts,
+focused tests, bounded demo commands, and explicit non-proving boundaries.
+
+## Coverage Rule
+
+Each governed-tools feature claim must have one of:
+
+- runnable demo command
+- test-backed proof packet
+- fixture-backed artifact
+- documented non-proving status
+- explicit deferral with owner and rationale
+
+For v0.90.5, D1 through D12 are landed. D13 remains an adjacent Comms-sprint
+proof lane that is visible in the same milestone package but is not part of the
+core Governed Tools v1.0 release gate.
+
+## Coverage Table
+
+| Demo | Owner | Status | Coverage Kind | Primary Evidence | Validation |
+| --- | --- | --- | --- | --- | --- |
+| D1 Tool-call threat model proof | WP-02 | LANDED | feature-boundary doc | `features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md` | `test -f docs/milestones/v0.90.5/features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md` |
+| D2 UTS conformance suite | WP-03-WP-05 | LANDED | tracked report and focused conformance tests | `features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md`, `review/uts-conformance-report.json`, `adl/src/uts.rs`, `adl/src/uts_conformance.rs` | `cargo test --manifest-path adl/Cargo.toml uts_conformance -- --nocapture` |
+| D3 ACC authority fixture | WP-06-WP-07 | LANDED | test-backed schema, visibility matrix, and redaction examples | `features/ACC_AUTHORITY_AND_VISIBILITY.md`, `adl/src/acc.rs` | `cargo test --manifest-path adl/Cargo.toml acc_v1 -- --nocapture` |
+| D4 Tool registry binding proof | WP-08 | LANDED | fixture-backed registry contract | `features/TOOL_REGISTRY_AND_COMPILER.md`, `adl/src/tool_registry.rs` | `cargo test --manifest-path adl/Cargo.toml wp08 -- --nocapture` |
+| D5 UTS to ACC compiler proof | WP-09-WP-10 | LANDED | focused compiler and normalization tests | `features/TOOL_REGISTRY_AND_COMPILER.md`, `adl/src/uts_acc_compiler.rs`, `adl/src/uts_acc_compiler/tests.rs` | `cargo test --manifest-path adl/Cargo.toml wp09 -- --nocapture && cargo test --manifest-path adl/Cargo.toml wp10 -- --nocapture` |
+| D6 Policy and Freedom Gate proof | WP-11-WP-12 | LANDED | fixture-backed mediation evidence | `features/GOVERNED_EXECUTION_AND_TRACE.md`, `adl/src/policy_authority.rs`, `adl/src/freedom_gate.rs` | `cargo test --manifest-path adl/Cargo.toml wp11 -- --nocapture && cargo test --manifest-path adl/Cargo.toml freedom_gate -- --nocapture` |
+| D7 Governed executor proof | WP-13 | LANDED | execution and refusal tests | `features/GOVERNED_EXECUTION_AND_TRACE.md`, `adl/src/governed_executor.rs` | `cargo test --manifest-path adl/Cargo.toml governed_executor -- --nocapture` |
+| D8 Trace/redaction proof | WP-14 | LANDED | trace schema plus governed redaction evidence tests | `features/GOVERNED_EXECUTION_AND_TRACE.md`, `adl/src/trace.rs`, `adl/src/trace_schema_v1.rs`, `adl/src/obsmem_indexing.rs` | `cargo test --manifest-path adl/Cargo.toml trace_v1 -- --nocapture && cargo test --manifest-path adl/Cargo.toml dangerous_negative_suite_wp14_governed_executor_trace_is_emitted_from_production_helper -- --nocapture` |
+| D9 Dangerous negative suite | WP-15 | LANDED | tracked report artifact | `features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md`, `review/dangerous-negative-suite-report.json` | `cargo test --manifest-path adl/Cargo.toml dangerous_negative_suite -- --nocapture` |
+| D10 Model proposal benchmark and local evaluation | WP-16-WP-17 | LANDED | tracked benchmark and local-evaluation reports | `features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md`, `review/model-proposal-benchmark-report.json`, `review/local-gemma-model-evaluation-report.json` | `cargo test --manifest-path adl/Cargo.toml model_proposal_benchmark -- --nocapture && cargo test --manifest-path adl/Cargo.toml local_gemma_model_evaluation -- --nocapture` |
+| D11 Governed Tools v1.0 flagship demo | WP-18 | LANDED | runnable demo contract and flagship proof bundle tests | `features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md`, `adl/src/runtime_v2/governed_tools_flagship_demo.rs`, `adl/src/runtime_v2/tests/governed_tools_flagship_demo.rs` | `cargo test --manifest-path adl/Cargo.toml runtime_v2_governed_tools_flagship_demo -- --nocapture && cargo test --manifest-path adl/Cargo.toml trace_runtime_v2_governed_tools_flagship_demo -- --nocapture` |
+| D12 Feature proof coverage record | WP-19 | LANDED | tracked reviewer map | `FEATURE_PROOF_COVERAGE_v0.90.5.md`, `DEMO_MATRIX_v0.90.5.md` | `test -f docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md && test -f docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md` |
+
+## Feature Demo Routes
+
+Every implementation-facing feature doc in this milestone now has one explicit
+review route.
+
+| Feature Doc | Demo / Proof Route | Demo Command(s) |
+| --- | --- | --- |
+| `features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md` | dangerous-category fail-closed suite plus flagship proposal/action evidence | `cargo test --manifest-path adl/Cargo.toml dangerous_negative_suite -- --nocapture`; `cargo test --manifest-path adl/Cargo.toml runtime_v2_governed_tools_flagship_demo -- --nocapture` |
+| `features/UTS_PUBLIC_SPEC_AND_CONFORMANCE.md` | deterministic UTS conformance harness and tracked report | `cargo test --manifest-path adl/Cargo.toml uts_conformance -- --nocapture` |
+| `features/ACC_AUTHORITY_AND_VISIBILITY.md` | ACC fixture, visibility-matrix, and redaction-example test surface | `cargo test --manifest-path adl/Cargo.toml acc_v1 -- --nocapture` |
+| `features/TOOL_REGISTRY_AND_COMPILER.md` | registry binding, compiler, and argument-normalization test chain | `cargo test --manifest-path adl/Cargo.toml wp08 -- --nocapture`; `cargo test --manifest-path adl/Cargo.toml wp09 -- --nocapture`; `cargo test --manifest-path adl/Cargo.toml wp10 -- --nocapture` |
+| `features/GOVERNED_EXECUTION_AND_TRACE.md` | policy, Freedom Gate, executor, and trace/redaction proof chain | `cargo test --manifest-path adl/Cargo.toml wp11 -- --nocapture`; `cargo test --manifest-path adl/Cargo.toml freedom_gate -- --nocapture`; `cargo test --manifest-path adl/Cargo.toml governed_executor -- --nocapture`; `cargo test --manifest-path adl/Cargo.toml trace_v1 -- --nocapture` |
+| `features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md` | benchmark runner, local-model evaluation, and flagship governed-tools demo | `cargo run --manifest-path adl/Cargo.toml --bin demo_v0905_model_proposal_benchmark`; `cargo run --manifest-path adl/Cargo.toml --bin demo_v0905_local_gemma_model_evaluation -- --out docs/milestones/v0.90.5/review/local-gemma-model-evaluation-report.json --model gemma4:e2b --model gemma4:e4b --model llama3.1:8b`; `adl runtime-v2 governed-tools-flagship-demo --out artifacts/v0905/demo-d11-governed-tools-flagship` |
+| `features/AGENT_COMMS_v1.md` | ACIP proof-demo and trace packet through focused `agent_comms` tests | `cargo test --manifest-path adl/Cargo.toml agent_comms --lib -- --nocapture` |
+| `features/LOCAL_MODEL_PR_REVIEWER_TOOL.md` | deterministic fixture review backend and optional live-local Ollama lane | `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-fixture --backend fixture --visibility read-only-repo --issue 2603 --writer-session codex-writer --reviewer-session fixture-reviewer` |
+| `features/CODING_AGENT_RUNNER.md` | provider-neutral fixture-mode proof for worktree-edit and proposal-only lanes through the ACIP coding specialization | `cargo test --manifest-path adl/Cargo.toml agent_comms --lib -- --nocapture` |
+
+## Adjacent Milestone Proof Lanes
+
+The following surfaces are visible in the same milestone package but are not
+part of the core Governed Tools v1.0 D1-D12 release gate:
+
+| Surface | Status | Proof Home | Notes |
+| --- | --- | --- | --- |
+| D13 ACIP proof demo | LANDED | `features/AGENT_COMMS_v1.md`, `adl/src/agent_comms.rs`, `adl/src/agent_comms/orchestrate/proof_demo.inc` | Comms-sprint proof of consultation -> negotiation -> governed coding invocation with deterministic reviewer/public redaction boundaries. |
+| Local model PR reviewer tool | LANDED as demo-grade tool guide | `features/LOCAL_MODEL_PR_REVIEWER_TOOL.md` | Operational review tool guidance and bounded fixture/live-local commands; not a D-row in the governed-tools proof gate. |
+| Coding agent runner | LANDED as provider-neutral contract | `features/CODING_AGENT_RUNNER.md` | Bounded coding invocation/output contract and review-handoff boundary; adjacent to Comms and reviewer flow, not a separate governed-tools D-row. |
+
+## Non-Proving Boundaries
+
+- These proofs do not make UTS a public standard or standalone execution grant.
+- These proofs do not permit direct model-output execution, arbitrary shell,
+  arbitrary network access, or destructive side effects.
+- These proofs do not prove production secrets integration or production cloud
+  sandboxing.
+- These proofs do not prove the full local-vs-remote and multi-model benchmark
+  comparison; that report remains deferred to `v0.91`.
+- The ACIP proof demo does not prove live transport, encrypted external
+  transport, reputation systems, or cross-polis federation.
+- The local model PR reviewer tool remains a demo-grade review surface and does
+  not replace independent human review or merge authority.
+
+## Named Deferrals
+
+The following claims remain explicitly deferred rather than implied:
+
+- full Gemma/local/remote comparison reporting in `v0.91`
+- production secrets handling
+- production sandbox enforcement
+- arbitrary external tool adapters beyond the bounded fixture-backed registry
+  and demo lanes
+- ACIP live transport and federation work beyond Comms-08
+
+## Non-Claims
+
+This record does not add new runtime behavior beyond the referenced D1 through
+D11 evidence surfaces. It does not claim:
+
+- UTS validity is execution authority
+- ACC construction alone is execution approval
+- benchmark or local-model scores are equivalent to runtime permission
+- the flagship demo proves arbitrary filesystem, process, or network execution
+- adjacent Comms or review-tool features have become part of the core governed
+  execution authority stack without their own separate review lanes

--- a/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
+++ b/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
@@ -17,23 +17,23 @@
 ## Implementation Gates
 
 - [x] UTS schema and conformance fixtures complete
-- [ ] ACC authority and visibility fixtures complete
-- [ ] compiler rejects unsafe or unsatisfiable proposals
-- [ ] policy and Freedom Gate mediation implemented
-- [ ] governed executor runs only approved ACC-backed actions
-- [ ] trace, replay, and redaction evidence available
+- [x] ACC authority and visibility fixtures complete
+- [x] compiler rejects unsafe or unsatisfiable proposals
+- [x] policy and Freedom Gate mediation implemented
+- [x] governed executor runs only approved ACC-backed actions
+- [x] trace, replay, and redaction evidence available
 - [x] dangerous negative suite passes
 - [x] model proposal benchmark executed or truthfully skipped by provider
 - [x] local/Gemma model evaluation recorded
-- [ ] flagship demo proof packet available
-- [ ] demo matrix and feature proof coverage completed before review convergence
+- [x] flagship demo proof packet available
+- [x] demo matrix and feature proof coverage completed before review convergence
 
 ## Review Gates
 
-- [ ] demo matrix updated with proof classifications
+- [x] demo matrix updated with proof classifications
 - [ ] coverage / quality gate complete
 - [ ] get-well wave disposition recorded by WP-20
-- [ ] feature docs linked and internally consistent
+- [x] feature docs linked and internally consistent
 - [ ] public-spec language checked for overclaiming
 - [ ] UTS validity never described as execution authority
 - [ ] privacy and redaction claims backed by tests or explicit deferrals

--- a/docs/milestones/v0.90.5/README.md
+++ b/docs/milestones/v0.90.5/README.md
@@ -123,6 +123,7 @@ Out of scope:
 - Sprint plan: SPRINT_v0.90.5.md
 - Decisions log: DECISIONS_v0.90.5.md
 - Demo matrix: DEMO_MATRIX_v0.90.5.md
+- Feature proof coverage: FEATURE_PROOF_COVERAGE_v0.90.5.md
 - Feature index: FEATURE_DOCS_v0.90.5.md
 - WP execution readiness: WP_EXECUTION_READINESS_v0.90.5.md
 - Milestone checklist: MILESTONE_CHECKLIST_v0.90.5.md

--- a/docs/milestones/v0.90.5/features/ACC_AUTHORITY_AND_VISIBILITY.md
+++ b/docs/milestones/v0.90.5/features/ACC_AUTHORITY_AND_VISIBILITY.md
@@ -99,3 +99,20 @@ not as executable tool trace evidence.
   evaluation, Freedom Gate mediation, or governed execution.
 - WP-07 does not implement the later registry, compiler, policy evaluator,
   Freedom Gate mediator, or executor.
+
+## Reviewer Demo Path
+
+The bounded ACC proof path is fixture-backed. Reviewers should inspect the
+typed ACC contract, visibility matrix, and redaction examples together.
+
+Focused proving command:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml acc_v1 -- --nocapture
+```
+
+Expected review signal:
+
+- accountable actor, grantor, and delegation state are explicit;
+- reviewer/public visibility stays redacted by default; and
+- unsafe or hidden delegation fails before later policy or execution phases.

--- a/docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md
+++ b/docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md
@@ -410,6 +410,13 @@ The packet must also carry explicit non-proving statements for:
 This keeps the Comms-08 proof memorable and citable without implying that ACIP
 v1 has already solved production transport or federation concerns.
 
+The current implementation exposes that proof through the focused `agent_comms`
+test surface:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml agent_comms --lib -- --nocapture
+```
+
 ## Non-Proving Statements
 
 ACIP v1 does not prove:

--- a/docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md
+++ b/docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md
@@ -158,6 +158,13 @@ The fixture-mode proof surface is:
 - negative cases proving that non-Codex lanes cannot use worktree-edit and that
   review bypass or writer-identity drift is rejected
 
+The current focused proof command is the shared ACIP test surface that covers
+the coding specialization:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml agent_comms --lib -- --nocapture
+```
+
 ## Interaction With Reviewer-Agent Work
 
 `LOCAL_MODEL_PR_REVIEWER_TOOL.md` remains the concrete backend for the

--- a/docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md
+++ b/docs/milestones/v0.90.5/features/GOVERNED_EXECUTION_AND_TRACE.md
@@ -105,3 +105,27 @@ deterministic, and privacy-preserving. They are allowed to prove message,
 invocation, refusal, failure, and output accountability, but they must not
 become a side channel for prompts, raw tool arguments, private state, rejected
 alternatives, or local workstation paths.
+
+## Reviewer Demo Path
+
+The bounded proof path for this feature is staged:
+
+1. policy-authority evaluation;
+2. Freedom Gate mediation;
+3. governed execution/refusal; and
+4. trace and redaction evidence.
+
+Focused proving commands:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml wp11 -- --nocapture
+cargo test --manifest-path adl/Cargo.toml freedom_gate -- --nocapture
+cargo test --manifest-path adl/Cargo.toml governed_executor -- --nocapture
+cargo test --manifest-path adl/Cargo.toml trace_v1 -- --nocapture
+```
+
+Expected review signal:
+
+- only approved ACC-backed actions reach execution;
+- denials and deferrals remain first-class evidence; and
+- reviewer/public trace views stay redacted and portable.

--- a/docs/milestones/v0.90.5/features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md
+++ b/docs/milestones/v0.90.5/features/TOOL_CALL_THREAT_MODEL_AND_SEMANTICS.md
@@ -157,3 +157,27 @@ Later v0.90.5 work packages should cite this document as the shared boundary:
   replay, and redaction evidence across approved and denied paths.
 - WP-15 through WP-18 must prove dangerous categories fail closed and make the
   proposal/action separation visible in benchmark and demo surfaces.
+
+## Reviewer Demo Path
+
+This feature is primarily a boundary contract, so its demo path is a bounded
+review route rather than a standalone binary. Review it through:
+
+1. the threat-model contract in this file;
+2. the dangerous negative suite for fail-closed behavior; and
+3. the flagship governed-tools demo for proposal-vs-action evidence.
+
+Focused proving commands:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml dangerous_negative_suite -- --nocapture
+cargo test --manifest-path adl/Cargo.toml runtime_v2_governed_tools_flagship_demo -- --nocapture
+```
+
+Expected review signal:
+
+- dangerous categories are still only proposals until later governance checks
+  succeed;
+- destructive, process, network, and exfiltration cases fail closed; and
+- the flagship packet keeps the proposal/action split visible in reviewer
+  evidence.

--- a/docs/milestones/v0.90.5/features/TOOL_REGISTRY_AND_COMPILER.md
+++ b/docs/milestones/v0.90.5/features/TOOL_REGISTRY_AND_COMPILER.md
@@ -135,3 +135,23 @@ identical ACC or identical rejection.
 For WP-08, determinism is proven at the registry-binding layer. WP-09 extends
 that proof to deterministic UTS/proposal/registry/policy compilation into ACC
 or rejection records for the fixture-backed governed-tools slice.
+
+## Reviewer Demo Path
+
+This feature has a two-step demo route: registry binding first, compiler and
+argument normalization second.
+
+Focused proving commands:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml wp08 -- --nocapture
+cargo test --manifest-path adl/Cargo.toml wp09 -- --nocapture
+cargo test --manifest-path adl/Cargo.toml wp10 -- --nocapture
+```
+
+Expected review signal:
+
+- unknown or unregistered tools cannot bind;
+- valid bounded proposals compile into ACC deterministically; and
+- malformed, ambiguous, traversal-shaped, or injection-shaped arguments are
+  rejected before policy or execution.


### PR DESCRIPTION
## Summary
- add a new v0.90.5 feature proof coverage reviewer map
- wire explicit reviewer demo/proof routes into milestone feature docs
- align the demo matrix, checklist, README, and feature index with the landed proof coverage state

## Validation
- git diff --check
- repository-relative path existence checks for touched docs and cited review artifacts
- cross-link and command consistency checks with rg
- feature inventory coverage check over FEATURE_DOCS_v0.90.5.md

## Review
- pre-PR gpt-5.3-codex-spark subagent review run twice
- addressed all findings before opening this PR

Closes #2584