### PR TITLE
[v0.91][WP-16][runtime] Secure Agent Comms substrate and A2A boundary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,7 +349,7 @@ jobs:
             bash adl/tools/check_coverage_impact.sh \
               --base "${{ github.event.pull_request.base.sha }}" \
               --head "${{ github.event.pull_request.head.sha }}" \
-              --summary coverage-summary.json \
+              --summary adl/coverage-summary.json \
               --require-summary-for-risk \
               --threshold "$PER_FILE_LINE_THRESHOLD"
           else

--- a/adl/src/agent_comms.rs
+++ b/adl/src/agent_comms.rs
@@ -22,6 +22,8 @@ const ACIP_CODING_FIXTURE_SCHEMA_VERSION: &str = "acip.coding.fixture.v1";
 const ACIP_TRACE_BUNDLE_SCHEMA_VERSION: &str = "acip.trace.bundle.v1";
 const ACIP_TRACE_FIXTURE_SCHEMA_VERSION: &str = "acip.trace.fixture.v1";
 const ACIP_PROOF_DEMO_SCHEMA_VERSION: &str = "acip.proof.demo.v1";
+const ACIP_A2A_ADAPTER_SCHEMA_VERSION: &str = "acip.a2a.adapter.v1";
+const ACIP_A2A_FIXTURE_SCHEMA_VERSION: &str = "acip.a2a.fixture.v1";
 const MAX_CONTENT_CHARS: usize = 4_000;
 const MAX_INLINE_SUMMARY_CHARS: usize = 512;
 const MAX_LIST_LEN: usize = 16;
@@ -590,6 +592,104 @@ pub enum AcipProofClassificationV1 {
     NonProving,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcipA2aTrustClassV1 {
+    Naked,
+    Guest,
+    Citizen,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcipA2aTransportBoundaryStatusV1 {
+    DeferredUntilTlsEquivalent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcipA2aSecurityPostureV1 {
+    TlsEquivalent,
+    MutualTlsEquivalent,
+    TlsOrMutualTlsEquivalent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aAgentCardClaimV1 {
+    pub agent_card_ref: String,
+    pub agent_id_claim: String,
+    pub display_name_claim: String,
+    pub advertised_capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aCapabilityMappingV1 {
+    pub external_capability_claim: String,
+    pub adl_capability: String,
+    pub policy_basis_ref: String,
+    pub invocation_required: bool,
+    pub direct_execution_forbidden: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aTrustClassificationV1 {
+    pub classification: AcipA2aTrustClassV1,
+    pub basis_refs: Vec<String>,
+    pub execution_authority_granted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aInvokeBoundaryV1 {
+    pub required_entrypoint: String,
+    pub invocation_contract_schema_ref: String,
+    pub trace_bundle_schema_ref: String,
+    pub direct_execution_forbidden: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aTransportBoundaryV1 {
+    pub local_scope_only: bool,
+    pub external_transport_status: AcipA2aTransportBoundaryStatusV1,
+    pub required_security_posture: AcipA2aSecurityPostureV1,
+    pub refusal_mode: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aAdapterBoundaryV1 {
+    pub schema_version: String,
+    pub adapter_id: String,
+    pub purpose: String,
+    pub identity_claim: AcipA2aAgentCardClaimV1,
+    pub capability_mappings: Vec<AcipA2aCapabilityMappingV1>,
+    pub trust_classification: AcipA2aTrustClassificationV1,
+    pub invoke_boundary: AcipA2aInvokeBoundaryV1,
+    pub transport_boundary: AcipA2aTransportBoundaryV1,
+    pub trace_evidence_refs: Vec<String>,
+    pub non_claims: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aNegativeCaseV1 {
+    pub name: String,
+    pub expected_error_substring: String,
+    pub value: JsonValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcipA2aFixtureSetV1 {
+    pub schema_version: String,
+    pub valid_adapters: Vec<AcipA2aAdapterBoundaryV1>,
+    pub negative_cases: Vec<AcipA2aNegativeCaseV1>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AcipProofDemoPacketV1 {
@@ -662,6 +762,12 @@ pub mod orchestrate {
     pub use trace::*;
 }
 
+pub mod a2a {
+    use super::*;
+    include!("agent_comms/a2a.inc");
+}
+
+pub use a2a::*;
 pub use dispatch::*;
 pub use orchestrate::*;
 pub use transport::*;

--- a/adl/src/agent_comms/a2a.inc
+++ b/adl/src/agent_comms/a2a.inc
@@ -1,0 +1,451 @@
+pub fn acip_a2a_adapter_boundary_v1_schema_json() -> Result<String> {
+    Ok(serde_json::to_string_pretty(&schema_for!(AcipA2aAdapterBoundaryV1))?)
+}
+
+pub fn acip_a2a_fixture_set_v1_schema_json() -> Result<String> {
+    Ok(serde_json::to_string_pretty(&schema_for!(AcipA2aFixtureSetV1))?)
+}
+
+pub fn validate_acip_a2a_adapter_boundary_v1_value(value: &JsonValue) -> Result<()> {
+    let adapter: AcipA2aAdapterBoundaryV1 =
+        serde_json::from_value(value.clone()).context("parse ACIP A2A adapter boundary v1")?;
+    validate_acip_a2a_adapter_boundary_v1(&adapter)
+}
+
+pub fn validate_acip_a2a_adapter_boundary_v1(adapter: &AcipA2aAdapterBoundaryV1) -> Result<()> {
+    if adapter.schema_version != ACIP_A2A_ADAPTER_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP A2A adapter boundary requires schema_version '{}'",
+            ACIP_A2A_ADAPTER_SCHEMA_VERSION
+        ));
+    }
+    validate_id(&adapter.adapter_id, "adapter_id")?;
+    validate_non_empty(&adapter.purpose, "purpose")?;
+
+    validate_repo_relative_ref(
+        &adapter.identity_claim.agent_card_ref,
+        "identity_claim.agent_card_ref",
+    )?;
+    validate_id(
+        &adapter.identity_claim.agent_id_claim,
+        "identity_claim.agent_id_claim",
+    )?;
+    validate_non_empty(
+        &adapter.identity_claim.display_name_claim,
+        "identity_claim.display_name_claim",
+    )?;
+    if adapter.identity_claim.advertised_capabilities.is_empty() {
+        return Err(anyhow!(
+            "identity_claim.advertised_capabilities must not be empty"
+        ));
+    }
+    let mut advertised = BTreeSet::new();
+    for capability in &adapter.identity_claim.advertised_capabilities {
+        validate_id(capability, "identity_claim.advertised_capabilities[]")?;
+        if !advertised.insert(capability.clone()) {
+            return Err(anyhow!(
+                "identity_claim.advertised_capabilities[] must not contain duplicates"
+            ));
+        }
+    }
+
+    if adapter.capability_mappings.is_empty() {
+        return Err(anyhow!("capability_mappings must not be empty"));
+    }
+    let mut mapped_claims = BTreeSet::new();
+    for mapping in &adapter.capability_mappings {
+        validate_id(
+            &mapping.external_capability_claim,
+            "capability_mappings[].external_capability_claim",
+        )?;
+        if !advertised.contains(&mapping.external_capability_claim) {
+            return Err(anyhow!(
+                "capability_mappings[].external_capability_claim must be advertised in the Agent Card"
+            ));
+        }
+        if !mapped_claims.insert(mapping.external_capability_claim.clone()) {
+            return Err(anyhow!(
+                "capability_mappings[] must not map the same external capability twice"
+            ));
+        }
+        validate_id(&mapping.adl_capability, "capability_mappings[].adl_capability")?;
+        validate_repo_relative_ref(
+            &mapping.policy_basis_ref,
+            "capability_mappings[].policy_basis_ref",
+        )?;
+        if !mapping.invocation_required || !mapping.direct_execution_forbidden {
+            return Err(anyhow!(
+                "A2A capability mappings must route through agent.invoke and forbid direct execution"
+            ));
+        }
+    }
+
+    if adapter.trust_classification.basis_refs.is_empty() {
+        return Err(anyhow!(
+            "trust_classification.basis_refs must not be empty"
+        ));
+    }
+    for basis_ref in &adapter.trust_classification.basis_refs {
+        validate_repo_relative_ref(basis_ref, "trust_classification.basis_refs[]")?;
+    }
+    if adapter.trust_classification.execution_authority_granted {
+        return Err(anyhow!(
+            "trust_classification must not grant execution authority directly"
+        ));
+    }
+
+    if adapter.invoke_boundary.required_entrypoint != "agent.invoke" {
+        return Err(anyhow!(
+            "A2A invoke boundary must route through agent.invoke"
+        ));
+    }
+    if adapter.invoke_boundary.invocation_contract_schema_ref
+        != ACIP_INVOCATION_CONTRACT_SCHEMA_VERSION
+    {
+        return Err(anyhow!(
+            "A2A invoke boundary must bind to '{}'",
+            ACIP_INVOCATION_CONTRACT_SCHEMA_VERSION
+        ));
+    }
+    if adapter.invoke_boundary.trace_bundle_schema_ref != ACIP_TRACE_BUNDLE_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "A2A invoke boundary must bind to '{}'",
+            ACIP_TRACE_BUNDLE_SCHEMA_VERSION
+        ));
+    }
+    if !adapter.invoke_boundary.direct_execution_forbidden {
+        return Err(anyhow!(
+            "A2A invoke boundary must forbid direct execution"
+        ));
+    }
+
+    if !adapter.transport_boundary.local_scope_only {
+        return Err(anyhow!(
+            "A2A transport boundary must remain local-only in v0.91"
+        ));
+    }
+    if adapter.transport_boundary.external_transport_status
+        != AcipA2aTransportBoundaryStatusV1::DeferredUntilTlsEquivalent
+    {
+        return Err(anyhow!(
+            "A2A external transport must remain deferred until TLS-equivalent protection exists"
+        ));
+    }
+    if adapter.transport_boundary.refusal_mode != "refuse" {
+        return Err(anyhow!(
+            "A2A transport boundary refusal_mode must be 'refuse'"
+        ));
+    }
+
+    if adapter.trace_evidence_refs.is_empty() {
+        return Err(anyhow!("trace_evidence_refs must not be empty"));
+    }
+    for evidence_ref in &adapter.trace_evidence_refs {
+        validate_repo_relative_ref(evidence_ref, "trace_evidence_refs[]")?;
+    }
+
+    if adapter.non_claims.is_empty() {
+        return Err(anyhow!("non_claims must not be empty"));
+    }
+    Ok(())
+}
+
+pub fn validate_acip_a2a_fixture_set_v1(fixtures: &AcipA2aFixtureSetV1) -> Result<()> {
+    if fixtures.schema_version != ACIP_A2A_FIXTURE_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "ACIP A2A fixture set requires schema_version '{}'",
+            ACIP_A2A_FIXTURE_SCHEMA_VERSION
+        ));
+    }
+    if fixtures.valid_adapters.is_empty() {
+        return Err(anyhow!("ACIP A2A fixture set requires valid_adapters"));
+    }
+    if fixtures.negative_cases.is_empty() {
+        return Err(anyhow!("ACIP A2A fixture set requires negative_cases"));
+    }
+
+    let mut trust_classes = BTreeSet::new();
+    for adapter in &fixtures.valid_adapters {
+        validate_acip_a2a_adapter_boundary_v1(adapter)?;
+        trust_classes.insert(adapter.trust_classification.classification.clone());
+    }
+    for required in [
+        AcipA2aTrustClassV1::Naked,
+        AcipA2aTrustClassV1::Guest,
+        AcipA2aTrustClassV1::Citizen,
+    ] {
+        if !trust_classes.contains(&required) {
+            return Err(anyhow!(
+                "ACIP A2A fixture set must cover trust class '{:?}'",
+                required
+            ));
+        }
+    }
+
+    for case in &fixtures.negative_cases {
+        validate_negative_case_name(&case.name, "negative_cases[].name")?;
+        validate_non_empty(
+            &case.expected_error_substring,
+            "negative_cases[].expected_error_substring",
+        )?;
+        validate_negative_result(
+            validate_acip_a2a_adapter_boundary_v1_value(&case.value),
+            &case.expected_error_substring,
+        )?;
+    }
+    Ok(())
+}
+
+pub fn acip_a2a_fixture_set_v1() -> AcipA2aFixtureSetV1 {
+    let feature_doc_ref = "docs/milestones/v0.91/features/A2A_EXTERNAL_AGENT_ADAPTER.md";
+    let trace_ref = "runtime/comms/trace/a2a-local-boundary-trace.json";
+    let agent_card_ref = "runtime/comms/a2a/agent-card-alpha.json";
+
+    let mk_adapter = |adapter_id: &str,
+                      trust: AcipA2aTrustClassV1,
+                      capability: &str,
+                      adl_capability: &str,
+                      basis_ref: &str| AcipA2aAdapterBoundaryV1 {
+        schema_version: ACIP_A2A_ADAPTER_SCHEMA_VERSION.to_string(),
+        adapter_id: adapter_id.to_string(),
+        purpose: "Governed A2A adapter boundary over local ACIP substrate.".to_string(),
+        identity_claim: AcipA2aAgentCardClaimV1 {
+            agent_card_ref: agent_card_ref.to_string(),
+            agent_id_claim: format!("{adapter_id}_agent"),
+            display_name_claim: format!("{adapter_id} Agent"),
+            advertised_capabilities: vec![
+                capability.to_string(),
+                "share_trace_summary".to_string(),
+            ],
+        },
+        capability_mappings: vec![AcipA2aCapabilityMappingV1 {
+            external_capability_claim: capability.to_string(),
+            adl_capability: adl_capability.to_string(),
+            policy_basis_ref: feature_doc_ref.to_string(),
+            invocation_required: true,
+            direct_execution_forbidden: true,
+        }],
+        trust_classification: AcipA2aTrustClassificationV1 {
+            classification: trust,
+            basis_refs: vec![basis_ref.to_string()],
+            execution_authority_granted: false,
+        },
+        invoke_boundary: AcipA2aInvokeBoundaryV1 {
+            required_entrypoint: "agent.invoke".to_string(),
+            invocation_contract_schema_ref: ACIP_INVOCATION_CONTRACT_SCHEMA_VERSION.to_string(),
+            trace_bundle_schema_ref: ACIP_TRACE_BUNDLE_SCHEMA_VERSION.to_string(),
+            direct_execution_forbidden: true,
+        },
+        transport_boundary: AcipA2aTransportBoundaryV1 {
+            local_scope_only: true,
+            external_transport_status:
+                AcipA2aTransportBoundaryStatusV1::DeferredUntilTlsEquivalent,
+            required_security_posture: AcipA2aSecurityPostureV1::TlsOrMutualTlsEquivalent,
+            refusal_mode: "refuse".to_string(),
+        },
+        trace_evidence_refs: vec![trace_ref.to_string()],
+        non_claims: vec![
+            "No direct execution authority is granted from Agent Card claims.".to_string(),
+            "External transport remains deferred in v0.91.".to_string(),
+        ],
+    };
+
+    let naked = mk_adapter(
+        "a2a_naked_boundary",
+        AcipA2aTrustClassV1::Naked,
+        "request_consultation",
+        "consult",
+        "runtime/comms/a2a/trust/naked.json",
+    );
+    let guest = mk_adapter(
+        "a2a_guest_boundary",
+        AcipA2aTrustClassV1::Guest,
+        "review_source_tree",
+        "review",
+        "runtime/comms/a2a/trust/guest.json",
+    );
+    let citizen = mk_adapter(
+        "a2a_citizen_boundary",
+        AcipA2aTrustClassV1::Citizen,
+        "submit_patch_proposal",
+        "delegate",
+        "runtime/comms/a2a/trust/citizen.json",
+    );
+
+    AcipA2aFixtureSetV1 {
+        schema_version: ACIP_A2A_FIXTURE_SCHEMA_VERSION.to_string(),
+        valid_adapters: vec![naked, guest, citizen],
+        negative_cases: vec![
+            AcipA2aNegativeCaseV1 {
+                name: "parallel_authority_model".to_string(),
+                expected_error_substring:
+                    "trust_classification must not grant execution authority directly"
+                        .to_string(),
+                value: json!({
+                    "schema_version": ACIP_A2A_ADAPTER_SCHEMA_VERSION,
+                    "adapter_id": "a2a_parallel_authority",
+                    "purpose": "bad",
+                    "identity_claim": {
+                        "agent_card_ref": agent_card_ref,
+                        "agent_id_claim": "parallel_agent",
+                        "display_name_claim": "Parallel Agent",
+                        "advertised_capabilities": ["request_consultation"]
+                    },
+                    "capability_mappings": [{
+                        "external_capability_claim": "request_consultation",
+                        "adl_capability": "consult",
+                        "policy_basis_ref": feature_doc_ref,
+                        "invocation_required": true,
+                        "direct_execution_forbidden": true
+                    }],
+                    "trust_classification": {
+                        "classification": "guest",
+                        "basis_refs": ["runtime/comms/a2a/trust/guest.json"],
+                        "execution_authority_granted": true
+                    },
+                    "invoke_boundary": {
+                        "required_entrypoint": "agent.invoke",
+                        "invocation_contract_schema_ref": ACIP_INVOCATION_CONTRACT_SCHEMA_VERSION,
+                        "trace_bundle_schema_ref": ACIP_TRACE_BUNDLE_SCHEMA_VERSION,
+                        "direct_execution_forbidden": true
+                    },
+                    "transport_boundary": {
+                        "local_scope_only": true,
+                        "external_transport_status": "deferred_until_tls_equivalent",
+                        "required_security_posture": "tls_or_mutual_tls_equivalent",
+                        "refusal_mode": "refuse"
+                    },
+                    "trace_evidence_refs": [trace_ref],
+                    "non_claims": ["External transport remains deferred in v0.91."]
+                }),
+            },
+            AcipA2aNegativeCaseV1 {
+                name: "direct_execution_grant".to_string(),
+                expected_error_substring:
+                    "A2A capability mappings must route through agent.invoke and forbid direct execution"
+                        .to_string(),
+                value: json!({
+                    "schema_version": ACIP_A2A_ADAPTER_SCHEMA_VERSION,
+                    "adapter_id": "a2a_direct_exec",
+                    "purpose": "bad",
+                    "identity_claim": {
+                        "agent_card_ref": agent_card_ref,
+                        "agent_id_claim": "direct_exec_agent",
+                        "display_name_claim": "Direct Exec Agent",
+                        "advertised_capabilities": ["submit_patch_proposal"]
+                    },
+                    "capability_mappings": [{
+                        "external_capability_claim": "submit_patch_proposal",
+                        "adl_capability": "delegate",
+                        "policy_basis_ref": feature_doc_ref,
+                        "invocation_required": false,
+                        "direct_execution_forbidden": false
+                    }],
+                    "trust_classification": {
+                        "classification": "citizen",
+                        "basis_refs": ["runtime/comms/a2a/trust/citizen.json"],
+                        "execution_authority_granted": false
+                    },
+                    "invoke_boundary": {
+                        "required_entrypoint": "agent.invoke",
+                        "invocation_contract_schema_ref": ACIP_INVOCATION_CONTRACT_SCHEMA_VERSION,
+                        "trace_bundle_schema_ref": ACIP_TRACE_BUNDLE_SCHEMA_VERSION,
+                        "direct_execution_forbidden": true
+                    },
+                    "transport_boundary": {
+                        "local_scope_only": true,
+                        "external_transport_status": "deferred_until_tls_equivalent",
+                        "required_security_posture": "tls_or_mutual_tls_equivalent",
+                        "refusal_mode": "refuse"
+                    },
+                    "trace_evidence_refs": [trace_ref],
+                    "non_claims": ["No direct execution authority is granted from Agent Card claims."]
+                }),
+            },
+            AcipA2aNegativeCaseV1 {
+                name: "missing_agent_invoke_boundary".to_string(),
+                expected_error_substring:
+                    "A2A invoke boundary must route through agent.invoke".to_string(),
+                value: json!({
+                    "schema_version": ACIP_A2A_ADAPTER_SCHEMA_VERSION,
+                    "adapter_id": "a2a_missing_invoke",
+                    "purpose": "bad",
+                    "identity_claim": {
+                        "agent_card_ref": agent_card_ref,
+                        "agent_id_claim": "missing_invoke_agent",
+                        "display_name_claim": "Missing Invoke Agent",
+                        "advertised_capabilities": ["review_source_tree"]
+                    },
+                    "capability_mappings": [{
+                        "external_capability_claim": "review_source_tree",
+                        "adl_capability": "review",
+                        "policy_basis_ref": feature_doc_ref,
+                        "invocation_required": true,
+                        "direct_execution_forbidden": true
+                    }],
+                    "trust_classification": {
+                        "classification": "guest",
+                        "basis_refs": ["runtime/comms/a2a/trust/guest.json"],
+                        "execution_authority_granted": false
+                    },
+                    "invoke_boundary": {
+                        "required_entrypoint": "external.execute",
+                        "invocation_contract_schema_ref": ACIP_INVOCATION_CONTRACT_SCHEMA_VERSION,
+                        "trace_bundle_schema_ref": ACIP_TRACE_BUNDLE_SCHEMA_VERSION,
+                        "direct_execution_forbidden": true
+                    },
+                    "transport_boundary": {
+                        "local_scope_only": true,
+                        "external_transport_status": "deferred_until_tls_equivalent",
+                        "required_security_posture": "tls_or_mutual_tls_equivalent",
+                        "refusal_mode": "refuse"
+                    },
+                    "trace_evidence_refs": [trace_ref],
+                    "non_claims": ["External transport remains deferred in v0.91."]
+                }),
+            },
+            AcipA2aNegativeCaseV1 {
+                name: "external_transport_without_local_gate".to_string(),
+                expected_error_substring:
+                    "A2A transport boundary must remain local-only in v0.91".to_string(),
+                value: json!({
+                    "schema_version": ACIP_A2A_ADAPTER_SCHEMA_VERSION,
+                    "adapter_id": "a2a_external_transport",
+                    "purpose": "bad",
+                    "identity_claim": {
+                        "agent_card_ref": agent_card_ref,
+                        "agent_id_claim": "external_transport_agent",
+                        "display_name_claim": "External Transport Agent",
+                        "advertised_capabilities": ["request_consultation"]
+                    },
+                    "capability_mappings": [{
+                        "external_capability_claim": "request_consultation",
+                        "adl_capability": "consult",
+                        "policy_basis_ref": feature_doc_ref,
+                        "invocation_required": true,
+                        "direct_execution_forbidden": true
+                    }],
+                    "trust_classification": {
+                        "classification": "naked",
+                        "basis_refs": ["runtime/comms/a2a/trust/naked.json"],
+                        "execution_authority_granted": false
+                    },
+                    "invoke_boundary": {
+                        "required_entrypoint": "agent.invoke",
+                        "invocation_contract_schema_ref": ACIP_INVOCATION_CONTRACT_SCHEMA_VERSION,
+                        "trace_bundle_schema_ref": ACIP_TRACE_BUNDLE_SCHEMA_VERSION,
+                        "direct_execution_forbidden": true
+                    },
+                    "transport_boundary": {
+                        "local_scope_only": false,
+                        "external_transport_status": "deferred_until_tls_equivalent",
+                        "required_security_posture": "tls_equivalent",
+                        "refusal_mode": "refuse"
+                    },
+                    "trace_evidence_refs": [trace_ref],
+                    "non_claims": ["No direct execution authority is granted from Agent Card claims."]
+                }),
+            },
+        ],
+    }
+}

--- a/adl/src/agent_comms/tests.inc
+++ b/adl/src/agent_comms/tests.inc
@@ -242,6 +242,67 @@
     }
 
     #[test]
+    fn acip_a2a_adapter_schemas_and_fixtures_are_available() {
+        let adapter_schema = acip_a2a_adapter_boundary_v1_schema_json().expect("adapter schema");
+        let fixture_schema = acip_a2a_fixture_set_v1_schema_json().expect("fixture schema");
+        assert!(adapter_schema.contains("\"trust_classification\""));
+        assert!(adapter_schema.contains("\"required_entrypoint\""));
+        assert!(fixture_schema.contains("\"valid_adapters\""));
+        assert!(fixture_schema.contains("\"negative_cases\""));
+
+        let fixtures = acip_a2a_fixture_set_v1();
+        validate_acip_a2a_fixture_set_v1(&fixtures).expect("A2A fixtures should validate");
+        assert_eq!(fixtures.valid_adapters.len(), 3);
+        assert_eq!(fixtures.negative_cases.len(), 4);
+    }
+
+    #[test]
+    fn acip_a2a_adapter_requires_all_trust_classifications() {
+        let mut fixtures = acip_a2a_fixture_set_v1();
+        fixtures
+            .valid_adapters
+            .retain(|adapter| adapter.trust_classification.classification != AcipA2aTrustClassV1::Citizen);
+        let error = validate_acip_a2a_fixture_set_v1(&fixtures)
+            .expect_err("missing trust classification coverage should fail");
+        assert!(error
+            .to_string()
+            .contains("ACIP A2A fixture set must cover trust class"));
+    }
+
+    #[test]
+    fn acip_a2a_adapter_rejects_parallel_authority_and_direct_execution() {
+        let fixtures = acip_a2a_fixture_set_v1();
+        for case_name in ["parallel_authority_model", "direct_execution_grant"] {
+            let case = fixtures
+                .negative_cases
+                .iter()
+                .find(|case| case.name == case_name)
+                .expect("negative case");
+            let error = validate_acip_a2a_adapter_boundary_v1_value(&case.value)
+                .expect_err("negative case should fail");
+            assert!(error.to_string().contains(&case.expected_error_substring));
+        }
+    }
+
+    #[test]
+    fn acip_a2a_adapter_rejects_missing_agent_invoke_and_external_transport() {
+        let fixtures = acip_a2a_fixture_set_v1();
+        for case_name in [
+            "missing_agent_invoke_boundary",
+            "external_transport_without_local_gate",
+        ] {
+            let case = fixtures
+                .negative_cases
+                .iter()
+                .find(|case| case.name == case_name)
+                .expect("negative case");
+            let error = validate_acip_a2a_adapter_boundary_v1_value(&case.value)
+                .expect_err("negative case should fail");
+            assert!(error.to_string().contains(&case.expected_error_substring));
+        }
+    }
+
+    #[test]
     fn acip_review_specialization_schemas_and_fixtures_are_available() {
         let contract_schema = acip_review_invocation_v1_schema_json().expect("review schema");
         let outcome_schema = acip_review_outcome_v1_schema_json().expect("outcome schema");

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -24,6 +24,17 @@ def step_run(name: str) -> str:
         raise SystemExit(f"missing workflow step: {name}")
     return match.group(1).strip()
 
+def step_block(name: str) -> str:
+    pattern = re.compile(
+        rf"^\s*-\s+name:\s+{re.escape(name)}\s*$"
+        rf"((?:\n^\s+.*$)*?)(?=\n^\s*-\s+name:|\Z)",
+        re.MULTILINE,
+    )
+    match = pattern.search(workflow)
+    if not match:
+        raise SystemExit(f"missing workflow step block: {name}")
+    return match.group(1)
+
 def step_if(name: str) -> str:
     pattern = re.compile(
         rf"^\s*-\s+name:\s+{re.escape(name)}\s*$"
@@ -89,21 +100,24 @@ if not runner_test.exists():
         "authoritative coverage runner contract test must exist"
     )
 
-if 'cargo llvm-cov report --json --summary-only --output-path coverage-summary.json' not in workflow:
+fast_summary_step = step_block("PR fast coverage summary (json)")
+if 'cargo llvm-cov report --json --summary-only --output-path coverage-summary.json' not in fast_summary_step:
     raise SystemExit(
-        "PR fast coverage summary must emit coverage-summary.json at the workflow root; "
+        "PR fast coverage summary must emit coverage-summary.json inside the adl working directory; "
         "workflow is missing that output path"
     )
 
-if '--summary adl/coverage-summary.json \\' not in workflow:
+authoritative_gate_step = step_block("Coverage-impact changed-source gate")
+if '--summary adl/coverage-summary.json \\' not in authoritative_gate_step:
     raise SystemExit(
         "authoritative changed-source coverage gate must read adl/coverage-summary.json from the runner output; "
         "workflow is missing that summary reference"
     )
 
-if '--summary coverage-summary.json \\' not in workflow:
+pr_preflight_step = step_block("PR coverage-impact preflight")
+if '--summary adl/coverage-summary.json \\' not in pr_preflight_step:
     raise SystemExit(
-        "PR coverage-impact preflight must read the root coverage-summary.json emitted by the fast lane; "
+        "PR coverage-impact preflight must read adl/coverage-summary.json emitted by the fast lane working directory; "
         "workflow is missing that summary reference"
     )
 

--- a/docs/milestones/v0.91/features/A2A_EXTERNAL_AGENT_ADAPTER.md
+++ b/docs/milestones/v0.91/features/A2A_EXTERNAL_AGENT_ADAPTER.md
@@ -50,6 +50,19 @@ The first tracked v0.91 planning boundary should establish:
 - mandatory `agent.invoke(...)` boundary rules
 - trace, refusal, and failure-taxonomy expectations
 
+The tracked v0.91 runtime slice for this boundary is intentionally narrow and
+review-facing:
+
+- `acip.a2a.adapter.v1` adapter-boundary contract
+- `acip.a2a.fixture.v1` fixture set covering `Naked`, `Guest`, and `Citizen`
+  trust classes
+- fail-closed negative fixtures for direct-execution grants, parallel authority,
+  missing `agent.invoke(...)` routing, and non-local transport posture
+
+This is still not a live external transport adapter. It is the governed
+boundary record that proves A2A consumes ADL invocation, trace, and authority
+surfaces instead of inventing a second execution model.
+
 ## v0.91.1 Scope
 
 The first implementation/hardening follow-on should land in `v0.91.1`:


### PR DESCRIPTION
Closes #2750

## Summary
Landed a bounded WP-16 A2A adapter boundary contract on top of the existing ACIP substrate, with validator-backed fixtures proving Agent Cards remain claims, `agent.invoke` is mandatory, trust classification does not grant direct authority, and external transport stays deferred/fail-closed in v0.91.

## Artifacts
- Runtime contract additions in `adl/src/agent_comms.rs`, `adl/src/agent_comms/a2a.inc`, and `adl/src/agent_comms/tests.inc`
- Feature-doc update in `docs/milestones/v0.91/features/A2A_EXTERNAL_AGENT_ADAPTER.md`
- Bound worktree planning/review surfaces:
  - `.adl/v0.91/tasks/issue-2750__v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary/spp.md`
  - `.adl/v0.91/tasks/issue-2750__v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary/srp.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml acip_a2a -- --nocapture`
    Verified the new A2A adapter schema, fixture set, trust-class coverage, and fail-closed negative cases.
  - `cargo test --manifest-path adl/Cargo.toml agent_comms -- --nocapture`
    Verified the broader ACIP substrate still passes its existing transport, invocation, review, coding, trace, and proof-demo coverage alongside the new A2A surface.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the WP-16 runtime slice remains lint-clean across the crate targets.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --phase run --input .adl/v0.91/tasks/issue-2750__v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary/spp.md`
    Verified the bound worktree SPP artifact generated by `pr run` is structurally valid.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase run --input .adl/v0.91/tasks/issue-2750__v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary/srp.md`
    Verified the bound worktree SRP artifact generated by `pr run` is structurally valid.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91/tasks/issue-2750__v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary/sor.md`
    Verified the issue-local SOR remains structurally valid while still in pre-publication worktree state.
  - `git diff --check`
    Verified the tracked delta contains no whitespace or patch-shape errors.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91/tasks/issue-2750__v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary/sip.md
- Output card: .adl/v0.91/tasks/issue-2750__v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary/sor.md
- Idempotency-Key: v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary-adl-v0-91-tasks-issue-2750-v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary-sip-md-adl-v0-91-tasks-issue-2750-v0-91-wp-16-runtime-secure-agent-comms-substrate-and-a2a-boundary-sor-md