### PR TITLE
[v0.91.1][demo] Fix broadcast-audio mini-sprint review findings

### DIFF
--- a/adl/tools/demo_v0911_multiagent_podcast_audio.sh
+++ b/adl/tools/demo_v0911_multiagent_podcast_audio.sh
@@ -181,13 +181,55 @@ for spec in "${TURN_FILES[@]}"; do
   IFS='|' read -r filename speaker role voice provider surrogate instructions <<< "$spec"
   original_text="$(cat "$SOURCE_DIR/out/podcast/$filename")"
   if [[ "$SPEAKERS_INTRODUCED" != *"|$speaker|"* ]]; then
-    text="I'm ${speaker}. ${original_text}"
+    if python3 - "$speaker" "$original_text" <<'PY'
+import re
+import sys
+
+speaker = sys.argv[1].strip().lower()
+text = sys.argv[2].strip().lower().replace("’", "'").replace("‘", "'")
+pattern = r"^['\"“”‘’\s-]*(i\s*'m|i\s+am)\s+" + re.escape(speaker) + r"([\s\.,;:!?-]|$)"
+sys.exit(0 if re.match(pattern, text) else 1)
+PY
+    then
+      text="$original_text"
+    else
+      text="I'm ${speaker}. ${original_text}"
+    fi
     SPEAKERS_INTRODUCED="${SPEAKERS_INTRODUCED}${speaker}|"
   else
     text="$original_text"
   fi
   out_wav="$SEGMENTS_DIR/${filename%.md}.wav"
-  if [[ "$provider" == "openai" ]]; then
+  if [[ "${ADL_PODCAST_AUDIO_TEST_TONES:-0}" == "1" ]]; then
+    python3 - "$out_wav" "$speaker" <<'PY'
+import math
+import struct
+import sys
+import wave
+
+out_path, speaker = sys.argv[1:3]
+rate = 24000
+duration = 1.2
+freq_map = {
+    'ChatGPT': 220.0,
+    'Gemini': 330.0,
+    'Claude': 262.0,
+}
+freq = freq_map.get(speaker, 247.0)
+amplitude = 9800
+frame_count = int(rate * duration)
+
+with wave.open(out_path, 'wb') as wf:
+    wf.setnchannels(1)
+    wf.setsampwidth(2)
+    wf.setframerate(rate)
+    frames = bytearray()
+    for i in range(frame_count):
+        sample = int(round(amplitude * math.sin(2.0 * math.pi * freq * (i / rate))))
+        frames.extend(struct.pack('<h', sample))
+    wf.writeframes(bytes(frames))
+PY
+  elif [[ "$provider" == "openai" ]]; then
     render_openai_wav "$text" "$voice" "$instructions" "$out_wav"
   elif [[ "$provider" == "gemini" ]]; then
     render_gemini_wav "$text" "$voice" "$out_wav"
@@ -421,6 +463,9 @@ for entry in segments:
     combined.append(frames)
     seen_speakers.add(entry['speaker'])
 channels, width, rate = params
+speech_only_rms = None
+speech_only_peak = None
+speech_only_frames = b''.join(combined)
 assembled_frames = b''
 for idx, frames in enumerate(combined):
     assembled_frames += frames
@@ -433,6 +478,7 @@ pre_mix_peak = None
 post_mix_rms = None
 post_mix_peak = None
 if width == 2:
+    speech_only_rms, speech_only_peak = measure_pcm_16le(speech_only_frames)
     pre_mix_rms, pre_mix_peak = measure_pcm_16le(assembled_frames)
     assembled_frames = normalize_pcm_16le(assembled_frames, final_mix_target_rms, rate, False)
     assembled_frames = compress_pcm_16le(assembled_frames)
@@ -450,15 +496,24 @@ manifest = {
     'mastering': {
         'segment_target_rms': speaker_target_rms,
         'speaker_tone_profiles': speaker_tone_profiles,
-        'fallback_casting': {
+        'active_rendering': {
+            'ChatGPT': {'provider': 'openai', 'voice': chatgpt_voice, 'mode': 'native'},
+            'Gemini': {
+                'provider': gemini_provider,
+                'voice': gemini_voice if gemini_provider == 'gemini' else gemini_openai_voice,
+                'mode': 'native' if gemini_provider == 'gemini' else 'surrogate',
+            },
+            'Claude': {'provider': claude_provider, 'voice': claude_voice, 'mode': 'surrogate'},
+        },
+        'available_fallback_casting': {
             'ChatGPT': {
                 'native': {'provider': 'openai', 'voice': chatgpt_voice},
             },
             'Gemini': {
                 'native': {'provider': 'gemini', 'voice': gemini_voice},
                 'surrogate': {
-                    'provider': gemini_provider,
-                    'voice': gemini_openai_voice if gemini_provider == 'openai' else gemini_voice,
+                    'provider': 'openai',
+                    'voice': gemini_openai_voice,
                     'intent': 'bright, quick, lightly androgynous analytical contrast',
                 },
             },
@@ -475,7 +530,11 @@ manifest = {
         'compression_threshold': compression_threshold,
         'compression_ratio': compression_ratio,
         'intro_duck_ms': intro_duck_ms,
-        'final_mix_metrics': {
+        'speech_only_input_metrics': {
+            'rms': round(speech_only_rms, 1) if speech_only_rms is not None else None,
+            'peak': speech_only_peak,
+        },
+        'full_episode_mix_metrics': {
             'pre_rms': round(pre_mix_rms, 1) if pre_mix_rms is not None else None,
             'pre_peak': pre_mix_peak,
             'post_rms': round(post_mix_rms, 1) if post_mix_rms is not None else None,
@@ -511,9 +570,9 @@ packet = [
     '',
     '- each speaker says their own name only on their first appearance',
     '- segment loudness is normalized toward a shared target so the episode is easier to follow',
+    '- the manifest separates speech-only input metrics from full-episode mix metrics so silence padding does not silently dilute the mastering story',
     '- the final episode mix gets one more mastering pass for overall loudness consistency and peak control',
     '- pause timing is deterministic but no longer one-size-fits-all; handoff gaps vary by speaker transition and closing position',
-    '- fallback casting is deliberately contrastive so Gemini stays brighter and quicker while Claude stays lower and more resonant',
     '',
     '## Proof Boundary',
     '',
@@ -521,6 +580,10 @@ packet = [
     '- Claude remains the transcript author for Claude turns even though the audio is rendered by a surrogate TTS lane',
     '- audio does not prove long-term identity continuity',
 ]
+if gemini_provider == 'gemini':
+    packet.insert(-5, '- Gemini rendered natively in this run, so the surrogate fallback casting lane remained available but inactive')
+else:
+    packet.insert(-5, '- fallback casting is active in this run so Gemini stays brighter and quicker while Claude stays lower and more resonant')
 Path(packet_path).write_text('\n'.join(packet).rstrip() + '\n', encoding='utf-8')
 PY
 rm -f "$SEGMENT_MANIFEST_TMP"

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -188,5 +188,6 @@ if ADL_OPERATIONAL_SKILLS_INSTALL_MODE=bogus bash "${repo_root}/adl/tools/instal
 fi
 
 bash "${repo_root}/adl/tools/test_sprint_conductor_helpers.sh"
+bash "${repo_root}/adl/tools/test_multiagent_podcast_audio_policy.sh"
 
 echo "PASS test_install_adl_operational_skills"

--- a/adl/tools/test_multiagent_podcast_audio_policy.sh
+++ b/adl/tools/test_multiagent_podcast_audio_policy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+make_source_episode() {
+  local root="$1"
+  mkdir -p "${root}/out/podcast"
+  cat >"${root}/transcript.md" <<'EOF'
+# Transcript
+EOF
+  cat >"${root}/proof_note.md" <<'EOF'
+# Proof note
+EOF
+  cat >"${root}/out/podcast/01-chatgpt-opening.md" <<'EOF'
+I'm ChatGPT, and today we're testing the audio wrapper.
+EOF
+  cat >"${root}/out/podcast/02-gemini-challenge.md" <<'EOF'
+The difficult part is making the proof surfaces stay honest.
+EOF
+  cat >"${root}/out/podcast/03-claude-reframe.md" <<'EOF'
+It also matters that the emotional texture stays coherent.
+EOF
+  cat >"${root}/out/podcast/04-chatgpt-bridge.md" <<'EOF'
+Let's bridge the technical and human sides of the review.
+EOF
+  cat >"${root}/out/podcast/05-gemini-deepening.md" <<'EOF'
+We can separate active rendering from available fallback casting.
+EOF
+  cat >"${root}/out/podcast/06-claude-closure.md" <<'EOF'
+That makes the packet more precise without making it colder.
+EOF
+}
+
+run_wrapper() {
+  local out_dir="$1"
+  local source_dir="$2"
+  local gemini_provider="$3"
+  ADL_PODCAST_AUDIO_TEST_TONES=1 \
+  ADL_PODCAST_AUDIO_SOURCE_DIR="${source_dir}" \
+  ADL_PODCAST_GEMINI_AUDIO_PROVIDER="${gemini_provider}" \
+  bash "${repo_root}/adl/tools/demo_v0911_multiagent_podcast_audio.sh" "${out_dir}" >/dev/null
+}
+
+source_dir="${tmpdir}/source_episode"
+make_source_episode "${source_dir}"
+
+native_out="${tmpdir}/native"
+surrogate_out="${tmpdir}/surrogate"
+run_wrapper "${native_out}" "${source_dir}" gemini
+run_wrapper "${surrogate_out}" "${source_dir}" openai
+
+python3 - "${native_out}/audio_manifest.json" "${native_out}/audio_packet.md" "${surrogate_out}/audio_manifest.json" "${surrogate_out}/audio_packet.md" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+native_manifest = json.loads(Path(sys.argv[1]).read_text())
+native_packet = Path(sys.argv[2]).read_text()
+surrogate_manifest = json.loads(Path(sys.argv[3]).read_text())
+surrogate_packet = Path(sys.argv[4]).read_text()
+
+native_mastering = native_manifest["mastering"]
+assert "speech_only_input_metrics" in native_mastering
+assert "full_episode_mix_metrics" in native_mastering
+assert "final_mix_metrics" not in native_mastering
+assert native_mastering["active_rendering"]["Gemini"]["provider"] == "gemini"
+assert native_mastering["active_rendering"]["Gemini"]["mode"] == "native"
+assert native_mastering["available_fallback_casting"]["Gemini"]["surrogate"]["provider"] == "openai"
+assert "surrogate fallback casting lane remained available but inactive" in native_packet
+assert "fallback casting is active in this run" not in native_packet
+
+surrogate_mastering = surrogate_manifest["mastering"]
+assert surrogate_mastering["active_rendering"]["Gemini"]["provider"] == "openai"
+assert surrogate_mastering["active_rendering"]["Gemini"]["mode"] == "surrogate"
+assert "fallback casting is active in this run" in surrogate_packet
+assert "surrogate fallback casting lane remained available but inactive" not in surrogate_packet
+PY
+
+echo "PASS test_multiagent_podcast_audio_policy"

--- a/demos/v0.91.1/multiagent_podcast_audio_demo.md
+++ b/demos/v0.91.1/multiagent_podcast_audio_demo.md
@@ -107,10 +107,10 @@ The audio follow-on is successful when:
 
 - one listenable combined episode audio file exists
 - per-turn audio segments exist with explicit speaker routing
-- the manifest shows which provider/voice rendered each speaker
-- the manifest records usable loudness/mastering metrics for the final mix
+- the manifest shows the active provider/voice route used for each speaker in the run
+- the manifest separates speech-only input metrics from full-episode final-mix metrics
 - the manifest records the bounded per-speaker tone-profile settings used for the run
-- the manifest records the fallback casting map used when surrogate rendering is active
+- the manifest records the available fallback-casting map without implying it was active when Gemini native TTS was used
 - the manifest records the deterministic timing policy used for handoff gaps
 - Claude's surrogate rendering is disclosed instead of implied away
 - each speaker introduces themselves naturally only on their first turn, for example `I'm ChatGPT`


### PR DESCRIPTION
Closes #2934

## Summary
Implemented the bounded broadcast-audio mini-sprint review fixes in the podcast audio wrapper, docs, and regression tests. The manifest now separates speech-only input metrics from full-episode mix metrics, reports active rendering separately from available fallback casting, and the wrapper has focused offline regression coverage for these policy surfaces.

## Artifacts
- Updated wrapper: `adl/tools/demo_v0911_multiagent_podcast_audio.sh`
- Updated reviewer doc: `demos/v0.91.1/multiagent_podcast_audio_demo.md`
- New regression test: `adl/tools/test_multiagent_podcast_audio_policy.sh`
- Updated install-path test: `adl/tools/test_install_adl_operational_skills.sh`
- Fresh proof packet:
  - `artifacts/v0911/multiagent_podcast_pilot_audio_verified/episode.wav`
  - `artifacts/v0911/multiagent_podcast_pilot_audio_verified/audio_manifest.json`
  - `artifacts/v0911/multiagent_podcast_pilot_audio_verified/audio_packet.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_multiagent_podcast_audio_policy.sh`
    Verified the wrapper policy surfaces offline with native and surrogate Gemini rendering modes.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Verified the install-path test suite remains green with the new wrapper regression.
  - `ADL_PODCAST_GEMINI_AUDIO_PROVIDER=openai bash adl/tools/demo_v0911_multiagent_podcast_audio.sh artifacts/v0911/multiagent_podcast_pilot_audio_verified`
    Regenerated the verified audio packet so the proof surface matches the repaired semantics.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2934__v0-91-1-demo-fix-broadcast-audio-mini-sprint-review-findings/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2934__v0-91-1-demo-fix-broadcast-audio-mini-sprint-review-findings/sor.md
- Idempotency-Key: v0-91-1-demo-fix-broadcast-audio-mini-sprint-review-findings-adl-v0-91-1-tasks-issue-2934-v0-91-1-demo-fix-broadcast-audio-mini-sprint-review-findings-sip-md-adl-v0-91-1-tasks-issue-2934-v0-91-1-demo-fix-broadcast-audio-mini-sprint-review-findings-sor-md