### PR TITLE
[v0.91.2][WP-05][quality] Coverage gate ergonomics

### DIFF
--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -183,6 +183,33 @@ candidate_filter_for_path() {
   esac
 }
 
+focused_summary_command_for_filter() {
+  local filter="$1"
+  printf 'cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- %s' "$filter"
+}
+
+rerun_preflight_command() {
+  printf 'bash adl/tools/check_coverage_impact.sh --base %s' "$BASE"
+  if [ -n "$CHANGED_FILES_FILE" ]; then
+    printf ' --changed-files %s' "$CHANGED_FILES_FILE"
+  elif [ "$INCLUDE_WORKTREE" = true ]; then
+    printf ' --include-working-tree'
+  else
+    printf ' --head %s' "$HEAD"
+  fi
+  printf ' --summary adl/target/coverage-impact-summary.json'
+}
+
+print_next_actions_for_path() {
+  local path="$1"
+  local context="$2"
+  local filter
+  filter="$(candidate_filter_for_path "$path")"
+  echo "    candidate filter: ${filter}"
+  echo "    ${context}: $(focused_summary_command_for_filter "$filter")"
+  echo "    rerun preflight: $(rerun_preflight_command)"
+}
+
 file_is_structural_module_barrel() {
   local path="$1"
   [ -f "$ROOT/$path" ] || return 1
@@ -230,6 +257,7 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
   fi
   failures=""
   missing=""
+  guidance=""
   while IFS=$'\t' read -r _status path; do
     [ -n "$path" ] || continue
     row="$(jq -r --arg path "$path" '
@@ -263,6 +291,8 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
         continue
       fi
       missing="${missing}  - ${path} (no coverage row in ${SUMMARY})"$'\n'
+      guidance="${guidance}  - ${path}"$'\n'
+      guidance="${guidance}$(print_next_actions_for_path "$path" "generate focused summary")"$'\n'
       continue
     fi
     pct="$(printf '%s\n' "$row" | awk -F '\t' '{ printf "%.2f", $3 + 0 }')"
@@ -271,6 +301,8 @@ if [ -n "$SUMMARY" ] && [ -s "$SUMMARY" ]; then
       continue
     fi
     failures="${failures}  - ${path} (${covered_count}, ${pct}% < ${THRESHOLD}%)"$'\n'
+    guidance="${guidance}  - ${path}"$'\n'
+    guidance="${guidance}$(print_next_actions_for_path "$path" "refresh focused summary after adding or expanding tests")"$'\n'
   done <<EOF
 $changed_source_rows
 EOF
@@ -279,6 +311,13 @@ EOF
     echo "Coverage-impact preflight failed for changed Rust source files:"
     [ -z "$missing" ] || printf '%s' "$missing"
     [ -z "$failures" ] || printf '%s' "$failures"
+    if [ -n "$guidance" ]; then
+      echo "Actionable next steps:"
+      printf '%s' "$guidance"
+      echo "Common failure modes:"
+      echo "  - no coverage row: your focused summary filter did not exercise the changed file"
+      echo "  - below threshold: add or extend focused tests, then refresh the summary and rerun the preflight"
+    fi
     echo "Full adl-coverage remains authoritative; fix or add focused tests before publication."
     exit 1
   fi
@@ -303,13 +342,12 @@ if [ "$REQUIRE_SUMMARY_FOR_RISK" = true ] && [ -n "$risk_rows" ]; then
   echo "Coverage-impact preflight needs coverage evidence for risky changed Rust source files:"
   while IFS=$'\t' read -r _status path lines delta reason; do
     [ -n "$path" ] || continue
-    filter="$(candidate_filter_for_path "$path")"
     echo "  - ${path} (${reason}; ${lines} lines, ${delta} changed)"
-    echo "    next action: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- ${filter}"
+    print_next_actions_for_path "$path" "generate focused summary"
   done <<EOF
 $risk_rows
 EOF
-  echo "Then rerun: bash adl/tools/check_coverage_impact.sh --base ${BASE} --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk"
+  echo "Then rerun: $(rerun_preflight_command) --require-summary-for-risk"
   exit 1
 fi
 

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -86,6 +86,17 @@ if bash "$SCRIPT" --changed-files "$changed" --require-summary-for-risk >/tmp/co
 fi
 grep -F "Coverage-impact preflight needs coverage evidence" /tmp/coverage-impact-missing.out >/dev/null
 grep -F "new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "candidate filter: new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- new_large_surface" /tmp/coverage-impact-missing.out >/dev/null
+grep -F "Then rerun: bash adl/tools/check_coverage_impact.sh --base origin/main --changed-files $changed --summary adl/target/coverage-impact-summary.json --require-summary-for-risk" /tmp/coverage-impact-missing.out >/dev/null
+
+branch_diff_changed="$TMP/branch-diff-changed.txt"
+printf 'A\tadl/src/runtime_v2/branch_mode_surface.rs\n' >"$branch_diff_changed"
+if bash "$SCRIPT" --base release/base --head feature/head --changed-files "$branch_diff_changed" --require-summary-for-risk >/tmp/coverage-impact-branch-mode.out 2>&1; then
+  echo "expected branch-diff guidance to fail without summary" >&2
+  exit 1
+fi
+grep -F "Then rerun: bash adl/tools/check_coverage_impact.sh --base release/base --changed-files $branch_diff_changed --summary adl/target/coverage-impact-summary.json --require-summary-for-risk" /tmp/coverage-impact-branch-mode.out >/dev/null
 
 docs_filters="$TMP/docs-filters.txt"
 bash "$SCRIPT" --changed-files "$docs_only" --print-risk-filters >"$docs_filters"
@@ -98,6 +109,9 @@ if bash "$SCRIPT" --changed-files "$changed" --summary "$low_summary" >/tmp/cove
   exit 1
 fi
 grep -F "77.00% < 80%" /tmp/coverage-impact-low.out >/dev/null
+grep -F "Actionable next steps:" /tmp/coverage-impact-low.out >/dev/null
+grep -F "refresh focused summary after adding or expanding tests: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- new_large_surface" /tmp/coverage-impact-low.out >/dev/null
+grep -F "Common failure modes:" /tmp/coverage-impact-low.out >/dev/null
 
 missing_summary="$TMP/missing-row-summary.json"
 make_summary "adl/src/runtime_v2/other.rs" 100 100 "$missing_summary"
@@ -106,6 +120,7 @@ if bash "$SCRIPT" --changed-files "$changed" --summary "$missing_summary" >/tmp/
   exit 1
 fi
 grep -F "no coverage row" /tmp/coverage-impact-missing-row.out >/dev/null
+grep -F "generate focused summary: cd adl && CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- new_large_surface" /tmp/coverage-impact-missing-row.out >/dev/null
 
 mkdir -p "$BARREL_DIR"
 cat >"$BARREL_DIR/mod.rs" <<'EOF'

--- a/docs/milestones/v0.91.2/DEMO_MATRIX_v0.91.2.md
+++ b/docs/milestones/v0.91.2/DEMO_MATRIX_v0.91.2.md
@@ -10,7 +10,7 @@ and summarized again during WP-17.
 | UTS + ACC JSON proposal benchmark | WP-02 | Test model proposal discipline against fixture tools. | benchmark report and fixtures | does not execute real tools |
 | Provider-native tool-call comparison | WP-03 | Compare native tool-call interfaces with ADL JSON proposal mode. | comparison report by model/provider | does not claim provider-wide conformance |
 | Runtime/test-cycle recovery proof | WP-04 | Show redundant proof phases are reduced safely. | `review/runtime_test_cycle_recovery_report.md` with landed `#3042`-`#3044` proof surfaces; `SLOW_TEST_TIMING_DIAGNOSTICS_v0.91.2.md` is supporting sibling evidence from `WP-05A` | does not weaken authoritative coverage |
-| Coverage ergonomics demo | WP-05 | Show changed-source coverage failures point to actionable tests. | diagnostic output and focused-test guide | does not waive thresholds silently |
+| Coverage ergonomics demo | WP-05 | Show changed-source coverage failures point to actionable tests. | `adl/tools/check_coverage_impact.sh` diagnostic output, `adl/tools/test_check_coverage_impact.sh`, and `review/coverage_gate_ergonomics_report.md` | does not waive thresholds silently |
 | CodeFriend review packet demo | WP-06 | Show repeatable packet-to-report review workflow. | packet, findings, product report | does not replace human review |
 | Review heuristics demo | WP-07 | Show review heuristics and skills produce bounded review artifacts. | skill demo output and acceptance checklist | does not invent source evidence |
 | Google Workspace CMS bridge demo | WP-08 | Show draft content-card and promotion packet workflow. | fixture/live-gated bridge artifact | does not make Workspace canonical |

--- a/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
@@ -19,7 +19,7 @@ Each feature should eventually have one truthful proof route:
 | Feature | WP | Intended Route | Status |
 | --- | --- | --- | --- |
 | UTS + ACC multi-model benchmark | WP-02, WP-03 | harness + comparison report | planned |
-| Runtime/test-cycle recovery | WP-04, WP-05 | WP-04 runtime recovery report plus WP-05 coverage ergonomics evidence | WP-04 landed; WP-05 planned |
+| Runtime/test-cycle recovery | WP-04, WP-05 | WP-04 runtime recovery report plus WP-05 coverage ergonomics evidence | landed |
 | CodeFriend productization | WP-06 | review packet + product-report package | planned |
 | Review heuristics and demos | WP-07 | skill/demo packet | planned |
 | Workspace CMS bridge | WP-08, WP-09 | bounded demo + adapter-boundary packet | planned |

--- a/docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md
+++ b/docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md
@@ -4,11 +4,11 @@
 
 - Feature Name: Runtime/Test-Cycle Recovery And Coverage Ergonomics
 - Milestone Target: `v0.91.2`
-- Status: WP-04 landed; WP-05 pending
+- Status: WP-04 and WP-05 landed
 - Planned WP Home: WP-04, WP-05
 - Source Docs: `.adl/docs/TBD/tools/RUNTIME_V2_TEST_CYCLE_RECOVERY_PLAN.md`; `.adl/docs/TBD/v0.90.5_TEST_RUNTIME_REDUCTION_PLAN.md`
 - Proof Modes: CI evidence, tests, report
-- Current WP-04 proof surface: `docs/milestones/v0.91.2/review/runtime_test_cycle_recovery_report.md`
+- Current proof surfaces: `docs/milestones/v0.91.2/review/runtime_test_cycle_recovery_report.md`; `docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md`
 
 ## Purpose
 
@@ -50,4 +50,8 @@ Supporting sibling evidence from `WP-05A`:
 
 - `#3045` / PR `#3052` nextest timing diagnostics
 
-`WP-05` remains responsible for the follow-on coverage ergonomics surface.
+The `WP-05` coverage ergonomics slice is now landed via:
+
+- improved actionable next-step diagnostics in `adl/tools/check_coverage_impact.sh`
+- focused regression coverage in `adl/tools/test_check_coverage_impact.sh`
+- `docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md`

--- a/docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md
+++ b/docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md
@@ -1,0 +1,51 @@
+# Coverage Gate Ergonomics Report
+
+## Scope
+
+This `WP-05` report records the bounded changed-source coverage ergonomics
+follow-on for `v0.91.2`.
+
+## Landed Surface
+
+- `adl/tools/check_coverage_impact.sh`
+- `adl/tools/test_check_coverage_impact.sh`
+
+## Outcome
+
+The changed-source preflight now emits actionable follow-up guidance instead of
+stopping at a bare threshold failure.
+
+For each risky or failing changed Rust source file, the gate now reports:
+
+- the changed file path
+- the candidate focused test filter
+- the exact focused `cargo llvm-cov` summary command to run next
+- the matching preflight rerun command for the current diff mode
+
+The summary-driven failure path now also explains two common failure modes:
+
+- `no coverage row`: the focused summary did not execute the changed file
+- `below threshold`: tests need to be added or expanded before the summary is
+  refreshed
+
+## Validation
+
+Focused proof for this issue:
+
+- `bash adl/tools/test_check_coverage_impact.sh`
+- `git diff --check`
+
+The shell test suite now covers:
+
+- risky changed-file guidance when summary evidence is missing
+- low-coverage summary failure guidance
+- missing coverage-row guidance
+- existing pass behavior for docs-only, test-only, structural barrel, and
+  non-executable-module cases
+
+## Non-Claims
+
+- This report does not waive the per-file threshold.
+- This report does not replace the authoritative GitHub `adl-coverage` job.
+- This report does not claim that every changed file can be solved with one
+  filter; it only makes the likely next action explicit.


### PR DESCRIPTION
Closes #3004

## Summary
Improved the changed-source coverage preflight so coverage failures now point
directly to the next focused test/summary action, recorded the common failure
mode guidance in a bounded review report, and updated the `v0.91.2`
feature/demo coverage docs to point at the landed WP-05 proof route.

## Artifacts
- `adl/tools/check_coverage_impact.sh`
- `adl/tools/test_check_coverage_impact.sh`
- `docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md`
- `docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md`
- `docs/milestones/v0.91.2/DEMO_MATRIX_v0.91.2.md`
- `docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_check_coverage_impact.sh`
    Proved the actionable next-step guidance, diff-context preservation, and common failure-mode examples across the changed-source coverage preflight paths.
  - `git diff --check`
    Proved the tracked patch is whitespace-clean.
  - Bounded pre-PR review subagent
    Reviewed the bounded WP-05 diff for behavioral regressions, misleading docs, and scope drift.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3004__v0-91-2-wp-05-coverage-gate-ergonomics/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3004__v0-91-2-wp-05-coverage-gate-ergonomics/sor.md
- Idempotency-Key: v0-91-2-wp-05-quality-coverage-gate-ergonomics-adl-v0-91-2-tasks-issue-3004-v0-91-2-wp-05-coverage-gate-ergonomics-sip-md-adl-v0-91-2-tasks-issue-3004-v0-91-2-wp-05-coverage-gate-ergonomics-sor-md