### PR TITLE
[v0.91][tools] Add sprint-conductor skill for sequential sprint orchestration

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -57,6 +57,7 @@ The tracked skill set is:
 - `spp-editor`
 - `sip-editor`
 - `sor-editor`
+- `sprint-conductor`
 - `stp-editor`
 - `test-generator`
 - `use-case-writer`
@@ -84,6 +85,7 @@ The normal workflow is:
 `arxiv-paper-writer` is a bounded helper skill for turning one concrete scholarly source packet into a reviewer-friendly arXiv-style manuscript packet without submitting, publishing, or inventing citations.
 `diagram-author` is a bounded helper skill for turning one source packet, issue, code slice, or doc surface into a reviewable diagram-as-code packet with explicit backend selection, optional SVG/PNG rendering, and truth boundaries.
 `workflow-conductor` is an orchestration front door rather than a lifecycle phase.
+`sprint-conductor` is a slow-path sprint orchestrator that sequences issues through the existing lifecycle and editor skills, then finishes with sprint review and closeout.
 `issue-folding` is a bounded issue-disposition helper for classifying duplicate, superseded, absorbed, already-satisfied, obsolete, or still-actionable issues before closeout.
 `issue-splitter` is a bounded issue-scope helper for deciding whether one issue should stay intact, split now, defer splitting, or stop for operator review.
 `issue-watcher` is a bounded wait-window helper for watching one issue, PR, branch, or dependency gate and routing blockers without mutating state.
@@ -104,6 +106,8 @@ The four editor skills are helper skills:
 - `stp-editor` for bounded `stp.md` cleanup
 - `sip-editor` for truthful `sip.md` cleanup
 - `sor-editor` for truthful `sor.md` cleanup
+
+`sprint-conductor` is a bounded orchestration helper rather than an editor skill. It sequences one sprint issue across ordered child issues using the existing lifecycle/editor stack, then assembles sprint review and sprint closeout evidence.
 
 ## Where The Skills Live
 

--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -16,6 +16,10 @@ sprint:
   completed_issue_numbers:
     - <u32>
   blocked_issue_number: <u32 or null>
+  review_paths:
+    - /absolute/or/repo-relative/path
+  closeout_paths:
+    - /absolute/or/repo-relative/path
 policy:
   require_sequential_closeout: true
   require_existing_issue_skills: true

--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,28 @@
+# Sprint Conductor Skill Input Schema
+
+```yaml
+skill_input_schema: sprint_conductor.v1
+mode: run_sprint_slow_path | resume_sprint_slow_path | review_and_closeout_sprint
+repo_root: /absolute/path
+sprint:
+  issue_number: <u32>
+  ordered_issue_numbers:
+    - <u32>
+  goal: <string or null>
+  version: <string or null>
+  slug: <string or null>
+  stop_date: <YYYY-MM-DD or null>
+  current_issue_number: <u32 or null>
+  completed_issue_numbers:
+    - <u32>
+  blocked_issue_number: <u32 or null>
+policy:
+  require_sequential_closeout: true
+  require_existing_issue_skills: true
+  require_editor_skills: true
+  require_code_review: true
+  capture_coverage_at_closeout: true
+  capture_rust_tracker_at_closeout: true
+  stop_on_blocker: true
+resume_from_state_path: /absolute/or/repo-relative/path/to/sprint_state.md
+```

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: sprint-conductor
+description: Lightweight slow-path sprint orchestrator for ADL. Use when one sprint issue should drive an ordered list of child issues through the existing lifecycle and editor skills sequentially, with no parallel issue execution, robust sprint-end review, and truthful sprint closeout including coverage and Rust tracker metrics.
+---
+
+# Sprint Conductor
+
+This skill is a thin sprint-level orchestrator over the existing ADL operational
+skills.
+
+Its job is to:
+- intake one concrete sprint issue and one explicit ordered issue list
+- enforce the slow path: one issue at a time, fully closed out before the next
+  issue starts
+- route each issue through the existing lifecycle and editor skills rather than
+  reimplementing them
+- preserve resumable sprint state in one lightweight local artifact
+- assemble a robust sprint-end review with code-facing review expectations
+- record sprint-end closeout truth including coverage and Rust tracker numbers
+- stop immediately on blocker rather than wandering across adjacent issue work
+
+This skill must remain lightweight.
+
+It must not replace:
+- `workflow-conductor`
+- `pr-init`
+- `pr-ready`
+- `pr-run`
+- `pr-finish`
+- `pr-janitor`
+- `pr-closeout`
+- `stp-editor`
+- `sip-editor`
+- `sor-editor`
+- review specialist skills
+
+It is a sprint orchestrator, not a second execution engine.
+
+## Design Basis
+
+This skill should track the repository's canonical operational skill family and
+sprint/review/closeout surfaces.
+
+At the moment, the key repo references are:
+- `/Users/daniel/git/agent-design-language/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
+- `/Users/daniel/git/agent-design-language/docs/templates/SPRINT_TEMPLATE.md`
+- `/Users/daniel/git/agent-design-language/docs/templates/RELEASE_PLAN_TEMPLATE.md`
+- `/Users/daniel/git/agent-design-language/adl/tools/report_large_rust_modules.sh`
+- `/Users/daniel/git/agent-design-language/adl/README.md`
+
+Within this bundle, the operational details live in:
+- `references/conductor-playbook.md`
+- `references/output-contract.md`
+
+## Entry Conditions
+
+Use this skill when all of the following are true:
+- there is one concrete sprint-management issue
+- the sprint has an explicit ordered list of issue numbers
+- the operator wants slow-path sequential execution rather than manual
+  issue-by-issue orchestration
+- sprint-end review and closeout should be handled as part of the same bounded
+  sprint flow
+
+Do not use this skill for:
+- multi-sprint planning
+- parallel issue execution
+- replacing issue-level lifecycle skills
+- silently widening sprint scope
+- broad portfolio or roadmap management
+
+## Required Inputs
+
+At minimum, gather:
+- `repo_root`
+- `sprint.issue_number`
+- `sprint.ordered_issue_numbers`
+- `sprint.goal`
+- one explicit policy block
+
+Useful additional inputs:
+- `sprint.version`
+- `sprint.slug`
+- `sprint.stop_date`
+- `sprint.current_issue_number`
+- `sprint.completed_issue_numbers`
+- `sprint.blocked_issue_number`
+- `sprint.review_paths`
+- `sprint.closeout_paths`
+- `resume_from_state_path`
+
+If there is no concrete sprint issue or ordered issue list, stop and report
+`blocked`.
+
+## Quick Start
+
+1. Resolve the concrete sprint issue and ordered child issue list.
+2. Create or load the sprint-state artifact.
+3. Confirm the current issue is the earliest not-yet-closed issue in the list.
+4. Route that issue through `workflow-conductor`.
+5. Run only the selected downstream lifecycle or editor skill.
+6. Re-check issue truth until the issue is fully closed out.
+7. Only then advance to the next ordered issue.
+8. After the final issue closes, assemble sprint review evidence.
+9. Record sprint closeout metrics including coverage and Rust tracker counts.
+10. Stop with one bounded sprint review/closeout result.
+
+## Execution Model
+
+This skill enforces:
+- exactly one active child issue at a time
+- no issue `N+1` work before issue `N` is fully closed out
+- editor-skill routing when cards drift
+- immediate stop on blocker
+- no silent creation of extra sprint-management issues
+
+Preferred per-issue routing model:
+- bootstrap missing -> `pr-init`
+- card-local STP issue -> `stp-editor`
+- card-local SIP issue -> `sip-editor`
+- card-local SOR issue -> `sor-editor`
+- structurally ready but not bound -> `pr-ready`
+- ready for execution bind -> `pr-run`
+- execution complete, needs publication -> `pr-finish`
+- PR in flight with actual blockers -> `pr-janitor`
+- merged or intentionally closed -> `pr-closeout`
+
+## Sprint Review Requirement
+
+Sprint review must be robust and code-facing.
+
+Minimum sprint review flow:
+1. collect the closed issue list, PR list, validation notes, and changed tracked
+   surfaces
+2. build a bounded review packet
+3. run a code-level review over the actual implementation surfaces changed by the
+   sprint
+4. run a test-focused review over validation adequacy and gaps
+5. run a synthesis pass that separates findings, non-findings, unresolved
+   questions, and residual risk
+
+Recommended review-skill stack:
+- `repo-packet-builder`
+- `repo-review-code`
+- `repo-review-tests`
+- `repo-review-docs` when tracked docs changed materially
+- `repo-review-security` when trust boundaries or execution authority changed
+- `repo-review-synthesis`
+
+The sprint review must not claim that docs/cards alone are sufficient when the
+sprint changed implementation code.
+
+## Sprint Closeout Requirement
+
+Sprint closeout must record:
+- sprint issue identity
+- ordered issue list and completion status
+- blocked/deferred/carryover state if any
+- sprint review result
+- current code coverage snapshot
+- current Rust tracker counts
+- recommended next sprint or remediation action
+
+Preferred metrics capture surfaces:
+- coverage command:
+  - `cargo llvm-cov --workspace --all-features --summary-only`
+- Rust tracker report:
+  - `bash adl/tools/report_large_rust_modules.sh --format tsv`
+
+If those commands are not run, the closeout must say whether the numbers came
+from CI, an existing quality gate artifact, or are still missing.
+
+## Stop Boundary
+
+This skill must stop after:
+- sequential issue orchestration through the existing skill family
+- one bounded sprint review result
+- one bounded sprint closeout result
+- surfacing any blocker that prevents safe continuation
+
+It must not:
+- parallelize child issues silently
+- absorb the underlying issue lifecycle logic
+- skip issue closeout to save time
+- invent coverage or Rust tracker numbers
+- reopen completed child issues without explicit operator direction
+
+## Output
+
+Return a concise structured result including:
+- sprint issue
+- ordered issue list
+- completed issues
+- blocked/current issue state
+- review status and review artifact paths
+- coverage status
+- Rust tracker status
+- continuation or stop recommendation
+- sprint-state artifact path

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -36,6 +36,12 @@ It must not replace:
 
 It is a sprint orchestrator, not a second execution engine.
 
+Important execution-boundary rule:
+- the sprint conductor itself should not directly implement child issue code
+- it may orchestrate child issues that legitimately edit tracked implementation
+  files through `pr-run`, `pr-finish`, and the normal issue lifecycle in the
+  bound issue worktree
+
 ## Design Basis
 
 This skill should track the repository's canonical operational skill family and
@@ -124,6 +130,8 @@ Preferred per-issue routing model:
 - execution complete, needs publication -> `pr-finish`
 - PR in flight with actual blockers -> `pr-janitor`
 - merged or intentionally closed -> `pr-closeout`
+- healthy PR open and awaiting human review or merge -> remain paused on the
+  current issue in a non-blocked waiting state
 
 ## Sprint Review Requirement
 
@@ -162,13 +170,24 @@ Sprint closeout must record:
 - recommended next sprint or remediation action
 
 Preferred metrics capture surfaces:
-- coverage command:
+- coverage command when the sprint surface warrants a fresh local snapshot:
   - `cargo llvm-cov --workspace --all-features --summary-only`
 - Rust tracker report:
   - `bash adl/tools/report_large_rust_modules.sh --format tsv`
 
-If those commands are not run, the closeout must say whether the numbers came
-from CI, an existing quality gate artifact, or are still missing.
+Coverage capture must be policy-driven rather than reflexive.
+
+Normal closeout sources include:
+- fresh local run when the sprint materially changed implementation surfaces and
+  the sprint policy requires it
+- CI evidence
+- an existing quality-gate or release-evidence artifact
+- `not_applicable` for docs-only, workflow-only, planning-only, or similarly
+  light sprint surfaces
+
+If local metrics commands are not run, the closeout must say whether the
+numbers came from CI, an existing quality gate artifact, or are not applicable
+for the sprint surface.
 
 ## Stop Boundary
 

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -1,0 +1,114 @@
+version: "0.1"
+kind: "adl-skill"
+id: "sprint-conductor"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "sprint_conductor.v1"
+    reference_doc: "../docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "sprint"
+      - "policy"
+    mode_enum:
+      - "run_sprint_slow_path"
+      - "resume_sprint_slow_path"
+      - "review_and_closeout_sprint"
+    policy_fields:
+      - "require_sequential_closeout"
+      - "require_existing_issue_skills"
+      - "require_editor_skills"
+      - "require_code_review"
+      - "capture_coverage_at_closeout"
+      - "capture_rust_tracker_at_closeout"
+      - "stop_on_blocker"
+    mode_requirements:
+      run_sprint_slow_path:
+        required_sprint_fields:
+          - "issue_number"
+          - "ordered_issue_numbers"
+          - "goal"
+      resume_sprint_slow_path:
+        required_sprint_fields:
+          - "issue_number"
+          - "ordered_issue_numbers"
+      review_and_closeout_sprint:
+        required_sprint_fields:
+          - "issue_number"
+          - "ordered_issue_numbers"
+  intent:
+    - "sprint_orchestration"
+    - "sequential_issue_execution"
+    - "review_and_closeout"
+  required_inputs:
+    - "repo_root"
+    - "sprint.issue_number"
+    - "sprint.ordered_issue_numbers"
+  optional_inputs:
+    - "sprint.goal"
+    - "sprint.version"
+    - "sprint.slug"
+    - "sprint.stop_date"
+    - "sprint.current_issue_number"
+    - "sprint.completed_issue_numbers"
+    - "sprint.blocked_issue_number"
+    - "resume_from_state_path"
+    - "sprint.review_paths"
+    - "sprint.closeout_paths"
+  stop_if_missing:
+    - "repo_root"
+    - "sprint.issue_number"
+    - "sprint.ordered_issue_numbers"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_sprint_conductor.v1_when_structured_input_is_used"
+    - "mode_must_match_supported_enum"
+    - "ordered_issue_numbers_must_be_nonempty_and_explicitly_ordered"
+    - "policy.require_sequential_closeout_must_be_true"
+    - "policy.require_existing_issue_skills_must_be_true"
+    - "policy.require_editor_skills_must_be_true"
+    - "policy.stop_on_blocker_must_be_true"
+execution:
+  mode: "orchestrate_existing_skills_sequentially"
+  allow_code_edits: false
+  allow_network: true
+  allow_subagents: false
+  workflow_role: "sprint_orchestrator"
+  preferred_commands:
+    - "workflow-conductor for issue routing"
+    - "pr-init/pr-ready/pr-run/pr-finish/pr-janitor/pr-closeout for child issue lifecycle"
+    - "repo-packet-builder and review specialist skills for sprint-end review"
+    - "cargo llvm-cov --workspace --all-features --summary-only"
+    - "bash adl/tools/report_large_rust_modules.sh --format tsv"
+  preferred_path: "sequential_child_issue_closeout_then_review_then_sprint_closeout"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**"
+    - "sprint review artifacts"
+    - "sprint closeout artifacts"
+  must_not_write:
+    - "tracked implementation source files directly"
+    - "unrelated issue bundles"
+  stop_on_partial_failure: true
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-sprint-conductor.md"
+  required_sections:
+    - "status"
+    - "sprint"
+    - "sequence"
+    - "current_state"
+    - "review"
+    - "closeout"
+    - "artifact"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -76,7 +76,7 @@ admission:
     - "policy.stop_on_blocker_must_be_true"
 execution:
   mode: "orchestrate_existing_skills_sequentially"
-  allow_code_edits: false
+  allow_code_edits: true
   allow_network: true
   allow_subagents: false
   workflow_role: "sprint_orchestrator"
@@ -94,7 +94,7 @@ boundaries:
     - "sprint review artifacts"
     - "sprint closeout artifacts"
   must_not_write:
-    - "tracked implementation source files directly"
+    - "tracked implementation source files directly outside the selected child issue lifecycle path"
     - "unrelated issue bundles"
   stop_on_partial_failure: true
 outputs:

--- a/adl/tools/skills/sprint-conductor/agents/openai.yaml
+++ b/adl/tools/skills/sprint-conductor/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Sprint Conductor
+short_description: Orchestrate one sprint issue through ordered child issues, review, and closeout
+default_prompt: Help me run this sprint sequentially through the existing ADL skills and finish with a robust sprint review and closeout.

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -1,0 +1,113 @@
+# Sprint Conductor Playbook
+
+## Purpose
+
+Run one sprint through the existing ADL issue workflow without replacing the
+issue-level skill family.
+
+This is the slow path.
+One issue at a time.
+No parallel child issue execution.
+
+## Inputs
+
+Required:
+- one sprint-management issue
+- ordered child issue list
+- sprint goal
+- explicit policy block
+
+Optional:
+- current issue
+- completed issues
+- blocked issue
+- prior sprint-state artifact
+
+## Core Loop
+
+1. Load or create sprint-state.
+2. Choose the earliest child issue in the ordered list that is not yet closed
+   out.
+3. Route that child issue through `workflow-conductor`.
+4. Run only the selected downstream lifecycle or editor skill.
+5. Re-check issue truth.
+6. If the issue is not fully closed out, repeat the routing loop for the same
+   issue.
+7. If the issue is fully closed out, mark it complete in sprint-state and move
+   to the next issue.
+8. If any blocker is encountered, stop and report the blocker in sprint-state.
+
+## Editor-Skill Rule
+
+If `workflow-conductor` selects:
+- `stp-editor`
+- `sip-editor`
+- `sor-editor`
+
+then the sprint conductor must run that editor skill first and must not try to
+work around malformed cards by hand.
+
+## Review Phase
+
+After the final child issue closes out:
+
+1. Build a bounded sprint review packet.
+2. Run a code-level review of the actual changed implementation surfaces.
+3. Run a test-focused review of validation adequacy and gaps.
+4. Run docs review if tracked docs changed materially.
+5. Run security review if trust boundaries or execution authority changed.
+6. Run synthesis and separate:
+   - confirmed findings
+   - non-findings
+   - unresolved questions
+   - residual risk
+
+Recommended review stack:
+- `repo-packet-builder`
+- `repo-review-code`
+- `repo-review-tests`
+- `repo-review-docs` when needed
+- `repo-review-security` when needed
+- `repo-review-synthesis`
+
+## Closeout Phase
+
+Record:
+- sprint issue
+- ordered issue list
+- completed issues
+- blocked/deferred/carryover state
+- sprint review result
+- coverage snapshot
+- Rust tracker counts
+- next action
+
+Preferred metrics sources:
+- coverage:
+  - `cargo llvm-cov --workspace --all-features --summary-only`
+- Rust tracker:
+  - `bash adl/tools/report_large_rust_modules.sh --format tsv`
+
+For the Rust tracker report, count the number of rows at each level:
+- `WATCH`
+- `REVIEW`
+- `RATIONALE`
+
+If metrics are taken from CI or an existing quality-gate artifact instead of a
+fresh local run, say so explicitly.
+
+## Stop Conditions
+
+Stop when:
+- all ordered child issues are fully closed out and the sprint review/closeout
+  artifacts are written
+- a child issue blocks and the operator must decide how to proceed
+- sprint scope changes materially and requires operator approval
+
+## Non-Goals
+
+Do not:
+- parallelize child issues
+- skip child issue closeout to save time
+- silently create additional sprint-management issues
+- widen the sprint because nearby work looks tempting

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -33,9 +33,12 @@ Optional:
 5. Re-check issue truth.
 6. If the issue is not fully closed out, repeat the routing loop for the same
    issue.
-7. If the issue is fully closed out, mark it complete in sprint-state and move
+7. If the issue is in a healthy PR-open waiting state, pause on that issue and
+   surface `ask_operator` rather than re-driving execution or janitoring a
+   non-blocked PR.
+8. If the issue is fully closed out, mark it complete in sprint-state and move
    to the next issue.
-8. If any blocker is encountered, stop and report the blocker in sprint-state.
+9. If any blocker is encountered, stop and report the blocker in sprint-state.
 
 ## Editor-Skill Rule
 
@@ -83,7 +86,7 @@ Record:
 - next action
 
 Preferred metrics sources:
-- coverage:
+- coverage when a fresh local snapshot is required by sprint policy:
   - `cargo llvm-cov --workspace --all-features --summary-only`
 - Rust tracker:
   - `bash adl/tools/report_large_rust_modules.sh --format tsv`
@@ -95,6 +98,8 @@ For the Rust tracker report, count the number of rows at each level:
 
 If metrics are taken from CI or an existing quality-gate artifact instead of a
 fresh local run, say so explicitly.
+`not_applicable` is also a normal outcome for docs-only, workflow-only,
+planning-only, or similarly light sprint surfaces.
 
 ## Stop Conditions
 

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -14,11 +14,11 @@ sequence:
   blocked_issue_number: <u32 or null>
   deferred_issue_numbers:
     - <u32>
-  continuation: continue | stop | ask_operator
+  continuation: continue | stop | ask_operator | waiting_for_review
 current_state:
   selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none
-  current_phase: intake | issue_loop | review | closeout | blocked
-  blocker_reason: none | child_issue_blocked | malformed_cards | review_findings_blocking | missing_metrics | operator_scope_decision | unknown
+  current_phase: intake | issue_loop | review | closeout | waiting | blocked
+  blocker_reason: none | child_issue_blocked | malformed_cards | review_findings_blocking | missing_metrics | operator_scope_decision | healthy_pr_waiting_for_review | unknown
 review:
   status: not_started | in_progress | done | blocked
   packet_path: <path or null>
@@ -34,10 +34,10 @@ closeout:
   status: not_started | in_progress | done | blocked
   closeout_note_path: <path or null>
   coverage:
-    source: local_run | ci | existing_quality_gate | missing
+    source: local_run | ci | existing_quality_gate | not_applicable | missing
     summary: <bounded text>
   rust_tracker:
-    source: local_run | ci | existing_quality_gate | missing
+    source: local_run | ci | existing_quality_gate | not_applicable | missing
     watch_count: <int or null>
     review_count: <int or null>
     rationale_count: <int or null>

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -1,7 +1,7 @@
 # Output Contract
 
 ```yaml
-status: done | blocked | failed
+status: done | waiting | blocked | failed
 sprint:
   issue_number: <u32>
   goal: <string or null>
@@ -16,11 +16,13 @@ sequence:
     - <u32>
   continuation: continue | stop | ask_operator | waiting_for_review
 current_state:
-  selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none
+  selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
   current_phase: intake | issue_loop | review | closeout | waiting | blocked
   blocker_reason: none | child_issue_blocked | malformed_cards | review_findings_blocking | missing_metrics | operator_scope_decision | healthy_pr_waiting_for_review | unknown
 review:
   status: not_started | in_progress | done | blocked
+  selected_skills:
+    - repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis
   packet_path: <path or null>
   code_review_path: <path or null>
   test_review_path: <path or null>

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -1,0 +1,52 @@
+# Output Contract
+
+```yaml
+status: done | blocked | failed
+sprint:
+  issue_number: <u32>
+  goal: <string or null>
+  ordered_issue_numbers:
+    - <u32>
+sequence:
+  current_issue_number: <u32 or null>
+  completed_issue_numbers:
+    - <u32>
+  blocked_issue_number: <u32 or null>
+  deferred_issue_numbers:
+    - <u32>
+  continuation: continue | stop | ask_operator
+current_state:
+  selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none
+  current_phase: intake | issue_loop | review | closeout | blocked
+  blocker_reason: none | child_issue_blocked | malformed_cards | review_findings_blocking | missing_metrics | operator_scope_decision | unknown
+review:
+  status: not_started | in_progress | done | blocked
+  packet_path: <path or null>
+  code_review_path: <path or null>
+  test_review_path: <path or null>
+  docs_review_path: <path or null>
+  security_review_path: <path or null>
+  synthesis_path: <path or null>
+  findings_summary:
+    confirmed_findings: <int or null>
+    unresolved_questions: <int or null>
+closeout:
+  status: not_started | in_progress | done | blocked
+  closeout_note_path: <path or null>
+  coverage:
+    source: local_run | ci | existing_quality_gate | missing
+    summary: <bounded text>
+  rust_tracker:
+    source: local_run | ci | existing_quality_gate | missing
+    watch_count: <int or null>
+    review_count: <int or null>
+    rationale_count: <int or null>
+actions_taken:
+  - <bounded step>
+artifact:
+  sprint_state_path: <path or null>
+  review_artifact_paths:
+    - <path>
+  closeout_artifact_paths:
+    - <path>
+```

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author spp-editor stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author spp-editor sprint-conductor stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -59,6 +59,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
   [[ -x "${root}/skills/diagram-author/scripts/render_diagrams.sh" ]]
   [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
+  [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]
@@ -91,6 +92,7 @@ assert_skill_bundle() {
   grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
   grep -Fq "diagram-as-code and model-as-code router" "${root}/skills/diagram-author/SKILL.md"
   grep -Fq "planning artifact rather than an execution log" "${root}/skills/spp-editor/SKILL.md"
+  grep -Fq "one issue at a time, fully closed out before the next" "${root}/skills/sprint-conductor/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
   grep -Fq "truthful execution and integration state" "${root}/skills/sor-editor/SKILL.md"
@@ -124,6 +126,7 @@ assert_skill_bundle() {
     "${root}/skills/arxiv-paper-writer/SKILL.md" \
     "${root}/skills/diagram-author/SKILL.md" \
     "${root}/skills/spp-editor/SKILL.md" \
+    "${root}/skills/sprint-conductor/SKILL.md" \
     "${root}/skills/stp-editor/SKILL.md" \
     "${root}/skills/sip-editor/SKILL.md" \
     "${root}/skills/sor-editor/SKILL.md"


### PR DESCRIPTION
## Summary
- add a lightweight `sprint-conductor` skill for slow-path sprint orchestration
- require sequential issue completion and closeout before advancing to the next issue
- add sprint review and sprint closeout contracts including coverage and Rust tracker capture

## Issue
- Closes #2855

## Validation
- not run (docs/skill bundle only in this pass)
