### PR TITLE
[v0.91.1][docs] Add Sprint 2 closeout note

### DIFF
--- a/docs/milestones/v0.91.1/SPRINT_2_CLOSEOUT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/SPRINT_2_CLOSEOUT_v0.91.1.md
@@ -1,0 +1,119 @@
+# v0.91.1 Sprint 2 Closeout
+
+## Purpose
+
+This note closes out Sprint 2 of `v0.91.1` with one tracked, reviewable
+summary of what landed in the Memory, ToM, Capability, Intelligence, and
+Learning wave.
+
+It is intentionally narrower than milestone closeout. This is a sprint-scoped
+evidence note, not a claim that the full `v0.91.1` milestone is review- or
+release-complete.
+
+## Scope
+
+Sprint 2 covers:
+
+1. `WP-07` / `#2829` Memory and identity architecture
+2. `WP-08` / `#2830` Theory of Mind foundation
+3. `WP-09` / `#2831` Capability and aptitude testing foundation
+4. `WP-10` / `#2832` Intelligence metric architecture
+5. `WP-11` / `#2833` Governed learning substrate
+6. `WP-12` / `#2834` ANRM/Gemma placement and trace dataset
+
+## Merged Execution Trail
+
+The sprint child lane merged through:
+
+1. `#2829` via `#2908` at `2026-05-09T20:22:19Z`
+2. `#2830` via `#2920` at `2026-05-09T22:54:38Z`
+3. `#2831` via `#2929` at `2026-05-09T23:56:00Z`
+4. `#2832` via `#2935` at `2026-05-10T01:55:41Z`
+5. `#2833` via `#2938` at `2026-05-10T02:35:35Z`
+6. `#2834` via `#2941` at `2026-05-10T05:39:30Z`
+
+All six Sprint 2 issues are closed.
+
+## Realized Sprint Shape
+
+This sprint should be described as a successful bounded cognition-and-evaluation
+foundation wave.
+
+What actually landed:
+
+- `WP-07`: runtime-visible memory/identity architecture packet, fixtures, and
+  focused tests
+- `WP-08`: bounded Theory of Mind packet, update-event contract, fixtures, and
+  focused tests
+- `WP-09`: first executable capability/aptitude harness and report surface
+- `WP-10`: evidence-bound intelligence metric architecture packet and tests
+- `WP-11`: governed learning packet with reviewable update and feedback
+  contract
+- `WP-12`: ANRM/Gemma placement and deterministic trace-dataset mapping
+
+This means Sprint 2 completed the planned foundational slice for memory, ToM,
+capability, intelligence, learning, and local-model placement. It did not
+claim final identity continuity, final intelligence, broad social cognition, or
+complete learning theory.
+
+## Proof Posture
+
+The tracked proof routes are recorded in
+[FEATURE_PROOF_COVERAGE_v0.91.1.md](FEATURE_PROOF_COVERAGE_v0.91.1.md), where
+all Sprint 2 features now read as `landed`:
+
+- Memory/identity architecture
+- Theory of Mind foundation
+- Capability/aptitude testing
+- Intelligence metric architecture
+- Governed learning
+- ANRM/Gemma placement
+
+The sprint therefore closed with feature-doc-plus-implementation proof routes,
+not with placeholder planning-only claims.
+
+## What Sprint 2 Completed
+
+- the bounded memory/identity architecture needed before inhabitant-runtime
+  integration
+- the bounded ToM foundation needed before broader later social-cognition work
+- the first executable capability surface for later intelligence and placement
+  work
+- the evidence-bound intelligence architecture rather than a vague metric claim
+- the governed learning substrate instead of open-ended adaptation language
+- the ANRM/Gemma placement and trace-dataset slice needed for local-model
+  evaluation and later comparison work
+
+## What Sprint 2 Did Not Complete
+
+- `WP-13` and later secure-comms / inhabitant-runtime proof work
+- `v0.92` identity-continuity and first-birthday claims
+- `v0.93` broader Theory of Mind and social-cognition governance work
+- complete local-model benchmarking or broader decoding/acceleration work now
+  tracked for `v0.91.2`
+
+## Residual Risk
+
+The main residual risk from this sprint is not “missing implementation” inside
+the bounded Sprint 2 scope. The larger risk is overreading these foundations as
+if they already prove:
+
+- final identity continuity
+- strong social cognition or reputation
+- complete intelligence validity
+- production-governed self-improvement
+
+The repo should continue to speak about these Sprint 2 surfaces as bounded
+foundations that enable Sprint 3 and later milestone work.
+
+## Closeout Judgment
+
+Sprint 2 was successful.
+
+Truthful final read:
+
+- the entire planned Sprint 2 issue wave landed and merged
+- the feature-proof coverage map reflects the landed state
+- the sprint completed a real bounded cognition/evaluation foundation band
+- the remaining work is downstream expansion and integration, not Sprint 2
+  incompleteness

--- a/docs/milestones/v0.91.1/SPRINT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/SPRINT_v0.91.1.md
@@ -36,6 +36,17 @@ which can invoke actions, and which must queue, reject, or quarantine requests.
 Goal: implement the bounded cognitive and evaluation surfaces that v0.92 needs
 without claiming completed identity, intelligence, or learning theory.
 
+Closeout status: complete. The Sprint 2 child lane merged through:
+- `#2829` via `#2908`
+- `#2830` via `#2920`
+- `#2831` via `#2929`
+- `#2832` via `#2935`
+- `#2833` via `#2938`
+- `#2834` via `#2941`
+
+The tracked closeout note lives in
+`docs/milestones/v0.91.1/SPRINT_2_CLOSEOUT_v0.91.1.md`.
+
 ## Sprint 3: Secure Comms And Inhabitant Runtime Proof
 
 | WP | Title | Primary Deliverable | Dependencies |


### PR DESCRIPTION
Closes #2951

## Summary

- add the missing Sprint 2 closeout note for the v0.91.1 WP-07 through WP-12 wave
- record the merged issue and PR trail for the Memory, ToM, Capability, Intelligence, Learning, and ANRM/Gemma tranche
- link the note from the main sprint plan so the closeout surface is discoverable

## Validation

- `git diff --check`
