### PR TITLE
[v0.91.1][tools] Fix false duplicate-local-identity bind failure

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -130,6 +130,10 @@ fn resolve_version_for_existing_issue(
     })
 }
 
+fn resolve_local_issue_identity(repo_root: &Path, issue: u32) -> Result<Option<(String, String)>> {
+    resolve_issue_scope_and_slug_from_local_state(repo_root, issue)
+}
+
 pub(crate) fn real_pr(args: &[String]) -> Result<()> {
     let Some(subcommand) = args.first().map(|s| s.as_str()) else {
         bail!(
@@ -270,6 +274,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     let parsed = parse_start_args(args)?;
     let repo_root = repo_root()?;
     let repo = default_repo(&repo_root)?;
+    let local_identity = resolve_local_issue_identity(&repo_root, parsed.issue)?;
 
     eprintln!(
         "• Deprecated compatibility path: prefer `adl/tools/pr.sh run {}` for execution-context binding.",
@@ -278,42 +283,53 @@ fn real_pr_start(args: &[String]) -> Result<()> {
 
     let mut title = parsed.title_arg.clone().unwrap_or_default();
     let mut slug = parsed.slug.clone().unwrap_or_default();
-    if slug.is_empty() && !title.is_empty() {
-        slug = sanitize_slug(&title);
-        if slug.is_empty() {
-            bail!("start: --title produced empty slug after sanitization");
-        }
-    }
+    let mut slug_from_local_identity = false;
     if title.is_empty() && !parsed.no_fetch_issue {
         eprintln!("• Fetching issue title via gh…");
         title = gh_issue_title(parsed.issue, &repo)?.unwrap_or_default();
     }
     if slug.is_empty() {
-        if parsed.no_fetch_issue {
+        if let Some((_, local_slug)) = local_identity.as_ref() {
+            slug = local_slug.clone();
+            slug_from_local_identity = true;
+        } else if !title.is_empty() {
+            slug = sanitize_slug(&title);
+            if slug.is_empty() {
+                bail!("start: --title produced empty slug after sanitization");
+            }
+        } else if parsed.no_fetch_issue {
             bail!("start: --slug is required when --no-fetch-issue is set");
         }
-        if title.is_empty() {
+        if slug.is_empty() && title.is_empty() {
             bail!(
                 "Could not fetch issue #{} title. Pass --slug or check gh auth/repo.",
                 parsed.issue
             );
         }
-        slug = sanitize_slug(&title);
+        if slug.is_empty() {
+            slug = sanitize_slug(&title);
+        }
     }
     if title.is_empty() {
         title = slug.clone();
     }
 
-    let version = resolve_version_for_existing_issue(
-        &repo_root,
-        &repo,
-        parsed.issue,
-        parsed.version.clone(),
-        parsed.no_fetch_issue,
-        "start",
-    )?;
+    let version = if let Some(version) = parsed.version.clone() {
+        version
+    } else if let Some((local_version, _)) = local_identity.as_ref() {
+        local_version.clone()
+    } else {
+        resolve_version_for_existing_issue(
+            &repo_root,
+            &repo,
+            parsed.issue,
+            None,
+            parsed.no_fetch_issue,
+            "start",
+        )?
+    };
     title = normalize_issue_title_for_version(&title, &version);
-    if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
+    if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() && !slug_from_local_identity {
         slug = sanitize_slug(&title);
         if slug.is_empty() {
             bail!("start: title produced empty slug after normalization");
@@ -568,47 +584,59 @@ fn real_pr_init(args: &[String]) -> Result<()> {
     let parsed = parse_init_args(args)?;
     let repo_root = repo_root()?;
     let repo = default_repo(&repo_root)?;
+    let local_identity = resolve_local_issue_identity(&repo_root, parsed.issue)?;
 
     let issue = parsed.issue;
     let mut title = parsed.title_arg.clone().unwrap_or_default();
     let mut slug = parsed.slug.clone().unwrap_or_default();
-    if slug.is_empty() && !title.is_empty() {
-        slug = sanitize_slug(&title);
-        if slug.is_empty() {
-            bail!("init: --title produced empty slug after sanitization");
-        }
-    }
+    let mut slug_from_local_identity = false;
 
     if title.is_empty() && !parsed.no_fetch_issue {
         eprintln!("• Fetching issue title via gh…");
         title = gh_issue_title(issue, &repo)?.unwrap_or_default();
     }
     if slug.is_empty() {
-        if parsed.no_fetch_issue {
+        if let Some((_, local_slug)) = local_identity.as_ref() {
+            slug = local_slug.clone();
+            slug_from_local_identity = true;
+        } else if !title.is_empty() {
+            slug = sanitize_slug(&title);
+            if slug.is_empty() {
+                bail!("init: --title produced empty slug after sanitization");
+            }
+        } else if parsed.no_fetch_issue {
             bail!("init: --slug is required when --no-fetch-issue is set");
         }
-        if title.is_empty() {
+        if slug.is_empty() && title.is_empty() {
             bail!(
                 "Could not fetch issue #{} title. Pass --slug or check gh auth/repo.",
                 issue
             );
         }
-        slug = sanitize_slug(&title);
+        if slug.is_empty() {
+            slug = sanitize_slug(&title);
+        }
     }
     if title.is_empty() {
         title = slug.clone();
     }
 
-    let version = resolve_version_for_existing_issue(
-        &repo_root,
-        &repo,
-        issue,
-        parsed.version.clone(),
-        parsed.no_fetch_issue,
-        "init",
-    )?;
+    let version = if let Some(version) = parsed.version.clone() {
+        version
+    } else if let Some((local_version, _)) = local_identity.as_ref() {
+        local_version.clone()
+    } else {
+        resolve_version_for_existing_issue(
+            &repo_root,
+            &repo,
+            issue,
+            None,
+            parsed.no_fetch_issue,
+            "init",
+        )?
+    };
     title = normalize_issue_title_for_version(&title, &version);
-    if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() {
+    if parsed.slug.as_deref().unwrap_or_default().trim().is_empty() && !slug_from_local_identity {
         slug = sanitize_slug(&title);
         if slug.is_empty() {
             bail!("init: title produced empty slug after normalization");

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -507,6 +507,249 @@ fn real_pr_start_rewrites_unbound_root_input_card_branch() {
 }
 
 #[test]
+fn real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-canonical-local-slug");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "canonical local slug\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref =
+        IssueRef::new(1288, "v0.86", "canonical-bind-slug").expect("canonical issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Canonical bind slug issue",
+    );
+    real_pr(&[
+        "init".to_string(),
+        "1288".to_string(),
+        "--slug".to_string(),
+        "canonical-bind-slug".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Canonical bind slug issue".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("init canonical bundle");
+
+    real_pr(&[
+        "start".to_string(),
+        "1288".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Title changed after bundle bootstrap".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("start should honor canonical local slug");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    assert!(worktree.is_dir());
+    assert_eq!(
+        run_capture(
+            "git",
+            &[
+                "-C",
+                path_str(&worktree).expect("wt path"),
+                "rev-parse",
+                "--abbrev-ref",
+                "HEAD"
+            ]
+        )
+        .expect("branch")
+        .trim(),
+        "codex/1288-canonical-bind-slug"
+    );
+    assert!(issue_ref.task_bundle_stp_path(&repo).is_file());
+    assert!(issue_ref.task_bundle_stp_path(&worktree).is_file());
+}
+
+#[test]
+fn real_pr_start_still_fails_closed_when_real_duplicate_bundle_exists() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-real-duplicate-bundle");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "duplicate bind test\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1289, "v0.86", "canonical-duplicate-bind").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Canonical duplicate bind");
+    real_pr(&[
+        "init".to_string(),
+        "1289".to_string(),
+        "--slug".to_string(),
+        "canonical-duplicate-bind".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Canonical duplicate bind".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("init canonical bundle");
+    let duplicate_task = repo.join(".adl/v0.86/tasks/issue-1289__legacy-duplicate-bind");
+    fs::create_dir_all(&duplicate_task).expect("duplicate task dir");
+
+    let err = real_pr(&[
+        "start".to_string(),
+        "1289".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Canonical duplicate bind".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("real duplicate should still fail closed");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    let text = err.to_string();
+    assert!(text.contains("duplicate local task-bundle identities detected"));
+    assert!(text.contains("legacy-duplicate-bind"));
+}
+
+#[test]
 fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-ready-worktree-cwd");


### PR DESCRIPTION
Closes #2892

## Summary
- prefer canonical local issue bundle identity during `pr start` / `pr.sh run <issue>` binding
- keep title-based slug synthesis only as a fallback when no local canonical bundle exists
- add regressions proving the false-positive bind path is fixed and real duplicate bundles still fail closed

## Validation
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_still_fails_closed_when_real_duplicate_bundle_exists -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml ensure_no_duplicate_issue_identities_rejects_duplicate_prompt_or_task_bundle -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_ -- --nocapture`
- `cargo fmt --manifest-path adl/Cargo.toml --all --check`
