### PR TITLE
[v0.91.3][tools] Enforce design-time card completion

### DIFF
--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -275,7 +275,7 @@ fn real_pr_create(args: &[String]) -> Result<()> {
     );
     println!("  READY      {}", ready.status);
     println!("  LIFECYCLE  {}", ready.lifecycle_state);
-    println!("  NEXT       qualitative STP/SIP review, then adl/tools/pr.sh run {issue} --slug {slug} --version {version}");
+    println!("  NEXT       qualitative SIP/STP/SPP/SRP design-time review, then adl/tools/pr.sh run {issue} --slug {slug} --version {version}");
     println!("  STATE      ISSUE_AND_BUNDLE_READY");
     eprintln!("• Done.");
     Ok(())
@@ -426,11 +426,6 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     eprintln!("• Target branch: {branch}");
     eprintln!("• Target worktree: {}", worktree_path.display());
 
-    ensure_git_metadata_writable()?;
-    fetch_origin_main_with_fallback()?;
-    ensure_local_branch_exists(&branch)?;
-    ensure_worktree_for_branch(&worktree_path, &branch)?;
-
     let source_path = ensure_source_issue_prompt(
         &repo_root,
         &repo,
@@ -445,13 +440,21 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     validate_authored_prompt_surface("start", &source_path, PromptSurfaceKind::IssuePrompt)?;
 
     let root_stp = ensure_task_bundle_stp(&repo_root, &issue_ref, &source_path)?;
+    validate_authored_prompt_surface("start", &root_stp, PromptSurfaceKind::Stp)?;
+
+    let root_paths = ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &branch, &source_path)?;
+    doctor::ensure_pr_run_design_time_ready(&repo_root, &issue_ref, &branch)?;
+
+    ensure_git_metadata_writable()?;
+    fetch_origin_main_with_fallback()?;
+    ensure_local_branch_exists(&branch)?;
+    ensure_worktree_for_branch(&worktree_path, &branch)?;
+
     let worktree_source = ensure_local_issue_prompt_copy(&worktree_path, &issue_ref, &source_path)?;
     mirror_docs_templates_into_worktree(&repo_root, &worktree_path)?;
     let worktree_stp = ensure_task_bundle_stp(&worktree_path, &issue_ref, &worktree_source)?;
-    validate_authored_prompt_surface("start", &root_stp, PromptSurfaceKind::Stp)?;
     validate_authored_prompt_surface("start", &worktree_stp, PromptSurfaceKind::Stp)?;
 
-    let root_paths = ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &branch, &source_path)?;
     sync_root_task_bundle_into_worktree(&repo_root, &worktree_path, &issue_ref)?;
     let worktree_paths = ensure_bootstrap_cards(
         &worktree_path,

--- a/adl/src/cli/pr_cmd.rs
+++ b/adl/src/cli/pr_cmd.rs
@@ -15,8 +15,8 @@ use super::pr_cmd_args::{
 };
 use super::pr_cmd_cards::{
     branch_indicates_unbound_state, ensure_bootstrap_cards, ensure_local_issue_prompt_copy,
-    ensure_source_issue_prompt, ensure_symlink, ensure_task_bundle_stp,
-    ensure_worktree_task_bundle_materialized, field_line_value,
+    ensure_pre_run_bootstrap_cards, ensure_source_issue_prompt, ensure_symlink,
+    ensure_task_bundle_stp, ensure_worktree_task_bundle_materialized, field_line_value,
     mirror_docs_templates_into_worktree, path_relative_to_repo,
     sync_root_task_bundle_into_worktree, validate_bootstrap_stp, validate_initialized_cards,
     validate_issue_body_for_create, validate_ready_cards, write_source_issue_prompt,
@@ -442,8 +442,9 @@ fn real_pr_start(args: &[String]) -> Result<()> {
     let root_stp = ensure_task_bundle_stp(&repo_root, &issue_ref, &source_path)?;
     validate_authored_prompt_surface("start", &root_stp, PromptSurfaceKind::Stp)?;
 
-    let root_paths = ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &branch, &source_path)?;
+    ensure_pre_run_bootstrap_cards(&repo_root, &issue_ref, &title, &source_path)?;
     doctor::ensure_pr_run_design_time_ready(&repo_root, &issue_ref, &branch)?;
+    let root_paths = ensure_bootstrap_cards(&repo_root, &issue_ref, &title, &branch, &source_path)?;
 
     ensure_git_metadata_writable()?;
     fetch_origin_main_with_fallback()?;

--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -461,7 +461,7 @@ pub(super) fn run_doctor_ready(
 pub(super) fn ensure_pr_run_design_time_ready(
     repo_root: &Path,
     issue_ref: &IssueRef,
-    expected_branch: &str,
+    _expected_branch: &str,
 ) -> Result<()> {
     let root_stp = issue_ref.task_bundle_stp_path(repo_root);
     let root_bundle_input = issue_ref.task_bundle_input_path(repo_root);
@@ -474,18 +474,6 @@ pub(super) fn ensure_pr_run_design_time_ready(
         &root_bundle_input,
         &root_bundle_output,
         repo_root,
-        StructuredBundlePaths {
-            plan_path: &root_bundle_plan,
-            review_policy_path: &root_bundle_review_policy,
-        },
-    )?;
-    validate_ready_cards(
-        repo_root,
-        issue_ref.issue_number(),
-        issue_ref.slug(),
-        expected_branch,
-        &root_bundle_input,
-        &root_bundle_output,
         StructuredBundlePaths {
             plan_path: &root_bundle_plan,
             review_policy_path: &root_bundle_review_policy,

--- a/adl/src/cli/pr_cmd/doctor.rs
+++ b/adl/src/cli/pr_cmd/doctor.rs
@@ -54,6 +54,7 @@ struct DoctorCardStageJson {
     path: String,
     state: &'static str,
     complete: bool,
+    design_time_complete: bool,
     final_ready: bool,
     next_editor: Option<&'static str>,
     detail: String,
@@ -457,6 +458,75 @@ pub(super) fn run_doctor_ready(
     })
 }
 
+pub(super) fn ensure_pr_run_design_time_ready(
+    repo_root: &Path,
+    issue_ref: &IssueRef,
+    expected_branch: &str,
+) -> Result<()> {
+    let root_stp = issue_ref.task_bundle_stp_path(repo_root);
+    let root_bundle_input = issue_ref.task_bundle_input_path(repo_root);
+    let root_bundle_output = issue_ref.task_bundle_output_path(repo_root);
+    let root_bundle_plan = issue_ref.task_bundle_plan_path(repo_root);
+    let root_bundle_review_policy = issue_ref.task_bundle_review_policy_path(repo_root);
+    validate_initialized_cards(
+        issue_ref.issue_number(),
+        issue_ref.slug(),
+        &root_bundle_input,
+        &root_bundle_output,
+        repo_root,
+        StructuredBundlePaths {
+            plan_path: &root_bundle_plan,
+            review_policy_path: &root_bundle_review_policy,
+        },
+    )?;
+    validate_ready_cards(
+        repo_root,
+        issue_ref.issue_number(),
+        issue_ref.slug(),
+        expected_branch,
+        &root_bundle_input,
+        &root_bundle_output,
+        StructuredBundlePaths {
+            plan_path: &root_bundle_plan,
+            review_policy_path: &root_bundle_review_policy,
+        },
+    )?;
+    let lifecycle = build_doctor_card_lifecycle(
+        repo_root,
+        &root_bundle_input,
+        &root_stp,
+        &root_bundle_plan,
+        &root_bundle_review_policy,
+        &root_bundle_output,
+    );
+    if lifecycle.pr_run_readiness == "ready" {
+        return Ok(());
+    }
+
+    let blockers = lifecycle
+        .stages
+        .iter()
+        .filter(|stage| ["SIP", "STP", "SPP", "SRP"].contains(&stage.stage))
+        .filter(|stage| !stage.design_time_complete)
+        .map(|stage| {
+            format!(
+                "- {}: {}{}",
+                stage.stage,
+                stage.detail,
+                stage
+                    .next_editor
+                    .map(|editor| format!(" Route through `{editor}`."))
+                    .unwrap_or_default()
+            )
+        })
+        .collect::<Vec<_>>();
+    bail!(
+        "start: design-time card completion gate failed for issue #{} before worktree binding. Repair cards with editor skills before rerunning `pr run`:\n{}",
+        issue_ref.issue_number(),
+        blockers.join("\n")
+    )
+}
+
 fn build_doctor_card_lifecycle(
     repo_root: &Path,
     sip_path: &Path,
@@ -479,8 +549,8 @@ fn build_doctor_card_lifecycle(
     let active_stage = next_required_stage.unwrap_or("SOR");
     let pr_run_readiness = if stages
         .iter()
-        .filter(|stage| ["SIP", "STP", "SPP"].contains(&stage.stage))
-        .all(|stage| stage.complete || stage.state == "pre_run")
+        .filter(|stage| ["SIP", "STP", "SPP", "SRP"].contains(&stage.stage))
+        .all(|stage| stage.design_time_complete)
     {
         "ready"
     } else {
@@ -511,18 +581,17 @@ fn classify_sip_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     let Some(text) = read_card_text(path) else {
         return missing_stage(repo_root, "SIP", path, "sip-editor");
     };
-    let branch = line_value_after_prefix(&text, "Branch:").unwrap_or_default();
-    if branch_indicates_unbound_state(&branch) {
+    if has_generic_sip_design_time_scaffold(&text) {
         return card_stage(
             repo_root,
             "SIP",
             path,
             stage_truth(
-                "pre_run",
+                "scaffold",
                 false,
                 false,
-                None,
-                "SIP is a truthful pre-run card; branch/worktree execution has not been bound yet.",
+                Some("sip-editor"),
+                "SIP is still generic bootstrap text and needs issue-specific design-time intent.",
             ),
         );
     }
@@ -535,7 +604,7 @@ fn classify_sip_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
             true,
             false,
             None,
-            "SIP is branch-bound and complete enough for execution planning.",
+            "SIP has issue-specific design-time intent for execution planning.",
         ),
     )
 }
@@ -577,22 +646,7 @@ fn classify_spp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
         return missing_stage(repo_root, "SPP", path, "spp-editor");
     };
     let status = line_value_after_prefix(&text, "status:").unwrap_or_default();
-    let branch = line_value_after_prefix(&text, "branch:").unwrap_or_default();
-    if branch_indicates_unbound_state(&branch) {
-        return card_stage(
-            repo_root,
-            "SPP",
-            path,
-            stage_truth(
-                "pre_run",
-                false,
-                false,
-                None,
-                "SPP is a truthful pre-run planning card; branch/worktree execution has not been bound yet.",
-            ),
-        );
-    }
-    if text.contains("Bootstrap-generated SPP") {
+    if has_generic_spp_design_time_scaffold(&text) {
         return card_stage(
             repo_root,
             "SPP",
@@ -602,7 +656,7 @@ fn classify_spp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
                 false,
                 false,
                 Some("spp-editor"),
-                "SPP is still bootstrap/pre-run planning scaffold and needs issue-specific plan truth.",
+                "SPP is still generic or truncated bootstrap planning text and needs issue-specific plan truth.",
             ),
         );
     }
@@ -616,7 +670,7 @@ fn classify_spp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
                 true,
                 false,
                 None,
-                "SPP has reviewed or approved planning state.",
+                "SPP has reviewed or approved design-time planning state.",
             ),
         );
     }
@@ -634,16 +688,47 @@ fn classify_spp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     )
 }
 
+fn has_generic_sip_design_time_scaffold(text: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "Prepare the linked issue prompt and review surfaces for truthful pre-run review before execution is bound.",
+        "Keep the linked issue prompt, SIP, and SOR aligned for review.",
+        "The linked source issue prompt is reviewable and structurally valid.",
+        "files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt",
+        "derive the exact command set from the linked issue prompt",
+    ];
+    MARKERS.iter().any(|marker| text.contains(marker))
+}
+
+fn has_generic_spp_design_time_scaffold(text: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "Bootstrap-generated SPP",
+        "Design-time generated SPP; review before execution",
+        "Review this SPP before execution; during runtime, update it before continuing if the actual execution sequence changes.",
+        "generated from source issue prompt, STP/SIP surfaces",
+    ];
+    MARKERS.iter().any(|marker| text.contains(marker)) || has_truncation_sentinel_line(text)
+}
+
+fn has_truncation_sentinel_line(text: &str) -> bool {
+    text.lines()
+        .map(str::trim)
+        .any(|line| matches!(line, "..." | "- ..." | "* ..." | "<...>"))
+}
+
 fn classify_srp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
     let Some(text) = read_card_text(path) else {
         return missing_stage(repo_root, "SRP", path, "srp-editor");
     };
     let has_review_results = srp_has_final_review_results(&text);
-    let has_policy_exception = text.contains("explicit policy exception")
+    let has_pre_review_absence_exception = text.contains("pre-execution review results are absent");
+    let has_policy_exception = (text.contains("explicit policy exception")
         || text.contains("review_results_exception:")
-        || text.contains("policy_exception:");
+        || text.contains("policy_exception:"))
+        && !has_pre_review_absence_exception;
     let legacy_policy_only = text.contains("# Structured Review Policy")
         || text.contains("artifact_type: \"structured_review_policy\"");
+    let structured_review_prompt = text.contains("# Structured Review Prompt")
+        && text.contains("artifact_type: \"structured_review_prompt\"");
     if has_review_results || has_policy_exception {
         return card_stage(
             repo_root,
@@ -655,6 +740,20 @@ fn classify_srp_stage(repo_root: &Path, path: &Path) -> DoctorCardStageJson {
                 true,
                 None,
                 "SRP contains review results or an explicit policy exception for final review truth.",
+            ),
+        );
+    }
+    if structured_review_prompt && !legacy_policy_only {
+        return card_stage(
+            repo_root,
+            "SRP",
+            path,
+            stage_truth(
+                "pre_review",
+                true,
+                false,
+                None,
+                "SRP is a Structured Review Prompt ready for review; final review results are not recorded yet.",
             ),
         );
     }
@@ -848,6 +947,7 @@ fn card_stage(
         path: path_relative_to_repo(repo_root, path),
         state: truth.state,
         complete: truth.complete,
+        design_time_complete: matches!(stage, "SIP" | "STP" | "SPP" | "SRP") && truth.complete,
         final_ready: truth.final_ready,
         next_editor: truth.next_editor,
         detail: truth.detail.to_string(),
@@ -928,10 +1028,11 @@ fn print_doctor_card_lifecycle_text(card_lifecycle: &DoctorCardLifecycleJson) {
     );
     for stage in &card_lifecycle.stages {
         println!(
-            "CARD_STAGE={}|{}|complete={}|final={}|editor={}|{}",
+            "CARD_STAGE={}|{}|complete={}|design_time={}|final={}|editor={}|{}",
             stage.stage,
             stage.state,
             stage.complete,
+            stage.design_time_complete,
             stage.final_ready,
             stage.next_editor.unwrap_or("none"),
             stage.path
@@ -964,7 +1065,7 @@ mod tests {
 
         assert_eq!(lifecycle.active_stage, "SRP");
         assert_eq!(lifecycle.next_required_stage, Some("SRP"));
-        assert_eq!(lifecycle.pr_run_readiness, "ready");
+        assert_eq!(lifecycle.pr_run_readiness, "blocked");
         assert_eq!(lifecycle.pr_finish_readiness, "blocked");
         assert_stage(&lifecycle, "SRP", "legacy_compatible", false, false);
         assert_stage(&lifecycle, "SOR", "complete", true, false);
@@ -1040,8 +1141,83 @@ mod tests {
     }
 
     #[test]
-    fn card_lifecycle_treats_unbound_sip_and_spp_as_pre_run_not_editor_defects() {
-        let repo = lifecycle_temp_repo("fresh-pre-run-cards");
+    fn card_lifecycle_accepts_pre_review_srp_prompt_without_final_results() {
+        let repo = lifecycle_temp_repo("pre-review-srp-prompt");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Branch: codex/3065-test\n",
+                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n\n## Review Instructions\n\nRun the bounded issue review after implementation.\n",
+                sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.pr_run_readiness, "ready");
+        assert_eq!(lifecycle.pr_finish_readiness, "blocked");
+        assert_stage(&lifecycle, "SRP", "pre_review", true, false);
+        let srp = lifecycle
+            .stages
+            .iter()
+            .find(|stage| stage.stage == "SRP")
+            .expect("srp stage exists");
+        assert!(srp.design_time_complete);
+        assert_eq!(srp.next_editor, None);
+    }
+
+    #[test]
+    fn card_lifecycle_does_not_treat_pre_execution_srp_absence_as_final_exception() {
+        let repo = lifecycle_temp_repo("pre-review-srp-absence-exception");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Branch: codex/3065-test\n",
+                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n",
+                srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent until implementation exists\"\n---\n\n# Structured Review Prompt\n\n## Review Instructions\n\nRun the bounded issue review after implementation.\n",
+                sor: "# output\n\nBranch: codex/3065-test\nStatus: DONE\n\n## Main Repo Integration (REQUIRED)\n- Worktree-only paths remaining: tracked change still on PR branch\n- Integration state: pr_open\n- Result: PASS\n\n## Validation\n- focused validation passed\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.pr_run_readiness, "ready");
+        assert_eq!(lifecycle.pr_finish_readiness, "blocked");
+        assert_stage(&lifecycle, "SRP", "pre_review", true, false);
+    }
+
+    #[test]
+    fn card_lifecycle_allows_ellipsis_in_reviewed_spp_prose() {
+        let repo = lifecycle_temp_repo("spp-ellipsis-prose");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Branch: codex/3065-test\n",
+                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"codex/3065-test\"\nstatus: \"reviewed\"\n---\n\n# Structured Plan Prompt\n\n## Validation\n\nInspect provider output like `downloading... done` without treating it as truncation.\n",
+                srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"codex/3065-test\"\nstatus: \"draft\"\n---\n\n# Structured Review Prompt\n",
+                sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.pr_run_readiness, "ready");
+        assert_stage(&lifecycle, "SPP", "complete", true, false);
+    }
+
+    #[test]
+    fn card_lifecycle_blocks_generic_pre_run_spp_before_execution() {
+        let repo = lifecycle_temp_repo("generic-pre-run-spp");
         let paths = write_lifecycle_fixture(
             &repo,
             LifecycleFixture {
@@ -1057,9 +1233,9 @@ mod tests {
             &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
         );
 
-        assert_eq!(lifecycle.pr_run_readiness, "ready");
-        assert_stage(&lifecycle, "SIP", "pre_run", false, false);
-        assert_stage(&lifecycle, "SPP", "pre_run", false, false);
+        assert_eq!(lifecycle.pr_run_readiness, "blocked");
+        assert_stage(&lifecycle, "SIP", "complete", true, false);
+        assert_stage(&lifecycle, "SPP", "scaffold", false, false);
         assert_eq!(
             lifecycle
                 .stages
@@ -1074,7 +1250,37 @@ mod tests {
                 .iter()
                 .find(|stage| stage.stage == "SPP")
                 .and_then(|stage| stage.next_editor),
-            None
+            Some("spp-editor")
+        );
+    }
+
+    #[test]
+    fn card_lifecycle_blocks_generic_sip_before_execution() {
+        let repo = lifecycle_temp_repo("generic-sip");
+        let paths = write_lifecycle_fixture(
+            &repo,
+            LifecycleFixture {
+                sip: "Branch: not bound yet\n\n## Goal\n\nPrepare the linked issue prompt and review surfaces for truthful pre-run review before execution is bound.\n",
+                stp: "## Required Outcome\n\nready\n\n## Acceptance Criteria\n\n- pass\n",
+                spp: "---\nbranch: \"not bound yet\"\nstatus: \"approved\"\n---\n\n# Structured Plan Prompt\n",
+                srp: "---\nartifact_type: \"structured_review_prompt\"\nbranch: \"not bound yet\"\nstatus: \"draft\"\nreview_results_exception: \"explicit policy exception: pre-execution review results are absent\"\n---\n\n# Structured Review Prompt\n",
+                sor: "Branch: not bound yet\nStatus: NOT_STARTED\n\n## Summary\n\nNo implementation has started yet.\n",
+            },
+        );
+
+        let lifecycle = build_doctor_card_lifecycle(
+            &repo, &paths.sip, &paths.stp, &paths.spp, &paths.srp, &paths.sor,
+        );
+
+        assert_eq!(lifecycle.pr_run_readiness, "blocked");
+        assert_stage(&lifecycle, "SIP", "scaffold", false, false);
+        assert_eq!(
+            lifecycle
+                .stages
+                .iter()
+                .find(|stage| stage.stage == "SIP")
+                .and_then(|stage| stage.next_editor),
+            Some("sip-editor")
         );
     }
 

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -670,6 +670,7 @@ version: "{version}"
 title: "{title}"
 branch: "{branch}"
 status: "draft"
+activation_state: "draft"
 plan_revision: 1
 source_refs:
   - kind: "issue"
@@ -695,7 +696,7 @@ constraints:
   - "runtime_execution_must_update_spp_if_plan_changes"
   - "no_hidden_scope_expansion"
 confidence: "medium"
-plan_summary: "Design-time operative plan for {title}; generated from source issue prompt, STP/SIP surfaces, dependencies, deliverables, acceptance criteria, and validation expectations."
+plan_summary: "Design-time operative plan for {title}; derived from the authored issue prompt, STP/SIP surfaces, dependencies, deliverables, acceptance criteria, and validation expectations."
 assumptions:
   - "The linked source issue prompt, STP, and SIP remain the canonical design-time inputs."
   - "Dependency details may need refresh when earlier issues land."
@@ -755,14 +756,14 @@ alternatives_considered:
     reason_not_chosen: "Chat-only planning is not durable or reviewable enough for this workflow surface."
 review_hooks:
   - "Check dependency truth, scope truthfulness, touched-file truthfulness, validation sufficiency, and re-plan triggers."
-notes: "Design-time generated SPP; review before execution and update during runtime if the plan changes."
+notes: "Design-time SPP derived from the authored issue prompt; update during runtime if the plan changes."
 ---
 
 # Structured Plan Prompt
 
 ## Plan Summary
 
-Design-time operative plan for this issue. Review this SPP before execution; during runtime, update it before continuing if the actual execution sequence changes.
+Design-time operative plan for this issue. Use this SPP to guide execution; during runtime, update it before continuing if the actual execution sequence changes.
 
 ## Codex Plan
 
@@ -817,7 +818,7 @@ Use this SPP as the design-time plan-of-record, then update it at runtime whenev
 
 ## Notes
 
-Design-time generated SPP; review before execution and update during runtime if the plan changes.
+Design-time SPP derived from the authored issue prompt; update during runtime if the plan changes.
 "#,
         slug = issue_ref.slug(),
         issue = issue_ref.issue_number(),
@@ -873,7 +874,7 @@ fn issue_prompt_section(text: &str, heading: &str) -> Option<String> {
 }
 
 fn one_line_summary(text: &str) -> String {
-    const MAX_LEN: usize = 220;
+    const MAX_LEN: usize = 420;
     let out = text
         .lines()
         .map(|line| line.trim().trim_start_matches("- ").trim())
@@ -882,7 +883,7 @@ fn one_line_summary(text: &str) -> String {
         .join("; ");
     if out.chars().count() > MAX_LEN {
         let mut truncated = out.chars().take(MAX_LEN).collect::<String>();
-        truncated.push_str("...");
+        truncated.push_str(" [summary truncated]");
         truncated
     } else {
         out
@@ -951,8 +952,7 @@ non_claims:
 policy_refs:
   - "{stp_rel}"
   - "{sip_rel}"
-review_results_exception: "explicit policy exception: pre-execution review results are absent until implementation exists; finalize this SRP with actual review findings before PR publication."
-notes: "Bootstrap-generated Structured Review Prompt; revise before use if issue-specific review constraints are needed."
+notes: "Structured Review Prompt prepared before execution; finalize with actual review findings before PR publication."
 ---
 
 # Structured Review Prompt
@@ -1019,7 +1019,7 @@ Use this prompt to govern the independent pre-PR review for this issue. Review r
 
 ## Notes
 
-Bootstrap-generated Structured Review Prompt; revise before use if issue-specific review constraints are needed.
+Structured Review Prompt prepared before execution; finalize with actual review findings before PR publication.
 "#,
         slug = issue_ref.slug(),
         issue = issue_ref.issue_number(),

--- a/adl/src/cli/pr_cmd_cards/cards.rs
+++ b/adl/src/cli/pr_cmd_cards/cards.rs
@@ -10,7 +10,10 @@ use super::shared::{
     ensure_symlink, field_line_value, output_card_title_matches_slug, path_relative_to_repo,
     replace_exact_line, replace_field_line, replace_field_line_in_file,
 };
-use super::validation::{validate_bootstrap_cards, validate_bootstrap_stp, StructuredBundlePaths};
+use super::validation::{
+    validate_bootstrap_cards, validate_bootstrap_stp, validate_initialized_cards,
+    StructuredBundlePaths,
+};
 use ::adl::control_plane::{
     card_input_path, card_output_path, card_plan_path, card_review_policy_path, card_stp_path,
     resolve_cards_root, IssueRef,
@@ -168,6 +171,26 @@ pub(crate) fn ensure_bootstrap_cards(
     branch: &str,
     source_path: &Path,
 ) -> Result<(PathBuf, PathBuf, PathBuf)> {
+    ensure_bootstrap_cards_with_mode(root, issue_ref, title, branch, source_path, true)
+}
+
+pub(crate) fn ensure_pre_run_bootstrap_cards(
+    root: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    source_path: &Path,
+) -> Result<(PathBuf, PathBuf, PathBuf)> {
+    ensure_bootstrap_cards_with_mode(root, issue_ref, title, "not bound yet", source_path, false)
+}
+
+fn ensure_bootstrap_cards_with_mode(
+    root: &Path,
+    issue_ref: &IssueRef,
+    title: &str,
+    branch: &str,
+    source_path: &Path,
+    bind_existing_cards: bool,
+) -> Result<(PathBuf, PathBuf, PathBuf)> {
     let bundle_stp = issue_ref.task_bundle_stp_path(root);
     let bundle_input = issue_ref.task_bundle_input_path(root);
     let bundle_output = issue_ref.task_bundle_output_path(root);
@@ -192,24 +215,26 @@ pub(crate) fn ensure_bootstrap_cards(
             source_path,
             &bundle_output,
         )?;
-    } else if field_line_value(&bundle_input, "Branch")?.trim() != branch {
+    } else if bind_existing_cards && field_line_value(&bundle_input, "Branch")?.trim() != branch {
         replace_field_line_in_file(&bundle_input, "Branch", branch)?;
     }
     if !bundle_output.is_file()
         || !output_card_title_matches_slug(&bundle_output, issue_ref.slug())?
     {
         write_output_card(root, &bundle_output, issue_ref, title, branch)?;
-    } else if field_line_value(&bundle_output, "Branch")?.trim() != branch {
+    } else if bind_existing_cards && field_line_value(&bundle_output, "Branch")?.trim() != branch {
         replace_field_line_in_file(&bundle_output, "Branch", branch)?;
     }
     if !bundle_plan.is_file() || plan_card_needs_design_time_refresh(&bundle_plan)? {
         write_plan_card(root, &bundle_plan, issue_ref, title, branch, source_path)?;
-    } else if field_line_value(&bundle_plan, "branch")?.trim() != branch {
+    } else if bind_existing_cards && field_line_value(&bundle_plan, "branch")?.trim() != branch {
         replace_field_line_in_file(&bundle_plan, "branch", &format!("\"{branch}\""))?;
     }
     if !bundle_review_policy.is_file() {
         write_review_policy_card(root, &bundle_review_policy, issue_ref, title, branch)?;
-    } else if field_line_value(&bundle_review_policy, "branch")?.trim() != branch {
+    } else if bind_existing_cards
+        && field_line_value(&bundle_review_policy, "branch")?.trim() != branch
+    {
         replace_field_line_in_file(&bundle_review_policy, "branch", &format!("\"{branch}\""))?;
     }
 
@@ -225,18 +250,30 @@ pub(crate) fn ensure_bootstrap_cards(
     ensure_symlink(&compat_plan, &bundle_plan)?;
     ensure_symlink(&compat_review_policy, &bundle_review_policy)?;
 
-    validate_bootstrap_cards(
-        root,
-        issue_ref.issue_number(),
-        issue_ref.slug(),
-        branch,
-        &bundle_input,
-        &bundle_output,
-        StructuredBundlePaths {
-            plan_path: &bundle_plan,
-            review_policy_path: &bundle_review_policy,
-        },
-    )?;
+    let structured_paths = StructuredBundlePaths {
+        plan_path: &bundle_plan,
+        review_policy_path: &bundle_review_policy,
+    };
+    if bind_existing_cards {
+        validate_bootstrap_cards(
+            root,
+            issue_ref.issue_number(),
+            issue_ref.slug(),
+            branch,
+            &bundle_input,
+            &bundle_output,
+            structured_paths,
+        )?;
+    } else {
+        validate_initialized_cards(
+            issue_ref.issue_number(),
+            issue_ref.slug(),
+            &bundle_input,
+            &bundle_output,
+            root,
+            structured_paths,
+        )?;
+    }
     validate_authored_prompt_surface("start", &bundle_input, PromptSurfaceKind::Sip)?;
     Ok((bundle_stp, bundle_input, bundle_output))
 }
@@ -461,6 +498,17 @@ fn render_bootstrap_output_card(
     let output_rel =
         path_relative_to_repo(repo_root, &issue_ref.task_bundle_output_path(repo_root));
     let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
+    let pre_run_unbound = branch_indicates_unbound_state(branch);
+    let status = if pre_run_unbound {
+        "NOT_STARTED"
+    } else {
+        "IN_PROGRESS"
+    };
+    let branch_action = if pre_run_unbound {
+        "Preserved pre-run branch truth; no execution branch or worktree is bound yet."
+    } else {
+        "Reserved the execution branch for later implementation."
+    };
     format!(
         r#"# {slug}
 
@@ -478,7 +526,7 @@ Run ID: issue-{issue}
 Version: {version}
 Title: {title}
 Branch: {branch}
-Status: IN_PROGRESS
+Status: {status}
 
 Execution:
 - Actor: issue-wave bootstrap
@@ -497,7 +545,7 @@ Pre-run output scaffold initialized during issue-wave opening. No implementation
 
 ## Actions taken
 - Opened the local issue bundle and wrote a truthful pre-run output scaffold.
-- Reserved the execution branch `{branch}` for later implementation.
+- {branch_action}
 - Deferred implementation, proof capture, and release integration to the execution lifecycle and PR publication.
 
 ## Main Repo Integration (REQUIRED)
@@ -606,6 +654,8 @@ verification_summary:
         version = issue_ref.scope(),
         title = title,
         branch = branch,
+        status = status,
+        branch_action = branch_action,
         output_rel = output_rel,
         timestamp = timestamp,
     )

--- a/adl/src/cli/tests/pr_cmd_inline/basics.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/basics.rs
@@ -788,6 +788,14 @@ fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
         "create should generate a reviewable design-time SPP"
     );
     assert!(
+        spp.contains("status: \"draft\""),
+        "create should not claim generated design-time SPPs were reviewed"
+    );
+    assert!(
+        spp.contains("activation_state: \"draft\""),
+        "create should leave generated SPPs in design-review state"
+    );
+    assert!(
         spp.contains("Implement only the bounded deliverables: create-path validation"),
         "SPP should derive implementation steps from source deliverables"
     );
@@ -804,6 +812,10 @@ fn real_pr_create_creates_issue_and_bootstraps_root_bundle() {
     assert!(
         !spp.contains("Bootstrap-generated SPP"),
         "SPP should not be the legacy generic scaffold"
+    );
+    assert!(
+        !spp.contains("Design-time generated SPP; review before execution"),
+        "SPP should not carry generic review-before-use marker text"
     );
     assert!(
         repo.join(".adl/v0.86/tasks/issue-1202__v0-86-tools-simplified-init-path/srp.md")

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs
@@ -600,6 +600,12 @@ fn real_pr_doctor_full_succeeds_when_invoked_from_started_worktree() {
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1197, "v0.86", "doctor-worktree-cwd").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Doctor worktree cwd");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Doctor worktree cwd",
+        "codex/1197-doctor-worktree-cwd",
+    );
     real_pr(&[
         "start".to_string(),
         "1197".to_string(),

--- a/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs
@@ -146,6 +146,12 @@ fn real_pr_start_bootstraps_worktree_and_ready_passes() {
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1152, "v0.86", "rust-start-ready-test").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Rust start ready test");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Rust start ready test",
+        "codex/1152-rust-start-ready-test",
+    );
     let local_templates = repo.join("docs/templates");
     fs::create_dir_all(local_templates.join("nested")).expect("create local templates");
     fs::write(
@@ -339,6 +345,12 @@ fn real_pr_start_repairs_preexisting_worktree_missing_task_bundle() {
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1153, "v0.86", "repair-worktree-bundle").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Repair worktree bundle");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Repair worktree bundle",
+        "codex/1153-repair-worktree-bundle",
+    );
     let branch = "codex/1153-repair-worktree-bundle";
     let worktree = issue_ref.default_worktree_path(&repo, None);
     assert!(Command::new("git")
@@ -498,6 +510,12 @@ fn real_pr_start_updates_existing_root_spp_and_srp_branch() {
             .expect("read root srp")
             .contains("branch: \"not bound yet\"")
     );
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Update root plan and review branch",
+        "not bound yet",
+    );
 
     real_pr(&[
         "start".to_string(),
@@ -649,6 +667,12 @@ fn real_pr_ready_blocks_invalid_worktree_srp() {
         &issue_ref,
         "[v0.86][tools] Ready invalid worktree srp",
     );
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Ready invalid worktree srp",
+        "codex/1917-ready-invalid-worktree-srp",
+    );
 
     real_pr(&[
         "start".to_string(),
@@ -799,6 +823,12 @@ fn real_pr_start_rewrites_unbound_root_input_card_branch() {
         "v0.86".to_string(),
     ])
     .expect("real_pr init");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Start rewrites unbound",
+        "not bound yet",
+    );
 
     let root_sip = issue_ref.task_bundle_input_path(&repo);
     assert_eq!(
@@ -925,6 +955,12 @@ fn real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists() {
         "v0.86".to_string(),
     ])
     .expect("init canonical bundle");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Canonical bind slug issue",
+        "not bound yet",
+    );
 
     real_pr(&[
         "start".to_string(),
@@ -1151,6 +1187,12 @@ fn real_pr_ready_succeeds_when_invoked_from_started_worktree() {
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1198, "v0.86", "ready-worktree-cwd").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Ready worktree cwd");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Ready worktree cwd",
+        "codex/1198-ready-worktree-cwd",
+    );
     real_pr(&[
         "start".to_string(),
         "1198".to_string(),

--- a/adl/src/cli/tests/pr_cmd_inline/mod.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/mod.rs
@@ -159,7 +159,7 @@ fn write_authored_sip(
 ) {
     let source_rel = path_relative_to_repo(repo_root, source_prompt);
     let content = format!(
-            "# ADL Input Card\n\nTask ID: {task_id}\nRun ID: {task_id}\nVersion: v0.86\nTitle: {title}\nBranch: {branch}\n\nContext:\n- Issue: https://github.com/example/repo/issues/{issue}\n- PR: none\n- Source Issue Prompt: {source_rel}\n- Docs: none\n- Other: none\n\n## Agent Execution Rules\n- Do not run `pr start`; the branch and worktree already exist.\n- Only modify files required for the issue.\n\n## Prompt Spec\n```yaml\nprompt_schema: adl.v1\nactor:\n  role: execution_agent\n  name: codex\nmodel:\n  id: gpt-5-codex\n  determinism_mode: stable\ninputs:\n  sections:\n    - goal\n    - required_outcome\n    - acceptance_criteria\n    - inputs\n    - target_files_surfaces\n    - validation_plan\n    - demo_proof_requirements\n    - constraints_policies\n    - system_invariants\n    - reviewer_checklist\n    - non_goals_out_of_scope\n    - notes_risks\n    - instructions_to_agent\noutputs:\n  output_card: .adl/v0.86/tasks/{bundle}/sor.md\n  summary_style: concise_structured\nconstraints:\n  include_system_invariants: true\n  include_reviewer_checklist: true\n  disallow_secrets: true\n  disallow_absolute_host_paths: true\nautomation_hints:\n  source_issue_prompt_required: true\n  target_files_surfaces_recommended: true\n  validation_plan_required: true\n  required_outcome_type_supported: true\nreview_surfaces:\n  - card_review_checklist.v1\n  - card_review_output.v1\n  - card_reviewer_gpt.v1.1\n```\n\nExecution:\n- Agent: codex\n- Provider: openai\n- Tools allowed: git, cargo\n- Sandbox / approvals: workspace-write\n- Source issue-prompt slug: {slug}\n- Required outcome type: code\n- Demo required: false\n\n## Goal\n\nBlock lifecycle execution when prompts are still bootstrap stubs.\n\n## Required Outcome\n\n- This issue must ship code and tests.\n\n## Acceptance Criteria\n\n- lifecycle commands reject placeholder prompt content\n\n## Inputs\n- issue body\n- task bundle cards\n\n## Target Files / Surfaces\n- adl/src/cli/pr_cmd.rs\n- adl/tools/pr.sh\n\n## Validation Plan\n- Required commands: cargo test --manifest-path Cargo.toml pr_cmd -- --nocapture\n- Required tests: targeted lifecycle validation coverage\n- Required artifacts / traces: none\n- Required reviewer or demo checks: none\n\n## Demo / Proof Requirements\n- Required demo(s): none\n- Required proof surface(s): command failure behavior and tests\n- If no demo is required, say why: tooling guardrail only\n\n## Constraints / Policies\n- Determinism requirements: stable error messages for the same stub input\n- Security / privacy requirements: no secrets or absolute host paths\n- Resource limits (time/CPU/memory/network): standard local test limits\n\n## System Invariants (must remain true)\n- Deterministic execution for identical inputs.\n- No hidden state or undeclared side effects.\n- Artifacts remain replay-compatible with the replay runner.\n- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.\n- Artifact schema changes are explicit and approved.\n\n## Reviewer Checklist (machine-readable hints)\n```yaml\ndeterminism_required: true\nnetwork_allowed: false\nartifact_schema_change: false\nreplay_required: true\nsecurity_sensitive: true\nci_validation_required: true\n```\n\n## Card Automation Hooks (prompt generation)\n- Prompt source fields:\n  - Goal\n  - Required Outcome\n  - Acceptance Criteria\n- Generation requirements:\n  - Deterministic output for identical input card content\n  - Preserve traceability back to the source issue prompt\n\n## Non-goals / Out of scope\n- rewriting historical issues automatically\n\n## Notes / Risks\n- none\n\n## Instructions to the Agent\n- Read the linked source issue prompt before starting work.\n- Do the work described above.\n- Write results to the paired output card file.\n",
+            "# ADL Input Card\n\nTask ID: {task_id}\nRun ID: {task_id}\nVersion: v0.86\nTitle: {title}\nBranch: {branch}\n\nContext:\n- Issue: https://github.com/example/repo/issues/{issue}\n- PR: https://github.com/example/repo/pull/{issue}\n- Source Issue Prompt: {source_rel}\n- Docs: none\n- Other: none\n\n## Agent Execution Rules\n- Do not run `pr start`; the branch and worktree already exist.\n- Only modify files required for the issue.\n\n## Prompt Spec\n```yaml\nprompt_schema: adl.v1\nactor:\n  role: execution_agent\n  name: codex\nmodel:\n  id: gpt-5-codex\n  determinism_mode: stable\ninputs:\n  sections:\n    - goal\n    - required_outcome\n    - acceptance_criteria\n    - inputs\n    - target_files_surfaces\n    - validation_plan\n    - demo_proof_requirements\n    - constraints_policies\n    - system_invariants\n    - reviewer_checklist\n    - non_goals_out_of_scope\n    - notes_risks\n    - instructions_to_agent\noutputs:\n  output_card: .adl/v0.86/tasks/{bundle}/sor.md\n  summary_style: concise_structured\nconstraints:\n  include_system_invariants: true\n  include_reviewer_checklist: true\n  disallow_secrets: true\n  disallow_absolute_host_paths: true\nautomation_hints:\n  source_issue_prompt_required: true\n  target_files_surfaces_recommended: true\n  validation_plan_required: true\n  required_outcome_type_supported: true\nreview_surfaces:\n  - card_review_checklist.v1\n  - card_review_output.v1\n  - card_reviewer_gpt.v1.1\n```\n\nExecution:\n- Agent: codex\n- Provider: openai\n- Tools allowed: git, cargo\n- Sandbox / approvals: workspace-write\n- Source issue-prompt slug: {slug}\n- Required outcome type: code\n- Demo required: false\n\n## Goal\n\nBlock lifecycle execution when prompts are still bootstrap stubs.\n\n## Required Outcome\n\n- This issue must ship code and tests.\n\n## Acceptance Criteria\n\n- lifecycle commands reject placeholder prompt content\n\n## Inputs\n- issue body\n- task bundle cards\n\n## Target Files / Surfaces\n- adl/src/cli/pr_cmd.rs\n- adl/tools/pr.sh\n\n## Validation Plan\n- Required commands: cargo test --manifest-path Cargo.toml pr_cmd -- --nocapture\n- Required tests: targeted lifecycle validation coverage\n- Required artifacts / traces: none\n- Required reviewer or demo checks: none\n\n## Demo / Proof Requirements\n- Required demo(s): none\n- Required proof surface(s): command failure behavior and tests\n- If no demo is required, say why: tooling guardrail only\n\n## Constraints / Policies\n- Determinism requirements: stable error messages for the same stub input\n- Security / privacy requirements: no secrets or absolute host paths\n- Resource limits (time/CPU/memory/network): standard local test limits\n\n## System Invariants (must remain true)\n- Deterministic execution for identical inputs.\n- No hidden state or undeclared side effects.\n- Artifacts remain replay-compatible with the replay runner.\n- Trace artifacts contain no secrets, prompts, tool arguments, or absolute host paths.\n- Artifact schema changes are explicit and approved.\n\n## Reviewer Checklist (machine-readable hints)\n```yaml\ndeterminism_required: true\nnetwork_allowed: false\nartifact_schema_change: false\nreplay_required: true\nsecurity_sensitive: true\nci_validation_required: true\n```\n\n## Card Automation Hooks (prompt generation)\n- Prompt source fields:\n  - Goal\n  - Required Outcome\n  - Acceptance Criteria\n- Generation requirements:\n  - Deterministic output for identical input card content\n  - Preserve traceability back to the source issue prompt\n\n## Non-goals / Out of scope\n- rewriting historical issues automatically\n\n## Notes / Risks\n- none\n\n## Instructions to the Agent\n- Read the linked source issue prompt before starting work.\n- Do the work described above.\n- Write results to the paired output card file.\n",
             task_id = issue_ref.task_issue_id(),
             title = title,
             branch = branch,
@@ -192,7 +192,8 @@ run_id: "{task_id}"
 version: v0.86
 title: "{title}"
 branch: "{branch}"
-status: "draft"
+status: "reviewed"
+activation_state: "reviewed"
 plan_revision: 1
 source_refs:
   - kind: "issue"
@@ -432,6 +433,35 @@ test
         sor_rel = sor_rel,
     );
     fs::write(path, content).expect("write authored srp");
+}
+
+fn write_design_time_ready_cards(repo: &Path, issue_ref: &IssueRef, title: &str, branch: &str) {
+    let source_path = issue_ref.issue_prompt_path(repo);
+    ensure_task_bundle_stp(repo, issue_ref, &source_path).expect("ensure task bundle stp");
+    ensure_bootstrap_cards(repo, issue_ref, title, branch, &source_path)
+        .expect("bootstrap design-time cards");
+    write_authored_sip(
+        &issue_ref.task_bundle_input_path(repo),
+        issue_ref,
+        title,
+        branch,
+        &source_path,
+        repo,
+    );
+    write_authored_spp(
+        &issue_ref.task_bundle_plan_path(repo),
+        issue_ref,
+        title,
+        branch,
+        repo,
+    );
+    write_authored_srp(
+        &issue_ref.task_bundle_review_policy_path(repo),
+        issue_ref,
+        title,
+        branch,
+        repo,
+    );
 }
 
 fn write_completed_sor_fixture(path: &Path, branch: &str) {

--- a/adl/src/cli/tests/pr_cmd_inline/mod.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/mod.rs
@@ -653,6 +653,7 @@ fn write_output_card_emits_truthful_pre_run_scaffold() {
     .expect("bootstrap output should validate");
 
     let text = fs::read_to_string(&output).expect("read output");
+    assert!(text.contains("Status: IN_PROGRESS"));
     assert!(text.contains("Pre-run output scaffold initialized during issue-wave opening."));
     assert!(text.contains("Local ignored output-card scaffold"));
     assert!(text.contains("Integration method used: direct write in main repo for the local ignored pre-run record; tracked implementation artifacts do not exist yet"));

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
@@ -43,6 +43,92 @@ fn real_pr_start_requires_explicit_version_when_no_fetch_issue_has_no_local_bund
 }
 
 #[test]
+fn real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready() {
+    let _guard = env_lock();
+    let repo = unique_temp_dir("adl-pr-start-design-time-card-gate");
+    copy_bootstrap_support_files(&repo);
+    init_git_repo(&repo);
+    assert!(Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    assert!(Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .expect("git config")
+        .success());
+    fs::write(repo.join("README.md"), "design-time gate fixture\n").expect("write readme");
+    assert!(Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(&repo)
+        .status()
+        .expect("git add")
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .expect("git commit")
+        .success());
+    assert!(Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&repo)
+        .status()
+        .expect("git branch")
+        .success());
+    let issue_ref = IssueRef::new(
+        1154,
+        "v0.86".to_string(),
+        "v0-86-tools-design-time-card-gate".to_string(),
+    )
+    .expect("issue ref");
+    write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Design-time card gate");
+    assert!(Command::new("git")
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(&repo)
+        .status()
+        .expect("git remote set-url")
+        .success());
+
+    let prev_dir = env::current_dir().expect("cwd");
+    env::set_current_dir(&repo).expect("chdir");
+
+    let err = real_pr(&[
+        "start".to_string(),
+        "1154".to_string(),
+        "--slug".to_string(),
+        "v0-86-tools-design-time-card-gate".to_string(),
+        "--title".to_string(),
+        "[v0.86][tools] Design-time card gate".to_string(),
+        "--no-fetch-issue".to_string(),
+        "--version".to_string(),
+        "v0.86".to_string(),
+    ])
+    .expect_err("start should block before worktree binding when generated SPP is not reviewed");
+
+    env::set_current_dir(prev_dir).expect("restore cwd");
+
+    let err_text = err.to_string();
+    assert!(
+        err_text.contains("design-time card completion gate failed"),
+        "unexpected error: {err_text}"
+    );
+    assert!(err_text.contains("SPP"));
+    assert!(
+        !repo.join(".worktrees/adl-wp-1154").exists(),
+        "design-time card gate should block before worktree creation"
+    );
+}
+
+#[test]
 fn real_pr_init_requires_explicit_or_inferable_version_for_issue() {
     let _guard = env_lock();
     let repo = unique_temp_dir("adl-pr-init-missing-version");
@@ -483,6 +569,12 @@ fn real_pr_ready_accepts_started_issue_when_output_branch_is_bootstrap_placehold
     env::set_current_dir(&repo).expect("chdir");
     let issue_ref = IssueRef::new(1198, "v0.86", "ready-branch-placeholder").expect("issue ref");
     write_authored_issue_prompt(&repo, &issue_ref, "[v0.86][tools] Ready branch placeholder");
+    write_design_time_ready_cards(
+        &repo,
+        &issue_ref,
+        "[v0.86][tools] Ready branch placeholder",
+        "codex/1198-ready-branch-placeholder",
+    );
 
     real_pr(&[
         "start".to_string(),
@@ -662,7 +754,8 @@ fn ensure_bootstrap_cards_creates_bundle_and_compat_links() {
         fs::read_to_string(issue_ref.task_bundle_review_policy_path(&repo)).expect("review prompt");
     assert!(review_prompt_text.contains("artifact_type: \"structured_review_prompt\""));
     assert!(review_prompt_text.contains("# Structured Review Prompt"));
-    assert!(review_prompt_text.contains("review_results_exception:"));
+    assert!(!review_prompt_text.contains("review_results_exception:"));
+    assert!(review_prompt_text.contains("Review results are intentionally absent"));
     assert!(!review_prompt_text.contains("# Structured Review Policy"));
     assert_eq!(
         field_line_value(&bundle_input, "Branch").expect("input branch"),

--- a/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs
@@ -126,6 +126,20 @@ fn real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready() {
         !repo.join(".worktrees/adl-wp-1154").exists(),
         "design-time card gate should block before worktree creation"
     );
+    let branch = "codex/1154-v0-86-tools-design-time-card-gate";
+    let root_sip = fs::read_to_string(issue_ref.task_bundle_input_path(&repo)).expect("read sip");
+    let root_sor = fs::read_to_string(issue_ref.task_bundle_output_path(&repo)).expect("read sor");
+    let root_spp = fs::read_to_string(issue_ref.task_bundle_plan_path(&repo)).expect("read spp");
+    let root_srp =
+        fs::read_to_string(issue_ref.task_bundle_review_policy_path(&repo)).expect("read srp");
+    assert!(root_sip.contains("Branch: not bound yet"));
+    assert!(root_sor.contains("Branch: not bound yet"));
+    assert!(root_sor.contains("Status: NOT_STARTED"));
+    assert!(!root_sor.contains("Status: IN_PROGRESS"));
+    assert!(!root_sip.contains(&format!("Branch: {branch}")));
+    assert!(!root_sor.contains(&format!("Branch: {branch}")));
+    assert!(!root_spp.contains(&format!("branch: \"{branch}\"")));
+    assert!(!root_srp.contains(&format!("branch: \"{branch}\"")));
 }
 
 #[test]

--- a/adl/tools/pr.sh
+++ b/adl/tools/pr.sh
@@ -1858,10 +1858,10 @@ Usage:
   adl/tools/pr.sh create --title "<title>" [--slug <slug>] [--body "<markdown>" | --body-file <path>] [--labels <csv>] [--version <v>]
 
 Notes:
-- Creates the GitHub issue and bootstraps the local root STP/SIP/SOR bundle.
+- Creates the GitHub issue and bootstraps the local root STP/SIP/SPP/SRP/SOR bundle.
 - Runs the doctor-ready structural check immediately after bootstrap and fails if the new issue is not ready for the next step.
 - Does not create the branch or worktree execution context.
-- After create, do qualitative STP/SIP review and then run `adl/tools/pr.sh run <issue> ...`.
+- After create, do qualitative SIP/STP/SPP/SRP design-time review and then run `adl/tools/pr.sh run <issue> ...`.
 EOF
 }
 

--- a/adl/tools/skills/sip-editor/SKILL.md
+++ b/adl/tools/skills/sip-editor/SKILL.md
@@ -45,6 +45,9 @@ This skill may:
 - fix truthful `Branch` state such as `not bound yet` vs bound execution branch
 - normalize target-file and validation-plan sections
 - align SIP wording with current lifecycle state
+- replace generic bootstrap intent with issue-specific design-time intent,
+  including concrete scope, dependencies, acceptance criteria, validation
+  expectations, and non-goals drawn from the source issue prompt
 - remove placeholders and stale review/execution notes
 
 This skill must not:

--- a/adl/tools/skills/sor-editor/SKILL.md
+++ b/adl/tools/skills/sor-editor/SKILL.md
@@ -46,6 +46,9 @@ This skill may:
 - fix integration wording such as `worktree_only`, `pr_open`, or main-repo claims
 - replace placeholders with concrete paths or commands when evidence is supplied
 - normalize validation sections to reflect only checks actually run
+- preserve the design-time boundary between a pre-execution scaffold and a
+  post-execution output record; do not mark output, validation, PR, merge, or
+  closeout truth as complete before it exists
 - tighten artifact and determinism wording for truthfulness
 
 This skill must not:

--- a/adl/tools/skills/spp-editor/SKILL.md
+++ b/adl/tools/skills/spp-editor/SKILL.md
@@ -71,6 +71,9 @@ This skill may:
 - align `SPP` wording with current pre-execution or plan-review state
 - tighten generated design-time plan steps, proof gates, stop conditions, and
   replan triggers when explicit issue evidence supports the change
+- mark an SPP `reviewed` or `approved` only after the issue-local plan is
+  specific enough to execute from tracked state; generic or truncated generated
+  plans remain editor blockers
 - remove placeholders and stale execution or branch-binding claims
 
 This skill must not:

--- a/adl/tools/skills/sprint-conductor/SKILL.md
+++ b/adl/tools/skills/sprint-conductor/SKILL.md
@@ -145,6 +145,8 @@ missing sprint-management issue first.
 This skill enforces:
 - exactly one active child issue at a time
 - no child issue execution before the whole sprint batch passes structured prompt review
+- no child issue execution before the whole sprint batch passes design-time
+  card-completion review for `SIP`, `STP`, `SPP`, and `SRP`
 - no issue `N+1` work before issue `N` is fully closed out
 - editor-skill routing when cards drift
 - immediate stop on true blocker
@@ -162,6 +164,10 @@ Preferred per-issue routing model:
 - sprint-wide structured prompt preflight not ready ->
   `check_sprint_structured_prompt_readiness.py`, then route flagged child issues
   through the matching editor skills before starting issue execution
+- sprint-wide design-time card preflight not ready -> route generic `SIP`,
+  incomplete `STP`, generic/truncated or unreviewed `SPP`, and legacy/incomplete
+  `SRP` cards through their matching editor skills before starting issue
+  execution
 - missing sprint-management issue and policy allows creation ->
   `create_missing_sprint_issue.py`, then continue with the ordered child issue
   flow from the created sprint anchor

--- a/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
+++ b/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py
@@ -36,6 +36,59 @@ def canonical_slug_from_bundle_dir(bundle_dir: Path) -> str:
     return name
 
 
+GENERIC_SIP_MARKERS = [
+    'Prepare the linked issue prompt and review surfaces for truthful pre-run review before execution is bound.',
+    'Keep the linked issue prompt, SIP, and SOR aligned for review.',
+    'The linked source issue prompt is reviewable and structurally valid.',
+    'files, docs, tests, commands, schemas, and artifacts named by the linked source issue prompt',
+    'derive the exact command set from the linked issue prompt',
+]
+
+GENERIC_SPP_MARKERS = [
+    'Bootstrap-generated SPP',
+    'Design-time generated SPP; review before execution',
+    'Review this SPP before execution; during runtime, update it before continuing if the actual execution sequence changes.',
+    'generated from source issue prompt, STP/SIP surfaces',
+]
+
+
+def contains_any(text: str, markers: list[str]) -> bool:
+    return any(marker in text for marker in markers)
+
+
+def has_truncation_sentinel_line(text: str) -> bool:
+    sentinels = {'...', '- ...', '* ...', '<...>'}
+    return any(line.strip() in sentinels for line in text.splitlines())
+
+
+def line_value_after_prefix(text: str, prefix: str) -> str:
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith(prefix):
+            return line.split(':', 1)[1].strip().strip('"').strip("'")
+    return ''
+
+
+def design_time_defect(card_name: str, text: str) -> str | None:
+    if card_name == 'sip.md' and contains_any(text, GENERIC_SIP_MARKERS):
+        return 'generic design-time SIP scaffold'
+    if card_name == 'stp.md':
+        if '## Required Outcome' not in text or '## Acceptance Criteria' not in text:
+            return 'incomplete design-time STP acceptance surface'
+    if card_name == 'spp.md':
+        status = line_value_after_prefix(text, 'status:')
+        if contains_any(text, GENERIC_SPP_MARKERS) or has_truncation_sentinel_line(text):
+            return 'generic or truncated design-time SPP scaffold'
+        if status not in {'reviewed', 'approved'}:
+            return 'SPP is not reviewed or approved for design-time execution'
+    if card_name == 'srp.md':
+        if '# Structured Review Policy' in text or 'artifact_type: "structured_review_policy"' in text:
+            return 'legacy SRP policy scaffold'
+        if '# Structured Review Prompt' not in text or 'artifact_type: "structured_review_prompt"' not in text:
+            return 'missing Structured Review Prompt semantics'
+    return None
+
+
 def inspect_issue(
     repo_root: Path,
     issue_number: int,
@@ -67,12 +120,19 @@ def inspect_issue(
 
     missing_cards: list[str] = []
     contradictory_cards: list[str] = []
+    design_time_defects: list[str] = []
     required_editor_skills: list[str] = []
 
     for card_name, editor_skill in required_cards.items():
         card_path = bundle_dir / card_name
         if not card_path.exists():
             missing_cards.append(card_name)
+            if editor_skill not in required_editor_skills:
+                required_editor_skills.append(editor_skill)
+            continue
+        defect = design_time_defect(card_name, card_path.read_text())
+        if defect:
+            design_time_defects.append(f'{card_name}: {defect}')
             if editor_skill not in required_editor_skills:
                 required_editor_skills.append(editor_skill)
 
@@ -85,12 +145,13 @@ def inspect_issue(
                 required_editor_skills.append('sor-editor')
 
     status = 'ready'
-    if contradictory_cards or missing_cards:
+    if contradictory_cards or missing_cards or design_time_defects:
         status = 'needs_editor_repair'
 
     notes.extend(
         [f'Missing {name}' for name in missing_cards] +
-        [f'Contradictory bootstrap residue in {name}' for name in contradictory_cards]
+        [f'Contradictory bootstrap residue in {name}' for name in contradictory_cards] +
+        [f'Design-time card defect in {defect}' for defect in design_time_defects]
     )
 
     return {
@@ -100,6 +161,7 @@ def inspect_issue(
         'status': status,
         'missing_cards': missing_cards,
         'contradictory_cards': contradictory_cards,
+        'design_time_defects': design_time_defects,
         'required_editor_skills': required_editor_skills,
         'notes': notes,
     }

--- a/adl/tools/skills/srp-editor/SKILL.md
+++ b/adl/tools/skills/srp-editor/SKILL.md
@@ -48,6 +48,9 @@ This skill may:
 - normalize `artifact_type` to `structured_review_prompt`
 - update headings and wording from legacy Structured Review Policy scaffolding
   to Structured Review Prompt semantics
+- prepare a complete review prompt before review while explicitly preserving
+  that findings, dispositions, and recommended outcome are absent until review
+  actually runs
 - add or tighten sections for review scope, review instructions, findings,
   dispositions, reviewer notes, residual risks, and recommended outcome
 - record review findings only when explicit review evidence is supplied

--- a/adl/tools/skills/stp-editor/SKILL.md
+++ b/adl/tools/skills/stp-editor/SKILL.md
@@ -43,6 +43,8 @@ Useful additional inputs:
 This skill may:
 - improve goal wording without changing intent
 - tighten required outcome and acceptance criteria
+- make the selected task explicit enough for design-time readiness, including
+  deliverables, touched surfaces, proof shape, invariants, and non-goals
 - normalize inputs, targets, validation plan, and constraints sections
 - remove template placeholders and contradictory notes
 - align STP wording with the tracked issue prompt and current lifecycle phase

--- a/adl/tools/skills/workflow-conductor/SKILL.md
+++ b/adl/tools/skills/workflow-conductor/SKILL.md
@@ -136,6 +136,10 @@ Important rule:
 - explicit `covered by #<n>` / `satisfied by #<n>` style references should block fresh execution when the referenced issue is already closed
 - repo-policy residue such as tracked legacy `.adl` issue records should escalate as a mechanical blocker rather than being mistaken for issue-local implementation work
 - linkage-only PR failures should route as a bounded janitor case rather than a generic merge-blocked state
+- design-time card-completion blockers from `pr doctor` should route to the
+  matching card editor before execution or publication continues; generic
+  `SIP`, incomplete `STP`, generic/truncated `SPP`, and legacy/incomplete
+  `SRP` surfaces are not safe to treat as ready merely because the files exist
 
 ## Policy Model
 

--- a/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
+++ b/adl/tools/skills/workflow-conductor/scripts/route_workflow.py
@@ -478,14 +478,12 @@ def infer_doctor_card_blocker(doctor):
         if not isinstance(stage, dict):
             continue
         editor = stage.get("next_editor")
-        if editor not in {"spp-editor", "srp-editor"}:
-            continue
-        if stage.get("state") == "pre_run":
+        if editor not in {"sip-editor", "stp-editor", "spp-editor", "srp-editor"}:
             continue
         if stage.get("complete") is True:
             continue
         stage_name = str(stage.get("stage", "")).lower()
-        if stage_name in {"spp", "srp"}:
+        if stage_name in {"sip", "stp", "spp", "srp"}:
             return stage_name
     return "none"
 

--- a/adl/tools/test_sprint_conductor_helpers.sh
+++ b/adl/tools/test_sprint_conductor_helpers.sh
@@ -110,34 +110,99 @@ PR_EOF
 chmod +x "${fake_repo}/adl/tools/pr.sh"
 
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/stp.md" <<'EOF2'
-stp
+## Required Outcome
+
+Complete WP-05 sprint trial work.
+
+## Acceptance Criteria
+
+- focused trial proof recorded
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/sip.md" <<'EOF2'
-sip
+Branch: not bound yet
+
+## Goal
+
+Execute WP-05 as the first child in the trial sprint.
+
+## Acceptance Criteria
+
+- issue-local proof remains bounded
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/sor.md" <<'EOF2'
 Status: NOT_STARTED
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/spp.md" <<'EOF2'
+---
 issue: 2827
+status: approved
+---
+
+# Structured Plan Prompt
+
+## Codex Plan
+
+1. [pending] Execute the bounded WP-05 task.
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2827__trial-wp05/srp.md" <<'EOF2'
+---
+artifact_type: "structured_review_prompt"
 issue: 2827
+---
+
+# Structured Review Prompt
+
+## Review Results
+
+- Not run yet.
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/stp.md" <<'EOF2'
-stp
+## Required Outcome
+
+Complete WP-06 sprint trial work.
+
+## Acceptance Criteria
+
+- focused trial proof recorded
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/sip.md" <<'EOF2'
-sip
+Branch: not bound yet
+
+## Goal
+
+Execute WP-06 after WP-05 closeout.
+
+## Acceptance Criteria
+
+- issue-local proof remains bounded
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/sor.md" <<'EOF2'
 Status: NOT_STARTED
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
+---
 issue: 2828
+status: approved
+---
+
+# Structured Plan Prompt
+
+## Codex Plan
+
+1. [pending] Execute the bounded WP-06 task.
+2. [pending] Inspect provider output such as `downloading... done` without treating prose ellipsis as truncation.
 EOF2
 cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md" <<'EOF2'
+---
+artifact_type: "structured_review_prompt"
 issue: 2828
+---
+
+# Structured Review Prompt
+
+## Review Results
+
+- Not run yet.
 EOF2
 
 python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/create_missing_sprint_issue.py" \
@@ -193,6 +258,94 @@ assert len(preflight["issue_results"]) == 2
 assert all(result["status"] == "ready" for result in preflight["issue_results"])
 assert all(result["canonical_slug"] for result in preflight["issue_results"])
 PY
+
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md" <<'EOF2'
+---
+issue: 2828
+---
+
+# Structured Review Prompt
+
+## Review Results
+
+- Not run yet.
+EOF2
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --state "${state_path}" >/dev/null
+
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+preflight = state["structured_prompt_preflight"]
+assert preflight["status"] == "needs_editor_repair"
+wp06 = [result for result in preflight["issue_results"] if result["issue_number"] == 2828][0]
+assert "srp-editor" in wp06["required_editor_skills"]
+assert any("srp.md" in defect for defect in wp06["design_time_defects"])
+PY
+
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/srp.md" <<'EOF2'
+---
+artifact_type: "structured_review_prompt"
+issue: 2828
+---
+
+# Structured Review Prompt
+
+## Review Results
+
+- Not run yet.
+EOF2
+
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
+---
+issue: 2828
+status: draft
+---
+
+Design-time generated SPP; review before execution.
+EOF2
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --state "${state_path}" >/dev/null
+
+python3 - "${state_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text())
+preflight = state["structured_prompt_preflight"]
+assert preflight["status"] == "needs_editor_repair"
+wp06 = [result for result in preflight["issue_results"] if result["issue_number"] == 2828][0]
+assert "spp-editor" in wp06["required_editor_skills"]
+assert any("spp.md" in defect for defect in wp06["design_time_defects"])
+PY
+
+cat >"${fake_repo}/.adl/v0.91.1/tasks/issue-2828__trial-wp06/spp.md" <<'EOF2'
+---
+issue: 2828
+status: approved
+---
+
+# Structured Plan Prompt
+
+## Codex Plan
+
+1. [pending] Execute the bounded WP-06 task.
+EOF2
+
+python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py" \
+  --repo-root "${fake_repo}" \
+  --ordered-issues "2827,2828" \
+  --state "${state_path}" >/dev/null
 
 if python3 "${repo_root}/adl/tools/skills/sprint-conductor/scripts/update_sprint_state.py" \
   --state "${state_path}" \

--- a/adl/tools/test_workflow_conductor_skill_contracts.sh
+++ b/adl/tools/test_workflow_conductor_skill_contracts.sh
@@ -80,6 +80,26 @@ cat >"${tmpdir}/stp_blocker.json" <<'EOF'
 }
 EOF
 
+cat >"${tmpdir}/sip_blocker.json" <<'EOF'
+{
+  "target": {"issue_number": 1647},
+  "workflow_state": {
+    "bootstrap_present": true,
+    "card_blocker": "sip",
+    "lifecycle_state": "pre_run",
+    "ready_state": "unknown",
+    "pr_state": "none",
+    "subagent_assigned": false,
+    "evidence_used": ["doctor_card_lifecycle"]
+  },
+  "policy": {
+    "skills_required": true,
+    "card_editor_skills_required": true,
+    "subagent_requirement": "optional"
+  }
+}
+EOF
+
 cat >"${tmpdir}/spp_blocker.json" <<'EOF'
 {
   "target": {"issue_number": 1647},
@@ -199,6 +219,7 @@ EOF
 
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/bootstrap_missing.json" >"${tmpdir}/bootstrap_missing.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/stp_blocker.json" >"${tmpdir}/stp_blocker.out.json"
+python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/sip_blocker.json" >"${tmpdir}/sip_blocker.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/spp_blocker.json" >"${tmpdir}/spp_blocker.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/srp_blocker.json" >"${tmpdir}/srp_blocker.out.json"
 python3 "${skills_root}/workflow-conductor/scripts/select_next_skill.py" --input "${tmpdir}/resume_to_run.json" >"${tmpdir}/resume_to_run.out.json"
@@ -222,6 +243,10 @@ assert bootstrap["selected_skill"]["skill_name"] == "pr-init"
 stp = load("stp_blocker.out.json")
 assert stp["selected_skill"]["skill_name"] == "stp-editor"
 assert stp["selected_skill"]["editor_skill"] == "stp-editor"
+
+sip = load("sip_blocker.out.json")
+assert sip["selected_skill"]["skill_name"] == "sip-editor"
+assert sip["selected_skill"]["editor_skill"] == "sip-editor"
 
 spp = load("spp_blocker.out.json")
 assert spp["selected_skill"]["skill_name"] == "spp-editor"
@@ -295,7 +320,7 @@ fi
 case "$issue" in
   2001)
     cat <<'JSON'
-{"schema":"adl.pr.doctor.v1","issue":2001,"version":"v0.88","slug":"route-run","branch":"codex/2001-route-run","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"pre_run","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2001-route-run.md","root_stp":".adl/v0.88/tasks/issue-2001__route-run/stp.md","root_input":".adl/v0.88/tasks/issue-2001__route-run/sip.md","root_output":".adl/v0.88/tasks/issue-2001__route-run/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"card_lifecycle":{"order":["SIP","STP","SPP","SRP","SOR"],"active_stage":"SIP","next_required_stage":"SIP","pr_run_readiness":"ready","pr_finish_readiness":"blocked","stages":[{"stage":"SIP","path":".adl/v0.88/tasks/issue-2001__route-run/sip.md","state":"pre_run","complete":false,"final_ready":false,"next_editor":null,"detail":"pre-run"},{"stage":"STP","path":".adl/v0.88/tasks/issue-2001__route-run/stp.md","state":"complete","complete":true,"final_ready":false,"next_editor":null,"detail":"complete"},{"stage":"SPP","path":".adl/v0.88/tasks/issue-2001__route-run/spp.md","state":"pre_run","complete":false,"final_ready":false,"next_editor":"spp-editor","detail":"pre-run compatibility fixture"},{"stage":"SRP","path":".adl/v0.88/tasks/issue-2001__route-run/srp.md","state":"final","complete":true,"final_ready":true,"next_editor":null,"detail":"policy exception"},{"stage":"SOR","path":".adl/v0.88/tasks/issue-2001__route-run/sor.md","state":"scaffold","complete":false,"final_ready":false,"next_editor":"sor-editor","detail":"pre-execution"}]},"doctor_status":"PASS"}
+{"schema":"adl.pr.doctor.v1","issue":2001,"version":"v0.88","slug":"route-run","branch":"codex/2001-route-run","mode":"full","preflight_status":"PASS","open_pr_count":0,"open_prs":[],"lifecycle_state":"pre_run","ready_status":"PASS","worktree":null,"source":".adl/v0.88/bodies/issue-2001-route-run.md","root_stp":".adl/v0.88/tasks/issue-2001__route-run/stp.md","root_input":".adl/v0.88/tasks/issue-2001__route-run/sip.md","root_output":".adl/v0.88/tasks/issue-2001__route-run/sor.md","wt_stp":null,"wt_input":null,"wt_output":null,"card_lifecycle":{"order":["SIP","STP","SPP","SRP","SOR"],"active_stage":"SOR","next_required_stage":"SOR","pr_run_readiness":"ready","pr_finish_readiness":"blocked","stages":[{"stage":"SIP","path":".adl/v0.88/tasks/issue-2001__route-run/sip.md","state":"complete","complete":true,"design_time_complete":true,"final_ready":false,"next_editor":null,"detail":"design-time complete"},{"stage":"STP","path":".adl/v0.88/tasks/issue-2001__route-run/stp.md","state":"complete","complete":true,"design_time_complete":true,"final_ready":false,"next_editor":null,"detail":"complete"},{"stage":"SPP","path":".adl/v0.88/tasks/issue-2001__route-run/spp.md","state":"complete","complete":true,"design_time_complete":true,"final_ready":false,"next_editor":null,"detail":"design-time complete"},{"stage":"SRP","path":".adl/v0.88/tasks/issue-2001__route-run/srp.md","state":"final","complete":true,"design_time_complete":false,"final_ready":true,"next_editor":null,"detail":"policy exception"},{"stage":"SOR","path":".adl/v0.88/tasks/issue-2001__route-run/sor.md","state":"scaffold","complete":false,"design_time_complete":false,"final_ready":false,"next_editor":"sor-editor","detail":"pre-execution"}]},"doctor_status":"PASS"}
 JSON
     ;;
   2004)

--- a/docs/planning/DESIGN_TIME_CARD_COMPLETION_PLAN.md
+++ b/docs/planning/DESIGN_TIME_CARD_COMPLETION_PLAN.md
@@ -2,12 +2,13 @@
 
 ## Status
 
-Planning document for issue `#3264`.
+Planning document for issue `#3264`; operational enforcement is implemented
+by issue `#3267`.
 
 This plan institutionalizes the rule that milestone issue waves should not be
 treated as ready merely because card files exist. Before execution starts,
-`SIP`, `STP`, and `SPP` should already be detailed, issue-specific,
-reviewable, and useful.
+`SIP`, `STP`, `SPP`, and the pre-review `SRP` should already be detailed,
+issue-specific, reviewable, and useful.
 
 This plan does not generate v0.91.4 cards. It defines the contract WP-17 should
 use when preparing the v0.91.4 core issue wave, sprint umbrellas, and
@@ -28,8 +29,31 @@ source issue prompt, the issue bundle should be prepared as follows:
   during run, finish, merge or closure, and closeout.
 
 The goal is not to pretend execution already happened. The goal is to make the
-next agent start from reviewed intent, selected task, and operative plan rather
-than from generic bootstrap text.
+next agent start from reviewed intent, selected task, operative plan, and
+review instructions rather than from generic bootstrap text.
+
+## Operational Automation
+
+Design-time completion is now a first-class C-SDLC automation target, not a
+human reminder.
+
+The deterministic enforcement path should be:
+
+1. `pr create` / `pr init` seed complete design-time cards where possible.
+2. `pr doctor` reports card-stage truth and blocks execution when design-time
+   cards are generic, incomplete, or stale.
+3. `workflow-conductor` routes card defects to the matching editor skill rather
+   than improvising fixes.
+4. `sprint-conductor` runs sprint-wide structured prompt and design-time card
+   preflight before the first child issue starts.
+5. Editor skills repair cards within their own card boundary.
+6. `SRP` records review results only after review; `SOR` records output truth
+   only after execution, publication, or closeout truth exists.
+
+This gives ADL a deterministic decomposition step before execution: the issue
+wave is split into reviewed issue-local work packets, each with its own
+operative plan and review prompt. That is how C-SDLC supports parallel work
+without returning to hidden chat memory or vague handoffs.
 
 ## Why This Matters
 
@@ -43,6 +67,8 @@ not semantically ready. Generic cards create several failure modes:
 - `SRP` review prompts are too generic to produce useful findings
 - `SOR` cards overclaim or remain stale because the expected proof surface was
   never clear
+- sprint umbrellas start child execution before the batch has passed a
+  deterministic card-readiness gate
 
 Design-time card completion moves more cognition into tracked, inspectable
 state. That supports C-SDLC, ObsMem, sprint resumption, and cross-session
@@ -162,8 +188,13 @@ For each core WP, sprint umbrella, and approved sidecar issue:
 7. Review the bundle before the issue is allowed to execute.
 8. Fix card findings with editor skills only.
 
-The wave is not execution-ready if `SIP`, `STP`, or `SPP` still read like
-generic bootstrap text.
+Generated `SPP` files may start as `draft` plans. They become execution-ready
+only after the design-time review/editor pass marks them `reviewed` or
+`approved`; raw `pr run` should block before worktree binding until that is
+true.
+
+The wave is not execution-ready if `SIP`, `STP`, `SPP`, or `SRP` still read
+like generic bootstrap text.
 
 ## v0.91.4 WP-17 Card Preparation Checklist
 
@@ -208,7 +239,9 @@ If the answer is no, the issue is not ready to execute.
 
 ## Tooling Implications
 
-This plan can be implemented incrementally.
+This plan can be implemented incrementally, but v0.91.3/v0.91.4 execution
+should treat the following as the operational minimum before relying on the new
+process.
 
 Near-term human/process changes:
 
@@ -224,13 +257,13 @@ Required tooling changes before relying on this process:
 - `pr doctor` should distinguish generic bootstrap text from design-time
   complete cards.
 - validator or doctor output should expose a `design_time_complete` status for
-  `SIP`, `STP`, and `SPP`.
+  `SIP`, `STP`, `SPP`, and pre-review `SRP`.
 - `workflow-conductor` should route generic or incomplete design-time cards to
   the matching editor skill before allowing execution or publication to
   continue.
 - `sprint-conductor` should run a sprint-wide design-time card preflight before
   the first child starts, and it should stop or repair through editor skills
-  when `SIP`, `STP`, or `SPP` remain generic.
+  when `SIP`, `STP`, `SPP`, or `SRP` remain generic or incomplete.
 - `sip-editor`, `stp-editor`, and `spp-editor` should know the
   design-time-complete bar for their own card types, not only mechanical
   formatting and branch truth.
@@ -241,18 +274,38 @@ Required tooling changes before relying on this process:
 - sprint setup should fail or warn when a child issue has generic design-time
   cards.
 
-These tooling changes should be routed as separate implementation issues, but
-they are not optional. The design-time card-completion rule should not become a
-trusted v0.91.3/v0.91.4 operating practice until the conductor, sprint
-conductor, and editor/tooling surfaces enforce or at least explicitly report the
-new readiness bar.
+The first enforcement slice is issue `#3267`, which wires this rule into doctor,
+workflow-conductor, sprint-conductor, and editor-skill contracts. Any remaining
+tooling gaps should be routed as bounded follow-on issues, but they are not
+optional. The design-time card-completion rule should not become a trusted
+v0.91.3/v0.91.4 operating practice until the conductor, sprint conductor, and
+editor/tooling surfaces enforce or at least explicitly report the new readiness
+bar.
+
+## Catch-Up Requirement
+
+After the enforcement tooling lands, issue `#3268` covers the bounded catch-up
+pass for the remaining open `v0.91.3` issue bundles.
+
+That issue should:
+
+- inspect all remaining `v0.91.3` core WPs, sprint umbrellas, and sidecars
+- run the doctor / sprint-preflight gates introduced by this process change
+- repair generic or incomplete `SIP`, `STP`, `SPP`, and `SRP` cards through the
+  matching editor skills
+- leave `SOR` as a truthful scaffold or truthful output record depending on
+  each issue's actual lifecycle state
+- stop before changing unrelated implementation scope
+
+The catch-up issue exists because automation only helps if the already-created
+issue wave is brought into the new contract before the milestone continues.
 
 ## Non-Goals
 
 This plan does not:
 
 - generate the v0.91.4 card wave
-- edit tooling implementation
+- generate the remaining v0.91.3 catch-up cards
 - change the `SIP -> STP -> SPP -> SRP -> SOR` lifecycle
 - make `SRP` review results available before review
 - make `SOR` outcome truth available before execution

--- a/docs/templates/CARD_LIFECYCLE_TEMPLATE_TARGETS.md
+++ b/docs/templates/CARD_LIFECYCLE_TEMPLATE_TARGETS.md
@@ -8,8 +8,10 @@ This document records the target template shape for all five ADL issue cards:
 SIP -> STP -> SPP -> SRP -> SOR
 ```
 
-It is a template and schema planning surface only. It does not enforce the new
-lifecycle, migrate active bundles, or change conductor/editor routing.
+It is a template and schema planning surface. Enforcement now belongs to the
+workflow tooling: doctor reports card-stage truth, workflow-conductor routes
+card defects to editor skills, and sprint-conductor must run sprint-wide card
+preflight before child execution starts.
 
 ## Compatibility Policy
 
@@ -42,7 +44,10 @@ Recommended activation states are:
 - `scaffold`: file exists for path stability but is not authoritative.
 - `draft`: issue-specific content is being authored or reviewed.
 - `active`: card is the current authoritative lifecycle surface.
-- `reviewed`: review has been applied and results are recorded.
+- `reviewed`: card has passed design-time review and is ready to guide its
+  lifecycle stage.
+- `approved`: card has explicit operator or reviewer approval for the next
+  lifecycle transition.
 - `pr_open`: outcome is represented by an open PR.
 - `merged`: outcome has landed on `main`.
 - `closed_no_pr`: issue closed intentionally without a merged PR.
@@ -100,6 +105,8 @@ Target responsibility:
 - review handoff plan
 - branch/worktree constraints
 - risks and fallback path
+- proof gates before proceeding
+- replan triggers when execution diverges
 
 Compatibility surfaces:
 
@@ -120,6 +127,14 @@ Target responsibility:
 - dispositions
 - residual risks
 - recommended outcome
+
+Design-time responsibility:
+
+- before review, `SRP` should be a complete Structured Review Prompt with
+  review scope and evidence rules
+- before review, `SRP` must not invent findings, dispositions, or recommended
+  outcome
+- after review, `SRP` records review results and finding dispositions
 
 Compatibility surfaces:
 

--- a/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
+++ b/docs/templates/PR_INIT_INVOCATION_TEMPLATE.md
@@ -208,11 +208,13 @@ It must stop after:
 - bootstrap validation
 
 The created bundle includes an initial `SPP`. That `SPP` is not a generic
-placeholder: it should be a deterministic design-time execution plan generated
-from the source issue prompt, dependencies, deliverables, acceptance criteria,
-validation expectations, and non-goals. Reviewers may tighten it before
-execution. Runtime agents must update it before continuing if the real execution
-sequence changes.
+placeholder: it should be a deterministic design-time execution-plan draft
+generated from the source issue prompt, dependencies, deliverables, acceptance
+criteria, validation expectations, and non-goals. It should not claim human or
+subagent review merely because the generator produced it. Before execution
+starts, the plan must pass design-time review or editor repair and be marked
+`reviewed` or `approved`. Runtime agents must update it before continuing if
+the real execution sequence changes.
 
 It must not continue into:
 - qualitative card review

--- a/docs/templates/STRUCTURED_PLAN_PROMPT_TEMPLATE.md
+++ b/docs/templates/STRUCTURED_PLAN_PROMPT_TEMPLATE.md
@@ -16,6 +16,13 @@ Tooling may create `spp.md` as an early scaffold for path stability. That file
 is not lifecycle-active until the plan has been tightened for the current issue
 and is ready to guide execution.
 
+For C-SDLC issue execution, a generic or truncated `SPP` is not enough.
+`pr doctor` and sprint-conductor preflight should treat an issue-local `SPP` as
+design-time complete only after it is issue-specific and marked `reviewed` or
+`approved`. A truthful pre-execution `SPP` is a decomposition artifact: it lets
+the milestone split work into smaller, inspectable, reviewable packets before
+agents start executing them.
+
 This template is compatible with Codex plan mode by carrying a simple
 `codex_plan` list. Each item has:
 
@@ -29,7 +36,9 @@ Recommended status semantics:
 
 - `scaffold`: file exists but has not been tailored to the issue.
 - `draft`: issue-specific plan is being authored or reviewed.
-- `active`: plan is the current execution guide.
+- `reviewed`: plan has passed design-time review and may guide execution.
+- `approved`: plan has explicit operator or reviewer approval for execution.
+- `active`: plan is the current execution guide after execution has started.
 - `superseded`: plan was replaced by a later revision.
 - `legacy_compatible`: historical plan shape retained for compatibility and
   detectable migration.
@@ -58,7 +67,7 @@ title: "<issue title>"
 branch: "not bound yet"
 lifecycle_stage: "SPP"
 status: "draft"
-activation_state: "scaffold | draft | active | superseded | legacy_compatible"
+activation_state: "scaffold | draft | reviewed | approved | active | superseded | legacy_compatible"
 plan_revision: 1
 source_refs:
   - kind: "issue"
@@ -165,5 +174,9 @@ notes: "<optional note>"
 - New templates should prefer explicit `lifecycle_stage` and
   `activation_state` fields so doctor/readiness tooling can distinguish
   scaffold presence from active plan truth.
+- New issue bundles should set `status` / `activation_state` to `reviewed` or
+  `approved` before execution begins. Generic scaffold text, known truncation
+  sentinels, and unreviewed `draft` status should block sprint start and route
+  back to `spp-editor`.
 - Sprint-scoped planning remains out of scope for this issue-level template
   unless a future schema adds an explicit sprint-plan card type.


### PR DESCRIPTION
## Summary
Implementation is complete for the design-time card-completion enforcement issue. The branch contains doctor, sprint-conductor, workflow-conductor, editor-skill, template, generator, and finish-guidance changes that make design-time card completion an operational C-SDLC gate instead of a human-only convention.

## Artifacts
- Local ignored output-card record at `.adl/v0.91.3/tasks/issue-3267__v0-91-3-tools-enforce-design-time-card-completion/sor.md`
- `adl/src/cli/pr_cmd.rs`
- `adl/src/cli/pr_cmd/doctor.rs`
- `adl/src/cli/pr_cmd_cards/cards.rs`
- `adl/src/cli/tests/pr_cmd_inline/basics.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle/diagnosis.rs`
- `adl/src/cli/tests/pr_cmd_inline/lifecycle/start_ready.rs`
- `adl/src/cli/tests/pr_cmd_inline/mod.rs`
- `adl/src/cli/tests/pr_cmd_inline/repo_helpers/bootstrap.rs`
- `adl/tools/skills/workflow-conductor/scripts/route_workflow.py`
- `adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py`
- `adl/tools/skills/workflow-conductor/SKILL.md`
- `adl/tools/skills/sprint-conductor/SKILL.md`
- `adl/tools/skills/sip-editor/SKILL.md`
- `adl/tools/skills/stp-editor/SKILL.md`
- `adl/tools/skills/spp-editor/SKILL.md`
- `adl/tools/skills/srp-editor/SKILL.md`
- `adl/tools/skills/sor-editor/SKILL.md`
- `adl/tools/test_workflow_conductor_skill_contracts.sh`
- `adl/tools/test_sprint_conductor_helpers.sh`
- `docs/planning/DESIGN_TIME_CARD_COMPLETION_PLAN.md`
- `docs/templates/CARD_LIFECYCLE_TEMPLATE_TARGETS.md`
- `docs/templates/PR_INIT_INVOCATION_TEMPLATE.md`
- `docs/templates/STRUCTURED_PLAN_PROMPT_TEMPLATE.md`

## Validation
- Validation commands and their purpose:
  - `cargo test --manifest-path adl/Cargo.toml pr_cmd::doctor -- --nocapture`
    Verified doctor card lifecycle behavior.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_create_creates_issue_and_bootstraps_root_bundle -- --nocapture`
    Verified issue creation generates the hardened design-time card bundle.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_init_refreshes_legacy_bootstrap_spp -- --nocapture`
    Verified init refreshes legacy bootstrap SPPs.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready -- --nocapture`
    Verified raw issue-mode start blocks before worktree binding when generated design-time cards are not ready.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_requires_explicit_version_when_no_fetch_issue_has_no_local_bundle -- --nocapture`
    Verified the adjacent missing-version guard still preserves its original narrow behavior after test cleanup.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_doctor_full_succeeds_when_invoked_from_started_worktree -- --nocapture`
    Verified doctor remains valid from a bound worktree after design-time card readiness changes.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture`
    Verified the normal start/ready success path with design-time-ready cards.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_ready_blocks_invalid_worktree_srp -- --nocapture`
    Verified invalid worktree SRPs still block readiness.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_ready_succeeds_when_invoked_from_started_worktree -- --nocapture`
    Verified ready still passes from the started worktree when cards are complete.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_rewrites_unbound_root_input_card_branch -- --nocapture`
    Verified start still rewrites unbound root SIP branch truth.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_updates_existing_root_spp_and_srp_branch -- --nocapture`
    Verified start still updates root SPP/SRP branch truth.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_repairs_preexisting_worktree_missing_task_bundle -- --nocapture`
    Verified start still repairs a preexisting worktree missing its task bundle.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_start_uses_canonical_local_slug_when_title_slug_drift_exists -- --nocapture`
    Verified start still prefers the canonical local slug when title slug drift exists.
  - `cargo test --manifest-path adl/Cargo.toml real_pr_ready_accepts_started_issue_when_output_branch_is_bootstrap_placeholder -- --nocapture`
    Verified ready still accepts a started issue whose output branch truth is still a bootstrap placeholder.
  - `CARGO_INCREMENTAL=0 cargo llvm-cov --workspace --all-features --json --summary-only --output-path target/coverage-impact-summary.json -- pr_cmd`
    Verified the focused `pr_cmd` suite under coverage after the test-fixture updates; result was 185 passing tests.
  - `bash adl/tools/check_coverage_impact.sh --base origin/main --include-working-tree --summary adl/target/coverage-impact-summary.json --require-summary-for-risk`
    Verified coverage-impact preflight for the changed Rust source files.
  - `cargo fmt --manifest-path adl/Cargo.toml --check`
    Verified Rust formatting after the final guidance fixes.
  - `bash adl/tools/test_sprint_conductor_helpers.sh`
    Verified sprint-conductor helper behavior.
  - `bash adl/tools/test_workflow_conductor_skill_contracts.sh`
    Verified workflow-conductor routing contracts.
  - `python3 -m py_compile adl/tools/skills/workflow-conductor/scripts/route_workflow.py adl/tools/skills/sprint-conductor/scripts/check_sprint_structured_prompt_readiness.py`
    Verified changed Python helpers compile.
  - `git diff --check`
    Verified whitespace cleanliness for the current diff.
  - `bash adl/tools/pr.sh doctor 3267 --slug v0-91-3-tools-enforce-design-time-card-completion --version v0.91.3 --mode full --json`
    Verified issue lifecycle readiness and card-stage truth after the implementation updates.
- Results:
  - PASS for all focused commands above

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3267__v0-91-3-tools-enforce-design-time-card-completion/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3267__v0-91-3-tools-enforce-design-time-card-completion/sor.md
- Idempotency-Key: v0-91-3-tools-enforce-design-time-card-completion-adl-src-cli-pr-cmd-rs-adl-src-cli-pr-cmd-doctor-rs-adl-src-cli-pr-cmd-cards-cards-rs-adl-src-cli-tests-pr-cmd-inline-basics-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-diagnosis-rs-adl-src-cli-tests-pr-cmd-inline-lifecycle-start-ready-rs-adl-src-cli-tests-pr-cmd-inline-mod-rs-adl-src-cli-tests-pr-cmd-inline-repo-helpers-bootstrap-rs-adl-tools-pr-sh-adl-tools-skills-sip-editor-skill-md-adl-tools-skills-sor-editor-skill-md-adl-tools-skills-spp-editor-skill-md-adl-tools-skills-sprint-conductor-skill-md-adl-tools-skills-sprint-conductor-scripts-check-sprint-structured-prompt-readiness-py-adl-tools-skills-srp-editor-skill-md-adl-tools-skills-stp-editor-skill-md-adl-tools-skills-workflow-conductor-skill-md-adl-tools-skills-workflow-conductor-scripts-route-workflow-py-adl-tools-test-sprint-conductor-helpers-sh-adl-tools-test-workflow-conductor-skill-contracts-sh-docs-planning-design-time-card-completion-plan-md-docs-templates-card-lifecycle-template-targets-md-docs-templates-pr-init-invocation-template-md-docs-templates-structured-plan-prompt-template-md-adl-v0-91-3-tasks-issue-3267-v0-91-3-tools-enforce-design-time-card-completion-sip-md-adl-v0-91-3-tasks-issue-3267-v0-91-3-tools-enforce-design-time-card-completion-sor-md

Closes #3267


## Review Fixes
- Fixed `PR3269_ISSUE3267_REVIEW_FINDINGS_2026-05-22` P1 root-card mutation: `pr run` now bootstraps missing cards in truthful pre-run state, runs the design-time gate before branch/start-state rewrites, then binds cards only after the gate passes.
- Added regression coverage proving a blocked design-time run leaves root SIP/SOR `not bound yet`, leaves SOR `NOT_STARTED`, avoids SPP/SRP branch rewrites, and creates no worktree.
- Fixed the CI closing-linkage blocker by adding `Closes #3267`.

## Review-Fix Validation
- `cargo fmt --manifest-path adl/Cargo.toml --check`
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_blocks_before_worktree_when_design_time_cards_are_not_ready -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml real_pr_start_bootstraps_worktree_and_ready_passes -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml pr_cmd::doctor -- --nocapture`
- `cargo test --manifest-path adl/Cargo.toml write_output_card_emits_truthful_pre_run_scaffold -- --nocapture`
- `cargo clippy --manifest-path adl/Cargo.toml --all-targets --all-features -- -D warnings`
- `git diff --check`
