### PR TITLE
[v0.91.3][tools] Fix release-version CI path policy for adl README docs

### DIFF
--- a/adl/tools/ci_path_policy.sh
+++ b/adl/tools/ci_path_policy.sh
@@ -199,7 +199,7 @@ is_reporting_only_coverage_workflow_change() {
 is_release_truth_doc_surface() {
   local path="$1"
   case "$path" in
-    README.md|CHANGELOG.md|REVIEW.md|docs/*)
+    README.md|CHANGELOG.md|REVIEW.md|adl/README.md|docs/*)
       return 0
       ;;
   esac

--- a/adl/tools/test_ci_path_policy.sh
+++ b/adl/tools/test_ci_path_policy.sh
@@ -26,6 +26,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
   mkdir -p adl/src docs
   printf 'pub fn baseline() -> bool { true }\n' > adl/src/lib.rs
+  printf '# adl baseline\n' > adl/README.md
   mkdir -p .github/workflows
   cat > adl/Cargo.toml <<'EOF'
 [package]
@@ -102,6 +103,36 @@ PY
   assert_has "$release_version_output" "coverage_lane=skip"
   assert_has "$release_version_output" "coverage_authority=not_required"
   assert_has "$release_version_output" "reason=release_version_only_cargo_surface_change_runs_lightweight_validation"
+
+  git checkout -q -b release-version-only-with-adl-readme "$base_sha"
+  python3 - <<'PY'
+from pathlib import Path
+
+manifest = Path("adl/Cargo.toml")
+manifest.write_text(manifest.read_text().replace('version = "0.90.3"', 'version = "0.90.4"', 1))
+
+lock = Path("adl/Cargo.lock")
+lock.write_text(lock.read_text().replace('version = "0.90.3"', 'version = "0.90.4"', 1))
+
+Path("README.md").write_text("# repo release truth\n")
+Path("CHANGELOG.md").write_text("# changelog\n\n- v0.90.4\n")
+Path("adl/README.md").write_text("# adl release truth\n")
+doc = Path("docs/readme.md")
+doc.write_text(doc.read_text() + "\nrelease-truth update with adl readme\n")
+PY
+  git add README.md CHANGELOG.md adl/README.md adl/Cargo.toml adl/Cargo.lock docs/readme.md
+  git commit -q -m release-version-only-with-adl-readme
+  release_version_adl_readme_head="$(git rev-parse HEAD)"
+
+  release_version_adl_readme_output="$("$POLICY" --event-name pull_request --base "$base_sha" --head "$release_version_adl_readme_head" --ref "refs/pull/1/merge")"
+  assert_has "$release_version_adl_readme_output" "rust_required=false"
+  assert_has "$release_version_adl_readme_output" "coverage_required=false"
+  assert_has "$release_version_adl_readme_output" "full_coverage_required=false"
+  assert_has "$release_version_adl_readme_output" "demo_smoke_required=false"
+  assert_has "$release_version_adl_readme_output" "release_version_only=true"
+  assert_has "$release_version_adl_readme_output" "coverage_lane=skip"
+  assert_has "$release_version_adl_readme_output" "coverage_authority=not_required"
+  assert_has "$release_version_adl_readme_output" "reason=release_version_only_cargo_surface_change_runs_lightweight_validation"
 
   git checkout -q -b cargo-structural-change "$base_sha"
   cat >> adl/Cargo.toml <<'EOF'


### PR DESCRIPTION
Closes #3274

## Summary
Fixed the CI path-policy regression that caused docs/version-truth PR `#3273`
to run the Rust PR-fast lane. `adl/README.md` is now treated as a release-truth
doc surface when `adl/Cargo.toml` and `adl/Cargo.lock` contain version-only
changes, and a regression test covers the `#3228` path shape.

## Artifacts
- `adl/tools/ci_path_policy.sh`
- `adl/tools/test_ci_path_policy.sh`

## Validation
- Validation commands and their purpose:
  - `bash adl/tools/test_ci_path_policy.sh`
    Verified PR path-policy classification, including the new `adl/README.md`
    release-version-only regression and existing runtime/source policy cases.
  - `bash adl/tools/test_ci_runtime_contracts.sh`
    Verified the workflow contract still expects the fail-closed PR-fast runner
    and release-version lane behavior.
  - `git diff --check`
    Verified whitespace cleanliness.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3274__v0-91-3-tools-fix-release-version-ci-path-policy-for-adl-readme-docs/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3274__v0-91-3-tools-fix-release-version-ci-path-policy-for-adl-readme-docs/sor.md
- Idempotency-Key: v0-91-3-tools-fix-release-version-ci-path-policy-for-adl-readme-docs-adl-tools-ci-path-policy-sh-adl-tools-test-ci-path-policy-sh-adl-v0-91-3-tasks-issue-3274-v0-91-3-tools-fix-release-version-ci-path-policy-for-adl-readme-docs-sip-md-adl-v0-91-3-tasks-issue-3274-v0-91-3-tools-fix-release-version-ci-path-policy-for-adl-readme-docs-sor-md