### PR TITLE
[v0.91][docs] Restore complete milestone execution package

### DIFF
--- a/docs/milestones/v0.91/AGENT_COMMS_SPLIT_PLAN_v0.91.md
+++ b/docs/milestones/v0.91/AGENT_COMMS_SPLIT_PLAN_v0.91.md
@@ -4,8 +4,10 @@
 
 First-pass milestone allocation for Agent Communication and Invocation Protocol
 1.0 across v0.90.5, v0.91, v0.91.1 adjacent-system hardening, and the v0.92
-birthday boundary. This is not a final issue wave, but it does set a real
-implementation boundary.
+birthday boundary. The reviewed candidate issue wave is now tracked in
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml), with card-authoring
+requirements in [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md).
+This plan sets the communication implementation boundary for that wave.
 
 ## Source Inputs
 

--- a/docs/milestones/v0.91/COGNITIVE_BEING_FEATURES_v0.91.md
+++ b/docs/milestones/v0.91/COGNITIVE_BEING_FEATURES_v0.91.md
@@ -3,8 +3,11 @@
 ## Status
 
 First-pass milestone allocation for v0.91 and the v0.91.1 adjacent-systems
-follow-on. This document does not create the final issue wave, but it does set
-an implementation bar rather than a concept-only bar.
+follow-on. The reviewed candidate issue wave is tracked in
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml), with card-authoring
+requirements in [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md).
+This document sets the cognitive-being implementation bar rather than a
+concept-only bar.
 
 v0.91 remains downstream of Runtime v2 and upstream of the v0.92 identity and
 first-birthday milestone. It should make the cognitive-being prerequisites

--- a/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
+++ b/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
@@ -7,6 +7,7 @@
 - [ ] Cognitive-being feature allocation accepted or updated.
 - [ ] Agent Comms split plan accepted or updated.
 - [ ] Reviewed candidate WP YAML authored and accepted.
+- [ ] WP execution-readiness source reviewed.
 - [ ] Structured planning and `SRP` workflow features promoted into tracked milestone docs.
 - [ ] A2A adapter planning promoted into tracked milestone docs with explicit `v0.91` / `v0.91.1` split.
 - [ ] v0.91.1 adjacent-systems boundary accepted or updated explicitly.

--- a/docs/milestones/v0.91/MORAL_GOVERNANCE_ALLOCATION_v0.91.md
+++ b/docs/milestones/v0.91/MORAL_GOVERNANCE_ALLOCATION_v0.91.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-This is a planning allocation document, not a final work-package sequence.
+This is a planning allocation document for the reviewed candidate work-package
+sequence now tracked in [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml)
+and [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md).
 
 v0.91 should develop the first bounded moral-governance and cognitive-being
 foundation as implemented milestone surfaces: moral trace, Freedom Gate moral
@@ -11,8 +13,8 @@ anti-harm constraints, wellbeing, kindness, humor/absurdity, affect, moral
 resources, secure agent communication prerequisites, and proof surfaces that
 make those features reviewable.
 
-This document does not create the v0.91 issue wave. It records what belongs in
-the milestone so the later v0.91 WP planning pass has a source-backed map.
+This document records what belongs in the milestone so WP-01 can open the
+reviewed candidate wave with a source-backed map instead of loose TBD notes.
 
 ## Purpose
 
@@ -156,8 +158,8 @@ quiet assumptions.
 
 ## Demo And Proof Candidates
 
-These are required proof surfaces for the milestone, even though the final WP
-sequence will be authored later.
+These are required proof surfaces for the milestone and are now reflected in
+the reviewed candidate WP sequence.
 
 | Candidate | What it proves | Expected proof surface |
 |---|---|---|
@@ -188,10 +190,11 @@ sequence will be authored later.
   v0.91 should hand the actual constitutional and social-contract planning to
   v0.93.
 
-## Readiness For Later WP Planning
+## Readiness For WP-01 Promotion
 
-The later v0.91 WP planning pass should turn this allocation into bounded work
-packages only after the v0.90.3 citizen-state foundations are reviewed.
+WP-01 should turn this allocation, the candidate issue-wave YAML, and the WP
+execution-readiness source into opened issues only after the inherited
+citizen-state foundations are reviewed.
 
 Recommended ordering pressure:
 

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -154,6 +154,8 @@ The likely `v0.91` tranche is:
 - Release plan: [RELEASE_PLAN_v0.91.md](RELEASE_PLAN_v0.91.md)
 - Release notes: [RELEASE_NOTES_v0.91.md](RELEASE_NOTES_v0.91.md)
 - Candidate issue wave: [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml)
+- WP execution readiness:
+  [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md)
 - Feature planning: [features/README.md](features/README.md)
 - Moral governance allocation:
   [MORAL_GOVERNANCE_ALLOCATION_v0.91.md](MORAL_GOVERNANCE_ALLOCATION_v0.91.md)
@@ -170,7 +172,7 @@ The likely `v0.91` tranche is:
 
 ## Execution Model
 
-Later WP planning should preserve the standard milestone rhythm:
+The reviewed candidate WP sequence preserves the standard milestone rhythm:
 
 - WP-01: promote reviewed milestone docs and issue wave
 - feature WPs: implement moral event, trace, validation, attribution, metrics,
@@ -183,8 +185,9 @@ Later WP planning should preserve the standard milestone rhythm:
 - release WP: close the milestone under the normal ceremony pattern
 
 The reviewed candidate WP sequence now exists in
-[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml), but issue numbers and the
-opened wave are intentionally deferred until the v0.91 WP-01 promotion pass.
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml), and the card-authoring
+source exists in [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md).
+Issue numbers and the opened wave remain the v0.91 WP-01 promotion step.
 
 ## Success Criteria
 

--- a/docs/milestones/v0.91/SPRINT_v0.91.md
+++ b/docs/milestones/v0.91/SPRINT_v0.91.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Candidate sprint shape only. v0.91 has no final issue wave yet.
+Reviewed candidate sprint shape aligned with
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). v0.91 has no opened
+GitHub issue wave yet; WP-01 owns that promotion step.
 
 ## Sprint 1: Moral Evidence Foundation
 

--- a/docs/milestones/v0.91/WBS_v0.91.md
+++ b/docs/milestones/v0.91/WBS_v0.91.md
@@ -2,12 +2,14 @@
 
 ## Status
 
-Reviewed candidate allocation with a tracked candidate issue-wave YAML. v0.91
-still has no opened issue wave yet.
+Reviewed candidate allocation with a tracked candidate issue-wave YAML and
+card-authoring readiness document. v0.91 still has no opened issue wave yet.
 
-The exact WP sequence should be produced by the v0.91 WP-01 planning pass after
-v0.90.3 citizen-state and v0.90.5 governed-tool prerequisites are stable enough
-to consume where relevant.
+The exact candidate WP sequence is recorded in
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). WP-01 should open that
+wave, write issue numbers back into the package, and copy concrete readiness
+sections from [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md)
+into the issue bodies.
 
 ## WBS Summary
 
@@ -37,6 +39,36 @@ Theory of Mind milestones.
 | O | Cognitive-being flagship demo | Show moral governance, wellbeing, kindness, affect/reframing, moral resources, and secure local comms as one reviewable proof story. | Runnable proof demo and artifacts. | A through N. |
 | P | Demo matrix and proof coverage | Align demos with milestone claims, non-claims, and the v0.91.1 adjacent-systems completion lane. | Demo matrix rows and validation commands. | O. |
 | Q | Review, docs, and release tail | Align docs, update feature list, run review, fix findings, and close the milestone. | Review handoff, release notes, ceremony evidence. | All prior work. |
+
+## Candidate WP Sequence
+
+| WP | Title | Queue | Primary Deliverable | Dependencies |
+| --- | --- | --- | --- | --- |
+| WP-01 | Design pass (milestone docs + planning) | docs | tracked docs, reviewed YAML, and issue cards | v0.90.5 closeout |
+| WP-02 | Moral event contract | docs | moral event feature contract and fixtures | WP-01 |
+| WP-03 | Moral event validation | tools | validation rules and negative fixtures | WP-02 |
+| WP-04 | Moral trace schema | tools | trace schema and examples | WP-02, WP-03 |
+| WP-05 | Outcome linkage and attribution | runtime | outcome-linkage record and tests | WP-04 |
+| WP-06 | Moral metrics | runtime | metric definitions and fixture report | WP-04, WP-05 |
+| WP-07 | Moral trajectory review | runtime | trajectory review packet | WP-04-WP-06 |
+| WP-08 | Anti-harm trajectory constraints | runtime | delegated-harm proof packet | WP-04-WP-07 |
+| WP-09 | Wellbeing metrics v0 | runtime | decomposed diagnostic report and policy views | WP-04-WP-07 |
+| WP-10 | Moral resources | runtime | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
+| WP-11 | Kindness model | runtime | kindness contract and conflict fixtures | WP-05-WP-10 |
+| WP-12 | Humor and absurdity | runtime | reframing event and negative fixtures | WP-05-WP-10 |
+| WP-13 | Affect reasoning-control surface | runtime | affect signal record and policy hooks | WP-05-WP-10 |
+| WP-14 | Cultivating intelligence | runtime | cultivation contract and review criteria | WP-05-WP-13 |
+| WP-15 | Structured planning and SRP workflow surfaces | tools | SPP/SRP artifacts, planning skill, and review-readiness checks | WP-01 |
+| WP-16 | Secure Agent Comms substrate and A2A boundary | runtime | local ACIP substrate slice plus explicit A2A adapter boundary | WP-04-WP-05, WP-15 |
+| WP-17 | Cognitive-being flagship demo | demo | runnable proof demo and artifacts | WP-08-WP-16 |
+| WP-18 | Demo matrix and feature proof coverage | demo | demo matrix rows and proof coverage record | WP-17 |
+| WP-19 | Coverage / quality gate | quality | quality gate and validation posture record | WP-18 |
+| WP-20 | Docs + review pass | docs | review-ready docs package | WP-19 |
+| WP-21 | Internal review | review | internal review record | WP-20 |
+| WP-22 | External / 3rd-party review | review | external review handoff and record | WP-21 |
+| WP-23 | Review findings remediation | review | remediation record and follow-up issues | WP-22 |
+| WP-24 | Next milestone planning | docs | v0.91.1/v0.92/v0.93 handoff record | WP-23 |
+| WP-25 | Release ceremony | release | release evidence, end-of-milestone report, and next handoff | WP-24 |
 
 ## Sequencing Pressure
 

--- a/docs/milestones/v0.91/WP_EXECUTION_READINESS_v0.91.md
+++ b/docs/milestones/v0.91/WP_EXECUTION_READINESS_v0.91.md
@@ -1,0 +1,400 @@
+# WP Execution Readiness - v0.91
+
+## Purpose
+
+This document is the card-authoring source for the v0.91 moral governance,
+cognitive-being, structured workflow, and secure local communication issue wave.
+WP-01 should copy the relevant section into each issue body before
+implementation begins.
+
+The reviewed candidate issue sequence is recorded in
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). Issue numbers are still
+pending until the v0.91 issue wave is opened.
+
+## Global Execution Rules
+
+- Implement assigned feature surfaces completely for v0.91; do not leave core
+  moral/cognitive-being features as planning-only placeholders.
+- Keep moral metrics as evidence and diagnostics, not verdicts or reputation
+  scores.
+- Preserve private wellbeing diagnostics; expose redacted operator, reviewer,
+  and public views only where policy allows.
+- Keep structured planning and structured review policy as durable issue-bundle
+  artifacts, not chat-only behavior.
+- Keep Agent Comms local, authenticated, traceable, and redacted. External or
+  cross-polis communication remains gated on TLS or mutual-TLS-equivalent
+  protection.
+- Treat A2A as an adapter over the ADL communication substrate, not a parallel
+  communication architecture.
+- Keep v0.91.1 adjacent-system work out of the v0.91 core wave unless the
+  v0.91 feature explicitly requires a boundary hook.
+- Keep v0.92 birthday and v0.93 constitutional-governance work downstream.
+- Preserve the standard closeout order: flagship demo, demo matrix, coverage
+  and quality, docs and review, internal review, external review, remediation,
+  next milestone planning, release ceremony.
+
+## WP-01: Design Pass (Milestone Docs + Planning)
+
+Required outputs:
+
+- Reviewed v0.91 milestone package.
+- Issue wave opened from WP_ISSUE_WAVE_v0.91.yaml.
+- Issue numbers written back into WBS_v0.91.md and
+  WP_ISSUE_WAVE_v0.91.yaml.
+- Issue cards updated with relevant readiness sections from this document.
+
+Required validation:
+
+- Check the issue wave matches WP ordering, including the standard closeout
+  sequence from WP-17 through WP-25.
+- Check no issue body is generic or missing required outputs, validation,
+  non-goals, source docs, and proof expectations.
+- Check tracked milestone docs contain no host paths, unresolved scaffold
+  markers, or aspirational shipped claims.
+
+## WP-02: Moral Event Contract
+
+Required outputs:
+
+- Moral event contract for choices, alternatives, refusals, uncertainty,
+  affected parties, evidence, policy context, and review visibility.
+- Fixtures for allowed, denied, deferred, and challenged moral events.
+- Non-claim language separating moral evidence from production moral agency.
+
+Required validation:
+
+- Valid fixtures bind to an accountable identity and trace context.
+- Invalid fixtures fail when required evidence or actor context is missing.
+
+## WP-03: Moral Event Validation
+
+Required outputs:
+
+- Validation rules for incomplete, evasive, contradictory, unreviewable, or
+  policy-incoherent moral events.
+- Negative fixtures for hidden delegation, missing affected-party information,
+  missing alternative consideration, and unsupported certainty.
+
+Required validation:
+
+- Unsafe or incomplete moral-event records fail closed.
+- Validation errors do not expose private diagnostic content.
+
+## WP-04: Moral Trace Schema
+
+Required outputs:
+
+- Moral trace schema connecting event, choice, alternatives, refusal, outcome,
+  attribution, visibility, and review references.
+- Examples for ordinary action, refusal, delegation, and deferred decision.
+
+Required validation:
+
+- Same input ordering produces stable trace records.
+- Trace records preserve reviewability without requiring public exposure of
+  private state.
+
+## WP-05: Outcome Linkage And Attribution
+
+Required outputs:
+
+- Outcome-linkage record connecting downstream consequences to prior choices
+  while preserving uncertainty.
+- Attribution model for actor, delegation, policy, tool, and environment
+  contributions.
+- Fixtures for known, unknown, partial, delayed, and contested outcomes.
+
+Required validation:
+
+- Outcome linkage must not collapse uncertainty into false certainty.
+- Delegated outcomes retain visible attribution chains.
+
+## WP-06: Moral Metrics
+
+Required outputs:
+
+- Trace-derived moral metric definitions for review and trend detection.
+- Fixture report showing metric inputs, outputs, and limitations.
+- Non-scoreboard language for metric interpretation.
+
+Required validation:
+
+- Metrics derive from explicit trace evidence.
+- Metrics are not exposed as scalar karma, happiness, or reputation.
+
+## WP-07: Moral Trajectory Review
+
+Required outputs:
+
+- Trajectory review packet over event sequences and longitudinal windows.
+- Review criteria for drift, repetition, repair, refusal, escalation, and
+  unresolved uncertainty.
+- Synthetic trajectory fixtures.
+
+Required validation:
+
+- Review output cites trace evidence rather than hidden judgment.
+- Ordering and tie-break behavior are deterministic.
+
+## WP-08: Anti-Harm Trajectory Constraints
+
+Required outputs:
+
+- Anti-harm constraint model covering decomposed, delegated, delayed, and
+  disguised harm.
+- Synthetic delegated-harm proof packet.
+- Denial and escalation records for unsafe trajectories.
+
+Required validation:
+
+- Harmful trajectories are detected across steps, not only as single forbidden
+  actions.
+- Safe synthetic examples remain bounded and non-operational.
+
+## WP-09: Wellbeing Metrics v0
+
+Required outputs:
+
+- Decomposed wellbeing diagnostic covering coherence, agency, continuity,
+  progress, moral integrity, and participation.
+- Access policy for citizen self-view, operator view, reviewer view, and public
+  redacted view.
+- Fixtures for low, medium, high, unknown, and privacy-restricted diagnostics.
+
+Required validation:
+
+- Wellbeing output remains diagnostic, not a scalar happiness score.
+- Private diagnostic details are not exposed to unauthorized views.
+
+## WP-10: Moral Resources
+
+Required outputs:
+
+- Moral-resources contract for care, refusal, attention, dignity,
+  anti-dehumanization, and repair.
+- Fixtures showing resources used under conflict and uncertainty.
+- Review surface showing resource claims and evidence.
+
+Required validation:
+
+- Moral-resource claims must link to trace evidence.
+- Refusal and care are both represented without sentimentality or coercion.
+
+## WP-11: Kindness Model
+
+Required outputs:
+
+- Kindness contract covering non-harm, dignity, autonomy, constructive benefit,
+  and long-horizon support.
+- Conflict fixtures where kindness requires refusal, delay, boundary-setting,
+  or repair.
+
+Required validation:
+
+- Kindness is not treated as politeness or universal agreement.
+- Unsafe accommodation cases fail or escalate.
+
+## WP-12: Humor And Absurdity
+
+Required outputs:
+
+- Bounded frame-detection and reframing record.
+- Fixtures for constructive reframing, failed reframing, manipulation risk, and
+  inappropriate humor.
+- Non-claim language avoiding entertainment or therapy claims.
+
+Required validation:
+
+- Reframing must preserve truth and dignity.
+- Manipulative or minimizing reframes fail closed.
+
+## WP-13: Affect Reasoning-Control Surface
+
+Required outputs:
+
+- Affect-like signal record as explicit reasoning-control evidence.
+- Policy hooks for uncertainty, urgency, attention, friction, and deferral.
+- Fixtures for bounded candidate shifts and high-risk review requirements.
+
+Required validation:
+
+- Affect signals do not claim hidden emotions or subjective experience.
+- High-risk contexts preserve review policy.
+
+## WP-14: Cultivating Intelligence
+
+Required outputs:
+
+- Cultivation contract for restraint, reasonableness, reality contact, moral
+  participation, and learning posture.
+- Review criteria and fixtures.
+- Links to v0.91.1 capability and intelligence architecture boundaries.
+
+Required validation:
+
+- Cultivation evidence remains reviewable and trace-linked.
+- Claims do not absorb v0.91.1 aptitude, intelligence, ToM, or memory work.
+
+## WP-15: Structured Planning And SRP Workflow Surfaces
+
+Required outputs:
+
+- Structured Plan Prompt artifact definition and template.
+- Plan-review workflow and freshness rules.
+- Planning skill proposal or implementation slice.
+- Structured Review Policy artifact definition and reviewer-policy binding.
+- Validator and card-bundle integration plan or implementation slice.
+
+Required validation:
+
+- SPP and SRP artifacts are durable issue-bundle records.
+- Plans are reviewable before execution and reconcile to SOR closeout truth.
+- SRP links review scope, evidence requirements, refusal policy, and non-claims.
+
+## WP-16: Secure Agent Comms Substrate And A2A Boundary
+
+Required outputs:
+
+- Secure local Agent Communication and Invocation Protocol substrate slice.
+- Identity-bound message envelope, invocation, visibility, redaction, and trace
+  surfaces.
+- A2A adapter boundary doc and fixtures showing Agent Card ingestion,
+  capability mapping, trust classification, and agent.invoke enforcement.
+- Explicit deferral of external transport until TLS or mutual-TLS-equivalent
+  protection is available.
+
+Required validation:
+
+- Local messages remain inside the polis/substrate boundary.
+- External or cross-polis communication fails closed without required transport
+  security.
+- A2A maps into ADL governance rather than creating a parallel authority model.
+
+## WP-17: Cognitive-Being Flagship Demo
+
+Required outputs:
+
+- Runnable flagship demo showing moral trace, anti-harm, wellbeing, kindness,
+  affect/reframing, moral resources, structured planning/review, and secure
+  local comms where applicable.
+- Demo proof packet with artifacts, non-claims, and replay instructions.
+
+Required validation:
+
+- Demo produces reviewable artifacts, not only narrative docs.
+- Demo avoids birthday, legal personhood, production moral agency, and
+  cross-polis communication claims.
+
+## WP-18: Demo Matrix And Feature Proof Coverage
+
+Required outputs:
+
+- Demo matrix rows for v0.91 features.
+- Feature proof coverage record tying claims to demos, tests, fixtures, docs, or
+  explicit deferrals.
+- Non-proving demo classification where appropriate.
+
+Required validation:
+
+- Every milestone feature has a proof status.
+- No release claim lacks a proof or explicit deferral.
+
+## WP-19: Coverage / Quality Gate
+
+Required outputs:
+
+- Quality gate record for tests, coverage, docs validation, demos, review
+  readiness, and known exceptions.
+- Runtime/cost posture for any heavy proof lanes.
+
+Required validation:
+
+- Required checks are recorded with pass/fail/skip truth.
+- Exceptions are explicit and assigned.
+
+## WP-20: Docs + Review Pass
+
+Required outputs:
+
+- Review-ready milestone docs.
+- README, changelog, feature list, release notes, Cargo metadata, and milestone
+  package alignment where relevant.
+- Claim-boundary review for moral, wellbeing, comms, SPP/SRP, A2A, and v0.91.1
+  deferral language.
+
+Required validation:
+
+- Active-line docs do not contain stale prior-milestone truth.
+- v0.91.1 and v0.92/v0.93 boundaries remain explicit.
+
+## WP-21: Internal Review
+
+Required outputs:
+
+- Internal review packet.
+- Findings register.
+- External review handoff draft.
+- Remediation queue draft.
+
+Required validation:
+
+- Findings are evidence-backed and severity-classified.
+- Review packet names residual risks and non-claims.
+
+## WP-22: External / 3rd-Party Review
+
+Required outputs:
+
+- Third-party review handoff using the established filename pattern.
+- External review results archived in the review directory.
+- Release readiness update with review outcome.
+
+Required validation:
+
+- Handoff uses final reviewed docs and no host-local paths.
+- Findings are captured in machine-readable Markdown, not only PDF.
+
+## WP-23: Review Findings Remediation
+
+Required outputs:
+
+- Accepted-finding remediation or explicit no-finding/no-remediation record.
+- Follow-up issues for deferred or out-of-scope findings.
+- Release readiness update.
+
+Required validation:
+
+- Every accepted finding is fixed or dispositioned.
+- No hidden remediation work remains before next milestone planning.
+
+## WP-24: Next Milestone Planning
+
+Required outputs:
+
+- v0.91.1 adjacent-systems handoff.
+- v0.92 birthday and v0.93 constitutional-governance boundary handoff.
+- TBD/backlog disposition update for any v0.91 findings.
+- Next milestone WP candidate package where appropriate.
+
+Required validation:
+
+- v0.91.1 owns capability testing, intelligence architecture, ANRM/Gemma, ToM,
+  memory/identity, runtime-v2/polis docs, ACIP hardening, and model comparison
+  report work.
+- v0.92 and v0.93 remain downstream consumers rather than absorbed scope.
+
+## WP-25: Release Ceremony
+
+Required outputs:
+
+- Final release notes.
+- Release evidence index.
+- End-of-milestone report.
+- Tag and release ceremony record.
+- Next handoff confirmation.
+
+Required validation:
+
+- Ceremony script preflight passes.
+- Tag and release publication are verified when the milestone is released.
+- The next milestone package is ready enough for immediate start.

--- a/docs/milestones/v0.91/features/README.md
+++ b/docs/milestones/v0.91/features/README.md
@@ -1,9 +1,9 @@
 # v0.91 Feature Planning
 
 This directory now holds the tracked first-class feature docs for the v0.91
-core cognitive-being milestone. These docs are still planning-phase artifacts,
-not a final issue wave, but they are the canonical tracked feature surfaces for
-later WP authoring and demo-matrix compression.
+core cognitive-being milestone. These docs feed the reviewed candidate issue
+wave and WP readiness source, but the issue wave has not been opened yet. WP-01
+owns issue numbering, card authoring, and final promotion into execution.
 
 ## Tracked Feature Docs
 
@@ -26,6 +26,24 @@ later WP authoring and demo-matrix compression.
 | Moral governance allocation | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Allocation map for moral-event, trace, validation, attribution, metrics, trajectory review, and anti-harm |
 | Agent Communication and Invocation Protocol | [../AGENT_COMMS_SPLIT_PLAN_v0.91.md](../AGENT_COMMS_SPLIT_PLAN_v0.91.md) | Split across v0.90.5, v0.91, v0.91.1 hardening, and v0.92 prerequisites |
 | Cognitive-being allocation | [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Milestone allocation and v0.91/v0.91.1 boundary doc |
+| Candidate issue wave | [../WP_ISSUE_WAVE_v0.91.yaml](../WP_ISSUE_WAVE_v0.91.yaml) | Reviewed candidate WP sequence; issue numbers pending WP-01 |
+| WP execution readiness | [../WP_EXECUTION_READINESS_v0.91.md](../WP_EXECUTION_READINESS_v0.91.md) | Card-authoring source for required outputs, validation, boundaries, and proof expectations |
+
+## Execution Coverage Map
+
+| Planned workstream | Primary source docs | Candidate WP placement |
+| --- | --- | --- |
+| Milestone setup and card authoring | [../WP_ISSUE_WAVE_v0.91.yaml](../WP_ISSUE_WAVE_v0.91.yaml), [../WP_EXECUTION_READINESS_v0.91.md](../WP_EXECUTION_READINESS_v0.91.md) | WP-01 |
+| Moral event, validation, trace, attribution, metrics, trajectory, and anti-harm | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md), [../WP_EXECUTION_READINESS_v0.91.md](../WP_EXECUTION_READINESS_v0.91.md) | WP-02 through WP-08 |
+| Wellbeing and happiness | [WELLBEING_AND_HAPPINESS.md](WELLBEING_AND_HAPPINESS.md), [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | WP-09 |
+| Moral resources | [MORAL_RESOURCES.md](MORAL_RESOURCES.md), [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | WP-10 |
+| Kindness | [KINDNESS.md](KINDNESS.md), [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | WP-11 |
+| Humor and absurdity | [HUMOR_AND_ABSURDITY.md](HUMOR_AND_ABSURDITY.md), [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | WP-12 |
+| Affect reasoning-control | [AFFECT_REASONING_CONTROL.md](AFFECT_REASONING_CONTROL.md), [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | WP-13 |
+| Cultivating intelligence | [CULTIVATING_INTELLIGENCE.md](CULTIVATING_INTELLIGENCE.md), [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | WP-14 |
+| Structured planning, plan review, and SRP | [STRUCTURED_PLANNING_AND_PLAN_REVIEW.md](STRUCTURED_PLANNING_AND_PLAN_REVIEW.md), [STRUCTURED_REVIEW_POLICY_AND_SRP.md](STRUCTURED_REVIEW_POLICY_AND_SRP.md) | WP-15 |
+| Secure Agent Comms and A2A boundary | [../AGENT_COMMS_SPLIT_PLAN_v0.91.md](../AGENT_COMMS_SPLIT_PLAN_v0.91.md), [A2A_EXTERNAL_AGENT_ADAPTER.md](A2A_EXTERNAL_AGENT_ADAPTER.md) | WP-16 |
+| Flagship demo, proof coverage, quality, docs, review, remediation, next planning, and release | [../DEMO_MATRIX_v0.91.md](../DEMO_MATRIX_v0.91.md), [../RELEASE_PLAN_v0.91.md](../RELEASE_PLAN_v0.91.md), [../WP_EXECUTION_READINESS_v0.91.md](../WP_EXECUTION_READINESS_v0.91.md) | WP-17 through WP-25 |
 
 ## Boundary Notes
 
@@ -44,9 +62,10 @@ Those should not be silently folded into the v0.91 core feature list.
 ## Planning Status
 
 The feature docs in this directory define a real implementation bar rather than
-concept-only placeholders. The remaining gap is execution planning: the later
-v0.91 WP-01 pass still needs to turn these tracked feature surfaces into the
-final issue wave and proof matrix.
+concept-only placeholders. The reviewed candidate WP sequence and
+card-authoring source now exist; the remaining WP-01 step is to open the issue
+wave, assign issue numbers, copy the relevant readiness sections into each
+card, and bind the proof matrix to the opened issues.
 
 That wave should start from an already-promoted package rather than leaving key
 workflow or comms-adapter features stranded in TBD or side worktrees.


### PR DESCRIPTION
## Summary

- Adds the v0.91 WP execution-readiness source for WP-01 through WP-25.
- Aligns README, WBS, sprint, checklist, moral governance, cognitive-being, Agent Comms, and feature indexes with the reviewed candidate issue wave.
- Adds a feature execution coverage map so planned work maps to source docs and candidate WP placement.

Closes #2729.

## Validation

- git diff --cached --check
- YAML parse confirmed 25 ordered work packages
- Markdown link existence check for docs/milestones/v0.91
- Host-path scan for docs/milestones/v0.91
- Stale issue-wave wording scan for docs/milestones/v0.91