### PR TITLE
[v0.91.3][WP-15][tools] Refresh review entrypoints and provider CLI parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ cargo run -q --manifest-path adl/Cargo.toml --bin adl -- adl/examples/v0-91-chat
 
 These are three high-signal recent demo entrypoints.
 
+Start with the active v0.91.3 proof lane:
+
+- [v0.91.3 README](docs/milestones/v0.91.3/README.md)
+- [v0.91.3 sprint plan](docs/milestones/v0.91.3/SPRINT_v0.91.3.md)
+- [v0.91.3 demo matrix](docs/milestones/v0.91.3/DEMO_MATRIX_v0.91.3.md)
+
 Generate the v0.91 cognitive-being flagship proof bundle:
 
 ```bash

--- a/adl/src/cli/provider_cmd.rs
+++ b/adl/src/cli/provider_cmd.rs
@@ -34,7 +34,11 @@ fn real_provider_setup(repo_root: &Path, args: &[String]) -> Result<()> {
     while i < args.len() {
         match args[i].as_str() {
             "--out" => {
-                out_dir = Some(PathBuf::from(required_value(args, i, "--out")?));
+                let value = required_value(args, i, "--out")?;
+                if value.starts_with('-') {
+                    return Err(anyhow!("--out requires a value"));
+                }
+                out_dir = Some(PathBuf::from(value));
                 i += 1;
             }
             "--force" => force = true,
@@ -436,6 +440,30 @@ mod tests {
             &repo,
         )
         .expect_err("missing out value should fail");
+        assert!(err.to_string().contains("--out requires a value"));
+
+        let err = real_provider_in_repo(
+            &[
+                "setup".to_string(),
+                "chatgpt".to_string(),
+                "--out".to_string(),
+                "--force".to_string(),
+            ],
+            &repo,
+        )
+        .expect_err("flag-like out value should fail");
+        assert!(err.to_string().contains("--out requires a value"));
+
+        let err = real_provider_in_repo(
+            &[
+                "setup".to_string(),
+                "chatgpt".to_string(),
+                "--out".to_string(),
+                "-h".to_string(),
+            ],
+            &repo,
+        )
+        .expect_err("single-dash flag-like out value should fail");
         assert!(err.to_string().contains("--out requires a value"));
     }
 


### PR DESCRIPTION
Closes #3284

## Summary
Repaired the bounded WP-15 reviewer-entrypoint and provider CLI parsing
findings by foregrounding the active v0.91.3 proof lane in the root README and
making `provider setup --out` fail closed when the next token is missing or
flag-like.

## Artifacts
- `README.md`
- `adl/src/cli/provider_cmd.rs`
- updated worktree `spp.md`, `srp.md`, and `sor.md` for `#3284`

## Validation
- Validation commands and their purpose:
  - `cargo test -p adl provider_cmd`
    Verified the provider parser fix, including the new rejection cases for
    missing and flag-like `--out` values.
  - `git diff --check`
    Verified no whitespace or patch-format defects remain in the bounded diff.
- Results:
  - PASS

Validation command/path rules:
- Prefer repository-relative paths in recorded commands and artifact references.
- Do not record absolute host paths in output records unless they are explicitly required and justified.
- `absolute_path_leakage_detected: false` means the final recorded artifact does not contain unjustified absolute host paths.
- Do not list commands without describing their effect.

## Local Artifacts
- Input card:  .adl/v0.91.3/tasks/issue-3284__v0-91-3-wp-15-tools-refresh-review-entrypoints-and-provider-cli-parsing/sip.md
- Output card: .adl/v0.91.3/tasks/issue-3284__v0-91-3-wp-15-tools-refresh-review-entrypoints-and-provider-cli-parsing/sor.md
- Idempotency-Key: v0-91-3-wp-15-tools-refresh-review-entrypoints-and-provider-cli-parsing-adl-v0-91-3-tasks-issue-3284-v0-91-3-wp-15-tools-refresh-review-entrypoints-and-provider-cli-parsing-sip-md-adl-v0-91-3-tasks-issue-3284-v0-91-3-wp-15-tools-refresh-review-entrypoints-and-provider-cli-parsing-sor-md