### PR TITLE
[v0.91.1][quality] Tighten coverage path-policy escalation

### DIFF
--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -162,6 +162,40 @@ is_full_coverage_policy_surface() {
   return 1
 }
 
+is_reporting_only_coverage_workflow_change() {
+  local path="$1"
+  [ "$path" = ".github/workflows/ci.yaml" ] || return 1
+  git diff --unified=0 "$base_sha" "$head_sha" -- "$path" 2>/dev/null \
+    | while IFS= read -r line; do
+        case "$line" in
+          diff\ --git*|index\ *|@@*|---*|+++*)
+            continue
+            ;;
+          +*|-*)
+            local content="${line#?}"
+            case "$content" in
+              *"Coverage summary (text)"*|\
+              *"Verify generated lcov file"*|\
+              *"Verify lcov path from repository root"*|\
+              *"Upload coverage artifact"*|\
+              *"Upload coverage to Codecov"*|\
+              *"adl/lcov.info"*|\
+              *"adl/coverage-summary.json"*|\
+              *"adl/coverage-summary.txt"*|\
+              *"coverage-summary.txt"*|\
+              *"coverage-summary.json"*|\
+              *"files: adl/lcov.info"*|\
+              *"flags: adl"*)
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+            ;;
+        esac
+      done
+}
+
 is_release_truth_doc_surface() {
   local path="$1"
   case "$path" in
@@ -358,6 +392,10 @@ EOF
     while IFS=$'\t' read -r _status path; do
       [ -n "$path" ] || continue
       if is_full_coverage_policy_surface "$path"; then
+        if is_reporting_only_coverage_workflow_change "$path"; then
+          reason="coverage_reporting_workflow_change_skips_authoritative_coverage"
+          continue
+        fi
         if [ "$coverage_required" = true ] || [ "$demo_smoke_required" = true ]; then
           mark_policy_surface_full_coverage \
             "pr_policy_surface_runtime_mixed" \

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -26,6 +26,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
   mkdir -p adl/src docs
   printf 'pub fn baseline() -> bool { true }\n' > adl/src/lib.rs
+  mkdir -p .github/workflows
   cat > adl/Cargo.toml <<'EOF'
 [package]
 name = "adl"
@@ -40,6 +41,23 @@ name = "adl"
 version = "0.90.3"
 EOF
   printf '# baseline\n' > docs/readme.md
+  cat > .github/workflows/ci.yaml <<'EOF'
+jobs:
+  adl-coverage:
+    steps:
+      - name: Coverage run and summary (json)
+        run: bash tools/run_authoritative_coverage_lane.sh
+      - name: Coverage summary (text)
+        run: cargo llvm-cov report --summary-only | tee coverage-summary.txt
+      - name: Upload coverage artifact
+        with:
+          path: |
+            adl/coverage-summary.txt
+      - name: Upload coverage to Codecov
+        with:
+          files: adl/lcov.info
+          flags: adl
+EOF
   git add .
   git commit -q -m baseline
   base_sha="$(git rev-parse HEAD)"
@@ -169,6 +187,47 @@ EOF
   assert_has "$policy_surface_output" "coverage_lane=authoritative_full"
   assert_has "$policy_surface_output" "coverage_authority=pr_policy_surface_tooling_only"
   assert_has "$policy_surface_output" "reason=coverage_policy_surface_change_runs_bounded_authoritative_coverage"
+
+  git checkout -q -b workflow-reporting-only-change "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+path = Path(".github/workflows/ci.yaml")
+path.write_text(path.read_text().replace("            adl/coverage-summary.txt\n", "            adl/coverage-summary.txt\n            adl/coverage-summary.json\n", 1))
+PY
+  git add .github/workflows/ci.yaml
+  git commit -q -m workflow-reporting-only-change
+  workflow_reporting_head="$(git rev-parse HEAD)"
+
+  workflow_reporting_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$workflow_reporting_head" --ref "refs/pull/1/merge")"
+  assert_has "$workflow_reporting_output" "rust_required=false"
+  assert_has "$workflow_reporting_output" "coverage_required=false"
+  assert_has "$workflow_reporting_output" "full_coverage_required=false"
+  assert_has "$workflow_reporting_output" "demo_smoke_required=false"
+  assert_has "$workflow_reporting_output" "release_version_only=false"
+  assert_has "$workflow_reporting_output" "coverage_lane=skip"
+  assert_has "$workflow_reporting_output" "coverage_authority=not_required"
+  assert_has "$workflow_reporting_output" "reason=coverage_reporting_workflow_change_skips_authoritative_coverage"
+
+  git checkout -q -b workflow-authoritative-policy-change "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+path = Path(".github/workflows/ci.yaml")
+path.write_text(path.read_text().replace("run: bash tools/run_authoritative_coverage_lane.sh", "run: bash tools/run_authoritative_coverage_lane.sh --strict", 1))
+PY
+  git add .github/workflows/ci.yaml
+  git commit -q -m workflow-authoritative-policy-change
+  workflow_policy_head="$(git rev-parse HEAD)"
+
+  workflow_policy_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$workflow_policy_head" --ref "refs/pull/1/merge")"
+  assert_has "$workflow_policy_output" "rust_required=false"
+  assert_has "$workflow_policy_output" "coverage_required=false"
+  assert_has "$workflow_policy_output" "full_coverage_required=true"
+  assert_has "$workflow_policy_output" "demo_smoke_required=false"
+  assert_has "$workflow_policy_output" "coverage_lane=authoritative_full"
+  assert_has "$workflow_policy_output" "coverage_authority=pr_policy_surface_tooling_only"
+  assert_has "$workflow_policy_output" "reason=coverage_policy_surface_change_runs_bounded_authoritative_coverage"
 
   git checkout -q -b runtime-policy-surface-change "$base_sha"
   mkdir -p adl/tools


### PR DESCRIPTION
Closes #2864

## Summary
Tightened the CI path-policy classifier so reporting-only changes inside
`.github/workflows/ci.yaml` no longer escalate to authoritative full coverage,
while real coverage-policy workflow changes still fail closed into the
authoritative lane.

## Artifacts
- Updated classifier logic in `adl/tools/ci_path_policy.sh`
- Expanded focused policy coverage tests in `adl/tools/test_ci_path_policy.sh`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/ci_path_policy.sh`
    Verified the updated classifier script parses successfully.
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified the focused path-policy contract, including the new lighter workflow-reporting class and the preserved authoritative policy surface class.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2864__v0-91-1-quality-tighten-coverage-path-policy-escalation/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2864__v0-91-1-quality-tighten-coverage-path-policy-escalation/sor.md
- Idempotency-Key: v0-91-1-quality-tighten-coverage-path-policy-escalation-adl-tools-ci-path-policy-sh-adl-tools-test-ci-path-policy-sh-adl-v0-91-1-tasks-issue-2864-v0-91-1-quality-tighten-coverage-path-policy-escalation-sip-md-adl-v0-91-1-tasks-issue-2864-v0-91-1-quality-tighten-coverage-path-policy-escalation-sor-md