### PR TITLE
[v0.91.2][quality] Add CI runtime budget observability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,10 @@ jobs:
       - name: ci runtime contract check
         run: bash tools/test_ci_runtime_contracts.sh
 
+      - name: ci runtime budget report contract check
+        run: bash adl/tools/test_summarize_ci_runtime.sh
+        working-directory: .
+
       - name: ci cache/linker contract check
         run: bash tools/test_ci_cache_linker_contracts.sh
 

--- a/adl/tools/summarize_ci_runtime.py
+++ b/adl/tools/summarize_ci_runtime.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Summarize GitHub Actions job timing JSON into CI runtime budget reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_JOB_BUDGETS = {
+    "adl-ci": 600.0,
+    "adl-coverage": 900.0,
+}
+
+DEFAULT_CATEGORY_BUDGETS = {
+    "lane-selection": 60.0,
+    "setup-install-cache": 240.0,
+    "tooling-contracts": 240.0,
+    "rust-test-execution": 600.0,
+    "coverage-execution": 900.0,
+    "reporting-upload": 120.0,
+    "skipped-policy": 60.0,
+    "other": 180.0,
+}
+
+
+@dataclass(frozen=True)
+class StepTiming:
+    job: str
+    name: str
+    category: str
+    seconds: float
+    conclusion: str
+    over_budget: bool
+    budget_seconds: float
+
+
+@dataclass(frozen=True)
+class JobTiming:
+    name: str
+    seconds: float
+    conclusion: str
+    over_budget: bool
+    budget_seconds: float
+    top_category: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize GitHub Actions jobs JSON into runtime budget and hotspot buckets."
+    )
+    parser.add_argument(
+        "jobs_json",
+        type=Path,
+        help="Path to JSON from `gh run view <run> --json jobs` or an equivalent jobs array.",
+    )
+    parser.add_argument(
+        "--job-budget",
+        action="append",
+        default=[],
+        metavar="JOB=SECONDS",
+        help="Override a job budget, for example `adl-ci=600`.",
+    )
+    parser.add_argument(
+        "--category-budget",
+        action="append",
+        default=[],
+        metavar="CATEGORY=SECONDS",
+        help="Override a category budget, for example `coverage-execution=900`.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format.",
+    )
+    return parser.parse_args()
+
+
+def parse_budget_overrides(values: list[str]) -> dict[str, float]:
+    overrides: dict[str, float] = {}
+    for value in values:
+        if "=" not in value:
+            raise SystemExit(f"invalid budget override {value!r}; expected NAME=SECONDS")
+        name, raw_seconds = value.split("=", 1)
+        name = name.strip()
+        if not name:
+            raise SystemExit(f"invalid budget override {value!r}; missing name")
+        try:
+            seconds = float(raw_seconds)
+        except ValueError as exc:
+            raise SystemExit(f"invalid budget override {value!r}; seconds must be numeric") from exc
+        if seconds < 0:
+            raise SystemExit(f"invalid budget override {value!r}; seconds must be non-negative")
+        overrides[name] = seconds
+    return overrides
+
+
+def parse_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+def elapsed_seconds(started_at: str | None, completed_at: str | None) -> float:
+    start = parse_time(started_at)
+    end = parse_time(completed_at)
+    if start is None or end is None:
+        return 0.0
+    return max((end - start).total_seconds(), 0.0)
+
+
+def load_jobs(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return [job for job in data if isinstance(job, dict)]
+    if isinstance(data, dict) and isinstance(data.get("jobs"), list):
+        return [job for job in data["jobs"] if isinstance(job, dict)]
+    raise SystemExit("input must be a jobs array or an object with a jobs array")
+
+
+def category_for_step(name: str) -> str:
+    lower = name.lower()
+    if "classify changed paths" in lower or "path-policy" in lower or "coverage-impact" in lower:
+        return "lane-selection"
+    if "install" in lower or "cache" in lower or "configure rust acceleration" in lower:
+        return "setup-install-cache"
+    if "tooling sanity" in lower or "contract" in lower or "guardrail" in lower or "docs command" in lower:
+        return "tooling-contracts"
+    if lower in {"fmt", "clippy", "test", "doc test"} or "nextest" in lower:
+        return "rust-test-execution"
+    if "skipped" in lower or "deferred" in lower or "covered by" in lower or "replacement" in lower:
+        return "skipped-policy"
+    if "coverage" in lower or "llvm-cov" in lower or "lcov" in lower or "codecov" in lower:
+        return "coverage-execution"
+    if "upload" in lower or "summary" in lower or "stats" in lower or "verify generated" in lower:
+        return "reporting-upload"
+    return "other"
+
+
+def budget_for(name: str, budgets: dict[str, float], default: float) -> float:
+    return budgets.get(name, default)
+
+
+def summarize(
+    jobs: list[dict[str, Any]],
+    job_budgets: dict[str, float],
+    category_budgets: dict[str, float],
+) -> dict[str, Any]:
+    job_rows: list[JobTiming] = []
+    step_rows: list[StepTiming] = []
+    category_totals: dict[str, float] = {}
+
+    for job in jobs:
+        job_name = str(job.get("name") or "unknown")
+        job_seconds = elapsed_seconds(job.get("startedAt"), job.get("completedAt"))
+        job_conclusion = str(job.get("conclusion") or job.get("status") or "unknown")
+        job_category_totals: dict[str, float] = {}
+
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            step_name = str(step.get("name") or "unknown")
+            seconds = elapsed_seconds(step.get("startedAt"), step.get("completedAt"))
+            category = category_for_step(step_name)
+            category_totals[category] = category_totals.get(category, 0.0) + seconds
+            job_category_totals[category] = job_category_totals.get(category, 0.0) + seconds
+            budget = budget_for(category, category_budgets, DEFAULT_CATEGORY_BUDGETS["other"])
+            step_rows.append(
+                StepTiming(
+                    job=job_name,
+                    name=step_name,
+                    category=category,
+                    seconds=seconds,
+                    conclusion=str(step.get("conclusion") or step.get("status") or "unknown"),
+                    over_budget=seconds > budget,
+                    budget_seconds=budget,
+                )
+            )
+
+        top_category = "none"
+        if job_category_totals:
+            top_category = max(job_category_totals.items(), key=lambda item: item[1])[0]
+        job_budget = budget_for(job_name, job_budgets, 600.0)
+        job_rows.append(
+            JobTiming(
+                name=job_name,
+                seconds=job_seconds,
+                conclusion=job_conclusion,
+                over_budget=job_seconds > job_budget,
+                budget_seconds=job_budget,
+                top_category=top_category,
+            )
+        )
+
+    return {
+        "jobs": [asdict(row) for row in sorted(job_rows, key=lambda row: row.seconds, reverse=True)],
+        "steps": [asdict(row) for row in sorted(step_rows, key=lambda row: row.seconds, reverse=True)],
+        "categories": [
+            {"category": category, "seconds": seconds, "budget_seconds": category_budgets.get(category)}
+            for category, seconds in sorted(category_totals.items(), key=lambda item: item[1], reverse=True)
+        ],
+    }
+
+
+def markdown_report(summary: dict[str, Any]) -> str:
+    lines = [
+        "# CI Runtime Budget Report",
+        "",
+        "## Job Budgets",
+        "",
+        "| Job | Seconds | Budget | Status | Dominant Bucket | Conclusion |",
+        "| --- | ---: | ---: | --- | --- | --- |",
+    ]
+    for row in summary["jobs"]:
+        status = "over_budget" if row["over_budget"] else "within_budget"
+        lines.append(
+            f"| `{row['name']}` | {row['seconds']:.1f} | {row['budget_seconds']:.1f} | "
+            f"{status} | `{row['top_category']}` | `{row['conclusion']}` |"
+        )
+
+    lines.extend(["", "## Runtime Buckets", "", "| Bucket | Seconds |", "| --- | ---: |"])
+    for row in summary["categories"]:
+        lines.append(f"| `{row['category']}` | {row['seconds']:.1f} |")
+
+    lines.extend(["", "## Slowest Steps", "", "| Job | Step | Bucket | Seconds | Budget | Status |", "| --- | --- | --- | ---: | ---: | --- |"])
+    for row in summary["steps"][:12]:
+        status = "over_budget" if row["over_budget"] else "within_budget"
+        lines.append(
+            f"| `{row['job']}` | `{row['name']}` | `{row['category']}` | "
+            f"{row['seconds']:.1f} | {row['budget_seconds']:.1f} | {status} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Routing Guidance",
+            "",
+            "- `lane-selection`: inspect `ci_path_policy` and coverage-impact classification.",
+            "- `setup-install-cache`: inspect toolchain, cache, linker, or runner setup.",
+            "- `rust-test-execution`: inspect test selection, slow-proof placement, or nextest hotspots.",
+            "- `coverage-execution`: inspect coverage lane policy and changed-source coverage scope.",
+            "- `tooling-contracts`: inspect shell/Python contract tests or guardrail scripts.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    job_budgets = {**DEFAULT_JOB_BUDGETS, **parse_budget_overrides(args.job_budget)}
+    category_budgets = {**DEFAULT_CATEGORY_BUDGETS, **parse_budget_overrides(args.category_budget)}
+    summary = summarize(load_jobs(args.jobs_json), job_budgets, category_budgets)
+    if args.format == "json":
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(markdown_report(summary), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_summarize_ci_runtime.sh
+++ b/adl/tools/test_summarize_ci_runtime.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/adl/tools/summarize_ci_runtime.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_has() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    echo "expected output to contain: $needle" >&2
+    echo "actual output:" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+fixture="$TMP/jobs.json"
+cat >"$fixture" <<'EOF'
+{
+  "jobs": [
+    {
+      "name": "adl-ci",
+      "startedAt": "2026-05-20T16:00:00Z",
+      "completedAt": "2026-05-20T16:08:00Z",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "Classify changed paths",
+          "startedAt": "2026-05-20T16:00:05Z",
+          "completedAt": "2026-05-20T16:00:15Z",
+          "conclusion": "success"
+        },
+        {
+          "name": "Install Rust toolchain",
+          "startedAt": "2026-05-20T16:00:15Z",
+          "completedAt": "2026-05-20T16:02:15Z",
+          "conclusion": "success"
+        },
+        {
+          "name": "test",
+          "startedAt": "2026-05-20T16:02:15Z",
+          "completedAt": "2026-05-20T16:07:45Z",
+          "conclusion": "success"
+        },
+        {
+          "name": "Rust validation skipped by path policy",
+          "startedAt": "2026-05-20T16:07:45Z",
+          "completedAt": "2026-05-20T16:07:50Z",
+          "conclusion": "skipped"
+        }
+      ]
+    },
+    {
+      "name": "adl-coverage",
+      "startedAt": "2026-05-20T16:00:00Z",
+      "completedAt": "2026-05-20T16:16:45Z",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "Determine PR fast coverage filters",
+          "startedAt": "2026-05-20T16:00:05Z",
+          "completedAt": "2026-05-20T16:00:25Z",
+          "conclusion": "success"
+        },
+        {
+          "name": "Coverage run and summary (json)",
+          "startedAt": "2026-05-20T16:00:25Z",
+          "completedAt": "2026-05-20T16:16:25Z",
+          "conclusion": "success"
+        },
+        {
+          "name": "Upload coverage artifact",
+          "startedAt": "2026-05-20T16:16:25Z",
+          "completedAt": "2026-05-20T16:16:40Z",
+          "conclusion": "success"
+        },
+        {
+          "name": "Coverage skipped by path policy",
+          "startedAt": "2026-05-20T16:16:40Z",
+          "completedAt": "2026-05-20T16:16:45Z",
+          "conclusion": "success"
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+markdown_output="$(python3 "$SCRIPT" "$fixture" --job-budget adl-coverage=900 --category-budget coverage-execution=900)"
+assert_has "$markdown_output" "# CI Runtime Budget Report"
+assert_has "$markdown_output" '| `adl-coverage` | 1005.0 | 900.0 | over_budget | `coverage-execution` | `success` |'
+assert_has "$markdown_output" '| `rust-test-execution` | 330.0 |'
+assert_has "$markdown_output" '| `skipped-policy` | 5.0 |'
+assert_has "$markdown_output" '| `Coverage run and summary (json)` | `coverage-execution` | 960.0 | 900.0 | over_budget |'
+assert_has "$markdown_output" "inspect coverage lane policy"
+
+json_output="$(python3 "$SCRIPT" "$fixture" --format json --job-budget adl-coverage=900 --category-budget coverage-execution=900)"
+assert_has "$json_output" '"name": "adl-coverage"'
+assert_has "$json_output" '"over_budget": true'
+assert_has "$json_output" '"category": "coverage-execution"'
+assert_has "$json_output" '"category": "skipped-policy"'
+
+echo "PASS test_summarize_ci_runtime"

--- a/docs/milestones/v0.91.2/CI_RUNTIME_BUDGETS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/CI_RUNTIME_BUDGETS_v0.91.2.md
@@ -1,0 +1,146 @@
+# CI Runtime Budgets - v0.91.2
+
+## Status
+
+Follow-on observability surface for `#3134`.
+
+This document adds the missing job/step-level view above the existing nextest
+hotspot report. It is meant to answer "where did the PR wait go?" without
+forcing an operator to read the full GitHub Actions log by hand.
+
+## Source Of Truth
+
+The current workflow file is:
+
+- `.github/workflows/ci.yaml`
+
+The issue text originally named `.github/workflows/ci.yml`; that is stale path
+wording. The repo uses `.yaml`.
+
+## Budget Model
+
+Budgets are triage thresholds, not release gates. A budget miss should route
+work; it should not silently fail or pass a release by itself.
+
+| Surface | Default Budget | What It Means |
+| --- | ---: | --- |
+| `adl-ci` job | `600s` | Ordinary PR CI should normally finish quickly unless Rust proof is required. |
+| `adl-coverage` job | `900s` | Coverage should be visible as the dominant cost when it is truly required. |
+| `lane-selection` bucket | `60s` | Path policy and coverage-impact classification should stay cheap. |
+| `setup-install-cache` bucket | `240s` | Toolchain, cache, linker, and setup overhead should not dominate ordinary PRs. |
+| `tooling-contracts` bucket | `240s` | Shell/Python/skill contract checks should remain bounded. |
+| `rust-test-execution` bucket | `600s` | Rust test work should point to the focused or slow-proof lane responsible. |
+| `coverage-execution` bucket | `900s` | Coverage cost should be explicit and routed through coverage policy. |
+| `reporting-upload` bucket | `120s` | Artifacts and summaries should not dominate runtime. |
+
+## Operator Commands
+
+Capture GitHub Actions job timing JSON:
+
+```bash
+gh run view <run-id> --json jobs > .adl/tmp/ci-jobs.json
+```
+
+Render the default Markdown report:
+
+```bash
+python3 adl/tools/summarize_ci_runtime.py .adl/tmp/ci-jobs.json
+```
+
+Render machine-readable output for follow-on analysis:
+
+```bash
+python3 adl/tools/summarize_ci_runtime.py .adl/tmp/ci-jobs.json --format json
+```
+
+Override a budget for a one-off analysis:
+
+```bash
+python3 adl/tools/summarize_ci_runtime.py .adl/tmp/ci-jobs.json \
+  --job-budget adl-coverage=1200 \
+  --category-budget coverage-execution=1200
+```
+
+## Runtime Buckets
+
+The report groups steps into routing buckets:
+
+- `lane-selection`: `ci_path_policy` and coverage-impact classification.
+- `setup-install-cache`: Rust toolchain, cache, linker, `sccache`, and setup.
+- `tooling-contracts`: shell, docs, guardrail, and skill contract checks.
+- `rust-test-execution`: `fmt`, `clippy`, nextest, and doctest work.
+- `coverage-execution`: `cargo llvm-cov`, coverage gates, and coverage reports.
+- `reporting-upload`: stats, summaries, and uploaded artifacts.
+- `skipped-policy`: explicit policy skips/deferred proof messages.
+- `other`: uncategorized steps that may need a script update if they become
+  common.
+
+## Representative Before State
+
+The captured `#3032` nextest log remains the slow-cycle before-state for the
+runtime/test recovery lane:
+
+- declared run: `1,882` tests across `28` binaries
+- completed timing rows parsed: `1,881`
+- slow threshold markers: `77`
+- total parsed completed runtime: `7364.644s`
+- dominant cluster: `runtime-v2-contract-registry/accessors`
+- dominant cluster total: `1860.104s`
+
+That test-body hotspot is already summarized by:
+
+```bash
+python3 adl/tools/summarize_nextest_timings.py .adl/docs/TBD/test-logs.txt --top 12 --min-seconds 45
+```
+
+The CI runtime budget report complements that test-body report by showing
+whether future PR delay comes from setup, lane selection, test execution,
+coverage execution, or reporting.
+
+## Representative Fast Docs PR State
+
+PR `#3147` was a recent docs-only publication-backlog update. Its GitHub checks
+completed quickly:
+
+| Check | Started | Completed | Approx Runtime |
+| --- | --- | --- | ---: |
+| `adl-ci` | `2026-05-20T16:11:27Z` | `2026-05-20T16:11:39Z` | `12s` |
+| `adl-coverage` | `2026-05-20T16:11:43Z` | `2026-05-20T16:11:52Z` | `9s` |
+
+That is the desired shape for docs-only changes: path policy should skip Rust
+and coverage work while still leaving green check evidence.
+
+## Routing Rules
+
+- If `lane-selection` is over budget, inspect `adl/tools/ci_path_policy.sh`,
+  `adl/tools/check_coverage_impact.sh`, and their contract tests.
+- If `setup-install-cache` dominates, inspect toolchain install, cache restore,
+  linker setup, and `sccache` stats before blaming tests.
+- If `rust-test-execution` dominates, run
+  `adl/tools/summarize_nextest_timings.py` against the captured nextest log and
+  route to test refactor, selector policy, or slow-proof consolidation.
+- If `coverage-execution` dominates, inspect whether the PR truly needed full
+  coverage or should have used changed-source coverage impact.
+- If `tooling-contracts` dominates, split or focus the expensive shell/Python
+  contract check rather than widening Rust test policy.
+- If `reporting-upload` dominates, inspect artifact size and upload scope.
+
+## Validation
+
+Focused validation for this observability surface:
+
+```bash
+python3 -m py_compile adl/tools/summarize_ci_runtime.py
+bash adl/tools/test_summarize_ci_runtime.sh
+```
+
+Do not run a full Rust or coverage suite merely to prove this parser. Use
+captured GitHub Actions JSON, a fixture, or an existing slow-run artifact unless
+the issue being diagnosed independently requires a real rerun.
+
+## Non-Claims
+
+- This surface does not fix slow tests by itself.
+- This surface does not replace nextest hotspot diagnosis.
+- This surface does not replace coverage gates, release proof, or human review.
+- These budgets are routing thresholds, not final quality gates.

--- a/docs/milestones/v0.91.2/SLOW_TEST_TIMING_DIAGNOSTICS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SLOW_TEST_TIMING_DIAGNOSTICS_v0.91.2.md
@@ -14,6 +14,12 @@ path or replace the argument with the path to the captured log under review.
 This diagnostic path is evidence only. It does not replace passing tests,
 coverage gates, release proof, or authoritative slow-proof obligations.
 
+For job/step-level GitHub Actions runtime diagnosis, use the companion budget
+surface:
+
+- `docs/milestones/v0.91.2/CI_RUNTIME_BUDGETS_v0.91.2.md`
+- `adl/tools/summarize_ci_runtime.py`
+
 ## Operator Command
 
 ```bash

--- a/docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md
+++ b/docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md
@@ -8,7 +8,7 @@
 - Planned WP Home: WP-04, WP-05
 - Source Docs: `.adl/docs/TBD/tools/RUNTIME_V2_TEST_CYCLE_RECOVERY_PLAN.md`; `.adl/docs/TBD/v0.90.5_TEST_RUNTIME_REDUCTION_PLAN.md`
 - Proof Modes: CI evidence, tests, report
-- Current proof surfaces: `docs/milestones/v0.91.2/review/runtime_test_cycle_recovery_report.md`; `docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md`
+- Current proof surfaces: `docs/milestones/v0.91.2/review/runtime_test_cycle_recovery_report.md`; `docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md`; `docs/milestones/v0.91.2/CI_RUNTIME_BUDGETS_v0.91.2.md`
 
 ## Purpose
 
@@ -60,3 +60,8 @@ Post-sprint follow-on `#3133` continues this line by tightening the ordinary
 PR-fast nextest selector so structural module-barrel wiring, such as
 `adl/src/lib.rs`, does not force a full nextest sweep when the real changed
 runtime surface is still narrowly mapped.
+
+Post-sprint follow-on `#3134` adds job/step-level CI runtime budget
+observability so future slowdowns can be routed to lane selection, setup/cache,
+Rust test execution, coverage execution, tooling contracts, or reporting
+instead of being treated as anecdotal PR pain.


### PR DESCRIPTION
Closes #3134

## Summary
Added CI runtime-budget observability for GitHub Actions jobs and steps so slow
PR checks can be routed by lane-selection, setup/cache, test execution,
coverage execution, tooling contracts, or reporting overhead.

## Artifacts
- `adl/tools/summarize_ci_runtime.py`
- `adl/tools/test_summarize_ci_runtime.sh`
- `docs/milestones/v0.91.2/CI_RUNTIME_BUDGETS_v0.91.2.md`
- `.github/workflows/ci.yaml`
- `docs/milestones/v0.91.2/SLOW_TEST_TIMING_DIAGNOSTICS_v0.91.2.md`
- `docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md`

## Validation
- Validation commands and their purpose:
  - `python3 -m py_compile adl/tools/summarize_ci_runtime.py adl/tools/summarize_nextest_timings.py`
    Verified Python syntax for the new and companion parser scripts.
  - `bash adl/tools/test_summarize_ci_runtime.sh`
    Verified CI runtime budget parsing, bucket routing, and JSON/Markdown
    output on a fixture.
  - `bash adl/tools/test_summarize_nextest_timings.sh`
    Verified the existing nextest timing parser still passes.
  - `bash -n adl/tools/test_summarize_ci_runtime.sh`
    Verified shell syntax for the new test script.
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml")'`
    Verified the edited GitHub Actions workflow remains valid YAML.
  - `git diff --check`
    Verified whitespace cleanliness.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3134__v0-91-2-quality-add-ci-runtime-budget-and-regression-observability/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3134__v0-91-2-quality-add-ci-runtime-budget-and-regression-observability/sor.md
- Idempotency-Key: v0-91-2-quality-add-ci-runtime-budget-observability-github-workflows-ci-yaml-adl-tools-summarize-ci-runtime-py-adl-tools-test-summarize-ci-runtime-sh-docs-milestones-v0-91-2-ci-runtime-budgets-v0-91-2-md-docs-milestones-v0-91-2-slow-test-timing-diagnostics-v0-91-2-md-docs-milestones-v0-91-2-features-runtime-test-cycle-recovery-md-adl-v0-91-2-tasks-issue-3134-v0-91-2-quality-add-ci-runtime-budget-and-regression-observability-sip-md-adl-v0-91-2-tasks-issue-3134-v0-91-2-quality-add-ci-runtime-budget-and-regression-observability-sor-md