### PR TITLE
[v0.91.3][tools] Avoid duplicate full validation between pr finish and CI

### DIFF
--- a/adl/src/cli/pr_cmd/finish_support.rs
+++ b/adl/src/cli/pr_cmd/finish_support.rs
@@ -109,11 +109,6 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
         })?;
     }
 
-    let finish_validation_plan = select_finish_validation_plan(&parsed.paths)?;
-    if !parsed.no_checks {
-        run_finish_validation_rust(&repo_root, &finish_validation_plan)?;
-    }
-
     stage_selected_paths_rust(&repo_root, &parsed.paths)?;
     ensure_no_staged_issue_bundle_mutations(&repo_root, &issue_ref)?;
     let has_uncommitted = has_uncommitted_changes(&repo_root)?;
@@ -130,6 +125,11 @@ pub(super) fn real_pr_finish(args: &[String]) -> Result<()> {
 
     let changed_paths = finish_changed_paths(&repo_root, has_uncommitted)?;
     validate_milestone_doc_drift_for_finish(&repo_root, issue_ref.scope(), &changed_paths)?;
+    let finish_validation_plan =
+        select_finish_validation_plan_for_finish(&parsed.paths, &changed_paths)?;
+    if !parsed.no_checks {
+        run_finish_validation_rust(&repo_root, &finish_validation_plan)?;
+    }
 
     let close_line = if parsed.no_close {
         None
@@ -470,6 +470,24 @@ pub(super) fn select_finish_validation_plan(paths_csv: &str) -> Result<FinishVal
             "cargo test --manifest-path adl/Cargo.toml --doc --all-features".to_string(),
         ],
     })
+}
+
+pub(super) fn select_finish_validation_plan_for_finish(
+    requested_paths_csv: &str,
+    changed_paths: &[String],
+) -> Result<FinishValidationPlan> {
+    let requested_paths = requested_paths_csv
+        .split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>();
+    if requested_paths.is_empty() {
+        bail!("finish: --paths resolved to empty");
+    }
+    if changed_paths.is_empty() {
+        bail!("finish: no changed tracked paths available for validation profile selection");
+    }
+    select_finish_validation_plan(&changed_paths.join(","))
 }
 
 fn finish_path_is_docs_only(path: &str) -> bool {

--- a/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
+++ b/adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::cli::pr_cmd::finish_support::real_pr_finish;
+use crate::cli::pr_cmd::finish_support::{
+    real_pr_finish, select_finish_validation_plan_for_finish,
+};
 
 #[test]
 fn parse_finish_args_requires_title_and_accepts_finish_flags() {
@@ -431,6 +433,34 @@ fn finish_validation_plan_supports_focused_local_ci_gated_mode() {
         .commands
         .iter()
         .any(|command| command.contains("cargo clippy")));
+}
+
+#[test]
+fn finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request() {
+    let docs_plan = select_finish_validation_plan_for_finish(
+        ".",
+        &["docs/milestones/v0.91.3/review/example.md".to_string()],
+    )
+    .expect("docs-only actual path plan");
+    assert_eq!(docs_plan.mode, FinishValidationMode::DocsOnly);
+    assert!(!docs_plan
+        .commands
+        .iter()
+        .any(|command: &String| command.contains("cargo nextest")));
+
+    let focused_plan = select_finish_validation_plan_for_finish(
+        ".",
+        &["adl/src/cli/pr_cmd/finish_support.rs".to_string()],
+    )
+    .expect("focused actual path plan");
+    assert_eq!(focused_plan.mode, FinishValidationMode::FocusedLocalCiGated);
+    assert!(focused_plan.commands.contains(
+        &"cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish".to_string()
+    ));
+    assert!(!focused_plan
+        .commands
+        .iter()
+        .any(|command: &String| command.contains("cargo clippy")));
 }
 
 #[test]

--- a/docs/default_workflow.md
+++ b/docs/default_workflow.md
@@ -142,12 +142,18 @@ when focused local checks directly prove the changed surface. The output record
 must say that full local validation was not run, list the focused commands that
 did run, and keep CI required before merge.
 
+`pr finish` chooses this profile from the actual changed tracked paths after
+staging, not from the broad operator staging request. For example, a finish
+invocation that stages `.` but only changes docs should use the docs-only local
+profile rather than paying for a full local Rust cycle that GitHub CI will run
+again on the same branch.
+
 Current implementation is intentionally narrower than the general policy: the
 focused `pr finish` lane currently applies only to docs-only paths and a
-bounded publication-control-plane slice (`pr_cmd`, `finish_support`, inline finish tests,
-CI path-policy / coverage-impact scripts, and the matching workflow/docs
-surfaces). Other changes still escalate to full local validation until more
-focused lanes are explicitly implemented and tested.
+bounded publication-control-plane slice (`pr_cmd`, `finish_support`, inline
+finish tests, CI path-policy / coverage-impact scripts, and the matching
+workflow/docs surfaces). Other actual changed paths still escalate to full
+local validation until more focused lanes are explicitly implemented and tested.
 
 Use full local validation for runtime, schema, security, release, broad tooling,
 or ambiguous changes.


### PR DESCRIPTION
Closes #3270

## Summary
Implemented the `#3270` finish-validation optimization. `pr finish` now stages
the requested paths first, computes the actual changed tracked paths, and
selects the validation profile from those real changed paths rather than from a
broad staging request such as `.`. This prevents docs-only or focused
publication-control-plane changes from accidentally paying for full local Rust
validation while preserving full local validation for unknown/risky actual
changed paths.

## Artifacts
- `adl/src/cli/pr_cmd/finish_support.rs`
- `adl/src/cli/tests/pr_cmd_inline/finish/arg_render.rs`
- `docs/default_workflow.md`

## Validation
- Validation commands and their purpose:
  - `cargo fmt --manifest-path adl/Cargo.toml --all --check`
    Verified Rust formatting for touched Rust files.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish_validation_profile_uses_actual_changed_paths_not_broad_stage_request -- --nocapture`
    Verified the new validation-profile selection regression.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish_validation_plan_supports_focused_local_ci_gated_mode -- --nocapture`
    Verified the existing focused validation-mode selection still works.
  - `cargo test --manifest-path adl/Cargo.toml cli::pr_cmd::tests::finish -- --nocapture`
    Verified the full finish test module.
  - `git diff --check`
    Verified tracked diff hygiene.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3270__v0-91-3-tools-avoid-duplicate-full-validation-between-pr-finish-and-ci/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3270__v0-91-3-tools-avoid-duplicate-full-validation-between-pr-finish-and-ci/sor.md
- Idempotency-Key: v0-91-3-tools-avoid-duplicate-full-validation-between-pr-finish-and-ci-adl-src-cli-pr-cmd-finish-support-rs-adl-src-cli-tests-pr-cmd-inline-finish-arg-render-rs-docs-default-workflow-md-adl-v0-91-3-tasks-issue-3270-v0-91-3-tools-avoid-duplicate-full-validation-between-pr-finish-and-ci-sip-md-adl-v0-91-3-tasks-issue-3270-v0-91-3-tools-avoid-duplicate-full-validation-between-pr-finish-and-ci-sor-md