### PR TITLE
Fix pr.sh Rust delegation exit propagation

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -235,15 +235,13 @@ delegate_pr_command_to_rust() {
   root="$(rust_pr_delegate_root)"
   manifest="$root/adl/Cargo.toml"
   if [[ -n "${ADL_PR_RUST_BIN:-}" ]]; then
-    "${ADL_PR_RUST_BIN}" pr "$subcommand" "$@"
-    return 0
+    exec "${ADL_PR_RUST_BIN}" pr "$subcommand" "$@"
   fi
   cached_bin="$(rust_pr_delegate_cached_bin || true)"
   if [[ -n "$cached_bin" ]]; then
-    "$cached_bin" pr "$subcommand" "$@"
-    return 0
+    exec "$cached_bin" pr "$subcommand" "$@"
   fi
-  cargo run --quiet --manifest-path "$manifest" --bin adl -- pr "$subcommand" "$@"
+  exec cargo run --quiet --manifest-path "$manifest" --bin adl -- pr "$subcommand" "$@"
 }
 
 require_rust_pr_delegate() {

--- a/adl/tools/test_five_command_regression_suite.sh
+++ b/adl/tools/test_five_command_regression_suite.sh
@@ -14,6 +14,7 @@ run_check() {
 
 run_check adl/tools/test_pr_init.sh
 run_check adl/tools/test_pr_create.sh
+run_check adl/tools/test_pr_delegate_exit_status.sh
 run_check adl/tools/test_pr_ready_prefers_built_binary.sh
 run_check adl/tools/test_pr_finish_delegates_to_rust.sh
 run_check adl/tools/test_pr_start_template_validation.sh

--- a/adl/tools/test_pr_delegate_exit_status.sh
+++ b/adl/tools/test_pr_delegate_exit_status.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PR_SH_SRC="$ROOT_DIR/adl/tools/pr.sh"
+CARD_PATHS_SRC="$ROOT_DIR/adl/tools/card_paths.sh"
+BASH_BIN="$(command -v bash)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mkdir -p "$repo/adl/tools" "$repo/adl"
+cp "$PR_SH_SRC" "$repo/adl/tools/pr.sh"
+cp "$CARD_PATHS_SRC" "$repo/adl/tools/card_paths.sh"
+chmod +x "$repo/adl/tools/pr.sh"
+touch "$repo/adl/Cargo.toml"
+
+(
+  cd "$repo"
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  git config commit.gpgsign false
+  echo "seed" > README.md
+  git add README.md
+  git commit -q -m "init"
+)
+
+set +e
+(
+  cd "$repo"
+  ADL_PR_RUST_BIN=/usr/bin/false \
+    "$BASH_BIN" adl/tools/pr.sh doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full >/dev/null
+)
+status=$?
+set -e
+
+[[ "$status" -eq 1 ]] || {
+  echo "assertion failed: expected delegated Rust exit status to propagate, got $status" >&2
+  exit 1
+}
+
+echo "pr.sh delegated exit status propagation: ok"


### PR DESCRIPTION
## Summary
- make `adl/tools/pr.sh` `exec` its delegated Rust control-plane command instead of spawning and returning through the shell wrapper
- preserve truthful exit and signal behavior for `ADL_PR_RUST_BIN`, fresh built binaries, and the cargo fallback path
- add a regression test that proves delegated nonzero status is surfaced by `pr.sh`

## Testing
- `bash -n adl/tools/pr.sh adl/tools/test_pr_delegate_exit_status.sh adl/tools/test_five_command_regression_suite.sh`
- `bash adl/tools/test_pr_delegate_exit_status.sh`
- `git diff --check`

Closes #2690
