### PR TITLE
[v0.91.2][review] Fix Sprint 3 closeout and guardrail review findings

### DIFF
--- a/adl/tools/test_workflow_guardrails.sh
+++ b/adl/tools/test_workflow_guardrails.sh
@@ -59,6 +59,31 @@ UNSAFE
   fi
   assert_contains "Unsafe command substitution detected" "$out" "unsafe report command"
 
+  local unsafe_backtick="$TMP/unsafe-report-backtick.txt"
+  cat >"$unsafe_backtick" <<'UNSAFE_BACKTICK'
+echo `pwd` > report.md
+UNSAFE_BACKTICK
+  if out="$(bash "$ROOT/adl/tools/workflow_guardrails.sh" safe-report-command --file "$unsafe_backtick" 2>&1)"; then
+    echo "expected unsafe backtick report command to fail" >&2
+    exit 1
+  fi
+  assert_contains "Unsafe command substitution detected" "$out" "unsafe backtick command"
+
+  local safe_markdown="$TMP/safe-markdown-report-command.txt"
+  cat >"$safe_markdown" <<'SAFE_MARKDOWN'
+cat > report.md <<'MD'
+# Report
+
+```bash
+echo safe
+```
+
+Literal text may mention $(pwd) without executing because this heredoc is quoted.
+MD
+SAFE_MARKDOWN
+  out="$(bash "$ROOT/adl/tools/workflow_guardrails.sh" safe-report-command --file "$safe_markdown")"
+  assert_contains "PASS safe-report-command" "$out" "safe markdown report command"
+
   out="$(bash "$ROOT/adl/tools/workflow_guardrails.sh" safe-report-command --command "python3 - <<'PY'\nprint('# Report')\nPY")"
   assert_contains "PASS safe-report-command" "$out" "safe report command"
 }

--- a/adl/tools/workflow_guardrails.sh
+++ b/adl/tools/workflow_guardrails.sh
@@ -119,7 +119,7 @@ cmd_safe_report_command() {
   fi
   [[ -n "$command_text" ]] || die "safe-report-command: provide --command or --file"
 
-  if grep -Eq '\$\(|`' <<<"$command_text"; then
+  if has_unsafe_command_substitution "$command_text"; then
     echo "BLOCKED safe-report-command" >&2
     echo "Unsafe command substitution detected in report-generation command." >&2
     echo "Use a quoted heredoc (for example, <<'EOF') or a language-native writer instead." >&2
@@ -127,6 +127,47 @@ cmd_safe_report_command() {
   fi
 
   echo "PASS safe-report-command"
+}
+
+has_unsafe_command_substitution() {
+  local command_text="$1"
+  local heredoc_end=""
+  local single_marker="<<'"
+  local double_marker='<<"'
+  local slash_marker="<<\\"
+  local line scan after delimiter
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -n "$heredoc_end" ]]; then
+      if [[ "$line" == "$heredoc_end" ]]; then
+        heredoc_end=""
+      fi
+      continue
+    fi
+
+    scan="$line"
+    if [[ "$line" == *"$single_marker"* ]]; then
+      scan="${line%%${single_marker}*}"
+      after="${line#*${single_marker}}"
+      delimiter="${after%%\'*}"
+      [[ -n "$delimiter" ]] && heredoc_end="$delimiter"
+    elif [[ "$line" == *"$double_marker"* ]]; then
+      scan="${line%%${double_marker}*}"
+      after="${line#*${double_marker}}"
+      delimiter="${after%%\"*}"
+      [[ -n "$delimiter" ]] && heredoc_end="$delimiter"
+    elif [[ "$line" == *"$slash_marker"* ]]; then
+      scan="${line%%${slash_marker}*}"
+      after="${line#*${slash_marker}}"
+      delimiter="${after%%[[:space:]]*}"
+      [[ -n "$delimiter" ]] && heredoc_end="$delimiter"
+    fi
+
+    if grep -Eq '\$\(|`' <<<"$scan"; then
+      return 0
+    fi
+  done <<<"$command_text"
+
+  return 1
 }
 
 cmd_card_drift() {

--- a/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md
@@ -25,15 +25,16 @@ Each feature should eventually have one truthful proof route:
 | Review heuristics and demos | WP-07 | heuristics promotion packet + bounded review demo packet + fixture review outputs + review-quality checklist | in_flight |
 | Workspace CMS bridge | WP-08, WP-09, #3091, #3092, #3093, #3094 | bounded demo + native CMS capability packet + live safety package + live bounded execution report + live content-card roundtrip report + project-ready operational package + `.adl` to GWS migration plan | landed baseline plus active hardening |
 | Code modernization | WP-10 | modernization interaction plan + dry-run evidence + reversibility/review policy + demo packet | active bounded packet |
-| Speculative decoding | WP-11 | `review/speculative_decoding/speculative_decoding_prototype_report.json` + `review/speculative_decoding/speculative_decoding_prototype_packet.md` | in_flight |
-| Repo visibility follow-on | WP-12 | tracked manifest packet + linkage report + reviewer-navigation packet | in_flight |
-| Publication program | WP-13 | tracked backlog packet + review-gates packet + Godel/GHB backlog note | in_flight |
+| Speculative decoding | WP-11 | `review/speculative_decoding/speculative_decoding_prototype_report.json` + `review/speculative_decoding/speculative_decoding_prototype_packet.md` | implemented |
+| Repo visibility follow-on | WP-12 | tracked manifest packet + linkage report + reviewer-navigation packet | implemented |
+| Publication program | WP-13 | tracked backlog packet + review-gates packet + Godel/GHB backlog note | implemented |
 | General intelligence paper packet | WP-14 | tracked claim/citation packet + review handoff + residual-risk register + next-authoring-steps packet + canonical paper-repo migration truth | implemented |
-| Rustdoc/doc cleanup | WP-15 | cleanup report + doc patch set | in_flight |
-| Workflow guardrails | WP-16 | `adl/tools/workflow_guardrails.sh` + `adl/tools/test_workflow_guardrails.sh` + workflow-guardrails runbook/proof packet | in_flight |
+| Rustdoc/doc cleanup | WP-15 | cleanup report + doc patch set | implemented |
+| Workflow guardrails | WP-16 | `adl/tools/workflow_guardrails.sh` + `adl/tools/test_workflow_guardrails.sh` + workflow-guardrails runbook/proof packet | implemented |
 | Demo/proof convergence | WP-17 | demo matrix and proof coverage | planned |
 
 ## Non-Claims
 
-- no feature in this milestone is landed yet through this document alone
-- this file is not evidence that any feature implementation has landed
+- this file alone is not evidence that a feature implementation has landed
+- implemented rows must remain backed by their named proof routes and merged
+  issue/PR evidence

--- a/docs/milestones/v0.91.2/features/PUBLICATION_PROGRAM.md
+++ b/docs/milestones/v0.91.2/features/PUBLICATION_PROGRAM.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Publication Program Package
 - Milestone Target: `v0.91.2`
-- Status: in_flight
+- Status: implemented
 - Planned WP Home: WP-13
 - Source Docs: `.adl/docs/TBD/publication/`; `.adl/docs/TBD/ARXIV_AUTHORING_PROCESS_NOTES.md`; `adl/tools/skills/docs/ARXIV_PAPER_WRITER_SKILL_INPUT_SCHEMA.md`; `adl/tools/skills/docs/MEDIUM_ARTICLE_WRITER_SKILL_INPUT_SCHEMA.md`
 - Proof Modes: tracked backlog packet, review-gates packet, backlog-note packet

--- a/docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md
+++ b/docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Repo Visibility Follow-On
 - Milestone Target: `v0.91.2`
-- Status: in_flight
+- Status: implemented
 - Planned WP Home: WP-12
 - Source Docs: `docs/milestones/v0.90/repo_visibility/README.md`; `docs/milestones/v0.90/repo_visibility/CANONICAL_SOURCE_MANIFEST_v0.90.yaml`; `docs/milestones/v0.90/repo_visibility/CODE_DOC_DEMO_LINKAGE_REPORT_v0.90.md`; `.adl/docs/TBD/repo_visibility/REPO_VISIBILITY_LAYER.md`; `.adl/docs/TBD/repo_visibility/CANONICAL_SOURCE_MANIFEST.md`; `.adl/docs/TBD/repo_visibility/CODE_DOC_LINKAGE_REPORT.md`
 - Proof Modes: tracked manifest packet, reviewer-navigation packet, feature/proof doc crosswalk

--- a/docs/milestones/v0.91.2/features/RUSTDOC_DOC_CLEANUP.md
+++ b/docs/milestones/v0.91.2/features/RUSTDOC_DOC_CLEANUP.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Rustdoc And Documentation Cleanup
 - Milestone Target: `v0.91.2`
-- Status: in_flight
+- Status: implemented
 - Planned WP Home: WP-15
 - Source Docs: `.adl/docs/TBD/RUSTDOC_GAP_ANALYSIS.md`; `.adl/docs/TBD/ADL_DOC_CLEANUP_LEDGER.md`
 - Proof Modes: docs, checks, review

--- a/docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md
+++ b/docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Speculative Decoding Prototype
 - Milestone Target: `v0.91.2`
-- Status: in_flight
+- Status: implemented
 - Planned WP Home: WP-11
 - Source Docs: `.adl/docs/TBD/ADL_AND_GENERIC_SPECULATIVE_DECODING.md`; `.adl/docs/TBD/ADL_AND_SPECULATIVE_CODING_REPLAY.md`
 - Proof Modes: design packet, deterministic prototype report, reviewer evaluation packet

--- a/docs/milestones/v0.91.2/features/WORKFLOW_GUARDRAILS.md
+++ b/docs/milestones/v0.91.2/features/WORKFLOW_GUARDRAILS.md
@@ -4,7 +4,7 @@
 
 - Feature Name: Workflow Guardrails Hardening
 - Milestone Target: `v0.91.2`
-- Status: in_flight
+- Status: implemented
 - Planned WP Home: WP-16
 - Source Docs: `.adl/docs/TBD/workflow_tooling/`
 - Proof Modes: scripts, fixtures, runbooks, review packet

--- a/docs/milestones/v0.91.2/review/workflow_guardrails/WORKFLOW_GUARDRAILS_PROOF_PACKET_v0.91.2.md
+++ b/docs/milestones/v0.91.2/review/workflow_guardrails/WORKFLOW_GUARDRAILS_PROOF_PACKET_v0.91.2.md
@@ -29,6 +29,8 @@ Covered failure behavior:
 - dirty tracked `main` checkout blocks
 - pending closeout-wave candidates block
 - unsafe report-generation command strings block
+- safe quoted-heredoc Markdown code fences pass without being mistaken for
+  executable command substitution
 - card-drift wrapper delegates to `pr doctor`
 
 ## Design Notes
@@ -44,6 +46,7 @@ Covered failure behavior:
 - `closeout-watch` still depends on `gh` availability and truthful GitHub
   state.
 - `safe-report-command` is a command-shape guardrail, not a complete shell
-  sandbox.
+  sandbox; it ignores literal quoted-heredoc bodies so Markdown fences and
+  explanatory command text can be written safely.
 - Card drift still requires the underlying doctor/editor lifecycle to repair
   the issue; this tool only routes and surfaces the condition.

--- a/docs/milestones/v0.91.2/review/workflow_guardrails/WORKFLOW_GUARDRAILS_RUNBOOK_v0.91.2.md
+++ b/docs/milestones/v0.91.2/review/workflow_guardrails/WORKFLOW_GUARDRAILS_RUNBOOK_v0.91.2.md
@@ -64,13 +64,15 @@ artifacts.
 Fail-closed behavior:
 
 - blocks shell command strings that use command substitution via `` `...` `` or
-  `$(...)`
+  `$(...)` outside literal quoted heredoc bodies
 - recommends safer alternatives:
   - quoted heredocs such as `<<'EOF'`
   - language-native file writers
 
 This guardrail is intentionally about command shape, not Markdown content. It
 does not forbid normal Markdown backticks inside the generated report itself.
+Quoted heredoc bodies are treated as literal report content, so Markdown code
+fences and explanatory command examples are allowed there.
 
 ### `card-drift`
 


### PR DESCRIPTION
Closes #3145

## Summary
Fixed the confirmed Sprint 3 review findings without reopening Sprint 3 feature scope. The tracked patch repairs the WP-16 `safe-report-command` false positive for safe quoted-heredoc Markdown fences, adds focused regression coverage, and updates v0.91.2 proof/status docs for completed Sprint 3 work. Local-only Sprint 3 control-plane records were also normalized so child issue doctors pass and the WP-14 audit trail records both merged PRs.

## Artifacts
- `adl/tools/workflow_guardrails.sh`
- `adl/tools/test_workflow_guardrails.sh`
- `docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md`
- `docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md`
- `docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md`
- `docs/milestones/v0.91.2/features/PUBLICATION_PROGRAM.md`
- `docs/milestones/v0.91.2/features/RUSTDOC_DOC_CLEANUP.md`
- `docs/milestones/v0.91.2/features/WORKFLOW_GUARDRAILS.md`
- `docs/milestones/v0.91.2/review/workflow_guardrails/WORKFLOW_GUARDRAILS_PROOF_PACKET_v0.91.2.md`
- `docs/milestones/v0.91.2/review/workflow_guardrails/WORKFLOW_GUARDRAILS_RUNBOOK_v0.91.2.md`
- Local-only Sprint 3 card/closeout truth updates under `.adl/v0.91.2/`

## Validation
- Validation commands and their purpose:
  - `bash -n adl/tools/workflow_guardrails.sh adl/tools/test_workflow_guardrails.sh`
    Verified shell syntax for the touched scripts.
  - `bash adl/tools/test_workflow_guardrails.sh`
    Verified focused WP-16 guardrail behavior including the safe Markdown code-fence regression.
  - `git diff --check`
    Verified whitespace cleanliness.
  - `jq empty .adl/v0.91.2/sprints/issue-3027__v0-91-2-sprint-3-runtime-ergonomics-publication-docs-and-workflow-guardrails-state.json`
    Verified local Sprint 3 state JSON validity.
  - `ADL_PR_RUST_BIN=<prebuilt-adl-binary> adl/tools/pr.sh doctor <issue> --version v0.91.2 --json`
    Verified local Sprint 3 child issue card truth for #3010 through #3015.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3145__v0-91-2-review-fix-sprint-3-closeout-and-guardrail-findings/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3145__v0-91-2-review-fix-sprint-3-closeout-and-guardrail-findings/sor.md
- Idempotency-Key: v0-91-2-review-fix-sprint-3-closeout-and-guardrail-review-findings-adl-tools-workflow-guardrails-sh-adl-tools-test-workflow-guardrails-sh-docs-milestones-v0-91-2-feature-proof-coverage-v0-91-2-md-docs-milestones-v0-91-2-features-speculative-decoding-prototype-md-docs-milestones-v0-91-2-features-repo-visibility-follow-on-md-docs-milestones-v0-91-2-features-publication-program-md-docs-milestones-v0-91-2-features-rustdoc-doc-cleanup-md-docs-milestones-v0-91-2-features-workflow-guardrails-md-docs-milestones-v0-91-2-review-workflow-guardrails-workflow-guardrails-proof-packet-v0-91-2-md-docs-milestones-v0-91-2-review-workflow-guardrails-workflow-guardrails-runbook-v0-91-2-md-adl-v0-91-2-tasks-issue-3145-v0-91-2-review-fix-sprint-3-closeout-and-guardrail-findings-sip-md-adl-v0-91-2-tasks-issue-3145-v0-91-2-review-fix-sprint-3-closeout-and-guardrail-findings-sor-md