### PR TITLE
[v0.91.3][tools/docs] Generate reviewable SPPs at issue creation

### DIFF
--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -53,6 +53,17 @@ fn file_exists_nonempty(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn plan_card_needs_design_time_refresh(path: &Path) -> Result<bool> {
+    if !path.is_file() {
+        return Ok(true);
+    }
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read SPP at {}", path.display()))?;
+    Ok(text.contains("Bootstrap-generated SPP")
+        || text.contains("Bootstrap planning surface for this issue")
+        || text.contains("Review the issue bundle and tighten the planned execution sequence."))
+}
+
 pub(crate) fn sync_root_task_bundle_into_worktree(
     primary_checkout_root: &Path,
     worktree_root: &Path,
@@ -191,8 +202,8 @@ pub(crate) fn ensure_bootstrap_cards(
     } else if field_line_value(&bundle_output, "Branch")?.trim() != branch {
         replace_field_line_in_file(&bundle_output, "Branch", branch)?;
     }
-    if !bundle_plan.is_file() {
-        write_plan_card(root, &bundle_plan, issue_ref, title, branch)?;
+    if !bundle_plan.is_file() || plan_card_needs_design_time_refresh(&bundle_plan)? {
+        write_plan_card(root, &bundle_plan, issue_ref, title, branch, source_path)?;
     } else if field_line_value(&bundle_plan, "branch")?.trim() != branch {
         replace_field_line_in_file(&bundle_plan, "branch", &format!("\"{branch}\""))?;
     }
@@ -248,8 +259,9 @@ pub(crate) fn write_plan_card(
     issue_ref: &IssueRef,
     title: &str,
     branch: &str,
+    source_path: &Path,
 ) -> Result<()> {
-    let text = render_bootstrap_plan_card(repo_root, issue_ref, title, branch);
+    let text = render_bootstrap_plan_card(repo_root, issue_ref, title, branch, source_path);
     fs::write(path, text)?;
     Ok(())
 }
@@ -604,10 +616,48 @@ fn render_bootstrap_plan_card(
     issue_ref: &IssueRef,
     title: &str,
     branch: &str,
+    source_path: &Path,
 ) -> String {
     let stp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_stp_path(repo_root));
     let sip_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_input_path(repo_root));
     let spp_rel = path_relative_to_repo(repo_root, &issue_ref.task_bundle_plan_path(repo_root));
+    let source_rel = path_relative_to_repo(repo_root, source_path);
+    let prompt = fs::read_to_string(source_path).unwrap_or_default();
+    let dependencies = issue_prompt_section(&prompt, "Dependencies")
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| "Review the source issue prompt for dependency truth.".to_string());
+    let deliverables = issue_prompt_section(&prompt, "Deliverables")
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| {
+            "Produce the deliverables named by the source issue prompt.".to_string()
+        });
+    let acceptance = issue_prompt_section(&prompt, "Acceptance Criteria")
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| {
+            "Satisfy the acceptance criteria named by the source issue prompt.".to_string()
+        });
+    let repo_inputs = issue_prompt_section(&prompt, "Repo Inputs")
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| "Use the repo inputs named by the source issue prompt.".to_string());
+    let non_goals = issue_prompt_section(&prompt, "Non-goals")
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| "Preserve the non-goals named by the source issue prompt.".to_string());
+    let demo_expectations = issue_prompt_section(&prompt, "Demo Expectations")
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| "Follow demo expectations from the source issue prompt.".to_string());
+    let validation_strategy = issue_prompt_section(&prompt, "Tooling Notes")
+        .or_else(|| issue_prompt_section(&prompt, "Acceptance Criteria"))
+        .map(|value| one_line_summary(&value))
+        .unwrap_or_else(|| {
+            "Run the smallest proving validation for the touched surface.".to_string()
+        });
+    let dependency_step = yaml_inline(&dependencies);
+    let deliverable_step = yaml_inline(&deliverables);
+    let acceptance_step = yaml_inline(&acceptance);
+    let repo_inputs_step = yaml_inline(&repo_inputs);
+    let non_goals_step = yaml_inline(&non_goals);
+    let demo_step = yaml_inline(&demo_expectations);
+    let validation_step = yaml_inline(&validation_strategy);
     format!(
         r#"---
 schema_version: "0.1"
@@ -624,72 +674,116 @@ plan_revision: 1
 source_refs:
   - kind: "issue"
     ref: "https://github.com/{repo}/issues/{issue}"
+  - kind: "source_issue_prompt"
+    ref: "{source_rel}"
   - kind: "stp"
     ref: "{stp_rel}"
   - kind: "sip"
     ref: "{sip_rel}"
 scope:
   files:
+    - "{source_rel}"
     - "{stp_rel}"
     - "{sip_rel}"
+    - "{spp_rel}"
   components:
     - "{slug}"
   out_of_scope:
-    - "implementation beyond the approved issue scope"
+    - "{non_goals_step}"
 constraints:
-  - "read_only_until_execution_is_approved"
+  - "design_time_plan_must_be_reviewed_before_execution"
+  - "runtime_execution_must_update_spp_if_plan_changes"
   - "no_hidden_scope_expansion"
 confidence: "medium"
-plan_summary: "Bootstrap planning surface for {title}; revise it before tracked execution if this issue needs an explicit reviewed execution plan."
+plan_summary: "Design-time operative plan for {title}; generated from source issue prompt, STP/SIP surfaces, dependencies, deliverables, acceptance criteria, and validation expectations."
 assumptions:
-  - "The linked STP and SIP remain the canonical issue-intent and execution-context inputs."
+  - "The linked source issue prompt, STP, and SIP remain the canonical design-time inputs."
+  - "Dependency details may need refresh when earlier issues land."
 proposed_steps:
   - id: "step-1"
-    description: "Review the linked STP and SIP, then tighten the planned execution sequence."
-    expected_output: "{spp_rel}"
+    description: "Confirm dependency readiness and starting state: {dependency_step}"
+    expected_output: "{sip_rel}"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-2"
+    description: "Review repo inputs and scoped surfaces before editing: {repo_inputs_step}"
+    expected_output: "{stp_rel}"
+    allowed_mode: "design_review_then_execution"
+  - id: "step-3"
+    description: "Implement only the bounded deliverables: {deliverable_step}"
+    expected_output: "tracked issue work product"
+    allowed_mode: "execution_after_approval"
+  - id: "step-4"
+    description: "Run focused proof gates for acceptance: {acceptance_step}"
+    expected_output: "validation evidence recorded in SOR"
+    allowed_mode: "execution_after_approval"
+  - id: "step-5"
+    description: "Record review in SRP, outcome truth in SOR, and refresh this SPP if execution diverges."
+    expected_output: "reviewed SRP and truthful SOR"
     allowed_mode: "execution_after_approval"
 codex_plan:
-  - step: "Review the issue bundle and tighten the planned execution sequence."
+  - step: "Confirm dependencies and starting state from the source issue prompt."
+    status: "pending"
+  - step: "Inspect repo inputs and target surfaces before editing."
+    status: "pending"
+  - step: "Implement the bounded deliverables only."
+    status: "pending"
+  - step: "Run focused validation and proof gates."
+    status: "pending"
+  - step: "Record SRP review results and SOR outcome truth."
     status: "pending"
 affected_areas:
   - "{slug}"
 invariants_to_preserve:
-  - "Do not claim implementation work inside the plan."
-  - "Do not expand touched files or validation beyond issue-local evidence without recording why."
+  - "Keep SPP issue-local; do not turn it into sprint orchestration."
+  - "Keep SRP as review-result truth and SOR as output truth."
+  - "Do not expand touched files or validation beyond issue-local evidence without updating this plan."
 risks_and_edge_cases:
-  - "The planned files or validations may drift if the issue prompt changes materially before execution."
+  - "Earlier dependency output may change the correct execution sequence."
+  - "Generated design-time plans can be incomplete; runtime must update SPP before continuing if reality changes."
 test_strategy:
-  - "Review the proposed validation commands before tracked execution."
-execution_handoff: "Use this artifact as the durable plan-of-record when planning is required before execution."
+  - "{validation_step}"
+  - "{demo_step}"
+execution_handoff: "Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes."
 required_permissions:
   - "workspace-write after execution approval"
 stop_conditions:
-  - "Stop and re-plan if the touched-file set or proving commands change materially."
+  - "Stop and re-plan if dependencies are unmet or materially different from this design-time plan."
+  - "Stop and update SPP if touched files, proof gates, or validation commands change materially."
+  - "Stop and route follow-on work if acceptance requires scope outside this issue."
 alternatives_considered:
   - description: "Rely only on transient chat planning."
     reason_not_chosen: "Chat-only planning is not durable or reviewable enough for this workflow surface."
 review_hooks:
-  - "Check scope truthfulness, touched-file truthfulness, validation sufficiency, and re-plan triggers."
-notes: "Bootstrap-generated SPP; revise before use if planning review is required."
+  - "Check dependency truth, scope truthfulness, touched-file truthfulness, validation sufficiency, and re-plan triggers."
+notes: "Design-time generated SPP; review before execution and update during runtime if the plan changes."
 ---
 
 # Structured Plan Prompt
 
 ## Plan Summary
 
-Bootstrap planning surface for this issue. Tighten the plan before tracked execution if plan review is required.
+Design-time operative plan for this issue. Review this SPP before execution; during runtime, update it before continuing if the actual execution sequence changes.
 
 ## Codex Plan
 
-1. [pending] Review the issue bundle and tighten the planned execution sequence.
+1. [pending] Confirm dependencies and starting state from the source issue prompt.
+2. [pending] Inspect repo inputs and target surfaces before editing.
+3. [pending] Implement the bounded deliverables only.
+4. [pending] Run focused validation and proof gates.
+5. [pending] Record SRP review results and SOR outcome truth.
 
 ## Assumptions
 
-- The linked STP and SIP remain the canonical issue-local inputs.
+- The linked source issue prompt, STP, and SIP remain the canonical design-time inputs.
+- Dependency details may need refresh when earlier issues land.
 
 ## Proposed Steps
 
-1. Review the linked STP and SIP, then tighten the planned execution sequence.
+1. Confirm dependency readiness and starting state: {dependencies_md}
+2. Review repo inputs and scoped surfaces before editing: {repo_inputs_md}
+3. Implement only the bounded deliverables: {deliverables_md}
+4. Run focused proof gates for acceptance: {acceptance_md}
+5. Record review in SRP, outcome truth in SOR, and refresh this SPP if execution diverges.
 
 ## Affected Areas
 
@@ -697,28 +791,33 @@ Bootstrap planning surface for this issue. Tighten the plan before tracked execu
 
 ## Invariants To Preserve
 
-- Do not claim implementation work inside the plan.
-- Do not expand touched files or validations without recording why.
+- Keep SPP issue-local; do not turn it into sprint orchestration.
+- Keep SRP as review-result truth and SOR as output truth.
+- Do not expand touched files or validations without updating this plan.
 
 ## Risks And Edge Cases
 
-- The planned files or validations may drift if the issue prompt changes materially before execution.
+- Earlier dependency output may change the correct execution sequence.
+- Generated design-time plans can be incomplete; runtime must update SPP before continuing if reality changes.
 
 ## Test Strategy
 
-- Review the proposed validation commands before tracked execution.
+- {validation_md}
+- {demo_md}
 
 ## Execution Handoff
 
-Use this artifact as the durable plan-of-record when planning is required before execution.
+Use this SPP as the design-time plan-of-record, then update it at runtime whenever the actual execution sequence changes.
 
 ## Stop Conditions
 
-- Stop and re-plan if the touched-file set or proving commands change materially.
+- Stop and re-plan if dependencies are unmet or materially different from this design-time plan.
+- Stop and update SPP if touched files, proof gates, or validation commands change materially.
+- Stop and route follow-on work if acceptance requires scope outside this issue.
 
 ## Notes
 
-Bootstrap-generated SPP; revise before use if planning review is required.
+Design-time generated SPP; review before execution and update during runtime if the plan changes.
 "#,
         slug = issue_ref.slug(),
         issue = issue_ref.issue_number(),
@@ -728,10 +827,70 @@ Bootstrap-generated SPP; revise before use if planning review is required.
         branch = branch,
         repo = default_repo(repo_root)
             .unwrap_or_else(|_| "danielbaustin/agent-design-language".to_string()),
+        source_rel = source_rel,
         stp_rel = stp_rel,
         sip_rel = sip_rel,
         spp_rel = spp_rel,
+        dependency_step = dependency_step,
+        deliverable_step = deliverable_step,
+        acceptance_step = acceptance_step,
+        repo_inputs_step = repo_inputs_step,
+        non_goals_step = non_goals_step,
+        demo_step = demo_step,
+        validation_step = validation_step,
+        dependencies_md = dependencies,
+        deliverables_md = deliverables,
+        acceptance_md = acceptance,
+        repo_inputs_md = repo_inputs,
+        demo_md = demo_expectations,
+        validation_md = validation_strategy,
     )
+}
+
+fn issue_prompt_section(text: &str, heading: &str) -> Option<String> {
+    let wanted = format!("## {heading}");
+    let mut in_section = false;
+    let mut lines = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == wanted {
+            in_section = true;
+            continue;
+        }
+        if in_section && trimmed.starts_with("## ") {
+            break;
+        }
+        if in_section {
+            lines.push(line);
+        }
+    }
+    let value = lines.join("\n").trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn one_line_summary(text: &str) -> String {
+    const MAX_LEN: usize = 220;
+    let out = text
+        .lines()
+        .map(|line| line.trim().trim_start_matches("- ").trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ");
+    if out.chars().count() > MAX_LEN {
+        let mut truncated = out.chars().take(MAX_LEN).collect::<String>();
+        truncated.push_str("...");
+        truncated
+    } else {
+        out
+    }
+}
+
+fn yaml_inline(text: &str) -> String {
+    text.replace('\\', "\\\\").replace('"', "'")
 }
 
 fn render_bootstrap_review_policy_card(

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -644,6 +644,66 @@ fn real_pr_init_existing_stp_is_left_untouched() {
 }
 
 #[test]
+fn real_pr_init_refreshes_legacy_bootstrap_spp() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-real-init-refresh-spp");
+    init_git_repo(&repo);
+    copy_bootstrap_support_files(&repo);
+    let issue_ref = IssueRef::new(
+        1151,
+        "v0.86".to_string(),
+        "v0-86-tools-init-refresh-spp".to_string(),
+    )
+    .expect("issue ref");
+    let spp_path = issue_ref.task_bundle_plan_path(&repo);
+    fs::create_dir_all(spp_path.parent().expect("parent")).expect("bundle dir");
+    fs::write(
+        &spp_path,
+        r#"---
+schema_version: "0.1"
+artifact_type: "structured_planning_prompt"
+branch: "not bound yet"
+---
+
+# Structured Plan Prompt
+
+Bootstrap-generated SPP.
+
+Bootstrap planning surface for this issue.
+
+Review the issue bundle and tighten the planned execution sequence.
+"#,
+    )
+    .expect("write legacy spp");
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+    let result = real_pr(&[
+        "init".to_string(),
+        "1151".to_string(),
+        "--slug".to_string(),
+        "v0-86-tools-init-refresh-spp".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Init refresh SPP".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ]);
+    env::set_current_dir(prev_dir).expect("restore cwd");
+    result.expect("real_pr init refresh spp");
+
+    let spp = fs::read_to_string(&spp_path).expect("read refreshed spp");
+    assert!(
+        spp.contains("Design-time operative plan"),
+        "legacy SPP should be replaced with a design-time plan"
+    );
+    assert!(
+        !spp.contains("Bootstrap-generated SPP"),
+        "legacy bootstrap wording should be removed"
+    );
+}
+
+#[test]
 fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-real-create");
@@ -718,6 +778,32 @@ fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
         repo.join(".adl/v0.86/tasks/issue-1202__v0-86-tools-simplified-init-path/spp.md")
             .is_file(),
         "create should bootstrap the root spp"
+    );
+    let spp = fs::read_to_string(
+        repo.join(".adl/v0.86/tasks/issue-1202__v0-86-tools-simplified-init-path/spp.md"),
+    )
+    .expect("read generated spp");
+    assert!(
+        spp.contains("Design-time operative plan"),
+        "create should generate a reviewable design-time SPP"
+    );
+    assert!(
+        spp.contains("Implement only the bounded deliverables: create-path validation"),
+        "SPP should derive implementation steps from source deliverables"
+    );
+    assert!(
+        spp.contains(
+            "Run focused proof gates for acceptance: invalid issue bodies are rejected early"
+        ),
+        "SPP should derive proof gates from acceptance criteria"
+    );
+    assert!(
+        spp.contains("Stop and update SPP if touched files, proof gates, or validation commands change materially."),
+        "SPP should include runtime replan triggers"
+    );
+    assert!(
+        !spp.contains("Bootstrap-generated SPP"),
+        "SPP should not be the legacy generic scaffold"
     );
     assert!(
         repo.join(".adl/v0.86/tasks/issue-1202__v0-86-tools-simplified-init-path/srp.md")

--- a/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
+++ b/adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md
@@ -1528,6 +1528,9 @@ It:
 
 - preserves the canonical manual `SPP` schema shape used by the first v0.91
   samples
+- supports design-time `SPP` plans generated during issue bootstrap from the
+  source issue prompt, dependencies, deliverables, acceptance criteria,
+  validation expectations, and non-goals
 - keeps `SPP` as a planning artifact rather than an execution log
 - validates `codex_plan` status values and planning-truth boundaries
 - tightens dependencies, assumptions, test strategy, and stop conditions
@@ -1538,6 +1541,7 @@ It:
 Use `spp-editor` when:
 
 - the `SPP` has stale plan structure or weak source references
+- the design-time `SPP` needs review tightening before execution
 - the `SPP` drifts away from the canonical manual sample shape
 - `codex_plan` values drift outside `pending`, `in_progress`, or `completed`
 - a planning artifact starts to read like an execution log

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -11,6 +11,9 @@ Its job is to:
 - normalize `SPP` structure and planning truth
 - preserve the canonical manual `SPP` schema shape used by the first v0.91
   samples
+- preserve and tighten design-time `SPP` plans generated during issue bootstrap
+  from the source issue prompt, dependencies, deliverables, acceptance criteria,
+  validation expectations, and non-goals
 - preserve `SPP` as a planning artifact rather than an execution log
 - validate and normalize `codex_plan` status values
 - tighten dependencies, assumptions, test strategy, stop conditions, and review
@@ -66,6 +69,8 @@ This skill may:
 - normalize assumptions, dependencies, source references, scope, risks, test
   strategy, stop conditions, and review hooks
 - align `SPP` wording with current pre-execution or plan-review state
+- tighten generated design-time plan steps, proof gates, stop conditions, and
+  replan triggers when explicit issue evidence supports the change
 - remove placeholders and stale execution or branch-binding claims
 
 This skill must not:

--- a/docs/cognitive-sdlc/card-lifecycle.md
+++ b/docs/cognitive-sdlc/card-lifecycle.md
@@ -36,6 +36,14 @@ It answers: what are we going to do?
 
 `SPP` records the issue-local operative execution plan.
 
+The first `SPP` should be generated during issue/card bootstrap as a
+design-time plan. It should be concrete enough for review before execution:
+steps, proof gates, dependency assumptions, stop conditions, out-of-scope
+boundaries, and validation strategy.
+
+Runtime execution must treat that plan as live truth rather than a historical
+memo. If execution diverges, update `SPP` first.
+
 It answers:
 
 - what step is active now
@@ -74,4 +82,3 @@ C-SDLC depends on the cards staying separate:
 - `SOR` preserves outcome truth.
 
 Collapsing those roles recreates the drift C-SDLC is designed to remove.
-

--- a/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
+++ b/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
@@ -207,6 +207,13 @@ It must stop after:
 - root bundle creation
 - bootstrap validation
 
+The created bundle includes an initial `SPP`. That `SPP` is not a generic
+placeholder: it should be a deterministic design-time execution plan generated
+from the source issue prompt, dependencies, deliverables, acceptance criteria,
+validation expectations, and non-goals. Reviewers may tighten it before
+execution. Runtime agents must update it before continuing if the real execution
+sequence changes.
+
 It must not continue into:
 - qualitative card review
 - branch creation

--- a/docs/tooling/card-lifecycle.md
+++ b/docs/tooling/card-lifecycle.md
@@ -90,6 +90,16 @@ docs at it without changing validators in this issue.
 
 The `SPP` is the execution-plan surface.
 
+At issue creation, bootstrap tooling should generate an initial design-time
+`SPP` from the source issue prompt, `STP`/`SIP` context, dependencies,
+deliverables, acceptance criteria, validation expectations, and non-goals. This
+makes the plan reviewable before execution rather than leaving a generic
+placeholder.
+
+At runtime, the `SPP` is still live operative plan truth. If the real execution
+sequence, touched files, proof gates, dependencies, or validation commands
+change materially, update the `SPP` before continuing and record why.
+
 It records:
 
 - execution sequence
@@ -99,6 +109,7 @@ It records:
 - stop conditions
 - risks and fallback path
 - worktree, branch, and scope constraints
+- replan triggers
 
 For issue scope, `SPP` remains issue-local. Sprint-scoped planning is a
 separate workflow extension and must use an explicit scope or separate editor

--- a/docs/tooling/structured-prompt-contracts.md
+++ b/docs/tooling/structured-prompt-contracts.md
@@ -212,9 +212,14 @@ text lines, includes:
 Freshly bootstrapped issues may report `SIP` and `SPP` as `pre_run` while the
 branch/worktree is still unbound. That state is not an editor-fixable defect by
 itself; it records that the issue is structurally ready for `pr run`, where the
-execution branch and worktree make those cards concrete. In contrast,
-branch-bound SPP/SRP drift with a `next_editor` remains a real card-local
-blocker and must be routed through the matching editor skill.
+execution branch and worktree make those cards concrete.
+
+The bootstrapped `SPP` should still be useful design-time plan truth. It should
+be generated from source issue context rather than from a generic placeholder,
+so reviewers can inspect the execution sequence, proof gates, and replan
+triggers before work starts. In contrast, branch-bound SPP/SRP drift with a
+`next_editor` remains a real card-local blocker and must be routed through the
+matching editor skill.
 
 Legacy SRP policy scaffolds remain validator-compatible while migration is in
 progress, but doctor output must classify them as `legacy_compatible` rather


### PR DESCRIPTION
Closes #3216

## Summary
Implemented design-time SPP generation for issue bootstrap so new issue bundles receive a reviewable operative execution plan instead of a generic placeholder. The generator now derives dependency, deliverable, acceptance, repo-input, validation, demo, and non-goal details from the source issue prompt, and it refreshes legacy generic SPPs when `pr init` is rerun.

## Artifacts
- `adl/src/cli/pr_cmd_cards/cards.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `docs/tooling/card-lifecycle.md`
- `docs/cognitive-sdlc/card-lifecycle.md`
- `docs/tooling/structured-prompt-contracts.md`
- `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
- `adl/tools/skills/docs/OPERATIONAL_SKILLS_GUIDE.md`
- `adl/tools/skills/spp-editor/SKILL.md`
- Local ignored v0.91.3 SPP regeneration proof in root `.adl/v0.91.3/tasks/**/spp.md`: 17/17 validated
- Local ignored v0.91.3 SPP regeneration proof in WP-01 worktree `.adl/v0.91.3/tasks/**/spp.md`: 16/16 validated

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml`
    Verified formatting for Rust changes.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_creates_issue_and_bootstraps_root_bundle -- --nocapture`
    Verified new issue creation produces design-time SPP content from source issue sections.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_init_refreshes_legacy_bootstrap_spp -- --nocapture`
    Verified old bootstrap SPP text is replaced on init.
  - `bash adl/tools/test_card_editor_skill_contracts.sh`
    Verified edited skill metadata/docs contracts.
  - `cargo build --manifest-path adl/Cargo.toml --bin adl`
    Verified the fixed binary builds for backfill use.
  - `bash adl/tools/validate_structured_prompt.sh --type spp --input <each v0.91.3 SPP>`
    Verified regenerated v0.91.3 SPPs validate in root and WP-01 worktree.
  - `git diff --check`
    Verified patch hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3216__v0-91-3-generate-reviewable-spps-at-issue-creation/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3216__v0-91-3-generate-reviewable-spps-at-issue-creation/sor.md
- Idempotency-Key: v0-91-3-tools-docs-generate-reviewable-spps-at-issue-creation-adl-src-cli-pr-cmd-cards-cards-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-docs-tooling-card-lifecycle-md-docs-cognitive-sdlc-card-lifecycle-md-docs-tooling-structured-prompt-contracts-md-docs-templates-pr-init-invocation-template-md-adl-tools-skills-docs-operational-skills-guide-md-adl-tools-skills-spp-editor-skill-md-adl-v0-91-3-tasks-issue-3216-v0-91-3-generate-reviewable-spps-at-issue-creation-sip-md-adl-v0-91-3-tasks-issue-3216-v0-91-3-generate-reviewable-spps-at-issue-creation-sor-md