### PR TITLE
[v0.91][tools] Harden sprint-conductor for first live trial

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -108,6 +108,7 @@ The four editor skills are helper skills:
 - `sor-editor` for truthful `sor.md` cleanup
 
 `sprint-conductor` is a bounded orchestration helper rather than an editor skill. It sequences one sprint issue across ordered child issues using the existing lifecycle/editor stack, then assembles sprint review and sprint closeout evidence.
+It now includes a small deterministic sprint-state helper, supports a bounded review-subagent exception when policy enables it, and should be installed or synced into the active Codex skills directory before live use.
 
 ## Where The Skills Live
 

--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -20,11 +20,18 @@ sprint:
     - /absolute/or/repo-relative/path
   closeout_paths:
     - /absolute/or/repo-relative/path
+  issue_records:
+    - issue_number: <u32>
+      status: pending | active | waiting_for_review | closed_out | blocked | deferred
+      pr_url: <url or null>
+      artifact_paths:
+        - /absolute/or/repo-relative/path
 policy:
   require_sequential_closeout: true
   require_existing_issue_skills: true
   require_editor_skills: true
   require_code_review: true
+  allow_review_subagent_exception: true
   capture_coverage_at_closeout: true
   capture_rust_tracker_at_closeout: true
   stop_on_blocker: true

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -41,6 +41,8 @@ Important execution-boundary rule:
 - it may orchestrate child issues that legitimately edit tracked implementation
   files through `pr-run`, `pr-finish`, and the normal issue lifecycle in the
   bound issue worktree
+- it may use a bounded review subagent exception during sprint review when the
+  sprint policy explicitly enables that path
 
 ## Design Basis
 
@@ -57,6 +59,7 @@ At the moment, the key repo references are:
 Within this bundle, the operational details live in:
 - `references/conductor-playbook.md`
 - `references/output-contract.md`
+- `scripts/update_sprint_state.py`
 
 ## Entry Conditions
 
@@ -93,6 +96,7 @@ Useful additional inputs:
 - `sprint.blocked_issue_number`
 - `sprint.review_paths`
 - `sprint.closeout_paths`
+- `sprint.issue_records`
 - `resume_from_state_path`
 
 If there is no concrete sprint issue or ordered issue list, stop and report
@@ -119,6 +123,7 @@ This skill enforces:
 - editor-skill routing when cards drift
 - immediate stop on blocker
 - no silent creation of extra sprint-management issues
+- resumable per-issue state with PR URLs and artifact links when available
 
 Preferred per-issue routing model:
 - bootstrap missing -> `pr-init`
@@ -155,6 +160,13 @@ Recommended review-skill stack:
 - `repo-review-security` when trust boundaries or execution authority changed
 - `repo-review-synthesis`
 
+Bounded review-subagent exception:
+- child issue execution remains issue-skill driven rather than subagent driven
+- sprint review may use one bounded reviewer subagent when sprint policy
+  explicitly enables that exception
+- if the exception is disabled, the sprint review must remain local and record
+  that no review subagent was used
+
 The sprint review must not claim that docs/cards alone are sufficient when the
 sprint changed implementation code.
 
@@ -164,6 +176,8 @@ Sprint closeout must record:
 - sprint issue identity
 - ordered issue list and completion status
 - blocked/deferred/carryover state if any
+- per-issue PR URLs when they exist
+- per-issue artifact links needed to resume or audit the sprint
 - sprint review result
 - current code coverage snapshot
 - current Rust tracker counts

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -25,6 +25,7 @@ admission:
       - "require_existing_issue_skills"
       - "require_editor_skills"
       - "require_code_review"
+      - "allow_review_subagent_exception"
       - "capture_coverage_at_closeout"
       - "capture_rust_tracker_at_closeout"
       - "stop_on_blocker"
@@ -61,6 +62,7 @@ admission:
     - "resume_from_state_path"
     - "sprint.review_paths"
     - "sprint.closeout_paths"
+    - "sprint.issue_records"
   stop_if_missing:
     - "repo_root"
     - "sprint.issue_number"
@@ -78,9 +80,10 @@ execution:
   mode: "orchestrate_existing_skills_sequentially"
   allow_code_edits: true
   allow_network: true
-  allow_subagents: false
+  allow_subagents: true
   workflow_role: "sprint_orchestrator"
   preferred_commands:
+    - "python3 adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py --state <path> --sprint-issue <n> --ordered-issues <csv>"
     - "workflow-conductor for issue routing"
     - "pr-init/pr-ready/pr-run/pr-finish/pr-janitor/pr-closeout for child issue lifecycle"
     - "repo-packet-builder and review specialist skills for sprint-end review"
@@ -100,7 +103,7 @@ boundaries:
 outputs:
   default_format: "markdown"
   structured_contract: "references/output-contract.md"
-  artifact_path_pattern: ".adl/reviews/<timestamp>-sprint-conductor.md"
+  artifact_path_pattern: ".adl/reviews/<timestamp>-sprint-<issue>-conductor.md"
   required_sections:
     - "status"
     - "sprint"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -21,6 +21,7 @@ Optional:
 - current issue
 - completed issues
 - blocked issue
+- issue records with PR URLs and artifact links
 - prior sprint-state artifact
 
 ## Core Loop
@@ -73,6 +74,12 @@ Recommended review stack:
 - `repo-review-security` when needed
 - `repo-review-synthesis`
 
+Bounded review-subagent exception:
+- child issue execution stays local to the normal issue skill path
+- one bounded reviewer subagent may be used during sprint review when sprint
+  policy explicitly enables it
+- if disabled, record that no review subagent was used
+
 ## Closeout Phase
 
 Record:
@@ -80,6 +87,8 @@ Record:
 - ordered issue list
 - completed issues
 - blocked/deferred/carryover state
+- per-issue PR URLs
+- per-issue artifact links
 - sprint review result
 - coverage snapshot
 - Rust tracker counts

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -7,6 +7,12 @@ sprint:
   goal: <string or null>
   ordered_issue_numbers:
     - <u32>
+  issue_records:
+    - issue_number: <u32>
+      status: pending | active | waiting_for_review | closed_out | blocked | deferred
+      pr_url: <url or null>
+      artifact_paths:
+        - <path>
 sequence:
   current_issue_number: <u32 or null>
   completed_issue_numbers:
@@ -47,6 +53,7 @@ actions_taken:
   - <bounded step>
 artifact:
   sprint_state_path: <path or null>
+  sprint_review_url: <url or null>
   review_artifact_paths:
     - <path>
   closeout_artifact_paths:

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -66,8 +66,20 @@ def select_next_issue(state: dict[str, Any]) -> None:
         state['current_issue_number'] = blocked
         state['continuation'] = 'ask_operator'
         return
+    record_by_issue = {
+        record.get('issue_number'): record for record in state.get('issue_records', [])
+    }
     for issue in state.get('ordered_issue_numbers', []):
         if issue not in completed:
+            record = record_by_issue.get(issue, {})
+            if record.get('status') == 'waiting_for_review':
+                state['current_issue_number'] = issue
+                state['continuation'] = 'waiting_for_review'
+                return
+            if record.get('status') in {'blocked', 'deferred'}:
+                state['current_issue_number'] = issue
+                state['continuation'] = 'ask_operator'
+                return
             state['current_issue_number'] = issue
             state['continuation'] = 'continue'
             return

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parse_csv_ints(raw: str) -> list[int]:
+    values = []
+    for part in raw.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        values.append(int(part))
+    return values
+
+
+def default_issue_records(ordered: list[int]) -> list[dict[str, Any]]:
+    return [
+        {
+            'issue_number': issue,
+            'status': 'pending',
+            'pr_url': None,
+            'artifact_paths': [],
+        }
+        for issue in ordered
+    ]
+
+
+def load_state(path: Path, sprint_issue: int, ordered: list[int]) -> dict[str, Any]:
+    if path.exists():
+        return json.loads(path.read_text())
+    return {
+        'sprint_issue_number': sprint_issue,
+        'ordered_issue_numbers': ordered,
+        'current_issue_number': ordered[0] if ordered else None,
+        'completed_issue_numbers': [],
+        'blocked_issue_number': None,
+        'continuation': 'continue',
+        'issue_records': default_issue_records(ordered),
+    }
+
+
+def ensure_issue_record(state: dict[str, Any], issue_number: int) -> dict[str, Any]:
+    for record in state.setdefault('issue_records', []):
+        if record.get('issue_number') == issue_number:
+            record.setdefault('artifact_paths', [])
+            record.setdefault('pr_url', None)
+            return record
+    record = {
+        'issue_number': issue_number,
+        'status': 'pending',
+        'pr_url': None,
+        'artifact_paths': [],
+    }
+    state['issue_records'].append(record)
+    return record
+
+
+def select_next_issue(state: dict[str, Any]) -> None:
+    completed = set(state.get('completed_issue_numbers', []))
+    blocked = state.get('blocked_issue_number')
+    if blocked is not None:
+        state['current_issue_number'] = blocked
+        state['continuation'] = 'ask_operator'
+        return
+    for issue in state.get('ordered_issue_numbers', []):
+        if issue not in completed:
+            state['current_issue_number'] = issue
+            state['continuation'] = 'continue'
+            return
+    state['current_issue_number'] = None
+    state['continuation'] = 'stop'
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--state', required=True)
+    parser.add_argument('--sprint-issue', type=int, required=True)
+    parser.add_argument('--ordered-issues', required=True)
+    parser.add_argument('--current-issue', type=int)
+    parser.add_argument('--mark-status', choices=['pending', 'active', 'waiting_for_review', 'closed_out', 'blocked', 'deferred'])
+    parser.add_argument('--pr-url')
+    parser.add_argument('--artifact-path', action='append', default=[])
+    parser.add_argument('--blocked-issue', type=int)
+    parser.add_argument('--clear-blocked', action='store_true')
+    parser.add_argument('--print-json', action='store_true')
+    args = parser.parse_args()
+
+    state_path = Path(args.state)
+    ordered = parse_csv_ints(args.ordered_issues)
+    state = load_state(state_path, args.sprint_issue, ordered)
+    state['sprint_issue_number'] = args.sprint_issue
+    state['ordered_issue_numbers'] = ordered
+
+    issue_number = args.current_issue or state.get('current_issue_number') or (ordered[0] if ordered else None)
+    if issue_number is not None:
+        record = ensure_issue_record(state, issue_number)
+        if args.mark_status:
+            record['status'] = args.mark_status
+            if args.mark_status == 'closed_out':
+                completed = set(state.setdefault('completed_issue_numbers', []))
+                completed.add(issue_number)
+                state['completed_issue_numbers'] = sorted(completed)
+            elif args.mark_status == 'blocked':
+                state['blocked_issue_number'] = issue_number
+            elif args.mark_status == 'waiting_for_review':
+                state['continuation'] = 'waiting_for_review'
+        if args.pr_url:
+            record['pr_url'] = args.pr_url
+        if args.artifact_path:
+            existing = set(record.get('artifact_paths', []))
+            for path in args.artifact_path:
+                existing.add(path)
+            record['artifact_paths'] = sorted(existing)
+
+    if args.blocked_issue is not None:
+        state['blocked_issue_number'] = args.blocked_issue
+        state['continuation'] = 'ask_operator'
+    if args.clear_blocked:
+        state['blocked_issue_number'] = None
+
+    select_next_issue(state)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+    if args.print_json:
+        print(json.dumps(state, indent=2, sort_keys=True))
+    else:
+        print(state_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -60,6 +60,7 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/diagram-author/scripts/render_diagrams.sh" ]]
   [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/update_sprint_state.py" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]


### PR DESCRIPTION
## Summary
- add a deterministic sprint-state helper for `sprint-conductor`
- allow a bounded review-subagent exception for sprint review
- record per-issue PR URLs and artifact links for resumability
- sync the bundle for first live trial readiness

## Issue
- Closes #2862

## Validation
- synced operational skills into `/Users/daniel/.codex/skills`
- did not start the live `#2827 -> #2828` narrow sprint trial because `#2826` is still open
