### PR TITLE
[v0.91.1][docs] Clarify Moderne/OpenRewrite/LST wording in v0.91.2 modernization docs

### DIFF
--- a/docs/milestones/v0.91.2/DEMO_MATRIX_v0.91.2.md
+++ b/docs/milestones/v0.91.2/DEMO_MATRIX_v0.91.2.md
@@ -15,7 +15,7 @@ and summarized again during WP-17.
 | Review heuristics demo | WP-07 | Show review heuristics and skills produce bounded review artifacts. | skill demo output and acceptance checklist | does not invent source evidence |
 | Google Workspace CMS bridge demo | WP-08 | Show draft content-card and promotion packet workflow. | fixture/live-gated bridge artifact | does not make Workspace canonical |
 | Rust-native GWS adapter boundary demo | WP-09 | Show typed adapter boundary or justified deferral. | adapter feasibility report | does not require live secrets |
-| Code modernization demo | WP-10 | Show modernization plan and bounded transformation surface. | modernization packet and dry-run evidence | does not mass-rewrite by default |
+| Moderne / OpenRewrite LST modernization demo | WP-10 | Show a bounded ADL-governed modernization plan around Moderne/OpenRewrite, deterministic recipes, and LST-based transformation. | modernization packet and dry-run evidence | does not mass-rewrite by default |
 | Speculative decoding prototype | WP-11 | Show bounded acceleration posture without weakening deterministic commit semantics. | prototype/evaluation packet and non-claim record | does not grant execution authority |
 | Repo visibility follow-on | WP-12 | Show reviewer/planner navigation improvements from bounded manifest/linkage follow-on work. | manifest/linkage packet and source-map evidence | does not claim full repo cognition |
 | Publication program package | WP-13 | Show arXiv/Medium backlog, authoring process, and review-gate readiness. | publication backlog, process docs, and review checklist | does not publish |

--- a/docs/milestones/v0.91.2/README.md
+++ b/docs/milestones/v0.91.2/README.md
@@ -21,7 +21,7 @@ reviewable systems:
   entire days.
 - CodeBuddy/review packet productization.
 - Google Workspace CMS bridge planning and bounded demo work.
-- Moderne/code-modernization workflow support.
+- Moderne / OpenRewrite LST modernization workflow support.
 - Bounded speculative-decoding evaluation inside ADL's deterministic runtime
   posture.
 - Repo-visibility follow-on work so canonical-source and linkage surfaces
@@ -48,7 +48,7 @@ v0.91.2 should not:
 - claim production external tool execution based on model output
 - silently move canonical docs into Google Workspace
 - publish papers or customer reports without review
-- treat code modernization as automatic mass rewrite
+- treat Moderne or OpenRewrite recipe execution as automatic mass rewrite
 - use test-cycle recovery as an excuse to weaken proof obligations
 
 ## Source Map
@@ -104,6 +104,6 @@ This package is grounded in:
 
 v0.91.2 is ready to close when the project has credible multi-model UTS+ACC
 evidence, a healthier test/runtime gate strategy, a review/productization path,
-a bounded Workspace CMS bridge demo, modernization and publication packages,
+a bounded Workspace CMS bridge demo, Moderne/OpenRewrite LST modernization and publication packages,
 and workflow guardrails that reduce the operational failures that slowed
 v0.90.5 and v0.91.

--- a/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
@@ -25,9 +25,9 @@ expensive, confusing test cycles.
 | WP-07 | Review heuristics skill and demos | review heuristics docs, skill/demo updates, proof examples | WP-06 |
 | WP-08 | Google Workspace CMS bridge demo | bounded Workspace content-card and promotion demo | WP-01; governed-tools authority and adapter boundary |
 | WP-09 | Rust-native GWS adapter boundary | adapter feasibility and typed contract boundary | WP-08 |
-| WP-10 | Code modernization demo | Moderne/code modernization interaction demo | WP-01 |
+| WP-10 | Moderne / OpenRewrite LST modernization demo | ADL-governed Moderne/OpenRewrite interaction demo | WP-01 |
 
-Goal: turn review, collaborative docs, and modernization ideas into bounded
+Goal: turn review, collaborative docs, and Moderne/OpenRewrite LST modernization ideas into bounded
 product surfaces without granting silent authority over canonical repo truth.
 
 ## Sprint 3: Runtime Ergonomics, Publication, Docs, And Workflow Guardrails

--- a/docs/milestones/v0.91.2/WBS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/WBS_v0.91.2.md
@@ -21,7 +21,7 @@ productize, publish, and maintain.
 | E | CodeBuddy productization | Promote review packet, product report, skill, and demo surfaces. | CodeBuddy product/review package | review skills |
 | F | Review skill and demo suite | Add review heuristics, skill demos, and repeatable review proof surfaces. | review demo matrix and skill docs | E |
 | G | Google Workspace CMS bridge | Build bounded bridge/demo for draft docs, comments, and promotion packets. | GWS CMS demo and adapter boundary | governed tools |
-| H | Code modernization | Define and prove Moderne/OpenRewrite-style modernization workflow. | modernization demo packet | C, E |
+| H | Code modernization | Define and prove a bounded Moderne/OpenRewrite modernization workflow grounded in deterministic recipes over the Lossless Semantic Tree (LST). | modernization demo packet | C, E |
 | I | Speculative decoding | Evaluate bounded runtime acceleration without weakening deterministic commit semantics. | feature contract, prototype plan, and proof posture | B, C |
 | J | Repo visibility follow-on | Turn the v0.90 prototype into a practical manifest/linkage follow-on for reviewers and planners. | manifest/linkage follow-on package | E, F |
 | K | Publication program | Prepare arXiv/Medium paper packets without direct publication. | publication backlog and first packets | review/evidence docs |
@@ -43,7 +43,7 @@ productize, publish, and maintain.
 | WP-07 | Review heuristics skill and demos | demo | review heuristics docs, skill/demo updates, proof examples | WP-06 |
 | WP-08 | Google Workspace CMS bridge demo | tools | bounded Workspace content-card and promotion demo | WP-01; governed-tools authority and adapter boundary |
 | WP-09 | Rust-native GWS adapter boundary | tools | adapter feasibility and typed contract boundary | WP-08 |
-| WP-10 | Code modernization demo | tools | Moderne/code modernization interaction demo | WP-01 |
+| WP-10 | Moderne / OpenRewrite LST modernization demo | tools | ADL-governed Moderne/OpenRewrite interaction demo | WP-01 |
 | WP-11 | Speculative decoding prototype | runtime | bounded speculative-decoding architecture and proof posture | WP-02, WP-04 |
 | WP-12 | Repo visibility follow-on | docs | manifest/linkage follow-on package | WP-06, WP-07 |
 | WP-13 | Publication program package | docs | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |

--- a/docs/milestones/v0.91.2/WP_EXECUTION_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/WP_EXECUTION_READINESS_v0.91.2.md
@@ -156,7 +156,7 @@ Required validation:
 
 Required outputs:
 
-- Moderne/OpenRewrite-style modernization interaction plan.
+- Moderne/OpenRewrite LST and recipe-driven modernization interaction plan.
 - Bounded demo with dry-run evidence.
 - Reversibility and review policy.
 

--- a/docs/milestones/v0.91.2/features/CODE_MODERNIZATION_DEMO.md
+++ b/docs/milestones/v0.91.2/features/CODE_MODERNIZATION_DEMO.md
@@ -1,8 +1,8 @@
-# Code Modernization Demo
+# Moderne / OpenRewrite LST Modernization Demo
 
 ## Metadata
 
-- Feature Name: Code Modernization Demo
+- Feature Name: Moderne / OpenRewrite LST Modernization Demo
 - Milestone Target: `v0.91.2`
 - Status: planned
 - Planned WP Home: WP-10
@@ -11,15 +11,26 @@
 
 ## Purpose
 
-Define and prove a bounded modernization workflow for ADL plus
-Moderne/OpenRewrite-style tools without turning modernization into automatic
-mass rewrite.
+Define and prove a bounded modernization workflow where ADL plans, constrains,
+and reviews deterministic code transformation around the Moderne platform and
+the OpenRewrite ecosystem, without turning modernization into automatic mass
+rewrite.
+
+The key terminology should stay explicit:
+
+- `Moderne` is the platform and multi-repo orchestration surface.
+- `OpenRewrite` is the transformation framework.
+- `LST` means `Lossless Semantic Tree`, the semantic code model that makes
+  transformations precise and repeatable.
+- `Recipes` are the deterministic transformation units that search and rewrite
+  code over the LST.
 
 ## Scope
 
 In scope:
 
-- Modernization interaction plan.
+- Moderne/OpenRewrite interaction plan.
+- Explicit LST and recipe framing in the demo packet.
 - Dry-run evidence.
 - Reversibility and review policy.
 - Relationship to CodeBuddy and Google Workspace surfaces.
@@ -29,9 +40,11 @@ Out of scope:
 - Unreviewed bulk rewrite.
 - Production service launch.
 - Automatic acceptance of generated patches.
+- vague “AI rewrites code automatically” positioning.
 
 ## Acceptance Criteria
 
 - Demo changes are source-grounded and reversible.
+- The packet names Moderne, OpenRewrite, LST, and recipes accurately.
 - Review policy is explicit.
 - Mass rewrite requires explicit follow-on approval.

--- a/docs/milestones/v0.91.2/features/README.md
+++ b/docs/milestones/v0.91.2/features/README.md
@@ -11,7 +11,7 @@ First-pass feature index for the proposed v0.91.2 pressure-release milestone.
 | CodeBuddy productization | [CODEBUDDY_PRODUCTIZATION.md](CODEBUDDY_PRODUCTIZATION.md) | `.adl/docs/TBD/codebuddy_ai/` | WP-06 | review packet, product report, skill-roadmap package |
 | Review heuristics and demos | [REVIEW_HEURISTICS_AND_DEMOS.md](REVIEW_HEURISTICS_AND_DEMOS.md) | `.adl/docs/TBD/workflow_tooling/ADL_REVIEW_HEURISTICS.md` | WP-07 | skill/demo surfaces for repeatable review |
 | Google Workspace CMS bridge | [GOOGLE_WORKSPACE_CMS_BRIDGE.md](GOOGLE_WORKSPACE_CMS_BRIDGE.md) | `.adl/docs/TBD/google_workspace_cms/` | WP-08, WP-09 | bounded content-card/promotion demo and adapter boundary |
-| Code modernization | [CODE_MODERNIZATION_DEMO.md](CODE_MODERNIZATION_DEMO.md) | `.adl/docs/TBD/code_modernization/` | WP-10 | Moderne/code-modernization demo and non-mass-rewrite policy |
+| Code modernization | [CODE_MODERNIZATION_DEMO.md](CODE_MODERNIZATION_DEMO.md) | `.adl/docs/TBD/code_modernization/` | WP-10 | Moderne / OpenRewrite LST demo and non-mass-rewrite policy |
 | Speculative decoding | [SPECULATIVE_DECODING_PROTOTYPE.md](SPECULATIVE_DECODING_PROTOTYPE.md) | `.adl/docs/TBD/ADL_AND_GENERIC_SPECULATIVE_DECODING.md`; `.adl/docs/TBD/ADL_AND_SPECULATIVE_CODING_REPLAY.md` | WP-11 | bounded runtime-acceleration architecture and proof posture |
 | Repo visibility follow-on | [REPO_VISIBILITY_FOLLOW_ON.md](REPO_VISIBILITY_FOLLOW_ON.md) | `.adl/docs/TBD/repo_visibility/` | WP-12 | bounded manifest/linkage follow-on without reopening the v0.90 baseline |
 | Publication program | [PUBLICATION_PROGRAM.md](PUBLICATION_PROGRAM.md) | `.adl/docs/TBD/publication/`; `.adl/docs/TBD/ARXIV_AUTHORING_PROCESS_NOTES.md` | WP-13 | paper backlog, process docs, review constraints |

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -195,7 +195,7 @@ ADL already provides a serious platform baseline:
 | CodeBuddy repo-review product layer | Planned | `docs/milestones/v0.91.2/features/CODEBUDDY_PRODUCTIZATION.md` plus existing CodeBuddy proof baseline | `v0.91.2` productization lane |
 | Review heuristics and reviewer demo lane | Planned | `docs/milestones/v0.91.2/features/REVIEW_HEURISTICS_AND_DEMOS.md` | `v0.91.2` |
 | Google Workspace CMS bridge and Rust-native adapter boundary | Planned | `docs/milestones/v0.91.2/features/GOOGLE_WORKSPACE_CMS_BRIDGE.md` | `v0.91.2` |
-| Automated repository modernization and external refactoring integration | Planned | `docs/milestones/v0.91.2/features/CODE_MODERNIZATION_DEMO.md` plus existing modernization planning docs | `v0.91.2` bounded modernization demo lane |
+| Automated repository modernization and external refactoring integration | Planned | `docs/milestones/v0.91.2/features/CODE_MODERNIZATION_DEMO.md` plus existing Moderne/OpenRewrite and code-modernization planning docs | `v0.91.2` bounded Moderne/OpenRewrite LST demo lane |
 | Generic speculative decoding runtime acceleration | Planned | `.adl/docs/TBD/ADL_AND_GENERIC_SPECULATIVE_DECODING.md`, `.adl/docs/TBD/ADL_AND_SPECULATIVE_CODING_REPLAY.md`, and `docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md` | `v0.91.2` |
 | Repo visibility follow-on | Planned | `docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md` plus the `v0.90` repo-visibility baseline | `v0.91.2` |
 | Publication packet program and GHB paper lane | Planned | `docs/milestones/v0.91.2/features/PUBLICATION_PROGRAM.md` plus GHB paper lineage docs | `v0.91.2` |


### PR DESCRIPTION
Closes #2964

## Summary
- clarify the v0.91.2 modernization lane as a Moderne/OpenRewrite/LST demo
- distinguish platform, framework, recipes, and semantic code model in the canonical feature doc
- align the surrounding milestone surfaces and feature list wording

## Validation
- git diff --check