### PR TITLE
[v0.91.3][docs] Promote ADR 0020-0028 to accepted records

### DIFF
--- a/docs/adr/0015-governed-tools-execution-authority-architecture.md
+++ b/docs/adr/0015-governed-tools-execution-authority-architecture.md
@@ -5,6 +5,7 @@
 - Related issue: #2717
 - Related milestone: v0.90.5
 - Builds on: ADR 0014
+- Superseded in part by: ADR 0020, ADR 0021
 
 ## Context
 

--- a/docs/adr/0018-structured-planning-and-review-policy-artifacts.md
+++ b/docs/adr/0018-structured-planning-and-review-policy-artifacts.md
@@ -5,6 +5,7 @@
 - Related milestone: v0.91
 - Related release line: v0.91.0
 - Builds on: ADR 0015, ADR 0017
+- Refined by: ADR 0024, ADR 0028
 
 ## Context
 

--- a/docs/adr/0020-universal-tool-schema-portable-tool-description-standard.md
+++ b/docs/adr/0020-universal-tool-schema-portable-tool-description-standard.md
@@ -1,0 +1,101 @@
+# ADR 0020: Universal Tool Schema As Portable Tool Description Standard
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0020-universal-tool-schema-portable-tool-description-standard.md
+- Target milestone: v0.91.2
+- Related issues: #3076, #3104, #3107, #3108, #3124
+- Related ADRs: supersedes the active UTS interpretation in ADR 0015
+
+## Context
+
+ADR 0015 recorded the v0.90.5 governed-tools stack as one coherent umbrella:
+model proposals, Universal Tool Schema (`UTS`), ACC, registry binding,
+compiler behavior, policy mediation, governed execution, and trace evidence.
+That was the right shape while ADL was making the whole tool-governance stack
+legible.
+
+The v0.91.2 work separates two concerns that now have different audiences:
+
+- UTS is becoming a portable, provider-neutral, potentially standalone
+  tool-description standard.
+- ACC remains ADL's runtime authority and governance contract.
+
+UTS v1.1 evidence from the local-model and hosted-frontier benchmark issues is
+strong enough that ADL should record its active architectural stance clearly,
+without making ADL the only home of the standard.
+
+## Decision
+
+ADL adopts UTS as the portable, provider-neutral tool-description standard for
+model-facing tool surfaces.
+
+UTS describes a tool. It does not authorize tool execution.
+
+ADL may project UTS definitions into provider-native tool/function-call
+surfaces, including OpenAI-style tool definitions, and may normalize
+provider-native outputs back into UTS proposal records. That compatibility is a
+schema and adapter boundary, not a trust boundary.
+
+The normative UTS package should move toward the standalone
+`universal-tool-schema` repository. ADL remains an origin, adopter, benchmark
+user, and governance-companion example, not the exclusive owner of UTS as a
+standard.
+
+## Requirements
+
+- UTS must remain provider-neutral and transport-neutral.
+- UTS must preserve compatibility with provider-native tool/function-call
+  shapes where that can be done without weakening authority boundaries.
+- UTS records should include enough metadata for runtimes to reason about
+  side effects, determinism, idempotence, replay posture, observability,
+  security posture, and error surfaces.
+- A valid UTS record is only a valid description or proposal input.
+- Runtime permission, actor identity, delegation, visibility, policy, Freedom
+  Gate decisions, redaction, and trace authority remain outside UTS.
+
+## Consequences
+
+### Positive
+
+- Developers can reason about UTS as a drop-in or adapter-backed replacement
+  for naked tool schemas without inheriting ADL runtime machinery.
+- ADL can test and compare provider-native calls against a portable schema.
+- The UTS standardization path can move into a separate repository without
+  losing ADL provenance or benchmark evidence.
+
+### Negative
+
+- ADL docs must be careful not to call UTS an execution authority.
+- Provider-native compatibility needs explicit projection and normalization
+  language.
+- ACC and the UTS-to-ACC compiler boundary must stay clear enough that future
+  work cannot smuggle permission into schema validity.
+
+## Alternatives Considered
+
+### Keep UTS bundled inside the governed-tools umbrella
+
+This preserves ADR 0015 as-is, but it obscures the public-standard path and
+makes UTS look more ADL-specific than it now is.
+
+### Treat UTS as the authority boundary
+
+This is simpler externally, but false to ADL. Tool description is not
+permission, and valid JSON is not a governed action.
+
+## Validation Notes
+
+This ADR was reviewed against:
+
+- the UTS v1.1 local-model benchmark evidence from #3076
+- the UTS v1.1 hosted-frontier benchmark evidence from #3104
+- the standalone UTS repository plan from #3107
+- the canonical UTS conformance panel and fixture work from #3108
+
+## Non-Claims
+
+- This ADR does not accept or publish UTS as an external standard by itself.
+- This ADR does not move UTS artifacts into the standalone repo.
+- This ADR does not grant execution authority from UTS validity.

--- a/docs/adr/0021-adl-capability-contract-runtime-authority-boundary.md
+++ b/docs/adr/0021-adl-capability-contract-runtime-authority-boundary.md
@@ -1,0 +1,93 @@
+# ADR 0021: ADL Capability Contract As Governed Runtime Authority Boundary
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0021-adl-capability-contract-runtime-authority-boundary.md
+- Target milestone: v0.91.2
+- Related issues: #3076, #3104, #3124
+- Related ADRs: supersedes the ACC and governed-execution portions of ADR 0015
+
+## Context
+
+ADR 0015 made ADL's governed-tools stack explicit. v0.91.2 sharpens that stack
+by separating portable description from runtime authority.
+
+UTS describes tool shape. ACC decides whether a proposed capability exercise
+can become an authorized ADL action.
+
+The distinction matters across v0.91.2:
+
+- benchmark work compares proposal behavior without treating proposals as
+  execution
+- modernization and other write-capable integrations need a governed execution
+  boundary
+- speculative decoding must not turn generated candidate text into hidden
+  side-effect authority
+
+## Decision
+
+ADL treats the ADL Capability Contract (`ACC`) as the runtime-facing authority
+contract for capability exercise.
+
+A model proposal, provider-native tool call, or valid UTS record becomes
+actionable only after ACC construction, policy mediation, Freedom Gate review,
+and required trace/redaction constraints.
+
+ACC is ADL-native. Unlike UTS, it is not intended to be a provider-neutral
+schema standard. It is the governed authority boundary that binds actor,
+grantor, delegation, visibility, policy, replay, failure posture, and evidence.
+
+## Requirements
+
+- ACC records must preserve actor identity, grantor attribution, delegation,
+  standing, authority scope, visibility, privacy, replay posture, failure
+  posture, and trace requirements.
+- Provider-native calls and UTS records are untrusted inputs until normalized
+  into the governed proposal-to-ACC path.
+- Missing authority, unsafe ambiguity, destructive intent, exfiltration risk,
+  adapter mismatch, under-attributed proposals, or policy failure must fail
+  closed.
+- Policy and Freedom Gate mediation must happen before execution.
+- Trace/redaction evidence must make proposal, normalization, ACC construction,
+  decision, execution or denial, and redaction posture reviewable.
+
+## Consequences
+
+### Positive
+
+- Keeps ADL's authority model explicit as UTS becomes more portable.
+- Gives write-capable integrations and speculative-decoding work a common
+  authority boundary.
+- Prevents provider-native tool calling from bypassing ADL governance.
+
+### Negative
+
+- ACC changes now carry significant architecture weight.
+- Tool adapters must preserve the description-versus-authority split.
+- Docs must avoid treating ACC as a generic public schema when it is really an
+  ADL governance contract.
+
+## Alternatives Considered
+
+### Treat provider-native tool calls as executable intent
+
+This is incompatible with ADL's governed execution model. Provider output is
+proposal evidence, not permission.
+
+### Fold ACC into UTS
+
+This would make UTS less portable and blur schema validity with governed
+authority.
+
+## Validation Notes
+
+This ADR was reviewed against the v0.91.2 UTS/ACC benchmark
+evidence, provider-native comparison evidence, and code-modernization authority
+notes.
+
+## Non-Claims
+
+- This ADR does not claim every ACC field is final.
+- This ADR does not replace Freedom Gate or operator confirmation.
+- This ADR does not authorize real destructive tool execution.

--- a/docs/adr/0022-speculative-decoding-deterministic-commit-boundary.md
+++ b/docs/adr/0022-speculative-decoding-deterministic-commit-boundary.md
@@ -1,0 +1,79 @@
+# ADR 0022: Speculative Decoding Deterministic Commit Boundary
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0022-speculative-decoding-deterministic-commit-boundary.md
+- Target milestone: v0.91.2
+- Related issue: #3124
+- Related ADRs: ADR 0012, ADR 0013, ADR 0015, ADR 0018, ADR 0021
+
+## Context
+
+v0.91.2 includes a speculative decoding evaluation lane. Speculative decoding
+can be valuable runtime acceleration, but it touches ADL's most important
+runtime distinction: a candidate proposal is not an authoritative commit.
+
+ADL already depends on deterministic commit semantics, replayable evidence,
+bounded execution, and governed side-effect authority. Speculative generation
+must fit inside those boundaries rather than becoming a hidden execution path.
+
+## Decision
+
+ADL may evaluate speculative decoding only as a bounded proposal-acceleration
+surface.
+
+Speculative tokens, candidate steps, draft tool calls, or draft reasoning
+fragments may improve latency or exploration. They may not silently commit
+state, execute tools, bypass replay, bypass ACC/Freedom Gate, or hide rejected
+paths from audit.
+
+Authoritative commit remains deterministic, reviewable, and governed.
+
+## Requirements
+
+- Speculative output must be classified as proposal material until accepted by
+  the normal commit path.
+- Accepted, rejected, and fallback speculative paths must be representable in
+  review evidence.
+- No speculative branch may perform hidden external side effects.
+- ACC and Freedom Gate remain authoritative for actions.
+- Performance claims must remain bounded to measured evaluation surfaces.
+
+## Consequences
+
+### Positive
+
+- Lets ADL explore acceleration without weakening its governance model.
+- Gives implementers a clear boundary between draft generation and committed
+  runtime state.
+- Preserves replay and audit semantics even if speculative paths become useful.
+
+### Negative
+
+- Speculative decoding integration is more constrained than a raw performance
+  optimization.
+- Benchmarks must measure both speed and governance-preservation behavior.
+- Runtime traces or evidence packets need enough detail to explain rejected and
+  accepted paths.
+
+## Alternatives Considered
+
+### Treat speculative output as ordinary committed output
+
+This would be faster to integrate, but it would blur proposal and commit.
+
+### Defer all speculative decoding until later milestones
+
+This avoids risk, but loses a useful v0.91.2 evaluation opportunity.
+
+## Validation Notes
+
+This ADR was reviewed against the speculative decoding feature doc,
+benchmark/evaluation packet, and any prototype results produced in v0.91.2.
+
+## Non-Claims
+
+- This ADR does not claim production-grade acceleration.
+- This ADR does not require speculative decoding in all runtimes.
+- This ADR does not permit hidden side effects or bypassed authority checks.

--- a/docs/adr/0023-google-workspace-cms-bridge-canonical-promotion-boundary.md
+++ b/docs/adr/0023-google-workspace-cms-bridge-canonical-promotion-boundary.md
@@ -1,0 +1,86 @@
+# ADR 0023: Google Workspace CMS Bridge And Canonical Repo Promotion Boundary
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0023-google-workspace-cms-bridge-canonical-promotion-boundary.md
+- Target milestone: v0.91.2
+- Related issues: #3091, #3092, #3093, #3094, #3111, #3112, #3122, #3124
+- Related ADRs: ADR 0013, ADR 0017, ADR 0020 and ADR 0021
+
+## Context
+
+v0.91.2 makes the Google Workspace CMS bridge real enough to need a durable
+architecture boundary. The bridge now covers fixture-backed demo evidence,
+typed adapter boundaries, bounded live read surfaces, live safety packaging,
+bounded content-card roundtrip contracts, and a reusable project operational
+package.
+
+That power is useful because Workspace is a humane collaborative surface for
+drafts, comments, content cards, review packets, and promotion packets. It is
+risky because Workspace can drift from Git history, hide authority boundaries,
+or become an accidental parallel source of truth.
+
+## Decision
+
+ADL may use Google Workspace as bounded draft, collaboration, content-card,
+review, and promotion-packet infrastructure.
+
+Google Workspace is not canonical repository truth.
+
+Tracked repository files and GitHub issue/PR history remain the canonical
+promotion boundary for ADL product, milestone, feature, release, and lifecycle
+truth. Workspace state may not silently edit, replace, or override canonical
+repo files.
+
+## Requirements
+
+- Workspace use must distinguish fixture mode, dry-run mode, and live-gated
+  execution.
+- Live execution must require explicit auth, explicit scope, explicit mode, and
+  explicit write approval.
+- Revision anchors and document/content-card bindings must be checked before
+  bounded mutation.
+- Promotion packets must identify source Workspace state, target repo paths,
+  issue/PR routing, and non-claims.
+- Workspace credentials and live outputs must avoid secrets and inappropriate
+  visibility leakage.
+- ACC/tool authority applies to live or write-capable Workspace actions.
+
+## Consequences
+
+### Positive
+
+- Enables a more collaborative working surface without replacing Git.
+- Makes Workspace proof packets useful to CodeFriend and future projects.
+- Gives future agents a clear answer to what GWS can and cannot mean.
+
+### Negative
+
+- GWS work requires strict promotion and revision discipline.
+- Live Workspace actions need safety, auth, scope, and redaction proof.
+- GWS cannot be used as an excuse to skip tracked repo updates.
+
+## Alternatives Considered
+
+### Make Workspace canonical
+
+This would improve collaborative editing ergonomics but undermine Git-native
+review, release evidence, and deterministic promotion.
+
+### Keep Workspace as demo-only
+
+This is safer but wastes the now-proven operational bridge.
+
+## Validation Notes
+
+This ADR was reviewed against the v0.91.2 GWS feature doc, review
+packet artifacts, live safety report, content-card roundtrip report, and the
+follow-on hardening that required confirmed live write persistence before
+claiming proof.
+
+## Non-Claims
+
+- This ADR does not require GWS for normal ADL issue execution.
+- This ADR does not authorize silent sync from Workspace into tracked repo
+  files.

--- a/docs/adr/0024-workflow-guardrails-issue-lifecycle-control-plane.md
+++ b/docs/adr/0024-workflow-guardrails-issue-lifecycle-control-plane.md
@@ -1,0 +1,86 @@
+# ADR 0024: Workflow Guardrails And Issue Lifecycle Control Plane
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0024-workflow-guardrails-issue-lifecycle-control-plane.md
+- Target milestone: v0.91.2
+- Related issues: #2986, #3069, #3089, #3101, #3118, #3124
+- Related ADRs: ADR 0018
+
+## Context
+
+Recent milestone failures were not only implementation bugs. Several were
+control-plane failures: work done on the wrong checkout, PRs not opened, local
+cards drifting from GitHub truth, sprint closeout overstating cleanliness, and
+review findings landing only after work was assumed complete.
+
+v0.91.2 adds `AGENTS.md`, workflow-conductor discipline, editor-only card
+normalization, sprint-conductor improvements, and a clarified card lifecycle:
+
+```text
+SIP -> STP -> SPP -> SRP -> SOR
+```
+
+ADR 0018 records the existence and semantics of the structured planning and
+review artifacts. This ADR records the surrounding lifecycle control
+plane.
+
+## Decision
+
+ADL treats conductor-first lifecycle routing, bound issue worktrees, editor-only
+card mutation, pre-PR subagent review, truthful PR publication, janitor routing,
+and post-merge closeout as architecture policy rather than optional operator
+habit.
+
+## Requirements
+
+- Use `workflow-conductor` for issue and lifecycle routing.
+- Execute tracked issue work in a bound worktree and branch, never directly on
+  `main`.
+- Mutate cards through the matching editor skill, not opportunistic hand edits.
+- Use `SIP -> STP -> SPP -> SRP -> SOR` as the canonical issue lifecycle.
+- Run bounded pre-PR review before publication and fix actionable findings.
+- Use PR janitor work only for real PR blockers, not broad scope expansion.
+- Perform closeout after merge or closure so GitHub, cards, artifacts, and
+  repo truth agree.
+- Fail closed when the workflow state is unsafe or ambiguous.
+
+## Consequences
+
+### Positive
+
+- Makes ADL issue work more reproducible and reviewable.
+- Reduces repeated drift between cards, PRs, and milestone docs.
+- Gives future agents one durable control-plane policy to follow.
+
+### Negative
+
+- Small changes require more explicit workflow discipline.
+- Editor and conductor skills become architecture-sensitive infrastructure.
+- Local ignored card storage remains a transitional weakness until ADR 0028 or
+  a successor tracked-state decision lands.
+
+## Alternatives Considered
+
+### Treat workflow rules as operator preference
+
+This has repeatedly failed. The process is now product infrastructure.
+
+### Collapse all lifecycle skills into one mega-conductor
+
+That would reduce visible steps, but it would hide responsibility and make
+review harder.
+
+## Validation Notes
+
+This ADR was reviewed against root `AGENTS.md`, the C-SDLC
+mini-sprint results, sprint-conductor repairs, editor-skill contracts, and
+workflow-guardrail evidence.
+
+## Non-Claims
+
+- This ADR does not claim the tracked-state migration is complete.
+- This ADR does not eliminate human judgment.
+- This ADR does not authorize silent merge, silent closeout, or destructive
+  cleanup of user work.

--- a/docs/adr/0025-codefriend-review-packet-product-boundary.md
+++ b/docs/adr/0025-codefriend-review-packet-product-boundary.md
@@ -1,0 +1,78 @@
+# ADR 0025: CodeFriend Review Packet Product Boundary
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0025-codefriend-review-packet-product-boundary.md
+- Target milestone: v0.91.2
+- Related issue: #3124
+- Related ADRs: ADR 0018, ADR 0024
+
+## Context
+
+v0.91.2 moves CodeFriend from an internal review-skill cluster toward a
+productizable review-packet workflow. The feature package includes evidence
+requirements, review packet workflow, product report template, skill/demo
+alignment, and the `CodeFriend.ai` naming boundary.
+
+This work needs an ADR because productization can easily overclaim what review
+automation proves.
+
+## Decision
+
+ADL treats CodeFriend as an evidence-bound review-packet and product-report
+workflow.
+
+CodeFriend may produce source-grounded findings, diagrams, remediation plans,
+test recommendations, synthesis packets, redaction checks, and customer-grade
+reports. It does not replace human judgment, customer approval, or
+publication-time responsibility.
+
+## Requirements
+
+- Review packets must identify source evidence, scope, skipped surfaces, and
+  residual risk.
+- Findings must be ordered by severity and tied to concrete evidence.
+- Diagrams and reports must distinguish source-backed claims from inference.
+- Redaction and publication boundaries must be explicit before external use.
+- Product language must preserve uncertainty and avoid unsupported claims.
+- Human review and operator approval remain part of the delivery boundary.
+
+## Consequences
+
+### Positive
+
+- Gives CodeFriend a credible product boundary without hype.
+- Connects review skills, diagrams, test planning, synthesis, and reporting
+  into one repeatable workflow.
+- Helps future customer-facing work stay evidence-bound.
+
+### Negative
+
+- Product reports must carry caveats and residual risk instead of sounding
+  magically certain.
+- Review-quality failures become product defects, not mere internal nits.
+- Publication and redaction review remain required work.
+
+## Alternatives Considered
+
+### Treat CodeFriend as just a bundle of skills
+
+This is accurate historically but too weak for productization.
+
+### Market CodeFriend as autonomous code-review authority
+
+This would be false and unsafe. CodeFriend produces governed evidence and
+recommendations, not unchallengeable authority.
+
+## Validation Notes
+
+This ADR was reviewed against the v0.91.2 CodeFriend feature doc,
+review packet workflow package, evidence requirements, product report template,
+and review heuristics demo results.
+
+## Non-Claims
+
+- This ADR does not authorize external publication.
+- This ADR does not claim CodeFriend replaces human review.
+- This ADR does not claim every CodeFriend report is automatically correct.

--- a/docs/adr/0026-repo-visibility-manifest-linkage-layer.md
+++ b/docs/adr/0026-repo-visibility-manifest-linkage-layer.md
@@ -1,0 +1,78 @@
+# ADR 0026: Repo Visibility Manifest And Linkage Layer
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0026-repo-visibility-manifest-linkage-layer.md
+- Target milestone: v0.91.2
+- Related issue: #3124
+- Related ADRs: ADR 0013, ADR 0025
+
+## Context
+
+v0.90 delivered a bounded repo-visibility prototype. v0.91.2 plans a practical
+follow-on that makes canonical source authority and code-doc-test-demo linkage
+more useful for review, planning, and productized CodeFriend packets.
+
+Repo visibility is not full repo cognition. It is a manifest and linkage layer
+that helps agents and reviewers understand which files, docs, tests, demos, and
+evidence surfaces are relevant.
+
+## Decision
+
+ADL treats repo visibility as a bounded manifest/linkage layer for source,
+documentation, tests, demos, proof packets, review surfaces, and milestone
+evidence.
+
+The layer supports reviewer and planner navigation. It does not replace
+canonical source files, Git history, issue/PR truth, or human review.
+
+## Requirements
+
+- Repo visibility artifacts must identify canonical source paths and related
+  proof surfaces.
+- Linkage should connect code, docs, tests, demos, issue work, and review
+  evidence where useful.
+- The layer must preserve uncertainty and missing-evidence markers.
+- The layer must not claim complete indexing, total repository cognition, or
+  automatic architectural understanding.
+- CodeFriend and milestone review can consume the layer as evidence routing,
+  not as proof by itself.
+
+## Consequences
+
+### Positive
+
+- Makes large-review and milestone-closeout work easier to navigate.
+- Gives CodeFriend a better packet-building substrate.
+- Reduces hidden dependency on session memory or local browsing.
+
+### Negative
+
+- Linkage artifacts can become stale if not maintained.
+- Partial visibility can be mistaken for complete knowledge unless non-claims
+  remain prominent.
+- Repo visibility work needs validation against real file existence and review
+  usefulness.
+
+## Alternatives Considered
+
+### Treat repo visibility as full repo cognition
+
+This overclaims what the current substrate can do.
+
+### Leave visibility as ad hoc search
+
+This keeps work lightweight but loses repeatability and packet quality.
+
+## Validation Notes
+
+This ADR was reviewed against the v0.90 baseline, v0.91.2 repo
+visibility feature doc, CodeFriend packet needs, and any bounded linkage proof
+created in the milestone.
+
+## Non-Claims
+
+- This ADR does not claim complete repository indexing.
+- This ADR does not replace source review.
+- This ADR does not make generated linkage authoritative without evidence.

--- a/docs/adr/0027-governed-code-modernization-moderne-openrewrite-lst.md
+++ b/docs/adr/0027-governed-code-modernization-moderne-openrewrite-lst.md
@@ -1,0 +1,77 @@
+# ADR 0027: Governed Code Modernization With Moderne/OpenRewrite LST
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0027-governed-code-modernization-moderne-openrewrite-lst.md
+- Target milestone: v0.91.2
+- Related issue: #3124
+- Related ADRs: ADR 0020, ADR 0021, ADR 0025
+
+## Context
+
+v0.91.2 includes a bounded modernization demo around Moderne, OpenRewrite,
+Lossless Semantic Trees (`LSTs`), and deterministic recipes.
+
+Modernization can be high-value, but it is also write-capable and potentially
+large-scale. ADL needs a decision boundary that distinguishes governed
+deterministic transformation from vague "AI rewrites code automatically"
+language.
+
+## Decision
+
+ADL may integrate Moderne/OpenRewrite-style modernization as a governed
+deterministic transformation workflow only when discovery, dry-run, review,
+patch generation, validation, and acceptance remain explicit and review-bound.
+
+Modernization recipes are proposed transformations. They do not become accepted
+source changes without issue/PR authority and review.
+
+## Requirements
+
+- Use accurate terminology: Moderne as platform, OpenRewrite as framework, LST
+  as lossless semantic code model, recipes as deterministic transformations.
+- Start with discovery and dry-run before patch authority.
+- Record affected files, recipe intent, validation expectations, and rollback
+  posture.
+- Keep generated patches reviewable and reversible.
+- Route write-capable modernization through ACC/Freedom Gate policy where live
+  tool execution is involved.
+- Connect modernization outputs to CodeFriend review packets and normal issue/PR
+  promotion only through explicit review boundaries.
+
+## Consequences
+
+### Positive
+
+- Lets ADL use powerful modernization tooling without losing review discipline.
+- Creates a clean story for deterministic refactoring and productized review.
+- Keeps large-scale code change under issue/PR governance.
+
+### Negative
+
+- Mass modernization remains intentionally slower than unreviewed automation.
+- Recipe outputs need validation and human review.
+- Tool integration must preserve authority and rollback semantics.
+
+## Alternatives Considered
+
+### Treat modernization as ordinary generated patching
+
+This loses the value of LST-aware deterministic recipes and weakens proof.
+
+### Allow automatic bulk rewrite
+
+This is outside ADL's governance posture and too risky for source authority.
+
+## Validation Notes
+
+This ADR was reviewed against the modernization feature doc,
+Moderne/OpenRewrite/LST planning notes, dry-run evidence, and CodeFriend review
+boundaries.
+
+## Non-Claims
+
+- This ADR does not authorize unreviewed bulk rewrite.
+- This ADR does not claim production modernization service readiness.
+- This ADR does not require Moderne for all future code modernization.

--- a/docs/adr/0028-c-sdlc-tracked-workflow-state-and-signed-trace.md
+++ b/docs/adr/0028-c-sdlc-tracked-workflow-state-and-signed-trace.md
@@ -1,0 +1,120 @@
+# ADR 0028: C-SDLC Tracked Workflow State And Signed Trace Boundary
+
+- Status: Accepted
+- Date: 2026-05-23
+- Accepted in: v0.91.3
+- Candidate source: docs/architecture/adr/0028-c-sdlc-tracked-workflow-state-and-signed-trace.md
+- Target milestone: v0.91.2 planning, v0.91.3/v0.91.4 implementation path
+- Related issues: #3099, #3100, #3120, #3124
+- Related ADRs: ADR 0018, ADR 0024
+
+## Context
+
+C-SDLC is a general model for governed software development with cognitive
+agents. ADL will implement it first for its own development workflow, but the
+idea is not ADL-only: other projects can implement C-SDLC with their own tools
+if they preserve the same audit and lifecycle principles.
+
+The current ADL workflow exposes the problem C-SDLC is meant to solve. Durable
+lifecycle truth has often lived in ignored local `.adl` records. That startup
+shortcut helped the project move quickly while the workflow was immature, but
+it now creates repeated truth drift and makes governed software development
+harder to audit.
+
+C-SDLC is intended to remodel software development for agents. If it is to be
+credible, its lifecycle records must be public, tracked, inspectable,
+auditable, and useful as memory. The system cannot depend on "the real state
+was on one machine."
+
+For ADL's implementation, C-SDLC has one canonical direction for durable
+workflow truth: tracked Git state plus signed trace evidence and ObsMem
+ingestion. Other implementations may choose different storage mechanics, but
+must preserve public inspectability, auditability, and durable evidence.
+
+## Decision
+
+ADL should implement C-SDLC by making durable workflow truth tracked in Git by
+the end of v0.91.4.
+
+Durable C-SDLC records include issue cards, sprint state, closeout artifacts,
+review findings, proof packets, promoted traces, signed trace bundles, and
+ObsMem ingestion surfaces derived from tracked evidence.
+
+Local `.adl` state should shrink toward ephemeral execution cache and temporary
+helper files. Durable C-SDLC truth should live in tracked Git state, not in
+ignored local-only records.
+
+Signed trace proof should not be deferred until full trace-query work. ADL's
+C-SDLC implementation needs a minimal signed trace slice before it becomes
+default operation.
+
+## Requirements
+
+- Track all durable workflow records needed for governance, review, closeout,
+  release evidence, or ObsMem ingestion in ADL's implementation.
+- Keep genuinely ephemeral caches, secrets, temporary helper files, and
+  non-durable scratch untracked.
+- Preserve the canonical lifecycle `SIP -> STP -> SPP -> SRP -> SOR`.
+- Add a minimal signed trace bundle for durable C-SDLC runs:
+  - trace event stream or trace manifest
+  - digest manifest for trace and key proof artifacts
+  - signature record
+  - verification command and expected result
+  - SOR/SRP/closeout linkage
+  - ObsMem ingestion linkage
+- Complete ADL's tracked workflow-state migration by the end of v0.91.4.
+
+## Consequences
+
+### Positive
+
+- Makes ADL's C-SDLC implementation auditable by future agents and humans.
+- Reduces truth drift between local cards, GitHub, PRs, and release evidence.
+- Gives ObsMem higher-quality governed memory inputs.
+- Makes signed trace part of the C-SDLC proof story early enough to matter.
+
+### Negative
+
+- Tracked workflow records will add PR noise and merge friction.
+- Tooling must classify durable versus ephemeral artifacts carefully.
+- The migration must be staged to avoid a giant historical cleanup burst.
+
+## Migration Path
+
+1. Define the tracked workflow home and artifact classification.
+2. Track new durable C-SDLC records first.
+3. Normalize the active milestone's open and recently closed workflow records.
+4. Add the minimal signed trace slice.
+5. Complete all durable C-SDLC tracking by the end of v0.91.4.
+6. Backfill older history selectively by governance and release-evidence value.
+
+## Alternatives Considered
+
+### Keep `.adl` mostly ignored
+
+This preserves low-noise local execution, but it perpetuates truth drift and
+weak auditability.
+
+### Wait for full trace query before signed traces
+
+Full TQL can wait. A minimal signed trace proof slice cannot, because ADL's
+C-SDLC governance needs durable signed evidence.
+
+## Validation Notes
+
+This ADR was reviewed against:
+
+- the C-SDLC tracked workflow state migration plan from 2026-05-19
+- the workflow state home decision memo from 2026-05-19, as superseded for
+  C-SDLC by the tracked-state direction
+- root `AGENTS.md`
+- the C-SDLC first-slice and completion planning issues
+- signed trace architecture and existing signing ADRs
+
+## Non-Claims
+
+- This ADR does not implement the migration.
+- This ADR does not claim C-SDLC can only be implemented by ADL.
+- This ADR does not require full TQL before C-SDLC adoption.
+- This ADR does not require tracking secrets, temporary caches, or scratch
+  material that is not durable workflow truth.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,7 +3,8 @@
 This directory contains accepted ADL architecture decision records.
 
 Candidate ADRs live in `docs/architecture/adr/` until they are reviewed and
-promoted.
+promoted. ADR 0020 through ADR 0028 were authored as candidates during the
+v0.91.2 ADR planning pass and accepted during the v0.91.3 review tail.
 
 ## Accepted Records
 
@@ -26,3 +27,12 @@ promoted.
 - `0017-secure-local-agent-comms-and-a2a-boundary.md`
 - `0018-structured-planning-and-review-policy-artifacts.md`
 - `0019-theory-of-mind-foundation.md`
+- `0020-universal-tool-schema-portable-tool-description-standard.md`
+- `0021-adl-capability-contract-runtime-authority-boundary.md`
+- `0022-speculative-decoding-deterministic-commit-boundary.md`
+- `0023-google-workspace-cms-bridge-canonical-promotion-boundary.md`
+- `0024-workflow-guardrails-issue-lifecycle-control-plane.md`
+- `0025-codefriend-review-packet-product-boundary.md`
+- `0026-repo-visibility-manifest-linkage-layer.md`
+- `0027-governed-code-modernization-moderne-openrewrite-lst.md`
+- `0028-c-sdlc-tracked-workflow-state-and-signed-trace.md`

--- a/docs/architecture/ADL_ARCHITECTURE.md
+++ b/docs/architecture/ADL_ARCHITECTURE.md
@@ -107,9 +107,9 @@ for integrated repository truth.
 The task bundle lifecycle is:
 
 1. Issue intent is captured in a tracked or generated issue prompt.
-2. STP/SIP/SOR cards are created in the versioned task area.
+2. SIP, STP, SPP, SRP, and SOR cards are created in the versioned task area.
 3. `pr run` copies or binds the executable packet into the worktree.
-4. Implementation and validation happen inside the worktree.
+4. Implementation, validation, and review happen inside the worktree.
 5. `pr finish` records the publication state in SOR.
 6. `pr closeout` reconciles GitHub closure, PR merge state, final cards, and
    local worktree cleanup.
@@ -225,7 +225,7 @@ Architecture review uses the same packet-first discipline:
 These invariants are intended to become automated checks where practical:
 
 - Implementation work for tracked issues occurs in issue worktrees.
-- STP/SIP/SOR cards exist before issue execution begins.
+- SIP/STP/SPP/SRP/SOR cards exist before issue execution begins.
 - SOR does not claim merge, closure, or validation that did not happen.
 - Public architecture docs do not contain host-absolute private paths or secret
   markers.

--- a/docs/architecture/ADL_ARCHITECTURE.md
+++ b/docs/architecture/ADL_ARCHITECTURE.md
@@ -262,7 +262,7 @@ See `diagrams/DIAGRAM_PACKET.md` for diagram evidence and assumptions.
 - `diagrams/runtime_v2_subsystem_structure.mmd`
 - `diagrams/codebuddy_review_flow.mmd`
 
-## ADR Candidates
+## ADR Candidate Provenance
 
-See `adr/CANDIDATE_ADRS.md`. The ADRs are candidates, not accepted decisions,
-until a human reviewer explicitly promotes them.
+See `adr/CANDIDATE_ADRS.md` for candidate provenance. ADR 0020 through ADR 0028
+were promoted to accepted records in `../adr/` during the v0.91.3 review tail.

--- a/docs/architecture/adr/CANDIDATE_ADRS.md
+++ b/docs/architecture/adr/CANDIDATE_ADRS.md
@@ -55,17 +55,19 @@ are not accepted ADRs until reviewed and promoted.
 
 ## v0.91.2 Candidate ADR Packet
 
-These candidate records were created for the v0.91.2 ADR authoring pass. They
-are not accepted decisions until reviewed and promoted.
+These candidate records were created for the v0.91.2 ADR authoring pass and
+promoted to accepted ADRs during the v0.91.3 review tail. The accepted records
+live in `docs/adr/`; the files in this directory remain the source candidate
+copies for provenance.
 
-| Candidate | File | Summary |
+| Candidate | Accepted record | Summary |
 | --- | --- | --- |
-| ADR 0020 | `0020-universal-tool-schema-portable-tool-description-standard.md` | UTS is portable tool description, not execution authority. |
-| ADR 0021 | `0021-adl-capability-contract-runtime-authority-boundary.md` | ACC is ADL-native governed runtime authority. |
-| ADR 0022 | `0022-speculative-decoding-deterministic-commit-boundary.md` | Speculative decoding may accelerate proposals, not commits. |
-| ADR 0023 | `0023-google-workspace-cms-bridge-canonical-promotion-boundary.md` | GWS is collaboration infrastructure, not canonical repo truth. |
-| ADR 0024 | `0024-workflow-guardrails-issue-lifecycle-control-plane.md` | ADL issue lifecycle discipline is architecture policy. |
-| ADR 0025 | `0025-codefriend-review-packet-product-boundary.md` | CodeFriend is evidence-bound review/report workflow. |
-| ADR 0026 | `0026-repo-visibility-manifest-linkage-layer.md` | Repo visibility is manifest/linkage support, not full repo cognition. |
-| ADR 0027 | `0027-governed-code-modernization-moderne-openrewrite-lst.md` | Modernization remains dry-run/review/approval bounded. |
-| ADR 0028 | `0028-c-sdlc-tracked-workflow-state-and-signed-trace.md` | C-SDLC durable workflow truth becomes tracked and signed-trace-backed. |
+| ADR 0020 | `../../adr/0020-universal-tool-schema-portable-tool-description-standard.md` | UTS is portable tool description, not execution authority. |
+| ADR 0021 | `../../adr/0021-adl-capability-contract-runtime-authority-boundary.md` | ACC is ADL-native governed runtime authority. |
+| ADR 0022 | `../../adr/0022-speculative-decoding-deterministic-commit-boundary.md` | Speculative decoding may accelerate proposals, not commits. |
+| ADR 0023 | `../../adr/0023-google-workspace-cms-bridge-canonical-promotion-boundary.md` | GWS is collaboration infrastructure, not canonical repo truth. |
+| ADR 0024 | `../../adr/0024-workflow-guardrails-issue-lifecycle-control-plane.md` | ADL issue lifecycle discipline is architecture policy. |
+| ADR 0025 | `../../adr/0025-codefriend-review-packet-product-boundary.md` | CodeFriend is evidence-bound review/report workflow. |
+| ADR 0026 | `../../adr/0026-repo-visibility-manifest-linkage-layer.md` | Repo visibility is manifest/linkage support, not full repo cognition. |
+| ADR 0027 | `../../adr/0027-governed-code-modernization-moderne-openrewrite-lst.md` | Modernization remains dry-run/review/approval bounded. |
+| ADR 0028 | `../../adr/0028-c-sdlc-tracked-workflow-state-and-signed-trace.md` | C-SDLC durable workflow truth becomes tracked and signed-trace-backed. |

--- a/docs/architecture/adr/CANDIDATE_ADRS.md
+++ b/docs/architecture/adr/CANDIDATE_ADRS.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-These are proposed decisions extracted from the v0.90 architecture packet. They
-are not accepted ADRs until reviewed and promoted.
+The remaining unpromoted entries in this file are proposed decisions extracted
+from the v0.90 architecture packet. They are not accepted ADRs until reviewed
+and promoted.
 
 ## Candidate 0001: Trace And Artifacts As Runtime Truth
 
@@ -23,7 +24,7 @@ are not accepted ADRs until reviewed and promoted.
 - Context: implementation on the root checkout creates drift, conflicts, and
   closeout ambiguity.
 - Proposed decision: tracked issue implementation should run in issue-specific
-  worktrees with STP/SIP/SOR truth recorded before finish and closeout.
+  worktrees with SIP/STP/SPP/SRP/SOR truth recorded before finish and closeout.
 - Consequences: conductor and lifecycle skills must route to worktree-bound
   execution, and closeout must reconcile GitHub and local truth.
 - Evidence: `docs/default_workflow.md`, `adl/src/control_plane.rs`, `pr-*`

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -9,7 +9,7 @@ Current tracked candidate file:
 
 - `CANDIDATE_ADRS.md`
 
-Current v0.91.2 candidate ADR files:
+Promoted v0.91.2 candidate ADR source files retained for provenance:
 
 - `0020-universal-tool-schema-portable-tool-description-standard.md`
 - `0021-adl-capability-contract-runtime-authority-boundary.md`
@@ -21,5 +21,6 @@ Current v0.91.2 candidate ADR files:
 - `0027-governed-code-modernization-moderne-openrewrite-lst.md`
 - `0028-c-sdlc-tracked-workflow-state-and-signed-trace.md`
 
-Candidate ADRs are not accepted decisions. Promote them only after human review
-and an explicit status change.
+These ADRs are accepted in `docs/adr/`. The copies in this directory preserve
+the original candidate review surface and should not be treated as the active
+accepted records.

--- a/docs/milestones/v0.91.2/ADR_PLAN_v0.91.2.md
+++ b/docs/milestones/v0.91.2/ADR_PLAN_v0.91.2.md
@@ -4,13 +4,14 @@
 
 Tracked ADR authoring plan for `v0.91.2`.
 
-This plan does not accept any ADR by itself. It records the candidate ADR set
-that should be reviewed before milestone closeout.
+This plan did not accept any ADR by itself. It recorded the candidate ADR set
+for review. ADR 0020 through ADR 0028 were promoted to accepted records in
+`docs/adr/` during the v0.91.3 review tail.
 
 ## Purpose
 
-`v0.91.2` turns several implicit architecture boundaries into explicit
-decision surfaces. The milestone now needs ADR candidates for the tooling split,
+`v0.91.2` turned several implicit architecture boundaries into explicit
+decision surfaces. The milestone needed ADR candidates for the tooling split,
 runtime proposal/commit boundaries, GWS promotion boundaries, workflow control
 plane, productization, repo visibility, modernization, and the C-SDLC
 tracked-state direction.
@@ -20,7 +21,7 @@ reviewable, and durable.
 
 ## Existing Baseline
 
-Accepted ADRs currently live in `docs/adr/` and run through ADR 0019.
+Accepted ADRs currently live in `docs/adr/` and run through ADR 0028.
 
 Key inherited decisions:
 
@@ -28,13 +29,13 @@ Key inherited decisions:
 - ADR 0018 records structured planning and review artifacts.
 - ADR 0019 records Theory of Mind as bounded social cognition, not authority.
 
-`v0.91.2` should not rewrite those records casually. It should add new
-candidate ADRs and, after review, promote accepted records with narrow
-supersession notes.
+`v0.91.2` did not rewrite those records casually. It added new candidate ADRs
+and, after review, promoted accepted records with narrow supersession notes.
+That promotion happened during v0.91.3.
 
-## Candidate ADR Set
+## Promoted ADR Set
 
-| Candidate | Title | Primary Boundary |
+| ADR | Title | Primary Boundary |
 | --- | --- | --- |
 | ADR 0020 | Universal Tool Schema As Portable Tool Description Standard | UTS is portable description, not authority; ADL adopts UTS while the standard moves toward a standalone repo. |
 | ADR 0021 | ADL Capability Contract As Governed Runtime Authority Boundary | ACC is ADL-native runtime authority for capability exercise. |
@@ -46,7 +47,8 @@ supersession notes.
 | ADR 0027 | Governed Code Modernization With Moderne/OpenRewrite LST | Modernization is deterministic, dry-run/review/approval bounded, not automatic mass rewrite. |
 | ADR 0028 | C-SDLC Tracked Workflow State And Signed Trace Boundary | Durable C-SDLC truth becomes tracked/auditable and signed-trace-backed by the end of v0.91.4. |
 
-Candidate files live in `docs/architecture/adr/`.
+Accepted files live in `docs/adr/`. The original candidate files remain in
+`docs/architecture/adr/` as provenance.
 
 ## Supersession Plan
 
@@ -55,7 +57,7 @@ Candidate files live in `docs/architecture/adr/`.
 Do not delete or rewrite ADR 0015. It remains historical truth for the v0.90.5
 governed-tools umbrella.
 
-After ADR 0020 and ADR 0021 are accepted:
+Now that ADR 0020 and ADR 0021 are accepted:
 
 - mark ADR 0015 as superseded or partially superseded by ADR 0020 and ADR 0021
 - point active UTS interpretation to ADR 0020
@@ -67,7 +69,7 @@ After ADR 0020 and ADR 0021 are accepted:
 Do not replace ADR 0018. It remains the artifact-contract decision for `SPP`
 and `SRP` and the refined card lifecycle.
 
-After ADR 0024 and ADR 0028 are accepted:
+Now that ADR 0024 and ADR 0028 are accepted:
 
 - point lifecycle-control-plane policy to ADR 0024
 - point tracked workflow-state and signed trace migration policy to ADR 0028
@@ -121,6 +123,6 @@ No standalone ADR is created yet for:
 - UTS and ACC are split.
 - ADR 0015 and ADR 0018 have clear supersession relationships.
 - C-SDLC tracked workflow state and signed traces are captured as ADR 0028.
-- Candidate records remain candidates until human review and explicit
+- Candidate records were promoted only after human review and explicit
   promotion.
 - The milestone decision surface points reviewers to this plan.

--- a/docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md
+++ b/docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md
@@ -5,7 +5,7 @@
 - [x] README, WBS, sprint plan, issue wave, execution readiness, and demo matrix exist.
 - [x] Feature index exists and names concrete WP homes.
 - [x] Missing milestone-planning package surfaces have been restored.
-- [x] ADR plan exists and names the v0.91.2 candidate ADR packet.
+- [x] ADR plan exists, names the v0.91.2 candidate ADR packet, and points to the promoted accepted ADR records.
 - [x] Issue wave opened into tracked GitHub issues.
 - [x] Local STP/SIP/SPP/SRP/SOR bundle wave generated for every WP and sprint umbrella.
 
@@ -23,6 +23,6 @@
 - [x] Internal review is complete.
 - [x] External review is complete.
 - [x] Accepted findings are fixed or dispositioned.
-- [ ] ADR candidates are reviewed, promoted, deferred, or explicitly carried forward.
+- [x] ADR candidates are reviewed, promoted, deferred, or explicitly carried forward.
 - [x] Release evidence and release readiness are prepared for ceremony.
 - [ ] Ceremony completed.

--- a/docs/milestones/v0.91.2/README.md
+++ b/docs/milestones/v0.91.2/README.md
@@ -39,9 +39,9 @@ reviewable systems:
 - Rustdoc and documentation cleanup.
 - Workflow guardrails that prevent main-branch writes, hung closeout watchers,
   and unsafe report-generation shell behavior from recurring.
-- ADR candidates that make the milestone's durable architecture boundaries
-  explicit before closeout, including the C-SDLC tracked-state and signed-trace
-  direction for v0.91.3/v0.91.4.
+- Accepted ADRs that make the milestone's durable architecture boundaries
+  explicit, including the C-SDLC tracked-state and signed-trace direction for
+  v0.91.3/v0.91.4.
 
 ## Milestone Role
 

--- a/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
+++ b/docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md
@@ -39,5 +39,4 @@ closeout.
 ## Remaining Gate
 
 - `WP-24` must still perform release ceremony and final closeout
-- ADR candidates exist for review, but they are not accepted release decisions
-  until promoted or explicitly carried forward
+- ADR 0020 through ADR 0028 are promoted to accepted records in `docs/adr/`

--- a/docs/planning/ADL_FEATURE_LIST.md
+++ b/docs/planning/ADL_FEATURE_LIST.md
@@ -128,7 +128,7 @@ ADL already provides a serious platform baseline:
 | Provider and transport substrate | Implemented baseline | provider docs, HTTP/local provider surfaces, reviewer package | Runtime/provider completion target: `v0.92` |
 | Remote execution baseline | Implemented baseline | bounded remote execution surfaces and docs | Runtime/security completion target: `v0.93` |
 | Human-in-the-loop pause/resume | Implemented baseline | runtime/control surfaces and review docs | MVP completion target: `v0.95` |
-| Structured authoring model | Implemented baseline | STP/SIP/SOR contracts and prompt tooling | MVP completion target: `v0.95` |
+| Structured authoring model | Implemented baseline | SIP/STP/SPP/SRP/SOR contracts and prompt tooling | MVP completion target: `v0.95` |
 | Structured planning and Structured Review Prompt workflow | Implemented baseline | `v0.91` SPP/SRP feature docs, readiness records, validation tooling, and issue-bundle workflow surfaces; historical records may still mention the older Structured Review Policy wording | Completed baseline by `v0.91.0`; validator/closeout hardening continues in `v0.91.1` |
 | Control-plane lifecycle | Implemented baseline | `pr init/create/start/run/finish`, doctor, janitor, closeout surfaces | MVP completion target: `v0.95` |
 | Editor and command-adapter surfaces | Implemented baseline | editor docs, demos, bounded command adapters | MVP completion target: `v0.95` |
@@ -309,9 +309,10 @@ the platform boundary between orchestration logic and execution backends.
 ### Structured Authoring and Control Plane
 
 The repo now has a real control-plane lifecycle around issue creation,
-bootstrap, run binding, validation, and closeout. STP/SIP/SOR records, doctor
-checks, janitoring, and bounded PR tooling give ADL a strong authoring and
-execution spine instead of relying on vague contributor habit.
+bootstrap, plan review, run binding, validation, review, and closeout.
+SIP/STP/SPP/SRP/SOR records, doctor checks, janitoring, and bounded PR tooling
+give ADL a strong authoring and execution spine instead of relying on vague
+contributor habit.
 
 ### Operational Skills as System Intelligence
 

--- a/docs/planning/TBD_PLAN_ALLOCATION_v0.91.2_TO_v0.95.md
+++ b/docs/planning/TBD_PLAN_ALLOCATION_v0.91.2_TO_v0.95.md
@@ -100,7 +100,7 @@ source notes to tracked execution homes.
 | `V0911_SPRINT1_REVIEW_FINDINGS_2026-05-09.md` | `v0.91.1` sprint-review evidence | Archive/provenance. |
 | `V0911_V0912_DOCS_REVIEW_REPORT_2026-05-07.md` | `v0.91.2` docs package source evidence | Archive after v0.91.2 planning stabilization. |
 | `V0911_WP19_REVIEW_FINDINGS_2026-05-10.md` | `v0.91.1` docs cleanup evidence | Archive after remediation. |
-| `V0912_ADR_PLAN_2026-05-13.md` | `v0.91.2` ADR plan and issue `#3124` | Allocated/executed. The tracked plan is `docs/milestones/v0.91.2/ADR_PLAN_v0.91.2.md`; candidate ADRs live in `docs/architecture/adr/` and remain candidates until human review and explicit promotion. |
+| `V0912_ADR_PLAN_2026-05-13.md` | `v0.91.2` ADR plan and issue `#3124`; v0.91.3 promotion issue `#3277` | Allocated/executed. The tracked plan is `docs/milestones/v0.91.2/ADR_PLAN_v0.91.2.md`; ADR 0020 through ADR 0028 are accepted in `docs/adr/`, with source candidate copies retained in `docs/architecture/adr/` for provenance. |
 | `V0912_DOCS_REVIEW_FINDINGS_2026-05-09.md` | `v0.91.2` docs package review evidence | Archive after remediation. |
 | `V0912_ISSUE_3121_REVIEW_FINDINGS_2026-05-20.md` | `v0.91.2` UTS benchmark cleanup/review lane | Active remediation evidence for `#3121`; archive after closeout. |
 | `V0912_ISSUE_3121_TEST_SUITE_ARCHITECTURE_2026-05-20.md` | `v0.91.2` UTS benchmark cleanup/review lane and future standalone UTS repo | Allocated as test-suite architecture source material. |
@@ -133,9 +133,10 @@ before or through `v0.95`:
 The C-SDLC workflow-state, SPP live-planning, and v0.91.3/v0.91.4 doc-review
 notes are allocated to the tracked C-SDLC milestone-planning lane, not GWS.
 
-The `V0912_ADR_PLAN_2026-05-13.md` note is now allocated through `#3124`.
-The tracked ADR plan and candidate ADR packet exist; review and explicit
-promotion remain release-tail work rather than untracked TBD scope.
+The `V0912_ADR_PLAN_2026-05-13.md` note is allocated through `#3124` and the
+v0.91.3 promotion follow-on `#3277`. The tracked ADR plan exists; ADR 0020
+through ADR 0028 are promoted to accepted records, with the candidate packet
+retained as provenance.
 
 The UTS benchmark plan, model panel, task panel, and `#3121` review notes are
 allocated to the active `v0.91.2` UTS benchmark lane and future standalone UTS

--- a/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
+++ b/docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md
@@ -29,7 +29,7 @@ references:
 
 - `docs/milestones/v0.91.2/features/CODEFRIEND_PRODUCTIZATION.md`
 - `docs/milestones/v0.91.2/review/codefriend_productization/`
-- `docs/architecture/adr/0025-codefriend-review-packet-product-boundary.md`
+- `docs/adr/0025-codefriend-review-packet-product-boundary.md`
 - `docs/planning/ADL_FEATURE_LIST.md`
 - `docs/planning/TBD_PLAN_ALLOCATION_v0.91.2_TO_v0.95.md`
 

--- a/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
+++ b/docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md
@@ -209,7 +209,7 @@ The current product boundary is:
   risk, and publication boundaries.
 - CodeFriend reports should be useful, but not magically certain.
 
-This follows the v0.91.2 productization package and ADR 0025 candidate.
+This follows the v0.91.2 productization package and ADR 0025.
 
 ### 3. Architecture Cognition Roadmap
 
@@ -332,7 +332,7 @@ Scope:
 
 Validation:
 
-- check against ADR 0025 and the v0.91.2 productization package
+- check against accepted ADR 0025 and the v0.91.2 productization package
 - mark speculative items as planned, not implemented
 
 ### Product Repo / Site Decision
@@ -378,7 +378,7 @@ Scope:
 Validation:
 
 - verify the roadmap does not overclaim alpha scope
-- check against the CodeFriend notes, ADR 0025, and current feature list
+- check against the CodeFriend notes, accepted ADR 0025, and current feature list
 - route any schedule conflicts back to milestone planning before issue seeding
 
 ## Non-Goals

--- a/docs/planning/codefriend/README.md
+++ b/docs/planning/codefriend/README.md
@@ -44,7 +44,7 @@ Current tracked baseline:
 - [CodeFriend product report template](../../milestones/v0.91.2/review/codefriend_productization/product_report_template.md)
 - [CodeFriend evidence requirements](../../milestones/v0.91.2/review/codefriend_productization/evidence_requirements.md)
 - [CodeFriend skill and demo alignment](../../milestones/v0.91.2/review/codefriend_productization/skill_demo_alignment.md)
-- [ADR 0025 candidate](../../architecture/adr/0025-codefriend-review-packet-product-boundary.md)
+- [ADR 0025](../../adr/0025-codefriend-review-packet-product-boundary.md)
 - [ADL feature list](../ADL_FEATURE_LIST.md)
 
 Operator-provided local input used for this planning pass:


### PR DESCRIPTION
Closes #3277

## Summary
Promoted ADR 0020 through ADR 0028 from reviewed candidate records into the
accepted ADR home under `docs/adr/`. Updated candidate provenance, accepted ADR
indexes, supersession/refinement metadata, milestone ADR planning truth, and
CodeFriend references so reviewers land on accepted ADR records rather than
candidate-only paths.

## Artifacts
- Accepted ADR records:
  - `docs/adr/0020-universal-tool-schema-portable-tool-description-standard.md`
  - `docs/adr/0021-adl-capability-contract-runtime-authority-boundary.md`
  - `docs/adr/0022-speculative-decoding-deterministic-commit-boundary.md`
  - `docs/adr/0023-google-workspace-cms-bridge-canonical-promotion-boundary.md`
  - `docs/adr/0024-workflow-guardrails-issue-lifecycle-control-plane.md`
  - `docs/adr/0025-codefriend-review-packet-product-boundary.md`
  - `docs/adr/0026-repo-visibility-manifest-linkage-layer.md`
  - `docs/adr/0027-governed-code-modernization-moderne-openrewrite-lst.md`
  - `docs/adr/0028-c-sdlc-tracked-workflow-state-and-signed-trace.md`
- Updated ADR/provenance/index surfaces:
  - `docs/adr/README.md`
  - `docs/architecture/adr/README.md`
  - `docs/architecture/adr/CANDIDATE_ADRS.md`
  - `docs/architecture/ADL_ARCHITECTURE.md`
  - `docs/adr/0015-governed-tools-execution-authority-architecture.md`
  - `docs/adr/0018-structured-planning-and-review-policy-artifacts.md`
- Updated planning/reference surfaces:
  - `docs/milestones/v0.91.2/ADR_PLAN_v0.91.2.md`
  - `docs/milestones/v0.91.2/MILESTONE_CHECKLIST_v0.91.2.md`
  - `docs/milestones/v0.91.2/README.md`
  - `docs/milestones/v0.91.2/RELEASE_READINESS_v0.91.2.md`
  - `docs/planning/TBD_PLAN_ALLOCATION_v0.91.2_TO_v0.95.md`
  - `docs/planning/codefriend/CODEFRIEND_REFERENCE_INVENTORY.md`
  - `docs/planning/codefriend/CODEFRIEND_SETUP_PLAN.md`
  - `docs/planning/codefriend/README.md`

## Validation
- Validation commands and their purpose:
  - `git diff --check`
    Verified whitespace/diff hygiene.
  - `for n in 0020 0021 0022 0023 0024 0025 0026 0027 0028; do ls docs/adr/${n}-*.md >/dev/null || exit 1; done; echo 'PASS accepted ADR files 0020-0028 exist'`
    Verified accepted ADR file presence.
  - `rg -n "# ADR 002[0-8] Candidate:|- Status: Candidate|after acceptance|This candidate should be reviewed" docs/adr/002{0,1,2,3,4,5,6,7,8}-*.md && exit 1 || echo 'PASS no candidate-status residue in promoted ADR files'`
    Verified accepted ADR status/title cleanup.
  - `for n in 0020 0021 0022 0023 0024 0025 0026 0027 0028; do rg -q "${n}-" docs/adr/README.md || exit 1; done; echo 'PASS docs/adr/README lists ADR 0020-0028'`
    Verified accepted ADR index coverage.
  - Changed-link Python check.
    Verified edited Markdown links resolve.
  - Bounded subagent review.
    Verified ADR promotion truth; one stale architecture doc finding was fixed.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3277__v0-91-3-docs-promote-adr-0020-0028-to-accepted-records/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3277__v0-91-3-docs-promote-adr-0020-0028-to-accepted-records/sor.md
- Idempotency-Key: v0-91-3-docs-promote-adr-0020-0028-to-accepted-records-docs-adr-docs-architecture-adl-architecture-md-docs-architecture-adr-docs-milestones-v0-91-2-docs-planning-tbd-plan-allocation-v0-91-2-to-v0-95-md-docs-planning-codefriend-adl-v0-91-3-tasks-issue-3277-v0-91-3-docs-promote-adr-0020-0028-to-accepted-records-sip-md-adl-v0-91-3-tasks-issue-3277-v0-91-3-docs-promote-adr-0020-0028-to-accepted-records-sor-md