### PR TITLE
[v0.91.1][tools] Prevent retained dirty worktrees and local slug drift from blocking future issue binds

### DIFF
--- a/adl/src/cli/pr_cmd/git_support.rs
+++ b/adl/src/cli/pr_cmd/git_support.rs
@@ -252,6 +252,20 @@ pub(super) fn ensure_local_branch_exists(branch: &str) -> Result<()> {
 }
 
 pub(super) fn branch_checked_out_worktree_path(branch: &str) -> Result<Option<PathBuf>> {
+    let primary_root = primary_checkout_root()?;
+    let normalized_primary_root = normalize_existing_worktree_path(&primary_root);
+    let canonical_worktrees_root = primary_root.join(".worktrees");
+    let normalized_canonical_worktrees_root =
+        normalize_existing_worktree_path(&canonical_worktrees_root);
+    let managed_worktree_root = std::env::var_os("ADL_WORKTREE_ROOT")
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                primary_root.join(path)
+            }
+        });
     let out = run_capture_allow_failure("git", &["worktree", "list", "--porcelain"])?;
     let Some(out) = out else { return Ok(None) };
     let mut current_worktree: Option<PathBuf> = None;
@@ -260,11 +274,36 @@ pub(super) fn branch_checked_out_worktree_path(branch: &str) -> Result<Option<Pa
             current_worktree = Some(PathBuf::from(path.trim()));
         } else if let Some(head_branch) = line.strip_prefix("branch refs/heads/") {
             if head_branch.trim() == branch {
-                return Ok(current_worktree);
+                let Some(candidate) = current_worktree.clone() else {
+                    continue;
+                };
+                let normalized_candidate = normalize_existing_worktree_path(&candidate);
+                let managed_root_matches = managed_worktree_root.as_ref().is_some_and(|root| {
+                    let normalized_root = normalize_existing_worktree_path(root);
+                    candidate.starts_with(root)
+                        || normalized_candidate.starts_with(&normalized_root)
+                });
+                if candidate == primary_root
+                    || normalized_candidate == normalized_primary_root
+                    || candidate.starts_with(&canonical_worktrees_root)
+                    || normalized_candidate.starts_with(&normalized_canonical_worktrees_root)
+                    || managed_root_matches
+                {
+                    return Ok(Some(candidate));
+                }
+                bail!(
+                    "start: branch '{}' is already checked out in non-canonical worktree '{}'. ADL only permits the primary checkout and repo-local '.worktrees/' worktrees. Remediation: remove or migrate the external worktree before rerunning.",
+                    branch,
+                    candidate.display()
+                );
             }
         }
     }
     Ok(None)
+}
+
+fn normalize_existing_worktree_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 pub(super) fn ensure_worktree_for_branch(worktree_path: &Path, branch: &str) -> Result<()> {

--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -169,6 +169,9 @@ pub(super) fn closeout_closed_completed_issue_bundle(
             .map(PathBuf::from)
             .as_deref(),
     );
+    if worktree_path.is_dir() {
+        scrub_noncanonical_issue_bundle_residue(&worktree_path, issue_ref)?;
+    }
     if worktree_path.is_dir() && has_uncommitted_or_untracked_changes(&worktree_path)? {
         let name = worktree_display_name(&worktree_path);
         record_worktree_prune_result(canonical_output, &format!("blocked_dirty: retained {name}"))?;
@@ -723,6 +726,68 @@ fn replace_worktree_only_paths_remaining(path: &Path, value: &str) -> Result<()>
         &format!("- Worktree-only paths remaining: {value}"),
     );
     fs::write(path, text)?;
+    Ok(())
+}
+
+fn scrub_noncanonical_issue_bundle_residue(
+    worktree_root: &Path,
+    issue_ref: &IssueRef,
+) -> Result<()> {
+    let adl_root = worktree_root.join(".adl");
+    if !adl_root.is_dir() {
+        return Ok(());
+    }
+
+    let canonical_body = issue_ref.issue_prompt_path(worktree_root);
+    let canonical_bundle = issue_ref.task_bundle_dir_path(worktree_root);
+    let body_prefix = format!("issue-{:04}-", issue_ref.issue_number());
+    let task_prefix = format!("issue-{:04}__", issue_ref.issue_number());
+
+    for scope_entry in fs::read_dir(&adl_root)? {
+        let scope_entry = scope_entry?;
+        let scope_path = scope_entry.path();
+
+        let bodies = scope_path.join("bodies");
+        if bodies.is_dir() {
+            for entry in fs::read_dir(&bodies)? {
+                let entry = entry?;
+                let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with("issue-")
+                    && (name.starts_with(&body_prefix) && path != canonical_body
+                        || !name.starts_with(&body_prefix))
+                {
+                    fs::remove_file(&path).with_context(|| {
+                        format!(
+                            "closeout: failed to scrub noncanonical local issue prompt residue '{}'",
+                            path.display()
+                        )
+                    })?;
+                }
+            }
+        }
+
+        let tasks = scope_path.join("tasks");
+        if tasks.is_dir() {
+            for entry in fs::read_dir(&tasks)? {
+                let entry = entry?;
+                let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with("issue-")
+                    && (name.starts_with(&task_prefix) && path != canonical_bundle
+                        || !name.starts_with(&task_prefix))
+                {
+                    fs::remove_dir_all(&path).with_context(|| {
+                        format!(
+                            "closeout: failed to scrub noncanonical local task-bundle residue '{}'",
+                            path.display()
+                        )
+                    })?;
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -1357,6 +1422,55 @@ mod tests {
 
         prune_issue_worktree(&repo, &repo, &issue_ref).expect_err("dirty worktree rejected");
         assert!(worktree.is_dir());
+    }
+
+    #[test]
+    fn scrub_noncanonical_issue_bundle_residue_keeps_only_canonical_issue_bundle() {
+        let _guard = env_lock();
+        let temp = temp_dir("adl-pr-lifecycle-scrub-foreign-bundles");
+        let repo = temp.join("repo");
+        let origin = temp.join("origin.git");
+        init_repo_with_origin(&repo, &origin);
+        let issue_ref = IssueRef::new(1410, "v0.87", "canonical-slug").expect("issue ref");
+        let foreign_ref = IssueRef::new(1411, "v0.87", "foreign-slug").expect("foreign issue ref");
+        let drift_ref =
+            IssueRef::new(1410, "v0.87", "stale-drift-slug").expect("same issue drift ref");
+        let worktree = issue_ref.default_worktree_path(&repo, None);
+        fs::create_dir_all(worktree.join(".adl").join("v0.87").join("bodies")).expect("bodies");
+        fs::create_dir_all(worktree.join(".adl").join("v0.87").join("tasks")).expect("tasks");
+
+        let canonical_body = issue_ref.issue_prompt_path(&worktree);
+        let canonical_bundle = issue_ref.task_bundle_dir_path(&worktree);
+        fs::create_dir_all(canonical_bundle.parent().expect("canonical bundle parent"))
+            .expect("canonical bundle parent mkdir");
+        fs::create_dir_all(&canonical_bundle).expect("canonical bundle");
+        fs::write(&canonical_body, "canonical body\n").expect("canonical body");
+        fs::write(canonical_bundle.join("stp.md"), "canonical stp\n").expect("canonical stp");
+
+        let foreign_body = foreign_ref.issue_prompt_path(&worktree);
+        let foreign_bundle = foreign_ref.task_bundle_dir_path(&worktree);
+        fs::create_dir_all(foreign_bundle.parent().expect("foreign bundle parent"))
+            .expect("foreign bundle parent mkdir");
+        fs::create_dir_all(&foreign_bundle).expect("foreign bundle");
+        fs::write(&foreign_body, "foreign body\n").expect("foreign body");
+        fs::write(foreign_bundle.join("stp.md"), "foreign stp\n").expect("foreign stp");
+
+        let drift_body = drift_ref.issue_prompt_path(&worktree);
+        let drift_bundle = drift_ref.task_bundle_dir_path(&worktree);
+        fs::create_dir_all(drift_bundle.parent().expect("drift bundle parent"))
+            .expect("drift bundle parent mkdir");
+        fs::create_dir_all(&drift_bundle).expect("drift bundle");
+        fs::write(&drift_body, "drift body\n").expect("drift body");
+        fs::write(drift_bundle.join("stp.md"), "drift stp\n").expect("drift stp");
+
+        scrub_noncanonical_issue_bundle_residue(&worktree, &issue_ref).expect("scrub");
+
+        assert!(canonical_body.is_file());
+        assert!(canonical_bundle.is_dir());
+        assert!(!foreign_body.exists());
+        assert!(!foreign_bundle.exists());
+        assert!(!drift_body.exists());
+        assert!(!drift_bundle.exists());
     }
 
     #[test]

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
@@ -4,7 +4,6 @@ use super::*;
 fn real_pr_finish_rejects_primary_checkout_when_issue_branch_is_bound_elsewhere() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-finish-bound-worktree-guard");
-    let worktree = temp.join("issue-worktree");
     let repo = temp.join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
     copy_bootstrap_support_files(&repo);
@@ -42,6 +41,8 @@ fn real_pr_finish_rejects_primary_checkout_when_issue_branch_is_bound_elsewhere(
         .status()
         .expect("git branch")
         .success());
+    let issue_ref = IssueRef::new(1153, "v0.86", "rust-finish-bound").expect("issue ref");
+    let worktree = issue_ref.default_worktree_path(&repo, None);
     assert!(Command::new("git")
         .args([
             "worktree",
@@ -55,8 +56,6 @@ fn real_pr_finish_rejects_primary_checkout_when_issue_branch_is_bound_elsewhere(
         .status()
         .expect("git worktree add")
         .success());
-
-    let issue_ref = IssueRef::new(1153, "v0.86", "rust-finish-bound").expect("issue ref");
     let bundle_dir = issue_ref.task_bundle_dir_path(&repo);
     fs::create_dir_all(&bundle_dir).expect("bundle dir");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish bound");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/sync_and_prompt.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/sync_and_prompt.rs
@@ -6,7 +6,6 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
     let temp = unique_temp_dir("adl-pr-finish-sync-output");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
-    let worktree = temp.join("worktree");
     fs::create_dir_all(&repo).expect("repo dir");
     copy_bootstrap_support_files(&repo);
     init_git_repo(&repo);
@@ -70,6 +69,9 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
         .status()
         .expect("git push")
         .success());
+    let issue_ref =
+        IssueRef::new(1153, "v0.86".to_string(), "rust-finish-sync".to_string()).expect("ref");
+    let worktree = issue_ref.default_worktree_path(&repo, None);
     assert!(Command::new("git")
         .args([
             "worktree",
@@ -83,9 +85,6 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
         .status()
         .expect("git worktree add")
         .success());
-
-    let issue_ref =
-        IssueRef::new(1153, "v0.86".to_string(), "rust-finish-sync".to_string()).expect("ref");
     let root_bundle_dir = issue_ref.task_bundle_dir_path(&repo);
     let wt_bundle_dir = issue_ref.task_bundle_dir_path(&worktree);
     fs::create_dir_all(&root_bundle_dir).expect("root bundle dir");
@@ -195,7 +194,6 @@ fn real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_c
     let temp = unique_temp_dir("adl-pr-finish-primary-prompt");
     let origin = temp.join("origin.git");
     let repo = temp.join("repo");
-    let worktree = temp.join("worktree");
     fs::create_dir_all(&repo).expect("repo dir");
     copy_bootstrap_support_files(&repo);
     init_git_repo(&repo);
@@ -259,6 +257,13 @@ fn real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_c
         .status()
         .expect("git push")
         .success());
+    let issue_ref = IssueRef::new(
+        1241,
+        "v0.86".to_string(),
+        "finish-primary-prompt".to_string(),
+    )
+    .expect("ref");
+    let worktree = issue_ref.default_worktree_path(&repo, None);
     assert!(Command::new("git")
         .args([
             "worktree",
@@ -272,13 +277,6 @@ fn real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_c
         .status()
         .expect("git worktree add")
         .success());
-
-    let issue_ref = IssueRef::new(
-        1241,
-        "v0.86".to_string(),
-        "finish-primary-prompt".to_string(),
-    )
-    .expect("ref");
     let root_bundle_dir = issue_ref.task_bundle_dir_path(&repo);
     let wt_bundle_dir = issue_ref.task_bundle_dir_path(&worktree);
     fs::create_dir_all(&root_bundle_dir).expect("root bundle dir");

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs
@@ -167,22 +167,40 @@ fn ensure_worktree_for_branch_rejects_branch_checked_out_elsewhere() {
     let temp = unique_temp_dir("adl-pr-worktree-conflict");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
     write_executable(
             &bin_dir.join("git"),
-            "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree /tmp/main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /tmp/existing\nHEAD cafefood\nbranch refs/heads/codex/1153-test\nEOF\n  exit 0\nfi\nexit 1\n",
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{0}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree {0}\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree {0}/.worktrees/existing\nHEAD cafefood\nbranch refs/heads/codex/1153-test\nEOF\n  exit 0\nfi\nexit 1\n",
+                repo.display(),
+                repo.join(".git").display(),
+            ),
         );
 
     let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
     }
-    let err = ensure_worktree_for_branch(Path::new("/tmp/requested"), "codex/1153-test")
-        .expect_err("conflicting worktree should fail");
+    env::set_current_dir(&repo).expect("chdir");
+    let err = ensure_worktree_for_branch(
+        &repo.join(".worktrees").join("requested"),
+        "codex/1153-test",
+    )
+    .expect_err("conflicting worktree should fail");
+    env::set_current_dir(old_pwd).expect("restore cwd");
     unsafe {
         env::set_var("PATH", old_path);
     }
     assert!(err.to_string().contains("already checked out in worktree"));
-    assert!(err.to_string().contains("/tmp/existing"));
+    assert!(err.to_string().contains(
+        &repo
+            .join(".worktrees")
+            .join("existing")
+            .display()
+            .to_string()
+    ));
 }
 
 #[test]
@@ -875,22 +893,135 @@ fn branch_checked_out_worktree_path_returns_none_without_match() {
     let temp = unique_temp_dir("adl-pr-worktree-none");
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
     write_executable(
             &bin_dir.join("git"),
-            "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree /tmp/main\nHEAD deadbeef\nbranch refs/heads/main\nEOF\n  exit 0\nfi\nexit 1\n",
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{0}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree {0}\nHEAD deadbeef\nbranch refs/heads/main\nEOF\n  exit 0\nfi\nexit 1\n",
+                repo.display(),
+                repo.join(".git").display(),
+            ),
         );
 
     let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
     }
+    env::set_current_dir(&repo).expect("chdir");
     assert_eq!(
         branch_checked_out_worktree_path("codex/missing").expect("none"),
         None
     );
+    env::set_current_dir(old_pwd).expect("restore cwd");
     unsafe {
         env::set_var("PATH", old_path);
     }
+}
+
+#[test]
+fn branch_checked_out_worktree_path_ignores_unrelated_noncanonical_worktrees() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-worktree-ignore-external");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
+    write_executable(
+            &bin_dir.join("git"),
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{0}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree /Users/daniel/.codex/worktrees/abcd/agent-design-language\nHEAD deadbeef\nbranch refs/heads/codex/external\n\nworktree {0}/.worktrees/adl-wp-1153\nHEAD cafefood\nbranch refs/heads/codex/1153-test\nEOF\n  exit 0\nfi\nexit 1\n",
+                repo.display(),
+                repo.join(".git").display(),
+            ),
+        );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let resolved =
+        branch_checked_out_worktree_path("codex/1153-test").expect("canonical worktree resolved");
+    env::set_current_dir(old_pwd).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    assert_eq!(resolved, Some(repo.join(".worktrees").join("adl-wp-1153")));
+}
+
+#[test]
+fn branch_checked_out_worktree_path_rejects_noncanonical_matching_branch() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-worktree-reject-external");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
+    write_executable(
+            &bin_dir.join("git"),
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{0}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree /Users/daniel/.codex/worktrees/abcd/agent-design-language\nHEAD deadbeef\nbranch refs/heads/codex/1153-test\nEOF\n  exit 0\nfi\nexit 1\n",
+                repo.display(),
+                repo.join(".git").display()
+            ),
+        );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let err = branch_checked_out_worktree_path("codex/1153-test")
+        .expect_err("non-canonical matching branch should fail");
+    env::set_current_dir(old_pwd).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+    }
+    assert!(err.to_string().contains("non-canonical worktree"));
+    assert!(err
+        .to_string()
+        .contains("/Users/daniel/.codex/worktrees/abcd/agent-design-language"));
+}
+
+#[test]
+fn branch_checked_out_worktree_path_accepts_explicit_managed_worktree_root() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-worktree-managed-root");
+    let bin_dir = temp.join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let repo = temp.join("repo");
+    let managed_root = temp.join("managed");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
+    fs::create_dir_all(&managed_root).expect("managed root");
+    write_executable(
+            &bin_dir.join("git"),
+            &format!(
+                "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{0}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  cat <<'EOF'\nworktree {2}/adl-wp-1153\nHEAD deadbeef\nbranch refs/heads/codex/1153-test\nEOF\n  exit 0\nfi\nexit 1\n",
+                repo.display(),
+                repo.join(".git").display(),
+                managed_root.display()
+            ),
+        );
+
+    let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
+    unsafe {
+        env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+        env::set_var("ADL_WORKTREE_ROOT", &managed_root);
+    }
+    env::set_current_dir(&repo).expect("chdir");
+    let resolved =
+        branch_checked_out_worktree_path("codex/1153-test").expect("managed worktree resolved");
+    env::set_current_dir(old_pwd).expect("restore cwd");
+    unsafe {
+        env::set_var("PATH", old_path);
+        env::remove_var("ADL_WORKTREE_ROOT");
+    }
+    assert_eq!(resolved, Some(managed_root.join("adl-wp-1153")));
 }
 
 #[test]
@@ -900,34 +1031,45 @@ fn ensure_worktree_for_branch_reuses_matching_path_and_creates_new_one() {
     let bin_dir = temp.join("bin");
     fs::create_dir_all(&bin_dir).expect("bin dir");
     let git_log = temp.join("git.log");
+    let repo = temp.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo git dir");
     write_executable(
             &bin_dir.join("git"),
             &format!(
-                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  if [ \"${{WT_MODE:-reuse}}\" = 'reuse' ]; then\n    cat <<'EOF'\nworktree /tmp/reuse-me\nHEAD deadbeef\nbranch refs/heads/codex/reuse\nEOF\n    exit 0\n  fi\n  printf 'worktree /tmp/main\\nHEAD deadbeef\\nbranch refs/heads/main\\n'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree add /tmp/create-me' ]; then\n  mkdir -p /tmp/create-me\n  exit 0\nfi\nexit 1\n",
-                git_log.display()
+                "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$*\" >> '{0}'\nif [ \"$1 $2\" = 'rev-parse --show-toplevel' ]; then\n  printf '%s\\n' '{1}'\n  exit 0\nfi\nif [ \"$1 $2\" = 'rev-parse --git-common-dir' ]; then\n  printf '%s\\n' '{2}'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree list --porcelain' ]; then\n  if [ \"${{WT_MODE:-reuse}}\" = 'reuse' ]; then\n    cat <<'EOF'\nworktree {1}/.worktrees/reuse-me\nHEAD deadbeef\nbranch refs/heads/codex/reuse\nEOF\n    exit 0\n  fi\n  printf 'worktree {1}\\nHEAD deadbeef\\nbranch refs/heads/main\\n'\n  exit 0\nfi\nif [ \"$1 $2 $3\" = 'worktree add {1}/.worktrees/create-me' ]; then\n  mkdir -p {1}/.worktrees/create-me\n  exit 0\nfi\nexit 1\n",
+                git_log.display(),
+                repo.display(),
+                repo.join(".git").display()
             ),
         );
 
     let old_path = env::var("PATH").unwrap_or_default();
+    let old_pwd = env::current_dir().expect("cwd");
     unsafe {
         env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
         env::set_var("WT_MODE", "reuse");
     }
-    ensure_worktree_for_branch(Path::new("/tmp/reuse-me"), "codex/reuse").expect("reuse");
+    env::set_current_dir(&repo).expect("chdir");
+    ensure_worktree_for_branch(&repo.join(".worktrees").join("reuse-me"), "codex/reuse")
+        .expect("reuse");
 
     unsafe {
         env::set_var("WT_MODE", "create");
     }
-    let create_path = Path::new("/tmp/create-me");
-    let _ = fs::remove_dir_all(create_path);
-    ensure_worktree_for_branch(create_path, "codex/create").expect("create");
+    let create_path = repo.join(".worktrees").join("create-me");
+    let _ = fs::remove_dir_all(&create_path);
+    ensure_worktree_for_branch(&create_path, "codex/create").expect("create");
 
+    env::set_current_dir(old_pwd).expect("restore cwd");
     unsafe {
         env::set_var("PATH", old_path);
         env::remove_var("WT_MODE");
     }
     let log = fs::read_to_string(&git_log).expect("git log");
-    assert!(log.contains("worktree add /tmp/create-me codex/create"));
+    assert!(log.contains(&format!(
+        "worktree add {} codex/create",
+        create_path.display()
+    )));
 }
 
 #[test]


### PR DESCRIPTION
Closes #2878

## Summary
Hardened ADL worktree truth so hidden external Git worktrees no longer silently participate in branch/worktree reuse, while preserving explicit `ADL_WORKTREE_ROOT` overrides and scrubbing noncanonical local issue bundle residue from retained dirty worktrees before closeout bails.

## Artifacts
- Tracked code updates:
  - `adl/src/cli/pr_cmd/git_support.rs`
  - `adl/src/cli/pr_cmd/lifecycle.rs`
  - `adl/src/cli/tests/pr_cmd_inline/repo_helpers.rs`
- Local ignored execution record:
  - `.adl/v0.91.1/tasks/issue-2878__v0-91-1-tools-prevent-retained-dirty-worktrees-and-local-slug-drift-from-blocking-future-issue-binds/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Normalized Rust formatting for the changed tooling and test files.
  - `cargo test --manifest-path adl/Cargo.toml branch_checked_out_worktree_path -- --nocapture`
    Verified canonical, managed-root, and noncanonical branch/worktree detection behavior.
  - `cargo test --manifest-path adl/Cargo.toml ensure_worktree_for_branch -- --nocapture`
    Verified canonical reuse and creation behavior still works with the filtered worktree model.
  - `cargo test --manifest-path adl/Cargo.toml scrub_noncanonical_issue_bundle_residue -- --nocapture`
    Verified retained dirty worktree cleanup preserves only the canonical current-issue bundle.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the changed tooling/test surfaces are lint-clean.
  - `git diff --check`
    Verified there is no whitespace or patch-format drift in the branch delta.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2878__v0-91-1-tools-prevent-retained-dirty-worktrees-and-local-slug-drift-from-blocking-future-issue-binds/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2878__v0-91-1-tools-prevent-retained-dirty-worktrees-and-local-slug-drift-from-blocking-future-issue-binds/sor.md
- Idempotency-Key: v0-91-1-tools-prevent-retained-dirty-worktrees-and-local-slug-drift-from-blocking-future-issue-binds-adl-v0-91-1-tasks-issue-2878-v0-91-1-tools-prevent-retained-dirty-worktrees-and-local-slug-drift-from-blocking-future-issue-binds-sip-md-adl-v0-91-1-tasks-issue-2878-v0-91-1-tools-prevent-retained-dirty-worktrees-and-local-slug-drift-from-blocking-future-issue-binds-sor-md