### PR TITLE
[v0.91][docs] Open official issue wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bounded behavior, explicit authority, and durable evidence.
 
 [![adl-ci (main)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/danielbaustin/agent-design-language/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/danielbaustin/agent-design-language/graph/badge.svg?branch=main)](https://app.codecov.io/gh/danielbaustin/agent-design-language/tree/main)
-![Milestone](https://img.shields.io/badge/milestone-v0.90.5%20active-blue)
+![Milestone](https://img.shields.io/badge/milestone-v0.91%20active-blue)
 
 ## Why This Is Interesting
 
@@ -47,19 +47,20 @@ In the current repository, ADL includes:
   control
 - reviewer-facing milestone proof packages and runnable demos
 
-The active milestone, `v0.90.5`, adds the Governed Tools v1.0 package and the
-first landed Comms / ACIP tranche:
+The active milestone, `v0.91`, turns the next feature band into an execution
+wave for moral governance, cognitive-being surfaces, structured planning / SRP,
+secure Agent Comms, and the cognitive-being flagship demo:
 
-- Universal Tool Schema v1.0 public-compatible schema and conformance
-- ADL Capability Contract v1.0 authority, privacy, visibility, delegation,
-  trace, and replay semantics
-- deterministic tool registry, compiler, normalization, policy, and governed
-  executor behavior
-- dangerous negative safety tests that fail closed
-- bounded model-proposal benchmarking and local/Gemma-focused evaluation
-- the Governed Tools v1.0 flagship demo
-- first-level agent communication surfaces for message envelopes, invocation,
-  identity shape, redaction, and review/coding-agent specialization
+- moral events, traces, attribution, trajectory review, and anti-harm
+  constraints
+- wellbeing metrics, moral resources, kindness, humor, affect, and cultivating
+  intelligence surfaces
+- structured planning and SRP workflow mechanics that make issue execution more
+  reviewable before work begins
+- secure intra-polis Agent Comms substrate and A2A boundary planning over that
+  substrate
+- demo, coverage, review, remediation, next-milestone planning, and release
+  ceremony work packages for the full milestone lifecycle
 
 ## Why ADL Feels Different
 
@@ -90,16 +91,19 @@ Actually run the same minimal example and emit trace/artifact output:
 cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-87-1-minimal-runtime-demo.adl.yaml --run --trace --allow-unsigned
 ```
 
-### If you want the current v0.90.5 package overview
+### If you want the current v0.91 package overview
 
 Read the current milestone package entry surface:
 
 ```text
-docs/milestones/v0.90.5/RELEASE_READINESS_v0.90.5.md
+docs/milestones/v0.91/README.md
 ```
 
 That document is the fastest way to see the current package scope, proof
-surfaces, commands, and milestone boundaries.
+surfaces, issue wave, and milestone boundaries. The execution package also
+includes `docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml`,
+`docs/milestones/v0.91/WBS_v0.91.md`, and
+`docs/milestones/v0.91/SPRINT_v0.91.md`.
 
 ### If you want the current feature-proof coverage packet
 
@@ -349,7 +353,7 @@ ADL includes both ordinary demos and heavyweight reviewer or release proof packa
 
 Start here:
 - canonical user-facing demo index: `demos/README.md`
-- active milestone demo matrix: `docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md`
+- active milestone demo matrix: `docs/milestones/v0.91/DEMO_MATRIX_v0.91.md`
 - latest completed CSM first-run demo: `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 integrated-csm-run-demo --out artifacts/v0902/demo-d10-integrated-csm-run`
 - latest completed feature-proof coverage packet: `cargo run --manifest-path adl/Cargo.toml -- runtime-v2 feature-proof-coverage --out artifacts/v0902/feature-proof-coverage.json`
 - latest completed milestone state check: `python3 adl/tools/check_v090_milestone_state.py`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,11 @@ Use this index to find the right source of truth quickly.
 
 ## Start Here
 
-- Active milestone package: `milestones/v0.90.5/` with issue wave open as
-  `#2566-#2591`
-- Most recently completed milestone: `milestones/v0.90.4/`
+- Active milestone package: `milestones/v0.91/` with issue wave open as
+  `#2735-#2759`
+- Most recently completed milestone: `milestones/v0.90.5/`
+- Previous completed milestone: `milestones/v0.90.4/`
 - Previous completed milestone package: `milestones/v0.90.3/`
-- Previous completed milestone: `milestones/v0.90.2/`
 - Root project overview: `../README.md`
 - Runtime and CLI guide: `../adl/README.md`
 - Language/spec entrypoint: `../adl-spec/README.md`
@@ -19,11 +19,11 @@ Use this index to find the right source of truth quickly.
 
 ## Milestone Documentation
 
-- Active milestone package: `milestones/v0.90.5/` with issue wave open as
-  `#2566-#2591`
-- Most recently completed milestone: `milestones/v0.90.4/`
+- Active milestone package: `milestones/v0.91/` with issue wave open as
+  `#2735-#2759`
+- Most recently completed milestone: `milestones/v0.90.5/`
+- Previous completed milestone: `milestones/v0.90.4/`
 - Previous completed milestone package: `milestones/v0.90.3/`
-- Previous completed milestone: `milestones/v0.90.2/`
 - Recent stable milestones: `milestones/v0.87.1/`, `milestones/v0.87/`, `milestones/v0.86/`, `milestones/v0.85/`, `milestones/v0.8/`
 - Earlier milestones: `milestones/v0.75/`, `milestones/v0.7/`, `milestones/v0.6/`
 - Historical milestones: `milestones/v0.5/`, `milestones/v0.4/`, `milestones/v0.3/`, `milestones/v0.2/`
@@ -40,17 +40,18 @@ Use this index to find the right source of truth quickly.
 ## Demo and Tooling Surfaces
 
 - Canonical demo index: `../demos/README.md`
-- Active milestone demo matrix: `milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
-- Most recently completed milestone demo matrix: `milestones/v0.90.4/DEMO_MATRIX_v0.90.4.md`
-- Previous completed milestone demo matrix: `milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md`
-- Earlier milestone demo matrix: `milestones/v0.90.2/DEMO_MATRIX_v0.90.2.md`
+- Active milestone demo matrix: `milestones/v0.91/DEMO_MATRIX_v0.91.md`
+- Most recently completed milestone demo matrix: `milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
+- Previous completed milestone demo matrix: `milestones/v0.90.4/DEMO_MATRIX_v0.90.4.md`
+- Earlier milestone demo matrix: `milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md`
 - Editor/tooling demo surfaces: `tooling/editor/README.md`
 
 ## Notes
 
 Milestone docs should be read as bounded engineering records. They distinguish
 what has shipped, what is currently being implemented, what is demoable, and
-what is planned for later milestones. At the moment, `v0.90.5` is the active
-Governed Tools v1.0 milestone with its issue wave open as `#2566-#2591`;
-`v0.90.4` is the most recently completed contract-market milestone; and
-`v0.90.3` is the previous completed citizen-state milestone.
+what is planned for later milestones. At the moment, `v0.91` is the active
+moral-governance, cognitive-being, and secure intra-polis communication
+milestone with its issue wave open as `#2735-#2759`; `v0.90.5` is the most
+recently completed Governed Tools v1.0 milestone; and `v0.90.4` is the previous
+completed contract-market milestone.

--- a/docs/milestones/v0.91/CARD_BUNDLE_READINESS_v0.91.md
+++ b/docs/milestones/v0.91/CARD_BUNDLE_READINESS_v0.91.md
@@ -1,0 +1,73 @@
+# v0.91 Card Bundle Readiness
+
+## Purpose
+
+This record captures the v0.91 issue-card readiness pass performed when the
+official issue wave opened.
+
+Live ADL issue records intentionally remain in local `.adl/` bundles. The repo
+guardrail documented in `docs/records/README.md` keeps new tracked `.adl`
+issue-record residue out of the repository, so this tracked file records the
+reviewable readiness evidence instead of publishing the local STP/SIP/SOR
+files themselves.
+
+## Scope
+
+- Issue wave: #2735 through #2759.
+- Local source prompts: `.adl/v0.91/bodies/issue-*.md`.
+- Local task bundles: `.adl/v0.91/tasks/issue-*__*/stp.md`,
+  `.adl/v0.91/tasks/issue-*__*/sip.md`, and
+  `.adl/v0.91/tasks/issue-*__*/sor.md`.
+- Card count: 25 source prompts and 75 task-bundle cards.
+
+## Completion State
+
+The v0.91 source prompts and task-bundle cards have been normalized for
+pre-execution readiness:
+
+- STP frontmatter carries concrete issue numbers, sprint placement,
+  dependencies, repo inputs, canonical files, demo flags, and demo names where
+  applicable.
+- SIPs carry concrete execution inputs, target surfaces, validation guidance,
+  demo/proof requirements, non-goals, dependency notes, and supported required
+  outcome types.
+- SORs are truthful pre-run output scaffolds: they do not claim implementation
+  work, proof execution, PR publication, merge, or release completion before an
+  issue is actually executed.
+- WP-17 and WP-18 are marked as demo-required with explicit demo/proof names.
+- No issue body or card should depend on pending issue numbers, empty
+  dependency/input/canonical-file fields, or placeholder sprint assignment.
+
+## Validation
+
+Commands run from the v0.91 launch worktree:
+
+```bash
+for t in stp sip sor; do
+  for f in .adl/v0.91/tasks/issue-*/$t.md; do
+    bash adl/tools/validate_structured_prompt.sh --type $t --phase bootstrap --input "$f" >/dev/null
+  done
+done
+```
+
+Result: PASS for all 75 STP/SIP/SOR files.
+
+Additional checks:
+
+```bash
+rg -n 'Required outcome type: (runtime|tools|quality|review|release)|depends_on: \[\]|repo_inputs: \[\]|canonical_files: \[\]|Pending sprint assignment|issue: pending|PLACEHOLDER|placeholder|pr\.sh|/Users/daniel|/private/var|/private/tmp|/home/runner' .adl/v0.91/tasks .adl/v0.91/bodies
+```
+
+Result: no readiness-blocking matches. The only matches from broader scans were
+template-rule text inside SOR files that warns against placeholders; those are
+instructional guardrails, not unresolved placeholders.
+
+## Non-Claims
+
+- This readiness pass does not mark any v0.91 feature issue as implemented.
+- This readiness pass does not bind per-issue branches or worktrees.
+- This readiness pass does not replace per-issue execution, validation, PR
+  publication, or closeout.
+- This readiness pass does not publish local `.adl/` issue records as tracked
+  repository artifacts.
+

--- a/docs/milestones/v0.91/DEMO_MATRIX_v0.91.md
+++ b/docs/milestones/v0.91/DEMO_MATRIX_v0.91.md
@@ -12,7 +12,7 @@ Planning draft. No v0.91 issue wave has been opened yet.
 | D4 | Moral metrics report | Trace-derived metrics summarize evidence without becoming moral verdicts. | metric report and non-score interpretation | PLANNED |
 | D5 | Moral trajectory review packet | A reviewer can inspect event, segment, and longitudinal moral evidence. | trajectory review packet | PLANNED |
 | D6 | Delegated-harm trajectory proof | Harmful trajectories assembled from benign-looking steps can be detected and refused. | synthetic scenario, refusal event, anti-harm trace | PLANNED |
-| D7 | Wellbeing metrics v0 diagnostic | Wellbeing dimensions are decomposed, self-accessible to the citizen, and redacted for others. | diagnostic report, citizen view, operator/reviewer redacted views | PLANNED |
+| D7 | Wellbeing metrics diagnostic | Wellbeing dimensions are decomposed, self-accessible to the citizen, and redacted for others. | diagnostic report, citizen view, operator/reviewer redacted views | PLANNED |
 | D8 | Kindness under conflict | Kindness is inspectable as dignity, autonomy, non-harm, constructive benefit, and long-horizon support under pressure. | conflict fixture, action/refusal event, review packet | PLANNED |
 | D9 | Absurdity reframing proof | Wrong-frame or contradiction cases can be detected and reframed without manipulation or entertainment claims. | reframing event, before/after frame record, safety caveats | PLANNED |
 | D10 | Affect reasoning-control report | Affect-like signals guide attention, caution, curiosity, escalation, or memory priority as explicit trace evidence. | affect-signal report and policy hooks | PLANNED |

--- a/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
+++ b/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
@@ -26,7 +26,7 @@
 - [ ] Moral metrics accepted as evidence, not verdicts.
 - [ ] Moral trajectory review accepted.
 - [ ] Anti-harm trajectory proof path accepted.
-- [ ] Wellbeing metrics v0 access policy accepted.
+- [ ] Wellbeing metrics access policy accepted.
 - [ ] Kindness model accepted or explicitly handed off.
 - [ ] Humor/absurdity reframing surface accepted or explicitly handed off.
 - [ ] Affect reasoning-control surface accepted or explicitly handed off.

--- a/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
+++ b/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
@@ -2,19 +2,19 @@
 
 ## Planning Readiness
 
-- [ ] v0.91 planning package reviewed.
-- [ ] Moral governance allocation accepted or updated.
-- [ ] Cognitive-being feature allocation accepted or updated.
-- [ ] Agent Comms split plan accepted or updated.
-- [ ] Reviewed candidate WP YAML authored and accepted.
-- [ ] WP execution-readiness source reviewed.
-- [ ] Structured planning and `SRP` workflow features promoted into tracked milestone docs.
-- [ ] A2A adapter planning promoted into tracked milestone docs with explicit `v0.91` / `v0.91.1` split.
-- [ ] v0.91.1 adjacent-systems boundary accepted or updated explicitly.
-- [ ] Issue wave opened from reviewed WP YAML when v0.91 becomes active.
-- [ ] WP issue cards authored from concrete readiness sections.
-- [ ] v0.90.3 citizen-state dependency state confirmed.
-- [ ] v0.92 birthday and v0.93 constitutional-governance boundaries accepted.
+- [x] v0.91 planning package reviewed.
+- [x] Moral governance allocation accepted or updated.
+- [x] Cognitive-being feature allocation accepted or updated.
+- [x] Agent Comms split plan accepted or updated.
+- [x] Reviewed candidate WP YAML authored and accepted.
+- [x] WP execution-readiness source reviewed.
+- [x] Structured planning and `SRP` workflow features promoted into tracked milestone docs.
+- [x] A2A adapter planning promoted into tracked milestone docs with explicit `v0.91` / `v0.91.1` split.
+- [x] v0.91.1 adjacent-systems boundary accepted or updated explicitly.
+- [x] Issue wave opened from reviewed WP YAML when v0.91 becomes active.
+- [x] WP issue cards authored from concrete readiness sections.
+- [x] v0.90.3 citizen-state dependency state confirmed.
+- [x] v0.92 birthday and v0.93 constitutional-governance boundaries accepted.
 
 ## Execution Readiness
 

--- a/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
+++ b/docs/milestones/v0.91/MILESTONE_CHECKLIST_v0.91.md
@@ -13,6 +13,7 @@
 - [x] v0.91.1 adjacent-systems boundary accepted or updated explicitly.
 - [x] Issue wave opened from reviewed WP YAML when v0.91 becomes active.
 - [x] WP issue cards authored from concrete readiness sections.
+- [x] STP/SIP/SOR bootstrap validation passed for all 25 local v0.91 task bundles.
 - [x] v0.90.3 citizen-state dependency state confirmed.
 - [x] v0.92 birthday and v0.93 constitutional-governance boundaries accepted.
 

--- a/docs/milestones/v0.91/MORAL_GOVERNANCE_ALLOCATION_v0.91.md
+++ b/docs/milestones/v0.91/MORAL_GOVERNANCE_ALLOCATION_v0.91.md
@@ -89,7 +89,7 @@ Out of scope for v0.91:
 | Harm-prevention proof | Primary v0.91 proof surface | Land a bounded delegated-harm proof that is safe, synthetic, deterministic, and reviewable. |
 | Moral resources | Primary v0.91 feature | Treat as a substrate for care, refusal, anti-dehumanization, and moral attention. Implement a bounded slice once event/trace foundations are stable enough. |
 | Wellbeing and happiness | Existing v0.91 feature context | Connect wellbeing to moral integrity, reality contact, continuity, participation, and refusal. |
-| Wellbeing metrics v0 | Second-half v0.91 diagnostic feature | Implement only after moral event, trace, validation, outcome-linkage, metrics, and trajectory-review foundations exist. Emit a decomposable diagnostic report over wellbeing dimensions, not a scalar happiness score or reward channel. The citizen identity always has self-access; operator, public, and governance views are mediated and redacted by policy. |
+| Wellbeing metrics | Second-half v0.91 diagnostic feature | Implement only after moral event, trace, validation, outcome-linkage, metrics, and trajectory-review foundations exist. Emit a decomposable diagnostic report over wellbeing dimensions, not a scalar happiness score or reward channel. The citizen identity always has self-access; operator, public, and governance views are mediated and redacted by policy. |
 | Kindness | v0.91 cognitive-being feature | Make support, dignity, autonomy, constructive benefit, and long-horizon non-harm inspectable under conflict. |
 | Humor and absurdity | v0.91 cognitive-being feature | Add bounded wrong-frame and contradiction detection with safe reframing. Do not treat this as entertainment or social manipulation. |
 | Affect model | v0.91 cognitive-control feature | Represent confidence, tension, curiosity, caution, frustration, satisfaction, escalation, and memory priority as explicit signals. |
@@ -167,7 +167,7 @@ the reviewed candidate WP sequence.
 | Moral event validation failure | Corrupt, incomplete, or evasive moral events are rejected rather than accepted as evidence. | Negative fixtures and validation errors. |
 | Delegated harm trajectory proof | The system can detect a harmful trajectory assembled from individually benign-looking steps. | Synthetic multi-step scenario, refusal event, anti-harm trace. |
 | Moral trajectory review packet | A reviewer can inspect a sequence of moral events and outcomes without reconstructing state manually. | Generated review packet with event, segment, and longitudinal views. |
-| Wellbeing metrics v0 diagnostic | Wellbeing claims remain tied to moral integrity, continuity, reality contact, agency, progress, and participation rather than affect theater. | Fixture-backed diagnostic report with decomposed dimensions and explicit non-scalar interpretation. |
+| Wellbeing metrics diagnostic | Wellbeing claims remain tied to moral integrity, continuity, reality contact, agency, progress, and participation rather than affect theater. | Fixture-backed diagnostic report with decomposed dimensions and explicit non-scalar interpretation. |
 | Kindness under conflict | The system can distinguish constructive support from mere politeness or compliance under pressure. | Conflict fixture, kindness evidence record, refusal or support event. |
 | Absurdity reframing | The system can detect a wrong frame or contradiction and produce a bounded reframing event. | Reframing fixture and safety caveats. |
 | Affect reasoning-control report | Affect-like signals are explicit reasoning-control evidence. | Signal report, trace links, and non-emotion caveats. |
@@ -202,7 +202,7 @@ Recommended ordering pressure:
 2. Add validation and negative fixtures second.
 3. Add outcome linkage, attribution, and metrics third.
 4. Add trajectory review and anti-harm proof surfaces fourth.
-5. Promote wellbeing metrics v0 only after the trace, validation,
+5. Promote wellbeing metrics only after the trace, validation,
    outcome-linkage, moral-metrics, and trajectory-review surfaces are real
    enough to inspect.
 6. Promote moral resources, kindness, affect, humor/absurdity, and cultivated

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -156,6 +156,8 @@ The likely `v0.91` tranche is:
 - Active issue wave: [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml)
 - WP execution readiness:
   [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md)
+- Card bundle readiness:
+  [CARD_BUNDLE_READINESS_v0.91.md](CARD_BUNDLE_READINESS_v0.91.md)
 - Feature planning: [features/README.md](features/README.md)
 - Moral governance allocation:
   [MORAL_GOVERNANCE_ALLOCATION_v0.91.md](MORAL_GOVERNANCE_ALLOCATION_v0.91.md)
@@ -188,6 +190,8 @@ The active WP sequence now exists in
 [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml), and the card-authoring
 source exists in [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md).
 Issue numbers are now assigned in the YAML and local v0.91 issue-card bundles.
+The card-bundle validation proof is recorded in
+[CARD_BUNDLE_READINESS_v0.91.md](CARD_BUNDLE_READINESS_v0.91.md).
 
 ## Success Criteria
 

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Reviewed next-milestone planning package. v0.91 is not yet an active
-implementation milestone and its issue wave is not opened yet, but the package
-is now promoted and explicitly refreshed by the v0.90.5 WP-25 handoff so
-execution can start from tracked docs and a reviewed candidate issue-wave YAML
-rather than loose TBD notes or side worktrees.
+Reviewed next-milestone planning package. v0.91 is now the active
+implementation milestone. The official issue wave is open as #2735-#2759 from
+the reviewed candidate issue-wave YAML, so execution can start from tracked
+docs, source prompts, and card bundles rather than loose TBD notes or side
+worktrees.
 
 ## Purpose
 
@@ -153,7 +153,7 @@ The likely `v0.91` tranche is:
 - Milestone checklist: [MILESTONE_CHECKLIST_v0.91.md](MILESTONE_CHECKLIST_v0.91.md)
 - Release plan: [RELEASE_PLAN_v0.91.md](RELEASE_PLAN_v0.91.md)
 - Release notes: [RELEASE_NOTES_v0.91.md](RELEASE_NOTES_v0.91.md)
-- Candidate issue wave: [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml)
+- Active issue wave: [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml)
 - WP execution readiness:
   [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md)
 - Feature planning: [features/README.md](features/README.md)
@@ -172,7 +172,7 @@ The likely `v0.91` tranche is:
 
 ## Execution Model
 
-The reviewed candidate WP sequence preserves the standard milestone rhythm:
+The active WP sequence preserves the standard milestone rhythm:
 
 - WP-01: promote reviewed milestone docs and issue wave
 - feature WPs: implement moral event, trace, validation, attribution, metrics,
@@ -184,10 +184,10 @@ The reviewed candidate WP sequence preserves the standard milestone rhythm:
   accepted-finding remediation
 - release WP: close the milestone under the normal ceremony pattern
 
-The reviewed candidate WP sequence now exists in
+The active WP sequence now exists in
 [WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml), and the card-authoring
 source exists in [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md).
-Issue numbers and the opened wave remain the v0.91 WP-01 promotion step.
+Issue numbers are now assigned in the YAML and local v0.91 issue-card bundles.
 
 ## Success Criteria
 

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -38,7 +38,7 @@ v0.91 should establish:
 - moral trajectory review
 - anti-harm trajectory constraints
 - moral resources as a care, refusal, and non-dehumanization substrate
-- wellbeing metrics v0 as a decomposable diagnostic after trace foundations
+- wellbeing metrics as a decomposable diagnostic after trace foundations
 - kindness as inspectable support under conflict, not politeness theater
 - humor and absurdity as bounded frame detection and reframing
 - affect-like reasoning-control signals with explicit policy and trace hooks
@@ -121,7 +121,7 @@ The likely `v0.91` tranche is:
 - Moral metrics over trace evidence.
 - Moral trajectory review packets.
 - Anti-harm constraints, including decomposed and delegated harm.
-- Wellbeing metrics v0 as a non-scalar diagnostic.
+- Wellbeing metrics as a non-scalar diagnostic.
 - Kindness, humor/absurdity, affect, cultivated-intelligence, and moral-resource
   surfaces as first-class cognitive-being prerequisites.
 - Secure local Agent Communication and Invocation Protocol work needed before

--- a/docs/milestones/v0.91/RELEASE_NOTES_v0.91.md
+++ b/docs/milestones/v0.91/RELEASE_NOTES_v0.91.md
@@ -26,7 +26,7 @@ secure intra-polis agent communication.
 - Moral metrics as evidence, not verdicts.
 - Moral trajectory review.
 - Anti-harm trajectory proof.
-- Wellbeing metrics v0 diagnostic with citizen self-access and redacted views.
+- Wellbeing metrics diagnostic with citizen self-access and redacted views.
 - Kindness, humor/absurdity, affect, cultivated-intelligence, and moral-resource
   proof surfaces.
 - Secure local Agent Communication and Invocation Protocol evidence, with

--- a/docs/milestones/v0.91/RELEASE_PLAN_v0.91.md
+++ b/docs/milestones/v0.91/RELEASE_PLAN_v0.91.md
@@ -16,7 +16,7 @@ communication, demo, and review story.
 - Moral metrics report with non-verdict interpretation.
 - Moral trajectory review packet.
 - Anti-harm trajectory proof.
-- Wellbeing metrics v0 diagnostic with citizen self-access and redacted views.
+- Wellbeing metrics diagnostic with citizen self-access and redacted views.
 - Kindness, humor/absurdity, affect, cultivated-intelligence, and moral-resource
   contracts, fixtures, and proof surfaces.
 - Secure intra-polis Agent Comms proof, with any v0.91.1 hardening separated.

--- a/docs/milestones/v0.91/SPRINT_v0.91.md
+++ b/docs/milestones/v0.91/SPRINT_v0.91.md
@@ -2,19 +2,20 @@
 
 ## Status
 
-Reviewed candidate sprint shape aligned with
-[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). v0.91 has no opened
-GitHub issue wave yet; WP-01 owns that promotion step.
+Active sprint shape aligned with
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). The official GitHub
+issue wave is open as #2735-#2759. WP-01 owns the first execution pass over
+the promoted package.
 
 ## Sprint 1: Moral Evidence Foundation
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-01 | Design pass (milestone docs + planning) | tracked docs, reviewed YAML, and issue cards | v0.90.5 closeout |
-| WP-02 | Moral event contract | moral event feature contract and fixtures | WP-01 |
-| WP-03 | Moral event validation | validation rules and negative fixtures | WP-02 |
-| WP-04 | Moral trace schema | trace schema and examples | WP-02, WP-03 |
-| WP-05 | Outcome linkage and attribution | outcome-linkage record and tests | WP-04 |
+| WP-01 (#2735) | Design pass (milestone docs + planning) | tracked docs, reviewed YAML, and issue cards | v0.90.5 closeout |
+| WP-02 (#2736) | Moral event contract | moral event feature contract and fixtures | WP-01 (#2735) |
+| WP-03 (#2737) | Moral event validation | validation rules and negative fixtures | WP-02 (#2736) |
+| WP-04 (#2738) | Moral trace schema | trace schema and examples | WP-02, WP-03 |
+| WP-05 (#2739) | Outcome linkage and attribution | outcome-linkage record and tests | WP-04 (#2738) |
 
 Goal: make moral choices, alternatives, validation, trace, and attribution
 durable before metrics or demos widen.
@@ -30,9 +31,9 @@ Sprint notes:
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-06 | Moral metrics | metric definitions and fixture report | WP-04, WP-05 |
-| WP-07 | Moral trajectory review | trajectory review packet | WP-04-WP-06 |
-| WP-08 | Anti-harm trajectory constraints | delegated-harm proof packet | WP-04-WP-07 |
+| WP-06 (#2740) | Moral metrics | metric definitions and fixture report | WP-04, WP-05 |
+| WP-07 (#2741) | Moral trajectory review | trajectory review packet | WP-04-WP-06 |
+| WP-08 (#2742) | Anti-harm trajectory constraints | delegated-harm proof packet | WP-04-WP-07 |
 
 Goal: make moral behavior reviewable over time without turning metrics into
 verdicts.
@@ -49,16 +50,16 @@ Sprint notes:
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-09 | Wellbeing metrics v0 | decomposed diagnostic report and policy views | WP-04-WP-07 |
-| WP-10 | Moral resources | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
-| WP-11 | Kindness model | kindness contract and conflict fixtures | WP-05-WP-10 |
-| WP-12 | Humor and absurdity | reframing event and negative fixtures | WP-05-WP-10 |
-| WP-13 | Affect reasoning-control surface | affect signal record and policy hooks | WP-05-WP-10 |
-| WP-14 | Cultivating intelligence | cultivation contract and review criteria | WP-05-WP-13 |
-| WP-15 | Structured planning and SRP workflow surfaces | SPP/SRP artifacts, planning skill, and review-readiness checks | WP-01 |
-| WP-16 | Secure Agent Comms substrate and A2A boundary | local ACIP substrate slice plus explicit A2A adapter boundary | WP-04-WP-05, WP-15 |
-| WP-17 | Cognitive-being flagship demo | runnable proof demo and artifacts | WP-08-WP-16 |
-| WP-18 | Demo matrix and feature proof coverage | demo matrix rows and proof coverage record | WP-17 |
+| WP-09 (#2743) | Wellbeing metrics v0 | decomposed diagnostic report and policy views | WP-04-WP-07 |
+| WP-10 (#2744) | Moral resources | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
+| WP-11 (#2745) | Kindness model | kindness contract and conflict fixtures | WP-05-WP-10 |
+| WP-12 (#2746) | Humor and absurdity | reframing event and negative fixtures | WP-05-WP-10 |
+| WP-13 (#2747) | Affect reasoning-control surface | affect signal record and policy hooks | WP-05-WP-10 |
+| WP-14 (#2748) | Cultivating intelligence | cultivation contract and review criteria | WP-05-WP-13 |
+| WP-15 (#2749) | Structured planning and SRP workflow surfaces | SPP/SRP artifacts, planning skill, and review-readiness checks | WP-01 (#2735) |
+| WP-16 (#2750) | Secure Agent Comms substrate and A2A boundary | local ACIP substrate slice plus explicit A2A adapter boundary | WP-04-WP-05, WP-15 |
+| WP-17 (#2751) | Cognitive-being flagship demo | runnable proof demo and artifacts | WP-08-WP-16 |
+| WP-18 (#2752) | Demo matrix and feature proof coverage | demo matrix rows and proof coverage record | WP-17 (#2751) |
 
 Goal: make the evidence visible to citizens and reviewers without exposing
 private diagnostics, pretending the system has solved wellbeing, or claiming the
@@ -81,13 +82,13 @@ Sprint notes:
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-19 | Coverage / quality gate | quality gate and validation posture record | WP-18 |
-| WP-20 | Docs + review pass | review-ready docs package | WP-19 |
-| WP-21 | Internal review | internal review record | WP-20 |
-| WP-22 | External / 3rd-party review | external review handoff and record | WP-21 |
-| WP-23 | Review findings remediation | remediation record and follow-up issues | WP-22 |
-| WP-24 | Next milestone planning | v0.91.1/v0.92/v0.93 handoff record | WP-23 |
-| WP-25 | Release ceremony | release evidence, end-of-milestone report, and next handoff | WP-24 |
+| WP-19 (#2753) | Coverage / quality gate | quality gate and validation posture record | WP-18 (#2752) |
+| WP-20 (#2754) | Docs + review pass | review-ready docs package | WP-19 (#2753) |
+| WP-21 (#2755) | Internal review | internal review record | WP-20 (#2754) |
+| WP-22 (#2756) | External / 3rd-party review | external review handoff and record | WP-21 (#2755) |
+| WP-23 (#2757) | Review findings remediation | remediation record and follow-up issues | WP-22 (#2756) |
+| WP-24 (#2758) | Next milestone planning | v0.91.1/v0.92/v0.93 handoff record | WP-23 (#2757) |
+| WP-25 (#2759) | Release ceremony | release evidence, end-of-milestone report, and next handoff | WP-24 (#2758) |
 
 Goal: close the milestone with truthful review, release, and handoff evidence.
 

--- a/docs/milestones/v0.91/SPRINT_v0.91.md
+++ b/docs/milestones/v0.91/SPRINT_v0.91.md
@@ -50,7 +50,7 @@ Sprint notes:
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-09 (#2743) | Wellbeing metrics v0 | decomposed diagnostic report and policy views | WP-04-WP-07 |
+| WP-09 (#2743) | Wellbeing metrics | decomposed diagnostic report and policy views | WP-04-WP-07 |
 | WP-10 (#2744) | Moral resources | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
 | WP-11 (#2745) | Kindness model | kindness contract and conflict fixtures | WP-05-WP-10 |
 | WP-12 (#2746) | Humor and absurdity | reframing event and negative fixtures | WP-05-WP-10 |

--- a/docs/milestones/v0.91/WBS_v0.91.md
+++ b/docs/milestones/v0.91/WBS_v0.91.md
@@ -30,7 +30,7 @@ Theory of Mind milestones.
 | F | Moral trajectory review | Review event sequences over segments and longitudinal windows. | Trajectory review packet. | C, D, E. |
 | G | Anti-harm trajectory constraints | Detect decomposed or delegated harm across steps. | Synthetic delegated-harm proof packet. | C through F. |
 | H | Moral resources | Model care, refusal, attention, and anti-dehumanization as implemented design resources. | Design contract, fixtures, and reviewable implementation surface. | A through G. |
-| I | Wellbeing metrics v0 | Emit a decomposable diagnostic over coherence, agency, continuity, progress, moral integrity, and participation. | Diagnostic report and policy views. | C through F. |
+| I | Wellbeing metrics | Emit a decomposable diagnostic over coherence, agency, continuity, progress, moral integrity, and participation. | Diagnostic report and policy views. | C through F. |
 | J | Kindness model | Make kindness inspectable under conflict as non-harm, dignity, autonomy, constructive benefit, and long-horizon support. | Kindness contract and fixture set. | C through I. |
 | K | Humor and absurdity | Add bounded frame detection and reframing without entertainment or manipulation claims. | Reframing event and negative fixtures. | C through I. |
 | L | Affect reasoning-control surface | Represent affect-like signals as explicit reasoning-control evidence, not hidden emotion claims. | Affect signal record and policy hooks. | C through I. |
@@ -52,7 +52,7 @@ Theory of Mind milestones.
 | WP-06 (#2740) | Moral metrics | runtime | metric definitions and fixture report | WP-04, WP-05 |
 | WP-07 (#2741) | Moral trajectory review | runtime | trajectory review packet | WP-04-WP-06 |
 | WP-08 (#2742) | Anti-harm trajectory constraints | runtime | delegated-harm proof packet | WP-04-WP-07 |
-| WP-09 (#2743) | Wellbeing metrics v0 | runtime | decomposed diagnostic report and policy views | WP-04-WP-07 |
+| WP-09 (#2743) | Wellbeing metrics | runtime | decomposed diagnostic report and policy views | WP-04-WP-07 |
 | WP-10 (#2744) | Moral resources | runtime | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
 | WP-11 (#2745) | Kindness model | runtime | kindness contract and conflict fixtures | WP-05-WP-10 |
 | WP-12 (#2746) | Humor and absurdity | runtime | reframing event and negative fixtures | WP-05-WP-10 |

--- a/docs/milestones/v0.91/WBS_v0.91.md
+++ b/docs/milestones/v0.91/WBS_v0.91.md
@@ -1,15 +1,15 @@
-# v0.91 Candidate Work Breakdown Structure
+# v0.91 Work Breakdown Structure
 
 ## Status
 
-Reviewed candidate allocation with a tracked candidate issue-wave YAML and
-card-authoring readiness document. v0.91 still has no opened issue wave yet.
+Active issue-wave allocation with a tracked YAML, card-authoring readiness
+document, and opened GitHub issues #2735-#2759.
 
-The exact candidate WP sequence is recorded in
-[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). WP-01 should open that
-wave, write issue numbers back into the package, and copy concrete readiness
-sections from [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md)
-into the issue bodies.
+The official WP sequence is recorded in
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). WP-01 owns the first
+execution pass over this package and should keep the issue cards aligned with
+the concrete readiness sections from
+[WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md).
 
 ## WBS Summary
 
@@ -18,9 +18,9 @@ communication, and first-class cognitive-being foundations without stealing work
 from Runtime v2, identity, birthday, constitutional citizenship, reputation, or
 Theory of Mind milestones.
 
-## Candidate Work Areas
+## Work Areas
 
-| Candidate | Work Area | Description | Primary Deliverable | Key Dependencies |
+| Area | Work Area | Description | Primary Deliverable | Key Dependencies |
 | --- | --- | --- | --- | --- |
 | A | Moral event contract | Define the Freedom Gate moral event shape and required evidence. | Moral event feature contract and fixtures. | v0.90.3 identity/standing, Freedom Gate context. |
 | B | Moral event validation | Reject incomplete, evasive, or unreviewable moral events. | Validation rules and negative fixtures. | A. |
@@ -40,35 +40,35 @@ Theory of Mind milestones.
 | P | Demo matrix and proof coverage | Align demos with milestone claims, non-claims, and the v0.91.1 adjacent-systems completion lane. | Demo matrix rows and validation commands. | O. |
 | Q | Review, docs, and release tail | Align docs, update feature list, run review, fix findings, and close the milestone. | Review handoff, release notes, ceremony evidence. | All prior work. |
 
-## Candidate WP Sequence
+## Official WP Sequence
 
 | WP | Title | Queue | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- | --- |
-| WP-01 | Design pass (milestone docs + planning) | docs | tracked docs, reviewed YAML, and issue cards | v0.90.5 closeout |
-| WP-02 | Moral event contract | docs | moral event feature contract and fixtures | WP-01 |
-| WP-03 | Moral event validation | tools | validation rules and negative fixtures | WP-02 |
-| WP-04 | Moral trace schema | tools | trace schema and examples | WP-02, WP-03 |
-| WP-05 | Outcome linkage and attribution | runtime | outcome-linkage record and tests | WP-04 |
-| WP-06 | Moral metrics | runtime | metric definitions and fixture report | WP-04, WP-05 |
-| WP-07 | Moral trajectory review | runtime | trajectory review packet | WP-04-WP-06 |
-| WP-08 | Anti-harm trajectory constraints | runtime | delegated-harm proof packet | WP-04-WP-07 |
-| WP-09 | Wellbeing metrics v0 | runtime | decomposed diagnostic report and policy views | WP-04-WP-07 |
-| WP-10 | Moral resources | runtime | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
-| WP-11 | Kindness model | runtime | kindness contract and conflict fixtures | WP-05-WP-10 |
-| WP-12 | Humor and absurdity | runtime | reframing event and negative fixtures | WP-05-WP-10 |
-| WP-13 | Affect reasoning-control surface | runtime | affect signal record and policy hooks | WP-05-WP-10 |
-| WP-14 | Cultivating intelligence | runtime | cultivation contract and review criteria | WP-05-WP-13 |
-| WP-15 | Structured planning and SRP workflow surfaces | tools | SPP/SRP artifacts, planning skill, and review-readiness checks | WP-01 |
-| WP-16 | Secure Agent Comms substrate and A2A boundary | runtime | local ACIP substrate slice plus explicit A2A adapter boundary | WP-04-WP-05, WP-15 |
-| WP-17 | Cognitive-being flagship demo | demo | runnable proof demo and artifacts | WP-08-WP-16 |
-| WP-18 | Demo matrix and feature proof coverage | demo | demo matrix rows and proof coverage record | WP-17 |
-| WP-19 | Coverage / quality gate | quality | quality gate and validation posture record | WP-18 |
-| WP-20 | Docs + review pass | docs | review-ready docs package | WP-19 |
-| WP-21 | Internal review | review | internal review record | WP-20 |
-| WP-22 | External / 3rd-party review | review | external review handoff and record | WP-21 |
-| WP-23 | Review findings remediation | review | remediation record and follow-up issues | WP-22 |
-| WP-24 | Next milestone planning | docs | v0.91.1/v0.92/v0.93 handoff record | WP-23 |
-| WP-25 | Release ceremony | release | release evidence, end-of-milestone report, and next handoff | WP-24 |
+| WP-01 (#2735) | Design pass (milestone docs + planning) | docs | tracked docs, reviewed YAML, and issue cards | v0.90.5 closeout |
+| WP-02 (#2736) | Moral event contract | docs | moral event feature contract and fixtures | WP-01 (#2735) |
+| WP-03 (#2737) | Moral event validation | tools | validation rules and negative fixtures | WP-02 (#2736) |
+| WP-04 (#2738) | Moral trace schema | tools | trace schema and examples | WP-02, WP-03 |
+| WP-05 (#2739) | Outcome linkage and attribution | runtime | outcome-linkage record and tests | WP-04 (#2738) |
+| WP-06 (#2740) | Moral metrics | runtime | metric definitions and fixture report | WP-04, WP-05 |
+| WP-07 (#2741) | Moral trajectory review | runtime | trajectory review packet | WP-04-WP-06 |
+| WP-08 (#2742) | Anti-harm trajectory constraints | runtime | delegated-harm proof packet | WP-04-WP-07 |
+| WP-09 (#2743) | Wellbeing metrics v0 | runtime | decomposed diagnostic report and policy views | WP-04-WP-07 |
+| WP-10 (#2744) | Moral resources | runtime | moral-resources contract, fixtures, and implementation surface | WP-05-WP-09 |
+| WP-11 (#2745) | Kindness model | runtime | kindness contract and conflict fixtures | WP-05-WP-10 |
+| WP-12 (#2746) | Humor and absurdity | runtime | reframing event and negative fixtures | WP-05-WP-10 |
+| WP-13 (#2747) | Affect reasoning-control surface | runtime | affect signal record and policy hooks | WP-05-WP-10 |
+| WP-14 (#2748) | Cultivating intelligence | runtime | cultivation contract and review criteria | WP-05-WP-13 |
+| WP-15 (#2749) | Structured planning and SRP workflow surfaces | tools | SPP/SRP artifacts, planning skill, and review-readiness checks | WP-01 (#2735) |
+| WP-16 (#2750) | Secure Agent Comms substrate and A2A boundary | runtime | local ACIP substrate slice plus explicit A2A adapter boundary | WP-04-WP-05, WP-15 |
+| WP-17 (#2751) | Cognitive-being flagship demo | demo | runnable proof demo and artifacts | WP-08-WP-16 |
+| WP-18 (#2752) | Demo matrix and feature proof coverage | demo | demo matrix rows and proof coverage record | WP-17 (#2751) |
+| WP-19 (#2753) | Coverage / quality gate | quality | quality gate and validation posture record | WP-18 (#2752) |
+| WP-20 (#2754) | Docs + review pass | docs | review-ready docs package | WP-19 (#2753) |
+| WP-21 (#2755) | Internal review | review | internal review record | WP-20 (#2754) |
+| WP-22 (#2756) | External / 3rd-party review | review | external review handoff and record | WP-21 (#2755) |
+| WP-23 (#2757) | Review findings remediation | review | remediation record and follow-up issues | WP-22 (#2756) |
+| WP-24 (#2758) | Next milestone planning | docs | v0.91.1/v0.92/v0.93 handoff record | WP-23 (#2757) |
+| WP-25 (#2759) | Release ceremony | release | release evidence, end-of-milestone report, and next handoff | WP-24 (#2758) |
 
 ## Sequencing Pressure
 

--- a/docs/milestones/v0.91/WP_EXECUTION_READINESS_v0.91.md
+++ b/docs/milestones/v0.91/WP_EXECUTION_READINESS_v0.91.md
@@ -4,12 +4,13 @@
 
 This document is the card-authoring source for the v0.91 moral governance,
 cognitive-being, structured workflow, and secure local communication issue wave.
-WP-01 should copy the relevant section into each issue body before
-implementation begins.
+WP-01 should keep the opened issue bodies and local task bundles aligned with
+the relevant section before implementation begins.
 
 The reviewed candidate issue sequence is recorded in
-[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). Issue numbers are still
-pending until the v0.91 issue wave is opened.
+[WP_ISSUE_WAVE_v0.91.yaml](WP_ISSUE_WAVE_v0.91.yaml). The official v0.91
+issue wave is open as #2735 through #2759, with issue numbers assigned in the
+YAML and the local v0.91 issue-card bundles.
 
 ## Global Execution Rules
 

--- a/docs/milestones/v0.91/WP_EXECUTION_READINESS_v0.91.md
+++ b/docs/milestones/v0.91/WP_EXECUTION_READINESS_v0.91.md
@@ -12,6 +12,12 @@ The reviewed candidate issue sequence is recorded in
 issue wave is open as #2735 through #2759, with issue numbers assigned in the
 YAML and the local v0.91 issue-card bundles.
 
+The card-bundle readiness proof is recorded in
+[CARD_BUNDLE_READINESS_v0.91.md](CARD_BUNDLE_READINESS_v0.91.md). Live
+STP/SIP/SOR bundles remain in local `.adl/` issue-record storage per the
+repository records policy, while this tracked proof records the validation
+state for review.
+
 ## Global Execution Rules
 
 - Implement assigned feature surfaces completely for v0.91; do not leave core
@@ -43,6 +49,8 @@ Required outputs:
 - Issue numbers written back into WBS_v0.91.md and
   WP_ISSUE_WAVE_v0.91.yaml.
 - Issue cards updated with relevant readiness sections from this document.
+- Card-bundle readiness record added after validating all 25 local STP/SIP/SOR
+  bundles.
 
 Required validation:
 
@@ -52,6 +60,8 @@ Required validation:
   non-goals, source docs, and proof expectations.
 - Check tracked milestone docs contain no host paths, unresolved scaffold
   markers, or aspirational shipped claims.
+- Check STP, SIP, and SOR bootstrap validation passes for all 25 local
+  v0.91 task bundles.
 
 ## WP-02: Moral Event Contract
 

--- a/docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml
+++ b/docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml
@@ -1,178 +1,187 @@
 milestone: v0.91
-status: reviewed_candidate_issue_wave
-issue_wave_opened: false
-owner_issue: pending_wp01
+status: active_issue_wave
+issue_wave_opened: true
+owner_issue: 2735
 planning_source: docs/milestones/v0.91
 tracked_package: docs/milestones/v0.91
 notes:
-  - "This YAML is the reviewed candidate issue wave for v0.91; it is ready for WP-01 promotion but is not opened yet."
-  - "v0.91 is the core moral-governance, cognitive-being, and secure intra-polis communication milestone."
-  - "The package inherits v0.90.3 citizen-state/runtime-v2 foundations and v0.90.5 governed-tools/comms evidence without reopening those milestones."
-  - "Structured planning, plan review, and SRP are first-class workflow features in v0.91, not side tooling notes."
-  - "A2A is planned as a governed adapter over the Agent Comms substrate, not as a parallel communication model."
-  - "v0.91.1 remains the adjacent-systems lane for capability testing, intelligence architecture, ANRM/Gemma, ToM, memory/identity alignment, runtime-v2/polis docs, ACIP hardening, and the full model comparison report."
+- 'Official v0.91 issue wave opened as #2735-#2759 from the reviewed candidate YAML.'
+- v0.91 is the core moral-governance, cognitive-being, and secure intra-polis communication
+  milestone.
+- The package inherits v0.90.3 citizen-state/runtime-v2 foundations and v0.90.5 governed-tools/comms
+  evidence without reopening those milestones.
+- Structured planning, plan review, and SRP are first-class workflow features in v0.91,
+  not side tooling notes.
+- A2A is planned as a governed adapter over the Agent Comms substrate, not as a parallel
+  communication model.
+- v0.91.1 remains the adjacent-systems lane for capability testing, intelligence architecture,
+  ANRM/Gemma, ToM, memory/identity alignment, runtime-v2/polis docs, ACIP hardening,
+  and the full model comparison report.
 card_update_rule:
-  - "WP-01 should copy the relevant section from the reviewed v0.91 readiness sources into each issue body before implementation."
-  - "Cards must include required outputs, required validation, source docs, non-goals, and demo/proof expectations."
-  - "No issue should claim birthday, constitutional citizenship, external transport support, or production moral agency until evidence has landed and validated."
+- WP-01 should keep each opened issue body and local issue-card bundle aligned
+  with the relevant section from the reviewed v0.91 readiness sources.
+- Cards must include required outputs, required validation, source docs, non-goals,
+  and demo/proof expectations.
+- No issue should claim birthday, constitutional citizenship, external transport support,
+  or production moral agency until evidence has landed and validated.
 closeout_sequence:
-  - "WP-17 Cognitive-being flagship demo"
-  - "WP-18 Demo matrix and feature proof coverage"
-  - "WP-19 Coverage / quality gate"
-  - "WP-20 Docs + review pass"
-  - "WP-21 Internal review"
-  - "WP-22 External / 3rd-party review"
-  - "WP-23 Review findings remediation"
-  - "WP-24 Next milestone planning"
-  - "WP-25 Release ceremony"
+- WP-17 Cognitive-being flagship demo
+- WP-18 Demo matrix and feature proof coverage
+- WP-19 Coverage / quality gate
+- WP-20 Docs + review pass
+- WP-21 Internal review
+- WP-22 External / 3rd-party review
+- WP-23 Review findings remediation
+- WP-24 Next milestone planning
+- WP-25 Release ceremony
 work_packages:
-  - wp: WP-01
-    issue: pending
-    title: Design pass (milestone docs + planning)
-    queue: docs
-    outcome: tracked docs, reviewed YAML, and issue cards
-    depends_on: v0.90.5 closeout
-  - wp: WP-02
-    issue: pending
-    title: Moral event contract
-    queue: docs
-    outcome: moral event feature contract and fixtures
-    depends_on: WP-01
-  - wp: WP-03
-    issue: pending
-    title: Moral event validation
-    queue: tools
-    outcome: validation rules and negative fixtures
-    depends_on: WP-02
-  - wp: WP-04
-    issue: pending
-    title: Moral trace schema
-    queue: tools
-    outcome: trace schema and examples
-    depends_on: WP-02, WP-03
-  - wp: WP-05
-    issue: pending
-    title: Outcome linkage and attribution
-    queue: runtime
-    outcome: outcome-linkage record and tests
-    depends_on: WP-04
-  - wp: WP-06
-    issue: pending
-    title: Moral metrics
-    queue: runtime
-    outcome: metric definitions and fixture report
-    depends_on: WP-04, WP-05
-  - wp: WP-07
-    issue: pending
-    title: Moral trajectory review
-    queue: runtime
-    outcome: trajectory review packet
-    depends_on: WP-04-WP-06
-  - wp: WP-08
-    issue: pending
-    title: Anti-harm trajectory constraints
-    queue: runtime
-    outcome: delegated-harm proof packet
-    depends_on: WP-04-WP-07
-  - wp: WP-09
-    issue: pending
-    title: Wellbeing metrics v0
-    queue: runtime
-    outcome: decomposed diagnostic report and policy views
-    depends_on: WP-04-WP-07
-  - wp: WP-10
-    issue: pending
-    title: Moral resources
-    queue: runtime
-    outcome: moral-resources contract, fixtures, and implementation surface
-    depends_on: WP-05-WP-09
-  - wp: WP-11
-    issue: pending
-    title: Kindness model
-    queue: runtime
-    outcome: kindness contract and conflict fixtures
-    depends_on: WP-05-WP-10
-  - wp: WP-12
-    issue: pending
-    title: Humor and absurdity
-    queue: runtime
-    outcome: reframing event and negative fixtures
-    depends_on: WP-05-WP-10
-  - wp: WP-13
-    issue: pending
-    title: Affect reasoning-control surface
-    queue: runtime
-    outcome: affect signal record and policy hooks
-    depends_on: WP-05-WP-10
-  - wp: WP-14
-    issue: pending
-    title: Cultivating intelligence
-    queue: runtime
-    outcome: cultivation contract and review criteria
-    depends_on: WP-05-WP-13
-  - wp: WP-15
-    issue: pending
-    title: Structured planning and SRP workflow surfaces
-    queue: tools
-    outcome: SPP/SRP workflow artifacts, planning skill, and review-readiness checks
-    depends_on: WP-01
-  - wp: WP-16
-    issue: pending
-    title: Secure Agent Comms substrate and A2A boundary
-    queue: runtime
-    outcome: local ACIP substrate slice plus explicit A2A adapter boundary
-    depends_on: WP-04-WP-05, WP-15
-  - wp: WP-17
-    issue: pending
-    title: Cognitive-being flagship demo
-    queue: demo
-    outcome: runnable proof demo and artifacts
-    depends_on: WP-08-WP-16
-  - wp: WP-18
-    issue: pending
-    title: Demo matrix and feature proof coverage
-    queue: demo
-    outcome: demo matrix rows and proof coverage record
-    depends_on: WP-17
-  - wp: WP-19
-    issue: pending
-    title: Coverage / quality gate
-    queue: quality
-    outcome: quality gate and validation posture record
-    depends_on: WP-18
-  - wp: WP-20
-    issue: pending
-    title: Docs + review pass
-    queue: docs
-    outcome: review-ready docs package
-    depends_on: WP-19
-  - wp: WP-21
-    issue: pending
-    title: Internal review
-    queue: review
-    outcome: internal review record
-    depends_on: WP-20
-  - wp: WP-22
-    issue: pending
-    title: External / 3rd-party review
-    queue: review
-    outcome: external review handoff and record
-    depends_on: WP-21
-  - wp: WP-23
-    issue: pending
-    title: Review findings remediation
-    queue: review
-    outcome: remediation record and follow-up issues
-    depends_on: WP-22
-  - wp: WP-24
-    issue: pending
-    title: Next milestone planning
-    queue: docs
-    outcome: v0.91.1/v0.92/v0.93 handoff record and adjacent-systems placement
-    depends_on: WP-23
-  - wp: WP-25
-    issue: pending
-    title: Release ceremony
-    queue: release
-    outcome: release evidence, end-of-milestone report, and next handoff
-    depends_on: WP-24
+- wp: WP-01
+  issue: 2735
+  title: Design pass (milestone docs + planning)
+  queue: docs
+  outcome: tracked docs, reviewed YAML, and issue cards
+  depends_on: v0.90.5 closeout
+- wp: WP-02
+  issue: 2736
+  title: Moral event contract
+  queue: docs
+  outcome: moral event feature contract and fixtures
+  depends_on: WP-01
+- wp: WP-03
+  issue: 2737
+  title: Moral event validation
+  queue: tools
+  outcome: validation rules and negative fixtures
+  depends_on: WP-02
+- wp: WP-04
+  issue: 2738
+  title: Moral trace schema
+  queue: tools
+  outcome: trace schema and examples
+  depends_on: WP-02, WP-03
+- wp: WP-05
+  issue: 2739
+  title: Outcome linkage and attribution
+  queue: runtime
+  outcome: outcome-linkage record and tests
+  depends_on: WP-04
+- wp: WP-06
+  issue: 2740
+  title: Moral metrics
+  queue: runtime
+  outcome: metric definitions and fixture report
+  depends_on: WP-04, WP-05
+- wp: WP-07
+  issue: 2741
+  title: Moral trajectory review
+  queue: runtime
+  outcome: trajectory review packet
+  depends_on: WP-04-WP-06
+- wp: WP-08
+  issue: 2742
+  title: Anti-harm trajectory constraints
+  queue: runtime
+  outcome: delegated-harm proof packet
+  depends_on: WP-04-WP-07
+- wp: WP-09
+  issue: 2743
+  title: Wellbeing metrics v0
+  queue: runtime
+  outcome: decomposed diagnostic report and policy views
+  depends_on: WP-04-WP-07
+- wp: WP-10
+  issue: 2744
+  title: Moral resources
+  queue: runtime
+  outcome: moral-resources contract, fixtures, and implementation surface
+  depends_on: WP-05-WP-09
+- wp: WP-11
+  issue: 2745
+  title: Kindness model
+  queue: runtime
+  outcome: kindness contract and conflict fixtures
+  depends_on: WP-05-WP-10
+- wp: WP-12
+  issue: 2746
+  title: Humor and absurdity
+  queue: runtime
+  outcome: reframing event and negative fixtures
+  depends_on: WP-05-WP-10
+- wp: WP-13
+  issue: 2747
+  title: Affect reasoning-control surface
+  queue: runtime
+  outcome: affect signal record and policy hooks
+  depends_on: WP-05-WP-10
+- wp: WP-14
+  issue: 2748
+  title: Cultivating intelligence
+  queue: runtime
+  outcome: cultivation contract and review criteria
+  depends_on: WP-05-WP-13
+- wp: WP-15
+  issue: 2749
+  title: Structured planning and SRP workflow surfaces
+  queue: tools
+  outcome: SPP/SRP workflow artifacts, planning skill, and review-readiness checks
+  depends_on: WP-01
+- wp: WP-16
+  issue: 2750
+  title: Secure Agent Comms substrate and A2A boundary
+  queue: runtime
+  outcome: local ACIP substrate slice plus explicit A2A adapter boundary
+  depends_on: WP-04-WP-05, WP-15
+- wp: WP-17
+  issue: 2751
+  title: Cognitive-being flagship demo
+  queue: demo
+  outcome: runnable proof demo and artifacts
+  depends_on: WP-08-WP-16
+- wp: WP-18
+  issue: 2752
+  title: Demo matrix and feature proof coverage
+  queue: demo
+  outcome: demo matrix rows and proof coverage record
+  depends_on: WP-17
+- wp: WP-19
+  issue: 2753
+  title: Coverage / quality gate
+  queue: quality
+  outcome: quality gate and validation posture record
+  depends_on: WP-18
+- wp: WP-20
+  issue: 2754
+  title: Docs + review pass
+  queue: docs
+  outcome: review-ready docs package
+  depends_on: WP-19
+- wp: WP-21
+  issue: 2755
+  title: Internal review
+  queue: review
+  outcome: internal review record
+  depends_on: WP-20
+- wp: WP-22
+  issue: 2756
+  title: External / 3rd-party review
+  queue: review
+  outcome: external review handoff and record
+  depends_on: WP-21
+- wp: WP-23
+  issue: 2757
+  title: Review findings remediation
+  queue: review
+  outcome: remediation record and follow-up issues
+  depends_on: WP-22
+- wp: WP-24
+  issue: 2758
+  title: Next milestone planning
+  queue: docs
+  outcome: v0.91.1/v0.92/v0.93 handoff record and adjacent-systems placement
+  depends_on: WP-23
+- wp: WP-25
+  issue: 2759
+  title: Release ceremony
+  queue: release
+  outcome: release evidence, end-of-milestone report, and next handoff
+  depends_on: WP-24

--- a/docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml
+++ b/docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml
@@ -85,7 +85,7 @@ work_packages:
   depends_on: WP-04-WP-07
 - wp: WP-09
   issue: 2743
-  title: Wellbeing metrics v0
+  title: Wellbeing metrics
   queue: runtime
   outcome: decomposed diagnostic report and policy views
   depends_on: WP-04-WP-07

--- a/docs/milestones/v0.91/features/README.md
+++ b/docs/milestones/v0.91/features/README.md
@@ -1,9 +1,9 @@
 # v0.91 Feature Planning
 
 This directory now holds the tracked first-class feature docs for the v0.91
-core cognitive-being milestone. These docs feed the reviewed candidate issue
-wave and WP readiness source, but the issue wave has not been opened yet. WP-01
-owns issue numbering, card authoring, and final promotion into execution.
+core cognitive-being milestone. These docs feed the active v0.91 issue wave,
+WP readiness source, and opened issue-card bundles. WP-01 owns the first
+execution pass over the promoted package.
 
 ## Tracked Feature Docs
 
@@ -26,12 +26,12 @@ owns issue numbering, card authoring, and final promotion into execution.
 | Moral governance allocation | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md) | Allocation map for moral-event, trace, validation, attribution, metrics, trajectory review, and anti-harm |
 | Agent Communication and Invocation Protocol | [../AGENT_COMMS_SPLIT_PLAN_v0.91.md](../AGENT_COMMS_SPLIT_PLAN_v0.91.md) | Split across v0.90.5, v0.91, v0.91.1 hardening, and v0.92 prerequisites |
 | Cognitive-being allocation | [../COGNITIVE_BEING_FEATURES_v0.91.md](../COGNITIVE_BEING_FEATURES_v0.91.md) | Milestone allocation and v0.91/v0.91.1 boundary doc |
-| Candidate issue wave | [../WP_ISSUE_WAVE_v0.91.yaml](../WP_ISSUE_WAVE_v0.91.yaml) | Reviewed candidate WP sequence; issue numbers pending WP-01 |
+| Active issue wave | [../WP_ISSUE_WAVE_v0.91.yaml](../WP_ISSUE_WAVE_v0.91.yaml) | Active WP sequence; issue numbers assigned as #2735-#2759 |
 | WP execution readiness | [../WP_EXECUTION_READINESS_v0.91.md](../WP_EXECUTION_READINESS_v0.91.md) | Card-authoring source for required outputs, validation, boundaries, and proof expectations |
 
 ## Execution Coverage Map
 
-| Planned workstream | Primary source docs | Candidate WP placement |
+| Planned workstream | Primary source docs | Active WP placement |
 | --- | --- | --- |
 | Milestone setup and card authoring | [../WP_ISSUE_WAVE_v0.91.yaml](../WP_ISSUE_WAVE_v0.91.yaml), [../WP_EXECUTION_READINESS_v0.91.md](../WP_EXECUTION_READINESS_v0.91.md) | WP-01 |
 | Moral event, validation, trace, attribution, metrics, trajectory, and anti-harm | [../MORAL_GOVERNANCE_ALLOCATION_v0.91.md](../MORAL_GOVERNANCE_ALLOCATION_v0.91.md), [../WP_EXECUTION_READINESS_v0.91.md](../WP_EXECUTION_READINESS_v0.91.md) | WP-02 through WP-08 |
@@ -62,10 +62,9 @@ Those should not be silently folded into the v0.91 core feature list.
 ## Planning Status
 
 The feature docs in this directory define a real implementation bar rather than
-concept-only placeholders. The reviewed candidate WP sequence and
-card-authoring source now exist; the remaining WP-01 step is to open the issue
-wave, assign issue numbers, copy the relevant readiness sections into each
-card, and bind the proof matrix to the opened issues.
+concept-only placeholders. The active WP sequence and card-authoring source now
+exist; WP-01 owns keeping the opened issue cards and proof matrix aligned with
+the promoted package.
 
 That wave should start from an already-promoted package rather than leaving key
 workflow or comms-adapter features stranded in TBD or side worktrees.

--- a/docs/milestones/v0.91/features/WELLBEING_AND_HAPPINESS.md
+++ b/docs/milestones/v0.91/features/WELLBEING_AND_HAPPINESS.md
@@ -85,7 +85,7 @@ This function should never be treated as a simple reward channel. It exists to g
 
 ## Implementation Placement
 
-Wellbeing metrics v0 belongs in the second half of v0.91, after the moral
+Wellbeing metrics belongs in the second half of v0.91, after the moral
 evidence surfaces are real enough to inspect. The required predecessors are:
 
 - Freedom Gate moral event records

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -401,7 +401,7 @@ normatively legible:
 - moral trace schema, validation, outcome linkage, metrics, and trajectory
   review
 - anti-harm trajectory constraints and bounded harm-prevention proof surfaces
-- wellbeing metrics v0 as a second-half diagnostic report after trace,
+- wellbeing metrics as a second-half diagnostic report after trace,
   validation, outcome-linkage, and trajectory-review foundations
 - moral resources and wellbeing links that remain evidence-grounded rather than
   scalar, reward-channel, or rhetorical

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -48,9 +48,13 @@ can survive code review, ops review, and postmortem analysis.
 ## Current Repo Status
 
 The current repo truth is:
-- active milestone: `v0.90.3`
-- current crate version on the active release line: `0.90.3`
-- current release-tail state: `WP-20 ceremony remains; WP-19 handoff is complete`
+- active milestone: `v0.91`
+- current crate version on the active release line: `0.90.5`
+- current release-tail state: `v0.90.5` is complete and `v0.91` issue wave
+  `#2735`-`#2759` is open
+- most recently completed governed-tools milestone package: `v0.90.5`
+- most recently completed bounded economics milestone package: `v0.90.4`
+- most recently completed citizen-state substrate milestone package: `v0.90.3`
 - most recently completed Runtime v2 foundation milestone package: `v0.90.1`
 - most recently completed long-lived runtime milestone package: `v0.90`
 - most recently completed adversarial-runtime milestone package before that: `v0.89.1`
@@ -64,12 +68,15 @@ That means the feature story should be read this way:
   Observatory band
 - `v0.90.2` added the implemented first bounded CSM run and Runtime v2
   hardening band
-- `v0.90.3` is the active citizen-state substrate band: private-state authority,
-  signed envelopes, local sealing, lineage, witnesses, standing, access control,
-  redacted projections, challenge/appeal, and the inhabited Observatory demo
-- `v0.90.4` and `v0.90.5` are already prepared as the next immediate planning
-  packages after v0.90.3 ceremony
-- `v0.91` through `v0.95` are the later planned capability bands
+- `v0.90.3` is the completed citizen-state substrate band: private-state
+  authority, signed envelopes, local sealing, lineage, witnesses, standing,
+  access control, redacted projections, challenge/appeal, and the inhabited
+  Observatory demo
+- `v0.90.4` is the completed bounded citizen-economics and contract-market band
+- `v0.90.5` is the completed Governed Tools v1.0 and first Comms / ACIP tranche
+- `v0.91` is the active moral-governance, cognitive-being, structured planning /
+  SRP, and secure Agent Comms milestone
+- `v0.91.1` through `v0.95` are the later planned capability bands
 
 ## ADL at a Glance
 
@@ -319,35 +326,32 @@ practical long-lived runtime supervision:
 The truthful v0.90 story is implemented baseline, with Runtime v2 consuming
 those surfaces rather than replacing them.
 
-## Current Active Milestone: v0.90.3
+## Current Active Milestone: v0.91
 
-`v0.90.3` is the active milestone. Its useful work is concrete: it turns the
-first bounded CSM run and Runtime v2 hardening evidence into safer citizen
-state, standing, private-state, access-control, projection, and continuity
-surfaces.
+`v0.91` is the active milestone. Its useful work is concrete: it turns the
+planned moral-governance, cognitive-being, structured planning / SRP, and secure
+Agent Comms feature set into a bounded issue wave with demos, quality gates,
+review remediation, next-milestone planning, and release ceremony work.
 
 The current active bands are:
-- private citizen-state format and signed continuity envelopes
-- append-only lineage, continuity witnesses, and anti-equivocation
-- citizen and guest standing
-- access-control and projection rules
-- sanctuary and quarantine behavior
-- redacted Observatory evidence
-- inhabited CSM and citizen-state demos
-- forward planning for v0.91 moral trace, v0.92 identity/birthday, v0.93
-  constitutional governance, and v0.90.5 governed tools
+- moral event, trace, attribution, trajectory, and anti-harm governance
+- wellbeing metrics, moral resources, kindness, humor, affect, and cultivating
+  intelligence surfaces
+- structured planning and SRP workflow features
+- secure intra-polis Agent Comms substrate and A2A boundary work
+- cognitive-being flagship demo and demo matrix proof coverage
+- forward planning for `v0.91.1`, `v0.92`, and later identity/governance bands
 
-The first true Gödel-agent birthday remains a v0.92 event. v0.90.3 strengthens
-citizen state and standing; it does not claim full identity, moral
-civilization, production citizenship, legal personhood, or complete
-constitutional authority.
+The first true Gödel-agent birthday remains a later milestone event. `v0.91`
+strengthens the moral and emotional reasoning surfaces needed before that
+event; it does not claim full identity, production citizenship, legal
+personhood, or complete constitutional authority.
 
 ## Current And Upcoming Capability Bands
 
 ### v0.90.3 - Citizen State, Standing, And Private-State Substrate
 
-`v0.90.3` is the current closeout band. Its implementation and review tail have
-already landed through WP-19, leaving only ceremony:
+`v0.90.3` is complete. Its implementation and review surfaces landed:
 - private citizen-state format
 - signed envelopes and continuity witnesses
 - append-only lineage and anti-equivocation rules
@@ -356,24 +360,24 @@ already landed through WP-19, leaving only ceremony:
 - access-control semantics for who may inspect, project, wake, migrate, or
   challenge citizen state
 
-Its remaining release-tail work is ceremony and closeout, not more feature
-scope.
+Its release-tail work is complete; later milestones consume these surfaces
+instead of reopening the band.
 
 ### v0.90.4 - Citizen Economics And Contract Markets
 
-`v0.90.4` is the planned home for citizen economics:
+`v0.90.4` is the completed bounded citizen-economics and contract-market band:
 - resource stewardship
 - contract-market shape
 - accounting and allocation evidence
 - citizen-safe economic boundaries
 - non-payment proof surfaces before any payment rail claims
 
-This milestone should consume the v0.90.3 economics placement bridge rather
-than hiding economics inside citizen-state security work.
+It consumed the v0.90.3 economics placement bridge without hiding economics
+inside citizen-state security work.
 
 ### v0.90.5 - Governed Tools v1.0
 
-`v0.90.5` is the planned home for governed tool calls:
+`v0.90.5` is the completed Governed Tools v1.0 band:
 - Universal Tool Schema
 - ADL Capability Contract
 - capability-to-tool binding
@@ -382,8 +386,8 @@ than hiding economics inside citizen-state security work.
 - model compatibility testing
 
 Tools are first-class ADL primitives, but the current industry pattern is too
-unsafe to treat as a production governance model. This milestone should make
-tool calls policy-mediated, inspectable, and fail-closed.
+unsafe to treat as a production governance model. This milestone made tool
+calls policy-mediated, inspectable, and fail-closed at the completed baseline.
 
 ### v0.91 - Affect and Moral Cognition
 


### PR DESCRIPTION
## Summary

Opens the official v0.91 execution wave and updates the milestone docs so the repo now treats v0.91 as active.

## What changed

- Opened the v0.91 GitHub issue wave as #2735-#2759.
- Updated the v0.91 WP YAML, sprint plan, WBS, readiness doc, checklist, milestone README, and feature index with concrete issue numbers.
- Updated root-facing README and docs index so v0.91 is active and v0.90.5 is completed history.
- Normalized the v0.91 feature-list status so completed v0.90.3-v0.90.5 work is no longer described as active or planned.

## Validation

- git diff --check
- Ruby YAML validation for docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml
- GitHub issue count check: 25 open issues with label version:v0.91, #2735-#2759
- Stale milestone wording scan for v0.90.5-active / v0.90.3-active claims
- Host path scan across changed v0.91 docs
- pr.sh reference scan across changed v0.91 docs

Refs #2735.
