### PR TITLE
[v0.90.5] Fix nightly coverage blocker reporting

### DIFF
--- a/.github/workflows/nightly-coverage-ratchet.yaml
+++ b/.github/workflows/nightly-coverage-ratchet.yaml
@@ -68,7 +68,7 @@ jobs:
               echo "- Checks step outcome: **${{ steps.checks.outcome }}**"
               echo
               echo "## Blocker"
-              echo "- `coverage-summary.json` was not produced. Coverage tooling likely failed before report generation."
+              echo '- `coverage-summary.json` was not produced. Coverage tooling likely failed before report generation.'
             } > "$report_path"
             echo "has_below_threshold=true" >> "$GITHUB_OUTPUT"
             echo "total_coverage=unknown" >> "$GITHUB_OUTPUT"
@@ -191,7 +191,7 @@ jobs:
 
           existing="$(gh issue list --state open --search "$title in:title" --json number,title --jq '.[] | select(.title == "'"$title"'") | .number' | head -n 1 || true)"
           if [ -n "${existing:-}" ]; then
-            gh issue comment "$existing" --body-file "$body_file"
+            gh issue edit "$existing" --body-file "$body_file"
           else
             gh issue create --title "$title" --body-file "$body_file"
           fi

--- a/adl/src/agent_comms/orchestrate/trace.inc
+++ b/adl/src/agent_comms/orchestrate/trace.inc
@@ -1272,3 +1272,265 @@ pub fn validate_acip_trace_fixture_set_v1(fixtures: &AcipTraceFixtureSetV1) -> R
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod trace_private_tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn known_event_ids(bundle: &AcipTraceBundleV1) -> BTreeSet<String> {
+        bundle
+            .trace_events
+            .iter()
+            .map(|event| event.event_id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn trace_private_helpers_cover_string_and_enum_branches() {
+        ensure_safe_trace_summary(
+            "Bounded review surface with deterministic replay metadata only.",
+            "summary",
+        )
+        .expect("safe summary");
+        assert!(ensure_safe_trace_summary("contains token material", "summary")
+            .expect_err("token-like summary should fail")
+            .to_string()
+            .contains("must not leak protected trace content 'token'"));
+        assert!(ensure_safe_trace_summary("copied from /tmp/demo", "summary")
+            .expect_err("tmp path should fail")
+            .to_string()
+            .contains("must not leak protected trace content '/tmp/'"));
+
+        ensure_redacted_trace_ref(
+            "runtime/comms/trace/reviewer_view.json",
+            "visible_artifact_refs[]",
+        )
+        .expect("redacted trace ref");
+        assert!(ensure_redacted_trace_ref(
+            "runtime/comms/trace/raw_args.json",
+            "visible_artifact_refs[]",
+        )
+        .expect_err("raw args should fail")
+        .to_string()
+        .contains("must not expose unredacted trace ref 'raw_args'"));
+
+        assert_eq!(trace_event_kind_str(&AcipTraceEventKindV1::MessageCreated), "message_created");
+        assert_eq!(
+            trace_event_kind_str(&AcipTraceEventKindV1::InvocationContractDeclared),
+            "invocation_contract_declared"
+        );
+        assert_eq!(
+            trace_event_kind_str(&AcipTraceEventKindV1::DecisionRecorded),
+            "decision_recorded"
+        );
+        assert_eq!(
+            trace_event_kind_str(&AcipTraceEventKindV1::InvocationCompleted),
+            "invocation_completed"
+        );
+        assert_eq!(
+            trace_event_kind_str(&AcipTraceEventKindV1::InvocationRefused),
+            "invocation_refused"
+        );
+        assert_eq!(
+            trace_event_kind_str(&AcipTraceEventKindV1::InvocationFailed),
+            "invocation_failed"
+        );
+
+        assert_eq!(trace_audience_str(&AcipTraceAudienceV1::Actor), "actor");
+        assert_eq!(trace_audience_str(&AcipTraceAudienceV1::Operator), "operator");
+        assert_eq!(trace_audience_str(&AcipTraceAudienceV1::Reviewer), "reviewer");
+        assert_eq!(trace_audience_str(&AcipTraceAudienceV1::Public), "public");
+        assert_eq!(trace_audience_str(&AcipTraceAudienceV1::Observatory), "observatory");
+    }
+
+    #[test]
+    fn trace_private_helpers_cover_event_audience_and_replay_validators() {
+        let bundle = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        let known_ids = known_event_ids(&bundle);
+
+        for event in &bundle.trace_events {
+            validate_acip_trace_event_v1(event, &bundle.conversation_id)
+                .expect("sample event should validate");
+        }
+        for view in &bundle.audience_views {
+            validate_acip_trace_audience_view_v1(view, &known_ids)
+                .expect("sample audience should validate");
+        }
+        validate_acip_replay_contract_v1(&bundle.replay_contract)
+            .expect("sample replay contract should validate");
+
+        let mut missing_invocation = bundle.trace_events[1].clone();
+        missing_invocation.invocation_id = None;
+        assert!(validate_acip_trace_event_v1(&missing_invocation, &bundle.conversation_id)
+            .expect_err("non-message event must carry invocation_id")
+            .to_string()
+            .contains("invocation_contract_declared trace event must carry invocation_id and contract_ref"));
+
+        let mut missing_refused_evidence =
+            sample_trace_bundle(AcipInvocationStatusV1::Refused).trace_events[3].clone();
+        missing_refused_evidence.evidence_refs.clear();
+        assert!(validate_acip_trace_event_v1(
+            &missing_refused_evidence,
+            &bundle.conversation_id
+        )
+        .expect_err("refused event must carry evidence")
+        .to_string()
+        .contains("invocation_refused trace event must carry invocation_id, contract_ref, decision_event_ref, and evidence_refs"));
+
+        let mut failed_without_redaction =
+            sample_trace_bundle(AcipInvocationStatusV1::Failed).trace_events[3].clone();
+        failed_without_redaction.requires_redaction = false;
+        assert!(validate_acip_trace_event_v1(&failed_without_redaction, &bundle.conversation_id)
+            .expect_err("failed event must require redaction")
+            .to_string()
+            .contains("invocation_failed trace event must require redaction"));
+
+        let actor_view = bundle.audience_views[0].clone();
+        validate_acip_trace_audience_view_v1(&actor_view, &known_ids)
+            .expect("actor audience may retain private refs");
+
+        let mut bad_reviewer_view = bundle.audience_views[2].clone();
+        bad_reviewer_view
+            .visible_artifact_refs
+            .push("runtime/comms/trace/raw_args.json".to_string());
+        assert!(validate_acip_trace_audience_view_v1(&bad_reviewer_view, &known_ids)
+            .expect_err("reviewer raw args should fail")
+            .to_string()
+            .contains("visible_artifact_refs[] must not expose unredacted trace ref 'raw_args'"));
+
+        let mut bad_replay = bundle.replay_contract.clone();
+        bad_replay.fixture_ref = "/tmp/replay.json".to_string();
+        assert!(validate_acip_replay_contract_v1(&bad_replay)
+            .expect_err("absolute fixture ref should fail")
+            .to_string()
+            .contains("fixture_ref"));
+
+        let mut bad_replay_case = bundle.replay_contract.clone();
+        bad_replay_case.fixture_case = "../bad".to_string();
+        assert!(validate_acip_replay_contract_v1(&bad_replay_case)
+            .expect_err("unsafe fixture case should fail")
+            .to_string()
+            .contains("fixture_case"));
+    }
+
+    #[test]
+    fn trace_private_sample_builders_cover_review_and_coding_variants() {
+        let invocation = sample_invocation_contract();
+        let completed_event = sample_invocation_event(
+            &invocation,
+            AcipInvocationStatusV1::Completed,
+            vec!["runtime/comms/invocation/review_report.json".to_string()],
+            "completed".to_string(),
+            None,
+            None,
+            vec!["runtime/comms/invocation/evidence/completed_trace.json".to_string()],
+        );
+        assert_eq!(completed_event.invocation_id, invocation.invocation_id);
+        assert_eq!(completed_event.status, AcipInvocationStatusV1::Completed);
+        assert_eq!(
+            completed_event.contract_ref.as_deref(),
+            Some("runtime/comms/invocation/contracts/review_request.json")
+        );
+
+        let review_contract = sample_review_invocation_contract();
+        assert_eq!(review_contract.invocation.intent, AcipIntentV1::ReviewRequest);
+        assert_eq!(review_contract.invocation.expected_outputs.len(), 2);
+        assert!(review_contract.disposition_contract.gate_result_required);
+
+        let blocked_outcome = sample_review_outcome(
+            &review_contract,
+            AcipReviewDispositionV1::Blocked,
+            AcipReviewHandoffOutcomeV1::FixFindingsAndRerunReview,
+            Some("runtime/comms/review/findings.json".to_string()),
+            vec!["runtime/comms/review/residual_risk.json".to_string()],
+            false,
+        );
+        assert_eq!(blocked_outcome.invocation_id, review_contract.invocation.invocation_id);
+        assert_eq!(blocked_outcome.disposition, AcipReviewDispositionV1::Blocked);
+        assert!(!blocked_outcome.pr_open_allowed);
+
+        for (provider_lane, expected_session, expected_model, expected_worktree_required) in [
+            (
+                AcipCodingProviderLaneV1::CodexIssueWorktree,
+                "writer-session-codex",
+                "gpt-5-codex",
+                true,
+            ),
+            (
+                AcipCodingProviderLaneV1::ChatgptApi,
+                "writer-session-openai",
+                "gpt-5-api",
+                false,
+            ),
+            (
+                AcipCodingProviderLaneV1::ClaudeApi,
+                "writer-session-anthropic",
+                "claude-api",
+                false,
+            ),
+            (
+                AcipCodingProviderLaneV1::LocalOllama,
+                "writer-session-ollama",
+                "gemma3-local",
+                false,
+            ),
+            (
+                AcipCodingProviderLaneV1::OtherProposalOnly,
+                "writer-session-other",
+                "other-provider",
+                false,
+            ),
+        ] {
+            for (execution_mode, expected_patch_format, expected_output_ref) in [
+                (
+                    AcipCodingExecutionModeV1::WorktreeEdit,
+                    "patch_manifest_v1",
+                    "runtime/comms/coding/patch_manifest.json",
+                ),
+                (
+                    AcipCodingExecutionModeV1::UnappliedPatch,
+                    "unified_diff",
+                    "runtime/comms/coding/proposed_changes.diff",
+                ),
+                (
+                    AcipCodingExecutionModeV1::StructuredProposal,
+                    "structured_proposal_v1",
+                    "runtime/comms/coding/proposal.json",
+                ),
+            ] {
+                let contract =
+                    sample_coding_invocation_contract(provider_lane.clone(), execution_mode.clone());
+                assert_eq!(contract.provider_lane, provider_lane);
+                assert_eq!(contract.execution_mode, execution_mode);
+                assert_eq!(contract.patch_format, expected_patch_format);
+                assert_eq!(
+                    contract.approval_policy.writer_session_id,
+                    expected_session.to_string()
+                );
+                assert_eq!(
+                    contract.approval_policy.writer_model_ref,
+                    expected_model.to_string()
+                );
+                assert_eq!(
+                    contract.issue_worktree_required,
+                    expected_worktree_required
+                );
+
+                let outcome = sample_coding_outcome(&contract);
+                assert_eq!(outcome.invocation_id, contract.invocation.invocation_id);
+                assert_eq!(outcome.provider_lane, provider_lane);
+                assert_eq!(outcome.execution_mode, execution_mode);
+                assert_eq!(outcome.primary_output_ref, expected_output_ref);
+                assert_eq!(
+                    outcome.writer_session_id,
+                    contract.approval_policy.writer_session_id
+                );
+                assert_eq!(
+                    outcome.writer_model_ref,
+                    contract.approval_policy.writer_model_ref
+                );
+            }
+        }
+    }
+}

--- a/adl/src/agent_comms/tests.inc
+++ b/adl/src/agent_comms/tests.inc
@@ -920,6 +920,127 @@
     }
 
     #[test]
+    fn acip_trace_event_and_audience_helpers_cover_remaining_validation_paths() {
+        let mut duplicate_audience = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        duplicate_audience.audience_views[4].audience = AcipTraceAudienceV1::Public;
+        assert!(validate_acip_trace_bundle_v1(&duplicate_audience)
+            .expect_err("duplicate audiences should fail")
+            .to_string()
+            .contains("trace bundle contains duplicate audience view 'public'"));
+
+        let mut missing_required_event = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        missing_required_event
+            .trace_events
+            .retain(|event| event.event_kind != AcipTraceEventKindV1::DecisionRecorded);
+        assert!(validate_acip_trace_bundle_v1(&missing_required_event)
+            .expect_err("missing required event kind should fail")
+            .to_string()
+            .contains("trace bundle must preserve canonical event order"));
+
+        let mut duplicate_event_id = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        duplicate_event_id.trace_events[3].event_id = "trace-0003".to_string();
+        assert!(validate_acip_trace_bundle_v1(&duplicate_event_id)
+            .expect_err("duplicate event id should fail")
+            .to_string()
+            .contains("trace bundle contains duplicate event_id 'trace-0003'"));
+
+        let mut bad_replay_fixture = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        bad_replay_fixture.replay_contract.fixture_ref = "/tmp/replay.json".to_string();
+        assert!(validate_acip_trace_bundle_v1(&bad_replay_fixture)
+            .expect_err("absolute replay fixture ref should fail")
+            .to_string()
+            .contains("fixture_ref"));
+
+        let mut bad_replay_case = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        bad_replay_case.replay_contract.fixture_case = "../bad".to_string();
+        assert!(validate_acip_trace_bundle_v1(&bad_replay_case)
+            .expect_err("unsafe replay fixture case should fail")
+            .to_string()
+            .contains("fixture_case"));
+
+        let mut prompt_leak = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        prompt_leak.trace_events[3].summary =
+            "Terminal event included prompt fragments for debugging.".to_string();
+        assert!(validate_acip_trace_bundle_v1(&prompt_leak)
+            .expect_err("prompt leak should fail")
+            .to_string()
+            .contains("summary must not leak protected trace content 'prompt'"));
+
+        let mut raw_args_ref = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        raw_args_ref.audience_views[2]
+            .visible_artifact_refs
+            .push("runtime/comms/trace/raw_args.json".to_string());
+        assert!(validate_acip_trace_bundle_v1(&raw_args_ref)
+            .expect_err("raw args ref should fail")
+            .to_string()
+            .contains("visible_artifact_refs[] must not expose unredacted trace ref 'raw_args'"));
+
+        let mut wrong_terminal_position = sample_trace_bundle(AcipInvocationStatusV1::Completed);
+        let terminal = wrong_terminal_position.trace_events.pop().expect("terminal event");
+        wrong_terminal_position.trace_events.insert(1, terminal);
+        assert!(validate_acip_trace_bundle_v1(&wrong_terminal_position)
+            .expect_err("terminal event must remain last")
+            .to_string()
+            .contains("trace bundle must preserve canonical event order"));
+    }
+
+    #[test]
+    fn acip_trace_sample_invocation_helpers_cover_event_status_and_value_parsing() {
+        let contract = sample_invocation_contract();
+        let completed = sample_invocation_event(
+            &contract,
+            AcipInvocationStatusV1::Completed,
+            vec!["runtime/comms/invocation/review_report.json".to_string()],
+            "required outputs satisfied".to_string(),
+            None,
+            None,
+            vec!["runtime/comms/invocation/evidence/completed_trace.json".to_string()],
+        );
+        assert_eq!(completed.status, AcipInvocationStatusV1::Completed);
+        assert!(completed.refusal_code.is_none());
+        assert!(completed.failure_code.is_none());
+
+        let refused = sample_invocation_event(
+            &contract,
+            AcipInvocationStatusV1::Refused,
+            Vec::new(),
+            "governed refusal".to_string(),
+            Some("policy_denied".to_string()),
+            None,
+            vec!["runtime/comms/invocation/evidence/refusal_trace.json".to_string()],
+        );
+        assert_eq!(refused.status, AcipInvocationStatusV1::Refused);
+        assert_eq!(refused.refusal_code.as_deref(), Some("policy_denied"));
+
+        let failed = sample_invocation_event(
+            &contract,
+            AcipInvocationStatusV1::Failed,
+            Vec::new(),
+            "execution failure".to_string(),
+            None,
+            Some("provider_error".to_string()),
+            vec!["runtime/comms/invocation/evidence/failure_trace.json".to_string()],
+        );
+        assert_eq!(failed.status, AcipInvocationStatusV1::Failed);
+        assert_eq!(failed.failure_code.as_deref(), Some("provider_error"));
+
+        let completed_value =
+            serde_json::to_value(sample_trace_bundle(AcipInvocationStatusV1::Completed))
+                .expect("serialize bundle");
+        validate_acip_trace_bundle_v1_value(&completed_value)
+            .expect("valid json bundle should parse and validate");
+
+        let parse_error = validate_acip_trace_bundle_v1_value(&serde_json::json!({
+            "schema_version": ACIP_TRACE_BUNDLE_SCHEMA_VERSION,
+            "conversation_id": 7
+        }))
+        .expect_err("malformed bundle json should fail");
+        assert!(parse_error
+            .to_string()
+            .contains("parse ACIP trace bundle v1"));
+    }
+
+    #[test]
     fn acip_proof_demo_packet_schema_and_fixture_are_available() {
         let schema = acip_proof_demo_packet_v1_schema_json().expect("proof schema");
         assert!(schema.contains("AcipProofDemoPacketV1"));

--- a/adl/src/cli/tooling_cmd/code_review.rs
+++ b/adl/src/cli/tooling_cmd/code_review.rs
@@ -54,6 +54,13 @@ pub(super) fn real_code_review(args: &[String]) -> Result<()> {
     fs::create_dir_all(&args.out).context("create code-review output directory")?;
 
     let root = repo_root()?;
+    run_code_review_for_root(&root, &args)
+}
+
+fn run_code_review_for_root(
+    root: &std::path::Path,
+    args: &code_review_types::CodeReviewArgs,
+) -> Result<()> {
     let packet = build_packet(&root, &args)?;
     let packet_id = packet_id(&packet);
     let result = run_reviewer(&args, &packet, &packet_id)?;
@@ -86,6 +93,21 @@ pub(super) fn real_code_review(args: &[String]) -> Result<()> {
         args.out.display()
     );
     Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn real_code_review_for_root(root: &std::path::Path, args: &[String]) -> Result<()> {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "help" | "--help" | "-h"))
+    {
+        println!("{}", tooling_usage());
+        return Ok(());
+    }
+
+    let args = code_review_args::parse_args(args)?;
+    fs::create_dir_all(&args.out).context("create code-review output directory")?;
+    run_code_review_for_root(root, &args)
 }
 
 fn packet_id(packet: &code_review_types::ReviewPacket) -> String {

--- a/adl/src/cli/tooling_cmd/code_review.rs
+++ b/adl/src/cli/tooling_cmd/code_review.rs
@@ -61,9 +61,9 @@ fn run_code_review_for_root(
     root: &std::path::Path,
     args: &code_review_types::CodeReviewArgs,
 ) -> Result<()> {
-    let packet = build_packet(&root, &args)?;
+    let packet = build_packet(root, args)?;
     let packet_id = packet_id(&packet);
-    let result = run_reviewer(&args, &packet, &packet_id)?;
+    let result = run_reviewer(args, &packet, &packet_id)?;
     let gate = evaluate_gate(&result, &packet);
 
     let packet_path = args.out.join("review_packet.json");

--- a/adl/src/cli/tooling_cmd/tests/code_review.rs
+++ b/adl/src/cli/tooling_cmd/tests/code_review.rs
@@ -448,6 +448,12 @@ fn code_review_build_packet_includes_staged_and_unstaged_worktree_diffs() {
 
 #[test]
 fn code_review_reviewer_real_code_review_fixture_run_writes_expected_artifacts() {
+    let root = init_temp_git_repo_with_changed_file(
+        "fixture-run",
+        "adl/src/cli/tooling_cmd/code_review.rs",
+        "pub fn sample() -> u8 { 1 }\n",
+        "pub fn sample() -> u8 { 2 }\n",
+    );
     let out = unique_temp_path("fixture-run");
     let args = vec![
         "--out".to_string(),
@@ -455,12 +461,15 @@ fn code_review_reviewer_real_code_review_fixture_run_writes_expected_artifacts()
         "--backend".to_string(),
         "fixture".to_string(),
         "--base".to_string(),
-        "origin/main".to_string(),
+        "HEAD".to_string(),
         "--head".to_string(),
         "HEAD".to_string(),
+        "--include-working-tree".to_string(),
+        "--file".to_string(),
+        "adl/src/cli/tooling_cmd/code_review.rs".to_string(),
     ];
 
-    real_code_review(&args).expect("run fixture code review");
+    super::real_code_review_for_root(&root, &args).expect("run fixture code review");
 
     let packet = std::fs::read_to_string(out.join("review_packet.json")).expect("read packet");
     let result = std::fs::read_to_string(out.join("review_result.json")).expect("read result");
@@ -523,6 +532,7 @@ fn code_review_reviewer_real_code_review_fixture_run_writes_expected_artifacts()
         Some("fixture")
     );
 
+    std::fs::remove_dir_all(&root).ok();
     std::fs::remove_dir_all(&out).ok();
 }
 

--- a/adl/src/obsmem_indexing.rs
+++ b/adl/src/obsmem_indexing.rs
@@ -796,4 +796,187 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn trace_indexed_memory_entry_normalize_dedupes_and_sorts_tags_steps_and_refs() {
+        let mut entry = IndexedMemoryEntry {
+            run_id: "r1".to_string(),
+            workflow_id: "wf".to_string(),
+            status: "success".to_string(),
+            failure_code: Some("provider_error".to_string()),
+            summary: "summary".to_string(),
+            tags: vec![
+                "workflow:wf".to_string(),
+                "workflow:wf".to_string(),
+                "failure:provider_error".to_string(),
+            ],
+            steps: vec![
+                IndexedStepContext {
+                    sequence: 2,
+                    step_id: "b".to_string(),
+                    event_kind: "step_finished".to_string(),
+                    context: "success=true".to_string(),
+                },
+                IndexedStepContext {
+                    sequence: 1,
+                    step_id: "a".to_string(),
+                    event_kind: "step_started".to_string(),
+                    context: "provider=local".to_string(),
+                },
+                IndexedStepContext {
+                    sequence: 1,
+                    step_id: "a".to_string(),
+                    event_kind: "step_started".to_string(),
+                    context: "provider=local".to_string(),
+                },
+            ],
+            trace_event_refs: vec![
+                MemoryTraceRef {
+                    event_sequence: 2,
+                    event_kind: "step_finished".to_string(),
+                    step_id: Some("b".to_string()),
+                    delegation_id: None,
+                },
+                MemoryTraceRef {
+                    event_sequence: 1,
+                    event_kind: "step_started".to_string(),
+                    step_id: Some("a".to_string()),
+                    delegation_id: None,
+                },
+                MemoryTraceRef {
+                    event_sequence: 1,
+                    event_kind: "step_started".to_string(),
+                    step_id: Some("a".to_string()),
+                    delegation_id: None,
+                },
+            ],
+        };
+
+        entry.normalize();
+
+        assert_eq!(
+            entry.tags,
+            vec![
+                "failure:provider_error".to_string(),
+                "workflow:wf".to_string()
+            ]
+        );
+        assert_eq!(entry.steps.len(), 2);
+        assert_eq!(entry.steps[0].sequence, 1);
+        assert_eq!(entry.trace_event_refs.len(), 2);
+        assert_eq!(entry.trace_event_refs[0].event_sequence, 1);
+    }
+
+    #[test]
+    fn trace_indexed_memory_entry_validate_rejects_empty_summary_and_missing_refs_and_tokens() {
+        let base_ref = MemoryTraceRef {
+            event_sequence: 0,
+            event_kind: "step_started".to_string(),
+            step_id: Some("s1".to_string()),
+            delegation_id: None,
+        };
+        let mut entry = IndexedMemoryEntry {
+            run_id: "r1".to_string(),
+            workflow_id: "wf".to_string(),
+            status: "success".to_string(),
+            failure_code: None,
+            summary: String::new(),
+            tags: vec![],
+            steps: vec![],
+            trace_event_refs: vec![base_ref.clone()],
+        };
+        assert!(entry
+            .validate()
+            .expect_err("empty summary should fail")
+            .message
+            .contains("non-empty summary"));
+
+        entry.summary = "ok".to_string();
+        entry.trace_event_refs.clear();
+        assert!(entry
+            .validate()
+            .expect_err("missing trace refs should fail")
+            .message
+            .contains("at least one trace event reference"));
+
+        entry.trace_event_refs.push(base_ref);
+        entry.summary = "gho_secret_like_value".to_string();
+        assert!(entry
+            .validate()
+            .expect_err("gh token-like text should fail")
+            .message
+            .contains("disallowed host-path or token-like content"));
+
+        entry.summary = "safe summary".to_string();
+        entry.tags = vec!["sk-live-token".to_string()];
+        assert!(entry
+            .validate()
+            .expect_err("openai token-like tag should fail")
+            .message
+            .contains("disallowed host-path or token-like content"));
+    }
+
+    #[test]
+    fn trace_obsmem_helper_functions_cover_parse_and_trace_mapping_branches() {
+        let tmp = unique_temp_dir("helper-branches");
+        let bad_json = tmp.join("bad.json");
+        std::fs::write(&bad_json, "{not-json").expect("write malformed json");
+        let parse_err = read_json(&bad_json).expect_err("malformed json should fail");
+        assert!(parse_err.message.contains("failed parsing"));
+
+        assert!(contains_disallowed_text("/home/runner/private"));
+        assert!(contains_disallowed_text("gho_secret"));
+        assert!(contains_disallowed_text("sk-secret"));
+        assert!(!contains_disallowed_text("reviewable summary"));
+
+        let lifecycle = TraceEventNormalized::LifecyclePhaseEntered {
+            phase: "governed".to_string(),
+        };
+        let boundary = TraceEventNormalized::ExecutionBoundaryCrossed {
+            boundary: "scheduler".to_string(),
+            state: "entered".to_string(),
+        };
+        let call_entered = TraceEventNormalized::CallEntered {
+            caller_step_id: "step.call".to_string(),
+            callee_workflow_id: "wf".to_string(),
+            namespace: "ns".to_string(),
+        };
+        let call_exited = TraceEventNormalized::CallExited {
+            caller_step_id: "step.call".to_string(),
+            status: "success".to_string(),
+            namespace: "ns".to_string(),
+        };
+        let chunk = TraceEventNormalized::StepOutputChunk {
+            step_id: "step.chunk".to_string(),
+            chunk_bytes: 42,
+        };
+
+        assert_eq!(
+            to_trace_ref(0, &lifecycle)
+                .expect("lifecycle ref")
+                .event_kind,
+            "lifecycle_phase_entered"
+        );
+        assert_eq!(
+            to_trace_ref(1, &boundary).expect("boundary ref").event_kind,
+            "execution_boundary_crossed"
+        );
+        assert_eq!(
+            to_trace_ref(2, &call_entered)
+                .expect("call entered ref")
+                .event_kind,
+            "call_entered"
+        );
+        assert_eq!(
+            to_trace_ref(3, &call_exited)
+                .expect("call exited ref")
+                .event_kind,
+            "call_exited"
+        );
+
+        let step_context = to_step_context(4, &chunk).expect("chunk context");
+        assert_eq!(step_context.step_id, "step.chunk");
+        assert_eq!(step_context.context, "chunk_bytes=42");
+        assert!(to_step_context(5, &lifecycle).is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- fix the nightly coverage report fallback string so shell quoting does not try to execute the literal coverage-summary.json marker
- update existing daily blocker issues by replacing the body instead of appending stale comments
- keep the nightly blocker issue aligned with the latest report on reruns

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-coverage-ratchet.yaml"); puts "yaml-ok"'
- python3 inline repro for the fallback report echo quoting

Closes #2703
