### PR TITLE
[v0.90.5][tools] Verify pr.sh exec delegation preserves wrapper cleanup semantics

### DIFF
--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -234,6 +234,10 @@ delegate_pr_command_to_rust() {
   local root manifest cached_bin
   root="$(rust_pr_delegate_root)"
   manifest="$root/adl/Cargo.toml"
+  # These Rust-owned delegated paths intentionally install no shell-level
+  # cleanup or trap-driven finalization in the wrapper before transfer. The
+  # wrapper contract here is limited to exact delegation and exit-status
+  # propagation into the Rust control plane.
   if [[ -n "${ADL_PR_RUST_BIN:-}" ]]; then
     exec "${ADL_PR_RUST_BIN}" pr "$subcommand" "$@"
   fi

--- a/adl/tools/test_pr_delegate_exit_status.sh
+++ b/adl/tools/test_pr_delegate_exit_status.sh
@@ -33,12 +33,26 @@ set +e
   ADL_PR_RUST_BIN=/usr/bin/false \
     "$BASH_BIN" adl/tools/pr.sh doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full >/dev/null
 )
-status=$?
+failure_status=$?
 set -e
 
-[[ "$status" -eq 1 ]] || {
-  echo "assertion failed: expected delegated Rust exit status to propagate, got $status" >&2
+[[ "$failure_status" -eq 1 ]] || {
+  echo "assertion failed: expected delegated Rust failure exit status to propagate, got $failure_status" >&2
   exit 1
 }
 
-echo "pr.sh delegated exit status propagation: ok"
+set +e
+(
+  cd "$repo"
+  ADL_PR_RUST_BIN=/usr/bin/true \
+    "$BASH_BIN" adl/tools/pr.sh doctor 1152 --slug rust-start --no-fetch-issue --version v0.86 --mode full >/dev/null
+)
+success_status=$?
+set -e
+
+[[ "$success_status" -eq 0 ]] || {
+  echo "assertion failed: expected delegated Rust success exit status to propagate, got $success_status" >&2
+  exit 1
+}
+
+echo "pr.sh delegated success/failure exit status propagation: ok"


### PR DESCRIPTION
Closes #2720

## Summary
- clarify the delegated wrapper contract for Rust-owned pr.sh command paths
- document that the wrapper installs no shell-level cleanup or trap semantics before exec on the delegated paths
- expand the focused shell regression to cover delegated success and failure exit propagation

## Validation
- not run in this session
- updated focused shell regression surface: `adl/tools/test_pr_delegate_exit_status.sh`