### PR TITLE
[v0.91.2][WP-22][security] Harden hosted benchmark adapters and artifacts

### DIFF
--- a/adl/tools/benchmark/hosted_provider_key_files.json
+++ b/adl/tools/benchmark/hosted_provider_key_files.json
@@ -1,8 +1,23 @@
 {
-  "schema_version": "adl.hosted_provider_key_files.v1",
+  "schema_version": "adl.hosted_provider_key_files.v2",
   "keys": {
-    "OPENAI_API_KEY": "/Users/daniel/keys/openai2.key",
-    "GEMINI_API_KEY": "/Users/daniel/keys/gcp-ace-2023.key",
-    "ANTHROPIC_API_KEY": "/Users/daniel/keys/ADL_demo_ref_04.txt"
+    "OPENAI_API_KEY": {
+      "source": "environment_or_file_env",
+      "env_var": "OPENAI_API_KEY",
+      "file_env_var": "ADL_OPENAI_API_KEY_FILE",
+      "example_rel_path": "secrets/openai_api_key.txt"
+    },
+    "GEMINI_API_KEY": {
+      "source": "environment_or_file_env",
+      "env_var": "GEMINI_API_KEY",
+      "file_env_var": "ADL_GEMINI_API_KEY_FILE",
+      "example_rel_path": "secrets/gemini_api_key.txt"
+    },
+    "ANTHROPIC_API_KEY": {
+      "source": "environment_or_file_env",
+      "env_var": "ANTHROPIC_API_KEY",
+      "file_env_var": "ADL_ANTHROPIC_API_KEY_FILE",
+      "example_rel_path": "secrets/anthropic_api_key.txt"
+    }
   }
 }

--- a/adl/tools/test_hosted_benchmark_hardening.sh
+++ b/adl/tools/test_hosted_benchmark_hardening.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - <<'PY'
+import importlib.util
+import json
+import pathlib
+import tempfile
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
+
+runner_path = pathlib.Path("adl/tools/uts_benchmark_runner.py")
+spec = importlib.util.spec_from_file_location("uts_benchmark_runner", runner_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+config_path = pathlib.Path("adl/tools/benchmark/hosted_provider_key_files.json")
+config_text = config_path.read_text(encoding="utf-8")
+config = json.loads(config_text)
+assert config["schema_version"] == "adl.hosted_provider_key_files.v2"
+for env_name in ("OPENAI_API_KEY", "GEMINI_API_KEY", "ANTHROPIC_API_KEY"):
+    entry = config["keys"][env_name]
+    assert isinstance(entry, dict), entry
+    assert entry["env_var"] == env_name, entry
+    assert entry["file_env_var"].startswith("ADL_"), entry
+for banned in ("/Users/", "/private/", "openai2.key", "gcp-ace-2023.key", "ADL_demo_ref_04.txt"):
+    assert banned not in config_text, banned
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    external = pathlib.Path(tmpdir) / "outside.json"
+    external.write_text("{}\n", encoding="utf-8")
+    shown = module.display_path(external)
+    assert shown.startswith("external/"), shown
+    assert str(external) not in shown, shown
+    assert "/private/" not in shown and "/Users/" not in shown, shown
+
+redacted = module.redact_artifact_excerpt('{"tool_call":{"name":"get_time","arguments":{}}}')
+assert "tool_call" not in redacted, redacted
+assert "get_time" not in redacted, redacted
+assert "sha256=" in redacted, redacted
+
+note = module.sanitize_artifact_note(
+    "provider_model_unavailable_or_error: OpenAI status=401: invalid api key at /Users/daniel/keys/openai2.key"
+)
+assert "OpenAI" not in note, note
+assert "401" not in note, note
+assert "/Users/" not in note, note
+assert ".key" not in note, note
+
+entry = {
+    "id": "hosted-test",
+    "provider_kind": "hosted",
+    "provider": "openai",
+    "model_id": "gpt-5.5",
+    "route": "openai",
+}
+task = {
+    "id": "get-time",
+    "kind": "tool_call",
+    "prompt": "Return a regular tool call for get_time with no arguments.",
+    "tool_name": "get_time",
+    "expected_arguments": {},
+    "optional_enum_arguments": {},
+    "require_exact_arguments": True,
+}
+
+original_invoke_model = module.invoke_model
+try:
+    module.invoke_model = lambda _entry, _prompt: ('{"tool_call":{"name":"get_time","arguments":{}}}', 11)
+    regular = module.run_lane(entry, [task], "regular")
+    case = regular["cases"][0]
+    assert case["passed"] is True, case
+    assert "get_time" not in case["raw_response_excerpt"], case
+    assert "sha256=" in case["raw_response_excerpt"], case
+
+    def raise_provider_error(_entry, _prompt):
+        raise RuntimeError(
+            "provider_model_unavailable_or_error: OpenAI status=401: invalid api key at /Users/daniel/keys/openai2.key"
+        )
+
+    module.invoke_model = raise_provider_error
+    failed = module.run_lane(entry, [task], "regular")
+    assert failed["status"] == "provider_failed", failed
+    assert failed["provider_failure_kind"] == "provider_auth_missing", failed
+    assert "/Users/" not in failed["note"], failed
+    assert "401" not in failed["note"], failed
+
+    governed = module.simplify_governed_result(
+        entry,
+        {
+            "run_status": "evaluated",
+            "scorecard": {"passed_count": 1, "total_cases": 1, "supports_governed_tool_use": True},
+            "cases": [
+                {
+                    "task_id": "governed-1",
+                    "classification": "ValidUsable",
+                    "passed": True,
+                    "duration_ms": 20,
+                    "raw_response_excerpt": '{"uts_proposal":{"tool_name":"get_time"}}',
+                    "notes": ["provider_model_unavailable_or_error: OpenAI status=500: upstream exploded"],
+                }
+            ],
+        },
+    )
+    governed_case = governed["cases"][0]
+    assert "uts_proposal" not in governed_case["raw_response_excerpt"], governed_case
+    assert "500" not in governed_case["note"], governed_case
+
+    with module.hosted_ollama_adapter(entry) as host:
+        parsed = urlparse(host)
+        assert parsed.path and parsed.path != "/", host
+        blocked_url = f"http://127.0.0.1:{parsed.port}/api/tags"
+        try:
+            urllib.request.urlopen(blocked_url)
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 403, exc.code
+        else:
+            raise AssertionError("adapter should reject requests without the bearer path token")
+
+        with urllib.request.urlopen(host + "/api/tags") as response:
+            doc = json.loads(response.read().decode("utf-8"))
+        assert doc["models"][0]["name"] == "gpt-5.5", doc
+finally:
+    module.invoke_model = original_invoke_model
+PY
+
+echo "Hosted benchmark hardening contracts verified."

--- a/adl/tools/uts_benchmark_runner.py
+++ b/adl/tools/uts_benchmark_runner.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import http.server
 import json
 import os
+import secrets
 import socket
 import shutil
 import subprocess
@@ -92,10 +94,12 @@ def load_json(path: Path) -> dict[str, Any]:
 
 
 def display_path(path: Path) -> str:
+    resolved = path.resolve()
     try:
-        return str(path.resolve().relative_to(REPO_ROOT))
+        return str(resolved.relative_to(REPO_ROOT))
     except ValueError:
-        return str(path)
+        name = resolved.name or "external-path"
+        return f"external/{safe_name(name)}"
 
 
 def utc_timestamp() -> str:
@@ -124,6 +128,38 @@ def select_models(panel: dict[str, Any], provider_kind: str, wanted_ids: list[st
 
 def safe_name(value: str) -> str:
     return "".join(char if char.isalnum() or char in "-._" else "_" for char in value)
+
+
+def redact_artifact_excerpt(raw: Any) -> str:
+    text = str(raw or "").strip()
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+    return f"[redacted response len={len(text)} sha256={digest}]"
+
+
+def sanitize_artifact_note(note: Any, failure_kind: str | None = None) -> str:
+    text = " ".join(str(note or "").split())
+    if not text:
+        return ""
+    kind = failure_kind or provider_failure_kind(text)
+    if kind:
+        return f"{kind} (redacted provider detail)"
+    redaction_markers = (
+        "/Users/",
+        "/private/",
+        ".key",
+        "api key",
+        "x-api-key",
+        "x-goog-api-key",
+        "authorization",
+        "bearer ",
+    )
+    lowered = text.lower()
+    if any(marker.lower() in lowered for marker in redaction_markers):
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+        return f"[redacted diagnostic len={len(text)} sha256={digest}]"
+    if len(text) > 160:
+        return text[:157] + "..."
+    return text
 
 
 def task_rows(task_panel: dict[str, Any]) -> list[dict[str, Any]]:
@@ -204,12 +240,12 @@ def matches_expected_arguments(args: dict[str, Any], task: dict[str, Any]) -> bo
     return True
 
 
-def read_key_file_map() -> dict[str, str]:
+def read_key_file_map() -> dict[str, Any]:
     path = Path(os.getenv("ADL_HOSTED_PROVIDER_KEYS_FILE", str(DEFAULT_KEY_FILES))).expanduser()
     if not path.is_file():
         return {}
     doc = load_json(path)
-    return {str(k): str(v) for k, v in (doc.get("keys") or {}).items()}
+    return {str(k): v for k, v in (doc.get("keys") or {}).items()}
 
 
 def extract_key_value(env_name: str, path: Path) -> str:
@@ -224,12 +260,28 @@ def extract_key_value(env_name: str, path: Path) -> str:
     return ""
 
 
+def hosted_key_file_env_var(env_name: str, entry: Any) -> str:
+    if isinstance(entry, dict):
+        file_env = entry.get("file_env_var")
+        if isinstance(file_env, str) and file_env:
+            return file_env
+    return f"ADL_{env_name}_FILE"
+
+
 def hosted_key(env_name: str) -> str:
     if os.getenv(env_name):
         return os.environ[env_name]
-    key_path = read_key_file_map().get(env_name)
-    if not key_path:
-        raise RuntimeError(f"missing required environment variable or key-file mapping: {env_name}")
+    entry = read_key_file_map().get(env_name)
+    key_path: str | None
+    if isinstance(entry, str):
+        key_path = entry
+    else:
+        file_env_var = hosted_key_file_env_var(env_name, entry)
+        key_path = os.getenv(file_env_var)
+        if not key_path:
+            raise RuntimeError(
+                f"missing required environment variable {env_name} or hosted key-file env {file_env_var}"
+            )
     path = Path(key_path).expanduser()
     if not path.is_file() or path.stat().st_size == 0:
         raise RuntimeError(f"configured key file is missing or empty for {env_name}")
@@ -473,12 +525,14 @@ def classify_uts(task: dict[str, Any], parsed: Any) -> tuple[str, bool, str]:
 
 def provider_failure_kind(note: str) -> str | None:
     lower = note.lower()
+    if "api_key" in lower or "api key" in lower or "unauthorized" in lower or "missing required environment variable" in lower:
+        return "provider_auth_missing"
+    if "missing or empty" in lower and "key file" in lower:
+        return "provider_auth_missing"
     if "does not exist" in lower or "model" in lower and "not" in lower and "found" in lower:
         return "provider_model_unavailable"
     if "credit balance" in lower or "billing" in lower:
         return "provider_billing_blocked"
-    if "api_key" in lower or "api key" in lower or "unauthorized" in lower:
-        return "provider_auth_missing"
     if "timed out" in lower:
         return "provider_timeout"
     if "provider_" in lower or "status=" in lower:
@@ -536,7 +590,10 @@ def run_lane(entry: dict[str, Any], tasks: list[dict[str, Any]], lane: str) -> d
             duration_ms = None
             classification = "runtime_or_parse_failure"
             passed = False
-            note = str(exc)
+            failure_kind = provider_failure_kind(raw)
+            note = sanitize_artifact_note(raw, failure_kind)
+        else:
+            failure_kind = None
         cases.append({
             "task_id": task["id"],
             "started_at": case_started_at,
@@ -544,10 +601,11 @@ def run_lane(entry: dict[str, Any], tasks: list[dict[str, Any]], lane: str) -> d
             "classification": classification,
             "passed": passed,
             "duration_ms": duration_ms,
-            "raw_response_excerpt": raw[:400],
+            "raw_response_excerpt": redact_artifact_excerpt(raw),
+            "provider_failure_kind": failure_kind,
             "note": note,
         })
-    failure_kinds = [provider_failure_kind(str(case["note"])) for case in cases if case["classification"] == "runtime_or_parse_failure"]
+    failure_kinds = [case.get("provider_failure_kind") for case in cases if case["classification"] == "runtime_or_parse_failure"]
     if len(failure_kinds) == len(cases) and failure_kinds and all(kind == failure_kinds[0] and kind for kind in failure_kinds):
         return {"status": "provider_failed", "provider_failure_kind": failure_kinds[0], "started_at": lane_started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": cases[0]["note"]}
     passed_count = sum(1 for case in cases if case["passed"])
@@ -594,10 +652,24 @@ def free_port() -> int:
 
 @contextlib.contextmanager
 def hosted_ollama_adapter(entry: dict[str, Any]):
+    token = secrets.token_urlsafe(18)
+    prefix = f"/adapter/{token}"
+
     class Handler(http.server.BaseHTTPRequestHandler):
+        def _authorized_path(self, suffix: str) -> bool:
+            return self.path == f"{prefix}{suffix}"
+
+        def _write_json(self, status: int, payload: dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
         def do_GET(self) -> None:
-            if self.path == "/api/tags":
-                body = json.dumps({
+            if self._authorized_path("/api/tags") or self._authorized_path("/api/ps"):
+                self._write_json(200, {
                     "models": [
                         {
                             "name": entry["model_id"],
@@ -608,21 +680,14 @@ def hosted_ollama_adapter(entry: dict[str, Any]):
                             "details": {"family": "hosted"},
                         }
                     ]
-                }).encode("utf-8")
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
+                })
                 return
-            body = json.dumps({"error": "not found"}).encode("utf-8")
-            self.send_response(404)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+            self._write_json(403, {"error": "adapter token required"})
 
         def do_POST(self) -> None:
+            if not self._authorized_path("/api/generate"):
+                self._write_json(403, {"error": "adapter token required"})
+                return
             try:
                 length = int(self.headers.get("Content-Length", "0"))
                 payload = json.loads(self.rfile.read(length).decode("utf-8")) if length else {}
@@ -631,19 +696,10 @@ def hosted_ollama_adapter(entry: dict[str, Any]):
                 routed = dict(entry)
                 routed["model_id"] = model
                 output, _ = invoke_hosted(routed, prompt)
-                body = json.dumps({"response": output, "done": True}).encode("utf-8")
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
+                self._write_json(200, {"response": output, "done": True})
             except Exception as exc:  # noqa: BLE001
-                body = json.dumps({"error": str(exc)}).encode("utf-8")
-                self.send_response(502)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
+                failure_kind = provider_failure_kind(str(exc))
+                self._write_json(502, {"error": sanitize_artifact_note(str(exc), failure_kind)})
 
         def log_message(self, _format: str, *args: Any) -> None:
             return
@@ -653,7 +709,7 @@ def hosted_ollama_adapter(entry: dict[str, Any]):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        yield f"http://127.0.0.1:{port}"
+        yield f"http://127.0.0.1:{port}{prefix}"
     finally:
         server.shutdown()
         server.server_close()
@@ -663,7 +719,14 @@ def hosted_ollama_adapter(entry: dict[str, Any]):
 def simplify_governed_result(entry: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
     cases = []
     for case in result.get("cases", []):
-        cases.append({"task_id": case.get("task_id"), "classification": case.get("classification"), "passed": bool(case.get("passed")), "duration_ms": case.get("duration_ms"), "raw_response_excerpt": case.get("raw_response_excerpt"), "note": "; ".join(case.get("notes", []))})
+        cases.append({
+            "task_id": case.get("task_id"),
+            "classification": case.get("classification"),
+            "passed": bool(case.get("passed")),
+            "duration_ms": case.get("duration_ms"),
+            "raw_response_excerpt": redact_artifact_excerpt(case.get("raw_response_excerpt")),
+            "note": sanitize_artifact_note("; ".join(case.get("notes", []))),
+        })
     scorecard = result.get("scorecard") or {}
     run_status = str(result.get("run_status", "")).lower()
     if run_status == "skipped":
@@ -679,6 +742,17 @@ def simplify_governed_result(entry: dict[str, Any], result: dict[str, Any]) -> d
             "note": "governed runner returned no scorecard and no cases",
         }
     return {"status": "evaluated", "passed_count": scorecard.get("passed_count", 0), "total_cases": scorecard.get("total_cases", len(cases)), "full_support": bool(scorecard.get("supports_governed_tool_use", False)), "cases": cases}
+
+
+def sanitize_governed_raw_artifact(doc: dict[str, Any]) -> dict[str, Any]:
+    for model in doc.get("models", []):
+        for case in model.get("cases", []):
+            if "raw_response_excerpt" in case:
+                case["raw_response_excerpt"] = redact_artifact_excerpt(case.get("raw_response_excerpt"))
+            notes = case.get("notes")
+            if isinstance(notes, list):
+                case["notes"] = [sanitize_artifact_note(note) for note in notes]
+    return doc
 
 
 def run_governed_lane(entry: dict[str, Any], task_panel_file: Path, raw_path: Path) -> dict[str, Any]:
@@ -704,16 +778,17 @@ def run_governed_lane(entry: dict[str, Any], task_panel_file: Path, raw_path: Pa
         note = f"governed subprocess timed out after {timeout}s"
         if exc.stderr:
             note += f": {str(exc.stderr)[:300]}"
-        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_timeout", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": note, "raw_artifact": display_path(raw_path)}
+        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_timeout", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": sanitize_artifact_note(note, "governed_runner_timeout"), "raw_artifact": display_path(raw_path)}
     except Exception as exc:  # noqa: BLE001
-        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_failed", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": str(exc), "raw_artifact": display_path(raw_path)}
+        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_failed", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": sanitize_artifact_note(str(exc), "governed_runner_failed"), "raw_artifact": display_path(raw_path)}
     if completed.returncode != 0:
         note = (completed.stderr or completed.stdout or "governed subprocess failed")[:500].replace("\n", " ")
-        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_failed", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": note, "raw_artifact": display_path(raw_path)}
+        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_failed", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": sanitize_artifact_note(note, "governed_runner_failed"), "raw_artifact": display_path(raw_path)}
     try:
-        doc = load_json(raw_path)
+        doc = sanitize_governed_raw_artifact(load_json(raw_path))
+        raw_path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
     except Exception as exc:  # noqa: BLE001
-        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_bad_output", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": str(exc), "raw_artifact": display_path(raw_path)}
+        return {"status": "provider_failed", "provider_failure_kind": "governed_runner_bad_output", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": sanitize_artifact_note(str(exc), "governed_runner_bad_output"), "raw_artifact": display_path(raw_path)}
     models = doc.get("models", [])
     if not models:
         return {"status": "provider_failed", "provider_failure_kind": "governed_runner_empty", "started_at": started_at, "completed_at": utc_timestamp(), "passed_count": 0, "total_cases": 0, "full_support": False, "cases": [], "note": "governed runner wrote no model results", "raw_artifact": display_path(raw_path)}
@@ -785,7 +860,7 @@ def write_artifacts(report: dict[str, Any], out_path: Path) -> None:
                 f"- Completed: `{lane.get('completed_at')}`",
                 f"- Note: `{lane.get('note', '')}`",
                 "",
-                "| Task | Passed | Classification | Duration ms | Note | Raw response excerpt |",
+                "| Task | Passed | Classification | Duration ms | Note | Redacted response marker |",
                 "|---|---:|---|---:|---|---|",
             ])
             cases = lane.get("cases", [])

--- a/docs/milestones/v0.91.2/review/uts_benchmark_evidence/README.md
+++ b/docs/milestones/v0.91.2/review/uts_benchmark_evidence/README.md
@@ -19,6 +19,9 @@ Current benchmark-validity guards:
 - requested model IDs must exist in the canonical model panel before a run starts
 - governed fail-closed tasks only pass on explicit refusal; a forbidden proposal rejected downstream by ACC is still a benchmark failure
 - the runner exits nonzero when any required lane does not reach `evaluated`, so provider/lane failures cannot be mistaken for proof
+- hosted-provider setup is environment-driven; the canonical key-file template no longer records operator-local absolute key paths
+- hosted governed-lane adapter traffic is token-guarded on localhost instead of exposing an unauthenticated loopback bridge
+- current durable benchmark artifacts store redacted response markers and redacted provider-failure summaries rather than raw hosted model output
 
 ## Historical artifacts
 
@@ -45,3 +48,19 @@ Expected output includes:
 ```
 
 Fresh benchmark rows should be produced under `artifacts/uts_runs/` and must include JSON, summary, details, provider status, and self-check artifacts as described in the runbook.
+
+## Hosted credential setup
+
+Use either direct provider environment variables or provider-specific file-path
+environment variables. The canonical config template is:
+
+- `adl/tools/benchmark/hosted_provider_key_files.json`
+
+Supported file-path environment variables are:
+
+- `ADL_OPENAI_API_KEY_FILE`
+- `ADL_GEMINI_API_KEY_FILE`
+- `ADL_ANTHROPIC_API_KEY_FILE`
+
+Do not commit machine-local credential paths into the template or benchmark
+evidence docs.

--- a/docs/milestones/v0.91.2/review/uts_benchmark_evidence/RUNBOOK.md
+++ b/docs/milestones/v0.91.2/review/uts_benchmark_evidence/RUNBOOK.md
@@ -12,6 +12,30 @@ python3 adl/tools/uts_benchmark_runner.py <provider-kind> <models-file> <out-jso
 
 `adl/tools/run_uts_benchmark.sh` is only a convenience wrapper around the canonical runner. The old lane-specific Python scripts are retired and are not supported entrypoints.
 
+## Hosted provider credentials
+
+Use provider environment variables directly when possible:
+
+- `OPENAI_API_KEY`
+- `GEMINI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
+If a file-backed setup is needed, use the provider-specific file-path
+environment variables referenced by the canonical template:
+
+- `ADL_OPENAI_API_KEY_FILE`
+- `ADL_GEMINI_API_KEY_FILE`
+- `ADL_ANTHROPIC_API_KEY_FILE`
+
+The canonical template file is:
+
+```text
+adl/tools/benchmark/hosted_provider_key_files.json
+```
+
+That template is intentionally portable and must not contain operator-local
+absolute paths.
+
 ## Required panels
 
 The canonical model and task panels are:
@@ -68,10 +92,11 @@ python3 adl/tools/uts_benchmark_runner.py \
 Local smoke should use a one-model file and must run when `ollama ps` is clean:
 
 ```bash
-printf 'Qwen3.5:35b-a3b\n' > /tmp/uts_one_local_model.txt
+mkdir -p artifacts/uts_runs/model_lists
+printf 'Qwen3.5:35b-a3b\n' > artifacts/uts_runs/model_lists/uts_one_local_model.txt
 python3 adl/tools/uts_benchmark_runner.py \
   local \
-  /tmp/uts_one_local_model.txt \
+  artifacts/uts_runs/model_lists/uts_one_local_model.txt \
   artifacts/uts_runs/utsbench_smoke_local_qwen35.json \
   --no-resume
 ```
@@ -96,6 +121,11 @@ Governed scoring rules that matter for proof:
 - must-compile tasks must match the canonical expected arguments, not just the tool name and wrapper shape
 - fail-closed tasks pass only on explicit refusal
 - a forbidden proposal that ACC later rejects is still a benchmark failure, not a refusal success
+
+Hosted governed runs now use an ephemeral token-guarded localhost adapter
+bridge. The adapter still binds to `127.0.0.1`, but requests without the
+randomized per-run path token are rejected instead of being forwarded to the
+backing hosted provider.
 
 ## Full hosted run
 
@@ -123,10 +153,11 @@ Expected clean output has no resident model rows.
 Use a one-model file per run:
 
 ```bash
-printf 'Qwen3.5:35b-a3b\n' > /tmp/uts_one_local_model.txt
+mkdir -p artifacts/uts_runs/model_lists
+printf 'Qwen3.5:35b-a3b\n' > artifacts/uts_runs/model_lists/uts_one_local_model.txt
 python3 adl/tools/uts_benchmark_runner.py \
   local \
-  /tmp/uts_one_local_model.txt \
+  artifacts/uts_runs/model_lists/uts_one_local_model.txt \
   artifacts/uts_runs/utsbench_local_qwen35.json \
   --include-governed \
   --no-resume
@@ -141,11 +172,12 @@ Repeat the same pattern for each local model. Never run `deepseek-r1:32b` on wuj
 Use `OLLAMA_HOST` for the remote AI node. DeepSeek is the required remote model:
 
 ```bash
-printf 'deepseek-r1:32b\n' > /tmp/uts_remote_deepseek_only.txt
+mkdir -p artifacts/uts_runs/model_lists
+printf 'deepseek-r1:32b\n' > artifacts/uts_runs/model_lists/uts_remote_deepseek_only.txt
 OLLAMA_HOST=http://192.168.68.77:11434 \
 python3 adl/tools/uts_benchmark_runner.py \
   local \
-  /tmp/uts_remote_deepseek_only.txt \
+  artifacts/uts_runs/model_lists/uts_remote_deepseek_only.txt \
   artifacts/uts_runs/utsbench_remote_deepseek.json \
   --include-governed \
   --no-resume
@@ -178,6 +210,13 @@ When `--include-governed` is used, governed raw artifacts are also written under
 ```text
 artifacts/uts_runs/utsbench_hosted_core_governed_raw/
 ```
+
+Current runner artifacts are hardened for portability and review:
+
+- non-repo paths are serialized as bounded external markers instead of absolute
+  host paths
+- raw model output is replaced with redacted response markers
+- provider failure details are reduced to bounded failure summaries
 
 ## Validity checks
 


### PR DESCRIPTION
Closes #3176

## Summary
Completed the bounded hosted benchmark security, privacy, and portability
remediation pass for `#3176`.

The issue now:

- replaces the committed hosted-provider key-path map with a portable
  environment-driven template
- keeps hosted key lookup compatible with direct provider env vars plus
  provider-specific file-path env vars instead of machine-local committed paths
- token-guards the ephemeral localhost hosted adapter used by the governed
  hosted lane so unauthenticated loopback requests are rejected by default
- redacts durable response excerpts and provider-failure details in the current
  canonical Python benchmark artifacts
- normalizes non-repo paths into bounded external markers instead of emitting
  absolute host paths into current supported artifact surfaces
- updates the supported hosted benchmark docs so setup and example paths stay
  portable and do not require private absolute-path conventions

## Artifacts
- Updated tracked hosted benchmark config and runner surfaces:
  - `adl/tools/benchmark/hosted_provider_key_files.json`
  - `adl/tools/uts_benchmark_runner.py`
- Added tracked focused hardening contract test:
  - `adl/tools/test_hosted_benchmark_hardening.sh`
- Updated tracked supported hosted benchmark evidence docs:
  - `docs/milestones/v0.91.2/review/uts_benchmark_evidence/README.md`
  - `docs/milestones/v0.91.2/review/uts_benchmark_evidence/RUNBOOK.md`
- Updated local ignored issue cards:
  - `.adl/v0.91.2/tasks/issue-3176__v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts/spp.md`
  - `.adl/v0.91.2/tasks/issue-3176__v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts/srp.md`
  - `.adl/v0.91.2/tasks/issue-3176__v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh run 3176 --slug v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts --version v0.91.2 --allow-open-pr-wave`
    Bound the issue branch and worktree for the hosted benchmark hardening pass.
  - `bash adl/tools/test_hosted_benchmark_hardening.sh`
    Verified portable key-template shape, artifact redaction, path normalization, provider-note sanitization, governed result simplification, and token-guarded localhost adapter behavior.
  - `bash adl/tools/test_uts_benchmark_runner_contracts.sh`
    Verified the broader benchmark runner contract still passes after the hosted hardening changes.
  - `python3 -m py_compile adl/tools/uts_benchmark_runner.py`
    Verified the hardened Python runner remains syntactically valid.
  - `python3 - <<'PY'`
    Verified the canonical hosted benchmark config and supported benchmark docs no longer contain operator-home path prefixes, private temp-path examples, or the old key filenames.
  - `git diff --check`
    Verified whitespace cleanliness for the tracked config, runner, test, and doc diff.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3176__v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3176__v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts/sor.md
- Idempotency-Key: v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts-adl-v0-91-2-tasks-issue-3176-v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts-sip-md-adl-v0-91-2-tasks-issue-3176-v0-91-2-wp-22-security-harden-hosted-benchmark-adapters-and-artifacts-sor-md