### PR TITLE
[v0.91.2][quality] Re-split bounded PR validation from release-scale Rust test lanes

### DIFF
--- a/adl/tools/run_pr_fast_test_lane.sh
+++ b/adl/tools/run_pr_fast_test_lane.sh
@@ -107,11 +107,35 @@ is_relevant_fast_lane_surface() {
   return 1
 }
 
+file_is_structural_module_barrel() {
+  local path="$1"
+  [ -f "$ROOT_DIR/$path" ] || return 1
+
+  awk '
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*\/\// { next }
+    /^[[:space:]]*#\[/ { next }
+    /^[[:space:]]*(pub[[:space:]]+)?mod[[:space:]]+[A-Za-z_][A-Za-z0-9_]*;[[:space:]]*$/ { next }
+    /^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?use[[:space:]].*;[[:space:]]*$/ { next }
+    { exit 1 }
+  ' "$ROOT_DIR/$path"
+}
+
+is_structural_companion_surface() {
+  local path="$1"
+  case "$path" in
+    adl/src/lib.rs)
+      file_is_structural_module_barrel "$path"
+      return $?
+      ;;
+  esac
+  return 1
+}
+
 is_broad_rust_surface() {
   local path="$1"
   case "$path" in
     adl/build.rs|\
-    adl/src/lib.rs|\
     adl/src/main.rs|\
     adl/src/adl.rs|\
     adl/src/schema.rs|\
@@ -136,6 +160,9 @@ is_broad_rust_surface() {
 filter_token_for_path() {
   local path="$1"
   case "$path" in
+    adl/src/lib.rs)
+      return 1
+      ;;
     adl/src/runtime_v2/mod.rs|adl/src/runtime_v2/tests.rs|adl/src/runtime_v2/validators.rs)
       printf 'runtime_v2'
       return 0
@@ -250,6 +277,9 @@ filter_token_for_path() {
 family_token_for_path() {
   local path="$1"
   case "$path" in
+    adl/src/lib.rs)
+      return 1
+      ;;
     adl/src/runtime_v2/*)
       printf 'runtime_v2'
       return 0
@@ -304,6 +334,7 @@ reason="ordinary_pr_fast_lane_fails_closed_to_full_nextest"
 filter_tokens=""
 filter_expression=""
 rust_surface_count=0
+structural_surface_count=0
 all_paths_have_precise_token=true
 all_paths_have_family_token=true
 classification_locked=false
@@ -314,6 +345,10 @@ declare -a family_tokens=()
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   if ! is_relevant_fast_lane_surface "$path"; then
+    continue
+  fi
+  if is_structural_companion_surface "$path"; then
+    structural_surface_count=$((structural_surface_count + 1))
     continue
   fi
   rust_surface_count=$((rust_surface_count + 1))
@@ -383,6 +418,7 @@ fi
 emit "mode" "$mode"
 emit "reason" "$reason"
 emit "rust_surface_count" "$rust_surface_count"
+emit "structural_surface_count" "$structural_surface_count"
 emit "filter_tokens" "$filter_tokens"
 emit "filter_expression" "$filter_expression"
 

--- a/adl/tools/test_run_pr_fast_test_lane.sh
+++ b/adl/tools/test_run_pr_fast_test_lane.sh
@@ -56,7 +56,20 @@ broad_runtime="$TMP/broad_runtime.txt"
 printf 'M\tadl/src/lib.rs\n' >"$broad_runtime"
 broad_runtime_output="$(bash "$SCRIPT" --changed-files "$broad_runtime" --print-plan)"
 assert_has "$broad_runtime_output" "mode=full"
-assert_has "$broad_runtime_output" "reason=broad_rust_surface_requires_full_nextest"
+assert_has "$broad_runtime_output" "reason=no_relevant_rust_surface_detected_for_fast_lane"
+assert_has "$broad_runtime_output" "structural_surface_count=1"
+
+structural_companion_runtime="$TMP/structural_companion_runtime.txt"
+cat >"$structural_companion_runtime" <<'EOF'
+M	adl/src/lib.rs
+M	adl/src/speculative_decoding_prototype.rs
+EOF
+structural_companion_runtime_output="$(bash "$SCRIPT" --changed-files "$structural_companion_runtime" --print-plan)"
+assert_has "$structural_companion_runtime_output" "mode=focused"
+assert_has "$structural_companion_runtime_output" "reason=bounded_rust_surface_runs_focused_nextest"
+assert_has "$structural_companion_runtime_output" "structural_surface_count=1"
+assert_has "$structural_companion_runtime_output" "filter_tokens=speculative_decoding_prototype"
+assert_has "$structural_companion_runtime_output" "filter_expression=test(speculative_decoding_prototype)"
 
 runtime_family="$TMP/runtime_family.txt"
 printf 'M\tadl/src/runtime_v2/mod.rs\n' >"$runtime_family"

--- a/docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md
+++ b/docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md
@@ -77,6 +77,14 @@ Runtime/source PRs:
 - defer full instrumented coverage to main/nightly/release evidence unless the
   path classifier fails closed
 
+Selector note:
+
+- structural module-barrel edits such as `adl/src/lib.rs` should not
+  automatically force the full PR-fast nextest lane when the rest of the diff
+  is a clearly bounded mapped module change
+- those structural surfaces remain fail-closed when they appear without another
+  bounded companion surface that supplies the proving token plan
+
 Pushes to `main`:
 
 - run full validation and full coverage

--- a/docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md
+++ b/docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md
@@ -55,3 +55,8 @@ The `WP-05` coverage ergonomics slice is now landed via:
 - improved actionable next-step diagnostics in `adl/tools/check_coverage_impact.sh`
 - focused regression coverage in `adl/tools/test_check_coverage_impact.sh`
 - `docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md`
+
+Post-sprint follow-on `#3133` continues this line by tightening the ordinary
+PR-fast nextest selector so structural module-barrel wiring, such as
+`adl/src/lib.rs`, does not force a full nextest sweep when the real changed
+runtime surface is still narrowly mapped.


### PR DESCRIPTION
Closes #3133

## Summary
Tightened the PR-fast nextest selector so a structural module-barrel edit in
`adl/src/lib.rs` no longer forces a full nextest sweep when the rest of the PR
supplies a clearly bounded mapped runtime token. Preserved fail-closed behavior
for barrel-only root-surface edits, added regression coverage, and updated the
retained CI/runtime policy docs to describe the narrower merge bar truthfully.

## Artifacts
- Updated selector: `adl/tools/run_pr_fast_test_lane.sh`
- Regression coverage: `adl/tools/test_run_pr_fast_test_lane.sh`
- Retained policy note: `docs/milestones/v0.90.3/CI_RUNTIME_POLICY_v0.90.3.md`
- Runtime recovery feature note: `docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md`
- Updated live execution plan: `.adl/v0.91.2/tasks/issue-3133__v0-91-2-quality-re-split-bounded-pr-validation-from-release-scale-rust-test-lanes/spp.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_run_pr_fast_test_lane.sh`
    Verified focused/family/full lane selection behavior, including the new
    structural-barrel `lib.rs` companion case.
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Verified the retained workflow contract still points at the intended
    bounded PR-fast and authoritative coverage split.
  - `git diff --check`
    Verified patch cleanliness for the touched selector/tests/docs surfaces.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3133__v0-91-2-quality-re-split-bounded-pr-validation-from-release-scale-rust-test-lanes/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3133__v0-91-2-quality-re-split-bounded-pr-validation-from-release-scale-rust-test-lanes/sor.md
- Idempotency-Key: v0-91-2-quality-re-split-bounded-pr-validation-from-release-scale-rust-test-lanes-adl-v0-91-2-tasks-issue-3133-v0-91-2-quality-re-split-bounded-pr-validation-from-release-scale-rust-test-lanes-sip-md-adl-v0-91-2-tasks-issue-3133-v0-91-2-quality-re-split-bounded-pr-validation-from-release-scale-rust-test-lanes-sor-md