### PR TITLE
[v0.90.5][records] Repair issue metadata parity drift

### DIFF
--- a/adl/tools/check_issue_metadata_parity.sh
+++ b/adl/tools/check_issue_metadata_parity.sh
@@ -88,7 +88,7 @@ def parse_prompt(path: Path):
     in_labels = False
     for line in lines:
         if line.startswith("title: "):
-            title = line.split(":", 1)[1].strip().strip('"')
+            title = line.split(":", 1)[1].strip().strip("\"'")
             in_labels = False
         elif line.startswith("issue_number: "):
             issue_number = int(line.split(":", 1)[1].strip())
@@ -115,22 +115,22 @@ def parse_prompt_with_fields(path: Path):
     in_labels = False
     for line in lines:
         if line.startswith("title: "):
-            data["title"] = line.split(":", 1)[1].strip().strip('"')
+            data["title"] = line.split(":", 1)[1].strip().strip("\"'")
             in_labels = False
         elif line.startswith("issue_number: "):
             data["issue_number"] = int(line.split(":", 1)[1].strip())
             in_labels = False
         elif line.startswith("slug: "):
-            data["slug"] = line.split(":", 1)[1].strip().strip('"')
+            data["slug"] = line.split(":", 1)[1].strip().strip("\"'")
             in_labels = False
         elif line.startswith("wp: "):
-            data["wp"] = line.split(":", 1)[1].strip().strip('"')
+            data["wp"] = line.split(":", 1)[1].strip().strip("\"'")
             in_labels = False
         elif line.startswith("labels:"):
             in_labels = True
             data["labels"] = []
         elif in_labels and line.startswith("  - "):
-            data["labels"].append(line.split("  - ", 1)[1].strip().strip('"'))
+            data["labels"].append(line.split("  - ", 1)[1].strip().strip("\"'"))
         elif line and not line.startswith(" "):
             in_labels = False
     return data


### PR DESCRIPTION
Closes #2707

## Summary
Repair the remaining v0.90.5 metadata parity backlog.

## Scope
- fix single-quote handling in `check_issue_metadata_parity.sh`
- align the stale canonical `#2566` local title with the correct GitHub title
- correct malformed GitHub titles for `#2625`, `#2683`, and `#2694`
- rerun `check_issue_metadata_parity.sh --version v0.90.5`

## Validation
- bash adl/tools/check_issue_metadata_parity.sh --version v0.90.5 --root <primary-root>