### PR TITLE
[v0.91.1][WP-23A][docs] Next milestone review pass

### DIFF
--- a/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
@@ -15,7 +15,7 @@ As of the current docs/review pass:
 - the review/remediation band is now recorded through explicit zero-findings
   disposition
 - the next-milestone handoff is now recorded
-- the final next-milestone review pass is now recorded
+- the final next-milestone review pass is published in PR `#2996` and pending merge
 - the remaining open tail is now `WP-24`
 
 ## What This Report Must Eventually Cover

--- a/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/END_OF_MILESTONE_REPORT_v0.91.1.md
@@ -15,6 +15,7 @@ As of the current docs/review pass:
 - the review/remediation band is now recorded through explicit zero-findings
   disposition
 - the next-milestone handoff is now recorded
+- the final next-milestone review pass is now recorded
 - the remaining open tail is now `WP-24`
 
 ## What This Report Must Eventually Cover

--- a/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
+++ b/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
@@ -23,7 +23,8 @@
 - [x] WP-20 Internal review
 - [x] WP-21 External / 3rd-party review
 - [x] WP-22 Review findings remediation
-- [x] WP-23 v0.92 birthday readiness handoff
+- [x] WP-23 Next milestone planning
+- [x] WP-23A Next milestone review pass
 - [ ] WP-24 Release ceremony
 
 ## Review And Release Readiness
@@ -34,5 +35,6 @@
 - [x] Internal review is complete.
 - [x] External review is complete or explicitly deferred.
 - [x] Accepted findings are fixed or dispositioned.
+- [x] Final next-milestone review pass is complete.
 - [ ] Release evidence and release readiness are complete.
 - [ ] Ceremony completed.

--- a/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
+++ b/docs/milestones/v0.91.1/MILESTONE_CHECKLIST_v0.91.1.md
@@ -24,7 +24,7 @@
 - [x] WP-21 External / 3rd-party review
 - [x] WP-22 Review findings remediation
 - [x] WP-23 Next milestone planning
-- [x] WP-23A Next milestone review pass
+- [ ] WP-23A Next milestone review pass
 - [ ] WP-24 Release ceremony
 
 ## Review And Release Readiness
@@ -35,6 +35,6 @@
 - [x] Internal review is complete.
 - [x] External review is complete or explicitly deferred.
 - [x] Accepted findings are fixed or dispositioned.
-- [x] Final next-milestone review pass is complete.
+- [ ] Final next-milestone review pass is complete.
 - [ ] Release evidence and release readiness are complete.
 - [ ] Ceremony completed.

--- a/docs/milestones/v0.91.1/NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md
@@ -1,0 +1,89 @@
+# Next Milestone Review Pass - v0.91.1
+
+## Purpose
+
+Record the bounded `WP-23A` pre-ceremony review pass over the downstream
+milestone package that `v0.91.1` is handing off.
+
+This review exists so the release tail keeps the shape that has worked well in
+prior milestones:
+
+- `WP-23` performs next-milestone planning / handoff
+- `WP-23A` performs one final review pass over that package
+- `WP-24` remains the ceremony and closeout step
+
+## Review Scope
+
+This pass reviewed:
+
+- `docs/planning/ADL_FEATURE_LIST.md`
+- `docs/milestones/v0.91.2/`
+- `docs/milestones/v0.92/`
+- `docs/milestones/v0.93/`
+- `docs/milestones/v0.94/`
+- `docs/milestones/v0.94.1/`
+- `docs/milestones/v0.95/`
+
+The review focused on:
+
+- feature-list completion targets
+- feature-doc existence and package indexing
+- milestone-package distribution through `v0.95`
+- downstream sequencing truth, especially the distinction between immediate
+  `v0.91.2` follow-on work and later `v0.92` birthday consumption
+
+## What Was Checked
+
+- Every feature-list canonical doc home through `v0.95` resolves to a tracked
+  file.
+- Feature-package `README.md` indexes exist and resolve for:
+  - `v0.91.2`
+  - `v0.92`
+  - `v0.93`
+  - `v0.94`
+  - `v0.94.1`
+  - `v0.95`
+- The `v0.91.2` planning package still correctly presents itself as the next
+  milestone in sequence without pretending it is already open for execution.
+- The `v0.92` package still preserves the birthday boundary rather than
+  absorbing tooling, governance, or economics prematurely.
+- The later `v0.93` through `v0.95` milestone packages still match the feature
+  list and tracked feature-doc allocation.
+
+## Result
+
+No blocking next-milestone package inconsistency was found in this pass.
+
+The important downstream truths hold:
+
+- `v0.91.2` is the immediate next milestone in sequence after `v0.91.1`
+- `v0.92` remains the later birthday/identity milestone
+- `v0.93` remains the constitutional governance and enterprise-security band
+- `v0.94` remains secure execution, trust convergence, and temporal reasoning
+- `v0.94.1` remains payments, settlement, and `x402` / Lightning follow-on
+- `v0.95` remains MVP convergence
+
+## Accepted Residuals
+
+The later milestones still contain forward-planning release-plan and
+release-notes placeholders. That is acceptable in this review because those
+milestones are still planned-only bands, not active execution waves.
+
+Those placeholders are not treated here as missing feature allocation so long
+as:
+
+- the milestone README/WBS/package story is coherent
+- the feature-doc package exists where the feature list says it exists
+- the feature list and milestone-package distribution do not contradict each
+  other
+
+## Follow-on Rule
+
+If later package cleanup finds a real contradiction, open a bounded follow-on
+issue rather than silently widening `WP-23A` into repo-wide docs cleanup.
+
+## Ceremony Readiness Effect
+
+This pass means the next-milestone package has had one final bounded review
+before ceremony. `WP-24` can stay the release ceremony step instead of
+absorbing another planning or review phase.

--- a/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
@@ -27,7 +27,8 @@ Known execution truth today:
 - `WP-19` aligned the reviewer-entry docs and active version/status surfaces
 - `WP-20` through `WP-22` now provide the internal review, external review,
   and explicit zero-findings remediation disposition
-- `WP-23` now provides the birthday-readiness handoff
+- `WP-23` now provides next-milestone planning and downstream handoff truth
+- supplemental `WP-23A` now provides the final next-milestone review pass
 - `WP-24` remains open for release ceremony
 
 ## Current Validation Posture
@@ -62,6 +63,7 @@ Known execution truth today:
 - docs review pass is complete
 - internal review, external review, and remediation disposition are complete
 - handoff is complete
+- next-milestone review pass is complete
 - release ceremony is still pending
 
 ## Required Inputs Before Final Pass/Fail Judgment

--- a/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/QUALITY_GATE_v0.91.1.md
@@ -28,7 +28,7 @@ Known execution truth today:
 - `WP-20` through `WP-22` now provide the internal review, external review,
   and explicit zero-findings remediation disposition
 - `WP-23` now provides next-milestone planning and downstream handoff truth
-- supplemental `WP-23A` now provides the final next-milestone review pass
+- supplemental `WP-23A` is carrying the final next-milestone review pass in PR `#2996`
 - `WP-24` remains open for release ceremony
 
 ## Current Validation Posture
@@ -63,7 +63,7 @@ Known execution truth today:
 - docs review pass is complete
 - internal review, external review, and remediation disposition are complete
 - handoff is complete
-- next-milestone review pass is complete
+- next-milestone review pass is pending merge of PR `#2996`
 - release ceremony is still pending
 
 ## Required Inputs Before Final Pass/Fail Judgment

--- a/docs/milestones/v0.91.1/README.md
+++ b/docs/milestones/v0.91.1/README.md
@@ -132,6 +132,8 @@ not import the broad provider-native benchmark planning surface.
   [review/WP22_REMEDIATION_QUEUE.md](review/WP22_REMEDIATION_QUEUE.md)
 - Next milestone handoff:
   [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
+- Next milestone review pass:
+  [NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md](NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md)
 - End-of-milestone report:
   [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 

--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -48,7 +48,10 @@ truthful `v0.91.1` release decision.
 - `WP-21` external / third-party review handoff and zero-finding record
 - `WP-22` accepted-finding disposition record with zero accepted findings
 - `WP-23` next-milestone planning and downstream handoff record
-- supplemental `WP-23A` next-milestone review-pass record
+
+## In-Flight Evidence
+
+- supplemental `WP-23A` next-milestone review-pass record in PR `#2996`
 
 ## Evidence Still Missing
 

--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -24,6 +24,7 @@ truthful `v0.91.1` release decision.
 - [review/WP22_REMEDIATION_QUEUE.md](review/WP22_REMEDIATION_QUEUE.md)
 - [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 - [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
+- [NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md](NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md)
 - [SPRINT_2_CLOSEOUT_v0.91.1.md](SPRINT_2_CLOSEOUT_v0.91.1.md)
 - [SPRINT_3_CLOSEOUT_v0.91.1.md](SPRINT_3_CLOSEOUT_v0.91.1.md)
 
@@ -46,7 +47,8 @@ truthful `v0.91.1` release decision.
 - `WP-20` internal review packet
 - `WP-21` external / third-party review handoff and zero-finding record
 - `WP-22` accepted-finding disposition record with zero accepted findings
-- `WP-23` `v0.92` birthday-readiness handoff record
+- `WP-23` next-milestone planning and downstream handoff record
+- supplemental `WP-23A` next-milestone review-pass record
 
 ## Evidence Still Missing
 

--- a/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_NOTES_v0.91.1.md
@@ -36,8 +36,9 @@ Sprint state:
   demo/proof coverage closeout
 - Sprint 4 quality/review/release tail now has the recorded quality gate,
   review-ready docs package, internal review record, and external review
-  record, the explicit zero-findings remediation disposition, and the `v0.92`
-  birthday-readiness handoff, but release closure remains open
+  record, the explicit zero-findings remediation disposition, the
+  next-milestone planning/handoff record, and the final next-milestone review
+  pass, but release closure remains open
 
 ## Still Pending
 

--- a/docs/milestones/v0.91.1/RELEASE_PLAN_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_PLAN_v0.91.1.md
@@ -27,8 +27,9 @@ without overclaiming birthday, identity, or external-transport completion.
 
 Do not mark `v0.91.1` releasable until:
 
-- `WP-16` through `WP-24` are completed or dispositioned truthfully
+- `WP-16` through `WP-23` are completed or dispositioned truthfully
+- supplemental `WP-23A` is merged truthfully as the final next-milestone review pass
+- `WP-24` ceremony is complete
 - the quality gate is recorded
 - internal/external review state is explicit
 - release readiness and release evidence are complete
-

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -29,12 +29,14 @@ complete until the release ceremony finishes.
 - [review/WP22_REMEDIATION_QUEUE.md](review/WP22_REMEDIATION_QUEUE.md)
 - [END_OF_MILESTONE_REPORT_v0.91.1.md](END_OF_MILESTONE_REPORT_v0.91.1.md)
 - [NEXT_MILESTONE_HANDOFF_v0.91.1.md](NEXT_MILESTONE_HANDOFF_v0.91.1.md)
+- [NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md](NEXT_MILESTONE_REVIEW_PASS_v0.91.1.md)
 - [SPRINT_2_CLOSEOUT_v0.91.1.md](SPRINT_2_CLOSEOUT_v0.91.1.md)
 - [SPRINT_3_CLOSEOUT_v0.91.1.md](SPRINT_3_CLOSEOUT_v0.91.1.md)
 
 ## Current Issue State
 
 - `WP-01` through `WP-23` are closed or ready to close with landed docs truth
+- supplemental `WP-23A` next-milestone review pass is complete
 - `WP-24` remains open for the final ceremony band
 - Sprint 2 is complete
 - Sprint 3 runtime/comms/inhabitant work is complete through `WP-17`
@@ -44,10 +46,6 @@ complete until the release ceremony finishes.
 
 ## Current Blockers
 
-- internal review is complete
-- external review is complete
-- review-findings remediation is complete as explicit zero-findings disposition
-- `v0.92` handoff is complete
 - release ceremony is pending
 
 ## Version Truth

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -36,7 +36,7 @@ complete until the release ceremony finishes.
 ## Current Issue State
 
 - `WP-01` through `WP-23` are closed or ready to close with landed docs truth
-- supplemental `WP-23A` next-milestone review pass is complete
+- supplemental `WP-23A` next-milestone review pass is in progress via PR `#2996`
 - `WP-24` remains open for the final ceremony band
 - Sprint 2 is complete
 - Sprint 3 runtime/comms/inhabitant work is complete through `WP-17`

--- a/docs/milestones/v0.91.1/SPRINT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/SPRINT_v0.91.1.md
@@ -69,11 +69,17 @@ authenticated local communication and observatory-visible evidence.
 | WP-20 (#2842) | Internal review | internal review record | WP-19 |
 | WP-21 (#2843) | External / 3rd-party review | external review handoff and record | WP-20 |
 | WP-22 (#2844) | Review findings remediation | remediation record and follow-up issues | WP-21 |
-| WP-23 (#2845) | v0.92 birthday readiness handoff | identity/birthday handoff record | WP-22 |
+| WP-23 (#2845) | Next milestone planning | downstream milestone handoff record | WP-22 |
 | WP-24 (#2846) | Release ceremony | release evidence and end-of-milestone report | WP-23 |
 
-Goal: leave v0.92 with a clean, evidence-backed path to identity and birthday
-work rather than another loose planning backlog.
+Goal: leave the downstream milestone package with a clean, evidence-backed path
+for immediate `v0.91.2` execution and later `v0.92` birthday/identity
+consumption rather than another loose planning backlog.
+
+Supplemental pre-ceremony review step:
+- `WP-23A` / `#2985` performs the final next-milestone review pass after
+  `WP-23` planning and before `WP-24` ceremony without renumbering the core
+  release-tail sequence.
 
 ## Supplemental Mini-Sprint: Test-Cycle Recovery
 

--- a/docs/milestones/v0.91.1/SPRINT_v0.91.1.md
+++ b/docs/milestones/v0.91.1/SPRINT_v0.91.1.md
@@ -70,7 +70,8 @@ authenticated local communication and observatory-visible evidence.
 | WP-21 (#2843) | External / 3rd-party review | external review handoff and record | WP-20 |
 | WP-22 (#2844) | Review findings remediation | remediation record and follow-up issues | WP-21 |
 | WP-23 (#2845) | Next milestone planning | downstream milestone handoff record | WP-22 |
-| WP-24 (#2846) | Release ceremony | release evidence and end-of-milestone report | WP-23 |
+| WP-23A (#2985) | Next milestone review pass | final pre-ceremony next-milestone review-pass record | WP-23 |
+| WP-24 (#2846) | Release ceremony | release evidence and end-of-milestone report | WP-23A |
 
 Goal: leave the downstream milestone package with a clean, evidence-backed path
 for immediate `v0.91.2` execution and later `v0.92` birthday/identity

--- a/docs/milestones/v0.91.1/WBS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/WBS_v0.91.1.md
@@ -60,7 +60,8 @@ and cognition implementation wave.
 | WP-21 (#2843) | External / 3rd-party review | review | external review handoff and record | WP-20 |
 | WP-22 (#2844) | Review findings remediation | review | remediation record and follow-up issues | WP-21 |
 | WP-23 (#2845) | Next milestone planning | docs | downstream milestone handoff record | WP-22 |
-| WP-24 (#2846) | Release ceremony | release | release evidence and end-of-milestone report | WP-23 |
+| WP-23A (#2985) | Next milestone review pass | docs | final pre-ceremony next-milestone review-pass record | WP-23 |
+| WP-24 (#2846) | Release ceremony | release | release evidence and end-of-milestone report | WP-23A |
 
 Supplemental pre-ceremony review step:
 - `WP-23A` / `#2985` performs the final next-milestone review pass after

--- a/docs/milestones/v0.91.1/WBS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/WBS_v0.91.1.md
@@ -59,8 +59,13 @@ and cognition implementation wave.
 | WP-20 (#2842) | Internal review | review | internal review record | WP-19 |
 | WP-21 (#2843) | External / 3rd-party review | review | external review handoff and record | WP-20 |
 | WP-22 (#2844) | Review findings remediation | review | remediation record and follow-up issues | WP-21 |
-| WP-23 (#2845) | v0.92 birthday readiness handoff | docs | identity/birthday handoff record | WP-22 |
+| WP-23 (#2845) | Next milestone planning | docs | downstream milestone handoff record | WP-22 |
 | WP-24 (#2846) | Release ceremony | release | release evidence and end-of-milestone report | WP-23 |
+
+Supplemental pre-ceremony review step:
+- `WP-23A` / `#2985` performs the final next-milestone review pass after
+  `WP-23` and before `WP-24` without renumbering the canonical release-tail
+  sequence.
 
 ## Sequencing Pressure
 


### PR DESCRIPTION
## Summary
- add a tracked `WP-23A` next-milestone review-pass artifact for the `v0.91.1` release tail
- align the `v0.91.1` release-tail trackers to the `WP-23 planning -> WP-23A review pass -> WP-24 ceremony` shape
- record the downstream milestone consistency audit through `v0.95` without widening the issue into unrelated cleanup

## Validation
- `git diff --check`
- feature-list canonical-home existence audit through `v0.95`
- feature-package README link audit for `v0.91.2`, `v0.92`, `v0.93`, `v0.94`, `v0.94.1`, and `v0.95`
- bounded docs review subagent with findings fixed before publication

Closes #2985
