### PR TITLE
[v0.91.2][docs] Create tracked ACC v1.1 spec and machine-readable schema as the ADL-specific companion to public UTS

### DIFF
--- a/adl-spec/schemas/README.md
+++ b/adl-spec/schemas/README.md
@@ -1,21 +1,23 @@
 # adl-spec/schemas
 
 Schema artifact directory for ADL spec publishing.
-Place versioned schema outputs here and keep narrative documentation in parent docs.
+Place versioned schema outputs here and keep narrative documentation in tracked
+spec docs.
 
 ## In This Directory
 
 - `adl_constitution.yaml` — constitutional governance artifact for delegation/runtime planning
 - `freedom_gate_event.yaml` — Freedom Gate event schema
-- `uts/v1.0/universal_tool_schema.v1.schema.json` — machine-readable current UTS baseline
-- `uts/v1.1/universal_tool_schema.v1_1.schema.json` — additive UTS v1.1 proposal tool schema
-- `uts/v1.1/tool_invocation.v1_1.schema.json` — additive UTS v1.1 proposal invocation schema
+- `uts/v1.0/universal_tool_schema.v1.schema.json` — current implemented UTS baseline schema
+- `uts/v1.1/universal_tool_schema.v1_1.schema.json` — additive UTS v1.1 schema target
+- `uts/v1.1/tool_invocation.v1_1.schema.json` — additive UTS invocation schema target
+- `acc/v1.0/adl_capability_contract.v1.schema.json` — current implemented ACC baseline schema
+- `acc/v1.1/adl_capability_contract.v1_1.schema.json` — additive ACC v1.1 schema target
 - future schema artifacts for ADL language versions
 
 ## See Also / Canonical Docs
 
-- Spec entrypoint: `../README.md`
-- Examples: `../examples/README.md`
-- Normative spec docs: `../spec/README.md`
+- UTS docs: `../../docs/specs/uts/`
+- ACC docs: `../../docs/specs/acc/`
 - Root project entrypoint: `../../README.md`
 - ADRs: `../../docs/adr/`

--- a/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json
+++ b/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://raw.githubusercontent.com/danielbaustin/agent-design-language/main/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json",
   "title": "ADL Capability Contract v1.0",
   "type": "object",
+  "additionalProperties": false,
   "required": [
     "schema_version",
     "contract_id",

--- a/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json
+++ b/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json
@@ -137,6 +137,7 @@
         "actor_kind": { "type": "string", "enum": ["human", "agent", "service", "operator"] },
         "authenticated": { "const": true },
         "authority_evidence": {
+          "description": "Reviewable authority evidence. `model_claim` is enumerated for diagnostic clarity but is not allowed to establish authority in valid ACC contracts.",
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/authorityEvidence" },
@@ -202,7 +203,10 @@
       "required": ["policy_id", "decision", "evidence_ref"],
       "properties": {
         "policy_id": { "type": "string", "minLength": 1 },
-        "decision": { "$ref": "#/$defs/decision" },
+        "decision": {
+          "description": "Coherence echo of the top-level ACC decision, recorded per policy check rather than serving as an independent policy-only decision vocabulary.",
+          "$ref": "#/$defs/decision"
+        },
         "evidence_ref": { "type": "string", "minLength": 1 }
       }
     },
@@ -253,11 +257,11 @@
       "additionalProperties": false,
       "required": ["actor_view", "operator_view", "reviewer_view", "public_report_view", "observatory_projection"],
       "properties": {
-        "actor_view": { "type": "string", "minLength": 1 },
-        "operator_view": { "type": "string", "minLength": 1 },
-        "reviewer_view": { "type": "string", "minLength": 1 },
-        "public_report_view": { "type": "string", "minLength": 1 },
-        "observatory_projection": { "type": "string", "minLength": 1 }
+        "actor_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what the actor may see; machine-actionable visibility levels live in `visibility_matrix`." },
+        "operator_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what the operator may see; machine-actionable visibility levels live in `visibility_matrix`." },
+        "reviewer_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what the reviewer may see; machine-actionable visibility levels live in `visibility_matrix`." },
+        "public_report_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what public reporting may expose; machine-actionable visibility levels live in `visibility_matrix`." },
+        "observatory_projection": { "type": "string", "minLength": 1, "description": "Human-readable summary of what observatory projections may expose; machine-actionable visibility levels live in `visibility_matrix`." }
       }
     },
     "visibilityMatrixEntry": {
@@ -285,7 +289,10 @@
       "additionalProperties": false,
       "required": ["exposes_citizen_private_state", "protected_state_refs"],
       "properties": {
-        "exposes_citizen_private_state": { "const": false },
+        "exposes_citizen_private_state": {
+          "const": false,
+          "description": "Positive compliance assertion. Valid ACC contracts must not expose citizen/private state through trace or replay surfaces."
+        },
         "protected_state_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
       }
     },

--- a/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json
+++ b/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json
@@ -1,0 +1,315 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/danielbaustin/agent-design-language/main/adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json",
+  "title": "ADL Capability Contract v1.0",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "contract_id",
+    "tool",
+    "actor",
+    "authority_grant",
+    "role_standing",
+    "delegation_chain",
+    "capability",
+    "policy_checks",
+    "confirmation",
+    "freedom_gate",
+    "execution",
+    "trace_replay",
+    "privacy_redaction",
+    "failure_policy",
+    "decision"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "acc.v1" },
+    "contract_id": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 },
+    "tool": { "$ref": "#/$defs/toolReference" },
+    "actor": { "$ref": "#/$defs/actorIdentity" },
+    "authority_grant": { "$ref": "#/$defs/authorityGrant" },
+    "role_standing": { "$ref": "#/$defs/roleStanding" },
+    "delegation_chain": { "type": "array", "items": { "$ref": "#/$defs/delegationStep" } },
+    "capability": { "$ref": "#/$defs/capabilityRequirement" },
+    "policy_checks": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/policyCheck" } },
+    "confirmation": { "$ref": "#/$defs/confirmationRequirement" },
+    "freedom_gate": { "$ref": "#/$defs/freedomGateRequirement" },
+    "execution": { "$ref": "#/$defs/executionSemantics" },
+    "trace_replay": { "$ref": "#/$defs/traceReplay" },
+    "privacy_redaction": { "$ref": "#/$defs/privacyRedaction" },
+    "failure_policy": { "$ref": "#/$defs/failurePolicy" },
+    "decision": { "$ref": "#/$defs/decision" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "decision": { "const": "allowed" } }, "required": ["decision"] },
+      "then": {
+        "properties": {
+          "authority_grant": { "properties": { "status": { "const": "active" } }, "required": ["status"] },
+          "execution": { "properties": { "approved_for_execution": { "const": true } }, "required": ["approved_for_execution"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "decision": { "const": "revoked" } }, "required": ["decision"] },
+      "then": {
+        "properties": {
+          "authority_grant": { "properties": { "status": { "const": "revoked" } }, "required": ["status"] },
+          "execution": { "properties": { "approved_for_execution": { "const": false } }, "required": ["approved_for_execution"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "decision": { "enum": ["denied", "delegated"] } }, "required": ["decision"] },
+      "then": {
+        "properties": {
+          "execution": { "properties": { "approved_for_execution": { "const": false } }, "required": ["approved_for_execution"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "authority_grant": { "properties": { "status": { "const": "delegated" } }, "required": ["status"] } }, "required": ["authority_grant"] },
+      "then": {
+        "properties": {
+          "delegation_chain": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "confirmation": { "properties": { "required": { "const": true } }, "required": ["required"] } }, "required": ["confirmation"] },
+      "then": {
+        "properties": {
+          "confirmation": {
+            "required": ["required", "confirmed_by_actor_id", "confirmation_id"],
+            "properties": {
+              "confirmed_by_actor_id": { "type": "string", "minLength": 1 },
+              "confirmation_id": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "freedom_gate": { "properties": { "required": { "const": true } }, "required": ["required"] } }, "required": ["freedom_gate"] },
+      "then": {
+        "properties": {
+          "freedom_gate": {
+            "properties": {
+              "decision": { "not": { "const": "not_required" } }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "decision": {
+      "type": "string",
+      "enum": ["allowed", "denied", "delegated", "revoked"]
+    },
+    "toolReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tool_name", "tool_version", "registry_tool_id", "adapter_id"],
+      "properties": {
+        "tool_name": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 },
+        "tool_version": { "type": "string", "minLength": 1 },
+        "registry_tool_id": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 },
+        "adapter_id": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 }
+      }
+    },
+    "authorityEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_id", "kind", "issuer"],
+      "properties": {
+        "evidence_id": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "enum": ["credential", "operator_grant", "registry_grant", "policy_record", "delegation_record", "model_claim"] },
+        "issuer": { "type": "string", "minLength": 1 }
+      }
+    },
+    "actorIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actor_id", "actor_kind", "authenticated", "authority_evidence"],
+      "properties": {
+        "actor_id": { "type": "string", "minLength": 1 },
+        "actor_kind": { "type": "string", "enum": ["human", "agent", "service", "operator"] },
+        "authenticated": { "const": true },
+        "authority_evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/authorityEvidence" },
+          "not": {
+            "contains": {
+              "type": "object",
+              "properties": { "kind": { "const": "model_claim" } },
+              "required": ["kind"]
+            }
+          }
+        }
+      }
+    },
+    "authorityGrant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["grant_id", "grantor_actor_id", "grantee_actor_id", "capability_id", "scope", "status"],
+      "properties": {
+        "grant_id": { "type": "string", "minLength": 1 },
+        "grantor_actor_id": { "type": "string", "minLength": 1 },
+        "grantee_actor_id": { "type": "string", "minLength": 1 },
+        "capability_id": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["active", "denied", "delegated", "revoked"] },
+        "revocation_reason": { "type": ["string", "null"] }
+      }
+    },
+    "roleStanding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "standing"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "standing": { "type": "string", "minLength": 1 }
+      }
+    },
+    "delegationStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["delegation_id", "grantor_actor_id", "delegate_actor_id", "grant_id", "depth"],
+      "properties": {
+        "delegation_id": { "type": "string", "minLength": 1 },
+        "grantor_actor_id": { "type": "string", "minLength": 1 },
+        "delegate_actor_id": { "type": "string", "minLength": 1 },
+        "grant_id": { "type": "string", "minLength": 1 },
+        "depth": { "type": "integer", "minimum": 1, "maximum": 8 }
+      }
+    },
+    "capabilityRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability_id", "side_effect_class", "resource_type", "resource_scope"],
+      "properties": {
+        "capability_id": { "type": "string", "minLength": 1 },
+        "side_effect_class": { "type": "string", "minLength": 1 },
+        "resource_type": { "type": "string", "minLength": 1 },
+        "resource_scope": { "type": "string", "minLength": 1 }
+      }
+    },
+    "policyCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_id", "decision", "evidence_ref"],
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "decision": { "$ref": "#/$defs/decision" },
+        "evidence_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "confirmationRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "confirmed_by_actor_id": { "type": ["string", "null"] },
+        "confirmation_id": { "type": ["string", "null"] }
+      }
+    },
+    "freedomGateRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "decision"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "decision": { "type": "string", "enum": ["not_required", "allowed", "denied", "deferred", "challenged", "escalated"] },
+        "event_id": { "type": ["string", "null"] }
+      }
+    },
+    "executionSemantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter_id", "environment", "dry_run", "approved_for_execution"],
+      "properties": {
+        "adapter_id": { "type": "string", "minLength": 1 },
+        "environment": { "type": "string", "minLength": 1 },
+        "dry_run": { "type": "boolean" },
+        "approved_for_execution": { "type": "boolean" }
+      }
+    },
+    "traceReplay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "replay_allowed", "replay_posture", "evidence_refs"],
+      "properties": {
+        "trace_id": { "type": "string", "minLength": 1 },
+        "replay_allowed": { "type": "boolean" },
+        "replay_posture": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "visibilityPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actor_view", "operator_view", "reviewer_view", "public_report_view", "observatory_projection"],
+      "properties": {
+        "actor_view": { "type": "string", "minLength": 1 },
+        "operator_view": { "type": "string", "minLength": 1 },
+        "reviewer_view": { "type": "string", "minLength": 1 },
+        "public_report_view": { "type": "string", "minLength": 1 },
+        "observatory_projection": { "type": "string", "minLength": 1 }
+      }
+    },
+    "visibilityMatrixEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audience", "level", "rationale"],
+      "properties": {
+        "audience": { "type": "string", "enum": ["actor", "operator", "reviewer", "public_report", "observatory_projection"] },
+        "level": { "type": "string", "enum": ["full", "redacted", "aggregate", "denied"] },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "redactionExample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["surface", "source_shape", "redacted_shape"],
+      "properties": {
+        "surface": { "type": "string", "enum": ["arguments", "results", "errors", "traces", "projections"] },
+        "source_shape": { "type": "string", "minLength": 1 },
+        "redacted_shape": { "type": "string", "minLength": 1 }
+      }
+    },
+    "tracePrivacyPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exposes_citizen_private_state", "protected_state_refs"],
+      "properties": {
+        "exposes_citizen_private_state": { "const": false },
+        "protected_state_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "privacyRedaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["data_sensitivity", "visibility", "redaction_rules", "visibility_matrix", "redaction_examples", "trace_privacy"],
+      "properties": {
+        "data_sensitivity": { "type": "string", "minLength": 1 },
+        "visibility": { "$ref": "#/$defs/visibilityPolicy" },
+        "redaction_rules": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "visibility_matrix": { "type": "array", "minItems": 5, "items": { "$ref": "#/$defs/visibilityMatrixEntry" } },
+        "redaction_examples": { "type": "array", "minItems": 5, "items": { "$ref": "#/$defs/redactionExample" } },
+        "trace_privacy": { "$ref": "#/$defs/tracePrivacyPolicy" }
+      }
+    },
+    "failurePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failure_code", "message", "retryable"],
+      "properties": {
+        "failure_code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "retryable": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json
+++ b/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://raw.githubusercontent.com/danielbaustin/agent-design-language/main/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json",
   "title": "ADL Capability Contract v1.1",
   "type": "object",
+  "additionalProperties": false,
   "required": [
     "schema_version",
     "contract_id",

--- a/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json
+++ b/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json
@@ -1,0 +1,344 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/danielbaustin/agent-design-language/main/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json",
+  "title": "ADL Capability Contract v1.1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "contract_id",
+    "tool",
+    "actor",
+    "authority_grant",
+    "role_standing",
+    "delegation_chain",
+    "capability",
+    "policy_checks",
+    "confirmation",
+    "freedom_gate",
+    "execution",
+    "trace_replay",
+    "privacy_redaction",
+    "failure_policy",
+    "decision"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "acc.v1.1" },
+    "compatible_versions": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["acc.v1", "acc.v1.1"] },
+      "uniqueItems": true
+    },
+    "governance_profile": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 },
+    "contract_id": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 },
+    "tool": { "$ref": "#/$defs/toolReference" },
+    "actor": { "$ref": "#/$defs/actorIdentity" },
+    "authority_grant": { "$ref": "#/$defs/authorityGrant" },
+    "role_standing": { "$ref": "#/$defs/roleStanding" },
+    "delegation_chain": { "type": "array", "items": { "$ref": "#/$defs/delegationStep" } },
+    "delegation_constraints": { "$ref": "#/$defs/delegationConstraints" },
+    "capability": { "$ref": "#/$defs/capabilityRequirement" },
+    "policy_checks": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/policyCheck" } },
+    "confirmation": { "$ref": "#/$defs/confirmationRequirement" },
+    "freedom_gate": { "$ref": "#/$defs/freedomGateRequirement" },
+    "execution": { "$ref": "#/$defs/executionSemantics" },
+    "trace_replay": { "$ref": "#/$defs/traceReplay" },
+    "privacy_redaction": { "$ref": "#/$defs/privacyRedaction" },
+    "failure_policy": { "$ref": "#/$defs/failurePolicy" },
+    "decision": { "$ref": "#/$defs/decision" }
+  },
+  "allOf": [
+    {
+      "if": { "required": ["compatible_versions"] },
+      "then": {
+        "properties": {
+          "compatible_versions": {
+            "allOf": [
+              { "contains": { "const": "acc.v1.1" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "decision": { "const": "allowed" } }, "required": ["decision"] },
+      "then": {
+        "properties": {
+          "authority_grant": { "properties": { "status": { "const": "active" } }, "required": ["status"] },
+          "execution": { "properties": { "approved_for_execution": { "const": true } }, "required": ["approved_for_execution"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "decision": { "const": "revoked" } }, "required": ["decision"] },
+      "then": {
+        "properties": {
+          "authority_grant": { "properties": { "status": { "const": "revoked" } }, "required": ["status"] },
+          "execution": { "properties": { "approved_for_execution": { "const": false } }, "required": ["approved_for_execution"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "decision": { "enum": ["denied", "delegated"] } }, "required": ["decision"] },
+      "then": {
+        "properties": {
+          "execution": { "properties": { "approved_for_execution": { "const": false } }, "required": ["approved_for_execution"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "authority_grant": { "properties": { "status": { "const": "delegated" } }, "required": ["status"] } }, "required": ["authority_grant"] },
+      "then": {
+        "properties": {
+          "delegation_chain": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "confirmation": { "properties": { "required": { "const": true } }, "required": ["required"] } }, "required": ["confirmation"] },
+      "then": {
+        "properties": {
+          "confirmation": {
+            "required": ["required", "confirmed_by_actor_id", "confirmation_id"],
+            "properties": {
+              "confirmed_by_actor_id": { "type": "string", "minLength": 1 },
+              "confirmation_id": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "freedom_gate": { "properties": { "required": { "const": true } }, "required": ["required"] } }, "required": ["freedom_gate"] },
+      "then": {
+        "properties": {
+          "freedom_gate": {
+            "properties": {
+              "decision": { "not": { "const": "not_required" } }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "decision": {
+      "type": "string",
+      "enum": ["allowed", "denied", "delegated", "revoked"]
+    },
+    "toolReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tool_name", "tool_version", "registry_tool_id", "adapter_id"],
+      "properties": {
+        "tool_name": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 },
+        "tool_version": { "type": "string", "minLength": 1 },
+        "registry_tool_id": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 },
+        "adapter_id": { "type": "string", "pattern": "^[a-z0-9._-]+$", "minLength": 1 }
+      }
+    },
+    "authorityEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_id", "kind", "issuer"],
+      "properties": {
+        "evidence_id": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "enum": ["credential", "operator_grant", "registry_grant", "policy_record", "delegation_record", "model_claim"] },
+        "issuer": { "type": "string", "minLength": 1 }
+      }
+    },
+    "actorIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actor_id", "actor_kind", "authenticated", "authority_evidence"],
+      "properties": {
+        "actor_id": { "type": "string", "minLength": 1 },
+        "actor_kind": { "type": "string", "enum": ["human", "agent", "service", "operator"] },
+        "authenticated": { "const": true },
+        "authority_evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/authorityEvidence" },
+          "not": {
+            "contains": {
+              "type": "object",
+              "properties": { "kind": { "const": "model_claim" } },
+              "required": ["kind"]
+            }
+          }
+        }
+      }
+    },
+    "authorityGrant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["grant_id", "grantor_actor_id", "grantee_actor_id", "capability_id", "scope", "status"],
+      "properties": {
+        "grant_id": { "type": "string", "minLength": 1 },
+        "grantor_actor_id": { "type": "string", "minLength": 1 },
+        "grantee_actor_id": { "type": "string", "minLength": 1 },
+        "capability_id": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["active", "denied", "delegated", "revoked"] },
+        "revocation_reason": { "type": ["string", "null"] }
+      }
+    },
+    "roleStanding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "standing"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "standing": { "type": "string", "minLength": 1 }
+      }
+    },
+    "delegationStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["delegation_id", "grantor_actor_id", "delegate_actor_id", "grant_id", "depth"],
+      "properties": {
+        "delegation_id": { "type": "string", "minLength": 1 },
+        "grantor_actor_id": { "type": "string", "minLength": 1 },
+        "delegate_actor_id": { "type": "string", "minLength": 1 },
+        "grant_id": { "type": "string", "minLength": 1 },
+        "depth": { "type": "integer", "minimum": 1, "maximum": 8 }
+      }
+    },
+    "delegationConstraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_depth", "allow_redelegation"],
+      "properties": {
+        "max_depth": { "type": "integer", "minimum": 1, "maximum": 8 },
+        "allow_redelegation": { "type": "boolean" },
+        "scope_ceiling": { "type": ["string", "null"], "minLength": 1 }
+      }
+    },
+    "capabilityRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability_id", "side_effect_class", "resource_type", "resource_scope"],
+      "properties": {
+        "capability_id": { "type": "string", "minLength": 1 },
+        "side_effect_class": { "type": "string", "minLength": 1 },
+        "resource_type": { "type": "string", "minLength": 1 },
+        "resource_scope": { "type": "string", "minLength": 1 }
+      }
+    },
+    "policyCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_id", "decision", "evidence_ref"],
+      "properties": {
+        "policy_id": { "type": "string", "minLength": 1 },
+        "decision": { "$ref": "#/$defs/decision" },
+        "evidence_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "confirmationRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "confirmed_by_actor_id": { "type": ["string", "null"] },
+        "confirmation_id": { "type": ["string", "null"] }
+      }
+    },
+    "freedomGateRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "decision"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "decision": { "type": "string", "enum": ["not_required", "allowed", "denied", "deferred", "challenged", "escalated"] },
+        "event_id": { "type": ["string", "null"] }
+      }
+    },
+    "executionSemantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter_id", "environment", "dry_run", "approved_for_execution"],
+      "properties": {
+        "adapter_id": { "type": "string", "minLength": 1 },
+        "environment": { "type": "string", "minLength": 1 },
+        "dry_run": { "type": "boolean" },
+        "approved_for_execution": { "type": "boolean" }
+      }
+    },
+    "traceReplay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "replay_allowed", "replay_posture", "evidence_refs"],
+      "properties": {
+        "trace_id": { "type": "string", "minLength": 1 },
+        "replay_allowed": { "type": "boolean" },
+        "replay_posture": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "visibilityPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actor_view", "operator_view", "reviewer_view", "public_report_view", "observatory_projection"],
+      "properties": {
+        "actor_view": { "type": "string", "minLength": 1 },
+        "operator_view": { "type": "string", "minLength": 1 },
+        "reviewer_view": { "type": "string", "minLength": 1 },
+        "public_report_view": { "type": "string", "minLength": 1 },
+        "observatory_projection": { "type": "string", "minLength": 1 }
+      }
+    },
+    "visibilityMatrixEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audience", "level", "rationale"],
+      "properties": {
+        "audience": { "type": "string", "enum": ["actor", "operator", "reviewer", "public_report", "observatory_projection"] },
+        "level": { "type": "string", "enum": ["full", "redacted", "aggregate", "denied"] },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "redactionExample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["surface", "source_shape", "redacted_shape"],
+      "properties": {
+        "surface": { "type": "string", "enum": ["arguments", "results", "errors", "traces", "projections"] },
+        "source_shape": { "type": "string", "minLength": 1 },
+        "redacted_shape": { "type": "string", "minLength": 1 }
+      }
+    },
+    "tracePrivacyPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exposes_citizen_private_state", "protected_state_refs"],
+      "properties": {
+        "exposes_citizen_private_state": { "const": false },
+        "protected_state_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "privacyRedaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["data_sensitivity", "visibility", "redaction_rules", "visibility_matrix", "redaction_examples", "trace_privacy"],
+      "properties": {
+        "data_sensitivity": { "type": "string", "minLength": 1 },
+        "visibility": { "$ref": "#/$defs/visibilityPolicy" },
+        "redaction_rules": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "visibility_matrix": { "type": "array", "minItems": 5, "items": { "$ref": "#/$defs/visibilityMatrixEntry" } },
+        "redaction_examples": { "type": "array", "minItems": 5, "items": { "$ref": "#/$defs/redactionExample" } },
+        "trace_privacy": { "$ref": "#/$defs/tracePrivacyPolicy" }
+      }
+    },
+    "failurePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failure_code", "message", "retryable"],
+      "properties": {
+        "failure_code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "retryable": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json
+++ b/adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json
@@ -156,6 +156,7 @@
         "actor_kind": { "type": "string", "enum": ["human", "agent", "service", "operator"] },
         "authenticated": { "const": true },
         "authority_evidence": {
+          "description": "Reviewable authority evidence. `model_claim` is enumerated for diagnostic clarity but is not allowed to establish authority in valid ACC contracts.",
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/authorityEvidence" },
@@ -231,7 +232,10 @@
       "required": ["policy_id", "decision", "evidence_ref"],
       "properties": {
         "policy_id": { "type": "string", "minLength": 1 },
-        "decision": { "$ref": "#/$defs/decision" },
+        "decision": {
+          "description": "Coherence echo of the top-level ACC decision, recorded per policy check rather than serving as an independent policy-only decision vocabulary.",
+          "$ref": "#/$defs/decision"
+        },
         "evidence_ref": { "type": "string", "minLength": 1 }
       }
     },
@@ -282,11 +286,11 @@
       "additionalProperties": false,
       "required": ["actor_view", "operator_view", "reviewer_view", "public_report_view", "observatory_projection"],
       "properties": {
-        "actor_view": { "type": "string", "minLength": 1 },
-        "operator_view": { "type": "string", "minLength": 1 },
-        "reviewer_view": { "type": "string", "minLength": 1 },
-        "public_report_view": { "type": "string", "minLength": 1 },
-        "observatory_projection": { "type": "string", "minLength": 1 }
+        "actor_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what the actor may see; machine-actionable visibility levels live in `visibility_matrix`." },
+        "operator_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what the operator may see; machine-actionable visibility levels live in `visibility_matrix`." },
+        "reviewer_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what the reviewer may see; machine-actionable visibility levels live in `visibility_matrix`." },
+        "public_report_view": { "type": "string", "minLength": 1, "description": "Human-readable summary of what public reporting may expose; machine-actionable visibility levels live in `visibility_matrix`." },
+        "observatory_projection": { "type": "string", "minLength": 1, "description": "Human-readable summary of what observatory projections may expose; machine-actionable visibility levels live in `visibility_matrix`." }
       }
     },
     "visibilityMatrixEntry": {
@@ -314,7 +318,10 @@
       "additionalProperties": false,
       "required": ["exposes_citizen_private_state", "protected_state_refs"],
       "properties": {
-        "exposes_citizen_private_state": { "const": false },
+        "exposes_citizen_private_state": {
+          "const": false,
+          "description": "Positive compliance assertion. Valid ACC contracts must not expose citizen/private state through trace or replay surfaces."
+        },
         "protected_state_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
       }
     },

--- a/docs/specs/acc/ACC_V1.0_SPEC.md
+++ b/docs/specs/acc/ACC_V1.0_SPEC.md
@@ -1,0 +1,311 @@
+# ACC v1.0 Specification
+
+## Status
+
+Tracked formal baseline for the current implemented ADL Capability Contract
+surface.
+
+This document describes the canonical current `ACC v1.0` baseline as
+implemented in:
+
+- [`adl/src/acc.rs`](../../../adl/src/acc.rs)
+
+Matching machine-readable schema:
+
+- [`adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json`](../../../adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json)
+
+## 1. Purpose
+
+`ACC v1.0` captures the current implemented baseline without overclaiming the
+additive `v1.1` direction that requires later repo/code adoption.
+
+This spec/schema package is intentionally conservative:
+
+- it matches the current Rust `AdlCapabilityContractV1` shape and validator
+  shape
+- it remains JSON-compatible and machine-validatable
+- it keeps UTS/ACC separation explicit
+- it does not treat structural validity as automatic execution authority
+
+The machine-readable JSON Schema captures the current object model plus several
+first-order coherence constraints. The runtime validator in
+[`adl/src/acc.rs`](../../../adl/src/acc.rs) remains the normative source for
+deeper semantic checks such as:
+
+- known-evidence linkage for `policy_checks.evidence_ref`
+- delegated-chain attribution against the grantor / grantee pair
+- visibility-matrix audience coverage
+- fail-closed public/projection visibility posture
+- full redaction-surface coverage
+- private-state leakage rejection in trace and redaction examples
+
+## 2. Canonical Object Shape
+
+A canonical `ACC v1.0` object contains:
+
+- `schema_version`
+- `contract_id`
+- `tool`
+- `actor`
+- `authority_grant`
+- `role_standing`
+- `delegation_chain`
+- `capability`
+- `policy_checks`
+- `confirmation`
+- `freedom_gate`
+- `execution`
+- `trace_replay`
+- `privacy_redaction`
+- `failure_policy`
+- `decision`
+
+## 3. Required Runtime Semantics
+
+### Accountable actor
+
+ACC requires an authenticated accountable actor.
+
+- `actor.authenticated` must be `true`
+- `actor.authority_evidence` must be present and non-empty
+- authority must not be grounded in model self-assertion
+
+### Authority grant
+
+The authority grant must bind the actor to the same capability named by the
+contract.
+
+- `authority_grant.grantee_actor_id` must match `actor.actor_id`
+- `authority_grant.capability_id` must match `capability.capability_id`
+
+### Policy and decision coherence
+
+`policy_checks` are required and must agree with the top-level `decision`.
+
+Examples of invalid combinations:
+
+- top-level `allowed` with a denied policy check
+- top-level `revoked` with allowed policy checks
+
+### Decision and execution coherence
+
+Execution approval is not independent of the top-level decision.
+
+- `allowed` requires an active grant and `approved_for_execution: true`
+- `revoked` requires a revoked grant
+- `denied`, `delegated`, and `revoked` must not approve execution
+
+### Confirmation and Freedom Gate
+
+When confirmation or Freedom Gate mediation is required, the contract must
+carry that fact explicitly.
+
+- required confirmation must name both confirming actor and confirmation id
+- required Freedom Gate mediation must not leave the decision as
+  `not_required`
+
+### Replay and privacy
+
+Replay metadata must remain evidence-backed and privacy-aware.
+
+- `trace_replay.trace_id` is required
+- `trace_replay.evidence_refs` must be non-empty
+- visibility and redaction policy must be complete
+- private-state leakage through trace metadata is invalid
+
+## 4. Machine-Readable Boundary
+
+The matching JSON Schema is intended to be truthful about the implemented
+contract shape and about several high-value cross-field constraints:
+
+- authenticated actor requirement
+- non-model authority-evidence requirement
+- active-grant / revoked-grant coherence
+- execution-approval coherence
+- confirmation and Freedom Gate requirement gating
+
+It does not fully encode every semantic rule currently enforced by
+`validate_acc_v1`. Where exact runtime linkage matters, the runtime validator
+remains the stronger proving surface.
+
+## 5. Canonical JSON Example
+
+```json
+{
+  "schema_version": "acc.v1",
+  "contract_id": "acc.review.github.create_issue.1001",
+  "tool": {
+    "tool_name": "github.create_issue",
+    "tool_version": "1.0",
+    "registry_tool_id": "github.create_issue",
+    "adapter_id": "github.public"
+  },
+  "actor": {
+    "actor_id": "runtime.review_agent",
+    "actor_kind": "agent",
+    "authenticated": true,
+    "authority_evidence": [
+      {
+        "evidence_id": "credential.runtime.review_agent",
+        "kind": "credential",
+        "issuer": "adl.runtime"
+      },
+      {
+        "evidence_id": "grant.github.issue.operator.primary",
+        "kind": "operator_grant",
+        "issuer": "operator.primary"
+      }
+    ]
+  },
+  "authority_grant": {
+    "grant_id": "grant.github.issue.operator.primary",
+    "grantor_actor_id": "operator.primary",
+    "grantee_actor_id": "runtime.review_agent",
+    "capability_id": "github.create_issue",
+    "scope": "repo:issues.write",
+    "status": "active",
+    "revocation_reason": null
+  },
+  "role_standing": {
+    "role": "review_agent",
+    "standing": "service_actor"
+  },
+  "delegation_chain": [],
+  "capability": {
+    "capability_id": "github.create_issue",
+    "side_effect_class": "external_write",
+    "resource_type": "github_issue",
+    "resource_scope": "repo"
+  },
+  "policy_checks": [
+    {
+      "policy_id": "policy.github.issue.creation",
+      "decision": "allowed",
+      "evidence_ref": "grant.github.issue.operator.primary"
+    }
+  ],
+  "confirmation": {
+    "required": false,
+    "confirmed_by_actor_id": null,
+    "confirmation_id": null
+  },
+  "freedom_gate": {
+    "required": false,
+    "decision": "not_required",
+    "event_id": null
+  },
+  "execution": {
+    "adapter_id": "github.public",
+    "environment": "production",
+    "dry_run": false,
+    "approved_for_execution": true
+  },
+  "trace_replay": {
+    "trace_id": "trace.github.issue.1001",
+    "replay_allowed": false,
+    "replay_posture": "governance_sensitive",
+    "evidence_refs": [
+      "credential.runtime.review_agent",
+      "grant.github.issue.operator.primary"
+    ]
+  },
+  "privacy_redaction": {
+    "data_sensitivity": "internal",
+    "visibility": {
+      "actor_view": "full",
+      "operator_view": "full",
+      "reviewer_view": "redacted",
+      "public_report_view": "aggregate",
+      "observatory_projection": "aggregate"
+    },
+    "redaction_rules": [
+      "redact_tokens",
+      "redact_private_state",
+      "aggregate_public_reporting"
+    ],
+    "visibility_matrix": [
+      {
+        "audience": "actor",
+        "level": "full",
+        "rationale": "actor requires complete local execution context"
+      },
+      {
+        "audience": "operator",
+        "level": "full",
+        "rationale": "operator owns grant and remediation review"
+      },
+      {
+        "audience": "reviewer",
+        "level": "redacted",
+        "rationale": "reviewers see enough for governance verification"
+      },
+      {
+        "audience": "public_report",
+        "level": "aggregate",
+        "rationale": "public reporting must fail closed"
+      },
+      {
+        "audience": "observatory_projection",
+        "level": "aggregate",
+        "rationale": "observatory projection must avoid full trace leakage"
+      }
+    ],
+    "redaction_examples": [
+      {
+        "surface": "arguments",
+        "source_shape": "title=Fix issue body=token:abc123",
+        "redacted_shape": "title=Fix issue body=[REDACTED]"
+      },
+      {
+        "surface": "results",
+        "source_shape": "issue_url=https://github.com/org/repo/issues/10",
+        "redacted_shape": "issue_url=https://github.com/org/repo/issues/[ID]"
+      },
+      {
+        "surface": "errors",
+        "source_shape": "403 invalid token abc123",
+        "redacted_shape": "403 invalid token [REDACTED]"
+      },
+      {
+        "surface": "traces",
+        "source_shape": "trace github.create_issue operator.primary",
+        "redacted_shape": "trace github.create_issue [REDACTED]"
+      },
+      {
+        "surface": "projections",
+        "source_shape": "created issue for citizen.private.ticket",
+        "redacted_shape": "created issue for protected ticket"
+      }
+    ],
+    "trace_privacy": {
+      "exposes_citizen_private_state": false,
+      "protected_state_refs": [
+        "citizen.ticket",
+        "operator.secret"
+      ]
+    }
+  },
+  "failure_policy": {
+    "failure_code": "github_issue_denied",
+    "message": "deny with recorded governance evidence when authority is insufficient",
+    "retryable": false
+  },
+  "decision": "allowed"
+}
+```
+
+## 6. Non-Claims
+
+`ACC v1.0` does not claim:
+
+- universal governance semantics across providers or ecosystems
+- direct equivalence with UTS validity
+- that runtime orchestration policy can be replaced by schema alone
+- that replay permission can be inferred from replayability alone
+
+## 7. Summary
+
+`ACC v1.0` is the current implemented ADL governance baseline.
+
+It exists to make authority, standing, decision, execution, replay, and privacy
+posture explicit and reviewable around capability invocation.

--- a/docs/specs/acc/ACC_V1.0_SPEC.md
+++ b/docs/specs/acc/ACC_V1.0_SPEC.md
@@ -32,8 +32,11 @@ first-order coherence constraints. The runtime validator in
 [`adl/src/acc.rs`](../../../adl/src/acc.rs) remains the normative source for
 deeper semantic checks such as:
 
+- actor / grant / capability identity equality
 - known-evidence linkage for `policy_checks.evidence_ref`
 - delegated-chain attribution against the grantor / grantee pair
+- execution adapter equality against the declared tool adapter
+- top-level / policy-check decision equality
 - visibility-matrix audience coverage
 - fail-closed public/projection visibility posture
 - full redaction-surface coverage
@@ -127,6 +130,17 @@ contract shape and about several high-value cross-field constraints:
 It does not fully encode every semantic rule currently enforced by
 `validate_acc_v1`. Where exact runtime linkage matters, the runtime validator
 remains the stronger proving surface.
+
+This includes several invariants that a second implementation SHOULD carry
+forward explicitly:
+
+- `authority_grant.grantee_actor_id == actor.actor_id`
+- `authority_grant.capability_id == capability.capability_id`
+- `execution.adapter_id == tool.adapter_id`
+- every `policy_checks[].decision == decision`
+- every `policy_checks[].evidence_ref` resolves to known evidence, grant, or
+  delegation lineage
+- visibility, redaction, and trace privacy checks fail closed
 
 ## 5. Canonical JSON Example
 

--- a/docs/specs/acc/ACC_V1.1_SPEC.md
+++ b/docs/specs/acc/ACC_V1.1_SPEC.md
@@ -1,0 +1,403 @@
+# ACC v1.1 Specification
+
+## Status
+
+Tracked normative next-version specification for the ADL Capability Contract.
+
+Status note:
+
+> This document defines the `ACC v1.1` adoption target.
+> The current implemented runtime baseline remains `ACC v1.0` until follow-on
+> code adoption lands.
+
+Matching machine-readable schema:
+
+- [`adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json`](../../../adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json)
+
+Implementation-facing baseline reference:
+
+- [`adl/src/acc.rs`](../../../adl/src/acc.rs)
+- [`ACC_V1.0_SPEC.md`](./ACC_V1.0_SPEC.md)
+
+## Normative Language
+
+The key words:
+
+- MUST
+- MUST NOT
+- REQUIRED
+- SHALL
+- SHALL NOT
+- SHOULD
+- SHOULD NOT
+- RECOMMENDED
+- MAY
+- OPTIONAL
+
+are to be interpreted as described in RFC 2119.
+
+## 1. Purpose
+
+This document defines the normative machine-readable structure for `ACC v1.1`
+as an evolutionary successor to the current implemented `ACC v1.0` baseline.
+
+`ACC v1.1` preserves the current governance model while tightening explicit
+versioning and delegation semantics.
+
+## 2. Evolution From ACC v1.0
+
+`ACC v1.1` is evolutionary, not a redesign.
+
+It preserves the current field families:
+
+- `schema_version`
+- `contract_id`
+- `tool`
+- `actor`
+- `authority_grant`
+- `role_standing`
+- `delegation_chain`
+- `capability`
+- `policy_checks`
+- `confirmation`
+- `freedom_gate`
+- `execution`
+- `trace_replay`
+- `privacy_redaction`
+- `failure_policy`
+- `decision`
+
+It adds only bounded new metadata:
+
+- `compatible_versions`
+- `governance_profile`
+- `delegation_constraints`
+
+`ACC v1.1` does not replace the anti-self-assertion model, the active-grant
+requirement, or the execution / replay / privacy separation already present in
+`ACC v1.0`.
+
+## 3. Core Design Rules
+
+ACC remains the ADL-specific runtime governance layer.
+
+ACC metadata MUST NOT be treated as equivalent to:
+
+- UTS validity
+- model preference
+- prompt content
+- self-asserted authority
+
+Authority MUST originate from reviewable runtime evidence such as:
+
+- credentials
+- operator grants
+- registry grants
+- policy records
+- delegation records
+
+`model_claim` MUST NOT establish authority in `ACC v1.1`.
+
+Standing semantics remain runtime-defined.
+
+`ACC v1.1` preserves standing-bearing fields and governance consequences
+without claiming one universal cross-runtime standing taxonomy.
+
+## 4. Additive Fields
+
+### `compatible_versions`
+
+Optional list of ACC versions that a runtime may parse as compatible.
+
+Example:
+
+```yaml
+compatible_versions:
+  - acc.v1
+  - acc.v1.1
+```
+
+This is version-negotiation metadata. It does not weaken runtime validation.
+
+### `governance_profile`
+
+Optional token naming the runtime governance profile expected by the contract.
+
+Examples:
+
+- `standard_reviewed_runtime`
+- `high_observability_runtime`
+- `restricted_external_mutation`
+
+This field is descriptive and routing-oriented. It does not replace the
+contract's explicit decision, execution, replay, or privacy fields.
+
+### `delegation_constraints`
+
+Optional additive delegation guardrails.
+
+Fields:
+
+- `max_depth`
+- `allow_redelegation`
+- `scope_ceiling`
+
+These constraints narrow delegated authority; they do not expand it.
+
+## 5. ACC-Lite Compatibility
+
+Some runtimes may adopt `ACC v1.1` incrementally.
+
+An `ACC-Lite` integration may focus operationally on a subset such as:
+
+- accountable actor identity
+- authority grant
+- top-level decision
+- execution approval posture
+- replay posture
+- observability / privacy posture
+
+This does not define a separate wire contract.
+
+It means a runtime may begin by enforcing the most important governance fields
+first while still targeting the canonical `ACC v1.1` schema and semantics.
+
+## 6. Canonical Minimal ACC Object
+
+Minimal `ACC v1.1` example:
+
+```yaml
+schema_version: acc.v1.1
+contract_id: acc.basic.1001
+compatible_versions:
+  - acc.v1
+  - acc.v1.1
+governance_profile: standard_reviewed_runtime
+
+tool:
+  tool_name: filesystem.search
+  tool_version: "1.0"
+  registry_tool_id: filesystem.search
+  adapter_id: local.filesystem
+
+actor:
+  actor_id: runtime.review_agent
+  actor_kind: agent
+  authenticated: true
+  authority_evidence:
+    - evidence_id: credential.runtime.review_agent
+      kind: credential
+      issuer: adl.runtime
+
+authority_grant:
+  grant_id: grant.readonly.1001
+  grantor_actor_id: operator.primary
+  grantee_actor_id: runtime.review_agent
+  capability_id: filesystem.search.read
+  scope: local-readonly
+  status: active
+
+role_standing:
+  role: review_agent
+  standing: service_actor
+
+delegation_chain: []
+
+capability:
+  capability_id: filesystem.search.read
+  side_effect_class: read
+  resource_type: filesystem
+  resource_scope: local
+
+policy_checks:
+  - policy_id: policy.local.readonly
+    decision: allowed
+    evidence_ref: grant.readonly.1001
+
+confirmation:
+  required: false
+  confirmed_by_actor_id: null
+  confirmation_id: null
+
+freedom_gate:
+  required: false
+  decision: not_required
+  event_id: null
+
+execution:
+  adapter_id: local.filesystem
+  environment: local
+  dry_run: false
+  approved_for_execution: true
+
+trace_replay:
+  trace_id: trace.local.readonly.1001
+  replay_allowed: true
+  replay_posture: reviewable
+  evidence_refs:
+    - credential.runtime.review_agent
+    - grant.readonly.1001
+
+privacy_redaction:
+  data_sensitivity: internal
+  visibility:
+    actor_view: full
+    operator_view: full
+    reviewer_view: redacted
+    public_report_view: aggregate
+    observatory_projection: aggregate
+  redaction_rules:
+    - redact_private_state
+  visibility_matrix:
+    - audience: actor
+      level: full
+      rationale: actor requires full local context
+    - audience: operator
+      level: full
+      rationale: operator owns authority review
+    - audience: reviewer
+      level: redacted
+      rationale: reviewer sees review-safe trace surfaces
+    - audience: public_report
+      level: aggregate
+      rationale: public report must fail closed
+    - audience: observatory_projection
+      level: aggregate
+      rationale: projection must avoid full trace disclosure
+  redaction_examples:
+    - surface: arguments
+      source_shape: path=/srv/secret.txt
+      redacted_shape: path=/srv/[REDACTED]
+    - surface: results
+      source_shape: content=secret
+      redacted_shape: content=[REDACTED]
+    - surface: errors
+      source_shape: permission denied for secret path
+      redacted_shape: permission denied for protected path
+    - surface: traces
+      source_shape: trace local secret path
+      redacted_shape: trace local protected path
+    - surface: projections
+      source_shape: projected citizen.private.record
+      redacted_shape: projected protected record
+  trace_privacy:
+    exposes_citizen_private_state: false
+    protected_state_refs:
+      - protected.record
+
+failure_policy:
+  failure_code: readonly_access_denied
+  message: deny execution when authority or standing is insufficient
+  retryable: false
+
+decision: allowed
+```
+
+## 7. Authority Scope Semantics
+
+The contract continues to express effective authority through the combination
+of:
+
+- `authority_grant.scope`
+- `capability.capability_id`
+- `capability.resource_type`
+- `capability.resource_scope`
+- `decision`
+- optional `delegation_constraints`
+
+`ACC v1.1` does not introduce a separate authority-shape object because the
+current model already makes authority reviewable through these fields.
+
+A runtime SHOULD interpret authority scope conservatively:
+
+- grants bound the ceiling of what may happen
+- capability metadata narrows what the invocation is actually attempting
+- delegation constraints can narrow the ceiling further
+- execution approval must not widen any of the above
+
+## 8. Governance Consistency Requirements
+
+Governance state MUST remain internally coherent.
+
+An ACC object MUST NOT simultaneously represent:
+
+- revoked authority and approved execution
+- denied governance review and approved execution
+- missing confirmation and confirmed execution when confirmation is required
+- required Freedom Gate mediation with a `not_required` decision
+
+Runtime validation SHOULD reject contradictory governance states.
+
+## 9. Delegation Constraints
+
+When present, `delegation_constraints` further narrow delegated execution.
+
+### `max_depth`
+
+- positive integer
+- MUST NOT exceed the runtime's supported delegation ceiling
+- SHOULD be greater than or equal to the maximum observed depth in
+  `delegation_chain`
+
+### `allow_redelegation`
+
+- boolean
+- `false` means the delegated actor may not create a further delegated contract
+
+### `scope_ceiling`
+
+- string token naming the maximum delegated scope that remains valid
+
+Delegated authority MUST NOT exceed:
+
+- the grant expressed in `authority_grant`
+- the resource boundaries in `capability`
+- standing restrictions
+- replay restrictions
+- explicit `delegation_constraints`
+
+## 10. Approval, Replay, And Freedom Gate Semantics
+
+`ACC v1.1` keeps these decisions inside the contract rather than pushing them
+into undefined external records.
+
+The contract itself carries:
+
+- execution approval posture in `execution.approved_for_execution`
+- replay posture in `trace_replay`
+- Freedom Gate mediation in `freedom_gate`
+- confirmation requirements in `confirmation`
+
+Runtimes MAY still emit companion trace or audit records, but those records are
+supplemental evidence rather than the primary contract surface.
+
+## 11. Machine-Readable Boundary
+
+The matching `ACC v1.1` JSON Schema is intended to remain evolutionary over the
+current `ACC v1.0` runtime contract.
+
+It captures:
+
+- the preserved field families from `ACC v1.0`
+- additive `compatible_versions`, `governance_profile`, and
+  `delegation_constraints`
+- key first-order coherence rules for decision, grant status, execution,
+  confirmation, and Freedom Gate semantics
+
+It does not yet encode every deeper runtime semantic already enforced by the
+current validator, such as exact evidence-reference linkage or full privacy
+coverage analysis. Those remain runtime-validator responsibilities unless and
+until a later schema/tooling pass encodes them more completely.
+
+Observability metadata in ACC describes governance visibility posture. It does
+not imply centralized logging, centralized monitoring, or centralized
+orchestration.
+
+## 12. Summary
+
+`ACC v1.1` is the next ADL governance target, built directly on the existing
+`ACC v1.0` model.
+
+It stays evolutionary by preserving the current contract shape and validator
+logic while adding explicit compatibility, governance-profile, and delegation
+constraint metadata.

--- a/docs/specs/acc/ACC_V1.1_SPEC.md
+++ b/docs/specs/acc/ACC_V1.1_SPEC.md
@@ -162,6 +162,9 @@ This does not define a separate wire contract.
 It means a runtime may begin by enforcing the most important governance fields
 first while still targeting the canonical `ACC v1.1` schema and semantics.
 
+`ACC-Lite` is therefore a runtime adoption profile, not a distinct schema
+variant.
+
 ## 6. Canonical Minimal ACC Object
 
 Minimal `ACC v1.1` adoption-target example:
@@ -169,131 +172,165 @@ Minimal `ACC v1.1` adoption-target example:
 This is the canonical next-version fixture for schema and docs review.
 It is not a current runtime fixture until follow-on code adoption lands.
 
-```yaml
-schema_version: acc.v1.1
-contract_id: acc.basic.1001
-compatible_versions:
-  - acc.v1
-  - acc.v1.1
-governance_profile: standard_reviewed_runtime
-
-tool:
-  tool_name: filesystem.search
-  tool_version: "1.0"
-  registry_tool_id: filesystem.search
-  adapter_id: local.filesystem
-
-actor:
-  actor_id: runtime.review_agent
-  actor_kind: agent
-  authenticated: true
-  authority_evidence:
-    - evidence_id: credential.runtime.review_agent
-      kind: credential
-      issuer: adl.runtime
-
-authority_grant:
-  grant_id: grant.readonly.1001
-  grantor_actor_id: operator.primary
-  grantee_actor_id: runtime.review_agent
-  capability_id: filesystem.search.read
-  scope: local-readonly
-  status: active
-
-role_standing:
-  role: review_agent
-  standing: service_actor
-
-delegation_chain: []
-
-capability:
-  capability_id: filesystem.search.read
-  side_effect_class: read
-  resource_type: filesystem
-  resource_scope: local
-
-policy_checks:
-  - policy_id: policy.local.readonly
-    decision: allowed
-    evidence_ref: grant.readonly.1001
-
-confirmation:
-  required: false
-  confirmed_by_actor_id: null
-  confirmation_id: null
-
-freedom_gate:
-  required: false
-  decision: not_required
-  event_id: null
-
-execution:
-  adapter_id: local.filesystem
-  environment: local
-  dry_run: false
-  approved_for_execution: true
-
-trace_replay:
-  trace_id: trace.local.readonly.1001
-  replay_allowed: true
-  replay_posture: reviewable
-  evidence_refs:
-    - credential.runtime.review_agent
-    - grant.readonly.1001
-
-privacy_redaction:
-  data_sensitivity: internal
-  visibility:
-    actor_view: full
-    operator_view: full
-    reviewer_view: redacted
-    public_report_view: aggregate
-    observatory_projection: aggregate
-  redaction_rules:
-    - redact_private_state
-  visibility_matrix:
-    - audience: actor
-      level: full
-      rationale: actor requires full local context
-    - audience: operator
-      level: full
-      rationale: operator owns authority review
-    - audience: reviewer
-      level: redacted
-      rationale: reviewer sees review-safe trace surfaces
-    - audience: public_report
-      level: aggregate
-      rationale: public report must fail closed
-    - audience: observatory_projection
-      level: aggregate
-      rationale: projection must avoid full trace disclosure
-  redaction_examples:
-    - surface: arguments
-      source_shape: path=/srv/secret.txt
-      redacted_shape: path=/srv/[REDACTED]
-    - surface: results
-      source_shape: content=secret
-      redacted_shape: content=[REDACTED]
-    - surface: errors
-      source_shape: permission denied for secret path
-      redacted_shape: permission denied for protected path
-    - surface: traces
-      source_shape: trace local secret path
-      redacted_shape: trace local protected path
-    - surface: projections
-      source_shape: projected citizen.private.record
-      redacted_shape: projected protected record
-  trace_privacy:
-    exposes_citizen_private_state: false
-    protected_state_refs:
-      - protected.record
-
-failure_policy:
-  failure_code: readonly_access_denied
-  message: deny execution when authority or standing is insufficient
-  retryable: false
-
-decision: allowed
+```json
+{
+  "schema_version": "acc.v1.1",
+  "contract_id": "acc.basic.1001",
+  "compatible_versions": [
+    "acc.v1",
+    "acc.v1.1"
+  ],
+  "governance_profile": "standard_reviewed_runtime",
+  "tool": {
+    "tool_name": "filesystem.search",
+    "tool_version": "1.0",
+    "registry_tool_id": "filesystem.search",
+    "adapter_id": "local.filesystem"
+  },
+  "actor": {
+    "actor_id": "runtime.review_agent",
+    "actor_kind": "agent",
+    "authenticated": true,
+    "authority_evidence": [
+      {
+        "evidence_id": "credential.runtime.review_agent",
+        "kind": "credential",
+        "issuer": "adl.runtime"
+      }
+    ]
+  },
+  "authority_grant": {
+    "grant_id": "grant.readonly.1001",
+    "grantor_actor_id": "operator.primary",
+    "grantee_actor_id": "runtime.review_agent",
+    "capability_id": "filesystem.search.read",
+    "scope": "local-readonly",
+    "status": "active",
+    "revocation_reason": null
+  },
+  "role_standing": {
+    "role": "review_agent",
+    "standing": "service_actor"
+  },
+  "delegation_chain": [],
+  "capability": {
+    "capability_id": "filesystem.search.read",
+    "side_effect_class": "read",
+    "resource_type": "filesystem",
+    "resource_scope": "local"
+  },
+  "policy_checks": [
+    {
+      "policy_id": "policy.local.readonly",
+      "decision": "allowed",
+      "evidence_ref": "grant.readonly.1001"
+    }
+  ],
+  "confirmation": {
+    "required": false,
+    "confirmed_by_actor_id": null,
+    "confirmation_id": null
+  },
+  "freedom_gate": {
+    "required": false,
+    "decision": "not_required",
+    "event_id": null
+  },
+  "execution": {
+    "adapter_id": "local.filesystem",
+    "environment": "local",
+    "dry_run": false,
+    "approved_for_execution": true
+  },
+  "trace_replay": {
+    "trace_id": "trace.local.readonly.1001",
+    "replay_allowed": true,
+    "replay_posture": "reviewable",
+    "evidence_refs": [
+      "credential.runtime.review_agent",
+      "grant.readonly.1001"
+    ]
+  },
+  "privacy_redaction": {
+    "data_sensitivity": "internal",
+    "visibility": {
+      "actor_view": "full",
+      "operator_view": "full",
+      "reviewer_view": "redacted",
+      "public_report_view": "aggregate",
+      "observatory_projection": "aggregate"
+    },
+    "redaction_rules": [
+      "redact_private_state"
+    ],
+    "visibility_matrix": [
+      {
+        "audience": "actor",
+        "level": "full",
+        "rationale": "actor requires full local context"
+      },
+      {
+        "audience": "operator",
+        "level": "full",
+        "rationale": "operator owns authority review"
+      },
+      {
+        "audience": "reviewer",
+        "level": "redacted",
+        "rationale": "reviewer sees review-safe trace surfaces"
+      },
+      {
+        "audience": "public_report",
+        "level": "aggregate",
+        "rationale": "public report must fail closed"
+      },
+      {
+        "audience": "observatory_projection",
+        "level": "aggregate",
+        "rationale": "projection must avoid full trace disclosure"
+      }
+    ],
+    "redaction_examples": [
+      {
+        "surface": "arguments",
+        "source_shape": "path=/srv/secret.txt",
+        "redacted_shape": "path=/srv/[REDACTED]"
+      },
+      {
+        "surface": "results",
+        "source_shape": "content=secret",
+        "redacted_shape": "content=[REDACTED]"
+      },
+      {
+        "surface": "errors",
+        "source_shape": "permission denied for secret path",
+        "redacted_shape": "permission denied for protected path"
+      },
+      {
+        "surface": "traces",
+        "source_shape": "trace local secret path",
+        "redacted_shape": "trace local protected path"
+      },
+      {
+        "surface": "projections",
+        "source_shape": "projected citizen.private.record",
+        "redacted_shape": "projected protected record"
+      }
+    ],
+    "trace_privacy": {
+      "exposes_citizen_private_state": false,
+      "protected_state_refs": [
+        "protected.record"
+      ]
+    }
+  },
+  "failure_policy": {
+    "failure_code": "readonly_access_denied",
+    "message": "deny execution when authority or standing is insufficient",
+    "retryable": false
+  },
+  "decision": "allowed"
+}
 ```
 
 ## 7. Authority Scope Semantics
@@ -330,6 +367,12 @@ An ACC object MUST NOT simultaneously represent:
 - required Freedom Gate mediation with a `not_required` decision
 
 Runtime validation SHOULD reject contradictory governance states.
+
+`policy_checks[].decision` intentionally reuses the top-level decision enum as
+a coherence echo rather than an independent policy-only decision vocabulary.
+
+In other words, policy checks in `ACC v1.1` are recorded as reviewable evidence
+that the final governance decision was consistently applied.
 
 ## 9. Delegation Constraints
 
@@ -388,9 +431,51 @@ It captures:
   confirmation, and Freedom Gate semantics
 
 It does not yet encode every deeper runtime semantic already enforced by the
-current validator, such as exact evidence-reference linkage or full privacy
-coverage analysis. Those remain runtime-validator responsibilities unless and
+current validator. Those remain runtime-validator responsibilities unless and
 until a later schema/tooling pass encodes them more completely.
+
+### Validator-only invariants that still govern `ACC v1.1`
+
+Implementations targeting `ACC v1.1` SHOULD enforce the following invariants in
+addition to JSON Schema validation:
+
+- `authority_grant.grantee_actor_id` MUST equal `actor.actor_id`
+- `authority_grant.capability_id` MUST equal `capability.capability_id`
+- allowed decisions MUST carry an active grant
+- revoked decisions MUST carry a revoked grant
+- delegated grants MUST carry a delegation chain
+- delegated chains MUST bind the authority grant's grantor/grantee pair
+- every `policy_checks[].decision` MUST equal the top-level `decision`
+- every `policy_checks[].evidence_ref` MUST resolve to known actor evidence,
+  the authority grant, or a delegation record
+- required confirmations MUST carry both confirming actor and confirmation id
+- required Freedom Gate mediation MUST not leave the decision at
+  `not_required`
+- `execution.adapter_id` MUST equal `tool.adapter_id`
+- non-allowed decisions MUST NOT approve execution
+- `trace_replay.trace_id` and `trace_replay.evidence_refs` MUST be present
+- visibility policy MUST be complete before execution
+- visibility matrix MUST cover all required audiences and fail closed for
+  `public_report` and `observatory_projection`
+- redaction examples MUST cover arguments, results, errors, traces, and
+  projections
+- redacted examples, trace metadata, and replay metadata MUST NOT leak
+  citizen/private-state markers
+
+The JSON Schema is therefore a structural contract plus first-order coherence
+checks, while the runtime validator remains the stronger proving surface for
+equality, linkage, attribution, and privacy invariants.
+
+### Validator-backed privacy assertions
+
+Two schema surfaces are intentionally stricter than generic booleans or free
+claims might suggest:
+
+- `actor.authority_evidence` enumerates `model_claim` so runtimes can emit
+  precise diagnostics, but `model_claim` MUST NOT establish authority
+- `trace_privacy.exposes_citizen_private_state` is fixed at `false` as a
+  positive compliance assertion; contracts that would expose citizen private
+  state are invalid rather than merely risky
 
 Observability metadata in ACC describes governance visibility posture. It does
 not imply centralized logging, centralized monitoring, or centralized

--- a/docs/specs/acc/ACC_V1.1_SPEC.md
+++ b/docs/specs/acc/ACC_V1.1_SPEC.md
@@ -164,7 +164,10 @@ first while still targeting the canonical `ACC v1.1` schema and semantics.
 
 ## 6. Canonical Minimal ACC Object
 
-Minimal `ACC v1.1` example:
+Minimal `ACC v1.1` adoption-target example:
+
+This is the canonical next-version fixture for schema and docs review.
+It is not a current runtime fixture until follow-on code adoption lands.
 
 ```yaml
 schema_version: acc.v1.1

--- a/docs/specs/acc/ADL_ACC_SPECIFICATION.md
+++ b/docs/specs/acc/ADL_ACC_SPECIFICATION.md
@@ -1,0 +1,787 @@
+# ADL Capability Contract (ACC)
+
+## Status
+Cross-version narrative companion specification for the ADL Capability
+Contract.
+
+This document explains the ACC model across the current implemented `ACC v1.0`
+baseline and the tracked `ACC v1.1` target.
+
+For normative version-specific requirements:
+
+- use [`ACC_V1.0_SPEC.md`](./ACC_V1.0_SPEC.md) for the current baseline
+- use [`ACC_V1.1_SPEC.md`](./ACC_V1.1_SPEC.md) for the next-version target
+
+## Scope
+
+ACC standardizes:
+- runtime capability governance semantics
+- authority metadata
+- standing-aware invocation
+- replay governance semantics
+- observability posture
+- delegation semantics
+- continuity-aware capability execution
+
+ACC does NOT standardize:
+- universal political governance
+- provider-specific runtime implementations
+- orchestration topology
+- transport protocols
+- model cognition
+- universal identity systems
+
+ACC is intentionally scoped to governance-aware runtimes.
+
+---
+
+## Internal Positioning
+
+ACC is the authoritative runtime governance layer for ADL-compatible runtimes.
+
+This document is not the version-specific normative winner in case of conflict;
+the versioned `ACC_V1.0_SPEC.md` and `ACC_V1.1_SPEC.md` documents govern their
+respective contract surfaces.
+
+All new ADL runtime governance work SHOULD target ACC semantics.
+
+ACC intentionally assumes:
+- governance-aware runtimes
+- replay-aware infrastructure
+- observability-aware orchestration
+- bounded capability execution
+- continuity-aware execution
+
+Future ACC revisions SHOULD remain backward-compatible where feasible.
+
+---
+
+## Normative Language
+
+The key words:
+- MUST
+- MUST NOT
+- REQUIRED
+- SHALL
+- SHALL NOT
+- SHOULD
+- SHOULD NOT
+- RECOMMENDED
+- MAY
+- OPTIONAL
+
+are to be interpreted as described in RFC 2119.
+
+---
+
+# 1. Purpose
+
+The ADL Capability Contract (ACC) defines the runtime governance and authority layer surrounding capability invocation inside ADL.
+
+ACC exists to answer questions that are intentionally outside the scope of UTS:
+
+- Who may invoke a capability?
+- Under what standing?
+- Under what authority?
+- Under what observability posture?
+- Under what replay conditions?
+- Under what review requirements?
+- Under what continuity constraints?
+
+ACC transforms capability invocation from:
+
+> raw function execution
+
+into:
+
+> governed capability exercise inside cognitive spacetime.
+
+ACC is intentionally more opinionated and runtime-aware than UTS.
+
+The specification prioritizes:
+- explicit authority
+- bounded execution
+- attributable invocation
+- replay-aware governance
+- inspectable delegation
+- continuity-aware execution
+
+ACC is intentionally ADL-runtime-oriented and is not currently proposed as a general ecosystem standard.
+
+The specification assumes:
+- continuity-aware runtimes
+- explicit observability systems
+- runtime trace infrastructure
+- bounded capability execution
+- governance-aware orchestration
+
+---
+
+# 2. Relationship To UTS
+
+UTS defines:
+
+> what a capability is.
+
+ACC defines:
+
+> who may exercise that capability, under what conditions, and with what governance constraints.
+
+UTS intentionally remains:
+- provider-neutral
+- transport-neutral
+- runtime-neutral
+
+ACC is intentionally:
+- ADL-runtime-aware
+- governance-aware
+- standing-aware
+- continuity-aware
+- observability-aware
+
+UTS validity does not imply:
+- authority
+- approval
+- execution permission
+- replay permission
+
+Those concerns are handled by ACC and associated runtime governance systems.
+
+ACC metadata alone MUST NOT imply:
+- execution approval
+- runtime authorization
+- replay authorization
+- policy override
+- standing elevation
+
+---
+
+# 3. Design Principles
+
+## Capability Before Invocation
+
+Capabilities are granted before they are exercised.
+
+A model or agent SHOULD NOT possess arbitrary unrestricted tool access.
+
+Instead:
+- authority is explicit
+- invocation is bounded
+- standing is evaluated
+- review posture is visible
+- side effects are inspectable
+
+---
+
+## Least-Authority Execution
+
+ACC SHOULD enforce least-authority execution.
+
+Invocation authority SHOULD be:
+- minimal
+- bounded
+- attributable
+- reviewable
+- revocable
+
+---
+
+## Governance Separation
+
+ACC intentionally separates:
+
+- capability description (UTS)
+- authority
+- approval
+- runtime governance
+- continuity-bearing execution
+
+This separation is foundational.
+
+---
+
+## Runtime Governance Boundary
+
+ACC intentionally separates:
+- capability description
+- capability governance
+- runtime approval
+- replay authorization
+- orchestration logic
+- runtime policy
+
+Authority MUST originate from:
+- runtime policy
+- standing validation
+- governance review
+- explicit capability grants
+- lawful delegation lineage
+
+Authority MUST NOT originate solely from:
+- model self-assertion
+- implicit prompt semantics
+- undeclared delegation
+
+---
+
+# 4. Core ACC Object
+
+A canonical ACC object SHOULD include:
+
+- contract identifier
+- version
+- capability reference
+- invoking identity
+- standing requirements
+- authority scope
+- invocation modes
+- observability posture
+- replay posture
+- review requirements
+- escalation semantics
+- refusal semantics
+- delegation policy
+- continuity requirements
+- retention policy
+- runtime constraints
+- governance consistency metadata
+
+---
+
+## Canonical Minimal ACC Object
+
+A minimal ACC object may look like:
+
+```yaml
+contract_id: acc-basic-1001
+version: 1.1
+
+capability:
+  filesystem.search
+
+authority_scope:
+  - read_only
+```
+
+This minimal structure is sufficient for:
+- lightweight governance integration
+- authority classification
+- standing-aware execution
+- runtime validation
+
+Advanced implementations may add:
+- replay posture
+- observability posture
+- delegation metadata
+- review requirements
+- continuity requirements
+
+---
+
+## ACC-Lite Compatibility
+
+A minimal ACC integration MAY support only:
+
+- capability reference
+- authority scope
+- replay posture
+- observability posture
+
+This profile is intended for:
+- incremental runtime adoption
+- lightweight governance integration
+- compatibility layers
+
+Advanced runtimes MAY additionally support:
+- delegation lineage
+- continuity-aware replay
+- governance routing
+- standing-aware execution
+
+---
+
+# 5. Standing Model
+
+ACC assumes invocation rights depend on standing.
+
+Example standing categories:
+
+- citizen
+- guest
+- service_actor
+- operator
+- governance_actor
+- external_counterparty
+- quarantined
+
+Standing may affect:
+- invocation eligibility
+- observability posture
+- replay posture
+- delegation ability
+- review requirements
+- escalation semantics
+
+Standing models MAY differ across runtimes.
+
+Standing semantics are intentionally runtime-specific and non-portable.
+
+---
+
+## Standing Semantics
+
+Standing is runtime-defined.
+
+ACC does not define universal standing policy.
+
+Instead, ACC provides metadata allowing runtimes to:
+- classify invocation eligibility
+- separate capability classes
+- enforce governance boundaries
+- route review-sensitive operations differently
+
+Standing models MAY differ across runtimes.
+
+---
+
+# 6. Invocation Modes
+
+ACC SHOULD support explicit invocation modes.
+
+Suggested modes:
+
+- direct_invocation
+- delegated_invocation
+- review_only
+- planning_only
+- simulation_only
+- governance_mediated
+
+Different invocation modes may imply different:
+- authority boundaries
+- review requirements
+- observability requirements
+- replay posture
+- escalation rules
+
+---
+
+## Invocation Intent
+
+ACC invocation MAY include explicit invocation intent.
+
+Suggested intents:
+- informational_query
+- planning
+- simulation
+- review
+- mutation
+- governance_action
+- remediation
+
+Intent metadata is intended to improve:
+- reviewability
+- planning-aware execution
+- operational debugging
+- governance routing
+- replay interpretation
+
+Intent metadata is descriptive governance metadata only.
+
+Intent metadata MUST NOT imply:
+- execution approval
+- authority
+- replay authorization
+- runtime permission
+
+---
+
+# 7. Authority Scope
+
+Authority scope SHOULD be explicit.
+
+Example scope categories:
+
+- read_only
+- local_mutation
+- external_mutation
+- governance_sensitive
+- continuity_sensitive
+- identity_sensitive
+
+Authority scope SHOULD remain:
+- inspectable
+- attributable
+- reviewable
+- bounded
+
+## Governance-Sensitive Definition
+
+Within ACC, `governance_sensitive` refers to capability exercise requiring elevated:
+- review posture
+- trace retention
+- policy evaluation
+- observability
+or
+- runtime authorization.
+
+---
+
+## Governance Consistency Requirements
+
+Governance state MUST remain internally coherent.
+
+An ACC object MUST NOT simultaneously represent:
+- revoked authority and approved execution
+- denied governance review and approved execution
+- denied replay authorization and replay execution approval
+- quarantined standing and unrestricted execution authority
+
+Runtime validation SHOULD reject contradictory governance states.
+
+---
+
+# 8. Review And Observability
+
+ACC integrates with:
+- review systems
+- observability systems
+- replay systems
+- governance systems
+
+Observability posture MAY include:
+
+- none
+- basic
+- full
+- governance
+
+Observability posture is descriptive governance metadata.
+
+Observability metadata does NOT require:
+- centralized logging
+- centralized monitoring
+- centralized storage
+- centralized orchestration
+
+Governance-sensitive invocation MAY require:
+- elevated observability
+- review workflows
+- explicit runtime approval
+- trace retention
+
+---
+
+# 9. Replay Semantics
+
+Replay posture MAY include:
+
+- deterministic
+- observational
+- non_replayable
+
+ACC does not guarantee replayability.
+
+Instead, ACC provides governance metadata surrounding replay posture and replay authorization.
+
+Replay authorization remains a runtime governance concern.
+
+---
+
+## Replay Governance Constraints
+
+Replayability metadata exists to support:
+- replay analysis
+- observability
+- governance review
+- planning-aware execution
+- operational debugging
+
+Replay execution MUST NOT occur solely because replayability metadata exists.
+
+Replay authorization MAY depend on:
+- standing
+- observability posture
+- runtime policy
+- governance review
+- continuity requirements
+- retention policy
+
+---
+
+# 10. Delegation
+
+Delegation SHOULD remain explicit.
+
+Delegated invocation SHOULD preserve:
+- attribution
+- authority lineage
+- standing constraints
+- observability posture
+- replay posture
+
+Delegation SHOULD NOT silently escalate authority.
+
+Delegated authority MUST NOT exceed:
+- the delegator's authority scope
+- runtime policy limits
+- standing restrictions
+- replay restrictions
+
+---
+
+## Delegation Constraints
+
+Delegation SHOULD remain:
+- explicit
+- bounded
+- attributable
+- reviewable
+
+Delegation SHOULD NOT:
+- silently broaden authority
+- bypass runtime review
+- bypass observability requirements
+- bypass replay restrictions
+
+Delegation chains SHOULD remain traceable.
+
+---
+
+# 11. Refusal And Escalation
+
+ACC SHOULD support explicit refusal semantics.
+
+Refusal reasons MAY include:
+
+- insufficient authority
+- insufficient standing
+- governance restriction
+- replay restriction
+- observability restriction
+- runtime policy restriction
+- safety concerns
+- unavailable capability
+
+Escalation SHOULD remain traceable.
+
+---
+
+# 12. Planning Integration
+
+ACC integrates with:
+- SIP
+- STP
+- SPP
+- SRP
+- Freedom Gate review
+
+Canonical execution flow:
+
+1. STP received
+2. SPP generated
+3. Runtime governance review
+4. ACC authority validation
+5. Invocation
+6. Trace + observability recording
+7. SRP generation
+8. Review
+
+Planning metadata is advisory runtime metadata.
+
+Planning metadata MUST NOT imply:
+- execution approval
+- runtime authorization
+- governance approval
+- replay authorization
+
+Execution approval MUST remain a separate runtime governance decision.
+
+---
+
+# 13. Runtime Constraints
+
+ACC capability enforcement MUST NOT rely solely on prompts.
+
+Enforcement SHOULD occur through:
+- runtime controls
+- authority checks
+- tool isolation
+- policy enforcement
+- observability systems
+- review systems
+
+Runtime enforcement SHOULD reject semantically contradictory governance states and governance integrity violations.
+
+---
+
+## Validation Expectations
+
+An ACC-aware runtime SHOULD be able to validate:
+- required fields
+- authority scope declarations
+- replay posture declarations
+- observability declarations
+- invocation mode declarations
+- standing requirements
+
+## Cross-Field Validation Expectations
+
+An ACC-aware runtime SHOULD validate cross-field consistency.
+
+Examples:
+- revoked authority MUST NOT coexist with approved execution
+- quarantined standing SHOULD NOT coexist with unrestricted mutation authority
+- denied governance review MUST NOT coexist with approved governance execution
+- replay denial MUST NOT coexist with approved replay execution
+
+Cross-field validation failures SHOULD be treated as governance integrity failures.
+
+---
+
+# 14. Threat Model
+
+ACC is designed to reduce risks associated with:
+
+- hidden authority escalation
+- prompt-driven capability leakage
+- unreviewable invocation
+- unsafe delegation
+- replay ambiguity
+- weak observability
+- continuity-breaking execution
+- governance bypass
+
+ACC does NOT solve all governance problems.
+
+Instead, it provides explicit runtime semantics supporting:
+- reviewability
+- attributable authority
+- bounded execution
+- continuity-aware governance
+
+---
+
+## Incremental Adoption
+
+ACC is designed for incremental adoption inside governance-aware runtimes.
+
+Implementations MAY initially adopt only:
+- authority scope metadata
+- standing-aware invocation
+- replay posture
+- observability posture
+
+without implementing:
+- full delegation semantics
+- continuity-aware replay
+- advanced governance routing
+- cross-runtime capability propagation
+
+This allows progressive runtime adoption.
+
+---
+
+# 17. Compatibility And Evolution
+
+ACC serves as the canonical governance schema baseline for future ADL runtime evolution.
+
+Future schema evolution SHOULD:
+- preserve replay interpretation where feasible
+- preserve observability semantics where feasible
+- preserve authority lineage where feasible
+- support incremental migration
+
+ACC implementations MAY expose compatibility profiles.
+
+---
+
+# 18. Future Work
+
+Possible future work:
+
+- formal JSON Schema definitions
+- protobuf bindings
+- delegation lineage schemas
+- cross-polis capability semantics
+- cryptographic signing models
+- capability revocation semantics
+- observability integration tooling
+- replay authorization tooling
+- governance interoperability profiles
+- delegated authority replay semantics
+- continuity-aware replay tooling
+- governance-aware planning integration
+
+---
+
+# 19. Summary
+
+ACC defines the governance and authority layer surrounding capability invocation inside ADL.
+
+ACC exists to support:
+- attributable authority
+- bounded execution
+- continuity-aware governance
+- replay-aware invocation
+- observability-aware execution
+- explicit delegation semantics
+- reviewable capability exercise
+
+ACC intentionally complements rather than replaces UTS.
+
+UTS provides interoperable capability semantics.
+
+ACC provides runtime governance semantics.
+
+Together:
+- UTS describes capabilities
+- ACC governs their exercise
+
+The long-term goal is not merely tool execution.
+
+It is:
+
+> lawful, reviewable, continuity-preserving capability exercise inside inhabitable cognitive systems.
+
+---
+
+## Final Note
+
+ACC is intentionally more opinionated and runtime-aware than UTS.
+
+UTS attempts to provide a broadly interoperable capability description layer.
+
+ACC focuses on:
+- governance
+- authority
+- reviewability
+- replay governance
+- observability-aware execution
+- continuity-aware capability exercise
+
+inside ADL-compatible runtimes.
+
+The specification therefore prioritizes:
+- explicit authority
+- bounded execution
+- attributable invocation
+- replay-aware governance
+- inspectable delegation
+
+rather than minimal runtime semantics.
+
+---
+
+## Governance Integrity Principle
+
+ACC assumes governance state must remain:
+- internally coherent
+- attributable
+- reviewable
+- replay-aware
+- continuity-preserving
+
+Semantically contradictory governance states SHOULD be treated as runtime governance failures.
+
+Authority MUST originate from lawful runtime governance processes rather than model self-assertion or implicit prompt semantics.

--- a/docs/specs/acc/ADL_ACC_SPECIFICATION.md
+++ b/docs/specs/acc/ADL_ACC_SPECIFICATION.md
@@ -31,7 +31,7 @@ ACC does NOT standardize:
 - model cognition
 - universal identity systems
 
-ACC is intentionally scoped to governance-aware runtimes.
+ACC is scoped to governance-aware runtimes.
 
 ---
 
@@ -45,7 +45,7 @@ respective contract surfaces.
 
 All new ADL runtime governance work SHOULD target ACC semantics.
 
-ACC intentionally assumes:
+ACC assumes:
 - governance-aware runtimes
 - replay-aware infrastructure
 - observability-aware orchestration
@@ -106,7 +106,8 @@ The specification prioritizes:
 - inspectable delegation
 - continuity-aware execution
 
-ACC is intentionally ADL-runtime-oriented and is not currently proposed as a general ecosystem standard.
+ACC is ADL-runtime-oriented and is not currently proposed as a general
+ecosystem standard.
 
 The specification assumes:
 - continuity-aware runtimes
@@ -132,7 +133,7 @@ UTS intentionally remains:
 - transport-neutral
 - runtime-neutral
 
-ACC is intentionally:
+ACC is:
 - ADL-runtime-aware
 - governance-aware
 - standing-aware
@@ -224,9 +225,9 @@ Authority MUST NOT originate solely from:
 
 ---
 
-# 4. Core ACC Object
+# 4. Core ACC Governance Model
 
-A canonical ACC object SHOULD include:
+Across the cross-version governance model, ACC may discuss:
 
 - contract identifier
 - version
@@ -245,6 +246,14 @@ A canonical ACC object SHOULD include:
 - retention policy
 - runtime constraints
 - governance consistency metadata
+
+The version-specific normative wire surfaces remain:
+
+- [`ACC_V1.0_SPEC.md`](./ACC_V1.0_SPEC.md)
+- [`ACC_V1.1_SPEC.md`](./ACC_V1.1_SPEC.md)
+
+So fields such as invocation mode remain conceptual or future additive design
+space unless they appear in a versioned schema/spec.
 
 ---
 
@@ -290,23 +299,24 @@ Advanced implementations may add:
 
 ## ACC-Lite Compatibility
 
-A minimal ACC integration MAY support only:
+A minimal ACC integration MAY focus operationally on:
 
-- capability reference
-- authority scope
+- accountable actor identity
+- authority grant
+- top-level decision
+- execution approval posture
 - replay posture
-- observability posture
+- observability / privacy posture
 
 This profile is intended for:
 - incremental runtime adoption
 - lightweight governance integration
 - compatibility layers
 
-Advanced runtimes MAY additionally support:
-- delegation lineage
-- continuity-aware replay
-- governance routing
-- standing-aware execution
+This does not define a separate wire contract.
+
+It describes a runtime adoption profile that still targets the canonical ACC
+schema while enforcing the most important governance fields first.
 
 ---
 
@@ -354,55 +364,17 @@ Standing models MAY differ across runtimes.
 
 ---
 
-# 6. Invocation Modes
+# 6. Invocation Metadata Boundary
 
-ACC SHOULD support explicit invocation modes.
+Invocation mode and invocation intent are useful governance concepts, but they
+are not part of the current `ACC v1.0` or `ACC v1.1` wire contract.
 
-Suggested modes:
+Runtimes MAY use local invocation-mode or invocation-intent overlays for
+planning, review routing, or debugging, but those overlays remain out of scope
+for the current canonical schema surfaces.
 
-- direct_invocation
-- delegated_invocation
-- review_only
-- planning_only
-- simulation_only
-- governance_mediated
-
-Different invocation modes may imply different:
-- authority boundaries
-- review requirements
-- observability requirements
-- replay posture
-- escalation rules
-
----
-
-## Invocation Intent
-
-ACC invocation MAY include explicit invocation intent.
-
-Suggested intents:
-- informational_query
-- planning
-- simulation
-- review
-- mutation
-- governance_action
-- remediation
-
-Intent metadata is intended to improve:
-- reviewability
-- planning-aware execution
-- operational debugging
-- governance routing
-- replay interpretation
-
-Intent metadata is descriptive governance metadata only.
-
-Intent metadata MUST NOT imply:
-- execution approval
-- authority
-- replay authorization
-- runtime permission
+If standardized later, they should be introduced as explicit additive fields
+rather than treated as implied current requirements.
 
 ---
 
@@ -632,7 +604,7 @@ An ACC-aware runtime SHOULD be able to validate:
 - authority scope declarations
 - replay posture declarations
 - observability declarations
-- invocation mode declarations
+- runtime-local invocation metadata overlays when present
 - standing requirements
 
 ## Cross-Field Validation Expectations
@@ -677,10 +649,12 @@ Instead, it provides explicit runtime semantics supporting:
 ACC is designed for incremental adoption inside governance-aware runtimes.
 
 Implementations MAY initially adopt only:
-- authority scope metadata
-- standing-aware invocation
+- accountable actor identity
+- authority grant
+- top-level decision
+- execution approval posture
 - replay posture
-- observability posture
+- observability / privacy posture
 
 without implementing:
 - full delegation semantics
@@ -692,7 +666,7 @@ This allows progressive runtime adoption.
 
 ---
 
-# 17. Compatibility And Evolution
+# 15. Compatibility And Evolution
 
 ACC serves as the canonical governance schema baseline for future ADL runtime evolution.
 
@@ -706,11 +680,12 @@ ACC implementations MAY expose compatibility profiles.
 
 ---
 
-# 18. Future Work
+# 16. Future Work
 
 Possible future work:
 
-- formal JSON Schema definitions
+- standardized invocation modes
+- standardized invocation intents
 - protobuf bindings
 - delegation lineage schemas
 - cross-polis capability semantics
@@ -725,7 +700,7 @@ Possible future work:
 
 ---
 
-# 19. Summary
+# 17. Summary
 
 ACC defines the governance and authority layer surrounding capability invocation inside ADL.
 

--- a/docs/specs/acc/ADL_ACC_SPECIFICATION.md
+++ b/docs/specs/acc/ADL_ACC_SPECIFICATION.md
@@ -248,9 +248,9 @@ A canonical ACC object SHOULD include:
 
 ---
 
-## Canonical Minimal ACC Object
+## Conceptual Minimal ACC Sketch
 
-A minimal ACC object may look like:
+A conceptual ACC authority sketch may look like:
 
 ```yaml
 contract_id: acc-basic-1001
@@ -263,11 +263,21 @@ authority_scope:
   - read_only
 ```
 
-This minimal structure is sufficient for:
-- lightweight governance integration
-- authority classification
-- standing-aware execution
-- runtime validation
+This sketch is intentionally not a schema-valid ACC runtime object.
+
+It is useful only as a compact conceptual summary of:
+- contract identity
+- capability intent
+- authority narrowing
+
+For a schema-valid minimal fixture, use the canonical minimal examples in:
+- [`ACC_V1.0_SPEC.md`](./ACC_V1.0_SPEC.md)
+- [`ACC_V1.1_SPEC.md`](./ACC_V1.1_SPEC.md)
+
+A runtime-valid ACC object must carry the full accountable contract shape,
+including actor identity, authority grant, standing, policy checks, execution
+posture, replay posture, privacy posture, failure policy, and top-level
+decision.
 
 Advanced implementations may add:
 - replay posture

--- a/docs/specs/acc/README.md
+++ b/docs/specs/acc/README.md
@@ -11,6 +11,20 @@ This directory now uses the following framing:
 - `ACC v1.1`
   - the tracked additive evolution target for subsequent code adoption
 
+Primary narrative specification:
+
+- [`ADL_ACC_SPECIFICATION.md`](./ADL_ACC_SPECIFICATION.md)
+
+Document authority hierarchy:
+
+- [`ACC_V1.0_SPEC.md`](./ACC_V1.0_SPEC.md) is the normative baseline spec for
+  the current implemented `ACC v1.0` contract
+- [`ACC_V1.1_SPEC.md`](./ACC_V1.1_SPEC.md) is the normative next-version spec
+  for the tracked `ACC v1.1` target
+- [`ADL_ACC_SPECIFICATION.md`](./ADL_ACC_SPECIFICATION.md) is the cross-version
+  narrative companion specification
+- this `README.md` is the entrypoint and orientation surface
+
 Unlike UTS, ACC is not positioned here as a public, provider-neutral standard.
 ACC is intentionally scoped to ADL-governed runtimes.
 

--- a/docs/specs/acc/README.md
+++ b/docs/specs/acc/README.md
@@ -1,0 +1,146 @@
+# ADL Capability Contract (ACC)
+
+## Status
+
+Tracked canonical ACC spec entrypoint.
+
+This directory now uses the following framing:
+
+- `ACC v1.0`
+  - the current implemented ACC baseline
+- `ACC v1.1`
+  - the tracked additive evolution target for subsequent code adoption
+
+Unlike UTS, ACC is not positioned here as a public, provider-neutral standard.
+ACC is intentionally scoped to ADL-governed runtimes.
+
+Machine-readable companions:
+
+- [`adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json`](../../../adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json)
+- [`adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json`](../../../adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json)
+
+Implementation-facing baseline reference:
+
+- [`adl/src/acc.rs`](../../../adl/src/acc.rs)
+
+## 1. Purpose
+
+The ADL Capability Contract defines the runtime authority and governance layer
+surrounding capability invocation inside ADL.
+
+ACC answers questions intentionally outside the scope of UTS:
+
+- who may invoke a capability
+- under what standing
+- under what authority evidence
+- under what delegation lineage
+- under what observability posture
+- under what replay conditions
+- under what review requirements
+- under what execution approval semantics
+- under what continuity-sensitive runtime constraints
+
+## 2. Relationship To UTS
+
+UTS answers:
+
+> What is this tool?
+
+ACC answers:
+
+> Who may exercise that capability, under what authority, and with what
+> governance constraints?
+
+The split is intentional.
+
+- `UTS` remains public, portable, and schema-semantic
+- `ACC` remains ADL-specific, runtime-aware, and governance-specific
+
+UTS validity does not imply:
+
+- authority
+- approval
+- execution permission
+- replay permission
+
+Those concerns remain ACC and runtime-governance concerns.
+
+See also:
+
+- [`docs/specs/uts/README.md`](../uts/README.md)
+- [`docs/explainers/UTS_AND_ACC.md`](../../explainers/UTS_AND_ACC.md)
+
+## 3. Current Implemented Baseline (`ACC v1.0`)
+
+The current implemented ACC baseline lives in:
+
+- [`adl/src/acc.rs`](../../../adl/src/acc.rs)
+
+That code currently uses:
+
+- `ACC_SCHEMA_VERSION_V1 = "acc.v1"`
+- `AdlCapabilityContractV1`
+- `validate_acc_v1`
+
+The authoritative tracked baseline for that shape is:
+
+- [`ACC_V1.0_SPEC.md`](./ACC_V1.0_SPEC.md)
+- [`adl_capability_contract.v1.schema.json`](../../../adl-spec/schemas/acc/v1.0/adl_capability_contract.v1.schema.json)
+
+## 4. Additive Evolution Target (`ACC v1.1`)
+
+`ACC v1.1` is the tracked next schema target for ADL runtime governance.
+
+It is intentionally evolutionary over `ACC v1.0`:
+
+- the current field families remain recognizable
+- the anti-self-assertion rule remains intact
+- the current decision / execution / replay split remains intact
+- new fields are additive rather than shape-replacing
+
+The tracked `v1.1` surfaces are:
+
+- [`ACC_V1.1_SPEC.md`](./ACC_V1.1_SPEC.md)
+- [`adl_capability_contract.v1_1.schema.json`](../../../adl-spec/schemas/acc/v1.1/adl_capability_contract.v1_1.schema.json)
+
+Code adoption for `ACC v1.1` is a follow-on step. These docs define the target
+clearly before that implementation work begins.
+
+## 5. Scope
+
+ACC standardizes ADL-specific governance metadata such as:
+
+- accountable actor identity
+- authority grants
+- role and standing
+- delegation lineage
+- policy checks
+- confirmation and Freedom Gate requirements
+- execution approval semantics
+- replay posture
+- privacy/redaction posture
+- visibility policy
+- failure policy
+
+Standing semantics remain runtime-specific. ACC standardizes the presence of
+standing-bearing metadata, not one universal standing policy.
+
+ACC does not standardize:
+
+- a universal governance model
+- provider-neutral orchestration semantics
+- model cognition
+- transport protocols
+- public/general tool schemas
+
+## 6. Summary
+
+The clean split is:
+
+- `UTS` is public and general
+- `ACC` is ADL-specific and governance-specific
+- `ACC v1.0` is the current implemented baseline
+- `ACC v1.1` is the additive next target
+
+That separation is what keeps the governed-tools model understandable,
+reviewable, and evolvable.


### PR DESCRIPTION
## Summary
- add tracked ACC v1.0 canonical spec and machine-readable schema
- define ACC v1.1 as an evolutionary tracked target over the current acc.v1 model
- update ACC schema/docs indexing and clarify the boundary between JSON Schema checks and deeper runtime-validator semantics

## Validation
- python3 JSON parse of ACC schemas
- git diff --check
- bounded subagent review

Closes #3035
