### PR TITLE
[v0.91.1][tools] Extend repo validator coverage to SPP and SRP artifacts

### DIFF
--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -223,8 +223,12 @@ pub(super) fn run_doctor_ready(
     let wt_stp = issue_ref.task_bundle_stp_path(&worktree_path);
     let root_bundle_input = issue_ref.task_bundle_input_path(repo_root);
     let root_bundle_output = issue_ref.task_bundle_output_path(repo_root);
+    let root_bundle_plan = issue_ref.task_bundle_plan_path(repo_root);
+    let root_bundle_review_policy = issue_ref.task_bundle_review_policy_path(repo_root);
     let wt_bundle_input = issue_ref.task_bundle_input_path(&worktree_path);
     let wt_bundle_output = issue_ref.task_bundle_output_path(&worktree_path);
+    let wt_bundle_plan = issue_ref.task_bundle_plan_path(&worktree_path);
+    let wt_bundle_review_policy = issue_ref.task_bundle_review_policy_path(&worktree_path);
     let closed_completed =
         lifecycle::issue_is_closed_and_completed(issue_ref.issue_number(), repo)?;
 
@@ -250,6 +254,9 @@ pub(super) fn run_doctor_ready(
             issue_ref.slug(),
             &root_bundle_input,
             &root_bundle_output,
+            repo_root,
+            &root_bundle_plan,
+            &root_bundle_review_policy,
         )?;
         return Ok(DoctorReadyResult {
             lifecycle_state: "closed",
@@ -269,6 +276,9 @@ pub(super) fn run_doctor_ready(
         issue_ref.slug(),
         &root_bundle_input,
         &root_bundle_output,
+        repo_root,
+        &root_bundle_plan,
+        &root_bundle_review_policy,
     )?;
     let root_input_body = fs::read_to_string(&root_bundle_input).with_context(|| {
         format!(
@@ -353,6 +363,8 @@ pub(super) fn run_doctor_ready(
         wt_branch.trim(),
         &root_bundle_input,
         &root_bundle_output,
+        &root_bundle_plan,
+        &root_bundle_review_policy,
     )?;
     validate_ready_cards(
         &worktree_path,
@@ -361,6 +373,8 @@ pub(super) fn run_doctor_ready(
         wt_branch.trim(),
         &wt_bundle_input,
         &wt_bundle_output,
+        &wt_bundle_plan,
+        &wt_bundle_review_policy,
     )?;
 
     Ok(DoctorReadyResult {

--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::cli::pr_cmd_cards::validate_bootstrap_output_card;
+use crate::cli::pr_cmd_cards::StructuredBundlePaths;
 use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -255,8 +256,10 @@ pub(super) fn run_doctor_ready(
             &root_bundle_input,
             &root_bundle_output,
             repo_root,
-            &root_bundle_plan,
-            &root_bundle_review_policy,
+            StructuredBundlePaths {
+                plan_path: &root_bundle_plan,
+                review_policy_path: &root_bundle_review_policy,
+            },
         )?;
         return Ok(DoctorReadyResult {
             lifecycle_state: "closed",
@@ -277,8 +280,10 @@ pub(super) fn run_doctor_ready(
         &root_bundle_input,
         &root_bundle_output,
         repo_root,
-        &root_bundle_plan,
-        &root_bundle_review_policy,
+        StructuredBundlePaths {
+            plan_path: &root_bundle_plan,
+            review_policy_path: &root_bundle_review_policy,
+        },
     )?;
     let root_input_body = fs::read_to_string(&root_bundle_input).with_context(|| {
         format!(
@@ -363,8 +368,10 @@ pub(super) fn run_doctor_ready(
         wt_branch.trim(),
         &root_bundle_input,
         &root_bundle_output,
-        &root_bundle_plan,
-        &root_bundle_review_policy,
+        StructuredBundlePaths {
+            plan_path: &root_bundle_plan,
+            review_policy_path: &root_bundle_review_policy,
+        },
     )?;
     validate_ready_cards(
         &worktree_path,
@@ -373,8 +380,10 @@ pub(super) fn run_doctor_ready(
         wt_branch.trim(),
         &wt_bundle_input,
         &wt_bundle_output,
-        &wt_bundle_plan,
-        &wt_bundle_review_policy,
+        StructuredBundlePaths {
+            plan_path: &wt_bundle_plan,
+            review_policy_path: &wt_bundle_review_policy,
+        },
     )?;
 
     Ok(DoctorReadyResult {

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -15,7 +15,9 @@ use super::github::{
 use super::lifecycle;
 use super::DEFAULT_VERSION;
 use crate::cli::pr_cmd_args::parse_finish_args;
-use crate::cli::pr_cmd_cards::{path_relative_to_repo, validate_bootstrap_stp};
+use crate::cli::pr_cmd_cards::{
+    path_relative_to_repo, validate_bootstrap_stp, validate_structured_artifact,
+};
 use crate::cli::pr_cmd_prompt::{
     resolve_issue_prompt_path, resolve_issue_scope_and_slug_from_local_state,
     validate_issue_prompt_exists,
@@ -64,6 +66,8 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         .output_path
         .clone()
         .unwrap_or_else(|| issue_ref.task_bundle_output_path(&repo_root));
+    let plan_path = issue_ref.task_bundle_plan_path(&repo_root);
+    let review_policy_path = issue_ref.task_bundle_review_policy_path(&repo_root);
 
     if !ensure_nonempty_file_path(&input_path)? {
         bail!("finish: missing input card: {}", input_path.display());
@@ -80,6 +84,8 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
     validate_authored_prompt_surface("finish", &source_path, PromptSurfaceKind::IssuePrompt)?;
     validate_authored_prompt_surface("finish", &stp_path, PromptSurfaceKind::Stp)?;
     validate_authored_prompt_surface("finish", &input_path, PromptSurfaceKind::Sip)?;
+    validate_structured_artifact(&repo_root, "finish", &plan_path, "spp")?;
+    validate_structured_artifact(&repo_root, "finish", &review_policy_path, "srp")?;
     validate_completed_sor(&repo_root, &output_path)?;
     ensure_issue_surfaces_are_local_only(&repo_root, &primary_root, &issue_ref, &source_path)?;
 

--- a/adl/src/cli/pr_cmd/lifecycle.rs
+++ b/adl/src/cli/pr_cmd/lifecycle.rs
@@ -77,7 +77,7 @@ pub(super) fn reconcile_closed_completed_issue_bundle(
         fs::create_dir_all(&bundle_dir)?;
     }
 
-    for relative in ["stp.md", "sip.md", "sor.md"] {
+    for relative in ["stp.md", "sip.md", "spp.md", "srp.md", "sor.md"] {
         let canonical_path = bundle_dir.join(relative);
         if ensure_nonempty_file_path(&canonical_path)? {
             continue;

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -10,7 +10,7 @@ use super::shared::{
     ensure_symlink, field_line_value, output_card_title_matches_slug, path_relative_to_repo,
     replace_exact_line, replace_field_line, replace_field_line_in_file,
 };
-use super::validation::{validate_bootstrap_cards, validate_bootstrap_stp};
+use super::validation::{validate_bootstrap_cards, validate_bootstrap_stp, StructuredBundlePaths};
 use ::adl::control_plane::{
     card_input_path, card_output_path, card_plan_path, card_review_policy_path, card_stp_path,
     resolve_cards_root, IssueRef,
@@ -217,8 +217,10 @@ pub(crate) fn ensure_bootstrap_cards(
         branch,
         &bundle_input,
         &bundle_output,
-        &bundle_plan,
-        &bundle_review_policy,
+        StructuredBundlePaths {
+            plan_path: &bundle_plan,
+            review_policy_path: &bundle_review_policy,
+        },
     )?;
     validate_authored_prompt_surface("start", &bundle_input, PromptSurfaceKind::Sip)?;
     Ok((bundle_stp, bundle_input, bundle_output))

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -2,14 +2,13 @@ use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use super::super::pr_cmd_validate::validate_authored_prompt_surface;
 use super::super::pr_cmd_validate::{bootstrap_stub_reason, PromptSurfaceKind};
 use super::shared::{
     branch_indicates_unbound_state, copy_directory_contents, deduplicate_exact_line, default_repo,
     ensure_symlink, field_line_value, output_card_title_matches_slug, path_relative_to_repo,
-    path_str, replace_exact_line, replace_field_line, replace_field_line_in_file,
+    replace_exact_line, replace_field_line, replace_field_line_in_file,
 };
 use super::validation::{validate_bootstrap_cards, validate_bootstrap_stp};
 use ::adl::control_plane::{
@@ -218,43 +217,11 @@ pub(crate) fn ensure_bootstrap_cards(
         branch,
         &bundle_input,
         &bundle_output,
+        &bundle_plan,
+        &bundle_review_policy,
     )?;
     validate_authored_prompt_surface("start", &bundle_input, PromptSurfaceKind::Sip)?;
-    validate_structured_bundle_artifacts(root, &bundle_plan, &bundle_review_policy)?;
     Ok((bundle_stp, bundle_input, bundle_output))
-}
-
-fn validate_structured_bundle_artifacts(
-    repo_root: &Path,
-    bundle_plan: &Path,
-    bundle_review_policy: &Path,
-) -> Result<()> {
-    let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
-    for (kind, path) in [("spp", bundle_plan), ("srp", bundle_review_policy)] {
-        let output = Command::new("bash")
-            .args([
-                path_str(&validator)?,
-                "--type",
-                kind,
-                "--input",
-                path_str(path)?,
-            ])
-            .output()
-            .with_context(|| "failed to spawn 'bash'")?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            let detail = if !stderr.is_empty() {
-                stderr
-            } else if !stdout.is_empty() {
-                stdout
-            } else {
-                format!("bash failed with status {:?}", output.status.code())
-            };
-            bail!("{kind}: failed validation: {}: {detail}", path.display());
-        }
-    }
-    Ok(())
 }
 
 pub(crate) fn write_output_card(

--- a/adl/src/cli/pr_cmd_cards/validation.rs
+++ b/adl/src/cli/pr_cmd_cards/validation.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use serde_yaml::Value;
 use std::path::Path;
 use std::process::Command;
 
@@ -36,12 +37,14 @@ pub(crate) fn validate_bootstrap_stp(repo_root: &Path, path: &Path) -> Result<()
 }
 
 pub(crate) fn validate_ready_cards(
-    _repo_root: &Path,
+    repo_root: &Path,
     issue: u32,
     slug: &str,
     actual_branch: &str,
     input_path: &Path,
     output_path: &Path,
+    plan_path: &Path,
+    review_policy_path: &Path,
 ) -> Result<()> {
     let expected = format!("issue-{:04}", issue);
     if field_line_value(input_path, "Task ID")? != expected {
@@ -65,6 +68,14 @@ pub(crate) fn validate_ready_cards(
     if !output_card_title_matches_slug(output_path, slug)? {
         bail!("ready: output card title mismatch");
     }
+    validate_started_structured_artifact(repo_root, "ready", plan_path, "spp", actual_branch)?;
+    validate_started_structured_artifact(
+        repo_root,
+        "ready",
+        review_policy_path,
+        "srp",
+        actual_branch,
+    )?;
     super::super::pr_cmd_validate::validate_authored_prompt_surface(
         "ready",
         input_path,
@@ -78,6 +89,9 @@ pub(crate) fn validate_initialized_cards(
     slug: &str,
     input_path: &Path,
     output_path: &Path,
+    repo_root: &Path,
+    plan_path: &Path,
+    review_policy_path: &Path,
 ) -> Result<()> {
     let expected = format!("issue-{:04}", issue);
     if field_line_value(input_path, "Task ID")? != expected {
@@ -95,6 +109,8 @@ pub(crate) fn validate_initialized_cards(
     if !output_card_title_matches_slug(output_path, slug)? {
         bail!("doctor: output card title mismatch");
     }
+    validate_structured_artifact(repo_root, "doctor", plan_path, "spp")?;
+    validate_structured_artifact(repo_root, "doctor", review_policy_path, "srp")?;
     super::super::pr_cmd_validate::validate_authored_prompt_surface(
         "doctor",
         input_path,
@@ -110,6 +126,8 @@ pub(crate) fn validate_bootstrap_cards(
     branch: &str,
     input_path: &Path,
     output_path: &Path,
+    plan_path: &Path,
+    review_policy_path: &Path,
 ) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
     run_status(
@@ -164,6 +182,8 @@ pub(crate) fn validate_bootstrap_cards(
     if !output_card_title_matches_slug(output_path, slug)? {
         bail!("start: output card title mismatch");
     }
+    validate_structured_artifact(repo_root, "start", plan_path, "spp")?;
+    validate_structured_artifact(repo_root, "start", review_policy_path, "srp")?;
     Ok(())
 }
 
@@ -209,4 +229,83 @@ fn branch_matches_started_state(recorded: &str, actual_branch: &str) -> bool {
         return true;
     }
     recorded.starts_with("TBD (run pr.sh start ")
+}
+
+pub(crate) fn validate_structured_artifact(
+    repo_root: &Path,
+    phase: &str,
+    path: &Path,
+    kind: &str,
+) -> Result<()> {
+    let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
+    let output = Command::new("bash")
+        .args([
+            path_str(&validator)?,
+            "--type",
+            kind,
+            "--input",
+            path_str(path)?,
+        ])
+        .output()
+        .with_context(|| "failed to spawn 'bash'")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("bash failed with status {:?}", output.status.code())
+        };
+        bail!(
+            "{phase}: {kind} failed validation: {}: {detail}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn validate_started_structured_artifact(
+    repo_root: &Path,
+    phase: &str,
+    path: &Path,
+    kind: &str,
+    actual_branch: &str,
+) -> Result<()> {
+    validate_structured_artifact(repo_root, phase, path, kind)?;
+    let text = std::fs::read_to_string(path)?;
+    let front_matter = text
+        .strip_prefix("---\n")
+        .and_then(|rest| rest.split_once("\n---\n").map(|(fm, _)| fm))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{phase}: {kind} missing YAML front matter: {}",
+                path.display()
+            )
+        })?;
+    let yaml: Value = serde_yaml::from_str(front_matter)?;
+    let mapping = yaml.as_mapping().ok_or_else(|| {
+        anyhow::anyhow!(
+            "{phase}: {kind} front matter must be a mapping: {}",
+            path.display()
+        )
+    })?;
+    let branch = mapping
+        .get(Value::String("branch".to_string()))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if branch != actual_branch {
+        bail!(
+            "{phase}: {kind} branch mismatch (expected {actual_branch}, found {})",
+            if branch.is_empty() {
+                "<empty>"
+            } else {
+                branch.as_str()
+            }
+        );
+    }
+    Ok(())
 }

--- a/adl/src/cli/pr_cmd_cards/validation.rs
+++ b/adl/src/cli/pr_cmd_cards/validation.rs
@@ -5,6 +5,11 @@ use std::process::Command;
 
 use super::shared::{field_line_value, output_card_title_matches_slug, path_str, run_status};
 
+pub(crate) struct StructuredBundlePaths<'a> {
+    pub(crate) plan_path: &'a Path,
+    pub(crate) review_policy_path: &'a Path,
+}
+
 pub(crate) fn validate_bootstrap_stp(repo_root: &Path, path: &Path) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
     let output = Command::new("bash")
@@ -43,8 +48,7 @@ pub(crate) fn validate_ready_cards(
     actual_branch: &str,
     input_path: &Path,
     output_path: &Path,
-    plan_path: &Path,
-    review_policy_path: &Path,
+    structured_paths: StructuredBundlePaths<'_>,
 ) -> Result<()> {
     let expected = format!("issue-{:04}", issue);
     if field_line_value(input_path, "Task ID")? != expected {
@@ -68,11 +72,17 @@ pub(crate) fn validate_ready_cards(
     if !output_card_title_matches_slug(output_path, slug)? {
         bail!("ready: output card title mismatch");
     }
-    validate_started_structured_artifact(repo_root, "ready", plan_path, "spp", actual_branch)?;
     validate_started_structured_artifact(
         repo_root,
         "ready",
-        review_policy_path,
+        structured_paths.plan_path,
+        "spp",
+        actual_branch,
+    )?;
+    validate_started_structured_artifact(
+        repo_root,
+        "ready",
+        structured_paths.review_policy_path,
         "srp",
         actual_branch,
     )?;
@@ -90,8 +100,7 @@ pub(crate) fn validate_initialized_cards(
     input_path: &Path,
     output_path: &Path,
     repo_root: &Path,
-    plan_path: &Path,
-    review_policy_path: &Path,
+    structured_paths: StructuredBundlePaths<'_>,
 ) -> Result<()> {
     let expected = format!("issue-{:04}", issue);
     if field_line_value(input_path, "Task ID")? != expected {
@@ -109,8 +118,13 @@ pub(crate) fn validate_initialized_cards(
     if !output_card_title_matches_slug(output_path, slug)? {
         bail!("doctor: output card title mismatch");
     }
-    validate_structured_artifact(repo_root, "doctor", plan_path, "spp")?;
-    validate_structured_artifact(repo_root, "doctor", review_policy_path, "srp")?;
+    validate_structured_artifact(repo_root, "doctor", structured_paths.plan_path, "spp")?;
+    validate_structured_artifact(
+        repo_root,
+        "doctor",
+        structured_paths.review_policy_path,
+        "srp",
+    )?;
     super::super::pr_cmd_validate::validate_authored_prompt_surface(
         "doctor",
         input_path,
@@ -126,8 +140,7 @@ pub(crate) fn validate_bootstrap_cards(
     branch: &str,
     input_path: &Path,
     output_path: &Path,
-    plan_path: &Path,
-    review_policy_path: &Path,
+    structured_paths: StructuredBundlePaths<'_>,
 ) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
     run_status(
@@ -182,8 +195,13 @@ pub(crate) fn validate_bootstrap_cards(
     if !output_card_title_matches_slug(output_path, slug)? {
         bail!("start: output card title mismatch");
     }
-    validate_structured_artifact(repo_root, "start", plan_path, "spp")?;
-    validate_structured_artifact(repo_root, "start", review_policy_path, "srp")?;
+    validate_structured_artifact(repo_root, "start", structured_paths.plan_path, "spp")?;
+    validate_structured_artifact(
+        repo_root,
+        "start",
+        structured_paths.review_policy_path,
+        "srp",
+    )?;
     Ok(())
 }
 

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -849,6 +849,8 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish default lane");
     fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
     write_authored_sip(
@@ -857,6 +859,20 @@ fn real_pr_finish_happy_path_is_covered_in_default_lane() {
         "[v0.86][tools] Rust finish default lane",
         "codex/1153-rust-finish-default-lane",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish default lane",
+        "codex/1153-rust-finish-default-lane",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish default lane",
+        "codex/1153-rust-finish-default-lane",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1153-rust-finish-default-lane");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/branch_and_gitignore.rs
@@ -190,6 +190,20 @@ fn real_pr_finish_rejects_main_and_reports_no_pr_when_only_local_bundle_sync_cha
         &issue_ref.issue_prompt_path(&repo),
         &repo,
     );
+    write_authored_spp(
+        &issue_ref.task_bundle_plan_path(&repo),
+        &issue_ref,
+        "Example",
+        "codex/1153-rust-finish-test",
+        &repo,
+    );
+    write_authored_srp(
+        &issue_ref.task_bundle_review_policy_path(&repo),
+        &issue_ref,
+        "Example",
+        "codex/1153-rust-finish-test",
+        &repo,
+    );
     write_completed_sor_fixture(&output, "codex/1153-rust-finish-test");
     let cards_root = resolve_cards_root(&repo, None);
     let compat_output = card_output_path(&cards_root, 1153);
@@ -321,6 +335,20 @@ fn real_pr_finish_rejects_staged_gitignore_changes_without_allow_flag() {
         "Example",
         "codex/1153-rust-finish-test",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &issue_ref.task_bundle_plan_path(&repo),
+        &issue_ref,
+        "Example",
+        "codex/1153-rust-finish-test",
+        &repo,
+    );
+    write_authored_srp(
+        &issue_ref.task_bundle_review_policy_path(&repo),
+        &issue_ref,
+        "Example",
+        "codex/1153-rust-finish-test",
         &repo,
     );
     write_completed_sor_fixture(

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/canonical_surfaces.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/canonical_surfaces.rs
@@ -92,6 +92,8 @@ fn real_pr_finish_refuses_to_publish_local_only_bundle_without_tracked_changes()
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(
         &repo,
         &issue_ref,
@@ -104,6 +106,20 @@ fn real_pr_finish_refuses_to_publish_local_only_bundle_without_tracked_changes()
         "[v0.86][tools] Rust finish ignored bundle",
         "codex/1157-rust-finish-ignored-bundle",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish ignored bundle",
+        "codex/1157-rust-finish-ignored-bundle",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish ignored bundle",
+        "codex/1157-rust-finish-ignored-bundle",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1157-rust-finish-ignored-bundle");
@@ -259,6 +275,8 @@ fn real_pr_finish_refuses_when_canonical_issue_surfaces_are_tracked() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(
         &repo,
         &issue_ref,
@@ -271,6 +289,20 @@ fn real_pr_finish_refuses_when_canonical_issue_surfaces_are_tracked() {
         "[v0.86][tools] Rust finish tracked bundle",
         "codex/1158-rust-finish-tracked-bundle",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish tracked bundle",
+        "codex/1158-rust-finish-tracked-bundle",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish tracked bundle",
+        "codex/1158-rust-finish-tracked-bundle",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1158-rust-finish-tracked-bundle");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/foreign_bundle.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/foreign_bundle.rs
@@ -93,6 +93,8 @@ fn real_pr_finish_rejects_staged_foreign_issue_bundle_mutations() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(
         &repo,
         &issue_ref,
@@ -105,6 +107,20 @@ fn real_pr_finish_rejects_staged_foreign_issue_bundle_mutations() {
         "[v0.86][tools] Rust finish foreign bundle",
         "codex/1161-rust-finish-foreign-bundle",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish foreign bundle",
+        "codex/1161-rust-finish-foreign-bundle",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish foreign bundle",
+        "codex/1161-rust-finish-foreign-bundle",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1161-rust-finish-foreign-bundle");
@@ -258,6 +274,8 @@ fn real_pr_finish_allows_deletion_only_cleanup_for_foreign_issue_bundle_residue(
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     let source = issue_ref.issue_prompt_path(&repo);
     write_authored_issue_prompt(
         &repo,
@@ -272,6 +290,20 @@ fn real_pr_finish_allows_deletion_only_cleanup_for_foreign_issue_bundle_residue(
         "[v0.86][tools] Rust finish foreign bundle delete",
         "codex/1161-rust-finish-foreign-bundle-delete",
         &source,
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish foreign bundle delete",
+        "codex/1161-rust-finish-foreign-bundle-delete",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish foreign bundle delete",
+        "codex/1161-rust-finish-foreign-bundle-delete",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1161-rust-finish-foreign-bundle-delete");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/output_truth.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/output_truth.rs
@@ -83,6 +83,8 @@ fn real_pr_finish_rejects_not_started_output_card_before_publication() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Output card guard");
     fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
     write_authored_sip(
@@ -91,6 +93,20 @@ fn real_pr_finish_rejects_not_started_output_card_before_publication() {
         "[v0.86][tools] Output card guard",
         "codex/1156-output-card-guard",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Output card guard",
+        "codex/1156-output-card-guard",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Output card guard",
+        "codex/1156-output-card-guard",
         &repo,
     );
     fs::write(
@@ -252,6 +268,8 @@ fn real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish closed stale");
     if let Some(parent) = stp.parent() {
         fs::create_dir_all(parent).expect("bundle dir");
@@ -263,6 +281,20 @@ fn real_pr_finish_rejects_closed_issue_with_stale_canonical_sor_truth() {
         "[v0.86][tools] Rust finish closed stale",
         "codex/1158-rust-finish-closed-stale",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish closed stale",
+        "codex/1158-rust-finish-closed-stale",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish closed stale",
+        "codex/1158-rust-finish-closed-stale",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1158-rust-finish-closed-stale");

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/sync_and_prompt.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/sync_and_prompt.rs
@@ -102,6 +102,10 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
 
     let root_input = issue_ref.task_bundle_input_path(&repo);
     let wt_input = issue_ref.task_bundle_input_path(&worktree);
+    let root_plan = issue_ref.task_bundle_plan_path(&repo);
+    let wt_plan = issue_ref.task_bundle_plan_path(&worktree);
+    let root_review_policy = issue_ref.task_bundle_review_policy_path(&repo);
+    let wt_review_policy = issue_ref.task_bundle_review_policy_path(&worktree);
     write_authored_sip(
         &root_input,
         &issue_ref,
@@ -110,12 +114,40 @@ fn real_pr_finish_syncs_completed_output_to_root_bundle_and_cards_surface() {
         &issue_ref.issue_prompt_path(&repo),
         &repo,
     );
+    write_authored_spp(
+        &root_plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish sync",
+        "codex/1153-rust-finish-sync",
+        &repo,
+    );
+    write_authored_srp(
+        &root_review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish sync",
+        "codex/1153-rust-finish-sync",
+        &repo,
+    );
     write_authored_sip(
         &wt_input,
         &issue_ref,
         "[v0.86][tools] Rust finish sync",
         "codex/1153-rust-finish-sync",
         &wt_issue_prompt,
+        &worktree,
+    );
+    write_authored_spp(
+        &wt_plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish sync",
+        "codex/1153-rust-finish-sync",
+        &worktree,
+    );
+    write_authored_srp(
+        &wt_review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish sync",
+        "codex/1153-rust-finish-sync",
         &worktree,
     );
 

--- a/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/sync_and_prompt.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/guardrails/sync_and_prompt.rs
@@ -291,6 +291,10 @@ fn real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_c
 
     let root_input = issue_ref.task_bundle_input_path(&repo);
     let wt_input = issue_ref.task_bundle_input_path(&worktree);
+    let root_plan = issue_ref.task_bundle_plan_path(&repo);
+    let wt_plan = issue_ref.task_bundle_plan_path(&worktree);
+    let root_review_policy = issue_ref.task_bundle_review_policy_path(&repo);
+    let wt_review_policy = issue_ref.task_bundle_review_policy_path(&worktree);
     write_authored_sip(
         &root_input,
         &issue_ref,
@@ -299,12 +303,40 @@ fn real_pr_finish_accepts_primary_checkout_issue_prompt_without_worktree_local_c
         &issue_ref.issue_prompt_path(&repo),
         &repo,
     );
+    write_authored_spp(
+        &root_plan,
+        &issue_ref,
+        "[v0.86][tools] Finish primary prompt",
+        "codex/1241-finish-primary-prompt",
+        &repo,
+    );
+    write_authored_srp(
+        &root_review_policy,
+        &issue_ref,
+        "[v0.86][tools] Finish primary prompt",
+        "codex/1241-finish-primary-prompt",
+        &repo,
+    );
     write_authored_sip(
         &wt_input,
         &issue_ref,
         "[v0.86][tools] Finish primary prompt",
         "codex/1241-finish-primary-prompt",
         &issue_ref.issue_prompt_path(&repo),
+        &worktree,
+    );
+    write_authored_spp(
+        &wt_plan,
+        &issue_ref,
+        "[v0.86][tools] Finish primary prompt",
+        "codex/1241-finish-primary-prompt",
+        &worktree,
+    );
+    write_authored_srp(
+        &wt_review_policy,
+        &issue_ref,
+        "[v0.86][tools] Finish primary prompt",
+        "codex/1241-finish-primary-prompt",
         &worktree,
     );
 

--- a/adl/src/cli/tests/pr_cmd_inline/finish/publication.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/publication.rs
@@ -88,6 +88,8 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish test");
     fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
     write_authored_sip(
@@ -96,6 +98,20 @@ fn real_pr_finish_creates_draft_pr_and_commits_branch_changes() {
         "[v0.86][tools] Rust finish test",
         "codex/1153-rust-finish-test",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1153-rust-finish-test",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1153-rust-finish-test",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1153-rust-finish-test");
@@ -331,6 +347,8 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish test");
     fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
     write_authored_sip(
@@ -339,6 +357,20 @@ fn real_pr_finish_fails_when_pr_janitor_auto_attach_fails() {
         "[v0.86][tools] Rust finish test",
         "codex/1154-rust-finish-test",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1154-rust-finish-test",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1154-rust-finish-test",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1154-rust-finish-test");
@@ -509,6 +541,8 @@ fn real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish test");
     fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
     write_authored_sip(
@@ -517,6 +551,20 @@ fn real_pr_finish_fails_when_post_merge_closeout_auto_attach_fails() {
         "[v0.86][tools] Rust finish test",
         "codex/1161-rust-finish-test",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1161-rust-finish-test",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test",
+        "codex/1161-rust-finish-test",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1161-rust-finish-test");
@@ -690,6 +738,8 @@ fn real_pr_finish_updates_existing_pr_and_marks_ready() {
     let stp = issue_ref.task_bundle_stp_path(&repo);
     let input = issue_ref.task_bundle_input_path(&repo);
     let output = issue_ref.task_bundle_output_path(&repo);
+    let plan = issue_ref.task_bundle_plan_path(&repo);
+    let review_policy = issue_ref.task_bundle_review_policy_path(&repo);
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust finish test edit");
     fs::copy(issue_ref.issue_prompt_path(&repo), &stp).expect("seed stp");
     write_authored_sip(
@@ -698,6 +748,20 @@ fn real_pr_finish_updates_existing_pr_and_marks_ready() {
         "[v0.86][tools] Rust finish test edit",
         "codex/1153-rust-finish-test-edit",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &plan,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test edit",
+        "codex/1153-rust-finish-test-edit",
+        &repo,
+    );
+    write_authored_srp(
+        &review_policy,
+        &issue_ref,
+        "[v0.86][tools] Rust finish test edit",
+        "codex/1153-rust-finish-test-edit",
         &repo,
     );
     write_completed_sor_fixture(&output, "codex/1153-rust-finish-test-edit");

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -394,6 +394,134 @@ fn real_pr_doctor_full_blocks_invalid_root_bootstrap_output_card() {
 }
 
 #[test]
+fn real_pr_doctor_full_blocks_invalid_root_spp() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-doctor-invalid-root-spp");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "doctor invalid spp\n").expect("seed file");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1916, "v0.86", "doctor-invalid-spp").expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Doctor invalid spp");
+    real_pr(&[
+        "init".to_string(),
+        "1916".to_string(),
+        "--slug".to_string(),
+        "doctor-invalid-spp".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Doctor invalid spp".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let root_sip = issue_ref.task_bundle_input_path(&repo);
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    write_authored_sip(
+        &root_sip,
+        &issue_ref,
+        "[v0.86][tools] Doctor invalid spp",
+        "not bound yet",
+        &source_path,
+        &repo,
+    );
+
+    let root_spp = issue_ref.task_bundle_plan_path(&repo);
+    let invalid_spp = fs::read_to_string(&root_spp)
+        .expect("read root spp")
+        .replace("status: \"draft\"", "status: \"queued\"");
+    fs::write(&root_spp, invalid_spp).expect("write invalid root spp");
+
+    let err = real_pr(&[
+        "doctor".to_string(),
+        "1916".to_string(),
+        "--slug".to_string(),
+        "doctor-invalid-spp".to_string(),
+        "--mode".to_string(),
+        "full".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("doctor should reject invalid root spp");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    let err = err.to_string();
+    assert!(err.contains("doctor: spp failed validation"));
+    assert!(err.contains("status must be one of: draft, reviewed, approved"));
+}
+
+#[test]
 fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-doctor-worktree-cwd");

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -917,12 +917,28 @@ fn real_pr_doctor_reconciles_closed_completed_issue_bundle_without_worktree() {
     fs::rename(&canonical_bundle, &duplicate_bundle).expect("move bundle to duplicate");
 
     let duplicate_sip = duplicate_bundle.join("sip.md");
+    let duplicate_spp = duplicate_bundle.join("spp.md");
+    let duplicate_srp = duplicate_bundle.join("srp.md");
     write_authored_sip(
         &duplicate_sip,
         &issue_ref,
         "[v0.87][tools] Finalize local task-bundle closeout when issues are actually closed",
         "codex/1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed",
         &issue_ref.issue_prompt_path(&repo),
+        &repo,
+    );
+    write_authored_spp(
+        &duplicate_spp,
+        &issue_ref,
+        "[v0.87][tools] Finalize local task-bundle closeout when issues are actually closed",
+        "codex/1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed",
+        &repo,
+    );
+    write_authored_srp(
+        &duplicate_srp,
+        &issue_ref,
+        "[v0.87][tools] Finalize local task-bundle closeout when issues are actually closed",
+        "codex/1410-v0-87-tools-finalize-local-task-bundle-closeout-when-issues-are-actually-closed",
         &repo,
     );
 

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -386,6 +386,148 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
 }
 
 #[test]
+fn real_pr_ready_blocks_invalid_worktree_srp() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-ready-invalid-worktree-srp");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "ready invalid srp\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref = IssueRef::new(1917, "v0.86", "ready-invalid-worktree-srp").expect("issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Ready invalid worktree srp",
+    );
+
+    real_pr(&[
+        "start".to_string(),
+        "1917".to_string(),
+        "--slug".to_string(),
+        "ready-invalid-worktree-srp".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Ready invalid worktree srp".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr start");
+
+    let root_sip = issue_ref.task_bundle_input_path(&repo);
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    let wt_sip = issue_ref.task_bundle_input_path(&worktree);
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    let branch = "codex/1917-ready-invalid-worktree-srp";
+    write_authored_sip(
+        &root_sip,
+        &issue_ref,
+        "[v0.86][tools] Ready invalid worktree srp",
+        branch,
+        &source_path,
+        &repo,
+    );
+    write_authored_sip(
+        &wt_sip,
+        &issue_ref,
+        "[v0.86][tools] Ready invalid worktree srp",
+        branch,
+        &issue_ref.issue_prompt_path(&worktree),
+        &worktree,
+    );
+
+    let wt_srp = issue_ref.task_bundle_review_policy_path(&worktree);
+    let invalid_srp = fs::read_to_string(&wt_srp)
+        .expect("read worktree srp")
+        .replace("status: \"draft\"", "status: \"queued\"");
+    fs::write(&wt_srp, invalid_srp).expect("write invalid worktree srp");
+
+    let err = real_pr(&[
+        "ready".to_string(),
+        "1917".to_string(),
+        "--slug".to_string(),
+        "ready-invalid-worktree-srp".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("ready should reject invalid worktree srp");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    let err = err.to_string();
+    assert!(err.contains("ready: srp failed validation"));
+    assert!(err.contains("status must be one of: draft, ready, approved"));
+}
+
+#[test]
 fn real_pr_start_rewrites_unbound_root_input_card_branch() {
     let _guard = env_lock();
     let temp = unique_temp_dir("adl-pr-start-rewrites-unbound");

--- a/adl/src/cli/tests/pr_cmd_inline/mod.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/mod.rs
@@ -171,6 +171,253 @@ fn write_authored_sip(
     fs::write(path, content).expect("write authored sip");
 }
 
+fn write_authored_spp(
+    path: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    branch: &str,
+    repo_root: &Path,
+) {
+    let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
+    let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
+    let spp_rel = path_relative_to_repo(repo_root, path);
+    let content = format!(
+        r#"---
+schema_version: "0.1"
+artifact_type: "structured_planning_prompt"
+name: "{slug}-execution-plan"
+issue: {issue}
+task_id: "{task_id}"
+run_id: "{task_id}"
+version: v0.86
+title: "{title}"
+branch: "{branch}"
+status: "draft"
+plan_revision: 1
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/example/repo/issues/{issue}"
+  - kind: "stp"
+    ref: "{stp_rel}"
+  - kind: "sip"
+    ref: "{sip_rel}"
+scope:
+  files:
+    - "{stp_rel}"
+    - "{sip_rel}"
+  components:
+    - "{slug}"
+  out_of_scope:
+    - "implementation beyond the approved issue scope"
+constraints:
+  - "read_only_until_execution_is_approved"
+confidence: "medium"
+plan_summary: "Authored planning surface for finish-path tests."
+assumptions:
+  - "The linked STP and SIP remain canonical."
+proposed_steps:
+  - id: "step-1"
+    description: "Review the bundle and tighten the execution sequence."
+    expected_output: "{spp_rel}"
+    allowed_mode: "execution_after_approval"
+codex_plan:
+  - step: "Review the bundle and tighten the execution sequence."
+    status: "pending"
+affected_areas:
+  - "{slug}"
+invariants_to_preserve:
+  - "Do not claim implementation work inside the plan."
+risks_and_edge_cases:
+  - "Validation inputs may need tightening before execution."
+test_strategy:
+  - "Review the proposed validation commands before execution."
+execution_handoff: "Use this artifact as the durable plan-of-record before execution."
+required_permissions:
+  - "workspace-write after execution approval"
+stop_conditions:
+  - "Stop and re-plan if the touched-file set changes."
+alternatives_considered:
+  - description: "Use transient chat planning only."
+    reason_not_chosen: "That would not leave a durable review surface."
+review_hooks:
+  - "Check scope truthfulness and validation sufficiency."
+notes: "test note"
+---
+
+# Structured Plan Prompt
+
+## Plan Summary
+
+test
+
+## Codex Plan
+
+1. [pending] test
+
+## Assumptions
+
+- test
+
+## Proposed Steps
+
+1. test
+
+## Affected Areas
+
+- test
+
+## Invariants To Preserve
+
+- test
+
+## Risks And Edge Cases
+
+- test
+
+## Test Strategy
+
+- test
+
+## Execution Handoff
+
+test
+
+## Stop Conditions
+
+- test
+
+## Notes
+
+test
+"#,
+        slug = issue_ref.slug(),
+        issue = issue_ref.issue_number(),
+        task_id = issue_ref.task_issue_id(),
+        title = title,
+        branch = branch,
+        stp_rel = stp_rel,
+        sip_rel = sip_rel,
+        spp_rel = spp_rel,
+    );
+    fs::write(path, content).expect("write authored spp");
+}
+
+fn write_authored_srp(
+    path: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    branch: &str,
+    repo_root: &Path,
+) {
+    let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
+    let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
+    let sor_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_output_path(repo_root));
+    let content = format!(
+        r#"---
+schema_version: "0.1"
+artifact_type: "structured_review_policy"
+name: "{slug}-review-policy"
+issue: {issue}
+task_id: "{task_id}"
+version: v0.86
+title: "{title}"
+branch: "{branch}"
+status: "draft"
+source_refs:
+  - kind: "issue"
+    ref: "https://github.com/example/repo/issues/{issue}"
+  - kind: "stp"
+    ref: "{stp_rel}"
+  - kind: "sip"
+    ref: "{sip_rel}"
+  - kind: "sor"
+    ref: "{sor_rel}"
+review_mode: "pre_pr_independent_review"
+timing: "before_pr_open"
+scope_basis:
+  - "{stp_rel}"
+  - "{sip_rel}"
+in_scope_surfaces:
+  - "tracked changes for this issue branch"
+evidence_policy:
+  - "Use repository evidence and issue-local validation only."
+validation_inputs:
+  - "Issue-local proofs recorded in the SOR."
+allowed_dispositions:
+  - "PASS"
+  - "BLOCK"
+reviewer_constraints:
+  - "Do not widen issue scope."
+refusal_policy:
+  - "Refuse claims that are unsupported by repository evidence."
+follow_up_routing:
+  - "Route actionable findings back to the issue branch."
+non_claims:
+  - "This policy does not guarantee review quality by itself."
+policy_refs:
+  - "{stp_rel}"
+notes: "test note"
+---
+
+# Structured Review Policy
+
+## Review Summary
+
+test
+
+## Scope Basis
+
+- test
+
+## In-Scope Surfaces
+
+- test
+
+## Evidence Rules
+
+- test
+
+## Validation Inputs
+
+- test
+
+## Allowed Dispositions
+
+- PASS
+- BLOCK
+
+## Reviewer Constraints
+
+- test
+
+## Refusal Policy
+
+- test
+
+## Follow-up Routing
+
+- test
+
+## Non-Claims
+
+- test
+
+## Notes
+
+test
+"#,
+        slug = issue_ref.slug(),
+        issue = issue_ref.issue_number(),
+        task_id = issue_ref.task_issue_id(),
+        title = title,
+        branch = branch,
+        stp_rel = stp_rel,
+        sip_rel = sip_rel,
+        sor_rel = sor_rel,
+    );
+    fs::write(path, content).expect("write authored srp");
+}
+
 fn write_completed_sor_fixture(path: &Path, branch: &str) {
     let body = format!(
         r#"# rust-finish-test


### PR DESCRIPTION
Closes #2895

## Summary
- validate `spp.md` and `srp.md` in the shared repo lifecycle validator path
- enforce those artifacts in `doctor` and `finish` instead of only `stp/sip/sor`
- add focused lifecycle regressions for invalid root `spp` and invalid worktree `srp`

## Validation
- cargo fmt --manifest-path adl/Cargo.toml --all
- cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_blocks_invalid_root_spp -- --nocapture
- cargo test --manifest-path adl/Cargo.toml real_pr_ready_blocks_invalid_worktree_srp -- --nocapture
- cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_reports_pre_run_ready_without_worktree -- --nocapture
- cargo test --manifest-path adl/Cargo.toml real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture
- git diff --check
