### PR TITLE
[v0.91.1][docs] Rescue stranded planning edits from retained v0.91.1 WP-01 worktree

### DIFF
--- a/docs/milestones/v0.91.2/README.md
+++ b/docs/milestones/v0.91.2/README.md
@@ -22,6 +22,10 @@ reviewable systems:
 - CodeBuddy/review packet productization.
 - Google Workspace CMS bridge planning and bounded demo work.
 - Moderne/code-modernization workflow support.
+- Bounded speculative-decoding evaluation inside ADL's deterministic runtime
+  posture.
+- Repo-visibility follow-on work so canonical-source and linkage surfaces
+  become more operationally useful.
 - Publication program artifacts, including the general-intelligence paper
   packet and future Gödel Agents paper backlog.
 - Rustdoc and documentation cleanup.
@@ -57,6 +61,8 @@ This package is grounded in:
 - `.adl/docs/TBD/codebuddy_ai/`
 - `.adl/docs/TBD/google_workspace_cms/`
 - `.adl/docs/TBD/code_modernization/`
+- `.adl/docs/TBD/ADL_AND_GENERIC_SPECULATIVE_DECODING.md`
+- `.adl/docs/TBD/repo_visibility/`
 - `.adl/docs/TBD/publication/`
 - `.adl/docs/TBD/general-intelligence-paper/`
 - `.adl/docs/TBD/RUSTDOC_GAP_ANALYSIS.md`

--- a/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
@@ -30,30 +30,34 @@ expensive, confusing test cycles.
 Goal: turn review, collaborative docs, and modernization ideas into bounded
 product surfaces without granting silent authority over canonical repo truth.
 
-## Sprint 3: Publication, Docs, And Workflow Guardrails
+## Sprint 3: Runtime Ergonomics, Publication, Docs, And Workflow Guardrails
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-11 | Publication program package | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
-| WP-12 | General intelligence paper packet | claim, citation, and review packet | WP-11 |
-| WP-13 | Rustdoc and doc cleanup | rustdoc/doc cleanup patches and report | WP-05 |
-| WP-14 | Workflow guardrails hardening | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
+| WP-11 | Speculative decoding prototype | bounded speculative-decoding architecture and proof posture | WP-02, WP-04 |
+| WP-12 | Repo visibility follow-on | manifest/linkage follow-on package | WP-06, WP-07 |
+| WP-13 | Publication program package | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
+| WP-14 | General intelligence paper packet | claim, citation, and review packet | WP-13 |
+| WP-15 | Rustdoc and doc cleanup | rustdoc/doc cleanup patches and report | WP-05 |
+| WP-16 | Workflow guardrails hardening | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
 
 Goal: make the project’s public intellectual surface and daily workflow less
-fragile, less ambiguous, and easier for other humans to review.
+fragile, less ambiguous, easier for other humans to review, and more honest
+about which runtime accelerations and repo-cognition surfaces are actually
+worth carrying forward.
 
 ## Sprint 4: Review, Remediation, And Release
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-15 | Demo matrix and proof coverage | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14 |
-| WP-16 | Coverage / quality gate | validation posture and test/coverage record | WP-15 |
-| WP-17 | Docs + review pass | review-ready docs package | WP-16 |
-| WP-18 | Internal review | internal review record | WP-17 |
-| WP-19 | External / 3rd-party review | external review handoff and record | WP-18 |
-| WP-20 | Review findings remediation | remediation record and follow-up issues | WP-19 |
-| WP-21 | Next milestone planning | v0.92/v0.93 handoff update | WP-20 |
-| WP-22 | Release ceremony | release evidence and end-of-milestone report | WP-21 |
+| WP-17 | Demo matrix and proof coverage | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
+| WP-18 | Coverage / quality gate | validation posture and test/coverage record | WP-17 |
+| WP-19 | Docs + review pass | review-ready docs package | WP-18 |
+| WP-20 | Internal review | internal review record | WP-19 |
+| WP-21 | External / 3rd-party review | external review handoff and record | WP-20 |
+| WP-22 | Review findings remediation | remediation record and follow-up issues | WP-21 |
+| WP-23 | Next milestone planning | v0.92/v0.93 handoff update | WP-22 |
+| WP-24 | Release ceremony | release evidence and end-of-milestone report | WP-23 |
 
 Goal: leave the next identity/governance milestones with cleaner test cycles,
 clearer publication and product surfaces, and fewer workflow foot-guns.
@@ -63,4 +67,8 @@ clearer publication and product surfaces, and fewer workflow foot-guns.
 UTS+ACC benchmark work and runtime/test-cycle recovery can proceed in parallel.
 CodeBuddy and review-skill work can proceed beside the Google Workspace bridge
 if both preserve canonical repo authority. Publication packet work can proceed
-beside doc cleanup, but no public release should happen before review.
+beside doc cleanup. Speculative decoding can proceed beside publication and doc
+cleanup once the benchmark and recovery surfaces define the bounded runtime
+constraints. Repo visibility can proceed beside review productization because
+it is meant to help reviewer navigation rather than bypass it. No public
+release should happen before review.

--- a/docs/milestones/v0.91.2/WBS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/WBS_v0.91.2.md
@@ -22,11 +22,13 @@ productize, publish, and maintain.
 | F | Review skill and demo suite | Add review heuristics, skill demos, and repeatable review proof surfaces. | review demo matrix and skill docs | E |
 | G | Google Workspace CMS bridge | Build bounded bridge/demo for draft docs, comments, and promotion packets. | GWS CMS demo and adapter boundary | governed tools |
 | H | Code modernization | Define and prove Moderne/OpenRewrite-style modernization workflow. | modernization demo packet | C, E |
-| I | Publication program | Prepare arXiv/Medium paper packets without direct publication. | publication backlog and first packets | review/evidence docs |
-| J | General intelligence paper packet | Advance the Mathematical Theory of General Intelligence source packet. | claim/citation/review-ready paper packet | I |
-| K | Rustdoc and documentation cleanup | Address rustdoc gaps and tracked doc hygiene debt. | doc cleanup report and patches | D |
-| L | Workflow guardrails | Prevent main writes, unsafe shell report generation, hung watchers, and card drift. | guardrail implementation and process docs | C, D |
-| M | Review, quality, and release | Validate the milestone, remediate findings, and hand off later work. | review-ready release package | all prior work |
+| I | Speculative decoding | Evaluate bounded runtime acceleration without weakening deterministic commit semantics. | feature contract, prototype plan, and proof posture | B, C |
+| J | Repo visibility follow-on | Turn the v0.90 prototype into a practical manifest/linkage follow-on for reviewers and planners. | manifest/linkage follow-on package | E, F |
+| K | Publication program | Prepare arXiv/Medium paper packets without direct publication. | publication backlog and first packets | review/evidence docs |
+| L | General intelligence paper packet | Advance the Mathematical Theory of General Intelligence source packet. | claim/citation/review-ready paper packet | K |
+| M | Rustdoc and documentation cleanup | Address rustdoc gaps and tracked doc hygiene debt. | doc cleanup report and patches | D |
+| N | Workflow guardrails | Prevent main writes, unsafe shell report generation, hung watchers, and card drift. | guardrail implementation and process docs | C, D |
+| O | Review, quality, and release | Validate the milestone, remediate findings, and hand off later work. | review-ready release package | all prior work |
 
 ## Candidate WP Sequence
 
@@ -42,23 +44,28 @@ productize, publish, and maintain.
 | WP-08 | Google Workspace CMS bridge demo | tools | bounded Workspace content-card and promotion demo | WP-01; governed-tools authority and adapter boundary |
 | WP-09 | Rust-native GWS adapter boundary | tools | adapter feasibility and typed contract boundary | WP-08 |
 | WP-10 | Code modernization demo | tools | Moderne/code modernization interaction demo | WP-01 |
-| WP-11 | Publication program package | docs | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
-| WP-12 | General intelligence paper packet | docs | claim, citation, and review packet | WP-11 |
-| WP-13 | Rustdoc and doc cleanup | docs | rustdoc/doc cleanup patches and report | WP-05 |
-| WP-14 | Workflow guardrails hardening | tools | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
-| WP-15 | Demo matrix and proof coverage | demo | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14 |
-| WP-16 | Coverage / quality gate | quality | validation posture and test/coverage record | WP-15 |
-| WP-17 | Docs + review pass | docs | review-ready docs package | WP-16 |
-| WP-18 | Internal review | review | internal review record | WP-17 |
-| WP-19 | External / 3rd-party review | review | external review handoff and record | WP-18 |
-| WP-20 | Review findings remediation | review | remediation record and follow-up issues | WP-19 |
-| WP-21 | Next milestone planning | docs | v0.92/v0.93 handoff update | WP-20 |
-| WP-22 | Release ceremony | release | release evidence and end-of-milestone report | WP-21 |
+| WP-11 | Speculative decoding prototype | runtime | bounded speculative-decoding architecture and proof posture | WP-02, WP-04 |
+| WP-12 | Repo visibility follow-on | docs | manifest/linkage follow-on package | WP-06, WP-07 |
+| WP-13 | Publication program package | docs | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
+| WP-14 | General intelligence paper packet | docs | claim, citation, and review packet | WP-13 |
+| WP-15 | Rustdoc and doc cleanup | docs | rustdoc/doc cleanup patches and report | WP-05 |
+| WP-16 | Workflow guardrails hardening | tools | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
+| WP-17 | Demo matrix and proof coverage | demo | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
+| WP-18 | Coverage / quality gate | quality | validation posture and test/coverage record | WP-17 |
+| WP-19 | Docs + review pass | docs | review-ready docs package | WP-18 |
+| WP-20 | Internal review | review | internal review record | WP-19 |
+| WP-21 | External / 3rd-party review | review | external review handoff and record | WP-20 |
+| WP-22 | Review findings remediation | review | remediation record and follow-up issues | WP-21 |
+| WP-23 | Next milestone planning | docs | v0.92/v0.93 handoff update | WP-22 |
+| WP-24 | Release ceremony | release | release evidence and end-of-milestone report | WP-23 |
 
 ## Sequencing Pressure
 
 Runtime/test-cycle recovery should begin early because every later milestone
 benefits from it. UTS+ACC benchmark work should separate model proposal quality
 from execution authority. Google Workspace and modernization demos must stay
-operator-gated and bounded. Publication work should produce packets and review
-surfaces, not direct publishing.
+operator-gated and bounded. Speculative decoding should stay bounded to
+deterministic commit semantics and must not smuggle in opaque runtime behavior
+under the banner of acceleration. Repo visibility should consume the delivered
+v0.90 baseline rather than pretending it never landed. Publication work should
+produce packets and review surfaces, not direct publishing.

--- a/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
+++ b/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
@@ -13,20 +13,24 @@ notes:
   authoritative proof.
 - Workspace, modernization, and publication work must remain review-gated and
   non-silent.
+- Speculative decoding must stay bounded to deterministic commit semantics and
+  runtime evidence rather than speed theater.
+- Repo visibility should consume the delivered v0.90 baseline and extend it
+  through a bounded follow-on instead of pretending the substrate is unstarted.
 card_update_rule:
 - When opened, every WP must receive STP, SIP, SPP, SRP, and SOR cards from the
   accepted readiness section.
 - Cards must name source docs, concrete outputs, validation commands, non-goals,
   demo/proof expectations, and review dependencies.
 closeout_sequence:
-- WP-15 Demo matrix and proof coverage
-- WP-16 Coverage / quality gate
-- WP-17 Docs + review pass
-- WP-18 Internal review
-- WP-19 External / 3rd-party review
-- WP-20 Review findings remediation
-- WP-21 Next milestone planning
-- WP-22 Release ceremony
+- WP-17 Demo matrix and proof coverage
+- WP-18 Coverage / quality gate
+- WP-19 Docs + review pass
+- WP-20 Internal review
+- WP-21 External / 3rd-party review
+- WP-22 Review findings remediation
+- WP-23 Next milestone planning
+- WP-24 Release ceremony
 work_packages:
 - wp: WP-01
   issue: null
@@ -110,6 +114,33 @@ work_packages:
   depends_on: WP-01
 - wp: WP-11
   issue: null
+  title: Speculative decoding prototype
+  queue: runtime
+  outcome: bounded speculative-decoding architecture and proof posture
+  depends_on: WP-02, WP-04
+  source_dependencies:
+  - ADL and generic speculative decoding planning note
+  - deterministic runtime and governed commit semantics
+  issue_graph_notes:
+  - Acceleration must not weaken deterministic commit, replay, or audit
+    boundaries.
+  - Freedom Gate and ACC remain authority for side effects; token acceleration
+    is not execution authority.
+- wp: WP-12
+  issue: null
+  title: Repo visibility follow-on
+  queue: docs
+  outcome: manifest/linkage follow-on package
+  depends_on: WP-06, WP-07
+  source_dependencies:
+  - v0.90 repo-visibility baseline
+  - canonical source manifest and code-doc linkage planning corpus
+  issue_graph_notes:
+  - Treat the v0.90 baseline as delivered truth.
+  - The follow-on must improve reviewer/planner navigation without claiming full
+    repo cognition.
+- wp: WP-13
+  issue: null
   title: Publication program package
   queue: docs
   outcome: arXiv/Medium paper-program backlog and process docs
@@ -120,69 +151,69 @@ work_packages:
   issue_graph_notes:
   - Publication packets must separate claims, citations, speculation, review
     status, and publication status.
-- wp: WP-12
+- wp: WP-14
   issue: null
   title: General intelligence paper packet
   queue: docs
   outcome: claim, citation, and review packet
-  depends_on: WP-11
-- wp: WP-13
+  depends_on: WP-13
+- wp: WP-15
   issue: null
   title: Rustdoc and doc cleanup
   queue: docs
   outcome: rustdoc/doc cleanup patches and report
   depends_on: WP-05
-- wp: WP-14
+- wp: WP-16
   issue: null
   title: Workflow guardrails hardening
   queue: tools
   outcome: main-write, watcher, and safe-report guardrails
   depends_on: WP-04, WP-05
-- wp: WP-15
+- wp: WP-17
   issue: null
   title: Demo matrix and proof coverage
   queue: demo
   outcome: demo matrix and proof coverage record
-  depends_on: WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14
-- wp: WP-16
+  depends_on: WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16
+- wp: WP-18
   issue: null
   title: Coverage / quality gate
   queue: quality
   outcome: validation posture and test/coverage record
-  depends_on: WP-15
-- wp: WP-17
+  depends_on: WP-17
+- wp: WP-19
   issue: null
   title: Docs + review pass
   queue: docs
   outcome: review-ready docs package
-  depends_on: WP-16
-- wp: WP-18
+  depends_on: WP-18
+- wp: WP-20
   issue: null
   title: Internal review
   queue: review
   outcome: internal review record
-  depends_on: WP-17
-- wp: WP-19
+  depends_on: WP-19
+- wp: WP-21
   issue: null
   title: External / 3rd-party review
   queue: review
   outcome: external review handoff and record
-  depends_on: WP-18
-- wp: WP-20
+  depends_on: WP-20
+- wp: WP-22
   issue: null
   title: Review findings remediation
   queue: review
   outcome: remediation record and follow-up issues
-  depends_on: WP-19
-- wp: WP-21
+  depends_on: WP-21
+- wp: WP-23
   issue: null
   title: Next milestone planning
   queue: docs
   outcome: v0.92/v0.93 handoff update
-  depends_on: WP-20
-- wp: WP-22
+  depends_on: WP-22
+- wp: WP-24
   issue: null
   title: Release ceremony
   queue: release
   outcome: release evidence and end-of-milestone report
-  depends_on: WP-21
+  depends_on: WP-23

--- a/docs/milestones/v0.91.2/features/README.md
+++ b/docs/milestones/v0.91.2/features/README.md
@@ -12,10 +12,12 @@ First-pass feature index for the proposed v0.91.2 pressure-release milestone.
 | Review heuristics and demos | [REVIEW_HEURISTICS_AND_DEMOS.md](REVIEW_HEURISTICS_AND_DEMOS.md) | `.adl/docs/TBD/workflow_tooling/ADL_REVIEW_HEURISTICS.md` | WP-07 | skill/demo surfaces for repeatable review |
 | Google Workspace CMS bridge | [GOOGLE_WORKSPACE_CMS_BRIDGE.md](GOOGLE_WORKSPACE_CMS_BRIDGE.md) | `.adl/docs/TBD/google_workspace_cms/` | WP-08, WP-09 | bounded content-card/promotion demo and adapter boundary |
 | Code modernization | [CODE_MODERNIZATION_DEMO.md](CODE_MODERNIZATION_DEMO.md) | `.adl/docs/TBD/code_modernization/` | WP-10 | Moderne/code-modernization demo and non-mass-rewrite policy |
-| Publication program | [PUBLICATION_PROGRAM.md](PUBLICATION_PROGRAM.md) | `.adl/docs/TBD/publication/`; `.adl/docs/TBD/ARXIV_AUTHORING_PROCESS_NOTES.md` | WP-11 | paper backlog, process docs, review constraints |
-| General intelligence paper | [GENERAL_INTELLIGENCE_PAPER_PACKET.md](GENERAL_INTELLIGENCE_PAPER_PACKET.md) | `.adl/docs/TBD/general-intelligence-paper/` | WP-12 | claim, citation, and review packet |
-| Rustdoc/doc cleanup | [RUSTDOC_DOC_CLEANUP.md](RUSTDOC_DOC_CLEANUP.md) | `.adl/docs/TBD/RUSTDOC_GAP_ANALYSIS.md`; `.adl/docs/TBD/ADL_DOC_CLEANUP_LEDGER.md` | WP-13 | rustdoc/doc cleanup report and patches |
-| Workflow guardrails | [WORKFLOW_GUARDRAILS.md](WORKFLOW_GUARDRAILS.md) | `.adl/docs/TBD/workflow_tooling/` | WP-14 | guardrails for main writes, closeout watchers, safe reports, and card drift |
+| Speculative decoding | [SPECULATIVE_DECODING_PROTOTYPE.md](SPECULATIVE_DECODING_PROTOTYPE.md) | `.adl/docs/TBD/ADL_AND_GENERIC_SPECULATIVE_DECODING.md` | WP-11 | bounded runtime-acceleration architecture and proof posture |
+| Repo visibility follow-on | [REPO_VISIBILITY_FOLLOW_ON.md](REPO_VISIBILITY_FOLLOW_ON.md) | `.adl/docs/TBD/repo_visibility/` | WP-12 | bounded manifest/linkage follow-on without reopening the v0.90 baseline |
+| Publication program | [PUBLICATION_PROGRAM.md](PUBLICATION_PROGRAM.md) | `.adl/docs/TBD/publication/`; `.adl/docs/TBD/ARXIV_AUTHORING_PROCESS_NOTES.md` | WP-13 | paper backlog, process docs, review constraints |
+| General intelligence paper | [GENERAL_INTELLIGENCE_PAPER_PACKET.md](GENERAL_INTELLIGENCE_PAPER_PACKET.md) | `.adl/docs/TBD/general-intelligence-paper/` | WP-14 | claim, citation, and review packet |
+| Rustdoc/doc cleanup | [RUSTDOC_DOC_CLEANUP.md](RUSTDOC_DOC_CLEANUP.md) | `.adl/docs/TBD/RUSTDOC_GAP_ANALYSIS.md`; `.adl/docs/TBD/ADL_DOC_CLEANUP_LEDGER.md` | WP-15 | rustdoc/doc cleanup report and patches |
+| Workflow guardrails | [WORKFLOW_GUARDRAILS.md](WORKFLOW_GUARDRAILS.md) | `.adl/docs/TBD/workflow_tooling/` | WP-16 | guardrails for main writes, closeout watchers, safe reports, and card drift |
 
 ## Promotion Rule
 

--- a/docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md
+++ b/docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md
@@ -1,0 +1,45 @@
+# Repo Visibility Follow-On
+
+## Metadata
+
+- Feature Name: Repo Visibility Follow-On
+- Milestone Target: `v0.91.2`
+- Status: planned
+- Planned WP Home: WP-12
+- Source Docs: `.adl/docs/TBD/repo_visibility/REPO_VISIBILITY_LAYER.md`; `.adl/docs/TBD/repo_visibility/CANONICAL_SOURCE_MANIFEST.md`; `.adl/docs/TBD/repo_visibility/CODE_DOC_LINKAGE_REPORT.md`
+- Proof Modes: manifest/report fixtures, reviewer-navigation evidence, doc crosswalk
+
+## Purpose
+
+Turn the delivered `v0.90` repo-visibility prototype into a smaller, practical
+follow-on that makes canonical source authority and code-doc linkage more
+usable for real review and planning work.
+
+This is not a request to reopen the original `v0.90` baseline as if nothing
+landed. The baseline is real. The missing work is the productized follow-on.
+
+## Scope
+
+In scope:
+
+- A bounded follow-on to the canonical-source manifest idea.
+- A bounded code-doc-test-demo linkage surface for active milestone work.
+- One reviewer-facing or planning-facing visibility proof that shows the
+  substrate is operationally useful.
+- Clear separation between the delivered prototype and the later full
+  repo-cognition convergence story.
+
+Out of scope:
+
+- Claiming full repo cognition, full indexing, or complete automation.
+- Reopening the whole `v0.90` repo-visibility tranche.
+- Treating the follow-on as a hidden prerequisite for current `v0.91.1` work.
+
+## Acceptance Criteria
+
+- The repo-visibility baseline from `v0.90` is treated as delivered truth.
+- The follow-on is scheduled explicitly inside `v0.91.2`, not left floating as
+  a vague `v0.95` hope.
+- The follow-on names one concrete manifest or linkage slice that can be
+  validated.
+- The feature keeps full convergence separate from the first bounded follow-on.

--- a/docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md
+++ b/docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md
@@ -1,0 +1,43 @@
+# Speculative Decoding Prototype
+
+## Metadata
+
+- Feature Name: Speculative Decoding Prototype
+- Milestone Target: `v0.91.2`
+- Status: planned
+- Planned WP Home: WP-11
+- Source Docs: `.adl/docs/TBD/ADL_AND_GENERIC_SPECULATIVE_DECODING.md`
+- Proof Modes: design packet, prototype plan, runtime-evidence note
+
+## Purpose
+
+Evaluate whether generic speculative decoding is worth carrying into ADL's
+runtime as a bounded acceleration surface without weakening deterministic commit
+semantics, replayability, or audit posture.
+
+The goal is not speed theater. The goal is to decide whether the acceleration
+pattern can live inside ADL honestly.
+
+## Scope
+
+In scope:
+
+- A bounded architecture and proof posture for speculative decoding in ADL.
+- Explicit separation between speculative proposal and authoritative commit.
+- Runtime evidence requirements for acceptance, rejection, and fallback.
+- Non-claims around side effects, Freedom Gate, ACC, and external authority.
+
+Out of scope:
+
+- Claiming production-grade runtime acceleration across all backends.
+- Replacing deterministic commit with hidden heuristics.
+- Smuggling world-changing authority through token-acceleration language.
+- Benchmark theater without a clear audit and replay story.
+
+## Acceptance Criteria
+
+- The feature states how speculative proposal differs from authoritative commit.
+- The design preserves replay, audit, and deterministic commit boundaries.
+- Freedom Gate and ACC remain the authority boundary for side effects.
+- The milestone leaves behind a bounded prototype/evaluation packet rather than
+  a vague runtime-performance aspiration.


### PR DESCRIPTION
Closes #2885

## Summary
Rescued the stranded `v0.91.2` planning edits from the retained `WP-01`
worktree into a dedicated `v0.91.1` docs branch, preserving the intended
Sprint 3 reshaping and the two new feature surfaces.

## Artifacts
- `docs/milestones/v0.91.2/README.md`
- `docs/milestones/v0.91.2/SPRINT_v0.91.2.md`
- `docs/milestones/v0.91.2/WBS_v0.91.2.md`
- `docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml`
- `docs/milestones/v0.91.2/features/README.md`
- `docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md`
- `docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml"); puts "yaml ok"'`
- `python3 feature README presence check`
- `git -C .worktrees/adl-wp-2823 diff -- <rescued files> | wc -l`
- `git diff --check`

## Local Artifacts
- Input card: `.adl/v0.91.1/tasks/issue-2885__v0-91-1-docs-rescue-stranded-planning-edits-from-retained-v0-91-1-wp-01-worktree/sip.md`
- Output card: `.adl/v0.91.1/tasks/issue-2885__v0-91-1-docs-rescue-stranded-planning-edits-from-retained-v0-91-1-wp-01-worktree/sor.md`
