### PR TITLE
[v0.91.2][C-SDLC] Fix sprint helper and SOR editor review findings

### DIFF
--- a/adl/tools/skills/sor-editor/adl-skill.yaml
+++ b/adl/tools/skills/sor-editor/adl-skill.yaml
@@ -33,14 +33,14 @@ admission:
     - "target.sor_path_must_be_present"
     - "policy.stop_after_edit_must_be_true"
     - "evidence.commands_run_must_be_explicit_when_validation_claims_are_changed"
-  execution:
-    mode: "auto_apply"
-    allow_code_edits: true
-    allow_network: false
-    allow_subagents: false
-    workflow_role: "card_editor"
-    preferred_path: "structured_input_then_direct_card_edit"
-    invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
+execution:
+  mode: "auto_apply"
+  allow_code_edits: true
+  allow_network: false
+  allow_subagents: false
+  workflow_role: "card_editor"
+  preferred_path: "structured_input_then_direct_card_edit"
+  invocation_guidance: "prefer_validated_structured_input_over_freeform_prose"
 boundaries:
   writes_limited_to:
     - ".adl/**/sor.md"

--- a/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
+++ b/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py
@@ -156,13 +156,17 @@ def bootstrap_local_bundle(
         )
         version = infer_version_from_title(title)
         slug = sanitize_slug(title)
+        source_path = issue_prompt_path(repo_root, version, sprint_issue_number, slug)
         bundle_dir = task_bundle_dir(repo_root, version, sprint_issue_number, slug)
+        stp_path = bundle_dir / 'stp.md'
+        write_file(source_path, body + '\n')
+        write_file(stp_path, body + '\n')
         return {
             'version': version,
             'slug': slug,
-            'source_path': str(issue_prompt_path(repo_root, version, sprint_issue_number, slug)),
+            'source_path': str(source_path),
             'bundle_dir': str(bundle_dir),
-            'stp_path': str(bundle_dir / 'stp.md'),
+            'stp_path': str(stp_path),
             'sip_path': str(bundle_dir / 'sip.md'),
             'sor_path': str(bundle_dir / 'sor.md'),
             'spp_path': str(bundle_dir / 'spp.md'),

--- a/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
+++ b/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py
@@ -87,13 +87,6 @@ def select_next_issue(state: dict[str, Any]) -> None:
         if issue not in completed:
             record = record_by_issue.get(issue, {})
             if record.get('status') == 'waiting_for_review':
-                later_issues = [
-                    later
-                    for later in state.get('ordered_issue_numbers', [])
-                    if later != issue and later not in completed
-                ]
-                if record.get('pr_url') and later_issues:
-                    continue
                 state['current_issue_number'] = issue
                 state['continuation'] = 'waiting_for_review'
                 return

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -74,6 +74,40 @@ state_path="${tmpdir}/sprint-state.json"
 fake_repo="${tmpdir}/fake-repo"
 mkdir -p "${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05"
 mkdir -p "${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06"
+mkdir -p "${fake_repo}/adl/tools"
+
+cat >"${fake_repo}/adl/tools/pr.sh" <<'PR_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" != "init" ]]; then
+  echo "unexpected fake pr.sh invocation: $*" >&2
+  exit 1
+fi
+
+issue_number="$2"
+mkdir -p ".adl/v0.91.1/bodies"
+mkdir -p ".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint"
+cat >".adl/v0.91.1/bodies/issue-${issue_number}-sprint-1-management-trial-sprint.md" <<'EOF2'
+generic pr init source stub
+EOF2
+cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/stp.md" <<'EOF2'
+generic pr init stp stub
+EOF2
+cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/sip.md" <<'EOF2'
+sip
+EOF2
+cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/sor.md" <<'EOF2'
+Status: NOT_STARTED
+EOF2
+cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/spp.md" <<'EOF2'
+issue: 3001
+EOF2
+cat >".adl/v0.91.1/tasks/issue-${issue_number}__sprint-1-management-trial-sprint/srp.md" <<'EOF2'
+issue: 3001
+EOF2
+PR_EOF
+chmod +x "${fake_repo}/adl/tools/pr.sh"
 
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/stp.md" <<'EOF2'
 stp
@@ -134,6 +168,12 @@ test -f "${fake_repo}/.adl/v0.91.1/bodies/issue-3001-sprint-1-management-trial-s
 test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/stp.md"
 test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/sip.md"
 test -f "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/sor.md"
+grep -q "Run the narrow sprint-conductor trial" "${fake_repo}/.adl/v0.91.1/bodies/issue-3001-sprint-1-management-trial-sprint.md"
+grep -q "Run the narrow sprint-conductor trial" "${fake_repo}/.adl/v0.91.1/tasks/issue-3001__sprint-1-management-trial-sprint/stp.md"
+if grep -q "generic pr init" "${fake_repo}/.adl/v0.91.1/bodies/issue-3001-sprint-1-management-trial-sprint.md"; then
+  echo "expected preferred-path bootstrap to replace generic local source prompt" >&2
+  exit 1
+fi
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
   --repo-root "${fake_repo}" \
@@ -188,8 +228,8 @@ assert record["status"] == "waiting_for_review"
 assert record["pr_url"] == "https://github.com/danielbaustin/agent-design-language/pull/4001"
 assert state["truth_check"]["status"] == "matched"
 assert state["truth_check"]["gate_passed"] is False
-assert state["current_issue_number"] == 2828
-assert state["continuation"] == "continue"
+assert state["current_issue_number"] == 2827
+assert state["continuation"] == "waiting_for_review"
 PY
 
 printf 'CLOSED\n' > "${issue_2827_state_file}"


### PR DESCRIPTION
Closes #3089

## Summary
Fixed three process-safety review findings in sprint-conductor helpers and
`sor-editor` metadata.

## Artifacts
- `adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py`
- `adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py`
- `adl/tools/skills/sor-editor/adl-skill.yaml`
- `adl/tools/test_sprint_conductor_helpers.sh`
- `.adl/v0.91.2/tasks/issue-3089__v0-91-2-c-sdlc-tools-fix-sprint-helper-and-sor-editor-review-findings/srp.md`
- `.adl/v0.91.2/tasks/issue-3089__v0-91-2-c-sdlc-tools-fix-sprint-helper-and-sor-editor-review-findings/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified sprint helper behavior.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Verified workflow conductor skill contracts.
  - `bash adl/tools/test_card_editor_skill_contracts.sh`
    Verified editor skill contracts.
  - `python3 -m py_compile adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py`
    Verified Python helper syntax.
  - Ruby YAML placement check
    Verified `sor-editor` metadata shape.
  - bounded pre-PR subagent review
    Verified the changed work product.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3089__v0-91-2-c-sdlc-tools-fix-sprint-helper-and-sor-editor-review-findings/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3089__v0-91-2-c-sdlc-tools-fix-sprint-helper-and-sor-editor-review-findings/sor.md
- Idempotency-Key: v0-91-2-c-sdlc-fix-sprint-helper-and-sor-editor-review-findings-adl-tools-skills-sprint-conductor-scripts-create-missing-sprint-issue-py-adl-tools-skills-sprint-conductor-scripts-update-sprint-state-py-adl-tools-skills-sor-editor-adl-skill-yaml-adl-tools-test-sprint-conductor-helpers-sh-adl-v0-91-2-tasks-issue-3089-v0-91-2-c-sdlc-tools-fix-sprint-helper-and-sor-editor-review-findings-sip-md-adl-v0-91-2-tasks-issue-3089-v0-91-2-c-sdlc-tools-fix-sprint-helper-and-sor-editor-review-findings-sor-md