### PR TITLE
[v0.91][tools] Add sprint-wide structured prompt preflight

### DIFF
--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -26,6 +26,20 @@ sprint:
       pr_url: <url or null>
       artifact_paths:
         - /absolute/or/repo-relative/path
+  structured_prompt_preflight:
+    status: not_run | ready | needs_editor_repair | blocked
+    required_card_types:
+      - stp.md | sip.md | sor.md | spp.md | srp.md
+    issue_results:
+      - issue_number: <u32>
+        bundle_path: /absolute/or/repo-relative/path | null
+        status: ready | needs_editor_repair | blocked
+        missing_cards:
+          - <filename>
+        contradictory_cards:
+          - <filename>
+        required_editor_skills:
+          - stp-editor | sip-editor | sor-editor | spp-editor
   truth_check:
     status: not_run | matched | drift_detected | blocked
     source: github_live | sprint_state_only | mixed
@@ -41,6 +55,7 @@ policy:
   require_editor_skills: true
   require_code_review: true
   allow_create_missing_sprint_issue: true | false
+  require_full_sprint_structured_prompt_readiness: true
   allow_review_subagent_exception: true
   max_review_subagents_when_exception_enabled: 1
   require_github_truth_recheck: true

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -15,6 +15,8 @@ Its job is to:
 - route each issue through the existing lifecycle and editor skills rather than
   reimplementing them
 - preserve resumable sprint state in one lightweight local artifact
+- verify and, when needed, repair structured prompt readiness across the entire
+  sprint before issue execution begins
 - assemble a robust sprint-end review with code-facing review expectations
 - record sprint-end closeout truth including coverage and Rust tracker numbers
 - manage the sprint-management issue to completion, including closing it only
@@ -114,20 +116,23 @@ missing sprint-management issue first.
    issue is missing and policy allows creation, create it through the bundled
    helper first.
 2. Create or load the sprint-state artifact.
-3. Confirm the current issue is the earliest not-yet-closed issue in the list.
-4. Route that issue through `workflow-conductor`.
-5. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
-6. Run only the selected downstream lifecycle or editor skill.
-7. Re-check issue truth until the issue is fully closed out. Every sprint-state transition consumes the last successful truth check, so the next transition requires a fresh recheck.
-8. Only then advance to the next ordered issue.
-9. After the final issue closes, assemble sprint review evidence.
-10. Record sprint closeout metrics including coverage and Rust tracker counts.
-11. Stop with one bounded sprint review/closeout result.
+3. Run sprint-wide structured prompt review before issue execution begins.
+4. If any child issue cards are not ready, repair them through the editor skills first.
+5. Confirm the current issue is the earliest not-yet-closed issue in the list.
+6. Route that issue through `workflow-conductor`.
+7. Re-check live issue and PR truth before acting. This is a blocking gate, not a suggestion.
+8. Run only the selected downstream lifecycle or editor skill.
+9. Re-check issue truth until the issue is fully closed out. Every sprint-state transition consumes the last successful truth check, so the next transition requires a fresh recheck.
+10. Only then advance to the next ordered issue.
+11. After the final issue closes, assemble sprint review evidence.
+12. Record sprint closeout metrics including coverage and Rust tracker counts.
+13. Stop with one bounded sprint review/closeout result.
 
 ## Execution Model
 
 This skill enforces:
 - exactly one active child issue at a time
+- no child issue execution before the whole sprint batch passes structured prompt review
 - no issue `N+1` work before issue `N` is fully closed out
 - editor-skill routing when cards drift
 - immediate stop on blocker
@@ -138,6 +143,9 @@ This skill enforces:
 - no sprint-state advancement without a fresh matched live GitHub truth check
 
 Preferred per-issue routing model:
+- sprint-wide structured prompt preflight not ready ->
+  `check_sprint_structured_prompt_readiness.py`, then route flagged child issues
+  through the matching editor skills before starting issue execution
 - missing sprint-management issue and policy allows creation ->
   `create_missing_sprint_issue.py`, then continue with the ordered child issue
   flow from the created sprint anchor

--- a/adl/tools/skills/sprint-conductor/adl-skill.yaml
+++ b/adl/tools/skills/sprint-conductor/adl-skill.yaml
@@ -26,6 +26,7 @@ admission:
       - "require_editor_skills"
       - "require_code_review"
       - "allow_create_missing_sprint_issue"
+      - "require_full_sprint_structured_prompt_readiness"
       - "allow_review_subagent_exception"
       - "max_review_subagents_when_exception_enabled"
       - "require_github_truth_recheck"
@@ -65,6 +66,7 @@ admission:
     - "sprint.review_paths"
     - "sprint.closeout_paths"
     - "sprint.issue_records"
+    - "sprint.structured_prompt_preflight"
     - "sprint.truth_check"
     - "review_subagent_ids"
   stop_if_missing:
@@ -78,6 +80,7 @@ admission:
     - "policy.require_sequential_closeout_must_be_true"
     - "policy.require_existing_issue_skills_must_be_true"
     - "policy.require_editor_skills_must_be_true"
+    - "policy.require_full_sprint_structured_prompt_readiness_must_be_true"
     - "policy.require_github_truth_recheck_must_be_true"
     - "policy.github_truth_gate_blocks_progress_must_be_true"
     - "policy.stop_on_blocker_must_be_true"
@@ -89,6 +92,7 @@ execution:
   allow_subagents: true
   workflow_role: "sprint_orchestrator"
   preferred_commands:
+    - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py --repo-root <repo> --ordered-issues <csv> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/close_sprint_issue.py --state <path> --summary <text>"
     - "python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py --repo-root <repo> --state <path> --require-match"

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -27,23 +27,30 @@ Optional:
 ## Core Loop
 
 1. Load or create sprint-state.
-2. If the sprint-management issue is missing:
+2. Run sprint-wide structured prompt review before starting issue execution:
+   - if every child issue is ready, continue
+   - if any child issue needs repair, route the matching editor skill before issue execution
+   - if any child issue is blocked, stop and report it
+3. If the sprint-management issue is missing:
    - create it through the bundled helper when policy allows, then continue
    - otherwise stop and report `missing_sprint_issue`
-3. Re-check live GitHub truth for the current sprint-state and require a matched result before any sprint-state transition.
-4. Choose the earliest child issue in the ordered list that is not yet closed
+4. Re-check live GitHub truth for the current sprint-state and require a matched result before any sprint-state transition.
+5. Choose the earliest child issue in the ordered list that is not yet closed
    out.
-5. Route that child issue through `workflow-conductor`.
-6. Run only the selected downstream lifecycle or editor skill.
-7. Re-check issue truth.
-8. If the issue is not fully closed out, repeat the routing loop for the same
+6. Route that child issue through `workflow-conductor`.
+7. Run only the selected downstream lifecycle or editor skill.
+8. Re-check issue truth.
+9. If the issue is not fully closed out, repeat the routing loop for the same
    issue.
-9. If the issue is in a healthy PR-open waiting state, pause on that issue and
+10. If the issue is in a healthy PR-open waiting state, pause on that issue and
    surface `ask_operator` rather than re-driving execution or janitoring a
    non-blocked PR.
-10. If the issue is fully closed out, mark it complete in sprint-state and move
+11. If the issue is fully closed out, mark it complete in sprint-state and move
    to the next issue.
-11. If any blocker is encountered, stop and report the blocker in sprint-state.
+12. If any blocker is encountered, stop and report the blocker in sprint-state.
+
+Preferred structured-prompt preflight helper:
+- `python3 adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py --repo-root <repo> --ordered-issues <csv> --state <path>`
 
 Preferred missing-sprint-issue helper:
 - `python3 adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py --repo-root <repo> --ordered-issues <csv> --title <title> --goal <goal> --state <path>`
@@ -60,6 +67,7 @@ If `workflow-conductor` selects:
 
 then the sprint conductor must run that editor skill first and must not try to
 work around malformed cards by hand.
+That rule applies both to sprint-wide preflight repair and to later issue-local drift.
 
 ## Review Phase
 

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -24,6 +24,22 @@ sequence:
   deferred_issue_numbers:
     - <u32>
   continuation: continue | stop | ask_operator | waiting_for_review
+structured_prompt_preflight:
+  status: not_run | ready | needs_editor_repair | blocked
+  required_card_types:
+    - stp.md | sip.md | sor.md | spp.md | srp.md
+  issue_results:
+    - issue_number: <u32>
+      bundle_path: <path or null>
+      status: ready | needs_editor_repair | blocked
+      missing_cards:
+        - <filename>
+      contradictory_cards:
+        - <filename>
+      required_editor_skills:
+        - stp-editor | sip-editor | sor-editor | spp-editor
+      notes:
+        - <bounded text>
 truth_check:
   status: not_run | matched | drift_detected | blocked
   source: github_live | sprint_state_only | mixed

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_csv_ints(raw: str) -> list[int]:
+    values: list[int] = []
+    for part in raw.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        values.append(int(part))
+    return values
+
+
+def find_bundle_dir(repo_root: Path, issue_number: int) -> tuple[Path | None, list[str]]:
+    matches = sorted(
+        repo_root.glob(f'.adl/*/tasks/issue-{issue_number}__*')
+    )
+    if not matches:
+        return None, [f'No local task bundle found for issue #{issue_number}.']
+    if len(matches) > 1:
+        rendered = ', '.join(str(path) for path in matches)
+        return None, [f'Ambiguous local task bundles for issue #{issue_number}: {rendered}']
+    return matches[0], []
+
+
+def inspect_issue(
+    repo_root: Path,
+    issue_number: int,
+    require_spp: bool,
+    require_srp: bool,
+) -> dict:
+    bundle_dir, notes = find_bundle_dir(repo_root, issue_number)
+    if bundle_dir is None:
+        return {
+            'issue_number': issue_number,
+            'bundle_path': None,
+            'status': 'blocked',
+            'missing_cards': [],
+            'contradictory_cards': [],
+            'required_editor_skills': [],
+            'notes': notes,
+        }
+
+    required_cards = {
+        'stp.md': 'stp-editor',
+        'sip.md': 'sip-editor',
+        'sor.md': 'sor-editor',
+    }
+    if require_spp:
+        required_cards['spp.md'] = 'spp-editor'
+    if require_srp:
+        required_cards['srp.md'] = 'spp-editor'
+
+    missing_cards: list[str] = []
+    contradictory_cards: list[str] = []
+    required_editor_skills: list[str] = []
+
+    for card_name, editor_skill in required_cards.items():
+        card_path = bundle_dir / card_name
+        if not card_path.exists():
+            missing_cards.append(card_name)
+            if editor_skill not in required_editor_skills:
+                required_editor_skills.append(editor_skill)
+
+    sor_path = bundle_dir / 'sor.md'
+    if sor_path.exists():
+        sor_text = sor_path.read_text()
+        if 'Status: IN_PROGRESS' in sor_text and 'No implementation has started yet' in sor_text:
+            contradictory_cards.append('sor.md')
+            if 'sor-editor' not in required_editor_skills:
+                required_editor_skills.append('sor-editor')
+
+    status = 'ready'
+    if contradictory_cards or missing_cards:
+        status = 'needs_editor_repair'
+
+    notes.extend(
+        [f'Missing {name}' for name in missing_cards] +
+        [f'Contradictory bootstrap residue in {name}' for name in contradictory_cards]
+    )
+
+    return {
+        'issue_number': issue_number,
+        'bundle_path': str(bundle_dir),
+        'status': status,
+        'missing_cards': missing_cards,
+        'contradictory_cards': contradictory_cards,
+        'required_editor_skills': required_editor_skills,
+        'notes': notes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repo-root', required=True)
+    parser.add_argument('--ordered-issues', required=True)
+    parser.add_argument('--state')
+    parser.add_argument('--require-spp', action='store_true')
+    parser.add_argument('--require-srp', action='store_true')
+    parser.add_argument('--print-json', action='store_true')
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root)
+    ordered = parse_csv_ints(args.ordered_issues)
+    issue_results = [
+        inspect_issue(repo_root, issue, args.require_spp, args.require_srp)
+        for issue in ordered
+    ]
+
+    overall_status = 'ready'
+    if any(result['status'] == 'blocked' for result in issue_results):
+        overall_status = 'blocked'
+    elif any(result['status'] == 'needs_editor_repair' for result in issue_results):
+        overall_status = 'needs_editor_repair'
+
+    result = {
+        'status': overall_status,
+        'required_card_types': ['stp.md', 'sip.md', 'sor.md'] +
+        (['spp.md'] if args.require_spp else []) +
+        (['srp.md'] if args.require_srp else []),
+        'issue_results': issue_results,
+        'notes': [
+            'Review and repair all child issue structured cards before starting issue execution.'
+            if overall_status != 'ready'
+            else 'All ordered child issue structured cards are ready for sprint start.'
+        ],
+    }
+
+    if args.state:
+        state_path = Path(args.state)
+        state = json.loads(state_path.read_text()) if state_path.exists() else {}
+        state['structured_prompt_preflight'] = result
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+
+    if args.print_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    elif args.state:
+        print(args.state)
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -40,6 +40,12 @@ def load_state(path: Path, sprint_issue: int, ordered: list[int]) -> dict[str, A
         'blocked_issue_number': None,
         'continuation': 'continue',
         'issue_records': default_issue_records(ordered),
+        'structured_prompt_preflight': {
+            'status': 'not_run',
+            'required_card_types': ['stp.md', 'sip.md', 'sor.md'],
+            'issue_results': [],
+            'notes': ['Run sprint-wide structured prompt preflight before starting issue execution.'],
+        },
         'truth_check': {
             'status': 'not_run',
             'source': 'sprint_state_only',
@@ -118,6 +124,16 @@ def require_truth_gate(state: dict[str, Any]) -> None:
     )
 
 
+def require_structured_prompt_preflight(state: dict[str, Any]) -> None:
+    preflight = state.get('structured_prompt_preflight') or {}
+    if preflight.get('status') == 'ready':
+        return
+    raise SystemExit(
+        'Refusing to advance sprint state before sprint-wide structured prompt review and repair is complete. '
+        'Run check_sprint_structured_prompt_readiness.py and fix any flagged child issue cards first.'
+    )
+
+
 def consume_truth_gate(state: dict[str, Any]) -> None:
     truth_check = state.setdefault('truth_check', {})
     truth_check['gate_passed'] = False
@@ -149,6 +165,7 @@ def main() -> int:
     state['sprint_issue_number'] = args.sprint_issue
     state['ordered_issue_numbers'] = ordered
     if state_preexisted and mutation_requested(args):
+        require_structured_prompt_preflight(state)
         require_truth_gate(state)
 
     issue_number = args.current_issue or state.get('current_issue_number') or (ordered[0] if ordered else None)

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -61,6 +61,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" ]]
+  [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/close_sprint_issue.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/update_sprint_state.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_sprint_truth.py" ]]

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -59,9 +59,31 @@ export PATH="${fakebin}:${PATH}"
 export FAKE_GH_LOG="${log_path}"
 
 state_path="${tmpdir}/sprint-state.json"
+fake_repo="${tmpdir}/fake-repo"
+mkdir -p "${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05"
+mkdir -p "${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06"
+
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/stp.md" <<'EOF'
+stp
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/sip.md" <<'EOF'
+sip
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/sor.md" <<'EOF'
+Status: NOT_STARTED
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/stp.md" <<'EOF'
+stp
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/sip.md" <<'EOF'
+sip
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/sor.md" <<'EOF'
+Status: NOT_STARTED
+EOF
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" \
-  --repo-root "${repo_root}" \
+  --repo-root "${fake_repo}" \
   --ordered-issues "2827,2828" \
   --title "[v0.91.1][sprint-1][management] Trial sprint" \
   --goal "Run the narrow sprint-conductor trial" \
@@ -82,6 +104,23 @@ assert state["truth_check"]["status"] == "not_run"
 assert state["truth_check"]["gate_passed"] is False
 PY
 
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --state "${state_path}" >/dev/null
+
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+preflight = state["structured_prompt_preflight"]
+assert preflight["status"] == "ready"
+assert len(preflight["issue_results"]) == 2
+assert all(result["status"] == "ready" for result in preflight["issue_results"])
+PY
+
 if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
   --state "${state_path}" \
   --sprint-issue 3001 \
@@ -93,7 +132,7 @@ if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint
 fi
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
-  --repo-root "${repo_root}" \
+  --repo-root "${fake_repo}" \
   --state "${state_path}" \
   --require-match >/dev/null
 
@@ -130,7 +169,7 @@ if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint
 fi
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_truth.py" \
-  --repo-root "${repo_root}" \
+  --repo-root "${fake_repo}" \
   --state "${state_path}" \
   --require-match >/dev/null
 
@@ -151,5 +190,29 @@ PY
 grep -Fq "issue create" "${log_path}"
 grep -Fq "issue close 3001 --comment Sprint completed cleanly." "${log_path}"
 grep -Fq "pr view https://github.com/danielbaustin/agent-design-language/pull/4001 --json state,isDraft,url" "${log_path}"
+
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/sor.md" <<'EOF'
+Status: IN_PROGRESS
+No implementation has started yet
+EOF
+broken_state_path="${tmpdir}/sprint-state-broken.json"
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --state "${broken_state_path}" >/dev/null
+
+python3 - "${broken_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+preflight = state["structured_prompt_preflight"]
+assert preflight["status"] == "needs_editor_repair"
+problem = next(result for result in preflight["issue_results"] if result["issue_number"] == 2828)
+assert problem["status"] == "needs_editor_repair"
+assert "sor.md" in problem["contradictory_cards"]
+assert "sor-editor" in problem["required_editor_skills"]
+PY
 
 echo "PASS test_sprint_conductor_helpers"


### PR DESCRIPTION
Closes #2898

## Summary
- add a deterministic sprint-wide structured-prompt readiness helper
- require sprint-wide structured prompt review and repair before issue execution begins
- block sprint-state advancement until both structured prompt preflight and live truth gates pass
- add automated validation for ready and needs-editor-repair preflight paths

## Testing
- bash adl/tools/test_sprint_conductor_helpers.sh
- bash adl/tools/test_install_adl_operational_skills.sh