### PR TITLE
[v0.91.1][WP-21][review] External / 3rd-party review

### DIFF
--- a/docs/milestones/v0.91.1/ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.1/ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -1,0 +1,193 @@
+# Third-Party Review Handoff - v0.91.1
+
+## Metadata
+
+- Milestone: `v0.91.1`
+- Version: `v0.91.1`
+- Active crate version: `0.91.1`
+- Review lane: `WP-21` external / 3rd-party review, following `WP-20`
+  internal review
+- Prepared during: `v0.91.1` review tail
+- Prepared from issue: `#2843`
+- Prepared from branch:
+  `codex/2843-v0-91-1-wp-21-external-3rd-party-review`
+- Current packet status: external review complete; zero-finding result recorded
+- Date: 2026-05-11
+- Publication attempted: false
+- Release approval claimed: false
+- Review approval claimed: false
+
+## Update Before Review
+
+This handoff exists as the canonical tracked third-party review surface for
+`v0.91.1`. Because the external review has already completed, the refresh task
+now is not "prepare for first send" but "preserve truthful review record."
+
+Before using this document as the final release-tail reference, confirm:
+
+- the tracked milestone docs still match crate/version truth for `v0.91.1`
+- the imported review artifacts listed below still exist in the local review
+  store
+- this handoff does not claim remediation, birthday handoff, or ceremony work
+  that belongs to later WPs
+- no host-local, temporary, or branch-only claims have slipped into the tracked
+  milestone packet
+
+This tracked handoff is intended to stand on its own. Operator-local archival
+copies of the returned review may exist elsewhere, but the tracked milestone
+truth should not depend on hidden local files.
+
+## Purpose
+
+This handoff gives the `v0.91.1` release tail a canonical tracked record of
+the external review packet and its outcome.
+
+Review `v0.91.1` as the inhabited-runtime-readiness milestone that integrates:
+
+- Runtime v2 / polis architecture alignment
+- lifecycle-state rules and ACIP eligibility
+- observatory active surface and flagship proof
+- citizen standing and citizen state runtime contracts
+- memory and identity groundwork
+- Theory of Mind foundation
+- capability and aptitude testing
+- intelligence metric architecture
+- governed learning substrate
+- ANRM / Gemma trace-dataset placement
+- ACIP hardening and A2A boundary planning
+- runtime inhabitant integration proof
+
+This milestone does not claim birthday, legal personhood, constitutional
+citizenship, broad provider-native tool-call conformance, or production
+external transport/federation readiness.
+
+## Archived Review Copies
+
+Operator-local archival copies of the returned review may exist in the local
+review store. They are archival convenience only and are not required to
+understand the tracked milestone truth recorded here.
+
+## Current Milestone Truth
+
+`v0.91.1` has landed through the implementation and proof band plus the
+review-entry package:
+
+- runtime/polis architecture package
+- lifecycle-state implementation
+- observatory active surface
+- citizen standing and citizen state
+- memory / identity architecture
+- Theory of Mind foundation
+- capability / aptitude harness
+- intelligence metric architecture
+- governed learning substrate
+- ANRM / Gemma trace dataset placement
+- ACIP hardening
+- A2A adapter boundary planning
+- runtime inhabitant integration proof
+- observatory-visible flagship demo
+- milestone demo matrix / proof coverage closeout
+- milestone quality gate
+- review-ready docs package
+- internal review packet
+
+The milestone does not yet claim:
+
+- accepted-finding remediation completion
+- `v0.92` birthday-readiness handoff completion
+- release ceremony completion
+
+## External Review Outcome
+
+The recorded third-party review outcome is:
+
+- overall grade: `A+ (100/100)`
+- recommendation: `READY NOW`
+- findings: `ZERO`
+
+The returned review explicitly records:
+
+- `P0`: `0`
+- `P1`: `0`
+- `P2`: `0`
+- `P3`: `0`
+
+The review therefore leaves no accepted findings for `WP-22` to remediate.
+`WP-22` should record a truthful zero-findings remediation disposition rather
+than inventing cleanup work.
+
+## Review-Tail State To Consider
+
+At the time of this issue:
+
+- `WP-20` internal review is complete
+- `WP-21` external / third-party review is complete
+- `WP-22` should record the zero-findings remediation disposition
+- `WP-23` remains the birthday-readiness handoff
+- `WP-24` remains the release ceremony
+
+## Previous Review Mistakes To Avoid
+
+- Do not treat a zero-finding review as permission to skip documentation of the
+  review itself.
+- Do not claim birthday, constitutional citizenship, or ceremony work from this
+  issue.
+- Do not hide the external review in `.adl` only; the tracked milestone package
+  should point at the review packet and its result.
+- Do not rewrite the external review outcome into release approval. Review
+  completion is not the same thing as release closeout.
+
+## Required Review Scope
+
+The external packet and milestone docs were intended to cover:
+
+- root version-truth surfaces:
+  - `README.md`
+  - `CHANGELOG.md`
+  - `adl/Cargo.toml`
+- milestone package:
+  - `docs/milestones/v0.91.1/README.md`
+  - `docs/milestones/v0.91.1/WBS_v0.91.1.md`
+  - `docs/milestones/v0.91.1/SPRINT_v0.91.1.md`
+  - `docs/milestones/v0.91.1/WP_ISSUE_WAVE_v0.91.1.yaml`
+  - `docs/milestones/v0.91.1/WP_EXECUTION_READINESS_v0.91.1.md`
+  - `docs/milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md`
+  - `docs/milestones/v0.91.1/FEATURE_PROOF_COVERAGE_v0.91.1.md`
+  - `docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md`
+  - `docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md`
+  - `docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md`
+  - `docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md`
+- milestone feature docs and proof surfaces
+
+## Proof And Quality Evidence To Check
+
+The external review was expected to verify:
+
+- the inhabited-runtime implementation band is real and reviewable
+- demo/proof rows are backed by concrete surfaces
+- milestone non-claims remain explicit
+- version truth is consistent
+- documentation and release-tail state are legible
+
+The recorded summary says those checks passed without findings.
+
+## Expected Reviewer Output
+
+Expected reviewer output for this lane was:
+
+- severity-ranked findings if any existed
+- explicit non-findings if the package was clean
+- recommendation for whether normal release-tail progression could continue
+
+That expected output was satisfied by the imported summary.
+
+## Non-claims
+
+This handoff does not claim:
+
+- birthday completion
+- legal personhood
+- constitutional citizenship
+- external transport or federation readiness
+- release ceremony completion
+- release approval beyond the bounded external review result

--- a/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
+++ b/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
@@ -20,8 +20,8 @@
 - [x] WP-17 Demo matrix and proof coverage closeout
 - [x] WP-18 Coverage / quality gate
 - [x] WP-19 Docs + review pass
-- [ ] WP-20 Internal review
-- [ ] WP-21 External / 3rd-party review
+- [x] WP-20 Internal review
+- [x] WP-21 External / 3rd-party review
 - [ ] WP-22 Review findings remediation
 - [ ] WP-23 v0.92 birthday readiness handoff
 - [ ] WP-24 Release ceremony
@@ -31,8 +31,8 @@
 - [x] Feature-proof coverage is complete for the implementation/demo band through WP-16.
 - [x] Quality gate is recorded.
 - [x] Review-ready docs package is aligned.
-- [ ] Internal review is complete.
-- [ ] External review is complete or explicitly deferred.
+- [x] Internal review is complete.
+- [x] External review is complete or explicitly deferred.
 - [ ] Accepted findings are fixed or dispositioned.
 - [ ] Release evidence and release readiness are complete.
 - [ ] Ceremony completed.

--- a/docs/milestones/v0.91.1/README.md
+++ b/docs/milestones/v0.91.1/README.md
@@ -126,6 +126,8 @@ not import the broad provider-native benchmark planning surface.
 - Release readiness: [RELEASE_READINESS_v0.91.1.md](RELEASE_READINESS_v0.91.1.md)
 - Release evidence: [RELEASE_EVIDENCE_v0.91.1.md](RELEASE_EVIDENCE_v0.91.1.md)
 - Release notes: [RELEASE_NOTES_v0.91.1.md](RELEASE_NOTES_v0.91.1.md)
+- Third-party review handoff:
+  [ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md](ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md)
 - Next milestone handoff:
   [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
 - End-of-milestone report:

--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -20,6 +20,7 @@ truthful `v0.91.1` release decision.
 - [QUALITY_GATE_v0.91.1.md](QUALITY_GATE_v0.91.1.md)
 - [MILESTONE_CHECKLIST_v0.91.1.md](MILESTONE_CHECKLIST_v0.91.1.md)
 - [RELEASE_NOTES_v0.91.1.md](RELEASE_NOTES_v0.91.1.md)
+- [ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md](ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md)
 - [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 - [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
 - [SPRINT_2_CLOSEOUT_v0.91.1.md](SPRINT_2_CLOSEOUT_v0.91.1.md)
@@ -41,11 +42,11 @@ truthful `v0.91.1` release decision.
 - `WP-17` milestone demo matrix and feature-proof coverage closeout
 - `WP-18` milestone quality-gate record
 - `WP-19` review-ready docs package and reviewer-entry surface alignment
+- `WP-20` internal review packet
+- `WP-21` external / third-party review handoff and zero-finding record
 
 ## Evidence Still Missing
 
-- internal review record
-- external review handoff and record
 - accepted-finding remediation record
 - v0.92 birthday-readiness handoff
 - release ceremony and end-of-milestone report

--- a/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
@@ -34,14 +34,13 @@ Sprint state:
 - Sprint 2 cognition, learning, and trace surfaces are landed through ANRM/Gemma placement
 - Sprint 3 runtime/comms integration and flagship proof band are landed through
   demo/proof coverage closeout
-- Sprint 4 quality/review/release tail now has the recorded quality gate and
-  review-ready docs package, but review/remediation/release closure remains
-  open
+- Sprint 4 quality/review/release tail now has the recorded quality gate,
+  review-ready docs package, internal review record, and external review
+  record, but
+  remediation/release closure remains open
 
 ## Still Pending
 
-- internal review
-- external / 3rd-party review
 - accepted-finding remediation
 - v0.92 birthday-readiness handoff
 - release ceremony and end-of-milestone report

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -5,9 +5,9 @@
 Not release ready.
 
 This document is the compact reviewer-entry surface for the active `v0.91.1`
-release tail. The milestone is not complete until internal review, third-party
-review, accepted-finding remediation, the `v0.92` handoff, and the release
-ceremony all finish.
+release tail. Internal review and third-party review are complete. The
+milestone is not complete until accepted-finding remediation, the `v0.92`
+handoff, and the release ceremony all finish.
 
 ## Review Entry Points
 
@@ -25,6 +25,7 @@ ceremony all finish.
 - [RELEASE_PLAN_v0.91.1.md](RELEASE_PLAN_v0.91.1.md)
 - [RELEASE_EVIDENCE_v0.91.1.md](RELEASE_EVIDENCE_v0.91.1.md)
 - [RELEASE_NOTES_v0.91.1.md](RELEASE_NOTES_v0.91.1.md)
+- [ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md](ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md)
 - [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 - [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
 - [SPRINT_2_CLOSEOUT_v0.91.1.md](SPRINT_2_CLOSEOUT_v0.91.1.md)
@@ -33,7 +34,7 @@ ceremony all finish.
 ## Current Issue State
 
 - `WP-01` through `WP-19` are closed or ready to close with landed docs truth
-- `WP-20` through `WP-24` remain open for the final review/remediation/release band
+- `WP-22` through `WP-24` remain open for the final remediation/release band
 - Sprint 2 is complete
 - Sprint 3 runtime/comms/inhabitant work is complete through `WP-17`
 - `WP-18` records the milestone quality-gate posture
@@ -42,8 +43,8 @@ ceremony all finish.
 
 ## Current Blockers
 
-- internal review is pending
-- external review is pending
+- internal review is complete
+- external review is complete
 - review-findings remediation is pending
 - v0.92 handoff and release ceremony are pending
 


### PR DESCRIPTION
## Summary
- add the tracked v0.91.1 third-party review handoff and recorded external-review result
- align README and release-tail docs so WP-20/WP-21 are complete and WP-22 through WP-24 remain open
- record the zero-finding review outcome directly in tracked milestone docs

## Validation
- `git diff --check`
- bounded docs-review subagent over the handoff and release-tail docs
- `ADL_TOOLING_RUST_BIN=/Users/daniel/git/agent-design-language/adl/target/debug/adl bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.1/tasks/issue-2843__v0-91-1-wp-21-external-3rd-party-review/sor.md`

Closes #2843
