### PR TITLE
[v0.91.1][WP-23][docs] v0.92 birthday readiness handoff

### DIFF
--- a/docs/milestones/v0.91.1/ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.1/ADL_v0.91.1_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -93,6 +93,7 @@ review-entry package:
 
 The milestone does not yet claim:
 
+- accepted-finding remediation completion
 - `v0.92` birthday-readiness handoff completion
 - release ceremony completion
 
@@ -112,8 +113,8 @@ The returned review explicitly records:
 - `P3`: `0`
 
 The review therefore leaves no accepted findings for `WP-22` to remediate.
-`WP-22` records a truthful zero-findings remediation disposition rather than
-inventing cleanup work.
+`WP-22` should record a truthful zero-findings remediation disposition rather
+than inventing cleanup work.
 
 ## Review-Tail State To Consider
 
@@ -121,7 +122,7 @@ At the time of this issue:
 
 - `WP-20` internal review is complete
 - `WP-21` external / third-party review is complete
-- `WP-22` records the zero-findings remediation disposition
+- `WP-22` should record the zero-findings remediation disposition
 - `WP-23` remains the birthday-readiness handoff
 - `WP-24` remains the release ceremony
 

--- a/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
@@ -9,12 +9,13 @@ structurally complete, but the milestone itself is still in progress.
 
 As of the current docs/review pass:
 
-- `WP-01` through `WP-22` are closed or ready to close with landed docs truth
+- `WP-01` through `WP-23` are closed or ready to close with landed docs truth
 - the implementation/demo band through `WP-17` is complete
 - the quality gate is now recorded
 - the review/remediation band is now recorded through explicit zero-findings
   disposition
-- the remaining open tail is now `WP-23` and `WP-24`
+- the next-milestone handoff is now recorded
+- the remaining open tail is now `WP-24`
 
 ## What This Report Must Eventually Cover
 

--- a/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
+++ b/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
@@ -23,7 +23,7 @@
 - [x] WP-20 Internal review
 - [x] WP-21 External / 3rd-party review
 - [x] WP-22 Review findings remediation
-- [ ] WP-23 v0.92 birthday readiness handoff
+- [x] WP-23 v0.92 birthday readiness handoff
 - [ ] WP-24 Release ceremony
 
 ## Review And Release Readiness

--- a/docs/milestones/v0.91.1/NEXT_MILESTONE_HANDOFF_v0.91.1.md
+++ b/docs/milestones/v0.91.1/NEXT_MILESTONE_HANDOFF_v0.91.1.md
@@ -2,36 +2,153 @@
 
 ## Purpose
 
-Record what `v0.91.1` is supposed to hand to later milestones once its runtime
-readiness band is complete.
+Record the clean `v0.91.1` downstream handoff after the inhabited-runtime
+readiness milestone has landed its implementation, proof, review, and
+zero-findings remediation surfaces.
 
-## Current Handoff Direction
+`v0.91.1` does not hand off a vague runtime thesis. It hands off concrete
+runtime, memory, cognition, comms, and reviewable proof surfaces that the
+birthday milestone can consume without redefining them, while the immediate next
+milestone in sequence remains `v0.91.2`.
 
-`v0.91.1` should hand:
+## Immediate Next Milestone
 
-- concrete inhabited-runtime evidence to `v0.92`
-- clearer runtime substrate truth to `v0.91.2`
-- ACIP/A2A local-boundary truth to later transport and federation work
+`v0.91.2` is the next milestone in sequence after `v0.91.1`.
+
+Its job remains tooling, evaluation, productization, publication, and workflow
+pressure-release work. The `WP-23` handoff does not replace that sequencing.
+Instead, it makes sure the later `v0.92` birthday milestone already has a clean,
+truthful substrate when it becomes active.
+
+## What v0.91.1 Actually Landed
+
+`v0.91.1` landed:
+
+- Runtime v2 / polis architecture alignment
+- lifecycle-state implementation and ACIP eligibility rules
+- observatory active surface and operator-visible runtime packet flow
+- citizen standing and citizen state runtime contracts
+- memory and identity architecture groundwork
+- Theory of Mind foundation
+- capability and aptitude testing foundation
+- intelligence metric architecture
+- governed learning substrate
+- ANRM / Gemma placement and trace-dataset architecture
+- ACIP hardening and A2A boundary planning
+- runtime inhabitant integration proof
+- observatory-visible flagship runtime demo
+- milestone demo matrix and feature-proof coverage closeout
+- milestone quality-gate record
+- review-ready docs package
+- internal review record
+- external / third-party review record
+- explicit zero-findings remediation disposition
+
+This means the later birthday milestone starts from a real inhabited-runtime
+substrate rather than a planning-only placeholder.
+
+## Zero-Leftover Result
+
+- There is no hidden `v0.91.1` backlog pretending runtime readiness still needs
+  to be invented.
+- There is no fake remediation debt bucket being carried into `v0.92`.
+- There is no birthday claim being smuggled into `v0.91.1` by implication.
+
+What remains after this handoff is deliberately assigned later-band work, not
+unfinished `v0.91.1` truth.
 
 ## v0.92 Placement
 
-`v0.92` should consume:
+`v0.92` remains the first true Gödel-agent birthday milestone.
 
-- runtime inhabitant proof surfaces
+It should consume `v0.91.1` as the adjacent-systems prerequisite for:
+
+- stable name and identity architecture grounded in a real runtime substrate
+- continuity evidence across bounded cycles
+- memory grounding tied to runtime-visible artifacts
+- capability envelope at birth
+- ACP / cognitive profiles grounded in memory, capability, continuity, ToM,
+  intelligence, and governed-learning evidence
+- birth witnesses and citizen-facing receipt
+- reviewer-facing proof that distinguishes birth from startup, wake, snapshot,
+  simulation, in-transit, shutdown, or forced-suspension states
+
+`v0.92` should not need to reopen:
+
+- lifecycle-state transition evidence
+- ACIP invocation eligibility rules
+- citizen standing or citizen-state substrate semantics
+- observatory active-surface fundamentals
+- ToM foundation schemas
+- capability harness or intelligence-metric foundation work
+- governed-learning boundary basics
+- inhabited-runtime proof as a thesis
+
+## Exact `v0.92` Inputs From `v0.91.1`
+
+The birthday milestone should treat the following as direct upstream evidence:
+
+- runtime inhabitant proof and flagship demo artifacts
+- lifecycle-state evidence proving what is and is not a birth event
 - memory/identity architecture outputs
-- citizen state and lifecycle evidence
-- birthday-readiness handoff from `WP-23`
+- citizen state and standing runtime truth
+- Theory of Mind foundation evidence
+- capability and aptitude testing harness outputs
+- intelligence metric architecture and governed-learning evidence
+- observatory-visible runtime projections and operator reports
+- ANRM / Gemma evidence where local-model profile context matters
 
-## v0.91.2 Placement
+This gives `v0.92` enough substrate to ask the real birthday questions without
+quietly rebuilding runtime readiness first.
 
-`v0.91.2` should consume:
+## What `v0.92` Must Still Add
 
-- clearer runtime substrate/package truth
-- reviewable docs and feature surfaces
-- remaining tooling and benchmark backlog that `v0.91.1` does not own
+`v0.91.1` is not the birthday milestone. `v0.92` still must add:
+
+- birthday contract and negative cases
+- stable-name and identity-root architecture
+- explicit continuity record
+- memory-grounding rules for birth
+- capability envelope at birth
+- ACP / cognitive profile record with bounded privacy and non-reputation rules
+- witness set and citizen-facing receipt
+- reviewer packet proving why the event counts as birth
+
+## Non-Claims Preserved
+
+This handoff does not claim:
+
+- first true birthday already happened in `v0.91.1`
+- full identity continuity is already solved
+- constitutional citizenship
+- legal personhood
+- production external transport or federation readiness
+- final intelligence, Theory of Mind, or wellbeing answers
+
+## `v0.91.2` Placement
+
+`v0.91.2` still remains the tooling, evaluation, productization, publication,
+and workflow pressure-release milestone.
+
+It should consume the cleaner runtime/package truth from `v0.91.1`, but it does
+not replace the birthday handoff and does not absorb identity/birth semantics.
+`v0.91.2` is next in sequence; `v0.92` is the later consumer of the
+birthday-readiness handoff recorded here.
+
+## `v0.93` Placement
+
+`v0.93` remains the downstream constitutional-governance, IAM, social-cognition,
+and enterprise-security milestone.
+
+It should consume identity-bearing citizen evidence from `v0.92`, not absorb
+birth semantics into governance.
 
 ## Non-Reduction Rule
 
-- `v0.91.1` is not only planning cleanup
-- `v0.91.2` does not replace the inhabited-runtime implementation band
+This handoff does not reduce any downstream milestone:
 
+- `v0.91.2` remains tooling and workflow pressure-release
+- `v0.92` remains identity, continuity, and first true birthday
+- `v0.93` remains constitutional citizenship and governance
+
+The point of this handoff is to sharpen those boundaries, not blur them.

--- a/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
@@ -27,7 +27,8 @@ Known execution truth today:
 - `WP-19` aligned the reviewer-entry docs and active version/status surfaces
 - `WP-20` through `WP-22` now provide the internal review, external review,
   and explicit zero-findings remediation disposition
-- `WP-23` and `WP-24` remain open for handoff and release ceremony
+- `WP-23` now provides the birthday-readiness handoff
+- `WP-24` remains open for release ceremony
 
 ## Current Validation Posture
 
@@ -60,7 +61,8 @@ Known execution truth today:
   coherent enough to enter the review tail
 - docs review pass is complete
 - internal review, external review, and remediation disposition are complete
-- handoff and release ceremony are still pending
+- handoff is complete
+- release ceremony is still pending
 
 ## Required Inputs Before Final Pass/Fail Judgment
 
@@ -76,8 +78,7 @@ Known execution truth today:
 
 ## Why The Gate Is Still Not Ready
 
-- release evidence, handoff, and ceremony (`WP-23` and `WP-24`) are not
-  complete yet
+- release evidence and ceremony (`WP-24`) are not complete yet
 
 
 ## Gate Value Provided By WP-18

--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -46,8 +46,8 @@ truthful `v0.91.1` release decision.
 - `WP-20` internal review packet
 - `WP-21` external / third-party review handoff and zero-finding record
 - `WP-22` accepted-finding disposition record with zero accepted findings
+- `WP-23` `v0.92` birthday-readiness handoff record
 
 ## Evidence Still Missing
 
-- v0.92 birthday-readiness handoff
 - release ceremony and end-of-milestone report

--- a/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
@@ -36,12 +36,11 @@ Sprint state:
   demo/proof coverage closeout
 - Sprint 4 quality/review/release tail now has the recorded quality gate,
   review-ready docs package, internal review record, and external review
-  record, plus the explicit zero-findings remediation disposition, but
-  handoff/release closure remains open
+  record, the explicit zero-findings remediation disposition, and the `v0.92`
+  birthday-readiness handoff, but release closure remains open
 
 ## Still Pending
 
-- v0.92 birthday-readiness handoff
 - release ceremony and end-of-milestone report
 
 ## Not Claimed

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -7,7 +7,7 @@ Not release ready.
 This document is the compact reviewer-entry surface for the active `v0.91.1`
 release tail. Internal review and third-party review are complete. The
 accepted-finding remediation disposition is also complete. The milestone is not
-complete until the `v0.92` handoff and the release ceremony both finish.
+complete until the release ceremony finishes.
 
 ## Review Entry Points
 
@@ -34,8 +34,8 @@ complete until the `v0.92` handoff and the release ceremony both finish.
 
 ## Current Issue State
 
-- `WP-01` through `WP-22` are closed or ready to close with landed docs truth
-- `WP-23` and `WP-24` remain open for the final handoff/release band
+- `WP-01` through `WP-23` are closed or ready to close with landed docs truth
+- `WP-24` remains open for the final ceremony band
 - Sprint 2 is complete
 - Sprint 3 runtime/comms/inhabitant work is complete through `WP-17`
 - `WP-18` records the milestone quality-gate posture
@@ -47,7 +47,8 @@ complete until the `v0.92` handoff and the release ceremony both finish.
 - internal review is complete
 - external review is complete
 - review-findings remediation is complete as explicit zero-findings disposition
-- `v0.92` handoff and release ceremony are pending
+- `v0.92` handoff is complete
+- release ceremony is pending
 
 ## Version Truth
 

--- a/docs/milestones/v0.91.1/review/WP22_REMEDIATION_QUEUE.md
+++ b/docs/milestones/v0.91.1/review/WP22_REMEDIATION_QUEUE.md
@@ -24,8 +24,8 @@ No accepted findings.
   no-remediation outcome explicitly rather than implying it by silence.
 - If any later operator-chosen cleanup is desired, it should be routed as
   follow-on work rather than represented as accepted release-tail remediation.
-- `WP-23` remains the next-milestone planning and birthday-readiness handoff
-  step; `WP-22` does not claim that work.
+- `WP-23` owns the next-milestone planning and birthday-readiness handoff step;
+  `WP-22` does not claim that work.
 
 ## Queue Rule
 


### PR DESCRIPTION
## Summary
- expand the v0.91.1 next-milestone handoff into a concrete birthday-readiness packet
- make the distinction explicit that v0.91.2 is next in sequence while v0.92 is the downstream birthday consumer
- align the release-tail docs so only the ceremony remains pending

## Validation
- `git diff --check`
- bounded docs-review subagent over the WP-23 tranche with findings fixed before publication

Closes #2845
