### PR TITLE
[v0.91.3][demo][WP-04][feature] Upgrade ADL Podcast Studio v2 demo

### DIFF
--- a/adl/tools/demo_v0913_podcast_studio_v2.sh
+++ b/adl/tools/demo_v0913_podcast_studio_v2.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REVIEW_DIR="$ROOT_DIR/docs/milestones/v0.91.3/review/podcast_studio_v2"
+CARD_PATH="$ROOT_DIR/demos/v0.91.3/adl_podcast_studio_v2_episode_card.html"
+FEATURE_PATH="$ROOT_DIR/docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md"
+
+case "${1:-}" in
+  --print-review-dir)
+    printf '%s\n' "$REVIEW_DIR"
+    exit 0
+    ;;
+  --print-card-path)
+    printf '%s\n' "$CARD_PATH"
+    exit 0
+    ;;
+esac
+
+python3 "$ROOT_DIR/adl/tools/generate_podcast_studio_v2_packet.py" \
+  --review-dir "$REVIEW_DIR" \
+  --card-path "$CARD_PATH" \
+  --feature-path "$FEATURE_PATH"

--- a/adl/tools/generate_podcast_studio_v2_packet.py
+++ b/adl/tools/generate_podcast_studio_v2_packet.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from textwrap import dedent
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REVIEW_DIR = ROOT / "docs/milestones/v0.91.3/review/podcast_studio_v2"
+DEFAULT_CARD_PATH = ROOT / "demos/v0.91.3/adl_podcast_studio_v2_episode_card.html"
+DEFAULT_FEATURE_PATH = ROOT / "docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md"
+
+DEMO = {
+    "demo_name": "ADL Podcast Studio v2",
+    "milestone_version": "v0.91.3",
+    "issue": "#3223",
+    "wp": "demo WP-04",
+    "series_name": "ADL Podcast Studio",
+    "episode_title": "Episode 04: Can governed creative production feel alive?",
+    "episode_slug": "episode-04-governed-creative-production",
+    "topic": "What would make a governed five-minute sprint feel genuinely alive instead of merely fast?",
+    "bounded_purpose": "Show a repeatable, inspectable media-production system that turns a bounded topic into a full episode packet without hidden credentials or fake audio claims.",
+    "timebox_claim": "Episode packet generation is deterministic and quick; this demo does not claim live five-minute end-to-end creative production.",
+}
+
+HOSTS = [
+    {
+        "name": "ChatGPT",
+        "show_role": "Host / framing synthesizer",
+        "studio_job": "opens the question, keeps the cadence human, and closes with the governing thesis",
+        "style": "warm, direct, high-clarity host energy",
+        "color": "#f97316",
+    },
+    {
+        "name": "Gemini",
+        "show_role": "Systems producer / counter-pressure",
+        "studio_job": "stress-tests the process, points out latency and orchestration debt, and names the engineering bottlenecks",
+        "style": "bright, incisive, operationally sharp",
+        "color": "#14b8a6",
+    },
+    {
+        "name": "Claude",
+        "show_role": "Story editor / moral ballast",
+        "studio_job": "rescues the human meaning, protects truth boundaries, and keeps the show from collapsing into sterile workflow worship",
+        "style": "measured, reflective, emotionally precise",
+        "color": "#60a5fa",
+    },
+]
+
+SEGMENTS = [
+    {
+        "id": "topic-brief",
+        "title": "Topic Brief",
+        "owner": "Producer",
+        "content": dedent(
+            """
+            # Topic Brief
+
+            ## Episode Question
+
+            What would make a governed five-minute sprint feel genuinely alive instead of merely fast?
+
+            ## Why this episode exists
+
+            The C-SDLC mini-sprint has already produced visible artifacts, but the harder test is whether the process can feel like real creative production rather than bureaucratic throughput. This episode packages that tension directly.
+
+            ## Production boundary
+
+            - no hidden credentials
+            - no fake live audio claim
+            - every role contribution must be inspectable
+            - the packet should still feel like a show, not just a log dump
+
+            ## Desired listener outcome
+
+            A reviewer should come away believing the team can produce repeatable media artifacts under governance, while also understanding that literal fully-automated five-minute delivery remains unproven.
+            """
+        ).strip()
+    },
+    {
+        "id": "transcript",
+        "title": "Transcript",
+        "owner": "Roundtable",
+        "turns": [
+            {
+                "speaker": "ChatGPT",
+                "label": "Opening frame",
+                "body": "Welcome back to ADL Podcast Studio. Today's question is uncomfortable on purpose: what would make a governed five-minute sprint feel alive instead of merely fast? We have a beautiful proof chain, we have visible artifacts, and we have enough scars now to know that speed theater is cheap. The real bar is whether governance can support a creative act without draining it of pulse. THESIS: a five-minute sprint only matters if it can preserve surprise, taste, and truth at the same time.",
+            },
+            {
+                "speaker": "Gemini",
+                "label": "Counter-pressure",
+                "body": "The engineering answer is that life disappears when the system spends its budget on synchronization rather than production. If cards, PRs, proofs, and validation lanes all require manual re-assembly, you get governance without flow. That does not mean the model is wrong. It means the active gates are still too post-hoc, the validation path is too heavy, and too much of the packet is authored after the work rather than emitted as part of the work.",
+            },
+            {
+                "speaker": "Claude",
+                "label": "Human meaning check",
+                "body": "And yet raw speed is not the thing people actually crave. They want to feel that something worth caring about came into being. A lifeless sprint can be fast and still empty. The governed version only earns its keep if it protects authorship, keeps claims honest, and leaves behind an artifact someone can love or dispute. In that sense, bureaucracy is not the enemy; dead language is.",
+            },
+            {
+                "speaker": "ChatGPT",
+                "label": "Bridge",
+                "body": "So the real upgrade path is not 'delete governance.' It is to move more of the truth production into the artifact itself. The demo should carry its own packet. The review surface should read like a coherent show dossier. The operator should not need secret context to understand what happened. When the artifact tells the story cleanly, governance starts to feel less like drag and more like stagecraft.",
+            },
+            {
+                "speaker": "Gemini",
+                "label": "Operational deepening",
+                "body": "Exactly. If the one-command path yields a topic brief, role map, transcript, best-lines cut, audio manifest, and episode card every time, then the system starts acting like a production line rather than an aspiration. The remaining non-proof is also clear: we are not yet rendering real final audio here, and we are not yet collapsing all review latency into five minutes. But the machinery becomes inspectable, reproducible, and improvable instead of mythic.",
+            },
+            {
+                "speaker": "Claude",
+                "label": "Closure",
+                "body": "Then perhaps aliveness comes from proportion. Let automation handle the packet geometry, let governance hold the truth boundary, and let human judgment preserve taste. If those pieces stay in the right order, speed becomes a consequence rather than an idol. The show feels alive when the artifact still has a soul after the process has finished touching it.",
+            },
+        ],
+    },
+    {
+        "id": "best-lines",
+        "title": "Best Lines",
+        "owner": "Editor",
+        "quotes": [
+            "A five-minute sprint only matters if it can preserve surprise, taste, and truth at the same time.",
+            "The active gates are still too post-hoc, the validation path is too heavy, and too much of the packet is authored after the work rather than emitted as part of the work.",
+            "Bureaucracy is not the enemy; dead language is.",
+            "When the artifact tells the story cleanly, governance starts to feel less like drag and more like stagecraft.",
+            "The show feels alive when the artifact still has a soul after the process has finished touching it.",
+        ],
+    },
+]
+
+
+def transcript_markdown() -> str:
+    lines = [
+        f"# {DEMO['series_name']}",
+        "",
+        f"## {DEMO['episode_title']}",
+        "",
+        f"**Topic:** {DEMO['topic']}",
+        "",
+        "## Transcript",
+        "",
+    ]
+    for turn_number, turn in enumerate(SEGMENTS[1]["turns"], start=1):
+        lines.extend(
+            [
+                f"### Turn {turn_number} - {turn['speaker']} ({turn['label']})",
+                "",
+                turn["body"],
+                "",
+            ]
+        )
+    return "\n".join(lines).strip() + "\n"
+
+
+def display_path(path: Path) -> str:
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def host_lineup_markdown() -> str:
+    lines = [
+        "# Host Lineup",
+        "",
+        "## Stable production roles",
+        "",
+    ]
+    for host in HOSTS:
+        lines.extend(
+            [
+                f"### {host['name']}",
+                f"- show role: {host['show_role']}",
+                f"- studio job: {host['studio_job']}",
+                f"- voice / style target: {host['style']}",
+                "",
+            ]
+        )
+    return "\n".join(lines).strip() + "\n"
+
+
+def best_lines_markdown() -> str:
+    lines = ["# Best Lines", ""]
+    for quote in SEGMENTS[2]["quotes"]:
+        lines.append(f"- {quote}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def reviewer_proof_note() -> str:
+    return dedent(
+        f"""
+        # Reviewer Proof Note
+
+        ## Bounded claim
+
+        This demo proves ADL can package one recurring episode as a deterministic, reviewable production packet with explicit roles, visible transcript authorship, a polished episode card, and truthful audio-render status.
+
+        ## What this packet proves
+
+        - one-command packet generation can produce all required review surfaces without hidden credentials
+        - role boundaries are visible in the packet itself
+        - the transcript, best-lines pass, and episode card can read like one coherent show package rather than disconnected scraps
+        - audio status remains exact and boring instead of inflated
+
+        ## What this packet suggests
+
+        - a governed creative-production lane can feel more alive when artifact quality and truth are authored together
+        - the C-SDLC can support repeatable media production if more packet truth moves into first-class generators
+
+        ## What this packet does not prove
+
+        - live provider-backed episode generation
+        - real final-audio render success
+        - literal five-minute end-to-end production
+        - production publishing or distribution readiness
+
+        ## Review boundary
+
+        The bounded review bar for this issue is whether a reviewer can inspect each deliverable directly from repo-relative tracked artifacts and whether the packet avoids hidden prerequisites or inflated render claims.
+        """
+    ).strip() + "\n"
+
+
+def packet_markdown(review_dir: Path, card_path: Path, feature_path: Path) -> str:
+    review_display = display_path(review_dir)
+    card_display = display_path(card_path)
+    feature_display = display_path(feature_path)
+    artifacts = [
+        f"{review_display}/ct_demo_004_topic_brief.md",
+        f"{review_display}/ct_demo_004_host_lineup.md",
+        f"{review_display}/ct_demo_004_transcript.md",
+        f"{review_display}/ct_demo_004_best_lines.md",
+        f"{review_display}/ct_demo_004_audio_render_manifest.json",
+        f"{review_display}/ct_demo_004_episode_packet.md",
+        f"{review_display}/ct_demo_004_reviewer_proof_note.md",
+        card_display,
+        feature_display,
+    ]
+    bullet_list = "\n".join(f"- `{artifact}`" for artifact in artifacts)
+    return (
+        f"# Podcast Studio v2 Demo Proof Packet v0.91.3\n\n"
+        f"## Demo Identity\n\n"
+        f"- demo name: {DEMO['demo_name']}\n"
+        f"- issue / WP: {DEMO['wp']} / {DEMO['issue']}\n"
+        f"- milestone version: `{DEMO['milestone_version']}`\n"
+        f"- primary artifact: `{card_display}`\n\n"
+        f"## Bounded Purpose\n\n"
+        f"{DEMO['bounded_purpose']}\n\n"
+        "## Claims\n\n"
+        "- ADL can package one deterministic recurring episode packet with visible role boundaries.\n"
+        "- The demo can stay truthful about audio render status without requiring hidden credentials.\n\n"
+        "## Non-Claims\n\n"
+        "- This packet does not claim live provider-backed conversation generation.\n"
+        "- This packet does not claim real final-audio rendering or publication readiness.\n\n"
+        "## Run Path\n\n"
+        "- primary command: `bash adl/tools/demo_v0913_podcast_studio_v2.sh`\n"
+        "- operator prerequisites: repository checkout only; no secrets or external services required\n"
+        "- run status: `passed`\n\n"
+        "## Timebox Truth\n\n"
+        "- timebox claim: packet generation is fast and deterministic, but literal five-minute end-to-end show production is not claimed here\n"
+        "- evidence type: `estimated`\n"
+        "- start evidence: local bounded generator invocation\n"
+        "- end evidence: tracked packet regeneration plus validator/test completion\n"
+        "- elapsed result: bounded local packet regeneration only; no five-minute proof claim\n\n"
+        "## Validation Evidence\n\n"
+        "```bash\n"
+        "bash adl/tools/demo_v0913_podcast_studio_v2.sh\n"
+        f"python3 adl/tools/validate_podcast_studio_v2_packet.py {review_display} {card_display} {feature_display}\n"
+        "bash adl/tools/test_podcast_studio_v2_packet.sh\n"
+        "```\n\n"
+        "Validation not run:\n\n"
+        "- real provider-backed audio generation, because the bounded demo intentionally avoids hidden credentials and fake live-audio claims\n\n"
+        "## Review Evidence\n\n"
+        "- review surface: bounded local review over the generated packet, helper, validator, and episode card\n"
+        "- findings fixed before publication: any packet-shape, role-visibility, or audio-status truth drift found during bounded review\n"
+        "- residual risks: the packet is a deterministic production-system demo, not a proof of real publishing or live-render reliability\n\n"
+        "## Result Classification\n\n"
+        "| Claim | Classification | Reason |\n"
+        "| --- | --- | --- |\n"
+        "| deterministic recurring episode packet exists | `passed` | one-command packet generation writes all required review surfaces without hidden credentials |\n"
+        "| audio render status stays truthful | `passed` | manifest records `manifest_only` instead of implying a real render |\n"
+        "| literal five-minute creative production is proven | `partial` | the artifact is strong, but this packet does not measure or prove the full timebox target |\n\n"
+        "## Skipped Work\n\n"
+        "- skipped scope: live provider-backed generation and final audio synthesis\n"
+        "- why it was skipped: this bounded issue requires a no-secrets-needed proof path and exact render claims\n\n"
+        "## Repo-Relative Artifacts\n\n"
+        f"{bullet_list}\n"
+    )
+
+
+def episode_packet_markdown(card_path: Path) -> str:
+    card_display = display_path(card_path)
+    return dedent(
+        f"""
+        # Episode Packet
+
+        ## Series
+
+        - series: {DEMO['series_name']}
+        - episode: {DEMO['episode_title']}
+        - slug: `{DEMO['episode_slug']}`
+
+        ## Packet Checklist
+
+        - [x] topic brief
+        - [x] host lineup
+        - [x] transcript
+        - [x] best-lines extract
+        - [x] audio render manifest
+        - [x] episode card
+        - [x] reviewer proof note
+
+        ## Canonical Command
+
+        ```bash
+        bash adl/tools/demo_v0913_podcast_studio_v2.sh
+        ```
+
+        ## Reviewer Path
+
+        1. Read `ct_demo_004_topic_brief.md`.
+        2. Read `ct_demo_004_host_lineup.md`.
+        3. Inspect `ct_demo_004_transcript.md` and `ct_demo_004_best_lines.md`.
+        4. Verify exact render status in `ct_demo_004_audio_render_manifest.json`.
+        5. Open `{card_display}`.
+        6. Confirm the claims/non-claims in `ct_demo_004_reviewer_proof_note.md`.
+        """
+    ).strip() + "\n"
+
+
+def audio_manifest() -> dict:
+    return {
+        "schema": "adl.podcast_studio_v2.audio_manifest.v1",
+        "series_name": DEMO["series_name"],
+        "episode_title": DEMO["episode_title"],
+        "episode_slug": DEMO["episode_slug"],
+        "render_status": "manifest_only",
+        "rendered_audio_present": False,
+        "canonical_command": "bash adl/tools/demo_v0913_podcast_studio_v2.sh",
+        "render_policy": {
+            "live_audio_required": False,
+            "hidden_credentials_required": False,
+            "truth_boundary": "This bounded demo records routing and intended render posture without claiming a final audio artifact.",
+        },
+        "speaker_routes": [
+            {
+                "speaker": host["name"],
+                "transcript_identity": host["name"],
+                "intended_voice_style": host["style"],
+                "render_path": "not_run_manifest_only",
+            }
+            for host in HOSTS
+        ],
+        "reason_not_rendered": "The bounded v0.91.3 demo proves recurring packet production without requiring hidden credentials or claiming a final audio render.",
+    }
+
+
+def feature_markdown(review_dir: Path, card_path: Path) -> str:
+    review_display = display_path(review_dir)
+    card_display = display_path(card_path)
+    return dedent(
+        f"""
+        # Podcast Studio v2 Demo
+
+        ## Summary
+
+        `WP-04` upgrades the older podcast pilot into a deterministic production-system demo.
+
+        The result is not a live provider-backed episode factory. It is a repeatable, inspectable one-command packet generator that emits a topic brief, host lineup, transcript, best-lines extract, truthful audio render manifest, reviewer proof note, and polished episode card.
+
+        ## Canonical Command
+
+        ```bash
+        bash adl/tools/demo_v0913_podcast_studio_v2.sh
+        ```
+
+        ## What It Proves
+
+        - one recurring episode packet can be regenerated deterministically
+        - role boundaries are visible across the packet
+        - audio render status can stay exact without hidden credentials
+        - the production artifact can feel like a show package rather than a bare validation log
+
+        ## What It Does Not Prove
+
+        - live provider-backed episode generation
+        - final rendered audio output
+        - literal five-minute end-to-end creative production
+        - publishing or distribution readiness
+
+        ## Proof Surfaces
+
+        - `{review_display}/`
+        - `{card_display}`
+        - `adl/tools/demo_v0913_podcast_studio_v2.sh`
+        - `adl/tools/validate_podcast_studio_v2_packet.py`
+        """
+    ).strip() + "\n"
+
+
+def review_readme(card_path: Path) -> str:
+    card_display = display_path(card_path)
+    return dedent(
+        """
+        # Podcast Studio v2 Review Packet
+
+        This packet holds the bounded proof surfaces for `WP-04` / `#3223`.
+
+        Start with:
+
+        1. `PODCAST_STUDIO_V2_PACKET_v0.91.3.md`
+        2. `ct_demo_004_episode_packet.md`
+        3. `ct_demo_004_reviewer_proof_note.md`
+        4. `__CARD_PATH__`
+        """
+    ).replace("__CARD_PATH__", card_display).strip() + "\n"
+
+
+def episode_card_html() -> str:
+    host_cards = "\n".join(
+        dedent(
+            f"""
+            <article class="host-card" style="--host-color: {host['color']};">
+              <p class="eyebrow">{html.escape(host['show_role'])}</p>
+              <h3>{html.escape(host['name'])}</h3>
+              <p>{html.escape(host['studio_job'])}</p>
+              <p class="voice">Voice target: {html.escape(host['style'])}</p>
+            </article>
+            """
+        ).strip()
+        for host in HOSTS
+    )
+    transcript_cards = "\n".join(
+        dedent(
+            f"""
+            <article class="turn-card">
+              <div class="turn-meta">
+                <span class="turn-speaker">{html.escape(turn['speaker'])}</span>
+                <span class="turn-label">{html.escape(turn['label'])}</span>
+              </div>
+              <p>{html.escape(turn['body'])}</p>
+            </article>
+            """
+        ).strip()
+        for turn in SEGMENTS[1]["turns"]
+    )
+    best_lines = "\n".join(
+        f"<li>{html.escape(quote)}</li>" for quote in SEGMENTS[2]["quotes"]
+    )
+    return dedent(
+        f"""
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>{html.escape(DEMO['episode_title'])}</title>
+          <style>
+            :root {{
+              --bg: #130f0c;
+              --panel: rgba(34, 24, 18, 0.88);
+              --panel-strong: rgba(47, 32, 24, 0.96);
+              --text: #f8efe6;
+              --muted: #d1b8a5;
+              --line: rgba(255, 214, 170, 0.16);
+              --accent: #f59e0b;
+              --accent-2: #14b8a6;
+            }}
+            * {{ box-sizing: border-box; }}
+            body {{
+              margin: 0;
+              font-family: "Georgia", "Times New Roman", serif;
+              color: var(--text);
+              background:
+                radial-gradient(circle at top, rgba(245, 158, 11, 0.18), transparent 32%),
+                linear-gradient(180deg, #1b140f 0%, #100b08 54%, #090706 100%);
+            }}
+            .page {{
+              max-width: 1200px;
+              margin: 0 auto;
+              padding: 40px 24px 72px;
+            }}
+            .hero {{
+              display: grid;
+              gap: 24px;
+              grid-template-columns: 1.2fr 0.8fr;
+              align-items: end;
+            }}
+            .hero-copy h1 {{
+              margin: 0;
+              font-size: clamp(2.8rem, 6vw, 5.4rem);
+              line-height: 0.95;
+              letter-spacing: -0.04em;
+            }}
+            .hero-copy p {{
+              max-width: 42rem;
+              font-size: 1.1rem;
+              line-height: 1.6;
+              color: var(--muted);
+            }}
+            .eyebrow {{
+              margin: 0 0 10px;
+              text-transform: uppercase;
+              letter-spacing: 0.18em;
+              font-size: 0.78rem;
+              color: #fcd34d;
+            }}
+            .hero-card,
+            .panel {{
+              background: var(--panel);
+              border: 1px solid var(--line);
+              border-radius: 28px;
+              box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
+              backdrop-filter: blur(14px);
+            }}
+            .hero-card {{
+              padding: 24px;
+            }}
+            .hero-card dl {{
+              margin: 0;
+              display: grid;
+              gap: 14px;
+            }}
+            .hero-card dt {{
+              font-size: 0.72rem;
+              text-transform: uppercase;
+              letter-spacing: 0.16em;
+              color: #fdba74;
+            }}
+            .hero-card dd {{
+              margin: 4px 0 0;
+              color: var(--muted);
+            }}
+            .grid {{
+              margin-top: 28px;
+              display: grid;
+              gap: 24px;
+              grid-template-columns: 1.1fr 0.9fr;
+            }}
+            .panel {{
+              padding: 24px;
+            }}
+            .panel h2 {{
+              margin-top: 0;
+              font-size: 1.5rem;
+            }}
+            .host-grid {{
+              display: grid;
+              gap: 16px;
+            }}
+            .host-card {{
+              border: 1px solid color-mix(in srgb, var(--host-color) 38%, transparent);
+              background: linear-gradient(135deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01));
+              border-radius: 22px;
+              padding: 18px;
+            }}
+            .host-card h3 {{
+              margin: 0 0 6px;
+              font-size: 1.35rem;
+            }}
+            .host-card .voice {{
+              color: color-mix(in srgb, var(--host-color) 58%, white);
+            }}
+            .turn-card {{
+              padding: 18px 0;
+              border-top: 1px solid var(--line);
+            }}
+            .turn-card:first-of-type {{
+              border-top: 0;
+              padding-top: 0;
+            }}
+            .turn-meta {{
+              display: flex;
+              gap: 12px;
+              align-items: baseline;
+              flex-wrap: wrap;
+              margin-bottom: 10px;
+            }}
+            .turn-speaker {{
+              font-size: 1.1rem;
+              font-weight: 700;
+            }}
+            .turn-label {{
+              color: #fdba74;
+              text-transform: uppercase;
+              letter-spacing: 0.14em;
+              font-size: 0.76rem;
+            }}
+            .status-strip {{
+              display: flex;
+              gap: 12px;
+              flex-wrap: wrap;
+              margin-top: 12px;
+            }}
+            .pill {{
+              padding: 10px 14px;
+              border-radius: 999px;
+              border: 1px solid var(--line);
+              background: rgba(255, 255, 255, 0.04);
+              color: var(--muted);
+              font-size: 0.92rem;
+            }}
+            ul {{
+              padding-left: 20px;
+            }}
+            @media (max-width: 900px) {{
+              .hero,
+              .grid {{
+                grid-template-columns: 1fr;
+              }}
+            }}
+          </style>
+        </head>
+        <body>
+          <main class="page">
+            <section class="hero">
+              <div class="hero-copy">
+                <p class="eyebrow">ADL Podcast Studio v2</p>
+                <h1>{html.escape(DEMO['episode_title'])}</h1>
+                <p>
+                  A deterministic, no-secrets-needed production-system demo for the C-SDLC mini-sprint.
+                  This artifact packages the topic, cast, transcript, best lines, and exact audio truth
+                  without pretending that live final rendering has already been solved.
+                </p>
+                <div class="status-strip">
+                  <span class="pill">Packet status: local pass</span>
+                  <span class="pill">Audio status: manifest only</span>
+                  <span class="pill">Credentials: not required</span>
+                </div>
+              </div>
+              <aside class="hero-card">
+                <dl>
+                  <div>
+                    <dt>Topic</dt>
+                    <dd>{html.escape(DEMO['topic'])}</dd>
+                  </div>
+                  <div>
+                    <dt>Bounded claim</dt>
+                    <dd>{html.escape(DEMO['bounded_purpose'])}</dd>
+                  </div>
+                  <div>
+                    <dt>Non-claim</dt>
+                    <dd>Real rendered episode audio and literal five-minute end-to-end proof are not claimed here.</dd>
+                  </div>
+                </dl>
+              </aside>
+            </section>
+
+            <section class="grid">
+              <section class="panel">
+                <p class="eyebrow">Cast</p>
+                <h2>Stable Host Lineup</h2>
+                <div class="host-grid">
+                  {host_cards}
+                </div>
+              </section>
+
+              <section class="panel">
+                <p class="eyebrow">Production Truth</p>
+                <h2>Render Status</h2>
+                <p>
+                  This bounded demo keeps transcript authorship and audio render status separate.
+                  The packet records routing intent and studio posture, but it does not claim a real final audio file.
+                </p>
+                <div class="status-strip">
+                  <span class="pill">render_status: manifest_only</span>
+                  <span class="pill">rendered_audio_present: false</span>
+                  <span class="pill">truth boundary: exact</span>
+                </div>
+              </section>
+            </section>
+
+            <section class="grid">
+              <section class="panel">
+                <p class="eyebrow">Episode</p>
+                <h2>Transcript</h2>
+                {transcript_cards}
+              </section>
+
+              <section class="panel">
+                <p class="eyebrow">Highlights</p>
+                <h2>Best Lines</h2>
+                <ul>
+                  {best_lines}
+                </ul>
+              </section>
+            </section>
+          </main>
+        </body>
+        </html>
+        """
+    ).strip() + "\n"
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def generate(review_dir: Path, card_path: Path, feature_path: Path) -> None:
+    write(review_dir / "README.md", review_readme(card_path))
+    write(review_dir / "PODCAST_STUDIO_V2_PACKET_v0.91.3.md", packet_markdown(review_dir, card_path, feature_path))
+    write(review_dir / "ct_demo_004_topic_brief.md", SEGMENTS[0]["content"] + "\n")
+    write(review_dir / "ct_demo_004_host_lineup.md", host_lineup_markdown())
+    write(review_dir / "ct_demo_004_transcript.md", transcript_markdown())
+    write(review_dir / "ct_demo_004_best_lines.md", best_lines_markdown())
+    write(review_dir / "ct_demo_004_episode_packet.md", episode_packet_markdown(card_path))
+    write(review_dir / "ct_demo_004_reviewer_proof_note.md", reviewer_proof_note())
+    write(
+        review_dir / "ct_demo_004_audio_render_manifest.json",
+        json.dumps(audio_manifest(), indent=2) + "\n",
+    )
+    write(card_path, episode_card_html())
+    write(feature_path, feature_markdown(review_dir, card_path))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate the v0.91.3 podcast studio v2 demo packet.")
+    parser.add_argument("--review-dir", type=Path, default=DEFAULT_REVIEW_DIR)
+    parser.add_argument("--card-path", type=Path, default=DEFAULT_CARD_PATH)
+    parser.add_argument("--feature-path", type=Path, default=DEFAULT_FEATURE_PATH)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    generate(args.review_dir, args.card_path, args.feature_path)
+    print(args.review_dir)
+    print(args.card_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adl/tools/test_podcast_studio_v2_packet.sh
+++ b/adl/tools/test_podcast_studio_v2_packet.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REVIEW_DIR="$ROOT_DIR/docs/milestones/v0.91.3/review/podcast_studio_v2"
+CARD_PATH="$ROOT_DIR/demos/v0.91.3/adl_podcast_studio_v2_episode_card.html"
+FEATURE_PATH="$ROOT_DIR/docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md"
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_BASE="${TMP_BASE%/}"
+TMP_OUT="$(mktemp -d "${TMP_BASE}/adl-podcast-studio-v2.XXXXXX")"
+trap 'rm -rf "$TMP_OUT"' EXIT
+
+bash "$ROOT_DIR/adl/tools/demo_v0913_podcast_studio_v2.sh" >"$TMP_OUT/default-run.out"
+python3 "$ROOT_DIR/adl/tools/validate_podcast_studio_v2_packet.py" "$REVIEW_DIR" "$CARD_PATH" "$FEATURE_PATH"
+
+GENERATED_PATHS=()
+while IFS= read -r path; do
+  GENERATED_PATHS+=("$path")
+done < <(
+  find "$REVIEW_DIR" -maxdepth 1 -type f | sort
+  printf '%s\n' "$CARD_PATH"
+  printf '%s\n' "$FEATURE_PATH"
+)
+
+BEFORE_HASHES_FILE="$TMP_OUT/before.hashes"
+AFTER_HASHES_FILE="$TMP_OUT/after.hashes"
+>"$BEFORE_HASHES_FILE"
+>"$AFTER_HASHES_FILE"
+for path in "${GENERATED_PATHS[@]}"; do
+  printf '%s  %s\n' "$(shasum -a 256 "$path" | awk '{print $1}')" "$path" >>"$BEFORE_HASHES_FILE"
+done
+
+bash "$ROOT_DIR/adl/tools/demo_v0913_podcast_studio_v2.sh" >"$TMP_OUT/default-rerun.out"
+
+for path in "${GENERATED_PATHS[@]}"; do
+  printf '%s  %s\n' "$(shasum -a 256 "$path" | awk '{print $1}')" "$path" >>"$AFTER_HASHES_FILE"
+done
+
+cmp -s "$BEFORE_HASHES_FILE" "$AFTER_HASHES_FILE"
+
+CUSTOM_REVIEW_DIR="$TMP_OUT/review/podcast_studio_v2"
+CUSTOM_CARD_PATH="$TMP_OUT/adl_podcast_studio_v2_episode_card.html"
+CUSTOM_FEATURE_PATH="$TMP_OUT/PODCAST_STUDIO_V2_DEMO.md"
+python3 "$ROOT_DIR/adl/tools/generate_podcast_studio_v2_packet.py" \
+  --review-dir "$CUSTOM_REVIEW_DIR" \
+  --card-path "$CUSTOM_CARD_PATH" \
+  --feature-path "$CUSTOM_FEATURE_PATH" \
+  >"$TMP_OUT/custom-run.out"
+python3 "$ROOT_DIR/adl/tools/validate_podcast_studio_v2_packet.py" "$CUSTOM_REVIEW_DIR" "$CUSTOM_CARD_PATH" "$CUSTOM_FEATURE_PATH"
+
+grep -F "$CUSTOM_CARD_PATH" "$CUSTOM_REVIEW_DIR/README.md" >/dev/null
+grep -F "$CUSTOM_CARD_PATH" "$CUSTOM_REVIEW_DIR/PODCAST_STUDIO_V2_PACKET_v0.91.3.md" >/dev/null
+grep -F "$CUSTOM_FEATURE_PATH" "$CUSTOM_REVIEW_DIR/PODCAST_STUDIO_V2_PACKET_v0.91.3.md" >/dev/null
+grep -F "$CUSTOM_REVIEW_DIR/" "$CUSTOM_FEATURE_PATH" >/dev/null
+
+[[ "$(bash "$ROOT_DIR/adl/tools/demo_v0913_podcast_studio_v2.sh" --print-review-dir)" == "$REVIEW_DIR" ]]
+[[ "$(bash "$ROOT_DIR/adl/tools/demo_v0913_podcast_studio_v2.sh" --print-card-path)" == "$CARD_PATH" ]]
+
+echo "PASS: podcast studio v2 demo packet is deterministic and helper output is truthful"

--- a/adl/tools/validate_podcast_studio_v2_packet.py
+++ b/adl/tools/validate_podcast_studio_v2_packet.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REQUIRED_FILES = [
+    "README.md",
+    "PODCAST_STUDIO_V2_PACKET_v0.91.3.md",
+    "ct_demo_004_topic_brief.md",
+    "ct_demo_004_host_lineup.md",
+    "ct_demo_004_transcript.md",
+    "ct_demo_004_best_lines.md",
+    "ct_demo_004_audio_render_manifest.json",
+    "ct_demo_004_episode_packet.md",
+    "ct_demo_004_reviewer_proof_note.md",
+]
+
+REQUIRED_PACKET_SNIPPETS = [
+    "## Demo Identity",
+    "## Bounded Purpose",
+    "## Claims",
+    "## Non-Claims",
+    "## Run Path",
+    "## Timebox Truth",
+    "## Validation Evidence",
+    "## Review Evidence",
+    "## Result Classification",
+]
+
+REQUIRED_CARD_SNIPPETS = [
+    "ADL Podcast Studio v2",
+    "Packet status: local pass",
+    "Audio status: manifest only",
+    "Stable Host Lineup",
+    "Transcript",
+    "Best Lines",
+]
+
+
+def fail(message: str) -> int:
+    print(f"FAIL: {message}", file=sys.stderr)
+    return 1
+
+
+def require_snippets(path: Path, snippets: list[str], label: str) -> int:
+    text = path.read_text(encoding="utf-8")
+    for snippet in snippets:
+        if snippet not in text:
+            return fail(f"{label} missing snippet: {snippet}")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) not in (3, 4):
+        return fail("usage: validate_podcast_studio_v2_packet.py <review-dir> <episode-card-path> [feature-path]")
+
+    review_dir = Path(sys.argv[1])
+    card_path = Path(sys.argv[2])
+    feature_path = (
+        Path(sys.argv[3])
+        if len(sys.argv) == 4
+        else Path(__file__).resolve().parents[2] / "docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md"
+    )
+
+    if not review_dir.is_dir():
+        return fail(f"review dir missing: {review_dir}")
+    if not card_path.is_file():
+        return fail(f"episode card missing: {card_path}")
+    if not feature_path.is_file():
+        return fail(f"feature doc missing: {feature_path}")
+
+    for rel_path in REQUIRED_FILES:
+        path = review_dir / rel_path
+        if not path.is_file():
+            return fail(f"required file missing: {path}")
+
+    if require_snippets(review_dir / "PODCAST_STUDIO_V2_PACKET_v0.91.3.md", REQUIRED_PACKET_SNIPPETS, "packet"):
+        return 1
+
+    if require_snippets(
+        review_dir / "ct_demo_004_topic_brief.md",
+        ["# Topic Brief", "## Episode Question", "## Production boundary", "## Desired listener outcome"],
+        "topic brief",
+    ):
+        return 1
+
+    if require_snippets(
+        review_dir / "ct_demo_004_host_lineup.md",
+        [
+            "# Host Lineup",
+            "### ChatGPT",
+            "### Gemini",
+            "### Claude",
+            "show role:",
+            "studio job:",
+            "voice / style target:",
+        ],
+        "host lineup",
+    ):
+        return 1
+
+    if require_snippets(
+        review_dir / "ct_demo_004_episode_packet.md",
+        ["# Episode Packet", "## Packet Checklist", "## Canonical Command", "## Reviewer Path"],
+        "episode packet",
+    ):
+        return 1
+
+    if require_snippets(
+        review_dir / "ct_demo_004_reviewer_proof_note.md",
+        [
+            "# Reviewer Proof Note",
+            "## Bounded claim",
+            "## What this packet proves",
+            "## What this packet suggests",
+            "## What this packet does not prove",
+            "## Review boundary",
+        ],
+        "reviewer proof note",
+    ):
+        return 1
+
+    card_text = card_path.read_text(encoding="utf-8")
+    for snippet in REQUIRED_CARD_SNIPPETS:
+        if snippet not in card_text:
+            return fail(f"episode card missing snippet: {snippet}")
+
+    manifest = json.loads((review_dir / "ct_demo_004_audio_render_manifest.json").read_text(encoding="utf-8"))
+    if manifest.get("render_status") != "manifest_only":
+        return fail("audio render manifest must report render_status=manifest_only")
+    if manifest.get("rendered_audio_present") is not False:
+        return fail("audio render manifest must report rendered_audio_present=false")
+    if manifest.get("render_policy", {}).get("hidden_credentials_required") is not False:
+        return fail("audio render manifest must report hidden_credentials_required=false")
+
+    transcript_text = (review_dir / "ct_demo_004_transcript.md").read_text(encoding="utf-8")
+    for snippet in ("# ADL Podcast Studio", "## Episode 04: Can governed creative production feel alive?", "## Transcript"):
+        if snippet not in transcript_text:
+            return fail(f"transcript missing snippet: {snippet}")
+    for speaker in ("ChatGPT", "Gemini", "Claude"):
+        if speaker not in transcript_text:
+            return fail(f"transcript missing speaker: {speaker}")
+    if transcript_text.count("### Turn ") != 6:
+        return fail("transcript must contain exactly 6 turns")
+
+    best_lines_text = (review_dir / "ct_demo_004_best_lines.md").read_text(encoding="utf-8")
+    if best_lines_text.count("- ") < 5:
+        return fail("best lines must contain at least five bullet quotes")
+
+    feature_text = feature_path.read_text(encoding="utf-8")
+    for snippet in (
+        "# Podcast Studio v2 Demo",
+        "## Canonical Command",
+        "## What It Proves",
+        "## What It Does Not Prove",
+    ):
+        if snippet not in feature_text:
+            return fail(f"feature doc missing snippet: {snippet}")
+
+    print("PASS: podcast studio v2 packet and episode card satisfy the bounded contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/README.md
+++ b/demos/README.md
@@ -124,6 +124,12 @@ If you want the current C-SDLC sprint-console replay demo:
 bash adl/tools/demo_v0913_five_minute_sprint_console.sh --print-url
 ```
 
+If you want the current C-SDLC podcast-studio production packet:
+
+```bash
+bash adl/tools/demo_v0913_podcast_studio_v2.sh
+```
+
 If you want the integrated Runtime v2 foundation proof demo:
 
 ```bash

--- a/demos/v0.91.3/adl_podcast_studio_v2_episode_card.html
+++ b/demos/v0.91.3/adl_podcast_studio_v2_episode_card.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>Episode 04: Can governed creative production feel alive?</title>
+          <style>
+            :root {
+              --bg: #130f0c;
+              --panel: rgba(34, 24, 18, 0.88);
+              --panel-strong: rgba(47, 32, 24, 0.96);
+              --text: #f8efe6;
+              --muted: #d1b8a5;
+              --line: rgba(255, 214, 170, 0.16);
+              --accent: #f59e0b;
+              --accent-2: #14b8a6;
+            }
+            * { box-sizing: border-box; }
+            body {
+              margin: 0;
+              font-family: "Georgia", "Times New Roman", serif;
+              color: var(--text);
+              background:
+                radial-gradient(circle at top, rgba(245, 158, 11, 0.18), transparent 32%),
+                linear-gradient(180deg, #1b140f 0%, #100b08 54%, #090706 100%);
+            }
+            .page {
+              max-width: 1200px;
+              margin: 0 auto;
+              padding: 40px 24px 72px;
+            }
+            .hero {
+              display: grid;
+              gap: 24px;
+              grid-template-columns: 1.2fr 0.8fr;
+              align-items: end;
+            }
+            .hero-copy h1 {
+              margin: 0;
+              font-size: clamp(2.8rem, 6vw, 5.4rem);
+              line-height: 0.95;
+              letter-spacing: -0.04em;
+            }
+            .hero-copy p {
+              max-width: 42rem;
+              font-size: 1.1rem;
+              line-height: 1.6;
+              color: var(--muted);
+            }
+            .eyebrow {
+              margin: 0 0 10px;
+              text-transform: uppercase;
+              letter-spacing: 0.18em;
+              font-size: 0.78rem;
+              color: #fcd34d;
+            }
+            .hero-card,
+            .panel {
+              background: var(--panel);
+              border: 1px solid var(--line);
+              border-radius: 28px;
+              box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
+              backdrop-filter: blur(14px);
+            }
+            .hero-card {
+              padding: 24px;
+            }
+            .hero-card dl {
+              margin: 0;
+              display: grid;
+              gap: 14px;
+            }
+            .hero-card dt {
+              font-size: 0.72rem;
+              text-transform: uppercase;
+              letter-spacing: 0.16em;
+              color: #fdba74;
+            }
+            .hero-card dd {
+              margin: 4px 0 0;
+              color: var(--muted);
+            }
+            .grid {
+              margin-top: 28px;
+              display: grid;
+              gap: 24px;
+              grid-template-columns: 1.1fr 0.9fr;
+            }
+            .panel {
+              padding: 24px;
+            }
+            .panel h2 {
+              margin-top: 0;
+              font-size: 1.5rem;
+            }
+            .host-grid {
+              display: grid;
+              gap: 16px;
+            }
+            .host-card {
+              border: 1px solid color-mix(in srgb, var(--host-color) 38%, transparent);
+              background: linear-gradient(135deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01));
+              border-radius: 22px;
+              padding: 18px;
+            }
+            .host-card h3 {
+              margin: 0 0 6px;
+              font-size: 1.35rem;
+            }
+            .host-card .voice {
+              color: color-mix(in srgb, var(--host-color) 58%, white);
+            }
+            .turn-card {
+              padding: 18px 0;
+              border-top: 1px solid var(--line);
+            }
+            .turn-card:first-of-type {
+              border-top: 0;
+              padding-top: 0;
+            }
+            .turn-meta {
+              display: flex;
+              gap: 12px;
+              align-items: baseline;
+              flex-wrap: wrap;
+              margin-bottom: 10px;
+            }
+            .turn-speaker {
+              font-size: 1.1rem;
+              font-weight: 700;
+            }
+            .turn-label {
+              color: #fdba74;
+              text-transform: uppercase;
+              letter-spacing: 0.14em;
+              font-size: 0.76rem;
+            }
+            .status-strip {
+              display: flex;
+              gap: 12px;
+              flex-wrap: wrap;
+              margin-top: 12px;
+            }
+            .pill {
+              padding: 10px 14px;
+              border-radius: 999px;
+              border: 1px solid var(--line);
+              background: rgba(255, 255, 255, 0.04);
+              color: var(--muted);
+              font-size: 0.92rem;
+            }
+            ul {
+              padding-left: 20px;
+            }
+            @media (max-width: 900px) {
+              .hero,
+              .grid {
+                grid-template-columns: 1fr;
+              }
+            }
+          </style>
+        </head>
+        <body>
+          <main class="page">
+            <section class="hero">
+              <div class="hero-copy">
+                <p class="eyebrow">ADL Podcast Studio v2</p>
+                <h1>Episode 04: Can governed creative production feel alive?</h1>
+                <p>
+                  A deterministic, no-secrets-needed production-system demo for the C-SDLC mini-sprint.
+                  This artifact packages the topic, cast, transcript, best lines, and exact audio truth
+                  without pretending that live final rendering has already been solved.
+                </p>
+                <div class="status-strip">
+                  <span class="pill">Packet status: local pass</span>
+                  <span class="pill">Audio status: manifest only</span>
+                  <span class="pill">Credentials: not required</span>
+                </div>
+              </div>
+              <aside class="hero-card">
+                <dl>
+                  <div>
+                    <dt>Topic</dt>
+                    <dd>What would make a governed five-minute sprint feel genuinely alive instead of merely fast?</dd>
+                  </div>
+                  <div>
+                    <dt>Bounded claim</dt>
+                    <dd>Show a repeatable, inspectable media-production system that turns a bounded topic into a full episode packet without hidden credentials or fake audio claims.</dd>
+                  </div>
+                  <div>
+                    <dt>Non-claim</dt>
+                    <dd>Real rendered episode audio and literal five-minute end-to-end proof are not claimed here.</dd>
+                  </div>
+                </dl>
+              </aside>
+            </section>
+
+            <section class="grid">
+              <section class="panel">
+                <p class="eyebrow">Cast</p>
+                <h2>Stable Host Lineup</h2>
+                <div class="host-grid">
+                  <article class="host-card" style="--host-color: #f97316;">
+  <p class="eyebrow">Host / framing synthesizer</p>
+  <h3>ChatGPT</h3>
+  <p>opens the question, keeps the cadence human, and closes with the governing thesis</p>
+  <p class="voice">Voice target: warm, direct, high-clarity host energy</p>
+</article>
+<article class="host-card" style="--host-color: #14b8a6;">
+  <p class="eyebrow">Systems producer / counter-pressure</p>
+  <h3>Gemini</h3>
+  <p>stress-tests the process, points out latency and orchestration debt, and names the engineering bottlenecks</p>
+  <p class="voice">Voice target: bright, incisive, operationally sharp</p>
+</article>
+<article class="host-card" style="--host-color: #60a5fa;">
+  <p class="eyebrow">Story editor / moral ballast</p>
+  <h3>Claude</h3>
+  <p>rescues the human meaning, protects truth boundaries, and keeps the show from collapsing into sterile workflow worship</p>
+  <p class="voice">Voice target: measured, reflective, emotionally precise</p>
+</article>
+                </div>
+              </section>
+
+              <section class="panel">
+                <p class="eyebrow">Production Truth</p>
+                <h2>Render Status</h2>
+                <p>
+                  This bounded demo keeps transcript authorship and audio render status separate.
+                  The packet records routing intent and studio posture, but it does not claim a real final audio file.
+                </p>
+                <div class="status-strip">
+                  <span class="pill">render_status: manifest_only</span>
+                  <span class="pill">rendered_audio_present: false</span>
+                  <span class="pill">truth boundary: exact</span>
+                </div>
+              </section>
+            </section>
+
+            <section class="grid">
+              <section class="panel">
+                <p class="eyebrow">Episode</p>
+                <h2>Transcript</h2>
+                <article class="turn-card">
+  <div class="turn-meta">
+    <span class="turn-speaker">ChatGPT</span>
+    <span class="turn-label">Opening frame</span>
+  </div>
+  <p>Welcome back to ADL Podcast Studio. Today&#x27;s question is uncomfortable on purpose: what would make a governed five-minute sprint feel alive instead of merely fast? We have a beautiful proof chain, we have visible artifacts, and we have enough scars now to know that speed theater is cheap. The real bar is whether governance can support a creative act without draining it of pulse. THESIS: a five-minute sprint only matters if it can preserve surprise, taste, and truth at the same time.</p>
+</article>
+<article class="turn-card">
+  <div class="turn-meta">
+    <span class="turn-speaker">Gemini</span>
+    <span class="turn-label">Counter-pressure</span>
+  </div>
+  <p>The engineering answer is that life disappears when the system spends its budget on synchronization rather than production. If cards, PRs, proofs, and validation lanes all require manual re-assembly, you get governance without flow. That does not mean the model is wrong. It means the active gates are still too post-hoc, the validation path is too heavy, and too much of the packet is authored after the work rather than emitted as part of the work.</p>
+</article>
+<article class="turn-card">
+  <div class="turn-meta">
+    <span class="turn-speaker">Claude</span>
+    <span class="turn-label">Human meaning check</span>
+  </div>
+  <p>And yet raw speed is not the thing people actually crave. They want to feel that something worth caring about came into being. A lifeless sprint can be fast and still empty. The governed version only earns its keep if it protects authorship, keeps claims honest, and leaves behind an artifact someone can love or dispute. In that sense, bureaucracy is not the enemy; dead language is.</p>
+</article>
+<article class="turn-card">
+  <div class="turn-meta">
+    <span class="turn-speaker">ChatGPT</span>
+    <span class="turn-label">Bridge</span>
+  </div>
+  <p>So the real upgrade path is not &#x27;delete governance.&#x27; It is to move more of the truth production into the artifact itself. The demo should carry its own packet. The review surface should read like a coherent show dossier. The operator should not need secret context to understand what happened. When the artifact tells the story cleanly, governance starts to feel less like drag and more like stagecraft.</p>
+</article>
+<article class="turn-card">
+  <div class="turn-meta">
+    <span class="turn-speaker">Gemini</span>
+    <span class="turn-label">Operational deepening</span>
+  </div>
+  <p>Exactly. If the one-command path yields a topic brief, role map, transcript, best-lines cut, audio manifest, and episode card every time, then the system starts acting like a production line rather than an aspiration. The remaining non-proof is also clear: we are not yet rendering real final audio here, and we are not yet collapsing all review latency into five minutes. But the machinery becomes inspectable, reproducible, and improvable instead of mythic.</p>
+</article>
+<article class="turn-card">
+  <div class="turn-meta">
+    <span class="turn-speaker">Claude</span>
+    <span class="turn-label">Closure</span>
+  </div>
+  <p>Then perhaps aliveness comes from proportion. Let automation handle the packet geometry, let governance hold the truth boundary, and let human judgment preserve taste. If those pieces stay in the right order, speed becomes a consequence rather than an idol. The show feels alive when the artifact still has a soul after the process has finished touching it.</p>
+</article>
+              </section>
+
+              <section class="panel">
+                <p class="eyebrow">Highlights</p>
+                <h2>Best Lines</h2>
+                <ul>
+                  <li>A five-minute sprint only matters if it can preserve surprise, taste, and truth at the same time.</li>
+<li>The active gates are still too post-hoc, the validation path is too heavy, and too much of the packet is authored after the work rather than emitted as part of the work.</li>
+<li>Bureaucracy is not the enemy; dead language is.</li>
+<li>When the artifact tells the story cleanly, governance starts to feel less like drag and more like stagecraft.</li>
+<li>The show feels alive when the artifact still has a soul after the process has finished touching it.</li>
+                </ul>
+              </section>
+            </section>
+          </main>
+        </body>
+        </html>

--- a/docs/milestones/v0.91.3/DEMO_MATRIX_v0.91.3.md
+++ b/docs/milestones/v0.91.3/DEMO_MATRIX_v0.91.3.md
@@ -18,6 +18,7 @@ packages execute.
 | Five-minute-sprint first proof | WP-09 / #3207 | Show one bounded transition can execute with measurable coordination behavior. | `review/first_proof_demo/` packet, deterministic demo command, and metrics snapshot that separately classify process success versus literal five-minute success | in_flight |
 | Five-minute HTML game sprint demo | demo WP-02 / #3221 | Build the first visible C-SDLC creative-production demo as a playable browser game with explicit proof notes. | `demos/v0.91.3/starharvest_five_minute_sprint_demo.html`, `review/five_minute_html_game/` packet, and validator-backed packet proof | in_flight |
 | Five-minute sprint console demo | demo WP-03 / #3222 | Make the Starharvest mini-sprint legible as a governed process with roles, work states, review events, and launch truth on one visual surface. | `demos/v0.91.3/five_minute_sprint_console_demo.html`, `review/five_minute_sprint_console/` packet, and validator-backed packet proof | in_flight |
+| Podcast Studio v2 demo | demo WP-04 / #3223 | Turn the older podcast pilot into a deterministic recurring production-system packet with inspectable roles, transcript, and truthful audio status. | `demos/v0.91.3/adl_podcast_studio_v2_episode_card.html`, `review/podcast_studio_v2/` packet, and validator-backed packet proof | local_pass_pending_pr |
 
 ## Demo Rules
 

--- a/docs/milestones/v0.91.3/FEATURE_PROOF_COVERAGE_v0.91.3.md
+++ b/docs/milestones/v0.91.3/FEATURE_PROOF_COVERAGE_v0.91.3.md
@@ -19,6 +19,7 @@ their owning work packages execute.
 | Five-minute-sprint first proof | `features/FIVE_MINUTE_SPRINT_FIRST_PROOF.md` | Bounded demo records transition timing and coordination behavior. | in_flight under #3207 with `review/first_proof_demo/` packet, deterministic demo command, and metrics snapshot |
 | Five-minute HTML game sprint demo | `features/FIVE_MINUTE_HTML_GAME_SPRINT_DEMO.md` | A bounded C-SDLC creative-production slice yields a runnable visible browser artifact plus proof packet. | in_flight under demo #3221 with `demos/v0.91.3/` artifact, `review/five_minute_html_game/` packet, and focused validator/test proof |
 | Five-minute sprint console demo | `features/FIVE_MINUTE_SPRINT_CONSOLE_DEMO.md` | A bounded mission-control replay makes the Starharvest mini-sprint legible through timer, roles, work-state, review, artifact, and launch surfaces. | in_flight under demo #3222 with `demos/v0.91.3/` console artifact, `review/five_minute_sprint_console/` packet, and focused validator/test proof |
+| Podcast Studio v2 demo | `features/PODCAST_STUDIO_V2_DEMO.md` | A bounded media-production system emits a recurring episode packet, polished episode card, and truthful audio manifest without hidden credentials. | local pass under demo #3223 with `demos/v0.91.3/` episode card, `review/podcast_studio_v2/` packet, and focused validator/test proof; PR publication still pending |
 
 ## Required Evidence
 
@@ -41,6 +42,7 @@ The milestone proof package should include:
 - shared C-SDLC demo proof contract for later mini-sprint demo packets
 - visible creative-production demo artifact with review packet and truthful run path
 - visual sprint-console replay that keeps process truth adjacent to the creative artifact
+- deterministic podcast-studio packet with explicit role surfaces and truthful audio manifest
 
 ## Non-Claims
 

--- a/docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md
+++ b/docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md
@@ -1,0 +1,34 @@
+# Podcast Studio v2 Demo
+
+## Summary
+
+`WP-04` upgrades the older podcast pilot into a deterministic production-system demo.
+
+The result is not a live provider-backed episode factory. It is a repeatable, inspectable one-command packet generator that emits a topic brief, host lineup, transcript, best-lines extract, truthful audio render manifest, reviewer proof note, and polished episode card.
+
+## Canonical Command
+
+```bash
+bash adl/tools/demo_v0913_podcast_studio_v2.sh
+```
+
+## What It Proves
+
+- one recurring episode packet can be regenerated deterministically
+- role boundaries are visible across the packet
+- audio render status can stay exact without hidden credentials
+- the production artifact can feel like a show package rather than a bare validation log
+
+## What It Does Not Prove
+
+- live provider-backed episode generation
+- final rendered audio output
+- literal five-minute end-to-end creative production
+- publishing or distribution readiness
+
+## Proof Surfaces
+
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/`
+- `demos/v0.91.3/adl_podcast_studio_v2_episode_card.html`
+- `adl/tools/demo_v0913_podcast_studio_v2.sh`
+- `adl/tools/validate_podcast_studio_v2_packet.py`

--- a/docs/milestones/v0.91.3/features/README.md
+++ b/docs/milestones/v0.91.3/features/README.md
@@ -7,6 +7,7 @@ Feature docs:
 - [C-SDLC Demo Proof Contract](C_SDLC_DEMO_PROOF_CONTRACT.md)
 - [Five-Minute HTML Game Sprint Demo](FIVE_MINUTE_HTML_GAME_SPRINT_DEMO.md)
 - [Five-Minute Sprint Console Demo](FIVE_MINUTE_SPRINT_CONSOLE_DEMO.md)
+- [Podcast Studio v2 Demo](PODCAST_STUDIO_V2_DEMO.md)
 - [Cognitive SDLC First Slice](COGNITIVE_SDLC_FIRST_SLICE.md)
 - [Cognitive Transition Manifest](COGNITIVE_TRANSITION_MANIFEST.md)
 - [Card Lifecycle Integration](CARD_LIFECYCLE_INTEGRATION.md)

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/PODCAST_STUDIO_V2_PACKET_v0.91.3.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/PODCAST_STUDIO_V2_PACKET_v0.91.3.md
@@ -1,0 +1,79 @@
+# Podcast Studio v2 Demo Proof Packet v0.91.3
+
+## Demo Identity
+
+- demo name: ADL Podcast Studio v2
+- issue / WP: demo WP-04 / #3223
+- milestone version: `v0.91.3`
+- primary artifact: `demos/v0.91.3/adl_podcast_studio_v2_episode_card.html`
+
+## Bounded Purpose
+
+Show a repeatable, inspectable media-production system that turns a bounded topic into a full episode packet without hidden credentials or fake audio claims.
+
+## Claims
+
+- ADL can package one deterministic recurring episode packet with visible role boundaries.
+- The demo can stay truthful about audio render status without requiring hidden credentials.
+
+## Non-Claims
+
+- This packet does not claim live provider-backed conversation generation.
+- This packet does not claim real final-audio rendering or publication readiness.
+
+## Run Path
+
+- primary command: `bash adl/tools/demo_v0913_podcast_studio_v2.sh`
+- operator prerequisites: repository checkout only; no secrets or external services required
+- run status: `passed`
+
+## Timebox Truth
+
+- timebox claim: packet generation is fast and deterministic, but literal five-minute end-to-end show production is not claimed here
+- evidence type: `estimated`
+- start evidence: local bounded generator invocation
+- end evidence: tracked packet regeneration plus validator/test completion
+- elapsed result: bounded local packet regeneration only; no five-minute proof claim
+
+## Validation Evidence
+
+```bash
+bash adl/tools/demo_v0913_podcast_studio_v2.sh
+python3 adl/tools/validate_podcast_studio_v2_packet.py docs/milestones/v0.91.3/review/podcast_studio_v2 demos/v0.91.3/adl_podcast_studio_v2_episode_card.html docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md
+bash adl/tools/test_podcast_studio_v2_packet.sh
+```
+
+Validation not run:
+
+- real provider-backed audio generation, because the bounded demo intentionally avoids hidden credentials and fake live-audio claims
+
+## Review Evidence
+
+- review surface: bounded local review over the generated packet, helper, validator, and episode card
+- findings fixed before publication: any packet-shape, role-visibility, or audio-status truth drift found during bounded review
+- residual risks: the packet is a deterministic production-system demo, not a proof of real publishing or live-render reliability
+
+## Result Classification
+
+| Claim | Classification | Reason |
+| --- | --- | --- |
+| deterministic recurring episode packet exists | `passed` | one-command packet generation writes all required review surfaces without hidden credentials |
+| audio render status stays truthful | `passed` | manifest records `manifest_only` instead of implying a real render |
+| literal five-minute creative production is proven | `partial` | the artifact is strong, but this packet does not measure or prove the full timebox target |
+
+## Skipped Work
+
+- skipped scope: live provider-backed generation and final audio synthesis
+- why it was skipped: this bounded issue requires a no-secrets-needed proof path and exact render claims
+
+## Repo-Relative Artifacts
+
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_topic_brief.md`
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_host_lineup.md`
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_transcript.md`
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_best_lines.md`
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_audio_render_manifest.json`
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_episode_packet.md`
+- `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_reviewer_proof_note.md`
+- `demos/v0.91.3/adl_podcast_studio_v2_episode_card.html`
+- `docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md`

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/README.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/README.md
@@ -1,0 +1,10 @@
+# Podcast Studio v2 Review Packet
+
+This packet holds the bounded proof surfaces for `WP-04` / `#3223`.
+
+Start with:
+
+1. `PODCAST_STUDIO_V2_PACKET_v0.91.3.md`
+2. `ct_demo_004_episode_packet.md`
+3. `ct_demo_004_reviewer_proof_note.md`
+4. `demos/v0.91.3/adl_podcast_studio_v2_episode_card.html`

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_audio_render_manifest.json
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_audio_render_manifest.json
@@ -1,0 +1,35 @@
+{
+  "schema": "adl.podcast_studio_v2.audio_manifest.v1",
+  "series_name": "ADL Podcast Studio",
+  "episode_title": "Episode 04: Can governed creative production feel alive?",
+  "episode_slug": "episode-04-governed-creative-production",
+  "render_status": "manifest_only",
+  "rendered_audio_present": false,
+  "canonical_command": "bash adl/tools/demo_v0913_podcast_studio_v2.sh",
+  "render_policy": {
+    "live_audio_required": false,
+    "hidden_credentials_required": false,
+    "truth_boundary": "This bounded demo records routing and intended render posture without claiming a final audio artifact."
+  },
+  "speaker_routes": [
+    {
+      "speaker": "ChatGPT",
+      "transcript_identity": "ChatGPT",
+      "intended_voice_style": "warm, direct, high-clarity host energy",
+      "render_path": "not_run_manifest_only"
+    },
+    {
+      "speaker": "Gemini",
+      "transcript_identity": "Gemini",
+      "intended_voice_style": "bright, incisive, operationally sharp",
+      "render_path": "not_run_manifest_only"
+    },
+    {
+      "speaker": "Claude",
+      "transcript_identity": "Claude",
+      "intended_voice_style": "measured, reflective, emotionally precise",
+      "render_path": "not_run_manifest_only"
+    }
+  ],
+  "reason_not_rendered": "The bounded v0.91.3 demo proves recurring packet production without requiring hidden credentials or claiming a final audio render."
+}

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_best_lines.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_best_lines.md
@@ -1,0 +1,7 @@
+# Best Lines
+
+- A five-minute sprint only matters if it can preserve surprise, taste, and truth at the same time.
+- The active gates are still too post-hoc, the validation path is too heavy, and too much of the packet is authored after the work rather than emitted as part of the work.
+- Bureaucracy is not the enemy; dead language is.
+- When the artifact tells the story cleanly, governance starts to feel less like drag and more like stagecraft.
+- The show feels alive when the artifact still has a soul after the process has finished touching it.

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_episode_packet.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_episode_packet.md
@@ -1,0 +1,32 @@
+# Episode Packet
+
+## Series
+
+- series: ADL Podcast Studio
+- episode: Episode 04: Can governed creative production feel alive?
+- slug: `episode-04-governed-creative-production`
+
+## Packet Checklist
+
+- [x] topic brief
+- [x] host lineup
+- [x] transcript
+- [x] best-lines extract
+- [x] audio render manifest
+- [x] episode card
+- [x] reviewer proof note
+
+## Canonical Command
+
+```bash
+bash adl/tools/demo_v0913_podcast_studio_v2.sh
+```
+
+## Reviewer Path
+
+1. Read `ct_demo_004_topic_brief.md`.
+2. Read `ct_demo_004_host_lineup.md`.
+3. Inspect `ct_demo_004_transcript.md` and `ct_demo_004_best_lines.md`.
+4. Verify exact render status in `ct_demo_004_audio_render_manifest.json`.
+5. Open `demos/v0.91.3/adl_podcast_studio_v2_episode_card.html`.
+6. Confirm the claims/non-claims in `ct_demo_004_reviewer_proof_note.md`.

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_host_lineup.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_host_lineup.md
@@ -1,0 +1,18 @@
+# Host Lineup
+
+## Stable production roles
+
+### ChatGPT
+- show role: Host / framing synthesizer
+- studio job: opens the question, keeps the cadence human, and closes with the governing thesis
+- voice / style target: warm, direct, high-clarity host energy
+
+### Gemini
+- show role: Systems producer / counter-pressure
+- studio job: stress-tests the process, points out latency and orchestration debt, and names the engineering bottlenecks
+- voice / style target: bright, incisive, operationally sharp
+
+### Claude
+- show role: Story editor / moral ballast
+- studio job: rescues the human meaning, protects truth boundaries, and keeps the show from collapsing into sterile workflow worship
+- voice / style target: measured, reflective, emotionally precise

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_reviewer_proof_note.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_reviewer_proof_note.md
@@ -1,0 +1,28 @@
+# Reviewer Proof Note
+
+## Bounded claim
+
+This demo proves ADL can package one recurring episode as a deterministic, reviewable production packet with explicit roles, visible transcript authorship, a polished episode card, and truthful audio-render status.
+
+## What this packet proves
+
+- one-command packet generation can produce all required review surfaces without hidden credentials
+- role boundaries are visible in the packet itself
+- the transcript, best-lines pass, and episode card can read like one coherent show package rather than disconnected scraps
+- audio status remains exact and boring instead of inflated
+
+## What this packet suggests
+
+- a governed creative-production lane can feel more alive when artifact quality and truth are authored together
+- the C-SDLC can support repeatable media production if more packet truth moves into first-class generators
+
+## What this packet does not prove
+
+- live provider-backed episode generation
+- real final-audio render success
+- literal five-minute end-to-end production
+- production publishing or distribution readiness
+
+## Review boundary
+
+The bounded review bar for this issue is whether a reviewer can inspect each deliverable directly from repo-relative tracked artifacts and whether the packet avoids hidden prerequisites or inflated render claims.

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_topic_brief.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_topic_brief.md
@@ -1,0 +1,20 @@
+# Topic Brief
+
+## Episode Question
+
+What would make a governed five-minute sprint feel genuinely alive instead of merely fast?
+
+## Why this episode exists
+
+The C-SDLC mini-sprint has already produced visible artifacts, but the harder test is whether the process can feel like real creative production rather than bureaucratic throughput. This episode packages that tension directly.
+
+## Production boundary
+
+- no hidden credentials
+- no fake live audio claim
+- every role contribution must be inspectable
+- the packet should still feel like a show, not just a log dump
+
+## Desired listener outcome
+
+A reviewer should come away believing the team can produce repeatable media artifacts under governance, while also understanding that literal fully-automated five-minute delivery remains unproven.

--- a/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_transcript.md
+++ b/docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_transcript.md
@@ -1,0 +1,31 @@
+# ADL Podcast Studio
+
+## Episode 04: Can governed creative production feel alive?
+
+**Topic:** What would make a governed five-minute sprint feel genuinely alive instead of merely fast?
+
+## Transcript
+
+### Turn 1 - ChatGPT (Opening frame)
+
+Welcome back to ADL Podcast Studio. Today's question is uncomfortable on purpose: what would make a governed five-minute sprint feel alive instead of merely fast? We have a beautiful proof chain, we have visible artifacts, and we have enough scars now to know that speed theater is cheap. The real bar is whether governance can support a creative act without draining it of pulse. THESIS: a five-minute sprint only matters if it can preserve surprise, taste, and truth at the same time.
+
+### Turn 2 - Gemini (Counter-pressure)
+
+The engineering answer is that life disappears when the system spends its budget on synchronization rather than production. If cards, PRs, proofs, and validation lanes all require manual re-assembly, you get governance without flow. That does not mean the model is wrong. It means the active gates are still too post-hoc, the validation path is too heavy, and too much of the packet is authored after the work rather than emitted as part of the work.
+
+### Turn 3 - Claude (Human meaning check)
+
+And yet raw speed is not the thing people actually crave. They want to feel that something worth caring about came into being. A lifeless sprint can be fast and still empty. The governed version only earns its keep if it protects authorship, keeps claims honest, and leaves behind an artifact someone can love or dispute. In that sense, bureaucracy is not the enemy; dead language is.
+
+### Turn 4 - ChatGPT (Bridge)
+
+So the real upgrade path is not 'delete governance.' It is to move more of the truth production into the artifact itself. The demo should carry its own packet. The review surface should read like a coherent show dossier. The operator should not need secret context to understand what happened. When the artifact tells the story cleanly, governance starts to feel less like drag and more like stagecraft.
+
+### Turn 5 - Gemini (Operational deepening)
+
+Exactly. If the one-command path yields a topic brief, role map, transcript, best-lines cut, audio manifest, and episode card every time, then the system starts acting like a production line rather than an aspiration. The remaining non-proof is also clear: we are not yet rendering real final audio here, and we are not yet collapsing all review latency into five minutes. But the machinery becomes inspectable, reproducible, and improvable instead of mythic.
+
+### Turn 6 - Claude (Closure)
+
+Then perhaps aliveness comes from proportion. Let automation handle the packet geometry, let governance hold the truth boundary, and let human judgment preserve taste. If those pieces stay in the right order, speed becomes a consequence rather than an idol. The show feels alive when the artifact still has a soul after the process has finished touching it.


### PR DESCRIPTION
Closes #3223

## Summary
Completed the bounded demo `WP-04` implementation pass for `#3223`.

The issue now provides:

- a deterministic one-command podcast-studio-v2 packet generator
- a focused validator and shell test lane that prove packet shape, path truth,
  and deterministic regeneration
- a polished episode-card artifact in `demos/v0.91.3/`
- a bounded review packet under `docs/milestones/v0.91.3/review/podcast_studio_v2/`
- milestone demo/proof wiring for the new production-system demo

The core result is strong and truthful: ADL now demonstrates a repeatable media
production packet with visible role boundaries and exact audio manifest status,
without hidden credentials. The key explicit boundary is that the audio lane is
still `manifest_only`, so the issue does not claim live rendered audio or
literal five-minute end-to-end creative production.

## Artifacts
- New tracked tooling:
  - `adl/tools/demo_v0913_podcast_studio_v2.sh`
  - `adl/tools/generate_podcast_studio_v2_packet.py`
  - `adl/tools/validate_podcast_studio_v2_packet.py`
  - `adl/tools/test_podcast_studio_v2_packet.sh`
- New tracked demo artifact:
  - `demos/v0.91.3/adl_podcast_studio_v2_episode_card.html`
- New tracked docs:
  - `docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/README.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/PODCAST_STUDIO_V2_PACKET_v0.91.3.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_topic_brief.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_host_lineup.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_transcript.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_best_lines.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_audio_render_manifest.json`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_episode_packet.md`
  - `docs/milestones/v0.91.3/review/podcast_studio_v2/ct_demo_004_reviewer_proof_note.md`
- Updated tracked docs:
  - `demos/README.md`
  - `docs/milestones/v0.91.3/features/README.md`
  - `docs/milestones/v0.91.3/DEMO_MATRIX_v0.91.3.md`
  - `docs/milestones/v0.91.3/FEATURE_PROOF_COVERAGE_v0.91.3.md`
- Updated local ignored issue cards:
  - `.adl/v0.91.3/tasks/issue-3223__v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo/spp.md`
  - `.adl/v0.91.3/tasks/issue-3223__v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo/srp.md`
  - `.adl/v0.91.3/tasks/issue-3223__v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo/sor.md`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/demo_v0913_podcast_studio_v2.sh`
    Verified the canonical one-command packet generation path.
  - `python3 adl/tools/validate_podcast_studio_v2_packet.py docs/milestones/v0.91.3/review/podcast_studio_v2 demos/v0.91.3/adl_podcast_studio_v2_episode_card.html docs/milestones/v0.91.3/features/PODCAST_STUDIO_V2_DEMO.md`
    Verified packet/content truth, episode-card snippets, transcript structure, and feature-doc presence.
  - `bash adl/tools/test_podcast_studio_v2_packet.sh`
    Verified deterministic regeneration across all generated outputs plus custom-path behavior.
  - `git diff --check`
    Verified whitespace cleanliness.
- Results:
  - PASS

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3223__v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3223__v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo/sor.md
- Idempotency-Key: v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo-adl-v0-91-3-tasks-issue-3223-v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo-sip-md-adl-v0-91-3-tasks-issue-3223-v0-91-3-demo-wp-04-feature-upgrade-adl-podcast-studio-v2-demo-sor-md