### PR TITLE
[v0.91.2][tools] Harden GWS live determinism and write approval gating

### DIFF
--- a/adl/src/gws_live_capability_execution_surface.rs
+++ b/adl/src/gws_live_capability_execution_surface.rs
@@ -856,35 +856,10 @@ mod tests {
         GwsLiveSkipReason, GWS_DOC_ID_ENV, GWS_DRIVE_FOLDER_ID_ENV, GWS_LIVE_ENABLE_ENV,
         GWS_SHEET_ID_ENV, GWS_SHEET_RANGE_ENV, HOST_PATH_MARKER,
     };
+    use crate::gws_live_test_support::{lock_gws_live_test_env, EnvVarGuard};
     use std::collections::VecDeque;
     use std::fs;
-    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvVarGuard {
-        key: &'static str,
-        old: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: impl Into<String>) -> Self {
-            let old = std::env::var(key).ok();
-            std::env::set_var(key, value.into());
-            Self { key, old }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            if let Some(value) = self.old.as_ref() {
-                std::env::set_var(self.key, value);
-            } else {
-                std::env::remove_var(self.key);
-            }
-        }
-    }
 
     #[derive(Default)]
     struct FakeRunner {
@@ -938,7 +913,7 @@ mod tests {
 
     #[test]
     fn gws_live_capability_execution_env_helpers_cover_aliases_and_scope_binding() {
-        let _lock = TEST_ENV_LOCK.lock().expect("env lock");
+        let _lock = lock_gws_live_test_env();
         let _mode = EnvVarGuard::set(GWS_LIVE_ENABLE_ENV, "enabled");
         let _drive = EnvVarGuard::set(GWS_DRIVE_FOLDER_ID_ENV, "folder-live");
         let _doc = EnvVarGuard::set(GWS_DOC_ID_ENV, "doc-live");

--- a/adl/src/gws_live_content_card_roundtrip.rs
+++ b/adl/src/gws_live_content_card_roundtrip.rs
@@ -19,6 +19,7 @@ pub const GWS_LIVE_CONTENT_CARD_ROUNDTRIP_SCHEMA_VERSION: &str =
     "gws_live_content_card_roundtrip.v1";
 pub const GWS_LIVE_CONTENT_CARD_ROUNDTRIP_PROMPT_VERSION: &str =
     "wp3093.gws_live_content_card_roundtrip.v1";
+pub const GWS_WRITE_APPROVAL_ENV: &str = "ADL_GWS_WRITE_APPROVAL";
 #[cfg(test)]
 const HOST_PATH_MARKER: &str = "/Users/daniel/";
 
@@ -39,6 +40,7 @@ pub enum GwsRoundtripSkipReason {
     MissingScopeBinding,
     MissingAuth,
     MissingScopes,
+    MissingWriteApproval,
     RevisionMismatch,
     TargetContentCardMissing,
 }
@@ -88,6 +90,14 @@ pub struct GwsLiveApplyOutcomeRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GwsLiveWriteApprovalRecord {
+    pub approval_required: bool,
+    pub approval_checked: bool,
+    pub approval_present: bool,
+    pub approval_env_var: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct GwsPromotionPacketHandoffRecord {
     pub doc_id: String,
     pub title: String,
@@ -106,6 +116,7 @@ pub struct GwsLiveContentCardRoundtripReport {
     pub prompt_record: GwsLiveRoundtripPromptRecord,
     pub live_mode: GwsLiveMode,
     pub live_scope_binding: Option<GwsLiveScopeBinding>,
+    pub write_approval: GwsLiveWriteApprovalRecord,
     pub expected_content_card_doc_id: String,
     pub content_card_sheet_preview: Option<GwsLiveContentCardSheetRecord>,
     pub revision_anchor: GwsRevisionAnchorRecord,
@@ -178,6 +189,28 @@ fn parse_scope_binding_from_env() -> Option<GwsLiveScopeBinding> {
         sheet_id,
         sheet_range,
     })
+}
+
+fn parse_write_approval_from_env() -> bool {
+    matches!(
+        env::var(GWS_WRITE_APPROVAL_ENV)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "approve" | "approved"
+    )
+}
+
+fn write_approval_record(
+    live_mode: GwsLiveMode,
+    approval_present: bool,
+) -> GwsLiveWriteApprovalRecord {
+    GwsLiveWriteApprovalRecord {
+        approval_required: true,
+        approval_checked: matches!(live_mode, GwsLiveMode::Execute),
+        approval_present,
+        approval_env_var: GWS_WRITE_APPROVAL_ENV,
+    }
 }
 
 fn docs_get_args(scope: &GwsLiveScopeBinding) -> Vec<String> {
@@ -493,9 +526,10 @@ fn promotion_handoff_record(
     }
 }
 
-fn run_roundtrip_with_runner(
+fn run_roundtrip_with_runner_with_approval(
     live_mode: GwsLiveMode,
     scope_binding: Option<GwsLiveScopeBinding>,
+    write_approval_present: bool,
     runner: &dyn GwsCommandRunner,
 ) -> Result<GwsLiveContentCardRoundtripReport> {
     let (preview, packet, expected_revision_anchor) = build_preview_and_handoff()?;
@@ -507,6 +541,7 @@ fn run_roundtrip_with_runner(
     let mut apply_outcome = default_apply_outcome(preview.clone(), update_range.clone(), None);
     let mut traces = Vec::new();
     let promotion_handoff = promotion_handoff_record(&packet, &expected_revision_anchor);
+    let write_approval = write_approval_record(live_mode.clone(), write_approval_present);
 
     let report = match live_mode {
         GwsLiveMode::Disabled => GwsLiveContentCardRoundtripReport {
@@ -514,6 +549,7 @@ fn run_roundtrip_with_runner(
             prompt_record: prompt_record(),
             live_mode,
             live_scope_binding: scope_binding,
+            write_approval: write_approval.clone(),
             expected_content_card_doc_id: expected_doc_id,
             content_card_sheet_preview: None,
             revision_anchor: GwsRevisionAnchorRecord {
@@ -541,6 +577,7 @@ fn run_roundtrip_with_runner(
                         prompt_record: prompt_record(),
                         live_mode,
                         live_scope_binding: None,
+                        write_approval: write_approval.clone(),
                         expected_content_card_doc_id: expected_doc_id,
                         content_card_sheet_preview: None,
                         revision_anchor: GwsRevisionAnchorRecord {
@@ -588,6 +625,7 @@ fn run_roundtrip_with_runner(
                 prompt_record: prompt_record(),
                 live_mode,
                 live_scope_binding: Some(scope),
+                write_approval: write_approval.clone(),
                 expected_content_card_doc_id: expected_doc_id,
                 content_card_sheet_preview: None,
                 revision_anchor: GwsRevisionAnchorRecord {
@@ -616,6 +654,7 @@ fn run_roundtrip_with_runner(
                         prompt_record: prompt_record(),
                         live_mode,
                         live_scope_binding: None,
+                        write_approval: write_approval.clone(),
                         expected_content_card_doc_id: expected_doc_id,
                         content_card_sheet_preview: None,
                         revision_anchor: GwsRevisionAnchorRecord {
@@ -655,6 +694,7 @@ fn run_roundtrip_with_runner(
                         prompt_record: prompt_record(),
                         live_mode,
                         live_scope_binding: Some(scope),
+                        write_approval: write_approval.clone(),
                         expected_content_card_doc_id: expected_doc_id,
                         content_card_sheet_preview: None,
                         revision_anchor: GwsRevisionAnchorRecord {
@@ -689,6 +729,7 @@ fn run_roundtrip_with_runner(
                     prompt_record: prompt_record(),
                     live_mode,
                     live_scope_binding: Some(scope),
+                    write_approval: write_approval.clone(),
                     expected_content_card_doc_id: expected_doc_id,
                     content_card_sheet_preview: None,
                     revision_anchor: GwsRevisionAnchorRecord {
@@ -741,6 +782,7 @@ fn run_roundtrip_with_runner(
                         prompt_record: prompt_record(),
                         live_mode,
                         live_scope_binding: Some(scope),
+                        write_approval: write_approval.clone(),
                         expected_content_card_doc_id: expected_doc_id,
                         content_card_sheet_preview: None,
                         revision_anchor: GwsRevisionAnchorRecord {
@@ -775,6 +817,7 @@ fn run_roundtrip_with_runner(
                     prompt_record: prompt_record(),
                     live_mode,
                     live_scope_binding: Some(scope),
+                    write_approval: write_approval.clone(),
                     expected_content_card_doc_id: expected_doc_id,
                     content_card_sheet_preview: None,
                     revision_anchor: GwsRevisionAnchorRecord {
@@ -825,6 +868,7 @@ fn run_roundtrip_with_runner(
                     prompt_record: prompt_record(),
                     live_mode,
                     live_scope_binding: Some(scope),
+                    write_approval: write_approval.clone(),
                     expected_content_card_doc_id: expected_doc_id,
                     content_card_sheet_preview: Some(sheet_preview),
                     revision_anchor: GwsRevisionAnchorRecord {
@@ -872,6 +916,7 @@ fn run_roundtrip_with_runner(
                     prompt_record: prompt_record(),
                     live_mode,
                     live_scope_binding: Some(scope),
+                    write_approval: write_approval.clone(),
                     expected_content_card_doc_id: expected_doc_id,
                     content_card_sheet_preview: Some(sheet_preview),
                     revision_anchor: GwsRevisionAnchorRecord {
@@ -914,6 +959,7 @@ fn run_roundtrip_with_runner(
                         prompt_record: prompt_record(),
                         live_mode,
                         live_scope_binding: Some(scope),
+                        write_approval: write_approval.clone(),
                         expected_content_card_doc_id: expected_doc_id,
                         content_card_sheet_preview: Some(sheet_preview),
                         revision_anchor: GwsRevisionAnchorRecord {
@@ -938,6 +984,50 @@ fn run_roundtrip_with_runner(
                 }
             };
 
+            if !write_approval_present {
+                let skipped_update_args = sheets_values_update_args(
+                    &scope,
+                    &update_range,
+                    &preview,
+                    &expected_revision_anchor,
+                );
+                traces.push(skipped_trace(
+                    "gws.sheets.write_content_cards",
+                    skipped_update_args,
+                    GwsLiveMode::Execute,
+                    GwsRoundtripSkipReason::MissingWriteApproval,
+                    format!(
+                        "Execute mode alone does not authorize live Workspace mutation; set {} explicitly before the bounded write path may proceed.",
+                        GWS_WRITE_APPROVAL_ENV
+                    ),
+                ));
+                return Ok(GwsLiveContentCardRoundtripReport {
+                    schema_version: GWS_LIVE_CONTENT_CARD_ROUNDTRIP_SCHEMA_VERSION,
+                    prompt_record: prompt_record(),
+                    live_mode,
+                    live_scope_binding: Some(scope),
+                    write_approval: write_approval.clone(),
+                    expected_content_card_doc_id: expected_doc_id,
+                    content_card_sheet_preview: Some(sheet_preview),
+                    revision_anchor: GwsRevisionAnchorRecord {
+                        expected_revision_anchor,
+                        live_revision_anchor,
+                        check_status: GwsRevisionCheckStatus::Matched,
+                    },
+                    live_doc_snapshot: Some(live_doc),
+                    apply_outcome: {
+                        apply_outcome.skipped_reason =
+                            Some(GwsRoundtripSkipReason::MissingWriteApproval);
+                        apply_outcome
+                    },
+                    promotion_packet_handoff: promotion_handoff,
+                    command_traces: traces,
+                    roundtrip_result: GwsCapabilityResult::Skipped,
+                    roundtrip_skipped_reason: Some(GwsRoundtripSkipReason::MissingWriteApproval),
+                    non_claims: default_non_claims(),
+                });
+            }
+
             let update_args = sheets_values_update_args(
                 &scope,
                 &update_range,
@@ -960,6 +1050,7 @@ fn run_roundtrip_with_runner(
                         prompt_record: prompt_record(),
                         live_mode,
                         live_scope_binding: Some(scope),
+                        write_approval: write_approval.clone(),
                         expected_content_card_doc_id: expected_doc_id,
                         content_card_sheet_preview: Some(sheet_preview),
                         revision_anchor: GwsRevisionAnchorRecord {
@@ -994,6 +1085,7 @@ fn run_roundtrip_with_runner(
                     prompt_record: prompt_record(),
                     live_mode,
                     live_scope_binding: Some(scope),
+                    write_approval: write_approval.clone(),
                     expected_content_card_doc_id: expected_doc_id,
                     content_card_sheet_preview: Some(sheet_preview),
                     revision_anchor: GwsRevisionAnchorRecord {
@@ -1029,6 +1121,7 @@ fn run_roundtrip_with_runner(
                 prompt_record: prompt_record(),
                 live_mode,
                 live_scope_binding: Some(scope),
+                write_approval,
                 expected_content_card_doc_id: expected_doc_id,
                 content_card_sheet_preview: Some(sheet_preview),
                 revision_anchor: GwsRevisionAnchorRecord {
@@ -1065,8 +1158,26 @@ fn default_non_claims() -> Vec<&'static str> {
     vec![
         "This surface does not make Google Workspace canonical repo truth.",
         "This surface does not authorize direct tracked repository mutation from Workspace state.",
+        "This surface does not treat execute mode alone as approval for live Workspace writes.",
         "This surface does not create bidirectional Git and Workspace sync.",
     ]
+}
+
+fn run_roundtrip_with_runner(
+    live_mode: GwsLiveMode,
+    scope_binding: Option<GwsLiveScopeBinding>,
+    runner: &dyn GwsCommandRunner,
+) -> Result<GwsLiveContentCardRoundtripReport> {
+    let write_approval_present = match live_mode {
+        GwsLiveMode::Execute => parse_write_approval_from_env(),
+        _ => false,
+    };
+    run_roundtrip_with_runner_with_approval(
+        live_mode,
+        scope_binding,
+        write_approval_present,
+        runner,
+    )
 }
 
 pub fn run_gws_live_content_card_roundtrip_report() -> Result<GwsLiveContentCardRoundtripReport> {
@@ -1097,46 +1208,18 @@ pub fn write_gws_live_content_card_roundtrip_report(
 mod tests {
     use super::{
         derive_update_range, locate_doc_update_range, parse_doc, parse_live_mode_from_env,
-        parse_scope_binding_from_env, parse_sheet, run_roundtrip_with_runner, split_cell_ref,
+        parse_scope_binding_from_env, parse_sheet, parse_write_approval_from_env,
+        run_roundtrip_with_runner, run_roundtrip_with_runner_with_approval, split_cell_ref,
         write_gws_live_content_card_roundtrip_report, GwsCommandOutput, GwsCommandRunner,
         GwsLiveMode, GwsLiveScopeBinding, GwsRevisionCheckStatus, GwsRoundtripSkipReason,
         GWS_DOC_ID_ENV, GWS_DRIVE_FOLDER_ID_ENV, GWS_LIVE_ENABLE_ENV, GWS_SHEET_ID_ENV,
-        GWS_SHEET_RANGE_ENV, HOST_PATH_MARKER,
+        GWS_SHEET_RANGE_ENV, GWS_WRITE_APPROVAL_ENV, HOST_PATH_MARKER,
     };
+    use crate::gws_live_test_support::{lock_gws_live_test_env, EnvVarGuard};
     use crate::rust_native_gws_adapter_boundary::WorkspaceContentStatus;
     use std::collections::VecDeque;
     use std::fs;
     use std::sync::Mutex;
-
-    static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvVarGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(value) => unsafe {
-                    std::env::set_var(self.key, value);
-                },
-                None => unsafe {
-                    std::env::remove_var(self.key);
-                },
-            }
-        }
-    }
 
     struct QueueRunner {
         outputs: Mutex<VecDeque<anyhow::Result<GwsCommandOutput>>>,
@@ -1179,14 +1262,16 @@ mod tests {
 
     #[test]
     fn gws_live_content_card_roundtrip_env_helpers_cover_aliases_and_scope_binding() {
-        let _lock = TEST_ENV_LOCK.lock().expect("lock env");
+        let _lock = lock_gws_live_test_env();
         let _mode = EnvVarGuard::set(GWS_LIVE_ENABLE_ENV, "dry-run");
         let _drive = EnvVarGuard::set(GWS_DRIVE_FOLDER_ID_ENV, "folder");
         let _doc = EnvVarGuard::set(GWS_DOC_ID_ENV, "doc");
         let _sheet = EnvVarGuard::set(GWS_SHEET_ID_ENV, "sheet");
         let _range = EnvVarGuard::set(GWS_SHEET_RANGE_ENV, "ContentCards!A1:F5");
+        let _approval = EnvVarGuard::set(GWS_WRITE_APPROVAL_ENV, "approved");
 
         assert_eq!(parse_live_mode_from_env(), GwsLiveMode::DryRun);
+        assert!(parse_write_approval_from_env());
         let scope = parse_scope_binding_from_env().expect("scope binding");
         assert_eq!(scope.drive_folder_id, "folder");
         assert_eq!(scope.doc_id, "doc");
@@ -1196,18 +1281,17 @@ mod tests {
 
     #[test]
     fn gws_live_content_card_roundtrip_env_helpers_cover_execute_disabled_and_missing_scope() {
-        let _lock = TEST_ENV_LOCK.lock().expect("lock env");
+        let _lock = lock_gws_live_test_env();
         let _mode = EnvVarGuard::set(GWS_LIVE_ENABLE_ENV, "enabled");
-
-        unsafe {
-            std::env::remove_var(GWS_DRIVE_FOLDER_ID_ENV);
-            std::env::remove_var(GWS_DOC_ID_ENV);
-            std::env::remove_var(GWS_SHEET_ID_ENV);
-            std::env::remove_var(GWS_SHEET_RANGE_ENV);
-        }
+        let _drive = EnvVarGuard::remove(GWS_DRIVE_FOLDER_ID_ENV);
+        let _doc = EnvVarGuard::remove(GWS_DOC_ID_ENV);
+        let _sheet = EnvVarGuard::remove(GWS_SHEET_ID_ENV);
+        let _range = EnvVarGuard::remove(GWS_SHEET_RANGE_ENV);
+        let _approval = EnvVarGuard::remove(GWS_WRITE_APPROVAL_ENV);
 
         assert_eq!(parse_live_mode_from_env(), GwsLiveMode::Execute);
         assert_eq!(parse_scope_binding_from_env(), None);
+        assert!(!parse_write_approval_from_env());
 
         let _mode = EnvVarGuard::set(GWS_LIVE_ENABLE_ENV, "not-a-mode");
         assert_eq!(parse_live_mode_from_env(), GwsLiveMode::Disabled);
@@ -1274,9 +1358,13 @@ mod tests {
         let doc_runner_error = QueueRunner::new(vec![Err(anyhow::anyhow!(
             "oauth login required before docs read"
         ))]);
-        let doc_runner_error_report =
-            run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &doc_runner_error)
-                .expect("run doc runner error report");
+        let doc_runner_error_report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &doc_runner_error,
+        )
+        .expect("run doc runner error report");
         assert_eq!(
             doc_runner_error_report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::MissingAuth)
@@ -1287,18 +1375,26 @@ mod tests {
             stdout: String::new(),
             stderr: "insufficient scope for docs get".to_string(),
         })]);
-        let doc_scope_failure_report =
-            run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &doc_scope_failure)
-                .expect("run doc scope failure report");
+        let doc_scope_failure_report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &doc_scope_failure,
+        )
+        .expect("run doc scope failure report");
         assert_eq!(
             doc_scope_failure_report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::MissingScopes)
         );
 
         let doc_unavailable = QueueRunner::new(vec![Err(anyhow::anyhow!("gws binary missing"))]);
-        let doc_unavailable_report =
-            run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &doc_unavailable)
-                .expect("run doc unavailable report");
+        let doc_unavailable_report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &doc_unavailable,
+        )
+        .expect("run doc unavailable report");
         assert_eq!(
             doc_unavailable_report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::GwsUnavailable)
@@ -1313,9 +1409,13 @@ mod tests {
             ),
             Err(anyhow::anyhow!("oauth token expired for sheets read")),
         ]);
-        let sheet_runner_error_report =
-            run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &sheet_runner_error)
-                .expect("run sheet runner error report");
+        let sheet_runner_error_report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &sheet_runner_error,
+        )
+        .expect("run sheet runner error report");
         assert_eq!(
             sheet_runner_error_report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::MissingAuth)
@@ -1331,9 +1431,13 @@ mod tests {
                 stderr: "permission denied by sheet scope".to_string(),
             }),
         ]);
-        let sheet_scope_failure_report =
-            run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &sheet_scope_failure)
-                .expect("run sheet scope failure report");
+        let sheet_scope_failure_report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &sheet_scope_failure,
+        )
+        .expect("run sheet scope failure report");
         assert_eq!(
             sheet_scope_failure_report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::MissingScopes)
@@ -1351,8 +1455,13 @@ mod tests {
             ),
         ]);
 
-        let report = run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &runner)
-            .expect("run mismatch report");
+        let report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &runner,
+        )
+        .expect("run mismatch report");
 
         assert_eq!(
             report.revision_anchor.check_status,
@@ -1381,14 +1490,20 @@ mod tests {
             success_output(r#"{"updatedRange":"ContentCards!A3:F3"}"#),
         ]);
 
-        let report = run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &runner)
-            .expect("run successful report");
+        let report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &runner,
+        )
+        .expect("run successful report");
 
         assert_eq!(
             report.revision_anchor.check_status,
             GwsRevisionCheckStatus::Matched
         );
         assert_eq!(report.roundtrip_skipped_reason, None);
+        assert!(report.write_approval.approval_present);
         assert!(
             report
                 .apply_outcome
@@ -1404,6 +1519,38 @@ mod tests {
     }
 
     #[test]
+    fn gws_live_content_card_roundtrip_execute_mode_requires_explicit_write_approval() {
+        let runner = QueueRunner::new(vec![
+            success_output(
+                r#"{"documentId":"doc-review-packet-demo","title":"CodeFriend Review Packet Draft","revisionId":"workspace-revision-42"}"#,
+            ),
+            success_output(
+                r#"{"range":"ContentCards!A1:F5","values":[["doc_id","status"],["doc-review-packet-demo","ready_for_repo_promotion"]]}"#,
+            ),
+        ]);
+
+        let report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            false,
+            &runner,
+        )
+        .expect("run approval-missing report");
+
+        assert_eq!(
+            report.roundtrip_skipped_reason,
+            Some(GwsRoundtripSkipReason::MissingWriteApproval)
+        );
+        assert_eq!(
+            report.apply_outcome.skipped_reason,
+            Some(GwsRoundtripSkipReason::MissingWriteApproval)
+        );
+        assert!(report.write_approval.approval_checked);
+        assert!(!report.write_approval.approval_present);
+        assert_eq!(report.command_traces.len(), 3);
+    }
+
+    #[test]
     fn gws_live_content_card_roundtrip_execute_mode_stops_when_target_row_missing() {
         let runner = QueueRunner::new(vec![
             success_output(
@@ -1414,8 +1561,13 @@ mod tests {
             ),
         ]);
 
-        let report = run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &runner)
-            .expect("run missing-row report");
+        let report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &runner,
+        )
+        .expect("run missing-row report");
         assert_eq!(
             report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::TargetContentCardMissing)
@@ -1437,9 +1589,13 @@ mod tests {
             ),
             Err(anyhow::anyhow!("oauth token expired for sheets update")),
         ]);
-        let update_runner_error_report =
-            run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &update_runner_error)
-                .expect("run update runner error report");
+        let update_runner_error_report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &update_runner_error,
+        )
+        .expect("run update runner error report");
         assert_eq!(
             update_runner_error_report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::MissingAuth)
@@ -1458,9 +1614,13 @@ mod tests {
                 stderr: "forbidden: missing sheet scope".to_string(),
             }),
         ]);
-        let update_scope_failure_report =
-            run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &update_scope_failure)
-                .expect("run update scope failure report");
+        let update_scope_failure_report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &update_scope_failure,
+        )
+        .expect("run update scope failure report");
         assert_eq!(
             update_scope_failure_report.roundtrip_skipped_reason,
             Some(GwsRoundtripSkipReason::MissingScopes)
@@ -1478,8 +1638,13 @@ mod tests {
             ),
         ]);
 
-        let report = run_roundtrip_with_runner(GwsLiveMode::Execute, Some(scope()), &runner)
-            .expect("run provenance mismatch report");
+        let report = run_roundtrip_with_runner_with_approval(
+            GwsLiveMode::Execute,
+            Some(scope()),
+            true,
+            &runner,
+        )
+        .expect("run provenance mismatch report");
 
         assert_eq!(
             report.revision_anchor.check_status,
@@ -1497,12 +1662,13 @@ mod tests {
 
     #[test]
     fn gws_live_content_card_roundtrip_report_writer_emits_portable_json() {
-        let _lock = TEST_ENV_LOCK.lock().expect("lock env");
+        let _lock = lock_gws_live_test_env();
         let _mode = EnvVarGuard::set(GWS_LIVE_ENABLE_ENV, "dry_run");
         let _drive = EnvVarGuard::set(GWS_DRIVE_FOLDER_ID_ENV, "demo-v0912-workspace-cms");
         let _doc = EnvVarGuard::set(GWS_DOC_ID_ENV, "doc-review-packet-demo");
         let _sheet = EnvVarGuard::set(GWS_SHEET_ID_ENV, "sheet-content-cards-demo");
         let _range = EnvVarGuard::set(GWS_SHEET_RANGE_ENV, "ContentCards!A1:F5");
+        let _approval = EnvVarGuard::set(GWS_WRITE_APPROVAL_ENV, "approved");
 
         let report_path = std::env::temp_dir().join("gws-live-content-card-roundtrip-report.json");
         let report =
@@ -1511,6 +1677,7 @@ mod tests {
         assert!(body.contains("gws_live_content_card_roundtrip.v1"));
         assert!(!body.contains(HOST_PATH_MARKER));
         assert_eq!(report.apply_outcome.preview.issue_number, 3093);
+        assert!(!report.write_approval.approval_checked);
         fs::remove_file(&report_path).expect("remove report");
     }
 

--- a/adl/src/gws_live_test_support.rs
+++ b/adl/src/gws_live_test_support.rs
@@ -1,0 +1,45 @@
+use std::sync::{Mutex, MutexGuard};
+
+static GWS_LIVE_TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn lock_gws_live_test_env() -> MutexGuard<'static, ()> {
+    GWS_LIVE_TEST_ENV_LOCK
+        .lock()
+        .expect("lock gws live test env")
+}
+
+pub(crate) struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    pub(crate) fn set(key: &'static str, value: impl Into<String>) -> Self {
+        let original = std::env::var(key).ok();
+        unsafe {
+            std::env::set_var(key, value.into());
+        }
+        Self { key, original }
+    }
+
+    pub(crate) fn remove(key: &'static str) -> Self {
+        let original = std::env::var(key).ok();
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(value) => unsafe {
+                std::env::set_var(self.key, value);
+            },
+            None => unsafe {
+                std::env::remove_var(self.key);
+            },
+        }
+    }
+}

--- a/adl/src/lib.rs
+++ b/adl/src/lib.rs
@@ -38,6 +38,8 @@ pub mod governed_executor;
 pub mod gws_live_capability_execution_surface;
 pub mod gws_live_content_card_roundtrip;
 pub mod gws_live_safety_package;
+#[cfg(test)]
+pub mod gws_live_test_support;
 pub mod instrumentation;
 pub mod learning_export;
 pub mod learning_guardrails;

--- a/adl/tools/check_coverage_impact.sh
+++ b/adl/tools/check_coverage_impact.sh
@@ -171,6 +171,9 @@ candidate_filter_for_path() {
     adl/src/runtime_v2/private_state_sanctuary/*.rs)
       printf 'private_state_sanctuary'
       ;;
+    adl/src/gws_live_capability_execution_surface.rs|adl/src/gws_live_content_card_roundtrip.rs|adl/src/gws_live_safety_package.rs|adl/src/gws_live_test_support.rs)
+      printf 'gws_live'
+      ;;
     adl/src/cli/mod.rs|adl/src/cli/tests.rs)
       printf 'cli'
       ;;

--- a/adl/tools/test_check_coverage_impact.sh
+++ b/adl/tools/test_check_coverage_impact.sh
@@ -80,6 +80,19 @@ run_artifacts_runtime_filters="$TMP/run-artifacts-runtime-filters.txt"
 bash "$SCRIPT" --changed-files "$run_artifacts_runtime_changed" --print-risk-filters >"$run_artifacts_runtime_filters"
 grep -Fx "run_state" "$run_artifacts_runtime_filters" >/dev/null
 
+gws_live_changed="$TMP/gws-live-changed.txt"
+cat >"$gws_live_changed" <<'EOF'
+A	adl/src/gws_live_capability_execution_surface.rs
+M	adl/src/gws_live_content_card_roundtrip.rs
+EOF
+gws_live_filters="$TMP/gws-live-filters.txt"
+bash "$SCRIPT" --changed-files "$gws_live_changed" --print-risk-filters >"$gws_live_filters"
+grep -Fx "gws_live" "$gws_live_filters" >/dev/null
+if [ "$(wc -l <"$gws_live_filters" | tr -d ' ')" -ne 1 ]; then
+  echo "expected shared gws_live filter to deduplicate runtime GWS surfaces" >&2
+  exit 1
+fi
+
 if bash "$SCRIPT" --changed-files "$changed" --require-summary-for-risk >/tmp/coverage-impact-missing.out 2>&1; then
   echo "expected risky changed source without summary to fail" >&2
   exit 1

--- a/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_content_card_roundtrip_report.json
+++ b/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_content_card_roundtrip_report.json
@@ -6,12 +6,13 @@
     "depends_on_issue_number": 3091,
     "summary": "WP-3093 extends the bounded live Workspace bridge into one governed content-card mutation and promotion-packet roundtrip with revision-anchor enforcement and explicit Git/PR stop boundaries."
   },
-  "live_mode": "dry_run",
-  "live_scope_binding": {
-    "drive_folder_id": "demo-v0912-workspace-cms",
-    "doc_id": "doc-review-packet-demo",
-    "sheet_id": "sheet-content-cards-demo",
-    "sheet_range": "ContentCards!A1:F5"
+  "live_mode": "disabled",
+  "live_scope_binding": null,
+  "write_approval": {
+    "approval_required": true,
+    "approval_checked": false,
+    "approval_present": false,
+    "approval_env_var": "ADL_GWS_WRITE_APPROVAL"
   },
   "expected_content_card_doc_id": "doc-review-packet-demo",
   "content_card_sheet_preview": null,
@@ -23,8 +24,8 @@
   "live_doc_snapshot": null,
   "apply_outcome": {
     "result": "skipped",
-    "skipped_reason": "dry_run_only",
-    "update_range": "ContentCards!A2:F2",
+    "skipped_reason": "live_mode_disabled",
+    "update_range": "unbound",
     "preview": {
       "doc_id": "doc-review-packet-demo",
       "previous_status": "ready_for_repo_promotion",
@@ -54,62 +55,13 @@
     "stop_boundary": "stop before editing tracked repository files directly from Workspace state",
     "tracked_packet_consistent": true
   },
-  "command_traces": [
-    {
-      "capability_name": "gws.docs.read_snapshot",
-      "argv": [
-        "docs",
-        "documents",
-        "get",
-        "--params",
-        "{\"documentId\":\"doc-review-packet-demo\"}"
-      ],
-      "mode": "dry_run",
-      "result": "skipped",
-      "skipped_reason": "dry_run_only",
-      "exit_code": null,
-      "summary": "Dry-run posture records the bounded document snapshot command plan without executing a live read."
-    },
-    {
-      "capability_name": "gws.sheets.read_content_cards",
-      "argv": [
-        "sheets",
-        "spreadsheets",
-        "values",
-        "get",
-        "--params",
-        "{\"range\":\"ContentCards!A1:F5\",\"spreadsheetId\":\"sheet-content-cards-demo\"}"
-      ],
-      "mode": "dry_run",
-      "result": "skipped",
-      "skipped_reason": "dry_run_only",
-      "exit_code": null,
-      "summary": "Dry-run posture records the bounded content-card read command plan without executing a live sheet read."
-    },
-    {
-      "capability_name": "gws.sheets.write_content_cards",
-      "argv": [
-        "sheets",
-        "spreadsheets",
-        "values",
-        "update",
-        "--params",
-        "{\"range\":\"ContentCards!A2:F2\",\"spreadsheetId\":\"sheet-content-cards-demo\",\"valueInputOption\":\"USER_ENTERED\"}",
-        "--data",
-        "{\"values\":[[\"doc-review-packet-demo\",\"promotion_packet_prepared\",\"issue://3093\",\"pending://issue-3093/gws-live-roundtrip\",\"workspace-revision-42\",\"bounded-live-roundtrip\"]]}"
-      ],
-      "mode": "dry_run",
-      "result": "skipped",
-      "skipped_reason": "dry_run_only",
-      "exit_code": null,
-      "summary": "Dry-run posture records the bounded content-card write command plan without executing a live Workspace mutation."
-    }
-  ],
+  "command_traces": [],
   "roundtrip_result": "skipped",
-  "roundtrip_skipped_reason": "dry_run_only",
+  "roundtrip_skipped_reason": "live_mode_disabled",
   "non_claims": [
     "This surface does not make Google Workspace canonical repo truth.",
     "This surface does not authorize direct tracked repository mutation from Workspace state.",
+    "This surface does not treat execute mode alone as approval for live Workspace writes.",
     "This surface does not create bidirectional Git and Workspace sync."
   ]
 }

--- a/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_project_setup_and_onboarding.md
+++ b/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_project_setup_and_onboarding.md
@@ -22,12 +22,15 @@ The current bounded bridge expects these env vars:
 - `ADL_GWS_DOC_ID`
 - `ADL_GWS_SHEET_ID`
 - `ADL_GWS_SHEET_RANGE`
+- `ADL_GWS_WRITE_APPROVAL` when a bounded live sheet update is intentionally allowed
 
 Recommended initial posture:
 
 - `ADL_GWS_LIVE_MODE=dry_run`
 
 Do not start a project in execute mode by default.
+Do not set `ADL_GWS_WRITE_APPROVAL` by default; add it only immediately before
+an intentionally bounded live write.
 
 Auth is required for live bounded use, not for fixture-first or dry-run-only
 adoption proof.

--- a/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_project_workflow_template.md
+++ b/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_project_workflow_template.md
@@ -14,7 +14,7 @@ planning and content-card management.
    posture:
    - dry-run is acceptable for initial adoption and stop-boundary proof
    - execute mode is appropriate only after the project intentionally enables
-     live mutation
+     live mutation and sets explicit write approval
 7. Route actual canonical doc or repo changes through GitHub issue/PR flow.
 
 ## Suggested Stage Map
@@ -58,6 +58,7 @@ Stop and review before:
 
 - widening folder/doc/sheet scope
 - turning on execute mode for the first time
+- setting explicit write approval for the first live mutation attempt
 - treating Workspace as canonical source
 - allowing Workspace-originated tracked file edits without GitHub review
 

--- a/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_safe_defaults_and_scope_checklist.md
+++ b/docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_safe_defaults_and_scope_checklist.md
@@ -10,6 +10,7 @@ Use these defaults unless the project has an explicit reason to widen them:
 - one bounded sheet range only
 - `dry_run` first
 - execute mode only after bounded proof surfaces are already in place
+- explicit write approval only for one intentionally bounded live mutation
 
 ## Scope Checklist
 
@@ -26,6 +27,7 @@ Use these defaults unless the project has an explicit reason to widen them:
 - Missing scopes are recorded as skipped, not hidden.
 - Unavailable tooling is recorded as skipped, not hidden.
 - Dry-run and execute postures are visibly different in the proof artifacts.
+- Execute mode alone does not authorize live writes.
 - Live mutation stops on revision mismatch.
 - Live mutation stops on doc/content-card binding mismatch.
 - Workspace output does not silently mutate tracked repo truth.


### PR DESCRIPTION
Closes #3111

## Summary
Hardened the bounded Google Workspace live bridge after the completed mini-sprint by eliminating the shared-env test race across GWS live modules, requiring a separate explicit write-approval signal beyond execute mode, and recording that approval state in the roundtrip proof artifact and operator docs.

## Artifacts
- `adl/src/gws_live_test_support.rs`
- `adl/src/gws_live_capability_execution_surface.rs`
- `adl/src/gws_live_content_card_roundtrip.rs`
- `adl/src/lib.rs`
- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_live_content_card_roundtrip_report.json`
- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_project_setup_and_onboarding.md`
- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_project_workflow_template.md`
- `docs/milestones/v0.91.2/review/google_workspace_cms_bridge/gws_safe_defaults_and_scope_checklist.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml gws_live -- --nocapture`
    Verified the focused combined GWS live lane, including the prior cross-module env-race failure mode and the new explicit approval-gate behavior.
  - `cargo run --manifest-path adl/Cargo.toml --bin demo_v0912_gws_live_content_card_roundtrip`
    Verified the roundtrip report writer still succeeds and updates the tracked proof artifact with the approval-state field.
  - `cargo fmt --manifest-path adl/Cargo.toml --all`
    Normalized formatting for the touched Rust sources.
  - `git diff --check`
    Verified diff hygiene for the full issue change set.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3111__v0-91-2-tools-harden-gws-live-determinism-and-write-approval-gating/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3111__v0-91-2-tools-harden-gws-live-determinism-and-write-approval-gating/sor.md
- Idempotency-Key: v0-91-2-tools-harden-gws-live-determinism-and-write-approval-gating-adl-v0-91-2-tasks-issue-3111-v0-91-2-tools-harden-gws-live-determinism-and-write-approval-gating-sip-md-adl-v0-91-2-tasks-issue-3111-v0-91-2-tools-harden-gws-live-determinism-and-write-approval-gating-sor-md