### PR TITLE
[v0.91][tools] Harden sprint-conductor residual safeguards

### DIFF
--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -26,14 +26,24 @@ sprint:
       pr_url: <url or null>
       artifact_paths:
         - /absolute/or/repo-relative/path
+  truth_check:
+    source: github_live | sprint_state_only | mixed
+    checked_issue_numbers:
+      - <u32>
+    checked_pr_urls:
+      - <url>
 policy:
   require_sequential_closeout: true
   require_existing_issue_skills: true
   require_editor_skills: true
   require_code_review: true
   allow_review_subagent_exception: true
+  max_review_subagents_when_exception_enabled: 1
+  require_github_truth_recheck: true
   capture_coverage_at_closeout: true
   capture_rust_tracker_at_closeout: true
   stop_on_blocker: true
+review_subagent_ids:
+  - <id>
 resume_from_state_path: /absolute/or/repo-relative/path/to/sprint_state.md
 ```

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -59,7 +59,9 @@ At the moment, the key repo references are:
 Within this bundle, the operational details live in:
 - `references/conductor-playbook.md`
 - `references/output-contract.md`
+- `scripts/check_sprint_truth.py`
 - `scripts/update_sprint_state.py`
+- `scripts/validate_review_subagent_policy.py`
 
 ## Entry Conditions
 
@@ -108,12 +110,13 @@ If there is no concrete sprint issue or ordered issue list, stop and report
 2. Create or load the sprint-state artifact.
 3. Confirm the current issue is the earliest not-yet-closed issue in the list.
 4. Route that issue through `workflow-conductor`.
-5. Run only the selected downstream lifecycle or editor skill.
-6. Re-check issue truth until the issue is fully closed out.
-7. Only then advance to the next ordered issue.
-8. After the final issue closes, assemble sprint review evidence.
-9. Record sprint closeout metrics including coverage and Rust tracker counts.
-10. Stop with one bounded sprint review/closeout result.
+5. Re-check live issue and PR truth before acting.
+6. Run only the selected downstream lifecycle or editor skill.
+7. Re-check issue truth until the issue is fully closed out.
+8. Only then advance to the next ordered issue.
+9. After the final issue closes, assemble sprint review evidence.
+10. Record sprint closeout metrics including coverage and Rust tracker counts.
+11. Stop with one bounded sprint review/closeout result.
 
 ## Execution Model
 
@@ -166,6 +169,7 @@ Bounded review-subagent exception:
   explicitly enables that exception
 - if the exception is disabled, the sprint review must remain local and record
   that no review subagent was used
+- the bundle should validate this boundary mechanically before review execution
 
 The sprint review must not claim that docs/cards alone are sufficient when the
 sprint changed implementation code.
@@ -225,6 +229,7 @@ Return a concise structured result including:
 - ordered issue list
 - completed issues
 - blocked/current issue state
+- truth-check status and source
 - review status and review artifact paths
 - coverage status
 - Rust tracker status

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -26,6 +26,8 @@ admission:
       - "require_editor_skills"
       - "require_code_review"
       - "allow_review_subagent_exception"
+      - "max_review_subagents_when_exception_enabled"
+      - "require_github_truth_recheck"
       - "capture_coverage_at_closeout"
       - "capture_rust_tracker_at_closeout"
       - "stop_on_blocker"
@@ -63,6 +65,8 @@ admission:
     - "sprint.review_paths"
     - "sprint.closeout_paths"
     - "sprint.issue_records"
+    - "sprint.truth_check"
+    - "review_subagent_ids"
   stop_if_missing:
     - "repo_root"
     - "sprint.issue_number"
@@ -75,6 +79,7 @@ admission:
     - "policy.require_sequential_closeout_must_be_true"
     - "policy.require_existing_issue_skills_must_be_true"
     - "policy.require_editor_skills_must_be_true"
+    - "policy.require_github_truth_recheck_must_be_true"
     - "policy.stop_on_blocker_must_be_true"
 execution:
   mode: "orchestrate_existing_skills_sequentially"
@@ -83,7 +88,9 @@ execution:
   allow_subagents: true
   workflow_role: "sprint_orchestrator"
   preferred_commands:
+    - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py --state <path> --sprint-issue <n> --ordered-issues <csv>"
+    - "python3 adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py --allow-review-subagent-exception <bool> --max-review-subagents 1"
     - "workflow-conductor for issue routing"
     - "pr-init/pr-ready/pr-run/pr-finish/pr-janitor/pr-closeout for child issue lifecycle"
     - "repo-packet-builder and review specialist skills for sprint-end review"
@@ -108,6 +115,7 @@ outputs:
     - "status"
     - "sprint"
     - "sequence"
+    - "truth_check"
     - "current_state"
     - "review"
     - "closeout"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -27,19 +27,23 @@ Optional:
 ## Core Loop
 
 1. Load or create sprint-state.
-2. Choose the earliest child issue in the ordered list that is not yet closed
+2. Re-check live GitHub truth for the current sprint-state when possible.
+3. Choose the earliest child issue in the ordered list that is not yet closed
    out.
-3. Route that child issue through `workflow-conductor`.
-4. Run only the selected downstream lifecycle or editor skill.
-5. Re-check issue truth.
-6. If the issue is not fully closed out, repeat the routing loop for the same
+4. Route that child issue through `workflow-conductor`.
+5. Run only the selected downstream lifecycle or editor skill.
+6. Re-check issue truth.
+7. If the issue is not fully closed out, repeat the routing loop for the same
    issue.
-7. If the issue is in a healthy PR-open waiting state, pause on that issue and
+8. If the issue is in a healthy PR-open waiting state, pause on that issue and
    surface `ask_operator` rather than re-driving execution or janitoring a
    non-blocked PR.
-8. If the issue is fully closed out, mark it complete in sprint-state and move
+9. If the issue is fully closed out, mark it complete in sprint-state and move
    to the next issue.
-9. If any blocker is encountered, stop and report the blocker in sprint-state.
+10. If any blocker is encountered, stop and report the blocker in sprint-state.
+
+Preferred live-truth helper:
+- `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path>`
 
 ## Editor-Skill Rule
 
@@ -79,6 +83,8 @@ Bounded review-subagent exception:
 - one bounded reviewer subagent may be used during sprint review when sprint
   policy explicitly enables it
 - if disabled, record that no review subagent was used
+- validate the declared reviewer-subagent set before review execution:
+  - `python3 adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py --allow-review-subagent-exception <bool> --max-review-subagents 1`
 
 ## Closeout Phase
 
@@ -125,3 +131,12 @@ Do not:
 - skip child issue closeout to save time
 - silently create additional sprint-management issues
 - widen the sprint because nearby work looks tempting
+
+## Standard-Path Guardrails
+
+If `sprint-conductor` becomes a normal operating path rather than a narrow
+trial, the next hardening step should be:
+- make GitHub truth-checks mandatory before and after each child issue handoff
+- require one explicit routing artifact per child issue
+- fail review startup when more than the allowed bounded reviewer-subagent set
+  is declared

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -21,6 +21,15 @@ sequence:
   deferred_issue_numbers:
     - <u32>
   continuation: continue | stop | ask_operator | waiting_for_review
+truth_check:
+  status: not_run | matched | drift_detected | blocked
+  source: github_live | sprint_state_only | mixed
+  checked_issue_numbers:
+    - <u32>
+  checked_pr_urls:
+    - <url>
+  notes:
+    - <bounded text>
 current_state:
   selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
   current_phase: intake | issue_loop | review | closeout | waiting | blocked
@@ -29,6 +38,8 @@ review:
   status: not_started | in_progress | done | blocked
   selected_skills:
     - repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis
+  review_subagent_ids:
+    - <id>
   packet_path: <path or null>
   code_review_path: <path or null>
   test_review_path: <path or null>

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def run_json(cmd: list[str]) -> Any:
+    out = subprocess.check_output(cmd, text=True)
+    return json.loads(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repo-root', required=True)
+    parser.add_argument('--state', required=True)
+    parser.add_argument('--print-json', action='store_true')
+    args = parser.parse_args()
+
+    state_path = Path(args.state)
+    state = json.loads(state_path.read_text())
+    issue_records = state.get('issue_records', [])
+    issue_numbers = [record.get('issue_number') for record in issue_records if record.get('issue_number') is not None]
+    pr_urls = [record.get('pr_url') for record in issue_records if record.get('pr_url')]
+
+    notes: list[str] = []
+    drift = False
+
+    for issue_number in issue_numbers:
+        issue = run_json([
+            'gh', 'issue', 'view', str(issue_number), '--json', 'number,state,title,url'
+        ])
+        record = next((r for r in issue_records if r.get('issue_number') == issue_number), None)
+        if record is None:
+            continue
+        record['github_issue_state'] = issue.get('state')
+        if issue.get('state') == 'CLOSED' and record.get('status') not in {'closed_out'}:
+            drift = True
+            notes.append(f'issue #{issue_number} is CLOSED on GitHub but local status is {record.get("status")}')
+        if issue.get('state') == 'OPEN' and record.get('status') == 'closed_out':
+            drift = True
+            notes.append(f'issue #{issue_number} is OPEN on GitHub but local status is closed_out')
+
+    for pr_url in pr_urls:
+        pr = run_json(['gh', 'pr', 'view', pr_url, '--json', 'state,isDraft,url'])
+        matching = next((r for r in issue_records if r.get('pr_url') == pr_url), None)
+        if matching is None:
+            continue
+        matching['github_pr_state'] = pr.get('state')
+        matching['github_pr_is_draft'] = pr.get('isDraft')
+
+    truth_check = {
+        'status': 'drift_detected' if drift else 'matched',
+        'source': 'github_live',
+        'checked_issue_numbers': issue_numbers,
+        'checked_pr_urls': pr_urls,
+        'notes': notes,
+    }
+    state['truth_check'] = truth_check
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+
+    if args.print_json:
+        print(json.dumps(truth_check, indent=2, sort_keys=True))
+    else:
+        print(state_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py
+++ b/adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+
+
+def parse_bool(raw: str) -> bool:
+    lowered = raw.strip().lower()
+    if lowered in {'1', 'true', 'yes', 'on'}:
+        return True
+    if lowered in {'0', 'false', 'no', 'off'}:
+        return False
+    raise ValueError(f'invalid boolean: {raw}')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--allow-review-subagent-exception', required=True)
+    parser.add_argument('--max-review-subagents', type=int, default=1)
+    parser.add_argument('--review-subagent-id', action='append', default=[])
+    args = parser.parse_args()
+
+    allowed = parse_bool(args.allow_review_subagent_exception)
+    count = len(args.review_subagent_id)
+
+    if not allowed and count > 0:
+        raise SystemExit('review subagent ids were supplied even though the exception is disabled')
+    if allowed and count > args.max_review_subagents:
+        raise SystemExit(f'review subagent count {count} exceeds allowed maximum {args.max_review_subagents}')
+
+    print('review_subagent_policy_ok')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -61,6 +61,8 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/update_sprint_state.py" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_truth.py" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/validate_review_subagent_policy.py" ]]
   [[ -f "${root}/skills/stp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sip-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sor-editor/SKILL.md" ]]


### PR DESCRIPTION
## Summary
- add live GitHub truth-check guidance and helper coverage for sprint state
- add mechanical validation for the bounded reviewer-subagent exception
- extend sprint-conductor contracts with truth-check fields and review subagent state

## Issue
- Closes #2869

## Validation
- not run in this pass
- this remains non-blocking follow-on hardening for the narrow first sprint trial
