### PR TITLE
[v0.91][tools] Make pr run always materialize task bundles in the bound worktree

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -17,9 +17,9 @@ use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
     ensure_source_issue_prompt, ensure_symlink, ensure_task_bundle_stp,
     ensure_worktree_task_bundle_materialized, field_line_value,
-    mirror_docs_templates_into_worktree, path_relative_to_repo, sync_root_task_bundle_into_worktree,
-    validate_bootstrap_stp, validate_initialized_cards, validate_issue_body_for_create,
-    validate_ready_cards, write_source_issue_prompt,
+    mirror_docs_templates_into_worktree, path_relative_to_repo,
+    sync_root_task_bundle_into_worktree, validate_bootstrap_stp, validate_initialized_cards,
+    validate_issue_body_for_create, validate_ready_cards, write_source_issue_prompt,
 };
 #[cfg(test)]
 use super::pr_cmd_prompt::load_issue_prompt;

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -15,10 +15,11 @@ use super::pr_cmd_args::{
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
-    ensure_source_issue_prompt, ensure_symlink, ensure_task_bundle_stp, field_line_value,
-    mirror_docs_templates_into_worktree, path_relative_to_repo, validate_bootstrap_stp,
-    validate_initialized_cards, validate_issue_body_for_create, validate_ready_cards,
-    write_source_issue_prompt,
+    ensure_source_issue_prompt, ensure_symlink, ensure_task_bundle_stp,
+    ensure_worktree_task_bundle_materialized, field_line_value,
+    mirror_docs_templates_into_worktree, path_relative_to_repo, sync_root_task_bundle_into_worktree,
+    validate_bootstrap_stp, validate_initialized_cards, validate_issue_body_for_create,
+    validate_ready_cards, write_source_issue_prompt,
 };
 #[cfg(test)]
 use super::pr_cmd_prompt::load_issue_prompt;
@@ -416,6 +417,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     validate_authored_prompt_surface("start", &worktree_stp, PromptSurfaceKind::Stp)?;
 
     let root_paths = ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &branch, &source_path)?;
+    sync_root_task_bundle_into_worktree(&repo_root, &worktree_path, &issue_ref)?;
     let worktree_paths = ensure_bootstrap_cards(
         &worktree_path,
         &issue_ref,
@@ -423,6 +425,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
         &branch,
         &worktree_source,
     )?;
+    ensure_worktree_task_bundle_materialized(&worktree_path, &issue_ref)?;
 
     println!("• Agent:");
     println!("  STP    {}", worktree_stp.display());

--- a/adl/src/cli/pr_cmd_cards.rs
+++ b/adl/src/cli/pr_cmd_cards.rs
@@ -75,6 +75,97 @@ pub(crate) fn ensure_local_issue_prompt_copy(
     Ok(local_source_path)
 }
 
+fn file_exists_nonempty(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.len() > 0)
+        .unwrap_or(false)
+}
+
+pub(crate) fn sync_root_task_bundle_into_worktree(
+    primary_checkout_root: &Path,
+    worktree_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    let worktree_bundle_dir = issue_ref.worktree_task_bundle_dir_path(worktree_root);
+    if let Some(parent) = worktree_bundle_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::create_dir_all(&worktree_bundle_dir)?;
+
+    let bundle_pairs = [
+        (
+            issue_ref.task_bundle_stp_path(primary_checkout_root),
+            issue_ref.worktree_task_bundle_stp_path(worktree_root),
+        ),
+        (
+            issue_ref.task_bundle_input_path(primary_checkout_root),
+            issue_ref.worktree_task_bundle_input_path(worktree_root),
+        ),
+        (
+            issue_ref.task_bundle_output_path(primary_checkout_root),
+            issue_ref.worktree_task_bundle_output_path(worktree_root),
+        ),
+        (
+            issue_ref.task_bundle_plan_path(primary_checkout_root),
+            issue_ref.worktree_task_bundle_plan_path(worktree_root),
+        ),
+        (
+            issue_ref.task_bundle_review_policy_path(primary_checkout_root),
+            issue_ref.worktree_task_bundle_review_policy_path(worktree_root),
+        ),
+    ];
+
+    for (root_path, worktree_path) in bundle_pairs {
+        if file_exists_nonempty(&worktree_path) {
+            continue;
+        }
+        if !file_exists_nonempty(&root_path) {
+            bail!(
+                "start: cannot materialize missing worktree bundle file '{}' because the canonical root file '{}' is absent",
+                worktree_path.display(),
+                root_path.display()
+            );
+        }
+        if let Some(parent) = worktree_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&root_path, &worktree_path).with_context(|| {
+            format!(
+                "start: failed to sync canonical bundle file '{}' into worktree path '{}'",
+                root_path.display(),
+                worktree_path.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn ensure_worktree_task_bundle_materialized(
+    worktree_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    let expected = [
+        issue_ref.worktree_task_bundle_stp_path(worktree_root),
+        issue_ref.worktree_task_bundle_input_path(worktree_root),
+        issue_ref.worktree_task_bundle_output_path(worktree_root),
+        issue_ref.worktree_task_bundle_plan_path(worktree_root),
+        issue_ref.worktree_task_bundle_review_policy_path(worktree_root),
+    ];
+    let missing: Vec<String> = expected
+        .iter()
+        .filter(|path| !file_exists_nonempty(path))
+        .map(|path| path.display().to_string())
+        .collect();
+    if !missing.is_empty() {
+        bail!(
+            "start: bound worktree is missing canonical task-bundle surfaces after materialization; refusing partial execution surface:\n{}",
+            missing.join("\n")
+        );
+    }
+    Ok(())
+}
+
 pub(crate) fn mirror_docs_templates_into_worktree(
     repo_root: &Path,
     worktree_root: &Path,

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -260,6 +260,126 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
 }
 
 #[test]
+fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-repair-worktree-bundle");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "repair worktree bundle test\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1153, "v0.86", "repair-worktree-bundle").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Repair worktree bundle");
+    let branch = "codex/1153-repair-worktree-bundle";
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            path_str(&worktree).expect("wt path"),
+            "origin/main",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git worktree add")
+        .success());
+    assert!(!issue_ref.worktree_task_bundle_dir_path(&worktree).exists());
+
+    real_pr(&[
+        "start".to_string(),
+        "1153".to_string(),
+        "--slug".to_string(),
+        "repair-worktree-bundle".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Repair worktree bundle".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr start");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    assert!(issue_ref.worktree_task_bundle_stp_path(&worktree).is_file());
+    assert!(issue_ref.worktree_task_bundle_input_path(&worktree).is_file());
+    assert!(issue_ref.worktree_task_bundle_output_path(&worktree).is_file());
+    assert!(issue_ref.worktree_task_bundle_plan_path(&worktree).is_file());
+    assert!(issue_ref
+        .worktree_task_bundle_review_policy_path(&worktree)
+        .is_file());
+}
+
+#[test]
 fn real_pr_start_rewrites_unbound_root_input_card_branch() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-rewrites-unbound");

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -371,9 +371,15 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
     env::set_current_dir(prev_dir).expect("restore cwd");
 
     assert!(issue_ref.worktree_task_bundle_stp_path(&worktree).is_file());
-    assert!(issue_ref.worktree_task_bundle_input_path(&worktree).is_file());
-    assert!(issue_ref.worktree_task_bundle_output_path(&worktree).is_file());
-    assert!(issue_ref.worktree_task_bundle_plan_path(&worktree).is_file());
+    assert!(issue_ref
+        .worktree_task_bundle_input_path(&worktree)
+        .is_file());
+    assert!(issue_ref
+        .worktree_task_bundle_output_path(&worktree)
+        .is_file());
+    assert!(issue_ref
+        .worktree_task_bundle_plan_path(&worktree)
+        .is_file());
     assert!(issue_ref
         .worktree_task_bundle_review_policy_path(&worktree)
         .is_file());

--- a/adl/src/control_plane.rs
+++ b/adl/src/control_plane.rs
@@ -146,6 +146,31 @@ impl IssueRef {
             .join("tasks")
             .join(self.task_bundle_dir_name())
     }
+
+    pub fn worktree_task_bundle_stp_path(&self, worktree_root: &Path) -> PathBuf {
+        self.worktree_task_bundle_dir_path(worktree_root)
+            .join("stp.md")
+    }
+
+    pub fn worktree_task_bundle_input_path(&self, worktree_root: &Path) -> PathBuf {
+        self.worktree_task_bundle_dir_path(worktree_root)
+            .join("sip.md")
+    }
+
+    pub fn worktree_task_bundle_output_path(&self, worktree_root: &Path) -> PathBuf {
+        self.worktree_task_bundle_dir_path(worktree_root)
+            .join("sor.md")
+    }
+
+    pub fn worktree_task_bundle_plan_path(&self, worktree_root: &Path) -> PathBuf {
+        self.worktree_task_bundle_dir_path(worktree_root)
+            .join("spp.md")
+    }
+
+    pub fn worktree_task_bundle_review_policy_path(&self, worktree_root: &Path) -> PathBuf {
+        self.worktree_task_bundle_dir_path(worktree_root)
+            .join("srp.md")
+    }
 }
 
 /// Normalize a human-facing slug into a workflow-safe path segment.

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -158,7 +158,17 @@ changed_line_delta_for_path() {
 
 candidate_filter_for_path() {
   local path="$1"
-  basename "$path" .rs
+  case "$path" in
+    adl/src/cli/pr_cmd*|adl/src/cli/tests/pr_cmd*|adl/src/cli/pr_cmd/*|docs/default_workflow.md)
+      printf 'pr_cmd'
+      ;;
+    adl/src/cli/mod.rs|adl/src/cli/tests.rs)
+      printf 'cli'
+      ;;
+    *)
+      basename "$path" .rs
+      ;;
+  esac
 }
 
 file_is_structural_module_barrel() {

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -50,7 +50,7 @@ bash "$SCRIPT" --changed-files "$changed" --print-risk-filters >"$risk_filters"
 grep -Fx "new_large_surface" "$risk_filters" >/dev/null
 
 control_plane_changed="$TMP/control-plane-changed.txt"
-printf 'M\tadl/src/cli/pr_cmd_cards.rs\n' >"$control_plane_changed"
+printf 'A\tadl/src/cli/pr_cmd_cards.rs\n' >"$control_plane_changed"
 control_plane_filters="$TMP/control-plane-filters.txt"
 bash "$SCRIPT" --changed-files "$control_plane_changed" --print-risk-filters >"$control_plane_filters"
 grep -Fx "pr_cmd" "$control_plane_filters" >/dev/null

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -49,6 +49,12 @@ risk_filters="$TMP/risk-filters.txt"
 bash "$SCRIPT" --changed-files "$changed" --print-risk-filters >"$risk_filters"
 grep -Fx "new_large_surface" "$risk_filters" >/dev/null
 
+control_plane_changed="$TMP/control-plane-changed.txt"
+printf 'M\tadl/src/cli/pr_cmd_cards.rs\n' >"$control_plane_changed"
+control_plane_filters="$TMP/control-plane-filters.txt"
+bash "$SCRIPT" --changed-files "$control_plane_changed" --print-risk-filters >"$control_plane_filters"
+grep -Fx "pr_cmd" "$control_plane_filters" >/dev/null
+
 if bash "$SCRIPT" --changed-files "$changed" --require-summary-for-risk >/tmp/coverage-impact-missing.out 2>&1; then
   echo "expected risky changed source without summary to fail" >&2
   exit 1


### PR DESCRIPTION
Closes #2797

## Summary
- repair issue-mode worktree task-bundle materialization from canonical root bundle state
- fail loudly if the bound worktree still cannot produce a complete canonical local bundle
- add regression coverage for a pre-existing correct-branch worktree missing its local bundle

## Validation
- not run locally in this session
