### PR TITLE
[v0.91.2][WP-22][docs] Make WP-20B the controlling review packet

### DIFF
--- a/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
@@ -35,6 +35,17 @@ Sprint 4 work lands.
 | Full authoritative coverage evidence | `pass` | `bash adl/tools/run_authoritative_coverage_lane.sh` completed during WP-18 with `2066` tests passed, `2` skipped, and `coverage-summary.json` emitted | Full release coverage has now been captured explicitly for the current milestone state; this still does not replace later Sprint 4 review/remediation/ceremony work. |
 | Release-tail review/remediation/ceremony | `not_ready` | `WP-19` docs review is closed; `WP-20` through `WP-24` remain open in Sprint 4 | The milestone cannot close from WP-18 alone. |
 
+## Controlling Review Packet Note
+
+For Sprint 4 review and remediation routing, the controlling internal-review
+surface is:
+
+- `docs/milestones/v0.91.2/review/internal_review_full/`
+
+The older thin `WP-20` packet under `review/internal_review/` remains
+background context only and must not be treated as the controlling
+external-review or remediation handoff surface.
+
 ## Required Inputs Before Final Pass/Fail Judgment
 
 - demo matrix and feature-proof coverage

--- a/docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md
@@ -24,6 +24,8 @@ Track the milestone package and proof surfaces required for a truthful
 - Workspace/modernization/publication/doc/guardrail packets
 - demo/proof convergence and bounded code-feature demo follow-on packets
 - quality-gate packet and authoritative coverage evidence
+- controlling internal-review packet and findings under `review/internal_review_full/`
+- external-review handoff and remediation routing docs tied to the `WP-20B` packet
 
 ## Current Judgment
 
@@ -31,3 +33,7 @@ This is an in-progress release evidence index. It records substantial landed
 evidence through `WP-19`, but it is not a
 final release verdict until `WP-20` through `WP-24` complete internal/external review,
 remediation, handoff, release-evidence, and ceremony work.
+
+The thin `WP-20` packet under `review/internal_review/` is retained for
+historical context, but it is not the controlling review packet for this
+release-tail path.

--- a/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
@@ -25,6 +25,8 @@ Not release ready.
 - Sprint 1 `#3025`, Sprint 2 `#3026`, and Sprint 3 `#3027` are closed
 - Sprint 4 umbrella `#3028` remains open; `WP-20` through `WP-24` remain pending
 - no final release proof, review, or ceremony state exists yet
+- the controlling internal-review packet for the remaining handoff/remediation path is `docs/milestones/v0.91.2/review/internal_review_full/`
+- the older thin `WP-20` packet remains background context only and is not sufficient as the release-tail handoff surface by itself
 
 ## Current Blockers
 

--- a/docs/milestones/v0.91.2/review/internal_review/REVIEW_PACKET.md
+++ b/docs/milestones/v0.91.2/review/internal_review/REVIEW_PACKET.md
@@ -1,10 +1,15 @@
 # v0.91.2 WP-20 Internal Review Packet
 
+Status: superseded as the controlling handoff surface by
+`docs/milestones/v0.91.2/review/internal_review_full/`.
+
 ## Verdict
 
-`v0.91.2` is ready to proceed to WP-21 external / third-party review.
+This thinner `WP-20` packet is no longer the controlling readiness or handoff
+surface for `WP-21`.
 
-It is not release-ready yet, and the docs correctly say so.
+Use the `WP-20B` full internal review packet and its findings as the controlling
+input for external-review handoff and `WP-22` remediation routing.
 
 ## What Passed Internal Review
 
@@ -22,4 +27,7 @@ It is not release-ready yet, and the docs correctly say so.
 
 ## Recommendation
 
-Proceed to WP-21 external review with the findings and non-claims in this packet. Route accepted findings to WP-22 or explicit follow-on issues before WP-24 release ceremony.
+Do not treat this packet alone as authorization to proceed. If `WP-21`
+continues, it must do so using the `WP-20B` full packet, its findings register,
+and its non-claims as the controlling evidence surface. Route accepted findings
+to `WP-22` or explicit follow-on issues before the `WP-24` release ceremony.

--- a/docs/milestones/v0.91.2/review/internal_review/REVIEW_REPORT.md
+++ b/docs/milestones/v0.91.2/review/internal_review/REVIEW_REPORT.md
@@ -1,8 +1,11 @@
 # v0.91.2 WP-20 Internal Review Report
 
+Status: superseded as the controlling `WP-21` handoff surface by
+`docs/milestones/v0.91.2/review/internal_review_full/`.
+
 ## Verdict
 
-Proceed to WP-21 external review.
+Do not treat this thin `WP-20` report as the controlling go-forward signal.
 
 Do not claim release readiness yet.
 
@@ -19,4 +22,5 @@ Do not claim release readiness yet.
 
 ## Next Step
 
-Start WP-21 external / third-party review using `WP21_EXTERNAL_REVIEW_HANDOFF.md`.
+If `WP-21` continues, use `WP21_EXTERNAL_REVIEW_HANDOFF.md` together with the
+`WP-20B` full internal review packet as the controlling evidence surface.

--- a/docs/milestones/v0.91.2/review/internal_review/WP21_EXTERNAL_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.2/review/internal_review/WP21_EXTERNAL_REVIEW_HANDOFF.md
@@ -2,7 +2,24 @@
 
 ## Recommended Status
 
-Proceed to WP-21 external / third-party review.
+Proceed only with the `WP-20B` full internal review packet as the controlling
+evidence surface.
+
+The older thin `WP-20` packet remains useful as background context, but it is
+not the controlling readiness surface for this handoff.
+
+## Controlling Packet
+
+- `docs/milestones/v0.91.2/review/internal_review_full/README.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/SYNTHESIS_REPORT.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/FINDINGS_REGISTER.md`
+
+## Reviewer Non-Claims
+
+- Do not treat this handoff as release approval.
+- Do not treat the benchmark claims as publication-ready superiority claims.
+- Do not treat hosted-provider benchmark artifacts as public-safe unless the
+  `WP-22` remediation issues land or are explicitly bounded.
 
 ## External Review Focus
 
@@ -14,6 +31,7 @@ Proceed to WP-21 external / third-party review.
 - publication-program and general-intelligence-paper unsupported-claim boundaries
 - workflow guardrail proof strength
 - retained `#3121` closeout-truth gap routing
+- the `WP-20B` findings register and its grouped remediation routes
 
 ## Do Not Ask External Review To Accept
 

--- a/docs/milestones/v0.91.2/review/internal_review/WP22_REMEDIATION_QUEUE.md
+++ b/docs/milestones/v0.91.2/review/internal_review/WP22_REMEDIATION_QUEUE.md
@@ -1,9 +1,25 @@
 # v0.91.2 WP-22 Remediation Queue Draft
 
+Controlling upstream packet:
+- `docs/milestones/v0.91.2/review/internal_review_full/`
+
 ## Accepted Internal Review Items To Route
 
 1. Retained `#3121` closeout residue must be fixed or explicitly deferred with final release-tail owner.
 2. WP-21/WP-22 handoff must preserve release non-claims and prevent review/remediation from being mistaken for release approval.
+
+## Grouped Remediation Routing
+
+- Benchmark validity and failure-gate truth:
+  - `#3175`
+- Hosted-provider security and artifact portability:
+  - `#3176`
+- Controlling packet, handoff truth, and release-tail evidence routing:
+  - `#3177`
+- CI pinning and validation reproducibility:
+  - `#3178`
+- Provider native-tool capability reporting:
+  - `#3179`
 
 ## Candidate Follow-On Routing
 

--- a/docs/milestones/v0.91.2/review/uts_remote_open_model_evidence_memo_2026-05-20.md
+++ b/docs/milestones/v0.91.2/review/uts_remote_open_model_evidence_memo_2026-05-20.md
@@ -103,19 +103,20 @@ Before making a stronger public claim, the benchmark should add more remote rows
 
 ## Evidence sources used
 
-Main remote row artifacts:
+This memo currently depends on historical non-portable working artifacts rather
+than tracked benchmark evidence. Treat the strongest rows here as
+historical/non-public support, not as the canonical release-facing proof path.
 
-- `/private/tmp/uts-toolkit-gemma431-remote-v1.json`
-- `/private/tmp/uts-acc-gemma431-remote-v3.json`
-- `/private/tmp/uts-toolkit-gemma426-remote-v1.json`
-- `/private/tmp/uts-toolkit-gemma327b-remote-v1.json`
-- `/private/tmp/uts-toolkit-qwen3coder30b-remote-v1.json`
-- `/private/tmp/uts-toolkit-gemma4e4b-remote-v1.json`
-- `/private/tmp/uts-toolkit-gemma4e2b-remote-v1.json`
-- `/private/tmp/uts-toolkit-deepseek32-remote-v3.json`
-- `/private/tmp/uts-acc-deepseek32-remote-v4.json`
-- `/private/tmp/uts-toolkit-gptoss-remote-v1.json`
-- `/private/tmp/uts-toolkit-qwen330b-remote-v1.json`
+Historical working evidence families used:
+
+- Gemma 4 31B remote toolkit and governed working rows
+- Gemma 4 26B and 27B remote toolkit working rows
+- Qwen3 Coder 30B and Qwen3 30B remote toolkit working rows
+- DeepSeek 32B remote toolkit and governed working rows
+- GPT-OSS remote toolkit working row
+
+Canonical release-facing benchmark proof should instead route through the
+tracked benchmark runbook and the current supported benchmark evidence packet.
 
 ## Bottom line
 


### PR DESCRIPTION
Closes #3177

## Summary
Completed the bounded docs and evidence-routing pass for `#3177`.

The issue now:

- makes `docs/milestones/v0.91.2/review/internal_review_full/` the explicit
  controlling internal-review packet for `WP-21` and `WP-22`
- downgrades the thin `WP-20` review packet and report to background context
  instead of an authoritative proceed-to-WP-21 surface
- updates the `WP-21` external handoff and `WP-22` remediation queue to point
  at the `WP-20B` packet and the grouped remediation issue set
- downgrades the remote UTS memo's non-portable working evidence references to
  historical/non-public support instead of release-facing proof
- updates release-tail docs so the controlling internal-review packet is named
  explicitly rather than implied

## Artifacts
- Updated tracked handoff and release-tail docs:
  - `docs/milestones/v0.91.2/review/internal_review/REVIEW_PACKET.md`
  - `docs/milestones/v0.91.2/review/internal_review/REVIEW_REPORT.md`
  - `docs/milestones/v0.91.2/review/internal_review/WP21_EXTERNAL_REVIEW_HANDOFF.md`
  - `docs/milestones/v0.91.2/review/internal_review/WP22_REMEDIATION_QUEUE.md`
  - `docs/milestones/v0.91.2/review/uts_remote_open_model_evidence_memo_2026-05-20.md`
  - `docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md`
  - `docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md`
  - `docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md`
- Updated local ignored issue cards:
  - `.adl/v0.91.2/tasks/issue-3177__v0-91-2-wp-20b-controlling-packet-and-handoff-truth/spp.md`
  - `.adl/v0.91.2/tasks/issue-3177__v0-91-2-wp-20b-controlling-packet-and-handoff-truth/srp.md`
  - `.adl/v0.91.2/tasks/issue-3177__v0-91-2-wp-20b-controlling-packet-and-handoff-truth/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh run 3177 --slug v0-91-2-wp-20b-controlling-packet-and-handoff-truth --version v0.91.2 --allow-open-pr-wave`
    Bound the issue branch and worktree for the controlling-packet docs pass.
  - `rg -n 'Proceed to WP-21|Proceed to WP-21 external|ready to proceed to WP-21|Start WP-21 external' docs/milestones/v0.91.2/review/internal_review docs/milestones/v0.91.2/review/internal_review_full docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md`
    Verified the touched handoff and release-tail docs no longer contain stale thin-packet proceed language.
  - `rg -n '<private-temp-path-patterns>' docs/milestones/v0.91.2/review/internal_review docs/milestones/v0.91.2/review/internal_review_full docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md docs/milestones/v0.91.2/review/uts_remote_open_model_evidence_memo_2026-05-20.md`
    Verified the touched release-facing docs no longer contain private temp-path evidence references.
  - `git diff --check`
    Verified whitespace cleanliness for the tracked docs diff.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3177__v0-91-2-wp-20b-controlling-packet-and-handoff-truth/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3177__v0-91-2-wp-20b-controlling-packet-and-handoff-truth/sor.md
- Idempotency-Key: v0-91-2-wp-22-docs-make-wp-20b-the-controlling-review-packet-adl-v0-91-2-tasks-issue-3177-v0-91-2-wp-20b-controlling-packet-and-handoff-truth-sip-md-adl-v0-91-2-tasks-issue-3177-v0-91-2-wp-20b-controlling-packet-and-handoff-truth-sor-md