### PR TITLE
[v0.91.1][WP-22][review] Review findings remediation

### DIFF
--- a/docs/milestones/v0.91.1/ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.1/ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -93,7 +93,6 @@ review-entry package:
 
 The milestone does not yet claim:
 
-- accepted-finding remediation completion
 - `v0.92` birthday-readiness handoff completion
 - release ceremony completion
 
@@ -113,8 +112,8 @@ The returned review explicitly records:
 - `P3`: `0`
 
 The review therefore leaves no accepted findings for `WP-22` to remediate.
-`WP-22` should record a truthful zero-findings remediation disposition rather
-than inventing cleanup work.
+`WP-22` records a truthful zero-findings remediation disposition rather than
+inventing cleanup work.
 
 ## Review-Tail State To Consider
 
@@ -122,7 +121,7 @@ At the time of this issue:
 
 - `WP-20` internal review is complete
 - `WP-21` external / third-party review is complete
-- `WP-22` should record the zero-findings remediation disposition
+- `WP-22` records the zero-findings remediation disposition
 - `WP-23` remains the birthday-readiness handoff
 - `WP-24` remains the release ceremony
 

--- a/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
@@ -9,11 +9,12 @@ structurally complete, but the milestone itself is still in progress.
 
 As of the current docs/review pass:
 
-- `WP-01` through `WP-19` are closed or ready to close with landed docs truth
+- `WP-01` through `WP-22` are closed or ready to close with landed docs truth
 - the implementation/demo band through `WP-17` is complete
 - the quality gate is now recorded
-- the review/remediation/handoff/ceremony tail (`WP-20` through `WP-24`)
-  remains open
+- the review/remediation band is now recorded through explicit zero-findings
+  disposition
+- the remaining open tail is now `WP-23` and `WP-24`
 
 ## What This Report Must Eventually Cover
 

--- a/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
+++ b/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
@@ -22,7 +22,7 @@
 - [x] WP-19 Docs + review pass
 - [x] WP-20 Internal review
 - [x] WP-21 External / 3rd-party review
-- [ ] WP-22 Review findings remediation
+- [x] WP-22 Review findings remediation
 - [ ] WP-23 v0.92 birthday readiness handoff
 - [ ] WP-24 Release ceremony
 
@@ -33,6 +33,6 @@
 - [x] Review-ready docs package is aligned.
 - [x] Internal review is complete.
 - [x] External review is complete or explicitly deferred.
-- [ ] Accepted findings are fixed or dispositioned.
+- [x] Accepted findings are fixed or dispositioned.
 - [ ] Release evidence and release readiness are complete.
 - [ ] Ceremony completed.

--- a/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
@@ -25,8 +25,9 @@ Known execution truth today:
 - this issue records the quality gate posture for the milestone package before
   the review/remediation/release tail
 - `WP-19` aligned the reviewer-entry docs and active version/status surfaces
-- `WP-20` through `WP-24` remain open for internal review, external review,
-  remediation, handoff, and release ceremony
+- `WP-20` through `WP-22` now provide the internal review, external review,
+  and explicit zero-findings remediation disposition
+- `WP-23` and `WP-24` remain open for handoff and release ceremony
 
 ## Current Validation Posture
 
@@ -58,8 +59,8 @@ Known execution truth today:
 - milestone planning, feature, demo, and proof-coverage surfaces exist and are
   coherent enough to enter the review tail
 - docs review pass is complete
-- internal review, external review, remediation, and release ceremony are still
-  pending
+- internal review, external review, and remediation disposition are complete
+- handoff and release ceremony are still pending
 
 ## Required Inputs Before Final Pass/Fail Judgment
 
@@ -75,9 +76,6 @@ Known execution truth today:
 
 ## Why The Gate Is Still Not Ready
 
-- internal review (`WP-20`) is not complete yet
-- external review (`WP-21`) is not complete yet
-- accepted-finding remediation (`WP-22`) is not complete yet
 - release evidence, handoff, and ceremony (`WP-23` and `WP-24`) are not
   complete yet
 

--- a/docs/milestones/v0.91.1/README.md
+++ b/docs/milestones/v0.91.1/README.md
@@ -128,6 +128,8 @@ not import the broad provider-native benchmark planning surface.
 - Release notes: [RELEASE_NOTES_v0.91.1.md](RELEASE_NOTES_v0.91.1.md)
 - Third-party review handoff:
   [ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md](ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md)
+- Remediation queue:
+  [review/WP22_REMEDIATION_QUEUE.md](review/WP22_REMEDIATION_QUEUE.md)
 - Next milestone handoff:
   [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
 - End-of-milestone report:

--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -21,6 +21,7 @@ truthful `v0.91.1` release decision.
 - [MILESTONE_CHECKLIST_v0.91.1.md](MILESTONE_CHECKLIST_v0.91.1.md)
 - [RELEASE_NOTES_v0.91.1.md](RELEASE_NOTES_v0.91.1.md)
 - [ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md](ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md)
+- [review/WP22_REMEDIATION_QUEUE.md](review/WP22_REMEDIATION_QUEUE.md)
 - [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 - [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
 - [SPRINT_2_CLOSEOUT_v0.91.1.md](SPRINT_2_CLOSEOUT_v0.91.1.md)
@@ -44,9 +45,9 @@ truthful `v0.91.1` release decision.
 - `WP-19` review-ready docs package and reviewer-entry surface alignment
 - `WP-20` internal review packet
 - `WP-21` external / third-party review handoff and zero-finding record
+- `WP-22` accepted-finding disposition record with zero accepted findings
 
 ## Evidence Still Missing
 
-- accepted-finding remediation record
 - v0.92 birthday-readiness handoff
 - release ceremony and end-of-milestone report

--- a/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
@@ -36,12 +36,11 @@ Sprint state:
   demo/proof coverage closeout
 - Sprint 4 quality/review/release tail now has the recorded quality gate,
   review-ready docs package, internal review record, and external review
-  record, but
-  remediation/release closure remains open
+  record, plus the explicit zero-findings remediation disposition, but
+  handoff/release closure remains open
 
 ## Still Pending
 
-- accepted-finding remediation
 - v0.92 birthday-readiness handoff
 - release ceremony and end-of-milestone report
 

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -6,8 +6,8 @@ Not release ready.
 
 This document is the compact reviewer-entry surface for the active `v0.91.1`
 release tail. Internal review and third-party review are complete. The
-milestone is not complete until accepted-finding remediation, the `v0.92`
-handoff, and the release ceremony all finish.
+accepted-finding remediation disposition is also complete. The milestone is not
+complete until the `v0.92` handoff and the release ceremony both finish.
 
 ## Review Entry Points
 
@@ -26,6 +26,7 @@ handoff, and the release ceremony all finish.
 - [RELEASE_EVIDENCE_v0.91.1.md](RELEASE_EVIDENCE_v0.91.1.md)
 - [RELEASE_NOTES_v0.91.1.md](RELEASE_NOTES_v0.91.1.md)
 - [ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md](ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md)
+- [review/WP22_REMEDIATION_QUEUE.md](review/WP22_REMEDIATION_QUEUE.md)
 - [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 - [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
 - [SPRINT_2_CLOSEOUT_v0.91.1.md](SPRINT_2_CLOSEOUT_v0.91.1.md)
@@ -33,8 +34,8 @@ handoff, and the release ceremony all finish.
 
 ## Current Issue State
 
-- `WP-01` through `WP-19` are closed or ready to close with landed docs truth
-- `WP-22` through `WP-24` remain open for the final remediation/release band
+- `WP-01` through `WP-22` are closed or ready to close with landed docs truth
+- `WP-23` and `WP-24` remain open for the final handoff/release band
 - Sprint 2 is complete
 - Sprint 3 runtime/comms/inhabitant work is complete through `WP-17`
 - `WP-18` records the milestone quality-gate posture
@@ -45,8 +46,8 @@ handoff, and the release ceremony all finish.
 
 - internal review is complete
 - external review is complete
-- review-findings remediation is pending
-- v0.92 handoff and release ceremony are pending
+- review-findings remediation is complete as explicit zero-findings disposition
+- `v0.92` handoff and release ceremony are pending
 
 ## Version Truth
 

--- a/docs/milestones/v0.91.1/review/WP22_REMEDIATION_QUEUE.md
+++ b/docs/milestones/v0.91.1/review/WP22_REMEDIATION_QUEUE.md
@@ -1,0 +1,33 @@
+# WP-22 Remediation Queue - v0.91.1
+
+## Source
+
+Derived from `WP-20` internal review and `WP-21` external / 3rd-party review.
+
+## Disposition
+
+The external review returned zero accepted findings, so there are no accepted
+review findings to remediate in `WP-22`.
+
+The internal review exercised the milestone package and the external review
+rechecked the release-tail truth. That produced a meaningful release-tail
+result, but it did not emit any accepted blocker, deferral, or follow-up issue
+that belongs in a remediation queue.
+
+## Queue
+
+No accepted findings.
+
+## Notes
+
+- `WP-22` is still a meaningful closeout step because it records the
+  no-remediation outcome explicitly rather than implying it by silence.
+- If any later operator-chosen cleanup is desired, it should be routed as
+  follow-on work rather than represented as accepted release-tail remediation.
+- `WP-23` remains the next-milestone planning and birthday-readiness handoff
+  step; `WP-22` does not claim that work.
+
+## Queue Rule
+
+This queue is a routing surface only. In `v0.91.1`, the truthful routing
+result is that no accepted remediation items were emitted from review.


### PR DESCRIPTION
## Summary
- add a canonical WP-22 remediation queue for the zero-findings outcome
- align v0.91.1 release-tail docs so WP-22 is recorded explicitly
- keep the remaining open tail limited to WP-23 and WP-24

## Validation
- `git diff --check`
- `ADL_TOOLING_RUST_BIN=/Users/daniel/git/agent-design-language/adl/target/debug/adl bash adl/tools/validate_structured_prompt.sh --type sip --phase bootstrap --input .adl/v0.91.1/tasks/issue-2844__v0-91-1-wp-22-review-findings-remediation/sip.md`
- `ADL_TOOLING_RUST_BIN=/Users/daniel/git/agent-design-language/adl/target/debug/adl bash adl/tools/validate_structured_prompt.sh --type sor --phase bootstrap --input .adl/v0.91.1/tasks/issue-2844__v0-91-1-wp-22-review-findings-remediation/sor.md`

Closes #2844
