### PR TITLE
[v0.91.1][demo] Add Hey Jude audio follow-on packet

### DIFF
--- a/adl/tools/demo_v0911_five_agent_hey_jude_audio.sh
+++ b/adl/tools/demo_v0911_five_agent_hey_jude_audio.sh
@@ -1,0 +1,559 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/artifacts/v0911/five_agent_hey_jude_audio}"
+SOURCE_DIR="${ADL_HEY_JUDE_AUDIO_SOURCE_DIR:-$OUT_DIR/source_episode}"
+SEGMENTS_DIR="$OUT_DIR/audio/segments"
+MIX_AUDIO="$OUT_DIR/episode.wav"
+AUDIO_MANIFEST="$OUT_DIR/audio_manifest.json"
+AUDIO_PACKET="$OUT_DIR/audio_packet.md"
+PROOF_NOTE="$OUT_DIR/proof_note.md"
+PLAYBACK_TRANSCRIPT="$OUT_DIR/playback_transcript.md"
+CUE_TIMING_REGISTER="$OUT_DIR/cue_timing_register.json"
+OPENAI_KEY_FILE="${ADL_OPENAI_KEY_FILE:-$HOME/keys/openai2.key}"
+OPENAI_TTS_MODEL="${ADL_HEY_JUDE_OPENAI_TTS_MODEL:-gpt-4o-mini-tts}"
+BACKING_TRACK_PATH="${ADL_HEY_JUDE_BACKING_WAV:-}"
+LAYER8_VOICE="${ADL_HEY_JUDE_LAYER8_VOICE:-ash}"
+CHATGPT_VOICE="${ADL_HEY_JUDE_CHATGPT_VOICE:-coral}"
+CLAUDE_VOICE="${ADL_HEY_JUDE_CLAUDE_VOICE:-onyx}"
+GEMINI_VOICE="${ADL_HEY_JUDE_GEMINI_VOICE:-echo}"
+DEEPSEEK_VOICE="${ADL_HEY_JUDE_DEEPSEEK_VOICE:-sage}"
+
+load_key() {
+  local env_name="$1"
+  local key_file="$2"
+  if [[ -n "${!env_name:-}" ]]; then
+    return 0
+  fi
+  if [[ ! -s "$key_file" ]]; then
+    echo "missing required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  local key_value
+  key_value="$(python3 - "$env_name" "$key_file" <<'PY'
+import sys
+env_name, path = sys.argv[1:3]
+raw = open(path, encoding='utf-8').read().strip()
+value = raw
+for line in raw.splitlines():
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#'):
+        continue
+    if stripped.startswith(env_name + '='):
+        value = stripped.split('=', 1)[1].strip().strip("'\"")
+        break
+    value = stripped.strip("'\"")
+    break
+print(value, end='')
+PY
+)"
+  if [[ -z "$key_value" ]]; then
+    echo "empty required key file for $env_name: $key_file" >&2
+    return 1
+  fi
+  export "$env_name=$key_value"
+}
+
+render_openai_wav() {
+  local text="$1"
+  local voice="$2"
+  local instructions="$3"
+  local out_path="$4"
+  local payload
+  payload="$(python3 - "$text" "$voice" "$instructions" "$OPENAI_TTS_MODEL" <<'PY'
+import json, sys
+text, voice, instructions, model = sys.argv[1:5]
+print(json.dumps({
+  'model': model,
+  'voice': voice,
+  'input': text,
+  'instructions': instructions,
+  'response_format': 'wav',
+}))
+PY
+)"
+  curl -sS https://api.openai.com/v1/audio/speech \
+    --connect-timeout 10 \
+    --max-time 120 \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    --output "$out_path"
+}
+
+if [[ "${ADL_HEY_JUDE_AUDIO_TEST_TONES:-0}" != "1" ]]; then
+  load_key OPENAI_API_KEY "$OPENAI_KEY_FILE"
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$SEGMENTS_DIR"
+
+if [[ ! -f "$SOURCE_DIR/transcript.md" ]]; then
+  bash "$ROOT_DIR/adl/tools/demo_v0891_five_agent_hey_jude.sh" "$SOURCE_DIR"
+fi
+
+python3 "$ROOT_DIR/adl/tools/validate_five_agent_music_demo.py" "$SOURCE_DIR" >/dev/null
+
+python3 - "$SOURCE_DIR" "$SEGMENTS_DIR" "$CUE_TIMING_REGISTER" "$PLAYBACK_TRANSCRIPT" "$AUDIO_MANIFEST" "$AUDIO_PACKET" "$PROOF_NOTE" "$MIX_AUDIO" "$BACKING_TRACK_PATH" "$LAYER8_VOICE" "$CHATGPT_VOICE" "$CLAUDE_VOICE" "$GEMINI_VOICE" "$DEEPSEEK_VOICE" <<'PY'
+from __future__ import annotations
+
+from array import array
+import base64
+import json
+import math
+import os
+import struct
+import subprocess
+import sys
+import urllib.request
+import wave
+from pathlib import Path
+
+(
+    source_dir,
+    segments_dir,
+    cue_timing_path,
+    playback_transcript_path,
+    manifest_path,
+    packet_path,
+    proof_note_path,
+    mix_audio_path,
+    backing_track_path,
+    layer8_voice,
+    chatgpt_voice,
+    claude_voice,
+    gemini_voice,
+    deepseek_voice,
+) = sys.argv[1:15]
+
+ROOT = Path(source_dir)
+SEGMENTS = Path(segments_dir)
+TEST_TONES = os.environ.get("ADL_HEY_JUDE_AUDIO_TEST_TONES") == "1"
+OPENAI_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_TTS_MODEL = os.environ.get("ADL_HEY_JUDE_OPENAI_TTS_MODEL", "gpt-4o-mini-tts")
+RATE = 24000
+SAMPLE_WIDTH = 2
+CHANNELS = 1
+TARGET_RMS = 3500.0
+FINAL_CEILING = 25000
+DUCK_GAIN = 0.26
+
+INSERTS = [
+    {
+        "turn": 1,
+        "speaker": "Layer 8",
+        "role": "human bandleader",
+        "section": "Opening",
+        "source_file": "01-layer8-opening.md",
+        "voice": layer8_voice,
+        "instructions": "Speak like a calm bandleader cueing a live room with grounded confidence.",
+        "start_ms": 900,
+    },
+    {
+        "turn": 2,
+        "speaker": "ChatGPT",
+        "role": "conductor-builder",
+        "section": "Opening",
+        "source_file": "02-chatgpt-opening.md",
+        "voice": chatgpt_voice,
+        "instructions": "Speak warmly and clearly, like a conductor setting up the next moment.",
+        "start_ms": 5200,
+    },
+    {
+        "turn": 3,
+        "speaker": "Claude",
+        "role": "reflective harmonizer",
+        "section": "Verse Rotation",
+        "source_file": "03-claude-verse.md",
+        "voice": claude_voice,
+        "instructions": "Speak lower, slower, and reflectively, like a thoughtful harmonizer entering the arrangement.",
+        "start_ms": 13000,
+    },
+    {
+        "turn": 4,
+        "speaker": "Gemini",
+        "role": "bright performer",
+        "section": "Verse Rotation",
+        "source_file": "04-gemini-verse.md",
+        "voice": gemini_voice,
+        "instructions": "Speak brightly, briskly, and musically, like a performer lifting the energy.",
+        "start_ms": 20500,
+    },
+    {
+        "turn": 5,
+        "speaker": "DeepSeek",
+        "role": "pattern keeper",
+        "section": "Curtain Call",
+        "source_file": "10-deepseek-curtain.md",
+        "voice": deepseek_voice,
+        "instructions": "Speak with measured clarity, like a pattern keeper closing the room with a final cue.",
+        "start_ms": 31500,
+    },
+]
+
+BANNED_STRINGS = [
+    "Take a sad song and make it better",
+    "Remember to let her into your heart",
+]
+
+
+def first_snippet(path: Path, speaker: str) -> str:
+    text = path.read_text(encoding="utf-8").strip()
+    for banned in BANNED_STRINGS:
+        if banned in text:
+            raise SystemExit(f"copyright-sensitive text leaked into source snippet: {banned}")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    joined = " ".join(lines[:3]).strip()
+    clipped = joined[:260].rsplit(" ", 1)[0] if len(joined) > 260 else joined
+    return f"{speaker}. {clipped}"
+
+
+def render_test_tone(out_path: Path, speaker: str) -> None:
+    freq_map = {
+        "Layer 8": 180.0,
+        "ChatGPT": 220.0,
+        "Claude": 260.0,
+        "Gemini": 330.0,
+        "DeepSeek": 300.0,
+    }
+    freq = freq_map.get(speaker, 240.0)
+    duration = 1.9
+    frame_count = int(RATE * duration)
+    amplitude = 9200
+    with wave.open(str(out_path), "wb") as wf:
+        wf.setnchannels(CHANNELS)
+        wf.setsampwidth(SAMPLE_WIDTH)
+        wf.setframerate(RATE)
+        frames = bytearray()
+        for i in range(frame_count):
+            sample = int(round(amplitude * math.sin(2.0 * math.pi * freq * (i / RATE))))
+            frames.extend(struct.pack("<h", sample))
+        wf.writeframes(bytes(frames))
+
+
+def render_openai_wav(text: str, voice: str, instructions: str, out_path: Path) -> None:
+    payload = json.dumps(
+        {
+            "model": OPENAI_TTS_MODEL,
+            "voice": voice,
+            "input": text,
+            "instructions": instructions,
+            "response_format": "wav",
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/audio/speech",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {OPENAI_KEY}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        out_path.write_bytes(resp.read())
+
+
+def stereo_to_mono(frames: bytes, channels: int) -> bytes:
+    if channels == 1:
+        return frames
+    if channels != 2:
+        raise SystemExit(f"unsupported channel count: {channels}")
+    samples = array("h")
+    samples.frombytes(frames)
+    mono = array("h")
+    for i in range(0, len(samples), 2):
+        left = int(samples[i])
+        right = int(samples[i + 1])
+        mono.append(int(round((left + right) / 2.0)))
+    return mono.tobytes()
+
+
+def resample_linear(frames: bytes, src_rate: int, dst_rate: int) -> bytes:
+    if src_rate == dst_rate:
+        return frames
+    source = array("h")
+    source.frombytes(frames)
+    if not source:
+        return frames
+    target_length = max(1, int(round(len(source) * dst_rate / src_rate)))
+    target = array("h")
+    if len(source) == 1:
+        target.extend([source[0]] * target_length)
+        return target.tobytes()
+    step = src_rate / dst_rate
+    for i in range(target_length):
+        position = i * step
+        left = int(position)
+        right = min(left + 1, len(source) - 1)
+        frac = position - left
+        value = int(round((1.0 - frac) * int(source[left]) + frac * int(source[right])))
+        target.append(max(-32768, min(32767, value)))
+    return target.tobytes()
+
+
+def read_wav_mono_resampled(path: Path, target_rate: int) -> bytes:
+    with wave.open(str(path), "rb") as wf:
+        channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        framerate = wf.getframerate()
+        frames = wf.readframes(wf.getnframes())
+    if sampwidth != 2:
+        raise SystemExit(f"unsupported wav sample width for backing track: {sampwidth}")
+    frames = stereo_to_mono(frames, channels)
+    if framerate != target_rate:
+        frames = resample_linear(frames, framerate, target_rate)
+    return frames
+
+
+def measure(frames: bytes) -> tuple[float, int]:
+    samples = array("h")
+    samples.frombytes(frames)
+    if not samples:
+        return 0.0, 0
+    rms = math.sqrt(sum(int(s) * int(s) for s in samples) / len(samples))
+    peak = max(abs(int(s)) for s in samples)
+    return rms, peak
+
+
+def normalize(frames: bytes, target_rms: float) -> bytes:
+    samples = array("h")
+    samples.frombytes(frames)
+    if not samples:
+        return frames
+    rms, peak = measure(frames)
+    if rms <= 1.0:
+        return frames
+    scale_rms = target_rms / rms
+    scale_peak = FINAL_CEILING / peak if peak > 0 else scale_rms
+    scale = min(scale_rms, scale_peak, 5.0)
+    for i, sample in enumerate(samples):
+        value = int(round(sample * scale))
+        value = max(-32768, min(32767, value))
+        samples[i] = value
+    return samples.tobytes()
+
+
+def compress_limit(frames: bytes) -> bytes:
+    samples = array("h")
+    samples.frombytes(frames)
+    threshold = 11000
+    ratio = 2.2
+    for i, sample in enumerate(samples):
+        sign = 1 if sample >= 0 else -1
+        magnitude = abs(int(sample))
+        if magnitude > threshold:
+            magnitude = threshold + int(round((magnitude - threshold) / ratio))
+        value = sign * min(magnitude, FINAL_CEILING)
+        samples[i] = max(-32768, min(32767, value))
+    return samples.tobytes()
+
+
+def mix_voice_over(backing: bytes, voice_frames: bytes, start_frame: int) -> bytes:
+    backing_samples = array("h")
+    backing_samples.frombytes(backing)
+    voice_samples = array("h")
+    voice_samples.frombytes(voice_frames)
+    required = start_frame + len(voice_samples)
+    if len(backing_samples) < required:
+        backing_samples.extend([0] * (required - len(backing_samples)))
+    for i, sample in enumerate(voice_samples):
+        idx = start_frame + i
+        bed = int(round(backing_samples[idx] * DUCK_GAIN))
+        mixed = bed + int(sample)
+        backing_samples[idx] = max(-32768, min(32767, mixed))
+    return backing_samples.tobytes()
+
+
+segment_entries = []
+for entry in INSERTS:
+    text = first_snippet(ROOT / "out" / "performance" / entry["source_file"], entry["speaker"])
+    out_path = SEGMENTS / f"{entry['turn']:02d}-{entry['speaker'].lower().replace(' ', '-')}.wav"
+    if TEST_TONES:
+        render_test_tone(out_path, entry["speaker"])
+    else:
+        render_openai_wav(text, entry["voice"], entry["instructions"], out_path)
+    with wave.open(str(out_path), "rb") as wf:
+        frames = wf.readframes(wf.getnframes())
+        params = (wf.getnchannels(), wf.getsampwidth(), wf.getframerate())
+    if params != (CHANNELS, SAMPLE_WIDTH, RATE):
+        if params[1] != 2:
+            raise SystemExit(f"unsupported segment sample width: {params}")
+        raw = frames
+        raw = stereo_to_mono(raw, params[0])
+        if params[2] != RATE:
+            raw = resample_linear(raw, params[2], RATE)
+        frames = raw
+        with wave.open(str(out_path), "wb") as wf:
+            wf.setnchannels(CHANNELS)
+            wf.setsampwidth(SAMPLE_WIDTH)
+            wf.setframerate(RATE)
+            wf.writeframes(frames)
+    frames = normalize(frames, TARGET_RMS)
+    frames = compress_limit(frames)
+    with wave.open(str(out_path), "wb") as wf:
+        wf.setnchannels(CHANNELS)
+        wf.setsampwidth(SAMPLE_WIDTH)
+        wf.setframerate(RATE)
+        wf.writeframes(frames)
+    rms, peak = measure(frames)
+    segment_entries.append(
+        {
+            **entry,
+            "spoken_text": text,
+            "audio_file": out_path.name,
+            "segment_metrics": {"rms": round(rms, 1), "peak": peak},
+        }
+    )
+
+end_frame = max(int((entry["start_ms"] / 1000.0) * RATE) + wave.open(str(SEGMENTS / entry["audio_file"]), "rb").getnframes() for entry in segment_entries)
+base_length = end_frame + int(2.5 * RATE)
+if backing_track_path:
+    backing_path = Path(backing_track_path)
+    if not backing_path.is_file():
+        raise SystemExit(f"backing track not found: {backing_track_path}")
+    backing = read_wav_mono_resampled(backing_path, RATE)
+else:
+    backing_path = None
+    backing = b"\x00" * (base_length * SAMPLE_WIDTH)
+
+mixed = backing
+for entry in segment_entries:
+    with wave.open(str(SEGMENTS / entry["audio_file"]), "rb") as wf:
+        frames = wf.readframes(wf.getnframes())
+        frame_count = wf.getnframes()
+    entry["duration_ms"] = int(round((frame_count / RATE) * 1000))
+    entry["end_ms"] = entry["start_ms"] + entry["duration_ms"]
+    mixed = mix_voice_over(mixed, frames, int((entry["start_ms"] / 1000.0) * RATE))
+
+mixed = compress_limit(normalize(mixed, 3200.0))
+mix_rms, mix_peak = measure(mixed)
+with wave.open(mix_audio_path, "wb") as wf:
+    wf.setnchannels(CHANNELS)
+    wf.setsampwidth(SAMPLE_WIDTH)
+    wf.setframerate(RATE)
+    wf.writeframes(mixed)
+
+cue_register = {
+    "schema_version": "adl.hey_jude_audio_cue_register.v1",
+    "source_episode_root": str(ROOT),
+    "backing_track": {
+        "provided": backing_path is not None,
+        "asset_name": backing_path.name if backing_path else None,
+        "mode": "operator_supplied_local_wav" if backing_path else "voice_only_no_bed",
+    },
+    "voice_inserts": [
+        {
+            "turn": entry["turn"],
+            "speaker": entry["speaker"],
+            "role": entry["role"],
+            "section": entry["section"],
+            "source_text_file": f"out/performance/{entry['source_file']}",
+            "audio_file": f"audio/segments/{entry['audio_file']}",
+            "start_ms": entry["start_ms"],
+            "end_ms": entry["end_ms"],
+        }
+        for entry in segment_entries
+    ],
+}
+Path(cue_timing_path).write_text(json.dumps(cue_register, indent=2) + "\n", encoding="utf-8")
+
+playback_lines = [
+    "# Hey Jude Audio Playback Transcript",
+    "",
+    "> Spoken interjection track aligned to the bounded five-agent proof packet.",
+    "",
+]
+for entry in segment_entries:
+    playback_lines.extend(
+        [
+            f"## {entry['speaker']} · {entry['section']}",
+            "",
+            f"- start: `{entry['start_ms']}ms`",
+            f"- end: `{entry['end_ms']}ms`",
+            f"- source: `out/performance/{entry['source_file']}`",
+            "",
+            entry["spoken_text"],
+            "",
+        ]
+    )
+Path(playback_transcript_path).write_text("\n".join(playback_lines).rstrip() + "\n", encoding="utf-8")
+
+manifest = {
+    "schema_version": "adl.hey_jude_audio_manifest.v1",
+    "demo_id": "v0.91.1.five_agent_hey_jude_audio_follow_on",
+    "source_demo_id": "v0.89.1.five_agent_hey_jude_midi_demo",
+    "source_episode_root": str(ROOT),
+    "mixed_audio": Path(mix_audio_path).name,
+    "backing_track": cue_register["backing_track"],
+    "render_mode": "spoken_interjection_mix",
+    "voices": {
+        "Layer 8": {"provider": "openai", "voice": layer8_voice, "mode": "surrogate_spoken"},
+        "ChatGPT": {"provider": "openai", "voice": chatgpt_voice, "mode": "native_spoken"},
+        "Claude": {"provider": "openai", "voice": claude_voice, "mode": "surrogate_spoken"},
+        "Gemini": {"provider": "openai", "voice": gemini_voice, "mode": "surrogate_spoken"},
+        "DeepSeek": {"provider": "openai", "voice": deepseek_voice, "mode": "surrogate_spoken"},
+    },
+    "timing": cue_register["voice_inserts"],
+    "mastering": {
+        "segment_target_rms": TARGET_RMS,
+        "final_mix_metrics": {"rms": round(mix_rms, 1), "peak": mix_peak},
+        "duck_gain": DUCK_GAIN,
+    },
+    "proof_surfaces": {
+        "source_transcript": "source_episode/transcript.md",
+        "source_manifest": "source_episode/performance_manifest.json",
+        "midi_event_log": "source_episode/midi_event_log.json",
+        "cue_timeline": "source_episode/cue_timeline.json",
+        "playback_transcript": Path(playback_transcript_path).name,
+        "cue_timing_register": Path(cue_timing_path).name,
+        "audio_packet": Path(packet_path).name,
+        "proof_note": Path(proof_note_path).name,
+    },
+}
+Path(manifest_path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+packet = [
+    "# Hey Jude Audio Follow-On Packet",
+    "",
+    "- source proof packet: `source_episode/`",
+    f"- mixed audio artifact: `{Path(mix_audio_path).name}`",
+    "- render mode: spoken interjection mix over optional operator-supplied backing track",
+    "",
+    "## What This Adds",
+    "",
+    "- a replayable mixed audio file",
+    "- five timed spoken inserts aligned to the bounded ensemble structure",
+    "- a playback transcript and cue register that preserve reviewability",
+    "",
+    "## What This Does Not Claim",
+    "",
+    "- no full synthetic singing of the song",
+    "- no repo-distributed copyrighted backing audio",
+    "- no general music platform or live-performance guarantee",
+    "",
+    "## Copyright / Provenance",
+    "",
+    f"- backing track active: `{'yes' if backing_path else 'no'}`",
+    f"- backing asset name: `{backing_path.name if backing_path else 'not_applicable'}`",
+    "- any backing track is operator-supplied local media and not a tracked repo artifact",
+]
+Path(packet_path).write_text("\n".join(packet).rstrip() + "\n", encoding="utf-8")
+
+proof_note = [
+    "# Hey Jude Audio Follow-On Proof Note",
+    "",
+    "- The original transcript/MIDI proof path remains the canonical coordination surface.",
+    "- This follow-on adds a listenable spoken-performance layer without replacing the source proof packet.",
+    "- Audio authorship and audio rendering remain separate from the source transcript authorship.",
+]
+Path(proof_note_path).write_text("\n".join(proof_note).rstrip() + "\n", encoding="utf-8")
+PY
+
+echo "Hey Jude audio proof surfaces:"
+echo "  $MIX_AUDIO"
+echo "  $AUDIO_MANIFEST"
+echo "  $AUDIO_PACKET"
+echo "  $PLAYBACK_TRANSCRIPT"
+echo "  $CUE_TIMING_REGISTER"

--- a/adl/tools/test_demo_v0911_five_agent_hey_jude_audio.sh
+++ b/adl/tools/test_demo_v0911_five_agent_hey_jude_audio.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+BACKING_WAV="$TMPDIR_ROOT/backing.wav"
+python3 - "$BACKING_WAV" <<'PY'
+import math
+import struct
+import sys
+import wave
+
+out_path = sys.argv[1]
+rate = 24000
+duration = 40.0
+freq = 196.0
+amplitude = 3600
+frame_count = int(rate * duration)
+with wave.open(out_path, 'wb') as wf:
+    wf.setnchannels(1)
+    wf.setsampwidth(2)
+    wf.setframerate(rate)
+    frames = bytearray()
+    for i in range(frame_count):
+        wobble = math.sin(2.0 * math.pi * (i / rate) * 0.4) * 0.15
+        sample = int(round(amplitude * (1.0 + wobble) * math.sin(2.0 * math.pi * freq * (i / rate))))
+        frames.extend(struct.pack('<h', sample))
+    wf.writeframes(bytes(frames))
+PY
+
+OUT_DIR="$TMPDIR_ROOT/artifacts"
+(
+  cd "$ROOT_DIR"
+  ADL_HEY_JUDE_AUDIO_TEST_TONES=1 \
+  ADL_HEY_JUDE_BACKING_WAV="$BACKING_WAV" \
+  bash adl/tools/demo_v0911_five_agent_hey_jude_audio.sh "$OUT_DIR" >/dev/null
+)
+
+python3 "$ROOT_DIR/adl/tools/validate_five_agent_hey_jude_audio_demo.py" "$OUT_DIR"
+
+for required in \
+  "$OUT_DIR/episode.wav" \
+  "$OUT_DIR/audio_manifest.json" \
+  "$OUT_DIR/audio_packet.md" \
+  "$OUT_DIR/proof_note.md" \
+  "$OUT_DIR/playback_transcript.md" \
+  "$OUT_DIR/cue_timing_register.json" \
+  "$OUT_DIR/source_episode/performance_manifest.json" \
+  "$OUT_DIR/source_episode/transcript.md"; do
+  [[ -f "$required" ]] || {
+    echo "assertion failed: missing artifact $required" >&2
+    exit 1
+  }
+done
+
+echo "demo_v0911_five_agent_hey_jude_audio: ok"

--- a/adl/tools/validate_five_agent_hey_jude_audio_demo.py
+++ b/adl/tools/validate_five_agent_hey_jude_audio_demo.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import json
+import sys
+import wave
+from pathlib import Path
+
+
+REQUIRED_FILES = [
+    "episode.wav",
+    "audio_manifest.json",
+    "audio_packet.md",
+    "proof_note.md",
+    "playback_transcript.md",
+    "cue_timing_register.json",
+    "source_episode/performance_manifest.json",
+    "source_episode/transcript.md",
+]
+
+REQUIRED_SPEAKERS = {"Layer 8", "ChatGPT", "Claude", "Gemini", "DeepSeek"}
+BANNED_STRINGS = [
+    "Take a sad song and make it better",
+    "Remember to let her into your heart",
+]
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return fail("usage: validate_five_agent_hey_jude_audio_demo.py <artifact_root>")
+    root = Path(sys.argv[1])
+    for rel in REQUIRED_FILES:
+        if not (root / rel).is_file():
+            return fail(f"missing required artifact: {rel}")
+
+    manifest = json.loads((root / "audio_manifest.json").read_text(encoding="utf-8"))
+    register = json.loads((root / "cue_timing_register.json").read_text(encoding="utf-8"))
+    packet = (root / "audio_packet.md").read_text(encoding="utf-8")
+    transcript = (root / "playback_transcript.md").read_text(encoding="utf-8")
+    source_transcript = (root / "source_episode/transcript.md").read_text(encoding="utf-8")
+
+    if manifest["schema_version"] != "adl.hey_jude_audio_manifest.v1":
+        return fail("unexpected audio manifest schema version")
+    if manifest["source_demo_id"] != "v0.89.1.five_agent_hey_jude_midi_demo":
+        return fail("unexpected source demo id")
+
+    insert_speakers = {entry["speaker"] for entry in register["voice_inserts"]}
+    if insert_speakers != REQUIRED_SPEAKERS:
+        return fail(f"unexpected insert speakers: {sorted(insert_speakers)}")
+
+    if len(register["voice_inserts"]) != 5:
+        return fail("expected exactly five voice inserts")
+
+    for entry in register["voice_inserts"]:
+        if entry["end_ms"] <= entry["start_ms"]:
+            return fail(f"invalid timing window for {entry['speaker']}")
+
+    if "operator-supplied local media" not in packet:
+        return fail("audio packet missing local-media copyright note")
+
+    for banned in BANNED_STRINGS:
+        if banned in transcript or banned in source_transcript:
+            return fail("copyright-sensitive lyric text leaked into transcript surfaces")
+
+    with wave.open(str(root / "episode.wav"), "rb") as wf:
+        if wf.getnframes() <= 0:
+            return fail("mixed audio file is empty")
+
+    print("validate_five_agent_hey_jude_audio_demo: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/v0.91.1/five_agent_hey_jude_audio_demo.md
+++ b/demos/v0.91.1/five_agent_hey_jude_audio_demo.md
@@ -1,0 +1,71 @@
+# Five-Agent Hey Jude Audio Follow-On
+
+Canonical command:
+
+```bash
+bash adl/tools/demo_v0911_five_agent_hey_jude_audio.sh
+```
+
+## What It Does
+
+This `v0.91.1` follow-on keeps the original `v0.89.1` five-agent `Hey Jude`
+proof packet intact, then adds one bounded spoken-performance audio layer on
+top.
+
+The follow-on:
+
+- reuses the source transcript/MIDI/cue packet from the original demo
+- accepts an operator-supplied local backing WAV through
+  `ADL_HEY_JUDE_BACKING_WAV`
+- renders five timed spoken interjections for the existing cast
+- exports one mixed replayable audio artifact plus aligned timing/transcript
+  proof surfaces
+
+## Inputs
+
+- optional local backing track:
+  - `ADL_HEY_JUDE_BACKING_WAV=/path/to/local_backing.wav`
+- optional output directory:
+  - `bash adl/tools/demo_v0911_five_agent_hey_jude_audio.sh /custom/out`
+
+If no backing WAV is supplied, the follow-on still renders a voice-only mix so
+the proof route remains runnable.
+
+## Primary Proof Surfaces
+
+- `episode.wav`
+- `audio_manifest.json`
+- `audio_packet.md`
+- `proof_note.md`
+- `playback_transcript.md`
+- `cue_timing_register.json`
+- `source_episode/performance_manifest.json`
+- `source_episode/transcript.md`
+
+## Why It Matters
+
+This turns the original flagship from:
+
+- a transcript-and-MIDI proof packet
+
+into:
+
+- a more listenable replay artifact that still keeps the coordination evidence
+  visible and reviewable
+
+## Bounded Claim
+
+This follow-on proves:
+
+- the existing ensemble timing plan can drive a replayable spoken-performance
+  mix
+- the source proof packet remains intact and machine-reviewable
+- a local operator-supplied backing track can be layered in without shipping
+  copyrighted audio in the repo
+
+## Non-Claims
+
+- no full synthetic singing of the song
+- no repo-distributed copyrighted backing track
+- no generalized music engine
+- no claim of studio mastering or live-performance reliability


### PR DESCRIPTION
Closes #2853

## Summary
Built the `v0.91.1` Hey Jude audio follow-on as a bounded spoken-performance packet layered on top of the existing `v0.89.1` proof surface. The new wrapper can render a listenable mixed episode, validate the packet contract, and run deterministically in offline tone-test mode without live TTS.

## Artifacts
- New wrapper: `adl/tools/demo_v0911_five_agent_hey_jude_audio.sh`
- New focused test: `adl/tools/test_demo_v0911_five_agent_hey_jude_audio.sh`
- New validator: `adl/tools/validate_five_agent_hey_jude_audio_demo.py`
- New reviewer doc: `demos/v0.91.1/five_agent_hey_jude_audio_demo.md`
- Fresh proof packet:
  - `artifacts/v0911/five_agent_hey_jude_audio/episode.wav`
  - `artifacts/v0911/five_agent_hey_jude_audio/audio_manifest.json`
  - `artifacts/v0911/five_agent_hey_jude_audio/audio_packet.md`
  - `artifacts/v0911/five_agent_hey_jude_audio/playback_transcript.md`
  - `artifacts/v0911/five_agent_hey_jude_audio/cue_timing_register.json`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_demo_v0911_five_agent_hey_jude_audio.sh`
    Verified the audio wrapper, test-tone path, local-backing-track path, and packet validator together.
  - `python3 adl/tools/validate_five_agent_hey_jude_audio_demo.py artifacts/v0911/five_agent_hey_jude_audio`
    Verified the real rendered artifact packet after the wrapper implementation landed.
  - `bash adl/tools/demo_v0911_five_agent_hey_jude_audio.sh`
    Generated the listenable canonical proof packet from the implemented wrapper.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2853__v0-91-1-demo-hey-jude-audio-upgrade-follow-on/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2853__v0-91-1-demo-hey-jude-audio-upgrade-follow-on/sor.md
- Idempotency-Key: v0-91-1-demo-add-hey-jude-audio-follow-on-packet-adl-v0-91-1-tasks-issue-2853-v0-91-1-demo-hey-jude-audio-upgrade-follow-on-sip-md-adl-v0-91-1-tasks-issue-2853-v0-91-1-demo-hey-jude-audio-upgrade-follow-on-sor-md