### PR TITLE
[v0.91.1][docs] Prepare v0.91.2 milestone planning package surfaces

### DIFF
--- a/docs/milestones/v0.91.2/CARD_BUNDLE_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/CARD_BUNDLE_READINESS_v0.91.2.md
@@ -1,0 +1,24 @@
+# Card Bundle Readiness - v0.91.2
+
+## Status
+
+Planned, not opened.
+
+## Current State
+
+`v0.91.2` does not yet have an opened issue wave, so the full STP/SIP/SPP/SRP/SOR
+bundle set is not yet expected to exist for every WP.
+
+## Opening Rule
+
+When the milestone opens:
+
+- each WP should receive STP, SIP, SPP, SRP, and SOR cards
+- bundle validation should be recorded
+- the package should be updated from planned to active state
+
+## Non-Claims
+
+- this doc does not claim the issue wave is already opened
+- this doc does not claim per-WP card bundles already exist
+

--- a/docs/milestones/v0.91.2/DECISIONS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/DECISIONS_v0.91.2.md
@@ -1,0 +1,27 @@
+# Decisions - v0.91.2
+
+## Status
+
+Working milestone-decision record for the planned `v0.91.2` package.
+
+## Current Decisions
+
+1. `v0.91.2` is a tooling/evaluation/productization milestone, not a moral
+   governance or runtime-inhabitant milestone.
+2. UTS + ACC benchmark work must preserve proposal-versus-authority separation.
+3. Runtime/test-cycle recovery may reduce waste, but not by silently weakening
+   proof obligations.
+4. Workspace and modernization work remain bounded demos, not canonical-source
+   replacement or mass rewrite authority.
+5. Publication work must stay packetized and review-gated.
+6. Workflow guardrails are a first-class milestone surface because recent
+   failures were real project risks.
+
+## Decision Inputs
+
+- [README.md](README.md)
+- [WBS_v0.91.2.md](WBS_v0.91.2.md)
+- [SPRINT_v0.91.2.md](SPRINT_v0.91.2.md)
+- [WP_EXECUTION_READINESS_v0.91.2.md](WP_EXECUTION_READINESS_v0.91.2.md)
+- [features/README.md](features/README.md)
+

--- a/docs/milestones/v0.91.2/DESIGN_v0.91.2.md
+++ b/docs/milestones/v0.91.2/DESIGN_v0.91.2.md
@@ -1,0 +1,44 @@
+# Design - v0.91.2
+
+## Design Center
+
+`v0.91.2` is designed as a pressure-release milestone: reduce operational pain,
+improve evaluation and productization surfaces, and keep authority boundaries
+intact.
+
+Key design rules:
+
+- model/tool-call comparison must not weaken ACC/Freedom Gate authority
+- runtime/test-cycle recovery must preserve proving posture
+- review/product surfaces must cite evidence and preserve uncertainty
+- Workspace and modernization demos must stay bounded and reversible
+- publication work must remain packetized and review-gated
+- workflow guardrails must fail closed rather than clobbering user work
+
+## Core Surfaces
+
+- benchmark harness and comparison report
+- runtime/test-cycle recovery packet
+- CodeBuddy/review packet productization
+- Workspace bridge and adapter-boundary packet
+- modernization demo packet
+- publication packet and paper backlog
+- rustdoc/doc cleanup packet
+- workflow guardrails and runbooks
+
+## Proof Flow
+
+The milestone should converge toward:
+
+1. benchmark and runtime-recovery truth
+2. review/product/workspace/moderization truth
+3. publication/doc/guardrail truth
+4. demo/proof coverage, quality gate, review, remediation, and ceremony
+
+## Boundary Rules
+
+- no hidden tool authority through provider-native APIs
+- no repo-truth replacement through external doc systems
+- no publication claims without review
+- no mass rewrite claims through modernization demos
+

--- a/docs/milestones/v0.91.2/END_OF_MILESTONE_REPORT_v0.91.2.md
+++ b/docs/milestones/v0.91.2/END_OF_MILESTONE_REPORT_v0.91.2.md
@@ -1,0 +1,18 @@
+# End Of Milestone Report - v0.91.2
+
+## Status
+
+Not complete. This is a milestone report scaffold restored so the package is
+structurally complete, but the milestone itself has not started execution.
+
+## What This Report Must Eventually Cover
+
+- benchmark outcome
+- runtime/test-cycle recovery outcome
+- product/workspace/modernization/publication/doc/guardrail outcomes
+- quality, review, remediation, handoff, and ceremony outcomes
+
+## Current Judgment
+
+Do not treat this report as release closure.
+

--- a/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
@@ -1,0 +1,37 @@
+# Feature Proof Coverage - v0.91.2
+
+## Status
+
+Planned milestone coverage map. `v0.91.2` is not open for execution yet, so
+these are intended proof routes rather than landed proofs.
+
+## Coverage Rule
+
+Each feature should eventually have one truthful proof route:
+
+- executable benchmark, report, or harness
+- bounded demo packet
+- docs/product/report packet
+- explicit quality/review/release surface
+
+## Feature Coverage Map
+
+| Feature | WP | Intended Route | Status |
+| --- | --- | --- | --- |
+| UTS + ACC multi-model benchmark | WP-02, WP-03 | harness + comparison report | planned |
+| Runtime/test-cycle recovery | WP-04, WP-05 | runtime-analysis packet + coverage ergonomics evidence | planned |
+| CodeBuddy productization | WP-06 | review packet + product-report package | planned |
+| Review heuristics and demos | WP-07 | skill/demo packet | planned |
+| Workspace CMS bridge | WP-08, WP-09 | bounded demo + adapter-boundary packet | planned |
+| Code modernization | WP-10 | dry-run modernization demo | planned |
+| Publication program | WP-11 | backlog/process packet | planned |
+| General intelligence paper packet | WP-12 | claim/citation/review packet | planned |
+| Rustdoc/doc cleanup | WP-13 | cleanup report + doc patch set | planned |
+| Workflow guardrails | WP-14 | guardrail proofs + runbook | planned |
+| Demo/proof convergence | WP-15 | demo matrix and proof coverage | planned |
+
+## Non-Claims
+
+- no feature in this milestone is landed yet through this document alone
+- this file is not evidence that the issue wave has opened
+

--- a/docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md
+++ b/docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md
@@ -1,0 +1,27 @@
+# Milestone Checklist - v0.91.2
+
+## Planning Readiness
+
+- [x] README, WBS, sprint plan, issue wave, execution readiness, and demo matrix exist.
+- [x] Feature index exists and names concrete WP homes.
+- [x] Missing milestone-planning package surfaces have been restored.
+- [ ] Candidate issue wave opened into tracked GitHub issues.
+- [ ] Local STP/SIP/SPP/SRP/SOR bundle wave generated for every WP.
+
+## Execution Readiness
+
+- [ ] Benchmark harness scope accepted.
+- [ ] Runtime/test-cycle recovery scope accepted.
+- [ ] Review-product, Workspace, modernization, publication, rustdoc, and guardrail scopes accepted.
+- [ ] Quality/review/release tail accepted.
+
+## Review And Release Readiness
+
+- [ ] Feature-proof coverage is complete for the whole milestone.
+- [ ] Quality gate is recorded.
+- [ ] Internal review is complete.
+- [ ] External review is complete or explicitly deferred.
+- [ ] Accepted findings are fixed or dispositioned.
+- [ ] Release evidence and release readiness are complete.
+- [ ] Ceremony completed.
+

--- a/docs/milestones/v0.91.2/NEXT_MILESTONE_HANDOFF_v0.91.2.md
+++ b/docs/milestones/v0.91.2/NEXT_MILESTONE_HANDOFF_v0.91.2.md
@@ -1,0 +1,27 @@
+# Next Milestone Handoff - v0.91.2
+
+## Purpose
+
+Record what `v0.91.2` is intended to hand forward once the tooling and
+productization band is complete.
+
+## Intended Handoff Direction
+
+`v0.91.2` should eventually hand:
+
+- better benchmark and provider-comparison evidence
+- healthier test/coverage operating posture
+- better review and product-report surfaces
+- safer Workspace and workflow guardrails
+
+## Downstream Consumers
+
+- later runtime and identity milestones that benefit from cheaper proving loops
+- later product/reporting work that benefits from better review packets
+- later workflow automation that depends on stronger guardrails
+
+## Non-Reduction Rule
+
+- `v0.91.2` should not replace `v0.91.1`
+- `v0.91.2` should not silently absorb future identity or governance milestones
+

--- a/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
@@ -1,0 +1,32 @@
+# v0.91.2 Coverage and Quality Gate
+
+## Metadata
+
+- Milestone: `v0.91.2`
+- Status: pending
+- Canonical gate WP: `WP-16`
+
+## Purpose
+
+This document is the milestone-level quality gate surface for `v0.91.2`. It
+must record the final CI, coverage, docs, demo, and review posture once the
+milestone reaches its quality phase.
+
+## Current State
+
+The quality gate is not complete yet, and the milestone is not open for
+execution.
+
+## Required Inputs Before Pass/Fail Judgment
+
+- benchmark and runtime-recovery proof surfaces
+- product/workspace/moderization/publication/doc/guardrail outputs
+- feature-proof coverage and demo matrix
+- internal and external review records
+- remediation record
+- release evidence and release readiness package
+
+## Current Judgment
+
+`NOT_READY`
+

--- a/docs/milestones/v0.91.2/README.md
+++ b/docs/milestones/v0.91.2/README.md
@@ -67,12 +67,31 @@ This package is grounded in:
 ## Document Map
 
 - WBS: [WBS_v0.91.2.md](WBS_v0.91.2.md)
+- Vision: [VISION_v0.91.2.md](VISION_v0.91.2.md)
+- Design: [DESIGN_v0.91.2.md](DESIGN_v0.91.2.md)
+- Decisions: [DECISIONS_v0.91.2.md](DECISIONS_v0.91.2.md)
 - Sprint plan: [SPRINT_v0.91.2.md](SPRINT_v0.91.2.md)
 - Candidate issue wave: [WP_ISSUE_WAVE_v0.91.2.yaml](WP_ISSUE_WAVE_v0.91.2.yaml)
 - Execution readiness:
   [WP_EXECUTION_READINESS_v0.91.2.md](WP_EXECUTION_READINESS_v0.91.2.md)
 - Demo matrix: [DEMO_MATRIX_v0.91.2.md](DEMO_MATRIX_v0.91.2.md)
+- Feature proof coverage:
+  [FEATURE_PROOF_COVERAGE_v0.91.2.md](FEATURE_PROOF_COVERAGE_v0.91.2.md)
+- Quality gate: [QUALITY_GATE_v0.91.2.md](QUALITY_GATE_v0.91.2.md)
 - Feature index: [features/README.md](features/README.md)
+- Card bundle readiness:
+  [CARD_BUNDLE_READINESS_v0.91.2.md](CARD_BUNDLE_READINESS_v0.91.2.md)
+- SPP readiness: [SPP_READINESS_v0.91.2.md](SPP_READINESS_v0.91.2.md)
+- Milestone checklist:
+  [MILESTONE_CHECKLIST_v0.91.2.md](MILESTONE_CHECKLIST_v0.91.2.md)
+- Release plan: [RELEASE_PLAN_v0.91.2.md](RELEASE_PLAN_v0.91.2.md)
+- Release readiness: [RELEASE_READINESS_v0.91.2.md](RELEASE_READINESS_v0.91.2.md)
+- Release evidence: [RELEASE_EVIDENCE_v0.91.2.md](RELEASE_EVIDENCE_v0.91.2.md)
+- Release notes: [RELEASE_NOTES_v0.91.2.md](RELEASE_NOTES_v0.91.2.md)
+- Next milestone handoff:
+  [NEXT_MILESTONE_HANDOFF_v0.91.2.md](NEXT_MILESTONE_HANDOFF_v0.91.2.md)
+- End-of-milestone report:
+  [END_OF_MILESTONE_REPORT_v0.91.2.md](END_OF_MILESTONE_REPORT_v0.91.2.md)
 
 ## Success Criteria
 

--- a/docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md
@@ -1,0 +1,31 @@
+# Release Evidence - v0.91.2
+
+## Purpose
+
+Track the milestone package and intended proof surfaces required for a truthful
+`v0.91.2` release decision once the milestone is actually executed.
+
+## Current Core Package
+
+- [README.md](README.md)
+- [WBS_v0.91.2.md](WBS_v0.91.2.md)
+- [SPRINT_v0.91.2.md](SPRINT_v0.91.2.md)
+- [WP_ISSUE_WAVE_v0.91.2.yaml](WP_ISSUE_WAVE_v0.91.2.yaml)
+- [WP_EXECUTION_READINESS_v0.91.2.md](WP_EXECUTION_READINESS_v0.91.2.md)
+- [DEMO_MATRIX_v0.91.2.md](DEMO_MATRIX_v0.91.2.md)
+- [FEATURE_PROOF_COVERAGE_v0.91.2.md](FEATURE_PROOF_COVERAGE_v0.91.2.md)
+- [QUALITY_GATE_v0.91.2.md](QUALITY_GATE_v0.91.2.md)
+
+## Planned Evidence Families
+
+- benchmark and comparison reports
+- runtime/test-cycle recovery reports
+- review-product surfaces
+- Workspace/modernization/publication/doc/guardrail packets
+- release-tail quality and review records
+
+## Current Judgment
+
+This is a package scaffold only. It is not evidence that the milestone has
+executed.
+

--- a/docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md
@@ -1,0 +1,24 @@
+# v0.91.2 Release Notes
+
+## Status
+
+Draft scaffold only. `v0.91.2` is not open for execution and does not yet have
+release-ready notes.
+
+## Theme
+
+Tooling, evaluation, productization, publication, and workflow guardrails.
+
+## Intended Highlight Areas
+
+- UTS + ACC benchmarking
+- runtime/test-cycle recovery
+- review-product and Workspace bridge work
+- modernization, publication, rustdoc/doc cleanup, and workflow guardrails
+
+## Not Claimed
+
+- executed milestone completion
+- final review or release state
+- any benchmark or tooling result not yet produced
+

--- a/docs/milestones/v0.91.2/RELEASE_PLAN_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_PLAN_v0.91.2.md
@@ -1,0 +1,35 @@
+# Release Plan - v0.91.2
+
+## Release Theme
+
+Ship the pressure-release milestone that makes later work faster, safer, and
+more reviewable without weakening proof or authority boundaries.
+
+## Required Evidence
+
+- benchmark harness and comparison report
+- runtime/test-cycle recovery packet
+- review-product surfaces
+- Workspace bridge packet
+- modernization demo packet
+- publication and rustdoc/doc packets
+- workflow guardrails packet
+- feature-proof coverage and quality gate
+- review and remediation records
+
+## Release Risks
+
+- benchmark work could be mistaken for execution authority
+- runtime recovery could be mistaken for permission to weaken proofs
+- Workspace bridge could be mistaken for canonical-source relocation
+- publication packets could be mistaken for publication itself
+- guardrail docs could understate the severity of workflow failures
+
+## Release Rule
+
+Do not mark `v0.91.2` releasable until:
+
+- the issue wave is actually opened and executed
+- quality, review, remediation, and ceremony surfaces are complete
+- release readiness and release evidence are complete
+

--- a/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
@@ -1,0 +1,32 @@
+# Release Readiness - v0.91.2
+
+## Status
+
+Not release ready.
+
+## Review Entry Points
+
+- [README.md](README.md)
+- [WBS_v0.91.2.md](WBS_v0.91.2.md)
+- [SPRINT_v0.91.2.md](SPRINT_v0.91.2.md)
+- [WP_ISSUE_WAVE_v0.91.2.yaml](WP_ISSUE_WAVE_v0.91.2.yaml)
+- [WP_EXECUTION_READINESS_v0.91.2.md](WP_EXECUTION_READINESS_v0.91.2.md)
+- [DEMO_MATRIX_v0.91.2.md](DEMO_MATRIX_v0.91.2.md)
+- [FEATURE_PROOF_COVERAGE_v0.91.2.md](FEATURE_PROOF_COVERAGE_v0.91.2.md)
+- [QUALITY_GATE_v0.91.2.md](QUALITY_GATE_v0.91.2.md)
+- [RELEASE_PLAN_v0.91.2.md](RELEASE_PLAN_v0.91.2.md)
+- [RELEASE_EVIDENCE_v0.91.2.md](RELEASE_EVIDENCE_v0.91.2.md)
+
+## Current State
+
+- `v0.91.2` is a proposed follow-on milestone
+- the issue wave is still candidate/planned
+- no final release proof, review, or ceremony state exists yet
+
+## Current Blockers
+
+- issue wave not opened
+- no executed WPs
+- no quality gate
+- no review or remediation state
+

--- a/docs/milestones/v0.91.2/SPP_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPP_READINESS_v0.91.2.md
@@ -1,0 +1,29 @@
+# v0.91.2 SPP Readiness
+
+## Purpose
+
+Record the planning-surface readiness of Structured Plan Prompt (`SPP`)
+artifacts for the future `v0.91.2` issue wave.
+
+## Current State
+
+`v0.91.2` is not yet open for execution, so `SPP` readiness here is package
+policy/readiness rather than a claim that all issue-local `spp.md` files
+already exist.
+
+## What Is Ready
+
+- the milestone package recognizes `SPP` as a required issue-wave artifact
+- issue-wave and execution-readiness docs already call for `SPP` when the wave
+  opens
+
+## Remaining Gaps
+
+- the actual issue-wave bundle generation is still pending
+- per-issue SPP quality cannot be claimed before that wave exists
+
+## Non-Claims
+
+- this doc does not claim opened issue execution
+- this doc does not claim generated per-WP `SPP` files
+

--- a/docs/milestones/v0.91.2/VISION_v0.91.2.md
+++ b/docs/milestones/v0.91.2/VISION_v0.91.2.md
@@ -1,0 +1,49 @@
+# Vision - v0.91.2
+
+## Tooling, Evaluation, And Workflow Pressure Release
+
+`v0.91.2` is the tooling, evaluation, productization, publication, and
+repo-health milestone that should clear the highest-value backlog after
+`v0.91.1`.
+
+## Strategic Thesis
+
+The milestone should turn recurring friction into bounded, reviewable work
+products:
+
+- UTS + ACC multi-model benchmarking with explicit authority boundaries
+- runtime/test-cycle recovery that reduces wasted time without weakening proof
+- CodeBuddy review-product surfaces
+- Workspace bridge and modernization demos that stay bounded and review-gated
+- publication packets that stop before unreviewed public claims
+- workflow guardrails that prevent the repo/process failures we have been
+  seeing
+
+## What Success Looks Like
+
+At closeout, reviewers should be able to inspect:
+
+- a benchmark report that separates model proposal quality from execution authority
+- a runtime/test-cycle recovery packet with before/after proving posture
+- review-product and Workspace bridge packets
+- bounded publication and rustdoc cleanup packages
+- workflow guardrail proofs and runbooks
+
+## What This Enables
+
+`v0.91.2` should enable:
+
+- faster and less wasteful future milestone execution
+- better review and reporting products
+- safer collaborative-doc and automation experiments
+- cleaner handoff into later identity, birthday, and governance milestones
+
+## What It Must Avoid
+
+`v0.91.2` should not claim:
+
+- inhabited-runtime completion from `v0.91.1`
+- authority transfer from provider-native tool calls
+- silent canonical-source movement into external systems
+- public release or publication without explicit review
+


### PR DESCRIPTION
Closes #2888

## Summary
Prepared the missing milestone-planning package surfaces for `v0.91.2` as
`v0.91.1` preparatory roadmap work, and updated the milestone `README`
document map so the package is navigable as a planned, not-yet-open milestone.

## Classification
- This PR belongs to the active `v0.91.1` issue wave.
- `v0.91.2` remains planned/not-open.
- The edited artifacts live under `docs/milestones/v0.91.2/`, but this does not
  open a `v0.91.2` execution issue.

## Artifacts
- `docs/milestones/v0.91.2/VISION_v0.91.2.md`
- `docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md`
- `docs/milestones/v0.91.2/DESIGN_v0.91.2.md`
- `docs/milestones/v0.91.2/DECISIONS_v0.91.2.md`
- `docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md`
- `docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md`
- `docs/milestones/v0.91.2/RELEASE_PLAN_v0.91.2.md`
- `docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md`
- `docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md`
- `docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md`
- `docs/milestones/v0.91.2/NEXT_MILESTONE_HANDOFF_v0.91.2.md`
- `docs/milestones/v0.91.2/END_OF_MILESTONE_REPORT_v0.91.2.md`
- `docs/milestones/v0.91.2/CARD_BUNDLE_READINESS_v0.91.2.md`
- `docs/milestones/v0.91.2/SPP_READINESS_v0.91.2.md`
- updated `docs/milestones/v0.91.2/README.md`

## Validation
- `git -C .worktrees/adl-wp-2888 diff --check`
- `python3 existence/link check for restored v0.91.2 docs`
- `grep posture check over restored v0.91.2 docs`

## Local Artifacts
- Input card: `.adl/v0.91.1/tasks/issue-2888__v0-91-1-docs-prepare-v0-91-2-milestone-planning-package-surfaces/sip.md`
- Output card: `.adl/v0.91.1/tasks/issue-2888__v0-91-1-docs-prepare-v0-91-2-milestone-planning-package-surfaces/sor.md`
