### PR TITLE
[v0.91.1][WP-12][tests] Enforce ANRM/Gemma tracked review artifact parity

### DIFF
--- a/adl/tools/test_build_v0911_anrm_trace_dataset.sh
+++ b/adl/tools/test_build_v0911_anrm_trace_dataset.sh
@@ -7,6 +7,7 @@ trap 'rm -rf "$TMPDIR_ROOT"' EXIT
 
 OUT_A="$TMPDIR_ROOT/out-a"
 OUT_B="$TMPDIR_ROOT/out-b"
+TRACKED_REVIEW_DIR="$ROOT_DIR/docs/milestones/v0.91.1/review/anrm_gemma_trace_dataset"
 HOST_PATH_PATTERN='/'"Users/"'|/'"private/"'|/'"tmp/"'|[A-Za-z]:\\'
 
 (
@@ -19,6 +20,15 @@ cmp "$OUT_A/anrm_trace_dataset.json" "$OUT_B/anrm_trace_dataset.json"
 cmp "$OUT_A/anrm_trace_extractor_spec.json" "$OUT_B/anrm_trace_extractor_spec.json"
 cmp "$OUT_A/anrm_gemma_placement_package.json" "$OUT_B/anrm_gemma_placement_package.json"
 cmp "$OUT_A/anrm_trace_dataset_limitations.md" "$OUT_B/anrm_trace_dataset_limitations.md"
+
+cmp "$OUT_A/anrm_trace_dataset.json" \
+  "$TRACKED_REVIEW_DIR/anrm_trace_dataset.json"
+cmp "$OUT_A/anrm_trace_extractor_spec.json" \
+  "$TRACKED_REVIEW_DIR/anrm_trace_extractor_spec.json"
+cmp "$OUT_A/anrm_gemma_placement_package.json" \
+  "$TRACKED_REVIEW_DIR/anrm_gemma_placement_package.json"
+cmp "$OUT_A/anrm_trace_dataset_limitations.md" \
+  "$TRACKED_REVIEW_DIR/anrm_trace_dataset_limitations.md"
 
 python3 - "$OUT_A/anrm_trace_dataset.json" "$OUT_A/anrm_trace_extractor_spec.json" "$OUT_A/anrm_gemma_placement_package.json" <<'PY'
 import json


### PR DESCRIPTION
Closes #2953

## Summary
Added a tracked-artifact parity guard to the WP-12 ANRM/Gemma generator test so fresh output must match the checked-in review artifacts cited by the milestone docs, not just a second temporary run.

## Artifacts
- Updated generator parity test at `adl/tools/test_build_v0911_anrm_trace_dataset.sh`
- Updated local output record at `.adl/v0.91.1/tasks/issue-2953__wp-12-enforce-anrm-gemma-tracked-review-artifact-parity/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_build_v0911_anrm_trace_dataset.sh`
    Verified deterministic WP-12 generator output, tracked-artifact parity, schema/content invariants, and no host-local path leakage.
  - `git diff --check`
    Verified clean patch formatting after the parity change.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.1/tasks/issue-2953__wp-12-enforce-anrm-gemma-tracked-review-artifact-parity/sip.md
- Output card: .adl/v0.91.1/tasks/issue-2953__wp-12-enforce-anrm-gemma-tracked-review-artifact-parity/sor.md
- Idempotency-Key: v0-91-1-wp-12-tests-enforce-anrm-gemma-tracked-review-artifact-parity-adl-v0-91-1-tasks-issue-2953-wp-12-enforce-anrm-gemma-tracked-review-artifact-parity-sip-md-adl-v0-91-1-tasks-issue-2953-wp-12-enforce-anrm-gemma-tracked-review-artifact-parity-sor-md