### PR TITLE
[v0.91.2][WP-05A] Add slow-test timing diagnostics

### DIFF
--- a/adl/tools/summarize_nextest_timings.py
+++ b/adl/tools/summarize_nextest_timings.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Summarize nextest timing logs into reviewable hotspot reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+EVENT_RE = re.compile(
+    r"^\s*(?P<status>PASS|FAIL|SLOW)\s+"
+    r"\[\s*(?P<op>[<>]?)\s*(?P<seconds>\d+(?:\.\d+)?)s\]\s+"
+    r"\((?P<progress>[^)]*)\)\s+"
+    r"(?P<rest>.+?)\s*$"
+)
+START_RE = re.compile(r"Starting\s+(?P<count>\d+)\s+tests\s+across\s+(?P<binaries>\d+)\s+binaries")
+
+
+@dataclass(frozen=True)
+class TestEvent:
+    status: str
+    seconds: float
+    binary: str
+    test_name: str
+    family: str
+    cluster: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize cargo-nextest PASS/SLOW timing logs into hotspot families."
+    )
+    parser.add_argument("log", type=Path, help="Path to a captured nextest log.")
+    parser.add_argument("--top", type=int, default=20, help="Number of top completed tests to print.")
+    parser.add_argument(
+        "--min-seconds",
+        type=float,
+        default=1.0,
+        help="Minimum completed-test duration included in family/cluster summaries.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format.",
+    )
+    return parser.parse_args()
+
+
+def split_binary_and_test(rest: str) -> tuple[str, str]:
+    parts = rest.split(None, 1)
+    if len(parts) == 1:
+        return "unknown", parts[0]
+    return parts[0], parts[1]
+
+
+def family_for(test_name: str) -> str:
+    if "::tests::" in test_name:
+        prefix, tail = test_name.split("::tests::", 1)
+        first = tail.split("::", 1)[0]
+        if first:
+            return f"{prefix}::{first}"
+        return prefix
+    parts = test_name.split("::")
+    if len(parts) >= 3:
+        return "::".join(parts[:3])
+    if len(parts) >= 2:
+        return "::".join(parts[:2])
+    return test_name
+
+
+def cluster_for(test_name: str) -> str:
+    lower = test_name.lower()
+    if "contract_registry" in lower or "accessors" in lower or "shared_registry" in lower:
+        return "runtime-v2-contract-registry/accessors"
+    if "materializes_fixture" in lower or "materializes_fixtures" in lower:
+        return "proof-materialization"
+    if "golden" in lower:
+        return "golden-fixture"
+    if "proof_route" in lower:
+        return "proof-route"
+    if "validation_rejects" in lower or "validate_against_rejects" in lower:
+        return "validation-negative"
+    if "runtime_v2" in lower:
+        return "runtime-v2-other"
+    if "coverage" in lower:
+        return "coverage"
+    return "other"
+
+
+def parse_log(path: Path) -> tuple[list[TestEvent], list[TestEvent], dict[str, int]]:
+    completed: list[TestEvent] = []
+    slow_markers: list[TestEvent] = []
+    metadata = {"declared_tests": 0, "declared_binaries": 0, "parsed_lines": 0}
+
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        start_match = START_RE.search(line)
+        if start_match:
+            metadata["declared_tests"] = int(start_match.group("count"))
+            metadata["declared_binaries"] = int(start_match.group("binaries"))
+
+        match = EVENT_RE.match(line)
+        if not match:
+            continue
+
+        binary, test_name = split_binary_and_test(match.group("rest"))
+        event = TestEvent(
+            status=match.group("status"),
+            seconds=float(match.group("seconds")),
+            binary=binary,
+            test_name=test_name,
+            family=family_for(test_name),
+            cluster=cluster_for(test_name),
+        )
+        metadata["parsed_lines"] += 1
+        if event.status == "SLOW":
+            slow_markers.append(event)
+        else:
+            completed.append(event)
+
+    return completed, slow_markers, metadata
+
+
+def summarize(events: list[TestEvent], min_seconds: float) -> dict[str, list[dict[str, float | int | str]]]:
+    family_totals: dict[str, dict[str, float | int | str]] = defaultdict(
+        lambda: {"family": "", "count": 0, "total_seconds": 0.0, "max_seconds": 0.0}
+    )
+    cluster_totals: dict[str, dict[str, float | int | str]] = defaultdict(
+        lambda: {"cluster": "", "count": 0, "total_seconds": 0.0, "max_seconds": 0.0}
+    )
+
+    for event in events:
+        if event.seconds < min_seconds:
+            continue
+        family = family_totals[event.family]
+        family["family"] = event.family
+        family["count"] = int(family["count"]) + 1
+        family["total_seconds"] = float(family["total_seconds"]) + event.seconds
+        family["max_seconds"] = max(float(family["max_seconds"]), event.seconds)
+
+        cluster = cluster_totals[event.cluster]
+        cluster["cluster"] = event.cluster
+        cluster["count"] = int(cluster["count"]) + 1
+        cluster["total_seconds"] = float(cluster["total_seconds"]) + event.seconds
+        cluster["max_seconds"] = max(float(cluster["max_seconds"]), event.seconds)
+
+    def ordered(rows: dict[str, dict[str, float | int | str]]) -> list[dict[str, float | int | str]]:
+        return sorted(
+            rows.values(),
+            key=lambda row: (float(row["total_seconds"]), float(row["max_seconds"]), str(row.get("family") or row.get("cluster"))),
+            reverse=True,
+        )
+
+    return {"families": ordered(family_totals), "clusters": ordered(cluster_totals)}
+
+
+def routing_hint(cluster: str, count: int, max_seconds: float) -> str:
+    if cluster == "runtime-v2-contract-registry/accessors":
+        return "Route to Runtime v2 registry/accessor refactor or authoritative slow-proof consolidation."
+    if cluster == "proof-materialization":
+        return "Route to proof-materialization slow-lane review; keep one authoritative root proof where needed."
+    if count >= 3 and max_seconds >= 45.0:
+        return "Repeated family-level setup pattern; consider table/collapse refactor."
+    if max_seconds >= 60.0:
+        return "Individual slow outlier; inspect whether the expensive proof path is still intentional."
+    return "Monitor; no immediate refactor signal from timing alone."
+
+
+def markdown_report(
+    completed: list[TestEvent],
+    slow_markers: list[TestEvent],
+    metadata: dict[str, int],
+    top: int,
+    min_seconds: float,
+) -> str:
+    summaries = summarize(completed, min_seconds)
+    top_events = sorted(completed, key=lambda event: event.seconds, reverse=True)[:top]
+    total_seconds = sum(event.seconds for event in completed)
+    slow_thresholds = defaultdict(int)
+    for marker in slow_markers:
+        slow_thresholds[f">{marker.seconds:.0f}s"] += 1
+
+    lines = [
+        "# Nextest Timing Hotspot Report",
+        "",
+        "## Summary",
+        "",
+        f"- Declared nextest run: {metadata['declared_tests']} tests across {metadata['declared_binaries']} binaries",
+        f"- Completed timing rows parsed: {len(completed)}",
+        f"- Slow threshold markers parsed: {len(slow_markers)}",
+        f"- Total parsed completed runtime: {total_seconds:.3f}s",
+        f"- Family/cluster summaries include completed tests >= {min_seconds:.3f}s",
+        "",
+    ]
+
+    if slow_thresholds:
+        lines.extend(["## Slow Threshold Markers", ""])
+        for threshold, count in sorted(slow_thresholds.items()):
+            lines.append(f"- {threshold}: {count}")
+        lines.append("")
+
+    lines.extend(["## Top Completed Tests", ""])
+    lines.append("| Rank | Seconds | Family | Cluster | Test |")
+    lines.append("| ---: | ---: | --- | --- | --- |")
+    for index, event in enumerate(top_events, start=1):
+        lines.append(
+            f"| {index} | {event.seconds:.3f} | `{event.family}` | `{event.cluster}` | `{event.test_name}` |"
+        )
+    lines.append("")
+
+    lines.extend(["## Hotspot Families", ""])
+    lines.append("| Rank | Total Seconds | Count | Max Seconds | Family | Routing Hint |")
+    lines.append("| ---: | ---: | ---: | ---: | --- | --- |")
+    for index, row in enumerate(summaries["families"][:top], start=1):
+        family_events = [event for event in completed if event.family == row["family"]]
+        dominant_cluster = summarize(family_events, min_seconds)["clusters"][0]["cluster"] if family_events else "other"
+        hint = routing_hint(str(dominant_cluster), int(row["count"]), float(row["max_seconds"]))
+        lines.append(
+            f"| {index} | {float(row['total_seconds']):.3f} | {int(row['count'])} | "
+            f"{float(row['max_seconds']):.3f} | `{row['family']}` | {hint} |"
+        )
+    lines.append("")
+
+    lines.extend(["## Hotspot Clusters", ""])
+    lines.append("| Rank | Total Seconds | Count | Max Seconds | Cluster | Routing Hint |")
+    lines.append("| ---: | ---: | ---: | ---: | --- | --- |")
+    for index, row in enumerate(summaries["clusters"][:top], start=1):
+        hint = routing_hint(str(row["cluster"]), int(row["count"]), float(row["max_seconds"]))
+        lines.append(
+            f"| {index} | {float(row['total_seconds']):.3f} | {int(row['count'])} | "
+            f"{float(row['max_seconds']):.3f} | `{row['cluster']}` | {hint} |"
+        )
+    lines.append("")
+
+    lines.extend(
+        [
+            "## Routing Guidance",
+            "",
+            "- Treat this report as diagnosis only; it is not a substitute for passing tests, coverage, or release proof.",
+            "- Create test-refactor issues when a family has repeated slow completed tests with the same setup shape.",
+            "- Keep a test in an authoritative slow-proof lane when it is the one end-to-end proof path for a feature contract.",
+            "- Use focused reruns for changed bounded surfaces, but keep broad or ambiguous Rust changes fail-closed.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def json_report(
+    completed: list[TestEvent],
+    slow_markers: list[TestEvent],
+    metadata: dict[str, int],
+    top: int,
+    min_seconds: float,
+) -> str:
+    summaries = summarize(completed, min_seconds)
+    payload = {
+        "metadata": metadata,
+        "completed_count": len(completed),
+        "slow_marker_count": len(slow_markers),
+        "total_completed_seconds": round(sum(event.seconds for event in completed), 3),
+        "top_completed_tests": [asdict(event) for event in sorted(completed, key=lambda event: event.seconds, reverse=True)[:top]],
+        "families": summaries["families"][:top],
+        "clusters": summaries["clusters"][:top],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    if args.top < 1:
+        print("summarize_nextest_timings: --top must be >= 1", file=sys.stderr)
+        return 2
+    if not args.log.exists():
+        print(f"summarize_nextest_timings: input not found: {args.log}", file=sys.stderr)
+        return 2
+
+    completed, slow_markers, metadata = parse_log(args.log)
+    if args.format == "json":
+        sys.stdout.write(json_report(completed, slow_markers, metadata, args.top, args.min_seconds))
+    else:
+        sys.stdout.write(markdown_report(completed, slow_markers, metadata, args.top, args.min_seconds))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_summarize_nextest_timings.sh
+++ b/adl/tools/test_summarize_nextest_timings.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/summarize_nextest_timings.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_has() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    echo "expected output to contain: $needle" >&2
+    echo "actual output:" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+fixture="$TMP/nextest.log"
+cat >"$fixture" <<'EOF'
+    Starting 5 tests across 2 binaries
+        PASS [ 181.281s] ( 1/5) adl runtime_v2::tests::a2a_adapter_boundary::runtime_v2_a2a_adapter_boundary_contract_registry_smoke_covers_accessors
+        SLOW [> 60.000s] (─────────) adl runtime_v2::tests::theory_of_mind_foundation::runtime_v2_theory_of_mind_foundation_write_to_root_materializes_fixture
+        PASS [  75.270s] ( 2/5) adl runtime_v2::tests::theory_of_mind_foundation::runtime_v2_theory_of_mind_foundation_write_to_root_materializes_fixture
+        PASS [   0.011s] ( 3/5) adl acc::tests::acc_v1_rejects_hidden_delegation
+        PASS [  49.000s] ( 4/5) adl runtime_v2::tests::observatory_flagship::runtime_v2_observatory_flagship_review_bundle_matches_tracked_artifacts
+        PASS [   2.443s] ( 5/5) adl::bin/adl cli::tests::godel::real_godel_inspect_reads_persisted_runtime_artifacts
+EOF
+
+markdown_output="$(python3 "$SCRIPT" "$fixture" --top 5 --min-seconds 1)"
+assert_has "$markdown_output" "Declared nextest run: 5 tests across 2 binaries"
+assert_has "$markdown_output" "Total parsed completed runtime: 308.005s"
+assert_has "$markdown_output" 'runtime-v2-contract-registry/accessors'
+assert_has "$markdown_output" 'proof-materialization'
+assert_has "$markdown_output" "Route to Runtime v2 registry/accessor refactor or authoritative slow-proof consolidation."
+assert_has "$markdown_output" "Route to proof-materialization slow-lane review; keep one authoritative root proof where needed."
+
+json_output="$(python3 "$SCRIPT" "$fixture" --top 2 --format json)"
+assert_has "$json_output" '"completed_count": 5'
+assert_has "$json_output" '"slow_marker_count": 1'
+assert_has "$json_output" '"declared_tests": 5'
+assert_has "$json_output" '"cluster": "runtime-v2-contract-registry/accessors"'
+
+echo "PASS test_summarize_nextest_timings"

--- a/docs/milestones/v0.91.2/SLOW_TEST_TIMING_DIAGNOSTICS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SLOW_TEST_TIMING_DIAGNOSTICS_v0.91.2.md
@@ -1,0 +1,110 @@
+# Slow Test Timing Diagnostics v0.91.2
+
+## Purpose
+
+Use `adl/tools/summarize_nextest_timings.py` when a nextest lane is slow enough
+that reading the raw log by hand becomes wasteful. The tool parses ordinary
+`PASS [   N.NNNs] ...` rows plus `SLOW [> N.NNNs] ...` threshold markers and
+turns them into a reviewable hotspot report.
+
+The log path in the commands below is intentionally an operator-supplied,
+ignored artifact. In a clean checkout, first save a captured nextest log at that
+path or replace the argument with the path to the captured log under review.
+
+This diagnostic path is evidence only. It does not replace passing tests,
+coverage gates, release proof, or authoritative slow-proof obligations.
+
+## Operator Command
+
+```bash
+python3 adl/tools/summarize_nextest_timings.py .adl/docs/TBD/test-logs.txt --top 12 --min-seconds 45
+```
+
+Use `--format json` when a follow-on tool or issue planner needs structured
+data:
+
+```bash
+python3 adl/tools/summarize_nextest_timings.py .adl/docs/TBD/test-logs.txt --top 12 --min-seconds 45 --format json
+```
+
+## Routing Rules
+
+- Create a test-refactor issue when a family has repeated slow completed tests
+  with the same setup shape.
+- Keep a test in an authoritative slow-proof lane when it is the one
+  end-to-end proof path for a feature contract.
+- Treat contract-registry/accessor clusters as candidates for shared registry
+  proof consolidation or authoritative slow-lane demotion.
+- Treat proof-materialization clusters as candidates for explicit-path default
+  proof plus root-materialization slow-lane proof.
+- Keep broad or ambiguous Rust changes fail-closed; timing diagnostics should
+  never narrow a test lane by themselves.
+
+## Example Report From The Supplied #3032 Log
+
+The supplied `.adl/docs/TBD/test-logs.txt` log declares `1,882` tests across
+`28` binaries and produced:
+
+- Completed timing rows parsed: `1,881`
+- Slow threshold markers parsed: `77`
+- Total parsed completed runtime: `7364.644s`
+- Threshold markers: `63` over `60s`, `13` over `120s`, and `1` over `180s`
+
+### Top Completed Tests
+
+| Rank | Seconds | Family | Cluster | Test |
+| ---: | ---: | --- | --- | --- |
+| 1 | 181.281 | `runtime_v2::a2a_adapter_boundary` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::a2a_adapter_boundary::runtime_v2_a2a_adapter_boundary_contract_registry_smoke_covers_accessors` |
+| 2 | 179.933 | `runtime_v2::theory_of_mind_foundation` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::theory_of_mind_foundation::runtime_v2_theory_of_mind_foundation_contract_registry_smoke_covers_accessors` |
+| 3 | 178.840 | `runtime_v2::agent_lifecycle_state` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::agent_lifecycle_state::runtime_v2_agent_lifecycle_state_contract_registry_accessors_cover_runtime_v2_contracts_module` |
+| 4 | 178.825 | `runtime_v2::governed_learning_substrate` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::governed_learning_substrate::runtime_v2_governed_learning_substrate_contract_accessors_cover_shared_registry` |
+| 5 | 178.801 | `runtime_v2::runtime_inhabitant_integration` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::runtime_inhabitant_integration::runtime_v2_runtime_inhabitant_integration_contract_accessors_cover_shared_registry` |
+| 6 | 178.785 | `runtime_v2::acip_hardening` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::acip_hardening::runtime_v2_acip_hardening_contract_registry_smoke_covers_accessors` |
+| 7 | 178.728 | `runtime_v2::citizen_state_substrate` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::citizen_state_substrate::runtime_v2_citizen_state_substrate_contract_accessors_cover_shared_registry` |
+| 8 | 178.594 | `runtime_v2::memory_identity_architecture` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::memory_identity_architecture::runtime_v2_memory_identity_architecture_contract_registry_smoke_covers_accessors` |
+| 9 | 178.568 | `runtime_v2::intelligence_metric_architecture` | `runtime-v2-contract-registry/accessors` | `runtime_v2::tests::intelligence_metric_architecture::runtime_v2_intelligence_metric_architecture_contract_accessors_cover_shared_registry` |
+| 10 | 163.371 | `runtime_v2::observatory_flagship` | `runtime-v2-other` | `runtime_v2::tests::observatory_flagship::runtime_v2_observatory_flagship_rejects_shape_and_boundary_drift` |
+| 11 | 163.157 | `runtime_v2::observatory_flagship` | `runtime-v2-other` | `runtime_v2::tests::observatory_flagship::runtime_v2_observatory_flagship_review_surfaces_are_stable_and_serializable` |
+| 12 | 146.979 | `runtime_v2::observatory_flagship` | `runtime-v2-other` | `runtime_v2::tests::observatory_flagship::runtime_v2_observatory_flagship_review_bundle_matches_tracked_artifacts` |
+
+### Hotspot Families
+
+| Rank | Total Seconds | Count | Max Seconds | Family | Routing Hint |
+| ---: | ---: | ---: | ---: | --- | --- |
+| 1 | 878.262 | 8 | 178.801 | `runtime_v2::runtime_inhabitant_integration` | Repeated family-level setup pattern; consider table/collapse refactor. |
+| 2 | 770.216 | 9 | 178.568 | `runtime_v2::intelligence_metric_architecture` | Route to Runtime v2 registry/accessor refactor or authoritative slow-proof consolidation. |
+| 3 | 770.212 | 9 | 178.825 | `runtime_v2::governed_learning_substrate` | Route to Runtime v2 registry/accessor refactor or authoritative slow-proof consolidation. |
+| 4 | 699.842 | 8 | 179.933 | `runtime_v2::theory_of_mind_foundation` | Route to Runtime v2 registry/accessor refactor or authoritative slow-proof consolidation. |
+| 5 | 657.238 | 8 | 181.281 | `runtime_v2::a2a_adapter_boundary` | Repeated family-level setup pattern; consider table/collapse refactor. |
+| 6 | 614.812 | 6 | 178.594 | `runtime_v2::memory_identity_architecture` | Repeated family-level setup pattern; consider table/collapse refactor. |
+
+### Hotspot Clusters
+
+| Rank | Total Seconds | Count | Max Seconds | Cluster | Routing Hint |
+| ---: | ---: | ---: | ---: | --- | --- |
+| 1 | 1860.104 | 12 | 181.281 | `runtime-v2-contract-registry/accessors` | Route to Runtime v2 registry/accessor refactor or authoritative slow-proof consolidation. |
+| 2 | 1685.765 | 23 | 163.371 | `runtime-v2-other` | Repeated family-level setup pattern; consider table/collapse refactor. |
+| 3 | 1556.955 | 19 | 134.933 | `validation-negative` | Repeated family-level setup pattern; consider table/collapse refactor. |
+| 4 | 631.773 | 9 | 100.002 | `golden-fixture` | Repeated family-level setup pattern; consider table/collapse refactor. |
+| 5 | 566.277 | 8 | 75.270 | `proof-materialization` | Route to proof-materialization slow-lane review; keep one authoritative root proof where needed. |
+| 6 | 537.449 | 7 | 99.923 | `proof-route` | Repeated family-level setup pattern; consider table/collapse refactor. |
+
+## Validation
+
+Focused validation for this diagnostic surface in a clean checkout:
+
+```bash
+python3 -m py_compile adl/tools/summarize_nextest_timings.py
+bash adl/tools/test_summarize_nextest_timings.sh
+```
+
+To reproduce the #3032 example report, provide the captured log locally first,
+then run:
+
+```bash
+python3 adl/tools/summarize_nextest_timings.py .adl/docs/TBD/test-logs.txt --top 12 --min-seconds 45
+```
+
+Do not run full nextest merely to prove the parser. Use an existing captured log
+or a small fixture unless the issue being diagnosed independently requires a
+real test rerun.


### PR DESCRIPTION
Closes #3045

## Summary
Added a focused nextest timing diagnostic tool plus a v0.91.2 runbook/example report so operators can summarize long nextest logs into top slow tests, family totals, cluster buckets, slow-threshold markers, and routing hints. The supplied #3032 log now surfaces the Runtime v2 contract-registry/accessor cluster and proof-materialization cluster without manual scanning.

## Artifacts
- `adl/tools/summarize_nextest_timings.py`
- `adl/tools/test_summarize_nextest_timings.sh`
- `docs/milestones/v0.91.2/SLOW_TEST_TIMING_DIAGNOSTICS_v0.91.2.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/summarize_nextest_timings.py`
    Proved the parser module compiles.
  - `bash -n adl/tools/test_summarize_nextest_timings.sh`
    Proved the shell contract test parses.
  - `bash adl/tools/test_summarize_nextest_timings.sh`
    Proved the diagnostic report can identify top slow tests, cluster families, slow markers, and JSON fields from a bounded fixture.
  - `python3 adl/tools/summarize_nextest_timings.py .adl/docs/TBD/test-logs.txt --top 12 --min-seconds 45`
    Proved the supplied slow-test log produces an actionable Markdown report with the required Runtime v2 clusters.
  - `python3 adl/tools/summarize_nextest_timings.py .adl/docs/TBD/test-logs.txt --top 3 --min-seconds 45 --format json`
    Proved machine-readable output exists for later automation.
  - `git diff --check`
    Proved the diff is whitespace-clean.
  - Bounded subagent review
    Proved no blocking parser or validation issue remained; low-severity docs findings were corrected.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3045__v0-91-2-wp-05a-slow-test-timing-diagnostics/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3045__v0-91-2-wp-05a-slow-test-timing-diagnostics/sor.md
- Idempotency-Key: v0-91-2-wp-05a-add-slow-test-timing-diagnostics-adl-tools-summarize-nextest-timings-py-adl-tools-test-summarize-nextest-timings-sh-docs-milestones-v0-91-2-slow-test-timing-diagnostics-v0-91-2-md-adl-v0-91-2-tasks-issue-3045-v0-91-2-wp-05a-slow-test-timing-diagnostics-sip-md-adl-v0-91-2-tasks-issue-3045-v0-91-2-wp-05a-slow-test-timing-diagnostics-sor-md