### PR TITLE
[v0.91.2][docs] Create repo-level AGENTS.md for ADL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# ADL Agent Guidelines
+
+This file is the repository-local operating contract for coding agents working
+in ADL.
+
+It follows the OpenAI `AGENTS.md` pattern of keeping one predictable,
+high-signal instruction surface at the repo root, then adapts that pattern to
+ADL's real workflow and review discipline.
+
+## Core Principles
+
+These are the four behavioral principles at the center of this file.
+
+1. Think before coding.
+   - Understand the goal, the acceptance surface, and the smallest safe change
+     before editing.
+2. Simplicity first.
+   - Prefer the simplest truthful solution over cleverness, abstraction churn,
+     or framework theater.
+3. Make surgical changes.
+   - Change only the files and behavior needed for the issue you are working
+     on.
+4. Stay goal-driven.
+   - Keep work tied to the issue outcome, not to adjacent cleanup or tempting
+     side quests.
+
+## Workflow Rules
+
+These rules are mandatory for ADL issue work.
+
+1. Use `workflow-conductor` for every issue and lifecycle stage.
+   - Do not bypass the conductor for issue execution, review routing,
+     publication, janitor work, or closeout.
+2. Edit cards only with editor skills.
+   - Use `stp-editor`, `sip-editor`, `spp-editor`, `sor-editor`, or other
+     issue-card editor skills when card surfaces need normalization.
+   - Do not hand-edit cards opportunistically.
+3. Always work in a bound worktree on a specific branch.
+   - Never do tracked issue work on `main`.
+   - Use the repo-native issue-mode `pr run` flow to bind execution context.
+4. Always review work with a subagent before opening the PR.
+   - Run a bounded review subagent over the changed work product.
+   - Fix all actionable findings immediately before publication.
+5. Always perform closeout after the issue is closed.
+   - Use the normal closeout path so issue truth, cards, artifacts, and GitHub
+     state all agree.
+
+## Repository-Specific Working Style
+
+- ADL is deterministic by design. Do not introduce hidden state, undeclared
+  side effects, or review-hostile magic.
+- Treat model/tool output as governed work, not free authority.
+- Keep milestone claims, proof claims, and review claims evidence-bound.
+- Prefer repo-relative paths in artifacts and records.
+- Do not silently widen issue scope.
+
+## Where To Start
+
+For a normal tracked issue:
+
+1. read the source issue prompt and current task bundle
+2. route through `workflow-conductor`
+3. follow the conductor-selected lifecycle step
+4. if the issue is ready for execution binding, use `adl/tools/pr.sh run <issue>`
+5. make the bounded change in the issue worktree
+6. run the smallest meaningful validation for the touched surface
+7. run a pre-PR subagent review and fix findings
+8. publish through the normal PR workflow
+9. perform closeout after merge/closure
+
+## Validation Expectations
+
+- Run the smallest proving validation that matches the issue's outcome type.
+- Do not skip required proof just because the change is small.
+- Do not run broad validation reflexively when focused proof is enough.
+- Keep review records and output cards truthful about what was and was not run.
+
+## Review And Publication Rules
+
+- No PR should open before the work has had bounded subagent review.
+- Findings come before summary.
+- Fixes should stay within the issue's scope unless the operator explicitly
+  widens it.
+- If review uncovers a separate problem, open or route a follow-on issue
+  instead of hiding new scope inside the current one.
+
+## Non-Goals For This File
+
+This root `AGENTS.md` is intentionally compact.
+
+It is not:
+
+- the full milestone manual
+- a replacement for skill docs
+- a substitute for issue cards
+- the final word on nested package-specific agent guidance
+
+## Source Baseline Used
+
+This file was shaped from two OpenAI-adjacent baselines plus ADL-specific
+workflow policy:
+
+- the open `agents.md` project framing of `AGENTS.md` as a predictable
+  repository-local instruction surface
+- OpenAI Cookbook's practical repository-guidelines-style `AGENTS.md`
+- ADL's conductor, worktree, review, and closeout discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,20 @@ It is not:
 
 ## Source Baseline Used
 
-This file was shaped from two OpenAI-adjacent baselines plus ADL-specific
-workflow policy:
+This file was shaped from the OpenAI/source baselines named by `#2986`, plus
+ADL-specific workflow policy:
 
-- the open `agents.md` project framing of `AGENTS.md` as a predictable
-  repository-local instruction surface
-- OpenAI Cookbook's practical repository-guidelines-style `AGENTS.md`
+- issue-named OpenAI `agents.md` GitHub baseline:
+  `https://github.com/openai/agents.md`
+- official OpenAI guide for `AGENTS.md` in Codex:
+  `https://developers.openai.com/codex/guides/agents-md`
+- practical OpenAI repository example:
+  `https://github.com/openai/openai-cookbook/blob/main/AGENTS.md`
+- broader open-format companion reference:
+  `https://agents.md/`
 - ADL's conductor, worktree, review, and closeout discipline
+
+The issue named the GitHub `openai/agents.md` baseline explicitly. That
+repository now routes into the broader `agents.md` effort, so this file keeps
+both the issue-named GitHub source and the live `agents.md` reference visible
+for traceability.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ production markets.
   cognitive loop behind Gödel-agent work.
 - [Examples](adl/examples/README.md): runnable ADL examples.
 - [Demos](demos/README.md): demo-oriented proof surfaces.
+- [AGENTS.md](AGENTS.md): repository-local operating contract for coding agents.
 
 ## Project Status
 


### PR DESCRIPTION
Closes #2986

## Summary
- add a root AGENTS.md for ADL using the OpenAI AGENTS baseline shape
- include the four core Karpathy principles as the behavioral center
- capture ADL-specific workflow rules including conductor usage, worktree-only execution, pre-PR subagent review, and closeout discipline
- add a README docs-map link for discoverability

## Validation
- pre-PR subagent review over AGENTS.md and the README link surface
- no actionable findings remained after fixing the workflow-entrypoint contradiction
- no broad tests run (docs-only change)