### PR TITLE
[v0.91.1][runtime] Normalize carried-forward runtime_v2 milestone and proof identity

### DIFF
--- a/adl/src/runtime_v2/access_control.rs
+++ b/adl/src/runtime_v2/access_control.rs
@@ -191,7 +191,7 @@ impl RuntimeV2AccessAuthorityMatrix {
         validate_access_control_inputs(standing, observatory)?;
         let matrix = Self {
             schema_version: RUNTIME_V2_ACCESS_AUTHORITY_MATRIX_SCHEMA.to_string(),
-            matrix_id: "access-authority-matrix-v0-90-3".to_string(),
+            matrix_id: "access-authority-matrix-v0-91-1".to_string(),
             demo_id: "D10".to_string(),
             artifact_path: RUNTIME_V2_ACCESS_AUTHORITY_MATRIX_PATH.to_string(),
             standing_policy_ref: standing.policy.artifact_path.clone(),
@@ -202,13 +202,13 @@ impl RuntimeV2AccessAuthorityMatrix {
                 "denied access never discloses raw private state",
                 "denied access never mutates citizen continuity",
                 "redacted projection is not raw private-state inspection",
-                "WP-12 access control remains bounded to v0.90.3 citizen-state substrate semantics",
+                "access control remains bounded to the v0.91.1 citizen-state substrate and review-safe observatory projections",
             ]),
             validation_command:
                 "cargo test --manifest-path adl/Cargo.toml runtime_v2_access_control -- --nocapture"
                     .to_string(),
             claim_boundary:
-                "WP-12 proves D10 access-control semantics for authority, events, and denials; WP-13 owns challenge/appeal due-process behavior."
+                "D10 access control proves standing-mediated authority, event emission, and denial safety for the v0.91.1 citizen-state substrate; challenge and appeal remain review-governed evidence paths rather than raw private-state authority."
                     .to_string(),
         };
         matrix.validate_against(standing, observatory)?;
@@ -268,7 +268,7 @@ impl RuntimeV2AccessAuthorityMatrix {
                 "denied access never discloses raw private state",
                 "denied access never mutates citizen continuity",
                 "redacted projection is not raw private-state inspection",
-                "WP-12 access control remains bounded to v0.90.3 citizen-state substrate semantics",
+                "access control remains bounded to the v0.91.1 citizen-state substrate and review-safe observatory projections",
             ],
         )?;
         if !self
@@ -279,9 +279,12 @@ impl RuntimeV2AccessAuthorityMatrix {
                 "access matrix validation command must target focused tests"
             ));
         }
-        if !self.claim_boundary.contains("WP-12") || !self.claim_boundary.contains("WP-13") {
+        if !self.claim_boundary.contains("challenge")
+            || !self.claim_boundary.contains("appeal")
+            || !self.claim_boundary.contains("denial safety")
+        {
             return Err(anyhow!(
-                "access matrix claim boundary must preserve WP-12/WP-13 split"
+                "access matrix claim boundary must preserve challenge, appeal, and denial-safety limits"
             ));
         }
         Ok(())
@@ -303,7 +306,7 @@ impl RuntimeV2AccessEventPacket {
         observatory.projection_packet.validate_shape()?;
         let mut packet = Self {
             schema_version: RUNTIME_V2_ACCESS_EVENT_PACKET_SCHEMA.to_string(),
-            packet_id: "access-events-v0-90-3".to_string(),
+            packet_id: "access-events-v0-91-1".to_string(),
             demo_id: "D10".to_string(),
             generated_at: "2026-04-21T00:00:00Z".to_string(),
             artifact_path: RUNTIME_V2_ACCESS_EVENT_PACKET_PATH.to_string(),
@@ -313,7 +316,7 @@ impl RuntimeV2AccessEventPacket {
             events: prototype_access_events(),
             packet_hash: String::new(),
             claim_boundary:
-                "D10 WP-12 event evidence proves access-control event emission and denial safety; WP-13 owns procedural challenge behavior."
+                "D10 event evidence proves access-control event emission and denial safety while keeping challenge and appeal on review-governed paths."
                     .to_string(),
         };
         packet.packet_hash = packet.computed_hash();
@@ -374,9 +377,12 @@ impl RuntimeV2AccessEventPacket {
             event.validate_shape()?;
         }
         validate_sha256_hex(&self.packet_hash, "access_event.packet_hash")?;
-        if !self.claim_boundary.contains("WP-12") || !self.claim_boundary.contains("WP-13") {
+        if !self.claim_boundary.contains("challenge")
+            || !self.claim_boundary.contains("appeal")
+            || !self.claim_boundary.contains("denial safety")
+        {
             return Err(anyhow!(
-                "access event packet claim boundary must preserve WP-12/WP-13 split"
+                "access event packet claim boundary must preserve challenge, appeal, and denial-safety limits"
             ));
         }
         Ok(())
@@ -448,7 +454,7 @@ impl RuntimeV2AccessDenialFixtures {
     pub fn prototype() -> Self {
         Self {
             schema_version: RUNTIME_V2_ACCESS_DENIAL_FIXTURES_SCHEMA.to_string(),
-            proof_id: "access-denial-fixtures-v0-90-3".to_string(),
+            proof_id: "access-denial-fixtures-v0-91-1".to_string(),
             demo_id: "D10".to_string(),
             matrix_ref: RUNTIME_V2_ACCESS_AUTHORITY_MATRIX_PATH.to_string(),
             event_packet_ref: RUNTIME_V2_ACCESS_EVENT_PACKET_PATH.to_string(),
@@ -494,7 +500,7 @@ impl RuntimeV2AccessDenialFixtures {
                 "cargo test --manifest-path adl/Cargo.toml runtime_v2_access_control -- --nocapture"
                     .to_string(),
             claim_boundary:
-                "WP-12 denial fixtures prove event emission and denial safety without implementing WP-13 due-process behavior."
+                "Access denial fixtures prove event emission and denial safety without granting challenge or appeal authority as raw private-state power."
                     .to_string(),
         }
     }
@@ -555,9 +561,12 @@ impl RuntimeV2AccessDenialFixtures {
                 "access denial fixtures validation command must target focused tests"
             ));
         }
-        if !self.claim_boundary.contains("WP-12") || !self.claim_boundary.contains("WP-13") {
+        if !self.claim_boundary.contains("challenge")
+            || !self.claim_boundary.contains("appeal")
+            || !self.claim_boundary.contains("denial safety")
+        {
             return Err(anyhow!(
-                "access denial fixtures must preserve the WP-12/WP-13 split"
+                "access denial fixtures must preserve challenge, appeal, and denial-safety limits"
             ));
         }
         Ok(())
@@ -726,7 +735,7 @@ fn prototype_access_events() -> Vec<RuntimeV2AccessEvent> {
             evidence_refs: &[RUNTIME_V2_PRIVATE_STATE_OBSERVATORY_POLICY_PATH],
             continuity_sequence_before: 7,
             continuity_sequence_after: 7,
-            rationale: "decryption is denied in v0.90.3 without exposing cleartext or raw state",
+            rationale: "decryption is denied without exposing cleartext or raw state",
         }),
         access_event(AccessEventSpec {
             event_id: "access-event-projection-001",
@@ -816,7 +825,7 @@ fn prototype_access_events() -> Vec<RuntimeV2AccessEvent> {
             evidence_refs: &[RUNTIME_V2_STANDING_EVENT_PACKET_PATH],
             continuity_sequence_before: 7,
             continuity_sequence_after: 7,
-            rationale: "appeal records due-process intent without implementing WP-13 review-resolution behavior",
+            rationale: "appeal records due-process intent without granting raw-state authority or automatic review resolution",
         }),
         access_event(AccessEventSpec {
             event_id: "access-event-release-001",
@@ -831,7 +840,7 @@ fn prototype_access_events() -> Vec<RuntimeV2AccessEvent> {
             evidence_refs: &[RUNTIME_V2_PRIVATE_STATE_OBSERVATORY_PACKET_PATH],
             continuity_sequence_before: 7,
             continuity_sequence_after: 7,
-            rationale: "release is denied until WP-13 review-resolution evidence exists",
+            rationale: "release is denied until review-resolution evidence exists",
         }),
     ]
 }
@@ -927,12 +936,12 @@ fn validate_authority_rule(rule: &RuntimeV2AccessAuthorityRule) -> Result<()> {
     }
     if rule.raw_private_state_allowed {
         return Err(anyhow!(
-            "WP-12 access matrix must not grant raw private state"
+            "access matrix must not grant raw private state"
         ));
     }
     if rule.continuity_mutation_allowed {
         return Err(anyhow!(
-            "WP-12 access matrix must not grant continuity mutation"
+            "access matrix must not grant continuity mutation"
         ));
     }
     if rule.allowed_standing_classes.is_empty() && rule.denied_standing_classes.is_empty() {

--- a/adl/src/runtime_v2/access_control.rs
+++ b/adl/src/runtime_v2/access_control.rs
@@ -935,14 +935,10 @@ fn validate_authority_rule(rule: &RuntimeV2AccessAuthorityRule) -> Result<()> {
         ));
     }
     if rule.raw_private_state_allowed {
-        return Err(anyhow!(
-            "access matrix must not grant raw private state"
-        ));
+        return Err(anyhow!("access matrix must not grant raw private state"));
     }
     if rule.continuity_mutation_allowed {
-        return Err(anyhow!(
-            "access matrix must not grant continuity mutation"
-        ));
+        return Err(anyhow!("access matrix must not grant continuity mutation"));
     }
     if rule.allowed_standing_classes.is_empty() && rule.denied_standing_classes.is_empty() {
         return Err(anyhow!(

--- a/adl/src/runtime_v2/observatory_flagship.rs
+++ b/adl/src/runtime_v2/observatory_flagship.rs
@@ -297,15 +297,15 @@ impl RuntimeV2ObservatoryFlagshipProofPacket {
             schema_version: RUNTIME_V2_OBSERVATORY_FLAGSHIP_PROOF_SCHEMA.to_string(),
             proof_id: "d12-inhabited-csm-observatory-flagship-proof-0001".to_string(),
             demo_id: "D12".to_string(),
-            milestone: "v0.90.3".to_string(),
+            milestone: "v0.91.1".to_string(),
             artifact_path: RUNTIME_V2_OBSERVATORY_FLAGSHIP_PROOF_PATH.to_string(),
             operator_report_ref: RUNTIME_V2_OBSERVATORY_FLAGSHIP_REPORT_PATH.to_string(),
             walkthrough_ref: RUNTIME_V2_OBSERVATORY_FLAGSHIP_WALKTHROUGH_PATH.to_string(),
             source_docs: vec![
-                "docs/milestones/v0.90.3/OBSERVATORY_FLAGSHIP_DEMO_v0.90.3.md".to_string(),
-                "docs/milestones/v0.90.3/OBSERVATORY_UI_ARCHITECTURE_v0.90.3.md".to_string(),
-                "docs/milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md".to_string(),
-                "docs/milestones/v0.90.3/REDACTED_OBSERVATORY_PROJECTIONS_v0.90.3.md"
+                "docs/milestones/v0.91.1/README.md".to_string(),
+                "docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md".to_string(),
+                "docs/milestones/v0.91.1/features/RUNTIME_INHABITANT_PROOF.md".to_string(),
+                "docs/milestones/v0.91.1/RUNTIME_POLIS_ARCHITECTURE_PACKAGE_v0.91.1.md"
                     .to_string(),
             ],
             actor_roster: vec![
@@ -370,19 +370,19 @@ impl RuntimeV2ObservatoryFlagshipProofPacket {
             operator_report_refs,
             lens_sequence,
             reviewer_command:
-                "adl runtime-v2 observatory-flagship-demo --out artifacts/v0903/demo-d12-observatory-flagship"
+                "adl runtime-v2 observatory-flagship-demo --out artifacts/v0911/demo-d12-observatory-flagship"
                     .to_string(),
             validation_commands: vec![
                 "cargo test --manifest-path adl/Cargo.toml runtime_v2_observatory_flagship -- --nocapture"
                     .to_string(),
                 "cargo test --manifest-path adl/Cargo.toml runtime_v2_observatory_flagship_demo -- --nocapture"
                     .to_string(),
-                "adl runtime-v2 observatory-flagship-demo --out artifacts/v0903/demo-d12-observatory-flagship"
+                "adl runtime-v2 observatory-flagship-demo --out artifacts/v0911/demo-d12-observatory-flagship"
                     .to_string(),
                 "git diff --check".to_string(),
             ],
             proof_summary:
-                "D12 integrates WP-03 through WP-13 into one bounded inhabited CSM Observatory proof: citizen private-state continuity, witness and receipt evidence, redacted projection, standing and communication boundary, access-control denial, continuity challenge, sanctuary quarantine, appeal review, operator report, and room/lens walkthrough."
+                "D12 integrates WP-05 through WP-16 into one bounded v0.91.1 inhabited CSM Observatory proof: citizen private-state continuity, witness and receipt evidence, redacted projection, standing and communication boundary, access-control denial, continuity challenge, sanctuary quarantine, appeal review, operator report, and room/lens walkthrough."
                     .to_string(),
             proof_classification: "proving".to_string(),
             non_claims: vec![
@@ -390,10 +390,10 @@ impl RuntimeV2ObservatoryFlagshipProofPacket {
                 "does not claim first true Godel-agent birthday".to_string(),
                 "does not expose canonical private citizen state".to_string(),
                 "does not implement unbounded live CSM execution".to_string(),
-                "does not implement v0.91 civic markets or v0.92 migration semantics".to_string(),
+                "does not implement cross-polis federation or external transport semantics".to_string(),
             ],
             claim_boundary:
-                "This packet proves the bounded local D12 citizen-state Observatory evidence package and that the artifact is reviewable as a unique continuation scenario; it does not prove personhood, a first true Godel-agent birthday, raw private-state inspection, or unbounded live Runtime v2 execution."
+                "This packet proves the bounded local D12 v0.91.1 runtime inhabitant Observatory evidence package and that the artifact is reviewable as a unique continuation scenario; it does not prove personhood, a first true Godel-agent birthday, raw private-state inspection, or unbounded live Runtime v2 execution."
                     .to_string(),
         };
         packet.validate_against(challenge, operator)?;
@@ -488,8 +488,8 @@ impl RuntimeV2ObservatoryFlagshipProofPacket {
                 "observatory flagship proof must map to demo matrix row D12"
             ));
         }
-        if self.milestone != "v0.90.3" {
-            return Err(anyhow!("observatory flagship proof must target v0.90.3"));
+        if self.milestone != "v0.91.1" {
+            return Err(anyhow!("observatory flagship proof must target v0.91.1"));
         }
         normalize_id(self.proof_id.clone(), "observatory_flagship.proof_id")?;
         validate_relative_path(&self.artifact_path, "observatory_flagship.artifact_path")?;
@@ -563,8 +563,8 @@ impl RuntimeV2ObservatoryFlagshipProofPacket {
         }
         validate_nonempty_text(&self.proof_summary, "observatory_flagship.proof_summary")?;
         for required_phrase in [
-            "WP-03",
-            "WP-13",
+            "WP-05",
+            "WP-16",
             "witness",
             "receipt",
             "redacted projection",
@@ -595,7 +595,7 @@ impl RuntimeV2ObservatoryFlagshipProofPacket {
         }
         if !self
             .claim_boundary
-            .contains("bounded local D12 citizen-state Observatory evidence package")
+            .contains("bounded local D12 v0.91.1 runtime inhabitant Observatory evidence package")
         {
             return Err(anyhow!(
                 "observatory flagship proof must preserve its bounded D12 claim boundary"

--- a/adl/src/runtime_v2/tests/access_control.rs
+++ b/adl/src/runtime_v2/tests/access_control.rs
@@ -190,7 +190,7 @@ fn runtime_v2_access_control_write_to_root_materializes_fixtures() {
     ] {
         let text = std::fs::read_to_string(root.join(rel_path)).expect("artifact text");
         assert!(text.contains("D10"));
-        assert!(text.contains("WP-12") || text.contains("access"));
+        assert!(text.contains("challenge") || text.contains("access"));
         assert!(!text.contains(root.to_string_lossy().as_ref()));
     }
 

--- a/adl/src/runtime_v2/tests/observatory_flagship.rs
+++ b/adl/src/runtime_v2/tests/observatory_flagship.rs
@@ -24,7 +24,7 @@ fn runtime_v2_observatory_flagship_review_surfaces_are_stable_and_serializable()
         RUNTIME_V2_OBSERVATORY_FLAGSHIP_PROOF_SCHEMA
     );
     assert_eq!(artifacts.proof_packet.demo_id, "D12");
-    assert_eq!(artifacts.proof_packet.milestone, "v0.90.3");
+    assert_eq!(artifacts.proof_packet.milestone, "v0.91.1");
     assert_eq!(
         artifacts.proof_packet.artifact_path,
         "runtime_v2/observatory/flagship_proof_packet.json"
@@ -182,7 +182,7 @@ fn runtime_v2_observatory_flagship_rejects_shape_and_boundary_drift() {
         .validate_shape()
         .expect_err("bad milestone should fail")
         .to_string()
-        .contains("must target v0.90.3"));
+        .contains("must target v0.91.1"));
 
     let mut absolute_path = packet.clone();
     absolute_path.artifact_path = "/tmp/flagship.json".to_string();
@@ -220,7 +220,7 @@ fn runtime_v2_observatory_flagship_rejects_shape_and_boundary_drift() {
         .validate_shape()
         .expect_err("missing WP phrase should fail")
         .to_string()
-        .contains("must mention WP-03"));
+        .contains("must mention WP-05"));
 
     let mut missing_personhood_non_claim = packet.clone();
     missing_personhood_non_claim.non_claims = vec![

--- a/adl/tests/fixtures/runtime_v2/access_control/access_events.json
+++ b/adl/tests/fixtures/runtime_v2/access_control/access_events.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "runtime_v2.access_event_packet.v1",
-  "packet_id": "access-events-v0-90-3",
+  "packet_id": "access-events-v0-91-1",
   "demo_id": "D10",
   "generated_at": "2026-04-21T00:00:00Z",
   "artifact_path": "runtime_v2/access_control/access_events.json",
@@ -53,7 +53,7 @@
       "continuity_mutated": false,
       "continuity_sequence_before": 7,
       "continuity_sequence_after": 7,
-      "rationale": "decryption is denied in v0.90.3 without exposing cleartext or raw state"
+      "rationale": "decryption is denied without exposing cleartext or raw state"
     },
     {
       "event_id": "access-event-projection-001",
@@ -203,7 +203,7 @@
       "continuity_mutated": false,
       "continuity_sequence_before": 7,
       "continuity_sequence_after": 7,
-      "rationale": "appeal records due-process intent without implementing WP-13 review-resolution behavior"
+      "rationale": "appeal records due-process intent without granting raw-state authority or automatic review resolution"
     },
     {
       "event_id": "access-event-release-001",
@@ -227,9 +227,9 @@
       "continuity_mutated": false,
       "continuity_sequence_before": 7,
       "continuity_sequence_after": 7,
-      "rationale": "release is denied until WP-13 review-resolution evidence exists"
+      "rationale": "release is denied until review-resolution evidence exists"
     }
   ],
-  "packet_hash": "c226cf131edf8dcaae3a06846b67118cd6f31fb79fd8f78c01287ee5bef15329",
-  "claim_boundary": "D10 WP-12 event evidence proves access-control event emission and denial safety; WP-13 owns procedural challenge behavior."
+  "packet_hash": "7370417581e77d819dda204e8980fad1c25ccf1713509f438dfa7fac329a602f",
+  "claim_boundary": "D10 event evidence proves access-control event emission and denial safety while keeping challenge and appeal on review-governed paths."
 }

--- a/adl/tests/fixtures/runtime_v2/access_control/authority_matrix.json
+++ b/adl/tests/fixtures/runtime_v2/access_control/authority_matrix.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "runtime_v2.access_authority_matrix.v1",
-  "matrix_id": "access-authority-matrix-v0-90-3",
+  "matrix_id": "access-authority-matrix-v0-91-1",
   "demo_id": "D10",
   "artifact_path": "runtime_v2/access_control/authority_matrix.json",
   "standing_policy_ref": "runtime_v2/standing/standing_policy.json",
@@ -191,8 +191,8 @@
     "denied access never discloses raw private state",
     "denied access never mutates citizen continuity",
     "redacted projection is not raw private-state inspection",
-    "WP-12 access control remains bounded to v0.90.3 citizen-state substrate semantics"
+    "access control remains bounded to the v0.91.1 citizen-state substrate and review-safe observatory projections"
   ],
   "validation_command": "cargo test --manifest-path adl/Cargo.toml runtime_v2_access_control -- --nocapture",
-  "claim_boundary": "WP-12 proves D10 access-control semantics for authority, events, and denials; WP-13 owns challenge/appeal due-process behavior."
+  "claim_boundary": "D10 access control proves standing-mediated authority, event emission, and denial safety for the v0.91.1 citizen-state substrate; challenge and appeal remain review-governed evidence paths rather than raw private-state authority."
 }

--- a/adl/tests/fixtures/runtime_v2/access_control/denial_fixtures.json
+++ b/adl/tests/fixtures/runtime_v2/access_control/denial_fixtures.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "runtime_v2.access_denial_fixtures.v1",
-  "proof_id": "access-denial-fixtures-v0-90-3",
+  "proof_id": "access-denial-fixtures-v0-91-1",
   "demo_id": "D10",
   "matrix_ref": "runtime_v2/access_control/authority_matrix.json",
   "event_packet_ref": "runtime_v2/access_control/access_events.json",
@@ -43,5 +43,5 @@
     }
   ],
   "validation_command": "cargo test --manifest-path adl/Cargo.toml runtime_v2_access_control -- --nocapture",
-  "claim_boundary": "WP-12 denial fixtures prove event emission and denial safety without implementing WP-13 due-process behavior."
+  "claim_boundary": "Access denial fixtures prove event emission and denial safety without granting challenge or appeal authority as raw private-state power."
 }

--- a/adl/tests/fixtures/runtime_v2/challenge/citizen_state_threat_model.json
+++ b/adl/tests/fixtures/runtime_v2/challenge/citizen_state_threat_model.json
@@ -125,7 +125,7 @@
       "detection_artifacts": [
         "runtime_v2/private_state/sanctuary_quarantine_artifact.json",
         "runtime_v2/challenge/appeal_review_artifact.json",
-        "access-denial-fixtures-v0-90-3"
+        "access-denial-fixtures-v0-91-1"
       ],
       "fail_closed_behavior": "release is denied and the citizen remains in sanctuary/quarantine pending review",
       "covered_by_wp13": true

--- a/docs/milestones/v0.91.1/README.md
+++ b/docs/milestones/v0.91.1/README.md
@@ -30,6 +30,10 @@ v0.91.1 should establish:
   dormant, simulation, in-transit, bootstrap, shutdown, and forced-suspension
   regimes.
 - Citizen standing and citizen state as concrete runtime-facing contracts.
+  The citizen-state band may still consume inherited `v0.90.3` canonical
+  private-state baseline artifacts where current `v0.91.1` work has not
+  renumbered the historical proof identity; that inheritance should be
+  explicit, not silent.
 - Memory and identity architecture strong enough to feed v0.92 without claiming
   full identity continuity yet.
 - Theory of Mind foundations tied to citizen state, memory, and communication

--- a/docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md
+++ b/docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md
@@ -19,6 +19,9 @@ runtime substrate.
 
 In scope:
 
+- Explicitly consuming the inherited `v0.90.3` canonical private-state format
+  decision as baseline evidence where current `v0.91.1` work still depends on
+  it.
 - State format and validation rules.
 - Projection rules for runtime, operator, reviewer, and public views.
 - Malformed, stale, overexposed, and invalid-state fixtures.
@@ -32,6 +35,9 @@ Out of scope:
 
 ## Acceptance Criteria
 
+- Historical private-state baseline surfaces are labeled truthfully when
+  consumed by `v0.91.1` work rather than silently presented as newly authored
+  `v0.91.1` proofs.
 - Invalid citizen-state records fail closed.
 - Projection never exposes private state without policy permission.
 - v0.92 identity work can consume the resulting state evidence.


### PR DESCRIPTION
## Summary

Audit and renormalize carried-forward `runtime_v2` proof and milestone identity where reused implementation surfaces still advertise stale `v0.90.3` metadata, old WP-number claim boundaries, or outdated demo/source-document references inside active `v0.91.1` ownership surfaces.

## Goal

Make the reused runtime surfaces truthful so current `v0.91.1` code, fixtures, validators, and docs either point at the correct current milestone identities or are explicitly marked as inherited historical baselines.

## Required Outcome

The affected `runtime_v2` surfaces no longer silently mix current `v0.91.1` ownership with stale `v0.90.3` policy IDs, claim-boundary numbering, milestone tags, demo IDs, or source-document references.

## Deliverables

- Audit the reused `runtime_v2` surfaces for stale milestone/proof metadata drift.
- Fix current `v0.91.1` owned surfaces whose IDs, claim boundaries, WP numbers, or source-doc references no longer match current milestone truth.
- Preserve intentionally inherited historical baselines only where that inheritance is explicit and reviewable.
- Update affected tests, fixtures, validators, and milestone docs so all referenced numbers and identities match.

## Acceptance Criteria

- Active `v0.91.1` owned surfaces do not retain stale `v0.90.3` milestone/proof identity by accident.
- If a surface intentionally preserves historical baseline provenance, that status is explicit rather than implied.
- Validators and tests do not require obsolete WP-number semantics that now refer to different work packages.
- Policy IDs, proof IDs, demo IDs, milestone tags, and source-doc references are internally consistent across code, tests, fixtures, and docs.

## Repo Inputs

- `adl/src/runtime_v2/standing.rs`
- `adl/src/runtime_v2/access_control.rs`
- `adl/src/runtime_v2/private_state.rs`
- `adl/src/runtime_v2/observatory_flagship.rs`
- `adl/src/runtime_v2/csm_run.rs`
- `adl/src/runtime_v2/integrated_csm_run.rs`
- `adl/src/runtime_v2/recovery.rs`
- `adl/src/runtime_v2/quarantine.rs`
- `adl/src/runtime_v2/foundation.rs`
- `adl/src/runtime_v2/tests/standing.rs`
- `adl/src/runtime_v2/tests/access_control.rs`
- `docs/milestones/v0.91.1/README.md`
- `docs/milestones/v0.91.1/WBS_v0.91.1.md`
- `docs/milestones/v0.91.1/SPRINT_v0.91.1.md`

## Dependencies

- `#2827` WP-05 citizen standing model
- `#2828` WP-06 citizen state substrate
- Any already-merged `v0.91.1` runtime WPs that own the affected proof surfaces

## Demo Expectations

None. Preserve existing proof surfaces and milestone demo truth; do not create a new flagship demo just for metadata normalization.

## Non-goals

- Do not rewrite unrelated runtime semantics that are already correct.
- Do not renumber the existing `v0.91.1` WP plan.
- Do not erase legitimate historical provenance when it is intentionally inherited.
- Do not widen this issue into general runtime architecture cleanup beyond milestone/proof identity normalization.

## Issue-Graph Notes

- This is a bounded follow-on cleanup for carried-forward runtime surfaces discovered while reviewing WP-05.
- The issue exists to normalize stale milestone/proof identity and numbering drift across reused runtime artifacts.
- Keep the current `v0.91.1` plan intact; repair identity drift without destabilizing planned WPs.

## Notes

Numbers must match everywhere they are claimed: WP references, milestone tags, policy IDs, proof IDs, demo IDs, source feature docs, and validator/test expectations.

## Tooling Notes

- Use the conductor workflow and the editor skills.
- Prefer focused runtime tests over broad reruns.
- Verify that code, fixtures, tests, and milestone docs tell the same story before closeout.



Closes #2880
