### PR TITLE
[v0.91][skills] Create SPP editor skill

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -99,7 +99,8 @@ docs-only path-policy skip from full runtime validation, failed-closed
 classification, and release/main full-validation evidence.
 
 The four editor skills are helper skills:
-- `spp-editor` for truthful `spp.md` planning cleanup
+- `spp-editor` for truthful `spp.md` planning cleanup that preserves the
+  manual sample schema and markdown shape
 - `stp-editor` for bounded `stp.md` cleanup
 - `sip-editor` for truthful `sip.md` cleanup
 - `sor-editor` for truthful `sor.md` cleanup
@@ -1510,6 +1511,8 @@ remediation issues when a finding requires design decisions.
 
 It:
 
+- preserves the canonical manual `SPP` schema shape used by the first v0.91
+  samples
 - keeps `SPP` as a planning artifact rather than an execution log
 - validates `codex_plan` status values and planning-truth boundaries
 - tightens dependencies, assumptions, test strategy, and stop conditions
@@ -1520,6 +1523,7 @@ It:
 Use `spp-editor` when:
 
 - the `SPP` has stale plan structure or weak source references
+- the `SPP` drifts away from the canonical manual sample shape
 - `codex_plan` values drift outside `pending`, `in_progress`, or `completed`
 - a planning artifact starts to read like an execution log
 

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -54,6 +54,7 @@ The tracked skill set is:
 - `records-hygiene`
 - `review-quality-evaluator`
 - `review-to-test-planner`
+- `spp-editor`
 - `sip-editor`
 - `sor-editor`
 - `stp-editor`
@@ -97,7 +98,8 @@ The PR lifecycle skills share the CI runtime interpretation policy in
 docs-only path-policy skip from full runtime validation, failed-closed
 classification, and release/main full-validation evidence.
 
-The three editor skills are helper skills:
+The four editor skills are helper skills:
+- `spp-editor` for truthful `spp.md` planning cleanup
 - `stp-editor` for bounded `stp.md` cleanup
 - `sip-editor` for truthful `sip.md` cleanup
 - `sor-editor` for truthful `sor.md` cleanup
@@ -1500,6 +1502,71 @@ Use `documentation-specialist` for approved fixture text cleanup,
 `gap-analysis` when portability claims need evidence comparison, and focused
 remediation issues when a finding requires design decisions.
 
+## `spp-editor`
+
+### Purpose
+
+`spp-editor` is the bounded helper skill for `spp.md`.
+
+It:
+
+- keeps `SPP` as a planning artifact rather than an execution log
+- validates `codex_plan` status values and planning-truth boundaries
+- tightens dependencies, assumptions, test strategy, and stop conditions
+- stops before lifecycle orchestration or implementation
+
+### When To Use It
+
+Use `spp-editor` when:
+
+- the `SPP` has stale plan structure or weak source references
+- `codex_plan` values drift outside `pending`, `in_progress`, or `completed`
+- a planning artifact starts to read like an execution log
+
+Do not use it for:
+
+- creating branches/worktrees
+- claiming implementation results without evidence
+- rewriting `STP`, `SIP`, or `SOR` content
+
+### Required Inputs
+
+Minimum:
+
+- `repo_root`
+- `target.spp_path`
+
+Structured schema:
+
+- `adl/tools/skills/docs/SPP_EDITOR_SKILL_INPUT_SCHEMA.md`
+- schema id: `spp_editor.v1`
+
+### Example Invocation
+
+```yaml
+Use $spp-editor at /Users/daniel/git/agent-design-language/adl/tools/skills/spp-editor/SKILL.md with this validated input:
+
+skill_input_schema: spp_editor.v1
+mode: tighten_for_review
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  spp_path: .adl/v0.91/tasks/issue-2701__example/spp.md
+  issue_number: 2701
+  source_prompt_path: .adl/v0.91/bodies/issue-2701-example.md
+policy:
+  preserve_planning_truth: true
+  stop_after_edit: true
+  allow_execution_claims_without_evidence: false
+```
+
+### Output
+
+The structured result should identify:
+
+- which `SPP` path was edited
+- whether planning truth and `codex_plan` statuses were normalized
+- any remaining blockers that should stop readiness or execution
+
 ## `stp-editor`
 
 ### Purpose
@@ -2506,6 +2573,7 @@ surfaces:
 | `records-hygiene` | `RECORDS_HYGIENE_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | hygiene findings and follow-on recommendations only |
 | `review-quality-evaluator` | `REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review-quality evaluation only |
 | `review-to-test-planner` | `REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | test-generation handoff plan only |
+| `spp-editor` | `SPP_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | SPP normalization only |
 | `sip-editor` | `SIP_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | SIP normalization only |
 | `sor-editor` | `SOR_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | SOR normalization only |
 | `stp-editor` | `STP_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | STP normalization only |

--- a/adl/tools/skills/docs/SPP_EDITOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPP_EDITOR_SKILL_INPUT_SCHEMA.md
@@ -12,6 +12,8 @@ target:
   linked_sip_path: <path or null>
 policy:
   preserve_planning_truth: true
+  preserve_manual_schema_shape: true
+  preserve_manual_markdown_shape: true
   stop_after_edit: true
   allow_execution_claims_without_evidence: false
 ```

--- a/adl/tools/skills/docs/SPP_EDITOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPP_EDITOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,17 @@
+# SPP Editor Skill Input Schema
+
+```yaml
+skill_input_schema: spp_editor.v1
+mode: normalize_spp | tighten_for_review | repair_plan_drift
+repo_root: /absolute/path
+target:
+  spp_path: /absolute/or/repo-relative/path/to/spp.md
+  issue_number: <u32 or null>
+  source_prompt_path: <path or null>
+  linked_stp_path: <path or null>
+  linked_sip_path: <path or null>
+policy:
+  preserve_planning_truth: true
+  stop_after_edit: true
+  allow_execution_claims_without_evidence: false
+```

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: spp-editor
+description: Normalize and correct an SPP planning card so it preserves truthful pre-execution planning state, valid `codex_plan` statuses, and issue-local planning boundaries. Use when an `spp.md` has stale plan structure, invalid `codex_plan` values, missing stop conditions, weak source references, or readiness-blocking planning drift.
+---
+
+# SPP Editor
+
+This skill owns bounded editing of `spp.md` planning cards.
+
+Its job is to:
+- normalize `SPP` structure and planning truth
+- preserve `SPP` as a planning artifact rather than an execution log
+- validate and normalize `codex_plan` status values
+- tighten dependencies, assumptions, test strategy, stop conditions, and review
+  hooks
+- stop before execution, finish authoring, or broad workflow orchestration
+
+This is a helper skill, not a lifecycle orchestrator.
+
+## Required Inputs
+
+At minimum, gather:
+- repository root
+- `spp_path`
+- one explicit editing mode
+
+Useful additional inputs:
+- issue number
+- source prompt path
+- linked `stp.md` or `sip.md`
+- lifecycle phase (`pre_run`, `ready_review`, `stale_plan`)
+- explicit execution evidence if a caller wants any plan step marked completed
+
+## Quick Start
+
+1. Read the `SPP` and the linked source prompt if available.
+2. Determine the truthful planning state from the caller or inspected repo
+   state.
+3. Normalize `codex_plan`, source references, dependencies, and planning
+   boundaries.
+4. Remove placeholders, stale execution claims, and contradictory planning
+   notes.
+5. Emit a structured edit result and stop.
+
+## Allowed Edits
+
+This skill may:
+- fix invalid `codex_plan` statuses so they are only `pending`,
+  `in_progress`, or `completed`
+- demote unsupported completed implementation steps back to pending planning
+  state when execution evidence is absent
+- normalize assumptions, dependencies, risks, test strategy, stop conditions,
+  and review hooks
+- align `SPP` wording with current pre-execution or plan-review state
+- remove placeholders and stale execution or branch-binding claims
+
+This skill must not:
+- create or bind a branch or worktree
+- claim implementation is complete without explicit execution evidence
+- rewrite `STP`, `SIP`, or `SOR` instead of handing off
+- widen issue scope
+
+## Handoff
+
+Typical callers are:
+- `pr-ready` when planning readiness is blocked by `SPP` drift
+- human or review-driven card cleanup after `/plan` or equivalent planning
+  output
+- future `SPP` rollout and review-readiness flows
+
+## Output
+
+Return a concise structured result including:
+- target `SPP` path
+- planning state normalized
+- `codex_plan` issues corrected
+- unresolved blockers
+- recommended next handoff

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -9,6 +9,8 @@ This skill owns bounded editing of `spp.md` planning cards.
 
 Its job is to:
 - normalize `SPP` structure and planning truth
+- preserve the canonical manual `SPP` schema shape used by the first v0.91
+  samples
 - preserve `SPP` as a planning artifact rather than an execution log
 - validate and normalize `codex_plan` status values
 - tighten dependencies, assumptions, test strategy, stop conditions, and review
@@ -45,18 +47,32 @@ Useful additional inputs:
 ## Allowed Edits
 
 This skill may:
+- restore the canonical frontmatter shape with fields such as
+  `schema_version`, `artifact_type`, `name`, `run_id`, `milestone_sprint`,
+  `source_refs`, `scope`, `constraints`, `confidence`, `proposed_steps`,
+  `affected_areas`, `invariants_to_preserve`, `risks_and_edge_cases`,
+  `test_strategy`, `execution_handoff`, `required_permissions`,
+  `stop_conditions`, `alternatives_considered`, `review_hooks`, and `notes`
+- normalize `artifact_type` to `structured_planning_prompt`
+- ensure `schema_version` remains `0.1`
+- preserve the canonical markdown section order used by the hand-authored
+  samples: `Plan Summary`, `Codex Plan`, `Assumptions`, `Proposed Steps`,
+  `Affected Areas`, `Invariants To Preserve`, `Risks And Edge Cases`,
+  `Test Strategy`, `Execution Handoff`, `Stop Conditions`, and `Notes`
 - fix invalid `codex_plan` statuses so they are only `pending`,
   `in_progress`, or `completed`
 - demote unsupported completed implementation steps back to pending planning
   state when execution evidence is absent
-- normalize assumptions, dependencies, risks, test strategy, stop conditions,
-  and review hooks
+- normalize assumptions, dependencies, source references, scope, risks, test
+  strategy, stop conditions, and review hooks
 - align `SPP` wording with current pre-execution or plan-review state
 - remove placeholders and stale execution or branch-binding claims
 
 This skill must not:
 - create or bind a branch or worktree
 - claim implementation is complete without explicit execution evidence
+- erase concrete manual planning detail by collapsing issue-specific plans into
+  generic boilerplate
 - rewrite `STP`, `SIP`, or `SOR` instead of handing off
 - widen issue scope
 

--- a/adl/tools/skills/spp-editor/adl-skill.yaml
+++ b/adl/tools/skills/spp-editor/adl-skill.yaml
@@ -1,0 +1,56 @@
+version: "0.1"
+kind: "adl-skill"
+id: "spp-editor"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "spp_editor.v1"
+    reference_doc: "../docs/SPP_EDITOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "normalize_spp"
+      - "tighten_for_review"
+      - "repair_plan_drift"
+  intent:
+    - "spp_edit"
+    - "planning_card_normalization"
+    - "codex_plan_truth_repair"
+  required_inputs:
+    - "repo_root"
+    - "spp_path"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_spp_editor.v1_when_structured_input_is_used"
+    - "target.spp_path_must_be_present"
+    - "policy.stop_after_edit_must_be_true"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: true
+  allow_network: false
+  allow_subagents: false
+  workflow_role: "card_editor"
+  preferred_path: "structured_input_then_direct_card_edit"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**/spp.md"
+  must_not_write:
+    - ".adl/**/stp.md"
+    - ".adl/**/sip.md"
+    - ".adl/**/sor.md"
+    - "implementation source files"
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true

--- a/adl/tools/skills/spp-editor/agents/openai.yaml
+++ b/adl/tools/skills/spp-editor/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: SPP Editor
+short_description: Normalize truthful SPP planning cards
+default_prompt: Help me normalize an SPP planning card without turning it into an execution log.

--- a/adl/tools/skills/spp-editor/references/edit-playbook.md
+++ b/adl/tools/skills/spp-editor/references/edit-playbook.md
@@ -1,0 +1,31 @@
+# SPP Editor Playbook
+
+Use this skill only for bounded `spp.md` editing.
+
+Prefer this order:
+1. source issue prompt
+2. current `spp.md`
+3. linked `stp.md` or `sip.md` if available
+4. concrete caller findings about stale plans or `codex_plan` drift
+
+Check for:
+- invalid `codex_plan` statuses outside `pending`, `in_progress`, and
+  `completed`
+- implementation steps marked complete without explicit execution evidence
+- stale or weak source references
+- missing dependencies, assumptions, risks, test strategy, or stop conditions
+- missing review hooks or planning handoff notes
+- placeholders or stale branch/worktree/execution claims
+
+Safe edits:
+- normalize `codex_plan` status values
+- demote unsupported completed implementation steps to truthful planning state
+- tighten source refs, dependencies, assumptions, risks, test strategy, stop
+  conditions, and review hooks
+- remove placeholders and stale execution wording
+
+Unsafe edits:
+- inventing implementation evidence
+- claiming branch/worktree binding
+- rewriting `STP`, `SIP`, or `SOR` instead of handing off
+- widening issue scope

--- a/adl/tools/skills/spp-editor/references/edit-playbook.md
+++ b/adl/tools/skills/spp-editor/references/edit-playbook.md
@@ -9,23 +9,34 @@ Prefer this order:
 4. concrete caller findings about stale plans or `codex_plan` drift
 
 Check for:
+- frontmatter drift away from the canonical manual sample shape
+- missing `milestone_sprint` when the source issue is part of a sprinted
+  milestone wave
 - invalid `codex_plan` statuses outside `pending`, `in_progress`, and
   `completed`
 - implementation steps marked complete without explicit execution evidence
-- stale or weak source references
+- stale, weak, or missing source references to issue, STP, SIP, SOR, readiness
+  docs, or dependencies
+- missing `scope`, `constraints`, `confidence`, `proposed_steps`, or
+  `execution_handoff`
 - missing dependencies, assumptions, risks, test strategy, or stop conditions
 - missing review hooks or planning handoff notes
 - placeholders or stale branch/worktree/execution claims
 
 Safe edits:
+- restore the manual-sample schema shape and field names
+- restore the manual-sample markdown heading order and section labels
+- normalize `artifact_type` to `structured_planning_prompt`
+- normalize `schema_version` to `0.1`
 - normalize `codex_plan` status values
 - demote unsupported completed implementation steps to truthful planning state
-- tighten source refs, dependencies, assumptions, risks, test strategy, stop
-  conditions, and review hooks
+- tighten source refs, scope, dependencies, assumptions, risks, test strategy,
+  stop conditions, and review hooks
 - remove placeholders and stale execution wording
 
 Unsafe edits:
 - inventing implementation evidence
+- dropping concrete issue-local planning detail in favor of generic prose
 - claiming branch/worktree binding
 - rewriting `STP`, `SIP`, or `SOR` instead of handing off
 - widening issue scope

--- a/adl/tools/skills/spp-editor/references/output-contract.md
+++ b/adl/tools/skills/spp-editor/references/output-contract.md
@@ -1,0 +1,19 @@
+# Output Contract
+
+```yaml
+status: done | blocked | failed
+target:
+  spp_path: <path>
+edit_state:
+  planning_state_normalized: true | false
+  codex_plan_statuses_validated: true | false
+  placeholders_removed: true | false
+findings:
+  - severity: info | warning | blocking
+    area: planning | codex_plan | dependencies | structure | review_hooks
+    message: <short finding>
+actions_taken:
+  - <edit or normalization>
+handoff_state:
+  next_phase: qualitative_review | pr_ready | pr_run | blocked
+```

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author spp-editor stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -58,6 +58,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/arxiv-paper-writer/SKILL.md" ]]
   [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
   [[ -x "${root}/skills/diagram-author/scripts/render_diagrams.sh" ]]
+  [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]
@@ -89,6 +90,7 @@ assert_skill_bundle() {
   grep -Fq "stopping before publication" "${root}/skills/medium-article-writer/SKILL.md"
   grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
   grep -Fq "diagram-as-code and model-as-code router" "${root}/skills/diagram-author/SKILL.md"
+  grep -Fq "planning artifact rather than an execution log" "${root}/skills/spp-editor/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
   grep -Fq "truthful execution and integration state" "${root}/skills/sor-editor/SKILL.md"
@@ -121,6 +123,7 @@ assert_skill_bundle() {
     "${root}/skills/medium-article-writer/SKILL.md" \
     "${root}/skills/arxiv-paper-writer/SKILL.md" \
     "${root}/skills/diagram-author/SKILL.md" \
+    "${root}/skills/spp-editor/SKILL.md" \
     "${root}/skills/stp-editor/SKILL.md" \
     "${root}/skills/sip-editor/SKILL.md" \
     "${root}/skills/sor-editor/SKILL.md"


### PR DESCRIPTION
Closes #2766

## Summary
- add a bounded `spp-editor` operational skill bundle for `spp.md` planning cards
- add the `SPP` editor input-schema doc and minimal operational skill guide coverage
- include the new skill in the operational skill install test

## Validation
- not run (not requested)

## Notes
- kept scope bounded to the new `spp-editor` bundle and minimal skill-family wiring
- did not add conductor routing for `spp-editor` in this issue
