### PR TITLE
[v0.91.2][WP-21][docs] Normalize review handoff truth before external review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ Planning notes:
   CodeFriend productization, Workspace bridge work, modernization, publication
   packets, rustdoc/doc cleanup, repo-visibility follow-on work, and workflow
   guardrails.
-- Sprint 4 release-tail work has landed through `WP-18`: demo/proof
-  convergence, the bounded `WP-17A` code-feature demo follow-on, and the
-  quality-gate packet are closed. `WP-19` closes the docs review pass and
-  prepares main for `WP-20` internal review.
+- Sprint 4 release-tail work has landed through the docs/review-entry band:
+  demo/proof convergence, the bounded `WP-17A` code-feature demo follow-on,
+  the quality-gate packet, and the `WP-19` docs review pass are closed.
+- The first `WP-20` internal review packet was too thin for external handoff.
+  `WP-20B` is now the controlling full internal review packet, and accepted
+  `WP-20B` findings must be fixed and rechecked before `WP-21` external
+  review.
 - This is an active milestone entry, not a release entry.
 
 ## v0.91.1 (Completed milestone)

--- a/README.md
+++ b/README.md
@@ -146,12 +146,14 @@ from issue
 
 v0.91.2 is the active pressure-release milestone. Its issue wave was opened as
 `#3000` through `#3023`, with sprint-conductor umbrella issues `#3025` through
-`#3028`. Sprint 4 is now moving from release-tail documentation cleanup into
-internal review: `WP-17`, `WP-17A`, `WP-18`, and `WP-19` are closed, and
-`WP-20` through `WP-24` remain before release closeout. The milestone
-focuses on UTS + ACC benchmarking, runtime/test-cycle recovery, CodeFriend
-productization, Workspace bridge work, modernization, publication packets,
-rustdoc/doc cleanup, repo-visibility follow-on work, and workflow guardrails.
+`#3028`. Sprint 4 is in the review/remediation tail: `WP-17`, `WP-17A`,
+`WP-18`, and `WP-19` are closed; the initial `WP-20` internal review has been
+superseded for handoff truth by the corrective `WP-20B` full internal review;
+and accepted `WP-20B` findings must be fixed and rechecked before `WP-21`
+external review. The milestone focuses on UTS + ACC benchmarking,
+runtime/test-cycle recovery, CodeFriend productization, Workspace bridge work,
+modernization, publication packets, rustdoc/doc cleanup, repo-visibility
+follow-on work, and workflow guardrails.
 
 Start here:
 
@@ -159,6 +161,7 @@ Start here:
 - [v0.91.2 issue wave](docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml)
 - [v0.91.2 sprint plan](docs/milestones/v0.91.2/SPRINT_v0.91.2.md)
 - [v0.91.2 sprint-conductor plan](docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md)
+- [v0.91.2 third-party review handoff](docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md)
 
 ### v0.91.1 - Completed Inhabited Runtime Readiness Milestone
 
@@ -238,8 +241,9 @@ production markets.
 - Active milestone: v0.91.2
 - Current crate version: 0.91.2
 - Most recently completed milestone: v0.91.1
-- Current release-tail state: v0.91.2 Sprint 4 moves to WP-20 internal review
-  after closed WP-17/WP-17A/WP-18/WP-19 release-tail work
+- Current release-tail state: v0.91.2 Sprint 4 is in corrective
+  review/remediation after WP-20B; external review should wait until the
+  accepted WP-20B findings are fixed and rechecked
 - Previous completed milestone: v0.90.5
 - Primary implementation language: Rust
 

--- a/adl/README.md
+++ b/adl/README.md
@@ -24,7 +24,9 @@ It provides:
 ## Current Status
 
 - Current active milestone in the main repo: **v0.91.2**
-- Current release state: **Sprint 4 internal-review handoff (`WP-20` next)**
+- Current release state: **Sprint 4 corrective review/remediation after
+  `WP-20B`; external review is blocked until accepted findings are fixed and
+  rechecked**
 - Most recently completed milestone in the main repo: **v0.91.1**
 - Current crate version on the active release line: **0.91.2**
 
@@ -37,8 +39,10 @@ This README describes the runtime as it exists on the current `main` branch and 
 v0.91.2 is the active milestone. The runtime-adjacent work has landed through
 UTS + ACC benchmark expansion, runtime/test-cycle recovery, quality-gate
 ergonomics, workflow guardrails, and release-tail proof/quality surfaces.
-Sprint 4 is moving to `WP-20` internal review after the closed `WP-19` docs
-review pass.
+Sprint 4 is now in corrective review/remediation: the first `WP-20` internal
+review packet was too thin for external handoff, `WP-20B` is the controlling
+full internal review, and external review should not proceed until accepted
+`WP-20B` findings are fixed and rechecked.
 
 Highlights:
 - standalone and governed UTS/ACC benchmark evidence

--- a/docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -1,0 +1,313 @@
+# Third-Party Review Handoff - v0.91.2
+
+## Metadata
+
+- Milestone: `v0.91.2`
+- Version: `v0.91.2`
+- Active crate version: `0.91.2`
+- Review lane: `WP-21` external / 3rd-party review, following `WP-20`
+  internal review and `WP-20B` corrective full internal review
+- Prepared during: `v0.91.2` review tail
+- Prepared for issue: `#3020`
+- Controlling internal review source: `#3173`
+- Current packet status: draft handoff prepared; not sendable until accepted
+  `WP-20B` findings are fixed and rechecked
+- Date: 2026-05-21
+- Publication attempted: false
+- Release approval claimed: false
+- Review approval claimed: false
+
+## Update Before Review
+
+This handoff is the canonical tracked third-party review surface for `v0.91.2`,
+but it is not yet a sendable external-review packet. It must be refreshed from
+clean root `main` after accepted `WP-20B` findings are fixed and rechecked.
+
+Before review, confirm:
+
+- `README.md`, `CHANGELOG.md`, `adl/README.md`, `adl/Cargo.toml`,
+  `adl/Cargo.lock`, and `docs/milestones/v0.91.2/` agree on `v0.91.2`.
+- The `WP-20B` full internal review packet is the controlling internal review
+  surface, not the earlier thin `WP-20` packet.
+- accepted `WP-20B` findings are fixed or explicitly dispositioned and the
+  fixes have been rechecked
+- `WP-22` remediation routing is visible for all accepted `WP-20B` findings
+- any open remediation issues are clearly labeled as fixed, deferred, or out of
+  scope before the packet is sent
+- No host-local paths, temporary paths, worktree-only artifacts, raw credential
+  paths, or branch-only claims appear in the packet.
+- UTS benchmark claims are still bounded by the current benchmark-methodology
+  findings unless those findings have been fixed and reviewed.
+
+This tracked handoff should stand on its own. Operator-local archives may exist,
+but the external reviewer should not need hidden `.adl` notes, scratch files, or
+private workstation paths to understand the milestone truth.
+
+## Purpose
+
+Once the corrective findings are fixed and rechecked, this handoff gives a
+third-party reviewer a bounded `v0.91.2` review packet. Review `v0.91.2` as the
+pressure-release and productization milestone after `v0.91.1`.
+
+The review should cover:
+
+- UTS + ACC multi-model benchmark work and its evidence boundaries
+- runtime test-cycle recovery and CI/runtime-budget cleanup
+- review heuristics and demo cleanup
+- Google Workspace bridge planning and optionality boundaries
+- CodeFriend productization docs and naming cleanup
+- speculative decoding prototype planning
+- repo-visibility follow-on work
+- rustdoc and documentation cleanup
+- general-intelligence paper packet handling
+- publication program planning
+- workflow guardrails, card-lifecycle corrections, and sprint-conductor lessons
+- release-tail readiness, evidence, and non-claims
+
+The reviewer should produce evidence-backed findings with severity, location,
+impact, and recommended remediation. The reviewer should not rewrite docs,
+perform remediation, create release tags, merge PRs, close issues, or run the
+release ceremony.
+
+## Current Milestone Truth
+
+`v0.91.2` is active and the crate version is `0.91.2`.
+
+The milestone has landed substantial implementation, documentation, planning,
+and review work, but it is not release-ready. The release-tail quality gate is
+still `NOT_READY` until external review, remediation, next-milestone planning,
+and release ceremony work finish.
+
+Current review-tail truth:
+
+- `WP-01` through `WP-19` are recorded as closed in the milestone readiness
+  docs.
+- `WP-17A` is also recorded as closed as a bounded follow-on demo pass.
+- The first `WP-20` internal review packet was too thin and must not be used as
+  the sole review handoff.
+- `WP-20B` / `#3173` produced the controlling full internal review packet.
+- `WP-21` external review is blocked until accepted `WP-20B` findings are fixed
+  and rechecked.
+- `WP-22` remediation must route and resolve or explicitly defer the accepted
+  `WP-20B` findings before this handoff is sent.
+- `WP-23` remains next-milestone planning.
+- `WP-24` remains release ceremony.
+
+This handoff does not claim that the milestone is ready to close.
+
+## Controlling Internal Review Packet
+
+The controlling internal review packet is:
+
+- `docs/milestones/v0.91.2/review/internal_review_full/README.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/SYNTHESIS_REPORT.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/FINDINGS_REGISTER.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/SPECIALIST_COVERAGE.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/REVIEW_TO_TEST_PLAN.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/FINDING_TO_ISSUE_PLAN.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/REDACTION_AND_EVIDENCE_AUDIT.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/REVIEW_QUALITY_EVALUATION.md`
+- `docs/milestones/v0.91.2/review/internal_review_full/DIAGRAM_PLAN.md`
+
+The older `docs/milestones/v0.91.2/review/internal_review/` packet is historical
+context only. It should be treated as superseded for readiness and handoff
+truth unless a later remediation document explicitly says otherwise.
+
+## Active Findings And Remediation Routing
+
+The `WP-20B` synthesis found no `P0` findings, but it did find `P1` and `P2`
+risks that affect benchmark credibility, hosted-provider portability, security
+hygiene, and review handoff truth.
+
+Most important accepted findings:
+
+- the governed Rust UTS + ACC benchmark can pass wrong task arguments
+- hosted benchmark defaults include operator-local key-file paths
+- canonical benchmark profiles can reference models absent from the canonical
+  panel
+- the older `WP-20` packet can mislead reviewers unless `WP-20B` is made
+  controlling
+
+Recommended remediation routing from the full review packet:
+
+- Benchmark validity blocker: `P1-1`, `P1-3`, `P2-2`, `P2-3`, `P2-4`
+- Hosted provider security and portability: `P1-2`, `P2-5`, `P2-6`, `P2-7`,
+  `P3-1`
+- Evidence and handoff truth: `P1-4`, `P2-8`, `P2-11`, `P3-3`, `P3-4`
+- Tooling and supply-chain hygiene: `P2-9`, `P2-10`, `P3-2`
+- Provider native-tool capability reporting: `P2-1`
+
+Current planned child remediation issues:
+
+- `#3175`: benchmark scoring and failure gates
+- `#3176`: hosted benchmark adapter and artifact hardening
+- `#3177`: make `WP-20B` the controlling review packet
+- `#3178`: CI pinning and validation reproducibility
+- `#3179`: provider native-tool capability reporting
+
+If any of these issues remain open or unreviewed, external review should not
+begin. The reviewer should treat the relevant findings as unresolved unless the
+issue record proves otherwise.
+
+## Previous Review Mistakes To Avoid
+
+- Do not send stale version truth. Root docs, crate metadata, lockfile truth,
+  and milestone docs must agree on `v0.91.2`.
+- Do not use the thin `WP-20` packet as the controlling handoff after `WP-20B`.
+- Do not claim branch-only artifacts, local `.adl` notes, temporary files, or
+  workstation paths as release truth.
+- Do not treat internal-review completion as release readiness.
+- Do not treat UTS benchmark results as public superiority claims while
+  benchmark-methodology findings remain open or only partially resolved.
+- Do not hide docs-only, planning-only, fixture-only, or demo-only boundaries.
+- Do not mix ADL-governed UTS + ACC evidence with standalone UTS claims without
+  labeling the boundary.
+- Do not imply Google Workspace bridge work is required for C-SDLC or the core
+  ADL release line.
+- Do not claim release ceremony, release approval, or v0.91.3/v0.91.4
+  completion from this review lane.
+
+## Required Review Scope
+
+Review these top-level repository surfaces first:
+
+- `README.md`
+- `CHANGELOG.md`
+- `adl/README.md`
+- `adl/Cargo.toml`
+- `adl/Cargo.lock`
+- `docs/README.md`
+- `docs/planning/ADL_FEATURE_LIST.md`
+
+Review these `v0.91.2` milestone surfaces next:
+
+- `docs/milestones/v0.91.2/README.md`
+- `docs/milestones/v0.91.2/VISION_v0.91.2.md`
+- `docs/milestones/v0.91.2/DESIGN_v0.91.2.md`
+- `docs/milestones/v0.91.2/DECISIONS_v0.91.2.md`
+- `docs/milestones/v0.91.2/ADR_PLAN_v0.91.2.md`
+- `docs/milestones/v0.91.2/WBS_v0.91.2.md`
+- `docs/milestones/v0.91.2/SPRINT_v0.91.2.md`
+- `docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md`
+- `docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml`
+- `docs/milestones/v0.91.2/WP_EXECUTION_READINESS_v0.91.2.md`
+- `docs/milestones/v0.91.2/CARD_BUNDLE_READINESS_v0.91.2.md`
+- `docs/milestones/v0.91.2/SPP_READINESS_v0.91.2.md`
+- `docs/milestones/v0.91.2/CI_RUNTIME_BUDGETS_v0.91.2.md`
+- `docs/milestones/v0.91.2/DEMO_MATRIX_v0.91.2.md`
+- `docs/milestones/v0.91.2/FEATURE_PROOF_COVERAGE_v0.91.2.md`
+- `docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md`
+- `docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md`
+- `docs/milestones/v0.91.2/RELEASE_PLAN_v0.91.2.md`
+- `docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md`
+- `docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md`
+- `docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md`
+- `docs/milestones/v0.91.2/NEXT_MILESTONE_HANDOFF_v0.91.2.md`
+- `docs/milestones/v0.91.2/END_OF_MILESTONE_REPORT_v0.91.2.md`
+- `docs/milestones/v0.91.2/features/README.md`
+- `docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md`
+
+Review these feature docs where they intersect milestone claims:
+
+- `docs/milestones/v0.91.2/features/UTS_ACC_MULTI_MODEL_BENCHMARK.md`
+- `docs/milestones/v0.91.2/features/RUNTIME_TEST_CYCLE_RECOVERY.md`
+- `docs/milestones/v0.91.2/features/REVIEW_HEURISTICS_AND_DEMOS.md`
+- `docs/milestones/v0.91.2/features/GOOGLE_WORKSPACE_CMS_BRIDGE.md`
+- `docs/milestones/v0.91.2/features/CODEFRIEND_PRODUCTIZATION.md`
+- `docs/milestones/v0.91.2/features/SPECULATIVE_DECODING_PROTOTYPE.md`
+- `docs/milestones/v0.91.2/features/REPO_VISIBILITY_FOLLOW_ON.md`
+- `docs/milestones/v0.91.2/features/RUSTDOC_DOC_CLEANUP.md`
+- `docs/milestones/v0.91.2/features/GENERAL_INTELLIGENCE_PAPER_PACKET.md`
+- `docs/milestones/v0.91.2/features/PUBLICATION_PROGRAM.md`
+- `docs/milestones/v0.91.2/features/WORKFLOW_GUARDRAILS.md`
+
+Review these evidence and review surfaces:
+
+- `docs/milestones/v0.91.2/review/internal_review_full/`
+- `docs/milestones/v0.91.2/review/uts_acc_multi_model_benchmark_report.json`
+- `docs/milestones/v0.91.2/review/provider_native_tool_call_comparison_report.json`
+- `docs/milestones/v0.91.2/review/uts_remote_open_model_evidence_memo_2026-05-20.md`
+- `docs/milestones/v0.91.2/review/runtime_test_cycle_recovery_report.md`
+- `docs/milestones/v0.91.2/review/coverage_gate_ergonomics_report.md`
+- `docs/milestones/v0.91.2/review/sprint_1_closeout_truth_cleanup_3105.md`
+
+Review these implementation and tooling surfaces if a claim depends on
+executable behavior:
+
+- `adl/src/uts_acc_multi_model_benchmark.rs`
+- `adl/src/provider_substrate.rs`
+- `adl/src/provider_native_tool_call_comparison.rs`
+- `adl/tools/uts_benchmark_runner.py`
+- `adl/tools/benchmark/`
+- `adl/tools/run_uts_benchmark.sh`
+- `adl/tools/test_uts_benchmark_runner_contracts.sh`
+- `adl/tools/demo_v0912_quality_gate.sh`
+- `adl/tools/real_chatgpt_gemini_claude_provider_adapter.py`
+- `.github/workflows/`
+
+If a listed path does not exist in the branch under review, report that as a
+scope or handoff drift finding rather than assuming it exists elsewhere.
+
+## Proof And Quality Evidence To Check
+
+The external review should verify:
+
+- version truth is consistent across root, crate, lockfile, and milestone docs
+- `WP-20B` is the controlling internal review packet
+- `WP-22` remediation issues cover the accepted findings without hiding scope
+- benchmark claims are supported by scoring logic, task-argument checks,
+  profile/model consistency, and non-zero failure gates
+- hosted-provider docs and configs do not expose operator-local credential
+  paths or assume a private machine layout
+- benchmark reports and evidence do not persist unsafe raw excerpts or absolute
+  outside paths
+- release readiness remains honest while `WP-21` through `WP-24` are unfinished
+- GWS, C-SDLC, UTS, ACC, CodeFriend, and publication-program claims stay in
+  their correct lanes
+- docs distinguish completed work, planned work, evidence, caveats, and
+  non-claims
+
+## Suggested Validation Commands
+
+Run only the validation needed for the review question. Suggested focused
+commands:
+
+```sh
+cargo test --manifest-path adl/Cargo.toml uts_acc -- --nocapture
+python3 adl/tools/benchmark/deterministic_self_check.py
+bash adl/tools/test_uts_benchmark_runner_contracts.sh
+bash adl/tools/demo_v0912_quality_gate.sh
+```
+
+If a command is skipped, fails because of environment assumptions, or produces
+provider-dependent output, record that as review evidence rather than smoothing
+it over.
+
+## Expected Reviewer Output
+
+Expected reviewer output:
+
+- severity-ranked findings with file and line references
+- explicit non-findings for surfaces that are clean
+- a recommendation on whether `WP-22` remediation is sufficient to proceed
+- a list of findings that must be fixed before `WP-24` release ceremony
+- a list of findings that may be explicitly deferred without misleading the
+  release
+- clear notes on any claims that depend on local-only evidence, branch-only
+  artifacts, or unresolved provider behavior
+
+## Non-Claims
+
+This handoff does not claim:
+
+- release readiness
+- release ceremony completion
+- external review completion
+- accepted-finding remediation completion
+- public UTS benchmark superiority
+- provider/model conformance beyond the evidence reviewed
+- production-grade hosted-provider adapter security
+- Google Workspace bridge adoption
+- C-SDLC completion
+- v0.91.3 or v0.91.4 readiness
+- publication approval for papers, articles, or investor-facing materials

--- a/docs/milestones/v0.91.2/END_OF_MILESTONE_REPORT_v0.91.2.md
+++ b/docs/milestones/v0.91.2/END_OF_MILESTONE_REPORT_v0.91.2.md
@@ -16,5 +16,9 @@ for final closeout.
 ## Current Judgment
 
 Do not treat this report as release closure. `v0.91.2` has real execution
-through `WP-18` plus the bounded `WP-17A` demo follow-on, but Sprint 4 review,
-remediation, handoff, evidence, and ceremony work are still incomplete.
+through the `WP-19` docs/review-entry band plus the bounded `WP-17A` demo
+follow-on, and it has a corrective `WP-20B` full internal review packet. The
+first `WP-20` packet is superseded for handoff truth. Sprint 4 remediation,
+external review, handoff, evidence, and ceremony work are still incomplete, and
+accepted `WP-20B` findings must be fixed and rechecked before this report can
+become a closeout record.

--- a/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md
@@ -17,11 +17,15 @@ Sprint 4 work lands.
 
 ## Current State
 
-- `WP-01` through `WP-18` are closed, and `WP-17A` is also closed as a bounded
+- `WP-01` through `WP-19` are closed, and `WP-17A` is also closed as a bounded
   demo follow-on.
 - Sprint 1, Sprint 2, and Sprint 3 are closed; Sprint 4 is still open.
 - The milestone now has a converged demo/proof map, a release-tail doc set, and
   a passing closed-issue `SOR` truth checker.
+- The first `WP-20` internal review packet was too thin for external handoff;
+  `WP-20B` is the controlling full internal review packet.
+- Accepted `WP-20B` findings must be fixed and rechecked before `WP-21`
+  external review.
 - The milestone does not yet have a final review/remediation/ceremony outcome,
   so this gate is not the final release verdict.
 
@@ -33,7 +37,7 @@ Sprint 4 work lands.
 | CI/coverage policy contract | `pass` | `adl/tools/test_ci_path_policy.sh`, `adl/tools/test_ci_runtime_contracts.sh`, `adl/tools/test_run_authoritative_coverage_lane.sh`, and `adl/tools/test_check_coverage_impact.sh` | A green policy/contract surface proves the current CI split is internally consistent, not that full release coverage has already been rerun for this milestone. |
 | Closed-issue closeout truth | `partial` | Sprint 1 through Sprint 3 closeout truth is materially cleaner; known retained `#3121` residue remains explicitly deferred out of this issue | This keeps the milestone honest about one deferred closeout-truth gap instead of pretending the whole retained layer is clean. |
 | Full authoritative coverage evidence | `pass` | `bash adl/tools/run_authoritative_coverage_lane.sh` completed during WP-18 with `2066` tests passed, `2` skipped, and `coverage-summary.json` emitted | Full release coverage has now been captured explicitly for the current milestone state; this still does not replace later Sprint 4 review/remediation/ceremony work. |
-| Release-tail review/remediation/ceremony | `not_ready` | `WP-19` docs review is closed; `WP-20` through `WP-24` remain open in Sprint 4 | The milestone cannot close from WP-18 alone. |
+| Release-tail review/remediation/ceremony | `not_ready` | `WP-19` docs review is closed; `WP-20B` is the controlling internal review packet; accepted `WP-20B` findings remain release-tail blockers until fixed and rechecked | The milestone cannot proceed to clean external review or release ceremony from the thin `WP-20` packet. |
 
 ## Controlling Review Packet Note
 
@@ -53,6 +57,7 @@ external-review or remediation handoff surface.
 - closeout-truth status, including any explicitly deferred retained-card residue
 - review records
 - remediation record
+- `WP-20B` accepted-finding fixes and re-review outcome
 - release evidence and release readiness package
 - release ceremony and end-of-milestone report
 
@@ -92,5 +97,7 @@ ADL_V0912_QUALITY_GATE_RUN_HEAVY=1 bash adl/tools/demo_v0912_quality_gate.sh
   coverage evidence.
 - This gate does not replace the later Sprint 4 review, remediation, release
   evidence, or ceremony surfaces.
+- This gate does not allow external review to proceed from the superseded thin
+  `WP-20` packet while accepted `WP-20B` findings remain unresolved.
 - This gate does not claim the entire retained local closeout-truth layer is
   clean while `#3121` remains explicitly deferred.

--- a/docs/milestones/v0.91.2/README.md
+++ b/docs/milestones/v0.91.2/README.md
@@ -5,9 +5,12 @@
 Active milestone package. v0.91.2 is the follow-on pressure-release milestone
 after v0.91.1. The WP issue wave was opened as `#3000` through `#3023`, and the
 sprint-conductor umbrella issues were opened as `#3025` through `#3028`. Sprint
-4 is moving to `WP-20` internal review: `WP-17`, the bounded `WP-17A` demo
-follow-on, `WP-18`, and `WP-19` are closed; external review, remediation, next-milestone
-planning, and ceremony work remain.
+4 is in corrective review/remediation: `WP-17`, the bounded `WP-17A` demo
+follow-on, `WP-18`, and `WP-19` are closed; the first `WP-20` internal review
+packet was too thin for external handoff; `WP-20B` is the controlling full
+internal review packet; and accepted `WP-20B` findings must be fixed and
+rechecked before `WP-21` external review. External review, remediation,
+next-milestone planning, and ceremony work remain.
 
 ## Purpose
 
@@ -109,6 +112,8 @@ This package is grounded in:
 - Release readiness: [RELEASE_READINESS_v0.91.2.md](RELEASE_READINESS_v0.91.2.md)
 - Release evidence: [RELEASE_EVIDENCE_v0.91.2.md](RELEASE_EVIDENCE_v0.91.2.md)
 - Release notes: [RELEASE_NOTES_v0.91.2.md](RELEASE_NOTES_v0.91.2.md)
+- Third-party review handoff:
+  [ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md](ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md)
 - Next milestone handoff:
   [NEXT_MILESTONE_HANDOFF_v0.91.2.md](NEXT_MILESTONE_HANDOFF_v0.91.2.md)
 - End-of-milestone report:
@@ -116,13 +121,15 @@ This package is grounded in:
 
 ## Success Criteria
 
-v0.91.2 is ready to close when the project has credible multi-model UTS+ACC
-evidence, a healthier test/runtime gate strategy, a review/productization path,
-a bounded Workspace CMS bridge with reusable operational guidance,
-Moderne/OpenRewrite LST modernization and publication packages, and
-workflow guardrails that reduce the operational failures that slowed v0.90.5
-and v0.91, plus a reviewable ADR candidate packet for the durable architecture
-decisions introduced or clarified by the milestone.
+v0.91.2 is ready to close only when the project has credible multi-model
+UTS+ACC evidence, a healthier test/runtime gate strategy, a
+review/productization path, a bounded Workspace CMS bridge with reusable
+operational guidance, Moderne/OpenRewrite LST modernization and publication
+packages, workflow guardrails that reduce the operational failures that slowed
+v0.90.5 and v0.91, a reviewable ADR candidate packet for the durable
+architecture decisions introduced or clarified by the milestone, and completed
+review/remediation/ceremony truth. Accepted `WP-20B` findings must be fixed or
+explicitly dispositioned before external review or release ceremony claims.
 
 Execution note: WP-01 opened and carded the issue wave. Each WP starts only
 when routed through `workflow-conductor`, bound with `pr run`, reviewed before

--- a/docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md
@@ -26,14 +26,16 @@ Track the milestone package and proof surfaces required for a truthful
 - quality-gate packet and authoritative coverage evidence
 - controlling internal-review packet and findings under `review/internal_review_full/`
 - external-review handoff and remediation routing docs tied to the `WP-20B` packet
+- `WP-20B` full internal review packet and accepted-finding routing
 
 ## Current Judgment
 
 This is an in-progress release evidence index. It records substantial landed
-evidence through `WP-19`, but it is not a
-final release verdict until `WP-20` through `WP-24` complete internal/external review,
-remediation, handoff, release-evidence, and ceremony work.
+evidence through `WP-19` plus corrective `WP-20B` internal-review findings, but
+it is not a final release verdict.
 
 The thin `WP-20` packet under `review/internal_review/` is retained for
 historical context, but it is not the controlling review packet for this
-release-tail path.
+release-tail path. Accepted `WP-20B` findings must be fixed and rechecked
+before external review, and external review, remediation, handoff,
+release-evidence, and ceremony work must complete before closeout.

--- a/docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Working draft. `v0.91.2` has substantial executed content through `WP-18` plus
-the bounded `WP-17A` demo follow-on, but it does not yet have final
-release-ready notes.
+Working draft. `v0.91.2` has substantial executed content through the `WP-19`
+docs/review-entry band plus the bounded `WP-17A` demo follow-on, and it now has
+a corrective `WP-20B` full internal review packet. It does not yet have final
+release-ready notes: accepted `WP-20B` findings still need to be fixed and
+rechecked before clean external review or release ceremony claims.
 
 ## Theme
 
@@ -18,9 +20,13 @@ Tooling, evaluation, productization, publication, and workflow guardrails.
 - modernization, publication, rustdoc/doc cleanup, and workflow guardrails
 - demo/proof convergence, code-feature demo follow-ons, and quality-gate
   evidence
+- corrective `WP-20B` internal-review findings and remediation
 
 ## Not Claimed
 
-- executed milestone completion beyond the currently landed pre-release band
-- final review or release state
-- any benchmark or tooling result not yet produced
+- executed milestone completion beyond the currently landed pre-release and
+  corrective-review band
+- final external review or release state
+- clean external-review readiness while accepted `WP-20B` findings remain
+  unresolved
+- any benchmark or tooling result not yet produced, fixed, and reviewed

--- a/docs/milestones/v0.91.2/RELEASE_PLAN_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_PLAN_v0.91.2.md
@@ -16,6 +16,8 @@ more reviewable without weakening proof or authority boundaries.
 - workflow guardrails packet
 - demo-proof convergence plus missing code-feature demo follow-ons
 - feature-proof coverage and quality gate
+- `WP-20B` full internal review packet
+- accepted `WP-20B` finding fixes and re-review record
 - review and remediation records
 
 ## Release Risks
@@ -25,11 +27,18 @@ more reviewable without weakening proof or authority boundaries.
 - Workspace bridge could be mistaken for canonical-source relocation
 - publication packets could be mistaken for publication itself
 - guardrail docs could understate the severity of workflow failures
+- the thin `WP-20` internal review packet could be mistaken for controlling
+  review truth after `WP-20B`
+- external review could start before accepted `WP-20B` findings are fixed and
+  rechecked
 
 ## Release Rule
 
 Do not mark `v0.91.2` releasable until:
 
-- the remaining Sprint 4 work finishes cleanly beyond the already-executed `WP-01` through `WP-18` band plus bounded `WP-17A` follow-on
+- the remaining Sprint 4 work finishes cleanly beyond the already-executed
+  `WP-01` through `WP-19` band plus bounded `WP-17A` follow-on
+- the corrective `WP-20B` findings are fixed or explicitly dispositioned and
+  rechecked
 - quality, review, remediation, and ceremony surfaces are complete
 - release readiness and release evidence are complete

--- a/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
@@ -23,7 +23,11 @@ Not release ready.
 - `v0.91.2` is an active in-flight milestone with substantial executed work
 - `WP-01` through `WP-19` are closed, and `WP-17A` is also closed as a bounded follow-on demo pass
 - Sprint 1 `#3025`, Sprint 2 `#3026`, and Sprint 3 `#3027` are closed
-- Sprint 4 umbrella `#3028` remains open; `WP-20` through `WP-24` remain pending
+- Sprint 4 umbrella `#3028` remains open
+- the first `WP-20` internal review packet was too thin for external handoff
+- `WP-20B` / `#3173` is the controlling full internal review packet
+- accepted `WP-20B` findings must be fixed and rechecked before `WP-21`
+  external review
 - no final release proof, review, or ceremony state exists yet
 - the controlling internal-review packet for the remaining handoff/remediation path is `docs/milestones/v0.91.2/review/internal_review_full/`
 - the older thin `WP-20` packet remains background context only and is not sufficient as the release-tail handoff surface by itself
@@ -31,7 +35,10 @@ Not release ready.
 ## Current Blockers
 
 - Sprint 4 and the remaining review/release-tail work are not complete
+- accepted `WP-20B` findings are not yet recorded here as fixed and rechecked
+- external review is blocked until the corrective review/remediation state is
+  clean
 - release evidence and release ceremony surfaces are not complete
-- internal/external review, remediation, release evidence, and ceremony surfaces still need completion after the docs review pass
+- internal/external review, remediation, release evidence, and ceremony surfaces still need completion after the corrective internal-review pass
 - ADR candidates exist for review, but they are not accepted release decisions
   until promoted or explicitly carried forward

--- a/docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md
@@ -158,6 +158,10 @@ Child issues:
 
 Release-tail notes:
 
+- corrective gate: the original Sprint 4 list did not include `WP-20B`, but
+  `WP-20B` now controls external-review handoff truth because the first
+  `WP-20` packet was too thin; do not advance to `WP-21` until accepted
+  `WP-20B` findings are fixed and rechecked
 - if we later decide to preserve the extra pre-ceremony next-milestone review
   pass pattern from `v0.91.1`, add that step explicitly to the `v0.91.2`
   WBS, sprint plan, and issue wave before execution rather than silently

--- a/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
+++ b/docs/milestones/v0.91.2/SPRINT_v0.91.2.md
@@ -55,12 +55,16 @@ worth carrying forward.
 | --- | --- | --- | --- |
 | WP-17 (#3016) | Demo matrix and proof coverage | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
 | WP-18 (#3017) | Coverage / quality gate | validation posture and test/coverage record | WP-17 |
-| WP-19 (#3018) | Docs + review pass | review-ready docs package | WP-18 |
-| WP-20 (#3019) | Internal review | internal review record | WP-19 |
-| WP-21 (#3020) | External / 3rd-party review | external review handoff and record | WP-20 |
+| WP-19 (#3018) | Docs + review pass | docs review-entry package; later corrected by WP-20B truth updates | WP-18 |
+| WP-20 (#3019) | Internal review | internal review record; first packet superseded for handoff by `WP-20B` | WP-19 |
+| WP-21 (#3020) | External / 3rd-party review | external review handoff and record after accepted `WP-20B` findings are fixed and rechecked | WP-20 plus corrective `WP-20B` gate |
 | WP-22 (#3021) | Review findings remediation | remediation record and follow-up issues | WP-21 |
 | WP-23 (#3022) | Next milestone planning | v0.92/v0.93 handoff update | WP-22 |
 | WP-24 (#3023) | Release ceremony | release evidence and end-of-milestone report | WP-23 |
+
+Corrective review note: `WP-20B` was added after the original Sprint 4 plan
+because the first `WP-20` packet was too thin for external handoff. The sprint
+must treat `WP-20B` accepted findings as a hard gate before `WP-21`.
 
 Goal: leave the next identity/governance milestones with cleaner test cycles,
 clearer publication and product surfaces, and fewer workflow foot-guns.

--- a/docs/milestones/v0.91.2/WBS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/WBS_v0.91.2.md
@@ -31,7 +31,7 @@ productize, publish, and maintain.
 | L | General intelligence paper packet | Advance the Mathematical Theory of General Intelligence source packet. | claim/citation/review-ready paper packet | K |
 | M | Rustdoc and documentation cleanup | Address rustdoc gaps and tracked doc hygiene debt. | doc cleanup report and patches | D |
 | N | Workflow guardrails | Prevent main writes, unsafe shell report generation, hung watchers, and card drift. | guardrail implementation and process docs | C, D |
-| O | Review, quality, and release | Validate the milestone, remediate findings, and hand off later work. | review-ready release package | all prior work |
+| O | Review, quality, and release | Validate the milestone, remediate findings, and hand off later work. | review/remediation/release package with WP-20B truth preserved | all prior work |
 
 ## Candidate WP Sequence
 
@@ -55,9 +55,9 @@ productize, publish, and maintain.
 | WP-16 (#3015) | Workflow guardrails hardening | tools | main-write, watcher, and safe-report guardrails | WP-04, WP-05 |
 | WP-17 (#3016) | Demo matrix and proof coverage | demo | demo matrix and proof coverage record | WP-02, WP-03, WP-04, WP-05, WP-06, WP-07, WP-08, WP-09, WP-10, WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
 | WP-18 (#3017) | Coverage / quality gate | quality | validation posture and test/coverage record | WP-17 |
-| WP-19 (#3018) | Docs + review pass | docs | review-ready docs package | WP-18 |
-| WP-20 (#3019) | Internal review | review | internal review record | WP-19 |
-| WP-21 (#3020) | External / 3rd-party review | review | external review handoff and record | WP-20 |
+| WP-19 (#3018) | Docs + review pass | docs | docs review-entry package; later corrected by WP-20B truth updates | WP-18 |
+| WP-20 (#3019) | Internal review | review | internal review record; first packet superseded for handoff by `WP-20B` | WP-19 |
+| WP-21 (#3020) | External / 3rd-party review | review | external review handoff and record after accepted `WP-20B` findings are fixed and rechecked | WP-20 plus corrective `WP-20B` gate |
 | WP-22 (#3021) | Review findings remediation | review | remediation record and follow-up issues | WP-21 |
 | WP-23 (#3022) | Next milestone planning | docs | v0.92/v0.93 handoff update | WP-22 |
 | WP-24 (#3023) | Release ceremony | release | release evidence and end-of-milestone report | WP-23 |
@@ -70,6 +70,11 @@ productize, publish, and maintain.
 | Sprint 2 | #3026 | Review Product, Workspace Bridge, And Modernization | WP-06, WP-07, WP-08, WP-09, WP-10 |
 | Sprint 3 | #3027 | Runtime Ergonomics, Publication, Docs, And Workflow Guardrails | WP-11, WP-12, WP-13, WP-14, WP-15, WP-16 |
 | Sprint 4 | #3028 | Review, Remediation, Planning, And Release | WP-17, WP-18, WP-19, WP-20, WP-21, WP-22, WP-23, WP-24 |
+
+Corrective review note: the original issue wave did not include `WP-20B`.
+`WP-20B` now controls handoff truth because the first `WP-20` packet was too
+thin for external review. `WP-21` must not start until accepted `WP-20B`
+findings are fixed and rechecked.
 
 ## Sequencing Pressure
 

--- a/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
+++ b/docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml
@@ -41,6 +41,10 @@ closeout_sequence:
 - WP-22 Review findings remediation
 - WP-23 Next milestone planning
 - WP-24 Release ceremony
+- "Corrective review note: the original wave did not include WP-20B. WP-20B now
+  controls external-review handoff truth because the first WP-20 packet was too
+  thin. WP-21 must not start until accepted WP-20B findings are fixed and
+  rechecked."
 work_packages:
 - wp: WP-01
   issue: 3000
@@ -195,19 +199,19 @@ work_packages:
   issue: 3018
   title: Docs + review pass
   queue: docs
-  outcome: review-ready docs package
+  outcome: docs review-entry package; later corrected by WP-20B truth updates
   depends_on: WP-18
 - wp: WP-20
   issue: 3019
   title: Internal review
   queue: review
-  outcome: internal review record
+  outcome: internal review record; first packet superseded for external handoff by WP-20B
   depends_on: WP-19
 - wp: WP-21
   issue: 3020
   title: External / 3rd-party review
   queue: review
-  outcome: external review handoff and record
+  outcome: external review handoff and record after accepted WP-20B findings are fixed and rechecked
   depends_on: WP-20
 - wp: WP-22
   issue: 3021

--- a/docs/milestones/v0.91.2/features/README.md
+++ b/docs/milestones/v0.91.2/features/README.md
@@ -4,7 +4,8 @@
 
 Tracked feature index for the active `v0.91.2` pressure-release milestone.
 `WP-01` through `WP-19` have closed, the `WP-17A` follow-on is closed, and
-`WP-20` is the next internal-review step.
+`WP-20B` is the controlling corrective internal-review packet. External review
+must wait until accepted `WP-20B` findings are fixed and rechecked.
 
 | Feature Area | Feature Doc | Source Cluster | Planned WP Home | Required Outcome |
 | --- | --- | --- | --- |

--- a/docs/milestones/v0.91.2/review/internal_review/CLAIM_BOUNDARY_REVIEW.md
+++ b/docs/milestones/v0.91.2/review/internal_review/CLAIM_BOUNDARY_REVIEW.md
@@ -1,8 +1,16 @@
 # v0.91.2 WP-20 Claim Boundary Review
 
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
+
 ## Result
 
-Claim boundaries are mostly healthy and should be preserved in WP-21 and WP-22.
+Claim boundaries identified here remain useful, but they are not a complete
+external-review gate after `WP-20B`.
 
 ## Boundaries To Preserve
 
@@ -12,4 +20,6 @@ Claim boundaries are mostly healthy and should be preserved in WP-21 and WP-22.
 - Publication packets do not publish papers or approve submissions.
 - General-intelligence paper packets do not prove the paper's claims.
 - Workflow guardrails reduce operator failure modes; they do not eliminate all operator error.
-- `v0.91.2` is not release-ready until WP-21 through WP-24 complete.
+- `v0.91.2` is not release-ready until accepted `WP-20B` findings are fixed or
+  dispositioned, external review completes, remediation truth is recorded, and
+  release ceremony work completes.

--- a/docs/milestones/v0.91.2/review/internal_review/DEMO_PROOF_REGISTER.md
+++ b/docs/milestones/v0.91.2/review/internal_review/DEMO_PROOF_REGISTER.md
@@ -1,5 +1,12 @@
 # v0.91.2 WP-20 Demo And Proof Register
 
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
+
 ## Result
 
 The milestone has a reviewable demo/proof map.
@@ -13,4 +20,5 @@ The milestone has a reviewable demo/proof map.
 
 ## Review Judgment
 
-The proof map is sufficient for external review. It is not a release ceremony substitute.
+The proof map is useful review input. It is not sufficient by itself for clean
+external review after `WP-20B`, and it is not a release ceremony substitute.

--- a/docs/milestones/v0.91.2/review/internal_review/DOCS_REVIEW.md
+++ b/docs/milestones/v0.91.2/review/internal_review/DOCS_REVIEW.md
@@ -1,8 +1,16 @@
 # v0.91.2 WP-20 Internal Review Packet Docs Review
 
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
+
 ## Findings
 
-No docs-blocking findings found in the WP-20 internal review packet.
+This first pass reported no docs-blocking findings, but that judgment was
+incomplete. `WP-20B` found additional blockers and is now controlling.
 
 ## Reviewed Surfaces
 
@@ -21,7 +29,8 @@ No docs-blocking findings found in the WP-20 internal review packet.
 
 ## Claims Checked
 
-- WP-20 says v0.91.2 is ready for WP-21 external review, not release-ready.
+- The original WP-20 packet claimed external-review readiness, but that
+  conclusion is superseded by `WP-20B`.
 - WP-20 routes retained `#3121` closeout residue to WP-22/follow-on handling.
 - WP-20 preserves non-claims around UTS provider conformance, Workspace authority, publication approval, and release readiness.
 - WP-20 links its conclusion to existing WP-17/WP-18/WP-19 milestone evidence instead of inventing new demo proof.
@@ -33,4 +42,6 @@ No docs-blocking findings found in the WP-20 internal review packet.
 
 ## Residual Risk
 
-This is a local docs-review pass, not the required independent subagent review before PR publication. The PR should still receive bounded review before merge.
+This is a local historical docs-review pass, not the controlling review packet.
+Use `docs/milestones/v0.91.2/review/internal_review_full/` and the tracked
+top-level third-party review handoff for any current review decision.

--- a/docs/milestones/v0.91.2/review/internal_review/FINDINGS_REGISTER.md
+++ b/docs/milestones/v0.91.2/review/internal_review/FINDINGS_REGISTER.md
@@ -1,5 +1,12 @@
 # v0.91.2 WP-20 Internal Review Findings Register
 
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
+
 ## Findings
 
 ### P2-1 Retained `#3121` closeout residue remains an explicit release-tail truth gap
@@ -21,16 +28,21 @@ Route to WP-22 remediation or a bounded follow-on issue before release ceremony.
 
 Evidence:
 
-- `docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md` says WP-20 through WP-24 remain pending.
+- `docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md` says accepted
+  `WP-20B` findings must be fixed and rechecked before external review.
 - `docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md` says the current judgment is `NOT_READY`.
 
 Impact:
 
-This is correct lifecycle truth, not a defect. The risk is that external review or remediation compresses into release approval without preserving the expected boundaries.
+This was correct lifecycle truth for the first `WP-20` packet, but it is no
+longer sufficient. `WP-20B` found accepted blockers that must be fixed and
+rechecked before clean external review.
 
 Recommended route:
 
-Carry this finding into `WP21_EXTERNAL_REVIEW_HANDOFF.md` and `WP22_REMEDIATION_QUEUE.md` as a release-tail guardrail.
+Carry this finding into the top-level
+`docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md` and
+`WP-22` remediation records as a release-tail guardrail.
 
 ## Non-Findings Worth Preserving
 

--- a/docs/milestones/v0.91.2/review/internal_review/GAP_REGISTER.md
+++ b/docs/milestones/v0.91.2/review/internal_review/GAP_REGISTER.md
@@ -1,8 +1,17 @@
 # v0.91.2 WP-20 Internal Review Gap Register
 
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
+
 ## Gaps Before External Review
 
-No blocking gaps were found before WP-21 external review.
+The first `WP-20` pass did not find blocking gaps before WP-21 external review,
+but that conclusion is superseded. `WP-20B` found blockers that must be fixed
+and rechecked before clean external review.
 
 External review should still be asked to inspect:
 
@@ -11,10 +20,13 @@ External review should still be asked to inspect:
 - modernization dry-run proof boundaries
 - publication-program and general-intelligence-paper unsupported-claim boundaries
 - workflow guardrail proof strength
+- `WP-20B` accepted-finding fixes and re-review truth
 
 ## Gaps Before Release Closeout
 
 - disposition retained `#3121` closeout residue
+- fix or explicitly disposition accepted `WP-20B` findings
+- recheck the corrected handoff packet before external review
 - complete WP-21 external review
 - complete WP-22 remediation or explicit deferrals
 - complete WP-23 next-milestone planning

--- a/docs/milestones/v0.91.2/review/internal_review/QUALITY_GATE_REVIEW.md
+++ b/docs/milestones/v0.91.2/review/internal_review/QUALITY_GATE_REVIEW.md
@@ -1,8 +1,16 @@
 # v0.91.2 WP-20 Quality Gate Review
 
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
+
 ## Result
 
-Quality gate is truthful and reviewable.
+The quality gate remains truthful as `NOT_READY`, but this first `WP-20` review
+is not the controlling handoff after `WP-20B`.
 
 ## Evidence
 
@@ -11,7 +19,9 @@ Quality gate is truthful and reviewable.
 
 ## Review Judgment
 
-The gate correctly reports `NOT_READY` because WP-20 through WP-24 remain. This is a truthful release-tail state, not a failed WP-20 review.
+The gate correctly reports `NOT_READY`. After `WP-20B`, the strongest review
+truth is that accepted `WP-20B` findings must be fixed and rechecked before
+clean external review or release ceremony claims.
 
 ## Finding Link
 

--- a/docs/milestones/v0.91.2/review/internal_review/READINESS_GATE.md
+++ b/docs/milestones/v0.91.2/review/internal_review/READINESS_GATE.md
@@ -1,8 +1,16 @@
 # v0.91.2 WP-20 Internal Review Readiness Gate
 
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
+
 ## Result
 
-Ready for internal review. Not release-ready.
+The original internal review pass was allowed to run. The milestone is not
+release-ready, and it is not cleanly external-review-ready after `WP-20B`.
 
 ## Dependency State
 
@@ -13,12 +21,14 @@ Ready for internal review. Not release-ready.
 | WP-18 `#3017` | closed | GitHub issue state checked during WP-20 |
 | WP-19 `#3018` | closed | GitHub issue state checked during WP-20 |
 | WP-20 `#3019` | open | current issue |
-| WP-21 `#3020` | open | external review remains after WP-20 |
-| WP-22 `#3021` | open | remediation remains after WP-21 |
+| WP-20B `#3173` | corrective review | controlling full internal review packet |
+| WP-21 `#3020` | open | external review remains blocked until accepted `WP-20B` findings are fixed and rechecked |
+| WP-22 `#3021` | open | remediation must cover accepted `WP-20B` findings |
 
 ## Gate Evidence
 
-- `QUALITY_GATE_v0.91.2.md` records current gate judgment as `NOT_READY`, which is correct before WP-20 through WP-24 complete.
+- `QUALITY_GATE_v0.91.2.md` records current gate judgment as `NOT_READY`,
+  which remains correct while accepted `WP-20B` findings are unresolved.
 - `FEATURE_PROOF_COVERAGE_v0.91.2.md` maps WP-02 through WP-18 proof routes.
 - `DEMO_MATRIX_v0.91.2.md` names proving surfaces and non-claims.
 - `RELEASE_READINESS_v0.91.2.md` truthfully records that Sprint 4 remains open.
@@ -26,5 +36,6 @@ Ready for internal review. Not release-ready.
 ## Gate Classification
 
 - Internal review: allowed.
-- External review handoff: allowed after this packet is accepted.
+- External review handoff: blocked after `WP-20B` until accepted findings are
+  fixed and rechecked.
 - Release readiness: blocked until WP-21 through WP-24 complete and findings are dispositioned.

--- a/docs/milestones/v0.91.2/review/internal_review/REVIEW_PACKET.md
+++ b/docs/milestones/v0.91.2/review/internal_review/REVIEW_PACKET.md
@@ -1,12 +1,17 @@
 # v0.91.2 WP-20 Internal Review Packet
 
-Status: superseded as the controlling handoff surface by
-`docs/milestones/v0.91.2/review/internal_review_full/`.
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
 
 ## Verdict
 
-This thinner `WP-20` packet is no longer the controlling readiness or handoff
-surface for `WP-21`.
+Superseded. This packet originally claimed external-review readiness, but
+`WP-20B` later found accepted blockers. External review should not proceed
+until those findings are fixed and rechecked.
 
 Use the `WP-20B` full internal review packet and its findings as the controlling
 input for external-review handoff and `WP-22` remediation routing.
@@ -29,5 +34,7 @@ input for external-review handoff and `WP-22` remediation routing.
 
 Do not treat this packet alone as authorization to proceed. If `WP-21`
 continues, it must do so using the `WP-20B` full packet, its findings register,
-and its non-claims as the controlling evidence surface. Route accepted findings
-to `WP-22` or explicit follow-on issues before the `WP-24` release ceremony.
+and its non-claims as the controlling evidence surface. Use
+`docs/milestones/v0.91.2/review/internal_review_full/`,
+`docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md`, and fix or
+explicitly disposition accepted `WP-20B` findings before external review.

--- a/docs/milestones/v0.91.2/review/internal_review/REVIEW_REPORT.md
+++ b/docs/milestones/v0.91.2/review/internal_review/REVIEW_REPORT.md
@@ -1,11 +1,17 @@
 # v0.91.2 WP-20 Internal Review Report
 
-Status: superseded as the controlling `WP-21` handoff surface by
-`docs/milestones/v0.91.2/review/internal_review_full/`.
+## Supersession Status
+
+This file is historical `WP-20` review context. The first `WP-20` packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`. Do not use this file as
+standalone approval to start `WP-21`.
 
 ## Verdict
 
 Do not treat this thin `WP-20` report as the controlling go-forward signal.
+External review should wait until accepted `WP-20B` findings are fixed and
+rechecked.
 
 Do not claim release readiness yet.
 
@@ -22,5 +28,7 @@ Do not claim release readiness yet.
 
 ## Next Step
 
-If `WP-21` continues, use `WP21_EXTERNAL_REVIEW_HANDOFF.md` together with the
-`WP-20B` full internal review packet as the controlling evidence surface.
+Do not start WP-21 from this report or the nested
+`WP21_EXTERNAL_REVIEW_HANDOFF.md`. Use the top-level
+`docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md` after the
+accepted `WP-20B` findings are fixed and rechecked.

--- a/docs/milestones/v0.91.2/review/internal_review/RUN_MANIFEST.md
+++ b/docs/milestones/v0.91.2/review/internal_review/RUN_MANIFEST.md
@@ -1,5 +1,11 @@
 # v0.91.2 WP-20 Internal Review Run Manifest
 
+## Supersession Status
+
+This manifest records the first `WP-20` internal review run. That packet was
+too thin for external handoff and is superseded for readiness decisions by
+`docs/milestones/v0.91.2/review/internal_review_full/`.
+
 ## Target
 
 - Issue: `#3019`

--- a/docs/milestones/v0.91.2/review/internal_review/WP21_EXTERNAL_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.2/review/internal_review/WP21_EXTERNAL_REVIEW_HANDOFF.md
@@ -1,9 +1,17 @@
 # v0.91.2 WP-21 External Review Handoff
 
+## Supersession Status
+
+This nested handoff is historical `WP-20` review context. The first `WP-20`
+packet was too thin for external handoff and is superseded for readiness
+decisions by `docs/milestones/v0.91.2/review/internal_review_full/` and the
+top-level `docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md`.
+Do not send this nested file as the current external review handoff.
+
 ## Recommended Status
 
-Proceed only with the `WP-20B` full internal review packet as the controlling
-evidence surface.
+Blocked. Do not proceed to WP-21 external / third-party review until accepted
+`WP-20B` findings are fixed and rechecked.
 
 The older thin `WP-20` packet remains useful as background context, but it is
 not the controlling readiness surface for this handoff.
@@ -32,6 +40,7 @@ not the controlling readiness surface for this handoff.
 - workflow guardrail proof strength
 - retained `#3121` closeout-truth gap routing
 - the `WP-20B` findings register and its grouped remediation routes
+- accepted `WP-20B` finding fixes and re-review truth
 
 ## Do Not Ask External Review To Accept
 

--- a/docs/milestones/v0.91.2/review/internal_review/WP22_REMEDIATION_QUEUE.md
+++ b/docs/milestones/v0.91.2/review/internal_review/WP22_REMEDIATION_QUEUE.md
@@ -1,5 +1,11 @@
 # v0.91.2 WP-22 Remediation Queue Draft
 
+## Supersession Status
+
+This draft is historical `WP-20` review context. It has been superseded for
+current remediation planning by the `WP-20B` full internal review packet under
+`docs/milestones/v0.91.2/review/internal_review_full/`.
+
 Controlling upstream packet:
 - `docs/milestones/v0.91.2/review/internal_review_full/`
 
@@ -7,6 +13,8 @@ Controlling upstream packet:
 
 1. Retained `#3121` closeout residue must be fixed or explicitly deferred with final release-tail owner.
 2. WP-21/WP-22 handoff must preserve release non-claims and prevent review/remediation from being mistaken for release approval.
+3. Accepted `WP-20B` findings must be fixed or explicitly dispositioned and
+   rechecked before external review.
 
 ## Grouped Remediation Routing
 
@@ -24,3 +32,7 @@ Controlling upstream packet:
 ## Candidate Follow-On Routing
 
 - If the retained `#3121` residue is too broad for WP-22, open a bounded closeout-truth cleanup issue and reference it from release ceremony records.
+- Use `docs/milestones/v0.91.2/review/internal_review_full/FINDING_TO_ISSUE_PLAN.md`
+  as the current remediation grouping for benchmark validity, hosted-provider
+  portability/security, evidence/handoff truth, tooling hygiene, and provider
+  capability reporting.

--- a/docs/milestones/v0.91.2/review/internal_review_full/FINDINGS_REGISTER.md
+++ b/docs/milestones/v0.91.2/review/internal_review_full/FINDINGS_REGISTER.md
@@ -71,9 +71,13 @@ Evidence:
 - `docs/milestones/v0.91.2/review/internal_review/REVIEW_PACKET.md:5`
 - `docs/milestones/v0.91.2/review/internal_review/WP21_EXTERNAL_REVIEW_HANDOFF.md:5`
 
-The older WP-20 packet still says to proceed to WP-21, while WP-20B exists specifically because that review was incomplete.
+At WP-20B review time, the older WP-20 packet still said to proceed to WP-21,
+while WP-20B existed specifically because that review was incomplete. Current
+handoff docs must keep the older packet marked as superseded and keep WP-21
+blocked until accepted WP-20B findings are fixed and rechecked.
 
-Impact: external reviewers may be handed a stale readiness story unless WP-20B findings are made controlling.
+Impact: external reviewers may be handed a stale readiness story unless WP-20B
+findings remain controlling and the accepted fixes are rechecked before review.
 
 Route: WP-21/WP-22 handoff update.
 

--- a/docs/milestones/v0.91.2/review/internal_review_full/README.md
+++ b/docs/milestones/v0.91.2/review/internal_review_full/README.md
@@ -4,7 +4,9 @@ Status: completed review packet, not remediation.
 
 This packet corrects the too-thin WP-20 internal review by running a CodeFriend-style specialist review across code, tests, docs/evidence, security, architecture/methodology, and dependency/tooling surfaces.
 
-This packet does not claim v0.91.2 is release-ready. It feeds WP-22 remediation and WP-21 external-review handoff truth.
+This packet does not claim v0.91.2 is release-ready. It feeds WP-22 remediation
+and the WP-21 external-review handoff, but WP-21 should not start until
+accepted WP-20B findings are fixed and rechecked.
 
 Primary outputs:
 

--- a/docs/milestones/v0.91.2/review/internal_review_full/REVIEW_QUALITY_EVALUATION.md
+++ b/docs/milestones/v0.91.2/review/internal_review_full/REVIEW_QUALITY_EVALUATION.md
@@ -9,15 +9,19 @@ Strengths:
 - The review does not claim release approval.
 - The review identifies the prior WP-20 packet as insufficient instead of hiding the process gap.
 
-Quality blockers for publication:
+Quality blockers for external review/publication:
 
 - Test specialist lane was incomplete and had to be locally recovered with focused evidence checks.
-- Several findings require remediation before external reviewers can trust benchmark evidence.
+- Several findings require remediation and re-review before external reviewers
+  can trust benchmark evidence.
 - Redaction and path-portability findings block public use.
-- WP-21 handoff docs must be updated to reference WP-20B findings.
+- WP-21 handoff docs must keep WP-20B findings as controlling until the
+  accepted fixes are complete.
 
 Required before WP-21 external review:
 
 - Attach this packet as controlling context.
-- Mark old WP-20 readiness language as superseded or caveated.
+- Keep old WP-20 readiness language marked as superseded.
 - Route P1/P2 findings to WP-22.
+- Fix or explicitly disposition accepted WP-20B findings and recheck the
+  corrected packet.

--- a/docs/milestones/v0.91.2/review/internal_review_full/SYNTHESIS_REPORT.md
+++ b/docs/milestones/v0.91.2/review/internal_review_full/SYNTHESIS_REPORT.md
@@ -1,6 +1,7 @@
 # WP-20B Full Internal Review Synthesis
 
-Verdict: not release-ready; not external-review-ready without WP-20B caveats.
+Verdict: not release-ready; not external-review-ready until accepted WP-20B
+findings are fixed and rechecked.
 
 This full internal review found no P0s, but it found multiple P1/P2 risks that materially affect benchmark credibility, hosted-provider portability, security hygiene, and review handoff truth.
 
@@ -9,12 +10,15 @@ Most important findings:
 1. The governed Rust UTS+ACC benchmark can pass wrong task arguments.
 2. Hosted benchmark defaults include operator-local key-file paths.
 3. Canonical benchmark profiles can reference models absent from the canonical model panel.
-4. The old WP-20 packet still says to proceed to WP-21 even though WP-20B exists because that packet was insufficient.
+4. The old WP-20 packet originally said to proceed to WP-21 even though WP-20B
+   exists because that packet was insufficient.
 
 Release interpretation:
 
 - v0.91.2 can continue internal remediation.
-- WP-21 external review must receive this packet, not the thin WP-20 packet alone.
+- WP-21 external review must wait until accepted WP-20B findings are fixed and
+  rechecked; when it starts, it must receive this packet, not the thin WP-20
+  packet alone.
 - WP-22 must prioritize benchmark validity, redaction/portability, and handoff truth.
 - UTS benchmark superiority claims remain non-publication claims until the P1/P2 benchmark-methodology findings are fixed or explicitly bounded.
 

--- a/docs/milestones/v0.91.2/review/issue_3182_review/REVIEW.md
+++ b/docs/milestones/v0.91.2/review/issue_3182_review/REVIEW.md
@@ -8,7 +8,7 @@ Branch: `codex/3182-v0912-review-handoff-truth`
 
 ## Verdict
 
-Not PR-ready yet.
+PR-ready after follow-up card normalization.
 
 The documentation changes are directionally correct and satisfy the major
 review-truth goals: `WP-20B` is made controlling, the old `WP-20` packet is
@@ -16,14 +16,16 @@ marked historical, the new top-level third-party handoff exists, and `WP-21`
 external review is blocked until accepted `WP-20B` findings are fixed and
 rechecked.
 
-The blocker is lifecycle-card truth. The implementation and SOR say the issue
-is complete, but the SIP and SRP still contain scaffold/pre-review language.
-That creates exactly the kind of review-tail truth drift this issue is meant to
-eliminate.
+The initial blocker was lifecycle-card truth. After this review, the SIP, SRP,
+and SOR were normalized with the corresponding editor skills and validated
+successfully. The remaining scope is external review and `WP-20B` remediation
+work, not this handoff-truth repair.
 
 ## Findings
 
 ### P1: Issue cards contradict the completed worktree and would make publication truth unsafe
+
+Disposition: Fixed after review.
 
 Evidence:
 
@@ -34,17 +36,24 @@ Evidence:
 - `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sor.md:127`
 - `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sor.md:136`
 
-The SOR records `Status: DONE`, validation commands, and `Result: PASS`, but
-the SIP still says the issue is not started and the SRP still says review has
-not run because implementation has not been bound. That is a publication
-blocker for this issue because its purpose is to make reviewer-facing truth
-boring and consistent.
+At the time of this review, the SOR recorded `Status: DONE`, validation
+commands, and `Result: PASS`, but the SIP and SRP still carried pre-execution
+scaffold language. That was a publication blocker for this issue because its
+purpose is to make reviewer-facing truth boring and consistent. The blocker was
+then fixed with the editor-skill normalization recorded below.
 
 Recommended fix:
 
 - Normalize the SIP with `sip-editor`.
 - Normalize the SRP with `srp-editor` after this review result is incorporated.
 - Keep the SOR truth aligned with the final review disposition.
+
+Resolution evidence:
+
+- `bash adl/tools/validate_structured_prompt.sh --type sip --phase final --input .adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sip.md`
+- `bash adl/tools/validate_structured_prompt.sh --type srp --phase final --input .adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/srp.md`
+- `bash adl/tools/validate_structured_prompt.sh --type sor --phase final --input .adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sor.md`
+- Result: all three validators passed after normalization.
 
 ## Passing Checks
 

--- a/docs/milestones/v0.91.2/review/issue_3182_review/REVIEW.md
+++ b/docs/milestones/v0.91.2/review/issue_3182_review/REVIEW.md
@@ -1,0 +1,99 @@
+# Issue 3182 Review - Normalize v0.91.2 Review Handoff Truth
+
+Date: 2026-05-21
+Reviewer: Codex
+Scope: `/Users/daniel/git/agent-design-language/.worktrees/adl-wp-3182`
+Issue: `#3182`
+Branch: `codex/3182-v0912-review-handoff-truth`
+
+## Verdict
+
+Not PR-ready yet.
+
+The documentation changes are directionally correct and satisfy the major
+review-truth goals: `WP-20B` is made controlling, the old `WP-20` packet is
+marked historical, the new top-level third-party handoff exists, and `WP-21`
+external review is blocked until accepted `WP-20B` findings are fixed and
+rechecked.
+
+The blocker is lifecycle-card truth. The implementation and SOR say the issue
+is complete, but the SIP and SRP still contain scaffold/pre-review language.
+That creates exactly the kind of review-tail truth drift this issue is meant to
+eliminate.
+
+## Findings
+
+### P1: Issue cards contradict the completed worktree and would make publication truth unsafe
+
+Evidence:
+
+- `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sip.md:22`
+- `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/srp.md:105`
+- `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/srp.md:113`
+- `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sor.md:17`
+- `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sor.md:127`
+- `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sor.md:136`
+
+The SOR records `Status: DONE`, validation commands, and `Result: PASS`, but
+the SIP still says the issue is not started and the SRP still says review has
+not run because implementation has not been bound. That is a publication
+blocker for this issue because its purpose is to make reviewer-facing truth
+boring and consistent.
+
+Recommended fix:
+
+- Normalize the SIP with `sip-editor`.
+- Normalize the SRP with `srp-editor` after this review result is incorporated.
+- Keep the SOR truth aligned with the final review disposition.
+
+## Passing Checks
+
+- `docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md` exists
+  and clearly says the packet is draft/not sendable until accepted `WP-20B`
+  findings are fixed and rechecked.
+- Every markdown file under
+  `docs/milestones/v0.91.2/review/internal_review/` has a
+  `Supersession Status` section.
+- The new handoff's required-review path list contains no missing paths in the
+  current worktree.
+- `docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml` parses with Ruby YAML.
+- `git diff --check` passes.
+- Stale-phrase scans show the remaining `proceed to WP-21` style text is
+  caveated as blocked, superseded, or historical rather than active readiness
+  language.
+- The remediation issue references in the handoff are real: `#3175`, `#3176`,
+  and `#3177` are closed; `#3178` and `#3179` are open and correctly remain
+  blockers for external review.
+
+## Reviewed Surfaces
+
+- Root status docs: `README.md`, `CHANGELOG.md`, `adl/README.md`
+- Planning docs: `docs/planning/ADL_FEATURE_LIST.md`
+- v0.91.2 milestone docs under `docs/milestones/v0.91.2/`
+- Historical `WP-20` packet under
+  `docs/milestones/v0.91.2/review/internal_review/`
+- Corrective `WP-20B` packet under
+  `docs/milestones/v0.91.2/review/internal_review_full/`
+- New top-level handoff:
+  `docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md`
+- Local task cards under
+  `.adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/`
+
+## Validation Performed During Review
+
+```sh
+git status --short
+git diff --stat
+git diff --name-only
+ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml"); puts "yaml ok"'
+git diff --check
+rg -n "Proceed to WP-21|proceed to WP-21|ready to proceed|ready for external|external review should proceed|clean external-review readiness|release-ready|release ready|release is ready|completed remediation|findings are fixed|findings fixed|accepted findings fixed" README.md CHANGELOG.md adl/README.md docs/milestones/v0.91.2 docs/planning/ADL_FEATURE_LIST.md
+for f in docs/milestones/v0.91.2/review/internal_review/*.md; do if ! rg -q '^## Supersession Status$' "$f"; then echo "MISSING $f"; fi; done
+```
+
+## Residual Risk
+
+This was a docs/evidence review, not a code remediation review for the
+underlying `WP-20B` findings. It does not prove benchmark correctness,
+provider-security hardening, CI pinning, or native-tool capability reporting.
+Those remain governed by their remediation issues.

--- a/docs/milestones/v0.91.2/review/quality_gate/QUALITY_GATE_PACKET_v0.91.2.md
+++ b/docs/milestones/v0.91.2/review/quality_gate/QUALITY_GATE_PACKET_v0.91.2.md
@@ -23,7 +23,7 @@ review surface:
 | CI path-policy and coverage-lane contract | PASS | `bash adl/tools/test_ci_path_policy.sh`, `bash adl/tools/test_ci_runtime_contracts.sh`, `bash adl/tools/test_run_authoritative_coverage_lane.sh`, and `bash adl/tools/test_check_coverage_impact.sh` | Shows the current CI split remains internally coherent after the runtime/coverage recovery work. | Contract checks are not the same thing as a fresh full release coverage run. |
 | Retained closeout truth | PARTIAL | Sprint 1 through Sprint 3 closeout truth is materially cleaner; known retained `#3121` residue is explicitly deferred out of this issue | Keeps the packet honest about one remaining deferred retained-card gap. | This is a truth-hygiene gate, not feature proof. |
 | Full authoritative coverage evidence | PASS | `bash adl/tools/run_authoritative_coverage_lane.sh` completed during WP-18 with `2066` tests passed, `2` skipped, and `coverage-summary.json` written | Proves the heavyweight authoritative coverage lane still runs cleanly at the current milestone state. | This is strong release-tail evidence, but it still does not by itself approve the milestone for release. |
-| Release-tail review, remediation, and ceremony | NOT_READY | `WP-19` docs review is closed; `WP-20` through `WP-24` remain open in Sprint 4 | Preserves the real remaining path to closeout. | WP-18 cannot close the milestone by itself. |
+| Release-tail review, remediation, and ceremony | NOT_READY | `WP-19` docs review is closed; the first `WP-20` packet is superseded for handoff truth by `WP-20B`; accepted `WP-20B` findings must be fixed and rechecked before `WP-21` external review | Preserves the real remaining path to closeout. | WP-18 and the thin WP-20 packet cannot close the milestone or justify clean external review by themselves. |
 
 ## Command Surfaces
 
@@ -53,7 +53,9 @@ ADL_V0912_QUALITY_GATE_RUN_HEAVY=1 bash adl/tools/demo_v0912_quality_gate.sh
 
 The milestone still lacks:
 
-- final review records
+- fixed and rechecked accepted `WP-20B` findings
+- clean external-review handoff truth
+- final external review records
 - remediation truth
 - release evidence completion
 - ceremony and end-of-milestone closeout
@@ -65,4 +67,6 @@ The milestone still lacks:
 - This packet does not say `adl-ci` or `adl-coverage` on a docs-only or
   contract-only path are enough for release.
 - This packet does not claim `v0.91.2` is ready to ship.
+- This packet does not claim the first `WP-20` internal review packet is
+  sufficient for external handoff after the corrective `WP-20B` review.
 - This packet does not collapse remaining Sprint 4 work into “administrivia.”

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -56,8 +56,9 @@ The current repo truth is:
 - current crate version on the active release line: `0.91.2`
 - current milestone state: `v0.91.1` is complete and `v0.91.2` is active; the
   full `WP-01` / `#3000` through `WP-24` / `#3023` issue wave is opened, Sprint
-  4 has closed `WP-17`, `WP-17A`, `WP-18`, and `WP-19`, leaving `WP-20` as the
-  next internal-review step
+  4 has closed `WP-17`, `WP-17A`, `WP-18`, and `WP-19`; the initial `WP-20`
+  internal review is superseded for handoff truth by `WP-20B`, and external
+  review is blocked until accepted `WP-20B` findings are fixed and rechecked
 - most recently completed inhabited-runtime milestone package: `v0.91.1`
 - most recently completed moral-governance milestone package: `v0.91`
 - most recently completed governed-tools milestone package: `v0.90.5`


### PR DESCRIPTION
Closes #3182

## Summary
Completed the v0.91.2 review-handoff truth repair for #3182.

The issue now makes the tracked review-tail docs agree that the first `WP-20`
internal review packet was too thin, that `WP-20B` / `#3173` is the controlling
full internal review packet, and that `WP-21` external review must wait until
accepted `WP-20B` findings are fixed and rechecked.

## Artifacts
- Added top-level review handoff:
  - `docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md`
- Updated root and planning status surfaces:
  - `README.md`
  - `CHANGELOG.md`
  - `adl/README.md`
  - `docs/planning/ADL_FEATURE_LIST.md`
- Updated v0.91.2 milestone release-tail surfaces:
  - `docs/milestones/v0.91.2/README.md`
  - `docs/milestones/v0.91.2/WBS_v0.91.2.md`
  - `docs/milestones/v0.91.2/SPRINT_v0.91.2.md`
  - `docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml`
  - `docs/milestones/v0.91.2/SPRINT_CONDUCTOR_EXECUTION_PLAN_v0.91.2.md`
  - `docs/milestones/v0.91.2/features/README.md`
  - `docs/milestones/v0.91.2/QUALITY_GATE_v0.91.2.md`
  - `docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md`
  - `docs/milestones/v0.91.2/RELEASE_EVIDENCE_v0.91.2.md`
  - `docs/milestones/v0.91.2/RELEASE_PLAN_v0.91.2.md`
  - `docs/milestones/v0.91.2/RELEASE_NOTES_v0.91.2.md`
  - `docs/milestones/v0.91.2/END_OF_MILESTONE_REPORT_v0.91.2.md`
- Updated historical `WP-20` internal-review packet:
  - `docs/milestones/v0.91.2/review/internal_review/`
- Updated `WP-20B` full-review packet:
  - `docs/milestones/v0.91.2/review/internal_review_full/README.md`
  - `docs/milestones/v0.91.2/review/internal_review_full/SYNTHESIS_REPORT.md`
  - `docs/milestones/v0.91.2/review/internal_review_full/FINDINGS_REGISTER.md`
  - `docs/milestones/v0.91.2/review/internal_review_full/REVIEW_QUALITY_EVALUATION.md`
- Updated quality-gate packet:
  - `docs/milestones/v0.91.2/review/quality_gate/QUALITY_GATE_PACKET_v0.91.2.md`

## Validation
- Validation commands and their purpose:
  - `adl/tools/pr.sh run 3182 --slug v0912-review-handoff-truth --version v0.91.2 --allow-open-pr-wave`
    Bound the issue branch and worktree after the normal open-PR wave guard reported PR #3170.
  - `ruby -e 'require "yaml"; YAML.load_file("docs/milestones/v0.91.2/WP_ISSUE_WAVE_v0.91.2.yaml"); puts "yaml ok"'`
    Verified the updated issue-wave YAML parses.
  - `git diff --check`
    Verified whitespace cleanliness for the tracked docs patch.
  - `rg -n 'review-ready docs package|review-ready release package|Proceed to WP-21|ready for WP-21|Start WP-21|using `WP21_EXTERNAL_REVIEW_HANDOFF.md`|sufficient for external review|No blocking gaps were found|No docs-blocking findings|external review should receive|external review handoff prepared|WP-21 external review should|ready to proceed|allowed after this packet|external review handoff: allowed|must be updated to reference WP-20B|Mark old WP-20 readiness language as superseded or caveated' README.md CHANGELOG.md adl/README.md docs/planning/ADL_FEATURE_LIST.md docs/milestones/v0.91.2`
    Verified the targeted stale review-readiness phrase set has no hits.
  - `for f in docs/milestones/v0.91.2/review/internal_review/*.md; do if ! rg -q 'Supersession Status' "$f"; then echo "missing supersession: $f"; fi; done`
    Verified all historical WP-20 internal-review markdown docs have supersession markers.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3182__v0912-review-handoff-truth/sor.md
- Idempotency-Key: v0-91-2-wp-21-docs-normalize-review-handoff-truth-before-external-review-docs-milestones-v0-91-2-adl-v0-91-2-third-party-review-handoff-md-docs-milestones-v0-91-2-review-issue-3182-review-review-md-adl-v0-91-2-tasks-issue-3182-v0912-review-handoff-truth-sip-md-adl-v0-91-2-tasks-issue-3182-v0912-review-handoff-truth-sor-md