### PR TITLE
[v0.91][WP-01] Add SPP readiness template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable project-level changes are summarized here by milestone/release.
 
+## v0.91 (Active development)
+
+Status: Active. The v0.91 issue wave is open as `#2735-#2759`, and the crate
+version has advanced to `0.91.0` for the moral governance, cognitive-being,
+structured planning / SRP, and secure intra-polis Agent Comms development line.
+
+Planning notes:
+- The tracked v0.91 planning package lives under `docs/milestones/v0.91/`.
+- The active issue wave is recorded in
+  `docs/milestones/v0.91/WP_ISSUE_WAVE_v0.91.yaml`.
+- The first SPP-readiness slice is recorded in
+  `docs/milestones/v0.91/SPP_READINESS_v0.91.md`.
+- This is not a release entry; v0.90.5 remains the most recently completed
+  release line.
+
 ## v0.90.5 (Released 2026-05-05)
 
 Status: Released. The Governed Tools v1.0 issue wave opened as `#2566-#2591`

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ bash adl/tools/demo_v0871_suite.sh
   planning / SRP, secure Agent Comms, and the reviewed candidate v0.91 WP
   wave**
 - Most recently completed milestone: **v0.90.5**
-- Current crate version: **0.90.5**
-- Version note: **`0.90.5` is the completed Governed Tools v1.0 release line
-  while `v0.91` is the next prepared milestone package**
+- Current crate version: **0.91.0**
+- Version note: **`0.91.0` is the active v0.91 development line while
+  `v0.90.5` remains the completed Governed Tools v1.0 release line**
 - Previous completed milestone package: **v0.90.4**
 - Previous completed milestone: **v0.90.3**
 - Project changelog: `CHANGELOG.md`

--- a/adl/Cargo.lock
+++ b/adl/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adl"
-version = "0.90.5"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/adl/Cargo.toml
+++ b/adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adl"
-version = "0.90.5"
+version = "0.91.0"
 edition = "2021"
 default-run = "adl"
 license = "MIT OR Apache-2.0"

--- a/docs/milestones/v0.91/README.md
+++ b/docs/milestones/v0.91/README.md
@@ -158,6 +158,8 @@ The likely `v0.91` tranche is:
   [WP_EXECUTION_READINESS_v0.91.md](WP_EXECUTION_READINESS_v0.91.md)
 - Card bundle readiness:
   [CARD_BUNDLE_READINESS_v0.91.md](CARD_BUNDLE_READINESS_v0.91.md)
+- SPP readiness:
+  [SPP_READINESS_v0.91.md](SPP_READINESS_v0.91.md)
 - Feature planning: [features/README.md](features/README.md)
 - Moral governance allocation:
   [MORAL_GOVERNANCE_ALLOCATION_v0.91.md](MORAL_GOVERNANCE_ALLOCATION_v0.91.md)

--- a/docs/milestones/v0.91/SPP_READINESS_v0.91.md
+++ b/docs/milestones/v0.91/SPP_READINESS_v0.91.md
@@ -1,0 +1,70 @@
+# v0.91 SPP Readiness
+
+## Purpose
+
+This record captures the first structured planning prompt readiness slice for
+v0.91. The goal is to test the SPP template on a small number of real work
+packages before generating the rest of the milestone wave.
+
+The local SPP files remain workflow records under `.adl/` and are not published
+as tracked repository artifacts. This tracked record exists so reviewers can see
+what was tested, what was intentionally deferred, and what remains blocked on
+the planned SPP editor skill.
+
+## Scope
+
+- Template: `docs/templates/STRUCTURED_PLAN_PROMPT_TEMPLATE.md`.
+- Hand-authored sample SPPs: WP-01 through WP-03.
+- Local records:
+  - `.adl/v0.91/tasks/issue-2735__v0-91-wp-01-docs-design-pass-milestone-docs-planning/spp.md`
+  - `.adl/v0.91/tasks/issue-2736__v0-91-wp-02-docs-moral-event-contract/spp.md`
+  - `.adl/v0.91/tasks/issue-2737__v0-91-wp-03-tools-moral-event-validation/spp.md`
+
+## Template Contract
+
+The template introduces an SPP as a read-only planning artifact created after
+STP, SIP, and SOR records exist and before execution is bound.
+
+It is intentionally compatible with Codex plan mode through a `codex_plan`
+frontmatter list. Each plan item carries:
+
+- `step`: one concise execution step.
+- `status`: one of `pending`, `in_progress`, or `completed`.
+
+For pre-execution SPPs, implementation steps should remain `pending` until work
+actually happens.
+
+## Sample Findings
+
+The first three SPPs are useful enough to validate the shape, but they also show
+why the rest of the wave should not be mass-generated without an editor skill:
+
+- WP-01 needs a planning-readiness SPP that avoids claiming all SPPs are done.
+- WP-02 needs contract-specific non-claims so moral evidence does not become a
+  scoreboard or production moral-agency claim.
+- WP-03 needs dependency-aware stop conditions so it consumes WP-02 instead of
+  silently redefining the contract.
+
+## Deferred Work
+
+The remaining v0.91 SPPs are intentionally deferred until the SPP editor skill
+exists. Follow-on issue #2766 should create a bounded editor skill that can
+normalize SPPs the same way STP, SIP, and SOR cards are edited today.
+
+The editor skill should preserve:
+
+- concrete issue dependencies and source references
+- Codex-compatible `codex_plan` status values
+- truthful pre-execution state
+- stop conditions and non-goals
+- review hooks
+- no implementation or branch-binding claims before execution
+
+## Non-Claims
+
+- This pass does not create all v0.91 SPPs.
+- This pass does not mark any v0.91 feature issue as implemented.
+- This pass does not bind per-issue branches or worktrees.
+- This pass does not replace STP, SIP, or SOR cards.
+- This pass does not publish local `.adl/` issue records as tracked repository
+  artifacts.

--- a/docs/templates/STRUCTURED_PLAN_PROMPT_TEMPLATE.md
+++ b/docs/templates/STRUCTURED_PLAN_PROMPT_TEMPLATE.md
@@ -1,0 +1,137 @@
+# Structured Plan Prompt Template
+
+## Purpose
+
+Use this template for ADL `SPP` artifacts. An `SPP` is an issue-local,
+read-only planning artifact created after `STP`, `SIP`, and `SOR` exist and
+before execution is bound.
+
+This template is compatible with Codex plan mode by carrying a simple
+`codex_plan` list. Each item has:
+
+- `step`: one concise execution step
+- `status`: `pending`, `in_progress`, or `completed`
+
+For pre-execution plans, all implementation steps should normally remain
+`pending`. Do not mark work `completed` unless it has actually happened.
+
+## File Location
+
+```text
+.adl/<version>/tasks/issue-<n>__<slug>/spp.md
+```
+
+Live `.adl/` issue records remain local workflow artifacts. Tracked milestone
+docs may record SPP readiness evidence without publishing the local SPP files.
+
+## Template
+
+```markdown
+---
+schema_version: "0.1"
+artifact_type: "structured_planning_prompt"
+name: "<short plan name>"
+issue: <issue number>
+task_id: "issue-<n>"
+run_id: "issue-<n>"
+version: "<version>"
+title: "<issue title>"
+branch: "not bound yet"
+status: "draft"
+plan_revision: 1
+source_refs:
+  - kind: "issue"
+    ref: "<issue URL or number>"
+  - kind: "stp"
+    ref: ".adl/<version>/tasks/issue-<n>__<slug>/stp.md"
+scope:
+  files:
+    - "<path or glob>"
+  components:
+    - "<component>"
+  out_of_scope:
+    - "<explicit non-goal>"
+constraints:
+  - "read_only"
+  - "no_mutation"
+  - "no_side_effects"
+confidence: "medium"
+plan_summary: "<one paragraph summary>"
+assumptions:
+  - "<assumption>"
+proposed_steps:
+  - id: "step-1"
+    description: "<execution step>"
+    expected_output: "<artifact or result>"
+    allowed_mode: "execution_after_approval"
+codex_plan:
+  - step: "<same concise execution step used by Codex plan mode>"
+    status: "pending"
+affected_areas:
+  - "<path, module, doc, demo, or subsystem>"
+invariants_to_preserve:
+  - "<invariant>"
+risks_and_edge_cases:
+  - "<risk>"
+test_strategy:
+  - "<validation command or review check>"
+execution_handoff: "<how execution should use this plan>"
+required_permissions:
+  - "workspace-write after execution approval"
+stop_conditions:
+  - "<when to stop and re-plan>"
+alternatives_considered:
+  - description: "<alternative>"
+    reason_not_chosen: "<reason>"
+review_hooks:
+  - "<review emphasis>"
+notes: "<optional note>"
+---
+
+# Structured Plan Prompt
+
+## Plan Summary
+
+<Human-readable summary.>
+
+## Codex Plan
+
+1. [pending] <step>
+
+## Assumptions
+
+- <assumption>
+
+## Proposed Steps
+
+1. <step>
+
+## Affected Areas
+
+- <area>
+
+## Invariants To Preserve
+
+- <invariant>
+
+## Risks And Edge Cases
+
+- <risk>
+
+## Test Strategy
+
+- <validation>
+
+## Execution Handoff
+
+<Instructions for the execution agent.>
+
+## Stop Conditions
+
+- <stop condition>
+
+## Notes
+
+<Optional notes.>
+```
+


### PR DESCRIPTION
## Summary

Completes the WP-01 planning-readiness slice for structured planning prompts.

- adds the Codex-compatible SPP template
- records the v0.91 SPP readiness sample pass
- links v0.91 docs to the SPP readiness record
- advances crate identity to 0.91.0 for the active v0.91 development line
- records the active v0.91 development line in the changelog

## Scope

This PR intentionally does not generate every v0.91 SPP. The first three SPPs
were hand-authored as local workflow samples only, and the tracked readiness
record explains what they proved. Actual SPP editor skill development is split
to #2766.

## Validation

- cargo run --manifest-path adl/Cargo.toml --bin adl -- --version
- ruby YAML check: WP issue wave maps 25 WPs to #2735-#2759
- ruby YAML check: exactly 3 local SPP samples validate with Codex-compatible statuses
- git diff --check

Refs #2735
Refs #2766

