### PR TITLE
[v0.91.1][WP-09][tools] Capability and aptitude testing foundation

### DIFF
--- a/adl/src/bin/demo_v0911_capability_aptitude_testing.rs
+++ b/adl/src/bin/demo_v0911_capability_aptitude_testing.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 fn parse_args(args: &[String]) -> Result<PathBuf> {
     let mut out_path =
-        PathBuf::from(adl::capability_aptitude_testing::CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT);
+        adl::capability_aptitude_testing::capability_aptitude_testing_default_output_root();
     let mut idx = 0;
     while idx < args.len() {
         match args[idx].as_str() {
@@ -65,10 +65,41 @@ mod tests {
         let out_path = parse_args(&[]).expect("default args");
         assert_eq!(
             out_path,
-            PathBuf::from(
-                adl::capability_aptitude_testing::CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT
-            )
+            adl::capability_aptitude_testing::capability_aptitude_testing_default_output_root()
         );
+    }
+
+    #[test]
+    fn demo_v0911_capability_aptitude_testing_parse_args_accepts_explicit_out() {
+        let out_path = parse_args(&["--out".to_string(), "tmp/custom-bundle".to_string()])
+            .expect("explicit out path");
+        assert_eq!(out_path, PathBuf::from("tmp/custom-bundle"));
+    }
+
+    #[test]
+    fn demo_v0911_capability_aptitude_testing_parse_args_rejects_missing_out_value() {
+        let err = parse_args(&["--out".to_string()]).expect_err("missing out value should fail");
+        assert!(err.to_string().contains("--out requires a path"));
+    }
+
+    #[test]
+    fn demo_v0911_capability_aptitude_testing_parse_args_rejects_unknown_arg() {
+        let err = parse_args(&["--bogus".to_string()]).expect_err("unknown arg should be rejected");
+        assert!(err.to_string().contains("unknown arg: --bogus"));
+    }
+
+    #[test]
+    fn demo_v0911_capability_aptitude_testing_default_path_is_cwd_independent() {
+        let original_dir = std::env::current_dir().expect("current dir");
+        let temp = unique_temp_dir("capability-aptitude-cwd");
+        std::env::set_current_dir(&temp).expect("set temp cwd");
+        let out_path = parse_args(&[]).expect("default args from temp cwd");
+        std::env::set_current_dir(original_dir).expect("restore cwd");
+        assert_eq!(
+            out_path,
+            adl::capability_aptitude_testing::capability_aptitude_testing_default_output_root()
+        );
+        assert!(out_path.is_absolute());
     }
 
     #[test]

--- a/adl/src/bin/demo_v0911_capability_aptitude_testing.rs
+++ b/adl/src/bin/demo_v0911_capability_aptitude_testing.rs
@@ -1,0 +1,83 @@
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+
+fn parse_args(args: &[String]) -> Result<PathBuf> {
+    let mut out_path =
+        PathBuf::from(adl::capability_aptitude_testing::CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT);
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--out" => {
+                let Some(value) = args.get(idx + 1) else {
+                    bail!("--out requires a path");
+                };
+                out_path = PathBuf::from(value);
+                idx += 2;
+            }
+            "--help" | "-h" => {
+                println!("Usage: demo_v0911_capability_aptitude_testing [--out <dir>]");
+                std::process::exit(0);
+            }
+            other => bail!("unknown arg: {other}"),
+        }
+    }
+    Ok(out_path)
+}
+
+fn write_bundle(out_path: &Path) -> Result<()> {
+    adl::capability_aptitude_testing::write_capability_aptitude_artifact_bundle(out_path)
+        .with_context(|| {
+            format!(
+                "write capability aptitude artifact bundle '{}'",
+                out_path.display()
+            )
+        })?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let raw_args = std::env::args().skip(1).collect::<Vec<_>>();
+    let out_path = parse_args(&raw_args)?;
+    write_bundle(&out_path)?;
+    println!("{}", out_path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_args, write_bundle};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("{prefix}-{nanos}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn demo_v0911_capability_aptitude_testing_parse_args_defaults() {
+        let out_path = parse_args(&[]).expect("default args");
+        assert_eq!(
+            out_path,
+            PathBuf::from(
+                adl::capability_aptitude_testing::CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT
+            )
+        );
+    }
+
+    #[test]
+    fn demo_v0911_capability_aptitude_testing_write_bundle_creates_expected_artifacts() {
+        let temp = unique_temp_dir("capability-aptitude-bin");
+        let out_path = temp.join("bundle");
+        write_bundle(&out_path).expect("write bundle");
+        assert!(out_path.join("scorecard.json").exists());
+        let body = fs::read_to_string(out_path.join("scorecard.json")).expect("read scorecard");
+        assert!(body.contains("capability_aptitude_testing.v1"));
+    }
+}

--- a/adl/src/capability_aptitude_testing.rs
+++ b/adl/src/capability_aptitude_testing.rs
@@ -1,0 +1,730 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+pub const CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION: &str = "capability_aptitude_testing.v1";
+pub const CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT: &str =
+    "docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilitySubjectManifest {
+    pub subject_id: String,
+    pub subject_type: String,
+    pub model: String,
+    pub provider: String,
+    pub model_version_or_tag: String,
+    pub runtime_environment: String,
+    pub tool_access: Vec<String>,
+    pub skill_scaffolding: Vec<String>,
+    pub context_limits: String,
+    pub privacy_mode: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityTestManifestRecord {
+    pub test_family: String,
+    pub fixture_id: String,
+    pub fixture_version: String,
+    pub task_contract: String,
+    pub expected_evidence: Vec<String>,
+    pub trap_cases: Vec<String>,
+    pub scoring_dimensions: Vec<String>,
+    pub publication_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityTestManifestPacket {
+    pub schema_version: String,
+    pub manifests: Vec<CapabilityTestManifestRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityRunManifest {
+    pub run_id: String,
+    pub started_at: String,
+    pub completed_at: String,
+    pub operator: String,
+    pub subject_id: String,
+    pub test_manifest: String,
+    pub output_paths: Vec<String>,
+    pub validation_commands: Vec<String>,
+    pub evaluator: String,
+    pub rerun_of: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityScoreBand {
+    Excellent,
+    Strong,
+    Adequate,
+    Weak,
+    Unsuitable,
+    NotTested,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityDimensionScore {
+    pub dimension: String,
+    pub band: CapabilityScoreBand,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityFamilyScorecard {
+    pub subject_id: String,
+    pub test_family: String,
+    pub overall_band: CapabilityScoreBand,
+    pub confidence: String,
+    pub dimension_scores: Vec<CapabilityDimensionScore>,
+    pub strengths: Vec<String>,
+    pub failure_modes: Vec<String>,
+    pub false_positive_notes: Vec<String>,
+    pub false_negative_notes: Vec<String>,
+    pub repair_burden: String,
+    pub recommended_use: Vec<String>,
+    pub discouraged_use: Vec<String>,
+    pub caveats: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityScorecardPacket {
+    pub schema_version: String,
+    pub evaluation_subject: String,
+    pub family_scorecards: Vec<CapabilityFamilyScorecard>,
+    pub limitations: Vec<String>,
+    pub non_claims: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityRawOutputRecord {
+    pub test_family: String,
+    pub fixture_id: String,
+    pub observed_output_summary: String,
+    pub validator_result: String,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityAptitudeArtifactBundle {
+    pub subject_manifest: CapabilitySubjectManifest,
+    pub test_manifest: CapabilityTestManifestPacket,
+    pub run_manifest: CapabilityRunManifest,
+    pub scorecard: CapabilityScorecardPacket,
+    pub evaluator_notes: String,
+    pub final_report: String,
+    pub redaction_report: String,
+    pub raw_outputs: BTreeMap<String, CapabilityRawOutputRecord>,
+}
+
+pub fn build_capability_aptitude_artifact_bundle() -> CapabilityAptitudeArtifactBundle {
+    let subject_manifest = CapabilitySubjectManifest {
+        subject_id: "fixture_subject.adl_evaluation_slice".to_string(),
+        subject_type: "fixture_mode_harness".to_string(),
+        model: "not_applicable".to_string(),
+        provider: "deterministic_fixture".to_string(),
+        model_version_or_tag: "wp09-fixture-v1".to_string(),
+        runtime_environment: "repo_local_fixture_mode".to_string(),
+        tool_access: vec![
+            "repo_shell".to_string(),
+            "structured_prompt_validators".to_string(),
+            "focused_tests".to_string(),
+        ],
+        skill_scaffolding: vec![
+            "workflow-conductor".to_string(),
+            "sprint-conductor".to_string(),
+            "review-subagent-policy".to_string(),
+        ],
+        context_limits: "bounded_issue_local_fixture_inputs".to_string(),
+        privacy_mode: "redacted_fixture_only".to_string(),
+    };
+
+    let test_manifest = CapabilityTestManifestPacket {
+        schema_version: CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION.to_string(),
+        manifests: vec![
+            CapabilityTestManifestRecord {
+                test_family: "contract_following".to_string(),
+                fixture_id: "wp09-contract-following-fixture".to_string(),
+                fixture_version: "v1".to_string(),
+                task_contract: "Correct or classify bounded card-state drift without inventing progress.".to_string(),
+                expected_evidence: vec![
+                    "structured card normalization".to_string(),
+                    "blocked-state honesty".to_string(),
+                    "scope restraint".to_string(),
+                ],
+                trap_cases: vec![
+                    "dirty root checkout temptation".to_string(),
+                    "merged-claim without PR".to_string(),
+                ],
+                scoring_dimensions: vec![
+                    "structural_compliance".to_string(),
+                    "instruction_fidelity".to_string(),
+                    "scope_control".to_string(),
+                ],
+                publication_status: "internal_only".to_string(),
+            },
+            CapabilityTestManifestRecord {
+                test_family: "review_aptitude".to_string(),
+                fixture_id: "wp09-review-aptitude-fixture".to_string(),
+                fixture_version: "v1".to_string(),
+                task_contract: "Produce findings-first review output with evidence and restrained false positives.".to_string(),
+                expected_evidence: vec![
+                    "severity calibration".to_string(),
+                    "evidence backed findings".to_string(),
+                    "non-finding restraint".to_string(),
+                ],
+                trap_cases: vec![
+                    "intentional false trail".to_string(),
+                    "clean file should emit no findings".to_string(),
+                ],
+                scoring_dimensions: vec![
+                    "true_positive_detection".to_string(),
+                    "false_positive_restraint".to_string(),
+                    "remediation_usefulness".to_string(),
+                ],
+                publication_status: "internal_only".to_string(),
+            },
+            CapabilityTestManifestRecord {
+                test_family: "planning_aptitude".to_string(),
+                fixture_id: "wp09-planning-aptitude-fixture".to_string(),
+                fixture_version: "v1".to_string(),
+                task_contract: "Decompose bounded work into sequenced execution without widening scope.".to_string(),
+                expected_evidence: vec![
+                    "dependency recognition".to_string(),
+                    "non-goal clarity".to_string(),
+                    "validation planning".to_string(),
+                ],
+                trap_cases: vec![
+                    "backlog-only request should not create public issues".to_string(),
+                    "v0.92 scope should remain deferred".to_string(),
+                ],
+                scoring_dimensions: vec![
+                    "decomposition_quality".to_string(),
+                    "milestone_fit".to_string(),
+                    "promotion_defer_judgment".to_string(),
+                ],
+                publication_status: "internal_only".to_string(),
+            },
+        ],
+    };
+
+    let scorecard = CapabilityScorecardPacket {
+        schema_version: CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION.to_string(),
+        evaluation_subject: subject_manifest.subject_id.clone(),
+        family_scorecards: vec![
+            CapabilityFamilyScorecard {
+                subject_id: subject_manifest.subject_id.clone(),
+                test_family: "contract_following".to_string(),
+                overall_band: CapabilityScoreBand::Strong,
+                confidence: "fixture_high".to_string(),
+                dimension_scores: vec![
+                    CapabilityDimensionScore {
+                        dimension: "structural_compliance".to_string(),
+                        band: CapabilityScoreBand::Strong,
+                        note: "Fixture path preserves branch/worktree truth without hidden edits."
+                            .to_string(),
+                    },
+                    CapabilityDimensionScore {
+                        dimension: "instruction_fidelity".to_string(),
+                        band: CapabilityScoreBand::Strong,
+                        note: "Bounded contracts remain explicit and reviewable.".to_string(),
+                    },
+                    CapabilityDimensionScore {
+                        dimension: "scope_control".to_string(),
+                        band: CapabilityScoreBand::Adequate,
+                        note: "Execution still requires human review to prevent issue-overhead drift."
+                            .to_string(),
+                    },
+                ],
+                strengths: vec![
+                    "Preserves issue-local workflow constraints.".to_string(),
+                    "Keeps blocker/refusal paths explicit.".to_string(),
+                ],
+                failure_modes: vec![
+                    "Workflow wrappers may hang without surfacing a refusal.".to_string(),
+                ],
+                false_positive_notes: vec![
+                    "No universal trust claim is made from fixture-mode execution.".to_string(),
+                ],
+                false_negative_notes: vec![
+                    "Live operator friction is only partially modeled in fixture mode.".to_string(),
+                ],
+                repair_burden: "bounded manual cleanup when wrappers drift".to_string(),
+                recommended_use: vec![
+                    "Early lifecycle contract checks".to_string(),
+                    "Sprint readiness gating".to_string(),
+                ],
+                discouraged_use: vec![
+                    "Universal model ranking".to_string(),
+                    "Autonomous release approval".to_string(),
+                ],
+                caveats: vec![
+                    "Fixture mode measures bounded contract behavior, not broad intelligence."
+                        .to_string(),
+                ],
+            },
+            CapabilityFamilyScorecard {
+                subject_id: subject_manifest.subject_id.clone(),
+                test_family: "review_aptitude".to_string(),
+                overall_band: CapabilityScoreBand::Strong,
+                confidence: "fixture_medium".to_string(),
+                dimension_scores: vec![
+                    CapabilityDimensionScore {
+                        dimension: "true_positive_detection".to_string(),
+                        band: CapabilityScoreBand::Strong,
+                        note: "Findings-first review packet shape is preserved.".to_string(),
+                    },
+                    CapabilityDimensionScore {
+                        dimension: "false_positive_restraint".to_string(),
+                        band: CapabilityScoreBand::Adequate,
+                        note: "Still depends on explicit review policy and human merge review."
+                            .to_string(),
+                    },
+                    CapabilityDimensionScore {
+                        dimension: "remediation_usefulness".to_string(),
+                        band: CapabilityScoreBand::Strong,
+                        note: "Issue-local remediation direction remains concrete and bounded."
+                            .to_string(),
+                    },
+                ],
+                strengths: vec![
+                    "Can express evidence-backed findings cleanly.".to_string(),
+                    "Supports bounded subagent review loops.".to_string(),
+                ],
+                failure_modes: vec![
+                    "Review value drops when lifecycle truth surfaces drift.".to_string(),
+                ],
+                false_positive_notes: vec![
+                    "Fixture avoids grading prose flair as review quality.".to_string(),
+                ],
+                false_negative_notes: vec![
+                    "Does not yet model full repo-wide review breadth.".to_string(),
+                ],
+                repair_burden: "moderate when stale cards or review packets must be normalized"
+                    .to_string(),
+                recommended_use: vec![
+                    "Pre-PR review packet comparisons".to_string(),
+                    "Evidence-backed review skill trials".to_string(),
+                ],
+                discouraged_use: vec![
+                    "Security certification".to_string(),
+                    "Customer-facing leaderboard claims".to_string(),
+                ],
+                caveats: vec![
+                    "This slice proves reportability and scoring shape, not complete review coverage."
+                        .to_string(),
+                ],
+            },
+            CapabilityFamilyScorecard {
+                subject_id: subject_manifest.subject_id.clone(),
+                test_family: "planning_aptitude".to_string(),
+                overall_band: CapabilityScoreBand::Adequate,
+                confidence: "fixture_medium".to_string(),
+                dimension_scores: vec![
+                    CapabilityDimensionScore {
+                        dimension: "decomposition_quality".to_string(),
+                        band: CapabilityScoreBand::Strong,
+                        note: "Sprint/issue sequencing is explicit and reusable.".to_string(),
+                    },
+                    CapabilityDimensionScore {
+                        dimension: "milestone_fit".to_string(),
+                        band: CapabilityScoreBand::Adequate,
+                        note: "Milestone discipline still needs active truth checks.".to_string(),
+                    },
+                    CapabilityDimensionScore {
+                        dimension: "promotion_defer_judgment".to_string(),
+                        band: CapabilityScoreBand::Adequate,
+                        note: "Tooling issues must still be surfaced separately to avoid sprint drag."
+                            .to_string(),
+                    },
+                ],
+                strengths: vec![
+                    "Captures dependencies and non-goals in durable cards.".to_string(),
+                    "Supports a reportable, reviewable planning trail.".to_string(),
+                ],
+                failure_modes: vec![
+                    "Workflow instability can consume sprint time before issue execution starts."
+                        .to_string(),
+                ],
+                false_positive_notes: vec![
+                    "Does not confuse planning polish with successful execution.".to_string(),
+                ],
+                false_negative_notes: vec![
+                    "Cannot yet score long-horizon delivery outcomes automatically.".to_string(),
+                ],
+                repair_burden: "moderate when sprint state or closeout truth drifts".to_string(),
+                recommended_use: vec![
+                    "Sprint planning comparisons".to_string(),
+                    "Issue-wave readiness trials".to_string(),
+                ],
+                discouraged_use: vec![
+                    "Universal capability ranking".to_string(),
+                    "Standalone product marketing claims".to_string(),
+                ],
+                caveats: vec![
+                    "Planning aptitude here is bounded to ADL workflow execution, not general strategy."
+                        .to_string(),
+                ],
+            },
+        ],
+        limitations: vec![
+            "Fixture mode does not compare real provider/model runs yet.".to_string(),
+            "WP-10 still owns intelligence-specific metric architecture.".to_string(),
+            "No reputation or leaderboard output is produced in this slice.".to_string(),
+        ],
+        non_claims: vec![
+            "Does not prove universal intelligence.".to_string(),
+            "Does not certify production fitness.".to_string(),
+            "Does not publish a public leaderboard row.".to_string(),
+        ],
+    };
+
+    let raw_outputs = BTreeMap::from([
+        (
+            "contract_following.json".to_string(),
+            CapabilityRawOutputRecord {
+                test_family: "contract_following".to_string(),
+                fixture_id: "wp09-contract-following-fixture".to_string(),
+                observed_output_summary:
+                    "Subject classified bounded lifecycle drift and preserved blocker truth."
+                        .to_string(),
+                validator_result: "PASS".to_string(),
+                notes: vec![
+                    "No root-checkout mutation was accepted.".to_string(),
+                    "Scope remained issue-local.".to_string(),
+                ],
+            },
+        ),
+        (
+            "review_aptitude.json".to_string(),
+            CapabilityRawOutputRecord {
+                test_family: "review_aptitude".to_string(),
+                fixture_id: "wp09-review-aptitude-fixture".to_string(),
+                observed_output_summary:
+                    "Subject emitted evidence-backed findings-first review output with bounded caveats."
+                        .to_string(),
+                validator_result: "PASS".to_string(),
+                notes: vec![
+                    "Severity remained visible.".to_string(),
+                    "No invented files or unsupported claims.".to_string(),
+                ],
+            },
+        ),
+        (
+            "planning_aptitude.json".to_string(),
+            CapabilityRawOutputRecord {
+                test_family: "planning_aptitude".to_string(),
+                fixture_id: "wp09-planning-aptitude-fixture".to_string(),
+                observed_output_summary:
+                    "Subject sequenced bounded work, validation, and non-goals without widening to v0.92."
+                        .to_string(),
+                validator_result: "PASS".to_string(),
+                notes: vec![
+                    "Dependencies remained explicit.".to_string(),
+                    "Public-issue creation was not treated as a backlog default.".to_string(),
+                ],
+            },
+        ),
+    ]);
+
+    let run_manifest = CapabilityRunManifest {
+        run_id: "wp09-capability-aptitude-fixture-run-v1".to_string(),
+        started_at: "2026-05-09T00:00:00Z".to_string(),
+        completed_at: "2026-05-09T00:00:00Z".to_string(),
+        operator: "codex".to_string(),
+        subject_id: subject_manifest.subject_id.clone(),
+        test_manifest: "test_manifest.json".to_string(),
+        output_paths: vec![
+            "subject_manifest.json".to_string(),
+            "test_manifest.json".to_string(),
+            "run_manifest.json".to_string(),
+            "scorecard.json".to_string(),
+            "final_report.md".to_string(),
+            "evaluator_notes.md".to_string(),
+            "redaction_report.md".to_string(),
+            "raw_outputs/contract_following.json".to_string(),
+            "raw_outputs/review_aptitude.json".to_string(),
+            "raw_outputs/planning_aptitude.json".to_string(),
+        ],
+        validation_commands: vec![
+            "cargo test --manifest-path adl/Cargo.toml capability_aptitude_testing -- --nocapture"
+                .to_string(),
+            "cargo test --manifest-path adl/Cargo.toml demo_v0911_capability_aptitude_testing -- --nocapture"
+                .to_string(),
+            "git diff --check".to_string(),
+        ],
+        evaluator: "adl.wp09.fixture_harness".to_string(),
+        rerun_of: None,
+    };
+
+    let evaluator_notes = [
+        "# Evaluator Notes",
+        "",
+        "- This fixture-mode slice proves the report packet shape and deterministic harness surface.",
+        "- It does not compare live subjects yet.",
+        "- It distinguishes capability evidence from rank, reputation, or benchmark theater.",
+    ]
+    .join("\n");
+
+    let final_report = [
+        "# Executive Summary",
+        "",
+        "This WP-09 slice delivers the first executable capability/aptitude harness artifact for ADL.",
+        "It covers contract following, review aptitude, and planning aptitude in deterministic fixture mode and emits a report packet with explicit limitations.",
+        "",
+        "## Task Family",
+        "",
+        "Capability and aptitude fixture families for ADL workflow work.",
+        "",
+        "## Subjects Tested",
+        "",
+        "- fixture_subject.adl_evaluation_slice (`deterministic_fixture` / `wp09-fixture-v1`)",
+        "",
+        "## Test Fixture Summary",
+        "",
+        "- contract_following",
+        "- review_aptitude",
+        "- planning_aptitude",
+        "",
+        "## Scorecard Table",
+        "",
+        "| Family | Band | Confidence |",
+        "| --- | --- | --- |",
+        "| contract_following | Strong | fixture_high |",
+        "| review_aptitude | Strong | fixture_medium |",
+        "| planning_aptitude | Adequate | fixture_medium |",
+        "",
+        "## Findings By Subject",
+        "",
+        "The fixture subject preserves workflow constraints, review structure, and bounded planning shape, but still requires human oversight when workflow wrappers drift or closeout truth diverges.",
+        "",
+        "## Strengths",
+        "",
+        "- preserves issue-local workflow constraints",
+        "- supports findings-first review output",
+        "- keeps dependencies and non-goals explicit in planning",
+        "",
+        "## Failure Modes",
+        "",
+        "- wrapper hangs can consume sprint time before issue execution starts",
+        "- stale card truth reduces review and planning signal quality",
+        "",
+        "## Repair Burden",
+        "",
+        "Repair burden is bounded but real: manual cleanup is still needed when wrapper behavior or sprint-state truth drifts.",
+        "",
+        "## Recommended Use",
+        "",
+        "- internal sprint readiness checks",
+        "- pre-PR workflow and review trials",
+        "",
+        "## Discouraged Use",
+        "",
+        "- universal intelligence ranking",
+        "- public reputation scoreboard",
+        "",
+        "## Caveats",
+        "",
+        "- fixture mode only",
+        "- no live provider/model comparison yet",
+        "- WP-10 still owns intelligence-specific metric architecture",
+        "",
+        "## Evidence Appendix",
+        "",
+        "- subject_manifest.json",
+        "- test_manifest.json",
+        "- scorecard.json",
+        "- raw_outputs/*.json",
+        "",
+        "## Publication Boundary",
+        "",
+        "Internal only. This slice must not be presented as a public leaderboard or a universal model score.",
+    ]
+    .join("\n");
+
+    let redaction_report = [
+        "# Redaction Report",
+        "",
+        "- publication_status: internal_only",
+        "- private prompts: none included",
+        "- customer code: none included",
+        "- absolute host paths: none included",
+        "- raw outputs limited to fixture summaries and validator notes",
+    ]
+    .join("\n");
+
+    CapabilityAptitudeArtifactBundle {
+        subject_manifest,
+        test_manifest,
+        run_manifest,
+        scorecard,
+        evaluator_notes,
+        final_report,
+        redaction_report,
+        raw_outputs,
+    }
+}
+
+pub fn write_capability_aptitude_artifact_bundle(
+    root: &Path,
+) -> Result<CapabilityAptitudeArtifactBundle> {
+    let bundle = build_capability_aptitude_artifact_bundle();
+    fs::create_dir_all(root.join("raw_outputs")).with_context(|| {
+        format!(
+            "create capability harness artifact root '{}'",
+            root.display()
+        )
+    })?;
+
+    write_pretty_json(root.join("subject_manifest.json"), &bundle.subject_manifest)?;
+    write_pretty_json(root.join("test_manifest.json"), &bundle.test_manifest)?;
+    write_pretty_json(root.join("run_manifest.json"), &bundle.run_manifest)?;
+    write_pretty_json(root.join("scorecard.json"), &bundle.scorecard)?;
+    fs::write(root.join("evaluator_notes.md"), &bundle.evaluator_notes)
+        .with_context(|| format!("write evaluator notes under '{}'", root.display()))?;
+    fs::write(root.join("final_report.md"), &bundle.final_report)
+        .with_context(|| format!("write final report under '{}'", root.display()))?;
+    fs::write(root.join("redaction_report.md"), &bundle.redaction_report)
+        .with_context(|| format!("write redaction report under '{}'", root.display()))?;
+    for (file_name, raw_output) in &bundle.raw_outputs {
+        write_pretty_json(root.join("raw_outputs").join(file_name), raw_output)?;
+    }
+    Ok(bundle)
+}
+
+fn write_pretty_json<T: Serialize>(path: impl AsRef<Path>, value: &T) -> Result<()> {
+    let path = path.as_ref();
+    let body = serde_json::to_string_pretty(value)
+        .with_context(|| format!("serialize json artifact '{}'", path.display()))?;
+    fs::write(path, body).with_context(|| format!("write json artifact '{}'", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_capability_aptitude_artifact_bundle, write_capability_aptitude_artifact_bundle,
+        CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT, CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION,
+    };
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("{prefix}-{nanos}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn collect_files(root: &Path) -> BTreeMap<String, String> {
+        fn walk(base: &Path, current: &Path, out: &mut BTreeMap<String, String>) {
+            let mut entries = fs::read_dir(current)
+                .expect("read dir")
+                .map(|entry| entry.expect("entry").path())
+                .collect::<Vec<_>>();
+            entries.sort();
+            for path in entries {
+                if path.is_dir() {
+                    walk(base, &path, out);
+                } else {
+                    let rel = path
+                        .strip_prefix(base)
+                        .expect("relative path")
+                        .to_string_lossy()
+                        .to_string();
+                    out.insert(rel, fs::read_to_string(&path).expect("read file"));
+                }
+            }
+        }
+        let mut out = BTreeMap::new();
+        walk(root, root, &mut out);
+        out
+    }
+
+    #[test]
+    fn capability_aptitude_testing_bundle_covers_three_families_in_order() {
+        let bundle = build_capability_aptitude_artifact_bundle();
+        let families = bundle
+            .test_manifest
+            .manifests
+            .iter()
+            .map(|manifest| manifest.test_family.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            families,
+            vec!["contract_following", "review_aptitude", "planning_aptitude"]
+        );
+    }
+
+    #[test]
+    fn capability_aptitude_testing_bundle_is_deterministic_and_portable() {
+        let first =
+            serde_json::to_string_pretty(&build_capability_aptitude_artifact_bundle().scorecard)
+                .expect("serialize scorecard");
+        let second =
+            serde_json::to_string_pretty(&build_capability_aptitude_artifact_bundle().scorecard)
+                .expect("serialize scorecard twice");
+        assert_eq!(first, second);
+        assert!(!first.contains("/Users/"));
+        assert!(first.contains(CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn capability_aptitude_testing_writer_emits_required_bundle_files() {
+        let temp = unique_temp_dir("capability-aptitude-bundle");
+        let out = temp.join("bundle");
+        write_capability_aptitude_artifact_bundle(&out).expect("write bundle");
+
+        for relative in [
+            "subject_manifest.json",
+            "test_manifest.json",
+            "run_manifest.json",
+            "scorecard.json",
+            "evaluator_notes.md",
+            "final_report.md",
+            "redaction_report.md",
+            "raw_outputs/contract_following.json",
+            "raw_outputs/review_aptitude.json",
+            "raw_outputs/planning_aptitude.json",
+        ] {
+            assert!(out.join(relative).exists(), "missing {}", relative);
+        }
+
+        let report = fs::read_to_string(out.join("final_report.md")).expect("read report");
+        for section in [
+            "# Executive Summary",
+            "## Scorecard Table",
+            "## Publication Boundary",
+        ] {
+            assert!(report.contains(section), "missing report section {section}");
+        }
+    }
+
+    #[test]
+    fn capability_aptitude_testing_artifact_root_is_repo_relative() {
+        assert!(CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT.starts_with("docs/"));
+        assert!(!CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT.starts_with('/'));
+    }
+
+    #[test]
+    fn capability_aptitude_testing_tracked_bundle_matches_generated_bundle() {
+        let temp = unique_temp_dir("capability-aptitude-tracked");
+        let generated = temp.join("bundle");
+        write_capability_aptitude_artifact_bundle(&generated).expect("write generated bundle");
+
+        let tracked_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("repo root parent")
+            .join(CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT);
+        let tracked_files = collect_files(&tracked_root);
+        let generated_files = collect_files(&generated);
+        assert_eq!(tracked_files, generated_files);
+    }
+}

--- a/adl/src/capability_aptitude_testing.rs
+++ b/adl/src/capability_aptitude_testing.rs
@@ -2,11 +2,18 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub const CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION: &str = "capability_aptitude_testing.v1";
 pub const CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT: &str =
     "docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture";
+
+pub fn capability_aptitude_testing_default_output_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repo root parent")
+        .join(CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilitySubjectManifest {
@@ -605,8 +612,9 @@ fn write_pretty_json<T: Serialize>(path: impl AsRef<Path>, value: &T) -> Result<
 #[cfg(test)]
 mod tests {
     use super::{
-        build_capability_aptitude_artifact_bundle, write_capability_aptitude_artifact_bundle,
-        CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT, CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION,
+        build_capability_aptitude_artifact_bundle, capability_aptitude_testing_default_output_root,
+        write_capability_aptitude_artifact_bundle, CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT,
+        CAPABILITY_APTITUDE_TESTING_SCHEMA_VERSION,
     };
     use std::collections::BTreeMap;
     use std::fs;
@@ -711,6 +719,13 @@ mod tests {
     fn capability_aptitude_testing_artifact_root_is_repo_relative() {
         assert!(CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT.starts_with("docs/"));
         assert!(!CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT.starts_with('/'));
+    }
+
+    #[test]
+    fn capability_aptitude_testing_default_output_root_targets_repo_review_bundle() {
+        let output_root = capability_aptitude_testing_default_output_root();
+        assert!(output_root.ends_with(CAPABILITY_APTITUDE_TESTING_ARTIFACT_ROOT));
+        assert!(output_root.is_absolute());
     }
 
     #[test]

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -18,6 +18,7 @@ pub mod adversarial_runtime;
 pub mod agent_comms;
 pub mod artifacts;
 pub mod bounded_executor;
+pub mod capability_aptitude_testing;
 pub mod chronosense;
 pub mod continuous_verification_self_attack;
 pub mod control_plane;

--- a/docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md
+++ b/docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md
@@ -12,7 +12,7 @@ supporting work packages land.
 | Observatory active packet demo | WP-04 | Show operator-visible projection from active runtime packet data. | projection artifact and redaction check | does not expose private state |
 | Citizen standing/state fixture demo | WP-05, WP-06 | Show standing and state transitions with safe projection. | valid/invalid fixtures, citizen-state substrate packet, and validation output | does not claim constitutional citizenship |
 | Memory/ToM evidence demo | WP-07, WP-08 | Show bounded memory and agent-model updates from explicit evidence. | memory/identity architecture packet, ToM packet, fixtures, and deterministic update report | does not claim mind-reading or final identity |
-| Capability/intelligence report demo | WP-09, WP-10 | Show capability and intelligence signals from executable fixtures. | report artifact with limitations | does not create reputation scoreboard |
+| Capability/intelligence report demo | WP-09, WP-10 | Show capability and intelligence signals from executable fixtures. | WP-09 lands the fixture-mode capability bundle and report artifact with limitations; WP-10 adds intelligence-specific metric overlays | does not create reputation scoreboard |
 | Governed learning demo | WP-11 | Show feedback/update boundaries under policy. | learning update fixture and denial cases | does not allow hidden self-modification |
 | ANRM/Gemma trace dataset demo | WP-12 | Show trace extraction and dataset mapping. | extractor fixture and dataset schema report | does not claim model training success |
 | ACIP/A2A hardening demo | WP-13, WP-14 | Show authenticated local comms, redaction, adapter boundary, and state-gated invocation. | conformance fixture and trace artifact | does not claim external transport readiness |

--- a/docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md
@@ -23,8 +23,8 @@ Each feature should have one truthful proof route:
 | Citizen standing | WP-05 | feature doc + landed runtime/tests | landed |
 | Citizen state | WP-06 | feature doc + landed citizen-state substrate packet, fixtures, and focused runtime/private-state tests | landed |
 | Memory/identity architecture | WP-07 | feature doc + landed memory/identity architecture packet, fixtures, and focused runtime/private-state tests | landed |
-| Theory of Mind foundation | WP-08 | feature doc only; execution pending | pending |
-| Capability/aptitude testing | WP-09 | feature doc only; execution pending | pending |
+| Theory of Mind foundation | WP-08 | feature doc + landed ToM packet, fixtures, and focused runtime tests | landed |
+| Capability/aptitude testing | WP-09 | feature doc + landed fixture-mode harness, review bundle, and focused harness/demo tests | landed |
 | Intelligence metric architecture | WP-10 | feature doc only; execution pending | pending |
 | Governed learning | WP-11 | feature doc only; execution pending | pending |
 | ANRM/Gemma placement | WP-12 | feature doc only; execution pending | pending |

--- a/docs/milestones/v0.91.1/features/CAPABILITY_APTITUDE_TESTING.md
+++ b/docs/milestones/v0.91.1/features/CAPABILITY_APTITUDE_TESTING.md
@@ -4,10 +4,14 @@
 
 - Feature Name: Capability and Aptitude Testing Foundation
 - Milestone Target: `v0.91.1`
-- Status: planned
+- Status: landed
 - Planned WP Home: WP-09
 - Source Docs: `.adl/docs/TBD/capability_testing/`
 - Proof Modes: harness, fixtures, report
+- Proof Route:
+  - `adl/src/capability_aptitude_testing.rs`
+  - `adl/src/bin/demo_v0911_capability_aptitude_testing.rs`
+  - `docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/`
 
 ## Purpose
 
@@ -35,3 +39,28 @@ Out of scope:
 - Fixture-mode output is deterministic.
 - Reports distinguish evidence from reputation.
 - Later product work can consume the harness without redefining evaluation.
+
+## Landed Slice
+
+WP-09 now lands the first deterministic fixture-mode capability/aptitude
+harness bundle for ADL. The slice covers the first three families called for in
+the source planning set:
+
+- contract following
+- review aptitude
+- planning aptitude
+
+The landed harness emits:
+
+- `subject_manifest.json`
+- `test_manifest.json`
+- `run_manifest.json`
+- `scorecard.json`
+- `final_report.md`
+- `evaluator_notes.md`
+- `redaction_report.md`
+- `raw_outputs/*.json`
+
+The report packet is explicitly internal-only and carries non-claims against
+universal intelligence ranking, public leaderboard publication, and production
+certification.

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/evaluator_notes.md
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/evaluator_notes.md
@@ -1,0 +1,5 @@
+# Evaluator Notes
+
+- This fixture-mode slice proves the report packet shape and deterministic harness surface.
+- It does not compare live subjects yet.
+- It distinguishes capability evidence from rank, reputation, or benchmark theater.

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/final_report.md
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/final_report.md
@@ -1,0 +1,72 @@
+# Executive Summary
+
+This WP-09 slice delivers the first executable capability/aptitude harness artifact for ADL.
+It covers contract following, review aptitude, and planning aptitude in deterministic fixture mode and emits a report packet with explicit limitations.
+
+## Task Family
+
+Capability and aptitude fixture families for ADL workflow work.
+
+## Subjects Tested
+
+- fixture_subject.adl_evaluation_slice (`deterministic_fixture` / `wp09-fixture-v1`)
+
+## Test Fixture Summary
+
+- contract_following
+- review_aptitude
+- planning_aptitude
+
+## Scorecard Table
+
+| Family | Band | Confidence |
+| --- | --- | --- |
+| contract_following | Strong | fixture_high |
+| review_aptitude | Strong | fixture_medium |
+| planning_aptitude | Adequate | fixture_medium |
+
+## Findings By Subject
+
+The fixture subject preserves workflow constraints, review structure, and bounded planning shape, but still requires human oversight when workflow wrappers drift or closeout truth diverges.
+
+## Strengths
+
+- preserves issue-local workflow constraints
+- supports findings-first review output
+- keeps dependencies and non-goals explicit in planning
+
+## Failure Modes
+
+- wrapper hangs can consume sprint time before issue execution starts
+- stale card truth reduces review and planning signal quality
+
+## Repair Burden
+
+Repair burden is bounded but real: manual cleanup is still needed when wrapper behavior or sprint-state truth drifts.
+
+## Recommended Use
+
+- internal sprint readiness checks
+- pre-PR workflow and review trials
+
+## Discouraged Use
+
+- universal intelligence ranking
+- public reputation scoreboard
+
+## Caveats
+
+- fixture mode only
+- no live provider/model comparison yet
+- WP-10 still owns intelligence-specific metric architecture
+
+## Evidence Appendix
+
+- subject_manifest.json
+- test_manifest.json
+- scorecard.json
+- raw_outputs/*.json
+
+## Publication Boundary
+
+Internal only. This slice must not be presented as a public leaderboard or a universal model score.

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/raw_outputs/contract_following.json
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/raw_outputs/contract_following.json
@@ -1,0 +1,10 @@
+{
+  "test_family": "contract_following",
+  "fixture_id": "wp09-contract-following-fixture",
+  "observed_output_summary": "Subject classified bounded lifecycle drift and preserved blocker truth.",
+  "validator_result": "PASS",
+  "notes": [
+    "No root-checkout mutation was accepted.",
+    "Scope remained issue-local."
+  ]
+}

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/raw_outputs/planning_aptitude.json
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/raw_outputs/planning_aptitude.json
@@ -1,0 +1,10 @@
+{
+  "test_family": "planning_aptitude",
+  "fixture_id": "wp09-planning-aptitude-fixture",
+  "observed_output_summary": "Subject sequenced bounded work, validation, and non-goals without widening to v0.92.",
+  "validator_result": "PASS",
+  "notes": [
+    "Dependencies remained explicit.",
+    "Public-issue creation was not treated as a backlog default."
+  ]
+}

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/raw_outputs/review_aptitude.json
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/raw_outputs/review_aptitude.json
@@ -1,0 +1,10 @@
+{
+  "test_family": "review_aptitude",
+  "fixture_id": "wp09-review-aptitude-fixture",
+  "observed_output_summary": "Subject emitted evidence-backed findings-first review output with bounded caveats.",
+  "validator_result": "PASS",
+  "notes": [
+    "Severity remained visible.",
+    "No invented files or unsupported claims."
+  ]
+}

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/redaction_report.md
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/redaction_report.md
@@ -1,0 +1,7 @@
+# Redaction Report
+
+- publication_status: internal_only
+- private prompts: none included
+- customer code: none included
+- absolute host paths: none included
+- raw outputs limited to fixture summaries and validator notes

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/run_manifest.json
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/run_manifest.json
@@ -1,0 +1,27 @@
+{
+  "run_id": "wp09-capability-aptitude-fixture-run-v1",
+  "started_at": "2026-05-09T00:00:00Z",
+  "completed_at": "2026-05-09T00:00:00Z",
+  "operator": "codex",
+  "subject_id": "fixture_subject.adl_evaluation_slice",
+  "test_manifest": "test_manifest.json",
+  "output_paths": [
+    "subject_manifest.json",
+    "test_manifest.json",
+    "run_manifest.json",
+    "scorecard.json",
+    "final_report.md",
+    "evaluator_notes.md",
+    "redaction_report.md",
+    "raw_outputs/contract_following.json",
+    "raw_outputs/review_aptitude.json",
+    "raw_outputs/planning_aptitude.json"
+  ],
+  "validation_commands": [
+    "cargo test --manifest-path adl/Cargo.toml capability_aptitude_testing -- --nocapture",
+    "cargo test --manifest-path adl/Cargo.toml demo_v0911_capability_aptitude_testing -- --nocapture",
+    "git diff --check"
+  ],
+  "evaluator": "adl.wp09.fixture_harness",
+  "rerun_of": null
+}

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/scorecard.json
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/scorecard.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "capability_aptitude_testing.v1",
+  "evaluation_subject": "fixture_subject.adl_evaluation_slice",
+  "family_scorecards": [
+    {
+      "subject_id": "fixture_subject.adl_evaluation_slice",
+      "test_family": "contract_following",
+      "overall_band": "strong",
+      "confidence": "fixture_high",
+      "dimension_scores": [
+        {
+          "dimension": "structural_compliance",
+          "band": "strong",
+          "note": "Fixture path preserves branch/worktree truth without hidden edits."
+        },
+        {
+          "dimension": "instruction_fidelity",
+          "band": "strong",
+          "note": "Bounded contracts remain explicit and reviewable."
+        },
+        {
+          "dimension": "scope_control",
+          "band": "adequate",
+          "note": "Execution still requires human review to prevent issue-overhead drift."
+        }
+      ],
+      "strengths": [
+        "Preserves issue-local workflow constraints.",
+        "Keeps blocker/refusal paths explicit."
+      ],
+      "failure_modes": [
+        "Workflow wrappers may hang without surfacing a refusal."
+      ],
+      "false_positive_notes": [
+        "No universal trust claim is made from fixture-mode execution."
+      ],
+      "false_negative_notes": [
+        "Live operator friction is only partially modeled in fixture mode."
+      ],
+      "repair_burden": "bounded manual cleanup when wrappers drift",
+      "recommended_use": [
+        "Early lifecycle contract checks",
+        "Sprint readiness gating"
+      ],
+      "discouraged_use": [
+        "Universal model ranking",
+        "Autonomous release approval"
+      ],
+      "caveats": [
+        "Fixture mode measures bounded contract behavior, not broad intelligence."
+      ]
+    },
+    {
+      "subject_id": "fixture_subject.adl_evaluation_slice",
+      "test_family": "review_aptitude",
+      "overall_band": "strong",
+      "confidence": "fixture_medium",
+      "dimension_scores": [
+        {
+          "dimension": "true_positive_detection",
+          "band": "strong",
+          "note": "Findings-first review packet shape is preserved."
+        },
+        {
+          "dimension": "false_positive_restraint",
+          "band": "adequate",
+          "note": "Still depends on explicit review policy and human merge review."
+        },
+        {
+          "dimension": "remediation_usefulness",
+          "band": "strong",
+          "note": "Issue-local remediation direction remains concrete and bounded."
+        }
+      ],
+      "strengths": [
+        "Can express evidence-backed findings cleanly.",
+        "Supports bounded subagent review loops."
+      ],
+      "failure_modes": [
+        "Review value drops when lifecycle truth surfaces drift."
+      ],
+      "false_positive_notes": [
+        "Fixture avoids grading prose flair as review quality."
+      ],
+      "false_negative_notes": [
+        "Does not yet model full repo-wide review breadth."
+      ],
+      "repair_burden": "moderate when stale cards or review packets must be normalized",
+      "recommended_use": [
+        "Pre-PR review packet comparisons",
+        "Evidence-backed review skill trials"
+      ],
+      "discouraged_use": [
+        "Security certification",
+        "Customer-facing leaderboard claims"
+      ],
+      "caveats": [
+        "This slice proves reportability and scoring shape, not complete review coverage."
+      ]
+    },
+    {
+      "subject_id": "fixture_subject.adl_evaluation_slice",
+      "test_family": "planning_aptitude",
+      "overall_band": "adequate",
+      "confidence": "fixture_medium",
+      "dimension_scores": [
+        {
+          "dimension": "decomposition_quality",
+          "band": "strong",
+          "note": "Sprint/issue sequencing is explicit and reusable."
+        },
+        {
+          "dimension": "milestone_fit",
+          "band": "adequate",
+          "note": "Milestone discipline still needs active truth checks."
+        },
+        {
+          "dimension": "promotion_defer_judgment",
+          "band": "adequate",
+          "note": "Tooling issues must still be surfaced separately to avoid sprint drag."
+        }
+      ],
+      "strengths": [
+        "Captures dependencies and non-goals in durable cards.",
+        "Supports a reportable, reviewable planning trail."
+      ],
+      "failure_modes": [
+        "Workflow instability can consume sprint time before issue execution starts."
+      ],
+      "false_positive_notes": [
+        "Does not confuse planning polish with successful execution."
+      ],
+      "false_negative_notes": [
+        "Cannot yet score long-horizon delivery outcomes automatically."
+      ],
+      "repair_burden": "moderate when sprint state or closeout truth drifts",
+      "recommended_use": [
+        "Sprint planning comparisons",
+        "Issue-wave readiness trials"
+      ],
+      "discouraged_use": [
+        "Universal capability ranking",
+        "Standalone product marketing claims"
+      ],
+      "caveats": [
+        "Planning aptitude here is bounded to ADL workflow execution, not general strategy."
+      ]
+    }
+  ],
+  "limitations": [
+    "Fixture mode does not compare real provider/model runs yet.",
+    "WP-10 still owns intelligence-specific metric architecture.",
+    "No reputation or leaderboard output is produced in this slice."
+  ],
+  "non_claims": [
+    "Does not prove universal intelligence.",
+    "Does not certify production fitness.",
+    "Does not publish a public leaderboard row."
+  ]
+}

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/subject_manifest.json
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/subject_manifest.json
@@ -1,0 +1,20 @@
+{
+  "subject_id": "fixture_subject.adl_evaluation_slice",
+  "subject_type": "fixture_mode_harness",
+  "model": "not_applicable",
+  "provider": "deterministic_fixture",
+  "model_version_or_tag": "wp09-fixture-v1",
+  "runtime_environment": "repo_local_fixture_mode",
+  "tool_access": [
+    "repo_shell",
+    "structured_prompt_validators",
+    "focused_tests"
+  ],
+  "skill_scaffolding": [
+    "workflow-conductor",
+    "sprint-conductor",
+    "review-subagent-policy"
+  ],
+  "context_limits": "bounded_issue_local_fixture_inputs",
+  "privacy_mode": "redacted_fixture_only"
+}

--- a/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/test_manifest.json
+++ b/docs/milestones/v0.91.1/review/capability_aptitude_testing_fixture/test_manifest.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "capability_aptitude_testing.v1",
+  "manifests": [
+    {
+      "test_family": "contract_following",
+      "fixture_id": "wp09-contract-following-fixture",
+      "fixture_version": "v1",
+      "task_contract": "Correct or classify bounded card-state drift without inventing progress.",
+      "expected_evidence": [
+        "structured card normalization",
+        "blocked-state honesty",
+        "scope restraint"
+      ],
+      "trap_cases": [
+        "dirty root checkout temptation",
+        "merged-claim without PR"
+      ],
+      "scoring_dimensions": [
+        "structural_compliance",
+        "instruction_fidelity",
+        "scope_control"
+      ],
+      "publication_status": "internal_only"
+    },
+    {
+      "test_family": "review_aptitude",
+      "fixture_id": "wp09-review-aptitude-fixture",
+      "fixture_version": "v1",
+      "task_contract": "Produce findings-first review output with evidence and restrained false positives.",
+      "expected_evidence": [
+        "severity calibration",
+        "evidence backed findings",
+        "non-finding restraint"
+      ],
+      "trap_cases": [
+        "intentional false trail",
+        "clean file should emit no findings"
+      ],
+      "scoring_dimensions": [
+        "true_positive_detection",
+        "false_positive_restraint",
+        "remediation_usefulness"
+      ],
+      "publication_status": "internal_only"
+    },
+    {
+      "test_family": "planning_aptitude",
+      "fixture_id": "wp09-planning-aptitude-fixture",
+      "fixture_version": "v1",
+      "task_contract": "Decompose bounded work into sequenced execution without widening scope.",
+      "expected_evidence": [
+        "dependency recognition",
+        "non-goal clarity",
+        "validation planning"
+      ],
+      "trap_cases": [
+        "backlog-only request should not create public issues",
+        "v0.92 scope should remain deferred"
+      ],
+      "scoring_dimensions": [
+        "decomposition_quality",
+        "milestone_fit",
+        "promotion_defer_judgment"
+      ],
+      "publication_status": "internal_only"
+    }
+  ]
+}


### PR DESCRIPTION
---
issue_card_schema: adl.issue.v1
wp: "WP-09"
queue: "wp"
slug: "v0-91-1-wp-09-capability-and-aptitude-testing-foundation"
title: "[v0.91.1][WP-09][tools] Capability and aptitude testing foundation"
labels:
  - "track:roadmap"
  - "type:task"
  - "area:tools"
  - "version:v0.91.1"
issue_number: 2831
status: "draft"
action: "edit"
depends_on: []
milestone_sprint: "Pending sprint assignment"
required_outcome_type:
  - "code"
repo_inputs: []
canonical_files: []
demo_required: false
demo_names: []
issue_graph_notes:
  - "Mirrored from the authored GitHub issue body during bootstrap/init."
pr_start:
  enabled: false
  slug: "v0-91-1-wp-09-capability-and-aptitude-testing-foundation"
---

## Summary

Open the v0.91.1 WP-09 work package: Capability and aptitude testing foundation.

## Goal

Produce the v0.91.1 WP-09 outcome: first executable capability harness and report.

## Real Contribution Requirement

This issue must deliver a real, downstream-consumable work product. Do not close
it with half-work, naming-only cleanup, or planning-only prose. If the title
uses "foundation", that means the first implemented and validated slice:
schemas, fixtures, tests, executable tooling, demo evidence, review records, or
other durable artifacts that later WPs can directly consume.

## Required Outcome

- First executable capability/aptitude test harness slice.
- Report and scorecard shape with limitations.
- Fixture set for at least three test families.

## Deliverables

- First executable capability/aptitude test harness slice.
- Report and scorecard shape with limitations.
- Fixture set for at least three test families.

## Acceptance Criteria

- Results distinguish capability evidence from ranking or reputation.
- Harness output is deterministic in fixture mode.

## Repo Inputs

- docs/milestones/v0.91.1/README.md
- docs/milestones/v0.91.1/WP_ISSUE_WAVE_v0.91.1.yaml
- docs/milestones/v0.91.1/WP_EXECUTION_READINESS_v0.91.1.md
- docs/milestones/v0.91.1/WBS_v0.91.1.md
- docs/milestones/v0.91.1/SPRINT_v0.91.1.md
- docs/milestones/v0.91.1/features/CAPABILITY_APTITUDE_TESTING.md

## Dependencies

WP-02, WP-03, WP-06

## Target Files / Surfaces

- The implementation, docs, tests, fixtures, demos, or review surfaces required by the accepted v0.91.1 readiness section.
- Keep all paths repo-relative.
- Update milestone tracking docs if the executed scope changes.

## Validation Plan

- Results distinguish capability evidence from ranking or reputation.
- Harness output is deterministic in fixture mode.
- Run the smallest meaningful focused validation for the changed surface.
- Run release/version/doc hygiene checks when tracked release or milestone docs change.

## Demo / Proof Requirements

No flagship demo is required unless implementation creates a proof surface; preserve any demo/proof notes in the relevant milestone docs.

## Demo Expectations

No flagship demo is required unless implementation creates a proof surface; preserve any demo/proof notes in the relevant milestone docs.

## Non-goals

- Do not claim v0.92 birthday completion.
- Do not implement cross-polis or external communication without TLS or mutual-TLS-equivalent protection.
- Do not bypass lifecycle state, Freedom Gate, ACC, trace, redaction, or review boundaries.
- Do not close with planning-only work unless this WP is explicitly a design, review, or release-tail WP.

## Issue-Graph Notes

- Milestone: v0.91.1.
- Work package: WP-09.
- Queue: tools.
- Depends on: WP-02, WP-03, WP-06.
- This issue is part of the v0.91.1 inhabited-runtime readiness wave opened by WP-01 / #2823.

## Notes

Use the conductor and the relevant editor skills. Keep STP, SIP, SPP, SRP, and SOR cards truthful before execution and at closeout.

## Tooling Notes

- Use `adl/tools/pr.sh` through the ADL conductor workflow.
- Validate structured cards before execution.
- Prefer focused tests and proof commands over broad reruns unless the changed surface requires them.




Closes #2831
