### PR TITLE
[v0.91.2][docs] Refresh ADL universal tool schema document for UTS v1/v1.1 framing

### DIFF
--- a/adl-spec/schemas/README.md
+++ b/adl-spec/schemas/README.md
@@ -7,6 +7,9 @@ Place versioned schema outputs here and keep narrative documentation in parent d
 
 - `adl_constitution.yaml` — constitutional governance artifact for delegation/runtime planning
 - `freedom_gate_event.yaml` — Freedom Gate event schema
+- `uts/v1.0/universal_tool_schema.v1.schema.json` — machine-readable current UTS baseline
+- `uts/v1.1/universal_tool_schema.v1_1.schema.json` — additive UTS v1.1 proposal tool schema
+- `uts/v1.1/tool_invocation.v1_1.schema.json` — additive UTS v1.1 proposal invocation schema
 - future schema artifacts for ADL language versions
 
 ## See Also / Canonical Docs

--- a/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json
+++ b/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "adl://schemas/uts/v1.0/universal_tool_schema.v1.schema.json",
+  "title": "Universal Tool Schema v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "name",
+    "version",
+    "description",
+    "input_schema",
+    "output_schema",
+    "side_effect_class",
+    "determinism",
+    "replay_safety",
+    "idempotence",
+    "resources",
+    "authentication",
+    "data_sensitivity",
+    "exfiltration_risk",
+    "execution_environment",
+    "errors"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "uts.v1"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9._-]{2,79}$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 12
+    },
+    "input_schema": {
+      "$ref": "#/$defs/jsonSchemaFragment"
+    },
+    "output_schema": {
+      "$ref": "#/$defs/jsonSchemaFragment"
+    },
+    "side_effect_class": {
+      "type": "string",
+      "enum": [
+        "read",
+        "local_write",
+        "external_read",
+        "external_write",
+        "process",
+        "network",
+        "destructive",
+        "exfiltration"
+      ]
+    },
+    "determinism": {
+      "type": "string",
+      "enum": [
+        "deterministic",
+        "bounded_nondeterministic",
+        "nondeterministic"
+      ]
+    },
+    "replay_safety": {
+      "type": "string",
+      "enum": [
+        "replay_safe",
+        "replay_requires_approval",
+        "not_replay_safe"
+      ]
+    },
+    "idempotence": {
+      "type": "string",
+      "enum": [
+        "idempotent",
+        "conditionally_idempotent",
+        "not_idempotent"
+      ]
+    },
+    "resources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/resourceRequirement"
+      }
+    },
+    "authentication": {
+      "$ref": "#/$defs/authenticationRequirement"
+    },
+    "data_sensitivity": {
+      "type": "string",
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "secret",
+        "protected_prompt",
+        "private_state"
+      ]
+    },
+    "exfiltration_risk": {
+      "type": "string",
+      "enum": [
+        "none",
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "execution_environment": {
+      "$ref": "#/$defs/executionEnvironment"
+    },
+    "errors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/errorModel"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^x-(?!.*(?:authority|grant|freedom_gate|acc|execute|permission))[a-z0-9._-]+$"
+      },
+      "additionalProperties": {
+        "not": {
+          "type": "object",
+          "required": [
+            "required"
+          ],
+          "properties": {
+            "required": {
+              "const": true
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "jsonSchemaFragment": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": true
+    },
+    "resourceRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resource_type",
+        "scope"
+      ],
+      "properties": {
+        "resource_type": {
+          "type": "string",
+          "pattern": "^[a-z0-9._-]+$"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "authenticationRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "required"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "api_key",
+            "oauth",
+            "user_delegated",
+            "service_account"
+          ]
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "executionEnvironment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "isolation"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "fixture",
+            "dry_run",
+            "local",
+            "external_service",
+            "process",
+            "network"
+          ]
+        },
+        "isolation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "errorModel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "retryable"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z0-9._-]+$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "authentication": {
+            "properties": {
+              "required": {
+                "const": true
+              }
+            },
+            "required": [
+              "required"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "authentication": {
+            "properties": {
+              "mode": {
+                "not": {
+                  "const": "none"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "side_effect_class": {
+            "const": "exfiltration"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "exfiltration_risk": {
+            "const": "high"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "exfiltration_risk": {
+            "const": "high"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "side_effect_class": {
+            "const": "exfiltration"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json
+++ b/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "adl://schemas/uts/v1.1/tool_invocation.v1_1.schema.json",
+  "title": "UTS v1.1 Tool Invocation Proposal",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "invocation_id",
+    "caller",
+    "tool",
+    "intent",
+    "purpose",
+    "side_effect_expectations",
+    "replayability",
+    "observability"
+  ],
+  "properties": {
+    "invocation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "caller": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9._-]{2,79}$"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "intent": {
+      "type": "string",
+      "enum": [
+        "informational_query",
+        "planning",
+        "simulation",
+        "review",
+        "mutation",
+        "governance_action",
+        "observability_action",
+        "remediation"
+      ]
+    },
+    "purpose": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timeout_ms": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "retry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_attempts",
+        "strategy"
+      ],
+      "properties": {
+        "max_attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "strategy": {
+          "type": "string",
+          "enum": [
+            "none",
+            "immediate",
+            "fixed_delay",
+            "exponential_backoff"
+          ]
+        }
+      }
+    },
+    "side_effect_expectations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "none",
+          "local_state",
+          "external_state",
+          "irreversible",
+          "human_visible",
+          "governance_relevant"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "replayability": {
+      "type": "string",
+      "enum": [
+        "deterministic",
+        "observational",
+        "non_replayable"
+      ]
+    },
+    "observability": {
+      "type": "string",
+      "enum": [
+        "none",
+        "basic",
+        "full",
+        "governance"
+      ]
+    }
+  }
+}

--- a/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json
+++ b/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json
@@ -97,6 +97,26 @@
     "observability": {
       "type": "string",
       "enum": ["none", "basic", "full", "governance"]
+    },
+    "extensions": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^x-[a-z0-9._-]+$"
+      },
+      "additionalProperties": true
     }
-  }
+  },
+  "allOf": [
+    {
+      "not": {
+        "properties": {
+          "side_effect_expectations": {
+            "contains": { "const": "none" },
+            "minItems": 2
+          }
+        },
+        "required": ["side_effect_expectations"]
+      }
+    }
+  ]
 }

--- a/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json
+++ b/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "adl://schemas/uts/v1.1/tool_invocation.v1_1.schema.json",
-  "title": "UTS v1.1 Tool Invocation Proposal",
+  "$id": "https://raw.githubusercontent.com/danielbaustin/agent-design-language/main/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json",
+  "title": "UTS v1.1 Tool Invocation Metadata",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -11,7 +11,7 @@
     "intent",
     "purpose",
     "side_effect_expectations",
-    "replayability",
+    "replay_safety",
     "observability"
   ],
   "properties": {
@@ -26,12 +26,9 @@
     "tool": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "id",
-        "version"
-      ],
+      "required": ["name", "version"],
       "properties": {
-        "id": {
+        "name": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9._-]{2,79}$"
         },
@@ -65,10 +62,7 @@
     "retry": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "max_attempts",
-        "strategy"
-      ],
+      "required": ["max_attempts", "strategy"],
       "properties": {
         "max_attempts": {
           "type": "integer",
@@ -76,12 +70,7 @@
         },
         "strategy": {
           "type": "string",
-          "enum": [
-            "none",
-            "immediate",
-            "fixed_delay",
-            "exponential_backoff"
-          ]
+          "enum": ["none", "immediate", "fixed_delay", "exponential_backoff"]
         }
       }
     },
@@ -101,22 +90,13 @@
       },
       "uniqueItems": true
     },
-    "replayability": {
+    "replay_safety": {
       "type": "string",
-      "enum": [
-        "deterministic",
-        "observational",
-        "non_replayable"
-      ]
+      "enum": ["replay_safe", "replay_requires_approval", "not_replay_safe"]
     },
     "observability": {
       "type": "string",
-      "enum": [
-        "none",
-        "basic",
-        "full",
-        "governance"
-      ]
+      "enum": ["none", "basic", "full", "governance"]
     }
   }
 }

--- a/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json
+++ b/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json
@@ -1,36 +1,46 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "adl://schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json",
-  "title": "Universal Tool Schema v1.1 Proposal",
+  "$id": "https://raw.githubusercontent.com/danielbaustin/agent-design-language/main/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json",
+  "title": "Universal Tool Schema v1.1",
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "uts_version",
+    "schema_version",
     "compatible_versions",
-    "id",
+    "name",
     "version",
+    "description",
     "input_schema",
     "output_schema",
-    "side_effects"
+    "side_effect_class",
+    "determinism",
+    "replay_safety",
+    "idempotence",
+    "resources",
+    "authentication",
+    "data_sensitivity",
+    "exfiltration_risk",
+    "execution_environment",
+    "errors"
   ],
   "properties": {
-    "uts_version": {
+    "schema_version": {
       "type": "string",
-      "const": "1.1"
+      "const": "uts.v1.1"
     },
     "compatible_versions": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "string",
-        "enum": [
-          "1.0",
-          "1.1"
-        ]
+        "enum": ["uts.v1", "uts.v1.1"]
       },
-      "uniqueItems": true
+      "uniqueItems": true,
+      "contains": {
+        "const": "uts.v1.1"
+      }
     },
-    "id": {
+    "name": {
       "type": "string",
       "pattern": "^[a-z][a-z0-9._-]{2,79}$"
     },
@@ -38,7 +48,11 @@
       "type": "string",
       "minLength": 1
     },
-    "category": {
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "categories": {
       "type": "array",
       "items": {
         "type": "string",
@@ -62,6 +76,19 @@
     "output_schema": {
       "$ref": "#/$defs/jsonSchemaFragment"
     },
+    "side_effect_class": {
+      "type": "string",
+      "enum": [
+        "read",
+        "local_write",
+        "external_read",
+        "external_write",
+        "process",
+        "network",
+        "destructive",
+        "exfiltration"
+      ]
+    },
     "side_effects": {
       "type": "array",
       "minItems": 1,
@@ -78,45 +105,92 @@
       },
       "uniqueItems": true
     },
-    "replayability": {
+    "determinism": {
       "type": "string",
       "enum": [
         "deterministic",
-        "observational",
-        "non_replayable"
+        "bounded_nondeterministic",
+        "nondeterministic"
       ]
+    },
+    "replay_safety": {
+      "type": "string",
+      "enum": [
+        "replay_safe",
+        "replay_requires_approval",
+        "not_replay_safe"
+      ]
+    },
+    "idempotence": {
+      "type": "string",
+      "enum": [
+        "idempotent",
+        "conditionally_idempotent",
+        "not_idempotent"
+      ]
+    },
+    "resources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/resourceBoundary"
+      }
+    },
+    "authentication": {
+      "$ref": "#/$defs/authentication"
+    },
+    "data_sensitivity": {
+      "type": "string",
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "secret",
+        "protected_prompt",
+        "private_state"
+      ]
+    },
+    "exfiltration_risk": {
+      "type": "string",
+      "enum": ["none", "low", "medium", "high"]
+    },
+    "execution_environment": {
+      "$ref": "#/$defs/executionEnvironment"
+    },
+    "errors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/errorModel"
+      }
     },
     "observability": {
       "type": "string",
-      "enum": [
-        "none",
-        "basic",
-        "full",
-        "governance"
-      ]
+      "enum": ["none", "basic", "full", "governance"]
     },
     "planning": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "high_risk": {
-          "type": "boolean"
-        },
-        "irreversible": {
-          "type": "boolean"
-        },
-        "review_required": {
-          "type": "boolean"
-        }
+        "high_risk": { "type": "boolean" },
+        "irreversible": { "type": "boolean" },
+        "expensive": { "type": "boolean" },
+        "slow": { "type": "boolean" },
+        "review_recommended": { "type": "boolean" }
       }
+    },
+    "extensions": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^x-[a-z0-9._-]+$"
+      },
+      "additionalProperties": true
     }
   },
   "$defs": {
     "jsonSchemaFragment": {
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -124,6 +198,52 @@
         }
       },
       "additionalProperties": true
+    },
+    "resourceBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resource_type", "scope"],
+      "properties": {
+        "resource_type": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "minLength": 1 }
+      }
+    },
+    "authentication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "required"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["none", "api_key", "oauth", "user_delegated", "service_account"]
+        },
+        "required": { "type": "boolean" }
+      }
+    },
+    "executionEnvironment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "isolation"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["fixture", "dry_run", "local", "external_service", "process", "network"]
+        },
+        "isolation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "errorModel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "retryable"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "retryable": { "type": "boolean" }
+      }
     }
   }
 }

--- a/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json
+++ b/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "adl://schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json",
+  "title": "Universal Tool Schema v1.1 Proposal",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "uts_version",
+    "compatible_versions",
+    "id",
+    "version",
+    "input_schema",
+    "output_schema",
+    "side_effects"
+  ],
+  "properties": {
+    "uts_version": {
+      "type": "string",
+      "const": "1.1"
+    },
+    "compatible_versions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "1.0",
+          "1.1"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9._-]{2,79}$"
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "category": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "read_only",
+          "computational",
+          "state_mutating",
+          "external_network",
+          "human_visible",
+          "governance_sensitive",
+          "identity_sensitive",
+          "continuity_sensitive",
+          "observability_sensitive"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "input_schema": {
+      "$ref": "#/$defs/jsonSchemaFragment"
+    },
+    "output_schema": {
+      "$ref": "#/$defs/jsonSchemaFragment"
+    },
+    "side_effects": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "none",
+          "local_state",
+          "external_state",
+          "irreversible",
+          "human_visible",
+          "governance_relevant"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "replayability": {
+      "type": "string",
+      "enum": [
+        "deterministic",
+        "observational",
+        "non_replayable"
+      ]
+    },
+    "observability": {
+      "type": "string",
+      "enum": [
+        "none",
+        "basic",
+        "full",
+        "governance"
+      ]
+    },
+    "planning": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "high_risk": {
+          "type": "boolean"
+        },
+        "irreversible": {
+          "type": "boolean"
+        },
+        "review_required": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "jsonSchemaFragment": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/docs/specs/uts/ADL_UNIVERSAL_TOOL_SCHEMA.md
+++ b/docs/specs/uts/ADL_UNIVERSAL_TOOL_SCHEMA.md
@@ -11,6 +11,13 @@ This document describes:
 - the architectural separation between UTS schema semantics and ACC runtime
   governance
 
+Authority hierarchy:
+
+- [`UTS_V1.1_SCHEMA.md`](./UTS_V1.1_SCHEMA.md) is the normative technical
+  specification for the `v1.1` target
+- this document is the narrative companion specification
+- [`README.md`](./README.md) is the entrypoint and orientation surface
+
 ## Normative Language
 
 The key words:
@@ -316,6 +323,22 @@ Suggested values:
 - `continuity_sensitive`
 - `observability_sensitive`
 
+Suggested meanings:
+
+- `read_only`: no intended state mutation as the primary capability
+- `computational`: primarily transforms or computes over supplied inputs
+- `state_mutating`: intended to change local or remote state
+- `external_network`: expected to cross a network boundary
+- `human_visible`: expected to create or alter something a human will directly
+  see
+- `governance_sensitive`: likely to require elevated review or approval posture
+- `identity_sensitive`: touches identity, identity-bearing data, or identity
+  policy surfaces
+- `continuity_sensitive`: ADL-origin category for continuity, memory, or
+  identity-preservation surfaces; non-ADL runtimes may adapt or replace this
+  term
+- `observability_sensitive`: affects traces, metrics, logs, or review surfaces
+
 These tags support:
 
 - planning
@@ -376,6 +399,17 @@ It MUST NOT imply:
 
 That boundary keeps UTS out of ACC territory.
 
+Intent examples:
+
+- `informational_query`: look up a user profile
+- `planning`: generate an execution plan without acting
+- `simulation`: dry-run a migration or deployment
+- `review`: inspect a code diff or packet for findings
+- `mutation`: create or update a normal remote object
+- `governance_action`: approve or deny a governed action
+- `observability_action`: query traces, logs, or metrics
+- `remediation`: create or apply a targeted follow-up repair step
+
 ## 14. Invocation Companion Schema
 
 The `v1.1` invocation schema is a companion metadata contract.
@@ -402,6 +436,10 @@ Invocation companion rules:
 - `replay_safety` and `observability` MUST NOT silently weaken the tool
   definition's declared posture
 
+The invocation companion schema also supports constrained `x-` prefixed
+extensions for runtime-specific metadata that should not fragment the portable
+core contract.
+
 ## 15. Conformance
 
 A conformant `UTS` implementation SHOULD be able to validate:
@@ -417,6 +455,9 @@ The repository already contains implementation-facing conformance work in Rust.
 That code should be treated as the current reference implementation of UTS
 conformance until a standalone portable conformance suite is published.
 
+A future portable conformance package should include valid, invalid, and
+dangerous fixtures for both tool definitions and invocation companion records.
+
 ## 16. Transport Binding Note
 
 UTS is transport-neutral, but not transport-agnostic in the sense of ignoring
@@ -430,6 +471,13 @@ Future non-normative bindings may show how UTS maps onto:
 - local runtime registries
 
 Those bindings should preserve UTS semantics rather than redefine them.
+
+Illustrative sketch directions:
+
+- MCP-style: publish the UTS object as registry metadata alongside the tool
+  callable surface
+- OpenAI-compatible: wrap the UTS definition into the provider's function/tool
+  envelope while preserving richer metadata in side channels or extensions
 
 ## 17. Summary
 
@@ -448,6 +496,17 @@ The important structural truths are:
 - UTS keeps schema semantics separate from runtime authority
 - replayability, idempotence, determinism, data sensitivity, and exfiltration
   risk remain first-class fields
+
+Likely future optional registry field:
+
+- `lifecycle`
+  - `experimental`
+  - `active`
+  - `deprecated`
+  - `sunset`
+
+This is not yet part of the canonical `v1.1` schema, but it is a natural next
+optional field for tool catalogs and registries.
 
 That combination is what makes UTS stronger than ordinary tool-definition
 schemas.

--- a/docs/specs/uts/ADL_UNIVERSAL_TOOL_SCHEMA.md
+++ b/docs/specs/uts/ADL_UNIVERSAL_TOOL_SCHEMA.md
@@ -1,0 +1,453 @@
+# Universal Tool Schema (UTS)
+
+## Status
+
+Tracked canonical narrative specification for the Universal Tool Schema.
+
+This document describes:
+
+- the current implemented `UTS v1.0` baseline
+- the additive `UTS v1.1` target
+- the architectural separation between UTS schema semantics and ACC runtime
+  governance
+
+## Normative Language
+
+The key words:
+
+- MUST
+- MUST NOT
+- REQUIRED
+- SHALL
+- SHALL NOT
+- SHOULD
+- SHOULD NOT
+- RECOMMENDED
+- MAY
+- OPTIONAL
+
+are to be interpreted as described in RFC 2119.
+
+## 1. Introduction
+
+The Universal Tool Schema (UTS) defines a transport-independent,
+provider-neutral standard for describing tools, capabilities, and invocation
+semantics in agent systems.
+
+UTS exists to improve:
+
+- interoperability
+- safety posture
+- inspectability
+- replayability
+- observability
+- structured invocation
+
+UTS is intentionally narrower than runtime governance.
+
+It answers:
+
+> What is this tool, what does it touch, and what structural execution posture
+> does it declare?
+
+UTS does not answer:
+
+> Who may use it, under what authority, and with what approval?
+
+Those higher-layer questions belong to ACC and runtime governance.
+
+## 2. Scope
+
+UTS standardizes:
+
+- tool description
+- machine-readable input/output shape
+- side-effect semantics
+- replay posture metadata
+- observability posture metadata
+- transport-independent capability structure
+- invocation-companion metadata
+
+UTS does not standardize:
+
+- runtime governance policy
+- authorization frameworks
+- provider-specific safety systems
+- orchestration topology
+- agent cognition
+- identity systems
+
+UTS validity therefore does not imply:
+
+- authority
+- execution permission
+- replay permission
+- governance approval
+
+## 3. Core Design Principles
+
+### Transport Independence
+
+UTS defines semantics and structure without mandating a specific transport such
+as HTTP, gRPC, WebSocket, message bus, or local in-process invocation.
+
+### Provider Neutrality
+
+UTS is not tied to one model provider, one runtime, or one orchestration
+framework.
+
+### Human And Machine Readability
+
+UTS is designed to be:
+
+- machine-validatable
+- human-reviewable
+- diff-friendly
+- documentation-friendly
+
+Human readability is a core safety feature.
+
+### Incremental Adoption
+
+UTS is designed for gradual adoption.
+
+A runtime may begin by using only:
+
+- schema normalization
+- side-effect classification
+- replay metadata
+- observability metadata
+
+without replacing its existing transport or orchestration system.
+
+## 4. Relationship To ACC
+
+UTS and ACC are intentionally separate.
+
+UTS defines:
+
+- schema semantics
+- invocation-companion semantics
+- side effects
+- replay posture
+- observability posture
+
+ACC defines:
+
+- authority
+- approval
+- standing
+- delegation
+- runtime governance
+
+The split is load-bearing.
+
+A tool definition may be perfectly valid under UTS while still being denied by
+ACC or by runtime policy.
+
+## 5. UTS v1.0 Baseline
+
+The current implemented baseline lives in:
+
+- [`adl/src/uts.rs`](../../../adl/src/uts.rs)
+
+Its current field families are:
+
+- `schema_version`
+- `name`
+- `version`
+- `description`
+- `input_schema`
+- `output_schema`
+- `side_effect_class`
+- `determinism`
+- `replay_safety`
+- `idempotence`
+- `resources`
+- `authentication`
+- `data_sensitivity`
+- `exfiltration_risk`
+- `execution_environment`
+- `errors`
+- `extensions`
+
+The formal baseline documents for that shape are:
+
+- [`UTS_V1.0_SCHEMA.md`](./UTS_V1.0_SCHEMA.md)
+- [`universal_tool_schema.v1.schema.json`](../../../adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
+
+## 6. UTS v1.1 Additive Evolution
+
+`UTS v1.1` is additive over `UTS v1.0`.
+
+It preserves every core `v1.0` field family and adds new metadata alongside
+those fields rather than renaming or removing them.
+
+The additive `v1.1` fields are:
+
+- `compatible_versions`
+- `categories`
+- `side_effects`
+- `observability`
+- `planning`
+
+This means `v1.1` is not a fresh object model.
+
+It is a richer layer over the existing `v1.0` shape.
+
+The formal `v1.1` documents are:
+
+- [`UTS_V1.1_SCHEMA.md`](./UTS_V1.1_SCHEMA.md)
+- [`universal_tool_schema.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
+- [`tool_invocation.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+
+## 7. Compatibility And Version Negotiation
+
+`UTS v1.1` makes compatibility posture explicit.
+
+A `v1.1` definition MUST include:
+
+- `schema_version: uts.v1.1`
+- `compatible_versions`
+
+Example:
+
+```yaml
+schema_version: uts.v1.1
+compatible_versions:
+  - uts.v1
+  - uts.v1.1
+```
+
+Semantics:
+
+- a tool definition MUST be structurally valid under the `v1.1` schema
+- `compatible_versions` declares the set of UTS schema versions, including the
+  current `uts.v1.1` version, that the author expects a runtime to consume
+  compatibly
+- a runtime SHOULD validate against the highest version it supports
+- a runtime that only supports an earlier compatible version MAY ignore unknown
+  additive `v1.1` fields
+- compatibility does not permit renaming or removing preserved `v1.0` fields
+
+## 8. Side-Effect Semantics
+
+UTS requires explicit declaration of side effects.
+
+### v1.0 scalar field
+
+`side_effect_class` remains the preserved baseline field.
+
+Allowed `v1.0`-style values include:
+
+- `read`
+- `local_write`
+- `external_read`
+- `external_write`
+- `process`
+- `network`
+- `destructive`
+- `exfiltration`
+
+### v1.1 additive array field
+
+`side_effects` is the richer additive representation.
+
+Suggested values:
+
+- `none`
+- `local_state`
+- `external_state`
+- `irreversible`
+- `human_visible`
+- `governance_relevant`
+
+The array field does not replace the scalar field.
+
+It complements it so a tool can express multiple side-effect dimensions.
+
+## 9. Replayability, Determinism, And Idempotence
+
+UTS treats these as separate concepts.
+
+Preserved baseline fields:
+
+- `determinism`
+- `replay_safety`
+- `idempotence`
+
+This separation is intentional because these properties are not the same.
+
+A tool may be:
+
+- deterministic but not idempotent
+- idempotent but not replay-safe
+- replay-safe only under approval conditions
+
+This is one of the most important parts of the schema.
+
+## 10. Data Sensitivity And Exfiltration Risk
+
+UTS keeps the following strong fields from `v1.0`:
+
+- `data_sensitivity`
+- `exfiltration_risk`
+
+These fields are among the most valuable machine-readable signals in UTS.
+
+They allow runtimes to distinguish ordinary tool use from higher-risk data
+movement or disclosure surfaces before execution.
+
+## 11. Categories
+
+`categories` is an illustrative tagging/search taxonomy.
+
+It is not the primary normative governance surface.
+
+Suggested values:
+
+- `read_only`
+- `computational`
+- `state_mutating`
+- `external_network`
+- `human_visible`
+- `governance_sensitive`
+- `identity_sensitive`
+- `continuity_sensitive`
+- `observability_sensitive`
+
+These tags support:
+
+- planning
+- review
+- search/indexing
+- runtime routing
+
+Typed fields such as `side_effect_class`, `data_sensitivity`, and
+`exfiltration_risk` remain the stronger machine-readable semantics.
+
+## 12. Observability
+
+`UTS v1.1` adds explicit observability posture.
+
+Suggested levels:
+
+- `none`
+- `basic`
+- `full`
+- `governance`
+
+Interpretation:
+
+- `none`: no specific runtime visibility expectations beyond local control
+- `basic`: invocation recorded with timestamp and result status
+- `full`: invocation metadata and result posture are fully reviewable
+- `governance`: elevated audit/review posture is expected
+
+Observability metadata is metadata, not surveillance.
+
+It does not require:
+
+- centralized logging
+- centralized monitoring
+- centralized orchestration
+- centralized storage
+
+## 13. Planning Metadata
+
+`UTS v1.1` adds optional planning metadata.
+
+Suggested fields:
+
+- `high_risk`
+- `irreversible`
+- `expensive`
+- `slow`
+- `review_recommended`
+
+Planning metadata is descriptive only.
+
+It MUST NOT imply:
+
+- authority
+- approval
+- execution permission
+- replay authorization
+
+That boundary keeps UTS out of ACC territory.
+
+## 14. Invocation Companion Schema
+
+The `v1.1` invocation schema is a companion metadata contract.
+
+It is intended to capture:
+
+- invocation identity
+- caller identity
+- intent
+- purpose
+- side-effect expectations
+- replay-safety posture
+- observability posture
+- timeout/retry posture
+
+It is not, by itself, a full argument/result payload unless a runtime chooses
+that representation.
+
+Invocation companion rules:
+
+- `tool.name` and `tool.version` MUST refer to a tool definition
+- `side_effect_expectations` SHOULD be consistent with the tool definition and
+  MAY be a subset of the tool's full declared `side_effects`
+- `replay_safety` and `observability` MUST NOT silently weaken the tool
+  definition's declared posture
+
+## 15. Conformance
+
+A conformant `UTS` implementation SHOULD be able to validate:
+
+- required fields
+- schema structure
+- side-effect declarations
+- replay declarations
+- observability declarations
+- invocation-companion structure
+
+The repository already contains implementation-facing conformance work in Rust.
+That code should be treated as the current reference implementation of UTS
+conformance until a standalone portable conformance suite is published.
+
+## 16. Transport Binding Note
+
+UTS is transport-neutral, but not transport-agnostic in the sense of ignoring
+real deployment concerns.
+
+Future non-normative bindings may show how UTS maps onto:
+
+- MCP-style tool systems
+- HTTP/REST tool catalogs
+- OpenAI-compatible tool/function wrappers
+- local runtime registries
+
+Those bindings should preserve UTS semantics rather than redefine them.
+
+## 17. Summary
+
+UTS attempts to move tool ecosystems from:
+
+> ad hoc provider-specific function calling
+
+Toward:
+
+> structured, replayable, observable, transport-neutral capability invocation.
+
+The important structural truths are:
+
+- `UTS v1.0` is the current implemented baseline
+- `UTS v1.1` is additive over that baseline
+- UTS keeps schema semantics separate from runtime authority
+- replayability, idempotence, determinism, data sensitivity, and exfiltration
+  risk remain first-class fields
+
+That combination is what makes UTS stronger than ordinary tool-definition
+schemas.

--- a/docs/specs/uts/README.md
+++ b/docs/specs/uts/README.md
@@ -22,6 +22,17 @@ schema, UTS gives you a way to also express side effects, replay safety,
 idempotence, data sensitivity, exfiltration risk, and execution posture so a
 runtime can make better decisions before execution rather than after.
 
+Document authority hierarchy:
+
+- [`UTS_V1.1_SCHEMA.md`](./UTS_V1.1_SCHEMA.md) is the normative technical
+  specification for the `v1.1` target
+- [`ADL_UNIVERSAL_TOOL_SCHEMA.md`](./ADL_UNIVERSAL_TOOL_SCHEMA.md) is the
+  narrative companion specification
+- this `README.md` is the entrypoint and orientation surface
+
+If those documents ever disagree, the narrower normative technical spec wins
+over the narrative companion, and the narrative companion wins over the README.
+
 Unless a section explicitly says otherwise, statements in this note should be
 read as describing the current `UTS v1` posture. The guaranteed formal current
 baseline for `UTS v1` is the narrower

--- a/docs/specs/uts/README.md
+++ b/docs/specs/uts/README.md
@@ -20,9 +20,9 @@ separately and must not be treated as guaranteed current runtime behavior.
 
 Machine-readable companions:
 
-- [`adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
-- [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
-- [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+- [`adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json`](../../../adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
+- [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
+- [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
 
 Authority/governance companion:
 
@@ -86,7 +86,7 @@ UTS itself.
 
 The current implemented baseline lives in Rust today at:
 
-- [`adl/src/uts.rs`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl/src/uts.rs)
+- [`adl/src/uts.rs`](../../../adl/src/uts.rs)
 
 That baseline is expressed as `UniversalToolSchemaV1` and validated by
 `validate_uts_v1`.
@@ -115,7 +115,7 @@ current implemented surface already includes:
 The authoritative tracked baseline for that shape is:
 
 - [`UTS_V1.0_SCHEMA.md`](./UTS_V1.0_SCHEMA.md)
-- [`universal_tool_schema.v1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
+- [`universal_tool_schema.v1.schema.json`](../../../adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
 
 ## 4. Additive Proposal Direction (`UTS v1.1`)
 
@@ -131,8 +131,8 @@ The proposal direction does three things:
 The tracked proposal documents are:
 
 - [`UTS_V1.1_SCHEMA.md`](./UTS_V1.1_SCHEMA.md)
-- [`universal_tool_schema.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
-- [`tool_invocation.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+- [`universal_tool_schema.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
+- [`tool_invocation.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
 
 Proposal examples in the `v1.1` surfaces are illustrative. They are not
 guaranteed `v1` fixtures.
@@ -153,7 +153,7 @@ a valid portable schema, but neither fact grants execution authority.
 
 See also:
 
-- [`docs/explainers/UTS_AND_ACC.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/docs/explainers/UTS_AND_ACC.md)
+- [`docs/explainers/UTS_AND_ACC.md`](../../explainers/UTS_AND_ACC.md)
 
 ## 6. Invocation Semantics Versus Approval
 

--- a/docs/specs/uts/README.md
+++ b/docs/specs/uts/README.md
@@ -1,0 +1,198 @@
+# Universal Tool Schema (UTS)
+
+## Status
+
+Tracked canonical UTS spec entrypoint.
+
+This directory now uses the following framing:
+
+- `UTS v1`
+  - the currently implemented schema surface
+- `UTS v1.1`
+  - an additive evolution path and future standardization direction
+
+Unless a section explicitly says otherwise, statements in this note should be
+read as describing the current `UTS v1` posture. The guaranteed formal current
+baseline for `UTS v1` is the narrower
+[`UTS_V1.0_SCHEMA.md`](./UTS_V1.0_SCHEMA.md) document plus its matching
+machine-readable JSON Schema. Proposal material for `UTS v1.1` is called out
+separately and must not be treated as guaranteed current runtime behavior.
+
+Machine-readable companions:
+
+- [`adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
+- [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
+- [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+
+Authority/governance companion:
+
+- `UTS` defines schema semantics
+- `ACC` defines runtime authority, approval, and execution governance
+
+The two are intentionally related but not interchangeable.
+
+## 1. Purpose
+
+The Universal Tool Schema defines a transport-independent, provider-neutral
+model for describing tools, capabilities, and invocation semantics in agent
+systems.
+
+UTS exists to improve:
+
+- interoperability
+- inspectability
+- replayability
+- observability
+- structured invocation
+
+The goal is not merely to standardize function calling. The goal is to define a
+safer and more reviewable model for capability invocation across heterogeneous
+agent ecosystems.
+
+## 2. Scope
+
+UTS standardizes:
+
+- tool description
+- machine-readable input/output shape
+- side-effect semantics
+- replayability posture
+- observability posture
+- transport-independent capability structure
+
+UTS does not standardize:
+
+- runtime governance policy
+- provider-specific safety systems
+- authorization frameworks
+- orchestration topology
+- agent cognition
+- identity systems
+
+These concerns may be layered above UTS by runtimes or governance frameworks.
+
+UTS validity is therefore narrower than runtime authority:
+
+- `UTS validity != authority`
+- `UTS validity != execution permission`
+- `UTS validity != replay permission`
+
+A tool or invocation may be structurally valid under UTS while still requiring
+runtime review, authorization, or governance before it may execute or replay.
+In ADL terms, that higher-layer decision surface belongs in ACC rather than in
+UTS itself.
+
+## 3. Current Implemented Baseline (`UTS v1`)
+
+The current implemented baseline lives in Rust today at:
+
+- [`adl/src/uts.rs`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl/src/uts.rs)
+
+That baseline is expressed as `UniversalToolSchemaV1` and validated by
+`validate_uts_v1`.
+
+Its shape is intentionally richer than a minimal function-call schema. The
+current implemented surface already includes:
+
+- `schema_version`
+- `name`
+- `version`
+- `description`
+- `input_schema`
+- `output_schema`
+- `side_effect_class`
+- `determinism`
+- `replay_safety`
+- `idempotence`
+- `resources`
+- `authentication`
+- `data_sensitivity`
+- `exfiltration_risk`
+- `execution_environment`
+- `errors`
+- `extensions`
+
+The authoritative tracked baseline for that shape is:
+
+- [`UTS_V1.0_SCHEMA.md`](./UTS_V1.0_SCHEMA.md)
+- [`universal_tool_schema.v1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
+
+## 4. Additive Proposal Direction (`UTS v1.1`)
+
+`UTS v1.1` is an additive proposal. It is not the current wire contract.
+
+The proposal direction does three things:
+
+- keeps schema semantics cleanly separated from runtime authority
+- makes invocation metadata first-class and machine-validatable
+- improves standardization posture through explicit replayability,
+  observability, and version-negotiation semantics
+
+The tracked proposal documents are:
+
+- [`UTS_V1.1_SCHEMA.md`](./UTS_V1.1_SCHEMA.md)
+- [`universal_tool_schema.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
+- [`tool_invocation.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+
+Proposal examples in the `v1.1` surfaces are illustrative. They are not
+guaranteed `v1` fixtures.
+
+## 5. UTS And ACC
+
+UTS answers:
+
+> What is this tool?
+
+ACC answers:
+
+> Who may use it, under what authority, with what visibility, and with what
+> evidence?
+
+The split is intentional. A model can propose a tool call, and a tool can have
+a valid portable schema, but neither fact grants execution authority.
+
+See also:
+
+- [`docs/explainers/UTS_AND_ACC.md`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/docs/explainers/UTS_AND_ACC.md)
+
+## 6. Invocation Semantics Versus Approval
+
+Invocation contracts may describe structure and expected execution posture
+without deciding whether execution is allowed.
+
+Invocation contracts therefore remain responsible for expressing:
+
+- invocation intent
+- replayability classification
+- observability posture
+
+Authority, authorization, and governance remain layered runtime concerns.
+
+## 7. Non-Goals
+
+UTS does not attempt to:
+
+- solve alignment
+- define universal governance policy
+- replace authorization systems
+- replace orchestration frameworks
+- define agent cognition
+- define identity continuity
+- guarantee correctness of model outputs
+- guarantee tool safety
+- eliminate the need for runtime governance
+
+This scoped approach is intentional. It supports interoperability and
+incremental adoption without smuggling runtime approval into the schema layer.
+
+## 8. Summary
+
+The key distinction is simple:
+
+- `UTS v1` is the current implemented schema surface
+- `UTS v1.1` is the additive future direction
+- `UTS` defines schema semantics
+- `ACC` defines runtime authority and governance
+
+That separation keeps ADL's governed-tools model reviewable, portable, and
+honest about what schema validity does and does not mean.

--- a/docs/specs/uts/README.md
+++ b/docs/specs/uts/README.md
@@ -11,6 +11,17 @@ This directory now uses the following framing:
 - `UTS v1.1`
   - an additive evolution path and future standardization direction
 
+Primary narrative specification:
+
+- [`ADL_UNIVERSAL_TOOL_SCHEMA.md`](./ADL_UNIVERSAL_TOOL_SCHEMA.md)
+
+Why a consumer should care:
+
+If your current tool definitions stop at a name, description, and parameter
+schema, UTS gives you a way to also express side effects, replay safety,
+idempotence, data sensitivity, exfiltration risk, and execution posture so a
+runtime can make better decisions before execution rather than after.
+
 Unless a section explicitly says otherwise, statements in this note should be
 read as describing the current `UTS v1` posture. The guaranteed formal current
 baseline for `UTS v1` is the narrower
@@ -130,6 +141,7 @@ The proposal direction does three things:
 
 The tracked proposal documents are:
 
+- [`ADL_UNIVERSAL_TOOL_SCHEMA.md`](./ADL_UNIVERSAL_TOOL_SCHEMA.md)
 - [`UTS_V1.1_SCHEMA.md`](./UTS_V1.1_SCHEMA.md)
 - [`universal_tool_schema.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
 - [`tool_invocation.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)

--- a/docs/specs/uts/UTS_V1.0_SCHEMA.md
+++ b/docs/specs/uts/UTS_V1.0_SCHEMA.md
@@ -8,11 +8,11 @@ surface.
 This document describes the canonical current `UTS v1` baseline as implemented
 in:
 
-- [`adl/src/uts.rs`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl/src/uts.rs)
+- [`adl/src/uts.rs`](../../../adl/src/uts.rs)
 
 Matching machine-readable schema:
 
-- [`adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
+- [`adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json`](../../../adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
 
 ## 1. Purpose
 

--- a/docs/specs/uts/UTS_V1.0_SCHEMA.md
+++ b/docs/specs/uts/UTS_V1.0_SCHEMA.md
@@ -1,0 +1,287 @@
+# UTS v1.0 Schema
+
+## Status
+
+Tracked formal baseline for the current implemented Universal Tool Schema
+surface.
+
+This document describes the canonical current `UTS v1` baseline as implemented
+in:
+
+- [`adl/src/uts.rs`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl/src/uts.rs)
+
+Matching machine-readable schema:
+
+- [`adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.0/universal_tool_schema.v1.schema.json)
+
+## 1. Purpose
+
+`UTS v1.0` captures the current implemented baseline without overclaiming the
+additive `v1.1` direction that requires later repo/code adoption.
+
+This schema is intentionally conservative:
+
+- it matches the current Rust `UniversalToolSchemaV1` shape and key validator
+  rules
+- it remains JSON-compatible and machine-validatable
+- it does not imply runtime authority, execution permission, or replay
+  permission
+
+## 2. Canonical Object Shape
+
+A canonical `UTS v1.0` tool definition contains:
+
+- `schema_version`
+- `name`
+- `version`
+- `description`
+- `input_schema`
+- `output_schema`
+- `side_effect_class`
+- `determinism`
+- `replay_safety`
+- `idempotence`
+- `resources`
+- `authentication`
+- `data_sensitivity`
+- `exfiltration_risk`
+- `execution_environment`
+- `errors`
+- optional `extensions`
+
+## 3. Required Fields
+
+### `schema_version`
+
+- type: string
+- required value: `uts.v1`
+
+### `name`
+
+- type: string
+- required pattern: lowercase token-like identifier
+- semantic rule: 3-80 characters, starts lowercase, then lowercase ASCII,
+  digits, `-`, `_`, or `.`
+
+### `version`
+
+- type: string
+- semantic rule: numeric `major.minor.patch`
+
+### `description`
+
+- type: string
+- semantic rule: specific enough for reviewers
+
+### `input_schema`
+
+- type: JSON Schema fragment object
+- semantic rule: must include a non-empty `type`
+
+### `output_schema`
+
+- type: JSON Schema fragment object
+- semantic rule: must include a non-empty `type`
+
+### `side_effect_class`
+
+Allowed values:
+
+- `read`
+- `local_write`
+- `external_read`
+- `external_write`
+- `process`
+- `network`
+- `destructive`
+- `exfiltration`
+
+### `determinism`
+
+Allowed values:
+
+- `deterministic`
+- `bounded_nondeterministic`
+- `nondeterministic`
+
+### `replay_safety`
+
+Allowed values:
+
+- `replay_safe`
+- `replay_requires_approval`
+- `not_replay_safe`
+
+### `idempotence`
+
+Allowed values:
+
+- `idempotent`
+- `conditionally_idempotent`
+- `not_idempotent`
+
+### `resources`
+
+- type: array
+- semantic rule: at least one resource boundary is required
+
+Each entry contains:
+
+- `resource_type`
+- `scope`
+
+### `authentication`
+
+Required fields:
+
+- `mode`
+- `required`
+
+Allowed `mode` values:
+
+- `none`
+- `api_key`
+- `oauth`
+- `user_delegated`
+- `service_account`
+
+### `data_sensitivity`
+
+Allowed values:
+
+- `public`
+- `internal`
+- `confidential`
+- `secret`
+- `protected_prompt`
+- `private_state`
+
+### `exfiltration_risk`
+
+Allowed values:
+
+- `none`
+- `low`
+- `medium`
+- `high`
+
+### `execution_environment`
+
+Required fields:
+
+- `kind`
+- `isolation`
+
+Allowed `kind` values:
+
+- `fixture`
+- `dry_run`
+- `local`
+- `external_service`
+- `process`
+- `network`
+
+### `errors`
+
+- type: array
+- semantic rule: at least one error-model entry is required
+
+Each entry contains:
+
+- `code`
+- `message`
+- `retryable`
+
+## 4. Optional Fields
+
+### `extensions`
+
+- type: object
+- optional
+
+Extension keys remain constrained in the validator:
+
+- keys must be lower-case token-like strings
+- keys must start with `x-`
+- keys must not smuggle authority or approval semantics into the schema layer
+- required extension behavior is not allowed in the baseline
+
+## 5. Canonical JSON Example
+
+```json
+{
+  "schema_version": "uts.v1",
+  "name": "fixture.safe_read",
+  "version": "1.0.0",
+  "description": "Read a bounded local fixture for reviewer-visible conformance.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "fixture_id": {
+        "type": "string"
+      }
+    },
+    "required": ["fixture_id"],
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "content": {
+        "type": "string"
+      }
+    },
+    "required": ["content"],
+    "additionalProperties": false
+  },
+  "side_effect_class": "read",
+  "determinism": "deterministic",
+  "replay_safety": "replay_safe",
+  "idempotence": "idempotent",
+  "resources": [
+    {
+      "resource_type": "fixture",
+      "scope": "local-readonly"
+    }
+  ],
+  "authentication": {
+    "mode": "none",
+    "required": false
+  },
+  "data_sensitivity": "internal",
+  "exfiltration_risk": "none",
+  "execution_environment": {
+    "kind": "fixture",
+    "isolation": "local deterministic fixture only"
+  },
+  "errors": [
+    {
+      "code": "fixture_not_found",
+      "message": "The requested fixture is not available.",
+      "retryable": false
+    }
+  ],
+  "extensions": {
+    "x-adl-review-note": "UTS compatibility only; no execution authority."
+  }
+}
+```
+
+## 6. Explicit Non-Claims
+
+`UTS v1.0` does not by itself define:
+
+- runtime approval semantics
+- authorization semantics
+- replay permission
+- orchestration topology
+- actor authority
+- ACC governance rules
+
+Schema compatibility is not authority.
+
+## 7. Summary
+
+`UTS v1.0` is the truthful compatibility baseline for current ADL code. It is
+already machine-readable, but it remains scoped to schema semantics rather than
+runtime permission or governance.

--- a/docs/specs/uts/UTS_V1.1_SCHEMA.md
+++ b/docs/specs/uts/UTS_V1.1_SCHEMA.md
@@ -11,8 +11,8 @@ Status note:
 
 Matching machine-readable proposal artifacts:
 
-- [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
-- [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+- [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
+- [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
 
 ## Normative Language
 

--- a/docs/specs/uts/UTS_V1.1_SCHEMA.md
+++ b/docs/specs/uts/UTS_V1.1_SCHEMA.md
@@ -15,6 +15,13 @@ Matching machine-readable schema artifacts:
 - [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
 - [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
 
+Authority hierarchy:
+
+- this document is the normative technical specification for `UTS v1.1`
+- [`ADL_UNIVERSAL_TOOL_SCHEMA.md`](./ADL_UNIVERSAL_TOOL_SCHEMA.md) is the
+  narrative companion specification
+- [`README.md`](./README.md) is the entrypoint and orientation surface
+
 Implementation-facing baseline reference:
 
 - [`adl/src/uts.rs`](../../../adl/src/uts.rs)
@@ -161,6 +168,22 @@ Suggested values:
 - `continuity_sensitive`
 - `observability_sensitive`
 
+Suggested meanings:
+
+- `read_only`: no intended state mutation as the primary capability
+- `computational`: primarily transforms or computes over supplied inputs
+- `state_mutating`: intended to change local or remote state
+- `external_network`: expected to cross a network boundary
+- `human_visible`: expected to create or alter something a human will directly
+  see
+- `governance_sensitive`: likely to require elevated review or approval posture
+- `identity_sensitive`: touches identity, identity-bearing data, or identity
+  policy surfaces
+- `continuity_sensitive`: ADL-origin category for tools that affect continuity,
+  memory, or identity-preservation surfaces; non-ADL runtimes may adapt or
+  replace this term
+- `observability_sensitive`: affects traces, metrics, logs, or review surfaces
+
 ### `side_effects`
 
 `side_effects` is an additive richer representation of side-effect posture.
@@ -218,6 +241,17 @@ It MUST NOT imply:
 - approval
 - execution permission
 - replay permission
+
+Intent examples:
+
+- `informational_query`: look up a user profile
+- `planning`: generate an execution plan without acting
+- `simulation`: dry-run a migration or deployment
+- `review`: inspect a code diff or packet for findings
+- `mutation`: create or update a normal remote object
+- `governance_action`: approve or deny a governed action
+- `observability_action`: query traces, logs, or metrics
+- `remediation`: create or apply a targeted follow-up repair step
 
 ## 6. Side-Effect Migration Note
 
@@ -329,6 +363,9 @@ Invocation correspondence rules:
 - `replay_safety` and `observability` SHOULD match or refine the tool
   definition's posture; they MUST NOT silently weaken it
 
+The invocation companion schema also supports constrained extensions using the
+same `x-` prefix pattern as the tool-definition schema.
+
 ## 9. Canonical Invocation Example
 
 ```yaml
@@ -366,6 +403,15 @@ A conformant `UTS v1.1` implementation SHOULD:
   version is explicitly declared and the runtime supports that compatibility
 - reject malformed structural definitions
 
+A portable future conformance package SHOULD include:
+
+- valid tool definitions
+- invalid structural definitions
+- invalid semantic definitions
+- dangerous-but-well-formed definitions for policy testing
+- valid invocation companion records
+- invalid invocation companion records
+
 The repository already contains implementation-facing conformance work in the
 Rust codebase. That test posture should be treated as the current reference
 implementation of UTS conformance until a standalone portable conformance suite
@@ -384,6 +430,14 @@ A future non-normative appendix may show example bindings for:
 
 Those bindings should preserve UTS semantics rather than redefine them.
 
+Illustrative sketch directions:
+
+- MCP-style: publish the UTS object as registry metadata alongside the tool
+  callable surface
+- OpenAI-compatible: wrap the UTS tool definition into the provider's
+  function/tool envelope while preserving the richer metadata in side channels
+  or extension fields
+
 ## 12. Summary
 
 `UTS v1.1` is the next UTS target, built directly on the existing `UTS v1.0`
@@ -392,3 +446,14 @@ model.
 It stays additive by preserving the current core field vocabulary and semantics
 while adding explicit compatibility, richer side-effect expression,
 observability metadata, planning metadata, and invocation-companion structure.
+
+Suggested future optional field:
+
+- `lifecycle`
+  - `experimental`
+  - `active`
+  - `deprecated`
+  - `sunset`
+
+This is not yet part of the canonical `v1.1` schema, but it is a natural next
+optional field for registry/catalog use.

--- a/docs/specs/uts/UTS_V1.1_SCHEMA.md
+++ b/docs/specs/uts/UTS_V1.1_SCHEMA.md
@@ -1,0 +1,317 @@
+# UTS v1.1 Schema
+
+## Status
+
+Draft additive schema evolution proposal for Universal Tool Schema.
+
+Status note:
+
+> This document describes the proposed `UTS v1.1` additive schema evolution.
+> It is not the canonical current ADL `UTS v1` wire contract.
+
+Matching machine-readable proposal artifacts:
+
+- [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
+- [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3029/adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+
+## Normative Language
+
+The key words:
+
+- MUST
+- MUST NOT
+- REQUIRED
+- SHALL
+- SHALL NOT
+- SHOULD
+- SHOULD NOT
+- RECOMMENDED
+- MAY
+- OPTIONAL
+
+are to be interpreted as described in RFC 2119.
+
+## 1. Purpose
+
+This document defines the proposed machine-readable structure for:
+
+- `UTS v1.1` tool definitions
+- invocation metadata
+- replayability metadata
+- observability metadata
+- planning-aware metadata
+
+The goal is not to replace ACC or runtime governance. The goal is to make the
+schema layer more explicit, transportable, and reviewable.
+
+## 2. Design Principles
+
+`UTS v1.1` SHOULD remain:
+
+- transport-neutral
+- provider-neutral
+- runtime-neutral
+- JSON-compatible
+- human-reviewable
+- machine-validatable
+
+`UTS v1.1` intentionally avoids embedding:
+
+- governance policy
+- authorization semantics
+- runtime approval semantics
+- orchestration topology
+
+For ADL, that higher-layer authority/governance companion is ACC:
+
+- `UTS v1.1` defines schema and invocation semantics
+- `ACC` defines approval, authority, and execution governance
+
+UTS validity alone does not authorize execution or replay.
+
+## 3. Schema Layers
+
+### Core Tool Schema
+
+Defines:
+
+- identifier
+- version
+- compatibility metadata
+- input schema
+- output schema
+- side effects
+
+### Invocation Metadata
+
+Defines:
+
+- invocation semantics
+- intent
+- optional timeout/retry posture
+- replay posture
+
+### Replayability Metadata
+
+Defines:
+
+- deterministic replay posture
+- observational replay posture
+- non-replayable semantics
+
+### Observability Metadata
+
+Defines:
+
+- runtime visibility posture
+- audit expectations
+- governance-sensitive visibility
+
+Observability metadata describes visibility posture, not surveillance posture.
+It does not require centralized monitoring, and it remains compatible with:
+
+- local runtimes
+- private runtimes
+- operator-owned observability systems
+- bounded audit surfaces
+
+### Planning Metadata
+
+Defines:
+
+- high-risk indicators
+- irreversible-action indicators
+- review recommendations
+
+## 4. Canonical Minimal Tool Object
+
+Minimal proposal example:
+
+```yaml
+uts_version: "1.1"
+compatible_versions:
+  - "1.0"
+  - "1.1"
+id: filesystem.search
+version: "1.1"
+input_schema:
+  type: object
+output_schema:
+  type: object
+side_effects:
+  - none
+```
+
+Equivalent JSON example:
+
+```json
+{
+  "uts_version": "1.1",
+  "compatible_versions": ["1.0", "1.1"],
+  "id": "filesystem.search",
+  "version": "1.1",
+  "input_schema": {
+    "type": "object"
+  },
+  "output_schema": {
+    "type": "object"
+  },
+  "side_effects": ["none"]
+}
+```
+
+These are proposal examples for `UTS v1.1`, not guaranteed `UTS v1` fixtures.
+
+## 5. Extended Tool Object
+
+Illustrative proposal example:
+
+```yaml
+uts_version: "1.1"
+compatible_versions:
+  - "1.0"
+  - "1.1"
+id: github.create_issue
+version: "1.1"
+category:
+  - external_network
+  - governance_sensitive
+  - human_visible
+input_schema:
+  type: object
+  required:
+    - repository
+    - title
+output_schema:
+  type: object
+  required:
+    - issue_url
+side_effects:
+  - external_state
+  - human_visible
+  - governance_relevant
+replayability: observational
+observability: governance
+planning:
+  high_risk: true
+  irreversible: false
+  review_required: true
+```
+
+## 6. Version Negotiation
+
+`UTS v1.1` SHOULD make compatibility posture explicit.
+
+Suggested fields:
+
+- `uts_version`
+- `compatible_versions`
+
+Example:
+
+```yaml
+uts_version: "1.1"
+compatible_versions:
+  - "1.0"
+  - "1.1"
+```
+
+This makes migration strategy concrete and lets runtimes distinguish:
+
+- canonical current support
+- additive forward support
+- compatibility fallback posture
+
+## 7. Replayability Taxonomy
+
+Allowed proposal values:
+
+- `deterministic`
+- `observational`
+- `non_replayable`
+
+## 8. Observability Taxonomy
+
+Allowed proposal values:
+
+- `none`
+- `basic`
+- `full`
+- `governance`
+
+The observability taxonomy is metadata, not surveillance.
+
+## 9. Invocation Schema
+
+Canonical proposal invocation metadata SHOULD include:
+
+```yaml
+invocation_id: inv-1001
+caller: runtime.review_agent
+tool:
+  id: github.create_issue
+  version: "1.1"
+intent: remediation
+purpose: |
+  Create remediation issue from failed review findings.
+timeout_ms: 5000
+retry:
+  max_attempts: 1
+  strategy: fixed_delay
+side_effect_expectations:
+  - external_state
+  - human_visible
+replayability: observational
+observability: governance
+```
+
+## 10. Invocation Intent Taxonomy
+
+Suggested invocation intents:
+
+- `informational_query`
+- `planning`
+- `simulation`
+- `review`
+- `mutation`
+- `governance_action`
+- `observability_action`
+- `remediation`
+
+Runtimes MAY extend this taxonomy.
+
+## 11. Threat Model
+
+`UTS v1.1` is intended to reduce:
+
+- hidden side effects
+- replay ambiguity
+- weak observability
+- unsafe planning/execution coupling
+- ambiguous invocation semantics
+
+This is an operational goal, not a claim that schema alone eliminates runtime
+risk.
+
+## 12. Non-Claims
+
+`UTS v1.1` does not by itself grant:
+
+- authority
+- execution permission
+- replay permission
+
+Those remain ACC and runtime concerns.
+
+## 13. Summary
+
+`UTS v1.1` is the additive standards-facing direction:
+
+- cleaner invocation semantics
+- explicit replayability
+- explicit observability
+- explicit version negotiation
+- clean separation from ACC authority/governance
+
+It is a proposal surface, not a claim that the current code already implements
+the full model.

--- a/docs/specs/uts/UTS_V1.1_SCHEMA.md
+++ b/docs/specs/uts/UTS_V1.1_SCHEMA.md
@@ -2,17 +2,23 @@
 
 ## Status
 
-Draft additive schema evolution proposal for Universal Tool Schema.
+Tracked normative next-version specification for the Universal Tool Schema.
 
 Status note:
 
-> This document describes the proposed `UTS v1.1` additive schema evolution.
-> It is not the canonical current ADL `UTS v1` wire contract.
+> This document defines the `UTS v1.1` adoption target.
+> The current implemented runtime baseline remains `UTS v1.0` until follow-on
+> code adoption lands.
 
-Matching machine-readable proposal artifacts:
+Matching machine-readable schema artifacts:
 
 - [`adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/universal_tool_schema.v1_1.schema.json)
 - [`adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json`](../../../adl-spec/schemas/uts/v1.1/tool_invocation.v1_1.schema.json)
+
+Implementation-facing baseline reference:
+
+- [`adl/src/uts.rs`](../../../adl/src/uts.rs)
+- [`UTS_V1.0_SCHEMA.md`](./UTS_V1.0_SCHEMA.md)
 
 ## Normative Language
 
@@ -33,285 +39,356 @@ are to be interpreted as described in RFC 2119.
 
 ## 1. Purpose
 
-This document defines the proposed machine-readable structure for:
+This document defines the normative machine-readable structure for `UTS v1.1`
+as an evolutionary successor to the current implemented `UTS v1.0` baseline.
 
-- `UTS v1.1` tool definitions
-- invocation metadata
-- replayability metadata
-- observability metadata
-- planning-aware metadata
+`UTS v1.1` preserves the strongest parts of `v1.0` while adding explicit
+compatibility, richer side-effect expression, and clearer invocation metadata.
 
-The goal is not to replace ACC or runtime governance. The goal is to make the
-schema layer more explicit, transportable, and reviewable.
+## 2. Evolution From UTS v1.0
 
-## 2. Design Principles
+`UTS v1.1` is additive, not a rename-driven redesign.
 
-`UTS v1.1` SHOULD remain:
+It preserves the current field families from `UTS v1.0`:
 
-- transport-neutral
-- provider-neutral
-- runtime-neutral
-- JSON-compatible
-- human-reviewable
-- machine-validatable
+- `schema_version`
+- `name`
+- `version`
+- `description`
+- `input_schema`
+- `output_schema`
+- `side_effect_class`
+- `determinism`
+- `replay_safety`
+- `idempotence`
+- `resources`
+- `authentication`
+- `data_sensitivity`
+- `exfiltration_risk`
+- `execution_environment`
+- `errors`
+- `extensions`
 
-`UTS v1.1` intentionally avoids embedding:
+It adds only bounded new metadata:
 
-- governance policy
-- authorization semantics
-- runtime approval semantics
-- orchestration topology
-
-For ADL, that higher-layer authority/governance companion is ACC:
-
-- `UTS v1.1` defines schema and invocation semantics
-- `ACC` defines approval, authority, and execution governance
-
-UTS validity alone does not authorize execution or replay.
-
-## 3. Schema Layers
-
-### Core Tool Schema
-
-Defines:
-
-- identifier
-- version
-- compatibility metadata
-- input schema
-- output schema
-- side effects
-
-### Invocation Metadata
-
-Defines:
-
-- invocation semantics
-- intent
-- optional timeout/retry posture
-- replay posture
-
-### Replayability Metadata
-
-Defines:
-
-- deterministic replay posture
-- observational replay posture
-- non-replayable semantics
-
-### Observability Metadata
-
-Defines:
-
-- runtime visibility posture
-- audit expectations
-- governance-sensitive visibility
-
-Observability metadata describes visibility posture, not surveillance posture.
-It does not require centralized monitoring, and it remains compatible with:
-
-- local runtimes
-- private runtimes
-- operator-owned observability systems
-- bounded audit surfaces
-
-### Planning Metadata
-
-Defines:
-
-- high-risk indicators
-- irreversible-action indicators
-- review recommendations
-
-## 4. Canonical Minimal Tool Object
-
-Minimal proposal example:
-
-```yaml
-uts_version: "1.1"
-compatible_versions:
-  - "1.0"
-  - "1.1"
-id: filesystem.search
-version: "1.1"
-input_schema:
-  type: object
-output_schema:
-  type: object
-side_effects:
-  - none
-```
-
-Equivalent JSON example:
-
-```json
-{
-  "uts_version": "1.1",
-  "compatible_versions": ["1.0", "1.1"],
-  "id": "filesystem.search",
-  "version": "1.1",
-  "input_schema": {
-    "type": "object"
-  },
-  "output_schema": {
-    "type": "object"
-  },
-  "side_effects": ["none"]
-}
-```
-
-These are proposal examples for `UTS v1.1`, not guaranteed `UTS v1` fixtures.
-
-## 5. Extended Tool Object
-
-Illustrative proposal example:
-
-```yaml
-uts_version: "1.1"
-compatible_versions:
-  - "1.0"
-  - "1.1"
-id: github.create_issue
-version: "1.1"
-category:
-  - external_network
-  - governance_sensitive
-  - human_visible
-input_schema:
-  type: object
-  required:
-    - repository
-    - title
-output_schema:
-  type: object
-  required:
-    - issue_url
-side_effects:
-  - external_state
-  - human_visible
-  - governance_relevant
-replayability: observational
-observability: governance
-planning:
-  high_risk: true
-  irreversible: false
-  review_required: true
-```
-
-## 6. Version Negotiation
-
-`UTS v1.1` SHOULD make compatibility posture explicit.
-
-Suggested fields:
-
-- `uts_version`
 - `compatible_versions`
+- `categories`
+- `side_effects`
+- `observability`
+- `planning`
+
+`v1.1` therefore remains consumable by a `v1.0`-aware implementation that
+ignores unknown additive fields, while still letting newer runtimes act on the
+new metadata.
+
+## 3. Compatibility And Version Negotiation
+
+`UTS v1.1` makes compatibility posture explicit.
+
+Required fields:
+
+- `schema_version: uts.v1.1`
+- `compatible_versions`
+
+`compatible_versions` semantics:
+
+- a tool definition MUST be structurally valid under the `v1.1` schema
+- `compatible_versions` declares the set of UTS schema versions, including the
+  current `uts.v1.1` version, that the author expects a runtime to consume
+  compatibly
+- a runtime SHOULD validate against the highest version it supports
+- a runtime that only supports an earlier compatible version MAY ignore unknown
+  additive `v1.1` fields rather than rejecting the definition outright
+- compatibility does not permit renaming or removing the preserved `v1.0`
+  fields
 
 Example:
 
 ```yaml
-uts_version: "1.1"
+schema_version: uts.v1.1
 compatible_versions:
-  - "1.0"
-  - "1.1"
+  - uts.v1
+  - uts.v1.1
 ```
 
-This makes migration strategy concrete and lets runtimes distinguish:
+## 4. Preserved Core Tool Schema
 
-- canonical current support
-- additive forward support
-- compatibility fallback posture
+All `UTS v1.0` core schema semantics carry forward into `v1.1`.
 
-## 7. Replayability Taxonomy
+### Required preserved fields
 
-Allowed proposal values:
+- `schema_version`
+- `compatible_versions`
+- `name`
+- `version`
+- `description`
+- `input_schema`
+- `output_schema`
+- `side_effect_class`
+- `determinism`
+- `replay_safety`
+- `idempotence`
+- `resources`
+- `authentication`
+- `data_sensitivity`
+- `exfiltration_risk`
+- `execution_environment`
+- `errors`
 
-- `deterministic`
-- `observational`
-- `non_replayable`
+### Optional preserved field
 
-## 8. Observability Taxonomy
+- `extensions`
 
-Allowed proposal values:
+## 5. Additive v1.1 Fields
+
+### `categories`
+
+`categories` is an illustrative tagging/search taxonomy.
+
+It is not the primary normative governance surface. Typed fields such as
+`side_effect_class`, `data_sensitivity`, and `exfiltration_risk` remain the
+stronger machine-readable signals.
+
+Suggested values:
+
+- `read_only`
+- `computational`
+- `state_mutating`
+- `external_network`
+- `human_visible`
+- `governance_sensitive`
+- `identity_sensitive`
+- `continuity_sensitive`
+- `observability_sensitive`
+
+### `side_effects`
+
+`side_effects` is an additive richer representation of side-effect posture.
+
+It complements rather than replaces `side_effect_class`.
+
+Suggested values:
+
+- `none`
+- `local_state`
+- `external_state`
+- `irreversible`
+- `human_visible`
+- `governance_relevant`
+
+This allows multi-dimensional expression that `side_effect_class` alone cannot
+capture.
+
+### `observability`
+
+Suggested values:
 
 - `none`
 - `basic`
 - `full`
 - `governance`
 
-The observability taxonomy is metadata, not surveillance.
+Definitions:
 
-## 9. Invocation Schema
+- `none`: no specific runtime visibility expectations beyond local control
+- `basic`: invocation recorded with timestamp and result status
+- `full`: invocation metadata, arguments posture, and outputs posture are fully
+  reviewable in the runtime's normal trace model
+- `governance`: elevated audit/review posture is expected before or around
+  execution
 
-Canonical proposal invocation metadata SHOULD include:
+Observability metadata is metadata, not surveillance. It does not require
+centralized monitoring or centralized orchestration.
 
-```yaml
-invocation_id: inv-1001
-caller: runtime.review_agent
-tool:
-  id: github.create_issue
-  version: "1.1"
-intent: remediation
-purpose: |
-  Create remediation issue from failed review findings.
-timeout_ms: 5000
-retry:
-  max_attempts: 1
-  strategy: fixed_delay
-side_effect_expectations:
-  - external_state
-  - human_visible
-replayability: observational
-observability: governance
-```
+### `planning`
 
-## 10. Invocation Intent Taxonomy
+Suggested fields:
 
-Suggested invocation intents:
+- `high_risk`
+- `irreversible`
+- `expensive`
+- `slow`
+- `review_recommended`
 
-- `informational_query`
-- `planning`
-- `simulation`
-- `review`
-- `mutation`
-- `governance_action`
-- `observability_action`
-- `remediation`
+Planning metadata is descriptive execution-planning metadata only.
 
-Runtimes MAY extend this taxonomy.
-
-## 11. Threat Model
-
-`UTS v1.1` is intended to reduce:
-
-- hidden side effects
-- replay ambiguity
-- weak observability
-- unsafe planning/execution coupling
-- ambiguous invocation semantics
-
-This is an operational goal, not a claim that schema alone eliminates runtime
-risk.
-
-## 12. Non-Claims
-
-`UTS v1.1` does not by itself grant:
+It MUST NOT imply:
 
 - authority
+- approval
 - execution permission
 - replay permission
 
-Those remain ACC and runtime concerns.
+## 6. Side-Effect Migration Note
 
-## 13. Summary
+`UTS v1.0` used a single `side_effect_class` enum.
 
-`UTS v1.1` is the additive standards-facing direction:
+`UTS v1.1` keeps that field and adds `side_effects` for richer expression.
 
-- cleaner invocation semantics
-- explicit replayability
-- explicit observability
-- explicit version negotiation
-- clean separation from ACC authority/governance
+Suggested mapping examples:
 
-It is a proposal surface, not a claim that the current code already implements
-the full model.
+- `read` -> `side_effects: [none]`
+- `local_write` -> `side_effects: [local_state]`
+- `external_write` -> `side_effects: [external_state]`
+- `destructive` -> `side_effects: [external_state, irreversible]`
+- `exfiltration` -> `side_effects: [external_state, governance_relevant]`
+
+This is a design improvement, not a replacement of the scalar field.
+
+## 7. Canonical Extended Tool Object
+
+Illustrative complete `UTS v1.1` example:
+
+```yaml
+schema_version: uts.v1.1
+compatible_versions:
+  - uts.v1
+  - uts.v1.1
+name: github.create_issue
+version: 1.1.0
+description: Create a GitHub issue in a bounded repository under governed runtime control.
+categories:
+  - external_network
+  - human_visible
+  - governance_sensitive
+input_schema:
+  type: object
+  required:
+    - repository
+    - title
+  properties:
+    repository:
+      type: string
+    title:
+      type: string
+    body:
+      type: string
+output_schema:
+  type: object
+  required:
+    - issue_url
+  properties:
+    issue_url:
+      type: string
+      format: uri
+side_effect_class: external_write
+side_effects:
+  - external_state
+  - human_visible
+  - governance_relevant
+determinism: bounded_nondeterministic
+replay_safety: replay_requires_approval
+idempotence: conditionally_idempotent
+resources:
+  - resource_type: github_issue
+    scope: repository
+authentication:
+  mode: user_delegated
+  required: true
+data_sensitivity: internal
+exfiltration_risk: medium
+execution_environment:
+  kind: external_service
+  isolation: provider_controlled
+errors:
+  - code: permission_denied
+    message: Caller lacks permission to create issues in the target repository.
+    retryable: false
+observability: governance
+planning:
+  high_risk: true
+  irreversible: false
+  expensive: false
+  slow: false
+  review_recommended: true
+extensions:
+  x-adl-human-impact: issue_creation
+```
+
+## 8. Invocation Schema Relationship
+
+The invocation schema is a companion metadata contract, not a replacement for
+actual tool arguments.
+
+It is intended to capture:
+
+- invocation metadata
+- intent
+- reviewable execution posture
+- correspondence to the tool definition
+
+It is not, by itself, a full execution payload unless a runtime chooses to pair
+it with argument/result bodies elsewhere.
+
+Invocation correspondence rules:
+
+- `tool.name` and `tool.version` MUST refer to a tool definition
+- `side_effect_expectations` SHOULD be consistent with the tool definition and
+  MAY express a subset of the declared `side_effects` when a particular call is
+  narrower than the tool's full capability surface
+- `replay_safety` and `observability` SHOULD match or refine the tool
+  definition's posture; they MUST NOT silently weaken it
+
+## 9. Canonical Invocation Example
+
+```yaml
+invocation_id: inv-1842
+caller: runtime.review_agent
+
+tool:
+  name: github.create_issue
+  version: 1.1.0
+
+intent: remediation
+purpose: |
+  Create remediation issue from failed review findings.
+
+side_effect_expectations:
+  - external_state
+  - human_visible
+
+replay_safety: replay_requires_approval
+observability: governance
+
+timeout_ms: 30000
+retry:
+  max_attempts: 1
+  strategy: fixed_delay
+```
+
+## 10. Conformance Expectations
+
+A conformant `UTS v1.1` implementation SHOULD:
+
+- validate preserved `v1.0` fields using the same core baseline rules
+- validate additive `v1.1` fields when present
+- ignore unknown additive higher-version fields only when a compatible earlier
+  version is explicitly declared and the runtime supports that compatibility
+- reject malformed structural definitions
+
+The repository already contains implementation-facing conformance work in the
+Rust codebase. That test posture should be treated as the current reference
+implementation of UTS conformance until a standalone portable conformance suite
+is published.
+
+## 11. Transport Binding Note
+
+`UTS v1.1` remains transport-neutral.
+
+A future non-normative appendix may show example bindings for:
+
+- MCP-style tool registries
+- HTTP/REST tool catalogs
+- OpenAI-compatible tool/function wrappers
+- local runtime registries
+
+Those bindings should preserve UTS semantics rather than redefine them.
+
+## 12. Summary
+
+`UTS v1.1` is the next UTS target, built directly on the existing `UTS v1.0`
+model.
+
+It stays additive by preserving the current core field vocabulary and semantics
+while adding explicit compatibility, richer side-effect expression,
+observability metadata, planning metadata, and invocation-companion structure.


### PR DESCRIPTION
## Summary
- add tracked canonical UTS spec docs under `docs/specs/uts/`
- add machine-readable UTS schemas for the current v1 baseline and proposed v1.1 surfaces
- keep UTS schema semantics explicitly separate from ACC runtime authority and governance

## Validation
- `python3` JSON parse of the new schema files
- `git diff --check`
- bounded subagent review with no actionable findings

Closes #3029
