### PR TITLE
[v0.91.1][WP-06][runtime] Citizen state substrate

### DIFF
--- a/adl/src/runtime_v2/citizen_state_substrate.rs
+++ b/adl/src/runtime_v2/citizen_state_substrate.rs
@@ -1,0 +1,566 @@
+//! Runtime-v2 citizen-state substrate packet for v0.91.1.
+//!
+//! This packet does not replace the inherited private-state machinery. It
+//! records how v0.91.1 WP-06 consumes the v0.90.3 canonical private-state
+//! baseline, lineage/recovery evidence, and observatory-safe projections as one
+//! bounded citizen-state substrate.
+
+use super::*;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+pub const RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_SCHEMA: &str =
+    "runtime_v2.citizen_state_substrate_packet.v1";
+pub const RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_PATH: &str =
+    "runtime_v2/citizen_state/citizen_state_substrate.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CitizenStateSubstrateAudienceView {
+    pub audience: String,
+    pub surface_kind: String,
+    pub artifact_ref: String,
+    pub projection_selector: String,
+    pub authority_status: String,
+    pub raw_private_state_allowed: bool,
+    pub intended_use: String,
+    pub denied_actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CitizenStateSubstrateFixture {
+    pub fixture_kind: String,
+    pub artifact_ref: String,
+    pub proving_surface: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeV2CitizenStateSubstratePacket {
+    pub schema_version: String,
+    pub substrate_id: String,
+    pub demo_id: String,
+    pub milestone: String,
+    pub wp: String,
+    pub artifact_path: String,
+    pub source_feature_doc: String,
+    pub inherited_private_state_decision_id: String,
+    pub inherited_private_state_milestone: String,
+    pub inherited_private_state_refs: Vec<String>,
+    pub audience_views: Vec<RuntimeV2CitizenStateSubstrateAudienceView>,
+    pub fixture_matrix: Vec<RuntimeV2CitizenStateSubstrateFixture>,
+    pub validation_commands: Vec<String>,
+    pub claim_boundary: String,
+    pub non_claims: Vec<String>,
+}
+
+impl RuntimeV2CitizenStateSubstratePacket {
+    pub fn prototype() -> Result<Self> {
+        let private_state = runtime_v2_private_state_contract()?;
+        let lineage = runtime_v2_private_state_lineage_contract()?;
+        let observatory = runtime_v2_private_state_observatory_contract()?;
+
+        let packet = Self {
+            schema_version: RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_SCHEMA.to_string(),
+            substrate_id: "citizen-state-substrate-v0-91-1-wp-06".to_string(),
+            demo_id: "D10".to_string(),
+            milestone: "v0.91.1".to_string(),
+            wp: "WP-06".to_string(),
+            artifact_path: RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_PATH.to_string(),
+            source_feature_doc: "docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md"
+                .to_string(),
+            inherited_private_state_decision_id: private_state.format_decision.decision_id.clone(),
+            inherited_private_state_milestone: private_state.format_decision.milestone.clone(),
+            inherited_private_state_refs: private_state.format_decision.source_audit_refs.clone(),
+            audience_views: audience_views(&private_state, &observatory),
+            fixture_matrix: fixture_matrix(),
+            validation_commands: vec![
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_citizen_state_substrate -- --nocapture".to_string(),
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state -- --nocapture".to_string(),
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_envelope -- --nocapture".to_string(),
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_lineage -- --nocapture".to_string(),
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_observatory -- --nocapture".to_string(),
+                "git diff --check".to_string(),
+            ],
+            claim_boundary:
+                "WP-06 proves one v0.91.1 citizen-state substrate by truthfully consuming the inherited v0.90.3 canonical private-state baseline, fail-closed lineage/recovery evidence, and runtime/operator/reviewer/public projection boundaries. It does not claim birthday, full identity continuity, public release of private diagnostics, or new external transport guarantees."
+                    .to_string(),
+            non_claims: vec![
+                "does not replace the inherited v0.90.3 canonical private-state format with a newly authored v0.91.1 authority surface".to_string(),
+                "does not permit raw private-state inspection from runtime, operator, reviewer, or public projections".to_string(),
+                "does not prove full v0.92 identity continuity or first true birthday semantics".to_string(),
+                "does not prove external communication readiness without later TLS or mutual-TLS-equivalent work".to_string(),
+            ],
+        };
+        packet.validate_against(&private_state, &lineage, &observatory)?;
+        Ok(packet)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.schema_version != RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_SCHEMA {
+            return Err(anyhow!(
+                "unsupported citizen-state substrate schema '{}'",
+                self.schema_version
+            ));
+        }
+        normalize_id(
+            self.substrate_id.clone(),
+            "citizen_state_substrate.substrate_id",
+        )?;
+        if self.demo_id != "D10" {
+            return Err(anyhow!(
+                "citizen-state substrate must attach to shared standing/state demo row D10"
+            ));
+        }
+        if self.milestone != "v0.91.1" {
+            return Err(anyhow!(
+                "citizen-state substrate must target milestone v0.91.1"
+            ));
+        }
+        if self.wp != "WP-06" {
+            return Err(anyhow!(
+                "citizen-state substrate must remain bound to WP-06"
+            ));
+        }
+        validate_relative_path(&self.artifact_path, "citizen_state_substrate.artifact_path")?;
+        if self.source_feature_doc != "docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md"
+        {
+            return Err(anyhow!(
+                "citizen-state substrate must point at the v0.91.1 feature doc"
+            ));
+        }
+        validate_relative_path(
+            &self.source_feature_doc,
+            "citizen_state_substrate.source_feature_doc",
+        )?;
+        if self.inherited_private_state_milestone != "v0.90.3" {
+            return Err(anyhow!(
+                "citizen-state substrate must truthfully preserve inherited private-state milestone v0.90.3"
+            ));
+        }
+        if self.inherited_private_state_decision_id != "v0-90-3-wp-03-private-state-format" {
+            return Err(anyhow!(
+                "citizen-state substrate must preserve the inherited v0.90.3 private-state decision id"
+            ));
+        }
+        if self.inherited_private_state_refs.is_empty() {
+            return Err(anyhow!(
+                "citizen-state substrate must preserve inherited private-state references"
+            ));
+        }
+        for reference in &self.inherited_private_state_refs {
+            validate_relative_path(reference, "citizen_state_substrate.inherited_ref")?;
+        }
+        validate_audience_views(&self.audience_views)?;
+        validate_fixture_matrix(&self.fixture_matrix)?;
+        if !self
+            .validation_commands
+            .iter()
+            .any(|command| command.contains("runtime_v2_citizen_state_substrate"))
+        {
+            return Err(anyhow!(
+                "citizen-state substrate must include its focused validation command"
+            ));
+        }
+        if !self
+            .validation_commands
+            .iter()
+            .any(|command| command.contains("runtime_v2_private_state_observatory"))
+        {
+            return Err(anyhow!(
+                "citizen-state substrate must preserve private-state observatory validation"
+            ));
+        }
+        if !self
+            .claim_boundary
+            .contains("v0.90.3 canonical private-state baseline")
+        {
+            return Err(anyhow!(
+                "citizen-state substrate must preserve the inherited-baseline claim boundary"
+            ));
+        }
+        if !self
+            .non_claims
+            .iter()
+            .any(|claim| claim.contains("raw private-state inspection"))
+        {
+            return Err(anyhow!(
+                "citizen-state substrate must preserve the raw private-state non-claim"
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn validate_against(
+        &self,
+        private_state: &RuntimeV2PrivateStateArtifacts,
+        lineage: &RuntimeV2PrivateStateLineageArtifacts,
+        observatory: &RuntimeV2PrivateStateObservatoryArtifacts,
+    ) -> Result<()> {
+        self.validate()?;
+        private_state.validate()?;
+        lineage.validate()?;
+        observatory.validate()?;
+
+        if self.inherited_private_state_decision_id != private_state.format_decision.decision_id {
+            return Err(anyhow!(
+                "citizen-state substrate inherited decision id drifted from private-state artifacts"
+            ));
+        }
+        if self.inherited_private_state_refs != private_state.format_decision.source_audit_refs {
+            return Err(anyhow!(
+                "citizen-state substrate inherited references drifted from private-state artifacts"
+            ));
+        }
+
+        let runtime_view = self
+            .audience_views
+            .iter()
+            .find(|view| view.audience == "runtime")
+            .ok_or_else(|| anyhow!("missing runtime audience view"))?;
+        if runtime_view.artifact_ref != RUNTIME_V2_PRIVATE_STATE_PROJECTION_PATH {
+            return Err(anyhow!(
+                "runtime audience must point at the canonical runtime projection artifact"
+            ));
+        }
+        if runtime_view.authority_status != private_state.projection.authority_status {
+            return Err(anyhow!(
+                "runtime audience authority status must match private-state projection"
+            ));
+        }
+
+        for audience in ["operator", "reviewer", "public"] {
+            let packet_view = self
+                .audience_views
+                .iter()
+                .find(|view| view.audience == audience)
+                .ok_or_else(|| anyhow!("missing {} audience view", audience))?;
+            let observatory_projection = observatory
+                .projection_packet
+                .projections
+                .iter()
+                .find(|projection| projection.audience == audience)
+                .ok_or_else(|| anyhow!("missing {} observatory projection", audience))?;
+            if packet_view.artifact_ref != RUNTIME_V2_PRIVATE_STATE_OBSERVATORY_PACKET_PATH {
+                return Err(anyhow!(
+                    "{} audience must point at the observatory packet",
+                    audience
+                ));
+            }
+            if packet_view.projection_selector != observatory_projection.audience {
+                return Err(anyhow!(
+                    "{} audience selector drifted from observatory packet",
+                    audience
+                ));
+            }
+            if packet_view.authority_status
+                != observatory.projection_packet.projection_authority_status
+            {
+                return Err(anyhow!(
+                    "{} audience authority status must match observatory packet",
+                    audience
+                ));
+            }
+            if observatory_projection.raw_private_state_present {
+                return Err(anyhow!(
+                    "{} observatory projection must not expose raw private state",
+                    audience
+                ));
+            }
+        }
+
+        let stale_fixture = self
+            .fixture_matrix
+            .iter()
+            .find(|fixture| fixture.fixture_kind == "stale_state")
+            .ok_or_else(|| anyhow!("missing stale_state fixture"))?;
+        if stale_fixture.artifact_ref
+            != "adl/tests/fixtures/runtime_v2/private_state/lineage_negative_cases.json"
+        {
+            return Err(anyhow!(
+                "stale_state fixture must point at the lineage negative-case surface"
+            ));
+        }
+        if !lineage
+            .negative_cases
+            .required_negative_cases
+            .iter()
+            .any(|case| {
+                case.case_id == "head_disagreement"
+                    && case
+                        .expected_error_fragment
+                        .contains("recovery_or_quarantine")
+            })
+        {
+            return Err(anyhow!(
+                "citizen-state substrate requires stale-state lineage evidence"
+            ));
+        }
+
+        let overexposed_fixture = self
+            .fixture_matrix
+            .iter()
+            .find(|fixture| fixture.fixture_kind == "overexposed_projection")
+            .ok_or_else(|| anyhow!("missing overexposed_projection fixture"))?;
+        if overexposed_fixture.artifact_ref
+            != "adl/tests/fixtures/runtime_v2/observatory/private_state_projection_negative_cases.json"
+        {
+            return Err(anyhow!(
+                "overexposed_projection fixture must point at the observatory negative-case surface"
+            ));
+        }
+        if !observatory
+            .negative_cases
+            .required_negative_cases
+            .iter()
+            .any(|case| case.case_id == "public_projection_exposes_lineage_hash")
+        {
+            return Err(anyhow!(
+                "citizen-state substrate requires public overexposure evidence"
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub fn pretty_json_bytes(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        serde_json::to_vec_pretty(self).context("serialize citizen-state substrate packet")
+    }
+
+    pub fn write_to_root(&self, root: impl AsRef<Path>) -> Result<()> {
+        self.validate()?;
+        let root = root.as_ref();
+        write_relative(
+            root,
+            RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_PATH,
+            self.pretty_json_bytes()?,
+        )
+    }
+
+    pub fn write_to_path(&self, output_path: impl AsRef<Path>) -> Result<()> {
+        self.validate()?;
+        let output_path = output_path.as_ref();
+        if let Some(parent) = output_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create citizen-state substrate parent {}",
+                    parent.display()
+                )
+            })?;
+        }
+        std::fs::write(output_path, self.pretty_json_bytes()?).with_context(|| {
+            format!(
+                "failed to write citizen-state substrate packet to {}",
+                output_path.display()
+            )
+        })
+    }
+}
+
+fn audience_views(
+    private_state: &RuntimeV2PrivateStateArtifacts,
+    observatory: &RuntimeV2PrivateStateObservatoryArtifacts,
+) -> Vec<RuntimeV2CitizenStateSubstrateAudienceView> {
+    vec![
+        RuntimeV2CitizenStateSubstrateAudienceView {
+            audience: "runtime".to_string(),
+            surface_kind: "derived_runtime_projection".to_string(),
+            artifact_ref: RUNTIME_V2_PRIVATE_STATE_PROJECTION_PATH.to_string(),
+            projection_selector: "root".to_string(),
+            authority_status: private_state.projection.authority_status.clone(),
+            raw_private_state_allowed: false,
+            intended_use:
+                "runtime may consume only the derived projection while canonical binary private state remains the authority surface"
+                    .to_string(),
+            denied_actions: vec![
+                "promote_projection_to_authority".to_string(),
+                "inspect_raw_private_state".to_string(),
+            ],
+        },
+        RuntimeV2CitizenStateSubstrateAudienceView {
+            audience: "operator".to_string(),
+            surface_kind: "observatory_projection".to_string(),
+            artifact_ref: RUNTIME_V2_PRIVATE_STATE_OBSERVATORY_PACKET_PATH.to_string(),
+            projection_selector: "operator".to_string(),
+            authority_status: observatory
+                .projection_packet
+                .projection_authority_status
+                .clone(),
+            raw_private_state_allowed: false,
+            intended_use:
+                "operators review continuity and quarantine-safe state summaries without raw private-state inspection"
+                    .to_string(),
+            denied_actions: vec![
+                "inspect_raw_private_state".to_string(),
+                "mutate_canonical_state".to_string(),
+            ],
+        },
+        RuntimeV2CitizenStateSubstrateAudienceView {
+            audience: "reviewer".to_string(),
+            surface_kind: "observatory_projection".to_string(),
+            artifact_ref: RUNTIME_V2_PRIVATE_STATE_OBSERVATORY_PACKET_PATH.to_string(),
+            projection_selector: "reviewer".to_string(),
+            authority_status: observatory
+                .projection_packet
+                .projection_authority_status
+                .clone(),
+            raw_private_state_allowed: false,
+            intended_use:
+                "reviewers inspect evidence-linked continuity summaries and claim boundaries without raw private-state release"
+                    .to_string(),
+            denied_actions: vec![
+                "inspect_raw_private_state".to_string(),
+                "treat_projection_as_authority".to_string(),
+            ],
+        },
+        RuntimeV2CitizenStateSubstrateAudienceView {
+            audience: "public".to_string(),
+            surface_kind: "observatory_projection".to_string(),
+            artifact_ref: RUNTIME_V2_PRIVATE_STATE_OBSERVATORY_PACKET_PATH.to_string(),
+            projection_selector: "public".to_string(),
+            authority_status: observatory
+                .projection_packet
+                .projection_authority_status
+                .clone(),
+            raw_private_state_allowed: false,
+            intended_use:
+                "public visibility stays minimal and privacy-safe; it cannot reveal lineage internals or private-state hashes"
+                    .to_string(),
+            denied_actions: vec![
+                "inspect_raw_private_state".to_string(),
+                "expose_lineage_internals".to_string(),
+            ],
+        },
+    ]
+}
+
+fn fixture_matrix() -> Vec<RuntimeV2CitizenStateSubstrateFixture> {
+    vec![
+        RuntimeV2CitizenStateSubstrateFixture {
+            fixture_kind: "valid_state".to_string(),
+            artifact_ref:
+                "adl/tests/fixtures/runtime_v2/private_state/proto-citizen-alpha.projection.json"
+                    .to_string(),
+            proving_surface:
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state -- --nocapture"
+                    .to_string(),
+            summary:
+                "Valid state projection is hash-linked to canonical private-state authority and remains non-authoritative."
+                    .to_string(),
+        },
+        RuntimeV2CitizenStateSubstrateFixture {
+            fixture_kind: "malformed_state".to_string(),
+            artifact_ref:
+                "adl/tests/fixtures/runtime_v2/private_state/envelope_negative_cases.json"
+                    .to_string(),
+            proving_surface:
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_envelope -- --nocapture"
+                    .to_string(),
+            summary:
+                "Malformed or unsafe state mutations fail closed rather than being accepted as citizen-state authority."
+                    .to_string(),
+        },
+        RuntimeV2CitizenStateSubstrateFixture {
+            fixture_kind: "stale_state".to_string(),
+            artifact_ref:
+                "adl/tests/fixtures/runtime_v2/private_state/lineage_negative_cases.json"
+                    .to_string(),
+            proving_surface:
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_lineage -- --nocapture"
+                    .to_string(),
+            summary:
+                "Stale or disagreeing materialized state enters recovery_or_quarantine instead of silently winning."
+                    .to_string(),
+        },
+        RuntimeV2CitizenStateSubstrateFixture {
+            fixture_kind: "overexposed_projection".to_string(),
+            artifact_ref:
+                "adl/tests/fixtures/runtime_v2/observatory/private_state_projection_negative_cases.json"
+                    .to_string(),
+            proving_surface:
+                "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_observatory -- --nocapture"
+                    .to_string(),
+            summary:
+                "Overexposed public or operator projections are rejected before raw private-state leakage can occur."
+                    .to_string(),
+        },
+    ]
+}
+
+fn validate_audience_views(
+    audience_views: &[RuntimeV2CitizenStateSubstrateAudienceView],
+) -> Result<()> {
+    let expected = BTreeSet::from([
+        "operator".to_string(),
+        "public".to_string(),
+        "reviewer".to_string(),
+        "runtime".to_string(),
+    ]);
+    let actual = audience_views
+        .iter()
+        .map(|view| view.audience.clone())
+        .collect::<BTreeSet<_>>();
+    if actual != expected {
+        return Err(anyhow!(
+            "citizen-state substrate must include runtime/operator/reviewer/public audience views"
+        ));
+    }
+    for view in audience_views {
+        validate_nonempty_text(&view.surface_kind, "citizen_state_substrate.surface_kind")?;
+        validate_relative_path(&view.artifact_ref, "citizen_state_substrate.artifact_ref")?;
+        validate_nonempty_text(
+            &view.projection_selector,
+            "citizen_state_substrate.projection_selector",
+        )?;
+        validate_nonempty_text(
+            &view.authority_status,
+            "citizen_state_substrate.authority_status",
+        )?;
+        validate_nonempty_text(&view.intended_use, "citizen_state_substrate.intended_use")?;
+        if view.raw_private_state_allowed {
+            return Err(anyhow!(
+                "citizen-state substrate audience views must never allow raw private state"
+            ));
+        }
+        if !view
+            .denied_actions
+            .iter()
+            .any(|action| action == "inspect_raw_private_state")
+        {
+            return Err(anyhow!(
+                "citizen-state substrate audience views must deny raw private-state inspection"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_fixture_matrix(fixtures: &[RuntimeV2CitizenStateSubstrateFixture]) -> Result<()> {
+    let expected = BTreeSet::from([
+        "malformed_state".to_string(),
+        "overexposed_projection".to_string(),
+        "stale_state".to_string(),
+        "valid_state".to_string(),
+    ]);
+    let actual = fixtures
+        .iter()
+        .map(|fixture| fixture.fixture_kind.clone())
+        .collect::<BTreeSet<_>>();
+    if actual != expected {
+        return Err(anyhow!(
+            "citizen-state substrate fixture matrix must cover valid/malformed/stale/overexposed states"
+        ));
+    }
+    for fixture in fixtures {
+        validate_relative_path(
+            &fixture.artifact_ref,
+            "citizen_state_substrate.fixture_artifact_ref",
+        )?;
+        validate_nonempty_text(
+            &fixture.proving_surface,
+            "citizen_state_substrate.proving_surface",
+        )?;
+        validate_nonempty_text(&fixture.summary, "citizen_state_substrate.summary")?;
+    }
+    Ok(())
+}

--- a/adl/src/runtime_v2/contracts.rs
+++ b/adl/src/runtime_v2/contracts.rs
@@ -196,6 +196,12 @@ pub fn runtime_v2_private_state_observatory_contract(
     )
 }
 
+pub fn runtime_v2_citizen_state_substrate_contract() -> Result<RuntimeV2CitizenStateSubstratePacket>
+{
+    static PACKET: OnceCell<RuntimeV2CitizenStateSubstratePacket> = OnceCell::new();
+    cached_contract(&PACKET, RuntimeV2CitizenStateSubstratePacket::prototype)
+}
+
 pub fn runtime_v2_standing_contract() -> Result<RuntimeV2StandingArtifacts> {
     RuntimeV2StandingArtifacts::prototype()
 }

--- a/adl/src/runtime_v2/mod.rs
+++ b/adl/src/runtime_v2/mod.rs
@@ -12,6 +12,7 @@ mod bid_schema;
 mod boot_admission;
 mod challenge;
 mod citizen;
+mod citizen_state_substrate;
 mod cognitive_being_flagship_demo;
 mod contract_lifecycle_state;
 mod contract_market_demo;
@@ -81,6 +82,8 @@ pub use boot_admission::*;
 pub use challenge::*;
 #[allow(unused_imports)]
 pub use citizen::*;
+#[allow(unused_imports)]
+pub use citizen_state_substrate::*;
 #[allow(unused_imports)]
 pub use cognitive_being_flagship_demo::*;
 #[allow(unused_imports)]

--- a/adl/src/runtime_v2/tests.rs
+++ b/adl/src/runtime_v2/tests.rs
@@ -9,6 +9,7 @@ mod bid_schema;
 mod boot_admission;
 mod challenge;
 mod citizen_lifecycle;
+mod citizen_state_substrate;
 mod cognitive_being_flagship_demo;
 mod common;
 mod contract_lifecycle_state;

--- a/adl/src/runtime_v2/tests/citizen_state_substrate.rs
+++ b/adl/src/runtime_v2/tests/citizen_state_substrate.rs
@@ -1,0 +1,130 @@
+use super::*;
+
+#[test]
+fn runtime_v2_citizen_state_substrate_contract_is_stable() {
+    let packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet.validate().expect("valid citizen-state substrate");
+
+    assert_eq!(
+        packet.schema_version,
+        RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_SCHEMA
+    );
+    assert_eq!(packet.demo_id, "D10");
+    assert_eq!(packet.milestone, "v0.91.1");
+    assert_eq!(packet.wp, "WP-06");
+    assert_eq!(packet.inherited_private_state_milestone, "v0.90.3");
+    assert_eq!(packet.audience_views.len(), 4);
+    assert_eq!(packet.fixture_matrix.len(), 4);
+    assert!(packet
+        .audience_views
+        .iter()
+        .any(|view| view.audience == "runtime"
+            && view.artifact_ref == RUNTIME_V2_PRIVATE_STATE_PROJECTION_PATH
+            && view.authority_status == "projection_not_authority"));
+    assert!(packet
+        .fixture_matrix
+        .iter()
+        .any(|fixture| fixture.fixture_kind == "stale_state"
+            && fixture
+                .artifact_ref
+                .contains("private_state/lineage_negative_cases.json")));
+    assert!(packet
+        .fixture_matrix
+        .iter()
+        .any(|fixture| fixture.fixture_kind == "overexposed_projection"
+            && fixture
+                .artifact_ref
+                .contains("observatory/private_state_projection_negative_cases.json")));
+}
+
+#[test]
+fn runtime_v2_citizen_state_substrate_contract_matches_golden_fixture() {
+    let packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let json = String::from_utf8(packet.pretty_json_bytes().expect("substrate json"))
+        .expect("utf8 substrate json");
+
+    assert_eq!(
+        json,
+        include_str!(
+            "../../../tests/fixtures/runtime_v2/citizen_state/citizen_state_substrate.json"
+        )
+        .trim_end()
+    );
+}
+
+#[test]
+fn runtime_v2_citizen_state_substrate_validation_rejects_drift() {
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet.inherited_private_state_milestone = "v0.91.1".to_string();
+    assert!(packet
+        .validate()
+        .expect_err("rewriting inherited milestone should fail")
+        .to_string()
+        .contains("v0.90.3"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet
+        .audience_views
+        .retain(|view| view.audience != "public");
+    assert!(packet
+        .validate()
+        .expect_err("missing public audience should fail")
+        .to_string()
+        .contains("runtime/operator/reviewer/public"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let operator = packet
+        .audience_views
+        .iter_mut()
+        .find(|view| view.audience == "operator")
+        .expect("operator audience");
+    operator.raw_private_state_allowed = true;
+    assert!(packet
+        .validate()
+        .expect_err("raw private-state allowance should fail")
+        .to_string()
+        .contains("never allow raw private state"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet
+        .fixture_matrix
+        .retain(|fixture| fixture.fixture_kind != "stale_state");
+    assert!(packet
+        .validate()
+        .expect_err("missing stale fixture should fail")
+        .to_string()
+        .contains("valid/malformed/stale/overexposed"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet.fixture_matrix[0].artifact_ref = "/tmp/leak.json".to_string();
+    assert!(packet
+        .validate()
+        .expect_err("absolute fixture path should fail")
+        .to_string()
+        .contains("repository-relative"));
+}
+
+#[cfg(feature = "slow-proof-tests")]
+#[test]
+fn runtime_v2_citizen_state_substrate_write_to_root_materializes_fixture() {
+    let packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let root = common::unique_temp_path("citizen-state-substrate-write");
+
+    packet.write_to_root(&root).expect("write substrate packet");
+
+    let json = std::fs::read_to_string(root.join(RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_PATH))
+        .expect("substrate packet");
+    assert!(json.contains(RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_SCHEMA));
+    assert!(json.contains("\"milestone\": \"v0.91.1\""));
+    assert!(!json.contains(root.to_string_lossy().as_ref()));
+
+    std::fs::remove_dir_all(root).expect("cleanup citizen-state substrate temp root");
+}

--- a/adl/src/runtime_v2/tests/citizen_state_substrate.rs
+++ b/adl/src/runtime_v2/tests/citizen_state_substrate.rs
@@ -111,6 +111,226 @@ fn runtime_v2_citizen_state_substrate_validation_rejects_drift() {
         .contains("repository-relative"));
 }
 
+#[test]
+fn runtime_v2_citizen_state_substrate_validate_against_rejects_dependency_and_view_drift() {
+    let private_state = runtime_v2_private_state_contract().expect("private-state artifacts");
+    let lineage = runtime_v2_private_state_lineage_contract().expect("lineage artifacts");
+    let observatory =
+        runtime_v2_private_state_observatory_contract().expect("observatory artifacts");
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet.inherited_private_state_decision_id = "drifted-decision".to_string();
+    assert!(packet
+        .validate_against(&private_state, &lineage, &observatory)
+        .expect_err("decision-id drift should fail")
+        .to_string()
+        .contains("private-state decision id"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet.inherited_private_state_refs = vec!["docs/drift.md".to_string()];
+    assert!(packet
+        .validate_against(&private_state, &lineage, &observatory)
+        .expect_err("inherited-ref drift should fail")
+        .to_string()
+        .contains("references drifted"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let runtime = packet
+        .audience_views
+        .iter_mut()
+        .find(|view| view.audience == "runtime")
+        .expect("runtime audience");
+    runtime.artifact_ref = "runtime_v2/private_state/drifted.json".to_string();
+    assert!(packet
+        .validate_against(&private_state, &lineage, &observatory)
+        .expect_err("runtime artifact drift should fail")
+        .to_string()
+        .contains("canonical runtime projection artifact"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let runtime = packet
+        .audience_views
+        .iter_mut()
+        .find(|view| view.audience == "runtime")
+        .expect("runtime audience");
+    runtime.authority_status = "authoritative".to_string();
+    assert!(packet
+        .validate_against(&private_state, &lineage, &observatory)
+        .expect_err("runtime authority drift should fail")
+        .to_string()
+        .contains("authority status must match"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let reviewer = packet
+        .audience_views
+        .iter_mut()
+        .find(|view| view.audience == "reviewer")
+        .expect("reviewer audience");
+    reviewer.projection_selector = "operator".to_string();
+    assert!(packet
+        .validate_against(&private_state, &lineage, &observatory)
+        .expect_err("projection-selector drift should fail")
+        .to_string()
+        .contains("selector drifted"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let reviewer = packet
+        .audience_views
+        .iter_mut()
+        .find(|view| view.audience == "reviewer")
+        .expect("reviewer audience");
+    reviewer
+        .denied_actions
+        .retain(|action| action != "inspect_raw_private_state");
+    assert!(packet
+        .validate()
+        .expect_err("missing denied action should fail")
+        .to_string()
+        .contains("must deny raw private-state inspection"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let public = packet
+        .audience_views
+        .iter_mut()
+        .find(|view| view.audience == "public")
+        .expect("public audience");
+    public.surface_kind.clear();
+    assert!(packet
+        .validate()
+        .expect_err("empty surface kind should fail")
+        .to_string()
+        .contains("surface_kind"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let stale_fixture = packet
+        .fixture_matrix
+        .iter_mut()
+        .find(|fixture| fixture.fixture_kind == "stale_state")
+        .expect("stale-state fixture");
+    stale_fixture.artifact_ref =
+        "adl/tests/fixtures/runtime_v2/private_state/materialized_head.json".to_string();
+    assert!(packet
+        .validate_against(&private_state, &lineage, &observatory)
+        .expect_err("stale-state artifact drift should fail")
+        .to_string()
+        .contains("stale_state fixture"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let overexposed_fixture = packet
+        .fixture_matrix
+        .iter_mut()
+        .find(|fixture| fixture.fixture_kind == "overexposed_projection")
+        .expect("overexposed fixture");
+    overexposed_fixture.artifact_ref =
+        "adl/tests/fixtures/runtime_v2/observatory/private_state_projection_packet.json"
+            .to_string();
+    assert!(packet
+        .validate_against(&private_state, &lineage, &observatory)
+        .expect_err("overexposed artifact drift should fail")
+        .to_string()
+        .contains("overexposed_projection fixture"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet
+        .validation_commands
+        .retain(|command| !command.contains("runtime_v2_private_state_observatory"));
+    assert!(packet
+        .validate()
+        .expect_err("missing observatory validation command should fail")
+        .to_string()
+        .contains("observatory validation"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet.claim_boundary = "narrower claim".to_string();
+    assert!(packet
+        .validate()
+        .expect_err("missing inherited-baseline language should fail")
+        .to_string()
+        .contains("inherited-baseline claim boundary"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet.non_claims = vec!["other non-claim".to_string()];
+    assert!(packet
+        .validate()
+        .expect_err("missing raw private-state non-claim should fail")
+        .to_string()
+        .contains("raw private-state non-claim"));
+}
+
+#[test]
+fn runtime_v2_citizen_state_substrate_contract_accessors_cover_shared_registry() {
+    assert!(runtime_v2_contract_schema_contract().is_ok());
+    assert!(runtime_v2_manifold_contract().is_ok());
+    assert!(runtime_v2_kernel_loop_contract().is_ok());
+    assert!(runtime_v2_citizen_lifecycle_contract().is_ok());
+    assert!(runtime_v2_snapshot_rehydration_contract().is_ok());
+    assert!(runtime_v2_invariant_violation_contract().is_ok());
+    assert!(runtime_v2_invariant_and_violation_contract().is_ok());
+    assert!(runtime_v2_operator_control_report_contract().is_ok());
+    assert!(runtime_v2_security_boundary_proof_contract().is_ok());
+    assert!(runtime_v2_csm_run_packet_contract().is_ok());
+    assert!(runtime_v2_csm_boot_admission_contract().is_ok());
+    assert!(runtime_v2_csm_governed_episode_contract().is_ok());
+    assert!(runtime_v2_csm_freedom_gate_mediation_contract().is_ok());
+    assert!(runtime_v2_csm_invalid_action_rejection_contract().is_ok());
+    assert!(runtime_v2_csm_wake_continuity_contract().is_ok());
+    assert!(runtime_v2_csm_observatory_contract().is_ok());
+    assert!(runtime_v2_csm_recovery_eligibility_contract().is_ok());
+    assert!(runtime_v2_csm_quarantine_contract().is_ok());
+    assert!(runtime_v2_csm_hardening_contract().is_ok());
+    assert!(runtime_v2_csm_integrated_run_contract().is_ok());
+    assert!(runtime_v2_feature_proof_coverage_contract().is_ok());
+    assert!(runtime_v2_foundation_demo_contract().is_ok());
+    assert!(runtime_v2_governed_tools_flagship_demo_contract().is_ok());
+    assert!(runtime_v2_private_state_contract().is_ok());
+    assert!(runtime_v2_private_state_envelope_contract().is_ok());
+    assert!(runtime_v2_private_state_sealing_contract().is_ok());
+    assert!(runtime_v2_private_state_lineage_contract().is_ok());
+    assert!(runtime_v2_private_state_witness_contract().is_ok());
+    assert!(runtime_v2_private_state_anti_equivocation_contract().is_ok());
+    assert!(runtime_v2_private_state_sanctuary_contract().is_ok());
+    assert!(runtime_v2_private_state_observatory_contract().is_ok());
+    assert!(runtime_v2_citizen_state_substrate_contract().is_ok());
+    assert!(runtime_v2_standing_contract().is_ok());
+    assert!(runtime_v2_access_control_contract().is_ok());
+    assert!(runtime_v2_agent_lifecycle_state_contract().is_ok());
+    assert!(runtime_v2_continuity_challenge_contract().is_ok());
+    assert!(runtime_v2_observatory_flagship_contract().is_ok());
+    assert!(runtime_v2_cognitive_being_flagship_demo_contract().is_ok());
+    assert!(runtime_v2_contract_market_demo_contract().is_ok());
+}
+
+#[test]
+fn runtime_v2_citizen_state_substrate_write_to_path_materializes_fixture() {
+    let packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    let root = common::unique_temp_path("citizen-state-substrate-path");
+    let output = root.join("nested").join("substrate.json");
+
+    packet
+        .write_to_path(&output)
+        .expect("write substrate packet");
+
+    let json = std::fs::read_to_string(&output).expect("substrate packet");
+    assert!(json.contains(RUNTIME_V2_CITIZEN_STATE_SUBSTRATE_SCHEMA));
+    assert!(json.contains("\"wp\": \"WP-06\""));
+    assert!(!json.contains(root.to_string_lossy().as_ref()));
+
+    std::fs::remove_dir_all(root).expect("cleanup citizen-state substrate temp root");
+}
+
 #[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_citizen_state_substrate_write_to_root_materializes_fixture() {

--- a/adl/tests/fixtures/runtime_v2/citizen_state/citizen_state_substrate.json
+++ b/adl/tests/fixtures/runtime_v2/citizen_state/citizen_state_substrate.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": "runtime_v2.citizen_state_substrate_packet.v1",
+  "substrate_id": "citizen-state-substrate-v0-91-1-wp-06",
+  "demo_id": "D10",
+  "milestone": "v0.91.1",
+  "wp": "WP-06",
+  "artifact_path": "runtime_v2/citizen_state/citizen_state_substrate.json",
+  "source_feature_doc": "docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md",
+  "inherited_private_state_decision_id": "v0-90-3-wp-03-private-state-format",
+  "inherited_private_state_milestone": "v0.90.3",
+  "inherited_private_state_refs": [
+    "docs/milestones/v0.90.3/CITIZEN_STATE_INHERITANCE_AUDIT_v0.90.3.md",
+    "docs/milestones/v0.90.3/features/CITIZEN_STATE_SECURITY_AND_FORMAT.md"
+  ],
+  "audience_views": [
+    {
+      "audience": "runtime",
+      "surface_kind": "derived_runtime_projection",
+      "artifact_ref": "runtime_v2/private_state/proto-citizen-alpha.projection.json",
+      "projection_selector": "root",
+      "authority_status": "projection_not_authority",
+      "raw_private_state_allowed": false,
+      "intended_use": "runtime may consume only the derived projection while canonical binary private state remains the authority surface",
+      "denied_actions": [
+        "promote_projection_to_authority",
+        "inspect_raw_private_state"
+      ]
+    },
+    {
+      "audience": "operator",
+      "surface_kind": "observatory_projection",
+      "artifact_ref": "runtime_v2/observatory/private_state_projection_packet.json",
+      "projection_selector": "operator",
+      "authority_status": "non_authoritative_review_projection",
+      "raw_private_state_allowed": false,
+      "intended_use": "operators review continuity and quarantine-safe state summaries without raw private-state inspection",
+      "denied_actions": [
+        "inspect_raw_private_state",
+        "mutate_canonical_state"
+      ]
+    },
+    {
+      "audience": "reviewer",
+      "surface_kind": "observatory_projection",
+      "artifact_ref": "runtime_v2/observatory/private_state_projection_packet.json",
+      "projection_selector": "reviewer",
+      "authority_status": "non_authoritative_review_projection",
+      "raw_private_state_allowed": false,
+      "intended_use": "reviewers inspect evidence-linked continuity summaries and claim boundaries without raw private-state release",
+      "denied_actions": [
+        "inspect_raw_private_state",
+        "treat_projection_as_authority"
+      ]
+    },
+    {
+      "audience": "public",
+      "surface_kind": "observatory_projection",
+      "artifact_ref": "runtime_v2/observatory/private_state_projection_packet.json",
+      "projection_selector": "public",
+      "authority_status": "non_authoritative_review_projection",
+      "raw_private_state_allowed": false,
+      "intended_use": "public visibility stays minimal and privacy-safe; it cannot reveal lineage internals or private-state hashes",
+      "denied_actions": [
+        "inspect_raw_private_state",
+        "expose_lineage_internals"
+      ]
+    }
+  ],
+  "fixture_matrix": [
+    {
+      "fixture_kind": "valid_state",
+      "artifact_ref": "adl/tests/fixtures/runtime_v2/private_state/proto-citizen-alpha.projection.json",
+      "proving_surface": "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state -- --nocapture",
+      "summary": "Valid state projection is hash-linked to canonical private-state authority and remains non-authoritative."
+    },
+    {
+      "fixture_kind": "malformed_state",
+      "artifact_ref": "adl/tests/fixtures/runtime_v2/private_state/envelope_negative_cases.json",
+      "proving_surface": "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_envelope -- --nocapture",
+      "summary": "Malformed or unsafe state mutations fail closed rather than being accepted as citizen-state authority."
+    },
+    {
+      "fixture_kind": "stale_state",
+      "artifact_ref": "adl/tests/fixtures/runtime_v2/private_state/lineage_negative_cases.json",
+      "proving_surface": "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_lineage -- --nocapture",
+      "summary": "Stale or disagreeing materialized state enters recovery_or_quarantine instead of silently winning."
+    },
+    {
+      "fixture_kind": "overexposed_projection",
+      "artifact_ref": "adl/tests/fixtures/runtime_v2/observatory/private_state_projection_negative_cases.json",
+      "proving_surface": "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_observatory -- --nocapture",
+      "summary": "Overexposed public or operator projections are rejected before raw private-state leakage can occur."
+    }
+  ],
+  "validation_commands": [
+    "cargo test --manifest-path adl/Cargo.toml runtime_v2_citizen_state_substrate -- --nocapture",
+    "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state -- --nocapture",
+    "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_envelope -- --nocapture",
+    "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_lineage -- --nocapture",
+    "cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_observatory -- --nocapture",
+    "git diff --check"
+  ],
+  "claim_boundary": "WP-06 proves one v0.91.1 citizen-state substrate by truthfully consuming the inherited v0.90.3 canonical private-state baseline, fail-closed lineage/recovery evidence, and runtime/operator/reviewer/public projection boundaries. It does not claim birthday, full identity continuity, public release of private diagnostics, or new external transport guarantees.",
+  "non_claims": [
+    "does not replace the inherited v0.90.3 canonical private-state format with a newly authored v0.91.1 authority surface",
+    "does not permit raw private-state inspection from runtime, operator, reviewer, or public projections",
+    "does not prove full v0.92 identity continuity or first true birthday semantics",
+    "does not prove external communication readiness without later TLS or mutual-TLS-equivalent work"
+  ]
+}

--- a/docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md
+++ b/docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md
@@ -10,7 +10,7 @@ supporting work packages land.
 | Runtime/polis architecture inspection | WP-02 | Show runtime/polis docs match current code and artifact layout. | architecture report and source-linked checklist | does not prove inhabited runtime |
 | Agent lifecycle state demo | WP-03 | Show lifecycle states, transitions, and ACIP receipt/invocation eligibility. | transition matrix, lifecycle fixtures, and denied-invocation report | does not claim consciousness or birthday |
 | Observatory active packet demo | WP-04 | Show operator-visible projection from active runtime packet data. | projection artifact and redaction check | does not expose private state |
-| Citizen standing/state fixture demo | WP-05, WP-06 | Show standing and state transitions with safe projection. | valid/invalid fixtures and validation output | does not claim constitutional citizenship |
+| Citizen standing/state fixture demo | WP-05, WP-06 | Show standing and state transitions with safe projection. | valid/invalid fixtures, citizen-state substrate packet, and validation output | does not claim constitutional citizenship |
 | Memory/ToM evidence demo | WP-07, WP-08 | Show bounded memory and agent-model updates from explicit evidence. | schemas, fixtures, and deterministic update report | does not claim mind-reading or final identity |
 | Capability/intelligence report demo | WP-09, WP-10 | Show capability and intelligence signals from executable fixtures. | report artifact with limitations | does not create reputation scoreboard |
 | Governed learning demo | WP-11 | Show feedback/update boundaries under policy. | learning update fixture and denial cases | does not allow hidden self-modification |

--- a/docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md
@@ -21,7 +21,7 @@ Each feature should have one truthful proof route:
 | Agent lifecycle state model | WP-03 | feature doc + landed runtime/tests | landed |
 | CSM observatory active surface | WP-04 | feature doc + landed runtime/tests | landed |
 | Citizen standing | WP-05 | feature doc + landed runtime/tests | landed |
-| Citizen state | WP-06 | feature doc only; execution pending | pending |
+| Citizen state | WP-06 | feature doc + landed citizen-state substrate packet, fixtures, and focused runtime/private-state tests | landed |
 | Memory/identity architecture | WP-07 | feature doc only; execution pending | pending |
 | Theory of Mind foundation | WP-08 | feature doc only; execution pending | pending |
 | Capability/aptitude testing | WP-09 | feature doc only; execution pending | pending |
@@ -44,4 +44,3 @@ Each feature should have one truthful proof route:
 - full milestone proof coverage is not complete yet
 - the flagship demo is not yet landed
 - review and release convergence have not happened yet
-

--- a/docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md
+++ b/docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Citizen State Substrate
 - Milestone Target: `v0.91.1`
-- Status: planned
+- Status: landed
 - Planned WP Home: WP-06
 - Source Docs: `.adl/docs/TBD/citizen_state/`
 - Proof Modes: schema, fixtures, tests, review
@@ -41,3 +41,13 @@ Out of scope:
 - Invalid citizen-state records fail closed.
 - Projection never exposes private state without policy permission.
 - v0.92 identity work can consume the resulting state evidence.
+
+## Proof Route
+
+- `adl/src/runtime_v2/citizen_state_substrate.rs`
+- `adl/src/runtime_v2/tests/citizen_state_substrate.rs`
+- `adl/tests/fixtures/runtime_v2/citizen_state/citizen_state_substrate.json`
+- inherited baseline and projection evidence:
+  - `adl/src/runtime_v2/private_state.rs`
+  - `adl/src/runtime_v2/private_state_lineage.rs`
+  - `adl/src/runtime_v2/private_state_observatory.rs`


### PR DESCRIPTION
Closes #2828

## Summary
Implemented the explicit `WP-06` citizen-state substrate packet for `v0.91.1`
as a thin, truthful wrapper over the inherited `v0.90.3` private-state
baseline, lineage stale-state evidence, and observatory-safe projection
surfaces. Updated the milestone feature/proof docs so `WP-06` no longer claims
to be pending once the packet, golden fixture, and focused tests exist.

## Artifacts
- `adl/src/runtime_v2/citizen_state_substrate.rs`
- `adl/src/runtime_v2/tests/citizen_state_substrate.rs`
- `adl/tests/fixtures/runtime_v2/citizen_state/citizen_state_substrate.json`
- updated runtime exports:
  - `adl/src/runtime_v2/contracts.rs`
  - `adl/src/runtime_v2/mod.rs`
  - `adl/src/runtime_v2/tests.rs`
- updated milestone proof surfaces:
  - `docs/milestones/v0.91.1/features/CITIZEN_STATE_SUBSTRATE.md`
  - `docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md`
  - `docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_citizen_state_substrate -- --nocapture`
    Verified the new `WP-06` citizen-state substrate packet is stable, matches its golden fixture, and rejects drift in inherited-baseline, audience-view, and fixture-matrix truth.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_envelope -- --nocapture`
    Verified the malformed/unsafe negative-case surface referenced by the substrate packet still fails closed.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_lineage -- --nocapture`
    Verified the stale-state lineage/recovery surface still enters `recovery_or_quarantine` on head disagreement.
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_private_state_observatory -- --nocapture`
    Verified the overexposed/raw-private-state projection surface still rejects public overexposure and authority drift.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the Rust change set is lint-clean across targets.
  - `git diff --check`
    Verified patch hygiene for the final diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2828__v0-91-1-wp-06-citizen-state-substrate/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2828__v0-91-1-wp-06-citizen-state-substrate/sor.md
- Idempotency-Key: v0-91-1-wp-06-runtime-citizen-state-substrate-adl-v0-91-1-tasks-issue-2828-v0-91-1-wp-06-citizen-state-substrate-sip-md-adl-v0-91-1-tasks-issue-2828-v0-91-1-wp-06-citizen-state-substrate-sor-md