### PR TITLE
[v0.91.1][quality] Trim authoritative coverage reporting tail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -392,24 +392,24 @@ jobs:
           echo "Coverage authority: ${{ steps.path-policy.outputs.coverage_authority }}"
 
       - name: Coverage (ADL Rust workspace lcov)
-        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
+        if: github.event_name != 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Coverage summary (text)
-        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
+        if: github.event_name != 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: cargo llvm-cov report --summary-only | tee coverage-summary.txt
 
       - name: Verify generated lcov file
-        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
+        if: github.event_name != 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: test -s lcov.info && ls -l lcov.info
 
       - name: Verify lcov path from repository root
-        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
+        if: github.event_name != 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         run: test -s adl/lcov.info && ls -l adl/lcov.info
         working-directory: .
 
       - name: Upload coverage artifact
-        if: steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
+        if: github.event_name != 'pull_request' && steps.path-policy.outputs.full_coverage_required == 'true' && steps.path-policy.outputs.coverage_authority != 'pr_policy_surface_tooling_only'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adl-coverage-lcov

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -137,5 +137,19 @@ if expected_deferred_fragment not in deferred_policy_step:
         f"found: {deferred_policy_step}"
     )
 
+for step_name in (
+    "Coverage (ADL Rust workspace lcov)",
+    "Coverage summary (text)",
+    "Verify generated lcov file",
+    "Verify lcov path from repository root",
+    "Upload coverage artifact",
+):
+    step_condition = step_if(step_name)
+    if "github.event_name != 'pull_request'" not in step_condition:
+        raise SystemExit(
+            f"{step_name} must be skipped for pull_request authoritative coverage runs so PRs avoid nonessential reporting tail; "
+            f"found: {step_condition}"
+        )
+
 print("PASS test_ci_runtime_contracts")
 PY


### PR DESCRIPTION
Closes #2865

## Summary
Trimmed nonessential PR-only reporting tail from the authoritative coverage job while preserving the JSON summary and coverage-policy gates that still prove the coverage decision. Push and other non-PR authoritative events continue to generate LCOV, text summary, verification, and artifact-upload evidence.

## Artifacts
- Updated `.github/workflows/ci.yaml`
- Updated `adl/tools/test_ci_runtime_contracts.sh`
- Updated issue execution record at `.adl/v0.91.1/tasks/issue-2865__v0-91-1-quality-trim-authoritative-coverage-reporting-tail/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Smallest proving workflow contract validation for the changed authoritative coverage conditions.
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "PASS yaml"'`
    Structural YAML parse check for the edited GitHub Actions workflow.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2865__v0-91-1-quality-trim-authoritative-coverage-reporting-tail/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2865__v0-91-1-quality-trim-authoritative-coverage-reporting-tail/sor.md
- Idempotency-Key: v0-91-1-quality-trim-authoritative-coverage-reporting-tail-github-workflows-ci-yaml-adl-tools-test-ci-runtime-contracts-sh-adl-v0-91-1-tasks-issue-2865-v0-91-1-quality-trim-authoritative-coverage-reporting-tail-sip-md-adl-v0-91-1-tasks-issue-2865-v0-91-1-quality-trim-authoritative-coverage-reporting-tail-sor-md