### PR TITLE
[v0.91][WP-23][docs] Resolve WP-21 doc-truth findings

### DIFF
--- a/demos/v0.91/chatgpt_gemini_claude_review_panel_demo.md
+++ b/demos/v0.91/chatgpt_gemini_claude_review_panel_demo.md
@@ -44,6 +44,10 @@ bash adl/tools/demo_v091_chatgpt_gemini_claude_review_panel.sh
 
 ## Primary Proof Surfaces
 
+The paths below are operator-generated runtime outputs. They are written when
+the canonical command is executed and are not tracked artifacts in the primary
+checkout.
+
 - `artifacts/v091/chatgpt_gemini_claude_review_panel/transcript.md`
 - `artifacts/v091/chatgpt_gemini_claude_review_panel/panel_register.json`
 - `artifacts/v091/chatgpt_gemini_claude_review_panel/proof_note.md`

--- a/demos/v0.91/chatgpt_gemini_claude_triad_conversation_demo.md
+++ b/demos/v0.91/chatgpt_gemini_claude_triad_conversation_demo.md
@@ -42,6 +42,10 @@ bash adl/tools/demo_v091_chatgpt_gemini_claude_triad_conversation.sh
 
 ## Primary Proof Surfaces
 
+The paths below are operator-generated runtime outputs. They are written when
+the canonical command is executed and are not tracked artifacts in the primary
+checkout.
+
 - `artifacts/v091/chatgpt_gemini_claude_triad_conversation/transcript.md`
 - `artifacts/v091/chatgpt_gemini_claude_triad_conversation/proof_note.md`
 - `artifacts/v091/chatgpt_gemini_claude_triad_conversation/provider_invocations.json`

--- a/demos/v0.91/chatgpt_gemini_direct_conversation_demo.md
+++ b/demos/v0.91/chatgpt_gemini_direct_conversation_demo.md
@@ -2,14 +2,14 @@
 
 ## Summary
 
-This bounded `v0.91` demo runs a four-turn direct conversation workflow
+This bounded `v0.91` demo runs a preset-driven direct conversation workflow
 through the real ADL runtime using explicit `ChatGPT` and `Gemini` participant
 identities and live provider calls.
 
-The proof shape is intentionally narrow:
+The default shipped path is the `trust_possible` preset:
 
 - two named agents
-- four explicit sequential turns
+- six explicit sequential turns
 - one bounded stop rule
 - saved transcript, run summary, trace, and proof note
 
@@ -31,8 +31,9 @@ It does **not** claim:
 
 The runtime still uses a small local adapter boundary, but that adapter calls
 the real OpenAI and Gemini APIs with operator-managed credentials instead of a
-mock provider shim. The current default model choices are the top-tier text
-models for each family: `gpt-5.5` and `gemini-3.1-pro-preview`.
+mock provider shim. The current default model posture is quality-first:
+`gpt-5.5-pro` and `gemini-3.1-pro-preview`, with operator overrides available
+through environment variables.
 
 ## Canonical Command
 
@@ -41,6 +42,14 @@ From repository root:
 ```bash
 bash adl/tools/demo_v091_chatgpt_gemini_direct_conversation.sh
 ```
+
+The wrapper also supports bounded overrides such as:
+
+- `ADL_DEMO_PRESET`
+- `ADL_DEMO_QUESTION`
+- `ADL_DEMO_TURNS`
+- `ADL_LIVE_OPENAI_MODEL`
+- `ADL_LIVE_GEMINI_MODEL`
 
 ## What Runs
 
@@ -52,6 +61,10 @@ bash adl/tools/demo_v091_chatgpt_gemini_direct_conversation.sh
   - `adl/tools/demo_v091_chatgpt_gemini_direct_conversation.sh`
 
 ## Primary Proof Surfaces
+
+The paths below are operator-generated runtime outputs. They are written when
+the canonical command is executed and are not tracked artifacts in the primary
+checkout.
 
 - `artifacts/v091/chatgpt_gemini_direct_conversation/transcript.md`
 - `artifacts/v091/chatgpt_gemini_direct_conversation/proof_note.md`
@@ -70,7 +83,7 @@ bash adl/tools/demo_v091_chatgpt_gemini_direct_conversation.sh
 
 The demo is successful when:
 
-- the transcript contains four explicit turns
+- the transcript contains one explicit bounded turn sequence
 - `ChatGPT` and `Gemini` are explicit and distinguishable in every turn
 - the stop rule is explicit and visible in the proof surfaces
 - provider invocations show one live OpenAI lane and one live Gemini lane

--- a/demos/v0.91/chatgpt_gemini_task_handoff_demo.md
+++ b/demos/v0.91/chatgpt_gemini_task_handoff_demo.md
@@ -44,6 +44,10 @@ bash adl/tools/demo_v091_chatgpt_gemini_task_handoff.sh
 
 ## Primary Proof Surfaces
 
+The paths below are operator-generated runtime outputs. They are written when
+the canonical command is executed and are not tracked artifacts in the primary
+checkout.
+
 - `artifacts/v091/chatgpt_gemini_task_handoff/transcript.md`
 - `artifacts/v091/chatgpt_gemini_task_handoff/task_handoff_summary.json`
 - `artifacts/v091/chatgpt_gemini_task_handoff/proof_note.md`

--- a/docs/milestones/v0.91/DEMO_MATRIX_v0.91.md
+++ b/docs/milestones/v0.91/DEMO_MATRIX_v0.91.md
@@ -4,6 +4,11 @@
 
 Active proof matrix for the landed `v0.91` core feature set.
 
+For the multi-agent demo wave, reviewer-facing docs may cite runtime output
+paths under `artifacts/v091/...`. Those are operator-generated proof surfaces
+written by the canonical demo commands; they are not tracked artifacts in the
+primary checkout unless separately published.
+
 Rows `D1` through `D13` now point to concrete demo or proof homes from
 `WP-02` through `WP-17`. `D14` is the reviewer-facing coverage map added by
 `WP-18` so every tracked `v0.91` feature has one explicit proof route or

--- a/docs/milestones/v0.91/SPP_READINESS_v0.91.md
+++ b/docs/milestones/v0.91/SPP_READINESS_v0.91.md
@@ -8,8 +8,8 @@ packages before generating the rest of the milestone wave.
 
 The local SPP files remain workflow records under `.adl/` and are not published
 as tracked repository artifacts. This tracked record exists so reviewers can see
-what was tested, what was intentionally deferred, and what remains blocked on
-the planned SPP editor skill.
+what was tested, what was intentionally deferred, and what still remains beyond
+this first readiness slice.
 
 ## Scope
 
@@ -47,9 +47,13 @@ why the rest of the wave should not be mass-generated without an editor skill:
 
 ## Deferred Work
 
-The remaining v0.91 SPPs are intentionally deferred until the SPP editor skill
-exists. Follow-on issue #2766 should create a bounded editor skill that can
+The remaining v0.91 SPPs were intentionally deferred during this first
+readiness slice. That deferral is no longer blocked on a missing editor skill:
+issue `#2766` has landed the bounded `spp-editor` workflow surface that can
 normalize SPPs the same way STP, SIP, and SOR cards are edited today.
+
+What remains deferred is broader wave generation and stronger orchestration
+around reviewed planning state, not the existence of the editor itself.
 
 The editor skill should preserve:
 
@@ -59,6 +63,12 @@ The editor skill should preserve:
 - stop conditions and non-goals
 - review hooks
 - no implementation or branch-binding claims before execution
+
+Still-deferred follow-on workflow steps include:
+
+- wider v0.91 SPP generation beyond the first sample set
+- stronger plan-review orchestration
+- later workflow steps such as `pr-plan` and `pr-plan-review`
 
 ## Non-Claims
 


### PR DESCRIPTION
## Summary
- repair tracked demo-doc proof-reference truth for primary-checkout reviewers
- update the ChatGPT/Gemini direct-conversation doc to match landed six-turn preset-driven behavior
- update SPP readiness docs for post-#2766 reality

## Issue linkage
- Fixes #2813
- Fixes #2814
- Fixes #2815
- Closes #2757

## Validation
- no additional validation commands were run in this docs-only remediation pass
