### PR TITLE
[v0.91.2][WP-15][docs] Rustdoc and doc cleanup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,10 @@ Use this index to find the right source of truth quickly.
 
 ## Start Here
 
-- Active milestone package: `milestones/v0.91/` with issue wave open as
-  `#2735-#2759`
-- Most recently completed milestone: `milestones/v0.90.5/`
-- Previous completed milestone: `milestones/v0.90.4/`
-- Previous completed milestone package: `milestones/v0.90.3/`
+- Active milestone package: `milestones/v0.91.2/`
+- Most recently completed milestone: `milestones/v0.91.1/`
+- Previous completed milestone: `milestones/v0.91/`
+- Previous completed milestone package: `milestones/v0.90.5/`
 - Root project overview: `../README.md`
 - Runtime and CLI guide: `../adl/README.md`
 - Language/spec entrypoint: `../adl-spec/README.md`
@@ -19,11 +18,10 @@ Use this index to find the right source of truth quickly.
 
 ## Milestone Documentation
 
-- Active milestone package: `milestones/v0.91/` with issue wave open as
-  `#2735-#2759`
-- Most recently completed milestone: `milestones/v0.90.5/`
-- Previous completed milestone: `milestones/v0.90.4/`
-- Previous completed milestone package: `milestones/v0.90.3/`
+- Active milestone package: `milestones/v0.91.2/`
+- Most recently completed milestone: `milestones/v0.91.1/`
+- Previous completed milestone: `milestones/v0.91/`
+- Previous completed milestone package: `milestones/v0.90.5/`
 - Recent stable milestones: `milestones/v0.87.1/`, `milestones/v0.87/`, `milestones/v0.86/`, `milestones/v0.85/`, `milestones/v0.8/`
 - Earlier milestones: `milestones/v0.75/`, `milestones/v0.7/`, `milestones/v0.6/`
 - Historical milestones: `milestones/v0.5/`, `milestones/v0.4/`, `milestones/v0.3/`, `milestones/v0.2/`
@@ -40,18 +38,17 @@ Use this index to find the right source of truth quickly.
 ## Demo and Tooling Surfaces
 
 - Canonical demo index: `../demos/README.md`
-- Active milestone demo matrix: `milestones/v0.91/DEMO_MATRIX_v0.91.md`
-- Most recently completed milestone demo matrix: `milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
-- Previous completed milestone demo matrix: `milestones/v0.90.4/DEMO_MATRIX_v0.90.4.md`
-- Earlier milestone demo matrix: `milestones/v0.90.3/DEMO_MATRIX_v0.90.3.md`
+- Active milestone demo matrix: `milestones/v0.91.2/DEMO_MATRIX_v0.91.2.md`
+- Most recently completed milestone demo matrix: `milestones/v0.91.1/DEMO_MATRIX_v0.91.1.md`
+- Previous completed milestone demo matrix: `milestones/v0.91/DEMO_MATRIX_v0.91.md`
+- Earlier milestone demo matrix: `milestones/v0.90.5/DEMO_MATRIX_v0.90.5.md`
 - Editor/tooling demo surfaces: `tooling/editor/README.md`
 
 ## Notes
 
 Milestone docs should be read as bounded engineering records. They distinguish
 what has shipped, what is currently being implemented, what is demoable, and
-what is planned for later milestones. At the moment, `v0.91` is the active
-moral-governance, cognitive-being, and secure intra-polis communication
-milestone with its issue wave open as `#2735-#2759`; `v0.90.5` is the most
-recently completed Governed Tools v1.0 milestone; and `v0.90.4` is the previous
-completed contract-market milestone.
+what is planned for later milestones. At the moment, `v0.91.2` is the active
+tooling, evaluation, productization, publication, and repo-health milestone;
+`v0.91.1` is the most recently completed inhabited-runtime readiness package;
+and `v0.91` remains the earlier moral-governance wave.

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -39,7 +39,7 @@ The browser/editor adapter remains narrower:
 ## 1) Bootstrap Canonical Issue Bundle
 
 ```bash
-bash ./adl/tools/pr.sh init <issue_num> --slug <slug> --version v0.87
+bash ./adl/tools/pr.sh init <issue_num> --slug <slug> --version <milestone_version>
 ```
 
 Canonical local task bundle:
@@ -71,13 +71,17 @@ gh issue view <issue_num>
 ## 3) Confirm Readiness And Bind Run Phase
 
 ```bash
-bash ./adl/tools/pr.sh ready <issue_num> --slug <slug> --version v0.87
-bash ./adl/tools/pr.sh run <issue_num> --slug <slug> --version v0.87
+bash ./adl/tools/pr.sh ready <issue_num> --slug <slug> --version <milestone_version>
+bash ./adl/tools/pr.sh run <issue_num> --slug <slug> --version <milestone_version>
 ```
 
-Compatibility card paths:
+Legacy compatibility card paths:
 - `.adl/cards/<issue_num>/input_<issue_num>.md`
 - `.adl/cards/<issue_num>/output_<issue_num>.md`
+
+These legacy paths still appear in some older records and tools, but the
+canonical issue bundle for current work is the task-bundle directory under
+`.adl/<scope>/tasks/`.
 
 Preferred execution clone:
 - `.worktrees/adl-wp-<issue_num>`
@@ -123,9 +127,8 @@ Canonical regression proof surface for the implemented editing story:
 bash adl/tools/test_five_command_regression_suite.sh
 ```
 
-Bounded lifecycle proof/demo:
-
-- `docs/tooling/editor/five_command_demo.md`
+Bounded lifecycle proof/demo surfaces should come from the current issue or
+milestone packet rather than a legacy one-size-fits-all demo note.
 
 ### Compression-Safe Validation
 
@@ -200,9 +203,7 @@ surface needs it.
 ```bash
 bash ./adl/tools/pr.sh finish <issue_num> \
   --title "<title>" \
-  --paths "<comma-separated paths>" \
-  -f .adl/cards/<issue_num>/input_<issue_num>.md \
-  --output-card .adl/cards/<issue_num>/output_<issue_num>.md
+  --paths "<comma-separated repo paths>"
 ```
 
 Finish should only open or update the PR after review truth is captured or
@@ -210,6 +211,9 @@ explicitly deferred according to policy. The current publication-time `SOR`
 should be synced to the canonical task bundle under:
 
 - `.adl/<scope>/tasks/issue-<padded_issue>__<slug>/sor.md`
+
+Do not treat legacy `.adl/cards/<issue_num>/...` paths as the canonical finish
+surface for new issue work.
 
 ## 8) Report
 
@@ -224,7 +228,7 @@ Write a per-issue report under:
 - Wrong paths at `finish`:
   - Ensure `--paths` only includes intended repo paths; do not include local `.adl` artifacts.
 - Missing canonical STP:
-  - Re-run `pr.sh init <issue_num> --slug <slug> --version v0.87`.
+  - Re-run `pr.sh init <issue_num> --slug <slug> --version <milestone_version>`.
 - Stale GitHub issue body:
   - Reconcile the GitHub issue outside `pr.sh`, then re-run `pr.sh init <issue_num>` if the local root bundle must be reseeded.
 - Missing card files:

--- a/docs/milestones/v0.91.2/features/RUSTDOC_DOC_CLEANUP.md
+++ b/docs/milestones/v0.91.2/features/RUSTDOC_DOC_CLEANUP.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Rustdoc And Documentation Cleanup
 - Milestone Target: `v0.91.2`
-- Status: planned
+- Status: in_flight
 - Planned WP Home: WP-15
 - Source Docs: `.adl/docs/TBD/RUSTDOC_GAP_ANALYSIS.md`; `.adl/docs/TBD/ADL_DOC_CLEANUP_LEDGER.md`
 - Proof Modes: docs, checks, review
@@ -22,6 +22,8 @@ In scope:
 - Doc cleanup ledger update.
 - Stale milestone claim cleanup.
 - Validation for changed docs.
+- Top-level docs navigation and workflow-surface truth cleanup where those
+  surfaces still point at stale milestone or control-plane behavior.
 
 Out of scope:
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -6,6 +6,11 @@ survive individual milestone closeout.
 Use this directory for living planning surfaces that are updated as each
 milestone completes.
 
+These docs are durable planning truth, not the live execution/control-plane
+surface for a currently running milestone. For active issue-wave, sprint, and
+release-state truth, start in the relevant `docs/milestones/<version>/`
+package.
+
 Active planning docs:
 
 - `ADL_FEATURE_LIST.md` - full feature list, current status, implemented gaps,
@@ -36,6 +41,15 @@ Planning provenance docs:
   active next-sprint commitments
 - `DOC_CLEANUP_RECONCILIATION_1762.md` - historical cleanup reconciliation for
   issue `1762`; keep as provenance, not as live cleanup backlog
+
+## How To Read This Directory
+
+- Use this directory when the question is cross-milestone strategy, sequencing,
+  or long-horizon allocation.
+- Use milestone packages when the question is "what is active, proving, or
+  closing right now?"
+- Use local `.adl/docs/TBD/` only for local planning/control surfaces that have
+  not yet been promoted into tracked repo truth.
 
 ## Directory Boundaries
 


### PR DESCRIPTION
Closes #3014

## Summary
- refresh top-level docs navigation to current v0.91.2 milestone truth
- normalize default workflow examples away from stale v0.87-era defaults
- clarify planning README boundaries and mark the rustdoc/docs cleanup feature as in flight

## Validation
- git diff --check
- targeted stale-truth rg scan over touched docs