### PR TITLE
[v0.91.2][GWS] Auth, scope, redaction, and skipped-state safety package

### DIFF
--- a/adl/src/bin/demo_v0912_gws_live_safety_package.rs
+++ b/adl/src/bin/demo_v0912_gws_live_safety_package.rs
@@ -1,0 +1,88 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+fn resolve_out_path(arg: Option<String>) -> PathBuf {
+    arg.map(PathBuf::from).unwrap_or_else(|| {
+        PathBuf::from(adl::gws_live_safety_package::GWS_LIVE_SAFETY_PACKAGE_REPORT_ARTIFACT_PATH)
+    })
+}
+
+fn write_report(path: &PathBuf) -> Result<()> {
+    adl::gws_live_safety_package::write_gws_live_safety_package_report(path)
+        .with_context(|| format!("write gws live safety package report '{}'", path.display()))?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let out_path = resolve_out_path(std::env::args().nth(1));
+    write_report(&out_path)?;
+    println!("{}", out_path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_out_path, write_report};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_path(prefix: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}.json"))
+    }
+
+    #[test]
+    fn demo_v0912_gws_live_safety_package_resolve_out_path_uses_explicit_argument() {
+        let path = resolve_out_path(Some("tmp/gws-live-safety-package-report.json".to_string()));
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("tmp/gws-live-safety-package-report.json")
+        );
+    }
+
+    #[test]
+    fn demo_v0912_gws_live_safety_package_resolve_out_path_defaults_to_tracked_artifact_path() {
+        let path = resolve_out_path(None);
+        assert_eq!(
+            path,
+            std::path::PathBuf::from(
+                adl::gws_live_safety_package::GWS_LIVE_SAFETY_PACKAGE_REPORT_ARTIFACT_PATH
+            )
+        );
+    }
+
+    #[test]
+    fn demo_v0912_gws_live_safety_package_write_report_creates_expected_json_artifact() {
+        let path = unique_temp_path("gws-live-safety-package-bin");
+        write_report(&path).expect("write report");
+        let body = fs::read_to_string(&path).expect("read report");
+        assert!(body.contains("gws_live_safety_package.v1"));
+        fs::remove_file(&path).expect("remove report");
+    }
+
+    #[test]
+    fn demo_v0912_gws_live_safety_package_write_report_adds_context_on_failure() {
+        let dir = std::env::temp_dir().join(format!(
+            "gws-live-safety-package-dir-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be valid")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let error = write_report(&dir).expect_err("directory path should fail");
+        let message = error.to_string();
+        let context = error
+            .source()
+            .map(|source| source.to_string())
+            .unwrap_or_default();
+        assert!(message.contains("write gws live safety package report"));
+        assert!(message.contains(&dir.display().to_string()) || context.contains("Is a directory"));
+
+        fs::remove_dir_all(&dir).expect("remove temp dir");
+    }
+}

--- a/adl/src/gws_live_safety_package.rs
+++ b/adl/src/gws_live_safety_package.rs
@@ -1,0 +1,482 @@
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::{fs, path::Path};
+
+pub const GWS_LIVE_SAFETY_PACKAGE_REPORT_ARTIFACT_PATH: &str =
+    "docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_package_report.json";
+pub const GWS_LIVE_SAFETY_PACKAGE_SCHEMA_VERSION: &str = "gws_live_safety_package.v1";
+pub const GWS_LIVE_SAFETY_PACKAGE_PROMPT_VERSION: &str = "wp3092.gws_live_safety_package.v1";
+#[cfg(test)]
+const HOST_PATH_MARKER: &str = "/Users/daniel/";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GwsLiveSafetyPromptRecord {
+    pub prompt_version: &'static str,
+    pub issue_number: u32,
+    pub depends_on_issue_number: u32,
+    pub summary: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceAuthMode {
+    FixtureOnly,
+    OperatorOauthUser,
+    ServiceAccountScoped,
+    ExternalCliCredentialStore,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceScopeKind {
+    DriveFolderInventoryRead,
+    DriveFileMetadataRead,
+    DocsReadSnapshot,
+    SheetsReadContentCards,
+    SheetsPreviewContentCardUpdate,
+    SheetsApplyContentCardUpdate,
+    DriveRecordRevisionAnchor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceDataSensitivity {
+    MetadataOnly,
+    RedactedExcerpt,
+    PrivateBody,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceTracePosture {
+    MetadataOnly,
+    RedactedContentOnly,
+    IssueScopedLinkOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceSkippedReason {
+    LiveModeDisabled,
+    GwsUnavailable,
+    MissingAuth,
+    MissingScopes,
+    NetworkUnavailable,
+    OperatorDeclined,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceStopCondition {
+    RevisionMismatch,
+    AuthorityDrift,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkspaceAuthProfileRecord {
+    pub auth_mode: WorkspaceAuthMode,
+    pub permitted_for_live_project_use: bool,
+    pub secret_recording_policy: &'static str,
+    pub notes: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkspaceScopePolicyRecord {
+    pub capability_name: &'static str,
+    pub scope_kind: WorkspaceScopeKind,
+    pub minimum_scope_summary: &'static str,
+    pub write_capability: bool,
+    pub operator_approval_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkspaceRedactionRuleRecord {
+    pub scenario: &'static str,
+    pub data_sensitivity: WorkspaceDataSensitivity,
+    pub trace_posture: WorkspaceTracePosture,
+    pub default_public_artifact_behavior: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkspaceSkippedStateRecord {
+    pub reason: WorkspaceSkippedReason,
+    pub classification: &'static str,
+    pub operator_message: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkspaceStopConditionRecord {
+    pub condition: WorkspaceStopCondition,
+    pub classification: &'static str,
+    pub operator_message: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkspaceRunbookRecord {
+    pub stage: &'static str,
+    pub required_actions: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GwsLiveSafetyPackageReport {
+    pub schema_version: &'static str,
+    pub prompt_record: GwsLiveSafetyPromptRecord,
+    pub auth_profiles: Vec<WorkspaceAuthProfileRecord>,
+    pub scope_policies: Vec<WorkspaceScopePolicyRecord>,
+    pub redaction_rules: Vec<WorkspaceRedactionRuleRecord>,
+    pub skipped_states: Vec<WorkspaceSkippedStateRecord>,
+    pub stop_conditions: Vec<WorkspaceStopConditionRecord>,
+    pub operator_runbook: Vec<WorkspaceRunbookRecord>,
+    pub non_claims: Vec<&'static str>,
+}
+
+fn prompt_record() -> GwsLiveSafetyPromptRecord {
+    GwsLiveSafetyPromptRecord {
+        prompt_version: GWS_LIVE_SAFETY_PACKAGE_PROMPT_VERSION,
+        issue_number: 3092,
+        depends_on_issue_number: 3008,
+        summary: "WP-3092 defines the auth, scope, redaction, trace, and skipped-state contract required to use the bounded Workspace CMS bridge safely on real projects.",
+    }
+}
+
+fn auth_profiles() -> Vec<WorkspaceAuthProfileRecord> {
+    vec![
+        WorkspaceAuthProfileRecord {
+            auth_mode: WorkspaceAuthMode::FixtureOnly,
+            permitted_for_live_project_use: false,
+            secret_recording_policy: "no live credentials are used or recorded",
+            notes: vec![
+                "Fixture mode remains the default proof path for CI and PR validation.",
+                "Fixture mode is proving for schema and workflow truth, not for live Workspace reachability.",
+            ],
+        },
+        WorkspaceAuthProfileRecord {
+            auth_mode: WorkspaceAuthMode::OperatorOauthUser,
+            permitted_for_live_project_use: true,
+            secret_recording_policy: "record auth mode only; never persist tokens, refresh tokens, or raw credential files",
+            notes: vec![
+                "Use when one human operator is performing a bounded project workflow.",
+                "Prefer a narrowly scoped Workspace identity rather than a broad personal account.",
+            ],
+        },
+        WorkspaceAuthProfileRecord {
+            auth_mode: WorkspaceAuthMode::ServiceAccountScoped,
+            permitted_for_live_project_use: true,
+            secret_recording_policy: "record service-account mode and issuing system only; never persist key material",
+            notes: vec![
+                "Use only when the project can prove the account is narrowed to the exact Drive/Docs/Sheets scope.",
+                "Treat service-account write scopes as higher risk than read-only bounded demos.",
+            ],
+        },
+        WorkspaceAuthProfileRecord {
+            auth_mode: WorkspaceAuthMode::ExternalCliCredentialStore,
+            permitted_for_live_project_use: true,
+            secret_recording_policy: "record that external CLI credential storage was used without copying any secret-bearing path or content",
+            notes: vec![
+                "This is the likely first live adapter posture for `gws`-backed project use.",
+                "The bridge may rely on the operator-visible CLI auth flow, but ADL must still record only the mode, not the secret.",
+            ],
+        },
+    ]
+}
+
+fn scope_policies() -> Vec<WorkspaceScopePolicyRecord> {
+    vec![
+        WorkspaceScopePolicyRecord {
+            capability_name: "workspace.drive.list_folder",
+            scope_kind: WorkspaceScopeKind::DriveFolderInventoryRead,
+            minimum_scope_summary: "one explicit Drive folder inventory scope",
+            write_capability: false,
+            operator_approval_required: false,
+        },
+        WorkspaceScopePolicyRecord {
+            capability_name: "workspace.drive.read_file_metadata",
+            scope_kind: WorkspaceScopeKind::DriveFileMetadataRead,
+            minimum_scope_summary:
+                "metadata read for files already inside the bounded folder scope",
+            write_capability: false,
+            operator_approval_required: false,
+        },
+        WorkspaceScopePolicyRecord {
+            capability_name: "workspace.docs.read_snapshot",
+            scope_kind: WorkspaceScopeKind::DocsReadSnapshot,
+            minimum_scope_summary: "one explicit document snapshot read scope",
+            write_capability: false,
+            operator_approval_required: false,
+        },
+        WorkspaceScopePolicyRecord {
+            capability_name: "workspace.sheets.read_content_cards",
+            scope_kind: WorkspaceScopeKind::SheetsReadContentCards,
+            minimum_scope_summary: "one explicit sheet range read scope for content cards only",
+            write_capability: false,
+            operator_approval_required: false,
+        },
+        WorkspaceScopePolicyRecord {
+            capability_name: "workspace.sheets.preview_content_card_update",
+            scope_kind: WorkspaceScopeKind::SheetsPreviewContentCardUpdate,
+            minimum_scope_summary: "one explicit sheet range preview scope with no live mutation",
+            write_capability: false,
+            operator_approval_required: false,
+        },
+        WorkspaceScopePolicyRecord {
+            capability_name: "workspace.sheets.apply_content_card_update",
+            scope_kind: WorkspaceScopeKind::SheetsApplyContentCardUpdate,
+            minimum_scope_summary:
+                "one explicit sheet range write scope for one bounded content-card update",
+            write_capability: true,
+            operator_approval_required: true,
+        },
+        WorkspaceScopePolicyRecord {
+            capability_name: "workspace.drive.record_revision_anchor",
+            scope_kind: WorkspaceScopeKind::DriveRecordRevisionAnchor,
+            minimum_scope_summary:
+                "one bounded revision-anchor recording scope tied to the reviewed source doc",
+            write_capability: false,
+            operator_approval_required: false,
+        },
+    ]
+}
+
+fn redaction_rules() -> Vec<WorkspaceRedactionRuleRecord> {
+    vec![
+        WorkspaceRedactionRuleRecord {
+            scenario: "drive folder inventory",
+            data_sensitivity: WorkspaceDataSensitivity::MetadataOnly,
+            trace_posture: WorkspaceTracePosture::MetadataOnly,
+            default_public_artifact_behavior: "record folder ref, document ids, and bounded metadata only",
+        },
+        WorkspaceRedactionRuleRecord {
+            scenario: "docs snapshot read",
+            data_sensitivity: WorkspaceDataSensitivity::PrivateBody,
+            trace_posture: WorkspaceTracePosture::RedactedContentOnly,
+            default_public_artifact_behavior: "publish only redacted excerpts or issue-scoped references, never full private document bodies",
+        },
+        WorkspaceRedactionRuleRecord {
+            scenario: "sheet content-card read",
+            data_sensitivity: WorkspaceDataSensitivity::MetadataOnly,
+            trace_posture: WorkspaceTracePosture::MetadataOnly,
+            default_public_artifact_behavior: "publish only lifecycle/status rows that are already intended for repo-facing management",
+        },
+        WorkspaceRedactionRuleRecord {
+            scenario: "comments and suggestions",
+            data_sensitivity: WorkspaceDataSensitivity::PrivateBody,
+            trace_posture: WorkspaceTracePosture::IssueScopedLinkOnly,
+            default_public_artifact_behavior: "record that collaboration state exists without copying private discussion into public artifacts",
+        },
+        WorkspaceRedactionRuleRecord {
+            scenario: "promotion packet preparation",
+            data_sensitivity: WorkspaceDataSensitivity::RedactedExcerpt,
+            trace_posture: WorkspaceTracePosture::MetadataOnly,
+            default_public_artifact_behavior: "record title, revision anchor, target repo path, and issue/PR linkage without body-level leakage",
+        },
+    ]
+}
+
+fn skipped_states() -> Vec<WorkspaceSkippedStateRecord> {
+    vec![
+        WorkspaceSkippedStateRecord {
+            reason: WorkspaceSkippedReason::LiveModeDisabled,
+            classification: "skipped",
+            operator_message: "Live Workspace execution is disabled for this run; fixture proof remains valid.",
+        },
+        WorkspaceSkippedStateRecord {
+            reason: WorkspaceSkippedReason::GwsUnavailable,
+            classification: "skipped",
+            operator_message: "The `gws` adapter is unavailable; do not fail fixture-backed validation because live execution could not start.",
+        },
+        WorkspaceSkippedStateRecord {
+            reason: WorkspaceSkippedReason::MissingAuth,
+            classification: "skipped",
+            operator_message: "No live Workspace credentials are available; record the missing auth posture without retrying ambient authority.",
+        },
+        WorkspaceSkippedStateRecord {
+            reason: WorkspaceSkippedReason::MissingScopes,
+            classification: "skipped",
+            operator_message: "The available Workspace credentials do not cover the bounded requested capability scope.",
+        },
+        WorkspaceSkippedStateRecord {
+            reason: WorkspaceSkippedReason::NetworkUnavailable,
+            classification: "skipped",
+            operator_message: "Workspace live execution is unreachable; preserve fixture proof and record the network unavailability separately.",
+        },
+        WorkspaceSkippedStateRecord {
+            reason: WorkspaceSkippedReason::OperatorDeclined,
+            classification: "skipped",
+            operator_message: "The operator declined a live write or wider scope escalation; stop cleanly without treating that as a bridge defect.",
+        },
+    ]
+}
+
+fn stop_conditions() -> Vec<WorkspaceStopConditionRecord> {
+    vec![
+        WorkspaceStopConditionRecord {
+            condition: WorkspaceStopCondition::RevisionMismatch,
+            classification: "stop",
+            operator_message: "The recorded Workspace revision anchor no longer matches the reviewed source state; stop before preview, apply, or promotion work continues.",
+        },
+        WorkspaceStopConditionRecord {
+            condition: WorkspaceStopCondition::AuthorityDrift,
+            classification: "stop",
+            operator_message: "The requested live Workspace action exceeds the declared issue-scoped authority or bounded folder/doc/sheet scope.",
+        },
+    ]
+}
+
+fn operator_runbook() -> Vec<WorkspaceRunbookRecord> {
+    vec![
+        WorkspaceRunbookRecord {
+            stage: "preflight",
+            required_actions: vec![
+                "Confirm the project really needs live Workspace access rather than fixture proof.",
+                "Declare one explicit folder/doc/sheet scope before proposing any live capability call.",
+                "Record the intended auth mode and verify that secrets themselves will not enter repo artifacts or cards.",
+            ],
+        },
+        WorkspaceRunbookRecord {
+            stage: "live read path",
+            required_actions: vec![
+                "Use inventory and snapshot reads first, with metadata-only or redacted trace posture.",
+                "Treat private document bodies as withheld by default unless the operator explicitly approves a redacted excerpt.",
+                "If auth, scope, or `gws` availability is missing, classify the live path as skipped and keep fixture proof separate.",
+            ],
+        },
+        WorkspaceRunbookRecord {
+            stage: "live write path",
+            required_actions: vec![
+                "Require preview before any content-card mutation apply step.",
+                "Require explicit operator approval for bounded sheet-range writes.",
+                "Record revision anchors and issue/PR linkage before any promotion-oriented action.",
+            ],
+        },
+        WorkspaceRunbookRecord {
+            stage: "promotion boundary",
+            required_actions: vec![
+                "Prepare promotion packets as metadata-rich handoff artifacts, not as direct tracked-file edits.",
+                "Keep GitHub issue and PR flow as canonical authority after promotion.",
+                "Stop before any silent repo mutation from Workspace state.",
+            ],
+        },
+    ]
+}
+
+pub fn run_gws_live_safety_package_report() -> GwsLiveSafetyPackageReport {
+    GwsLiveSafetyPackageReport {
+        schema_version: GWS_LIVE_SAFETY_PACKAGE_SCHEMA_VERSION,
+        prompt_record: prompt_record(),
+        auth_profiles: auth_profiles(),
+        scope_policies: scope_policies(),
+        redaction_rules: redaction_rules(),
+        skipped_states: skipped_states(),
+        stop_conditions: stop_conditions(),
+        operator_runbook: operator_runbook(),
+        non_claims: vec![
+            "This package does not enable broad ambient Google Workspace authority.",
+            "This package does not make Google Workspace canonical repo truth.",
+            "This package does not authorize private document body export into public artifacts by default.",
+        ],
+    }
+}
+
+pub fn write_gws_live_safety_package_report(
+    path: impl AsRef<Path>,
+) -> Result<GwsLiveSafetyPackageReport> {
+    let report = run_gws_live_safety_package_report();
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create parent directories for '{}'", path.display()))?;
+    }
+    let body = serde_json::to_string_pretty(&report)?;
+    fs::write(path, body).with_context(|| format!("write '{}'", path.display()))?;
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        run_gws_live_safety_package_report, write_gws_live_safety_package_report,
+        WorkspaceAuthMode, WorkspaceSkippedReason, WorkspaceStopCondition,
+        GWS_LIVE_SAFETY_PACKAGE_REPORT_ARTIFACT_PATH,
+    };
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_path(prefix: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}.json"))
+    }
+
+    #[test]
+    fn gws_live_safety_package_covers_required_auth_scope_and_skipped_state_contracts() {
+        let report = run_gws_live_safety_package_report();
+        assert!(report
+            .auth_profiles
+            .iter()
+            .any(|profile| profile.auth_mode == WorkspaceAuthMode::OperatorOauthUser));
+        assert!(report
+            .scope_policies
+            .iter()
+            .any(|scope| scope.write_capability && scope.operator_approval_required));
+        assert!(report
+            .skipped_states
+            .iter()
+            .any(|state| state.reason == WorkspaceSkippedReason::MissingAuth));
+        assert!(report
+            .stop_conditions
+            .iter()
+            .any(|condition| condition.condition == WorkspaceStopCondition::RevisionMismatch));
+    }
+
+    #[test]
+    fn gws_live_safety_package_serializes_deterministically_without_host_paths() {
+        let first = serde_json::to_string_pretty(&run_gws_live_safety_package_report())
+            .expect("serialize first");
+        let second = serde_json::to_string_pretty(&run_gws_live_safety_package_report())
+            .expect("serialize second");
+        assert_eq!(first, second);
+        assert!(!first.contains(super::HOST_PATH_MARKER));
+    }
+
+    #[test]
+    fn gws_live_safety_package_report_writer_emits_portable_json() {
+        let report_path = unique_temp_path("gws-live-safety-package");
+        let report = write_gws_live_safety_package_report(&report_path).expect("write report");
+        let body = fs::read_to_string(&report_path).expect("read report");
+        assert!(body.contains("gws_live_safety_package.v1"));
+        assert!(body.contains("live_mode_disabled"));
+        assert_eq!(report.schema_version, "gws_live_safety_package.v1");
+        fs::remove_file(&report_path).expect("remove report");
+    }
+
+    #[test]
+    fn gws_live_safety_package_artifact_path_is_repo_relative_and_bounded() {
+        assert!(GWS_LIVE_SAFETY_PACKAGE_REPORT_ARTIFACT_PATH.starts_with("docs/"));
+        assert!(!GWS_LIVE_SAFETY_PACKAGE_REPORT_ARTIFACT_PATH.starts_with('/'));
+    }
+
+    #[test]
+    fn gws_live_safety_package_writer_adds_context_on_failure() {
+        let dir = std::env::temp_dir().join(format!(
+            "gws-live-safety-package-dir-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be valid")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let error =
+            write_gws_live_safety_package_report(&dir).expect_err("directory path should fail");
+        let message = error.to_string();
+        let context = error
+            .source()
+            .map(|source| source.to_string())
+            .unwrap_or_default();
+        assert!(message.contains(&dir.display().to_string()) || context.contains("Is a directory"));
+
+        fs::remove_dir_all(&dir).expect("remove temp dir");
+    }
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -35,6 +35,7 @@ pub mod failure_taxonomy;
 pub mod freedom_gate;
 pub mod godel;
 pub mod governed_executor;
+pub mod gws_live_safety_package;
 pub mod instrumentation;
 pub mod learning_export;
 pub mod learning_guardrails;

--- a/docs/milestones/v0.91.2/features/GOOGLE_WORKSPACE_CMS_BRIDGE.md
+++ b/docs/milestones/v0.91.2/features/GOOGLE_WORKSPACE_CMS_BRIDGE.md
@@ -6,7 +6,12 @@
 - Milestone Target: `v0.91.2`
 - Status: in_flight
 - Planned WP Home: WP-08, WP-09
-- Source Docs: `.adl/docs/TBD/google_workspace_cms/`
+- Source Docs:
+  - `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/workspace_cms_bridge_demo_packet.md`
+  - `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/workspace_revision_mismatch_and_authority_rules.md`
+  - `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_runbook.md`
+  - `.adl/docs/TBD/google_workspace_cms/GWS_TOOLING_DEPENDENCY_AND_SEQUENCING.md`
+  - `.adl/docs/TBD/google_workspace_cms/RUST_NATIVE_GWS_ADAPTER_PLAN.md`
 - Proof Modes: fixture demo, adapter boundary, review
 
 ## Purpose
@@ -47,6 +52,8 @@ Out of scope:
 - `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/workspace_demo_manifest.json`
 - `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/workspace_tool_capability_trace.json`
 - `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/rust_native_gws_adapter_boundary_report.json`
+- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_package_report.json`
+- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_runbook.md`
 
 ## Non-Claims
 
@@ -55,3 +62,4 @@ Out of scope:
 - `WP-08` does not authorize direct tracked repo edits from Workspace state.
 - `WP-09` does not claim live authenticated Workspace writes are enabled by
   default.
+- The live-safety package does not authorize ambient broad Workspace authority.

--- a/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_package_report.json
+++ b/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_package_report.json
@@ -1,0 +1,213 @@
+{
+  "schema_version": "gws_live_safety_package.v1",
+  "prompt_record": {
+    "prompt_version": "wp3092.gws_live_safety_package.v1",
+    "issue_number": 3092,
+    "depends_on_issue_number": 3008,
+    "summary": "WP-3092 defines the auth, scope, redaction, trace, and skipped-state contract required to use the bounded Workspace CMS bridge safely on real projects."
+  },
+  "auth_profiles": [
+    {
+      "auth_mode": "fixture_only",
+      "permitted_for_live_project_use": false,
+      "secret_recording_policy": "no live credentials are used or recorded",
+      "notes": [
+        "Fixture mode remains the default proof path for CI and PR validation.",
+        "Fixture mode is proving for schema and workflow truth, not for live Workspace reachability."
+      ]
+    },
+    {
+      "auth_mode": "operator_oauth_user",
+      "permitted_for_live_project_use": true,
+      "secret_recording_policy": "record auth mode only; never persist tokens, refresh tokens, or raw credential files",
+      "notes": [
+        "Use when one human operator is performing a bounded project workflow.",
+        "Prefer a narrowly scoped Workspace identity rather than a broad personal account."
+      ]
+    },
+    {
+      "auth_mode": "service_account_scoped",
+      "permitted_for_live_project_use": true,
+      "secret_recording_policy": "record service-account mode and issuing system only; never persist key material",
+      "notes": [
+        "Use only when the project can prove the account is narrowed to the exact Drive/Docs/Sheets scope.",
+        "Treat service-account write scopes as higher risk than read-only bounded demos."
+      ]
+    },
+    {
+      "auth_mode": "external_cli_credential_store",
+      "permitted_for_live_project_use": true,
+      "secret_recording_policy": "record that external CLI credential storage was used without copying any secret-bearing path or content",
+      "notes": [
+        "This is the likely first live adapter posture for `gws`-backed project use.",
+        "The bridge may rely on the operator-visible CLI auth flow, but ADL must still record only the mode, not the secret."
+      ]
+    }
+  ],
+  "scope_policies": [
+    {
+      "capability_name": "workspace.drive.list_folder",
+      "scope_kind": "drive_folder_inventory_read",
+      "minimum_scope_summary": "one explicit Drive folder inventory scope",
+      "write_capability": false,
+      "operator_approval_required": false
+    },
+    {
+      "capability_name": "workspace.drive.read_file_metadata",
+      "scope_kind": "drive_file_metadata_read",
+      "minimum_scope_summary": "metadata read for files already inside the bounded folder scope",
+      "write_capability": false,
+      "operator_approval_required": false
+    },
+    {
+      "capability_name": "workspace.docs.read_snapshot",
+      "scope_kind": "docs_read_snapshot",
+      "minimum_scope_summary": "one explicit document snapshot read scope",
+      "write_capability": false,
+      "operator_approval_required": false
+    },
+    {
+      "capability_name": "workspace.sheets.read_content_cards",
+      "scope_kind": "sheets_read_content_cards",
+      "minimum_scope_summary": "one explicit sheet range read scope for content cards only",
+      "write_capability": false,
+      "operator_approval_required": false
+    },
+    {
+      "capability_name": "workspace.sheets.preview_content_card_update",
+      "scope_kind": "sheets_preview_content_card_update",
+      "minimum_scope_summary": "one explicit sheet range preview scope with no live mutation",
+      "write_capability": false,
+      "operator_approval_required": false
+    },
+    {
+      "capability_name": "workspace.sheets.apply_content_card_update",
+      "scope_kind": "sheets_apply_content_card_update",
+      "minimum_scope_summary": "one explicit sheet range write scope for one bounded content-card update",
+      "write_capability": true,
+      "operator_approval_required": true
+    },
+    {
+      "capability_name": "workspace.drive.record_revision_anchor",
+      "scope_kind": "drive_record_revision_anchor",
+      "minimum_scope_summary": "one bounded revision-anchor recording scope tied to the reviewed source doc",
+      "write_capability": false,
+      "operator_approval_required": false
+    }
+  ],
+  "redaction_rules": [
+    {
+      "scenario": "drive folder inventory",
+      "data_sensitivity": "metadata_only",
+      "trace_posture": "metadata_only",
+      "default_public_artifact_behavior": "record folder ref, document ids, and bounded metadata only"
+    },
+    {
+      "scenario": "docs snapshot read",
+      "data_sensitivity": "private_body",
+      "trace_posture": "redacted_content_only",
+      "default_public_artifact_behavior": "publish only redacted excerpts or issue-scoped references, never full private document bodies"
+    },
+    {
+      "scenario": "sheet content-card read",
+      "data_sensitivity": "metadata_only",
+      "trace_posture": "metadata_only",
+      "default_public_artifact_behavior": "publish only lifecycle/status rows that are already intended for repo-facing management"
+    },
+    {
+      "scenario": "comments and suggestions",
+      "data_sensitivity": "private_body",
+      "trace_posture": "issue_scoped_link_only",
+      "default_public_artifact_behavior": "record that collaboration state exists without copying private discussion into public artifacts"
+    },
+    {
+      "scenario": "promotion packet preparation",
+      "data_sensitivity": "redacted_excerpt",
+      "trace_posture": "metadata_only",
+      "default_public_artifact_behavior": "record title, revision anchor, target repo path, and issue/PR linkage without body-level leakage"
+    }
+  ],
+  "skipped_states": [
+    {
+      "reason": "live_mode_disabled",
+      "classification": "skipped",
+      "operator_message": "Live Workspace execution is disabled for this run; fixture proof remains valid."
+    },
+    {
+      "reason": "gws_unavailable",
+      "classification": "skipped",
+      "operator_message": "The `gws` adapter is unavailable; do not fail fixture-backed validation because live execution could not start."
+    },
+    {
+      "reason": "missing_auth",
+      "classification": "skipped",
+      "operator_message": "No live Workspace credentials are available; record the missing auth posture without retrying ambient authority."
+    },
+    {
+      "reason": "missing_scopes",
+      "classification": "skipped",
+      "operator_message": "The available Workspace credentials do not cover the bounded requested capability scope."
+    },
+    {
+      "reason": "network_unavailable",
+      "classification": "skipped",
+      "operator_message": "Workspace live execution is unreachable; preserve fixture proof and record the network unavailability separately."
+    },
+    {
+      "reason": "operator_declined",
+      "classification": "skipped",
+      "operator_message": "The operator declined a live write or wider scope escalation; stop cleanly without treating that as a bridge defect."
+    }
+  ],
+  "stop_conditions": [
+    {
+      "condition": "revision_mismatch",
+      "classification": "stop",
+      "operator_message": "The recorded Workspace revision anchor no longer matches the reviewed source state; stop before preview, apply, or promotion work continues."
+    },
+    {
+      "condition": "authority_drift",
+      "classification": "stop",
+      "operator_message": "The requested live Workspace action exceeds the declared issue-scoped authority or bounded folder/doc/sheet scope."
+    }
+  ],
+  "operator_runbook": [
+    {
+      "stage": "preflight",
+      "required_actions": [
+        "Confirm the project really needs live Workspace access rather than fixture proof.",
+        "Declare one explicit folder/doc/sheet scope before proposing any live capability call.",
+        "Record the intended auth mode and verify that secrets themselves will not enter repo artifacts or cards."
+      ]
+    },
+    {
+      "stage": "live read path",
+      "required_actions": [
+        "Use inventory and snapshot reads first, with metadata-only or redacted trace posture.",
+        "Treat private document bodies as withheld by default unless the operator explicitly approves a redacted excerpt.",
+        "If auth, scope, or `gws` availability is missing, classify the live path as skipped and keep fixture proof separate."
+      ]
+    },
+    {
+      "stage": "live write path",
+      "required_actions": [
+        "Require preview before any content-card mutation apply step.",
+        "Require explicit operator approval for bounded sheet-range writes.",
+        "Record revision anchors and issue/PR linkage before any promotion-oriented action."
+      ]
+    },
+    {
+      "stage": "promotion boundary",
+      "required_actions": [
+        "Prepare promotion packets as metadata-rich handoff artifacts, not as direct tracked-file edits.",
+        "Keep GitHub issue and PR flow as canonical authority after promotion.",
+        "Stop before any silent repo mutation from Workspace state."
+      ]
+    }
+  ],
+  "non_claims": [
+    "This package does not enable broad ambient Google Workspace authority.",
+    "This package does not make Google Workspace canonical repo truth.",
+    "This package does not authorize private document body export into public artifacts by default."
+  ]
+}

--- a/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_runbook.md
+++ b/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_runbook.md
@@ -1,0 +1,111 @@
+# GWS Live Safety Runbook
+
+## Purpose
+
+Make the Google Workspace CMS bridge safe enough for routine project use by
+fixing one explicit contract for auth mode, scope, redaction, trace posture,
+and skipped-state behavior.
+
+Use this runbook whenever a project wants to move beyond fixture proof and
+touch a real bounded Drive, Docs, or Sheets surface.
+
+## Core Rules
+
+- Git remains canonical repo truth.
+- Workspace remains collaborative draft and management infrastructure.
+- Fixture mode remains the default proving path for CI and PR validation.
+- Live Workspace use is bounded, operator-visible, and optional.
+- Missing auth, missing scopes, or unavailable `gws` classify as `skipped`, not
+  silent failure and not proof of correctness.
+
+## Allowed Auth Modes
+
+- `fixture_only`
+  - use for normal CI, tracked report regeneration, and proof maintenance
+  - no live secrets or network access required
+- `operator_oauth_user`
+  - use for one human-owned bounded project workflow
+  - record the auth mode only, never the token
+- `service_account_scoped`
+  - use only when the account is narrowed to the exact Drive/Docs/Sheets scope
+  - treat write scopes as higher risk
+- `external_cli_credential_store`
+  - likely first live `gws` posture
+  - record only that the CLI credential flow was used, not any secret-bearing
+    path or material
+
+## Minimum Scope Rules
+
+- Inventory reads:
+  - one explicit Drive folder only
+- Docs snapshot reads:
+  - one explicit document only
+- Content-card reads:
+  - one explicit sheet range only
+- Content-card writes:
+  - one explicit sheet range only
+  - preview first
+  - explicit operator approval required
+- Revision-anchor recording:
+  - one explicit reviewed source doc only
+
+Do not broaden into ambient account-wide Drive, Docs, or Sheets authority.
+
+## Redaction Rules
+
+- Folder inventory:
+  - metadata only
+- Docs snapshot:
+  - redact by default
+  - never publish full private document bodies in public artifacts
+- Content-card state:
+  - publish only lifecycle metadata intended for repo-facing management
+- Comments and suggestions:
+  - record existence and linkage, not private discussion bodies
+- Promotion packets:
+  - record title, revision anchor, target repo path, and issue/PR linkage
+  - do not leak document bodies
+
+## Live Read Path
+
+1. Confirm the project actually needs live Workspace access.
+2. Declare the exact folder/doc/sheet scope.
+3. Record the auth mode without recording any secrets.
+4. Run bounded inventory/read operations first.
+5. Emit metadata-only or redacted traces.
+6. If auth, scope, network, or `gws` availability is missing, classify the
+   live path as `skipped`.
+
+## Live Write Path
+
+1. Start from a bounded preview operation.
+2. Require explicit operator approval before apply.
+3. Limit the write to one declared sheet range or equivalent bounded surface.
+4. Record revision anchors and issue/PR linkage before any promotion-oriented
+   action.
+5. Stop if revision mismatch or authority drift appears.
+
+## Promotion Boundary
+
+- Workspace may prepare a promotion packet.
+- Workspace may not directly edit tracked repo files.
+- Promotion remains issue-backed and PR-reviewed.
+- Revision mismatch is a stop condition, not background noise.
+
+## Skipped-State Taxonomy
+
+- `live_mode_disabled`
+- `gws_unavailable`
+- `missing_auth`
+- `missing_scopes`
+- `network_unavailable`
+- `operator_declined`
+
+All of these are truthful live-path skips. None of them should be rewritten as
+fixture success or hidden behind generic pass/fail language.
+
+## Non-Claims
+
+- This runbook does not authorize broad Workspace administration.
+- This runbook does not make Workspace canonical repo truth.
+- This runbook does not allow private document body export by default.


### PR DESCRIPTION
Closes #3092

## Summary
Implemented the bounded GWS live-safety package for future project use by adding
a code-owned safety contract and report generator, generating the tracked JSON
artifact, writing a reusable operator runbook, and updating the Workspace bridge
feature proof surface. Bounded pre-PR review found one medium gap around
machine-readable stop conditions and one traceability nit; both were fixed
before publication.

## Artifacts
- Local ignored output-card execution record at `.adl/v0.91.2/tasks/issue-3092__v0-91-2-tools-gws-auth-scope-redaction-and-skipped-state-safety-package/sor.md`
- `adl/src/gws_live_safety_package.rs`
- `adl/src/bin/demo_v0912_gws_live_safety_package.rs`
- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_package_report.json`
- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_safety_runbook.md`
- `docs/milestones/v0.91.2/features/GOOGLE_WORKSPACE_CMS_BRIDGE.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml gws_live_safety_package -- --nocapture`
    Verified the code-owned safety contract, generated report, and demo entrypoint all pass the focused Rust test lane.
  - `cargo run --manifest-path adl/Cargo.toml --bin demo_v0912_gws_live_safety_package`
    Regenerated the tracked JSON proof artifact from the code-owned safety contract.
  - `cargo clippy --manifest-path adl/Cargo.toml --all-targets -- -D warnings`
    Verified the bounded safety-package Rust surfaces are warning-clean.
  - `git diff --check`
    Verified the tracked patch is whitespace-clean.
  - `bounded pre-PR review subagent`
    Reviewed the bounded safety-package diff for truth drift, missing taxonomy, and traceability issues.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3092__v0-91-2-tools-gws-auth-scope-redaction-and-skipped-state-safety-package/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3092__v0-91-2-tools-gws-auth-scope-redaction-and-skipped-state-safety-package/sor.md
- Idempotency-Key: v0-91-2-gws-auth-scope-redaction-and-skipped-state-safety-package-adl-v0-91-2-tasks-issue-3092-v0-91-2-tools-gws-auth-scope-redaction-and-skipped-state-safety-package-sip-md-adl-v0-91-2-tasks-issue-3092-v0-91-2-tools-gws-auth-scope-redaction-and-skipped-state-safety-package-sor-md