### PR TITLE
[v0.90.5][WP-20] Coverage / quality gate

### DIFF
--- a/docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md
@@ -6,6 +6,10 @@ WP-19 / D12 is landed. Every core Governed Tools v1.0 feature claim now has
 one explicit proof home before WP-20 quality, WP-21 docs/review, and later
 release convergence.
 
+The landed Comms / ACIP tranche is also first-level milestone work for WP-20
+quality evidence, with its own explicit proof homes and non-proving
+boundaries.
+
 This record is a reviewer map. It does not grant execution authority by itself.
 It binds the demo matrix to the landed feature docs, tracked review artifacts,
 focused tests, bounded demo commands, and explicit non-proving boundaries.
@@ -20,9 +24,10 @@ Each governed-tools feature claim must have one of:
 - documented non-proving status
 - explicit deferral with owner and rationale
 
-For v0.90.5, D1 through D12 are landed. D13 remains an adjacent Comms-sprint
-proof lane that is visible in the same milestone package but is not part of the
-core Governed Tools v1.0 release gate.
+For v0.90.5, D1 through D12 are landed as the core Governed Tools v1.0 release
+rows. D13 is also landed as first-level milestone evidence for the Comms sprint.
+It remains distinct from the governed-execution authority stack even while it
+is included in the WP-20 quality story.
 
 ## Coverage Table
 
@@ -58,16 +63,17 @@ review route.
 | `features/LOCAL_MODEL_PR_REVIEWER_TOOL.md` | deterministic fixture review backend and optional live-local Ollama lane | `cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-fixture --backend fixture --visibility read-only-repo --issue 2603 --writer-session codex-writer --reviewer-session fixture-reviewer` |
 | `features/CODING_AGENT_RUNNER.md` | provider-neutral fixture-mode proof for worktree-edit and proposal-only lanes through the ACIP coding specialization | `cargo test --manifest-path adl/Cargo.toml agent_comms --lib -- --nocapture` |
 
-## Adjacent Milestone Proof Lanes
+## Companion First-Level Milestone Proof Lanes
 
-The following surfaces are visible in the same milestone package but are not
-part of the core Governed Tools v1.0 D1-D12 release gate:
+The following surfaces are first-level milestone evidence for WP-20 quality
+review, while remaining distinct from the core Governed Tools v1.0 D1-D12
+execution-authority gate:
 
 | Surface | Status | Proof Home | Notes |
 | --- | --- | --- | --- |
-| D13 ACIP proof demo | LANDED | `features/AGENT_COMMS_v1.md`, `adl/src/agent_comms.rs`, `adl/src/agent_comms/orchestrate/proof_demo.inc` | Comms-sprint proof of consultation -> negotiation -> governed coding invocation with deterministic reviewer/public redaction boundaries. |
-| Local model PR reviewer tool | LANDED as demo-grade tool guide | `features/LOCAL_MODEL_PR_REVIEWER_TOOL.md` | Operational review tool guidance and bounded fixture/live-local commands; not a D-row in the governed-tools proof gate. |
-| Coding agent runner | LANDED as provider-neutral contract | `features/CODING_AGENT_RUNNER.md` | Bounded coding invocation/output contract and review-handoff boundary; adjacent to Comms and reviewer flow, not a separate governed-tools D-row. |
+| D13 ACIP proof demo | LANDED | `features/AGENT_COMMS_v1.md`, `adl/src/agent_comms.rs`, `adl/src/agent_comms/orchestrate/proof_demo.inc` | Comms-sprint proof of consultation -> negotiation -> governed coding invocation with deterministic reviewer/public redaction boundaries; first-level milestone evidence for WP-20. |
+| Local model PR reviewer tool | LANDED as demo-grade tool guide | `features/LOCAL_MODEL_PR_REVIEWER_TOOL.md` | Operational review tool guidance and bounded fixture/live-local commands; first-level milestone evidence for review posture, not a D-row in the governed-tools execution gate. |
+| Coding agent runner | LANDED as provider-neutral contract | `features/CODING_AGENT_RUNNER.md` | Bounded coding invocation/output contract and review-handoff boundary; first-level milestone evidence for the Comms tranche, not a separate governed-tools D-row. |
 
 ## Non-Proving Boundaries
 
@@ -103,5 +109,5 @@ D11 evidence surfaces. It does not claim:
 - ACC construction alone is execution approval
 - benchmark or local-model scores are equivalent to runtime permission
 - the flagship demo proves arbitrary filesystem, process, or network execution
-- adjacent Comms or review-tool features have become part of the core governed
-  execution authority stack without their own separate review lanes
+- first-level Comms or review-tool features have become part of the core
+  governed execution authority stack without their own separate review lanes

--- a/docs/milestones/v0.90.5/GET_WELL_PLAN_v0.90.5.md
+++ b/docs/milestones/v0.90.5/GET_WELL_PLAN_v0.90.5.md
@@ -20,7 +20,8 @@ and must not reorder the Governed Tools v1.0 implementation state machine.
 - GW-01 through GW-05 are the bounded runtime-reduction slices opened from the
   detailed source plan.
 - WP-20, Coverage / quality gate, records final disposition and evidence from
-  the get-well wave before release closeout.
+  the get-well wave before release closeout in
+  `docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md`.
 - WP-25 captures any follow-on runtime-reduction work that remains after
   `v0.90.5`.
 
@@ -95,3 +96,7 @@ WP-20 must record one of these outcomes:
 
 No release closeout should claim that the validation-cost problem is solved
 unless the coverage/quality evidence supports that claim.
+
+The canonical WP-20 disposition record now lives in:
+
+- [Quality Gate - v0.90.5](QUALITY_GATE_v0.90.5.md)

--- a/docs/milestones/v0.90.5/GET_WELL_TRACKING_v0.90.5.md
+++ b/docs/milestones/v0.90.5/GET_WELL_TRACKING_v0.90.5.md
@@ -99,3 +99,11 @@ WP-20 must record the final GW wave outcome before release closeout:
 - deferred slices and rationale
 - updated authoritative coverage wall-time evidence
 - remaining tests over `45s` and over `60s`
+
+Recorded WP-20 disposition:
+
+- `docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md`
+- current outcome: merged GW wave is complete, and a post-GW authoritative
+  push run exists for current `main` (`25272620889`), but that run failed the
+  coverage gate and its runtime-effect summary has not yet been normalized into
+  this tracking artifact

--- a/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
+++ b/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
@@ -31,8 +31,9 @@
 ## Review Gates
 
 - [x] demo matrix updated with proof classifications
-- [ ] coverage / quality gate complete
-- [ ] get-well wave disposition recorded by WP-20
+- [x] [coverage / quality gate](QUALITY_GATE_v0.90.5.md) complete, including
+  first-level Comms evidence
+- [x] get-well wave disposition recorded by WP-20
 - [x] feature docs linked and internally consistent
 - [ ] public-spec language checked for overclaiming
 - [ ] UTS validity never described as execution authority

--- a/docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md
+++ b/docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md
@@ -18,6 +18,7 @@ It is the release-truth surface for:
 - the live coverage policy and evidence authority
 - the first-level milestone proof package for Governed Tools v1.0 and the
   landed Comms / ACIP tranche
+- the first-level gap-review and Rust maintainability / Rustdoc watch posture
 - the explicit exception register for still-pending or non-green validation
   posture
 - the get-well wave disposition that must be recorded before release closeout
@@ -44,6 +45,8 @@ The milestone also needs one canonical surface that states:
 - which evidence is authoritative for coverage posture versus runtime-cost
   remeasurement
 - which milestone proof surfaces count as first-level evidence
+- which open release-tail, closeout-drift, and Rust maintainability gaps remain
+  first-level release risks
 - which exceptions remain explicit rather than implied
 
 ## Gate Structure
@@ -61,6 +64,20 @@ The third proves the milestone is backed by reviewer-facing proof surfaces
 rather than scattered feature claims. The fourth keeps unresolved runtime-cost
 and watchdog posture explicit instead of pretending the remaining gaps are
 already solved.
+
+## First-Level Gap and Maintainability Inputs
+
+WP-20 also treats the existing gap-review and Rustdoc tracking surfaces as
+first-level evidence inputs rather than background notes.
+
+Primary inputs:
+
+- `.adl/docs/TBD/retired/gap_reviews/v0.90.5_gap_review.md`
+- `.adl/docs/TBD/RUSTDOC_GAP_ANALYSIS.md`
+- live GitHub issue list for `version:v0.90.5`
+
+These inputs matter because they describe release-tail incompleteness and Rust
+maintainability/documentation debt that CI-green alone does not capture.
 
 ## Required vs Documented Exceptions
 
@@ -180,12 +197,68 @@ Its primary proof surfaces are:
 - `docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md`
 - `docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md`
 
+The landed issue chain is:
+
+- `#2628` Comms-01: promote ACIP v1 general protocol architecture
+- `#2629` Comms-02: canonical ACIP envelope and identity model
+- `#2630` Comms-03: invocation contract and Freedom Gate event binding
+- `#2631` Comms-04: validation fixtures and conformance suite
+- `#2632` Comms-05: review-agent specialization and SRP policy binding
+- `#2627` Comms-06: coding-agent specialization and provider-neutral runner
+- `#2633` Comms-07: trace, replay, redaction, and evidence integration
+- `#2634` Comms-08: ACIP demo and proof coverage
+
+The quality significance of that chain is:
+
+- the milestone now has a stable message substrate rather than role-specific
+  prompt hacks
+- invocation is explicitly bound to policy / Freedom Gate references
+- reviewer-facing conformance, redaction, and evidence surfaces are present
+- coding and review specializations are bounded and do not collapse into
+  same-session write-and-bless authority
+- the final ACIP proof demo is deterministic and reviewable without pretending
+  to prove live transport or federation
+
 The WP-20 interpretation is:
 
 - Comms is first-level milestone work for proof, evidence, and review posture.
 - Comms is not execution authority by message alone.
 - Comms does not bypass UTS, ACC, policy evaluation, Freedom Gate, or governed
   execution.
+- Comms quality is evaluated through its own merged proof and conformance
+  surfaces, not by silently absorbing it into the governed-tools authority
+  stack.
+
+### Comms quality posture
+
+For WP-20, the Comms tranche is treated as substantively landed first-level
+work, not as a speculative future lane.
+
+Evidence used here:
+
+- Comms-08 PR evidence: [#2676](https://github.com/danielbaustin/agent-design-language/pull/2676)
+  merged green with `adl-ci` and `adl-coverage`
+- Comms feature and proof surfaces:
+  - `docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md`
+  - `docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md`
+  - `docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md`
+  - `docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
+  - `docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md`
+
+What WP-20 is willing to say:
+
+- the Comms tranche has first-level milestone proof and conformance visibility
+- the coding and reviewer lanes are bounded enough to participate in reviewable
+  milestone quality evidence
+- the ACIP proof-demo and supporting tests are part of the release-quality
+  story
+
+What WP-20 is not willing to say:
+
+- that ACIP is a production transport layer
+- that ACIP grants execution authority on its own
+- that Comms has erased the need for governed execution, review, or redaction
+  boundaries
 
 ### Proof-package rule
 
@@ -194,13 +267,74 @@ to `v0.90.5`; the landed Comms tranche must remain visible in the same quality
 story. At the same time, later docs must not erase the distinction between
 first-level milestone visibility and core execution-authority semantics.
 
-## 4) Exception Register and Get-Well Disposition
+## 4) Gap Review and Rust Maintainability Watch
+
+### Existing gap-review posture
+
+The existing `v0.90.5` gap review reports that the milestone is not yet ready
+for final closure because the release tail remains open and closeout truth is
+still incomplete.
+
+First-level findings still relevant to WP-20:
+
+- release-tail issues `#2586` through `#2591` are open
+- closeout truth drift remains a known class of risk for some already-closed
+  issues
+- milestone/release docs remain incomplete until later review-tail work lands
+- metadata parity and automation truth still require cleanup
+
+WP-20 does not duplicate the full gap-review report, but it now treats that
+report as a first-level risk surface for release quality.
+
+### Rust maintainability and Rustdoc tracker posture
+
+The existing Rustdoc gap tracker reports that ADL can generate docs today but
+has low public API documentation coverage and no compiler-level `missing_docs`
+enforcement.
+
+Key points from the tracker:
+
+- approximate public-item documentation coverage is about `8.8%`
+- `runtime_v2`, `godel`, `chronosense`, `trace`, and `control_plane` are among
+  the least documented architectural surfaces
+- maintainability/documentation debt is concentrated in the same large Rust
+  subsystems that are important for onboarding and review
+
+This is not a release blocker by itself for WP-20, but it is first-level
+quality context that later docs/review and planning work must not ignore.
+
+### Live open issue watch
+
+The current open issue list reinforces the same release-quality story:
+
+- release-tail work still open:
+  - `#2586` `WP-21`
+  - `#2587` `WP-22`
+  - `#2588` `WP-23`
+  - `#2589` `WP-24`
+  - `#2590` `WP-25`
+  - `#2591` `WP-26`
+- open Rust maintainability / refactor work:
+  - `#2663` split `adl/src/agent_comms.rs`
+  - `#2664` split `adl/src/uts_acc_compiler.rs`
+  - `#2665` / `#2688` split `adl/src/trace.rs`
+  - `#2686` split `adl/src/cli/tooling_cmd/code_review.rs`
+  - `#2687` split `adl/src/runtime_v2/private_state_sanctuary.rs`
+  - `#2690` fix Rust PR control-plane hangs in `pr.sh` lifecycle commands
+
+These issues are not all owned by WP-20, but they are part of the first-level
+quality and maintainability posture that this gate must surface truthfully.
+
+## 5) Exception Register and Get-Well Disposition
 
 ### Exception Register
 
 | Area | State | Owner | Rationale | Disposition |
 | --- | --- | --- | --- | --- |
 | Current `main` authoritative coverage posture | failure | `WP-20` / follow-on quality tail | The latest push-to-main run for head `4087678b` (`25272620889`) completed with `adl-ci` green but `adl-coverage` red at the coverage-policy enforcement step. | Record as an explicit gate exception; release-tail work must not describe current `main` as fully green until the coverage failure is fixed. |
+| Release-tail gap-review posture | open | `WP-21` through `WP-26` | The existing `v0.90.5` gap review still identifies the release tail as incomplete, with review, remediation, planning, and ceremony work not yet executed. | Keep these open issues as first-level release risks; WP-20 does not convert them into completed work. |
+| Closed-issue closeout drift class | explicit gap | `WP-24` / closeout follow-up | The existing `v0.90.5` gap review reports stale closeout truth on some already-closed issues. | Preserve as a named quality risk until later closeout normalization clears the affected records. |
+| Rust maintainability and Rustdoc coverage debt | explicit gap | maintainability backlog / `WP-25` planning | The Rustdoc tracker shows low public API documentation coverage, and multiple large Rust maintainability/refactor issues remain open in `v0.90.5`. | Record as first-level quality context and hand it forward into docs/review/planning rather than implying it is already resolved. |
 | Post-GW runtime-cost remeasurement normalization | explicit gap | `WP-20` / `WP-25` | A post-GW authoritative push run now exists (`25272620889`), but the tracking artifact does not yet record normalized remaining hotspot counts or a reviewed runtime-effect summary, and the run itself failed the coverage gate. | Quality gate is satisfied with an explicit measurement exception; runtime-cost closure remains a follow-on unless later work captures a green authoritative remeasurement. |
 | Nightly coverage watchdog stability | explicit gap | `daily blocker follow-up lane` | Recent `nightly-coverage-ratchet` runs failed before the merged fix in [#2691](https://github.com/danielbaustin/agent-design-language/pull/2691); the watchdog is not itself the canonical release gate. | Keep nightly failures visible, but do not let the watchdog replace the merge gate or milestone proof package. |
 

--- a/docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md
+++ b/docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md
@@ -1,0 +1,257 @@
+# v0.90.5 Coverage and Quality Gate
+
+## Metadata
+
+- Milestone: `v0.90.5`
+- Version: `v0.90.5`
+- Owner: `Daniel Austin / Codex`
+- Canonical issue / WP: `#2585` / `WP-20`
+- Scope: milestone quality, coverage, proof-package, and get-well posture
+
+## Purpose
+
+This document defines the canonical `v0.90.5` quality gate.
+
+It is the release-truth surface for:
+
+- the required repository merge-gate posture
+- the live coverage policy and evidence authority
+- the first-level milestone proof package for Governed Tools v1.0 and the
+  landed Comms / ACIP tranche
+- the explicit exception register for still-pending or non-green validation
+  posture
+- the get-well wave disposition that must be recorded before release closeout
+
+This document records the gate. It does not replace CI implementation, but the
+gate, the milestone docs, and the live GitHub enforcement surfaces must agree.
+
+## Why This Exists
+
+`v0.90.5` now has two first-level milestone proof bands that must remain
+reviewable together:
+
+- Governed Tools v1.0, with core proof rows `D1` through `D12`
+- the landed Comms / ACIP tranche, including `D13` and the coding/reviewer
+  companion feature surfaces
+
+That means "CI is green" is necessary, but not sufficient by itself.
+
+The milestone also needs one canonical surface that states:
+
+- which checks are required
+- which checks are enforced in CI
+- how coverage is judged
+- which evidence is authoritative for coverage posture versus runtime-cost
+  remeasurement
+- which milestone proof surfaces count as first-level evidence
+- which exceptions remain explicit rather than implied
+
+## Gate Structure
+
+The `v0.90.5` gate has four layers:
+
+1. baseline repository merge gate
+2. coverage posture gate
+3. milestone proof-package gate
+4. exception and get-well disposition gate
+
+The first layer proves the ordinary repository merge gate is green. The second
+proves coverage is governed by explicit thresholds and visible authority rules.
+The third proves the milestone is backed by reviewer-facing proof surfaces
+rather than scattered feature claims. The fourth keeps unresolved runtime-cost
+and watchdog posture explicit instead of pretending the remaining gaps are
+already solved.
+
+## Required vs Documented Exceptions
+
+- **Required** means the item must pass for the relevant phase.
+- **Exception documented** means the owner, rationale, and disposition are
+  explicit.
+- Exceptions do not convert a blocker into a pass.
+
+## 1) Baseline Repository Merge Gate
+
+The canonical merge-gate workflow is `.github/workflows/ci.yaml`.
+
+The required jobs are:
+
+- `adl-ci`
+- `adl-coverage`
+
+These jobs are the minimum repo gate, but they are not the whole milestone
+quality story. A green CI state is necessary, not sufficient, unless the
+milestone proof package named below also exists and remains truthful.
+
+### Current CI command and policy surfaces
+
+The merge-gate posture currently depends on:
+
+- `.github/workflows/ci.yaml`
+- `adl/tools/ci_path_policy.sh`
+- `adl/tools/run_pr_fast_test_lane.sh`
+- `adl/tools/run_authoritative_coverage_lane.sh`
+- `adl/tools/check_coverage_impact.sh`
+- `adl/tools/enforce_coverage_gates.sh`
+
+At a high level:
+
+- `adl-ci` enforces shell/tooling sanity, contract checks, guardrails, docs
+  command checks, CI runtime/cache contract checks, Rust validation when the
+  path policy requires it, and demo smoke when the path policy requires it.
+- `adl-coverage` enforces either a full authoritative all-features
+  `cargo llvm-cov nextest` lane or a bounded PR-fast coverage summary lane,
+  depending on path policy and changed-surface risk.
+
+### Truth rule
+
+WP-20 treats CI-green as required repository evidence, but not as a substitute
+for milestone proof surfaces. Release-tail docs must not imply that merge-gate
+success alone proves the flagship, local/Gemma, or ACIP proof stories.
+
+## 2) Coverage Posture Gate
+
+The current coverage gate is `adl-coverage`.
+
+It enforces:
+
+- workspace line coverage threshold: `90%`
+- per-file line coverage threshold: `80%`
+- active exclusion regex: `^$`
+
+That means there are no active per-file exclusions in the merge gate.
+
+Coverage enforcement is implemented by:
+
+- `adl/tools/run_authoritative_coverage_lane.sh`
+- `adl/tools/check_coverage_impact.sh`
+- `adl/tools/enforce_coverage_gates.sh`
+
+### Coverage authority rule
+
+- Push-to-main runs use the authoritative all-features coverage lane.
+- Pull requests may use a bounded PR-fast coverage lane when path policy allows
+  it.
+- Therefore, a green PR coverage check is valid merge-gate evidence, but it is
+  not automatically a full authoritative wall-time remeasurement of the entire
+  milestone.
+
+### Live evidence used by this gate
+
+- WP-19 PR evidence: [#2689](https://github.com/danielbaustin/agent-design-language/pull/2689)
+  merged on `2026-05-03` with green `adl-ci` and `adl-coverage` checks.
+- Flagship-demo PR evidence: [#2679](https://github.com/danielbaustin/agent-design-language/pull/2679)
+  merged on `2026-04-29` with green `adl-ci` and `adl-coverage` checks.
+- Comms-08 PR evidence: [#2676](https://github.com/danielbaustin/agent-design-language/pull/2676)
+  merged on `2026-04-29` with green `adl-ci` and `adl-coverage` checks.
+- Daily coverage-blocker fix PR evidence: [#2691](https://github.com/danielbaustin/agent-design-language/pull/2691)
+  merged on `2026-05-03` with green `adl-ci` and `adl-coverage` checks.
+- current `main` push evidence: GitHub Actions run `25272620889` for head
+  `4087678b` completed on `2026-05-03` with:
+  - `adl-ci`: success
+  - `adl-coverage`: failure at `Enforce coverage policy gates (workspace + per-file)`
+
+## 3) Milestone Proof-Package Gate
+
+WP-20 covers both core governed-tools proof rows and the landed Comms / ACIP
+tranche as first-level milestone work.
+
+### Core governed-tools first-level evidence
+
+The core Governed Tools v1.0 proof package is anchored by:
+
+- `docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
+- `docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md`
+- `docs/milestones/v0.90.5/features/MODEL_TESTING_AND_FLAGSHIP_DEMO.md`
+- `docs/milestones/v0.90.5/review/model-proposal-benchmark-report.json`
+- `docs/milestones/v0.90.5/review/local-gemma-model-evaluation-report.json`
+
+This covers the landed proof rows `D1` through `D12`.
+
+### Comms / ACIP first-level evidence
+
+The landed Comms tranche is also first-level milestone evidence for WP-20,
+even though it remains distinct from the governed-execution authority stack.
+
+Its primary proof surfaces are:
+
+- `docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md` (`D13`)
+- `docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md`
+- `docs/milestones/v0.90.5/features/AGENT_COMMS_v1.md`
+- `docs/milestones/v0.90.5/features/CODING_AGENT_RUNNER.md`
+- `docs/milestones/v0.90.5/features/LOCAL_MODEL_PR_REVIEWER_TOOL.md`
+
+The WP-20 interpretation is:
+
+- Comms is first-level milestone work for proof, evidence, and review posture.
+- Comms is not execution authority by message alone.
+- Comms does not bypass UTS, ACC, policy evaluation, Freedom Gate, or governed
+  execution.
+
+### Proof-package rule
+
+Later release-tail issues must not speak as though only Governed Tools mattered
+to `v0.90.5`; the landed Comms tranche must remain visible in the same quality
+story. At the same time, later docs must not erase the distinction between
+first-level milestone visibility and core execution-authority semantics.
+
+## 4) Exception Register and Get-Well Disposition
+
+### Exception Register
+
+| Area | State | Owner | Rationale | Disposition |
+| --- | --- | --- | --- | --- |
+| Current `main` authoritative coverage posture | failure | `WP-20` / follow-on quality tail | The latest push-to-main run for head `4087678b` (`25272620889`) completed with `adl-ci` green but `adl-coverage` red at the coverage-policy enforcement step. | Record as an explicit gate exception; release-tail work must not describe current `main` as fully green until the coverage failure is fixed. |
+| Post-GW runtime-cost remeasurement normalization | explicit gap | `WP-20` / `WP-25` | A post-GW authoritative push run now exists (`25272620889`), but the tracking artifact does not yet record normalized remaining hotspot counts or a reviewed runtime-effect summary, and the run itself failed the coverage gate. | Quality gate is satisfied with an explicit measurement exception; runtime-cost closure remains a follow-on unless later work captures a green authoritative remeasurement. |
+| Nightly coverage watchdog stability | explicit gap | `daily blocker follow-up lane` | Recent `nightly-coverage-ratchet` runs failed before the merged fix in [#2691](https://github.com/danielbaustin/agent-design-language/pull/2691); the watchdog is not itself the canonical release gate. | Keep nightly failures visible, but do not let the watchdog replace the merge gate or milestone proof package. |
+
+### Get-Well Disposition
+
+Baseline source: `docs/milestones/v0.90.5/GET_WELL_TRACKING_v0.90.5.md`
+
+- baseline authoritative coverage wall time: `660.944s`
+- baseline unique tests over `45s`: `39`
+- baseline tests over `60s`: `1`
+- baseline deduped cumulative runtime over `45s`: `1938.389s`
+
+Merged GW slices:
+
+- GW-00 / [#2592](https://github.com/danielbaustin/agent-design-language/issues/2592): baseline, budget, and tracking artifact
+- GW-01 / [#2593](https://github.com/danielbaustin/agent-design-language/issues/2593): external-counterparty proof-family collapse
+- GW-02 / [#2594](https://github.com/danielbaustin/agent-design-language/issues/2594): private-state observatory proof-family collapse
+- GW-03 / [#2595](https://github.com/danielbaustin/agent-design-language/issues/2595): delegation-subcontract proof-family collapse
+- GW-04 / [#2596](https://github.com/danielbaustin/agent-design-language/issues/2596): contract-market and resource-stewardship proof-family collapse
+- GW-05 / [#2597](https://github.com/danielbaustin/agent-design-language/issues/2597): CLI/demo proof-matrix tail reduction
+
+Measured effect:
+
+- Each merged GW slice has local proving evidence recorded in the tracking
+  artifact.
+- The merged PR surface is green for recent release-tail work, including
+  `#2689` and `#2691`.
+- A post-GW authoritative push run now exists for current `main`
+  (`25272620889`), but it failed the coverage-policy gate and has not yet been
+  normalized into a reviewed runtime-effect summary in the tracking artifact.
+
+WP-20 therefore records the get-well wave as:
+
+- **completed as a merged execution-support wave**
+- **not yet authoritatively closed on runtime-cost measurement**
+
+## WP-20 Outcome
+
+`WP-20` is **satisfied with explicit exceptions**.
+
+That means:
+
+- the canonical quality gate now exists
+- the repo merge gate, coverage posture, proof-package posture, and get-well
+  disposition are all documented in one place
+- Comms / ACIP is included as first-level milestone work in the quality story
+- unresolved coverage-gate failure on current `main` and incomplete runtime-cost
+  closure remain explicit rather than hidden
+
+This outcome does **not** claim:
+
+- that the runtime-cost problem is fully solved
+- that Comms has become execution authority
+- that later docs/review/release-tail work is already complete

--- a/docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md
+++ b/docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md
@@ -75,6 +75,8 @@ Primary inputs:
 - `.adl/docs/TBD/retired/gap_reviews/v0.90.5_gap_review.md`
 - `.adl/docs/TBD/RUSTDOC_GAP_ANALYSIS.md`
 - live GitHub issue list for `version:v0.90.5`
+- `docs/milestones/v0.90.5/README.md`
+- `docs/milestones/v0.90.5/RELEASE_NOTES_v0.90.5.md`
 
 These inputs matter because they describe release-tail incompleteness and Rust
 maintainability/documentation debt that CI-green alone does not capture.
@@ -325,6 +327,23 @@ The current open issue list reinforces the same release-quality story:
 These issues are not all owned by WP-20, but they are part of the first-level
 quality and maintainability posture that this gate must surface truthfully.
 
+### Planning-package truth still visible at WP-20
+
+The tracked planning package still matters at this stage because it defines
+parallel milestone work that has to remain visible even when WP-20 is focused
+on quality rather than fresh implementation.
+
+That includes:
+
+- the separate get-well runtime-reduction wave
+- the parallel Comms sprint
+- the bounded Python-reduction tranche described in
+  `docs/milestones/v0.90.5/README.md` and `docs/milestones/v0.90.5/WBS_v0.90.5.md`
+
+WP-20 does not claim the Python tranche is fully dispositioned here, but it
+does treat it as milestone truth that later closeout docs must not silently
+erase.
+
 ## 5) Exception Register and Get-Well Disposition
 
 ### Exception Register
@@ -335,6 +354,8 @@ quality and maintainability posture that this gate must surface truthfully.
 | Release-tail gap-review posture | open | `WP-21` through `WP-26` | The existing `v0.90.5` gap review still identifies the release tail as incomplete, with review, remediation, planning, and ceremony work not yet executed. | Keep these open issues as first-level release risks; WP-20 does not convert them into completed work. |
 | Closed-issue closeout drift class | explicit gap | `WP-24` / closeout follow-up | The existing `v0.90.5` gap review reports stale closeout truth on some already-closed issues. | Preserve as a named quality risk until later closeout normalization clears the affected records. |
 | Rust maintainability and Rustdoc coverage debt | explicit gap | maintainability backlog / `WP-25` planning | The Rustdoc tracker shows low public API documentation coverage, and multiple large Rust maintainability/refactor issues remain open in `v0.90.5`. | Record as first-level quality context and hand it forward into docs/review/planning rather than implying it is already resolved. |
+| Release notes and public closeout wording | draft | `WP-21` / `WP-26` | `RELEASE_NOTES_v0.90.5.md` is still explicitly aspirational and not yet aligned to final release evidence. | Keep release-note truth as a first-level release-tail gap until docs/review and release ceremony close it out. |
+| Python-reduction tranche disposition | explicit gap | `WP-25` planning | The milestone planning package reserves a bounded Python-reduction tranche, but WP-20 does not yet record a completed tranche disposition. | Keep the tranche visible as milestone truth and require explicit handoff or deferral in later planning/closeout work. |
 | Post-GW runtime-cost remeasurement normalization | explicit gap | `WP-20` / `WP-25` | A post-GW authoritative push run now exists (`25272620889`), but the tracking artifact does not yet record normalized remaining hotspot counts or a reviewed runtime-effect summary, and the run itself failed the coverage gate. | Quality gate is satisfied with an explicit measurement exception; runtime-cost closure remains a follow-on unless later work captures a green authoritative remeasurement. |
 | Nightly coverage watchdog stability | explicit gap | `daily blocker follow-up lane` | Recent `nightly-coverage-ratchet` runs failed before the merged fix in [#2691](https://github.com/danielbaustin/agent-design-language/pull/2691); the watchdog is not itself the canonical release gate. | Keep nightly failures visible, but do not let the watchdog replace the merge gate or milestone proof package. |
 

--- a/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
+++ b/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
@@ -18,7 +18,8 @@ Freedom Gate mediation, and trace.
 - simple bounded local/Gemma evaluation demo or explicit skip
 - flagship demo proof packet
 - feature proof coverage record
-- coverage / quality gate record
+- [coverage / quality gate record](QUALITY_GATE_v0.90.5.md), including
+  first-level Comms / ACIP evidence
 - get-well wave disposition
 - public-spec language audit and boundary note
 - internal and external review notes
@@ -43,7 +44,8 @@ evidence prove that model output cannot bypass governed execution.
 
 Do not move into release review until every feature claim has a proof,
 non-proving classification, or explicit deferral, and the coverage / quality
-gate has recorded the milestone validation posture.
+gate has recorded the milestone validation posture for both Governed Tools v1.0
+and the landed first-level Comms tranche.
 
 Do not describe UTS as a public standard, stable external contract, or
 standalone execution authority unless separate evidence and review approve that


### PR DESCRIPTION
Closes #2585

## Summary
- add the canonical `v0.90.5` quality gate artifact
- align release-tail milestone docs with the new gate and get-well disposition
- promote the landed Comms / ACIP tranche to first-level milestone evidence in the WP-20 quality story while keeping authority boundaries explicit

## Validation
- `git diff --check`
- verified `#2584` is closed and `#2592` through `#2597` are closed
- verified cited milestone and feature proof surfaces exist
- checked live GitHub run/PR evidence for `adl-ci` / `adl-coverage`
- attempted `adl tooling validate-structured-prompt` for the local `stp`/`sip` bundle, but the validator timed out locally and is recorded as a limitation in the output record
