### PR TITLE
[v0.91.1][demo] Add per-speaker EQ and dynamics polish to podcast audio

### DIFF
--- a/adl/tools/demo_v0911_multiagent_podcast_audio.sh
+++ b/adl/tools/demo_v0911_multiagent_podcast_audio.sh
@@ -224,6 +224,11 @@ compression_threshold = 11000
 compression_ratio = 2.25
 final_mix_target_rms = 3350.0
 final_mix_ceiling = 26500
+speaker_tone_profiles = {
+    'ChatGPT': {'low_gain': -0.05, 'high_gain': 0.09, 'makeup_gain': 1.02},
+    'Gemini': {'low_gain': -0.02, 'high_gain': -0.03, 'makeup_gain': 0.99},
+    'Claude': {'low_gain': -0.08, 'high_gain': 0.05, 'makeup_gain': 1.01},
+}
 
 def compress_pcm_16le(frames: bytes) -> bytes:
     samples = array('h')
@@ -271,6 +276,37 @@ def measure_pcm_16le(frames: bytes) -> tuple[float, int]:
     peak = max(abs(int(s)) for s in samples)
     return rms, peak
 
+def shape_voice_pcm_16le(frames: bytes, speaker: str) -> bytes:
+    profile = speaker_tone_profiles.get(speaker)
+    if profile is None:
+        return frames
+    samples = array('h')
+    samples.frombytes(frames)
+    if sys.byteorder != 'little':
+        samples.byteswap()
+    if not samples:
+        return frames
+
+    low_state = 0.0
+    low_alpha = 0.075
+    for i, sample in enumerate(samples):
+        x = float(sample)
+        low_state += low_alpha * (x - low_state)
+        low = low_state
+        high = x - low
+        shaped = x + (profile['low_gain'] * low) + (profile['high_gain'] * high)
+        shaped *= profile['makeup_gain']
+        value = int(round(shaped))
+        if value > 32767:
+            value = 32767
+        elif value < -32768:
+            value = -32768
+        samples[i] = value
+
+    if sys.byteorder != 'little':
+        samples.byteswap()
+    return samples.tobytes()
+
 def normalize_pcm_16le(frames: bytes, target_rms: float, rate: int, duck_intro: bool) -> bytes:
     samples = array('h')
     samples.frombytes(frames)
@@ -317,6 +353,7 @@ for entry in segments:
     if current_params[1] == 2:
         target_rms = speaker_target_rms.get(entry['speaker'], 3800.0)
         duck_intro = entry['speaker'] not in seen_speakers
+        frames = shape_voice_pcm_16le(frames, entry['speaker'])
         frames = normalize_pcm_16le(frames, target_rms, current_params[2], duck_intro)
         frames = compress_pcm_16le(frames)
         frames = limit_pcm_16le(frames, final_mix_ceiling)
@@ -360,6 +397,7 @@ manifest = {
     'episode_audio': Path(episode_audio_path).name,
     'mastering': {
         'segment_target_rms': speaker_target_rms,
+        'speaker_tone_profiles': speaker_tone_profiles,
         'final_mix_target_rms': final_mix_target_rms,
         'final_mix_ceiling': final_mix_ceiling,
         'compression_threshold': compression_threshold,

--- a/demos/v0.91.1/multiagent_podcast_audio_demo.md
+++ b/demos/v0.91.1/multiagent_podcast_audio_demo.md
@@ -21,7 +21,8 @@ This audio follow-on proves:
 - `Claude` can be rendered truthfully through a surrogate TTS lane while
   preserving Claude transcript authorship identity
 - the audio can be presented in a listener-friendly way with spoken speaker
-  intros, saved loudness metrics, and bounded mastering/limiting
+  intros, saved loudness metrics, bounded mastering/limiting, and mild
+  per-speaker tonal shaping
 
 It does **not** prove:
 
@@ -106,6 +107,7 @@ The audio follow-on is successful when:
 - per-turn audio segments exist with explicit speaker routing
 - the manifest shows which provider/voice rendered each speaker
 - the manifest records usable loudness/mastering metrics for the final mix
+- the manifest records the bounded per-speaker tone-profile settings used for the run
 - Claude's surrogate rendering is disclosed instead of implied away
 - each speaker introduces themselves naturally only on their first turn, for example `I'm ChatGPT`
 - overall segment volume is normalized enough that the episode does not feel


### PR DESCRIPTION
Closes #2923

## Summary
Added bounded per-speaker tonal shaping to the podcast audio wrapper so the three voices sound more coherent as one ensemble while remaining distinguishable and truthfully disclosed in the manifest.

## Artifacts
- Updated wrapper: `adl/tools/demo_v0911_multiagent_podcast_audio.sh`
- Updated demo doc: `demos/v0.91.1/multiagent_podcast_audio_demo.md`
- Verified audio packet: `artifacts/v0911/multiagent_podcast_pilot_audio_verified/episode.wav`
- Verified audio manifest: `artifacts/v0911/multiagent_podcast_pilot_audio_verified/audio_manifest.json`
- Verified audio packet note: `artifacts/v0911/multiagent_podcast_pilot_audio_verified/audio_packet.md`

## Validation
- Validation commands and their purpose:
  - `ADL_PODCAST_GEMINI_AUDIO_PROVIDER=openai bash adl/tools/demo_v0911_multiagent_podcast_audio.sh artifacts/v0911/multiagent_podcast_pilot_audio_verified`
    Regenerated the verified audio packet and proved the bounded tone-shaping path end-to-end.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2923__v0-91-1-demo-add-per-speaker-eq-and-dynamics-polish-to-podcast-audio/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2923__v0-91-1-demo-add-per-speaker-eq-and-dynamics-polish-to-podcast-audio/sor.md
- Idempotency-Key: v0-91-1-demo-add-per-speaker-eq-and-dynamics-polish-to-podcast-audio-adl-v0-91-1-tasks-issue-2923-v0-91-1-demo-add-per-speaker-eq-and-dynamics-polish-to-podcast-audio-sip-md-adl-v0-91-1-tasks-issue-2923-v0-91-1-demo-add-per-speaker-eq-and-dynamics-polish-to-podcast-audio-sor-md