### PR TITLE
[v0.91.1][docs] Restore missing milestone planning package surfaces

### DIFF
--- a/docs/milestones/v0.91.1/DECISIONS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/DECISIONS_v0.91.1.md
@@ -1,0 +1,28 @@
+# Decisions - v0.91.1
+
+## Status
+
+Working milestone-decision record for the active `v0.91.1` execution package.
+
+## Current Decisions
+
+1. `v0.91.1` is an implementation milestone, not a planning-only bridge.
+2. The milestone's hard success condition is an observatory-visible
+   agent-shaped runtime proof inside the CSM boundary.
+3. Runtime/polis claims must stay grounded in the current Runtime v2 code and
+   source packet, not older aspirational world-language.
+4. Citizen standing and citizen state are first-class runtime contracts.
+5. Historical `v0.90.3` private-state baselines may be inherited only when
+   that inheritance is explicit.
+6. ACIP/A2A work remains local and authenticated; external transport is out of
+   scope.
+7. `v0.92` owns the first true birthday and identity-continuity claims.
+
+## Decision Inputs
+
+- [README.md](README.md)
+- [WBS_v0.91.1.md](WBS_v0.91.1.md)
+- [SPRINT_v0.91.1.md](SPRINT_v0.91.1.md)
+- [RUNTIME_POLIS_ARCHITECTURE_PACKAGE_v0.91.1.md](RUNTIME_POLIS_ARCHITECTURE_PACKAGE_v0.91.1.md)
+- [features/README.md](features/README.md)
+

--- a/docs/milestones/v0.91.1/DESIGN_v0.91.1.md
+++ b/docs/milestones/v0.91.1/DESIGN_v0.91.1.md
@@ -1,0 +1,53 @@
+# Design - v0.91.1
+
+## Design Center
+
+`v0.91.1` is centered on making inhabited-runtime readiness concrete without
+collapsing into birthday or identity overclaim.
+
+Key design rules:
+
+- runtime claims must stay source-grounded
+- lifecycle state governs reception and invocation eligibility
+- standing and state remain explicit contracts
+- observatory visibility must preserve redaction boundaries
+- learning, intelligence, and ToM stay evidence-bound
+- communication remains local, authenticated, and policy-gated
+
+## Core Surfaces
+
+The milestone design is organized around:
+
+- runtime/polis architecture
+- lifecycle state model
+- CSM observatory active surface
+- citizen standing and citizen state
+- memory and identity architecture
+- Theory of Mind foundation
+- capability and aptitude testing
+- intelligence metric architecture
+- governed learning
+- ANRM/Gemma placement
+- ACIP hardening and A2A boundary
+- runtime inhabitant integration and flagship demo
+
+## Proof Flow
+
+The design should converge toward one bounded runtime proof path:
+
+1. architecture and lifecycle truth
+2. standing and state truth
+3. memory, ToM, capability, intelligence, and learning truth
+4. authenticated local communication truth
+5. integrated runtime inhabitant proof
+6. observatory-visible flagship demo
+
+## Boundary Rules
+
+The design should preserve:
+
+- no birthday or identity-completion claims
+- no external transport readiness claims
+- no hidden authority transfer through ACIP/A2A language
+- no public exposure of private citizen state
+

--- a/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
@@ -1,0 +1,27 @@
+# End Of Milestone Report - v0.91.1
+
+## Status
+
+Not complete. This is a milestone report scaffold restored so the package is
+structurally complete, but the milestone itself is still in progress.
+
+## Current Partial Outcome
+
+As of the current package repair:
+
+- `WP-01` through `WP-05` are closed
+- `WP-06` through `WP-24` remain open
+- the runtime proof and review/release tail are not complete
+
+## What This Report Must Eventually Cover
+
+- inhabited-runtime proof outcome
+- flagship demo outcome
+- quality and coverage outcome
+- review/remediation outcome
+- handoff and ceremony outcome
+
+## Current Judgment
+
+Do not treat this report as release closure.
+

--- a/docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md
@@ -1,0 +1,47 @@
+# Feature Proof Coverage - v0.91.1
+
+## Status
+
+Active milestone coverage map. Some early runtime surfaces are landed; the
+broader proof and demo convergence band is still pending.
+
+## Coverage Rule
+
+Each feature should have one truthful proof route:
+
+- landed implementation and focused validation
+- integrated demo route
+- explicit pending owner in the issue wave
+
+## Feature Coverage Map
+
+| Feature | WP | Current Route | Status |
+| --- | --- | --- | --- |
+| Runtime/polis architecture | WP-02 | [RUNTIME_POLIS_ARCHITECTURE_PACKAGE_v0.91.1.md](RUNTIME_POLIS_ARCHITECTURE_PACKAGE_v0.91.1.md) | landed |
+| Agent lifecycle state model | WP-03 | feature doc + landed runtime/tests | landed |
+| CSM observatory active surface | WP-04 | feature doc + landed runtime/tests | landed |
+| Citizen standing | WP-05 | feature doc + landed runtime/tests | landed |
+| Citizen state | WP-06 | feature doc only; execution pending | pending |
+| Memory/identity architecture | WP-07 | feature doc only; execution pending | pending |
+| Theory of Mind foundation | WP-08 | feature doc only; execution pending | pending |
+| Capability/aptitude testing | WP-09 | feature doc only; execution pending | pending |
+| Intelligence metric architecture | WP-10 | feature doc only; execution pending | pending |
+| Governed learning | WP-11 | feature doc only; execution pending | pending |
+| ANRM/Gemma placement | WP-12 | feature doc only; execution pending | pending |
+| ACIP hardening | WP-13 | feature doc only; execution pending | pending |
+| A2A adapter boundary | WP-14 | feature doc only; execution pending | pending |
+| Runtime inhabitant proof | WP-15 | integrated proof route planned | pending |
+| Observatory-visible flagship demo | WP-16 | demo route planned in [DEMO_MATRIX_v0.91.1.md](DEMO_MATRIX_v0.91.1.md) | pending |
+
+## Explicit Deferrals
+
+- `v0.91.2`: tooling, benchmark, productization, publication, and workflow
+  recovery surfaces
+- `v0.92`: birthday and identity-continuity work
+
+## Non-Claims
+
+- full milestone proof coverage is not complete yet
+- the flagship demo is not yet landed
+- review and release convergence have not happened yet
+

--- a/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
+++ b/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
@@ -1,0 +1,38 @@
+# Milestone Checklist - v0.91.1
+
+## Planning Readiness
+
+- [x] README, WBS, sprint plan, issue wave, execution readiness, and demo matrix exist.
+- [x] Feature index exists and names concrete WP homes.
+- [x] Card bundle readiness has been recorded.
+- [x] Runtime/polis architecture package exists.
+- [x] Missing milestone-planning package surfaces have been restored.
+
+## Execution Status
+
+- [x] WP-01 Design pass
+- [x] WP-02 Runtime and polis architecture alignment
+- [x] WP-03 Agent lifecycle state model
+- [x] WP-04 CSM observatory active surface
+- [x] WP-05 Citizen standing model
+- [ ] WP-06 Citizen state substrate
+- [ ] WP-07 through WP-16 implementation and flagship proof band
+- [ ] WP-17 Demo matrix and proof coverage closeout
+- [ ] WP-18 Coverage / quality gate
+- [ ] WP-19 Docs + review pass
+- [ ] WP-20 Internal review
+- [ ] WP-21 External / 3rd-party review
+- [ ] WP-22 Review findings remediation
+- [ ] WP-23 v0.92 birthday readiness handoff
+- [ ] WP-24 Release ceremony
+
+## Review And Release Readiness
+
+- [ ] Feature-proof coverage is complete for the whole milestone.
+- [ ] Quality gate is recorded.
+- [ ] Internal review is complete.
+- [ ] External review is complete or explicitly deferred.
+- [ ] Accepted findings are fixed or dispositioned.
+- [ ] Release evidence and release readiness are complete.
+- [ ] Ceremony completed.
+

--- a/docs/milestones/v0.91.1/NEXT_MILESTONE_HANDOFF_v0.91.1.md
+++ b/docs/milestones/v0.91.1/NEXT_MILESTONE_HANDOFF_v0.91.1.md
@@ -1,0 +1,37 @@
+# Next Milestone Handoff - v0.91.1
+
+## Purpose
+
+Record what `v0.91.1` is supposed to hand to later milestones once its runtime
+readiness band is complete.
+
+## Current Handoff Direction
+
+`v0.91.1` should hand:
+
+- concrete inhabited-runtime evidence to `v0.92`
+- clearer runtime substrate truth to `v0.91.2`
+- ACIP/A2A local-boundary truth to later transport and federation work
+
+## v0.92 Placement
+
+`v0.92` should consume:
+
+- runtime inhabitant proof surfaces
+- memory/identity architecture outputs
+- citizen state and lifecycle evidence
+- birthday-readiness handoff from `WP-23`
+
+## v0.91.2 Placement
+
+`v0.91.2` should consume:
+
+- clearer runtime substrate/package truth
+- reviewable docs and feature surfaces
+- remaining tooling and benchmark backlog that `v0.91.1` does not own
+
+## Non-Reduction Rule
+
+- `v0.91.1` is not only planning cleanup
+- `v0.91.2` does not replace the inhabited-runtime implementation band
+

--- a/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
@@ -1,0 +1,39 @@
+# v0.91.1 Coverage and Quality Gate
+
+## Metadata
+
+- Milestone: `v0.91.1`
+- Status: pending
+- Canonical gate WP: `WP-18`
+
+## Purpose
+
+This document is the milestone-level quality gate surface for `v0.91.1`. It
+must record the final CI, coverage, docs, demo, and review posture once the
+milestone reaches its quality phase.
+
+## Current State
+
+The quality gate is not complete yet.
+
+Known execution truth today:
+
+- `WP-01` through `WP-05` are closed
+- `WP-06` through `WP-24` remain open
+- the flagship demo and final proof-convergence band are not complete
+- internal review, external review, remediation, and release ceremony are not
+  complete
+
+## Required Inputs Before Pass/Fail Judgment
+
+- demo matrix and feature-proof coverage
+- final milestone CI and coverage evidence
+- docs + review pass outputs
+- internal and external review records
+- findings remediation record
+- release evidence and release readiness package
+
+## Current Judgment
+
+`NOT_READY`
+

--- a/docs/milestones/v0.91.1/README.md
+++ b/docs/milestones/v0.91.1/README.md
@@ -99,6 +99,9 @@ not import the broad provider-native benchmark planning surface.
 ## Document Map
 
 - WBS: [WBS_v0.91.1.md](WBS_v0.91.1.md)
+- Vision: [VISION_v0.91.1.md](VISION_v0.91.1.md)
+- Design: [DESIGN_v0.91.1.md](DESIGN_v0.91.1.md)
+- Decisions: [DECISIONS_v0.91.1.md](DECISIONS_v0.91.1.md)
 - Sprint plan: [SPRINT_v0.91.1.md](SPRINT_v0.91.1.md)
 - Active issue wave: [WP_ISSUE_WAVE_v0.91.1.yaml](WP_ISSUE_WAVE_v0.91.1.yaml)
 - Execution readiness:
@@ -106,9 +109,23 @@ not import the broad provider-native benchmark planning surface.
 - Runtime/polis architecture package:
   [RUNTIME_POLIS_ARCHITECTURE_PACKAGE_v0.91.1.md](RUNTIME_POLIS_ARCHITECTURE_PACKAGE_v0.91.1.md)
 - Demo matrix: [DEMO_MATRIX_v0.91.1.md](DEMO_MATRIX_v0.91.1.md)
+- Feature proof coverage:
+  [FEATURE_PROOF_COVERAGE_v0.91.1.md](FEATURE_PROOF_COVERAGE_v0.91.1.md)
+- Quality gate: [QUALITY_GATE_v0.91.1.md](QUALITY_GATE_v0.91.1.md)
 - Feature index: [features/README.md](features/README.md)
 - Card bundle readiness:
   [CARD_BUNDLE_READINESS_v0.91.1.md](CARD_BUNDLE_READINESS_v0.91.1.md)
+- SPP readiness: [SPP_READINESS_v0.91.1.md](SPP_READINESS_v0.91.1.md)
+- Milestone checklist:
+  [MILESTONE_CHECKLIST_v0.91.1.md](MILESTONE_CHECKLIST_v0.91.1.md)
+- Release plan: [RELEASE_PLAN_v0.91.1.md](RELEASE_PLAN_v0.91.1.md)
+- Release readiness: [RELEASE_READINESS_v0.91.1.md](RELEASE_READINESS_v0.91.1.md)
+- Release evidence: [RELEASE_EVIDENCE_v0.91.1.md](RELEASE_EVIDENCE_v0.91.1.md)
+- Release notes: [RELEASE_NOTES_v0.91.1.md](RELEASE_NOTES_v0.91.1.md)
+- Next milestone handoff:
+  [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
+- End-of-milestone report:
+  [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 
 ## Success Criteria
 

--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -1,0 +1,34 @@
+# Release Evidence - v0.91.1
+
+## Purpose
+
+Track the milestone package, proof surfaces, and evidence gaps required for a
+truthful `v0.91.1` release decision.
+
+## Current Core Package
+
+- [README.md](README.md)
+- [WBS_v0.91.1.md](WBS_v0.91.1.md)
+- [SPRINT_v0.91.1.md](SPRINT_v0.91.1.md)
+- [WP_ISSUE_WAVE_v0.91.1.yaml](WP_ISSUE_WAVE_v0.91.1.yaml)
+- [WP_EXECUTION_READINESS_v0.91.1.md](WP_EXECUTION_READINESS_v0.91.1.md)
+- [DEMO_MATRIX_v0.91.1.md](DEMO_MATRIX_v0.91.1.md)
+- [FEATURE_PROOF_COVERAGE_v0.91.1.md](FEATURE_PROOF_COVERAGE_v0.91.1.md)
+- [QUALITY_GATE_v0.91.1.md](QUALITY_GATE_v0.91.1.md)
+
+## Current Landed Evidence
+
+- `WP-02` runtime/polis architecture package
+- `WP-03` lifecycle-state implementation
+- `WP-04` observatory active surface implementation
+- `WP-05` citizen standing implementation
+
+## Evidence Still Missing
+
+- citizen-state implementation and later runtime slices
+- integrated runtime inhabitant proof
+- observatory-visible flagship demo
+- final quality gate
+- internal/external review records
+- remediation and ceremony records
+

--- a/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
@@ -1,0 +1,32 @@
+# v0.91.1 Release Notes
+
+## Status
+
+Draft only. `v0.91.1` is still in active execution and is not ready for final
+release notes.
+
+## Theme
+
+Inhabited-runtime readiness inside the CSM/polis boundary.
+
+## Landed So Far
+
+- runtime/polis architecture alignment
+- agent lifecycle state model
+- CSM observatory active surface
+- citizen standing model
+
+## Still Pending
+
+- citizen state and later runtime surfaces
+- integrated runtime inhabitant proof
+- flagship observatory demo
+- milestone review, remediation, and release ceremony
+
+## Not Claimed
+
+- final release completion
+- birthday or identity continuity
+- constitutional citizenship
+- external transport readiness
+

--- a/docs/milestones/v0.91.1/RELEASE_PLAN_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_PLAN_v0.91.1.md
@@ -1,0 +1,34 @@
+# Release Plan - v0.91.1
+
+## Release Theme
+
+Ship inhabited-runtime readiness as a bounded, reviewable runtime package
+without overclaiming birthday, identity, or external-transport completion.
+
+## Required Evidence
+
+- runtime/polis architecture package
+- lifecycle, standing, and state evidence
+- memory, ToM, capability, intelligence, and learning evidence
+- ACIP/A2A hardening evidence
+- runtime inhabitant integration proof
+- observatory-visible flagship demo
+- feature-proof coverage and quality gate
+- review and remediation records
+
+## Release Risks
+
+- runtime evidence may be mistaken for birthday or identity completion
+- ACIP/A2A work may be mistaken for external transport readiness
+- early landed slices may be mistaken for full milestone completion
+- docs may overclaim review or release state before those phases run
+
+## Release Rule
+
+Do not mark `v0.91.1` releasable until:
+
+- `WP-16` through `WP-24` are completed or dispositioned truthfully
+- the quality gate is recorded
+- internal/external review state is explicit
+- release readiness and release evidence are complete
+

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -1,0 +1,38 @@
+# Release Readiness - v0.91.1
+
+## Status
+
+Not release ready.
+
+## Review Entry Points
+
+- [README.md](README.md)
+- [WBS_v0.91.1.md](WBS_v0.91.1.md)
+- [SPRINT_v0.91.1.md](SPRINT_v0.91.1.md)
+- [WP_ISSUE_WAVE_v0.91.1.yaml](WP_ISSUE_WAVE_v0.91.1.yaml)
+- [DEMO_MATRIX_v0.91.1.md](DEMO_MATRIX_v0.91.1.md)
+- [FEATURE_PROOF_COVERAGE_v0.91.1.md](FEATURE_PROOF_COVERAGE_v0.91.1.md)
+- [QUALITY_GATE_v0.91.1.md](QUALITY_GATE_v0.91.1.md)
+- [RELEASE_PLAN_v0.91.1.md](RELEASE_PLAN_v0.91.1.md)
+- [RELEASE_EVIDENCE_v0.91.1.md](RELEASE_EVIDENCE_v0.91.1.md)
+
+## Current Issue State
+
+- `WP-01` through `WP-05` are closed
+- `WP-06` through `WP-24` are open
+- the final proof/demo/review/release band has not run yet
+
+## Current Blockers
+
+- citizen state and later runtime slices are still open
+- integrated runtime inhabitant proof is not landed
+- flagship demo is not landed
+- quality gate is pending
+- internal review, external review, remediation, handoff, and ceremony are pending
+
+## Version Truth
+
+- active milestone package: `v0.91.1`
+- `v0.91` is prior and structurally complete
+- `v0.91.2` is the follow-on tooling/productization milestone
+

--- a/docs/milestones/v0.91.1/SPP_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/SPP_READINESS_v0.91.1.md
@@ -1,0 +1,30 @@
+# v0.91.1 SPP Readiness
+
+## Purpose
+
+Record the planning-surface readiness of Structured Plan Prompt (`SPP`)
+artifacts across the `v0.91.1` issue wave.
+
+## Current State
+
+`v0.91.1` was opened with local STP, SIP, SPP, SRP, and SOR bundles for the
+issue wave, and the package already includes
+[CARD_BUNDLE_READINESS_v0.91.1.md](CARD_BUNDLE_READINESS_v0.91.1.md).
+
+## What Is Ready
+
+- the milestone treats `SPP` as a first-class planning artifact
+- issue-wave bundles include `spp.md`
+- package-level readiness is recorded in the card-bundle readiness doc
+
+## Remaining Gaps
+
+- per-issue SPP quality still depends on truthful issue-local maintenance
+- no claim is made here that all downstream SPPs remain perfect after issue
+  execution drift
+
+## Non-Claims
+
+- this doc does not claim milestone completion
+- this doc does not replace per-issue SPP review
+

--- a/docs/milestones/v0.91.1/VISION_v0.91.1.md
+++ b/docs/milestones/v0.91.1/VISION_v0.91.1.md
@@ -1,0 +1,58 @@
+# Vision - v0.91.1
+
+## Inhabited Runtime Readiness
+
+`v0.91.1` is the adjacent-systems implementation milestone that should make the
+CSM and polis boundary concrete enough for an observatory-visible agent-shaped
+runtime proof.
+
+## Strategic Thesis
+
+The milestone should turn the existing runtime/planning corpus into bounded,
+implemented surfaces that later identity and birthday work can consume
+directly:
+
+- runtime/polis architecture should be source-grounded rather than rhetorical
+- lifecycle state should decide when an agent may receive, queue, reject, or
+  invoke messages
+- standing and state should become explicit runtime contracts, not only prose
+- memory, ToM, capability, intelligence, and learning should stay
+  evidence-bound
+- ACIP/A2A should remain local, authenticated, traceable, and policy-gated
+- observatory/operator projection should make the runtime reviewable without
+  exposing private state
+
+## What Success Looks Like
+
+At closeout, reviewers should be able to inspect a bounded runtime proof
+surface that includes:
+
+- runtime/polis architecture aligned with current code
+- lifecycle-state evidence
+- standing and citizen-state packets
+- one authenticated local communication or invocation event
+- observatory/operator projection artifacts
+- explicit redaction and non-claim boundaries
+
+## What This Enables
+
+`v0.91.1` should enable:
+
+- `v0.91.2` tooling and evaluation work to operate against a clearer runtime
+  substrate
+- `v0.92` birthday and identity-readiness work to consume concrete runtime
+  surfaces instead of planning prose
+- later constitutional and social-governance work to inherit better runtime
+  evidence
+
+## What It Must Avoid
+
+`v0.91.1` should not claim:
+
+- the first true birthday
+- durable identity continuity
+- constitutional citizenship
+- legal personhood
+- external or cross-polis transport readiness
+- broad provider-native tool-call conformance
+


### PR DESCRIPTION
Closes #2887

## Summary
Restored the missing milestone-planning package surfaces for `v0.91.1` and
updated the milestone `README` document map so the package is once again
navigable as an active but incomplete execution milestone.

## Artifacts
- `docs/milestones/v0.91.1/VISION_v0.91.1.md`
- `docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md`
- `docs/milestones/v0.91.1/DESIGN_v0.91.1.md`
- `docs/milestones/v0.91.1/DECISIONS_v0.91.1.md`
- `docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md`
- `docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md`
- `docs/milestones/v0.91.1/RELEASE_PLAN_v0.91.1.md`
- `docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md`
- `docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md`
- `docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md`
- `docs/milestones/v0.91.1/NEXT_MILESTONE_HANDOFF_v0.91.1.md`
- `docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md`
- `docs/milestones/v0.91.1/SPP_READINESS_v0.91.1.md`
- updated `docs/milestones/v0.91.1/README.md`

## Validation
- `git -C .worktrees/adl-wp-2887 diff --check`
  Verified the docs delta is whitespace-clean.
- `python3 existence/link check for restored v0.91.1 docs`
  Verified every restored milestone doc exists and each one is linked from
  `docs/milestones/v0.91.1/README.md`.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2887__v0-91-1-docs-restore-missing-milestone-planning-package-surfaces/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2887__v0-91-1-docs-restore-missing-milestone-planning-package-surfaces/sor.md
- Idempotency-Key: v0-91-1-docs-restore-missing-milestone-planning-package-surfaces-adl-v0-91-1-tasks-issue-2887-v0-91-1-docs-restore-missing-milestone-planning-package-surfaces-sip-md-adl-v0-91-1-tasks-issue-2887-v0-91-1-docs-restore-missing-milestone-planning-package-surfaces-sor-md