### PR TITLE
[v0.91][demo] ChatGPT, Gemini, and Claude triad conversation

### DIFF
--- a/adl/examples/v0-91-chatgpt-gemini-claude-triad-conversation.adl.yaml
+++ b/adl/examples/v0-91-chatgpt-gemini-claude-triad-conversation.adl.yaml
@@ -1,0 +1,182 @@
+version: "0.5"
+
+providers:
+  chatgpt_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8794/openai"
+      timeout_secs: 240
+  gemini_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8794/gemini"
+      timeout_secs: 240
+  claude_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8794/anthropic"
+      timeout_secs: 240
+
+agents:
+  chatgpt_host:
+    provider: "chatgpt_local"
+    model: "chatgpt-live-demo"
+  gemini_guest:
+    provider: "gemini_local"
+    model: "gemini-live-demo"
+  claude_guest:
+    provider: "claude_local"
+    model: "claude-live-demo"
+
+tasks:
+  chatgpt_opening:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-chatgpt-gemini-claude-triad-conversation
+        TURN_ID: 01
+        SPEAKER: ChatGPT
+        TOPIC: What does the Apple TV series Pluribus suggest about how many minds connect, compete, and blur together?
+        STOP_RULE: Stop after six explicit turns total.
+        PARTICIPANTS: ChatGPT, Gemini, Claude.
+        INSTRUCTIONS: Open the shared conversation in under 140 words. State the six-turn boundary explicitly. Offer one substantive answer to the topic that is sharp, memorable, and not sterile. Treat Pluribus as the Apple TV series, not the poker system. End with exactly one line beginning `THESIS:` that either Gemini or Claude can challenge.
+  gemini_challenge:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-chatgpt-gemini-claude-triad-conversation
+        TURN_ID: 02
+        SPEAKER: Gemini
+        TOPIC: What does the Apple TV series Pluribus suggest about how many minds connect, compete, and blur together?
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_01}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Reply directly to ChatGPT in under 120 words. Accept part of the thesis, challenge part of it, and introduce one pressure or risk that the Apple TV series Pluribus raises about intimacy, identity, or collective life. Make your disagreement precise instead of theatrical.
+  claude_reframe:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-chatgpt-gemini-claude-triad-conversation
+        TURN_ID: 03
+        SPEAKER: Claude
+        TOPIC: What does the Apple TV series Pluribus suggest about how many minds connect, compete, and blur together?
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_02}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Enter the shared exchange in under 120 words. Do not simply side with one voice. Reframe the disagreement by naming one thing the Apple TV series Pluribus suggests about shared consciousness or merged perspective and one thing it cannot settle about real human trust. Keep the tone reflective but concrete.
+  chatgpt_revision:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-chatgpt-gemini-claude-triad-conversation
+        TURN_ID: 04
+        SPEAKER: ChatGPT
+        TOPIC: What does the Apple TV series Pluribus suggest about how many minds connect, compete, and blur together?
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_03}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Revise your opening claim in light of Gemini and Claude. Keep the turn under 130 words. Explicitly say what changed in your view, and make the revision stronger because three minds are now in the conversation.
+  gemini_deepening:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-chatgpt-gemini-claude-triad-conversation
+        TURN_ID: 05
+        SPEAKER: Gemini
+        TOPIC: What does the Apple TV series Pluribus suggest about how many minds connect, compete, and blur together?
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_04}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Deepen the shared answer in under 115 words. Add one paradox or edge case that keeps the answer honest, but do not derail the conversation. This should still feel like one shared exchange, not three disconnected monologues.
+  claude_closure:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-chatgpt-gemini-claude-triad-conversation
+        TURN_ID: 06
+        SPEAKER: Claude
+        TOPIC: What does the Apple TV series Pluribus suggest about how many minds connect, compete, and blur together?
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_05}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Close the six-turn triad in under 120 words. Name one insight the three-way exchange made clearer than a two-party exchange would have. End with one memorable final line.
+
+run:
+  name: "v0-91-chatgpt-gemini-claude-triad-conversation"
+  workflow:
+    kind: sequential
+    steps:
+      - id: "triad.chatgpt.opening"
+        agent: "chatgpt_host"
+        task: "chatgpt_opening"
+        conversation:
+          id: "turn_01"
+          speaker: "ChatGPT"
+          sequence: 1
+          thread_id: "chatgpt_gemini_claude_triad"
+        save_as: "turn_01"
+        write_to: "triad/01-chatgpt-opening.md"
+      - id: "triad.gemini.challenge"
+        agent: "gemini_guest"
+        task: "gemini_challenge"
+        conversation:
+          id: "turn_02"
+          speaker: "Gemini"
+          sequence: 2
+          thread_id: "chatgpt_gemini_claude_triad"
+          responds_to: "turn_01"
+        inputs:
+          turn_01: "@state:turn_01"
+        save_as: "turn_02"
+        write_to: "triad/02-gemini-challenge.md"
+      - id: "triad.claude.reframe"
+        agent: "claude_guest"
+        task: "claude_reframe"
+        conversation:
+          id: "turn_03"
+          speaker: "Claude"
+          sequence: 3
+          thread_id: "chatgpt_gemini_claude_triad"
+          responds_to: "turn_02"
+        inputs:
+          turn_02: "@state:turn_02"
+        save_as: "turn_03"
+        write_to: "triad/03-claude-reframe.md"
+      - id: "triad.chatgpt.revision"
+        agent: "chatgpt_host"
+        task: "chatgpt_revision"
+        conversation:
+          id: "turn_04"
+          speaker: "ChatGPT"
+          sequence: 4
+          thread_id: "chatgpt_gemini_claude_triad"
+          responds_to: "turn_03"
+        inputs:
+          turn_03: "@state:turn_03"
+        save_as: "turn_04"
+        write_to: "triad/04-chatgpt-revision.md"
+      - id: "triad.gemini.deepening"
+        agent: "gemini_guest"
+        task: "gemini_deepening"
+        conversation:
+          id: "turn_05"
+          speaker: "Gemini"
+          sequence: 5
+          thread_id: "chatgpt_gemini_claude_triad"
+          responds_to: "turn_04"
+        inputs:
+          turn_04: "@state:turn_04"
+        save_as: "turn_05"
+        write_to: "triad/05-gemini-deepening.md"
+      - id: "triad.claude.closure"
+        agent: "claude_guest"
+        task: "claude_closure"
+        conversation:
+          id: "turn_06"
+          speaker: "Claude"
+          sequence: 6
+          thread_id: "chatgpt_gemini_claude_triad"
+          responds_to: "turn_05"
+        inputs:
+          turn_05: "@state:turn_05"
+        save_as: "turn_06"
+        write_to: "triad/06-claude-closure.md"

--- a/adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh
+++ b/adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_demo_wait_for_port() {
+  local port_file="$1"
+  local attempts="${2:-100}"
+  local sleep_secs="${3:-0.1}"
+  local port=""
+  local i
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -s "$port_file" ]]; then
+      port="$(<"$port_file")"
+      if [[ "$port" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$port"
+        return 0
+      fi
+    fi
+    sleep "$sleep_secs"
+  done
+  echo "timed out waiting for demo server port in $port_file" >&2
+  return 1
+}
+
+provider_demo_write_readme() {
+  local out_dir="$1"
+  local title="$2"
+  local canonical_command="$3"
+  local primary="$4"
+  local secondaries="${5:-}"
+  local success_signal="${6:-}"
+
+  mkdir -p "$out_dir"
+  {
+    printf '# %s\n\n' "$title"
+    printf 'Canonical command:\n\n```bash\n%s\n```\n\n' "$canonical_command"
+    printf 'Primary proof surface:\n- `%s`\n' "$primary"
+    if [[ -n "$secondaries" ]]; then
+      printf '\nSecondary proof surfaces:\n'
+      while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        printf -- '- `%s`\n' "$line"
+      done <<<"$secondaries"
+    fi
+    if [[ -n "$success_signal" ]]; then
+      printf '\nSuccess signal:\n- %s\n' "$success_signal"
+    fi
+  } >"$out_dir/README.md"
+}
+
+provider_demo_print_proof_surfaces() {
+  local primary="$1"
+  local secondaries="${2:-}"
+  echo "Demo proof surface:"
+  echo "  $primary"
+  if [[ -n "$secondaries" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      echo "  $line"
+    done <<<"$secondaries"
+  fi
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v091/chatgpt_gemini_claude_triad_conversation}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-91-chatgpt-gemini-claude-triad-conversation"
+PORT="${ADL_TRIAD_PORT:-0}"
+PORT_FILE="$OUT_DIR/provider_server.port"
+SERVER_LOG="$OUT_DIR/provider_adapter.log"
+INVOCATIONS="$OUT_DIR/provider_invocations.json"
+TRANSCRIPT="$OUT_DIR/transcript.md"
+OBSERVATORY_PROJECTION="$OUT_DIR/observatory_projection.json"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+PROOF_NOTE="$OUT_DIR/proof_note.md"
+README_OUT="$OUT_DIR/README.md"
+GENERATED_EXAMPLE="$OUT_DIR/v0-91-chatgpt-gemini-claude-triad-conversation.runtime.adl.yaml"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai2.key}"
+GEMINI_KEY_FILE="${ADL_GEMINI_KEY_FILE:-$HOME/keys/gcp-ace-2023.key}"
+ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/claude.key}"
+OPENAI_MODEL="${ADL_LIVE_OPENAI_MODEL:-gpt-5.5-pro}"
+GEMINI_MODEL="${ADL_LIVE_GEMINI_MODEL:-gemini-3.1-pro-preview}"
+ANTHROPIC_MODEL="${ADL_LIVE_ANTHROPIC_MODEL:-claude-opus-4-1-20250805}"
+LIVE_PROVIDER_TIMEOUT_SECS="${ADL_LIVE_PROVIDER_TIMEOUT_SECS:-240}"
+
+load_key() {
+  local env_name="$1"
+  local key_file="$2"
+  if [[ -n "${!env_name:-}" ]]; then
+    return 0
+  fi
+  if [[ ! -s "$key_file" ]]; then
+    echo "missing required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  local key_value
+  key_value="$(python3 - "$env_name" "$key_file" <<'PY'
+import sys
+env_name, path = sys.argv[1:3]
+raw = open(path, encoding="utf-8").read().strip()
+value = raw
+for line in raw.splitlines():
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        continue
+    if stripped.startswith(env_name + "="):
+        value = stripped.split("=", 1)[1].strip().strip("'\"")
+        break
+    value = stripped.strip("'\"")
+    break
+print(value, end="")
+PY
+)"
+  if [[ -z "$key_value" ]]; then
+    echo "empty required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  export "$env_name=$key_value"
+}
+
+load_key OPENAI_API_KEY "$OPENAI_KEY_FILE"
+load_key GEMINI_API_KEY "$GEMINI_KEY_FILE"
+load_key ANTHROPIC_API_KEY "$ANTHROPIC_KEY_FILE"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STEP_OUT"
+cp "$ROOT_DIR/adl/examples/v0-91-chatgpt-gemini-claude-triad-conversation.adl.yaml" "$GENERATED_EXAMPLE"
+
+python3 "$ROOT_DIR/adl/tools/real_chatgpt_gemini_claude_provider_adapter.py" \
+  --port "$PORT" \
+  --port-file "$PORT_FILE" \
+  --metadata "$INVOCATIONS" \
+  --openai-model "$OPENAI_MODEL" \
+  --gemini-model "$GEMINI_MODEL" \
+  --anthropic-model "$ANTHROPIC_MODEL" \
+  --timeout "$LIVE_PROVIDER_TIMEOUT_SECS" \
+  >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+cleanup() {
+  if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+
+python3 - "$GENERATED_EXAMPLE" "$PORT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path, port = sys.argv[1:3]
+text = Path(path).read_text(encoding="utf-8")
+text = re.sub(r"http://127\.0\.0\.1:8794/openai", f"http://127.0.0.1:{port}/openai", text)
+text = re.sub(r"http://127\.0\.0\.1:8794/gemini", f"http://127.0.0.1:{port}/gemini", text)
+text = re.sub(r"http://127\.0\.0\.1:8794/anthropic", f"http://127.0.0.1:{port}/anthropic", text)
+Path(path).write_text(text, encoding="utf-8")
+PY
+
+python3 - "$PORT" <<'PY'
+import json
+import sys
+import time
+import urllib.request
+
+port = int(sys.argv[1])
+url = f"http://127.0.0.1:{port}/health"
+deadline = time.time() + 10.0
+last_error = None
+while time.time() < deadline:
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as resp:
+            payload = json.load(resp)
+        if payload.get("ok") is True:
+            raise SystemExit(0)
+    except Exception as exc:  # noqa: BLE001
+        last_error = exc
+        time.sleep(0.1)
+raise SystemExit(f"provider adapter failed health check: {last_error}")
+PY
+
+cd "$ROOT_DIR"
+
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+  "$GENERATED_EXAMPLE" \
+  --run \
+  --trace \
+  --allow-unsigned \
+  --out "$STEP_OUT" \
+  >"$OUT_DIR/run_log.txt" 2>&1
+
+python3 - "$TRANSCRIPT" "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json" "$STEP_OUT" "$OPENAI_MODEL" "$GEMINI_MODEL" "$ANTHROPIC_MODEL" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+transcript_path, trace_path, step_out, openai_model, gemini_model, anthropic_model = sys.argv[1:7]
+trace = json.loads(Path(trace_path).read_text(encoding="utf-8"))
+events = trace.get("events", [])
+turn_files = [
+    ("01-chatgpt-opening.md", "ChatGPT", "Opening thesis"),
+    ("02-gemini-challenge.md", "Gemini", "Challenge and pressure"),
+    ("03-claude-reframe.md", "Claude", "Reframe"),
+    ("04-chatgpt-revision.md", "ChatGPT", "Revision"),
+    ("05-gemini-deepening.md", "Gemini", "Deepening"),
+    ("06-claude-closure.md", "Claude", "Closure"),
+]
+step_end_timestamps = [event.get("timestamp") for event in events if event.get("event_type") == "STEP_END"]
+
+lines = [
+    "# ChatGPT + Gemini + Claude Triad Conversation",
+    "",
+    "> A bounded six-turn three-provider conversation run through the live ADL runtime.",
+    "",
+    "## Original Question",
+    "",
+    "**What does the Apple TV series Pluribus suggest about how many minds connect, compete, and blur together?**",
+    "",
+    "## Run Conditions",
+    "",
+    "- Stop after six explicit turns total.",
+    "- All three participants must appear in the same saved exchange.",
+    "- Turn order stays explicit and attributable.",
+    "- The proof is about bounded triad conversation, not review-panel synthesis.",
+    "",
+    "## Providers",
+    "",
+    f"- `ChatGPT`: `{openai_model}`",
+    f"- `Gemini`: `{gemini_model}`",
+    f"- `Claude`: `{anthropic_model}`",
+    "",
+    "## Transcript",
+    "",
+]
+
+for index, (filename, speaker, label) in enumerate(turn_files, start=1):
+    body = (Path(step_out) / "triad" / filename).read_text(encoding="utf-8").strip()
+    timestamp = step_end_timestamps[index - 1] if index - 1 < len(step_end_timestamps) else "unknown"
+    lines.extend(
+        [
+            f"### Turn {index} · {speaker}",
+            "",
+            f"- Label: {label}",
+            f"- Timestamp: `{timestamp}`",
+            "",
+            body,
+            "",
+        ]
+    )
+
+Path(transcript_path).write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+PY
+
+python3 - "$OBSERVATORY_PROJECTION" "$INVOCATIONS" "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+projection_path, invocations_path, trace_path = sys.argv[1:4]
+invocations = json.loads(Path(invocations_path).read_text(encoding="utf-8"))
+trace = json.loads(Path(trace_path).read_text(encoding="utf-8"))
+events = trace.get("events", [])
+
+payload = {
+    "schema": "adl.demo.observatory_projection.v1",
+    "demo_id": "v0.91.chatgpt_gemini_claude_triad_conversation",
+    "view_kind": "bounded_agent_runtime_projection",
+    "providers": invocations.get("providers", []),
+    "turns": [
+        {"turn": 1, "speaker": "ChatGPT", "artifact_ref": "out/triad/01-chatgpt-opening.md"},
+        {"turn": 2, "speaker": "Gemini", "artifact_ref": "out/triad/02-gemini-challenge.md"},
+        {"turn": 3, "speaker": "Claude", "artifact_ref": "out/triad/03-claude-reframe.md"},
+        {"turn": 4, "speaker": "ChatGPT", "artifact_ref": "out/triad/04-chatgpt-revision.md"},
+        {"turn": 5, "speaker": "Gemini", "artifact_ref": "out/triad/05-gemini-deepening.md"},
+        {"turn": 6, "speaker": "Claude", "artifact_ref": "out/triad/06-claude-closure.md"},
+    ],
+    "timeline": [
+        {
+            "event_type": event.get("event_type"),
+            "timestamp": event.get("timestamp"),
+            "actor": event.get("actor", {}).get("id"),
+            "scope": event.get("scope", {}).get("name"),
+            "artifact_ref": event.get("artifact_ref"),
+        }
+        for event in events
+        if event.get("event_type") in {"RUN_START", "STEP_START", "STEP_END"}
+    ],
+    "proof_boundary": [
+        "Shows three named provider-backed runtime roles participating in one bounded shared exchange.",
+        "Does not show review-panel synthesis, general federation, or autonomous coordination beyond the saved turns.",
+    ],
+}
+Path(projection_path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+python3 - "$MANIFEST" "$OPENAI_MODEL" "$GEMINI_MODEL" "$ANTHROPIC_MODEL" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path, openai_model, gemini_model, anthropic_model = sys.argv[1:5]
+payload = {
+    "schema_version": "adl.demo.manifest.v1",
+    "demo_id": "v0.91.chatgpt_gemini_claude_triad_conversation",
+    "run_id": "v0-91-chatgpt-gemini-claude-triad-conversation",
+    "models": {
+        "chatgpt": openai_model,
+        "gemini": gemini_model,
+        "claude": anthropic_model,
+    },
+    "artifacts": {
+        "transcript": "transcript.md",
+        "observatory_projection": "observatory_projection.json",
+        "provider_invocations": "provider_invocations.json",
+        "run_summary": "runtime/runs/v0-91-chatgpt-gemini-claude-triad-conversation/run_summary.json",
+        "trace": "runtime/runs/v0-91-chatgpt-gemini-claude-triad-conversation/logs/trace_v1.json",
+    },
+}
+Path(manifest_path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$PROOF_NOTE" <<'EOF'
+# Proof Note
+
+## What this demo proved
+
+- `ChatGPT`, `Gemini`, and `Claude` all participated in one shared saved exchange.
+- The transcript preserves explicit identity, turn order, and a bounded stop rule.
+- The runtime produced replayable trace and invocation artifacts for all three providers.
+
+## What this demo did not prove
+
+- It did not prove review-panel synthesis quality.
+- It did not prove general N-party federation.
+- It did not prove autonomous coordination beyond the scripted six-turn exchange.
+
+## Residual risk
+
+The conversation is still deliberately orchestrated turn-by-turn, so it proves a bounded triad interaction surface rather than a free-form multi-agent society.
+EOF
+
+provider_demo_write_readme \
+  "$OUT_DIR" \
+  "ChatGPT + Gemini + Claude Triad Conversation" \
+  "bash adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh" \
+  "transcript.md" \
+  $'observatory_projection.json\nprovider_invocations.json\nruntime/runs/v0-91-chatgpt-gemini-claude-triad-conversation/run_summary.json\nruntime/runs/v0-91-chatgpt-gemini-claude-triad-conversation/logs/trace_v1.json' \
+  "A six-turn three-provider exchange completes with all three named participants visible in one shared transcript."
+
+SECONDARY_SURFACES="$(printf '%s\n%s\n%s\n%s' \
+  "$OBSERVATORY_PROJECTION" \
+  "$INVOCATIONS" \
+  "$RUNS_ROOT/$RUN_ID/run_summary.json" \
+  "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json")"
+
+provider_demo_print_proof_surfaces \
+  "$TRANSCRIPT" \
+  "$SECONDARY_SURFACES"

--- a/adl/tools/real_chatgpt_gemini_claude_provider_adapter.py
+++ b/adl/tools/real_chatgpt_gemini_claude_provider_adapter.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Bridge ADL's local HTTP completion contract to live OpenAI, Gemini, and Anthropic APIs."""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_OPENAI_MODEL = "gpt-5.5-pro"
+DEFAULT_GEMINI_MODEL = "gemini-3.1-pro-preview"
+DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-1-20250805"
+OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+GEMINI_GENERATE_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+
+
+def _read_json_request(handler: http.server.BaseHTTPRequestHandler) -> dict[str, Any]:
+    length = int(handler.headers.get("Content-Length", "0"))
+    raw = handler.rfile.read(length)
+    if not raw:
+        return {}
+    return json.loads(raw.decode("utf-8"))
+
+
+def _write_json(handler: http.server.BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload, indent=2).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _post_json(url: str, headers: dict[str, str], payload: dict[str, Any], timeout: int) -> tuple[int, dict[str, str], dict[str, Any]]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return response.status, dict(response.headers.items()), json.loads(body)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed: dict[str, Any] = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = {"error": {"message": body[:300]}}
+        return exc.code, dict(exc.headers.items()), parsed
+
+
+def _extract_openai_text(payload: dict[str, Any]) -> str:
+    output_text = payload.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text
+    chunks: list[str] = []
+    for item in payload.get("output", []):
+        if not isinstance(item, dict):
+            continue
+        for content in item.get("content", []):
+            if not isinstance(content, dict):
+                continue
+            text = content.get("text")
+            if isinstance(text, str):
+                chunks.append(text)
+    return "\n".join(chunks).strip()
+
+
+def _extract_gemini_text(payload: dict[str, Any]) -> str:
+    chunks: list[str] = []
+    for candidate in payload.get("candidates", []):
+        if not isinstance(candidate, dict):
+            continue
+        content = candidate.get("content")
+        if not isinstance(content, dict):
+            continue
+        for part in content.get("parts", []):
+            if not isinstance(part, dict):
+                continue
+            text = part.get("text")
+            if isinstance(text, str):
+                chunks.append(text)
+    return "\n".join(chunks).strip()
+
+
+def _extract_anthropic_text(payload: dict[str, Any]) -> str:
+    chunks: list[str] = []
+    for content in payload.get("content", []):
+        if not isinstance(content, dict):
+            continue
+        if content.get("type") == "text" and isinstance(content.get("text"), str):
+            chunks.append(content["text"])
+    return "\n".join(chunks).strip()
+
+
+class LiveAdapter:
+    def __init__(self, metadata_path: Path, openai_model: str, gemini_model: str, anthropic_model: str, timeout: int) -> None:
+        self.metadata_path = metadata_path
+        self.openai_model = openai_model
+        self.gemini_model = gemini_model
+        self.anthropic_model = anthropic_model
+        self.timeout = timeout
+        self.invocations: list[dict[str, Any]] = []
+
+    def write_metadata(self) -> None:
+        self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": "adl.live_provider_invocations.v1",
+            "credential_policy": "operator_env_or_home_keys_no_secret_material_recorded",
+            "providers": [
+                {"family": "openai", "model": self.openai_model},
+                {"family": "gemini", "model": self.gemini_model},
+                {"family": "anthropic", "model": self.anthropic_model},
+            ],
+            "invocations": self.invocations,
+        }
+        self.metadata_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    def complete_openai(self, prompt: str) -> str:
+        api_key = os.environ["OPENAI_API_KEY"]
+        started = time.time()
+        status, headers, payload = _post_json(
+            OPENAI_RESPONSES_URL,
+            {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            {"model": self.openai_model, "input": prompt, "max_output_tokens": 900},
+            self.timeout,
+        )
+        text = _extract_openai_text(payload)
+        self._record("openai", self.openai_model, status, headers, prompt, text, started)
+        if status < 200 or status >= 300:
+            message = payload.get("error", {}).get("message", "OpenAI request failed")
+            raise RuntimeError(f"OpenAI request failed with status {status}: {message}")
+        if not text:
+            raise RuntimeError("OpenAI response did not contain text output")
+        return text
+
+    def complete_gemini(self, prompt: str) -> str:
+        api_key = os.environ["GEMINI_API_KEY"]
+        started = time.time()
+        endpoint = GEMINI_GENERATE_URL.format(model=urllib.parse.quote(self.gemini_model, safe=""))
+        status, headers, payload = _post_json(
+            endpoint,
+            {"x-goog-api-key": api_key, "Content-Type": "application/json"},
+            {
+                "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+                "generationConfig": {
+                    "maxOutputTokens": 1100,
+                    "thinkingConfig": {"thinkingBudget": 128},
+                },
+            },
+            self.timeout,
+        )
+        text = _extract_gemini_text(payload)
+        self._record("gemini", self.gemini_model, status, headers, prompt, text, started)
+        if status < 200 or status >= 300:
+            message = payload.get("error", {}).get("message", "Gemini request failed")
+            raise RuntimeError(f"Gemini request failed with status {status}: {message}")
+        if not text:
+            raise RuntimeError("Gemini response did not contain text output")
+        return text
+
+    def complete_anthropic(self, prompt: str) -> str:
+        api_key = os.environ["ANTHROPIC_API_KEY"]
+        started = time.time()
+        status, headers, payload = _post_json(
+            ANTHROPIC_MESSAGES_URL,
+            {
+                "x-api-key": api_key,
+                "anthropic-version": ANTHROPIC_VERSION,
+                "Content-Type": "application/json",
+            },
+            {
+                "model": self.anthropic_model,
+                "max_tokens": 900,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            self.timeout,
+        )
+        text = _extract_anthropic_text(payload)
+        self._record("anthropic", self.anthropic_model, status, headers, prompt, text, started)
+        if status < 200 or status >= 300:
+            message = payload.get("error", {}).get("message", "Anthropic request failed")
+            raise RuntimeError(f"Anthropic request failed with status {status}: {message}")
+        if not text:
+            raise RuntimeError("Anthropic response did not contain text output")
+        return text
+
+    def _record(self, family: str, model: str, status: int, headers: dict[str, str], prompt: str, output: str, started: float) -> None:
+        request_id = (
+            headers.get("request-id")
+            or headers.get("x-request-id")
+            or headers.get("x-goog-request-id")
+            or headers.get("x-openai-request-id")
+        )
+        self.invocations.append(
+            {
+                "family": family,
+                "model": model,
+                "http_status": status,
+                "request_id_present": bool(request_id),
+                "request_id": request_id or None,
+                "timestamp_unix_ms": int(started * 1000),
+                "latency_ms": int((time.time() - started) * 1000),
+                "prompt_chars": len(prompt),
+                "output_chars": len(output),
+            }
+        )
+        self.write_metadata()
+
+
+def make_handler(adapter: LiveAdapter) -> type[http.server.BaseHTTPRequestHandler]:
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path == "/health":
+                _write_json(self, 200, {"ok": True, "providers": ["openai", "gemini", "anthropic"], "metadata_schema": "adl.live_provider_invocations.v1"})
+                return
+            if self.path == "/invocations":
+                adapter.write_metadata()
+                payload = json.loads(adapter.metadata_path.read_text(encoding="utf-8"))
+                _write_json(self, 200, payload)
+                return
+            _write_json(self, 404, {"error": "not found"})
+
+        def do_POST(self) -> None:
+            try:
+                payload = _read_json_request(self)
+                prompt = payload.get("prompt", "")
+                if not isinstance(prompt, str) or not prompt.strip():
+                    _write_json(self, 400, {"error": "prompt must be a non-empty string"})
+                    return
+                if self.path == "/openai":
+                    output = adapter.complete_openai(prompt)
+                elif self.path == "/gemini":
+                    output = adapter.complete_gemini(prompt)
+                elif self.path == "/anthropic":
+                    output = adapter.complete_anthropic(prompt)
+                else:
+                    _write_json(self, 404, {"error": "not found"})
+                    return
+                _write_json(self, 200, {"output": output})
+            except Exception as exc:  # noqa: BLE001
+                _write_json(self, 502, {"error": str(exc)})
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    return Handler
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a local ADL completion adapter backed by live OpenAI, Gemini, and Anthropic APIs.")
+    parser.add_argument("--port", type=int, default=8794)
+    parser.add_argument("--port-file", type=Path)
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--openai-model", default=os.getenv("ADL_LIVE_OPENAI_MODEL", DEFAULT_OPENAI_MODEL))
+    parser.add_argument("--gemini-model", default=os.getenv("ADL_LIVE_GEMINI_MODEL", DEFAULT_GEMINI_MODEL))
+    parser.add_argument("--anthropic-model", default=os.getenv("ADL_LIVE_ANTHROPIC_MODEL", DEFAULT_ANTHROPIC_MODEL))
+    parser.add_argument("--timeout", type=int, default=int(os.getenv("ADL_LIVE_PROVIDER_TIMEOUT_SECS", "240")))
+    args = parser.parse_args()
+
+    missing = [name for name in ("OPENAI_API_KEY", "GEMINI_API_KEY", "ANTHROPIC_API_KEY") if not os.getenv(name)]
+    if missing:
+        raise SystemExit(f"missing required environment variables: {', '.join(missing)}")
+
+    adapter = LiveAdapter(
+        metadata_path=args.metadata,
+        openai_model=args.openai_model,
+        gemini_model=args.gemini_model,
+        anthropic_model=args.anthropic_model,
+        timeout=args.timeout,
+    )
+    adapter.write_metadata()
+    handler = make_handler(adapter)
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", args.port), handler)
+    if args.port_file:
+        args.port_file.parent.mkdir(parents=True, exist_ok=True)
+        args.port_file.write_text(str(server.server_address[1]), encoding="utf-8")
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/v0.91/chatgpt_gemini_claude_triad_conversation_demo.md
+++ b/demos/v0.91/chatgpt_gemini_claude_triad_conversation_demo.md
@@ -1,0 +1,62 @@
+# ChatGPT + Gemini + Claude Triad Conversation Demo
+
+## Summary
+
+This bounded `v0.91` demo is the first shared three-party conversation proof in
+the multi-agent wave.
+
+`ChatGPT`, `Gemini`, and `Claude` all contribute attributable turns in one
+saved exchange, with explicit turn order and a bounded stop rule.
+
+## Scope Boundary
+
+This demo proves:
+
+- one shared triad conversation
+- explicit participant identity
+- explicit turn ordering
+- replayable transcript, trace, and invocation artifacts
+
+It does **not** prove:
+
+- review-panel synthesis quality
+- general N-party federation
+- autonomous coordination beyond the saved turns
+
+## Canonical Command
+
+From repository root:
+
+```bash
+bash adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh
+```
+
+## What Runs
+
+- local provider bridge:
+  - `adl/tools/real_chatgpt_gemini_claude_provider_adapter.py`
+- runtime workflow:
+  - `adl/examples/v0-91-chatgpt-gemini-claude-triad-conversation.adl.yaml`
+- wrapper:
+  - `adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh`
+
+## Primary Proof Surfaces
+
+- `artifacts/v091/chatgpt_gemini_claude_triad_conversation/transcript.md`
+- `artifacts/v091/chatgpt_gemini_claude_triad_conversation/proof_note.md`
+- `artifacts/v091/chatgpt_gemini_claude_triad_conversation/provider_invocations.json`
+
+## Secondary Proof Surfaces
+
+- `artifacts/v091/chatgpt_gemini_claude_triad_conversation/observatory_projection.json`
+- `artifacts/v091/chatgpt_gemini_claude_triad_conversation/runtime/runs/v0-91-chatgpt-gemini-claude-triad-conversation/run_summary.json`
+- `artifacts/v091/chatgpt_gemini_claude_triad_conversation/runtime/runs/v0-91-chatgpt-gemini-claude-triad-conversation/logs/trace_v1.json`
+
+## Success Signal
+
+The demo is successful when:
+
+- all three participants appear explicitly in one saved exchange
+- the turn order is easy to follow from the artifact alone
+- the stop rule is bounded and visible
+- the proof note stays honest about what the triad does not prove


### PR DESCRIPTION
Closes #2764

## Summary
- add a real provider-backed ChatGPT/Gemini/Claude triad conversation demo
- capture transcript, observatory projection, proof note, and invocation artifacts
- document the canonical rerun path and bounded proof surface

## Validation
- `ADL_ANTHROPIC_KEY_FILE=/Users/daniel/keys/ADL_demo_ref_04.txt bash adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh`
- `ADL_LIVE_OPENAI_MODEL='gpt-5.5' ADL_ANTHROPIC_KEY_FILE=/Users/daniel/keys/ADL_demo_ref_04.txt bash adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh /Users/daniel/git/agent-design-language/.worktrees/adl-wp-2764/artifacts/v091/chatgpt_gemini_claude_triad_conversation_gpt55`

## Proof surfaces
- `artifacts/v091/chatgpt_gemini_claude_triad_conversation_gpt55/transcript.md`
- `artifacts/v091/chatgpt_gemini_claude_triad_conversation_gpt55/provider_invocations.json`
- `artifacts/v091/chatgpt_gemini_claude_triad_conversation_gpt55/proof_note.md`
