### PR TITLE
[v0.91.1][demo] Multi-agent podcast pilot

### DIFF
--- a/adl/examples/v0-91-1-multi-agent-podcast-pilot.adl.yaml
+++ b/adl/examples/v0-91-1-multi-agent-podcast-pilot.adl.yaml
@@ -106,7 +106,7 @@ tasks:
         PREVIOUS_TURN_START
         {{turn_05}}
         PREVIOUS_TURN_END
-        INSTRUCTIONS: Close the episode in under 120 words. Name one insight that became clearer because three minds were in the conversation rather than two. End with one memorable final line.
+        INSTRUCTIONS: Close the episode in under 120 words. Name one insight that became clearer because three minds were in the conversation rather than two. Do not refer to yourself in the third person, and do not contrast `Claude` with `my` perspective. End with one memorable final line.
 
 run:
   name: "v0-91-1-multi-agent-podcast-pilot"

--- a/adl/examples/v0-91-1-multi-agent-podcast-pilot.adl.yaml
+++ b/adl/examples/v0-91-1-multi-agent-podcast-pilot.adl.yaml
@@ -1,0 +1,190 @@
+version: "0.5"
+
+providers:
+  chatgpt_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8796/openai"
+      timeout_secs: 240
+  gemini_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8796/gemini"
+      timeout_secs: 240
+  claude_local:
+    type: "http"
+    config:
+      endpoint: "http://127.0.0.1:8796/anthropic"
+      timeout_secs: 240
+
+agents:
+  chatgpt_host:
+    provider: "chatgpt_local"
+    model: "chatgpt-live-demo"
+  gemini_guest:
+    provider: "gemini_local"
+    model: "gemini-live-demo"
+  claude_guest:
+    provider: "claude_local"
+    model: "claude-live-demo"
+
+tasks:
+  host_opening:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-1-multi-agent-podcast-pilot
+        TURN_ID: 01
+        SPEAKER: ChatGPT
+        ROLE: host_and_synthesizer
+        SERIES_NAME: ADL Multi-Agent Podcast
+        EPISODE_TITLE: Episode 1
+        TOPIC: __PODCAST_TOPIC__
+        STOP_RULE: Stop after six explicit turns total.
+        PARTICIPANTS: ChatGPT, Gemini, Claude.
+        INSTRUCTIONS: Open the episode in under 135 words. State the topic and the six-turn boundary explicitly. Sound like a thoughtful host rather than a moderator reading a checklist. End with exactly one line beginning `THESIS:` that presents a debatable position.
+  gemini_challenge:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-1-multi-agent-podcast-pilot
+        TURN_ID: 02
+        SPEAKER: Gemini
+        ROLE: challenger_and_systems_analyst
+        TOPIC: __PODCAST_TOPIC__
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_01}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Reply directly to ChatGPT in under 120 words. Challenge the thesis precisely. Add one systems-level pressure, tradeoff, or edge case. Keep it sharp, not theatrical.
+  claude_reframe:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-1-multi-agent-podcast-pilot
+        TURN_ID: 03
+        SPEAKER: Claude
+        ROLE: refiner_and_moral_stylist
+        TOPIC: __PODCAST_TOPIC__
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_02}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Enter in under 120 words. Reframe the disagreement by naming one human or moral stake the prior turns are circling. Do not merely agree with either voice.
+  chatgpt_bridge:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-1-multi-agent-podcast-pilot
+        TURN_ID: 04
+        SPEAKER: ChatGPT
+        ROLE: host_and_synthesizer
+        TOPIC: __PODCAST_TOPIC__
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_03}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Bridge the discussion in under 125 words. Explicitly say what changed in your view after hearing Gemini and Claude. Make the synthesis stronger, not vaguer.
+  gemini_deepening:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-1-multi-agent-podcast-pilot
+        TURN_ID: 05
+        SPEAKER: Gemini
+        ROLE: challenger_and_systems_analyst
+        TOPIC: __PODCAST_TOPIC__
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_04}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Deepen the answer in under 115 words. Add one paradox, failure mode, or implementation wrinkle that keeps the episode honest.
+  claude_closure:
+    prompt:
+      user: |
+        DEMO_ID: v0-91-1-multi-agent-podcast-pilot
+        TURN_ID: 06
+        SPEAKER: Claude
+        ROLE: refiner_and_moral_stylist
+        TOPIC: __PODCAST_TOPIC__
+        STOP_RULE: Stop after six explicit turns total.
+        PREVIOUS_TURN_START
+        {{turn_05}}
+        PREVIOUS_TURN_END
+        INSTRUCTIONS: Close the episode in under 120 words. Name one insight that became clearer because three minds were in the conversation rather than two. End with one memorable final line.
+
+run:
+  name: "v0-91-1-multi-agent-podcast-pilot"
+  workflow:
+    kind: sequential
+    steps:
+      - id: "podcast.chatgpt.opening"
+        agent: "chatgpt_host"
+        task: "host_opening"
+        conversation:
+          id: "turn_01"
+          speaker: "ChatGPT"
+          sequence: 1
+          thread_id: "adl_multiagent_podcast"
+        save_as: "turn_01"
+        write_to: "podcast/01-chatgpt-opening.md"
+      - id: "podcast.gemini.challenge"
+        agent: "gemini_guest"
+        task: "gemini_challenge"
+        conversation:
+          id: "turn_02"
+          speaker: "Gemini"
+          sequence: 2
+          thread_id: "adl_multiagent_podcast"
+          responds_to: "turn_01"
+        inputs:
+          turn_01: "@state:turn_01"
+        save_as: "turn_02"
+        write_to: "podcast/02-gemini-challenge.md"
+      - id: "podcast.claude.reframe"
+        agent: "claude_guest"
+        task: "claude_reframe"
+        conversation:
+          id: "turn_03"
+          speaker: "Claude"
+          sequence: 3
+          thread_id: "adl_multiagent_podcast"
+          responds_to: "turn_02"
+        inputs:
+          turn_02: "@state:turn_02"
+        save_as: "turn_03"
+        write_to: "podcast/03-claude-reframe.md"
+      - id: "podcast.chatgpt.bridge"
+        agent: "chatgpt_host"
+        task: "chatgpt_bridge"
+        conversation:
+          id: "turn_04"
+          speaker: "ChatGPT"
+          sequence: 4
+          thread_id: "adl_multiagent_podcast"
+          responds_to: "turn_03"
+        inputs:
+          turn_03: "@state:turn_03"
+        save_as: "turn_04"
+        write_to: "podcast/04-chatgpt-bridge.md"
+      - id: "podcast.gemini.deepening"
+        agent: "gemini_guest"
+        task: "gemini_deepening"
+        conversation:
+          id: "turn_05"
+          speaker: "Gemini"
+          sequence: 5
+          thread_id: "adl_multiagent_podcast"
+          responds_to: "turn_04"
+        inputs:
+          turn_04: "@state:turn_04"
+        save_as: "turn_05"
+        write_to: "podcast/05-gemini-deepening.md"
+      - id: "podcast.claude.closure"
+        agent: "claude_guest"
+        task: "claude_closure"
+        conversation:
+          id: "turn_06"
+          speaker: "Claude"
+          sequence: 6
+          thread_id: "adl_multiagent_podcast"
+          responds_to: "turn_05"
+        inputs:
+          turn_05: "@state:turn_05"
+        save_as: "turn_06"
+        write_to: "podcast/06-claude-closure.md"

--- a/adl/tools/demo_v0911_multiagent_podcast_pilot.sh
+++ b/adl/tools/demo_v0911_multiagent_podcast_pilot.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_demo_wait_for_port() {
+  local port_file="$1"
+  local attempts="${2:-100}"
+  local sleep_secs="${3:-0.1}"
+  local port=""
+  local i
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -s "$port_file" ]]; then
+      port="$(<"$port_file")"
+      if [[ "$port" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$port"
+        return 0
+      fi
+    fi
+    sleep "$sleep_secs"
+  done
+  echo "timed out waiting for demo server port in $port_file" >&2
+  return 1
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0911/multiagent_podcast_pilot}"
+RUNTIME_ROOT="$OUT_DIR/runtime"
+RUNS_ROOT="$RUNTIME_ROOT/runs"
+STEP_OUT="$OUT_DIR/out"
+RUN_ID="v0-91-1-multi-agent-podcast-pilot"
+PORT="${ADL_PODCAST_PORT:-0}"
+PORT_FILE="$OUT_DIR/provider_server.port"
+SERVER_LOG="$OUT_DIR/provider_adapter.log"
+INVOCATIONS="$OUT_DIR/provider_invocations.json"
+TRANSCRIPT="$OUT_DIR/transcript.md"
+PROOF_NOTE="$OUT_DIR/proof_note.md"
+OBSERVATORY_PROJECTION="$OUT_DIR/observatory_projection.json"
+MANIFEST="$OUT_DIR/demo_manifest.json"
+EPISODE_CONTRACT="$OUT_DIR/episode_contract.json"
+SERIES_MANIFEST="$OUT_DIR/series_manifest.json"
+EPISODE_PACKET="$OUT_DIR/episode_packet.md"
+BEST_LINES="$OUT_DIR/best_lines.md"
+GENERATED_EXAMPLE="$OUT_DIR/v0-91-1-multi-agent-podcast-pilot.runtime.adl.yaml"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai2.key}"
+GEMINI_KEY_FILE="${ADL_GEMINI_KEY_FILE:-$HOME/keys/gcp-ace-2023.key}"
+ANTHROPIC_KEY_FILE="${ADL_ANTHROPIC_KEY_FILE:-$HOME/keys/ADL_demo_ref_04.txt}"
+OPENAI_MODEL="${ADL_LIVE_OPENAI_MODEL:-gpt-5.5}"
+GEMINI_MODEL="${ADL_LIVE_GEMINI_MODEL:-gemini-3.1-pro-preview}"
+ANTHROPIC_MODEL="${ADL_LIVE_ANTHROPIC_MODEL:-claude-opus-4-1-20250805}"
+LIVE_PROVIDER_TIMEOUT_SECS="${ADL_LIVE_PROVIDER_TIMEOUT_SECS:-240}"
+PODCAST_TOPIC="${ADL_PODCAST_TOPIC:-Should AI systems have consistent personalities across conversations?}"
+SERIES_NAME="${ADL_PODCAST_SERIES_NAME:-ADL Multi-Agent Podcast}"
+EPISODE_TITLE="${ADL_PODCAST_EPISODE_TITLE:-Episode 1: Should AI systems have consistent personalities across conversations?}"
+
+load_key() {
+  local env_name="$1"
+  local key_file="$2"
+  if [[ -n "${!env_name:-}" ]]; then
+    return 0
+  fi
+  if [[ ! -s "$key_file" ]]; then
+    echo "missing required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  local key_value
+  key_value="$(python3 - "$env_name" "$key_file" <<'PY'
+import sys
+env_name, path = sys.argv[1:3]
+raw = open(path, encoding='utf-8').read().strip()
+value = raw
+for line in raw.splitlines():
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#'):
+        continue
+    if stripped.startswith(env_name + '='):
+        value = stripped.split('=', 1)[1].strip().strip("'\"")
+        break
+    value = stripped.strip("'\"")
+    break
+print(value, end='')
+PY
+)"
+  if [[ -z "$key_value" ]]; then
+    echo "empty required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  export "$env_name=$key_value"
+}
+
+load_key OPENAI_API_KEY "$OPENAI_KEY_FILE"
+load_key GEMINI_API_KEY "$GEMINI_KEY_FILE"
+load_key ANTHROPIC_API_KEY "$ANTHROPIC_KEY_FILE"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STEP_OUT"
+cp "$ROOT_DIR/adl/examples/v0-91-1-multi-agent-podcast-pilot.adl.yaml" "$GENERATED_EXAMPLE"
+
+python3 "$ROOT_DIR/adl/tools/real_chatgpt_gemini_claude_provider_adapter.py" \
+  --port "$PORT" \
+  --port-file "$PORT_FILE" \
+  --metadata "$INVOCATIONS" \
+  --openai-model "$OPENAI_MODEL" \
+  --gemini-model "$GEMINI_MODEL" \
+  --anthropic-model "$ANTHROPIC_MODEL" \
+  --timeout "$LIVE_PROVIDER_TIMEOUT_SECS" \
+  >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+cleanup() {
+  if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+PORT="$(provider_demo_wait_for_port "$PORT_FILE")"
+
+python3 - "$GENERATED_EXAMPLE" "$PORT" "$PODCAST_TOPIC" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path, port, topic = sys.argv[1:4]
+text = Path(path).read_text(encoding='utf-8')
+text = text.replace('__PODCAST_TOPIC__', topic)
+text = re.sub(r'http://127\.0\.0\.1:8796/openai', f'http://127.0.0.1:{port}/openai', text)
+text = re.sub(r'http://127\.0\.0\.1:8796/gemini', f'http://127.0.0.1:{port}/gemini', text)
+text = re.sub(r'http://127\.0\.0\.1:8796/anthropic', f'http://127.0.0.1:{port}/anthropic', text)
+Path(path).write_text(text, encoding='utf-8')
+PY
+
+python3 - "$PORT" <<'PY'
+import json
+import sys
+import time
+import urllib.request
+
+port = int(sys.argv[1])
+url = f'http://127.0.0.1:{port}/health'
+deadline = time.time() + 10.0
+last_error = None
+while time.time() < deadline:
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as resp:
+            payload = json.load(resp)
+        if payload.get('ok') is True:
+            raise SystemExit(0)
+    except Exception as exc:
+        last_error = exc
+        time.sleep(0.1)
+raise SystemExit(f'provider adapter failed health check: {last_error}')
+PY
+
+cd "$ROOT_DIR"
+ADL_RUNTIME_ROOT="$RUNTIME_ROOT" \
+ADL_RUNS_ROOT="$RUNS_ROOT" \
+cargo run --quiet --manifest-path adl/Cargo.toml --bin adl -- \
+  "$GENERATED_EXAMPLE" \
+  --run \
+  --trace \
+  --allow-unsigned \
+  --out "$STEP_OUT" \
+  >"$OUT_DIR/run_log.txt" 2>&1
+
+python3 - "$TRANSCRIPT" "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json" "$STEP_OUT" "$OPENAI_MODEL" "$GEMINI_MODEL" "$ANTHROPIC_MODEL" "$PODCAST_TOPIC" "$SERIES_NAME" "$EPISODE_TITLE" "$EPISODE_CONTRACT" "$SERIES_MANIFEST" "$EPISODE_PACKET" "$BEST_LINES" "$OUT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    transcript_path,
+    trace_path,
+    step_out,
+    openai_model,
+    gemini_model,
+    anthropic_model,
+    topic,
+    series_name,
+    episode_title,
+    contract_path,
+    manifest_path,
+    packet_path,
+    best_lines_path,
+    out_dir,
+) = sys.argv[1:15]
+
+trace = json.loads(Path(trace_path).read_text(encoding='utf-8'))
+events = trace.get('events', [])
+step_end_timestamps = [event.get('timestamp') for event in events if event.get('event_type') == 'STEP_END']
+turn_files = [
+    ('01-chatgpt-opening.md', 'ChatGPT', 'Host opening'),
+    ('02-gemini-challenge.md', 'Gemini', 'Challenge'),
+    ('03-claude-reframe.md', 'Claude', 'Reframe'),
+    ('04-chatgpt-bridge.md', 'ChatGPT', 'Bridge and synthesis'),
+    ('05-gemini-deepening.md', 'Gemini', 'Deepening'),
+    ('06-claude-closure.md', 'Claude', 'Closure'),
+]
+role_map = {
+    'ChatGPT': 'host / synthesizer',
+    'Gemini': 'challenger / systems analyst',
+    'Claude': 'refiner / moral stylist',
+}
+voice_map = {
+    'ChatGPT': 'warm, thoughtful, feminine, grounded',
+    'Gemini': 'androgynous, bright, incisive',
+    'Claude': 'masculine, reflective, slightly formal',
+}
+turns = []
+for index, (filename, speaker, label) in enumerate(turn_files, start=1):
+    body = (Path(step_out) / 'podcast' / filename).read_text(encoding='utf-8').strip()
+    timestamp = step_end_timestamps[index - 1] if index - 1 < len(step_end_timestamps) else 'unknown'
+    turns.append({
+        'turn': index,
+        'speaker': speaker,
+        'label': label,
+        'timestamp': timestamp,
+        'body': body,
+    })
+
+transcript_lines = [
+    f'# {series_name}',
+    '',
+    f'## {episode_title}',
+    '',
+    '> A bounded six-turn three-provider transcript-first episode run through the live ADL runtime.',
+    '',
+    '## Original Question',
+    '',
+    f'**{topic}**',
+    '',
+    '## Episode Conditions',
+    '',
+    '- Stop after six explicit turns total.',
+    '- All three participants must appear in the same saved exchange.',
+    '- Stable participant roles remain explicit and attributable.',
+    '- Transcript-first proof remains primary; this pilot does not depend on audio.',
+    '',
+    '## Participants',
+    '',
+    f"- `ChatGPT`: {role_map['ChatGPT']}",
+    f"- `Gemini`: {role_map['Gemini']}",
+    f"- `Claude`: {role_map['Claude']}",
+    '',
+    '## Providers',
+    '',
+    f'- `ChatGPT`: `{openai_model}`',
+    f'- `Gemini`: `{gemini_model}`',
+    f'- `Claude`: `{anthropic_model}`',
+    '',
+    '## Transcript',
+    '',
+]
+for turn in turns:
+    transcript_lines.extend([
+        f"### Turn {turn['turn']} · {turn['speaker']}",
+        '',
+        f"- Role: {role_map[turn['speaker']]}",
+        f"- Label: {turn['label']}",
+        f"- Timestamp: `{turn['timestamp']}`",
+        '',
+        turn['body'],
+        '',
+    ])
+Path(transcript_path).write_text('\n'.join(transcript_lines).rstrip() + '\n', encoding='utf-8')
+
+contract = {
+    'schema_version': 'adl.demo.multiagent_podcast_episode_contract.v1',
+    'series_name': series_name,
+    'episode_title': episode_title,
+    'topic': topic,
+    'format': 'transcript_first_roundtable',
+    'stop_rule': {'type': 'fixed_turn_count', 'turns': 6},
+    'participants': {
+        speaker.lower(): {
+            'role': role_map[speaker],
+            'voice_casting': voice_map[speaker],
+        }
+        for speaker in role_map
+    },
+    'proof_expectations': {
+        'required_artifacts': [
+            'transcript.md',
+            'proof_note.md',
+            'provider_invocations.json',
+            'episode_contract.json',
+        ],
+        'transcript_first': True,
+        'audio_required': False,
+        'identity_continuity_claim_allowed': False,
+    },
+    'non_goals': [
+        'broad_media_platform',
+        'native_audio_for_all_providers',
+        'long_term_identity_proof',
+        'autonomous_federation_claims',
+    ],
+}
+series_manifest = {
+    'schema_version': 'adl.demo.multiagent_podcast_series_manifest.v1',
+    'series_name': series_name,
+    'pilot_episode_title': episode_title,
+    'episode_count': 1,
+    'default_roles': {
+        speaker.lower(): role_map[speaker] for speaker in role_map
+    },
+}
+Path(contract_path).write_text(json.dumps(contract, indent=2) + '\n', encoding='utf-8')
+Path(manifest_path).write_text(json.dumps(series_manifest, indent=2) + '\n', encoding='utf-8')
+
+best_lines = ['# Best Lines', '']
+for turn in turns:
+    first_line = next((line.strip() for line in turn['body'].splitlines() if line.strip()), '')
+    best_lines.append(f"- `{turn['speaker']}`: {first_line}")
+Path(best_lines_path).write_text('\n'.join(best_lines).rstrip() + '\n', encoding='utf-8')
+
+packet = [
+    f'# {episode_title} Packet',
+    '',
+    f'- Series: `{series_name}`',
+    f'- Topic: `{topic}`',
+    '- Format: `transcript_first_roundtable`',
+    '- Stop rule: `6 turns total`',
+    '',
+    '## Included Artifacts',
+    '',
+    '- `transcript.md`',
+    '- `proof_note.md`',
+    '- `provider_invocations.json`',
+    '- `episode_contract.json`',
+    '- `series_manifest.json`',
+    '- `best_lines.md`',
+    '',
+    '## Stable Roles',
+    '',
+    f"- `ChatGPT`: {role_map['ChatGPT']}",
+    f"- `Gemini`: {role_map['Gemini']}",
+    f"- `Claude`: {role_map['Claude']}",
+    '',
+    '## Voice Casting Recommendation',
+    '',
+    f"- `ChatGPT`: {voice_map['ChatGPT']}",
+    f"- `Gemini`: {voice_map['Gemini']}",
+    f"- `Claude`: {voice_map['Claude']}",
+    '',
+    '## Proof Boundary',
+    '',
+    '- This pilot proves one reusable transcript-first episode shape.',
+    '- It does not prove persistent identity continuity, native audio availability, or a broad media product.',
+]
+Path(packet_path).write_text('\n'.join(packet).rstrip() + '\n', encoding='utf-8')
+
+readme = [
+    f'# {episode_title}',
+    '',
+    'Canonical command:',
+    '',
+    '```bash',
+    'bash adl/tools/demo_v0911_multiagent_podcast_pilot.sh',
+    '```',
+    '',
+    'Primary proof surfaces:',
+    '- `transcript.md`',
+    '- `proof_note.md`',
+    '- `episode_contract.json`',
+    '- `best_lines.md`',
+    '',
+    'Secondary proof surfaces:',
+    '- `provider_invocations.json`',
+    '- `observatory_projection.json`',
+    '- `series_manifest.json`',
+    '- `episode_packet.md`',
+    '',
+    'Success signal:',
+    '- one six-turn episode packet exists with explicit roles, a saved transcript, and an honest proof note',
+]
+Path(out_dir, 'README.md').write_text('\n'.join(readme).rstrip() + '\n', encoding='utf-8')
+PY
+
+python3 - "$OBSERVATORY_PROJECTION" "$INVOCATIONS" "$RUNS_ROOT/$RUN_ID/logs/trace_v1.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+projection_path, invocations_path, trace_path = sys.argv[1:4]
+invocations = json.loads(Path(invocations_path).read_text(encoding='utf-8'))
+trace = json.loads(Path(trace_path).read_text(encoding='utf-8'))
+events = trace.get('events', [])
+payload = {
+    'schema': 'adl.demo.observatory_projection.v1',
+    'demo_id': 'v0.91.1.multiagent_podcast_pilot',
+    'view_kind': 'bounded_agent_runtime_projection',
+    'providers': invocations.get('providers', []),
+    'turns': [
+        {'turn': 1, 'speaker': 'ChatGPT', 'artifact_ref': 'out/podcast/01-chatgpt-opening.md'},
+        {'turn': 2, 'speaker': 'Gemini', 'artifact_ref': 'out/podcast/02-gemini-challenge.md'},
+        {'turn': 3, 'speaker': 'Claude', 'artifact_ref': 'out/podcast/03-claude-reframe.md'},
+        {'turn': 4, 'speaker': 'ChatGPT', 'artifact_ref': 'out/podcast/04-chatgpt-bridge.md'},
+        {'turn': 5, 'speaker': 'Gemini', 'artifact_ref': 'out/podcast/05-gemini-deepening.md'},
+        {'turn': 6, 'speaker': 'Claude', 'artifact_ref': 'out/podcast/06-claude-closure.md'},
+    ],
+    'trace_event_count': len(events),
+}
+Path(projection_path).write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+PY
+
+python3 - "$MANIFEST" "$TRANSCRIPT" "$PROOF_NOTE" "$OBSERVATORY_PROJECTION" "$EPISODE_CONTRACT" "$BEST_LINES" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path, transcript_path, proof_note_path, projection_path, contract_path, best_lines_path = sys.argv[1:7]
+payload = {
+    'schema_version': 'adl.demo.manifest.v1',
+    'demo_id': 'v0.91.1.multiagent_podcast_pilot',
+    'primary_artifacts': [
+        Path(transcript_path).name,
+        Path(proof_note_path).name,
+        Path(contract_path).name,
+        Path(best_lines_path).name,
+    ],
+    'secondary_artifacts': [
+        Path(projection_path).name,
+        'provider_invocations.json',
+        'series_manifest.json',
+        'episode_packet.md',
+    ],
+}
+Path(manifest_path).write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+PY
+
+cat > "$PROOF_NOTE" <<EOF2
+# Multi-Agent Podcast Pilot Proof Note
+
+## What This Pilot Proves
+
+- one reusable transcript-first podcast episode shape exists
+- three named participants can keep stable explicit roles in one saved episode
+- the packet preserves transcript, proof note, role contract, and reviewable outputs
+
+## What This Pilot Does Not Prove
+
+- long-term identity continuity across episodes
+- native audio support from every provider
+- a broad always-on media platform
+- autonomous multi-agent federation or society
+
+## Boundaries
+
+- topic: \
+$PODCAST_TOPIC\
+
+- stop rule: six explicit turns total
+- audio: optional and not required for the pilot
+- proof priority: transcript and role attribution over entertainment value
+EOF2
+
+echo "Podcast pilot proof surfaces:"
+echo "  $TRANSCRIPT"
+echo "  $PROOF_NOTE"
+echo "  $EPISODE_CONTRACT"
+echo "  $BEST_LINES"
+echo "  $SERIES_MANIFEST"

--- a/demos/v0.91.1/multiagent_podcast_episode_contract.md
+++ b/demos/v0.91.1/multiagent_podcast_episode_contract.md
@@ -13,6 +13,15 @@ This contract defines the smallest truthful recurring episode shape for the
 - stop rule: fixed turn count, visible in the saved transcript
 - proof boundary: bounded attributable conversation, not identity continuity
 
+## Recurring Cadence
+
+- target cadence: one episode per week
+- release shape: one bounded episode packet at a time
+- repeatability requirement: each episode should be runnable from the same
+  canonical wrapper with only bounded topic/title overrides
+- operations constraint: weekly repetition must not require a new bespoke
+  workflow per episode
+
 ## Stable Pilot Roles
 
 - `ChatGPT`: host / synthesizer
@@ -44,6 +53,13 @@ A reviewer should be able to answer all of the following from the packet alone:
 - what the episode proved
 - what the episode did not prove
 
+For the recurring weekly format, a reviewer should also be able to answer:
+
+- whether this episode follows the same stable packet shape as the prior one
+- which parts changed episode-to-episode: topic, title, models, or operator
+  overrides
+- whether the episode still stayed inside the same proof boundary
+
 ## Audio Boundary
 
 Audio is optional in the pilot.
@@ -61,3 +77,4 @@ This episode contract does not imply:
 - native audio support from every provider
 - persistent long-term identity continuity
 - autonomous federation or social cognition beyond the saved run
+- daily or continuous publishing pressure beyond the bounded weekly cadence

--- a/demos/v0.91.1/multiagent_podcast_episode_contract.md
+++ b/demos/v0.91.1/multiagent_podcast_episode_contract.md
@@ -1,0 +1,63 @@
+# Multi-Agent Podcast Episode Contract
+
+## Purpose
+
+This contract defines the smallest truthful recurring episode shape for the
+`v0.91.1` podcast pilot.
+
+## Episode Shape
+
+- format: transcript-first roundtable
+- turn count: six explicit turns total
+- participant count: three named participants
+- stop rule: fixed turn count, visible in the saved transcript
+- proof boundary: bounded attributable conversation, not identity continuity
+
+## Stable Pilot Roles
+
+- `ChatGPT`: host / synthesizer
+- `Gemini`: challenger / systems analyst
+- `Claude`: refiner / moral stylist
+
+These are pilot defaults for the recurring format, not proof of permanent
+long-lived identity.
+
+## Required Proof Surfaces
+
+Each episode should preserve:
+
+- transcript
+- proof note
+- provider invocation log
+- episode contract
+- series manifest or equivalent role packet
+- optional best-lines excerpt block
+
+## Review Expectations
+
+A reviewer should be able to answer all of the following from the packet alone:
+
+- what the topic was
+- who spoke in each turn
+- what role each participant was playing
+- what the stop rule was
+- what the episode proved
+- what the episode did not prove
+
+## Audio Boundary
+
+Audio is optional in the pilot.
+
+The recurring format should remain truthful if:
+
+- transcript author identity and audio renderer identity differ
+- one provider requires a surrogate TTS path
+
+## Non-Goals
+
+This episode contract does not imply:
+
+- a broad always-on media platform
+- native audio support from every provider
+- persistent long-term identity continuity
+- autonomous federation or social cognition beyond the saved run

--- a/demos/v0.91.1/multiagent_podcast_pilot_demo.md
+++ b/demos/v0.91.1/multiagent_podcast_pilot_demo.md
@@ -1,0 +1,108 @@
+# Multi-Agent Podcast Pilot Demo
+
+## Summary
+
+This bounded `v0.91.1` demo turns the earlier multi-agent conversation wave
+into one recurring transcript-first episode format.
+
+Unlike the earlier panel that discussed whether a podcast should exist, this
+pilot is an actual episode run with:
+
+- one bounded topic
+- one stable three-participant role split
+- one explicit episode contract
+- one reusable packet shape for future episodes
+
+## Scope Boundary
+
+This pilot proves:
+
+- ADL can run one reusable transcript-first podcast episode through the
+  existing three-provider multi-agent runtime path
+- participant roles can stay explicit and attributable across the episode
+- the episode packet can preserve transcript, proof note, role story, and
+  reviewability without widening into a media platform
+
+It does **not** prove:
+
+- stable long-term identity continuity across episodes
+- native audio production for all providers
+- an always-on show infrastructure
+- autonomous multi-agent federation or social cognition
+
+## Canonical Command
+
+From repository root:
+
+```bash
+bash adl/tools/demo_v0911_multiagent_podcast_pilot.sh
+```
+
+Useful bounded overrides:
+
+- `ADL_PODCAST_TOPIC`
+- `ADL_PODCAST_EPISODE_TITLE`
+- `ADL_PODCAST_SERIES_NAME`
+- `ADL_LIVE_OPENAI_MODEL`
+- `ADL_LIVE_GEMINI_MODEL`
+- `ADL_LIVE_ANTHROPIC_MODEL`
+
+## What Runs
+
+- dedicated podcast pilot wrapper:
+  - `adl/tools/demo_v0911_multiagent_podcast_pilot.sh`
+- dedicated runtime workflow:
+  - `adl/examples/v0-91-1-multi-agent-podcast-pilot.adl.yaml`
+- provider bridge:
+  - `adl/tools/real_chatgpt_gemini_claude_provider_adapter.py`
+
+## Stable Pilot Roles
+
+- `ChatGPT`: host / synthesizer
+- `Gemini`: challenger / systems analyst
+- `Claude`: refiner / moral stylist
+
+## Tracked Episode Contract
+
+- `demos/v0.91.1/multiagent_podcast_episode_contract.md`
+
+## Primary Proof Surfaces
+
+The paths below are operator-generated runtime outputs. They are written when
+the canonical command is executed and are not tracked artifacts in the primary
+checkout.
+
+- `artifacts/v0911/multiagent_podcast_pilot/transcript.md`
+- `artifacts/v0911/multiagent_podcast_pilot/proof_note.md`
+- `artifacts/v0911/multiagent_podcast_pilot/episode_contract.json`
+- `artifacts/v0911/multiagent_podcast_pilot/best_lines.md`
+
+## Secondary Proof Surfaces
+
+- `artifacts/v0911/multiagent_podcast_pilot/provider_invocations.json`
+- `artifacts/v0911/multiagent_podcast_pilot/observatory_projection.json`
+- `artifacts/v0911/multiagent_podcast_pilot/series_manifest.json`
+- `artifacts/v0911/multiagent_podcast_pilot/episode_packet.md`
+- `artifacts/v0911/multiagent_podcast_pilot/runtime/runs/v0-91-1-multi-agent-podcast-pilot/run_summary.json`
+- `artifacts/v0911/multiagent_podcast_pilot/runtime/runs/v0-91-1-multi-agent-podcast-pilot/logs/trace_v1.json`
+
+## Default Episode Topic
+
+The default pilot question is:
+
+- `Should AI systems have consistent personalities across conversations?`
+
+That topic was chosen because it is:
+
+- directly relevant to the recurring-series idea
+- broad enough to invite disagreement
+- concrete enough to avoid abstract drift
+
+## Success Signal
+
+The pilot is successful when:
+
+- one saved six-turn episode packet exists under a stable output root
+- all three participants remain explicit and easy to distinguish
+- the episode reads like one coherent show segment rather than three detached monologues
+- the proof note remains honest about what the pilot does not prove

--- a/demos/v0.91.1/multiagent_podcast_pilot_demo.md
+++ b/demos/v0.91.1/multiagent_podcast_pilot_demo.md
@@ -12,6 +12,7 @@ pilot is an actual episode run with:
 - one stable three-participant role split
 - one explicit episode contract
 - one reusable packet shape for future episodes
+- one intended recurring weekly cadence
 
 ## Scope Boundary
 
@@ -62,6 +63,18 @@ Useful bounded overrides:
 - `Gemini`: challenger / systems analyst
 - `Claude`: refiner / moral stylist
 
+## Recurring Series Intention
+
+This pilot is designed as the first bounded episode in a repeatable series:
+
+- target cadence: `1 episode / week`
+- stable infrastructure: same canonical wrapper and packet shape
+- bounded per-episode variation: topic, title, model overrides, and later audio
+  rendering choices
+
+The point is to make the format regularly repeatable without turning the pilot
+into a broad media-platform commitment.
+
 ## Tracked Episode Contract
 
 - `demos/v0.91.1/multiagent_podcast_episode_contract.md`
@@ -98,6 +111,9 @@ That topic was chosen because it is:
 - broad enough to invite disagreement
 - concrete enough to avoid abstract drift
 
+Later weekly episodes can rotate topics while preserving the same packet and
+proof structure.
+
 ## Success Signal
 
 The pilot is successful when:
@@ -106,3 +122,5 @@ The pilot is successful when:
 - all three participants remain explicit and easy to distinguish
 - the episode reads like one coherent show segment rather than three detached monologues
 - the proof note remains honest about what the pilot does not prove
+- the packet shape is stable enough to be run again next week without bespoke
+  redesign

--- a/docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md
+++ b/docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md
@@ -18,6 +18,7 @@ supporting work packages land.
 | ACIP/A2A hardening demo | WP-13, WP-14 | Show authenticated local comms, redaction, adapter boundary, and state-gated invocation. | conformance fixture and trace artifact | does not claim external transport readiness |
 | Runtime inhabitant integration proof | WP-15 | Show standing, state, lifecycle, memory, comms, capability, learning, and observatory surfaces integrated into one agent-shaped run surface. | integrated run packet, dependency checklist, trace/projection fixture, and redaction check | does not claim birthday, full identity continuity, or flagship completeness |
 | Observatory-visible agent flagship demo | WP-16 | Show an agent-shaped run inside the CSM boundary with operator projection. | run artifacts, trace, lifecycle state, comms evidence, projection | does not claim birthday or autonomous federation |
+| Multi-agent podcast pilot | supplemental demo follow-on | Turn the earlier multi-agent transcript wave into one recurring transcript-first episode format. | episode contract, pilot transcript, role register, and proof note | does not claim long-term identity continuity, native audio production, or a broad media platform |
 
 ## Flagship Acceptance
 


### PR DESCRIPTION
Closes #2852

## Summary
- add a dedicated v0.91.1 multi-agent podcast pilot workflow and wrapper
- add tracked episode-contract and reviewer-facing pilot demo docs
- extend the v0.91.1 demo matrix with the podcast pilot surface

## Validation
- bash -n adl/tools/demo_v0911_multiagent_podcast_pilot.sh
- structural surface existence checks only

## Notes
- this PR builds a dedicated runnable pilot surface without yet claiming a live provider run in this branch
- the pilot stays transcript-first and keeps audio as a later optional follow-on


## Latest successful rerun
- successful live provider-backed rerun completed from the issue worktree
- packet root: `artifacts/v0911/multiagent_podcast_pilot/`
- key artifacts:
  - `artifacts/v0911/multiagent_podcast_pilot/transcript.md`
  - `artifacts/v0911/multiagent_podcast_pilot/proof_note.md`
  - `artifacts/v0911/multiagent_podcast_pilot/episode_contract.json`
  - `artifacts/v0911/multiagent_podcast_pilot/best_lines.md`
- notable improvement: Claude's closing turn no longer self-references awkwardly and the episode reads more like a coherent show segment
