### PR TITLE
[v0.91.3][Sprint 2] Fix review closeout truth

### DIFF
--- a/adl/tools/validate_merge_readiness_packet.py
+++ b/adl/tools/validate_merge_readiness_packet.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+"""
+Validate the tracked merge-readiness packet contract.
+
+This validator is intentionally shape-oriented for Sprint 2: it checks required
+files and required packet sections/snippets. It does not yet query live GitHub
+truth, CI status, or linked artifact existence beyond packet-local files.
+"""
 import sys
 from pathlib import Path
 

--- a/docs/milestones/v0.91.3/review/merge_readiness/ct_demo_001_merge_gate.md
+++ b/docs/milestones/v0.91.3/review/merge_readiness/ct_demo_001_merge_gate.md
@@ -61,6 +61,6 @@ The gate would fail closed if any of the following were true:
 
 ## Residual Risks
 
-- this is a first bounded gate record, not the full default merge-gate runtime
+- this is a first bounded post-hoc gate record, not yet an operative pre-merge enforcement gate
 - Sprint 4 still owns the broader milestone quality gate
-- `WP-07` still needs to turn review/result truth into an ObsMem handoff surface
+- live ObsMem ingestion and signed-trace proof remain later work

--- a/docs/milestones/v0.91.3/review/obsmem_handoff/ct_demo_001_obsmem_handoff.json
+++ b/docs/milestones/v0.91.3/review/obsmem_handoff/ct_demo_001_obsmem_handoff.json
@@ -36,9 +36,9 @@
       "signed trace proof remains out of scope for v0.91.3"
     ],
     "follow_on_work": [
-      "WP-06 merge-readiness gate",
-      "WP-07 ObsMem handoff",
-      "WP-09 five-minute-sprint timing metrics"
+      "WP-09 five-minute-sprint timing metrics",
+      "live ObsMem ingestion and retrieval against the tracked handoff packet",
+      "signed-trace proof and later trace-linked memory hardening"
     ],
     "citations": [
       "docs/milestones/v0.91.3/review/evidence_bundle/ct_demo_001_evidence_bundle.md",

--- a/docs/milestones/v0.91.3/review/obsmem_handoff/ct_demo_001_obsmem_handoff.md
+++ b/docs/milestones/v0.91.3/review/obsmem_handoff/ct_demo_001_obsmem_handoff.md
@@ -60,6 +60,6 @@
 
 ## Follow-On Work
 
-- `WP-06` merge-readiness gate
-- `WP-07` ObsMem handoff
 - `WP-09` five-minute-sprint timing metrics
+- live ObsMem ingestion and retrieval against the tracked handoff packet
+- signed-trace proof and later trace-linked memory hardening


### PR DESCRIPTION
## Summary

- Clarify that the Sprint 2 merge-readiness gate is a first bounded post-hoc proof record, not yet an operative pre-merge enforcement gate.
- Remove stale WP-06/WP-07 follow-on claims from the ObsMem handoff packet now that those children are merged.
- Document the current merge-readiness validator boundary so Sprint 2 closeout does not overclaim validation strength.

## Validation

- `python3 adl/tools/validate_merge_readiness_packet.py docs/milestones/v0.91.3/review/merge_readiness`
- `bash adl/tools/test_merge_readiness_packet.sh`
- `python3 adl/tools/validate_obsmem_handoff_packet.py docs/milestones/v0.91.3/review/obsmem_handoff`
- `bash adl/tools/test_obsmem_handoff_packet.sh`
- `git diff --check`

Closes #3213