### PR TITLE
[v0.91.2][C-SDLC] Align editor and conductor routing

### DIFF
--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -55,6 +55,7 @@ The tracked skill set is:
 - `review-quality-evaluator`
 - `review-to-test-planner`
 - `spp-editor`
+- `srp-editor`
 - `sip-editor`
 - `sor-editor`
 - `sprint-conductor`
@@ -100,9 +101,11 @@ The PR lifecycle skills share the CI runtime interpretation policy in
 docs-only path-policy skip from full runtime validation, failed-closed
 classification, and release/main full-validation evidence.
 
-The four editor skills are helper skills:
+The five card editor skills are helper skills:
 - `spp-editor` for truthful `spp.md` planning cleanup that preserves the
   manual sample schema and markdown shape
+- `srp-editor` for truthful `srp.md` review-prompt cleanup that preserves
+  review policy, review results, finding dispositions, and residual risk
 - `stp-editor` for bounded `stp.md` cleanup
 - `sip-editor` for truthful `sip.md` cleanup
 - `sor-editor` for truthful `sor.md` cleanup
@@ -254,8 +257,8 @@ Default policy:
   or PR surgery
 - keep the primary checkout on clean `main`; tracked implementation and repair
   edits happen in the bound issue worktree
-- use `stp-editor`, `sip-editor`, or `sor-editor` when those cards need
-  normalization
+- use `stp-editor`, `sip-editor`, `spp-editor`, `srp-editor`, or `sor-editor`
+  when those cards need normalization
 - attach `pr-janitor` after PR publication for check, conflict, and review
   monitoring
 - record policy compliance, validation profile, commands, and any bypasses in
@@ -456,6 +459,13 @@ reduce recurring card failures:
 - `sip-editor`
   - normalizes truthful lifecycle state in `sip.md`
   - does not create the branch/worktree itself or claim execution completion
+- `spp-editor`
+  - normalizes truthful planning state in `spp.md`
+  - does not turn planning into execution history or widen issue scope
+- `srp-editor`
+  - normalizes review policy, review results, findings, dispositions, and
+    residual risk in `srp.md`
+  - does not invent review evidence or resolve findings without proof
 - `sor-editor`
   - normalizes truthful execution and integration state in `sor.md`
   - does not invent validation or publish the PR itself
@@ -1576,6 +1586,84 @@ The structured result should identify:
 - whether planning truth and `codex_plan` statuses were normalized
 - any remaining blockers that should stop readiness or execution
 
+## `srp-editor`
+
+### Purpose
+
+`srp-editor` is the bounded helper skill for `srp.md`.
+
+It:
+
+- preserves `SRP` as Structured Review Prompt, not just legacy Structured
+  Review Policy
+- keeps review instructions, review scope, findings, dispositions, and residual
+  risk together in the same card
+- normalizes review-result truth after bounded human or subagent review
+- stops before implementation, publication, merge, or output-card authoring
+
+### When To Use It
+
+Use `srp-editor` when:
+
+- the `SRP` is missing, stale, or still policy-only scaffolding
+- review results need to be recorded after a bounded review
+- findings, dispositions, or residual risk are incomplete or overstated
+- doctor/card lifecycle evidence reports incomplete SRP truth
+
+Do not use it for:
+
+- inventing review results or claiming no findings without a review
+- resolving findings without evidence
+- rewriting `STP`, `SIP`, `SPP`, or `SOR` content
+
+### Required Inputs
+
+Minimum:
+
+- `repo_root`
+- `target.srp_path`
+
+Structured schema:
+
+- `adl/tools/skills/docs/SRP_EDITOR_SKILL_INPUT_SCHEMA.md`
+- schema id: `srp_editor.v1`
+
+### Example Invocation
+
+```yaml
+Use $srp-editor at /Users/daniel/git/agent-design-language/adl/tools/skills/srp-editor/SKILL.md with this validated input:
+
+skill_input_schema: srp_editor.v1
+mode: record_review_results
+repo_root: /Users/daniel/git/agent-design-language
+target:
+  srp_path: .adl/v0.91.2/tasks/issue-3066__example/srp.md
+  issue_number: 3066
+  source_prompt_path: .adl/v0.91.2/bodies/issue-3066-example.md
+evidence:
+  review_performed: true
+  reviewer: bounded-review-subagent
+  review_artifact_paths:
+    - .adl/reviews/issue-3066-review.md
+  findings: []
+policy:
+  preserve_review_policy: true
+  preserve_review_result_truth: true
+  stop_after_edit: true
+  allow_review_claims_without_evidence: false
+```
+
+### Output
+
+The structured result should identify:
+
+- which `SRP` path was edited
+- whether Structured Review Prompt semantics were normalized
+- whether review results, findings, dispositions, and residual risk are
+  truthful
+- any remaining blockers that should stop finish or require implementation
+  repair
+
 ## `stp-editor`
 
 ### Purpose
@@ -2583,6 +2671,7 @@ surfaces:
 | `review-quality-evaluator` | `REVIEW_QUALITY_EVALUATOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | review-quality evaluation only |
 | `review-to-test-planner` | `REVIEW_TO_TEST_PLANNER_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | test-generation handoff plan only |
 | `spp-editor` | `SPP_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | SPP normalization only |
+| `srp-editor` | `SRP_EDITOR_SKILL_INPUT_SCHEMA.md` | `references/output-contract.md` | SRP review truth normalization only |
 | `sip-editor` | `SIP_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | SIP normalization only |
 | `sor-editor` | `SOR_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | SOR normalization only |
 | `stp-editor` | `STP_EDITOR_SKILL_INPUT_SCHEMA.md` | card-editor shared contract | STP normalization only |

--- a/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SPRINT_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -50,7 +50,7 @@ sprint:
         contradictory_cards:
           - <filename>
         required_editor_skills:
-          - stp-editor | sip-editor | sor-editor | spp-editor
+          - stp-editor | sip-editor | spp-editor | srp-editor | sor-editor
   truth_check:
     status: not_run | matched | drift_detected | blocked
     source: github_live | sprint_state_only | mixed

--- a/adl/tools/skills/docs/SRP_EDITOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/SRP_EDITOR_SKILL_INPUT_SCHEMA.md
@@ -1,0 +1,30 @@
+# SRP Editor Skill Input Schema
+
+```yaml
+skill_input_schema: srp_editor.v1
+mode: normalize_srp | record_review_results | repair_review_truth_drift
+repo_root: /absolute/path
+target:
+  srp_path: /absolute/or/repo-relative/path/to/srp.md
+  issue_number: <u32 or null>
+  source_prompt_path: <path or null>
+  linked_stp_path: <path or null>
+  linked_sip_path: <path or null>
+  linked_spp_path: <path or null>
+  linked_sor_path: <path or null>
+evidence:
+  review_performed: true | false
+  reviewer: <bounded name or role or null>
+  review_artifact_paths:
+    - <path>
+  findings:
+    - id: <bounded finding id>
+      severity: P0 | P1 | P2 | P3 | info
+      summary: <bounded text>
+      disposition: fixed | accepted | deferred | unresolved | not_applicable
+policy:
+  preserve_review_policy: true
+  preserve_review_result_truth: true
+  stop_after_edit: true
+  allow_review_claims_without_evidence: false
+```

--- a/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
+++ b/adl/tools/skills/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md
@@ -15,6 +15,8 @@ target:
   source_prompt_path: <path optional>
   stp_path: <path optional>
   sip_path: <path optional>
+  spp_path: <path optional>
+  srp_path: <path optional>
   sor_path: <path optional>
   doctor_result: <path_or_summary optional>
   pr_state: <state optional>
@@ -40,6 +42,8 @@ dispatch:
     pr-closeout: [<argv token>, ...] optional
     stp-editor: [<argv token>, ...] optional
     sip-editor: [<argv token>, ...] optional
+    spp-editor: [<argv token>, ...] optional
+    srp-editor: [<argv token>, ...] optional
     sor-editor: [<argv token>, ...] optional
 ```
 
@@ -100,6 +104,8 @@ Exactly one primary target should drive the mode.
 If editor skills are required, the conductor should prefer:
 - `stp-editor`
 - `sip-editor`
+- `spp-editor`
+- `srp-editor`
 - `sor-editor`
 
 when the blocker is card-local.

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -36,6 +36,8 @@ It must not replace:
 - `pr-closeout`
 - `stp-editor`
 - `sip-editor`
+- `spp-editor`
+- `srp-editor`
 - `sor-editor`
 - review specialist skills
 
@@ -166,6 +168,8 @@ Preferred per-issue routing model:
 - bootstrap missing -> `pr-init`
 - card-local STP issue -> `stp-editor`
 - card-local SIP issue -> `sip-editor`
+- card-local SPP issue -> `spp-editor`
+- card-local SRP issue -> `srp-editor`
 - card-local SOR issue -> `sor-editor`
 - structurally ready but not bound -> `pr-ready`
 - ready for execution bind -> `pr-run`

--- a/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/sprint-conductor/references/conductor-playbook.md
@@ -77,11 +77,16 @@ Preferred child-closeout advancement helper:
 If `workflow-conductor` selects:
 - `stp-editor`
 - `sip-editor`
+- `spp-editor`
+- `srp-editor`
 - `sor-editor`
 
 then the sprint conductor must run that editor skill first and must not try to
 work around malformed cards by hand.
 That rule applies both to sprint-wide preflight repair and to later issue-local drift.
+Sprint-scoped `spp.md` surfaces are not mandatory unless the sprint schema
+explicitly declares them; do not widen issue-level `spp-editor` into a
+sprint-level planning editor by accident.
 
 ## Review Phase
 

--- a/adl/tools/skills/sprint-conductor/references/output-contract.md
+++ b/adl/tools/skills/sprint-conductor/references/output-contract.md
@@ -49,7 +49,7 @@ structured_prompt_preflight:
       contradictory_cards:
         - <filename>
       required_editor_skills:
-        - stp-editor | sip-editor | sor-editor | spp-editor
+          - stp-editor | sip-editor | spp-editor | srp-editor | sor-editor
       notes:
         - <bounded text>
 installed_skill_parity:
@@ -75,7 +75,7 @@ truth_check:
   notes:
     - <bounded text>
 current_state:
-  selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | issue-watcher | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
+  selected_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | issue-watcher | pr-janitor | pr-closeout | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
   current_phase: intake | issue_loop | review | closeout | waiting | watching | blocked
   blocker_reason: none | child_issue_blocked | malformed_cards | review_findings_blocking | missing_metrics | operator_scope_decision | missing_sprint_issue | unknown
 review:
@@ -113,7 +113,7 @@ next_handoff:
   status: continue | wait_and_recheck | ask_operator | stop
   target_issue_number: <u32 or null>
   target_pr_url: <url or null>
-  next_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | issue-watcher | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
+  next_skill: workflow-conductor | pr-init | pr-ready | pr-run | pr-finish | issue-watcher | pr-janitor | pr-closeout | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | repo-packet-builder | repo-review-code | repo-review-tests | repo-review-docs | repo-review-security | repo-review-synthesis | none
   rationale: <bounded text>
 artifact:
   sprint_state_path: <path or null>

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
@@ -63,7 +63,7 @@ def inspect_issue(
     if require_spp:
         required_cards['spp.md'] = 'spp-editor'
     if require_srp:
-        required_cards['srp.md'] = 'spp-editor'
+        required_cards['srp.md'] = 'srp-editor'
 
     missing_cards: list[str] = []
     contradictory_cards: list[str] = []

--- a/adl/tools/skills/srp-editor/SKILL.md
+++ b/adl/tools/skills/srp-editor/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: srp-editor
+description: Normalize and correct an SRP review card so it preserves Structured Review Prompt semantics, review-result truth, finding dispositions, and residual-risk boundaries. Use when an `srp.md` is missing, still uses legacy Structured Review Policy scaffolding, lacks review results, or overclaims review completion.
+---
+
+# SRP Editor
+
+This skill owns bounded editing of `srp.md` review cards.
+
+Its job is to:
+- normalize `SRP` structure as a Structured Review Prompt
+- preserve review instructions and policy while also recording review results
+- keep findings, dispositions, reviewer scope, and residual risk truthful
+- retire legacy Structured Review Policy wording when final SRP truth is needed
+- stop before implementation, finish publication, merge, or output-card authoring
+
+This is a helper skill, not a lifecycle orchestrator.
+
+## Required Inputs
+
+At minimum, gather:
+- repository root
+- `srp_path`
+- one explicit editing mode
+
+Useful additional inputs:
+- issue number
+- source prompt path
+- linked `stp.md`, `sip.md`, `spp.md`, or `sor.md`
+- review findings or reviewer notes
+- review outcome and finding dispositions
+
+## Quick Start
+
+1. Read the SRP and the linked source prompt if available.
+2. Determine whether the SRP is still a legacy policy scaffold or a final
+   Structured Review Prompt record.
+3. Preserve the issue-local review policy and reviewer instructions.
+4. Normalize review-result truth, findings, dispositions, and residual risk to
+   the evidence supplied by the caller.
+5. Remove unsupported completion claims and stale Structured Review Policy-only
+   language when final SRP truth is required.
+6. Emit a structured edit result and stop.
+
+## Allowed Edits
+
+This skill may:
+- normalize `artifact_type` to `structured_review_prompt`
+- update headings and wording from legacy Structured Review Policy scaffolding
+  to Structured Review Prompt semantics
+- add or tighten sections for review scope, review instructions, findings,
+  dispositions, reviewer notes, residual risks, and recommended outcome
+- record review findings only when explicit review evidence is supplied
+- mark no-findings review results only when an actual review was performed
+- preserve unresolved findings and route them back to implementation or
+  follow-on issue creation
+- remove placeholders and stale review-completion claims
+
+This skill must not:
+- invent review results, reviewer coverage, or validation evidence
+- resolve findings that have not been fixed or explicitly accepted
+- rewrite `STP`, `SIP`, `SPP`, or `SOR` instead of handing off
+- publish or merge a PR
+- widen issue scope
+
+## Handoff
+
+Typical callers are:
+- `workflow-conductor` when doctor or card evidence reports an incomplete SRP
+- `sprint-conductor` during sprint-wide structured prompt preflight
+- `pr-run` or human review after bounded subagent review results are available
+- `pr-finish` when final review truth blocks publication
+
+## Output
+
+Return a concise structured result including:
+- target `SRP` path
+- review prompt semantics normalized
+- review results recorded or explicitly absent
+- finding dispositions updated
+- unresolved blockers
+- recommended next handoff

--- a/adl/tools/skills/srp-editor/adl-skill.yaml
+++ b/adl/tools/skills/srp-editor/adl-skill.yaml
@@ -1,0 +1,58 @@
+version: "0.1"
+kind: "adl-skill"
+id: "srp-editor"
+codex_compat:
+  skill_file: "SKILL.md"
+  trigger_frontmatter:
+    - "name"
+    - "description"
+admission:
+  input_schema:
+    id: "srp_editor.v1"
+    reference_doc: "../docs/SRP_EDITOR_SKILL_INPUT_SCHEMA.md"
+    required_top_level_fields:
+      - "skill_input_schema"
+      - "mode"
+      - "repo_root"
+      - "target"
+      - "policy"
+    mode_enum:
+      - "normalize_srp"
+      - "record_review_results"
+      - "repair_review_truth_drift"
+  intent:
+    - "srp_edit"
+    - "review_card_normalization"
+    - "review_result_truth_repair"
+  required_inputs:
+    - "repo_root"
+    - "srp_path"
+  prevalidation_rules:
+    - "repo_root_must_be_absolute"
+    - "skill_input_schema_must_equal_srp_editor.v1_when_structured_input_is_used"
+    - "target.srp_path_must_be_present"
+    - "policy.stop_after_edit_must_be_true"
+    - "evidence.review_results_must_be_explicit_when_findings_or_outcome_are_changed"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: true
+  allow_network: false
+  allow_subagents: false
+  workflow_role: "card_editor"
+  preferred_path: "structured_input_then_direct_card_edit"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+boundaries:
+  writes_limited_to:
+    - ".adl/**/srp.md"
+  must_not_write:
+    - ".adl/**/stp.md"
+    - ".adl/**/sip.md"
+    - ".adl/**/spp.md"
+    - ".adl/**/sor.md"
+    - "implementation source files"
+outputs:
+  default_format: "markdown"
+  structured_contract: "references/output-contract.md"
+security:
+  trusted_root_required: true
+  deny_symlink_escape: true

--- a/adl/tools/skills/srp-editor/agents/openai.yaml
+++ b/adl/tools/skills/srp-editor/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: SRP Editor
+short_description: Normalize truthful SRP review cards
+default_prompt: Help me normalize an SRP review card without inventing review results or hiding unresolved findings.

--- a/adl/tools/skills/srp-editor/references/edit-playbook.md
+++ b/adl/tools/skills/srp-editor/references/edit-playbook.md
@@ -1,0 +1,35 @@
+# SRP Editor Playbook
+
+Use this skill only for bounded `srp.md` editing.
+
+Prefer this order:
+1. source issue prompt
+2. current `srp.md`
+3. linked `stp.md`, `sip.md`, `spp.md`, or `sor.md` if available
+4. concrete review findings, reviewer notes, and finding dispositions supplied
+   by the caller
+
+Check for:
+- legacy Structured Review Policy wording when final Structured Review Prompt
+  truth is required
+- missing review scope, reviewer instructions, or review-result sections
+- review results claimed without supplied review evidence
+- unresolved findings hidden as complete work
+- finding dispositions that do not distinguish fixed, accepted, deferred, and
+  unresolved results
+- residual risk omitted after review
+- stale placeholders or PR/merge claims
+
+Safe edits:
+- normalize `artifact_type` and headings to Structured Review Prompt semantics
+- preserve review policy and reviewer instructions
+- record supplied findings and dispositions truthfully
+- preserve unresolved findings and residual risk
+- remove stale or unsupported review-completion claims
+
+Unsafe edits:
+- inventing review evidence
+- claiming no findings without an actual review
+- resolving findings without evidence
+- rewriting `STP`, `SIP`, `SPP`, or `SOR` instead of handing off
+- widening issue scope

--- a/adl/tools/skills/srp-editor/references/output-contract.md
+++ b/adl/tools/skills/srp-editor/references/output-contract.md
@@ -1,0 +1,20 @@
+# Output Contract
+
+```yaml
+status: done | blocked | failed
+target:
+  srp_path: <path>
+edit_state:
+  review_prompt_semantics_normalized: true | false
+  review_results_truthful: true | false
+  finding_dispositions_normalized: true | false
+  residual_risk_recorded: true | false
+findings:
+  - severity: info | warning | blocking
+    area: semantics | review_scope | findings | dispositions | residual_risk
+    message: <short finding>
+actions_taken:
+  - <edit or normalization>
+handoff_state:
+  next_phase: qualitative_review | implementation_repair | pr_finish | blocked
+```

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -28,6 +28,8 @@ It must not replace:
 - `pr-closeout`
 - `stp-editor`
 - `sip-editor`
+- `spp-editor`
+- `srp-editor`
 - `sor-editor`
 
 It must stop at the routing/dispatch boundary rather than reimplementing the selected skill's underlying work.
@@ -84,6 +86,8 @@ Useful additional inputs:
 - `stp_path`
 - `sip_path`
 - `sor_path`
+- `spp_path`
+- `srp_path`
 - current `pr_state`
 - requested `stop_boundary`
 
@@ -114,6 +118,8 @@ Preferred next-skill mapping:
 - bootstrap missing -> `pr-init`
 - card-local STP issue -> `stp-editor`
 - card-local SIP issue -> `sip-editor`
+- card-local SPP issue -> `spp-editor`
+- card-local SRP issue -> `srp-editor`
 - card-local SOR issue -> `sor-editor`
 - structurally ready but not bound -> `pr-ready`
 - ready for execution bind -> `pr-run`

--- a/adl/tools/skills/workflow-conductor/adl-skill.yaml
+++ b/adl/tools/skills/workflow-conductor/adl-skill.yaml
@@ -64,6 +64,8 @@ admission:
     - "source_prompt_path"
     - "stp_path"
     - "sip_path"
+    - "spp_path"
+    - "srp_path"
     - "sor_path"
     - "pr_state"
     - "stop_boundary"

--- a/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
+++ b/adl/tools/skills/workflow-conductor/references/conductor-playbook.md
@@ -36,6 +36,8 @@ checkout just because the primary checkout is where the conductor was invoked.
 - missing bootstrap/root bundle -> `pr-init`
 - STP-only card defect -> `stp-editor`
 - SIP-only card defect -> `sip-editor`
+- SPP-only card defect -> `spp-editor`
+- SRP-only card defect -> `srp-editor`
 - SOR-only card defect -> `sor-editor`
 - issue structurally pre-run -> `pr-ready`
 - issue ready for execution or binding -> `pr-run`

--- a/adl/tools/skills/workflow-conductor/references/output-contract.md
+++ b/adl/tools/skills/workflow-conductor/references/output-contract.md
@@ -15,8 +15,8 @@ workflow_state:
     - <doctor_json_or_path_or_state_surface>
 selected_skill:
   phase: init | ready | run | finish | janitor | closeout | editor | blocked
-  skill_name: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none
-  editor_skill: stp-editor | sip-editor | sor-editor | none
+  skill_name: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | none
+  editor_skill: stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | none
 workflow_compliance:
   skills_required: true | false
   card_editor_skills_required: true | false
@@ -31,12 +31,12 @@ workflow_compliance:
 actions_taken:
   - <routing or policy action>
 handoff_state:
-  next_phase: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | human_review | blocked
+  next_phase: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | human_review | blocked
   continuation: continue | ask_operator | stop
   escalation_reason: none | operator_override_required | ambiguous_live_state | healthy_pr_waiting | manual_review_required | policy_block | child_issue_wave_satisfied | related_issue_ref_satisfied | sibling_issue_artifact_satisfied | child_issue_wave_active | related_issue_ref_active | repo_policy_residue | unsafe_root_checkout_execution | mismatched_publication_surface | rebind_to_issue_worktree_required
 dispatch:
   mode: route_only | plan_subtask | invoke_subtask
-  selected_skill: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | sor-editor | none
+  selected_skill: pr-init | pr-ready | pr-run | pr-finish | pr-janitor | pr-closeout | stp-editor | sip-editor | spp-editor | srp-editor | sor-editor | none
   skill_file: <absolute skill path or null>
   command_source: none | builtin | override
   command: <argv array or null>

--- a/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
+++ b/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
@@ -27,6 +27,8 @@ SKILL_FILES = {
     "pr-closeout": "adl/tools/skills/pr-closeout/SKILL.md",
     "stp-editor": "adl/tools/skills/stp-editor/SKILL.md",
     "sip-editor": "adl/tools/skills/sip-editor/SKILL.md",
+    "spp-editor": "adl/tools/skills/spp-editor/SKILL.md",
+    "srp-editor": "adl/tools/skills/srp-editor/SKILL.md",
     "sor-editor": "adl/tools/skills/sor-editor/SKILL.md",
 }
 
@@ -444,15 +446,45 @@ def classify_pr_state(pr):
     return pr_state, blocker_class
 
 
-def infer_card_blocker(bundle: Path):
+def expects_extended_card_lifecycle(target: dict, bundle: Path) -> bool:
+    if target.get("spp_path") or target.get("srp_path"):
+        return True
+    return (bundle / "spp.md").exists() or (bundle / "srp.md").exists()
+
+
+def infer_card_blocker(bundle: Path, target: dict | None = None):
+    target = target or {}
     expected = {
-        "stp": bundle / "stp.md",
         "sip": bundle / "sip.md",
-        "sor": bundle / "sor.md",
+        "stp": bundle / "stp.md",
     }
+    if expects_extended_card_lifecycle(target, bundle):
+        if target.get("spp_path") or (bundle / "spp.md").exists():
+            expected["spp"] = Path(target.get("spp_path") or bundle / "spp.md")
+        if target.get("srp_path") or (bundle / "srp.md").exists():
+            expected["srp"] = Path(target.get("srp_path") or bundle / "srp.md")
+    expected["sor"] = bundle / "sor.md"
     for blocker, path in expected.items():
         if not path.exists():
             return blocker
+    return "none"
+
+
+def infer_doctor_card_blocker(doctor):
+    lifecycle = doctor.get("card_lifecycle") if isinstance(doctor, dict) else None
+    if not isinstance(lifecycle, dict):
+        return "none"
+    for stage in lifecycle.get("stages", []) or []:
+        if not isinstance(stage, dict):
+            continue
+        editor = stage.get("next_editor")
+        if editor not in {"spp-editor", "srp-editor"}:
+            continue
+        if stage.get("complete") is True:
+            continue
+        stage_name = str(stage.get("stage", "")).lower()
+        if stage_name in {"spp", "srp"}:
+            return stage_name
     return "none"
 
 
@@ -498,7 +530,7 @@ def collect_route_issue(repo_root: Path, payload):
     bundle, source_prompt, identity = gather_issue_surface(repo_root, issue_number)
 
     bootstrap_present = bool(bundle and source_prompt)
-    card_blocker = infer_card_blocker(bundle) if bundle else "none"
+    card_blocker = infer_card_blocker(bundle, target) if bundle else "none"
     workflow = {
         "bootstrap_present": bootstrap_present,
         "card_blocker": card_blocker,
@@ -562,6 +594,10 @@ def collect_route_issue(repo_root: Path, payload):
     if doctor:
         workflow["lifecycle_state"] = doctor.get("lifecycle_state", "unknown")
         workflow["ready_state"] = doctor.get("ready_status", "unknown").lower()
+        doctor_card_blocker = infer_doctor_card_blocker(doctor)
+        if doctor_card_blocker != "none":
+            workflow["card_blocker"] = doctor_card_blocker
+            workflow["evidence_used"].append("doctor_card_lifecycle")
         doctor_blocker = classify_doctor_state(doctor)
         if workflow["blocker_class"] == "none":
             workflow["blocker_class"] = doctor_blocker
@@ -601,7 +637,7 @@ def collect_route_task_bundle(repo_root: Path, payload):
     observed = payload.get("observed_state", {})
     workflow = {
         "bootstrap_present": bool(bundle.exists() and source_prompt),
-        "card_blocker": infer_card_blocker(bundle) if bundle.exists() else "stp",
+        "card_blocker": infer_card_blocker(bundle, target) if bundle.exists() else "stp",
         "lifecycle_state": "pre_run",
         "ready_state": "unknown",
         "pr_state": "none",
@@ -646,7 +682,7 @@ def collect_route_branch(repo_root: Path, payload):
     bundle, source_prompt, bundle_identity = gather_issue_surface(repo_root, identity["issue_number"])
     workflow = {
         "bootstrap_present": bool(bundle and source_prompt),
-        "card_blocker": infer_card_blocker(bundle) if bundle else "none",
+        "card_blocker": infer_card_blocker(bundle, target) if bundle else "none",
         "lifecycle_state": "pre_run",
         "ready_state": "unknown",
         "pr_state": "none",
@@ -665,6 +701,10 @@ def collect_route_branch(repo_root: Path, payload):
     if doctor:
         workflow["lifecycle_state"] = doctor.get("lifecycle_state", "unknown")
         workflow["ready_state"] = doctor.get("ready_status", "unknown").lower()
+        doctor_card_blocker = infer_doctor_card_blocker(doctor)
+        if doctor_card_blocker != "none":
+            workflow["card_blocker"] = doctor_card_blocker
+            workflow["evidence_used"].append("doctor_card_lifecycle")
         workflow["blocker_class"] = classify_doctor_state(doctor)
         workflow["evidence_used"].append("doctor_json")
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):
@@ -723,7 +763,7 @@ def collect_route_worktree(repo_root: Path, payload):
         resolved_target.setdefault("source_prompt_path", str(source_prompt))
     workflow = {
         "bootstrap_present": bool(source_prompt),
-        "card_blocker": infer_card_blocker(bundle),
+        "card_blocker": infer_card_blocker(bundle, target),
         "lifecycle_state": "run_bound",
         "ready_state": "pass",
         "pr_state": "none",
@@ -740,6 +780,10 @@ def collect_route_worktree(repo_root: Path, payload):
         if workflow["lifecycle_state"] != "execution_done" or doctor_lifecycle == "execution_done":
             workflow["lifecycle_state"] = doctor_lifecycle
         workflow["ready_state"] = doctor.get("ready_status", "unknown").lower()
+        doctor_card_blocker = infer_doctor_card_blocker(doctor)
+        if doctor_card_blocker != "none":
+            workflow["card_blocker"] = doctor_card_blocker
+            workflow["evidence_used"].append("doctor_card_lifecycle")
         workflow["blocker_class"] = classify_doctor_state(doctor)
         workflow["evidence_used"].append("doctor_json")
     if workflow["blocker_class"] == "none" and detect_tracked_adl_residue(repo_root):

--- a/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
+++ b/adl/tools/skills/workflow-conductor/scripts/select_next_skill.py
@@ -12,6 +12,8 @@ def editor_for(blocker: str) -> str:
     return {
         "stp": "stp-editor",
         "sip": "sip-editor",
+        "spp": "spp-editor",
+        "srp": "srp-editor",
         "sor": "sor-editor",
     }.get(blocker, "none")
 
@@ -43,7 +45,7 @@ def evaluate(payload):
         skill_name = "pr-init"
         continuation = "continue"
         escalation_reason = "none"
-    elif card_blocker in ("stp", "sip", "sor"):
+    elif card_blocker in ("stp", "sip", "spp", "srp", "sor"):
         detected_phase = "card_local_blocker"
         selected_phase = "editor"
         skill_name = editor_for(card_blocker)
@@ -186,7 +188,7 @@ def evaluate(payload):
         blocked_by_policy = True
         bypasses.append({"component": "required_card_skill_by_type", "reason": "selected_editor_mismatch"})
 
-    if card_blocker in ("stp", "sip", "sor") and policy.get("card_editor_skills_required", True) and editor_skill == "none":
+    if card_blocker in ("stp", "sip", "spp", "srp", "sor") and policy.get("card_editor_skills_required", True) and editor_skill == "none":
         policy_result = "FAIL"
         blocked_by_policy = True
         bypasses.append({"component": "card_editor_skills_required", "reason": "card_blocker_not_routed_to_editor"})

--- a/adl/tools/test_card_editor_skill_contracts.sh
+++ b/adl/tools/test_card_editor_skill_contracts.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 skills_root="${repo_root}/adl/tools/skills"
 
-for skill in stp-editor sip-editor sor-editor; do
+for skill in stp-editor sip-editor spp-editor srp-editor sor-editor; do
   [[ -f "${skills_root}/${skill}/SKILL.md" ]]
   [[ -f "${skills_root}/${skill}/adl-skill.yaml" ]]
   [[ -f "${skills_root}/${skill}/agents/openai.yaml" ]]
@@ -14,11 +14,18 @@ done
 
 [[ -f "${skills_root}/docs/STP_EDITOR_SKILL_INPUT_SCHEMA.md" ]]
 [[ -f "${skills_root}/docs/SIP_EDITOR_SKILL_INPUT_SCHEMA.md" ]]
+[[ -f "${skills_root}/docs/SPP_EDITOR_SKILL_INPUT_SCHEMA.md" ]]
+[[ -f "${skills_root}/docs/SRP_EDITOR_SKILL_INPUT_SCHEMA.md" ]]
 [[ -f "${skills_root}/docs/SOR_EDITOR_SKILL_INPUT_SCHEMA.md" ]]
 
 grep -Fq "must not:" "${skills_root}/stp-editor/SKILL.md"
 grep -Fq "must not:" "${skills_root}/sip-editor/SKILL.md"
+grep -Fq "must not:" "${skills_root}/spp-editor/SKILL.md"
+grep -Fq "must not:" "${skills_root}/srp-editor/SKILL.md"
 grep -Fq "must not:" "${skills_root}/sor-editor/SKILL.md"
+grep -Fq 'preserve `SPP` as a planning artifact rather than an execution log' "${skills_root}/spp-editor/SKILL.md"
+grep -Fq "Structured Review Prompt" "${skills_root}/srp-editor/SKILL.md"
+grep -Fq "invent review results" "${skills_root}/srp-editor/SKILL.md"
 grep -Fq "invent validation that did not happen" "${skills_root}/sor-editor/SKILL.md"
 grep -Fq 'fix truthful `Branch` state such as `not bound yet` vs bound execution branch' "${skills_root}/sip-editor/SKILL.md"
 grep -Fq "tighten clarity around goal, required outcome, acceptance criteria, and scope" "${skills_root}/stp-editor/SKILL.md"
@@ -27,5 +34,6 @@ grep -Fq "stp-editor" "${skills_root}/pr-init/SKILL.md"
 grep -Fq "sip-editor" "${skills_root}/pr-ready/SKILL.md"
 grep -Fq "sor-editor" "${skills_root}/pr-run/SKILL.md"
 grep -Fq "sor-editor" "${skills_root}/pr-finish/SKILL.md"
+grep -Fq "srp-editor" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 
 echo "PASS test_card_editor_skill_contracts"

--- a/adl/tools/test_install_adl_operational_skills.sh
+++ b/adl/tools/test_install_adl_operational_skills.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 assert_skill_bundle() {
   local root="$1"
 
-  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author spp-editor sprint-conductor stp-editor sip-editor sor-editor; do
+  for skill in workflow-conductor issue-watcher pr-init pr-ready pr-run pr-finish pr-janitor pr-closeout repo-code-review repo-packet-builder redaction-and-evidence-auditor repo-architecture-review repo-dependency-review repo-diagram-planner architecture-diagram-reviewer review-to-test-planner adr-curator architecture-fitness-function-author finding-to-issue-planner test-generator demo-operator release-evidence review-readiness-cleanup portable-contract-normalizer medium-article-writer arxiv-paper-writer diagram-author spp-editor srp-editor sprint-conductor stp-editor sip-editor sor-editor; do
     [[ -d "${root}/skills/${skill}" ]]
   done
 
@@ -59,6 +59,7 @@ assert_skill_bundle() {
   [[ -f "${root}/skills/diagram-author/SKILL.md" ]]
   [[ -x "${root}/skills/diagram-author/scripts/render_diagrams.sh" ]]
   [[ -f "${root}/skills/spp-editor/SKILL.md" ]]
+  [[ -f "${root}/skills/srp-editor/SKILL.md" ]]
   [[ -f "${root}/skills/sprint-conductor/SKILL.md" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" ]]
   [[ -x "${root}/skills/sprint-conductor/scripts/check_installed_skill_parity.py" ]]
@@ -101,6 +102,7 @@ assert_skill_bundle() {
   grep -Fq "without submitting, publishing, inventing citations" "${root}/skills/arxiv-paper-writer/SKILL.md"
   grep -Fq "diagram-as-code and model-as-code router" "${root}/skills/diagram-author/SKILL.md"
   grep -Fq "planning artifact rather than an execution log" "${root}/skills/spp-editor/SKILL.md"
+  grep -Fq "Structured Review Prompt" "${root}/skills/srp-editor/SKILL.md"
   grep -Fq "one issue at a time, fully closed out before the next" "${root}/skills/sprint-conductor/SKILL.md"
   grep -Fq "bounded editing of \`stp.md\`" "${root}/skills/stp-editor/SKILL.md"
   grep -Fq "truthful lifecycle state" "${root}/skills/sip-editor/SKILL.md"
@@ -135,6 +137,7 @@ assert_skill_bundle() {
     "${root}/skills/arxiv-paper-writer/SKILL.md" \
     "${root}/skills/diagram-author/SKILL.md" \
     "${root}/skills/spp-editor/SKILL.md" \
+    "${root}/skills/srp-editor/SKILL.md" \
     "${root}/skills/sprint-conductor/SKILL.md" \
     "${root}/skills/stp-editor/SKILL.md" \
     "${root}/skills/sip-editor/SKILL.md" \

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -333,4 +333,24 @@ assert "sor.md" in problem["contradictory_cards"]
 assert "sor-editor" in problem["required_editor_skills"]
 PY
 
+rm -f "${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md"
+missing_srp_state_path="${tmpdir}/sprint-state-missing-srp.json"
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --state "${missing_srp_state_path}" >/dev/null
+
+python3 - "${missing_srp_state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+preflight = state["structured_prompt_preflight"]
+assert preflight["status"] == "needs_editor_repair"
+problem = next(result for result in preflight["issue_results"] if result["issue_number"] == 2828)
+assert "srp.md" in problem["missing_cards"]
+assert "srp-editor" in problem["required_editor_skills"]
+PY
+
 echo "PASS test_sprint_conductor_helpers"

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -14,6 +14,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 [[ -f "${skills_root}/workflow-conductor/scripts/route_workflow.py" ]]
 [[ -f "${skills_root}/workflow-conductor/scripts/select_next_skill.py" ]]
 [[ -f "${skills_root}/docs/WORKFLOW_CONDUCTOR_SKILL_INPUT_SCHEMA.md" ]]
+[[ -f "${skills_root}/srp-editor/SKILL.md" ]]
 
 grep -Fq "thin orchestrator" "${skills_root}/workflow-conductor/SKILL.md"
 grep -Fq "dispatch one bounded downstream skill subtask" "${skills_root}/workflow-conductor/SKILL.md"
@@ -36,6 +37,9 @@ grep -Fq "preserve bound issue worktree identity" "${skills_root}/workflow-condu
 grep -Fq "unsafe_root_checkout_execution" "${skills_root}/workflow-conductor/references/output-contract.md"
 grep -Fq "mismatched_publication_surface" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
 grep -Fq "rebind_to_issue_worktree_required" "${skills_root}/docs/OPERATIONAL_SKILLS_GUIDE.md"
+grep -Fq "card-local SPP issue -> \`spp-editor\`" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "card-local SRP issue -> \`srp-editor\`" "${skills_root}/workflow-conductor/SKILL.md"
+grep -Fq "srp-editor" "${skills_root}/workflow-conductor/references/output-contract.md"
 
 cat >"${tmpdir}/bootstrap_missing.json" <<'EOF'
 {
@@ -67,6 +71,46 @@ cat >"${tmpdir}/stp_blocker.json" <<'EOF'
     "pr_state": "none",
     "subagent_assigned": false,
     "evidence_used": ["stp_path"]
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional"
+  }
+}
+EOF
+
+cat >"${tmpdir}/spp_blocker.json" <<'EOF'
+{
+  "target": {"issue_number": 1647},
+  "workflow_state": {
+    "bootstrap_present": true,
+    "card_blocker": "spp",
+    "lifecycle_state": "pre_run",
+    "ready_state": "unknown",
+    "pr_state": "none",
+    "subagent_assigned": false,
+    "evidence_used": ["doctor_card_lifecycle"]
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional"
+  }
+}
+EOF
+
+cat >"${tmpdir}/srp_blocker.json" <<'EOF'
+{
+  "target": {"issue_number": 1647},
+  "workflow_state": {
+    "bootstrap_present": true,
+    "card_blocker": "srp",
+    "lifecycle_state": "pre_run",
+    "ready_state": "unknown",
+    "pr_state": "none",
+    "subagent_assigned": false,
+    "evidence_used": ["doctor_card_lifecycle"]
   },
   "policy": {
     "skills_required": true,
@@ -155,6 +199,8 @@ EOF
 
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/bootstrap_missing.json" >"${tmpdir}/bootstrap_missing.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/stp_blocker.json" >"${tmpdir}/stp_blocker.out.json"
+python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/spp_blocker.json" >"${tmpdir}/spp_blocker.out.json"
+python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/srp_blocker.json" >"${tmpdir}/srp_blocker.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/resume_to_run.json" >"${tmpdir}/resume_to_run.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/pr_in_flight.json" >"${tmpdir}/pr_in_flight.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/required_subagent_missing.json" >"${tmpdir}/required_subagent_missing.out.json"
@@ -176,6 +222,14 @@ assert bootstrap["selected_skill"]["skill_name"] == "pr-init"
 stp = load("stp_blocker.out.json")
 assert stp["selected_skill"]["skill_name"] == "stp-editor"
 assert stp["selected_skill"]["editor_skill"] == "stp-editor"
+
+spp = load("spp_blocker.out.json")
+assert spp["selected_skill"]["skill_name"] == "spp-editor"
+assert spp["selected_skill"]["editor_skill"] == "spp-editor"
+
+srp = load("srp_blocker.out.json")
+assert srp["selected_skill"]["skill_name"] == "srp-editor"
+assert srp["selected_skill"]["editor_skill"] == "srp-editor"
 
 resume = load("resume_to_run.out.json")
 assert resume["selected_skill"]["skill_name"] == "pr-run"
@@ -510,6 +564,32 @@ cat >"${tmpdir}/route_task_bundle_dispatch.json" <<EOF
         "-lc",
         "printf 'EDITOR:%s\\n' \"{issue_number}\" >> \"${tmpdir}/editor-dispatch.log\""
       ]
+    }
+  },
+  "observed_state": {
+    "subagent_assigned": false
+  }
+}
+EOF
+
+cat >"${tmpdir}/route_task_bundle_missing_srp.json" <<EOF
+{
+  "skill_input_schema": "workflow_conductor.v1",
+  "mode": "route_task_bundle",
+  "repo_root": "${fixture_repo}",
+  "target": {
+    "task_bundle_path": ".adl/v0.88/tasks/issue-2001__route-run",
+    "srp_path": ".adl/v0.88/tasks/issue-2001__route-run/srp.md"
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional",
+    "bypass_without_explicit_blocker": false,
+    "allow_phase_inference": true,
+    "stop_after_routing": true,
+    "required_card_skill_by_type": {
+      "srp": "srp-editor"
     }
   },
   "observed_state": {
@@ -965,6 +1045,7 @@ python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "$
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_issue_dispatch.json" --artifact-path ".adl/reviews/route-issue-dispatch.md" >"${tmpdir}/route_issue_dispatch.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_task_bundle.json" --artifact-path ".adl/reviews/route-task-bundle.md" >"${tmpdir}/route_task_bundle.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_task_bundle_dispatch.json" --artifact-path ".adl/reviews/route-task-bundle-dispatch.md" >"${tmpdir}/route_task_bundle_dispatch.out.json"
+python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_task_bundle_missing_srp.json" --artifact-path ".adl/reviews/route-task-bundle-missing-srp.md" >"${tmpdir}/route_task_bundle_missing_srp.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_finish.json" --artifact-path ".adl/reviews/route-finish.md" >"${tmpdir}/route_finish.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_worktree_finish.json" --artifact-path ".adl/reviews/route-worktree-finish.md" >"${tmpdir}/route_worktree_finish.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/route_workflow.py" --input "${tmpdir}/route_worktree_disambiguated.json" --artifact-path ".adl/reviews/route-worktree-disambiguated.md" >"${tmpdir}/route_worktree_disambiguated.out.json"
@@ -1019,6 +1100,13 @@ assert route_editor_dispatch["dispatch"]["command_source"] == "override"
 assert route_editor_dispatch["dispatch"]["status"] == "invoked"
 assert route_editor_dispatch["dispatch"]["result"] == "success"
 assert (tmp / "editor-dispatch.log").read_text().strip() == "EDITOR:2003"
+
+route_missing_srp = load("route_task_bundle_missing_srp.out.json")
+assert route_missing_srp["selected_skill"]["skill_name"] == "srp-editor"
+assert route_missing_srp["selected_skill"]["editor_skill"] == "srp-editor"
+assert route_missing_srp["workflow_state"]["detected_phase"] == "card_local_blocker"
+assert route_missing_srp["workflow_compliance"]["policy_result"] == "PASS"
+assert (repo / ".adl/reviews/route-task-bundle-missing-srp.md").exists()
 
 route_finish = load("route_finish.out.json")
 assert route_finish["selected_skill"]["skill_name"] == "pr-finish"


### PR DESCRIPTION
Closes #3066

## Summary
Aligned the editor/conductor skill surfaces with the canonical
`SIP -> STP -> SPP -> SRP -> SOR` lifecycle. The branch adds a tracked
`srp-editor` skill bundle, teaches `workflow-conductor` to route SPP/SRP
card-local blockers to `spp-editor`/`srp-editor`, updates `sprint-conductor`
preflight so missing SRP routes to `srp-editor`, and extends focused tests and
installer coverage.

## Artifacts
- `adl/tools/skills/srp-editor/SKILL.md`
- `adl/tools/skills/srp-editor/adl-skill.yaml`
- `adl/tools/skills/srp-editor/agents/openai.yaml`
- `adl/tools/skills/srp-editor/references/edit-playbook.md`
- `adl/tools/skills/srp-editor/references/output-contract.md`
- `adl/tools/skills/docs/SRP_EDITOR_SKILL_INPUT_SCHEMA.md`
- Updated workflow-conductor routing, contracts, and tests.
- Updated sprint-conductor preflight, contracts, and tests.
- Updated `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`.
- Issue-local SPP and SRP were normalized through their editor-skill semantics.

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_card_editor_skill_contracts.sh`
    Verified card-editor contract coverage, including the new `srp-editor`.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Verified selector and full workflow routing for SPP/SRP editor handoff.
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified sprint preflight maps missing SRP to `srp-editor`.
  - `bash adl/tools/test_install_adl_operational_skills.sh`
    Verified installability of the operational skill bundle including
    `srp-editor`.
  - `bash adl/tools/validate_skill_frontmatter.sh adl/tools/skills/srp-editor/SKILL.md adl/tools/skills/workflow-conductor/SKILL.md adl/tools/skills/sprint-conductor/SKILL.md`
    Verified touched/new skill frontmatter.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3066__v0-91-2-c-sdlc-skills-align-editor-and-conductor-routing/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3066__v0-91-2-c-sdlc-skills-align-editor-and-conductor-routing/sor.md
- Idempotency-Key: v0-91-2-c-sdlc-align-editor-and-conductor-routing-adl-v0-91-2-tasks-issue-3066-v0-91-2-c-sdlc-skills-align-editor-and-conductor-routing-sip-md-adl-v0-91-2-tasks-issue-3066-v0-91-2-c-sdlc-skills-align-editor-and-conductor-routing-sor-md