### PR TITLE
[v0.91.1][tools] Fix sprint-conductor bootstrap and sprint lifecycle gaps

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -400,7 +400,7 @@ fn real_pr_start(args: &[String]) -> Result<()> {
             )
         })
         .unwrap_or(false);
-    if !(parsed.allow_open_pr_wave || sprint_wave_override) && !unresolved.is_empty() {
+    if !(parsed.allow_open_pr_wave || sprint_wave_override || unresolved.is_empty()) {
         bail!(
             "start: unresolved open PR queue detected for {} [{}:{}]. Resolve or merge these PRs first, or rerun with --allow-open-pr-wave if you are deliberately overriding the guard:\n{}",
             version,

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -392,7 +392,15 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     };
     let unresolved =
         unresolved_milestone_pr_wave(&repo, &version, &target_queue.queue, Some(&branch))?;
-    if !parsed.allow_open_pr_wave && !unresolved.is_empty() {
+    let sprint_wave_override = std::env::var("ADL_SPRINT_ALLOW_OPEN_PR_WAVE")
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false);
+    if !(parsed.allow_open_pr_wave || sprint_wave_override) && !unresolved.is_empty() {
         bail!(
             "start: unresolved open PR queue detected for {} [{}:{}]. Resolve or merge these PRs first, or rerun with --allow-open-pr-wave if you are deliberately overriding the guard:\n{}",
             version,

--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use super::git_support::{
     branch_checked_out_worktree_path, commits_ahead_of_origin_main, current_branch, default_repo,
     ensure_not_on_main_branch, has_uncommitted_changes, path_str, primary_checkout_root, repo_root,
-    run_capture, run_status, run_status_allow_failure,
+    run_capture, run_capture_allow_failure, run_status, run_status_allow_failure,
 };
 use super::github::{
     attach_post_merge_closeout, attach_pr_janitor, current_pr_url,
@@ -703,7 +703,7 @@ pub(super) fn tracked_issue_surface_paths(
         else {
             continue;
         };
-        if run_status_allow_failure(
+        if run_capture_allow_failure(
             "git",
             &[
                 "-C",
@@ -713,7 +713,9 @@ pub(super) fn tracked_issue_surface_paths(
                 "--",
                 &repo_relative,
             ],
-        )? {
+        )?
+        .is_some()
+        {
             tracked.insert(repo_relative);
         }
     }
@@ -729,8 +731,31 @@ pub(super) fn stage_selected_paths_rust(repo_root: &Path, csv: &str) -> Result<(
     if paths.is_empty() {
         bail!("finish: --paths resolved to empty");
     }
+    let mut stageable = Vec::new();
+    for path in paths {
+        if path.starts_with(".adl/") {
+            let tracked = run_status_allow_failure(
+                "git",
+                &[
+                    "-C",
+                    path_str(repo_root)?,
+                    "ls-files",
+                    "--error-unmatch",
+                    "--",
+                    path,
+                ],
+            )?;
+            if !tracked {
+                continue;
+            }
+        }
+        stageable.push(path);
+    }
+    if stageable.is_empty() {
+        bail!("finish: --paths resolved only to local-only .adl issue surfaces; no tracked repo paths remain to stage");
+    }
     let mut args = vec!["-C", path_str(repo_root)?, "add", "--"];
-    args.extend(paths);
+    args.extend(stageable);
     run_status("git", &args)?;
     Ok(())
 }

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -31,6 +31,7 @@ structured_prompt_preflight:
   issue_results:
     - issue_number: <u32>
       bundle_path: <path or null>
+      canonical_slug: <slug or null>
       status: ready | needs_editor_repair | blocked
       missing_cards:
         - <filename>

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
@@ -28,6 +28,14 @@ def find_bundle_dir(repo_root: Path, issue_number: int) -> tuple[Path | None, li
     return matches[0], []
 
 
+def canonical_slug_from_bundle_dir(bundle_dir: Path) -> str:
+    name = bundle_dir.name
+    marker = '__'
+    if marker in name:
+        return name.split(marker, 1)[1]
+    return name
+
+
 def inspect_issue(
     repo_root: Path,
     issue_number: int,
@@ -39,6 +47,7 @@ def inspect_issue(
         return {
             'issue_number': issue_number,
             'bundle_path': None,
+            'canonical_slug': None,
             'status': 'blocked',
             'missing_cards': [],
             'contradictory_cards': [],
@@ -87,6 +96,7 @@ def inspect_issue(
     return {
         'issue_number': issue_number,
         'bundle_path': str(bundle_dir),
+        'canonical_slug': canonical_slug_from_bundle_dir(bundle_dir),
         'status': status,
         'missing_cards': missing_cards,
         'contradictory_cards': contradictory_cards,
@@ -100,8 +110,10 @@ def main() -> int:
     parser.add_argument('--repo-root', required=True)
     parser.add_argument('--ordered-issues', required=True)
     parser.add_argument('--state')
-    parser.add_argument('--require-spp', action='store_true')
-    parser.add_argument('--require-srp', action='store_true')
+    parser.add_argument('--require-spp', dest='require_spp', action='store_true', default=True)
+    parser.add_argument('--skip-spp', dest='require_spp', action='store_false')
+    parser.add_argument('--require-srp', dest='require_srp', action='store_true', default=True)
+    parser.add_argument('--skip-srp', dest='require_srp', action='store_false')
     parser.add_argument('--print-json', action='store_true')
     args = parser.parse_args()
 

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -25,6 +25,152 @@ def run_json(cmd: list[str]) -> Any:
     return json.loads(out)
 
 
+def sanitize_slug(raw: str) -> str:
+    slug = raw.strip().lower()
+    slug = re.sub(r'^\[[^\]]+\]', '', slug).strip()
+    slug = re.sub(r'[^a-z0-9]+', '-', slug)
+    slug = re.sub(r'-{2,}', '-', slug).strip('-')
+    return slug or 'sprint-management-issue'
+
+
+def infer_version_from_title(title: str) -> str:
+    match = re.search(r'\[(v[0-9][^\]]*)\]', title)
+    if not match:
+        raise SystemExit(
+            f'Unable to infer milestone version from sprint title: {title!r}'
+        )
+    return match.group(1)
+
+
+def issue_prompt_path(repo_root: Path, version: str, issue_number: int, slug: str) -> Path:
+    return repo_root / '.adl' / version / 'bodies' / f'issue-{issue_number:04d}-{slug}.md'
+
+
+def task_bundle_dir(repo_root: Path, version: str, issue_number: int, slug: str) -> Path:
+    return repo_root / '.adl' / version / 'tasks' / f'issue-{issue_number:04d}__{slug}'
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def fallback_bootstrap_local_bundle(
+    repo_root: Path,
+    sprint_issue_number: int,
+    title: str,
+    issue_url: str,
+    body: str,
+) -> dict[str, str]:
+    version = infer_version_from_title(title)
+    slug = sanitize_slug(title)
+    source_path = issue_prompt_path(repo_root, version, sprint_issue_number, slug)
+    bundle_dir = task_bundle_dir(repo_root, version, sprint_issue_number, slug)
+    stp_path = bundle_dir / 'stp.md'
+    sip_path = bundle_dir / 'sip.md'
+    sor_path = bundle_dir / 'sor.md'
+    spp_path = bundle_dir / 'spp.md'
+    srp_path = bundle_dir / 'srp.md'
+
+    write_file(source_path, body + '\n')
+    write_file(stp_path, body + '\n')
+    write_file(
+        sip_path,
+        (
+            "# ADL Input Card\n\n"
+            f"Task ID: issue-{sprint_issue_number}\n"
+            f"Run ID: issue-{sprint_issue_number}\n"
+            f"Version: {version}\n"
+            f"Title: {title}\n"
+            "Branch: not bound yet\n\n"
+            "Context:\n"
+            f"- Issue: {issue_url}\n"
+            f"- Source Issue Prompt: {source_path.relative_to(repo_root)}\n\n"
+            "## Agent Execution Rules\n"
+            "- This issue is not started yet; do not assume a branch or worktree already exists.\n"
+        ),
+    )
+    write_file(
+        sor_path,
+        (
+            f"# issue-{sprint_issue_number}\n\n"
+            f"Task ID: issue-{sprint_issue_number}\n"
+            f"Run ID: issue-{sprint_issue_number}\n"
+            f"Version: {version}\n"
+            f"Title: {title}\n"
+            "Branch: not bound yet\n"
+            "Status: NOT_STARTED\n"
+        ),
+    )
+    write_file(
+        spp_path,
+        (
+            "issue: {issue}\n"
+            "task_id: \"issue-{issue}\"\n"
+            "run_id: \"issue-{issue}\"\n"
+            "codex_plan:\n"
+            "  status: pending\n"
+            "  step: \"Sprint management issue created; detailed plan pending execution.\"\n"
+        ).format(issue=sprint_issue_number),
+    )
+    write_file(
+        srp_path,
+        (
+            "issue: {issue}\n"
+            "task_id: \"issue-{issue}\"\n"
+            "review_status: pending\n"
+            "notes:\n"
+            "  - \"Sprint management issue created; review policy pending execution.\"\n"
+        ).format(issue=sprint_issue_number),
+    )
+    return {
+        'version': version,
+        'slug': slug,
+        'source_path': str(source_path),
+        'bundle_dir': str(bundle_dir),
+        'stp_path': str(stp_path),
+        'sip_path': str(sip_path),
+        'sor_path': str(sor_path),
+        'spp_path': str(spp_path),
+        'srp_path': str(srp_path),
+    }
+
+
+def bootstrap_local_bundle(
+    repo_root: Path,
+    sprint_issue_number: int,
+    title: str,
+    issue_url: str,
+    body: str,
+) -> dict[str, str]:
+    init_script = repo_root / 'adl' / 'tools' / 'pr.sh'
+    if init_script.is_file():
+        subprocess.check_call(
+            [
+                'bash',
+                str(init_script),
+                'init',
+                str(sprint_issue_number),
+            ],
+            cwd=repo_root,
+        )
+        version = infer_version_from_title(title)
+        slug = sanitize_slug(title)
+        bundle_dir = task_bundle_dir(repo_root, version, sprint_issue_number, slug)
+        return {
+            'version': version,
+            'slug': slug,
+            'source_path': str(issue_prompt_path(repo_root, version, sprint_issue_number, slug)),
+            'bundle_dir': str(bundle_dir),
+            'stp_path': str(bundle_dir / 'stp.md'),
+            'sip_path': str(bundle_dir / 'sip.md'),
+            'sor_path': str(bundle_dir / 'sor.md'),
+            'spp_path': str(bundle_dir / 'spp.md'),
+            'srp_path': str(bundle_dir / 'srp.md'),
+        }
+    return fallback_bootstrap_local_bundle(repo_root, sprint_issue_number, title, issue_url, body)
+
+
 def default_issue_records(ordered: list[int]) -> list[dict[str, Any]]:
     return [
         {
@@ -89,6 +235,7 @@ def main() -> int:
     parser.add_argument('--print-json', action='store_true')
     args = parser.parse_args()
 
+    repo_root = Path(args.repo_root)
     ordered = parse_csv_ints(args.ordered_issues)
     child_titles: dict[int, str] = {}
     for issue in ordered:
@@ -108,12 +255,14 @@ def main() -> int:
     if not match:
         raise SystemExit(f'Unable to parse created issue number from URL: {issue_url}')
     sprint_issue_number = int(match.group(1))
+    local_bundle = bootstrap_local_bundle(repo_root, sprint_issue_number, args.title, issue_url, body)
 
     result = {
         'created': True,
         'sprint_issue_number': sprint_issue_number,
         'sprint_issue_url': issue_url,
         'ordered_issue_numbers': ordered,
+        'local_bundle': local_bundle,
     }
 
     if args.state:
@@ -128,6 +277,7 @@ def main() -> int:
             'completed_issue_numbers': [],
             'blocked_issue_number': None,
             'continuation': 'continue',
+            'local_bundle': local_bundle,
             'issue_records': default_issue_records(ordered),
             'truth_check': {
                 'status': 'not_run',

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -87,6 +87,13 @@ def select_next_issue(state: dict[str, Any]) -> None:
         if issue not in completed:
             record = record_by_issue.get(issue, {})
             if record.get('status') == 'waiting_for_review':
+                later_issues = [
+                    later
+                    for later in state.get('ordered_issue_numbers', [])
+                    if later != issue and later not in completed
+                ]
+                if record.get('pr_url') and later_issues:
+                    continue
                 state['current_issue_number'] = issue
                 state['continuation'] = 'waiting_for_review'
                 return

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -72,6 +72,12 @@ EOF
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/sor.md" <<'EOF'
 Status: NOT_STARTED
 EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/spp.md" <<'EOF'
+issue: 2827
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/srp.md" <<'EOF'
+issue: 2827
+EOF
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/stp.md" <<'EOF'
 stp
 EOF
@@ -80,6 +86,12 @@ sip
 EOF
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/sor.md" <<'EOF'
 Status: NOT_STARTED
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF'
+issue: 2828
+EOF
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md" <<'EOF'
+issue: 2828
 EOF
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" \
@@ -102,7 +114,14 @@ assert state["current_issue_number"] == 2827
 assert len(state["issue_records"]) == 2
 assert state["truth_check"]["status"] == "not_run"
 assert state["truth_check"]["gate_passed"] is False
+bundle = state["local_bundle"]
+assert bundle["bundle_dir"].endswith("issue-3001__sprint-1-management-trial-sprint")
 PY
+
+test -f "${fake_repo}/.adl/v0.91.1/bodies/issue-3001-sprint-1-management-trial-sprint.md"
+test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/stp.md"
+test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/sip.md"
+test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/sor.md"
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
   --repo-root "${fake_repo}" \
@@ -117,8 +136,10 @@ from pathlib import Path
 state = json.loads(Path(sys.argv[1]).read_text())
 preflight = state["structured_prompt_preflight"]
 assert preflight["status"] == "ready"
+assert preflight["required_card_types"] == ["stp.md", "sip.md", "sor.md", "spp.md", "srp.md"]
 assert len(preflight["issue_results"]) == 2
 assert all(result["status"] == "ready" for result in preflight["issue_results"])
+assert all(result["canonical_slug"] for result in preflight["issue_results"])
 PY
 
 if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
@@ -155,7 +176,8 @@ assert record["status"] == "waiting_for_review"
 assert record["pr_url"] == "https://github.com/danielbaustin/agent-design-language/pull/4001"
 assert state["truth_check"]["status"] == "matched"
 assert state["truth_check"]["gate_passed"] is False
-assert state["continuation"] == "waiting_for_review"
+assert state["current_issue_number"] == 2828
+assert state["continuation"] == "continue"
 PY
 
 if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \


### PR DESCRIPTION
## Summary

Fix the concrete sprint-conductor and PR lifecycle gaps surfaced by `#2901` and `#2907`.

## What changed

- bootstrap a local sprint-management bundle when `create_missing_sprint_issue.py` creates the sprint issue
- require full sprint card preflight by default: `stp/sip/sor/spp/srp`
- record canonical child-issue slugs during preflight so sprint execution can reuse real local identity
- allow a child issue in `waiting_for_review` with a PR URL to stop blocking later sequential sprint children
- add a sprint-mode open-PR-wave policy hook via `ADL_SPRINT_ALLOW_OPEN_PR_WAVE`
- stop `pr finish` from emitting bogus local-only `.adl` pathspec noise while probing tracked issue surfaces

## Validation

- `bash adl/tools/test_sprint_conductor_helpers.sh`
- `cargo test --manifest-path adl/Cargo.toml finish_path_tracking_covers_staged_vs_head_changes_and_local_only_issue_surfaces -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_finish_creates_draft_pr_and_commits_branch_changes -- --nocapture`

Closes #2901
Closes #2907
