### PR TITLE
[v0.91.1][demo] Improve podcast loudness mastering and limiting

### DIFF
--- a/adl/tools/demo_v0911_multiagent_podcast_audio.sh
+++ b/adl/tools/demo_v0911_multiagent_podcast_audio.sh
@@ -222,6 +222,8 @@ speaker_target_rms = {
 intro_duck_ms = 425
 compression_threshold = 11000
 compression_ratio = 2.25
+final_mix_target_rms = 3350.0
+final_mix_ceiling = 26500
 
 def compress_pcm_16le(frames: bytes) -> bytes:
     samples = array('h')
@@ -243,6 +245,31 @@ def compress_pcm_16le(frames: bytes) -> bytes:
     if sys.byteorder != 'little':
         samples.byteswap()
     return samples.tobytes()
+
+def limit_pcm_16le(frames: bytes, ceiling: int) -> bytes:
+    samples = array('h')
+    samples.frombytes(frames)
+    if sys.byteorder != 'little':
+        samples.byteswap()
+    for i, sample in enumerate(samples):
+        if sample > ceiling:
+            samples[i] = ceiling
+        elif sample < -ceiling:
+            samples[i] = -ceiling
+    if sys.byteorder != 'little':
+        samples.byteswap()
+    return samples.tobytes()
+
+def measure_pcm_16le(frames: bytes) -> tuple[float, int]:
+    samples = array('h')
+    samples.frombytes(frames)
+    if sys.byteorder != 'little':
+        samples.byteswap()
+    if not samples:
+        return 0.0, 0
+    rms = math.sqrt(sum(int(s) * int(s) for s in samples) / len(samples))
+    peak = max(abs(int(s)) for s in samples)
+    return rms, peak
 
 def normalize_pcm_16le(frames: bytes, target_rms: float, rate: int, duck_intro: bool) -> bytes:
     samples = array('h')
@@ -292,27 +319,59 @@ for entry in segments:
         duck_intro = entry['speaker'] not in seen_speakers
         frames = normalize_pcm_16le(frames, target_rms, current_params[2], duck_intro)
         frames = compress_pcm_16le(frames)
+        frames = limit_pcm_16le(frames, final_mix_ceiling)
         with wave.open(str(segment_path), 'wb') as out_segment:
             out_segment.setnchannels(current_params[0])
             out_segment.setsampwidth(current_params[1])
             out_segment.setframerate(current_params[2])
             out_segment.writeframes(frames)
+        segment_rms, segment_peak = measure_pcm_16le(frames)
+        entry['segment_metrics'] = {
+            'rms': round(segment_rms, 1),
+            'peak': segment_peak,
+        }
     combined.append(frames)
     seen_speakers.add(entry['speaker'])
 channels, width, rate = params
 silence = b'\x00' * int(rate * width * channels * (GAP_MS / 1000.0))
+assembled_frames = b''
+for idx, frames in enumerate(combined):
+    assembled_frames += frames
+    if idx != len(combined) - 1:
+        assembled_frames += silence
+pre_mix_rms = None
+pre_mix_peak = None
+post_mix_rms = None
+post_mix_peak = None
+if width == 2:
+    pre_mix_rms, pre_mix_peak = measure_pcm_16le(assembled_frames)
+    assembled_frames = normalize_pcm_16le(assembled_frames, final_mix_target_rms, rate, False)
+    assembled_frames = compress_pcm_16le(assembled_frames)
+    assembled_frames = limit_pcm_16le(assembled_frames, final_mix_ceiling)
+    post_mix_rms, post_mix_peak = measure_pcm_16le(assembled_frames)
 with wave.open(episode_audio_path, 'wb') as out:
     out.setnchannels(channels)
     out.setsampwidth(width)
     out.setframerate(rate)
-    for idx, frames in enumerate(combined):
-        out.writeframes(compress_pcm_16le(frames) if width == 2 else frames)
-        if idx != len(combined) - 1:
-            out.writeframes(silence)
+    out.writeframes(assembled_frames)
 manifest = {
     'schema_version': 'adl.demo.multiagent_podcast_audio_manifest.v1',
     'source_episode_root': str(Path(source_dir)),
     'episode_audio': Path(episode_audio_path).name,
+    'mastering': {
+        'segment_target_rms': speaker_target_rms,
+        'final_mix_target_rms': final_mix_target_rms,
+        'final_mix_ceiling': final_mix_ceiling,
+        'compression_threshold': compression_threshold,
+        'compression_ratio': compression_ratio,
+        'intro_duck_ms': intro_duck_ms,
+        'final_mix_metrics': {
+            'pre_rms': round(pre_mix_rms, 1) if pre_mix_rms is not None else None,
+            'pre_peak': pre_mix_peak,
+            'post_rms': round(post_mix_rms, 1) if post_mix_rms is not None else None,
+            'post_peak': post_mix_peak,
+        },
+    },
     'segments': segments,
 }
 Path(manifest_path).write_text(json.dumps(manifest, indent=2) + '\n', encoding='utf-8')
@@ -331,8 +390,9 @@ packet = [
     '',
     '## Audio Presentation',
     '',
-    '- each speaker says their own name at the start of each segment',
+    '- each speaker says their own name only on their first appearance',
     '- segment loudness is normalized toward a shared target so the episode is easier to follow',
+    '- the final episode mix gets one more mastering pass for overall loudness consistency and peak control',
     '',
     '## Proof Boundary',
     '',

--- a/demos/v0.91.1/multiagent_podcast_audio_demo.md
+++ b/demos/v0.91.1/multiagent_podcast_audio_demo.md
@@ -21,7 +21,7 @@ This audio follow-on proves:
 - `Claude` can be rendered truthfully through a surrogate TTS lane while
   preserving Claude transcript authorship identity
 - the audio can be presented in a listener-friendly way with spoken speaker
-  intros and simple loudness normalization
+  intros, saved loudness metrics, and bounded mastering/limiting
 
 It does **not** prove:
 
@@ -105,7 +105,10 @@ The audio follow-on is successful when:
 - one listenable combined episode audio file exists
 - per-turn audio segments exist with explicit speaker routing
 - the manifest shows which provider/voice rendered each speaker
+- the manifest records usable loudness/mastering metrics for the final mix
 - Claude's surrogate rendering is disclosed instead of implied away
 - each speaker introduces themselves naturally only on their first turn, for example `I'm ChatGPT`
 - overall segment volume is normalized enough that the episode does not feel
   erratic or lopsided
+- the final mix has a bounded mastering pass that tightens loudness spread and
+  controls peaks without introducing a heavyweight external production pipeline


### PR DESCRIPTION
Closes #2922

## Summary
Implemented a bounded mastering pass in the podcast audio wrapper by adding saved per-segment loudness metrics, a final-mix loudness target, and a final limiter/compression stage for the combined episode mix.

## Artifacts
- Updated wrapper: `adl/tools/demo_v0911_multiagent_podcast_audio.sh`
- Updated demo doc: `demos/v0.91.1/multiagent_podcast_audio_demo.md`
- Verified audio packet: `artifacts/v0911/multiagent_podcast_pilot_audio_verified/episode.wav`
- Verified audio manifest: `artifacts/v0911/multiagent_podcast_pilot_audio_verified/audio_manifest.json`
- Verified audio packet note: `artifacts/v0911/multiagent_podcast_pilot_audio_verified/audio_packet.md`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/demo_v0911_multiagent_podcast_audio.sh`
    Verified the updated shell wrapper parses successfully after the mastering changes.
  - `ADL_PODCAST_GEMINI_AUDIO_PROVIDER=openai bash adl/tools/demo_v0911_multiagent_podcast_audio.sh artifacts/v0911/multiagent_podcast_pilot_audio_verified`
    Regenerated the verified audio packet and proved the updated mastering path end-to-end.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2922__v0-91-1-demo-improve-podcast-loudness-mastering-and-limiting/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2922__v0-91-1-demo-improve-podcast-loudness-mastering-and-limiting/sor.md
- Idempotency-Key: v0-91-1-demo-improve-podcast-loudness-mastering-and-limiting-adl-v0-91-1-tasks-issue-2922-v0-91-1-demo-improve-podcast-loudness-mastering-and-limiting-sip-md-adl-v0-91-1-tasks-issue-2922-v0-91-1-demo-improve-podcast-loudness-mastering-and-limiting-sor-md