### PR TITLE
[v0.91.2][WP-22][tooling] Fix CI pinning and validation reproducibility

### DIFF
--- a/.github/workflows/v0871_milestone_closeout_gate.yaml
+++ b/.github/workflows/v0871_milestone_closeout_gate.yaml
@@ -12,7 +12,7 @@ jobs:
       issues: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run v0.87.1 closed-issue SOR truth gate
         env:

--- a/adl/tools/benchmark/portable_benchmark_common.py
+++ b/adl/tools/benchmark/portable_benchmark_common.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+"""Internal UTS benchmark support helpers.
+
+This module is import-only support for the canonical runner
+`adl/tools/uts_benchmark_runner.py`. It is not a supported execution entrypoint
+or release-proof surface by itself.
+"""
 import json
 import os
 import time
@@ -331,3 +337,11 @@ def write_markdown_reports(report, lane_title, support_key, out_path: Path):
 def write_markdown_report(report, lane_title, support_key, out_path: Path):
     summary_path, _ = write_markdown_reports(report, lane_title, support_key, out_path)
     return summary_path
+
+
+if __name__ == '__main__':
+    raise SystemExit(
+        'portable_benchmark_common.py is an internal support module; use '
+        'python3 adl/tools/uts_benchmark_runner.py or '
+        'adl/tools/run_uts_benchmark.sh instead.'
+    )

--- a/adl/tools/install_local_authoritative_coverage_prereqs.sh
+++ b/adl/tools/install_local_authoritative_coverage_prereqs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  adl/tools/install_local_authoritative_coverage_prereqs.sh
+
+Install local operator-side prerequisites for
+adl/tools/run_local_authoritative_coverage_gate.sh.
+
+This script exists to keep prerequisite installation separate from validation.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+command -v cargo >/dev/null 2>&1 || {
+  echo "cargo is required to install local authoritative coverage prerequisites" >&2
+  exit 1
+}
+
+if cargo nextest --version >/dev/null 2>&1; then
+  echo "cargo-nextest already available."
+  exit 0
+fi
+
+echo "Installing cargo-nextest for local authoritative coverage validation..."
+cargo install cargo-nextest --locked
+cargo nextest --version >/dev/null 2>&1 || {
+  echo "cargo-nextest installation did not produce a runnable cargo nextest command" >&2
+  exit 1
+}
+
+echo "cargo-nextest installed successfully."

--- a/adl/tools/run_local_authoritative_coverage_gate.sh
+++ b/adl/tools/run_local_authoritative_coverage_gate.sh
@@ -36,6 +36,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "$PRINT_PLAN" = true ]; then
+  printf 'prereq_install=adl/tools/install_local_authoritative_coverage_prereqs.sh\n'
   printf 'runner=adl/tools/run_authoritative_coverage_lane.sh\n'
   printf 'gate=adl/tools/enforce_coverage_gates.sh coverage-summary.json\n'
   printf 'summary_copy=adl/target/local-authoritative-coverage-summary.json\n'
@@ -54,20 +55,11 @@ cargo llvm-cov --version >/dev/null 2>&1 || {
   echo "cargo-llvm-cov is required for local authoritative coverage validation" >&2
   exit 1
 }
-
-ensure_cargo_nextest() {
-  if cargo nextest --version >/dev/null 2>&1; then
-    return 0
-  fi
-  echo "cargo-nextest not found; installing it locally for authoritative coverage validation..."
-  cargo install cargo-nextest --locked
-  cargo nextest --version >/dev/null 2>&1 || {
-    echo "cargo-nextest installation did not produce a runnable cargo nextest command" >&2
-    exit 1
-  }
+cargo nextest --version >/dev/null 2>&1 || {
+  echo "cargo-nextest is required for local authoritative coverage validation" >&2
+  echo "Run adl/tools/install_local_authoritative_coverage_prereqs.sh or install cargo-nextest explicitly before rerunning this gate." >&2
+  exit 1
 }
-
-ensure_cargo_nextest
 
 rm -f "$TMP_SUMMARY" "$SUMMARY_PATH"
 trap 'rm -f "$TMP_SUMMARY"' EXIT

--- a/adl/tools/test_ci_runtime_contracts.sh
+++ b/adl/tools/test_ci_runtime_contracts.sh
@@ -9,8 +9,10 @@ import pathlib
 import re
 import sys
 
-workflow = pathlib.Path(sys.argv[1]).read_text()
+workflow_path = pathlib.Path(sys.argv[1])
+workflow = workflow_path.read_text()
 runner_test = pathlib.Path(sys.argv[2])
+workflow_root = workflow_path.parent
 
 def step_run(name: str) -> str:
     pattern = re.compile(
@@ -46,6 +48,17 @@ def step_if(name: str) -> str:
     if not match:
         raise SystemExit(f"missing workflow if condition for step: {name}")
     return match.group(1).strip()
+
+checkout_sha = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+for candidate in sorted(workflow_root.glob("*.y*ml")):
+    text = candidate.read_text()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses: actions/checkout@") and checkout_sha not in stripped:
+            raise SystemExit(
+                f"workflow must pin actions/checkout to the canonical SHA; "
+                f"found {stripped!r} in {candidate.name}"
+            )
 
 ordinary_test = step_run("test")
 expected_ordinary_test = (

--- a/adl/tools/test_run_local_authoritative_coverage_gate.sh
+++ b/adl/tools/test_run_local_authoritative_coverage_gate.sh
@@ -6,12 +6,84 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 plan="$(bash "$ROOT_DIR/adl/tools/run_local_authoritative_coverage_gate.sh" --print-plan)"
 
 for required in \
+  "prereq_install=adl/tools/install_local_authoritative_coverage_prereqs.sh" \
   "runner=adl/tools/run_authoritative_coverage_lane.sh" \
   "gate=adl/tools/enforce_coverage_gates.sh coverage-summary.json" \
   "summary_copy=adl/target/local-authoritative-coverage-summary.json"
 do
   if ! grep -F "$required" <<<"$plan" >/dev/null 2>&1; then
     echo "missing local authoritative coverage plan token: $required" >&2
+    exit 1
+  fi
+done
+
+bash -n "$ROOT_DIR/adl/tools/run_local_authoritative_coverage_gate.sh"
+bash -n "$ROOT_DIR/adl/tools/install_local_authoritative_coverage_prereqs.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/bin"
+cat >"$TMP_DIR/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_DIR="${FAKE_CARGO_LOG_DIR:?}"
+case "${1:-}" in
+  llvm-cov)
+    if [[ "${2:-}" == "--version" ]]; then
+      exit 0
+    fi
+    echo "unexpected fake cargo llvm-cov args: $*" >&2
+    exit 98
+    ;;
+  nextest)
+    if [[ "${2:-}" == "--version" ]]; then
+      exit 1
+    fi
+    echo "unexpected fake cargo nextest args: $*" >&2
+    exit 98
+    ;;
+  install)
+    printf '%s\n' "$*" >>"$LOG_DIR/install.log"
+    exit 99
+    ;;
+  *)
+    echo "unexpected fake cargo invocation: $*" >&2
+    exit 97
+    ;;
+esac
+EOF
+chmod +x "$TMP_DIR/bin/cargo"
+cat >"$TMP_DIR/bin/jq" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TMP_DIR/bin/jq"
+
+set +e
+gate_output="$(
+  PATH="$TMP_DIR/bin:$PATH" \
+  FAKE_CARGO_LOG_DIR="$TMP_DIR" \
+  bash "$ROOT_DIR/adl/tools/run_local_authoritative_coverage_gate.sh" 2>&1
+)"
+gate_status=$?
+set -e
+
+if [[ $gate_status -eq 0 ]]; then
+  echo "expected local authoritative coverage gate to fail when cargo-nextest is missing" >&2
+  exit 1
+fi
+
+if [[ -f "$TMP_DIR/install.log" ]]; then
+  echo "local authoritative coverage gate must not auto-install cargo-nextest" >&2
+  exit 1
+fi
+
+for required in \
+  "cargo-nextest is required for local authoritative coverage validation" \
+  "Run adl/tools/install_local_authoritative_coverage_prereqs.sh or install cargo-nextest explicitly before rerunning this gate."
+do
+  if ! grep -F "$required" <<<"$gate_output" >/dev/null 2>&1; then
+    echo "missing expected missing-nextest guidance: $required" >&2
     exit 1
   fi
 done

--- a/adl/tools/test_uts_benchmark_entrypoint_contracts.sh
+++ b/adl/tools/test_uts_benchmark_entrypoint_contracts.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNBOOK="$ROOT_DIR/docs/milestones/v0.91.2/review/uts_benchmark_evidence/RUNBOOK.md"
+README="$ROOT_DIR/docs/milestones/v0.91.2/review/uts_benchmark_evidence/README.md"
+WRAPPER="$ROOT_DIR/adl/tools/run_uts_benchmark.sh"
+
+grep -F "Use exactly one Python runner for benchmark execution:" "$RUNBOOK" >/dev/null 2>&1 || {
+  echo "runbook must preserve the one-runner contract" >&2
+  exit 1
+}
+
+if ! python3 - "$RUNBOOK" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+needle = (
+    "`adl/tools/benchmark/portable_benchmark_common.py` is an internal support\n"
+    "module only and must not be treated as a second runner or review-proof command."
+)
+if needle not in text:
+    raise SystemExit(1)
+PY
+then
+  echo "runbook must explicitly mark portable_benchmark_common.py as internal support only" >&2
+  exit 1
+fi
+
+if ! python3 - "$README" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+needle = (
+    "`adl/tools/benchmark/portable_benchmark_common.py` is internal import-only\n"
+    "support and must not be treated as a second runner or a supported CLI surface."
+)
+if needle not in text:
+    raise SystemExit(1)
+PY
+then
+  echo "README must explicitly mark portable_benchmark_common.py as internal import-only support" >&2
+  exit 1
+fi
+
+grep -F 'RUNNER="$SCRIPT_DIR/uts_benchmark_runner.py"' "$WRAPPER" >/dev/null 2>&1 || {
+  echo "wrapper must continue routing to the canonical benchmark runner" >&2
+  exit 1
+}
+
+set +e
+module_output="$(python3 "$ROOT_DIR/adl/tools/benchmark/portable_benchmark_common.py" 2>&1)"
+module_status=$?
+set -e
+
+if [[ $module_status -eq 0 ]]; then
+  echo "portable_benchmark_common.py must not succeed as a direct entrypoint" >&2
+  exit 1
+fi
+
+if ! grep -F 'portable_benchmark_common.py is an internal support module' <<<"$module_output" >/dev/null 2>&1; then
+  echo "direct module execution must explain the canonical runner path" >&2
+  exit 1
+fi
+
+echo "PASS test_uts_benchmark_entrypoint_contracts"

--- a/docs/milestones/v0.91.2/review/uts_benchmark_evidence/README.md
+++ b/docs/milestones/v0.91.2/review/uts_benchmark_evidence/README.md
@@ -13,6 +13,8 @@ The only supported Python benchmark runner is:
 - `adl/tools/uts_benchmark_runner.py`
 
 `adl/tools/run_uts_benchmark.sh` is a convenience wrapper around that canonical runner. Lane-specific Python runner scripts are retired and must not be used as PR proof.
+`adl/tools/benchmark/portable_benchmark_common.py` is internal import-only
+support and must not be treated as a second runner or a supported CLI surface.
 
 Current benchmark-validity guards:
 

--- a/docs/milestones/v0.91.2/review/uts_benchmark_evidence/RUNBOOK.md
+++ b/docs/milestones/v0.91.2/review/uts_benchmark_evidence/RUNBOOK.md
@@ -11,6 +11,8 @@ python3 adl/tools/uts_benchmark_runner.py <provider-kind> <models-file> <out-jso
 ```
 
 `adl/tools/run_uts_benchmark.sh` is only a convenience wrapper around the canonical runner. The old lane-specific Python scripts are retired and are not supported entrypoints.
+`adl/tools/benchmark/portable_benchmark_common.py` is an internal support
+module only and must not be treated as a second runner or review-proof command.
 
 ## Hosted provider credentials
 


### PR DESCRIPTION
Closes #3178

## Summary
Completed the bounded reproducibility and validation-contract remediation pass
for `#3178`.

The issue now:

- pins the last floating `actions/checkout@v4` reference to the canonical SHA
- makes `adl/tools/run_local_authoritative_coverage_gate.sh` fail closed when
  `cargo-nextest` is missing instead of auto-installing it
- adds an explicit operator-side prereq installer for the local authoritative
  coverage gate
- strengthens workflow and local coverage contract checks around that split
- marks `portable_benchmark_common.py` as internal-only support and blocks it
  from being misused as a direct benchmark entrypoint
- tightens the benchmark evidence docs so the one-runner contract is explicit

## Artifacts
- Updated tracked workflow and tooling surfaces:
  - `.github/workflows/v0871_milestone_closeout_gate.yaml`
  - `adl/tools/run_local_authoritative_coverage_gate.sh`
  - `adl/tools/install_local_authoritative_coverage_prereqs.sh`
  - `adl/tools/test_run_local_authoritative_coverage_gate.sh`
  - `adl/tools/test_ci_runtime_contracts.sh`
  - `adl/tools/benchmark/portable_benchmark_common.py`
  - `adl/tools/test_uts_benchmark_entrypoint_contracts.sh`
- Updated tracked benchmark docs:
  - `docs/milestones/v0.91.2/review/uts_benchmark_evidence/README.md`
  - `docs/milestones/v0.91.2/review/uts_benchmark_evidence/RUNBOOK.md`
- Updated local ignored issue cards:
  - `.adl/v0.91.2/tasks/issue-3178__v0-91-2-ci-pinning-and-validation-reproducibility/spp.md`
  - `.adl/v0.91.2/tasks/issue-3178__v0-91-2-ci-pinning-and-validation-reproducibility/srp.md`
  - `.adl/v0.91.2/tasks/issue-3178__v0-91-2-ci-pinning-and-validation-reproducibility/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh run 3178 --slug v0-91-2-ci-pinning-and-validation-reproducibility --version v0.91.2 --allow-open-pr-wave`
    Bound the issue branch and worktree for the reproducibility remediation pass.
  - `bash adl/tools/test_run_local_authoritative_coverage_gate.sh`
    Verified the local authoritative coverage gate plan, syntax, and missing-nextest fail-closed behavior.
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Verified the CI runtime contract, including canonical checkout SHA pinning across workflow files.
  - `bash adl/tools/test_uts_benchmark_entrypoint_contracts.sh`
    Verified the one-runner benchmark contract, wrapper routing, docs wording, and internal helper rejection behavior.
  - `git diff --check`
    Verified whitespace cleanliness for the tracked diff.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3178__v0-91-2-ci-pinning-and-validation-reproducibility/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3178__v0-91-2-ci-pinning-and-validation-reproducibility/sor.md
- Idempotency-Key: v0-91-2-wp-22-tooling-fix-ci-pinning-and-validation-reproducibility-adl-v0-91-2-tasks-issue-3178-v0-91-2-ci-pinning-and-validation-reproducibility-sip-md-adl-v0-91-2-tasks-issue-3178-v0-91-2-ci-pinning-and-validation-reproducibility-sor-md