### PR TITLE
[v0.90.5][comms] Validate ACIP required outputs by identity, not substring

### DIFF
--- a/adl/src/agent_comms/dispatch/invocation.inc
+++ b/adl/src/agent_comms/dispatch/invocation.inc
@@ -196,8 +196,7 @@ pub fn validate_acip_invocation_event_against_contract(
                 .filter(|expected| expected.required)
             {
                 let matched = event.output_refs.iter().any(|output_ref| {
-                    output_ref.contains(&expected.output_id)
-                        || output_ref.contains(&expected.output_kind)
+                    output_ref_matches_expected_output(output_ref, expected)
                 });
                 if !matched {
                     return Err(anyhow!(
@@ -221,6 +220,20 @@ pub fn validate_acip_invocation_event_against_contract(
         AcipInvocationStatusV1::Refused | AcipInvocationStatusV1::Failed => {}
     }
     Ok(())
+}
+
+fn output_ref_matches_expected_output(
+    output_ref: &str,
+    expected: &AcipExpectedOutputV1,
+) -> bool {
+    let Some(file_name) = output_ref.rsplit('/').next() else {
+        return false;
+    };
+    let stem = file_name
+        .rsplit_once('.')
+        .map(|(stem, _)| stem)
+        .unwrap_or(file_name);
+    stem == expected.output_id || stem == expected.output_kind
 }
 
 

--- a/adl/src/agent_comms/tests.inc
+++ b/adl/src/agent_comms/tests.inc
@@ -1161,6 +1161,41 @@
     }
 
     #[test]
+    fn acip_invocation_event_accepts_exact_required_output_identity() {
+        let contract = sample_invocation_contract();
+        let event = sample_invocation_event(
+            &contract,
+            AcipInvocationStatusV1::Completed,
+            vec!["runtime/comms/invocation/review_report.json".to_string()],
+            "completed_output_contract".to_string(),
+            None,
+            None,
+            vec!["runtime/comms/invocation/evidence/review_trace.json".to_string()],
+        );
+        validate_acip_invocation_event_against_contract(&contract, &event)
+            .expect("exact required output identity should pass");
+    }
+
+    #[test]
+    fn acip_invocation_event_rejects_incidental_required_output_substring_match() {
+        let contract = sample_invocation_contract();
+        let event = sample_invocation_event(
+            &contract,
+            AcipInvocationStatusV1::Completed,
+            vec!["runtime/comms/invocation/review_report_shadow.json".to_string()],
+            "completed_output_contract".to_string(),
+            None,
+            None,
+            vec!["runtime/comms/invocation/evidence/review_trace.json".to_string()],
+        );
+        let error = validate_acip_invocation_event_against_contract(&contract, &event)
+            .expect_err("incidental substring match should fail");
+        assert!(error
+            .to_string()
+            .contains("completed invocation must satisfy declared required output contracts"));
+    }
+
+    #[test]
     fn acip_invocation_event_preserves_contract_input_and_trace_binding() {
         let contract = sample_invocation_contract();
         let mut event = sample_invocation_event(


### PR DESCRIPTION
Closes #2721

## Summary

Validate required ACIP outputs by exact output-ref identity instead of broad
substring containment.

## Scope

- replace substring matching in `adl/src/agent_comms/dispatch/invocation.inc`
  with a leaf-identity match helper
- add focused positive and negative tests for exact-match and incidental-token
  rejection behavior

## Validation

- `cargo fmt --manifest-path adl/Cargo.toml`
- `cargo test --manifest-path adl/Cargo.toml --lib acip_invocation_event_ -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml --lib acip_invocation_fixture_set_matches_required_contract_and_negative_cases -- --nocapture`
- `git diff --check`
