### PR TITLE
[v0.91.2][WP-01] Open milestone issue wave

### DIFF
--- a/adl/src/cli/tooling_cmd/wp_issue_wave.rs
+++ b/adl/src/cli/tooling_cmd/wp_issue_wave.rs
@@ -43,7 +43,6 @@ struct WaveEntry {
 struct WbsRow {
     wp: String,
     work_package: String,
-    queue: Option<String>,
     description: String,
     deliverable: String,
     dependencies: Vec<String>,
@@ -185,16 +184,9 @@ fn build_entry(
         bail!("no sprint mapping found for {}", row.wp);
     };
     let is_closeout = is_closeout_row(&row.work_package, &row.issue_column);
-    let inferred_area = infer_area(&row.work_package, is_closeout);
-    let explicit_queue = row
-        .queue
-        .as_deref()
-        .filter(|value| !value.trim().is_empty());
-    let queue = explicit_queue.unwrap_or_else(|| infer_queue(&row.work_package, inferred_area));
-    let area = area_for_queue(queue).unwrap_or(inferred_area);
-    let outcome = explicit_queue
-        .and_then(outcome_for_queue)
-        .unwrap_or_else(|| infer_outcome(&row.work_package, area));
+    let area = infer_area(&row.work_package, is_closeout);
+    let queue = infer_queue(&row.work_package, area);
+    let outcome = infer_outcome(&row.work_package, area);
     let slug = format!(
         "{}-{}-{}",
         slugify(version),
@@ -321,31 +313,6 @@ fn infer_outcome(work_package: &str, area: &str) -> &'static str {
     }
 }
 
-fn area_for_queue(queue: &str) -> Option<&'static str> {
-    match queue.trim() {
-        "demo" => Some("demo"),
-        "docs" => Some("docs"),
-        "quality" => Some("quality"),
-        "release" => Some("release"),
-        "review" => Some("review"),
-        "runtime" => Some("runtime"),
-        "tools" => Some("tools"),
-        _ => None,
-    }
-}
-
-fn outcome_for_queue(queue: &str) -> Option<&'static str> {
-    match queue.trim() {
-        "demo" => Some("demo"),
-        "docs" => Some("docs"),
-        "quality" => Some("tests"),
-        "release" => Some("release"),
-        "review" => Some("review"),
-        "runtime" | "tools" => Some("code"),
-        _ => None,
-    }
-}
-
 fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
     let mut rows = Vec::new();
     let table = extract_wbs_table(text)?;
@@ -353,9 +320,6 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
     let issue_second_shape = header_cols
         .get(1)
         .is_some_and(|value| value.eq_ignore_ascii_case("Issue"));
-    let current_queue_shape = header_cols
-        .get(2)
-        .is_some_and(|value| value.eq_ignore_ascii_case("Queue"));
     for line in table.into_iter().skip(2) {
         let cols = split_markdown_row(&line);
         if cols.len() != 5 && cols.len() != 6 {
@@ -364,11 +328,10 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
                 cols.len()
             );
         }
-        let (work_package, queue, description, deliverable, dependencies, issue_column) =
+        let (work_package, description, deliverable, dependencies, issue_column) =
             if cols.len() == 6 && issue_second_shape {
                 (
                     cols[2].to_string(),
-                    None,
                     cols[3].to_string(),
                     cols[4].to_string(),
                     cols[5].to_string(),
@@ -377,25 +340,14 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
             } else if cols.len() == 6 {
                 (
                     cols[1].to_string(),
-                    None,
                     cols[2].to_string(),
                     cols[3].to_string(),
                     cols[4].to_string(),
                     cols[5].to_string(),
                 )
-            } else if current_queue_shape {
-                (
-                    cols[1].to_string(),
-                    Some(cols[2].to_string()),
-                    cols[1].to_string(),
-                    cols[3].to_string(),
-                    cols[4].to_string(),
-                    "issue to be seeded".to_string(),
-                )
             } else {
                 (
                     cols[1].to_string(),
-                    None,
                     cols[2].to_string(),
                     cols[3].to_string(),
                     cols[4].to_string(),
@@ -407,14 +359,9 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
         } else {
             extract_wp_refs(cols[4])
         };
-        let wp = extract_wp_refs(cols[0])
-            .into_iter()
-            .next()
-            .unwrap_or_else(|| cols[0].to_string());
         rows.push(WbsRow {
-            wp,
+            wp: cols[0].to_string(),
             work_package,
-            queue,
             description,
             deliverable,
             dependencies: dependency_refs,
@@ -428,7 +375,6 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
 fn extract_wbs_table(text: &str) -> Result<Vec<String>> {
     extract_markdown_table(text, "## Work Packages")
         .or_else(|_| extract_markdown_table(text, "## Work Package Shape"))
-        .or_else(|_| extract_markdown_table(text, "## Candidate WP Sequence"))
 }
 
 fn parse_sprint_overview(version: &str, text: &str) -> Result<BTreeMap<String, (String, String)>> {
@@ -469,16 +415,7 @@ fn parse_sprint_sections(version: &str, text: &str) -> Result<BTreeMap<String, (
                 .take_while(|ch| ch.is_ascii_digit())
                 .collect::<String>();
             if !number.is_empty() {
-                let label_suffix = rest[number.len()..]
-                    .trim()
-                    .trim_start_matches(['-', ':'])
-                    .trim();
-                let sprint_label = if label_suffix.is_empty() {
-                    format!("Sprint {number}")
-                } else {
-                    format!("Sprint {number}: {label_suffix}")
-                };
-                current = Some((format!("{version}-s{number}"), sprint_label));
+                current = Some((format!("{version}-s{number}"), format!("Sprint {number}")));
                 continue;
             }
         }
@@ -493,21 +430,12 @@ fn parse_sprint_sections(version: &str, text: &str) -> Result<BTreeMap<String, (
             current = None;
             continue;
         }
-        let Some((sprint_id, sprint_label)) = &current else {
-            continue;
-        };
-        if line.starts_with('|') {
-            let cols = split_markdown_row(line);
-            if let Some(first_col) = cols.first() {
-                for wp in extract_wp_refs(first_col) {
-                    mapping.insert(wp, (sprint_id.clone(), sprint_label.clone()));
-                }
-            }
-            continue;
-        }
         if !line.starts_with("- ") {
             continue;
         }
+        let Some((sprint_id, sprint_label)) = &current else {
+            continue;
+        };
         for wp in extract_wp_refs(line) {
             mapping.insert(wp, (sprint_id.clone(), sprint_label.clone()));
         }
@@ -725,7 +653,7 @@ mod tests {
         );
         assert_eq!(wp02.queue, "tools");
         assert_eq!(wp02.outcome, "docs");
-        assert_eq!(wp02.milestone_sprint, "Sprint 1: Compression Enablement");
+        assert_eq!(wp02.milestone_sprint, "Sprint 1");
         assert_eq!(wp02.sprint_id, "v0.90.1-s1");
         assert_eq!(wp02.dependencies, vec!["WP-01"]);
 
@@ -773,57 +701,7 @@ mod tests {
             .expect("wp15a present");
         assert_eq!(wp15a.queue, "review");
         assert_eq!(wp15a.outcome, "review");
-        assert_eq!(wp15a.milestone_sprint, "Sprint 4: Review And Remediation");
+        assert_eq!(wp15a.milestone_sprint, "Sprint 4");
         assert_eq!(wp15a.dependencies, vec!["WP-15"]);
-    }
-
-    #[test]
-    fn generate_wave_doc_accepts_v0912_active_tables_with_issue_numbers_and_queues() {
-        let wbs = include_str!("../../../../docs/milestones/v0.91.2/WBS_v0.91.2.md");
-        let sprint = include_str!("../../../../docs/milestones/v0.91.2/SPRINT_v0.91.2.md");
-
-        let wave = generate_wave_doc(
-            "v0.91.2",
-            wbs,
-            sprint,
-            "docs/milestones/v0.91.2/WBS_v0.91.2.md",
-            "docs/milestones/v0.91.2/SPRINT_v0.91.2.md",
-        )
-        .expect("generate active v0.91.2 wave");
-
-        assert_eq!(wave.entries.len(), 23);
-
-        let wp02 = &wave.entries[0];
-        assert_eq!(wp02.wp, "WP-02");
-        assert_eq!(wp02.queue, "tools");
-        assert_eq!(wp02.labels[2], "area:tools");
-        assert_eq!(wp02.summary, "UTS + ACC multi-model benchmark harness");
-        assert_eq!(
-            wp02.milestone_sprint,
-            "Sprint 1: Benchmark And Test-Cycle Recovery"
-        );
-        assert_eq!(wp02.dependencies, vec!["WP-01"]);
-
-        let wp10 = wave
-            .entries
-            .iter()
-            .find(|entry| entry.wp == "WP-10")
-            .expect("wp10 present");
-        assert_eq!(
-            wp10.work_package,
-            "Moderne / OpenRewrite LST modernization demo"
-        );
-        assert_eq!(wp10.queue, "tools");
-        assert_eq!(wp10.summary, wp10.work_package);
-
-        let wp24 = wave.entries.last().expect("wp24 present");
-        assert_eq!(wp24.wp, "WP-24");
-        assert_eq!(wp24.queue, "release");
-        assert_eq!(wp24.outcome, "release");
-        assert_eq!(
-            wp24.milestone_sprint,
-            "Sprint 4: Review, Remediation, And Release"
-        );
-        assert_eq!(wp24.dependencies, vec!["WP-23"]);
     }
 }

--- a/adl/src/cli/tooling_cmd/wp_issue_wave.rs
+++ b/adl/src/cli/tooling_cmd/wp_issue_wave.rs
@@ -43,6 +43,7 @@ struct WaveEntry {
 struct WbsRow {
     wp: String,
     work_package: String,
+    queue: Option<String>,
     description: String,
     deliverable: String,
     dependencies: Vec<String>,
@@ -184,9 +185,16 @@ fn build_entry(
         bail!("no sprint mapping found for {}", row.wp);
     };
     let is_closeout = is_closeout_row(&row.work_package, &row.issue_column);
-    let area = infer_area(&row.work_package, is_closeout);
-    let queue = infer_queue(&row.work_package, area);
-    let outcome = infer_outcome(&row.work_package, area);
+    let inferred_area = infer_area(&row.work_package, is_closeout);
+    let explicit_queue = row
+        .queue
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let queue = explicit_queue.unwrap_or_else(|| infer_queue(&row.work_package, inferred_area));
+    let area = area_for_queue(queue).unwrap_or(inferred_area);
+    let outcome = explicit_queue
+        .and_then(outcome_for_queue)
+        .unwrap_or_else(|| infer_outcome(&row.work_package, area));
     let slug = format!(
         "{}-{}-{}",
         slugify(version),
@@ -313,6 +321,31 @@ fn infer_outcome(work_package: &str, area: &str) -> &'static str {
     }
 }
 
+fn area_for_queue(queue: &str) -> Option<&'static str> {
+    match queue.trim() {
+        "demo" => Some("demo"),
+        "docs" => Some("docs"),
+        "quality" => Some("quality"),
+        "release" => Some("release"),
+        "review" => Some("review"),
+        "runtime" => Some("runtime"),
+        "tools" => Some("tools"),
+        _ => None,
+    }
+}
+
+fn outcome_for_queue(queue: &str) -> Option<&'static str> {
+    match queue.trim() {
+        "demo" => Some("demo"),
+        "docs" => Some("docs"),
+        "quality" => Some("tests"),
+        "release" => Some("release"),
+        "review" => Some("review"),
+        "runtime" | "tools" => Some("code"),
+        _ => None,
+    }
+}
+
 fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
     let mut rows = Vec::new();
     let table = extract_wbs_table(text)?;
@@ -320,6 +353,9 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
     let issue_second_shape = header_cols
         .get(1)
         .is_some_and(|value| value.eq_ignore_ascii_case("Issue"));
+    let current_queue_shape = header_cols
+        .get(2)
+        .is_some_and(|value| value.eq_ignore_ascii_case("Queue"));
     for line in table.into_iter().skip(2) {
         let cols = split_markdown_row(&line);
         if cols.len() != 5 && cols.len() != 6 {
@@ -328,10 +364,11 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
                 cols.len()
             );
         }
-        let (work_package, description, deliverable, dependencies, issue_column) =
+        let (work_package, queue, description, deliverable, dependencies, issue_column) =
             if cols.len() == 6 && issue_second_shape {
                 (
                     cols[2].to_string(),
+                    None,
                     cols[3].to_string(),
                     cols[4].to_string(),
                     cols[5].to_string(),
@@ -340,14 +377,25 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
             } else if cols.len() == 6 {
                 (
                     cols[1].to_string(),
+                    None,
                     cols[2].to_string(),
                     cols[3].to_string(),
                     cols[4].to_string(),
                     cols[5].to_string(),
                 )
+            } else if current_queue_shape {
+                (
+                    cols[1].to_string(),
+                    Some(cols[2].to_string()),
+                    cols[1].to_string(),
+                    cols[3].to_string(),
+                    cols[4].to_string(),
+                    "issue to be seeded".to_string(),
+                )
             } else {
                 (
                     cols[1].to_string(),
+                    None,
                     cols[2].to_string(),
                     cols[3].to_string(),
                     cols[4].to_string(),
@@ -359,9 +407,14 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
         } else {
             extract_wp_refs(cols[4])
         };
+        let wp = extract_wp_refs(cols[0])
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| cols[0].to_string());
         rows.push(WbsRow {
-            wp: cols[0].to_string(),
+            wp,
             work_package,
+            queue,
             description,
             deliverable,
             dependencies: dependency_refs,
@@ -375,6 +428,7 @@ fn parse_wbs_rows(text: &str) -> Result<Vec<WbsRow>> {
 fn extract_wbs_table(text: &str) -> Result<Vec<String>> {
     extract_markdown_table(text, "## Work Packages")
         .or_else(|_| extract_markdown_table(text, "## Work Package Shape"))
+        .or_else(|_| extract_markdown_table(text, "## Candidate WP Sequence"))
 }
 
 fn parse_sprint_overview(version: &str, text: &str) -> Result<BTreeMap<String, (String, String)>> {
@@ -415,7 +469,16 @@ fn parse_sprint_sections(version: &str, text: &str) -> Result<BTreeMap<String, (
                 .take_while(|ch| ch.is_ascii_digit())
                 .collect::<String>();
             if !number.is_empty() {
-                current = Some((format!("{version}-s{number}"), format!("Sprint {number}")));
+                let label_suffix = rest[number.len()..]
+                    .trim()
+                    .trim_start_matches(['-', ':'])
+                    .trim();
+                let sprint_label = if label_suffix.is_empty() {
+                    format!("Sprint {number}")
+                } else {
+                    format!("Sprint {number}: {label_suffix}")
+                };
+                current = Some((format!("{version}-s{number}"), sprint_label));
                 continue;
             }
         }
@@ -430,12 +493,21 @@ fn parse_sprint_sections(version: &str, text: &str) -> Result<BTreeMap<String, (
             current = None;
             continue;
         }
-        if !line.starts_with("- ") {
-            continue;
-        }
         let Some((sprint_id, sprint_label)) = &current else {
             continue;
         };
+        if line.starts_with('|') {
+            let cols = split_markdown_row(line);
+            if let Some(first_col) = cols.first() {
+                for wp in extract_wp_refs(first_col) {
+                    mapping.insert(wp, (sprint_id.clone(), sprint_label.clone()));
+                }
+            }
+            continue;
+        }
+        if !line.starts_with("- ") {
+            continue;
+        }
         for wp in extract_wp_refs(line) {
             mapping.insert(wp, (sprint_id.clone(), sprint_label.clone()));
         }
@@ -653,7 +725,7 @@ mod tests {
         );
         assert_eq!(wp02.queue, "tools");
         assert_eq!(wp02.outcome, "docs");
-        assert_eq!(wp02.milestone_sprint, "Sprint 1");
+        assert_eq!(wp02.milestone_sprint, "Sprint 1: Compression Enablement");
         assert_eq!(wp02.sprint_id, "v0.90.1-s1");
         assert_eq!(wp02.dependencies, vec!["WP-01"]);
 
@@ -701,7 +773,57 @@ mod tests {
             .expect("wp15a present");
         assert_eq!(wp15a.queue, "review");
         assert_eq!(wp15a.outcome, "review");
-        assert_eq!(wp15a.milestone_sprint, "Sprint 4");
+        assert_eq!(wp15a.milestone_sprint, "Sprint 4: Review And Remediation");
         assert_eq!(wp15a.dependencies, vec!["WP-15"]);
+    }
+
+    #[test]
+    fn generate_wave_doc_accepts_v0912_active_tables_with_issue_numbers_and_queues() {
+        let wbs = include_str!("../../../../docs/milestones/v0.91.2/WBS_v0.91.2.md");
+        let sprint = include_str!("../../../../docs/milestones/v0.91.2/SPRINT_v0.91.2.md");
+
+        let wave = generate_wave_doc(
+            "v0.91.2",
+            wbs,
+            sprint,
+            "docs/milestones/v0.91.2/WBS_v0.91.2.md",
+            "docs/milestones/v0.91.2/SPRINT_v0.91.2.md",
+        )
+        .expect("generate active v0.91.2 wave");
+
+        assert_eq!(wave.entries.len(), 23);
+
+        let wp02 = &wave.entries[0];
+        assert_eq!(wp02.wp, "WP-02");
+        assert_eq!(wp02.queue, "tools");
+        assert_eq!(wp02.labels[2], "area:tools");
+        assert_eq!(wp02.summary, "UTS + ACC multi-model benchmark harness");
+        assert_eq!(
+            wp02.milestone_sprint,
+            "Sprint 1: Benchmark And Test-Cycle Recovery"
+        );
+        assert_eq!(wp02.dependencies, vec!["WP-01"]);
+
+        let wp10 = wave
+            .entries
+            .iter()
+            .find(|entry| entry.wp == "WP-10")
+            .expect("wp10 present");
+        assert_eq!(
+            wp10.work_package,
+            "Moderne / OpenRewrite LST modernization demo"
+        );
+        assert_eq!(wp10.queue, "tools");
+        assert_eq!(wp10.summary, wp10.work_package);
+
+        let wp24 = wave.entries.last().expect("wp24 present");
+        assert_eq!(wp24.wp, "WP-24");
+        assert_eq!(wp24.queue, "release");
+        assert_eq!(wp24.outcome, "release");
+        assert_eq!(
+            wp24.milestone_sprint,
+            "Sprint 4: Review, Remediation, And Release"
+        );
+        assert_eq!(wp24.dependencies, vec!["WP-23"]);
     }
 }

--- a/docs/milestones/v0.91.2/CARD_BUNDLE_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/CARD_BUNDLE_READINESS_v0.91.2.md
@@ -2,23 +2,64 @@
 
 ## Status
 
-Planned, not opened.
+Active. The v0.91.2 WP issue wave and sprint umbrella issue wave are open.
 
 ## Current State
 
-`v0.91.2` does not yet have an opened issue wave, so the full STP/SIP/SPP/SRP/SOR
-bundle set is not yet expected to exist for every WP.
+`v0.91.2` now has an opened issue wave:
+
+- WP-01 is `#3000`
+- WP-02 through WP-24 are `#3001` through `#3023`
+- Sprint umbrellas are `#3025` through `#3028`
+- Sidecar issue `#3024` is an unscheduled docs cleanup issue, not part of the
+  canonical WP/sprint sequence
+
+The full STP/SIP/SPP/SRP/SOR bundle set exists in the durable primary-checkout
+local bundle root at `.adl/v0.91.2/tasks/` for the opened WP issues and sprint
+umbrella issues before execution binding. Those `.adl` bundles are local
+workflow records, not tracked PR files.
 
 ## Opening Rule
 
-When the milestone opens:
+Opening pass result:
 
-- each WP should receive STP, SIP, SPP, SRP, and SOR cards
-- bundle validation should be recorded
-- the package should be updated from planned to active state
+- each WP received STP, SIP, SPP, SRP, and SOR cards
+- each sprint umbrella received STP, SIP, SPP, SRP, and SOR cards
+- bundle validation was recorded during WP-01
+- the package was updated from planned to active state
+
+## Validation Record
+
+Command:
+
+```bash
+for issue in {3000..3028}; do
+  if [[ "$issue" == "3024" ]]; then
+    expected_kind="sidecar"
+  fi
+  d="$(find .adl/v0.91.2/tasks -maxdepth 1 -type d -name "issue-${issue}__*" | head -1)"
+  test -n "$d"
+  for t in stp sip spp srp sor; do
+    f="$d/$t.md"
+    test -s "$f"
+    if [[ "$t" == sip || "$t" == sor ]]; then
+      ADL_TOOLING_RUST_BIN=adl/target/debug/adl \
+        bash adl/tools/validate_structured_prompt.sh \
+          --type "$t" --phase bootstrap --input "$f" >/dev/null
+    else
+      ADL_TOOLING_RUST_BIN=adl/target/debug/adl \
+        bash adl/tools/validate_structured_prompt.sh \
+          --type "$t" --input "$f" >/dev/null
+    fi
+  done
+done
+```
+
+Result: `PASS issue-30xx v0.91.2 task cards`
 
 ## Non-Claims
 
-- this doc does not claim the issue wave is already opened
-- this doc does not claim per-WP card bundles already exist
-
+- this doc does not claim any WP implementation has started
+- this doc does not claim sprint execution has started
+- this doc does not claim sidecar issue `#3024` is part of the canonical WP or
+  sprint issue wave

--- a/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Planned milestone coverage map. `v0.91.2` is not open for execution yet, so
-these are intended proof routes rather than landed proofs.
+Active milestone coverage map. `v0.91.2` is open for execution, but these are
+still intended proof routes rather than landed proofs until the named WPs close.
 
 ## Coverage Rule
 
@@ -35,4 +35,4 @@ Each feature should eventually have one truthful proof route:
 ## Non-Claims
 
 - no feature in this milestone is landed yet through this document alone
-- this file is not evidence that the issue wave has opened
+- this file is not evidence that any feature implementation has landed

--- a/docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md
+++ b/docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md
@@ -5,8 +5,8 @@
 - [x] README, WBS, sprint plan, issue wave, execution readiness, and demo matrix exist.
 - [x] Feature index exists and names concrete WP homes.
 - [x] Missing milestone-planning package surfaces have been restored.
-- [ ] Candidate issue wave opened into tracked GitHub issues.
-- [ ] Local STP/SIP/SPP/SRP/SOR bundle wave generated for every WP.
+- [x] Issue wave opened into tracked GitHub issues.
+- [x] Local STP/SIP/SPP/SRP/SOR bundle wave generated for every WP and sprint umbrella.
 
 ## Execution Readiness
 
@@ -24,4 +24,3 @@
 - [ ] Accepted findings are fixed or dispositioned.
 - [ ] Release evidence and release readiness are complete.
 - [ ] Ceremony completed.
-

--- a/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
@@ -14,8 +14,8 @@ milestone reaches its quality phase.
 
 ## Current State
 
-The quality gate is not complete yet, and the milestone is not open for
-execution.
+The quality gate is not complete yet. The milestone is open for execution, but
+WP-18 has not run.
 
 ## Required Inputs Before Pass/Fail Judgment
 

--- a/docs/milestones/v0.91.2/README.md
+++ b/docs/milestones/v0.91.2/README.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-First-pass planning package. v0.91.2 is the proposed follow-on pressure-release
-milestone after v0.91.1. It is not open for execution yet.
+Active milestone package. v0.91.2 is the follow-on pressure-release milestone
+after v0.91.1. The WP issue wave is open as `#3000` through `#3023`, and the
+sprint-conductor umbrella issues are open as `#3025` through `#3028`.
 
 ## Purpose
 
@@ -80,7 +81,7 @@ This package is grounded in:
 - Sprint plan: [SPRINT_v0.91.2.md](SPRINT_v0.91.2.md)
 - Sprint-conductor execution plan:
   [SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md](SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md)
-- Candidate issue wave: [WP_ISSUE_WAVE_v0.91.2.yaml](WP_ISSUE_WAVE_v0.91.2.yaml)
+- Active issue wave: [WP_ISSUE_WAVE_v0.91.2.yaml](WP_ISSUE_WAVE_v0.91.2.yaml)
 - Execution readiness:
   [WP_EXECUTION_READINESS_v0.91.2.md](WP_EXECUTION_READINESS_v0.91.2.md)
 - Demo matrix: [DEMO_MATRIX_v0.91.2.md](DEMO_MATRIX_v0.91.2.md)
@@ -109,3 +110,7 @@ evidence, a healthier test/runtime gate strategy, a review/productization path,
 a bounded Workspace CMS bridge demo, Moderne/OpenRewrite LST modernization and publication packages,
 and workflow guardrails that reduce the operational failures that slowed
 v0.90.5 and v0.91.
+
+Execution note: WP-01 opened and carded the issue wave. Feature implementation
+has not started until the relevant WP is routed through `workflow-conductor`,
+bound with `pr run`, reviewed before PR publication, and closed out after merge.

--- a/docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft scaffold only. `v0.91.2` is not open for execution and does not yet have
+Draft scaffold only. `v0.91.2` is open for execution, but it does not yet have
 release-ready notes.
 
 ## Theme
@@ -21,4 +21,3 @@ Tooling, evaluation, productization, publication, and workflow guardrails.
 - executed milestone completion
 - final review or release state
 - any benchmark or tooling result not yet produced
-

--- a/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
@@ -19,14 +19,13 @@ Not release ready.
 
 ## Current State
 
-- `v0.91.2` is a proposed follow-on milestone
-- the issue wave is still candidate/planned
+- `v0.91.2` is an active follow-on milestone
+- the WP issue wave is open as `#3000` through `#3023`
+- sprint-conductor umbrella issues are open as `#3025` through `#3028`
 - no final release proof, review, or ceremony state exists yet
 
 ## Current Blockers
 
-- issue wave not opened
 - no executed WPs
 - no quality gate
 - no review or remediation state
-

--- a/docs/milestones/v0.91.2/SPP_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPP_READINESS_v0.91.2.md
@@ -3,27 +3,28 @@
 ## Purpose
 
 Record the planning-surface readiness of Structured Plan Prompt (`SPP`)
-artifacts for the future `v0.91.2` issue wave.
+artifacts for the active `v0.91.2` issue wave.
 
 ## Current State
 
-`v0.91.2` is not yet open for execution, so `SPP` readiness here is package
-policy/readiness rather than a claim that all issue-local `spp.md` files
-already exist.
+`v0.91.2` is open for execution. Issue-local `spp.md` files exist in the
+durable primary-checkout local bundle root for WP-01 through WP-24 and for
+Sprint 1 through Sprint 4 umbrella issues before child execution binding.
 
 ## What Is Ready
 
 - the milestone package recognizes `SPP` as a required issue-wave artifact
 - issue-wave and execution-readiness docs already call for `SPP` when the wave
   opens
+- WP and sprint umbrella `SPP` cards were generated, normalized, and validated
+  during WP-01
 
 ## Remaining Gaps
 
-- the actual issue-wave bundle generation is still pending
-- per-issue SPP quality cannot be claimed before that wave exists
+- per-issue `SPP` cards remain pre-execution plans and must be revised through
+  `spp-editor` if execution scope changes materially
 
 ## Non-Claims
 
-- this doc does not claim opened issue execution
-- this doc does not claim generated per-WP `SPP` files
-
+- this doc does not claim child issue execution has started
+- this doc does not claim `SPP` cards are implementation evidence

--- a/docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Planned operating model for `v0.91.2`. This document does not open the
-milestone by itself. It defines how the milestone should be executed once the
-issue wave is seeded.
+Active operating model for `v0.91.2`. This document did not open the milestone
+by itself; WP-01 opened the issue wave and sprint umbrellas from the canonical
+milestone package.
 
 ## Purpose
 
@@ -68,7 +68,7 @@ the `v0.91.2` conductor experiment.
 Before relying on this operating model:
 
 - `WP-01` must land first as the milestone-opening design/docs/planning pass
-- the `v0.91.2` issue wave should be opened and carded
+- the `v0.91.2` issue wave is opened and carded
 - child issues should have truthful `STP`, `SIP`, `SPP`, `SRP`, and `SOR`
   surfaces
 - docs-only issues should preserve docs-only validation/finish paths
@@ -82,13 +82,15 @@ how sprint-conductor should execute it.
 
 ### Sprint 1: Benchmark And Test-Cycle Recovery
 
+Sprint umbrella: `#3025`
+
 Child issues:
 
-- `WP-01` Design pass (milestone docs + planning)
-- `WP-02` UTS + ACC multi-model benchmark harness
-- `WP-03` Provider-native tool-call comparison
-- `WP-04` Runtime/test-cycle recovery
-- `WP-05` Coverage gate ergonomics
+- `WP-01` / `#3000` Design pass (milestone docs + planning)
+- `WP-02` / `#3001` UTS + ACC multi-model benchmark harness
+- `WP-03` / `#3002` Provider-native tool-call comparison
+- `WP-04` / `#3003` Runtime/test-cycle recovery
+- `WP-05` / `#3004` Coverage gate ergonomics
 
 Why this sprint exists:
 
@@ -100,13 +102,15 @@ Why this sprint exists:
 
 ### Sprint 2: Review Product, Workspace Bridge, And Modernization
 
+Sprint umbrella: `#3026`
+
 Child issues:
 
-- `WP-06` CodeBuddy review packet productization
-- `WP-07` Review heuristics skill and demos
-- `WP-08` Google Workspace CMS bridge demo
-- `WP-09` Rust-native GWS adapter boundary
-- `WP-10` Moderne / OpenRewrite LST modernization demo
+- `WP-06` / `#3005` CodeBuddy review packet productization
+- `WP-07` / `#3006` Review heuristics skill and demos
+- `WP-08` / `#3007` Google Workspace CMS bridge demo
+- `WP-09` / `#3008` Rust-native GWS adapter boundary
+- `WP-10` / `#3009` Moderne / OpenRewrite LST modernization demo
 
 Why this sprint exists:
 
@@ -117,14 +121,16 @@ Why this sprint exists:
 
 ### Sprint 3: Runtime Ergonomics, Publication, Docs, And Workflow Guardrails
 
+Sprint umbrella: `#3027`
+
 Child issues:
 
-- `WP-11` Speculative decoding prototype
-- `WP-12` Repo visibility follow-on
-- `WP-13` Publication program package
-- `WP-14` General intelligence paper packet
-- `WP-15` Rustdoc and doc cleanup
-- `WP-16` Workflow guardrails hardening
+- `WP-11` / `#3010` Speculative decoding prototype
+- `WP-12` / `#3011` Repo visibility follow-on
+- `WP-13` / `#3012` Publication program package
+- `WP-14` / `#3013` General intelligence paper packet
+- `WP-15` / `#3014` Rustdoc and doc cleanup
+- `WP-16` / `#3015` Workflow guardrails hardening
 
 Why this sprint exists:
 
@@ -137,16 +143,18 @@ Why this sprint exists:
 
 ### Sprint 4: Review, Remediation, Planning, And Release
 
+Sprint umbrella: `#3028`
+
 Child issues:
 
-- `WP-17` Demo matrix and proof coverage
-- `WP-18` Coverage / quality gate
-- `WP-19` Docs + review pass
-- `WP-20` Internal review
-- `WP-21` External / 3rd-party review
-- `WP-22` Review findings remediation
-- `WP-23` Next milestone planning
-- `WP-24` Release ceremony
+- `WP-17` / `#3016` Demo matrix and proof coverage
+- `WP-18` / `#3017` Coverage / quality gate
+- `WP-19` / `#3018` Docs + review pass
+- `WP-20` / `#3019` Internal review
+- `WP-21` / `#3020` External / 3rd-party review
+- `WP-22` / `#3021` Review findings remediation
+- `WP-23` / `#3022` Next milestone planning
+- `WP-24` / `#3023` Release ceremony
 
 Release-tail notes:
 

--- a/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
@@ -2,17 +2,20 @@
 
 ## Status
 
-Candidate sprint plan for review.
+Active sprint plan. The complete v0.91.2 WP issue wave is open as `#3000`
+through `#3023`, with sprint-conductor umbrella issues `#3025` through
+`#3028`. Every WP and sprint umbrella has a prepared primary-checkout local
+STP, SIP, SPP, SRP, and SOR bundle before execution binding.
 
 ## Sprint 1: Benchmark And Test-Cycle Recovery
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-01 | Design pass (milestone docs + planning) | tracked docs, reviewed YAML, and issue cards | v0.91.1 closeout |
-| WP-02 | UTS + ACC multi-model benchmark harness | benchmark harness and fixture battery | WP-01; governed-tools baseline; ACIP substrate |
-| WP-03 | Provider-native tool-call comparison | JSON proposal vs provider-native comparison report | WP-02 |
-| WP-04 | Runtime/test-cycle recovery | reduced redundant proof phases and validation report | WP-01 |
-| WP-05 | Coverage gate ergonomics | changed-source diagnostics and focused-test guide | WP-04 |
+| WP-01 (#3000) | Design pass (milestone docs + planning) | tracked docs, reviewed YAML, and issue cards | v0.91.1 closeout |
+| WP-02 (#3001) | UTS + ACC multi-model benchmark harness | benchmark harness and fixture battery | WP-01; governed-tools baseline; ACIP substrate |
+| WP-03 (#3002) | Provider-native tool-call comparison | JSON proposal vs provider-native comparison report | WP-02 |
+| WP-04 (#3003) | Runtime/test-cycle recovery | reduced redundant proof phases and validation report | WP-01 |
+| WP-05 (#3004) | Coverage gate ergonomics | changed-source diagnostics and focused-test guide | WP-04 |
 
 Goal: stop guessing about tool-call model behavior and stop losing days to
 expensive, confusing test cycles.
@@ -21,11 +24,11 @@ expensive, confusing test cycles.
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-06 | CodeBuddy review packet productization | review packet and product-report workflow package | WP-01; review skills and evidence-packet substrate |
-| WP-07 | Review heuristics skill and demos | review heuristics docs, skill/demo updates, proof examples | WP-06 |
-| WP-08 | Google Workspace CMS bridge demo | bounded Workspace content-card and promotion demo | WP-01; governed-tools authority and adapter boundary |
-| WP-09 | Rust-native GWS adapter boundary | adapter feasibility and typed contract boundary | WP-08 |
-| WP-10 | Moderne / OpenRewrite LST modernization demo | ADL-governed Moderne/OpenRewrite interaction demo | WP-01 |
+| WP-06 (#3005) | CodeBuddy review packet productization | review packet and product-report workflow package | WP-01; review skills and evidence-packet substrate |
+| WP-07 (#3006) | Review heuristics skill and demos | review heuristics docs, skill/demo updates, proof examples | WP-06 |
+| WP-08 (#3007) | Google Workspace CMS bridge demo | bounded Workspace content-card and promotion demo | WP-01; governed-tools authority and adapter boundary |
+| WP-09 (#3008) | Rust-native GWS adapter boundary | adapter feasibility and typed contract boundary | WP-08 |
+| WP-10 (#3009) | Moderne / OpenRewrite LST modernization demo | ADL-governed Moderne/OpenRewrite interaction demo | WP-01 |
 
 Goal: turn review, collaborative docs, and Moderne/OpenRewrite LST modernization ideas into bounded
 product surfaces without granting silent authority over canonical repo truth.
@@ -34,12 +37,12 @@ product surfaces without granting silent authority over canonical repo truth.
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-11 | Speculative decoding prototype | bounded speculative-decoding architecture and proof posture | WP-02, WP-04 |
-| WP-12 | Repo visibility follow-on | manifest/linkage follow-on package | WP-06, WP-07 |
-| WP-13 | Publication program package | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
-| WP-14 | General intelligence paper packet | claim, citation, and review packet | WP-13 |
-| WP-15 | Rustdoc and doc cleanup | rustdoc/doc cleanup patches and report | WP-05 |
-| WP-16 | Workflow guardrails hardening | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
+| WP-11 (#3010) | Speculative decoding prototype | bounded speculative-decoding architecture and proof posture | WP-02, WP-04 |
+| WP-12 (#3011) | Repo visibility follow-on | manifest/linkage follow-on package | WP-06, WP-07 |
+| WP-13 (#3012) | Publication program package | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
+| WP-14 (#3013) | General intelligence paper packet | claim, citation, and review packet | WP-13 |
+| WP-15 (#3014) | Rustdoc and doc cleanup | rustdoc/doc cleanup patches and report | WP-05 |
+| WP-16 (#3015) | Workflow guardrails hardening | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
 
 Goal: make the project’s public intellectual surface and daily workflow less
 fragile, less ambiguous, easier for other humans to review, and more honest
@@ -50,14 +53,14 @@ worth carrying forward.
 
 | WP | Title | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- |
-| WP-17 | Demo matrix and proof coverage | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
-| WP-18 | Coverage / quality gate | validation posture and test/coverage record | WP-17 |
-| WP-19 | Docs + review pass | review-ready docs package | WP-18 |
-| WP-20 | Internal review | internal review record | WP-19 |
-| WP-21 | External / 3rd-party review | external review handoff and record | WP-20 |
-| WP-22 | Review findings remediation | remediation record and follow-up issues | WP-21 |
-| WP-23 | Next milestone planning | v0.92/v0.93 handoff update | WP-22 |
-| WP-24 | Release ceremony | release evidence and end-of-milestone report | WP-23 |
+| WP-17 (#3016) | Demo matrix and proof coverage | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
+| WP-18 (#3017) | Coverage / quality gate | validation posture and test/coverage record | WP-17 |
+| WP-19 (#3018) | Docs + review pass | review-ready docs package | WP-18 |
+| WP-20 (#3019) | Internal review | internal review record | WP-19 |
+| WP-21 (#3020) | External / 3rd-party review | external review handoff and record | WP-20 |
+| WP-22 (#3021) | Review findings remediation | remediation record and follow-up issues | WP-21 |
+| WP-23 (#3022) | Next milestone planning | v0.92/v0.93 handoff update | WP-22 |
+| WP-24 (#3023) | Release ceremony | release evidence and end-of-milestone report | WP-23 |
 
 Goal: leave the next identity/governance milestones with cleaner test cycles,
 clearer publication and product surfaces, and fewer workflow foot-guns.
@@ -73,8 +76,8 @@ That means the intended parallelization shape is:
 
 - Sprint 1 may proceed before Sprint 2 only if the milestone owner chooses to
   overlap umbrellas and the dependency truth still holds
-- Sprint 2 may proceed beside Sprint 3A or Sprint 3B only as separate
-  umbrellas, not as parallel child issues inside one umbrella
+- Sprint 2 may proceed beside Sprint 3 only as a separate umbrella, not as
+  parallel child issues inside one umbrella
 - Publication packet work may sit beside doc cleanup only when they are carried
   as distinct umbrellas or distinct sequential child issues in the same
   umbrella
@@ -82,3 +85,12 @@ That means the intended parallelization shape is:
   but it should still execute as one child issue at a time
 
 No public release should happen before review.
+
+## Sprint Umbrella Issues
+
+| Sprint | Issue | Ordered Children |
+| --- | --- | --- |
+| Sprint 1 | #3025 | #3000, #3001, #3002, #3003, #3004 |
+| Sprint 2 | #3026 | #3005, #3006, #3007, #3008, #3009 |
+| Sprint 3 | #3027 | #3010, #3011, #3012, #3013, #3014, #3015 |
+| Sprint 4 | #3028 | #3016, #3017, #3018, #3019, #3020, #3021, #3022, #3023 |

--- a/docs/milestones/v0.91.2/WBS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/WBS_v0.91.2.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Candidate WBS for review. Issue numbers are intentionally not assigned yet.
+Active WBS. The complete v0.91.2 WP issue wave is open as `#3000` through
+`#3023`, with sprint-conductor umbrella issues `#3025` through `#3028`.
+Every WP and sprint umbrella has a prepared primary-checkout local STP, SIP,
+SPP, SRP, and SOR bundle before execution binding.
 
 ## WBS Summary
 
@@ -34,30 +37,39 @@ productize, publish, and maintain.
 
 | WP | Title | Queue | Primary Deliverable | Dependencies |
 | --- | --- | --- | --- | --- |
-| WP-01 | Design pass (milestone docs + planning) | docs | tracked docs, reviewed YAML, and issue cards | v0.91.1 closeout |
-| WP-02 | UTS + ACC multi-model benchmark harness | tools | benchmark harness and fixture battery | WP-01; governed-tools baseline; ACIP substrate |
-| WP-03 | Provider-native tool-call comparison | tools | JSON proposal vs provider-native comparison report | WP-02 |
-| WP-04 | Runtime/test-cycle recovery | quality | reduced redundant proof phases and validation report | WP-01 |
-| WP-05 | Coverage gate ergonomics | quality | changed-source diagnostics and focused-test guide | WP-04 |
-| WP-06 | CodeBuddy review packet productization | tools | review packet and product-report workflow package | WP-01; review skills and evidence-packet substrate |
-| WP-07 | Review heuristics skill and demos | demo | review heuristics docs, skill/demo updates, proof examples | WP-06 |
-| WP-08 | Google Workspace CMS bridge demo | tools | bounded Workspace content-card and promotion demo | WP-01; governed-tools authority and adapter boundary |
-| WP-09 | Rust-native GWS adapter boundary | tools | adapter feasibility and typed contract boundary | WP-08 |
-| WP-10 | Moderne / OpenRewrite LST modernization demo | tools | ADL-governed Moderne/OpenRewrite interaction demo | WP-01 |
-| WP-11 | Speculative decoding prototype | runtime | bounded speculative-decoding architecture and proof posture | WP-02, WP-04 |
-| WP-12 | Repo visibility follow-on | docs | manifest/linkage follow-on package | WP-06, WP-07 |
-| WP-13 | Publication program package | docs | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
-| WP-14 | General intelligence paper packet | docs | claim, citation, and review packet | WP-13 |
-| WP-15 | Rustdoc and doc cleanup | docs | rustdoc/doc cleanup patches and report | WP-05 |
-| WP-16 | Workflow guardrails hardening | tools | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
-| WP-17 | Demo matrix and proof coverage | demo | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
-| WP-18 | Coverage / quality gate | quality | validation posture and test/coverage record | WP-17 |
-| WP-19 | Docs + review pass | docs | review-ready docs package | WP-18 |
-| WP-20 | Internal review | review | internal review record | WP-19 |
-| WP-21 | External / 3rd-party review | review | external review handoff and record | WP-20 |
-| WP-22 | Review findings remediation | review | remediation record and follow-up issues | WP-21 |
-| WP-23 | Next milestone planning | docs | v0.92/v0.93 handoff update | WP-22 |
-| WP-24 | Release ceremony | release | release evidence and end-of-milestone report | WP-23 |
+| WP-01 (#3000) | Design pass (milestone docs + planning) | docs | tracked docs, reviewed YAML, and issue cards | v0.91.1 closeout |
+| WP-02 (#3001) | UTS + ACC multi-model benchmark harness | tools | benchmark harness and fixture battery | WP-01; governed-tools baseline; ACIP substrate |
+| WP-03 (#3002) | Provider-native tool-call comparison | tools | JSON proposal vs provider-native comparison report | WP-02 |
+| WP-04 (#3003) | Runtime/test-cycle recovery | quality | reduced redundant proof phases and validation report | WP-01 |
+| WP-05 (#3004) | Coverage gate ergonomics | quality | changed-source diagnostics and focused-test guide | WP-04 |
+| WP-06 (#3005) | CodeBuddy review packet productization | tools | review packet and product-report workflow package | WP-01; review skills and evidence-packet substrate |
+| WP-07 (#3006) | Review heuristics skill and demos | demo | review heuristics docs, skill/demo updates, proof examples | WP-06 |
+| WP-08 (#3007) | Google Workspace CMS bridge demo | tools | bounded Workspace content-card and promotion demo | WP-01; governed-tools authority and adapter boundary |
+| WP-09 (#3008) | Rust-native GWS adapter boundary | tools | adapter feasibility and typed contract boundary | WP-08 |
+| WP-10 (#3009) | Moderne / OpenRewrite LST modernization demo | tools | ADL-governed Moderne/OpenRewrite interaction demo | WP-01 |
+| WP-11 (#3010) | Speculative decoding prototype | runtime | bounded speculative-decoding architecture and proof posture | WP-02, WP-04 |
+| WP-12 (#3011) | Repo visibility follow-on | docs | manifest/linkage follow-on package | WP-06, WP-07 |
+| WP-13 (#3012) | Publication program package | docs | arXiv/Medium paper-program backlog and process docs | WP-01; review/evidence docs and publication process notes |
+| WP-14 (#3013) | General intelligence paper packet | docs | claim, citation, and review packet | WP-13 |
+| WP-15 (#3014) | Rustdoc and doc cleanup | docs | rustdoc/doc cleanup patches and report | WP-05 |
+| WP-16 (#3015) | Workflow guardrails hardening | tools | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
+| WP-17 (#3016) | Demo matrix and proof coverage | demo | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
+| WP-18 (#3017) | Coverage / quality gate | quality | validation posture and test/coverage record | WP-17 |
+| WP-19 (#3018) | Docs + review pass | docs | review-ready docs package | WP-18 |
+| WP-20 (#3019) | Internal review | review | internal review record | WP-19 |
+| WP-21 (#3020) | External / 3rd-party review | review | external review handoff and record | WP-20 |
+| WP-22 (#3021) | Review findings remediation | review | remediation record and follow-up issues | WP-21 |
+| WP-23 (#3022) | Next milestone planning | docs | v0.92/v0.93 handoff update | WP-22 |
+| WP-24 (#3023) | Release ceremony | release | release evidence and end-of-milestone report | WP-23 |
+
+## Sprint Umbrellas
+
+| Sprint | Issue | Title | Ordered Children |
+| --- | --- | --- | --- |
+| Sprint 1 | #3025 | Benchmark And Test-Cycle Recovery | WP-01, WP-02, WP-03, WP-04, WP-05 |
+| Sprint 2 | #3026 | Review Product, Workspace Bridge, And Modernization | WP-06, WP-07, WP-08, WP-09, WP-10 |
+| Sprint 3 | #3027 | Runtime Ergonomics, Publication, Docs, And Workflow Guardrails | WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
+| Sprint 4 | #3028 | Review, Remediation, Planning, And Release | WP-17, WP-18, WP-19, WP-20, WP-21, WP-22, WP-23, WP-24 |
 
 ## Sequencing Pressure
 

--- a/docs/milestones/v0.91.2/WP_EXECUTION_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/WP_EXECUTION_READINESS_v0.91.2.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document is the candidate card-authoring source for the v0.91.2 tooling,
+This document is the accepted card-authoring source for the v0.91.2 tooling,
 evaluation, productization, publication, and workflow-hardening wave.
 
 ## Global Execution Rules
@@ -27,7 +27,7 @@ Required outputs:
 
 Required validation:
 
-- Candidate issue wave matches sprint, WBS, and feature index.
+- Active issue wave matches sprint, WBS, and feature index.
 - Every WP has outputs, validation, source docs, and non-goals.
 
 ## WP-02: UTS + ACC Multi-Model Benchmark Harness

--- a/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
+++ b/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
@@ -1,7 +1,7 @@
 milestone: v0.91.2
-status: candidate_issue_wave
-issue_wave_opened: false
-owner_issue: null
+status: active_issue_wave_open
+issue_wave_opened: true
+owner_issue: 3000
 planning_source: docs/milestones/v0.91.2
 tracked_package: docs/milestones/v0.91.2
 notes:
@@ -17,6 +17,16 @@ notes:
   runtime evidence rather than speed theater.
 - Repo visibility should consume the delivered v0.90 baseline and extend it
   through a bounded follow-on instead of pretending the substrate is unstarted.
+- "WP-01 opened as issue #3000 after the v0.91.1 release ceremony completed."
+- "WP-02 through WP-24 opened as issues #3001 through #3023 during the WP-01
+  issue-wave and card-readiness pass."
+- "Sprint-conductor umbrella issues were opened as #3025 through #3028 from the
+  canonical sprint plan and execution overlay."
+- Every opened WP and sprint umbrella has a primary-checkout local STP, SIP,
+  SPP, SRP, and SOR bundle prepared and structurally validated before execution
+  binding.
+- "Issue #3024 is an unscheduled v0.91.2 sidecar docs cleanup issue for stale
+  legacy swarm references; it is not part of the canonical WP or sprint wave."
 card_update_rule:
 - When opened, every WP must receive STP, SIP, SPP, SRP, and SOR cards from the
   accepted readiness section.
@@ -33,13 +43,13 @@ closeout_sequence:
 - WP-24 Release ceremony
 work_packages:
 - wp: WP-01
-  issue: null
+  issue: 3000
   title: Design pass (milestone docs + planning)
   queue: docs
   outcome: tracked docs, reviewed YAML, and issue cards
   depends_on: v0.91.1 closeout
 - wp: WP-02
-  issue: null
+  issue: 3001
   title: UTS + ACC multi-model benchmark harness
   queue: tools
   outcome: benchmark harness and fixture battery
@@ -53,25 +63,25 @@ work_packages:
   - Preserve the split between ADL JSON proposal mode and provider-native
     tool/function-call mode.
 - wp: WP-03
-  issue: null
+  issue: 3002
   title: Provider-native tool-call comparison
   queue: tools
   outcome: JSON proposal vs provider-native comparison report
   depends_on: WP-02
 - wp: WP-04
-  issue: null
+  issue: 3003
   title: Runtime/test-cycle recovery
   queue: quality
   outcome: reduced redundant proof phases and validation report
   depends_on: WP-01
 - wp: WP-05
-  issue: null
+  issue: 3004
   title: Coverage gate ergonomics
   queue: quality
   outcome: changed-source diagnostics and focused-test guide
   depends_on: WP-04
 - wp: WP-06
-  issue: null
+  issue: 3005
   title: CodeBuddy review packet productization
   queue: tools
   outcome: review packet and product-report workflow package
@@ -83,13 +93,13 @@ work_packages:
   - Product language must preserve evidence, uncertainty, and reviewer
     responsibility.
 - wp: WP-07
-  issue: null
+  issue: 3006
   title: Review heuristics skill and demos
   queue: demo
   outcome: review heuristics docs, skill/demo updates, proof examples
   depends_on: WP-06
 - wp: WP-08
-  issue: null
+  issue: 3007
   title: Google Workspace CMS bridge demo
   queue: tools
   outcome: bounded Workspace content-card and promotion demo
@@ -101,19 +111,19 @@ work_packages:
   - Google Workspace remains collaborative draft infrastructure and must not
     override canonical Git truth without reviewed issue/PR authority.
 - wp: WP-09
-  issue: null
+  issue: 3008
   title: Rust-native GWS adapter boundary
   queue: tools
   outcome: adapter feasibility and typed contract boundary
   depends_on: WP-08
 - wp: WP-10
-  issue: null
-  title: Code modernization demo
+  issue: 3009
+  title: Moderne / OpenRewrite LST modernization demo
   queue: tools
-  outcome: Moderne/code modernization interaction demo
+  outcome: ADL-governed Moderne/OpenRewrite interaction demo
   depends_on: WP-01
 - wp: WP-11
-  issue: null
+  issue: 3010
   title: Speculative decoding prototype
   queue: runtime
   outcome: bounded speculative-decoding architecture and proof posture
@@ -127,7 +137,7 @@ work_packages:
   - Freedom Gate and ACC remain authority for side effects; token acceleration
     is not execution authority.
 - wp: WP-12
-  issue: null
+  issue: 3011
   title: Repo visibility follow-on
   queue: docs
   outcome: manifest/linkage follow-on package
@@ -140,7 +150,7 @@ work_packages:
   - The follow-on must improve reviewer/planner navigation without claiming full
     repo cognition.
 - wp: WP-13
-  issue: null
+  issue: 3012
   title: Publication program package
   queue: docs
   outcome: arXiv/Medium paper-program backlog and process docs
@@ -152,68 +162,109 @@ work_packages:
   - Publication packets must separate claims, citations, speculation, review
     status, and publication status.
 - wp: WP-14
-  issue: null
+  issue: 3013
   title: General intelligence paper packet
   queue: docs
   outcome: claim, citation, and review packet
   depends_on: WP-13
 - wp: WP-15
-  issue: null
+  issue: 3014
   title: Rustdoc and doc cleanup
   queue: docs
   outcome: rustdoc/doc cleanup patches and report
   depends_on: WP-05
 - wp: WP-16
-  issue: null
+  issue: 3015
   title: Workflow guardrails hardening
   queue: tools
   outcome: main-write, watcher, and safe-report guardrails
   depends_on: WP-04, WP-05
 - wp: WP-17
-  issue: null
+  issue: 3016
   title: Demo matrix and proof coverage
   queue: demo
   outcome: demo matrix and proof coverage record
   depends_on: WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16
 - wp: WP-18
-  issue: null
+  issue: 3017
   title: Coverage / quality gate
   queue: quality
   outcome: validation posture and test/coverage record
   depends_on: WP-17
 - wp: WP-19
-  issue: null
+  issue: 3018
   title: Docs + review pass
   queue: docs
   outcome: review-ready docs package
   depends_on: WP-18
 - wp: WP-20
-  issue: null
+  issue: 3019
   title: Internal review
   queue: review
   outcome: internal review record
   depends_on: WP-19
 - wp: WP-21
-  issue: null
+  issue: 3020
   title: External / 3rd-party review
   queue: review
   outcome: external review handoff and record
   depends_on: WP-20
 - wp: WP-22
-  issue: null
+  issue: 3021
   title: Review findings remediation
   queue: review
   outcome: remediation record and follow-up issues
   depends_on: WP-21
 - wp: WP-23
-  issue: null
+  issue: 3022
   title: Next milestone planning
   queue: docs
   outcome: v0.92/v0.93 handoff update
   depends_on: WP-22
 - wp: WP-24
-  issue: null
+  issue: 3023
   title: Release ceremony
   queue: release
   outcome: release evidence and end-of-milestone report
   depends_on: WP-23
+sprint_umbrellas:
+- sprint: Sprint 1
+  issue: 3025
+  title: Benchmark And Test-Cycle Recovery
+  ordered_children:
+  - WP-01
+  - WP-02
+  - WP-03
+  - WP-04
+  - WP-05
+- sprint: Sprint 2
+  issue: 3026
+  title: Review Product, Workspace Bridge, And Modernization
+  ordered_children:
+  - WP-06
+  - WP-07
+  - WP-08
+  - WP-09
+  - WP-10
+- sprint: Sprint 3
+  issue: 3027
+  title: Runtime Ergonomics, Publication, Docs, And Workflow Guardrails
+  ordered_children:
+  - WP-11
+  - WP-12
+  - WP-13
+  - WP-14
+  - WP-15
+  - WP-16
+- sprint: Sprint 4
+  issue: 3028
+  title: Review, Remediation, Planning, And Release
+  ordered_children:
+  - WP-17
+  - WP-18
+  - WP-19
+  - WP-20
+  - WP-21
+  - WP-22
+  - WP-23
+  - WP-24

--- a/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
+++ b/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
@@ -26,7 +26,7 @@ notes:
   SPP, SRP, and SOR bundle prepared and structurally validated before execution
   binding.
 - "Issue #3024 is an unscheduled v0.91.2 sidecar docs cleanup issue for stale
-  legacy swarm references; it is not part of the canonical WP or sprint wave."
+  terminology references; it is not part of the canonical WP or sprint wave."
 card_update_rule:
 - When opened, every WP must receive STP, SIP, SPP, SRP, and SOR cards from the
   accepted readiness section.


### PR DESCRIPTION
Closes #3000

## Summary
WP-01 opened the active v0.91.2 issue wave, created sprint-conductor umbrella issues, normalized local structured prompt bundles, and updated tracked milestone truth from planned to active.

## Artifacts
- GitHub WP issue wave: `#3000` through `#3023`
- GitHub sprint umbrella issues: `#3025` through `#3028`
- Sidecar issue noted but not scheduled in the canonical wave: `#3024`
- Tooling parser sidecar split from WP-01: `#3031` / PR `#3033`
- Local ignored structured prompt bundles for issue `#3000` through `#3028`
- Updated tracked milestone docs under `docs/milestones/v0.91.2/`

## Scope Boundary
- This PR is docs/control-plane only.
- The `adl/src/cli/tooling_cmd/wp_issue_wave.rs` parser hardening is intentionally split out to sidecar issue `#3031` / PR `#3033`.

## Validation
- `for d in .adl/v0.91.2/tasks/issue-30*; do ... validate_structured_prompt.sh ...; done`
  Verified all local v0.91.2 STP/SIP/SPP/SRP/SOR bundles for issue `#3000` through `#3028`.
- `ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml"); puts "PASS"'`\n  Verified `WP_ISSUE_WAVE_v0.91.2.yaml` parses.\n- `bash adl/tools/check_no_new_legacy_swarm_refs.sh`\n  Verified the WP-01 docs do not add blocked legacy terminology.\n- `git diff --check`\n  Verified whitespace cleanliness.\n- A full `pr finish` validation was also run before the parser split and passed 1928 nextest tests, but that run included the now-split parser file; it is retained only as historical evidence, not as a required docs-only validation claim.\n\n## Local Artifacts\n- Input card:  `.adl/v0.91.2/tasks/issue-3000__v0-91-2-wp-01-design-pass/sip.md`\n- Output card: `.adl/v0.91.2/tasks/issue-3000__v0-91-2-wp-01-design-pass/sor.md`