### PR TITLE
[v0.91][docs] Add WP map to sprint plan

### DIFF
--- a/docs/milestones/v0.91/SPRINT_v0.91.md
+++ b/docs/milestones/v0.91/SPRINT_v0.91.md
@@ -6,6 +6,36 @@ Reviewed candidate sprint shape aligned with
 [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). v0.91 has no opened
 GitHub issue wave yet; WP-01 owns that promotion step.
 
+## Candidate WP Sprint Map
+
+| Sprint | WP | Title | Primary Deliverable | Dependencies |
+| --- | --- | --- | --- | --- |
+| Sprint 1 | WP-01 | Design pass (milestone docs + planning) | tracked docs, reviewed YAML, and issue cards | v0.90.5 closeout |
+| Sprint 1 | WP-02 | Moral event contract | moral event feature contract and fixtures | WP-01 |
+| Sprint 1 | WP-03 | Moral event validation | validation rules and negative fixtures | WP-02 |
+| Sprint 1 | WP-04 | Moral trace schema | trace schema and examples | WP-02, WP-03 |
+| Sprint 1 | WP-05 | Outcome linkage and attribution | outcome-linkage record and tests | WP-04 |
+| Sprint 2 | WP-06 | Moral metrics | metric definitions and fixture report | WP-04, WP-05 |
+| Sprint 2 | WP-07 | Moral trajectory review | trajectory review packet | WP-04-WP-06 |
+| Sprint 2 | WP-08 | Anti-harm trajectory constraints | delegated-harm proof packet | WP-04-WP-07 |
+| Sprint 3 | WP-09 | Wellbeing metrics v0 | decomposed diagnostic report and policy views | WP-04-WP-07 |
+| Sprint 3 | WP-10 | Moral resources | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
+| Sprint 3 | WP-11 | Kindness model | kindness contract and conflict fixtures | WP-05-WP-10 |
+| Sprint 3 | WP-12 | Humor and absurdity | reframing event and negative fixtures | WP-05-WP-10 |
+| Sprint 3 | WP-13 | Affect reasoning-control surface | affect signal record and policy hooks | WP-05-WP-10 |
+| Sprint 3 | WP-14 | Cultivating intelligence | cultivation contract and review criteria | WP-05-WP-13 |
+| Sprint 3 | WP-15 | Structured planning and SRP workflow surfaces | SPP/SRP artifacts, planning skill, and review-readiness checks | WP-01 |
+| Sprint 3 | WP-16 | Secure Agent Comms substrate and A2A boundary | local ACIP substrate slice plus explicit A2A adapter boundary | WP-04-WP-05, WP-15 |
+| Sprint 3 | WP-17 | Cognitive-being flagship demo | runnable proof demo and artifacts | WP-08-WP-16 |
+| Sprint 3 | WP-18 | Demo matrix and feature proof coverage | demo matrix rows and proof coverage record | WP-17 |
+| Sprint 4 | WP-19 | Coverage / quality gate | quality gate and validation posture record | WP-18 |
+| Sprint 4 | WP-20 | Docs + review pass | review-ready docs package | WP-19 |
+| Sprint 4 | WP-21 | Internal review | internal review record | WP-20 |
+| Sprint 4 | WP-22 | External / 3rd-party review | external review handoff and record | WP-21 |
+| Sprint 4 | WP-23 | Review findings remediation | remediation record and follow-up issues | WP-22 |
+| Sprint 4 | WP-24 | Next milestone planning | v0.91.1/v0.92/v0.93 handoff record | WP-23 |
+| Sprint 4 | WP-25 | Release ceremony | release evidence, end-of-milestone report, and next handoff | WP-24 |
+
 ## Sprint 1: Moral Evidence Foundation
 
 - WP-01: Promote reviewed v0.91 milestone package.


### PR DESCRIPTION
## Summary

- Adds a Candidate WP Sprint Map to docs/milestones/v0.91/SPRINT_v0.91.md.
- Lists WP-01 through WP-25 directly in the sprint doc with deliverables and dependencies.
- Keeps the sprint plan aligned with the reviewed v0.91 WBS and issue-wave YAML.

Closes #2731.

## Validation

- git diff --check
- Ruby check confirmed SPRINT_v0.91.md contains WP-01 through WP-25