### PR TITLE
[v0.91.2][docs] Tighten AGENTS.md for C-SDLC workflow truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ These rules are mandatory for ADL issue work.
    - Do not bypass the conductor for issue execution, review routing,
      publication, janitor work, or closeout.
 2. Edit cards only with editor skills.
-   - Use `stp-editor`, `sip-editor`, `spp-editor`, `sor-editor`, or other
-     issue-card editor skills when card surfaces need normalization.
+   - Use `sip-editor`, `stp-editor`, `spp-editor`, `srp-editor`, `sor-editor`,
+     or other issue-card editor skills when card surfaces need normalization.
    - Do not hand-edit cards opportunistically.
 3. Always work in a bound worktree on a specific branch.
    - Never do tracked issue work on `main`.
@@ -53,6 +53,9 @@ These rules are mandatory for ADL issue work.
 - Keep milestone claims, proof claims, and review claims evidence-bound.
 - Prefer repo-relative paths in artifacts and records.
 - Do not silently widen issue scope.
+- Preserve the canonical card lifecycle: `SIP -> STP -> SPP -> SRP -> SOR`.
+  `SRP` is the Structured Review Prompt and review-result surface; `SOR` is the
+  truthful execution and integration record.
 
 ## Where To Start
 
@@ -65,7 +68,7 @@ For a normal tracked issue:
 5. make the bounded change in the issue worktree
 6. run the smallest meaningful validation for the touched surface
 7. run a pre-PR subagent review and fix findings
-8. publish through the normal PR workflow
+8. verify PR base/stack topology, then publish through the normal PR workflow
 9. perform closeout after merge/closure
 
 ## Validation Expectations
@@ -78,6 +81,8 @@ For a normal tracked issue:
 ## Review And Publication Rules
 
 - No PR should open before the work has had bounded subagent review.
+- Verify the intended base branch before publication and verify the actual PR
+  base immediately after creation, especially for stacked issue work.
 - Findings come before summary.
 - Fixes should stay within the issue's scope unless the operator explicitly
   widens it.
@@ -96,6 +101,8 @@ It is not:
 - the final word on nested package-specific agent guidance
 
 ## Source Baseline Used
+
+Last reviewed: 2026-05-19.
 
 This file was shaped from the OpenAI/source baselines named by `#2986`, plus
 ADL-specific workflow policy:


### PR DESCRIPTION
Closes #3118

## Summary
Updated the root `AGENTS.md` operating contract so it reflects the corrected C-SDLC workflow. The edit explicitly names `srp-editor`, records the canonical `SIP -> STP -> SPP -> SRP -> SOR` lifecycle, defines SRP/SOR roles, requires PR base/stack verification before and after publication, and adds a lightweight source-baseline review date.

## Artifacts
- `AGENTS.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace and patch hygiene for the tracked docs change.
  - `rg -n "srp-editor|SIP -> STP -> SPP -> SRP -> SOR|Structured Review Prompt|base branch|Last reviewed" AGENTS.md`
    Verified the acceptance-surface text is present in `AGENTS.md`.
  - Bounded pre-PR review subagent over the `AGENTS.md` diff.
    Verified the issue acceptance criteria were satisfied and returned no findings.
  - `bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input .adl/v0.91.2/tasks/issue-3118__v0-91-2-docs-tighten-agents-md-for-c-sdlc-workflow-truth/srp.md`
    Verified final SRP contract compliance after recording review results.
  - `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.2/tasks/issue-3118__v0-91-2-docs-tighten-agents-md-for-c-sdlc-workflow-truth/sor.md`
    Verified final SOR contract compliance.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3118__v0-91-2-docs-tighten-agents-md-for-c-sdlc-workflow-truth/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3118__v0-91-2-docs-tighten-agents-md-for-c-sdlc-workflow-truth/sor.md
- Idempotency-Key: v0-91-2-docs-tighten-agents-md-for-c-sdlc-workflow-truth-agents-md-adl-v0-91-2-tasks-issue-3118-v0-91-2-docs-tighten-agents-md-for-c-sdlc-workflow-truth-sip-md-adl-v0-91-2-tasks-issue-3118-v0-91-2-docs-tighten-agents-md-for-c-sdlc-workflow-truth-sor-md