### PR TITLE
[v0.91.2][WP-04B] Refactor Runtime v2 materialization slow tests

### DIFF
--- a/adl/src/runtime_v2/tests/governed_learning_substrate.rs
+++ b/adl/src/runtime_v2/tests/governed_learning_substrate.rs
@@ -169,6 +169,7 @@ fn runtime_v2_governed_learning_substrate_write_to_path_materializes_fixture() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_governed_learning_substrate_write_to_root_materializes_fixture() {
     let packet =

--- a/adl/src/runtime_v2/tests/intelligence_metric_architecture.rs
+++ b/adl/src/runtime_v2/tests/intelligence_metric_architecture.rs
@@ -147,6 +147,7 @@ fn runtime_v2_intelligence_metric_architecture_write_to_path_materializes_fixtur
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_intelligence_metric_architecture_write_to_root_materializes_fixture() {
     let packet = runtime_v2_intelligence_metric_architecture_contract()

--- a/adl/src/runtime_v2/tests/theory_of_mind_foundation.rs
+++ b/adl/src/runtime_v2/tests/theory_of_mind_foundation.rs
@@ -169,6 +169,7 @@ fn runtime_v2_theory_of_mind_foundation_write_to_path_materializes_fixture() {
     );
 }
 
+#[cfg(feature = "slow-proof-tests")]
 #[test]
 fn runtime_v2_theory_of_mind_foundation_write_to_root_materializes_fixture() {
     let packet =


### PR DESCRIPTION
Closes #3043

## Summary
Refactored one representative Runtime v2 proof-materialization cluster by moving duplicated root-materialization proof for Theory of Mind, intelligence metric architecture, and governed learning into the authoritative `slow-proof-tests` lane. The default lane still keeps explicit-path materialization proof for the same packets, plus existing golden, validation, and proof-route coverage.

## Artifacts
- `adl/src/runtime_v2/tests/theory_of_mind_foundation.rs`
- `adl/src/runtime_v2/tests/intelligence_metric_architecture.rs`
- `adl/src/runtime_v2/tests/governed_learning_substrate.rs`

## Validation
- Validation commands and their purpose:
  - Default-lane root-materialization list checks verified the reclassified root tests no longer run in ordinary default test discovery.
  - Slow-lane `--features slow-proof-tests` list and nextest checks verified authoritative proof is preserved.
  - Default-lane explicit-path nextest check verified ordinary PR proof remains in place for the same packets.
  - Format and diff checks verified repository hygiene.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3043__v0-91-2-wp-04b-runtime-v2-proof-materialization-slow-tests/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3043__v0-91-2-wp-04b-runtime-v2-proof-materialization-slow-tests/sor.md
- Idempotency-Key: v0-91-2-wp-04b-refactor-runtime-v2-materialization-slow-tests-adl-src-runtime-v2-tests-theory-of-mind-foundation-rs-adl-src-runtime-v2-tests-intelligence-metric-architecture-rs-adl-src-runtime-v2-tests-governed-learning-substrate-rs-adl-v0-91-2-tasks-issue-3043-v0-91-2-wp-04b-runtime-v2-proof-materialization-slow-tests-sip-md-adl-v0-91-2-tasks-issue-3043-v0-91-2-wp-04b-runtime-v2-proof-materialization-slow-tests-sor-md