### PR TITLE
[v0.91.1][WP-18][quality] Record milestone quality gate

### DIFF
--- a/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
@@ -7,11 +7,13 @@ structurally complete, but the milestone itself is still in progress.
 
 ## Current Partial Outcome
 
-As of the current package repair:
+As of the current quality-gate pass:
 
-- `WP-01` through `WP-05` are closed
-- `WP-06` through `WP-24` remain open
-- the runtime proof and review/release tail are not complete
+- `WP-01` through `WP-18` are closed and landed
+- the implementation/demo band through `WP-17` is complete
+- the quality gate is now recorded
+- the docs/review/remediation/handoff/ceremony tail (`WP-19` through `WP-24`)
+  remains open
 
 ## What This Report Must Eventually Cover
 
@@ -24,4 +26,3 @@ As of the current package repair:
 ## Current Judgment
 
 Do not treat this report as release closure.
-

--- a/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
+++ b/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
@@ -18,7 +18,7 @@
 - [x] WP-06 Citizen state substrate
 - [x] WP-07 through WP-16 implementation and flagship proof band
 - [x] WP-17 Demo matrix and proof coverage closeout
-- [ ] WP-18 Coverage / quality gate
+- [x] WP-18 Coverage / quality gate
 - [ ] WP-19 Docs + review pass
 - [ ] WP-20 Internal review
 - [ ] WP-21 External / 3rd-party review
@@ -29,7 +29,7 @@
 ## Review And Release Readiness
 
 - [x] Feature-proof coverage is complete for the implementation/demo band through WP-16.
-- [ ] Quality gate is recorded.
+- [x] Quality gate is recorded.
 - [ ] Internal review is complete.
 - [ ] External review is complete or explicitly deferred.
 - [ ] Accepted findings are fixed or dispositioned.

--- a/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Milestone: `v0.91.1`
-- Status: pending
+- Status: recorded / not yet release-ready
 - Canonical gate WP: `WP-18`
 
 ## Purpose
@@ -14,17 +14,52 @@ milestone reaches its quality phase.
 
 ## Current State
 
-The quality gate is not complete yet.
+The quality gate record now exists, but the milestone is not release-ready yet.
 
 Known execution truth today:
 
-- `WP-01` through `WP-05` are closed
-- `WP-06` through `WP-24` remain open
-- the flagship demo and final proof-convergence band are not complete
-- internal review, external review, remediation, and release ceremony are not
-  complete
+- `WP-01` through `WP-17` are closed and landed
+- the implementation/demo convergence band through `WP-16` is landed
+- `WP-17` recorded the final demo/proof coverage truth for the landed runtime
+  band
+- this issue records the quality gate posture for the milestone package before
+  the review/remediation/release tail
+- `WP-19` through `WP-24` remain open for docs review, internal review,
+  external review, remediation, handoff, and release ceremony
 
-## Required Inputs Before Pass/Fail Judgment
+## Current Validation Posture
+
+### Demo and proof coverage
+
+- [DEMO_MATRIX_v0.91.1.md](DEMO_MATRIX_v0.91.1.md) and
+  [FEATURE_PROOF_COVERAGE_v0.91.1.md](FEATURE_PROOF_COVERAGE_v0.91.1.md)
+  now record one truthful proof route for every landed `WP-02` through `WP-16`
+  feature.
+- [SPRINT_3_CLOSEOUT_v0.91.1.md](SPRINT_3_CLOSEOUT_v0.91.1.md) records the
+  merged secure-comms and inhabited-runtime proof wave through `WP-17`.
+
+### CI and coverage evidence
+
+- The milestone already has a focused test-cycle and coverage-policy record in
+  [TEST_CYCLE_MINI_SPRINT_CLOSEOUT_v0.91.1.md](TEST_CYCLE_MINI_SPRINT_CLOSEOUT_v0.91.1.md).
+- That closeout records the pre/post authoritative-coverage evidence currently
+  available:
+  - baseline authoritative `main` run `25567349404`
+  - baseline coverage runtime `525.078s`
+  - first post-sprint authoritative `main` run `25610627099`
+  - truthful conclusion: useful routing/reporting wins landed, but no clean
+    full-authoritative wall-time reduction was proven yet
+- That means the quality gate may cite real coverage-policy and runtime
+  evidence, but it must not overclaim a solved test-time story.
+
+### Docs and review posture
+
+- milestone planning, feature, demo, and proof-coverage surfaces exist and are
+  coherent enough to enter the review tail
+- docs review, internal review, external review, remediation, and release
+  ceremony are still pending
+
+## Required Inputs Before Final Pass/Fail Judgment
 
 - demo matrix and feature-proof coverage
 - final milestone CI and coverage evidence
@@ -37,3 +72,20 @@ Known execution truth today:
 
 `NOT_READY`
 
+## Why The Gate Is Still Not Ready
+
+- the docs/review pass (`WP-19`) is not complete yet
+- internal review (`WP-20`) is not complete yet
+- external review (`WP-21`) is not complete yet
+- accepted-finding remediation (`WP-22`) is not complete yet
+- release evidence, handoff, and ceremony (`WP-23` and `WP-24`) are not
+  complete yet
+
+## Gate Value Provided By WP-18
+
+This issue does still deliver a real release-tail work product:
+
+- it converts the milestone-wide quality gate from a placeholder into a
+  truthful status record
+- it binds the current proof-coverage state to the current CI/coverage state
+- it makes the remaining blockers explicit before the review tail begins

--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -22,13 +22,21 @@ truthful `v0.91.1` release decision.
 - `WP-03` lifecycle-state implementation
 - `WP-04` observatory active surface implementation
 - `WP-05` citizen standing implementation
+- `WP-06` citizen state substrate
+- `WP-07` through `WP-12` memory, ToM, capability, intelligence, governed
+  learning, and ANRM/Gemma runtime proof surfaces
+- `WP-13` ACIP hardening
+- `WP-14` A2A adapter boundary
+- `WP-15` runtime inhabitant proof
+- `WP-16` observatory-visible flagship demo
+- `WP-17` milestone demo matrix and feature-proof coverage closeout
+- `WP-18` milestone quality-gate record
 
 ## Evidence Still Missing
 
-- citizen-state implementation and later runtime slices
-- integrated runtime inhabitant proof
-- observatory-visible flagship demo
-- final quality gate
-- internal/external review records
-- remediation and ceremony records
-
+- docs/review pass package
+- internal review record
+- external review handoff and record
+- accepted-finding remediation record
+- v0.92 birthday-readiness handoff
+- release ceremony and end-of-milestone report

--- a/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
@@ -25,17 +25,26 @@ Inhabited-runtime readiness inside the CSM/polis boundary.
 - ACIP conformance and local encryption hardening
 - A2A adapter boundary and compatibility plan
 - runtime inhabitant integration
+- observatory-visible flagship demo
+- milestone demo matrix / proof coverage closeout
+- milestone quality-gate record
 
 Sprint state:
 - Sprint 1 runtime foundations are landed through citizen state
 - Sprint 2 cognition, learning, and trace surfaces are landed through ANRM/Gemma placement
-- Sprint 3 runtime/comms integration is landed through runtime inhabitant integration
+- Sprint 3 runtime/comms integration and flagship proof band are landed through
+  demo/proof coverage closeout
+- Sprint 4 quality/review/release tail has started with the recorded quality
+  gate, but review/remediation/release closure remains open
 
 ## Still Pending
 
-- observatory-visible flagship demo, including direct lifecycle/comms/inhabitant proof binding
-- milestone demo matrix / proof coverage closeout
-- milestone review, remediation, and release ceremony
+- docs + review pass
+- internal review
+- external / 3rd-party review
+- accepted-finding remediation
+- v0.92 birthday-readiness handoff
+- release ceremony and end-of-milestone report
 
 ## Not Claimed
 

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -18,16 +18,20 @@ Not release ready.
 
 ## Current Issue State
 
-- `WP-01` through `WP-15` are closed and landed
-- `WP-16` is the active flagship demo proof issue
-- `WP-17` through `WP-24` remain open for the final review/release band
-- Sprint 2 is complete, Sprint 3 runtime/comms/inhabitant work is landed through `WP-15`, and the remaining milestone-critical runtime proof surface is the WP-16 flagship demo
+- `WP-01` through `WP-18` are closed and landed
+- `WP-19` through `WP-24` remain open for the final docs/review/release band
+- Sprint 2 is complete
+- Sprint 3 runtime/comms/inhabitant work is complete through `WP-17`
+- `WP-18` now records the milestone quality-gate posture rather than leaving it
+  implicit
 
 ## Current Blockers
 
-- the observatory-visible flagship demo is still open and is being tightened to directly bind lifecycle-state, ACIP, A2A, and runtime-inhabitant evidence
-- quality gate is pending
-- internal review, external review, remediation, handoff, and ceremony are pending
+- docs + review pass is pending
+- internal review is pending
+- external review is pending
+- review-findings remediation is pending
+- v0.92 handoff and release ceremony are pending
 
 ## Version Truth
 


### PR DESCRIPTION
Closes #2840

## Summary
- record the v0.91.1 milestone quality gate as a real release-tail artifact
- update stale release-facing docs to reflect the landed Sprint 3 and WP-18 state
- keep the milestone truthfully not release-ready while review/remediation/ceremony work remains

## Validation
- git diff --check
- bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.1/tasks/issue-2840__v0-91-1-wp-18-coverage-quality-gate/sor.md
- rg -n 'WP-01 through |WP-19|quality gate is recorded|WP-17 recorded|observatory-visible flagship demo|milestone quality-gate record|release ceremony and end-of-milestone report' docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md