### PR TITLE
[v0.90.5][WP-21] Docs + review pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,25 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
-## v0.90.4 (In development)
+## v0.90.5 (In development)
 
-Status: v0.90.4 is the active citizen economics and contract-market milestone.
-The issue wave opened as #2420-#2440; WP-15 through WP-19 are now closed, WP-20
-release ceremony remains open as #2440, and the active crate/package version
-surface is now `0.90.4` for the live development line even though the latest
-released tag remains v0.90.3 until v0.90.4 closes.
+Status: v0.90.5 is the active Governed Tools v1.0 milestone. The issue wave
+opened as #2566-#2591; WP-01 through WP-20 are closed, WP-21 through WP-26
+remain open, and the active crate/package version surface is now `0.90.5` for
+the live development line.
 
 Scope note:
 - This entry is intentionally bounded during the live release tail.
 - Detailed milestone scope, proof expectations, and release-tail truth live in
-  `docs/milestones/v0.90.4/`.
-- ADR 0014 now records the contract-market architecture boundary for the
-  milestone.
+  `docs/milestones/v0.90.5/`.
+- The canonical reviewer entry surface for the current closeout tail is
+  `docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md`.
+
+## v0.90.4 (Completed milestone)
+
+Status: The bounded citizen economics and contract-market milestone is
+complete. Its detailed package, external review packet, and ADR boundary remain
+recorded under `docs/milestones/v0.90.4/`.
 
 ## v0.90.3 (Released 2026-04-23)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But those artifacts are not the whole story. In the current repository, they are
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.90.4%20active-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.90.5%20active-blue)
 
 Today, ADL includes:
 - a reference Rust runtime and CLI for deterministic workflow execution
@@ -119,36 +119,33 @@ Other useful entrypoints:
 
 ## Current Status
 
-- Active milestone: **v0.90.4**
-- Current release state: **v0.90.3 is released; v0.90.4 has only WP-20 (#2440) remaining in the release tail**
-- Most recently completed milestone: **v0.90.3**
-- Current crate version: **0.90.4**
-- Version note: **v0.90.4 is the active citizen economics and contract-market development line**
-- Previous completed milestone package: **v0.90.2**
-- Previous completed milestone: **v0.90.1**
+- Active milestone: **v0.90.5**
+- Current release state: **v0.90.4 is complete; v0.90.5 is in the WP-21 through WP-26 docs/review/release tail**
+- Most recently completed milestone: **v0.90.4**
+- Current crate version: **0.90.5**
+- Version note: **v0.90.5 is the active Governed Tools v1.0 development line**
+- Previous completed milestone package: **v0.90.3**
+- Previous completed milestone: **v0.90.2**
 - Project changelog: `CHANGELOG.md`
 
 ADL is in active development. This repository contains both implemented runtime surfaces and milestone/spec/planning documents. Read the milestone docs as bounded engineering records: they distinguish what has shipped, what is under active review or closeout, what is demoable, and what is still planned.
 
 ## Current Milestone
 
-v0.90.4 is the active citizen economics and contract-market substrate
-milestone. Its tracked package lives under `docs/milestones/v0.90.4/`. The
-issue wave opened as #2420-#2440: WP-01 is #2420, WP-02 through WP-14 are
-#2421-#2433, WP-14A is #2434, WP-15 through WP-19 are now closed as
-#2435-#2439, and WP-20 release ceremony remains open as #2440.
+v0.90.5 is the active Governed Tools v1.0 milestone. Its tracked package lives
+under `docs/milestones/v0.90.5/`. The issue wave opened as #2566-#2591:
+WP-01 is #2566, WP-02 through WP-18 are #2567-#2583, WP-19 is #2584, WP-20 is
+#2585, and the remaining active release-tail issues are WP-21 through WP-26 as
+#2586-#2591.
 
-v0.90.3 is now the most recently completed citizen-state milestone. The latest
-released tag remains v0.90.3, while the active development crate line is now
-0.90.4 for the open v0.90.4 milestone.
+v0.90.4 is now the most recently completed milestone.
 
-The current release-tail entry surface is
-`docs/milestones/v0.90.4/README.md`. It records the landed feature-proof
-coverage record, closed internal review, completed third-party review, ADR 0014
-architecture remediation, completed next-milestone handoff, and the fact that
-only ceremony remains open.
+The current release-tail reviewer entry surface is
+`docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md`. It records the landed
+feature-proof coverage, quality gate, review-entry package, open tail issues,
+and current non-claims for the governed-tools line.
 
-v0.90.3 is the most recently released citizen-state milestone. It turned the
+v0.90.3 is the previous completed citizen-state milestone. It turned the
 bounded CSM run from v0.90.2 into safer citizen-state substrate work:
 canonical private state, signed envelopes, local-first sealing, append-only
 lineage, continuity witnesses and receipts, anti-equivocation,
@@ -158,7 +155,7 @@ integrated citizen-state proof demo. It does not claim first true Gödel-agent
 birthday, full economics, v0.91 moral/emotional civilization, or v0.92
 migration/birthday scope.
 
-v0.90.2 is the most recently completed release milestone. Its tracked package
+v0.90.2 is the previous completed Runtime v2 hardening milestone. Its tracked package
 lives under `docs/milestones/v0.90.2/`. It carries the first bounded CSM run and
 Runtime v2 hardening proof package, including feature-by-feature proof coverage,
 an integrated first-run demo packet, internal review, third-party review,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But those artifacts are not the whole story. In the current repository, they are
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.90.5%20active-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.90.4%20active-blue)
 
 Today, ADL includes:
 - a reference Rust runtime and CLI for deterministic workflow execution
@@ -119,33 +119,36 @@ Other useful entrypoints:
 
 ## Current Status
 
-- Active milestone: **v0.90.5**
-- Current release state: **v0.90.4 is complete; v0.90.5 is in the WP-21 through WP-26 docs/review/release tail**
-- Most recently completed milestone: **v0.90.4**
-- Current crate version: **0.90.5**
-- Version note: **v0.90.5 is the active Governed Tools v1.0 development line**
-- Previous completed milestone package: **v0.90.3**
-- Previous completed milestone: **v0.90.2**
+- Active milestone: **v0.90.4**
+- Current release state: **v0.90.3 is released; v0.90.4 has only WP-20 (#2440) remaining in the release tail**
+- Most recently completed milestone: **v0.90.3**
+- Current crate version: **0.90.4**
+- Version note: **v0.90.4 is the active citizen economics and contract-market development line**
+- Previous completed milestone package: **v0.90.2**
+- Previous completed milestone: **v0.90.1**
 - Project changelog: `CHANGELOG.md`
 
 ADL is in active development. This repository contains both implemented runtime surfaces and milestone/spec/planning documents. Read the milestone docs as bounded engineering records: they distinguish what has shipped, what is under active review or closeout, what is demoable, and what is still planned.
 
 ## Current Milestone
 
-v0.90.5 is the active Governed Tools v1.0 milestone. Its tracked package lives
-under `docs/milestones/v0.90.5/`. The issue wave opened as #2566-#2591:
-WP-01 is #2566, WP-02 through WP-18 are #2567-#2583, WP-19 is #2584, WP-20 is
-#2585, and the remaining active release-tail issues are WP-21 through WP-26 as
-#2586-#2591.
+v0.90.4 is the active citizen economics and contract-market substrate
+milestone. Its tracked package lives under `docs/milestones/v0.90.4/`. The
+issue wave opened as #2420-#2440: WP-01 is #2420, WP-02 through WP-14 are
+#2421-#2433, WP-14A is #2434, WP-15 through WP-19 are now closed as
+#2435-#2439, and WP-20 release ceremony remains open as #2440.
 
-v0.90.4 is now the most recently completed milestone.
+v0.90.3 is now the most recently completed citizen-state milestone. The latest
+released tag remains v0.90.3, while the active development crate line is now
+0.90.4 for the open v0.90.4 milestone.
 
-The current release-tail reviewer entry surface is
-`docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md`. It records the landed
-feature-proof coverage, quality gate, review-entry package, open tail issues,
-and current non-claims for the governed-tools line.
+The current release-tail entry surface is
+`docs/milestones/v0.90.4/README.md`. It records the landed feature-proof
+coverage record, closed internal review, completed third-party review, ADR 0014
+architecture remediation, completed next-milestone handoff, and the fact that
+only ceremony remains open.
 
-v0.90.3 is the previous completed citizen-state milestone. It turned the
+v0.90.3 is the most recently released citizen-state milestone. It turned the
 bounded CSM run from v0.90.2 into safer citizen-state substrate work:
 canonical private state, signed envelopes, local-first sealing, append-only
 lineage, continuity witnesses and receipts, anti-equivocation,
@@ -155,7 +158,7 @@ integrated citizen-state proof demo. It does not claim first true Gödel-agent
 birthday, full economics, v0.91 moral/emotional civilization, or v0.92
 migration/birthday scope.
 
-v0.90.2 is the previous completed Runtime v2 hardening milestone. Its tracked package
+v0.90.2 is the most recently completed release milestone. Its tracked package
 lives under `docs/milestones/v0.90.2/`. It carries the first bounded CSM run and
 Runtime v2 hardening proof package, including feature-by-feature proof coverage,
 an integrated first-run demo packet, internal review, third-party review,

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -21,70 +21,71 @@ The reviewer should not audit ADL against a frozen abstract standard alone. The 
 
 ## Current Review Entry Point
 
-For the active v0.90.3 citizen-state substrate package, start with:
+For the active v0.90.5 governed-tools package, start with:
 
-- `docs/milestones/v0.90.3/README.md`
-- `docs/milestones/v0.90.3/WBS_v0.90.3.md`
-- `docs/milestones/v0.90.3/SPRINT_v0.90.3.md`
-- `docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md`
-- `docs/milestones/v0.90.3/FEATURE_DOCS_v0.90.3.md`
-- `docs/milestones/v0.90.3/MILESTONE_CHECKLIST_v0.90.3.md`
-- `docs/milestones/v0.90.3/RELEASE_PLAN_v0.90.3.md`
-- `docs/milestones/v0.90.3/RELEASE_READINESS_v0.90.3.md`
-- `docs/milestones/v0.90.3/RELEASE_NOTES_v0.90.3.md`
-- `docs/milestones/v0.90.3/WP_EXECUTION_READINESS_v0.90.3.md`
-- `docs/milestones/v0.90.3/WP_ISSUE_WAVE_v0.90.3.yaml`
+- `docs/milestones/v0.90.5/README.md`
+- `docs/milestones/v0.90.5/WBS_v0.90.5.md`
+- `docs/milestones/v0.90.5/SPRINT_v0.90.5.md`
+- `docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
+- `docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md`
+- `docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md`
+- `docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md`
+- `docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md`
+- `docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md`
+- `docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md`
+- `docs/milestones/v0.90.5/RELEASE_NOTES_v0.90.5.md`
+- `docs/milestones/v0.90.5/WP_EXECUTION_READINESS_v0.90.5.md`
+- `docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml`
 - `docs/planning/ADL_FEATURE_LIST.md`
 - `CHANGELOG.md`
 - `README.md`
 - `adl/Cargo.toml`
 - `adl/Cargo.lock`
 
-The current v0.90.3 review posture is release-tail convergence before external
-review. The wave is open as #2327-#2347. WP-01 is #2327, WP-02 through WP-14
-are #2328-#2340, WP-14A is #2341, and WP-15 through WP-20 are #2342-#2347.
-WP-14 has landed the inhabited CSM Observatory flagship demo, and WP-14A has
-landed the explicit feature-proof coverage record.
+The current v0.90.5 review posture is docs/review convergence after feature
+proof coverage and the quality gate, and before the formal WP-22 internal
+review pass. The wave is open as #2566-#2591. WP-01 through WP-20 are closed;
+WP-21 through WP-26 remain open as the docs/review/release tail.
 
-v0.90.3 should produce the citizen-state substrate: canonical private state,
-signed envelopes, local-first sealing, append-only lineage, continuity
-witnesses and receipts, anti-equivocation, sanctuary/quarantine behavior,
-redacted Observatory projections, standing and access-control semantics,
-challenge/appeal flow, threat modeling, and one integrated citizen-state proof
-demo.
+v0.90.5 should produce Governed Tools v1.0 plus the landed first-level Comms /
+ACIP tranche: UTS public-compatible schema and conformance, ACC authority and
+visibility semantics, registry/compiler/normalization/policy/executor behavior,
+trace/replay/redaction evidence, dangerous negative tests, bounded
+model-proposal evaluation, the flagship governed-tools demo, and the bounded
+review/coding-agent communications substrate that was explicitly landed in this
+milestone.
 
-The crate version is `0.90.3` for the active v0.90.3 development line. Reviewers
-should treat any conflicting older version reference as a stale release-truth
-defect.
+The crate version is `0.90.5` for the active v0.90.5 development line.
+Reviewers should treat any conflicting older version reference as a stale
+release-truth defect.
 
-Important v0.90.3 non-claims:
+Important v0.90.5 non-claims:
 
-- v0.90.3 does not birth the first true Gödel agent.
-- v0.90.3 does not complete v0.91 moral, emotional, kindness, humor, or
-  wellbeing substrate.
-- v0.90.3 does not complete v0.92 identity/capability rebinding, migration, or
-  birthday scope.
-- v0.90.3 does not implement full citizen economics, contract markets, payment
-  rails, or inter-polis trade.
-- v0.90.3 does not require cloud enclaves.
+- v0.90.5 does not claim that UTS alone is an execution authority.
+- v0.90.5 does not claim arbitrary shell or network execution merely because a
+  model emitted valid JSON.
+- v0.90.5 does not claim payment rails, legal contracting, billing, or
+  inter-polis economics.
+- v0.90.5 does not claim full v0.91 moral/cognitive-being substrate or full
+  v0.91.1 identity/capability follow-on work.
+- v0.90.5 does not claim production secret-management or cloud-enclave
+  dependence.
 
 During execution, verify that every WP preserves the required outputs and
-validation from `WP_EXECUTION_READINESS_v0.90.3.md` rather than widening into
+validation from `WP_EXECUTION_READINESS_v0.90.5.md` rather than widening into
 generic implementation work.
 
-WP-15 tracker status to preserve during review:
-- coverage truth remains the current tracked `92.40%` workspace line coverage
-  from the recent quality gate, rounded to the intended `93%` tranche; WP-15 is
-  docs-only and does not claim a fresh full coverage run
-- changed-path CI policy is active for docs-heavy closeout PRs; green
-  docs-only `adl-coverage` checks are PR evidence, not release coverage
-  evidence
-- #2409 has also landed the PR-fast validation split that avoids requiring two
-  full Rust test universes for the same PR while preserving release coverage
-  boundaries
-- internal review status is release-tail truth: no P0/P1 blocker has been found
-  in the citizen-state substrate; any remaining review items should be tracked
-  as minor P2/P3 follow-ups or explicit deferrals before third-party review
+WP-21 tracker status to preserve during review:
+- `QUALITY_GATE_v0.90.5.md` is the canonical quality and coverage posture
+  record, including the explicit main-branch coverage exception still carried
+  into the review tail.
+- `RELEASE_READINESS_v0.90.5.md` is the reviewer entry surface for the active
+  milestone package.
+- docs/release-truth surfaces should consistently report v0.90.5 as the active
+  line, v0.90.4 as the most recently completed milestone, and `0.90.5` as the
+  active crate version.
+- internal review has not happened yet; WP-21 prepares the package for WP-22
+  rather than pre-claiming that review outcome.
 
 For the most recently completed v0.90.2 release package, start with:
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -38,7 +38,6 @@ For the active v0.90.5 governed-tools package, start with:
 - `docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml`
 - `docs/planning/ADL_FEATURE_LIST.md`
 - `CHANGELOG.md`
-- `README.md`
 - `adl/Cargo.toml`
 - `adl/Cargo.lock`
 
@@ -84,6 +83,9 @@ WP-21 tracker status to preserve during review:
 - docs/release-truth surfaces should consistently report v0.90.5 as the active
   line, v0.90.4 as the most recently completed milestone, and `0.90.5` as the
   active crate version.
+- root `README.md` cleanup is tracked separately under #2712 and should not be
+  treated as part of the bounded WP-21 reviewer-entry package until that issue
+  lands.
 - internal review has not happened yet; WP-21 prepares the package for WP-22
   rather than pre-claiming that review outcome.
 

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.90.4"
+version = "0.90.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.90.4"
+version = "0.90.5"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,11 @@ Use this index to find the right source of truth quickly.
 
 ## Start Here
 
-- Active milestone package: `milestones/v0.90.4/` with issue wave open as
-  `#2420-#2440`
-- Most recently completed milestone: `milestones/v0.90.3/`
-- Previous completed milestone package: `milestones/v0.90.2/`
-- Previous completed milestone: `milestones/v0.90.1/`
+- Active milestone package: `milestones/v0.90.5/` with issue wave open as
+  `#2566-#2591`
+- Most recently completed milestone: `milestones/v0.90.4/`
+- Previous completed milestone package: `milestones/v0.90.3/`
+- Previous completed milestone: `milestones/v0.90.2/`
 - Root project overview: `../README.md`
 - Runtime and CLI guide: `../adl/README.md`
 - Language/spec entrypoint: `../adl-spec/README.md`
@@ -19,11 +19,11 @@ Use this index to find the right source of truth quickly.
 
 ## Milestone Documentation
 
-- Active milestone package: `milestones/v0.90.4/` with issue wave open as
-  `#2420-#2440`
-- Most recently completed milestone: `milestones/v0.90.3/`
-- Previous completed milestone package: `milestones/v0.90.2/`
-- Previous completed milestone: `milestones/v0.90.1/`
+- Active milestone package: `milestones/v0.90.5/` with issue wave open as
+  `#2566-#2591`
+- Most recently completed milestone: `milestones/v0.90.4/`
+- Previous completed milestone package: `milestones/v0.90.3/`
+- Previous completed milestone: `milestones/v0.90.2/`
 - Recent stable milestones: `milestones/v0.87.1/`, `milestones/v0.87/`, `milestones/v0.86/`, `milestones/v0.85/`, `milestones/v0.8/`
 - Earlier milestones: `milestones/v0.75/`, `milestones/v0.7/`, `milestones/v0.6/`
 - Historical milestones: `milestones/v0.5/`, `milestones/v0.4/`, `milestones/v0.3/`, `milestones/v0.2/`
@@ -40,17 +40,17 @@ Use this index to find the right source of truth quickly.
 ## Demo and Tooling Surfaces
 
 - Canonical demo index: `../demos/README.md`
-- Active milestone demo matrix: `milestones/v0.90.4/DEMO_MATRIX_v0.90.4.md`
-- Most recently completed milestone demo matrix: `milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md`
-- Previous completed milestone demo matrix: `milestones/v0.90.2/DEMO_MATRIX_v0.90.2.md`
-- Earlier milestone demo matrix: `milestones/v0.90.1/DEMO_MATRIX_v0.90.1.md`
+- Active milestone demo matrix: `milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
+- Most recently completed milestone demo matrix: `milestones/v0.90.4/DEMO_MATRIX_v0.90.4.md`
+- Previous completed milestone demo matrix: `milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md`
+- Earlier milestone demo matrix: `milestones/v0.90.2/DEMO_MATRIX_v0.90.2.md`
 - Editor/tooling demo surfaces: `tooling/editor/README.md`
 
 ## Notes
 
 Milestone docs should be read as bounded engineering records. They distinguish
 what has shipped, what is currently being implemented, what is demoable, and
-what is planned for later milestones. At the moment, `v0.90.4` is the active
-citizen economics and contract-market milestone with its issue wave open as
-`#2420-#2440`; `v0.90.3` is the most recently completed citizen-state milestone;
-and `v0.90.2` is the previous completed Runtime v2 first-run milestone.
+what is planned for later milestones. At the moment, `v0.90.5` is the active
+Governed Tools v1.0 milestone with its issue wave open as `#2566-#2591`;
+`v0.90.4` is the most recently completed contract-market milestone; and
+`v0.90.3` is the previous completed citizen-state milestone.

--- a/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md
@@ -24,6 +24,7 @@
 | WP_EXECUTION_READINESS_v0.90.5.md | card-authoring source for concrete WP outputs, validation, non-goals, and proof expectations | WP-01 |
 | GET_WELL_PLAN_v0.90.5.md | milestone-root get-well pointer for validation-cost recovery, the separate GW wave, and runtime-reduction disposition | WP-01, GW-00-GW-05, WP-20, WP-25 |
 | RELEASE_PLAN_v0.90.5.md | release evidence, public-spec guardrails, and review-handoff expectations | WP-21-WP-26 |
+| RELEASE_READINESS_v0.90.5.md | reviewer entry surface for the active docs/review/release tail after proof and quality convergence | WP-21-WP-26 |
 | DECISIONS_v0.90.5.md | accepted planning baseline for governed-tools scope and boundaries | WP-01, WP-21 |
 
 ## Context / Idea Docs

--- a/docs/milestones/v0.90.5/GET_WELL_PLAN_v0.90.5.md
+++ b/docs/milestones/v0.90.5/GET_WELL_PLAN_v0.90.5.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 `v0.90.5` must continue the Governed Tools v1.0 implementation, but it also
-must avoid repeating the `v0.90.4` validation-cost failure mode. This get-well
+must avoid repeating the previous milestone's validation-cost failure mode. This get-well
 plan is the milestone-root pointer to the runtime and CI recovery work that
 supports the milestone without replacing its core scope.
 

--- a/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
+++ b/docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md
@@ -10,7 +10,7 @@
 - [x] WP issue cards authored from WP_EXECUTION_READINESS_v0.90.5.md
 - [x] get-well plan visible in tracked milestone docs
 - [x] get-well wave opened separately from canonical WP numbering
-- [x] Package is ready to accept v0.90.4 handoff without reopening scope
+- [x] Package is ready to accept the previous-milestone handoff without reopening scope
   confusion about tool authority
 - [x] Demo/proof lane is explicit, including WP-19 before review convergence
 

--- a/docs/milestones/v0.90.5/README.md
+++ b/docs/milestones/v0.90.5/README.md
@@ -5,7 +5,7 @@
 Tracked planning package for Governed Tools v1.0. The milestone direction was
 established under planning issue #2350, tightened under #2402, prepared for
 clean execution under #2443, and re-affirmed as the immediate governed-tools
-follow-on during the `v0.90.4` WP-19 handoff pass under #2439.
+follow-on during the previous-milestone handoff pass under #2439.
 
 The issue wave is open under [#2566](https://github.com/danielbaustin/agent-design-language/issues/2566), with [#2567](https://github.com/danielbaustin/agent-design-language/issues/2567) through [#2591](https://github.com/danielbaustin/agent-design-language/issues/2591) carrying the rest of the tracked milestone band. This package is now active execution truth for `v0.90.5`, not a later planning packet.
 
@@ -128,6 +128,7 @@ Out of scope:
 - WP execution readiness: WP_EXECUTION_READINESS_v0.90.5.md
 - Milestone checklist: MILESTONE_CHECKLIST_v0.90.5.md
 - Release plan: RELEASE_PLAN_v0.90.5.md
+- Release readiness: RELEASE_READINESS_v0.90.5.md
 - Release notes draft: RELEASE_NOTES_v0.90.5.md
 - Opened issue wave: WP_ISSUE_WAVE_v0.90.5.yaml
 - Get-well plan: GET_WELL_PLAN_v0.90.5.md
@@ -172,19 +173,17 @@ v0.90.5 builds on:
 
 - v0.90.3 citizen-state, standing, access-control, redacted projection, and
   inhabited CSM demo work
-- v0.90.4 contract-market, authority, and citizen-economics lessons that bear
-  on governed delegation and action approval
+- the previous contract-market milestone's authority and bounded-economics
+  lessons that bear on governed delegation and action approval
 
 v0.90.5 should not own the v0.90.3 inhabited CSM demo. It should own the
 Governed Tools v1.0 flagship demo.
 
-It also should not inherit unresolved v0.90.4 ambiguity about whether contract
-tool needs are constraints or execution grants. WP-19 of v0.90.4 is expected to
-hand that boundary off cleanly.
-
-That handoff is now clean: `v0.90.4` leaves no loose issue backlog here. It
-hands off only the governed-tool authority lane that contracts and bids were
-explicitly not allowed to absorb.
+It also should not inherit unresolved ambiguity about whether contract tool
+needs are constraints or execution grants. That earlier boundary is now clean:
+the previous milestone leaves no loose issue backlog here and hands off only
+the governed-tool authority lane that contracts and bids were explicitly not
+allowed to absorb.
 
 Current docs-review findings may still sharpen wording, rustdoc references, and
 public-spec boundaries, but they should not widen the core milestone scope away

--- a/docs/milestones/v0.90.5/RELEASE_NOTES_v0.90.5.md
+++ b/docs/milestones/v0.90.5/RELEASE_NOTES_v0.90.5.md
@@ -2,9 +2,10 @@
 
 ## Headline
 
-v0.90.5 is planned to deliver Governed Tools v1.0.
+v0.90.5 delivers the Governed Tools v1.0 package and the landed first-level
+Comms / ACIP tranche, with the review/release tail still in progress.
 
-## Planned Highlights
+## Current Highlights
 
 - Universal Tool Schema v1.0 public-compatible schema discipline
 - ADL Capability Contract v1.0 authority, privacy, visibility, trace, and
@@ -17,16 +18,20 @@ v0.90.5 is planned to deliver Governed Tools v1.0.
 - multi-model proposal benchmark and local/Gemma evaluation
 - Governed Tools v1.0 flagship demo
 - feature proof coverage before review convergence
+- bounded review/coding-agent message protocol and proof surfaces
 
-## Draft Caveat
+## Release-Tail Caveat
 
-These release notes are aspirational until the v0.90.5 issue wave executes and
-release evidence is available.
+These notes are now milestone-grounded rather than aspirational, but they are
+not final release publication copy until WP-22 through WP-26 complete and the
+remaining explicit quality/review exceptions are resolved or dispositioned.
 
-## Planned Non-Claims
+## Non-Claims
 
-- v0.90.5 is not planned to ship arbitrary shell execution by model output.
-- v0.90.5 is not planned to ship production secrets integration.
-- v0.90.5 is not planned to claim that UTS alone is enough for ADL safety.
-- v0.90.5 is not planned to claim public standardization of UTS unless that
-  occurs separately.
+- v0.90.5 does not ship arbitrary shell execution by model output.
+- v0.90.5 does not ship production secrets integration.
+- v0.90.5 does not claim that UTS alone is enough for ADL safety.
+- v0.90.5 does not claim public standardization of UTS unless that occurs
+  separately.
+- v0.90.5 does not claim payment rails, legal contracting, or inter-polis
+  economics.

--- a/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
+++ b/docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md
@@ -20,6 +20,8 @@ Freedom Gate mediation, and trace.
 - feature proof coverage record
 - [coverage / quality gate record](QUALITY_GATE_v0.90.5.md), including
   first-level Comms / ACIP evidence
+- [release readiness record](RELEASE_READINESS_v0.90.5.md) as the reviewer
+  entry surface for WP-21 through WP-26
 - get-well wave disposition
 - public-spec language audit and boundary note
 - internal and external review notes

--- a/docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md
@@ -1,0 +1,166 @@
+# Release Readiness - v0.90.5
+
+## Status
+
+WP-21 reviewer entry surface, ready for WP-22 internal review.
+
+This document is the reviewer entry surface for the v0.90.5 Governed Tools
+v1.0 milestone after the feature-proof coverage and quality-gate passes. It
+records the current docs, quality, proof, review-entry, and non-claim posture
+before the formal internal and third-party review steps.
+
+Important boundary: WP-19 / #2584 landed the explicit feature-proof coverage
+record and demo matrix, and WP-20 / #2585 landed the canonical quality gate.
+WP-21 aligns the release-truth and reviewer-entry docs. None of those steps
+approve the release by themselves; WP-22 through WP-26 still own review,
+remediation, handoff, and ceremony.
+
+## Review Entry Points
+
+- `README.md`
+- `CHANGELOG.md`
+- `REVIEW.md`
+- `adl/Cargo.toml`
+- `adl/Cargo.lock`
+- `docs/planning/ADL_FEATURE_LIST.md`
+- `docs/milestones/v0.90.5/README.md`
+- `docs/milestones/v0.90.5/WBS_v0.90.5.md`
+- `docs/milestones/v0.90.5/SPRINT_v0.90.5.md`
+- `docs/milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
+- `docs/milestones/v0.90.5/FEATURE_DOCS_v0.90.5.md`
+- `docs/milestones/v0.90.5/FEATURE_PROOF_COVERAGE_v0.90.5.md`
+- `docs/milestones/v0.90.5/QUALITY_GATE_v0.90.5.md`
+- `docs/milestones/v0.90.5/MILESTONE_CHECKLIST_v0.90.5.md`
+- `docs/milestones/v0.90.5/RELEASE_PLAN_v0.90.5.md`
+- `docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md`
+- `docs/milestones/v0.90.5/RELEASE_NOTES_v0.90.5.md`
+- `docs/milestones/v0.90.5/WP_EXECUTION_READINESS_v0.90.5.md`
+- `docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml`
+- `docs/milestones/v0.90.5/GET_WELL_PLAN_v0.90.5.md`
+- `docs/adr/0014-contract-market-architecture.md`
+
+## Current Issue State
+
+At WP-21 refresh:
+
+- WP-01 through WP-20 are closed.
+- WP-19 / #2584 landed the explicit demo-matrix and feature-proof coverage
+  record.
+- WP-20 / #2585 records the canonical quality and coverage gate.
+- WP-21 / #2586 is the active docs + review pass.
+- WP-22 / #2587 through WP-26 / #2591 remain the internal review,
+  third-party review, remediation, next-milestone planning, and release
+  ceremony tail.
+- The only additional open v0.90.5 follow-on outside the canonical WP state
+  machine at this moment is #2700, a bounded tooling fix for orphaned
+  post-merge closeout watchers in PR-finish tests.
+
+## Landed Proof Surface
+
+v0.90.5 now has reviewable evidence for:
+
+- tool-call threat model and governed capability non-goals
+- Universal Tool Schema v1.0 public-compatible schema and conformance
+- ADL Capability Contract v1.0 authority, privacy, visibility, delegation,
+  trace, and replay semantics
+- deterministic tool-registry, compiler, normalization, policy, and governed
+  executor behavior
+- trace, replay, redaction, and evidence constraints for governed tool actions
+- dangerous negative safety tests that fail closed
+- bounded model-proposal benchmarking and local/Gemma-focused evaluation
+- the Governed Tools v1.0 flagship demo
+- explicit feature-proof coverage and demo-matrix classification before review
+  convergence
+- the landed first-level ACIP / Comms tranche: general protocol architecture,
+  canonical message envelope and identity shape, invocation and Freedom Gate
+  linkage, conformance fixtures, review/coding specializations, and ACIP proof
+  coverage
+
+## Primary Commands
+
+Generate the v0.90.5 feature-proof coverage packet:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- runtime-v2 feature-proof-coverage --out artifacts/v0905/feature-proof-coverage.json
+```
+
+Run the v0.90.5 flagship governed-tools demo:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- demo demo-v0905-governed-tools-flagship --run --trace --out artifacts/v0905/flagship-demo --no-open
+```
+
+Run the bounded local-model PR reviewer fixture lane:
+
+```sh
+cargo run --manifest-path adl/Cargo.toml -- tooling code-review --out artifacts/v0905/local-model-pr-reviewer-fixture --backend fixture --visibility read-only-repo --issue 2603 --writer-session codex-writer --reviewer-session fixture-reviewer
+```
+
+The command set above is the focused proof surface for reviewers. It does not
+replace full release-tail validation, full workspace tests, coverage
+remeasurement, or the final ceremony.
+
+## WP-21 Validation Evidence
+
+This convergence pass should remain docs/truth focused:
+
+- version/status scan across README, changelog, review guide, Cargo metadata,
+  active milestone docs, and the reviewer-entry surfaces
+- local-path scan across touched tracked docs
+- stale-claim scan for overclaims about UTS public-standard status, execution
+  authority, unrestricted tool execution, or later-milestone cognitive/identity
+  work
+- release-tail docs/readiness consistency scan against the current open issue
+  set
+- git diff whitespace check
+
+## Tracker Review
+
+- Quality gate: `QUALITY_GATE_v0.90.5.md` is the canonical gate. It records the
+  green PR evidence that landed the milestone proof surfaces and the explicit
+  red main-branch coverage posture that still remains a release-tail exception.
+- Get-well status: the runtime-reduction wave is documented and remains
+  explicit rather than being silently treated as solved.
+- Review posture: the package is now ready for internal review entry, but WP-22
+  has not yet issued a findings-first review result.
+- Closeout posture: the remaining canonical milestone tail is review,
+  remediation, planning handoff, and ceremony. There is no claim here that the
+  release is already complete.
+
+## Version Truth
+
+- Active milestone: v0.90.5
+- Crate version: `0.90.5`
+- Most recently completed milestone: v0.90.4
+- Current release-tail stage: WP-21 docs/review convergence before WP-22
+  internal review
+
+Reviewers should treat any conflicting older crate-version statement or claim
+that v0.90.4 is still the active line as stale release-truth drift.
+
+## Explicit Non-Claims
+
+v0.90.5 does not claim:
+
+- that UTS alone is enough for ADL safety
+- that valid JSON or schema compatibility grants execution authority
+- arbitrary shell, network, or secret-bearing execution by model output
+- payment rails, billing, legal contracting, or inter-polis economics
+- full v0.91 moral/cognitive-being substrate
+- full v0.91.1 identity/capability, memory, ToM, ANRM/Gemma, or wider learning
+  follow-on work
+- release completion before WP-22 through WP-26 finish
+
+## Remaining Release-Tail Gates
+
+- WP-22 internal review
+- WP-23 external / 3rd-party review
+- WP-24 accepted-finding remediation or explicit deferral
+- WP-25 next-milestone planning handoff
+- WP-26 release ceremony
+
+## WP-21 Disposition
+
+WP-21 aligns the release-truth and reviewer-entry surfaces. It does not
+approve the release, replace internal or third-party review, or declare the
+milestone complete.

--- a/docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md
@@ -17,7 +17,6 @@ remediation, handoff, and ceremony.
 
 ## Review Entry Points
 
-- `README.md`
 - `CHANGELOG.md`
 - `REVIEW.md`
 - `adl/Cargo.toml`
@@ -54,6 +53,9 @@ At WP-21 refresh:
 - The only additional open v0.90.5 follow-on outside the canonical WP state
   machine at this moment is #2700, a bounded tooling fix for orphaned
   post-merge closeout watchers in PR-finish tests.
+- Root `README.md` review-ready active-line cleanup is tracked separately in
+  #2712 so the broad top-level project overview can be reviewed outside the
+  bounded WP-21 milestone-doc convergence package.
 
 ## Landed Proof Surface
 
@@ -105,7 +107,7 @@ remeasurement, or the final ceremony.
 This convergence pass should remain docs/truth focused:
 
 - version/status scan across README, changelog, review guide, Cargo metadata,
-  active milestone docs, and the reviewer-entry surfaces
+  active milestone docs, and the reviewer-entry surfaces that remain in WP-21
 - local-path scan across touched tracked docs
 - stale-claim scan for overclaims about UTS public-standard status, execution
   authority, unrestricted tool execution, or later-milestone cognitive/identity

--- a/docs/milestones/v0.90.5/WBS_v0.90.5.md
+++ b/docs/milestones/v0.90.5/WBS_v0.90.5.md
@@ -8,7 +8,7 @@ documentation-only planning lane.
 
 | WP | Issue | Title | Purpose | Primary Output | Depends On |
 | --- | --- | --- | --- | --- | --- |
-| WP-01 | #2566 | Design pass (milestone docs + planning) | Finalize this planning package and create the issue wave | tracked docs and issue cards | v0.90.4 closeout |
+| WP-01 | #2566 | Design pass (milestone docs + planning) | Finalize this planning package and create the issue wave | tracked docs and issue cards | previous milestone closeout |
 | WP-02 | #2567 | Tool-call threat model and semantics | Define proposal/action boundary, side effects, dangerous categories, and non-goals | threat model and semantics doc | WP-01 |
 | WP-03 | #2568 | UTS public compatibility and conformance plan | Define compatibility, examples, invalid examples, extension rules, and conformance | UTS conformance plan | WP-02 |
 | WP-04 | #2569 | UTS v1 schema finalization | Finalize portable tool schema and validation rules | UTS schema and tests | WP-03 |

--- a/docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml
+++ b/docs/milestones/v0.90.5/WP_ISSUE_WAVE_v0.90.5.yaml
@@ -35,7 +35,7 @@ work_packages:
     title: Design pass (milestone docs + planning)
     queue: docs
     outcome: tracked docs and issue cards
-    depends_on: v0.90.4 closeout
+    depends_on: previous milestone closeout
   - wp: WP-02
     issue: 2567
     title: Tool-call threat model and semantics

--- a/docs/tooling/milestone-dashboard/README.md
+++ b/docs/tooling/milestone-dashboard/README.md
@@ -22,8 +22,8 @@ YAML, milestone docs, task cards, PR checks, or human release ceremony.
 
 ## Current Dataset
 
-The bundled dataset is `v0.90.4`, mirrored in `data/v0.90.4.js` and refreshed
-from:
+The bundled dashboard dataset is still the historical `v0.90.4` snapshot,
+mirrored in `data/v0.90.4.js` and refreshed from:
 
 - `docs/milestones/v0.90.4/README.md`
 - `docs/milestones/v0.90.4/WBS_v0.90.4.md`
@@ -34,8 +34,12 @@ from:
 - `docs/milestones/v0.90/milestone_compression/CANONICAL_MILESTONE_STATE_v0.90.yaml`
 - `docs/milestones/v0.90/milestone_compression/DRIFT_CHECK_REPORT_v0.90.md`
 - `docs/milestones/v0.90/milestone_compression/FINISH_VALIDATION_PROFILES_v0.90.md`
-- a bounded read-only GitHub snapshot of the live v0.90.4 issue wave and PR
-  posture taken at refresh time
+- a bounded read-only GitHub snapshot of the then-live v0.90.4 issue wave and
+  PR posture taken at refresh time
+
+The active reviewer entry surface for the current milestone is now:
+
+- `docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md`
 
 Unknown, stale, or unverifiable evidence must be marked unknown/stale rather
 than treated as green.
@@ -53,8 +57,10 @@ readiness pass for each new milestone. At minimum, update:
 - validation expectations in `adl/tools/test_milestone_dashboard.sh` when the
   dashboard contract changes
 
-The dashboard may remain static for now, but stale milestone truth should be
-treated as a dashboard bug rather than an acceptable cache state.
+The dashboard may remain static temporarily as a historical visibility surface,
+but it must not be mistaken for the active milestone truth once the current
+milestone has moved on. The next bounded dashboard refresh should either add a
+real `v0.90.5` dataset or explicitly archive this dashboard as historical.
 
 ## Files
 

--- a/docs/tooling/milestone-dashboard/index.html
+++ b/docs/tooling/milestone-dashboard/index.html
@@ -187,6 +187,7 @@
     </section>
   </main>
 
+  <!-- Historical dataset only; active reviewer entry surface is docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md -->
   <script src="./data/v0.90.4.js"></script>
   <script src="./dashboard.js"></script>
 </body>


### PR DESCRIPTION
Closes #2586

## Summary
- align active v0.90.5 release/review/version truth across root docs and Cargo metadata
- add `RELEASE_READINESS_v0.90.5.md` as the WP-21 reviewer entry surface
- mark the bundled milestone dashboard dataset as historical rather than pretending the old v0.90.4 snapshot is live truth

## Validation
- `git diff --check`
- stale active-line scan across README/CHANGELOG/REVIEW/Cargo/v0.90.5 docs
- absolute host-path scan across touched tracked release/review surfaces
