### PR TITLE
[v0.91.1][WP-06][runtime] Enforce all claimed citizen-state substrate proving surfaces

### DIFF
--- a/adl/src/runtime_v2/citizen_state_substrate.rs
+++ b/adl/src/runtime_v2/citizen_state_substrate.rs
@@ -161,14 +161,24 @@ impl RuntimeV2CitizenStateSubstratePacket {
                 "citizen-state substrate must include its focused validation command"
             ));
         }
-        if !self
-            .validation_commands
-            .iter()
-            .any(|command| command.contains("runtime_v2_private_state_observatory"))
-        {
-            return Err(anyhow!(
-                "citizen-state substrate must preserve private-state observatory validation"
-            ));
+        for fixture in &self.fixture_matrix {
+            let expected_marker = proving_surface_marker(&fixture.proving_surface).ok_or_else(|| {
+                anyhow!(
+                    "citizen-state substrate fixture_kind '{}' must use a parseable proving surface",
+                    fixture.fixture_kind
+                )
+            })?;
+            if !self
+                .validation_commands
+                .iter()
+                .filter_map(|command| proving_surface_marker(command))
+                .any(|marker| marker == expected_marker)
+            {
+                return Err(anyhow!(
+                    "citizen-state substrate must preserve proving-surface validation for fixture_kind '{}'",
+                    fixture.fixture_kind
+                ));
+            }
         }
         if !self
             .claim_boundary
@@ -485,6 +495,16 @@ fn fixture_matrix() -> Vec<RuntimeV2CitizenStateSubstrateFixture> {
                     .to_string(),
         },
     ]
+}
+
+fn proving_surface_marker(command: &str) -> Option<&str> {
+    let tokens = command.split_whitespace().collect::<Vec<_>>();
+    let separator = tokens.iter().position(|token| *token == "--")?;
+    tokens[..separator]
+        .iter()
+        .rev()
+        .find(|token| !token.starts_with('-') && **token != "test" && **token != "cargo")
+        .copied()
 }
 
 fn validate_audience_views(

--- a/adl/src/runtime_v2/tests/citizen_state_substrate.rs
+++ b/adl/src/runtime_v2/tests/citizen_state_substrate.rs
@@ -103,6 +103,28 @@ fn runtime_v2_citizen_state_substrate_validation_rejects_drift() {
 
     let mut packet =
         runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet
+        .validation_commands
+        .retain(|command| !command.contains("runtime_v2_private_state_lineage"));
+    assert!(packet
+        .validate()
+        .expect_err("missing stale-state validation command should fail")
+        .to_string()
+        .contains("fixture_kind 'stale_state'"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
+    packet
+        .validation_commands
+        .retain(|command| !command.contains("runtime_v2_private_state_envelope"));
+    assert!(packet
+        .validate()
+        .expect_err("missing malformed-state validation command should fail")
+        .to_string()
+        .contains("fixture_kind 'malformed_state'"));
+
+    let mut packet =
+        runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");
     packet.fixture_matrix[0].artifact_ref = "/tmp/leak.json".to_string();
     assert!(packet
         .validate()
@@ -248,7 +270,7 @@ fn runtime_v2_citizen_state_substrate_validate_against_rejects_dependency_and_vi
         .validate()
         .expect_err("missing observatory validation command should fail")
         .to_string()
-        .contains("observatory validation"));
+        .contains("fixture_kind 'overexposed_projection'"));
 
     let mut packet =
         runtime_v2_citizen_state_substrate_contract().expect("citizen-state substrate packet");


### PR DESCRIPTION
Closes #2910

## Summary
Tightened the citizen-state substrate validation contract so every proving
surface named in the fixture matrix must also appear in the packet validation
command set. Added focused regression tests that fail if the malformed-state or
stale-state proving routes are removed.

## Artifacts
- Tracked runtime repairs:
  - `adl/src/runtime_v2/citizen_state_substrate.rs`
  - `adl/src/runtime_v2/tests/citizen_state_substrate.rs`
- Local issue records:
  - `.adl/v0.91.1/tasks/issue-2910__v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces/sip.md`
  - `.adl/v0.91.1/tasks/issue-2910__v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces/spp.md`
  - `.adl/v0.91.1/tasks/issue-2910__v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces/srp.md`
  - `.adl/v0.91.1/tasks/issue-2910__v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces/sor.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml runtime_v2_citizen_state_substrate -- --nocapture`
    Verified the citizen-state substrate contract stays stable and now fails when claimed fixture proving routes are removed.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the touched Rust surface remains warning-free.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2910__v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2910__v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces/sor.md
- Idempotency-Key: v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces-adl-v0-91-1-tasks-issue-2910-v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces-sip-md-adl-v0-91-1-tasks-issue-2910-v0-91-1-wp-06-runtime-enforce-all-claimed-citizen-state-substrate-proving-surfaces-sor-md