### PR TITLE
[v0.91][tools] Let sprint-conductor create and complete sprint issues

### DIFF
--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -5,7 +5,7 @@ skill_input_schema: sprint_conductor.v1
 mode: run_sprint_slow_path | resume_sprint_slow_path | review_and_closeout_sprint
 repo_root: /absolute/path
 sprint:
-  issue_number: <u32>
+  issue_number: <u32 or null>
   ordered_issue_numbers:
     - <u32>
   goal: <string or null>
@@ -39,6 +39,7 @@ policy:
   require_existing_issue_skills: true
   require_editor_skills: true
   require_code_review: true
+  allow_create_missing_sprint_issue: true | false
   allow_review_subagent_exception: true
   max_review_subagents_when_exception_enabled: 1
   require_github_truth_recheck: true

--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -34,6 +34,7 @@ sprint:
       - <u32>
     checked_pr_urls:
       - <url>
+  issue_closed: true | false
 policy:
   require_sequential_closeout: true
   require_existing_issue_skills: true

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -66,7 +66,8 @@ Within this bundle, the operational details live in:
 ## Entry Conditions
 
 Use this skill when all of the following are true:
-- there is one concrete sprint-management issue
+- there is one concrete sprint-management issue, or sprint policy explicitly
+  allows the skill to create the missing sprint-management issue first
 - the sprint has an explicit ordered list of issue numbers
 - the operator wants slow-path sequential execution rather than manual
   issue-by-issue orchestration
@@ -84,7 +85,7 @@ Do not use this skill for:
 
 At minimum, gather:
 - `repo_root`
-- `sprint.issue_number`
+- `sprint.issue_number` when it already exists
 - `sprint.ordered_issue_numbers`
 - `sprint.goal`
 - one explicit policy block
@@ -102,11 +103,14 @@ Useful additional inputs:
 - `resume_from_state_path`
 
 If there is no concrete sprint issue or ordered issue list, stop and report
-`blocked`.
+`blocked`, unless sprint policy explicitly allows the skill to create the
+missing sprint-management issue first.
 
 ## Quick Start
 
-1. Resolve the concrete sprint issue and ordered child issue list.
+1. Resolve the concrete sprint issue and ordered child issue list. If the sprint
+   issue is missing and policy allows creation, create it through the bundled
+   helper first.
 2. Create or load the sprint-state artifact.
 3. Confirm the current issue is the earliest not-yet-closed issue in the list.
 4. Route that issue through `workflow-conductor`.
@@ -126,10 +130,15 @@ This skill enforces:
 - editor-skill routing when cards drift
 - immediate stop on blocker
 - no silent creation of extra sprint-management issues
+- no missing sprint-management issue workaround outside the skill when sprint
+  policy allows the skill to create it directly
 - resumable per-issue state with PR URLs and artifact links when available
 - no sprint-state advancement without a fresh matched live GitHub truth check
 
 Preferred per-issue routing model:
+- missing sprint-management issue and policy allows creation ->
+  `create_missing_sprint_issue.py`, then continue with the ordered child issue
+  flow from the created sprint anchor
 - bootstrap missing -> `pr-init`
 - card-local STP issue -> `stp-editor`
 - card-local SIP issue -> `sip-editor`

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -17,6 +17,8 @@ Its job is to:
 - preserve resumable sprint state in one lightweight local artifact
 - assemble a robust sprint-end review with code-facing review expectations
 - record sprint-end closeout truth including coverage and Rust tracker numbers
+- manage the sprint-management issue to completion, including closing it only
+  after the sprint review and closeout are truly complete
 - stop immediately on blocker rather than wandering across adjacent issue work
 
 This skill must remain lightweight.
@@ -196,6 +198,7 @@ Sprint closeout must record:
 - current code coverage snapshot
 - current Rust tracker counts
 - recommended next sprint or remediation action
+- final sprint-management issue closure state
 
 Preferred metrics capture surfaces:
 - coverage command when the sprint surface warrants a fresh local snapshot:
@@ -223,6 +226,7 @@ This skill must stop after:
 - sequential issue orchestration through the existing skill family
 - one bounded sprint review result
 - one bounded sprint closeout result
+- final sprint-management issue closure when the sprint is truly complete
 - surfacing any blocker that prevents safe continuation
 
 It must not:
@@ -230,6 +234,7 @@ It must not:
 - absorb the underlying issue lifecycle logic
 - skip issue closeout to save time
 - invent coverage or Rust tracker numbers
+- close the sprint-management issue early
 - reopen completed child issues without explicit operator direction
 
 ## Output

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -90,6 +90,7 @@ execution:
   workflow_role: "sprint_orchestrator"
   preferred_commands:
     - "python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>"
+    - "python3 adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py --state <path> --summary <text>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match"
     - "python3 adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py --state <path> --sprint-issue <n> --ordered-issues <csv>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py --allow-review-subagent-exception <bool> --max-review-subagents 1"

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -25,6 +25,7 @@ admission:
       - "require_existing_issue_skills"
       - "require_editor_skills"
       - "require_code_review"
+      - "allow_create_missing_sprint_issue"
       - "allow_review_subagent_exception"
       - "max_review_subagents_when_exception_enabled"
       - "require_github_truth_recheck"
@@ -35,12 +36,10 @@ admission:
     mode_requirements:
       run_sprint_slow_path:
         required_sprint_fields:
-          - "issue_number"
           - "ordered_issue_numbers"
           - "goal"
       resume_sprint_slow_path:
         required_sprint_fields:
-          - "issue_number"
           - "ordered_issue_numbers"
       review_and_closeout_sprint:
         required_sprint_fields:
@@ -52,9 +51,9 @@ admission:
     - "review_and_closeout"
   required_inputs:
     - "repo_root"
-    - "sprint.issue_number"
     - "sprint.ordered_issue_numbers"
   optional_inputs:
+    - "sprint.issue_number"
     - "sprint.goal"
     - "sprint.version"
     - "sprint.slug"
@@ -70,7 +69,6 @@ admission:
     - "review_subagent_ids"
   stop_if_missing:
     - "repo_root"
-    - "sprint.issue_number"
     - "sprint.ordered_issue_numbers"
   prevalidation_rules:
     - "repo_root_must_be_absolute"
@@ -83,6 +81,7 @@ admission:
     - "policy.require_github_truth_recheck_must_be_true"
     - "policy.github_truth_gate_blocks_progress_must_be_true"
     - "policy.stop_on_blocker_must_be_true"
+    - "when_sprint.issue_number_is_missing_policy.allow_create_missing_sprint_issue_must_be_true_or_stop_blocked"
 execution:
   mode: "orchestrate_existing_skills_sequentially"
   allow_code_edits: true
@@ -90,6 +89,7 @@ execution:
   allow_subagents: true
   workflow_role: "sprint_orchestrator"
   preferred_commands:
+    - "python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match"
     - "python3 adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py --state <path> --sprint-issue <n> --ordered-issues <csv>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/validate_review_subagent_policy.py --allow-review-subagent-exception <bool> --max-review-subagents 1"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -105,6 +105,7 @@ Record:
 - coverage snapshot
 - Rust tracker counts
 - next action
+- sprint-management issue closeout
 
 Preferred metrics sources:
 - coverage when a fresh local snapshot is required by sprint policy:
@@ -122,11 +123,17 @@ fresh local run, say so explicitly.
 `not_applicable` is also a normal outcome for docs-only, workflow-only,
 planning-only, or similarly light sprint surfaces.
 
+Final sprint-management issue closeout:
+- keep the sprint-management issue open until all child issues are closed out
+- keep it open until sprint review and sprint closeout are complete
+- close it last through the bundled helper:
+  - `python3 adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py --state <path> --summary <text>`
+
 ## Stop Conditions
 
 Stop when:
-- all ordered child issues are fully closed out and the sprint review/closeout
-  artifacts are written
+- all ordered child issues are fully closed out, the sprint review/closeout
+  artifacts are written, and the sprint-management issue is closed
 - a child issue blocks and the operator must decide how to proceed
 - sprint scope changes materially and requires operator approval
 

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -12,7 +12,7 @@ No parallel child issue execution.
 ## Inputs
 
 Required:
-- one sprint-management issue
+- one sprint-management issue, or policy authority to let the skill create it
 - ordered child issue list
 - sprint goal
 - explicit policy block
@@ -27,20 +27,26 @@ Optional:
 ## Core Loop
 
 1. Load or create sprint-state.
-2. Re-check live GitHub truth for the current sprint-state and require a matched result before any sprint-state transition.
-3. Choose the earliest child issue in the ordered list that is not yet closed
+2. If the sprint-management issue is missing:
+   - create it through the bundled helper when policy allows, then continue
+   - otherwise stop and report `missing_sprint_issue`
+3. Re-check live GitHub truth for the current sprint-state and require a matched result before any sprint-state transition.
+4. Choose the earliest child issue in the ordered list that is not yet closed
    out.
-4. Route that child issue through `workflow-conductor`.
-5. Run only the selected downstream lifecycle or editor skill.
-6. Re-check issue truth.
-7. If the issue is not fully closed out, repeat the routing loop for the same
+5. Route that child issue through `workflow-conductor`.
+6. Run only the selected downstream lifecycle or editor skill.
+7. Re-check issue truth.
+8. If the issue is not fully closed out, repeat the routing loop for the same
    issue.
-8. If the issue is in a healthy PR-open waiting state, pause on that issue and
+9. If the issue is in a healthy PR-open waiting state, pause on that issue and
    surface `ask_operator` rather than re-driving execution or janitoring a
    non-blocked PR.
-9. If the issue is fully closed out, mark it complete in sprint-state and move
+10. If the issue is fully closed out, mark it complete in sprint-state and move
    to the next issue.
-10. If any blocker is encountered, stop and report the blocker in sprint-state.
+11. If any blocker is encountered, stop and report the blocker in sprint-state.
+
+Preferred missing-sprint-issue helper:
+- `python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>`
 
 Preferred live-truth helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match`
@@ -129,7 +135,7 @@ Stop when:
 Do not:
 - parallelize child issues
 - skip child issue closeout to save time
-- silently create additional sprint-management issues
+- silently create additional sprint-management issues when policy does not allow it
 - widen the sprint because nearby work looks tempting
 
 ## Standard-Path Guardrails

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -6,6 +6,7 @@ sprint:
   issue_number: <u32 or null>
   issue_url: <url or null>
   issue_created_by_skill: true | false
+  issue_closed: true | false
   goal: <string or null>
   ordered_issue_numbers:
     - <u32>
@@ -55,6 +56,7 @@ review:
 closeout:
   status: not_started | in_progress | done | blocked
   closeout_note_path: <path or null>
+  sprint_issue_close_summary: <bounded text or null>
   coverage:
     source: local_run | ci | existing_quality_gate | not_applicable | missing
     summary: <bounded text>

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -3,7 +3,9 @@
 ```yaml
 status: done | waiting | blocked | failed
 sprint:
-  issue_number: <u32>
+  issue_number: <u32 or null>
+  issue_url: <url or null>
+  issue_created_by_skill: true | false
   goal: <string or null>
   ordered_issue_numbers:
     - <u32>
@@ -34,7 +36,7 @@ truth_check:
 current_state:
   selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
   current_phase: intake | issue_loop | review | closeout | waiting | blocked
-  blocker_reason: none | child_issue_blocked | malformed_cards | review_findings_blocking | missing_metrics | operator_scope_decision | healthy_pr_waiting_for_review | unknown
+  blocker_reason: none | child_issue_blocked | malformed_cards | review_findings_blocking | missing_metrics | operator_scope_decision | healthy_pr_waiting_for_review | missing_sprint_issue | unknown
 review:
   status: not_started | in_progress | done | blocked
   selected_skills:

--- a/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--state', required=True)
+    parser.add_argument('--summary', required=True)
+    parser.add_argument('--print-json', action='store_true')
+    args = parser.parse_args()
+
+    state_path = Path(args.state)
+    state = json.loads(state_path.read_text())
+    sprint_issue_number = state.get('sprint_issue_number')
+    if sprint_issue_number is None:
+        raise SystemExit('Cannot close sprint-management issue because sprint_issue_number is missing from state.')
+
+    subprocess.check_call(
+        [
+            'gh',
+            'issue',
+            'close',
+            str(sprint_issue_number),
+            '--comment',
+            args.summary,
+        ]
+    )
+
+    state['sprint_issue_closed'] = True
+    state['sprint_issue_close_summary'] = args.summary
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+
+    result = {
+        'closed': True,
+        'sprint_issue_number': sprint_issue_number,
+        'state_path': str(state_path),
+    }
+    if args.print_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(sprint_issue_number)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def parse_csv_ints(raw: str) -> list[int]:
+    values: list[int] = []
+    for part in raw.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        values.append(int(part))
+    return values
+
+
+def run_json(cmd: list[str]) -> Any:
+    out = subprocess.check_output(cmd, text=True)
+    return json.loads(out)
+
+
+def default_issue_records(ordered: list[int]) -> list[dict[str, Any]]:
+    return [
+        {
+            'issue_number': issue,
+            'status': 'pending',
+            'pr_url': None,
+            'artifact_paths': [],
+        }
+        for issue in ordered
+    ]
+
+
+def build_body(goal: str, ordered: list[int], child_titles: dict[int, str], notes: str | None) -> str:
+    ordered_lines = '\n'.join(
+        f"{idx}. #{issue} {child_titles.get(issue, '').strip()}".rstrip()
+        for idx, issue in enumerate(ordered, start=1)
+    )
+    body = f"""## Summary
+
+Create the concrete sprint-management issue required to run one bounded `sprint-conductor` sprint.
+
+## Goal
+
+{goal}
+
+## Ordered Child Issue List
+
+{ordered_lines}
+
+## Trial Rules
+
+- Run child issues sequentially only.
+- Do not start the next child issue until the current one is fully closed out.
+- Use the existing issue lifecycle and editor skills for child issue execution.
+- Allow the bounded review-subagent exception only during sprint review when sprint policy explicitly enables it.
+- Stop and ask the operator if the sprint scope needs to widen.
+
+## Acceptance Criteria
+
+- A concrete sprint-management issue exists for this ordered child-issue list.
+- The sprint issue can be used directly as `sprint.issue_number` for `sprint-conductor`.
+- The ordered child-issue list is explicit and stable.
+
+## Non-goals
+
+- Do not widen this sprint beyond the declared ordered child-issue list.
+- Do not treat this as a release-closeout or roadmap issue.
+"""
+    if notes:
+        body += f"\n## Notes\n\n{notes.strip()}\n"
+    return body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repo-root', required=True)
+    parser.add_argument('--ordered-issues', required=True)
+    parser.add_argument('--title', required=True)
+    parser.add_argument('--goal', required=True)
+    parser.add_argument('--state')
+    parser.add_argument('--notes')
+    parser.add_argument('--print-json', action='store_true')
+    args = parser.parse_args()
+
+    ordered = parse_csv_ints(args.ordered_issues)
+    child_titles: dict[int, str] = {}
+    for issue in ordered:
+        issue_json = run_json(['gh', 'issue', 'view', str(issue), '--json', 'number,title'])
+        child_titles[issue] = issue_json.get('title', '')
+
+    body = build_body(args.goal, ordered, child_titles, args.notes)
+    with tempfile.NamedTemporaryFile('w', delete=False, suffix='.md') as handle:
+        handle.write(body)
+        body_path = Path(handle.name)
+
+    issue_url = subprocess.check_output(
+        ['gh', 'issue', 'create', '--title', args.title, '--body-file', str(body_path)],
+        text=True,
+    ).strip()
+    match = re.search(r'/issues/(\d+)$', issue_url)
+    if not match:
+        raise SystemExit(f'Unable to parse created issue number from URL: {issue_url}')
+    sprint_issue_number = int(match.group(1))
+
+    result = {
+        'created': True,
+        'sprint_issue_number': sprint_issue_number,
+        'sprint_issue_url': issue_url,
+        'ordered_issue_numbers': ordered,
+    }
+
+    if args.state:
+        state_path = Path(args.state)
+        state = {
+            'sprint_issue_number': sprint_issue_number,
+            'sprint_issue_url': issue_url,
+            'sprint_issue_created_by_skill': True,
+            'issue_created_by_skill': True,
+            'ordered_issue_numbers': ordered,
+            'current_issue_number': ordered[0] if ordered else None,
+            'completed_issue_numbers': [],
+            'blocked_issue_number': None,
+            'continuation': 'continue',
+            'issue_records': default_issue_records(ordered),
+            'truth_check': {
+                'status': 'not_run',
+                'source': 'sprint_state_only',
+                'gate_passed': False,
+                'checked_issue_numbers': [],
+                'checked_pr_urls': [],
+                'notes': ['Sprint issue created by skill; run live GitHub truth check before the first state transition.'],
+            },
+        }
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+        result['state_path'] = str(state_path)
+
+    if args.print_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(issue_url)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -60,6 +60,7 @@ assert_skill_bundle() {
   [[ -x "${root}/skills/diagram-author/scripts/render_diagrams.sh" ]]
   [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/update_sprint_state.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_truth.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/validate_review_subagent_policy.py" ]]

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -186,4 +186,6 @@ if ADL_OPERATIONAL_SKILLS_INSTALL_MODE=bogus bash "${repo_root}/adl/tools/instal
   exit 1
 fi
 
+bash "${repo_root}/adl/tools/test_sprint_conductor_helpers.sh"
+
 echo "PASS test_install_adl_operational_skills"

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -61,6 +61,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/close_sprint_issue.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/update_sprint_state.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_truth.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/validate_review_subagent_policy.py" ]]

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+fakebin="${tmpdir}/bin"
+mkdir -p "${fakebin}"
+log_path="${tmpdir}/gh.log"
+touch "${log_path}"
+
+cat >"${fakebin}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${FAKE_GH_LOG}"
+
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  issue_number="$3"
+  case "${issue_number}" in
+    2827)
+      echo '{"number":2827,"title":"[v0.91.1][WP-05][runtime] Citizen standing model","state":"OPEN","url":"https://github.com/danielbaustin/agent-design-language/issues/2827"}'
+      ;;
+    2828)
+      echo '{"number":2828,"title":"[v0.91.1][WP-06][runtime] Citizen state substrate","state":"OPEN","url":"https://github.com/danielbaustin/agent-design-language/issues/2828"}'
+      ;;
+    3001)
+      echo '{"number":3001,"title":"[v0.91.1][sprint-1][management] Trial sprint","state":"OPEN","url":"https://github.com/danielbaustin/agent-design-language/issues/3001"}'
+      ;;
+    *)
+      echo "unexpected gh issue view ${issue_number}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1" == "issue" && "$2" == "create" ]]; then
+  echo "https://github.com/danielbaustin/agent-design-language/issues/3001"
+  exit 0
+fi
+
+if [[ "$1" == "issue" && "$2" == "close" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  echo '{"state":"OPEN","isDraft":true,"url":"https://github.com/danielbaustin/agent-design-language/pull/4001"}'
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${fakebin}/gh"
+
+export PATH="${fakebin}:${PATH}"
+export FAKE_GH_LOG="${log_path}"
+
+state_path="${tmpdir}/sprint-state.json"
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" \
+  --repo-root "${repo_root}" \
+  --ordered-issues "2827,2828" \
+  --title "[v0.91.1][sprint-1][management] Trial sprint" \
+  --goal "Run the narrow sprint-conductor trial" \
+  --state "${state_path}" \
+  >/dev/null
+
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+assert state["sprint_issue_number"] == 3001
+assert state["sprint_issue_created_by_skill"] is True
+assert state["current_issue_number"] == 2827
+assert len(state["issue_records"]) == 2
+assert state["truth_check"]["status"] == "not_run"
+assert state["truth_check"]["gate_passed"] is False
+PY
+
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
+  --state "${state_path}" \
+  --sprint-issue 3001 \
+  --ordered-issues "2827,2828" \
+  --current-issue 2827 \
+  --mark-status active >/dev/null 2>&1; then
+  echo "expected update_sprint_state.py to fail without a truth gate" >&2
+  exit 1
+fi
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
+  --repo-root "${repo_root}" \
+  --state "${state_path}" \
+  --require-match >/dev/null
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
+  --state "${state_path}" \
+  --sprint-issue 3001 \
+  --ordered-issues "2827,2828" \
+  --current-issue 2827 \
+  --mark-status waiting_for_review \
+  --pr-url "https://github.com/danielbaustin/agent-design-language/pull/4001" >/dev/null
+
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+record = next(record for record in state["issue_records"] if record["issue_number"] == 2827)
+assert record["status"] == "waiting_for_review"
+assert record["pr_url"] == "https://github.com/danielbaustin/agent-design-language/pull/4001"
+assert state["truth_check"]["status"] == "matched"
+assert state["truth_check"]["gate_passed"] is False
+assert state["continuation"] == "waiting_for_review"
+PY
+
+if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
+  --state "${state_path}" \
+  --sprint-issue 3001 \
+  --ordered-issues "2827,2828" \
+  --current-issue 2827 \
+  --artifact-path ".adl/reviews/example.md" >/dev/null 2>&1; then
+  echo "expected second update_sprint_state.py call to fail after gate consumption" >&2
+  exit 1
+fi
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
+  --repo-root "${repo_root}" \
+  --state "${state_path}" \
+  --require-match >/dev/null
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py" \
+  --state "${state_path}" \
+  --summary "Sprint completed cleanly." >/dev/null
+
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+assert state["sprint_issue_closed"] is True
+assert state["sprint_issue_close_summary"] == "Sprint completed cleanly."
+PY
+
+grep -Fq "issue create" "${log_path}"
+grep -Fq "issue close 3001 --comment Sprint completed cleanly." "${log_path}"
+grep -Fq "pr view https://github.com/danielbaustin/agent-design-language/pull/4001 --json state,isDraft,url" "${log_path}"
+
+echo "PASS test_sprint_conductor_helpers"


### PR DESCRIPTION
Closes #2875

## Summary
- let sprint-conductor create a missing sprint-management issue when policy allows
- initialize sprint state from the created management issue
- require the skill to keep the sprint-management issue open until sprint execution, review, and closeout are complete
- close the sprint-management issue through a bundled helper at the end of the sprint lifecycle

## Testing
- not run (skill/contract/helper hardening only)