### PR TITLE
[v0.91.1][tools] Fix pr run worktree bundle materialization gap

### DIFF
--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -193,9 +193,13 @@ pub(crate) fn ensure_bootstrap_cards(
     }
     if !bundle_plan.is_file() {
         write_plan_card(root, &bundle_plan, issue_ref, title, branch)?;
+    } else if field_line_value(&bundle_plan, "branch")?.trim() != branch {
+        replace_field_line_in_file(&bundle_plan, "branch", &format!("\"{branch}\""))?;
     }
     if !bundle_review_policy.is_file() {
         write_review_policy_card(root, &bundle_review_policy, issue_ref, title, branch)?;
+    } else if field_line_value(&bundle_review_policy, "branch")?.trim() != branch {
+        replace_field_line_in_file(&bundle_review_policy, "branch", &format!("\"{branch}\""))?;
     }
 
     let cards_root = resolve_cards_root(root, None);

--- a/adl/src/cli/pr_cmd_cards/shared.rs
+++ b/adl/src/cli/pr_cmd_cards/shared.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 
 #[cfg(unix)]
 use std::os::unix::fs as unix_fs;
@@ -199,15 +199,39 @@ pub(crate) fn run_capture_allow_failure(program: &str, args: &[&str]) -> Result<
     }
 }
 
-pub(crate) fn run_status(program: &str, args: &[&str]) -> Result<()> {
-    let status = Command::new(program)
-        .args(args)
+fn current_adl_tooling_bin() -> Option<PathBuf> {
+    let current = std::env::current_exe().ok()?;
+    let file_name = current.file_name()?.to_str()?;
+    if file_name != "adl" {
+        return None;
+    }
+    Some(current)
+}
+
+pub(crate) fn run_status_with_adl_tooling_bin(program: &str, args: &[&str]) -> Result<()> {
+    let mut command = Command::new(program);
+    command.args(args);
+    if let Some(bin) = current_adl_tooling_bin() {
+        command.env("ADL_TOOLING_RUST_BIN", bin);
+    }
+    let status = command
         .status()
         .with_context(|| format!("failed to spawn '{program}'"))?;
     if !status.success() {
         bail!("{program} failed with status {:?}", status.code());
     }
     Ok(())
+}
+
+pub(crate) fn run_output_with_adl_tooling_bin(program: &str, args: &[&str]) -> Result<Output> {
+    let mut command = Command::new(program);
+    command.args(args);
+    if let Some(bin) = current_adl_tooling_bin() {
+        command.env("ADL_TOOLING_RUST_BIN", bin);
+    }
+    command
+        .output()
+        .with_context(|| format!("failed to spawn '{program}'"))
 }
 
 pub(crate) fn write_temp_markdown(prefix: &str, body: &str) -> Result<PathBuf> {

--- a/adl/src/cli/pr_cmd_cards/validation.rs
+++ b/adl/src/cli/pr_cmd_cards/validation.rs
@@ -1,9 +1,10 @@
+use super::shared::{
+    field_line_value, output_card_title_matches_slug, path_str, run_output_with_adl_tooling_bin,
+    run_status_with_adl_tooling_bin,
+};
 use anyhow::{bail, Context, Result};
 use serde_yaml::Value;
 use std::path::Path;
-use std::process::Command;
-
-use super::shared::{field_line_value, output_card_title_matches_slug, path_str, run_status};
 
 pub(crate) struct StructuredBundlePaths<'a> {
     pub(crate) plan_path: &'a Path,
@@ -12,16 +13,16 @@ pub(crate) struct StructuredBundlePaths<'a> {
 
 pub(crate) fn validate_bootstrap_stp(repo_root: &Path, path: &Path) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
-    let output = Command::new("bash")
-        .args([
+    let output = run_output_with_adl_tooling_bin(
+        "bash",
+        &[
             path_str(&validator)?,
             "--type",
             "stp",
             "--input",
             path_str(path)?,
-        ])
-        .output()
-        .with_context(|| "failed to spawn 'bash'")?;
+        ],
+    )?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -143,7 +144,7 @@ pub(crate) fn validate_bootstrap_cards(
     structured_paths: StructuredBundlePaths<'_>,
 ) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
-    run_status(
+    run_status_with_adl_tooling_bin(
         "bash",
         &[
             path_str(&validator)?,
@@ -155,7 +156,7 @@ pub(crate) fn validate_bootstrap_cards(
             path_str(input_path)?,
         ],
     )?;
-    run_status(
+    run_status_with_adl_tooling_bin(
         "bash",
         &[
             path_str(&validator)?,
@@ -213,7 +214,7 @@ pub(crate) fn validate_bootstrap_output_card(
     output_path: &Path,
 ) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
-    run_status(
+    run_status_with_adl_tooling_bin(
         "bash",
         &[
             path_str(&validator)?,
@@ -256,16 +257,16 @@ pub(crate) fn validate_structured_artifact(
     kind: &str,
 ) -> Result<()> {
     let validator = repo_root.join("adl/tools/validate_structured_prompt.sh");
-    let output = Command::new("bash")
-        .args([
+    let output = run_output_with_adl_tooling_bin(
+        "bash",
+        &[
             path_str(&validator)?,
             "--type",
             kind,
             "--input",
             path_str(path)?,
-        ])
-        .output()
-        .with_context(|| "failed to spawn 'bash'")?;
+        ],
+    )?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -228,6 +228,7 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     assert!(issue_ref.task_bundle_output_path(&repo).is_file());
     assert!(issue_ref.task_bundle_plan_path(&repo).is_file());
     assert!(issue_ref.task_bundle_review_policy_path(&repo).is_file());
+    assert!(issue_ref.issue_prompt_path(&worktree).is_file());
     assert!(issue_ref.task_bundle_stp_path(&worktree).is_file());
     assert!(issue_ref.task_bundle_input_path(&worktree).is_file());
     assert!(issue_ref.task_bundle_output_path(&worktree).is_file());
@@ -370,6 +371,7 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
 
     env::set_current_dir(prev_dir).expect("restore cwd");
 
+    assert!(issue_ref.issue_prompt_path(&worktree).is_file());
     assert!(issue_ref.worktree_task_bundle_stp_path(&worktree).is_file());
     assert!(issue_ref
         .worktree_task_bundle_input_path(&worktree)
@@ -383,6 +385,185 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
     assert!(issue_ref
         .worktree_task_bundle_review_policy_path(&worktree)
         .is_file());
+}
+
+#[test]
+fn real_pr_start_updates_existing_root_spp_and_srp_branch() {
+    let _guard = env_lock();
+    let temp = unique_temp_dir("adl-pr-start-updates-root-plan-review-branch");
+    let origin = temp.join("origin.git");
+    let repo = temp.join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(
+        repo.join("README.md"),
+        "update root plan/review branch test\n",
+    )
+    .expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-q",
+            path_str(&origin).expect("origin path")
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git init bare")
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            path_str(&origin).expect("origin path"),
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+    assert!(Command::new("git")
+        .args(["push", "-q", "-u", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git push")
+        .success());
+    assert!(Command::new("git")
+        .args(["fetch", "-q", "origin", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git fetch")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let issue_ref =
+        IssueRef::new(1154, "v0.86", "update-root-plan-review-branch").expect("issue ref");
+    write_authored_issue_prompt(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Update root plan and review branch",
+    );
+
+    real_pr(&[
+        "init".to_string(),
+        "1154".to_string(),
+        "--slug".to_string(),
+        "update-root-plan-review-branch".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Update root plan and review branch".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr init");
+
+    let branch = "codex/1154-update-root-plan-review-branch";
+    assert!(fs::read_to_string(issue_ref.task_bundle_plan_path(&repo))
+        .expect("read root spp")
+        .contains("branch: \"not bound yet\""));
+    assert!(
+        fs::read_to_string(issue_ref.task_bundle_review_policy_path(&repo))
+            .expect("read root srp")
+            .contains("branch: \"not bound yet\"")
+    );
+
+    real_pr(&[
+        "start".to_string(),
+        "1154".to_string(),
+        "--slug".to_string(),
+        "update-root-plan-review-branch".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Update root plan and review branch".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect("real_pr start");
+
+    let worktree = issue_ref.default_worktree_path(&repo, None);
+    let root_sip = issue_ref.task_bundle_input_path(&repo);
+    let wt_sip = issue_ref.task_bundle_input_path(&worktree);
+    let source_path = issue_ref.issue_prompt_path(&repo);
+    write_authored_sip(
+        &root_sip,
+        &issue_ref,
+        "[v0.86][tools] Update root plan and review branch",
+        branch,
+        &source_path,
+        &repo,
+    );
+    write_authored_sip(
+        &wt_sip,
+        &issue_ref,
+        "[v0.86][tools] Update root plan and review branch",
+        branch,
+        &issue_ref.issue_prompt_path(&worktree),
+        &worktree,
+    );
+
+    let ready = real_pr(&[
+        "ready".to_string(),
+        "1154".to_string(),
+        "--slug".to_string(),
+        "update-root-plan-review-branch".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ]);
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    ready.expect("real_pr ready");
+    assert!(fs::read_to_string(issue_ref.task_bundle_plan_path(&repo))
+        .expect("read updated root spp")
+        .contains(&format!("branch: \"{branch}\"")));
+    assert!(
+        fs::read_to_string(issue_ref.task_bundle_review_policy_path(&repo))
+            .expect("read updated root srp")
+            .contains(&format!("branch: \"{branch}\""))
+    );
+    assert!(
+        fs::read_to_string(issue_ref.task_bundle_plan_path(&worktree))
+            .expect("read worktree spp")
+            .contains(&format!("branch: \"{branch}\""))
+    );
+    assert!(
+        fs::read_to_string(issue_ref.task_bundle_review_policy_path(&worktree))
+            .expect("read worktree srp")
+            .contains(&format!("branch: \"{branch}\""))
+    );
 }
 
 #[test]

--- a/adl/tools/test_pr_run_materializes_worktree_cards.sh
+++ b/adl/tools/test_pr_run_materializes_worktree_cards.sh
@@ -52,8 +52,108 @@ chmod +x "$repo/adl/tools/pr.sh" "$repo/adl/tools/lint_prompt_spec.sh" "$repo/ad
 
 (
   cd "$repo"
+  mkdir -p .adl/v0.86/bodies
+  cat > .adl/v0.86/bodies/issue-910-validation-pass.md <<'EOF'
+---
+issue_card_schema: adl.issue.v1
+wp: "unassigned"
+queue: "tools"
+slug: "validation-pass"
+title: "[v0.86][tools] Validation pass"
+labels:
+  - "track:roadmap"
+  - "type:task"
+  - "area:tools"
+  - "version:v0.86"
+issue_number: 910
+status: "draft"
+action: "edit"
+depends_on: []
+milestone_sprint: "Test sprint"
+required_outcome_type:
+  - "code"
+repo_inputs:
+  - "adl/tools/pr.sh"
+canonical_files:
+  - "adl/tools/pr.sh"
+demo_required: false
+demo_names: []
+issue_graph_notes:
+  - "Regression proof for worktree-local bundle materialization."
+pr_start:
+  enabled: false
+  slug: "validation-pass"
+---
+
+## Summary
+
+Regression proof for issue-mode run bundle materialization.
+
+## Goal
+
+Make the issue-mode run binder leave a complete local worktree issue surface.
+
+## Required Outcome
+
+- local issue prompt copy exists in the worktree
+- local task bundle cards exist in the worktree
+
+## Deliverables
+
+- local issue prompt copy
+- local `stp.md`, `sip.md`, `sor.md`, `spp.md`, and `srp.md`
+
+## Acceptance Criteria
+
+- `pr run <issue>` creates the local issue prompt copy
+- `pr run <issue>` creates `stp.md`, `sip.md`, `sor.md`, `spp.md`, and `srp.md`
+
+## Repo Inputs
+
+- `adl/tools/pr.sh`
+
+## Dependencies
+
+None.
+
+## Target Files / Surfaces
+
+- issue-mode bind lifecycle
+
+## Validation Plan
+
+- run `adl/tools/pr.sh run 910 ...`
+
+## Demo / Proof Requirements
+
+None.
+
+## Demo Expectations
+
+None.
+
+## Non-goals
+
+- none
+
+## Issue-Graph Notes
+
+- shell regression only
+
+## Notes
+
+- authored issue prompt required
+
+## Tooling Notes
+
+- keep the proof focused
+EOF
   export ADL_PR_RUST_BIN="$REAL_ADL_BIN"
   "$BASH_BIN" adl/tools/pr.sh run 910 --slug validation-pass --no-fetch-issue --version v0.86 --allow-open-pr-wave >/dev/null
+  [[ -f ".worktrees/adl-wp-910/.adl/v0.86/bodies/issue-910-validation-pass.md" ]] || {
+    echo "assertion failed: expected run to materialize worktree-local issue prompt" >&2
+    exit 1
+  }
   [[ -f ".worktrees/adl-wp-910/.adl/v0.86/tasks/issue-0910__validation-pass/stp.md" ]] || {
     echo "assertion failed: expected run to materialize worktree-local stp.md" >&2
     exit 1
@@ -64,6 +164,14 @@ chmod +x "$repo/adl/tools/pr.sh" "$repo/adl/tools/lint_prompt_spec.sh" "$repo/ad
   }
   [[ -f ".worktrees/adl-wp-910/.adl/v0.86/tasks/issue-0910__validation-pass/sor.md" ]] || {
     echo "assertion failed: expected run to materialize worktree-local sor.md" >&2
+    exit 1
+  }
+  [[ -f ".worktrees/adl-wp-910/.adl/v0.86/tasks/issue-0910__validation-pass/spp.md" ]] || {
+    echo "assertion failed: expected run to materialize worktree-local spp.md" >&2
+    exit 1
+  }
+  [[ -f ".worktrees/adl-wp-910/.adl/v0.86/tasks/issue-0910__validation-pass/srp.md" ]] || {
+    echo "assertion failed: expected run to materialize worktree-local srp.md" >&2
     exit 1
   }
 )


### PR DESCRIPTION
## Summary
- stop Rust-owned start/run validation from falling back to hanging `cargo run` validator subprocesses when the running `adl` binary is already available
- update existing root `SPP`/`SRP` branch fields during `start` so pre-run bundles become truthfully ready after bind
- strengthen direct run/start regression coverage for worktree-local issue prompt and full bundle materialization

## Validation
- `bash adl/tools/test_pr_run_materializes_worktree_cards.sh`
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_repairs_preexisting_worktree_missing_task_bundle -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_updates_existing_root_spp_and_srp_branch -- --nocapture`
- `ADL_PR_RUST_BIN=.worktrees/adl-wp-2921/adl/target/debug/adl adl/tools/pr.sh run 2921 --no-fetch-issue --version v0.91.1`
- `ADL_PR_RUST_BIN=.worktrees/adl-wp-2921/adl/target/debug/adl adl/tools/pr.sh doctor 2921 --mode ready --no-fetch-issue --version v0.91.1`
- `git diff --check`

Closes #2921
