### PR TITLE
[v0.91.2][docs] Refit sprint-conductor execution plan to existing sprint structure

### DIFF
--- a/docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md
@@ -24,11 +24,27 @@ This plan is intentionally about execution shape, not feature scope.
 
 ## Operating Decision
 
-Use the milestone as the roadmap unit, but use bounded sprint-conductor
-umbrellas as the execution unit.
+Use the milestone as the roadmap unit, and use the already-defined milestone
+sprints as the sprint-conductor execution units.
 
-Do not run all of `v0.91.2` as one giant autonomous sprint. Instead, break it
-into coherent sprint-management umbrellas with explicit ordered issue lists.
+Do not run all of `v0.91.2` as one giant autonomous sprint. Also do not invent
+a second sprint topology on top of the existing milestone package. Instead,
+execute the canonical Sprint 1 through Sprint 4 structure through bounded
+sprint-management umbrellas with explicit ordered issue lists taken directly
+from the existing sprint plan and issue wave.
+
+## Source-Of-Truth Rule
+
+This document is an execution overlay, not a replacement milestone plan.
+
+The sprint and issue membership source of truth remains:
+
+- `docs/milestones/v0.91.2/SPRINT_v0.91.2.md`
+- `docs/milestones/v0.91.2/WBS_v0.91.2.md`
+- `docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml`
+
+If the milestone sprint structure or issue membership ever changes, update
+those canonical docs first and then align this execution plan to them.
 
 ## Operating Principles
 
@@ -59,32 +75,25 @@ Before relying on this operating model:
 - `#2956` sprint-conductor hardening should be landed or explicitly accepted as
   an execution dependency/risk
 
-## Sprint 0: Milestone Opening
+## Canonical Sprint Execution Model
 
-Child issues:
-
-- `WP-01` Design pass (milestone docs + planning)
-
-Why this cluster exists:
-
-- `WP-01` is the opening gate for the whole milestone
-- it seeds the issue wave, cards, and planning truth required by every later
-  umbrella
-- it should complete before the conductor-heavy execution band begins
-
-## Default Sprint Umbrellas
+This section preserves the existing `v0.91.2` sprint structure and explains
+how sprint-conductor should execute it.
 
 ### Sprint 1: Benchmark And Test-Cycle Recovery
 
 Child issues:
 
+- `WP-01` Design pass (milestone docs + planning)
 - `WP-02` UTS + ACC multi-model benchmark harness
 - `WP-03` Provider-native tool-call comparison
 - `WP-04` Runtime/test-cycle recovery
 - `WP-05` Coverage gate ergonomics
 
-Why this cluster exists:
+Why this sprint exists:
 
+- `WP-01` is the opening gate for the whole milestone and must close before
+  the rest of the sprint proceeds
 - it is one tightly related benchmark and cycle-time pressure-release band
 - the dependency spine is clear
 - the value of sequential closeout is high
@@ -99,41 +108,32 @@ Child issues:
 - `WP-09` Rust-native GWS adapter boundary
 - `WP-10` Moderne / OpenRewrite LST modernization demo
 
-Why this cluster exists:
+Why this sprint exists:
 
 - these are bounded product/demo surfaces
 - they share the same canonical-authority and operator-gating concerns
 - they benefit from one reviewed sprint closeout rather than five isolated
   tool/demo stories
 
-### Sprint 3A: Runtime Ergonomics And Repo Workflow Surfaces
+### Sprint 3: Runtime Ergonomics, Publication, Docs, And Workflow Guardrails
 
 Child issues:
 
 - `WP-11` Speculative decoding prototype
 - `WP-12` Repo visibility follow-on
-- `WP-16` Workflow guardrails hardening
-
-Why this cluster exists:
-
-- these issues all affect how the repo/runtime feels to operate
-- they are closer to one another than to the publication lane
-- they are likely to benefit from one concentrated review pass
-
-### Sprint 3B: Publication, Paper Packet, And Doc Hygiene
-
-Child issues:
-
 - `WP-13` Publication program package
 - `WP-14` General intelligence paper packet
 - `WP-15` Rustdoc and doc cleanup
+- `WP-16` Workflow guardrails hardening
 
-Why this cluster exists:
+Why this sprint exists:
 
-- these issues share a documentation/public-intellectual surface
-- they should stay bounded away from runtime/tooling hardening concerns
-- they can use lighter docs-oriented validation while still receiving sprint
-  review and closeout
+- it is the milestone's mixed ergonomics/publication/docs/guardrails band as
+  already defined in the canonical sprint plan
+- it combines runtime ergonomics, reviewer-facing docs work, and workflow
+  hardening in one explicit sequential sprint
+- sprint-conductor should preserve one active child issue at a time even though
+  the issue types vary across runtime, docs, and tooling surfaces
 
 ### Sprint 4: Review, Remediation, Planning, And Release
 
@@ -148,14 +148,17 @@ Child issues:
 - `WP-23` Next milestone planning
 - `WP-24` Release ceremony
 
-Release-tail note:
+Release-tail notes:
 
 - if we later decide to preserve the extra pre-ceremony next-milestone review
   pass pattern from `v0.91.1`, add that step explicitly to the `v0.91.2`
   WBS, sprint plan, and issue wave before execution rather than silently
   assuming it exists
+- `WP-22` may legitimately produce follow-up issues based on `WP-21` findings,
+  but that does not change the canonical Sprint 4 issue list; route those
+  follow-ons explicitly instead of treating them as a hidden sprint rewrite
 
-Why this cluster exists:
+Why this sprint exists:
 
 - the review/release tail is already a state machine
 - conductor sequencing is especially valuable here
@@ -163,16 +166,21 @@ Why this cluster exists:
 
 ## Execution Rules
 
-Every `v0.91.2` sprint umbrella should follow these rules:
+Every canonical `v0.91.2` sprint should follow these rules under
+`sprint-conductor`:
 
 - one active child issue at a time
-- do not start issue `N+1` before issue `N` is fully closed out
+- if an active child issue has a healthy open PR, classify it as
+  `waiting_for_review` rather than as an automatic failure state
+- while a child issue is in `waiting_for_review`, the sprint is paused at that
+  child; do not start issue `N+1`
+- start issue `N+1` only after issue `N` is merged or otherwise closed and
+  then fully closeouted locally
 - use `sprint-conductor` for orchestration only, not as a replacement for the
   issue lifecycle skills
 - use the normal issue lifecycle for the child work:
   `workflow-conductor`, `pr-ready`, `pr-run`, `pr-finish`, `pr-janitor`,
   `pr-closeout`
-- treat healthy open PRs as waiting state, not automatic failure state
 - stop immediately on scope drift or dependency ambiguity instead of widening
   the sprint implicitly
 
@@ -186,6 +194,11 @@ Before any sprint starts:
 - demo/proof expectations must already be written down
 - repo inputs and canonical files must be truthful
 - docs-only children should be marked for narrow docs-oriented validation
+
+Additional Sprint 1 rule:
+
+- `WP-01` must close before `WP-02` through `WP-05` begin, because the rest of
+  the milestone depends on the opening planning/card/package truth it creates
 
 If preflight fails, repair the cards first. Do not start the sprint with known
 bundle drift.
@@ -235,13 +248,13 @@ This operating model should be considered successful if `v0.91.2` shows:
 
 ## Notes
 
-- The main optimization is better issue-wave shape, not more aggressive model
-  autonomy.
-- `v0.91.2` should treat sprint-conductor as the default for bounded clusters,
-  especially mini-sprints, remediation bands, docs/review lanes, and coherent
-  feature tranches.
-- If a sprint becomes too heterogeneous, split it rather than forcing the
-  conductor to carry unrelated work under one umbrella.
+- The main optimization is better execution discipline inside the existing
+  issue-wave shape, not more aggressive model autonomy.
+- `v0.91.2` should treat sprint-conductor as the default for the canonical
+  Sprint 1 through Sprint 4 umbrellas already defined by the milestone package.
+- If a canonical sprint later proves too heterogeneous, change the canonical
+  milestone sprint docs first, then realign this plan; do not silently fork the
+  structure here.
 - Within one sprint umbrella, child issues run sequentially under the slow
   path. If operators choose to run multiple sprint umbrellas concurrently, that
   must be an explicit milestone-level decision and must not break the


### PR DESCRIPTION
Closes #2993

## Summary
- refit the sprint-conductor execution plan to overlay the existing Sprint 1 through Sprint 4 structure
- remove replacement topology language like Sprint 0 and Sprint 3A/3B
- clarify the waiting-state rule so open healthy PRs pause a sprint without allowing N+1 to start before merge/closeout

## Validation
- git diff --check