### PR TITLE
[v0.91.2][docs] Clean up stale legacy swarm references in current docs surfaces

### DIFF
--- a/docs/adr/0005-hitl-pause-resume.md
+++ b/docs/adr/0005-hitl-pause-resume.md
@@ -63,17 +63,17 @@ performed.
 
 ## CLI / Config Surface
 Canonical v0.6 resume surface:
-- `swarm resume <run_id>`
+- `adl resume <run_id>`
   - loads `.adl/runs/<run_id>/pause_state.json`
   - enforces strict validation before resuming
 
 ## Compatibility / Deprecated
 Legacy compatibility path (deprecated, internal/back-compat only):
-- `swarm <adl.yaml> --run --resume <run.json>`
+- `adl <adl.yaml> --run --resume <run.json>`
 
 This path is not part of the stable public v0.6 contract and may be removed
 without notice. Operational and documentation guidance should use
-`swarm resume <run_id>`.
+`adl resume <run_id>`.
 
 
 ## Determinism And Safety Considerations

--- a/docs/adr/0006-remote-signing-canonicalization.md
+++ b/docs/adr/0006-remote-signing-canonicalization.md
@@ -42,6 +42,6 @@ Both client and server must use the same routine:
 
 ## References
 
-- `swarm/src/remote_exec.rs`
-- `swarm/tools/demo_d11_signed_remote.sh`
+- `adl/src/remote_exec.rs`
+- `adl/tools/demo_d11_signed_remote.sh`
 - `docs/milestones/v0.7/DEMOS_v0.7.md`

--- a/docs/adr/0007-obsmem-external-boundary.md
+++ b/docs/adr/0007-obsmem-external-boundary.md
@@ -12,10 +12,10 @@ architectural documentation for why ObsMem is kept outside core runtime logic
 and how versioned contracts should be treated.
 
 Current runtime integration points are:
-- `swarm::obsmem_contract` (`ObsMemClient` trait and request/response types)
-- `swarm::obsmem_adapter` (runtime-facing adapter to contract client)
-- `swarm::obsmem_indexing` and `swarm::obsmem_retrieval_policy` (deterministic
-  indexing/query policy behavior)
+- `adl/src/obsmem_contract/` (`ObsMemClient` trait and request/response types)
+- `adl/src/obsmem_adapter.rs` (runtime-facing adapter to contract client)
+- `adl/src/obsmem_indexing.rs` and `adl/src/obsmem_retrieval_policy.rs`
+  (deterministic indexing/query policy behavior)
 
 ## Decision
 

--- a/docs/adr/0008-godel-stage-loop-v08.md
+++ b/docs/adr/0008-godel-stage-loop-v08.md
@@ -6,20 +6,20 @@ Accepted (v0.8).
 
 ## Context
 
-v0.8 introduces a real bounded Gödel runtime surface under `swarm/src/godel/`
+v0.8 introduces a real bounded Gödel runtime surface under `adl/src/godel/`
 with deterministic tests, canonical artifacts, and runnable demos. Review
 feedback highlighted that the implementation is now substantial enough to need
 an explicit architecture decision record, not just milestone prose.
 
 The shipped runtime surfaces are centered on:
-- `swarm/src/godel/stage_loop.rs`
-- `swarm/src/godel/hypothesis.rs`
-- `swarm/src/godel/mutation.rs`
-- `swarm/src/godel/evaluation.rs`
-- `swarm/src/godel/experiment_record.rs`
-- `swarm/src/godel/obsmem_index.rs`
-- `swarm/src/godel/workflow_template.rs`
-- `swarm/src/demo.rs` (`demo-c-godel-runtime`, `demo-d-godel-obsmem-loop`)
+- `adl/src/godel/stage_loop.rs`
+- `adl/src/godel/hypothesis.rs`
+- `adl/src/godel/mutation.rs`
+- `adl/src/godel/evaluation.rs`
+- `adl/src/godel/experiment_record.rs`
+- `adl/src/godel/obsmem_index.rs`
+- `adl/src/godel/workflow_template.rs`
+- `adl/src/demo.rs` (`demo-c-godel-runtime`, `demo-d-godel-obsmem-loop`)
 
 The main architectural question for v0.8 is not whether ADL has a full
 autonomous self-improvement agent. It does not. The question is how to expose a


### PR DESCRIPTION
---
issue_card_schema: adl.issue.v1
wp: "sidecar"
queue: "tools"
slug: "cleanup-stale-legacy-swarm-references-in-current-docs-surfaces"
title: "[v0.91.2][docs] Clean up stale legacy swarm references in current docs surfaces"
labels:
  - "track:roadmap"
  - "area:tools"
  - "type:task"
  - "version:v0.91.2"
issue_number: 3024
status: "draft"
action: "edit"
depends_on: 
  - "WP-01"
milestone_sprint: "Unscheduled v0.91.2 sidecar"
required_outcome_type:
  - "docs"
repo_inputs: 
  - "AGENTS.md"
  - "docs/milestones/v0.91.2/README.md"
  - "docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml"
canonical_files: 
  - "AGENTS.md"
  - "docs/milestones/v0.91.2/README.md"
  - "docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml"
demo_required: false
demo_names: []
issue_graph_notes: 
  - "Unscheduled v0.91.2 sidecar docs cleanup issue."
  - "Not part of the canonical WP-01 through WP-24 issue wave."
  - "Do not execute until explicitly scheduled or routed by the operator."
pr_start:
  enabled: false
  slug: "cleanup-stale-legacy-swarm-references-in-current-docs-surfaces"
---

# [v0.91.2][docs] Clean up stale legacy swarm references in current docs surfaces

## Summary

- remove or correct stale docs references that still imply `swarm/` is a live
  runtime/docs/examples surface
- reconcile docs with current repo truth: `adl/` is the active surface and the
  leftover local `swarm/` directory was only empty residue
- keep the cleanup bounded to broken or misleading current references rather
  than rewriting historical milestone narrative wholesale

## Goal

Repair misleading current-use docs references so operators and reviewers are not
pointed at a nonexistent live `swarm/` runtime tree.

## Required Outcome

Deliver one bounded docs cleanup pass that inventories stale `swarm` references
in current-use surfaces, corrects the broken or misleading active-path claims,
and leaves clearly historical milestone references alone unless they create
present-day operator confusion.

## Deliverables

- one bounded inventory of stale `swarm` references in current-use surfaces
- corrected current-use docs references that should now point to `adl/...` or
  other live repo paths
- a narrow reviewable patch set that leaves clearly historical references alone
  unless they are actively misleading

## Acceptance Criteria

- one bounded inventory exists for stale `swarm` docs references in current-use
  surfaces
- broken or misleading active-surface references are corrected to current repo
  truth
- historical references that remain are either clearly historical or
  intentionally left alone
- final docs no longer mislead an operator into believing `swarm/` is still the
  live runtime tree

## Repo Inputs

- https://github.com/danielbaustin/agent-design-language/issues/3024
- AGENTS.md
- docs/milestones/v0.91.2/README.md
- docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml

## Dependencies

- WP-01 / #3000 must have landed so the v0.91.2 milestone package and sidecar
  truth are stable before this cleanup executes

## Demo Expectations

- No demo is required.
- Proof for this issue is the bounded docs-reference audit plus the corrected
  docs patch set.

## Non-goals

- wholesale historical doc rewriting across old milestones
- repo-wide rename archaeology for its own sake
- code changes unrelated to docs/reference truth
- changing milestone scope without recording it explicitly

## Issue-Graph Notes

- This is an unscheduled `v0.91.2` sidecar issue.
- It is explicitly not part of the canonical `WP-01` through `WP-24` issue wave.
- Execute it only when the operator explicitly routes it, separate from the
  canonical sprint sequence.

## Notes

- Focus on current/reviewer/operator-facing docs first.
- Broken references to `swarm/examples`, `swarm/Cargo.toml`, `swarm/src`, or
  similar active-surface paths should be corrected when they still imply live
  repo truth.

## Tooling Notes

- Use the tracked issue/task-bundle workflow as normal.
- Default next steps should follow `pr-ready` and `pr-run`, not the older
  `pr start` path.

Closes #3024