### PR TITLE
[v0.91.2][WP-22][providers] Correct native-tool capability reporting

### DIFF
--- a/adl/src/provider_native_tool_call_comparison.rs
+++ b/adl/src/provider_native_tool_call_comparison.rs
@@ -591,7 +591,28 @@ mod tests {
     fn provider_native_tool_call_comparison_splits_direct_native_from_compatibility_counts() {
         let report = run_provider_native_tool_call_comparison();
         assert_eq!(report.direct_native_supported_count, 3);
-        assert_eq!(report.compatibility_supported_count, 2);
+        assert_eq!(report.compatibility_supported_count, 0);
+    }
+
+    #[test]
+    fn provider_native_tool_call_comparison_compatibility_profiles_do_not_report_native_tool_support(
+    ) {
+        let report = run_provider_native_tool_call_comparison();
+        for candidate_id in ["gemini_http_compat_flash", "deepseek_http_compat_chat"] {
+            let entry = report
+                .providers
+                .iter()
+                .find(|entry| entry.candidate_id == candidate_id)
+                .expect("compatibility entry");
+            assert_eq!(
+                entry.surface_class,
+                ProviderNativeSurfaceClass::CompatibilityHttpProfile
+            );
+            assert!(!entry.tool_calling.supported);
+            assert_eq!(entry.tool_calling.mode, CapabilityModeV1::None);
+            assert!(entry.structured_json.supported);
+            assert_eq!(entry.structured_json.mode, CapabilityModeV1::PromptBased);
+        }
     }
 
     #[test]

--- a/adl/src/provider_substrate.rs
+++ b/adl/src/provider_substrate.rs
@@ -226,6 +226,23 @@ fn infer_capability_defaults(
         };
     }
 
+    if matches!(transport, ProviderTransportV1::Http) && vendor == "generic_http" {
+        return ProviderCapabilitiesV1 {
+            tool_calling: CapabilitySupportV1 {
+                supported: false,
+                mode: CapabilityModeV1::None,
+            },
+            structured_json: CapabilitySupportV1 {
+                supported: true,
+                mode: CapabilityModeV1::PromptBased,
+            },
+            semantic_tool_fallback: CapabilitySupportV1 {
+                supported: false,
+                mode: CapabilityModeV1::None,
+            },
+        };
+    }
+
     let native_tool_calling = match transport {
         ProviderTransportV1::Http | ProviderTransportV1::InProcess => CapabilitySupportV1 {
             supported: true,
@@ -590,6 +607,64 @@ mod tests {
             CapabilityModeV1::Native
         );
         assert!(!substrate.capabilities.semantic_tool_fallback.supported);
+    }
+
+    #[test]
+    fn provider_substrate_marks_generic_http_profiles_as_compatibility_by_default() {
+        let mut spec = provider_spec("http");
+        spec.profile = Some("http:gemini-2.0-flash".to_string());
+        spec.default_model = Some("reasoning/default".to_string());
+        spec.config.insert(
+            "endpoint".to_string(),
+            json!("https://api.example.invalid/v1/complete"),
+        );
+        spec.config
+            .insert("provider_model_id".to_string(), json!("gemini-2.0-flash"));
+
+        let substrate = provider_substrate_v1("generic_http_profile", &spec).expect("substrate");
+        assert_eq!(substrate.vendor, "generic_http");
+        assert_eq!(substrate.transport, ProviderTransportV1::Http);
+        assert!(!substrate.capabilities.tool_calling.supported);
+        assert_eq!(
+            substrate.capabilities.tool_calling.mode,
+            CapabilityModeV1::None
+        );
+        assert!(substrate.capabilities.structured_json.supported);
+        assert_eq!(
+            substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::PromptBased
+        );
+    }
+
+    #[test]
+    fn provider_substrate_allows_explicit_native_override_for_generic_http_profiles() {
+        let mut spec = provider_spec("http");
+        spec.profile = Some("http:gemini-2.0-flash".to_string());
+        spec.default_model = Some("reasoning/default".to_string());
+        spec.config.insert(
+            "endpoint".to_string(),
+            json!("https://api.example.invalid/v1/complete"),
+        );
+        spec.config
+            .insert("provider_model_id".to_string(), json!("gemini-2.0-flash"));
+        spec.config.insert(
+            "capabilities".to_string(),
+            json!({
+                "tool_calling": { "supported": true, "mode": "native" },
+                "structured_json": { "supported": true, "mode": "native" }
+            }),
+        );
+
+        let substrate = provider_substrate_v1("generic_http_profile", &spec).expect("substrate");
+        assert!(substrate.capabilities.tool_calling.supported);
+        assert_eq!(
+            substrate.capabilities.tool_calling.mode,
+            CapabilityModeV1::Native
+        );
+        assert_eq!(
+            substrate.capabilities.structured_json.mode,
+            CapabilityModeV1::Native
+        );
     }
 
     #[test]

--- a/docs/milestones/v0.91.2/review/provider_native_tool_call_comparison_report.json
+++ b/docs/milestones/v0.91.2/review/provider_native_tool_call_comparison_report.json
@@ -7,7 +7,7 @@
   },
   "compared_provider_count": 6,
   "direct_native_supported_count": 3,
-  "compatibility_supported_count": 2,
+  "compatibility_supported_count": 0,
   "skipped_provider_count": 5,
   "unsupported_provider_count": 1,
   "json_proposal_baseline": {
@@ -149,12 +149,12 @@
         "provider_model_id": "gemini-2.0-flash",
         "capabilities": {
           "tool_calling": {
-            "supported": true,
-            "mode": "native"
+            "supported": false,
+            "mode": "none"
           },
           "structured_json": {
             "supported": true,
-            "mode": "native"
+            "mode": "prompt_based"
           },
           "semantic_tool_fallback": {
             "supported": false,
@@ -163,12 +163,12 @@
         }
       },
       "tool_calling": {
-        "supported": true,
-        "mode": "native"
+        "supported": false,
+        "mode": "none"
       },
       "structured_json": {
         "supported": true,
-        "mode": "native"
+        "mode": "prompt_based"
       },
       "semantic_tool_fallback": {
         "supported": false,
@@ -203,12 +203,12 @@
         "provider_model_id": "deepseek-chat",
         "capabilities": {
           "tool_calling": {
-            "supported": true,
-            "mode": "native"
+            "supported": false,
+            "mode": "none"
           },
           "structured_json": {
             "supported": true,
-            "mode": "native"
+            "mode": "prompt_based"
           },
           "semantic_tool_fallback": {
             "supported": false,
@@ -217,12 +217,12 @@
         }
       },
       "tool_calling": {
-        "supported": true,
-        "mode": "native"
+        "supported": false,
+        "mode": "none"
       },
       "structured_json": {
         "supported": true,
-        "mode": "native"
+        "mode": "prompt_based"
       },
       "semantic_tool_fallback": {
         "supported": false,


### PR DESCRIPTION
Closes #3179

## Summary
Completed the bounded provider capability truth remediation pass for `#3179`.

The issue now:

- stops generic HTTP compatibility profiles from reporting native tool-calling
  by default
- preserves explicit capability overrides for operators who intentionally model
  a compatibility surface as native
- updates the provider-native comparison logic so compatibility HTTP surfaces
  remain visible but are not counted as native-tool supported
- regenerates the tracked provider-native comparison report so the artifact now
  matches the corrected native-vs-compatibility split

## Artifacts
- Updated tracked provider capability and reporting surfaces:
  - `adl/src/provider_substrate.rs`
  - `adl/src/provider_native_tool_call_comparison.rs`
  - `docs/milestones/v0.91.2/review/provider_native_tool_call_comparison_report.json`
- Updated local ignored issue cards:
  - `.adl/v0.91.2/tasks/issue-3179__v0-91-2-provider-native-tool-capability-reporting/spp.md`
  - `.adl/v0.91.2/tasks/issue-3179__v0-91-2-provider-native-tool-capability-reporting/srp.md`
  - `.adl/v0.91.2/tasks/issue-3179__v0-91-2-provider-native-tool-capability-reporting/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/pr.sh run 3179 --slug v0-91-2-provider-native-tool-capability-reporting --version v0.91.2 --allow-open-pr-wave`
    Bound the issue branch and worktree for the provider capability truth pass.
  - `cargo test --manifest-path adl/Cargo.toml provider_substrate -- --nocapture`
    Verified provider capability defaults and explicit override behavior for native and compatibility surfaces.
  - `cargo test --manifest-path adl/Cargo.toml provider_native_tool_call_comparison -- --nocapture`
    Verified provider-native comparison counts, compatibility-vs-native reporting truth, and tracked report parity.
  - `cargo test --manifest-path adl/Cargo.toml demo_v0912_provider_native_tool_call_comparison -- --nocapture`
    Verified the report-writing demo surface still emits the corrected tracked artifact cleanly.
  - `cargo run --manifest-path adl/Cargo.toml --bin demo_v0912_provider_native_tool_call_comparison`
    Regenerated the tracked comparison report artifact from the corrected code path.
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting cleanliness after the code changes.
  - `git diff --check`
    Verified whitespace cleanliness for the tracked diff.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3179__v0-91-2-provider-native-tool-capability-reporting/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3179__v0-91-2-provider-native-tool-capability-reporting/sor.md
- Idempotency-Key: v0-91-2-wp-22-providers-correct-native-tool-capability-reporting-adl-v0-91-2-tasks-issue-3179-v0-91-2-provider-native-tool-capability-reporting-sip-md-adl-v0-91-2-tasks-issue-3179-v0-91-2-provider-native-tool-capability-reporting-sor-md