### PR TITLE
[v0.91][tools] Enforce sprint-conductor live truth gate

### DIFF
--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -27,7 +27,9 @@ sprint:
       artifact_paths:
         - /absolute/or/repo-relative/path
   truth_check:
+    status: not_run | matched | drift_detected | blocked
     source: github_live | sprint_state_only | mixed
+    gate_passed: true | false
     checked_issue_numbers:
       - <u32>
     checked_pr_urls:
@@ -40,6 +42,7 @@ policy:
   allow_review_subagent_exception: true
   max_review_subagents_when_exception_enabled: 1
   require_github_truth_recheck: true
+  github_truth_gate_blocks_progress: true
   capture_coverage_at_closeout: true
   capture_rust_tracker_at_closeout: true
   stop_on_blocker: true

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -110,9 +110,9 @@ If there is no concrete sprint issue or ordered issue list, stop and report
 2. Create or load the sprint-state artifact.
 3. Confirm the current issue is the earliest not-yet-closed issue in the list.
 4. Route that issue through `workflow-conductor`.
-5. Re-check live issue and PR truth before acting.
+5. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
 6. Run only the selected downstream lifecycle or editor skill.
-7. Re-check issue truth until the issue is fully closed out.
+7. Re-check issue truth until the issue is fully closed out. Every sprint-state transition consumes the last successful truth check, so the next transition requires a fresh recheck.
 8. Only then advance to the next ordered issue.
 9. After the final issue closes, assemble sprint review evidence.
 10. Record sprint closeout metrics including coverage and Rust tracker counts.
@@ -127,6 +127,7 @@ This skill enforces:
 - immediate stop on blocker
 - no silent creation of extra sprint-management issues
 - resumable per-issue state with PR URLs and artifact links when available
+- no sprint-state advancement without a fresh matched live GitHub truth check
 
 Preferred per-issue routing model:
 - bootstrap missing -> `pr-init`

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -28,6 +28,7 @@ admission:
       - "allow_review_subagent_exception"
       - "max_review_subagents_when_exception_enabled"
       - "require_github_truth_recheck"
+      - "github_truth_gate_blocks_progress"
       - "capture_coverage_at_closeout"
       - "capture_rust_tracker_at_closeout"
       - "stop_on_blocker"
@@ -80,6 +81,7 @@ admission:
     - "policy.require_existing_issue_skills_must_be_true"
     - "policy.require_editor_skills_must_be_true"
     - "policy.require_github_truth_recheck_must_be_true"
+    - "policy.github_truth_gate_blocks_progress_must_be_true"
     - "policy.stop_on_blocker_must_be_true"
 execution:
   mode: "orchestrate_existing_skills_sequentially"
@@ -88,7 +90,7 @@ execution:
   allow_subagents: true
   workflow_role: "sprint_orchestrator"
   preferred_commands:
-    - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path>"
+    - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match"
     - "python3 adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py --state <path> --sprint-issue <n> --ordered-issues <csv>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py --allow-review-subagent-exception <bool> --max-review-subagents 1"
     - "workflow-conductor for issue routing"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -27,7 +27,7 @@ Optional:
 ## Core Loop
 
 1. Load or create sprint-state.
-2. Re-check live GitHub truth for the current sprint-state when possible.
+2. Re-check live GitHub truth for the current sprint-state and require a matched result before any sprint-state transition.
 3. Choose the earliest child issue in the ordered list that is not yet closed
    out.
 4. Route that child issue through `workflow-conductor`.
@@ -43,7 +43,7 @@ Optional:
 10. If any blocker is encountered, stop and report the blocker in sprint-state.
 
 Preferred live-truth helper:
-- `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path>`
+- `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match`
 
 ## Editor-Skill Rule
 
@@ -136,7 +136,7 @@ Do not:
 
 If `sprint-conductor` becomes a normal operating path rather than a narrow
 trial, the next hardening step should be:
-- make GitHub truth-checks mandatory before and after each child issue handoff
+- preserve the mandatory GitHub truth gate before and after each child issue handoff while reducing operator friction around it
 - require one explicit routing artifact per child issue
 - fail review startup when more than the allowed bounded reviewer-subagent set
   is declared

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -24,6 +24,7 @@ sequence:
 truth_check:
   status: not_run | matched | drift_detected | blocked
   source: github_live | sprint_state_only | mixed
+  gate_passed: true | false
   checked_issue_numbers:
     - <u32>
   checked_pr_urls:

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py
@@ -18,6 +18,7 @@ def main() -> int:
     parser.add_argument('--repo-root', required=True)
     parser.add_argument('--state', required=True)
     parser.add_argument('--print-json', action='store_true')
+    parser.add_argument('--require-match', action='store_true')
     args = parser.parse_args()
 
     state_path = Path(args.state)
@@ -55,6 +56,7 @@ def main() -> int:
     truth_check = {
         'status': 'drift_detected' if drift else 'matched',
         'source': 'github_live',
+        'gate_passed': not drift,
         'checked_issue_numbers': issue_numbers,
         'checked_pr_urls': pr_urls,
         'notes': notes,
@@ -66,6 +68,8 @@ def main() -> int:
         print(json.dumps(truth_check, indent=2, sort_keys=True))
     else:
         print(state_path)
+    if args.require_match and drift:
+        return 2
     return 0
 
 

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -40,6 +40,14 @@ def load_state(path: Path, sprint_issue: int, ordered: list[int]) -> dict[str, A
         'blocked_issue_number': None,
         'continuation': 'continue',
         'issue_records': default_issue_records(ordered),
+        'truth_check': {
+            'status': 'not_run',
+            'source': 'sprint_state_only',
+            'gate_passed': False,
+            'checked_issue_numbers': [],
+            'checked_pr_urls': [],
+            'notes': ['Run live GitHub truth check before the first sprint-state transition.'],
+        },
     }
 
 
@@ -87,6 +95,39 @@ def select_next_issue(state: dict[str, Any]) -> None:
     state['continuation'] = 'stop'
 
 
+def mutation_requested(args: argparse.Namespace) -> bool:
+    return any(
+        [
+            args.current_issue is not None,
+            args.mark_status is not None,
+            args.pr_url is not None,
+            bool(args.artifact_path),
+            args.blocked_issue is not None,
+            args.clear_blocked,
+        ]
+    )
+
+
+def require_truth_gate(state: dict[str, Any]) -> None:
+    truth_check = state.get('truth_check') or {}
+    if truth_check.get('status') == 'matched' and truth_check.get('gate_passed') is True:
+        return
+    raise SystemExit(
+        'Refusing to advance sprint state without a fresh matched GitHub truth check. '
+        'Run check_sprint_truth.py --require-match before calling update_sprint_state.py.'
+    )
+
+
+def consume_truth_gate(state: dict[str, Any]) -> None:
+    truth_check = state.setdefault('truth_check', {})
+    truth_check['gate_passed'] = False
+    notes = [note for note in truth_check.get('notes', []) if isinstance(note, str)]
+    reminder = 'Truth gate consumed; rerun live GitHub truth check before the next sprint-state transition.'
+    if reminder not in notes:
+        notes.append(reminder)
+    truth_check['notes'] = notes
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--state', required=True)
@@ -102,10 +143,13 @@ def main() -> int:
     args = parser.parse_args()
 
     state_path = Path(args.state)
+    state_preexisted = state_path.exists()
     ordered = parse_csv_ints(args.ordered_issues)
     state = load_state(state_path, args.sprint_issue, ordered)
     state['sprint_issue_number'] = args.sprint_issue
     state['ordered_issue_numbers'] = ordered
+    if state_preexisted and mutation_requested(args):
+        require_truth_gate(state)
 
     issue_number = args.current_issue or state.get('current_issue_number') or (ordered[0] if ordered else None)
     if issue_number is not None:
@@ -135,6 +179,8 @@ def main() -> int:
         state['blocked_issue_number'] = None
 
     select_next_issue(state)
+    if state_preexisted and mutation_requested(args):
+        consume_truth_gate(state)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
     if args.print_json:


### PR DESCRIPTION
Closes #2871

## Summary
- make sprint-conductor truth checks fail closed when live GitHub state drifts
- require a fresh matched truth check before sprint-state mutations
- consume the truth gate after each sprint-state transition so the next transition requires a new recheck

## Testing
- not run (docs/config/helper hardening only)