### PR TITLE
[v0.91.2][tools] Adopt UTS v1.1 in code and tests before WP-02

### DIFF
--- a/adl/src/tool_registry.rs
+++ b/adl/src/tool_registry.rs
@@ -1,12 +1,14 @@
 use crate::uts::{
-    validate_uts_v1, UniversalToolSchemaV1, UtsAuthenticationModeV1,
+    upgrade_uts_v1_to_v1_1, validate_uts_v1_1, UniversalToolSchemaV1, UniversalToolSchemaV1_1,
+    UtsAuthenticationModeV1,
     UtsAuthenticationRequirementV1, UtsDataSensitivityV1, UtsDeterminismV1, UtsErrorModelV1,
+    UtsCategoryV1, UtsCompatibleVersionV1, UtsObservabilityV1, UtsPlanningMetadataV1,
     UtsExecutionEnvironmentKindV1, UtsExecutionEnvironmentV1, UtsExfiltrationRiskV1,
     UtsIdempotenceV1, UtsJsonSchemaFragmentV1, UtsReplaySafetyV1, UtsResourceRequirementV1,
-    UtsSideEffectClassV1, UTS_SCHEMA_VERSION_V1,
+    UtsSideEffectClassV1, UtsSideEffectTagV1, UTS_SCHEMA_VERSION_V1_1,
 };
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -46,8 +48,49 @@ pub struct RegisteredToolV1 {
     pub tool_name: String,
     pub tool_version: String,
     pub active: bool,
-    pub uts: UniversalToolSchemaV1,
+    #[serde(deserialize_with = "deserialize_registered_tool_uts")]
+    pub uts: UniversalToolSchemaV1_1,
     pub approved_adapter_ids: Vec<String>,
+}
+
+impl RegisteredToolV1 {
+    pub fn new(
+        registry_tool_id: String,
+        tool_name: String,
+        tool_version: String,
+        active: bool,
+        uts: impl Into<UniversalToolSchemaV1_1>,
+        approved_adapter_ids: Vec<String>,
+    ) -> Self {
+        Self {
+            registry_tool_id,
+            tool_name,
+            tool_version,
+            active,
+            uts: uts.into(),
+            approved_adapter_ids,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(untagged)]
+enum RegisteredToolUtsWireV1 {
+    V1(UniversalToolSchemaV1),
+    V1_1(UniversalToolSchemaV1_1),
+}
+
+fn deserialize_registered_tool_uts<'de, D>(
+    deserializer: D,
+) -> Result<UniversalToolSchemaV1_1, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let wire = RegisteredToolUtsWireV1::deserialize(deserializer)?;
+    Ok(match wire {
+        RegisteredToolUtsWireV1::V1(schema) => upgrade_uts_v1_to_v1_1(schema),
+        RegisteredToolUtsWireV1::V1_1(schema) => schema,
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -181,7 +224,7 @@ pub fn validate_tool_registry_v1(
                 )],
             )));
         }
-        if let Err(report) = validate_uts_v1(&tool.uts) {
+        if let Err(report) = validate_uts_v1_1(&tool.uts) {
             return Err(Box::new(reject(
                 ToolRegistryRejectionCodeV1::InvalidUts,
                 report
@@ -349,12 +392,17 @@ pub fn bind_tool_registry_v1(
     }
 }
 
-fn safe_read_uts() -> UniversalToolSchemaV1 {
-    UniversalToolSchemaV1 {
-        schema_version: UTS_SCHEMA_VERSION_V1.to_string(),
+fn safe_read_uts() -> UniversalToolSchemaV1_1 {
+    UniversalToolSchemaV1_1 {
+        schema_version: UTS_SCHEMA_VERSION_V1_1.to_string(),
+        compatible_versions: vec![
+            UtsCompatibleVersionV1::V1,
+            UtsCompatibleVersionV1::V1_1,
+        ],
         name: "fixture.safe_read".to_string(),
         version: "1.0.0".to_string(),
         description: "Read a bounded local fixture for registry binding tests.".to_string(),
+        categories: Some(vec![UtsCategoryV1::ReadOnly]),
         input_schema: UtsJsonSchemaFragmentV1 {
             schema_type: "object".to_string(),
             keywords: BTreeMap::from([
@@ -378,6 +426,7 @@ fn safe_read_uts() -> UniversalToolSchemaV1 {
             ]),
         },
         side_effect_class: UtsSideEffectClassV1::Read,
+        side_effects: Some(vec![UtsSideEffectTagV1::None]),
         determinism: UtsDeterminismV1::Deterministic,
         replay_safety: UtsReplaySafetyV1::ReplaySafe,
         idempotence: UtsIdempotenceV1::Idempotent,
@@ -400,6 +449,11 @@ fn safe_read_uts() -> UniversalToolSchemaV1 {
             message: "The requested fixture is not available.".to_string(),
             retryable: false,
         }],
+        observability: Some(UtsObservabilityV1::Basic),
+        planning: Some(UtsPlanningMetadataV1 {
+            review_recommended: Some(false),
+            ..UtsPlanningMetadataV1::default()
+        }),
         extensions: BTreeMap::new(),
     }
 }
@@ -426,6 +480,8 @@ pub fn wp08_tool_registry_v1_fixture() -> ToolRegistryV1 {
                     let mut uts = safe_read_uts();
                     uts.name = "fixture.disabled_write".to_string();
                     uts.side_effect_class = UtsSideEffectClassV1::LocalWrite;
+                    uts.categories = Some(vec![UtsCategoryV1::StateMutating]);
+                    uts.side_effects = Some(vec![UtsSideEffectTagV1::LocalState]);
                     uts.resources = vec![UtsResourceRequirementV1 {
                         resource_type: "fixture".to_string(),
                         scope: "local-disabled-write".to_string(),
@@ -535,6 +591,7 @@ pub fn wp08_registry_rejection_fixtures(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn valid_request() -> ToolBindingRequestV1 {
         ToolBindingRequestV1 {
@@ -560,6 +617,132 @@ mod tests {
             .evidence
             .iter()
             .any(|entry| entry.contains(TOOL_REGISTRY_SCHEMA_VERSION_V1)));
+    }
+
+    #[test]
+    fn wp08_registry_deserialize_accepts_legacy_uts_v1_and_upgrades_for_binding() {
+        let registry = serde_json::from_value::<ToolRegistryV1>(json!({
+            "schema_version": "tool_registry.v1",
+            "registry_id": "registry.legacy.fixture",
+            "tools": [{
+                "registry_tool_id": "registry.fixture.safe_read",
+                "tool_name": "fixture.safe_read",
+                "tool_version": "1.0.0",
+                "active": true,
+                "uts": {
+                    "schema_version": "uts.v1",
+                    "name": "fixture.safe_read",
+                    "version": "1.0.0",
+                    "description": "Read a bounded local fixture for registry binding tests.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": { "fixture_id": { "type": "string" } },
+                        "required": ["fixture_id"],
+                        "additionalProperties": false
+                    },
+                    "output_schema": {
+                        "type": "object",
+                        "properties": { "content": { "type": "string" } },
+                        "required": ["content"],
+                        "additionalProperties": false
+                    },
+                    "side_effect_class": "read",
+                    "determinism": "deterministic",
+                    "replay_safety": "replay_safe",
+                    "idempotence": "idempotent",
+                    "resources": [{ "resource_type": "fixture", "scope": "local-readonly" }],
+                    "authentication": { "mode": "none", "required": false },
+                    "data_sensitivity": "internal",
+                    "exfiltration_risk": "none",
+                    "execution_environment": {
+                        "kind": "dry_run",
+                        "isolation": "deterministic fixture dry run only"
+                    },
+                    "errors": [{
+                        "code": "fixture_not_found",
+                        "message": "The requested fixture is not available.",
+                        "retryable": false
+                    }],
+                    "extensions": {}
+                },
+                "approved_adapter_ids": ["adapter.fixture.safe_read.dry_run"]
+            }],
+            "adapters": [{
+                "adapter_id": "adapter.fixture.safe_read.dry_run",
+                "tool_name": "fixture.safe_read",
+                "tool_version": "1.0.0",
+                "capability_id": "capability.fixture.safe-read",
+                "side_effect_class": "read",
+                "execution_environment": "dry_run",
+                "supports_dry_run": true,
+                "approved_for_binding": true
+            }]
+        }))
+        .expect("legacy uts.v1 registry fixture should deserialize");
+
+        assert_eq!(registry.tools[0].uts.schema_version, UTS_SCHEMA_VERSION_V1_1);
+        assert_eq!(
+            registry.tools[0].uts.compatible_versions,
+            vec![UtsCompatibleVersionV1::V1, UtsCompatibleVersionV1::V1_1]
+        );
+        validate_tool_registry_v1(&registry).expect("upgraded legacy registry should validate");
+    }
+
+    #[test]
+    fn wp08_registered_tool_constructor_accepts_programmatic_legacy_uts_v1() {
+        let legacy = UniversalToolSchemaV1 {
+            schema_version: "uts.v1".to_string(),
+            name: "fixture.safe_read".to_string(),
+            version: "1.0.0".to_string(),
+            description: "Read a bounded local fixture for registry binding tests.".to_string(),
+            input_schema: UtsJsonSchemaFragmentV1 {
+                schema_type: "object".to_string(),
+                keywords: BTreeMap::new(),
+            },
+            output_schema: UtsJsonSchemaFragmentV1 {
+                schema_type: "object".to_string(),
+                keywords: BTreeMap::new(),
+            },
+            side_effect_class: UtsSideEffectClassV1::Read,
+            determinism: UtsDeterminismV1::Deterministic,
+            replay_safety: UtsReplaySafetyV1::ReplaySafe,
+            idempotence: UtsIdempotenceV1::Idempotent,
+            resources: vec![UtsResourceRequirementV1 {
+                resource_type: "fixture".to_string(),
+                scope: "local-readonly".to_string(),
+            }],
+            authentication: UtsAuthenticationRequirementV1 {
+                mode: UtsAuthenticationModeV1::None,
+                required: false,
+            },
+            data_sensitivity: UtsDataSensitivityV1::Internal,
+            exfiltration_risk: UtsExfiltrationRiskV1::None,
+            execution_environment: UtsExecutionEnvironmentV1 {
+                kind: UtsExecutionEnvironmentKindV1::DryRun,
+                isolation: "deterministic fixture dry run only".to_string(),
+            },
+            errors: vec![UtsErrorModelV1 {
+                code: "fixture_not_found".to_string(),
+                message: "The requested fixture is not available.".to_string(),
+                retryable: false,
+            }],
+            extensions: BTreeMap::new(),
+        };
+
+        let tool = RegisteredToolV1::new(
+            "registry.fixture.safe_read".to_string(),
+            "fixture.safe_read".to_string(),
+            "1.0.0".to_string(),
+            true,
+            legacy,
+            vec!["adapter.fixture.safe_read.dry_run".to_string()],
+        );
+
+        assert_eq!(tool.uts.schema_version, UTS_SCHEMA_VERSION_V1_1);
+        assert_eq!(
+            tool.uts.compatible_versions,
+            vec![UtsCompatibleVersionV1::V1, UtsCompatibleVersionV1::V1_1]
+        );
     }
 
     #[test]

--- a/adl/src/tool_registry.rs
+++ b/adl/src/tool_registry.rs
@@ -1,10 +1,9 @@
 use crate::uts::{
     upgrade_uts_v1_to_v1_1, validate_uts_v1_1, UniversalToolSchemaV1, UniversalToolSchemaV1_1,
-    UtsAuthenticationModeV1,
-    UtsAuthenticationRequirementV1, UtsDataSensitivityV1, UtsDeterminismV1, UtsErrorModelV1,
-    UtsCategoryV1, UtsCompatibleVersionV1, UtsObservabilityV1, UtsPlanningMetadataV1,
-    UtsExecutionEnvironmentKindV1, UtsExecutionEnvironmentV1, UtsExfiltrationRiskV1,
-    UtsIdempotenceV1, UtsJsonSchemaFragmentV1, UtsReplaySafetyV1, UtsResourceRequirementV1,
+    UtsAuthenticationModeV1, UtsAuthenticationRequirementV1, UtsCategoryV1, UtsCompatibleVersionV1,
+    UtsDataSensitivityV1, UtsDeterminismV1, UtsErrorModelV1, UtsExecutionEnvironmentKindV1,
+    UtsExecutionEnvironmentV1, UtsExfiltrationRiskV1, UtsIdempotenceV1, UtsJsonSchemaFragmentV1,
+    UtsObservabilityV1, UtsPlanningMetadataV1, UtsReplaySafetyV1, UtsResourceRequirementV1,
     UtsSideEffectClassV1, UtsSideEffectTagV1, UTS_SCHEMA_VERSION_V1_1,
 };
 use schemars::JsonSchema;
@@ -395,10 +394,7 @@ pub fn bind_tool_registry_v1(
 fn safe_read_uts() -> UniversalToolSchemaV1_1 {
     UniversalToolSchemaV1_1 {
         schema_version: UTS_SCHEMA_VERSION_V1_1.to_string(),
-        compatible_versions: vec![
-            UtsCompatibleVersionV1::V1,
-            UtsCompatibleVersionV1::V1_1,
-        ],
+        compatible_versions: vec![UtsCompatibleVersionV1::V1, UtsCompatibleVersionV1::V1_1],
         name: "fixture.safe_read".to_string(),
         version: "1.0.0".to_string(),
         description: "Read a bounded local fixture for registry binding tests.".to_string(),
@@ -680,7 +676,10 @@ mod tests {
         }))
         .expect("legacy uts.v1 registry fixture should deserialize");
 
-        assert_eq!(registry.tools[0].uts.schema_version, UTS_SCHEMA_VERSION_V1_1);
+        assert_eq!(
+            registry.tools[0].uts.schema_version,
+            UTS_SCHEMA_VERSION_V1_1
+        );
         assert_eq!(
             registry.tools[0].uts.compatible_versions,
             vec![UtsCompatibleVersionV1::V1, UtsCompatibleVersionV1::V1_1]

--- a/adl/src/uts.rs
+++ b/adl/src/uts.rs
@@ -721,10 +721,7 @@ pub fn validate_uts_v1_1(schema: &UniversalToolSchemaV1_1) -> Result<(), UtsVali
 pub fn upgrade_uts_v1_to_v1_1(schema: UniversalToolSchemaV1) -> UniversalToolSchemaV1_1 {
     UniversalToolSchemaV1_1 {
         schema_version: UTS_SCHEMA_VERSION_V1_1.to_string(),
-        compatible_versions: vec![
-            UtsCompatibleVersionV1::V1,
-            UtsCompatibleVersionV1::V1_1,
-        ],
+        compatible_versions: vec![UtsCompatibleVersionV1::V1, UtsCompatibleVersionV1::V1_1],
         name: schema.name,
         version: schema.version,
         description: schema.description,
@@ -1001,8 +998,8 @@ mod tests {
         value["compatible_versions"] = json!(["uts.v1"]);
 
         let schema = parse_valid_v1_1(value);
-        let err =
-            validate_uts_v1_1(&schema).expect_err("v1.1 schema without current version should fail");
+        let err = validate_uts_v1_1(&schema)
+            .expect_err("v1.1 schema without current version should fail");
 
         assert!(err.codes().contains(&"missing_current_compatible_version"));
     }

--- a/adl/src/uts.rs
+++ b/adl/src/uts.rs
@@ -1,11 +1,25 @@
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-pub const UTS_SCHEMA_VERSION_V1: &str = "uts.v1";
+pub const UTS_SCHEMA_VERSION_V1_0: &str = "uts.v1";
+pub const UTS_SCHEMA_VERSION_V1_1: &str = "uts.v1.1";
+pub const UTS_SCHEMA_VERSION_V1: &str = UTS_SCHEMA_VERSION_V1_0;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
+)]
+pub enum UtsCompatibleVersionV1 {
+    #[serde(rename = "uts.v1")]
+    V1,
+    #[serde(rename = "uts.v1.1")]
+    V1_1,
+}
+
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum UtsSideEffectClassV1 {
     Read,
@@ -91,6 +105,59 @@ pub enum UtsExecutionEnvironmentKindV1 {
     Network,
 }
 
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum UtsCategoryV1 {
+    ReadOnly,
+    Computational,
+    StateMutating,
+    ExternalNetwork,
+    HumanVisible,
+    GovernanceSensitive,
+    IdentitySensitive,
+    ContinuitySensitive,
+    ObservabilitySensitive,
+}
+
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum UtsSideEffectTagV1 {
+    None,
+    LocalState,
+    ExternalState,
+    Irreversible,
+    HumanVisible,
+    GovernanceRelevant,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UtsObservabilityV1 {
+    None,
+    Basic,
+    Full,
+    Governance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct UtsPlanningMetadataV1 {
+    #[serde(default)]
+    pub high_risk: Option<bool>,
+    #[serde(default)]
+    pub irreversible: Option<bool>,
+    #[serde(default)]
+    pub expensive: Option<bool>,
+    #[serde(default)]
+    pub slow: Option<bool>,
+    #[serde(default)]
+    pub review_recommended: Option<bool>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct UtsExecutionEnvironmentV1 {
@@ -140,6 +207,38 @@ pub struct UniversalToolSchemaV1 {
     pub exfiltration_risk: UtsExfiltrationRiskV1,
     pub execution_environment: UtsExecutionEnvironmentV1,
     pub errors: Vec<UtsErrorModelV1>,
+    #[serde(default)]
+    pub extensions: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct UniversalToolSchemaV1_1 {
+    pub schema_version: String,
+    pub compatible_versions: Vec<UtsCompatibleVersionV1>,
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    #[serde(default)]
+    pub categories: Option<Vec<UtsCategoryV1>>,
+    pub input_schema: UtsJsonSchemaFragmentV1,
+    pub output_schema: UtsJsonSchemaFragmentV1,
+    pub side_effect_class: UtsSideEffectClassV1,
+    #[serde(default)]
+    pub side_effects: Option<Vec<UtsSideEffectTagV1>>,
+    pub determinism: UtsDeterminismV1,
+    pub replay_safety: UtsReplaySafetyV1,
+    pub idempotence: UtsIdempotenceV1,
+    pub resources: Vec<UtsResourceRequirementV1>,
+    pub authentication: UtsAuthenticationRequirementV1,
+    pub data_sensitivity: UtsDataSensitivityV1,
+    pub exfiltration_risk: UtsExfiltrationRiskV1,
+    pub execution_environment: UtsExecutionEnvironmentV1,
+    pub errors: Vec<UtsErrorModelV1>,
+    #[serde(default)]
+    pub observability: Option<UtsObservabilityV1>,
+    #[serde(default)]
+    pub planning: Option<UtsPlanningMetadataV1>,
     #[serde(default)]
     pub extensions: BTreeMap<String, JsonValue>,
 }
@@ -239,6 +338,10 @@ fn extension_declares_required(value: &JsonValue) -> bool {
         .unwrap_or(false)
 }
 
+fn unique_count<T: Ord + Copy>(values: &[T]) -> usize {
+    values.iter().copied().collect::<BTreeSet<T>>().len()
+}
+
 /// Validate UTS v1 semantic constraints that are stricter than serde shape.
 ///
 /// This validator intentionally treats UTS validity as schema compatibility
@@ -247,12 +350,12 @@ fn extension_declares_required(value: &JsonValue) -> bool {
 pub fn validate_uts_v1(schema: &UniversalToolSchemaV1) -> Result<(), UtsValidationReport> {
     let mut errors = Vec::new();
 
-    if schema.schema_version != UTS_SCHEMA_VERSION_V1 {
+    if schema.schema_version != UTS_SCHEMA_VERSION_V1_0 {
         push_error(
             &mut errors,
             "unsupported_schema_version",
             "schema_version",
-            format!("schema_version must be {UTS_SCHEMA_VERSION_V1}"),
+            format!("schema_version must be {UTS_SCHEMA_VERSION_V1_0}"),
         );
     }
     if !valid_identifier(&schema.name) {
@@ -395,6 +498,267 @@ pub fn validate_uts_v1(schema: &UniversalToolSchemaV1) -> Result<(), UtsValidati
     }
 }
 
+pub fn validate_uts_v1_1(schema: &UniversalToolSchemaV1_1) -> Result<(), UtsValidationReport> {
+    let mut errors = Vec::new();
+
+    if schema.schema_version != UTS_SCHEMA_VERSION_V1_1 {
+        push_error(
+            &mut errors,
+            "unsupported_schema_version",
+            "schema_version",
+            format!("schema_version must be {UTS_SCHEMA_VERSION_V1_1}"),
+        );
+    }
+    if schema.compatible_versions.is_empty() {
+        push_error(
+            &mut errors,
+            "missing_compatible_versions",
+            "compatible_versions",
+            "compatible_versions must declare at least one supported UTS version",
+        );
+    } else {
+        if unique_count(&schema.compatible_versions) != schema.compatible_versions.len() {
+            push_error(
+                &mut errors,
+                "duplicate_compatible_versions",
+                "compatible_versions",
+                "compatible_versions must not contain duplicates",
+            );
+        }
+        if !schema
+            .compatible_versions
+            .contains(&UtsCompatibleVersionV1::V1_1)
+        {
+            push_error(
+                &mut errors,
+                "missing_current_compatible_version",
+                "compatible_versions",
+                "compatible_versions must include uts.v1.1 for v1.1 tool definitions",
+            );
+        }
+    }
+    if !valid_identifier(&schema.name) {
+        push_error(
+            &mut errors,
+            "invalid_name",
+            "name",
+            "name must be 3-80 chars, start lowercase, and use lowercase ascii, digits, dash, underscore, or dot",
+        );
+    }
+    if !valid_version(&schema.version) {
+        push_error(
+            &mut errors,
+            "invalid_version",
+            "version",
+            "version must use numeric major.minor.patch form",
+        );
+    }
+    if schema.description.trim().len() < 12 {
+        push_error(
+            &mut errors,
+            "missing_description",
+            "description",
+            "description must be specific enough for reviewers",
+        );
+    }
+    if !json_schema_fragment_has_type(&schema.input_schema) {
+        push_error(
+            &mut errors,
+            "invalid_input_schema",
+            "input_schema",
+            "input_schema must be a JSON Schema fragment with a type",
+        );
+    }
+    if !json_schema_fragment_has_type(&schema.output_schema) {
+        push_error(
+            &mut errors,
+            "invalid_output_schema",
+            "output_schema",
+            "output_schema must be a JSON Schema fragment with a type",
+        );
+    }
+    if schema.resources.is_empty() {
+        push_error(
+            &mut errors,
+            "missing_resources",
+            "resources",
+            "resources must declare at least one resource boundary",
+        );
+    }
+    for resource in &schema.resources {
+        if !valid_token(&resource.resource_type) || resource.scope.trim().is_empty() {
+            push_error(
+                &mut errors,
+                "invalid_resource",
+                "resources",
+                "resource_type must be token-like and scope must be non-empty",
+            );
+        }
+    }
+    if let Some(categories) = &schema.categories {
+        if categories.is_empty() {
+            push_error(
+                &mut errors,
+                "invalid_categories",
+                "categories",
+                "categories must not be empty when present",
+            );
+        } else if unique_count(categories) != categories.len() {
+            push_error(
+                &mut errors,
+                "duplicate_categories",
+                "categories",
+                "categories must not contain duplicates",
+            );
+        }
+    }
+    if let Some(side_effects) = &schema.side_effects {
+        if side_effects.is_empty() {
+            push_error(
+                &mut errors,
+                "invalid_side_effects",
+                "side_effects",
+                "side_effects must not be empty when present",
+            );
+        } else if unique_count(side_effects) != side_effects.len() {
+            push_error(
+                &mut errors,
+                "duplicate_side_effects",
+                "side_effects",
+                "side_effects must not contain duplicates",
+            );
+        } else if side_effects.contains(&UtsSideEffectTagV1::None) && side_effects.len() > 1 {
+            push_error(
+                &mut errors,
+                "contradictory_side_effects",
+                "side_effects",
+                "side_effects cannot combine none with other side-effect tags",
+            );
+        }
+    }
+    if schema.authentication.required
+        && matches!(schema.authentication.mode, UtsAuthenticationModeV1::None)
+    {
+        push_error(
+            &mut errors,
+            "invalid_authentication",
+            "authentication",
+            "required authentication cannot use mode none",
+        );
+    }
+    if matches!(schema.side_effect_class, UtsSideEffectClassV1::Exfiltration)
+        && !matches!(schema.exfiltration_risk, UtsExfiltrationRiskV1::High)
+    {
+        push_error(
+            &mut errors,
+            "invalid_exfiltration_risk",
+            "exfiltration_risk",
+            "exfiltration side effects must declare high exfiltration risk",
+        );
+    }
+    if !matches!(schema.side_effect_class, UtsSideEffectClassV1::Exfiltration)
+        && matches!(schema.exfiltration_risk, UtsExfiltrationRiskV1::High)
+    {
+        push_error(
+            &mut errors,
+            "ambiguous_side_effects",
+            "side_effect_class",
+            "high exfiltration risk must use the exfiltration side-effect class",
+        );
+    }
+    if schema.execution_environment.isolation.trim().is_empty() {
+        push_error(
+            &mut errors,
+            "missing_execution_isolation",
+            "execution_environment.isolation",
+            "execution environment must describe isolation posture",
+        );
+    }
+    if schema.errors.is_empty() {
+        push_error(
+            &mut errors,
+            "missing_error_model",
+            "errors",
+            "at least one error model entry is required",
+        );
+    }
+    for error in &schema.errors {
+        if !valid_token(&error.code) || error.message.trim().is_empty() {
+            push_error(
+                &mut errors,
+                "invalid_error_model",
+                "errors",
+                "error code must be token-like and message must be non-empty",
+            );
+        }
+    }
+    for key in schema.extensions.keys() {
+        let value = &schema.extensions[key];
+        if !extension_key_allowed(key) {
+            push_error(
+                &mut errors,
+                "invalid_extension_key",
+                "extensions",
+                format!("extension key '{key}' is not allowed for UTS v1.1"),
+            );
+        } else if extension_declares_required(value) {
+            push_error(
+                &mut errors,
+                "unsupported_required_extension",
+                "extensions",
+                format!("extension key '{key}' declares unsupported required behavior"),
+            );
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(UtsValidationReport { errors })
+    }
+}
+
+pub fn upgrade_uts_v1_to_v1_1(schema: UniversalToolSchemaV1) -> UniversalToolSchemaV1_1 {
+    UniversalToolSchemaV1_1 {
+        schema_version: UTS_SCHEMA_VERSION_V1_1.to_string(),
+        compatible_versions: vec![
+            UtsCompatibleVersionV1::V1,
+            UtsCompatibleVersionV1::V1_1,
+        ],
+        name: schema.name,
+        version: schema.version,
+        description: schema.description,
+        categories: None,
+        input_schema: schema.input_schema,
+        output_schema: schema.output_schema,
+        side_effect_class: schema.side_effect_class,
+        side_effects: None,
+        determinism: schema.determinism,
+        replay_safety: schema.replay_safety,
+        idempotence: schema.idempotence,
+        resources: schema.resources,
+        authentication: schema.authentication,
+        data_sensitivity: schema.data_sensitivity,
+        exfiltration_risk: schema.exfiltration_risk,
+        execution_environment: schema.execution_environment,
+        errors: schema.errors,
+        observability: None,
+        planning: None,
+        extensions: schema.extensions,
+    }
+}
+
+impl From<UniversalToolSchemaV1> for UniversalToolSchemaV1_1 {
+    fn from(schema: UniversalToolSchemaV1) -> Self {
+        upgrade_uts_v1_to_v1_1(schema)
+    }
+}
+
+pub fn uts_v1_1_schema_json() -> JsonValue {
+    serde_json::to_value(schema_for!(UniversalToolSchemaV1_1))
+        .expect("UTS v1.1 schema should serialize")
+}
+
 pub fn uts_v1_schema_json() -> JsonValue {
     serde_json::to_value(schema_for!(UniversalToolSchemaV1))
         .expect("UTS v1 schema should serialize")
@@ -454,7 +818,67 @@ mod tests {
         })
     }
 
+    fn valid_safe_read_v1_1_json() -> JsonValue {
+        json!({
+            "schema_version": "uts.v1.1",
+            "compatible_versions": ["uts.v1", "uts.v1.1"],
+            "name": "fixture.safe_read",
+            "version": "1.0.0",
+            "description": "Read a bounded local fixture for reviewer-visible conformance.",
+            "categories": ["read_only"],
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "fixture_id": { "type": "string" }
+                },
+                "required": ["fixture_id"],
+                "additionalProperties": false
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string" }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+            },
+            "side_effect_class": "read",
+            "side_effects": ["none"],
+            "determinism": "deterministic",
+            "replay_safety": "replay_safe",
+            "idempotence": "idempotent",
+            "resources": [
+                { "resource_type": "fixture", "scope": "local-readonly" }
+            ],
+            "authentication": { "mode": "none", "required": false },
+            "data_sensitivity": "internal",
+            "exfiltration_risk": "none",
+            "execution_environment": {
+                "kind": "fixture",
+                "isolation": "local deterministic fixture only"
+            },
+            "errors": [
+                {
+                    "code": "fixture_not_found",
+                    "message": "The requested fixture is not available.",
+                    "retryable": false
+                }
+            ],
+            "observability": "basic",
+            "planning": {
+                "review_recommended": false
+            },
+            "extensions": {
+                "x-adl-review-note": "UTS compatibility only; no execution authority."
+            }
+        })
+    }
+
     fn parse_valid(value: JsonValue) -> UniversalToolSchemaV1 {
+        serde_json::from_value(value).expect("example should deserialize")
+    }
+
+    fn parse_valid_v1_1(value: JsonValue) -> UniversalToolSchemaV1_1 {
         serde_json::from_value(value).expect("example should deserialize")
     }
 
@@ -466,7 +890,7 @@ mod tests {
 
     #[test]
     fn uts_v1_valid_exfiltration_description_passes_without_execution_authority() {
-        let mut value = valid_safe_read_json();
+        let mut value = valid_safe_read_v1_1_json();
         value["name"] = json!("fixture.exfiltration_trap");
         value["side_effect_class"] = json!("exfiltration");
         value["exfiltration_risk"] = json!("high");
@@ -479,8 +903,8 @@ mod tests {
             { "resource_type": "protected_prompt", "scope": "redacted-denial-fixture" }
         ]);
 
-        let schema = parse_valid(value);
-        validate_uts_v1(&schema).expect("dangerous UTS descriptions can be schema-compatible");
+        let schema = parse_valid_v1_1(value);
+        validate_uts_v1_1(&schema).expect("dangerous UTS descriptions can be schema-compatible");
 
         assert!(
             schema
@@ -569,6 +993,29 @@ mod tests {
         let err = validate_uts_v1(&schema).expect_err("required extension should fail");
 
         assert!(err.codes().contains(&"unsupported_required_extension"));
+    }
+
+    #[test]
+    fn uts_v1_1_rejects_schema_without_current_compatible_version() {
+        let mut value = valid_safe_read_v1_1_json();
+        value["compatible_versions"] = json!(["uts.v1"]);
+
+        let schema = parse_valid_v1_1(value);
+        let err =
+            validate_uts_v1_1(&schema).expect_err("v1.1 schema without current version should fail");
+
+        assert!(err.codes().contains(&"missing_current_compatible_version"));
+    }
+
+    #[test]
+    fn uts_v1_1_rejects_contradictory_side_effect_tags() {
+        let mut value = valid_safe_read_v1_1_json();
+        value["side_effects"] = json!(["none", "human_visible"]);
+
+        let schema = parse_valid_v1_1(value);
+        let err = validate_uts_v1_1(&schema).expect_err("contradictory side effects should fail");
+
+        assert!(err.codes().contains(&"contradictory_side_effects"));
     }
 
     #[test]
@@ -723,6 +1170,43 @@ mod tests {
             "exfiltration_risk",
             "execution_environment",
             "errors",
+            "extensions",
+        ] {
+            assert!(
+                properties.contains_key(key),
+                "UTS schema missing property {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn uts_v1_1_schema_generation_exposes_additive_surface() {
+        let schema = uts_v1_1_schema_json();
+        let properties = schema
+            .get("properties")
+            .and_then(JsonValue::as_object)
+            .expect("generated UTS schema should expose properties");
+
+        for key in [
+            "compatible_versions",
+            "name",
+            "version",
+            "categories",
+            "input_schema",
+            "output_schema",
+            "side_effect_class",
+            "side_effects",
+            "determinism",
+            "replay_safety",
+            "idempotence",
+            "resources",
+            "authentication",
+            "data_sensitivity",
+            "exfiltration_risk",
+            "execution_environment",
+            "errors",
+            "observability",
+            "planning",
             "extensions",
         ] {
             assert!(

--- a/adl/src/uts_acc_compiler/core.rs
+++ b/adl/src/uts_acc_compiler/core.rs
@@ -20,8 +20,9 @@ use crate::tool_registry::{
     ToolBindingSourceV1, ToolBindingV1, ToolRegistryV1,
 };
 use crate::uts::{
-    validate_uts_v1, UniversalToolSchemaV1, UtsDataSensitivityV1, UtsExecutionEnvironmentKindV1,
-    UtsExfiltrationRiskV1, UtsReplaySafetyV1, UtsResourceRequirementV1, UtsSideEffectClassV1,
+    validate_uts_v1_1, UniversalToolSchemaV1_1, UtsDataSensitivityV1,
+    UtsExecutionEnvironmentKindV1, UtsExfiltrationRiskV1, UtsReplaySafetyV1,
+    UtsResourceRequirementV1, UtsSideEffectClassV1,
 };
 
 fn side_effect_label(side_effect: &UtsSideEffectClassV1) -> &'static str {
@@ -48,7 +49,7 @@ fn environment_label(environment: &UtsExecutionEnvironmentKindV1) -> &'static st
     }
 }
 
-fn first_resource(schema: &UniversalToolSchemaV1) -> Option<&UtsResourceRequirementV1> {
+fn first_resource(schema: &UniversalToolSchemaV1_1) -> Option<&UtsResourceRequirementV1> {
     schema.resources.first()
 }
 
@@ -293,7 +294,7 @@ pub fn compile_uts_to_acc_v1(input: &UtsAccCompilerInputV1) -> UtsAccCompilerOut
         );
     };
 
-    if let Err(report) = validate_uts_v1(&tool.uts) {
+    if let Err(report) = validate_uts_v1_1(&tool.uts) {
         evidence_log.push(evidence(
             UtsAccCompilerEvidenceStageV1::Validation,
             format!("UTS validation errors: {:?}", report.codes()),

--- a/adl/src/uts_acc_compiler/fixtures.rs
+++ b/adl/src/uts_acc_compiler/fixtures.rs
@@ -5,11 +5,11 @@ use crate::tool_registry::{
 };
 use crate::uts::{
     UniversalToolSchemaV1_1, UtsAuthenticationModeV1, UtsAuthenticationRequirementV1,
-    UtsCategoryV1, UtsCompatibleVersionV1, UtsDataSensitivityV1, UtsDeterminismV1,
-    UtsErrorModelV1, UtsExecutionEnvironmentKindV1, UtsExecutionEnvironmentV1,
-    UtsExfiltrationRiskV1, UtsIdempotenceV1, UtsJsonSchemaFragmentV1, UtsObservabilityV1,
-    UtsPlanningMetadataV1, UtsReplaySafetyV1, UtsResourceRequirementV1, UtsSideEffectClassV1,
-    UtsSideEffectTagV1, UTS_SCHEMA_VERSION_V1_1,
+    UtsCategoryV1, UtsCompatibleVersionV1, UtsDataSensitivityV1, UtsDeterminismV1, UtsErrorModelV1,
+    UtsExecutionEnvironmentKindV1, UtsExecutionEnvironmentV1, UtsExfiltrationRiskV1,
+    UtsIdempotenceV1, UtsJsonSchemaFragmentV1, UtsObservabilityV1, UtsPlanningMetadataV1,
+    UtsReplaySafetyV1, UtsResourceRequirementV1, UtsSideEffectClassV1, UtsSideEffectTagV1,
+    UTS_SCHEMA_VERSION_V1_1,
 };
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -126,10 +126,7 @@ fn schema_for_tool(
 
     UniversalToolSchemaV1_1 {
         schema_version: UTS_SCHEMA_VERSION_V1_1.to_string(),
-        compatible_versions: vec![
-            UtsCompatibleVersionV1::V1,
-            UtsCompatibleVersionV1::V1_1,
-        ],
+        compatible_versions: vec![UtsCompatibleVersionV1::V1, UtsCompatibleVersionV1::V1_1],
         name: name.to_string(),
         version: "1.0.0".to_string(),
         description: format!("Fixture schema for compiler mapping case {name}."),

--- a/adl/src/uts_acc_compiler/fixtures.rs
+++ b/adl/src/uts_acc_compiler/fixtures.rs
@@ -4,10 +4,12 @@ use crate::tool_registry::{
     wp08_tool_registry_v1_fixture, RegisteredToolV1, ToolAdapterCapabilityV1, ToolRegistryV1,
 };
 use crate::uts::{
-    UniversalToolSchemaV1, UtsAuthenticationModeV1, UtsAuthenticationRequirementV1,
-    UtsDataSensitivityV1, UtsDeterminismV1, UtsErrorModelV1, UtsExecutionEnvironmentKindV1,
-    UtsExecutionEnvironmentV1, UtsExfiltrationRiskV1, UtsIdempotenceV1, UtsJsonSchemaFragmentV1,
-    UtsReplaySafetyV1, UtsResourceRequirementV1, UtsSideEffectClassV1, UTS_SCHEMA_VERSION_V1,
+    UniversalToolSchemaV1_1, UtsAuthenticationModeV1, UtsAuthenticationRequirementV1,
+    UtsCategoryV1, UtsCompatibleVersionV1, UtsDataSensitivityV1, UtsDeterminismV1,
+    UtsErrorModelV1, UtsExecutionEnvironmentKindV1, UtsExecutionEnvironmentV1,
+    UtsExfiltrationRiskV1, UtsIdempotenceV1, UtsJsonSchemaFragmentV1, UtsObservabilityV1,
+    UtsPlanningMetadataV1, UtsReplaySafetyV1, UtsResourceRequirementV1, UtsSideEffectClassV1,
+    UtsSideEffectTagV1, UTS_SCHEMA_VERSION_V1_1,
 };
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -18,12 +20,120 @@ fn schema_for_tool(
     resource_scope: &str,
     data_sensitivity: UtsDataSensitivityV1,
     exfiltration_risk: UtsExfiltrationRiskV1,
-) -> UniversalToolSchemaV1 {
-    UniversalToolSchemaV1 {
-        schema_version: UTS_SCHEMA_VERSION_V1.to_string(),
+) -> UniversalToolSchemaV1_1 {
+    let (categories, side_effects, observability, planning) = match side_effect {
+        UtsSideEffectClassV1::Read => (
+            vec![UtsCategoryV1::ReadOnly],
+            vec![UtsSideEffectTagV1::None],
+            UtsObservabilityV1::Basic,
+            UtsPlanningMetadataV1 {
+                review_recommended: Some(false),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+        UtsSideEffectClassV1::LocalWrite => (
+            vec![UtsCategoryV1::StateMutating],
+            vec![UtsSideEffectTagV1::LocalState],
+            UtsObservabilityV1::Full,
+            UtsPlanningMetadataV1 {
+                review_recommended: Some(true),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+        UtsSideEffectClassV1::ExternalRead => (
+            vec![UtsCategoryV1::ExternalNetwork],
+            vec![UtsSideEffectTagV1::ExternalState],
+            UtsObservabilityV1::Full,
+            UtsPlanningMetadataV1 {
+                expensive: Some(true),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+        UtsSideEffectClassV1::ExternalWrite => (
+            vec![
+                UtsCategoryV1::ExternalNetwork,
+                UtsCategoryV1::StateMutating,
+                UtsCategoryV1::HumanVisible,
+            ],
+            vec![
+                UtsSideEffectTagV1::ExternalState,
+                UtsSideEffectTagV1::HumanVisible,
+            ],
+            UtsObservabilityV1::Governance,
+            UtsPlanningMetadataV1 {
+                high_risk: Some(true),
+                review_recommended: Some(true),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+        UtsSideEffectClassV1::Process => (
+            vec![UtsCategoryV1::StateMutating],
+            vec![UtsSideEffectTagV1::Irreversible],
+            UtsObservabilityV1::Governance,
+            UtsPlanningMetadataV1 {
+                high_risk: Some(true),
+                slow: Some(true),
+                review_recommended: Some(true),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+        UtsSideEffectClassV1::Network => (
+            vec![UtsCategoryV1::ExternalNetwork],
+            vec![UtsSideEffectTagV1::ExternalState],
+            UtsObservabilityV1::Full,
+            UtsPlanningMetadataV1 {
+                slow: Some(true),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+        UtsSideEffectClassV1::Destructive => (
+            vec![
+                UtsCategoryV1::StateMutating,
+                UtsCategoryV1::GovernanceSensitive,
+            ],
+            vec![
+                UtsSideEffectTagV1::Irreversible,
+                UtsSideEffectTagV1::GovernanceRelevant,
+            ],
+            UtsObservabilityV1::Governance,
+            UtsPlanningMetadataV1 {
+                high_risk: Some(true),
+                irreversible: Some(true),
+                review_recommended: Some(true),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+        UtsSideEffectClassV1::Exfiltration => (
+            vec![
+                UtsCategoryV1::ExternalNetwork,
+                UtsCategoryV1::GovernanceSensitive,
+                UtsCategoryV1::ObservabilitySensitive,
+            ],
+            vec![
+                UtsSideEffectTagV1::ExternalState,
+                UtsSideEffectTagV1::GovernanceRelevant,
+            ],
+            UtsObservabilityV1::Governance,
+            UtsPlanningMetadataV1 {
+                high_risk: Some(true),
+                irreversible: Some(true),
+                expensive: Some(true),
+                review_recommended: Some(true),
+                ..UtsPlanningMetadataV1::default()
+            },
+        ),
+    };
+
+    UniversalToolSchemaV1_1 {
+        schema_version: UTS_SCHEMA_VERSION_V1_1.to_string(),
+        compatible_versions: vec![
+            UtsCompatibleVersionV1::V1,
+            UtsCompatibleVersionV1::V1_1,
+        ],
         name: name.to_string(),
         version: "1.0.0".to_string(),
         description: format!("Fixture schema for compiler mapping case {name}."),
+        categories: Some(categories),
         input_schema: UtsJsonSchemaFragmentV1 {
             schema_type: "object".to_string(),
             keywords: BTreeMap::from([
@@ -47,6 +157,7 @@ fn schema_for_tool(
             ]),
         },
         side_effect_class: side_effect,
+        side_effects: Some(side_effects),
         determinism: UtsDeterminismV1::Deterministic,
         replay_safety: UtsReplaySafetyV1::ReplaySafe,
         idempotence: UtsIdempotenceV1::Idempotent,
@@ -69,6 +180,8 @@ fn schema_for_tool(
             message: "The requested compiler fixture is not available.".to_string(),
             retryable: false,
         }],
+        observability: Some(observability),
+        planning: Some(planning),
         extensions: BTreeMap::new(),
     }
 }

--- a/adl/src/uts_acc_compiler/fixtures.rs
+++ b/adl/src/uts_acc_compiler/fixtures.rs
@@ -187,11 +187,39 @@ pub fn wp09_compiler_registry_fixture() -> ToolRegistryV1 {
     let mut registry = wp08_tool_registry_v1_fixture();
     for (name, side_effect, scope, sensitivity, exfiltration) in [
         (
+            "fixture.external_read",
+            UtsSideEffectClassV1::ExternalRead,
+            "external-read",
+            UtsDataSensitivityV1::Confidential,
+            UtsExfiltrationRiskV1::Low,
+        ),
+        (
+            "fixture.external_write",
+            UtsSideEffectClassV1::ExternalWrite,
+            "external-write",
+            UtsDataSensitivityV1::Confidential,
+            UtsExfiltrationRiskV1::Medium,
+        ),
+        (
             "fixture.local_write",
             UtsSideEffectClassV1::LocalWrite,
             "local-write",
             UtsDataSensitivityV1::Internal,
             UtsExfiltrationRiskV1::None,
+        ),
+        (
+            "fixture.process",
+            UtsSideEffectClassV1::Process,
+            "process-fixture",
+            UtsDataSensitivityV1::Confidential,
+            UtsExfiltrationRiskV1::Medium,
+        ),
+        (
+            "fixture.network",
+            UtsSideEffectClassV1::Network,
+            "network-fixture",
+            UtsDataSensitivityV1::Confidential,
+            UtsExfiltrationRiskV1::Medium,
         ),
         (
             "fixture.destructive",

--- a/adl/src/uts_acc_compiler/frontend.rs
+++ b/adl/src/uts_acc_compiler/frontend.rs
@@ -3,7 +3,7 @@ use super::{
     UtsArgumentNormalizationReportV1, WP10_MAX_ARGUMENT_BYTES_V1, WP10_MAX_STRING_BYTES_V1,
 };
 use crate::tool_registry::{registry_state_fingerprint_v1, ToolRegistryV1};
-use crate::uts::UniversalToolSchemaV1;
+use crate::uts::UniversalToolSchemaV1_1;
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -37,7 +37,7 @@ pub(crate) fn registry_evidence(registry: &ToolRegistryV1) -> String {
     format!("registry_state_digest={}", evidence_digest(&fingerprint))
 }
 
-fn schema_properties(schema: &UniversalToolSchemaV1) -> BTreeMap<String, JsonValue> {
+fn schema_properties(schema: &UniversalToolSchemaV1_1) -> BTreeMap<String, JsonValue> {
     schema
         .input_schema
         .keywords
@@ -52,7 +52,7 @@ fn schema_properties(schema: &UniversalToolSchemaV1) -> BTreeMap<String, JsonVal
         .unwrap_or_default()
 }
 
-fn schema_required_fields(schema: &UniversalToolSchemaV1) -> BTreeSet<String> {
+fn schema_required_fields(schema: &UniversalToolSchemaV1_1) -> BTreeSet<String> {
     schema
         .input_schema
         .keywords
@@ -65,7 +65,7 @@ fn schema_required_fields(schema: &UniversalToolSchemaV1) -> BTreeSet<String> {
         .collect()
 }
 
-fn schema_allows_additional_fields(schema: &UniversalToolSchemaV1) -> bool {
+fn schema_allows_additional_fields(schema: &UniversalToolSchemaV1_1) -> bool {
     schema
         .input_schema
         .keywords
@@ -195,7 +195,7 @@ fn scan_value_safety(
 }
 
 pub fn normalize_tool_proposal_arguments_v1(
-    schema: &UniversalToolSchemaV1,
+    schema: &UniversalToolSchemaV1_1,
     arguments: &BTreeMap<String, JsonValue>,
 ) -> Result<BTreeMap<String, JsonValue>, UtsArgumentNormalizationReportV1> {
     let mut errors = Vec::new();

--- a/adl/src/uts_acc_compiler/tests.rs
+++ b/adl/src/uts_acc_compiler/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::acc::{validate_acc_v1, AccDecisionV1};
-use crate::uts::UtsResourceRequirementV1;
+use crate::uts::{UtsCategoryV1, UtsObservabilityV1, UtsResourceRequirementV1, UtsSideEffectTagV1};
 use serde_json::json;
 use std::collections::BTreeMap;
 
@@ -57,6 +57,118 @@ fn wp09_maps_safe_read_to_allowed_acc() {
     assert_eq!(acc.decision, AccDecisionV1::Allowed);
     assert_eq!(acc.tool.tool_name, "fixture.safe_read");
     validate_acc_v1(&acc).expect("compiled safe-read ACC should validate");
+}
+
+#[test]
+fn wp09_registry_fixture_covers_v1_1_metadata_for_all_side_effect_lanes() {
+    let registry = wp09_compiler_registry_fixture();
+
+    let external_read = registry
+        .tools
+        .iter()
+        .find(|tool| tool.tool_name == "fixture.external_read")
+        .expect("external read fixture should exist");
+    assert_eq!(
+        external_read.uts.categories.as_ref().expect("categories"),
+        &vec![UtsCategoryV1::ExternalNetwork]
+    );
+    assert_eq!(
+        external_read
+            .uts
+            .side_effects
+            .as_ref()
+            .expect("side effects"),
+        &vec![UtsSideEffectTagV1::ExternalState]
+    );
+    assert_eq!(
+        external_read.uts.observability,
+        Some(UtsObservabilityV1::Full)
+    );
+    assert_eq!(
+        external_read
+            .uts
+            .planning
+            .as_ref()
+            .and_then(|p| p.expensive),
+        Some(true)
+    );
+
+    let external_write = registry
+        .tools
+        .iter()
+        .find(|tool| tool.tool_name == "fixture.external_write")
+        .expect("external write fixture should exist");
+    assert!(external_write
+        .uts
+        .categories
+        .as_ref()
+        .expect("categories")
+        .contains(&UtsCategoryV1::HumanVisible));
+    assert!(external_write
+        .uts
+        .side_effects
+        .as_ref()
+        .expect("side effects")
+        .contains(&UtsSideEffectTagV1::HumanVisible));
+    assert_eq!(
+        external_write.uts.observability,
+        Some(UtsObservabilityV1::Governance)
+    );
+    assert_eq!(
+        external_write
+            .uts
+            .planning
+            .as_ref()
+            .and_then(|p| p.high_risk),
+        Some(true)
+    );
+
+    let process = registry
+        .tools
+        .iter()
+        .find(|tool| tool.tool_name == "fixture.process")
+        .expect("process fixture should exist");
+    assert_eq!(
+        process.uts.side_effects.as_ref().expect("side effects"),
+        &vec![UtsSideEffectTagV1::Irreversible]
+    );
+    assert_eq!(
+        process.uts.planning.as_ref().and_then(|p| p.slow),
+        Some(true)
+    );
+
+    let network = registry
+        .tools
+        .iter()
+        .find(|tool| tool.tool_name == "fixture.network")
+        .expect("network fixture should exist");
+    assert_eq!(network.uts.observability, Some(UtsObservabilityV1::Full));
+    assert_eq!(
+        network.uts.planning.as_ref().and_then(|p| p.slow),
+        Some(true)
+    );
+}
+
+#[test]
+fn wp09_fixture_helpers_emit_expected_policy_and_proposal_defaults() {
+    let policy = wp09_policy_context_fixture();
+    assert_eq!(policy.actor_id, "actor.operator.alice");
+    assert!(policy.authenticated);
+    assert!(policy.execution_approved);
+    assert!(policy.replay_allowed);
+    assert!(policy.visibility_constructible);
+    assert!(policy.allow_sensitive_data);
+
+    let proposal = wp09_proposal_fixture("fixture.safe_read");
+    assert_eq!(proposal.tool_name, "fixture.safe_read");
+    assert_eq!(proposal.tool_version, "1.0.0");
+    assert_eq!(proposal.adapter_id, "adapter.fixture.safe_read.dry_run");
+    assert_eq!(
+        proposal.arguments.get("fixture_id"),
+        Some(&json!("fixture-a"))
+    );
+    assert!(proposal.dry_run_requested);
+    assert!(!proposal.ambiguous);
 }
 
 #[test]

--- a/adl/src/uts_conformance.rs
+++ b/adl/src/uts_conformance.rs
@@ -1,5 +1,5 @@
 use crate::uts::{
-    validate_uts_v1, UniversalToolSchemaV1, UtsSideEffectClassV1, UTS_SCHEMA_VERSION_V1,
+    validate_uts_v1_1, UniversalToolSchemaV1_1, UtsSideEffectClassV1, UTS_SCHEMA_VERSION_V1_1,
 };
 use serde::Serialize;
 use serde_json::{json, Value as JsonValue};
@@ -128,10 +128,22 @@ fn base_fixture(id: &'static str, side_effect: UtsSideEffectClassV1) -> JsonValu
     };
 
     json!({
-        "schema_version": UTS_SCHEMA_VERSION_V1,
+        "schema_version": UTS_SCHEMA_VERSION_V1_1,
+        "compatible_versions": ["uts.v1", "uts.v1.1"],
         "name": id,
         "version": "1.0.0",
-        "description": format!("{id} fixture for deterministic UTS v1 conformance review."),
+        "description": format!("{id} fixture for deterministic UTS v1.1 conformance review."),
+        "categories": [
+            match side_effect {
+                UtsSideEffectClassV1::Read => "read_only",
+                UtsSideEffectClassV1::LocalWrite => "state_mutating",
+                UtsSideEffectClassV1::ExternalRead | UtsSideEffectClassV1::ExternalWrite => "external_network",
+                UtsSideEffectClassV1::Process => "state_mutating",
+                UtsSideEffectClassV1::Network => "external_network",
+                UtsSideEffectClassV1::Destructive => "governance_sensitive",
+                UtsSideEffectClassV1::Exfiltration => "observability_sensitive"
+            }
+        ],
         "input_schema": {
             "type": "object",
             "properties": {
@@ -149,6 +161,15 @@ fn base_fixture(id: &'static str, side_effect: UtsSideEffectClassV1) -> JsonValu
             "additionalProperties": false
         },
         "side_effect_class": side_effect_wire(side_effect),
+        "side_effects": [
+            match side_effect {
+                UtsSideEffectClassV1::Read => "none",
+                UtsSideEffectClassV1::LocalWrite => "local_state",
+                UtsSideEffectClassV1::ExternalRead | UtsSideEffectClassV1::ExternalWrite | UtsSideEffectClassV1::Network => "external_state",
+                UtsSideEffectClassV1::Process | UtsSideEffectClassV1::Destructive => "irreversible",
+                UtsSideEffectClassV1::Exfiltration => "governance_relevant"
+            }
+        ],
         "determinism": "deterministic",
         "replay_safety": replay_safety,
         "idempotence": idempotence,
@@ -169,6 +190,20 @@ fn base_fixture(id: &'static str, side_effect: UtsSideEffectClassV1) -> JsonValu
                 "retryable": false
             }
         ],
+        "observability": match side_effect {
+            UtsSideEffectClassV1::Read => "basic",
+            UtsSideEffectClassV1::LocalWrite
+            | UtsSideEffectClassV1::ExternalRead
+            | UtsSideEffectClassV1::ExternalWrite
+            | UtsSideEffectClassV1::Network => "full",
+            UtsSideEffectClassV1::Process
+            | UtsSideEffectClassV1::Destructive
+            | UtsSideEffectClassV1::Exfiltration => "governance"
+        },
+        "planning": {
+            "review_recommended": matches!(side_effect, UtsSideEffectClassV1::LocalWrite | UtsSideEffectClassV1::ExternalWrite | UtsSideEffectClassV1::Process | UtsSideEffectClassV1::Destructive | UtsSideEffectClassV1::Exfiltration),
+            "high_risk": matches!(side_effect, UtsSideEffectClassV1::Process | UtsSideEffectClassV1::Destructive | UtsSideEffectClassV1::Exfiltration)
+        },
         "extensions": {
             "x-adl-conformance-note": "schema compatibility only; no runtime authority"
         }
@@ -228,7 +263,7 @@ pub fn uts_conformance_fixtures() -> Vec<UtsConformanceFixture> {
     missing_semantics
         .as_object_mut()
         .expect("fixture should be an object")
-        .remove("side_effect_class");
+        .remove("compatible_versions");
 
     let mut missing_security = base_fixture(
         "invalid.missing_security_metadata",
@@ -357,6 +392,7 @@ pub fn uts_conformance_fixtures() -> Vec<UtsConformanceFixture> {
 fn missing_required_reason(document: &JsonValue) -> Option<&'static str> {
     let object = document.as_object()?;
     if [
+        "compatible_versions",
         "side_effect_class",
         "determinism",
         "replay_safety",
@@ -432,9 +468,9 @@ fn evaluate_fixture(fixture: &UtsConformanceFixture) -> UtsConformanceCaseResult
         };
     }
 
-    let parsed = serde_json::from_value::<UniversalToolSchemaV1>(fixture.document.clone());
+    let parsed = serde_json::from_value::<UniversalToolSchemaV1_1>(fixture.document.clone());
     let (accepted, reason, side_effect_class) = match parsed {
-        Ok(schema) => match validate_uts_v1(&schema) {
+        Ok(schema) => match validate_uts_v1_1(&schema) {
             Ok(()) => (true, "accepted", Some(schema.side_effect_class)),
             Err(report) => (
                 false,
@@ -500,7 +536,7 @@ pub fn run_uts_conformance_suite() -> UtsConformanceReport {
     let passed = cases.iter().all(|case| case.passed);
 
     UtsConformanceReport {
-        schema_version: UTS_SCHEMA_VERSION_V1,
+        schema_version: UTS_SCHEMA_VERSION_V1_1,
         fixture_count: fixtures.len(),
         passed,
         cases,
@@ -555,7 +591,7 @@ mod tests {
     fn uts_conformance_suite_passes_all_expected_outcomes() {
         let report = run_uts_conformance_suite();
 
-        assert_eq!(report.schema_version, UTS_SCHEMA_VERSION_V1);
+        assert_eq!(report.schema_version, UTS_SCHEMA_VERSION_V1_1);
         assert_eq!(report.fixture_count, EXPECTED_IDS.len());
         let failed: Vec<&UtsConformanceCaseResult> =
             report.cases.iter().filter(|case| !case.passed).collect();
@@ -672,7 +708,7 @@ mod tests {
 
         assert!(report.passed);
         assert_eq!(report.fixture_count, EXPECTED_IDS.len());
-        assert_eq!(parsed["schema_version"], json!(UTS_SCHEMA_VERSION_V1));
+        assert_eq!(parsed["schema_version"], json!(UTS_SCHEMA_VERSION_V1_1));
         assert_eq!(parsed["fixture_count"], json!(EXPECTED_IDS.len()));
         assert!(parsed["passed"].as_bool().unwrap_or(false));
         assert!(body.ends_with('\n'));

--- a/docs/milestones/v0.90.5/review/uts-conformance-report.json
+++ b/docs/milestones/v0.90.5/review/uts-conformance-report.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "uts.v1",
+  "schema_version": "uts.v1.1",
   "fixture_count": 21,
   "passed": true,
   "cases": [


### PR DESCRIPTION
Closes #3032

## Summary
- preserve UTS v1.0 validation/schema APIs while adding explicit UTS v1.1 types and validators
- move the active registry/compiler/conformance surfaces onto UTS v1.1
- keep adoption additive by accepting legacy UTS v1.0 definitions through registry deserialization and programmatic upgrade helpers
- refresh the tracked UTS conformance artifact to the v1.1 report shape

## Validation
- bounded subagent review: no actionable findings remain
- `git diff --check`

## Notes
- no broad cargo validation run in this pass
- scope is limited to UTS code/test surface adoption before WP-02