### PR TITLE
[v0.91.2][WP-04C] Tighten PR fast-test lane selection

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -156,12 +156,15 @@ filter_token_for_path() {
       printf 'private_state_sanctuary'
       return 0
       ;;
-    adl/src/runtime_v2/*/*.rs|adl/src/runtime_v2/*/*/*.rs|adl/src/runtime_v2/*/*/*/*.rs)
+    adl/src/runtime_v2/tests/common.rs)
       return 1
       ;;
     adl/src/runtime_v2/tests/*)
       basename "$path" .rs
       return 0
+      ;;
+    adl/src/runtime_v2/*/*.rs|adl/src/runtime_v2/*/*/*.rs|adl/src/runtime_v2/*/*/*/*.rs)
+      return 1
       ;;
     adl/src/runtime_v2/[^/]*.rs)
       basename "$path" .rs
@@ -213,6 +216,10 @@ filter_token_for_path() {
       ;;
     adl/src/cli/*/*/*.rs|adl/src/cli/*/*/*/*.rs)
       return 1
+      ;;
+    adl/src/uts_acc_compiler.rs|adl/src/uts_acc_compiler/*.rs)
+      printf 'uts_acc_compiler'
+      return 0
       ;;
     adl/src/cli/[^/]*.rs|adl/src/cli/[^/]*/[^/]*.rs)
       basename "$path" .rs

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -100,6 +100,43 @@ assert_has "$identity_family_output" "mode=focused"
 assert_has "$identity_family_output" "filter_tokens=identity_cmd"
 assert_has "$identity_family_output" "filter_expression=test(identity_cmd)"
 
+runtime_test_files="$TMP/runtime_test_files.txt"
+cat >"$runtime_test_files" <<'EOF'
+M	adl/src/runtime_v2/tests/theory_of_mind_foundation.rs
+M	adl/src/runtime_v2/tests/intelligence_metric_architecture.rs
+M	adl/src/runtime_v2/tests/governed_learning_substrate.rs
+EOF
+runtime_test_files_output="$(bash "$SCRIPT" --changed-files "$runtime_test_files" --print-plan)"
+assert_has "$runtime_test_files_output" "mode=focused"
+assert_has "$runtime_test_files_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$runtime_test_files_output" "filter_tokens=theory_of_mind_foundation,intelligence_metric_architecture,governed_learning_substrate"
+assert_has "$runtime_test_files_output" "filter_expression=test(theory_of_mind_foundation) or test(intelligence_metric_architecture) or test(governed_learning_substrate)"
+
+runtime_test_helper="$TMP/runtime_test_helper.txt"
+printf 'M\tadl/src/runtime_v2/tests/common.rs\n' >"$runtime_test_helper"
+runtime_test_helper_output="$(bash "$SCRIPT" --changed-files "$runtime_test_helper" --print-plan)"
+assert_has "$runtime_test_helper_output" "mode=family"
+assert_has "$runtime_test_helper_output" "reason=bounded_family_surface_runs_family_nextest"
+assert_has "$runtime_test_helper_output" "filter_tokens=runtime_v2"
+assert_has "$runtime_test_helper_output" "filter_expression=test(runtime_v2)"
+
+uts_compiler_adoption="$TMP/uts_compiler_adoption.txt"
+cat >"$uts_compiler_adoption" <<'EOF'
+M	adl/src/tool_registry.rs
+M	adl/src/uts.rs
+M	adl/src/uts_acc_compiler/core.rs
+M	adl/src/uts_acc_compiler/fixtures.rs
+M	adl/src/uts_acc_compiler/frontend.rs
+M	adl/src/uts_acc_compiler/tests.rs
+M	adl/src/uts_conformance.rs
+M	docs/milestones/v0.90.5/review/uts-conformance-report.json
+EOF
+uts_compiler_adoption_output="$(bash "$SCRIPT" --changed-files "$uts_compiler_adoption" --print-plan)"
+assert_has "$uts_compiler_adoption_output" "mode=focused"
+assert_has "$uts_compiler_adoption_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$uts_compiler_adoption_output" "filter_tokens=tool_registry,uts,uts_acc_compiler,uts_conformance"
+assert_has "$uts_compiler_adoption_output" "filter_expression=test(tool_registry) or test(uts) or test(uts_acc_compiler) or test(uts_conformance)"
+
 too_many="$TMP/too_many.txt"
 cat >"$too_many" <<'EOF'
 M	adl/src/runtime_v2/contract_schema.rs


### PR DESCRIPTION
Closes #3044

## Summary
Tightened the PR-fast test selector for bounded Rust changes that were incorrectly falling into the broad Runtime v2 family or full default nextest sweep. The fix gives ordinary Runtime v2 test files their intended precise file-stem filters before the generic nested-runtime fallback, keeps the shared Runtime v2 test helper on the safer Runtime v2 family lane, and maps `uts_acc_compiler` module files to the existing UTS compiler test family so the `#3032`-style UTS v1.1 adoption shape stays focused instead of triggering a full 1,882-test run.

## Artifacts
- `adl/tools/run_pr_fast_test_lane.sh`
- `adl/tools/test_run_pr_fast_test_lane.sh`
- Local validation fixtures under `.adl/v0.91.2/issue-3044-fixtures/`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/run_pr_fast_test_lane.sh`
    Proved the modified selector remains syntactically valid shell.
  - `bash -n adl/tools/test_run_pr_fast_test_lane.sh`
    Proved the updated contract test remains syntactically valid shell.
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Proved the selector still emits reviewable focused/family/full decisions and preserves fail-closed fallback behavior, including the shared Runtime v2 test helper case.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/v0.91.2/issue-3044-fixtures/runtime-test-helper.txt --print-plan`
    Proved shared Runtime v2 test helper edits use the bounded Runtime v2 family lane rather than a misleading focused basename filter.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/v0.91.2/issue-3044-fixtures/runtime-test-files.txt --print-plan`
    Proved the bounded Runtime v2 test-file example now avoids the broad `test(runtime_v2)` family lane.
  - `bash adl/tools/run_pr_fast_test_lane.sh --changed-files .adl/v0.91.2/issue-3044-fixtures/uts-compiler-adoption.txt --print-plan`
    Proved the bounded `#3032` UTS compiler adoption example now avoids the full default nextest lane.
  - `git diff --check`
    Proved the diff is whitespace-clean.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3044__v0-91-2-wp-04c-tighten-pr-fast-test-lane-selection/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3044__v0-91-2-wp-04c-tighten-pr-fast-test-lane-selection/sor.md
- Idempotency-Key: v0-91-2-wp-04c-tighten-pr-fast-test-lane-selection-adl-tools-run-pr-fast-test-lane-sh-adl-tools-test-run-pr-fast-test-lane-sh-adl-v0-91-2-tasks-issue-3044-v0-91-2-wp-04c-tighten-pr-fast-test-lane-selection-sip-md-adl-v0-91-2-tasks-issue-3044-v0-91-2-wp-04c-tighten-pr-fast-test-lane-selection-sor-md