### PR TITLE
[v0.91.2][WP-21][docs] Fix stale third-party review handoff truth

### DIFF
--- a/docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md
+++ b/docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md
@@ -10,8 +10,10 @@
 - Prepared during: `v0.91.2` review tail
 - Prepared for issue: `#3020`
 - Controlling internal review source: `#3173`
-- Current packet status: ready to begin `WP-21` external / 3rd-party review;
-  accepted `WP-20B` remediation issues `#3175` through `#3179` are closed
+- Current packet status: live `WP-21` external / 3rd-party review handoff;
+  accepted `WP-20B` remediation issues `#3175` through `#3179` are closed,
+  and this document has been corrected after live reviewer feedback found stale
+  review-entry text
 - Date: 2026-05-21
 - Publication attempted: false
 - Release approval claimed: false
@@ -19,11 +21,12 @@
 
 ## Review Entry Check
 
-This handoff is the canonical tracked third-party review surface for `v0.91.2`,
-and it has been refreshed from clean `main` after accepted `WP-20B` remediation
-issues closed.
+This handoff is the canonical tracked third-party review surface for `v0.91.2`.
+It has been refreshed from clean `main` after accepted `WP-20B` remediation
+issues closed and corrected again during live `WP-21` review after a reviewer
+found stale handoff truth.
 
-Before review, confirm:
+During review, confirm:
 
 - `README.md`, `CHANGELOG.md`, `adl/README.md`, `adl/Cargo.toml`,
   `adl/Cargo.lock`, and `docs/milestones/v0.91.2/` agree on `v0.91.2`.
@@ -33,7 +36,7 @@ Before review, confirm:
   and `#3179` are closed
 - `WP-22` remediation routing remains visible for all accepted `WP-20B`
   findings
-- any future findings from `WP-21` external review are routed through `WP-22`
+- findings from `WP-21` external review are routed through `WP-22`
   remediation before release closeout
 - No host-local paths, temporary paths, worktree-only artifacts, raw credential
   paths, or branch-only claims appear in the packet.
@@ -88,7 +91,8 @@ Current review-tail truth:
   the sole review handoff.
 - `WP-20B` / `#3173` produced the controlling full internal review packet.
 - Accepted `WP-20B` remediation issues `#3175` through `#3179` have closed.
-- `WP-21` external review can start from this refreshed handoff packet.
+- `WP-21` external review is active and should use this corrected handoff
+  packet rather than the earlier stale refresh.
 - `WP-22` remains the route for any findings accepted from the external review.
 - `WP-23` remains next-milestone planning.
 - `WP-24` remains release ceremony.
@@ -234,7 +238,7 @@ Review these evidence and review surfaces:
 Review these implementation and tooling surfaces if a claim depends on
 executable behavior:
 
-- `adl/src/uts_acc_multi_model_benchmark.rs`
+- `adl/src/uts_acc_multi_model_benchmark/`
 - `adl/src/provider_substrate.rs`
 - `adl/src/provider_native_tool_call_comparison.rs`
 - `adl/tools/uts_benchmark_runner.py`
@@ -261,7 +265,9 @@ The external review should verify:
   paths or assume a private machine layout
 - benchmark reports and evidence do not persist unsafe raw excerpts or absolute
   outside paths
-- release readiness remains honest while `WP-21` through `WP-24` are unfinished
+- release readiness remains honest while live `WP-21` findings are being
+  dispositioned and before any required `WP-22` remediation, `WP-23`
+  next-milestone planning, and `WP-24` release ceremony work finishes
 - GWS, C-SDLC, UTS, ACC, CodeFriend, and publication-program claims stay in
   their correct lanes
 - docs distinguish completed work, planned work, evidence, caveats, and
@@ -289,7 +295,7 @@ Expected reviewer output:
 
 - severity-ranked findings with file and line references
 - explicit non-findings for surfaces that are clean
-- a recommendation on whether `WP-22` remediation is sufficient to proceed
+- recommended `WP-22` routing for any accepted external-review findings
 - a list of findings that must be fixed before `WP-24` release ceremony
 - a list of findings that may be explicitly deferred without misleading the
   release
@@ -302,8 +308,8 @@ This handoff does not claim:
 
 - release readiness
 - release ceremony completion
-- external review completion
-- accepted-finding remediation completion
+- external review approval
+- accepted external-review finding remediation completion
 - public UTS benchmark superiority
 - provider/model conformance beyond the evidence reviewed
 - production-grade hosted-provider adapter security


### PR DESCRIPTION
Closes #3189

## Summary
Updated the `v0.91.2` third-party review handoff after live reviewer feedback
found stale review-entry truth. The handoff now describes `WP-21` as active,
routes findings through `WP-22`, removes stale future-review wording, and
points to the current split UTS benchmark module path.

## Artifacts
- Updated `docs/milestones/v0.91.2/ADL_v0.91.2_THIRD_PARTY_REVIEW_HANDOFF.md`

## Validation
- Validation commands and their purpose:
  - path-existence check over bullet-listed review-scope paths in the handoff
    Verified the handoff does not point reviewers at missing repo paths.
  - targeted stale-language `rg` scan
    Verified the reviewer-identified stale `WP-21` and removed-path language is gone.
  - `git diff --check`
    Verified whitespace hygiene.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.2/tasks/issue-3189__v0-91-2-wp-21-docs-fix-stale-third-party-review-handoff-truth/sip.md
- Output card: .adl/v0.91.2/tasks/issue-3189__v0-91-2-wp-21-docs-fix-stale-third-party-review-handoff-truth/sor.md
- Idempotency-Key: v0-91-2-wp-21-docs-fix-stale-third-party-review-handoff-truth-docs-milestones-v0-91-2-adl-v0-91-2-third-party-review-handoff-md-adl-v0-91-2-tasks-issue-3189-v0-91-2-wp-21-docs-fix-stale-third-party-review-handoff-truth-sip-md-adl-v0-91-2-tasks-issue-3189-v0-91-2-wp-21-docs-fix-stale-third-party-review-handoff-truth-sor-md