### PR TITLE
[v0.91.3][docs] Create CodeFriend planning home and setup plan

### DIFF
--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -29,6 +29,9 @@ Active planning docs:
 - `POST_V095_ADL_CSM_LOGISTIC_SPLIT_PLAN.md` - planned post-`v0.95`
   repository split strategy for keeping ADL stable enough to use while a
   split-off repo carries the fast-moving innovation lane with regular mergeback
+- `codefriend/` - single tracked home for current CodeFriend planning,
+  including product setup, naming migration, source inventory, and links back to
+  historical milestone proof
 
 Planning provenance docs:
 

--- a/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
+++ b/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
@@ -13,6 +13,10 @@ repo-wide string replacement.
 - Current product name: `CodeFriend`
 - Current domain name: `CodeFriend.ai`
 - Legacy working name: `CodeBuddy`
+- Candidate alpha milestone band: `v0.93.x`
+
+The naming migration should support a future CodeFriend alpha milestone whose
+exit bar is a fully working alpha ready for testing.
 
 ## Current Tracked CodeFriend Surfaces
 

--- a/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
+++ b/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
@@ -18,6 +18,10 @@ repo-wide string replacement.
 The naming migration should support a future CodeFriend alpha milestone whose
 exit bar is a fully working alpha ready for testing.
 
+The alpha milestone is not the end state. Future CodeFriend planning must also
+cover the remaining structural-intelligence, executable-governance,
+architectural-memory, and product-delivery features after `v0.93.x`.
+
 ## Current Tracked CodeFriend Surfaces
 
 These surfaces already use current product naming and should remain primary

--- a/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
+++ b/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
@@ -1,0 +1,146 @@
+# CodeFriend Reference Inventory
+
+## Status
+
+Planning inventory for issue `#3238`.
+
+This inventory classifies observed `CodeFriend`, `CodeBuddy`, `codefriend`, and
+`codebuddy` references so later migration work can be precise instead of a
+repo-wide string replacement.
+
+## Current Product Name
+
+- Current product name: `CodeFriend`
+- Current domain name: `CodeFriend.ai`
+- Legacy working name: `CodeBuddy`
+
+## Current Tracked CodeFriend Surfaces
+
+These surfaces already use current product naming and should remain primary
+references:
+
+- `docs/milestones/v0.91.2/features/CODEFRIEND_PRODUCTIZATION.md`
+- `docs/milestones/v0.91.2/review/codefriend_productization/`
+- `docs/architecture/adr/0025-codefriend-review-packet-product-boundary.md`
+- `docs/planning/ADL_FEATURE_LIST.md`
+- `docs/planning/TBD_PLAN_ALLOCATION_v0.91.2_TO_v0.95.md`
+
+## Local Drafting Source
+
+Operator-provided local input used in this planning pass:
+
+- `.adl/docs/TBD/codebuddy_ai/CODEFRIEND_NOTES.md`
+
+That local note is provenance only for this issue; this tracked inventory and
+setup plan summarize the relevant content so future readers do not need the
+ignored local note.
+
+Ignored in this planning pass:
+
+- `.adl/docs/TBD/codebuddy_ai/ADL_MULTIAGENT_INVESTIGATE_ENHANCE.md`
+
+## Reference Classes
+
+### Class A: Current Product-Facing References
+
+These should use `CodeFriend` unless a document is explicitly historical.
+
+Examples:
+
+- current planning docs
+- product setup docs
+- public-facing README or landing-page copy
+- current feature-list entries
+- current review-product documentation
+
+### Class B: Historical Milestone Evidence
+
+These may preserve `CodeBuddy` when the text is describing the historical state
+of an earlier milestone or demo.
+
+Examples:
+
+- `docs/milestones/v0.90/DEMO_MATRIX_v0.90.md`
+- `demos/v0.90/codebuddy_multi_agent_review_showcase_demo.md`
+- older release notes or milestone handoffs that recorded the working name used
+  at that time
+
+Potential action:
+
+- add a short note that CodeBuddy was the predecessor working name for
+  CodeFriend, but do not rewrite history unless the doc is actively reused for
+  current product copy.
+
+### Class C: Internal Skill And Schema Compatibility
+
+These require a dedicated migration decision because they may affect artifact
+paths, schema names, or fixture compatibility.
+
+Examples:
+
+- `.adl/reviews/codebuddy/<run_id>/`
+- `codebuddy.repo_packet`
+- `codebuddy.product_report`
+- `codebuddy_review_engine`
+- skill descriptions that say `CodeBuddy-style`
+- generated filenames such as `codebuddy_product_report.md`
+
+Potential action:
+
+- keep temporarily as compatibility identifiers
+- create a future versioned migration plan for artifact roots and schema names
+- avoid silent renames that break existing review artifacts
+
+### Class D: Current CodeFriend Adjacent Surfaces
+
+These mention CodeFriend but are not the canonical product docs.
+
+Examples:
+
+- Google Workspace bridge docs that mention future CodeFriend projects
+- Moderne/code-modernization docs that mention CodeFriend packets
+- repo-visibility docs that route reviewers to CodeFriend proof surfaces
+
+Potential action:
+
+- leave in place when they are accurate
+- link back to `docs/planning/codefriend/` when they become active planning
+  inputs
+
+## Recommended Migration Order
+
+1. Update current product-facing docs and glossary entries.
+2. Add historical-name signposts where older milestone/demo docs are still
+   likely to be read.
+3. Decide whether internal schema and artifact roots keep `codebuddy` as a
+   compatibility name or receive a versioned `codefriend` successor.
+4. Only then rename scripts, fixtures, generated filenames, or artifact paths.
+
+## Known High-Value Cleanup Targets
+
+Targets likely worth addressing in the first naming-migration issue:
+
+- `docs/GLOSSARY.md`
+- current docs under `docs/planning/`
+- current architecture docs that describe the active review-product lane
+- current demo indexes that mention the old name without historical context
+
+Targets that should be handled more carefully:
+
+- `adl/tools/skills/**`
+- `adl/tools/skills/**/scripts/**`
+- artifact path patterns under `.adl/reviews/codebuddy/`
+- schema names beginning with `codebuddy.`
+- historical milestone docs from v0.90 and v0.91
+
+## Validation For Migration Issues
+
+Any naming migration issue should run:
+
+- `rg -n "CodeBuddy|codebuddy|CodeFriend|codefriend" ...`
+- Markdown relative-link validation for changed docs
+- `git diff --check`
+- targeted skill/schema tests if internal names or scripts change
+
+Do not run broad code tests for a docs-only naming pass unless scripts or schema
+paths are changed.

--- a/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
+++ b/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
@@ -54,6 +54,112 @@ Alpha exit bar:
 - Naming, docs, product boundaries, and demo material use `CodeFriend` /
   `CodeFriend.ai` consistently.
 
+The alpha milestone is not the whole CodeFriend roadmap. It should make
+CodeFriend real enough to test. Later roadmap bands should add the remaining
+architecture-intelligence, governance, memory, integration, and product-delivery
+features.
+
+## Post-Alpha Roadmap
+
+These bands are product-roadmap planning buckets, not final ADL milestone
+commitments. They should be translated into concrete milestone packages after
+the `v0.93.x` alpha plan is reviewed.
+
+### `v0.93.x`: Working Alpha
+
+Goal: one complete, testable product path.
+
+Expected capability:
+
+- repository review packet creation
+- specialist review lane execution
+- review synthesis
+- product-report generation
+- redaction/publication-safety check
+- architecture-aware findings and diagrams
+- sample repo, sample packet, sample report, and runbook
+- clear product boundary and human-review requirement
+
+Exit bar:
+
+- CodeFriend is ready for operator/customer-style alpha testing.
+
+### Post-Alpha Band 1: Structural Intelligence
+
+Goal: move beyond packetized review into architecture understanding.
+
+Candidate features:
+
+- dependency graph intelligence
+- coupling and cohesion analysis
+- connascence analysis
+- architectural quantum detection
+- blast-radius prediction
+- PR architectural impact summaries
+- architectural drift scoring
+- longitudinal trend reports
+
+Exit bar:
+
+- CodeFriend can explain structural risk and drift over time, not just produce
+  one-time review findings.
+
+### Post-Alpha Band 2: Executable Governance
+
+Goal: turn architectural policy into repeatable fitness functions.
+
+Candidate features:
+
+- architecture fitness-function authoring
+- layer and boundary violation checks
+- ADR-required-change detection
+- evidence completeness gates
+- review-packet publication gates
+- policy exceptions with explicit rationale
+- CI-friendly governance reports
+
+Exit bar:
+
+- CodeFriend can help teams define and run architecture governance checks
+  without turning governance into vague advice.
+
+### Post-Alpha Band 3: Architectural Memory
+
+Goal: preserve rationale, tradeoffs, and engineering history.
+
+Candidate features:
+
+- ADR timeline generation
+- stale ADR detection
+- PR-to-ADR linkage
+- rationale extraction from issues, PRs, and reviews
+- architectural trajectory summaries
+- trace-linked decision history
+- queryable product/repo memory
+
+Exit bar:
+
+- CodeFriend can answer why the architecture changed, not only what changed.
+
+### Post-Alpha Band 4: Productization And Delivery
+
+Goal: make CodeFriend practical for repeated external testing and eventual
+customer use.
+
+Candidate features:
+
+- product repo or product package decision
+- polished public-facing README and examples
+- sample customer-style reports
+- onboarding flow
+- pricing/packaging assumptions, if needed later
+- redaction and legal/publication review gates
+- repeatable demo and trial workflow
+
+Exit bar:
+
+- CodeFriend has a repeatable delivery surface suitable for broader testing.
+
 ## Near-Term Setup Goals
 
 Before the product milestone starts, CodeFriend work should prepare:
@@ -65,6 +171,7 @@ Before the product milestone starts, CodeFriend work should prepare:
 - a setup sequence for any future product repo, site, demo, or customer-facing
   package
 - candidate WBS / sprint shape for the `v0.93.x` CodeFriend alpha milestone
+- post-alpha roadmap bands for the remaining CodeFriend feature set
 - follow-on issues for execution instead of hidden scope expansion
 
 ## Workstreams
@@ -164,6 +271,10 @@ Candidate `v0.93.x` work bands:
 The alpha milestone should prove one complete path, not every future
 architecture-cognition capability.
 
+The remaining feature set should be planned after the alpha milestone as
+separate roadmap bands for structural intelligence, executable governance,
+architectural memory, and product delivery.
+
 ### 6. Product Setup Sequence
 
 The likely setup sequence is:
@@ -253,6 +364,23 @@ Validation:
 - verify naming, evidence, redaction, and review boundaries
 - review before issue seeding
 
+### CodeFriend Post-Alpha Roadmap Plan
+
+Scope:
+
+- turn the post-alpha bands in this document into concrete future milestone
+  candidates
+- decide which features belong immediately after the alpha and which should wait
+  until later product testing
+- keep structural intelligence, executable governance, architectural memory,
+  and product-delivery work separate enough to review
+
+Validation:
+
+- verify the roadmap does not overclaim alpha scope
+- check against the CodeFriend notes, ADR 0025, and current feature list
+- route any schedule conflicts back to milestone planning before issue seeding
+
 ## Non-Goals
 
 - Do not implement the product app in this planning issue.
@@ -264,6 +392,7 @@ Validation:
 - Do not use unfinished investigation notes as source truth.
 - Do not treat scattered cleanup as a substitute for a dedicated CodeFriend
   alpha milestone.
+- Do not treat the `v0.93.x` alpha as the final CodeFriend feature set.
 
 ## Review Checklist
 
@@ -276,3 +405,5 @@ Validation:
   planning issue.
 - The plan frames CodeFriend alpha as a likely `v0.93.x` milestone with a
   working alpha ready for testing as the exit bar.
+- The plan includes post-alpha roadmap bands for the rest of the CodeFriend
+  feature set.

--- a/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
+++ b/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
@@ -1,0 +1,209 @@
+# CodeFriend Setup Plan
+
+## Status
+
+Planning surface for issue `#3238`.
+
+This document prepares near-term CodeFriend setup work. It does not implement
+the product application, rename all historical identifiers, or claim external
+delivery readiness.
+
+## Product Name
+
+Current product/domain name: `CodeFriend.ai`.
+
+Use `CodeFriend` for current product-facing docs. Treat `CodeBuddy` as a legacy
+working name unless the reference is deliberately historical, internal schema
+lineage, or part of a compatibility path that needs a dedicated migration.
+
+## Product Thesis
+
+CodeFriend should not be positioned as autocomplete, generic code generation, or
+an autonomous code-review authority.
+
+The stronger positioning is:
+
+> Continuous architectural cognition for software teams.
+
+That means CodeFriend should help make software architecture continuously
+observable, reviewable, measurable, governable, and explainable.
+
+The v0.91.2 productization proof already established the first concrete slice:
+evidence-bound review packets, specialist reviews, diagrams, remediation plans,
+redaction checks, and customer-grade report templates. The next step is to turn
+that proof into a clearer product setup path.
+
+## Near-Term Setup Goals
+
+Over the next few days, CodeFriend work should prepare:
+
+- a single tracked planning home for product docs
+- a naming migration plan from legacy `CodeBuddy` surfaces to `CodeFriend`
+- an alpha product boundary grounded in review packets and product reports
+- a roadmap from useful review automation toward architectural cognition
+- a setup sequence for any future product repo, site, demo, or customer-facing
+  package
+- follow-on issues for execution instead of hidden scope expansion
+
+## Workstreams
+
+### 1. Naming And Document Consolidation
+
+Goal: make current product docs say `CodeFriend` and give operators one place
+to find product planning.
+
+Required follow-on work:
+
+- update user-facing docs that still describe the current product as
+  `CodeBuddy`
+- preserve historical milestone/demo references when changing them would distort
+  past evidence
+- decide whether internal schema names such as `codebuddy.repo_packet` remain
+  compatibility identifiers or receive a versioned migration
+- add signposts where legacy directory names remain intentionally unchanged
+
+Do not perform a repo-wide string replacement. The migration needs review
+because some references are historical, some are product-facing, and some are
+runtime/schema compatibility surfaces.
+
+### 2. Product Boundary
+
+Goal: keep CodeFriend credible and evidence-bound.
+
+The current product boundary is:
+
+- CodeFriend produces source-grounded findings, diagrams, remediation plans,
+  tests recommendations, architecture summaries, redaction checks, and
+  customer-grade reports.
+- CodeFriend does not replace human judgment.
+- CodeFriend must identify evidence, skipped surfaces, assumptions, residual
+  risk, and publication boundaries.
+- CodeFriend reports should be useful, but not magically certain.
+
+This follows the v0.91.2 productization package and ADR 0025 candidate.
+
+### 3. Architecture Cognition Roadmap
+
+Goal: make the product direction sharper than generic AI code review.
+
+The current strategic direction is:
+
+- Alpha: assistive engineering automation with architecture-aware review,
+  diagrams, ADR drafts, docs, reports, dependency summaries, and review packets.
+- Structural intelligence: coupling, cohesion, dependency graph intelligence,
+  blast-radius prediction, architecture drift detection, governance scoring,
+  and PR architectural impact analysis.
+- Cognitive governance: architectural memory, rationale continuity, trace-linked
+  decisions, executable governance, and adaptive engineering workflows.
+
+The important product wedge is not "AI writes code." The wedge is "teams can see
+and govern architectural drift before it becomes expensive."
+
+### 4. Architecture Fitness Functions
+
+Goal: turn architecture governance from static advice into executable checks.
+
+Candidate fitness-function lanes:
+
+- dependency cycles
+- forbidden imports
+- layer isolation
+- ADR-required changes
+- security boundary checks
+- traceability requirements
+- evidence completeness for review packets
+- product-report publication gates
+
+This should start small. The alpha needs low-friction governance that developers
+trust before more advanced architectural cognition is attempted.
+
+### 5. Product Setup Sequence
+
+The likely near-term setup sequence is:
+
+1. Finish this planning home and reference inventory.
+2. Open a naming-migration issue for user-facing docs and obvious product copy.
+3. Open a product setup issue for the CodeFriend alpha package.
+4. Decide whether CodeFriend gets a separate repo, a product subdirectory, or a
+   staged external package after the alpha package is clear.
+5. Prepare a polished sample review packet and product report.
+6. Prepare a public-facing README or landing-page brief after product boundary
+   language is reviewed.
+7. Review redaction, evidence, and publication safety before any external use.
+
+## Follow-On Issue Candidates
+
+### User-Facing Naming Migration
+
+Scope:
+
+- update current user-facing `CodeBuddy` references to `CodeFriend`
+- leave historical, schema, and compatibility references alone unless reviewed
+- add signposts for intentionally preserved legacy names
+
+Validation:
+
+- scan for `CodeBuddy`, `codebuddy`, `CodeFriend`, and `codefriend`
+- review changed references by category
+- run docs link and whitespace checks
+
+### CodeFriend Alpha Package
+
+Scope:
+
+- define the minimum review packet -> specialist review -> synthesis -> product
+  report flow that can be shown as CodeFriend alpha
+- include evidence requirements, redaction boundary, and sample output
+- avoid claiming a shipped SaaS product
+
+Validation:
+
+- run or reference an existing fixture-backed review packet
+- verify product-report template alignment
+- check evidence and redaction requirements
+
+### Architecture Cognition Roadmap
+
+Scope:
+
+- turn the architecture-cognition notes into a roadmap document
+- separate alpha automation, structural intelligence, and cognitive governance
+- identify first fitness functions
+
+Validation:
+
+- check against ADR 0025 and the v0.91.2 productization package
+- mark speculative items as planned, not implemented
+
+### Product Repo / Site Decision
+
+Scope:
+
+- decide where CodeFriend external-facing material lives
+- define what must be ready before `CodeFriend.ai` is used publicly
+- define what stays inside ADL as source proof and what moves to product docs
+
+Validation:
+
+- review redaction and publication boundaries
+- verify no private local paths or unpublished customer-like claims leak
+
+## Non-Goals
+
+- Do not implement the product app in this planning issue.
+- Do not rename all internal `codebuddy` schemas or artifact paths in one pass.
+- Do not claim CodeFriend is autonomous review authority.
+- Do not depend on GWS as canonical CodeFriend infrastructure.
+- Do not depend on C-SDLC completion as a prerequisite for the alpha review
+  packet product lane.
+- Do not use unfinished investigation notes as source truth.
+
+## Review Checklist
+
+- Current product naming uses `CodeFriend` / `CodeFriend.ai`.
+- The planning docs live under `docs/planning/codefriend/`.
+- Historical v0.91.2 proof links still resolve.
+- Legacy `CodeBuddy` references are classified before migration.
+- Product claims stay evidence-bound.
+- Follow-on issues are bounded and do not hide implementation work in this
+  planning issue.

--- a/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
+++ b/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
@@ -4,9 +4,13 @@
 
 Planning surface for issue `#3238`.
 
-This document prepares near-term CodeFriend setup work. It does not implement
-the product application, rename all historical identifiers, or claim external
-delivery readiness.
+This document prepares CodeFriend setup work for a future product milestone.
+Current planning assumption: CodeFriend alpha is large enough to own a whole
+milestone, likely in the `v0.93.x` band. That milestone should end with a fully
+working alpha version of CodeFriend ready for testing.
+
+This document does not implement the product application, rename all historical
+identifiers, or claim external delivery readiness.
 
 ## Product Name
 
@@ -33,9 +37,26 @@ evidence-bound review packets, specialist reviews, diagrams, remediation plans,
 redaction checks, and customer-grade report templates. The next step is to turn
 that proof into a clearer product setup path.
 
+## Milestone Target
+
+Candidate milestone: `v0.93.x`.
+
+Alpha exit bar:
+
+- CodeFriend has a working alpha flow ready for testing.
+- The alpha can run a repository review packet through evidence collection,
+  specialist review lanes, synthesis, redaction/publication checks, and a
+  human-friendly report.
+- The alpha has clear setup docs, runbooks, sample inputs, sample outputs, and
+  review boundaries.
+- The alpha demonstrates architecture-cognition value, not just generic code
+  review.
+- Naming, docs, product boundaries, and demo material use `CodeFriend` /
+  `CodeFriend.ai` consistently.
+
 ## Near-Term Setup Goals
 
-Over the next few days, CodeFriend work should prepare:
+Before the product milestone starts, CodeFriend work should prepare:
 
 - a single tracked planning home for product docs
 - a naming migration plan from legacy `CodeBuddy` surfaces to `CodeFriend`
@@ -43,6 +64,7 @@ Over the next few days, CodeFriend work should prepare:
 - a roadmap from useful review automation toward architectural cognition
 - a setup sequence for any future product repo, site, demo, or customer-facing
   package
+- candidate WBS / sprint shape for the `v0.93.x` CodeFriend alpha milestone
 - follow-on issues for execution instead of hidden scope expansion
 
 ## Workstreams
@@ -117,19 +139,46 @@ Candidate fitness-function lanes:
 This should start small. The alpha needs low-friction governance that developers
 trust before more advanced architectural cognition is attempted.
 
-### 5. Product Setup Sequence
+### 5. Product Milestone Shape
 
-The likely near-term setup sequence is:
+Goal: prepare a whole CodeFriend alpha milestone instead of scattering alpha
+setup across unrelated issues.
+
+Candidate `v0.93.x` work bands:
+
+- design pass and issue-wave readiness
+- user-facing naming migration
+- alpha product boundary and README/runbook
+- review-packet runner polish
+- specialist lane packaging
+- architecture-cognition first slice
+- architecture fitness-function first slice
+- sample repo / sample packet / sample report
+- redaction and publication-safety gate
+- demo and testing handoff
+- internal review
+- external review
+- remediation
+- release/alpha readiness ceremony
+
+The alpha milestone should prove one complete path, not every future
+architecture-cognition capability.
+
+### 6. Product Setup Sequence
+
+The likely setup sequence is:
 
 1. Finish this planning home and reference inventory.
 2. Open a naming-migration issue for user-facing docs and obvious product copy.
-3. Open a product setup issue for the CodeFriend alpha package.
-4. Decide whether CodeFriend gets a separate repo, a product subdirectory, or a
+3. Create a `v0.93.x` CodeFriend alpha milestone plan and issue wave.
+4. Open product setup issues for the CodeFriend alpha package.
+5. Decide whether CodeFriend gets a separate repo, a product subdirectory, or a
    staged external package after the alpha package is clear.
-5. Prepare a polished sample review packet and product report.
-6. Prepare a public-facing README or landing-page brief after product boundary
+6. Prepare a polished sample review packet and product report.
+7. Prepare a public-facing README or landing-page brief after product boundary
    language is reviewed.
-7. Review redaction, evidence, and publication safety before any external use.
+8. Review redaction, evidence, and publication safety before any external use.
+9. Close the alpha milestone only when the working alpha is ready for testing.
 
 ## Follow-On Issue Candidates
 
@@ -188,6 +237,22 @@ Validation:
 - review redaction and publication boundaries
 - verify no private local paths or unpublished customer-like claims leak
 
+### CodeFriend Alpha Milestone Plan
+
+Scope:
+
+- author the `v0.93.x` CodeFriend alpha milestone package
+- define WBS, sprint plan, feature docs, demo matrix, quality gate, and review
+  tail
+- set the alpha exit bar as "fully working alpha ready for testing"
+
+Validation:
+
+- compare the package against this planning home and v0.91.2 productization
+  proof
+- verify naming, evidence, redaction, and review boundaries
+- review before issue seeding
+
 ## Non-Goals
 
 - Do not implement the product app in this planning issue.
@@ -197,6 +262,8 @@ Validation:
 - Do not depend on C-SDLC completion as a prerequisite for the alpha review
   packet product lane.
 - Do not use unfinished investigation notes as source truth.
+- Do not treat scattered cleanup as a substitute for a dedicated CodeFriend
+  alpha milestone.
 
 ## Review Checklist
 
@@ -207,3 +274,5 @@ Validation:
 - Product claims stay evidence-bound.
 - Follow-on issues are bounded and do not hide implementation work in this
   planning issue.
+- The plan frames CodeFriend alpha as a likely `v0.93.x` milestone with a
+  working alpha ready for testing as the exit bar.

--- a/docs/planning/codefriend/README.md
+++ b/docs/planning/codefriend/README.md
@@ -4,6 +4,11 @@
 
 Tracked planning home for current CodeFriend work.
 
+Current milestone planning assumption: CodeFriend alpha should become a
+dedicated product milestone, likely in the `v0.93.x` band. The exit bar for
+that milestone is a fully working alpha version of CodeFriend ready for
+operator/customer-style testing.
+
 CodeFriend is the current product name. `CodeFriend.ai` is the current domain
 name. Older `CodeBuddy` / `codebuddy` references are historical working-name
 lineage unless a later issue explicitly promotes them to current product copy.
@@ -52,5 +57,5 @@ operators have one durable CodeFriend entry point.
 ## Boundary
 
 This home does not claim CodeFriend is a shipped product. It records planning
-for product setup, naming cleanup, architecture-cognition positioning, and
-follow-on execution.
+for product setup, naming cleanup, architecture-cognition positioning, and a
+future `v0.93.x` alpha milestone whose goal is a working testable product.

--- a/docs/planning/codefriend/README.md
+++ b/docs/planning/codefriend/README.md
@@ -1,0 +1,56 @@
+# CodeFriend Planning Home
+
+## Status
+
+Tracked planning home for current CodeFriend work.
+
+CodeFriend is the current product name. `CodeFriend.ai` is the current domain
+name. Older `CodeBuddy` / `codebuddy` references are historical working-name
+lineage unless a later issue explicitly promotes them to current product copy.
+
+## Purpose
+
+Keep CodeFriend planning in one tracked location instead of spreading product
+strategy, naming migration, setup notes, and source maps across milestone docs
+and local-only notes.
+
+## Documents In This Home
+
+- [CodeFriend setup plan](CODEFRIEND_SETUP_PLAN.md)
+- [CodeFriend reference inventory](CODEFRIEND_REFERENCE_INVENTORY.md)
+
+## Source Baseline
+
+Current tracked baseline:
+
+- [CodeFriend productization feature](../../milestones/v0.91.2/features/CODEFRIEND_PRODUCTIZATION.md)
+- [CodeFriend review-packet workflow package](../../milestones/v0.91.2/review/codefriend_productization/review_packet_workflow_package.md)
+- [CodeFriend product report template](../../milestones/v0.91.2/review/codefriend_productization/product_report_template.md)
+- [CodeFriend evidence requirements](../../milestones/v0.91.2/review/codefriend_productization/evidence_requirements.md)
+- [CodeFriend skill and demo alignment](../../milestones/v0.91.2/review/codefriend_productization/skill_demo_alignment.md)
+- [ADR 0025 candidate](../../architecture/adr/0025-codefriend-review-packet-product-boundary.md)
+- [ADL feature list](../ADL_FEATURE_LIST.md)
+
+Operator-provided local input used for this planning pass:
+
+- `.adl/docs/TBD/codebuddy_ai/CODEFRIEND_NOTES.md`
+
+That local note is not required to read this package; the relevant planning
+content is summarized in the tracked setup plan.
+
+Explicitly ignored for this pass:
+
+- `.adl/docs/TBD/codebuddy_ai/ADL_MULTIAGENT_INVESTIGATE_ENHANCE.md`
+
+## Placement Rule
+
+Future CodeFriend planning docs should go under `docs/planning/codefriend/`
+unless they are milestone-specific proof artifacts. Milestone proof artifacts may
+stay inside their milestone package, but this directory should link to them so
+operators have one durable CodeFriend entry point.
+
+## Boundary
+
+This home does not claim CodeFriend is a shipped product. It records planning
+for product setup, naming cleanup, architecture-cognition positioning, and
+follow-on execution.

--- a/docs/planning/codefriend/README.md
+++ b/docs/planning/codefriend/README.md
@@ -9,6 +9,11 @@ dedicated product milestone, likely in the `v0.93.x` band. The exit bar for
 that milestone is a fully working alpha version of CodeFriend ready for
 operator/customer-style testing.
 
+Planning must also extend beyond `v0.93.x`: the alpha milestone should prove a
+usable first product, while later CodeFriend roadmap bands add the remaining
+structural-intelligence, architecture-governance, fitness-function,
+organizational-memory, and product-delivery features.
+
 CodeFriend is the current product name. `CodeFriend.ai` is the current domain
 name. Older `CodeBuddy` / `codebuddy` references are historical working-name
 lineage unless a later issue explicitly promotes them to current product copy.
@@ -58,4 +63,6 @@ operators have one durable CodeFriend entry point.
 
 This home does not claim CodeFriend is a shipped product. It records planning
 for product setup, naming cleanup, architecture-cognition positioning, and a
-future `v0.93.x` alpha milestone whose goal is a working testable product.
+future `v0.93.x` alpha milestone whose goal is a working testable product. It
+also records that later CodeFriend planning must continue past the alpha to
+complete the full feature set.


### PR DESCRIPTION
Closes #3238

## Summary
Created a single tracked CodeFriend planning home under `docs/planning/codefriend/` so current CodeFriend setup, naming migration, and product-roadmap planning live together.

The plan now frames CodeFriend alpha as a likely dedicated `v0.93.x` product milestone, with the exit bar that a fully working alpha version of CodeFriend is ready for testing. It also records post-alpha roadmap bands for the remaining CodeFriend feature set beyond `v0.93.x`.

## Changes
- Added `docs/planning/codefriend/README.md` as the central CodeFriend planning index.
- Added `docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md` for CodeFriend.ai setup, product boundary, architecture-cognition positioning, candidate `v0.93.x` alpha milestone shape, post-alpha roadmap bands, and follow-on issue candidates.
- Added `docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md` to classify `CodeFriend`, `CodeBuddy`, `codefriend`, and `codebuddy` references before a migration pass.
- Updated `docs/planning/README.md` to point to the new CodeFriend home.

## Validation
- `python3 - <<'PY' ... PY`: verified Markdown relative links for `docs/planning/codefriend/*.md` and `docs/planning/README.md`.
- `git diff --check`: verified whitespace cleanliness.
- `bash adl/tools/validate_structured_prompt.sh --type sor --input ...`: verified issue SOR contract in worktree and root local card bundle.
- Bounded docs review: checked placement, source-boundary truth, current naming posture, ignored investigation-note boundary, `v0.93.x` alpha framing, post-alpha roadmap scope, and follow-on migration scope.

## Notes
The unfinished `.adl/docs/TBD/codebuddy_ai/ADL_MULTIAGENT_INVESTIGATE_ENHANCE.md` note is explicitly ignored. Historical milestone proof docs remain in their milestone package and are linked from the new CodeFriend planning home instead of being moved in this issue.