### PR TITLE
[v0.91.1][review] Normalize closed-issue closeout truth blocking release ceremony

### DIFF
--- a/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_EVIDENCE_v0.91.1.md
@@ -51,7 +51,21 @@ truthful `v0.91.1` release decision.
 
 ## In-Flight Evidence
 
-- supplemental `WP-23A` next-milestone review-pass record in PR `#2996`
+- merged `WP-23A` next-milestone review-pass record from PR `#2996`
+- `#2998` closeout-truth normalization evidence for the historical
+  release-ceremony blocker
+
+## Ceremony Preflight Evidence
+
+- `bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.91.1`
+  passes after restoring missing canonical local bundles and normalizing stale
+  completed-phase `SIP`/`SOR` truth
+- from the bound `WP-24` worktree on
+  `codex/2846-v0-91-1-wp-24-release-ceremony`,
+  `bash adl/tools/release_ceremony.sh --version v0.91.1 --target-branch codex/2846-v0-91-1-wp-24-release-ceremony --allow-dirty`
+  now passes preflight without `--skip-sor-gate`
+- the prior blocker was historical root-bundle reconciliation drift, not
+  missing landed milestone work
 
 ## Evidence Still Missing
 

--- a/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
+++ b/docs/milestones/v0.91.1/RELEASE_READINESS_v0.91.1.md
@@ -35,8 +35,7 @@ complete until the release ceremony finishes.
 
 ## Current Issue State
 
-- `WP-01` through `WP-23` are closed or ready to close with landed docs truth
-- supplemental `WP-23A` next-milestone review pass is in progress via PR `#2996`
+- `WP-01` through `WP-23A` are closed with landed docs truth
 - `WP-24` remains open for the final ceremony band
 - Sprint 2 is complete
 - Sprint 3 runtime/comms/inhabitant work is complete through `WP-17`
@@ -47,6 +46,19 @@ complete until the release ceremony finishes.
 ## Current Blockers
 
 - release ceremony is pending
+
+## Ceremony Gate Status
+
+- historical closed-issue closeout residue that previously blocked `WP-24`
+  has been normalized in `#2998`
+- `bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.91.1`
+  now passes against the full closed `v0.91.1` issue set
+- from the bound `WP-24` worktree on
+  `codex/2846-v0-91-1-wp-24-release-ceremony`,
+  `bash adl/tools/release_ceremony.sh --version v0.91.1 --target-branch codex/2846-v0-91-1-wp-24-release-ceremony --allow-dirty`
+  now passes its full preflight without `--skip-sor-gate`
+- the remaining release-tail dependency is the ceremony itself, not stale local
+  lifecycle-record truth
 
 ## Version Truth
 


### PR DESCRIPTION
## Summary
- normalize the historical closed-issue lifecycle-record residue that was blocking the v0.91.1 ceremony preflight
- document the repaired ceremony gate state in the v0.91.1 release-tail docs
- confirm the full release ceremony preflight now passes without `--skip-sor-gate`

## Validation
- `bash adl/tools/check_milestone_closed_issue_sor_truth.sh --version v0.91.1`
- `bash adl/tools/release_ceremony.sh --version v0.91.1 --target-branch codex/2846-v0-91-1-wp-24-release-ceremony --allow-dirty`

Closes #2998