### PR TITLE
[v0.91.2][tools] Adopt ACC v1.1 in code and tests after the tracked spec lands

### DIFF
--- a/adl/src/acc.rs
+++ b/adl/src/acc.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 pub const ACC_SCHEMA_VERSION_V1: &str = "acc.v1";
+pub const ACC_SCHEMA_VERSION_V1_0: &str = ACC_SCHEMA_VERSION_V1;
+pub const ACC_SCHEMA_VERSION_V1_1: &str = "acc.v1.1";
 pub const ACC_MAX_DELEGATION_DEPTH_V1: u8 = 8;
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -266,6 +268,42 @@ pub struct AdlCapabilityContractV1 {
     pub decision: AccDecisionV1,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AccDelegationConstraintsV1_1 {
+    pub max_depth: u8,
+    pub allow_redelegation: bool,
+    #[serde(default)]
+    pub scope_ceiling: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AdlCapabilityContractV1_1 {
+    pub schema_version: String,
+    #[serde(default)]
+    pub compatible_versions: Option<Vec<String>>,
+    #[serde(default)]
+    pub governance_profile: Option<String>,
+    pub contract_id: String,
+    pub tool: AccToolReferenceV1,
+    pub actor: AccActorIdentityV1,
+    pub authority_grant: AccAuthorityGrantV1,
+    pub role_standing: AccRoleStandingV1,
+    pub delegation_chain: Vec<AccDelegationStepV1>,
+    #[serde(default)]
+    pub delegation_constraints: Option<AccDelegationConstraintsV1_1>,
+    pub capability: AccCapabilityRequirementV1,
+    pub policy_checks: Vec<AccPolicyCheckV1>,
+    pub confirmation: AccConfirmationRequirementV1,
+    pub freedom_gate: AccFreedomGateRequirementV1,
+    pub execution: AccExecutionSemanticsV1,
+    pub trace_replay: AccTraceReplayV1,
+    pub privacy_redaction: AccPrivacyRedactionV1,
+    pub failure_policy: AccFailurePolicyV1,
+    pub decision: AccDecisionV1,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccValidationError {
     pub code: &'static str,
@@ -408,6 +446,27 @@ fn policy_evidence_ref_is_known(contract: &AdlCapabilityContractV1, evidence_ref
             .delegation_chain
             .iter()
             .any(|step| step.delegation_id == evidence_ref)
+}
+
+fn project_acc_v1_1_to_v1(contract: &AdlCapabilityContractV1_1) -> AdlCapabilityContractV1 {
+    AdlCapabilityContractV1 {
+        schema_version: ACC_SCHEMA_VERSION_V1.to_string(),
+        contract_id: contract.contract_id.clone(),
+        tool: contract.tool.clone(),
+        actor: contract.actor.clone(),
+        authority_grant: contract.authority_grant.clone(),
+        role_standing: contract.role_standing.clone(),
+        delegation_chain: contract.delegation_chain.clone(),
+        capability: contract.capability.clone(),
+        policy_checks: contract.policy_checks.clone(),
+        confirmation: contract.confirmation.clone(),
+        freedom_gate: contract.freedom_gate.clone(),
+        execution: contract.execution.clone(),
+        trace_replay: contract.trace_replay.clone(),
+        privacy_redaction: contract.privacy_redaction.clone(),
+        failure_policy: contract.failure_policy.clone(),
+        decision: contract.decision.clone(),
+    }
 }
 
 pub fn validate_acc_v1(contract: &AdlCapabilityContractV1) -> Result<(), AccValidationReport> {
@@ -755,9 +814,148 @@ pub fn validate_acc_v1(contract: &AdlCapabilityContractV1) -> Result<(), AccVali
     }
 }
 
+pub fn upgrade_acc_v1_to_v1_1(contract: AdlCapabilityContractV1) -> AdlCapabilityContractV1_1 {
+    AdlCapabilityContractV1_1 {
+        schema_version: ACC_SCHEMA_VERSION_V1_1.to_string(),
+        compatible_versions: Some(vec![
+            ACC_SCHEMA_VERSION_V1.to_string(),
+            ACC_SCHEMA_VERSION_V1_1.to_string(),
+        ]),
+        governance_profile: Some("standard_reviewed_runtime".to_string()),
+        contract_id: contract.contract_id,
+        tool: contract.tool,
+        actor: contract.actor,
+        authority_grant: contract.authority_grant,
+        role_standing: contract.role_standing,
+        delegation_chain: contract.delegation_chain,
+        delegation_constraints: None,
+        capability: contract.capability,
+        policy_checks: contract.policy_checks,
+        confirmation: contract.confirmation,
+        freedom_gate: contract.freedom_gate,
+        execution: contract.execution,
+        trace_replay: contract.trace_replay,
+        privacy_redaction: contract.privacy_redaction,
+        failure_policy: contract.failure_policy,
+        decision: contract.decision,
+    }
+}
+
+impl From<AdlCapabilityContractV1> for AdlCapabilityContractV1_1 {
+    fn from(contract: AdlCapabilityContractV1) -> Self {
+        upgrade_acc_v1_to_v1_1(contract)
+    }
+}
+
+pub fn validate_acc_v1_1(contract: &AdlCapabilityContractV1_1) -> Result<(), AccValidationReport> {
+    let mut projected = project_acc_v1_1_to_v1(contract);
+    projected.schema_version = ACC_SCHEMA_VERSION_V1.to_string();
+    let mut errors = match validate_acc_v1(&projected) {
+        Ok(()) => Vec::new(),
+        Err(report) => report.errors,
+    };
+
+    if contract.schema_version != ACC_SCHEMA_VERSION_V1_1 {
+        push_error(
+            &mut errors,
+            "unsupported_schema_version",
+            "schema_version",
+            format!("schema_version must be {ACC_SCHEMA_VERSION_V1_1}"),
+        );
+    }
+
+    if let Some(compatible_versions) = &contract.compatible_versions {
+        if compatible_versions.is_empty() {
+            push_error(
+                &mut errors,
+                "invalid_compatible_versions",
+                "compatible_versions",
+                "compatible_versions must not be empty when present",
+            );
+        } else if !compatible_versions
+            .iter()
+            .any(|version| version == ACC_SCHEMA_VERSION_V1_1)
+        {
+            push_error(
+                &mut errors,
+                "missing_self_compatible_version",
+                "compatible_versions",
+                "compatible_versions must include acc.v1.1 when present",
+            );
+        }
+    }
+
+    if contract
+        .governance_profile
+        .as_deref()
+        .is_some_and(|profile| !valid_token(profile))
+    {
+        push_error(
+            &mut errors,
+            "invalid_governance_profile",
+            "governance_profile",
+            "governance_profile must be a non-empty token",
+        );
+    }
+
+    if let Some(constraints) = &contract.delegation_constraints {
+        if constraints.max_depth == 0 || constraints.max_depth > ACC_MAX_DELEGATION_DEPTH_V1 {
+            push_error(
+                &mut errors,
+                "invalid_delegation_constraints",
+                "delegation_constraints.max_depth",
+                "delegation_constraints.max_depth must stay within the ACC delegation bound",
+            );
+        }
+        if constraints
+            .scope_ceiling
+            .as_deref()
+            .is_some_and(|scope| scope.trim().is_empty())
+        {
+            push_error(
+                &mut errors,
+                "invalid_delegation_constraints",
+                "delegation_constraints.scope_ceiling",
+                "delegation_constraints.scope_ceiling must be omitted or non-empty",
+            );
+        }
+        if contract
+            .delegation_chain
+            .iter()
+            .any(|step| step.depth > constraints.max_depth)
+        {
+            push_error(
+                &mut errors,
+                "delegation_constraints_exceeded",
+                "delegation_constraints.max_depth",
+                "delegation chain depth must not exceed delegation_constraints.max_depth",
+            );
+        }
+        if !constraints.allow_redelegation && contract.delegation_chain.len() > 1 {
+            push_error(
+                &mut errors,
+                "redelegation_not_allowed",
+                "delegation_constraints.allow_redelegation",
+                "delegation chain cannot redelegate when allow_redelegation is false",
+            );
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(AccValidationReport { errors })
+    }
+}
+
 pub fn acc_v1_schema_json() -> JsonValue {
     serde_json::to_value(schema_for!(AdlCapabilityContractV1))
         .expect("ACC v1 schema should serialize")
+}
+
+pub fn acc_v1_1_schema_json() -> JsonValue {
+    serde_json::to_value(schema_for!(AdlCapabilityContractV1_1))
+        .expect("ACC v1.1 schema should serialize")
 }
 
 fn base_contract(id: &'static str) -> AdlCapabilityContractV1 {
@@ -1006,6 +1204,21 @@ mod tests {
         validate_acc_v1(&contract).expect("allowed authority fixture should pass");
         assert_eq!(contract.decision, AccDecisionV1::Allowed);
         assert!(contract.execution.approved_for_execution);
+    }
+
+    #[test]
+    fn acc_v1_1_upgraded_allowed_authority_fixture_passes() {
+        let contract = upgrade_acc_v1_to_v1_1(base_contract("acc.fixture.allowed_safe_read"));
+
+        validate_acc_v1_1(&contract).expect("upgraded authority fixture should pass");
+        assert_eq!(contract.schema_version, ACC_SCHEMA_VERSION_V1_1);
+        assert_eq!(
+            contract
+                .compatible_versions
+                .as_ref()
+                .expect("compatible versions"),
+            &vec!["acc.v1".to_string(), "acc.v1.1".to_string()]
+        );
     }
 
     #[test]
@@ -1327,6 +1540,27 @@ mod tests {
             assert!(
                 properties.contains_key(key),
                 "ACC schema missing property {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn acc_v1_1_schema_generation_exposes_additive_governance_surface() {
+        let schema = acc_v1_1_schema_json();
+        let properties = schema
+            .get("properties")
+            .and_then(JsonValue::as_object)
+            .expect("generated ACC v1.1 schema should expose properties");
+
+        for key in [
+            "schema_version",
+            "compatible_versions",
+            "governance_profile",
+            "delegation_constraints",
+        ] {
+            assert!(
+                properties.contains_key(key),
+                "ACC v1.1 schema missing property {key}"
             );
         }
     }

--- a/adl/src/uts_acc_compiler.rs
+++ b/adl/src/uts_acc_compiler.rs
@@ -1,4 +1,4 @@
-use crate::acc::{AccGrantStatusV1, AdlCapabilityContractV1};
+use crate::acc::{AccGrantStatusV1, AdlCapabilityContractV1, AdlCapabilityContractV1_1};
 use crate::tool_registry::ToolRegistryV1;
 use crate::uts::UtsSideEffectClassV1;
 use schemars::JsonSchema;
@@ -12,7 +12,7 @@ mod frontend;
 #[cfg(test)]
 mod tests;
 
-pub use core::compile_uts_to_acc_v1;
+pub use core::{compile_uts_to_acc_v1, compile_uts_to_acc_v1_1};
 pub use fixtures::{
     wp09_compiler_input_fixture, wp09_compiler_registry_fixture, wp09_policy_context_fixture,
     wp09_proposal_fixture,
@@ -136,6 +136,17 @@ pub struct UtsAccCompilerOutcomeV1 {
     pub decision: UtsAccCompilerDecisionV1,
     #[serde(default)]
     pub acc: Option<AdlCapabilityContractV1>,
+    #[serde(default)]
+    pub rejection: Option<UtsAccRejectionRecordV1>,
+    pub evidence: Vec<UtsAccCompilerEvidenceV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct UtsAccCompilerOutcomeV1_1 {
+    pub decision: UtsAccCompilerDecisionV1,
+    #[serde(default)]
+    pub acc: Option<AdlCapabilityContractV1_1>,
     #[serde(default)]
     pub rejection: Option<UtsAccRejectionRecordV1>,
     pub evidence: Vec<UtsAccCompilerEvidenceV1>,

--- a/adl/src/uts_acc_compiler/core.rs
+++ b/adl/src/uts_acc_compiler/core.rs
@@ -3,17 +3,19 @@ use super::frontend::{
 };
 use super::{
     evidence, reject, UtsAccCompilerDecisionV1, UtsAccCompilerEvidenceStageV1,
-    UtsAccCompilerInputV1, UtsAccCompilerOutcomeV1, UtsAccCompilerRejectionCodeV1,
-    UtsAccPolicyContextV1,
+    UtsAccCompilerInputV1, UtsAccCompilerOutcomeV1, UtsAccCompilerOutcomeV1_1,
+    UtsAccCompilerRejectionCodeV1, UtsAccPolicyContextV1,
 };
 use crate::acc::{
-    acc_v1_redaction_examples, acc_v1_visibility_matrix, validate_acc_v1, AccActorIdentityV1,
-    AccActorKindV1, AccAuthorityEvidenceKindV1, AccAuthorityEvidenceV1, AccAuthorityGrantV1,
-    AccCapabilityRequirementV1, AccConfirmationRequirementV1, AccDecisionV1, AccDelegationStepV1,
+    acc_v1_redaction_examples, acc_v1_visibility_matrix, upgrade_acc_v1_to_v1_1, validate_acc_v1,
+    validate_acc_v1_1, AccActorIdentityV1, AccActorKindV1, AccAuthorityEvidenceKindV1,
+    AccAuthorityEvidenceV1, AccAuthorityGrantV1, AccCapabilityRequirementV1,
+    AccConfirmationRequirementV1, AccDecisionV1, AccDelegationConstraintsV1_1, AccDelegationStepV1,
     AccExecutionSemanticsV1, AccFailurePolicyV1, AccFreedomGateDecisionV1,
     AccFreedomGateRequirementV1, AccGrantStatusV1, AccPolicyCheckV1, AccPrivacyRedactionV1,
     AccRoleStandingV1, AccToolReferenceV1, AccTracePrivacyPolicyV1, AccTraceReplayV1,
-    AccVisibilityPolicyV1, AdlCapabilityContractV1, ACC_SCHEMA_VERSION_V1,
+    AccVisibilityPolicyV1, AdlCapabilityContractV1, ACC_MAX_DELEGATION_DEPTH_V1,
+    ACC_SCHEMA_VERSION_V1,
 };
 use crate::tool_registry::{
     bind_tool_registry_v1, RegisteredToolV1, ToolBindingDecisionV1, ToolBindingRequestV1,
@@ -466,5 +468,30 @@ pub fn compile_uts_to_acc_v1(input: &UtsAccCompilerInputV1) -> UtsAccCompilerOut
         acc: Some(acc),
         rejection: None,
         evidence: evidence_log,
+    }
+}
+
+pub fn compile_uts_to_acc_v1_1(input: &UtsAccCompilerInputV1) -> UtsAccCompilerOutcomeV1_1 {
+    let outcome = compile_uts_to_acc_v1(input);
+    let upgraded_acc = outcome.acc.map(|acc| {
+        let mut upgraded = upgrade_acc_v1_to_v1_1(acc);
+        upgraded.governance_profile = Some("standard_reviewed_runtime".to_string());
+        upgraded.delegation_constraints = Some(AccDelegationConstraintsV1_1 {
+            max_depth: ACC_MAX_DELEGATION_DEPTH_V1,
+            allow_redelegation: false,
+            scope_ceiling: Some(upgraded.capability.resource_scope.clone()),
+        });
+        upgraded
+    });
+
+    if let Some(ref acc) = upgraded_acc {
+        validate_acc_v1_1(acc).expect("upgraded ACC v1.1 compiler output should validate");
+    }
+
+    UtsAccCompilerOutcomeV1_1 {
+        decision: outcome.decision,
+        acc: upgraded_acc,
+        rejection: outcome.rejection,
+        evidence: outcome.evidence,
     }
 }

--- a/adl/src/uts_acc_compiler/tests.rs
+++ b/adl/src/uts_acc_compiler/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::acc::{validate_acc_v1, AccDecisionV1};
+use crate::acc::{
+    validate_acc_v1, validate_acc_v1_1, AccDecisionV1, ACC_SCHEMA_VERSION_V1,
+    ACC_SCHEMA_VERSION_V1_1,
+};
 use crate::uts::{UtsCategoryV1, UtsObservabilityV1, UtsResourceRequirementV1, UtsSideEffectTagV1};
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -57,6 +60,7 @@ fn wp09_maps_safe_read_to_allowed_acc() {
     assert_eq!(acc.decision, AccDecisionV1::Allowed);
     assert_eq!(acc.tool.tool_name, "fixture.safe_read");
     validate_acc_v1(&acc).expect("compiled safe-read ACC should validate");
+    assert_eq!(acc.schema_version, ACC_SCHEMA_VERSION_V1);
 }
 
 #[test]
@@ -191,6 +195,25 @@ fn wp09_maps_delegated_local_write_to_delegated_acc() {
     assert!(!acc.execution.approved_for_execution);
     assert_eq!(acc.delegation_chain.len(), 1);
     validate_acc_v1(&acc).expect("compiled delegated ACC should validate");
+}
+
+#[test]
+fn wp09_maps_safe_read_to_allowed_acc_v1_1() {
+    let input = wp09_compiler_input_fixture("fixture.safe_read");
+    let outcome = compile_uts_to_acc_v1_1(&input);
+
+    assert_eq!(outcome.decision, UtsAccCompilerDecisionV1::AccEmitted);
+    let acc = outcome.acc.expect("safe read should compile to ACC v1.1");
+    assert_eq!(acc.decision, AccDecisionV1::Allowed);
+    validate_acc_v1_1(&acc).expect("compiled safe-read ACC v1.1 should validate");
+    assert_eq!(acc.schema_version, ACC_SCHEMA_VERSION_V1_1);
+    assert_eq!(
+        acc.compatible_versions
+            .as_ref()
+            .expect("compatible versions"),
+        &vec!["acc.v1".to_string(), "acc.v1.1".to_string()]
+    );
+    assert!(acc.delegation_constraints.is_some());
 }
 
 #[test]


### PR DESCRIPTION
Closes #3036

## Summary
Adopted `ACC v1.1` additively in code and tests without breaking the existing `ACC v1.0` public path. The final implementation keeps `acc.v1` validator/compiler behavior intact, adds explicit `ACC v1.1` schema/validator/upgrade surfaces in `adl/src/acc.rs`, and adds a parallel `compile_uts_to_acc_v1_1` path plus focused `v1.1` tests.

## Artifacts
- Local ignored output record at `.adl/v0.91.2/tasks/issue-3036__v0-91-2-tools-adopt-acc-v1-1-in-code-and-tests-after-the-tracked-spec-lands/sor.md`
- Tracked implementation artifacts:
  - `adl/src/acc.rs`
  - `adl/src/uts_acc_compiler.rs`
  - `adl/src/uts_acc_compiler/core.rs`
  - `adl/src/uts_acc_compiler/tests.rs`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml acc_v1_1 -- --nocapture`
    Verified the new `ACC v1.1` validator/schema/upgrade behavior.
  - `cargo test --manifest-path adl/Cargo.toml wp09_ -- --nocapture`
    Verified UTS-to-ACC compiler behavior across preserved `v1.0` and additive `v1.1` paths.
  - `cargo test --manifest-path adl/Cargo.toml governed_executor -- --nocapture`
    Verified governed executor safety behavior remained correct on the preserved `ACC v1.0` path.
  - `cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- acc`
    Generated focused coverage evidence for the ACC adoption change set.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified coverage-impact preflight passed for the risky ACC source edits.
  - `git diff --check`
    Verified the tracked patch set is formatting-clean.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3036__v0-91-2-tools-adopt-acc-v1-1-in-code-and-tests-after-the-tracked-spec-lands/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3036__v0-91-2-tools-adopt-acc-v1-1-in-code-and-tests-after-the-tracked-spec-lands/sor.md
- Idempotency-Key: v0-91-2-tools-adopt-acc-v1-1-in-code-and-tests-after-the-tracked-spec-lands-adl-v0-91-2-tasks-issue-3036-v0-91-2-tools-adopt-acc-v1-1-in-code-and-tests-after-the-tracked-spec-lands-sip-md-adl-v0-91-2-tasks-issue-3036-v0-91-2-tools-adopt-acc-v1-1-in-code-and-tests-after-the-tracked-spec-lands-sor-md