### PR TITLE
[v0.91.3][tools] Add versioned project planning templates

### DIFF
--- a/adl/tools/validate_planning_template.py
+++ b/adl/tools/validate_planning_template.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Validate filled ADL planning-template documents.
+
+This validator intentionally proves only structural readiness:
+- registry parses
+- selected template exists and is active
+- required sections are present
+- unresolved placeholders are absent
+
+It does not prove review, approval, release, PR, or closeout truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ANGLE_PLACEHOLDER = re.compile(r"<[A-Za-z][A-Za-z0-9_]*>")
+CURLY_PLACEHOLDER = re.compile(r"\{\{[A-Za-z][A-Za-z0-9_]*\}\}")
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"registry not found: {path}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"registry JSON is invalid: {path}: {exc}")
+    if data.get("schema") != "adl.planning_template_registry.v1":
+        raise SystemExit(f"unsupported registry schema: {data.get('schema')!r}")
+    return data
+
+
+def validate_required_sections(text: str, required_sections: list[str]) -> list[str]:
+    missing: list[str] = []
+    for section in required_sections:
+        pattern = re.compile(rf"^#+\s+{re.escape(section)}\s*$", re.MULTILINE)
+        if not pattern.search(text):
+            missing.append(section)
+    return missing
+
+
+def validate_document(registry: dict[str, Any], template_key: str, input_path: Path) -> int:
+    templates = registry.get("templates", {})
+    template = templates.get(template_key)
+    if not isinstance(template, dict):
+        print(f"unknown template key: {template_key}", file=sys.stderr)
+        return 2
+    if template.get("status") != "active":
+        print(f"template is not active: {template_key}", file=sys.stderr)
+        return 2
+
+    template_path_value = template.get("path")
+    if not isinstance(template_path_value, str):
+        print(f"template path is missing or invalid: {template_key}", file=sys.stderr)
+        return 2
+    template_path = Path(template_path_value)
+    template_root = str(registry.get("template_root", ""))
+    if template_root and not template_path_value.startswith(template_root):
+        print(
+            f"template path is outside active template root: {template_path_value}",
+            file=sys.stderr,
+        )
+        return 2
+    if not template_path.exists():
+        print(f"registered template file does not exist: {template_path}", file=sys.stderr)
+        return 2
+    if template.get("version") != registry.get("planning_template_set"):
+        print(
+            f"template version does not match registry set: {template_key}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        text = input_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"input not found: {input_path}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    unresolved = sorted(set(ANGLE_PLACEHOLDER.findall(text) + CURLY_PLACEHOLDER.findall(text)))
+    if unresolved:
+        failures.append("unresolved placeholders: " + ", ".join(unresolved))
+
+    required_sections = template.get("required_sections", [])
+    if not isinstance(required_sections, list):
+        failures.append(f"registry required_sections is not a list for {template_key}")
+    else:
+        missing = validate_required_sections(text, [str(item) for item in required_sections])
+        if missing:
+            failures.append("missing required sections: " + ", ".join(missing))
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "status": "PASS",
+                "template": template_key,
+                "input": str(input_path),
+                "registry_template_set": registry.get("planning_template_set"),
+                "claim_boundary": "structural validation only; not review or approval",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", default="docs/templates/planning/current.json")
+    parser.add_argument("--template", required=True)
+    parser.add_argument("--input", required=True)
+    args = parser.parse_args()
+
+    registry = load_registry(Path(args.registry))
+    return validate_document(registry, args.template, Path(args.input))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/templates/planning/1.0.0/decisions.md
+++ b/docs/templates/planning/1.0.0/decisions.md
@@ -1,0 +1,30 @@
+# Decisions Template
+
+## Metadata
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Date: `<date>`
+- Owner: `<owner>`
+
+## Purpose
+Capture significant decisions (architecture, scope, process) at the time they are made.
+
+## How To Use
+- Add one row per decision.
+- Prefer links to issues/PRs over long prose.
+- Keep status current: `accepted`, `rejected`, `deferred`, `superseded`.
+
+## Decision Log
+| ID | Decision | Status | Rationale | Alternatives | Impact | Link |
+|---|---|---|---|---|---|---|
+| D-01 | <decision_1> | <status_1> | <rationale_1> | <alternatives_1> | <impact_1> | <link_1> |
+| D-02 | <decision_2> | <status_2> | <rationale_2> | <alternatives_2> | <impact_2> | <link_2> |
+
+## Open Questions
+- <open_question_1> (Owner: <owner_oq1>) (Issue: <issue_oq1>)
+- <open_question_2> (Owner: <owner_oq2>) (Issue: <issue_oq2>)
+
+## Exit Criteria
+- All milestone-critical decisions are logged with a rationale.
+- Deferred/rejected/superseded options are explicitly recorded.
+- Open questions have owners and tracking links.

--- a/docs/templates/planning/1.0.0/demo_matrix.md
+++ b/docs/templates/planning/1.0.0/demo_matrix.md
@@ -1,0 +1,255 @@
+# Demo Matrix Template
+
+## Metadata
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Date: `<date>`
+- Owner: `<owner>`
+- Related issues / work packages: <issues_or_wps>
+
+## Purpose
+Define the canonical milestone demo program: which bounded demos exist, which milestone claims they prove, how to run them, and what artifacts or proof surfaces reviewers should inspect.
+
+## How To Use
+- Use this document for runnable milestone evidence, not for broad feature brainstorming.
+- Keep demo rows and per-demo sections aligned so a reviewer can move from summary -> execution -> proof surface without reconstructing context by hand.
+- Prefer bounded, replayable, copy/paste-friendly commands over aspirational demo descriptions.
+- If a milestone claim cannot yet be shown through a runnable demo, say so explicitly and record the substitute proof surface.
+- Keep names stable across milestones where practical so comparisons remain easy.
+- If a section is not relevant, include a one-line rationale instead of deleting it.
+
+## Scope
+
+In scope for `<milestone>`:
+- <in_scope_demo_area_1>
+- <in_scope_demo_area_2>
+- <in_scope_demo_area_3>
+
+Out of scope for `<milestone>`:
+- <out_of_scope_demo_area_1>
+- <out_of_scope_demo_area_2>
+
+## Runtime Preconditions
+
+Working directory:
+
+```bash
+<working_directory_command>
+```
+
+Deterministic runtime / provider assumptions:
+
+```bash
+<runtime_preconditions>
+```
+
+Additional environment / fixture requirements:
+- <env_requirement_1>
+- <env_requirement_2>
+
+## Related Docs
+- Design contract: `<design_doc>`
+- WBS / milestone mapping: `<wbs_doc>`
+- Sprint / execution plan: `<sprint_doc>`
+- Release / checklist context: `<release_or_checklist_doc>`
+- Other proof-surface docs: <other_related_docs>
+
+## Demo Coverage Summary
+
+Use this table as the fast review surface for milestone coverage.
+
+| Demo ID | Demo title | Milestone claim / WP proved | Command entry point | Primary proof surface | Success signal | Determinism / replay note | Status |
+|---|---|---|---|---|---|---|---|
+| D1 | <demo_title_1> | <claim_or_wp_1> | `<command_stub_1>` | `<proof_surface_1>` | <success_signal_1> | <determinism_note_1> | <status_1> |
+| D2 | <demo_title_2> | <claim_or_wp_2> | `<command_stub_2>` | `<proof_surface_2>` | <success_signal_2> | <determinism_note_2> | <status_2> |
+| D3 | <demo_title_3> | <claim_or_wp_3> | `<command_stub_3>` | `<proof_surface_3>` | <success_signal_3> | <determinism_note_3> | <status_3> |
+
+Status guidance:
+- `PLANNED` = intended but not yet validated
+- `READY` = runnable and locally validated
+- `BLOCKED` = known dependency or missing proof surface
+- `LANDED` = milestone evidence exists and is ready for review
+
+## Coverage Rules
+- Every major milestone claim should map to a runnable demo or an explicit alternate proof surface.
+- Every demo should name one primary proof surface that a reviewer can inspect directly.
+- Commands should be copy/paste-ready and should not require private local state.
+- Success signals should say what to check, not just “command exits 0”.
+- Determinism / replay notes should explain how stability is judged.
+
+## Demo Details
+
+Repeat one block per demo in the coverage summary.
+
+### <demo_id_1>) <demo_title_1>
+
+Description:
+- <demo_description_1>
+- <demo_description_1b>
+
+Milestone claims / work packages covered:
+- <claim_detail_1a>
+- <claim_detail_1b>
+
+Commands to run:
+
+```bash
+<demo_commands_1>
+```
+
+Expected artifacts:
+- `<artifact_1a>`
+- `<artifact_1b>`
+- `<artifact_1c>`
+
+Primary proof surface:
+- `<primary_proof_surface_1>`
+
+Secondary proof surfaces:
+- `<secondary_proof_surface_1a>`
+- `<secondary_proof_surface_1b>`
+
+Expected success signals:
+- <success_detail_1a>
+- <success_detail_1b>
+
+Determinism / replay notes:
+- <determinism_detail_1a>
+- <determinism_detail_1b>
+
+Reviewer checks:
+- <reviewer_check_1a>
+- <reviewer_check_1b>
+
+Known limits / caveats:
+- <caveat_1>
+
+---
+
+### <demo_id_2>) <demo_title_2>
+
+Description:
+- <demo_description_2>
+
+Milestone claims / work packages covered:
+- <claim_detail_2a>
+
+Commands to run:
+
+```bash
+<demo_commands_2>
+```
+
+Expected artifacts:
+- `<artifact_2a>`
+- `<artifact_2b>`
+
+Primary proof surface:
+- `<primary_proof_surface_2>`
+
+Expected success signals:
+- <success_detail_2a>
+
+Determinism / replay notes:
+- <determinism_detail_2a>
+
+Reviewer checks:
+- <reviewer_check_2a>
+
+Known limits / caveats:
+- <caveat_2>
+
+---
+
+### <demo_id_3>) <demo_title_3>
+
+Description:
+- <demo_description_3>
+
+Milestone claims / work packages covered:
+- <claim_detail_3a>
+
+Commands to run:
+
+```bash
+<demo_commands_3>
+```
+
+Expected artifacts:
+- `<artifact_3a>`
+
+Primary proof surface:
+- `<primary_proof_surface_3>`
+
+Expected success signals:
+- <success_detail_3a>
+
+Determinism / replay notes:
+- <determinism_detail_3a>
+
+Reviewer checks:
+- <reviewer_check_3a>
+
+Known limits / caveats:
+- <caveat_3>
+
+## Cross-Demo Validation
+
+Required baseline validation:
+
+```bash
+<baseline_validation_commands>
+```
+
+Cross-demo checks:
+- <cross_demo_check_1>
+- <cross_demo_check_2>
+- <cross_demo_check_3>
+
+Failure policy:
+- If one demo is blocked, record the blocker and say whether milestone review can proceed with an alternate proof surface.
+- If deterministic behavior is expected but not observed, record the exact unstable artifact or command output.
+
+## Determinism Evidence
+
+Evidence directory / run root:
+- `<evidence_root>`
+
+Repeatability approach:
+- <repeatability_rule_1>
+- <repeatability_rule_2>
+
+Normalization rules:
+- <normalization_rule_1>
+- <normalization_rule_2>
+
+Observed results summary:
+- <determinism_result_1>
+- <determinism_result_2>
+- <determinism_result_3>
+
+## Reviewer Sign-Off Surface
+
+For each demo, the reviewer should be able to answer:
+- What milestone claim does this demo prove?
+- Which command should be run first?
+- Which artifact or trace is the primary proof surface?
+- What deterministic or replay guarantee is being claimed?
+- What caveats or substitutions apply?
+
+Review owners:
+- <review_owner_1>
+- <review_owner_2>
+
+Review status:
+- <review_status_note>
+
+## Notes
+- <note_1>
+- <note_2>
+
+## Exit Criteria
+- The milestone’s major claims are mapped to bounded demos or explicit alternate proof surfaces.
+- Each demo has runnable commands, expected artifacts, and a clear success signal.
+- Determinism / replay expectations are explicit where required.
+- A reviewer can inspect the matrix and locate the primary proof surface for each demo without extra reconstruction work.

--- a/docs/templates/planning/1.0.0/design.md
+++ b/docs/templates/planning/1.0.0/design.md
@@ -1,0 +1,74 @@
+# Design Template
+
+## Metadata
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Date: `<date>`
+- Owner: `<owner>`
+- Related issues: <issues>
+
+## Purpose
+Define what we are building, why, and how we validate it — concisely, with links to issues/PRs.
+
+## Problem Statement
+<problem_statement>
+
+## Goals
+- <goal_1>
+- <goal_2>
+
+## Non-Goals
+- <non_goal_1>
+- <non_goal_2>
+
+## Scope
+### In scope
+- <in_scope_1>
+- <in_scope_2>
+
+### Out of scope
+- <out_of_scope_1>
+- <out_of_scope_2>
+
+## Requirements
+### Functional
+- <functional_requirement_1>
+- <functional_requirement_2>
+
+### Non-functional
+- Deterministic behavior and reproducible outputs.
+- Clear failure semantics and observability.
+- <non_functional_requirement_1>
+
+## Proposed Design
+### Overview
+<architecture_summary>
+
+### Interfaces / Data contracts
+- <interface_or_contract_1>
+- <interface_or_contract_2>
+
+### Execution semantics
+<execution_semantics>
+
+## Risks and Mitigations
+- Risk: <risk_1>
+  - Mitigation: <mitigation_1>
+- Risk: <risk_2>
+  - Mitigation: <mitigation_2>
+
+## Alternatives Considered
+- Option: <alternative_1>
+  - Tradeoff: <tradeoff_1>
+- Option: <alternative_2>
+  - Tradeoff: <tradeoff_2>
+
+## Validation Plan
+- Checks/tests: <validation_checks>
+- Success metrics: <success_metrics>
+- Rollback/fallback: <rollback_plan>
+
+## Exit Criteria
+- Goals/non-goals and scope boundaries are explicit.
+- Validation plan is actionable and referenced by the milestone checklist.
+- Major open questions are resolved or tracked in the decision log.

--- a/docs/templates/planning/1.0.0/feature_doc.md
+++ b/docs/templates/planning/1.0.0/feature_doc.md
@@ -1,0 +1,146 @@
+# Feature Document Template
+
+## Metadata
+- Feature Name: `<feature_name>`
+- Milestone Target: `<milestone>`
+- Status: `<status>` (draft | planned | in-progress | complete)
+- Owner: `<owner>`
+- Doc Role: `<doc_role>` (primary | supporting)
+- Supporting Docs: `<supporting_docs>` (list of related feature docs)
+- Feature Types: `<feature_types>` (list: runtime | artifact | policy | architecture)
+- Proof Modes: `<proof_modes>` (list: demo | tests | schema | replay | review)
+
+## Template Rules
+
+- Every section must be completed or explicitly marked `N/A` with a brief justification.
+- Sections such as Execution Flow, Demo, Tests, or Schema Validation may be `N/A` for non-runtime or non-artifact features, but must state why.
+
+## Purpose
+
+Describe what this feature is, why it exists, and what problem it solves.
+
+## Context
+
+- Related milestone: `<milestone>`
+- Related issues: `<issues>`
+- Dependencies: `<dependencies>`
+
+Explain how this feature fits into the broader ADL architecture and roadmap.
+
+## Coverage / Ownership
+
+Describe how this document participates in the coverage model.
+
+- Primary owner doc: <primary_owner_doc>
+- Covered surfaces:
+  - <surface_1>
+  - <surface_2>
+- Related / supporting docs:
+  - <supporting_doc_1>
+
+## Overview
+
+Provide a concise description of the feature’s behavior and responsibilities.
+
+Key capabilities:
+- <capability_1>
+- <capability_2>
+- <capability_3>
+
+## Design
+
+### Core Concepts
+
+Describe the main concepts, abstractions, or entities introduced by this feature.
+
+- <concept_1>
+- <concept_2>
+
+### Architecture
+
+Explain how the feature is structured and how it integrates with existing systems.
+
+- Inputs (explicit sources / triggers):
+  - <input_1>
+- Outputs (artifacts / side effects):
+  - <output_1>
+- Interfaces (APIs, CLI, files, schemas):
+  - <interface_1>
+- Invariants (must always hold):
+  - <invariant_1>
+
+### Data / Artifacts
+
+Describe any artifacts, schemas, or persistent data structures.
+
+- <artifact_1>
+- <artifact_2>
+
+## Execution Flow
+
+If this is a runtime or artifact-bearing feature, describe the execution flow. If not, state "N/A" and explain why.
+
+1. <step_1>
+2. <step_2>
+3. <step_3>
+
+## Determinism and Constraints
+
+- Determinism guarantees (what must be repeatable and how):
+  - <determinism_1>
+- Constraints (performance, ordering, limits):
+  - <constraint_1>
+
+## Integration Points
+
+List integrations generically; include only what applies.
+
+| System / Surface | Integration Type | Description |
+| --- | --- | --- |
+| <system_1> | <type> (read/write/trigger/observe) | <description> |
+| <system_2> | <type> | <description> |
+
+Common systems (use if applicable): Gödel, AEE, ObsMem, Identity, Governance, Trace, Authoring, Providers.
+
+## Validation
+
+Describe all validation modes required for this feature. Not all features require demos.
+
+### Demo (if applicable)
+- Demo script(s): <demo_script>
+- Expected behavior: <expected_behavior>
+
+### Deterministic / Replay
+- Replay requirements: <replay_requirements>
+- Determinism guarantees: <determinism_1>
+
+### Schema / Artifact Validation
+- Schemas involved: <schema_1>
+- Artifact checks: <artifact_check_1>
+
+### Tests
+- Test surfaces: <test_surface_1>
+
+### Review / Proof Surface
+- Review method (manual/automated): <review_method>
+- Evidence location: <proof_surface>
+
+## Acceptance Criteria
+
+- Functional correctness (what must work): <criteria_1>
+- Determinism / replay correctness: <criteria_2>
+- Validation completeness (tests/schema/demo/review as applicable): <criteria_3>
+
+## Risks
+
+- Primary risks (failure modes): <risk_1>
+- Mitigations: <mitigation_1>
+
+## Future Work
+
+- Follow-ups / extensions: <future_1>
+- Known gaps / deferrals: <future_2>
+
+## Notes
+
+Additional notes, assumptions, or references.

--- a/docs/templates/planning/1.0.0/milestone_checklist.md
+++ b/docs/templates/planning/1.0.0/milestone_checklist.md
@@ -1,0 +1,52 @@
+# Milestone Checklist Template
+
+## Metadata
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Target release date: `<target_release_date>`
+- Owner: `<owner>`
+
+## Purpose
+Ship/no-ship gate for the milestone. Check items only when evidence exists.
+
+## Planning
+- [ ] Milestone goal defined (`<goal_doc_link>`)
+- [ ] Scope + non-goals documented (`<scope_doc_link>`)
+- [ ] WBS created and mapped to issues (`<wbs_link>`)
+- [ ] Decision log initialized (`<decisions_link>`)
+- [ ] Sprint plan created (`<sprint_plan_link>`)
+
+## Execution Discipline
+- [ ] New issue bundles use the target lifecycle
+  `SIP -> STP -> SPP -> SRP -> SOR`, or legacy compatibility exceptions are
+  explicitly documented
+- [ ] Each burst writes artifacts under `.adl/reports/burst/<timestamp>/`
+- [ ] Draft PR opened for each issue before merge
+- [ ] Transient failures retried and documented
+- [ ] "Green-only merge" policy followed
+
+## Quality Gates
+- [ ] `cargo fmt` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo test` passes
+- [ ] CI is green on the merge target
+- [ ] Coverage signal is not red (or exception documented) (`<coverage_link_or_note>`)
+- [ ] No unresolved high-priority blockers (`<blocker_report_link>`)
+
+## Release Packaging
+- [ ] Release notes finalized (`<release_notes_link>`)
+- [ ] Tag verified: `<tag_name>`
+- [ ] GitHub Release drafted (`<release_draft_link>`)
+- [ ] Links validated in release body
+- [ ] Release published
+
+## Post-Release
+- [ ] Milestone/epic issues closed with release links
+- [ ] Deferred items moved to next milestone backlog
+- [ ] Follow-up bugs/tech debt captured as issues
+- [ ] Roadmap/status docs updated (`<roadmap_update_link>`)
+- [ ] Retrospective summary recorded (`<retro_link>`)
+
+## Exit Criteria
+- All required gates are checked, or each exception has an owner + due date.
+- Milestone can be audited end-to-end via the links captured above.

--- a/docs/templates/planning/1.0.0/readme.md
+++ b/docs/templates/planning/1.0.0/readme.md
@@ -1,0 +1,133 @@
+
+
+# Milestone README Template
+
+## Metadata
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Date: `<date>`
+- Owner: `<owner>`
+
+## Purpose
+Provide a single entry point for the milestone: what it is, why it matters, what is included, and how to navigate the canonical documents and artifacts.
+
+## How To Use
+- Start here before reading individual milestone documents.
+- Use this README to locate the canonical design, execution, and validation surfaces.
+- Keep this document concise and navigational; detailed content belongs in the linked docs.
+- Keep links up to date as files move or are renamed.
+
+## Overview
+
+`<milestone>` represents the stage where `<project_name>` moves from `<previous_state>` to `<target_state>`.
+
+This milestone focuses on:
+- <focus_1>
+- <focus_2>
+- <focus_3>
+
+Key outcomes:
+- <outcome_1>
+- <outcome_2>
+- <outcome_3>
+
+## Scope Summary
+
+### In scope
+- <in_scope_1>
+- <in_scope_2>
+- <in_scope_3>
+
+### Out of scope
+- <out_of_scope_1>
+- <out_of_scope_2>
+
+## Document Map
+
+Canonical milestone documents:
+
+- Vision: `<vision_doc>`
+- Design: `<design_doc>`
+- Work Breakdown Structure (WBS): `<wbs_doc>`
+- Sprint plan: `<sprint_doc>`
+- Decisions log: `<decisions_doc>`
+- Demo matrix: `<demo_matrix_doc>`
+- Milestone checklist: `<checklist_doc>`
+- Release plan / process: `<release_process_doc>`
+- Release notes: `<release_notes_doc>`
+
+Supporting / domain-specific docs:
+- <supporting_doc_1>
+- <supporting_doc_2>
+- <supporting_doc_3>
+
+## Execution Model
+
+This milestone is executed as a sequence of work packages (WPs):
+
+- WP-01: Design pass (docs + planning)
+- WP-02 – WP-12: Feature and system work
+- WP-13: Demo matrix and integration demos
+- WP-14: Coverage / quality gate
+- WP-15: Docs and review convergence
+- WP-16: Release ceremony
+
+Execution expectations:
+- Each WP is tracked by an issue and implemented via PRs.
+- Each issue follows the structured card lifecycle
+  `SIP -> STP -> SPP -> SRP -> SOR`, plus any required reports.
+- All work merges under green CI and passes quality gates.
+
+## Demo and Validation Surface
+
+Primary validation is defined in:
+- Demo matrix: `<demo_matrix_doc>`
+
+Additional validation surfaces:
+- Test suite results
+- Generated artifacts under `.adl/runs/`
+- Trace and replay outputs
+
+Success criteria:
+- <success_criteria_1>
+- <success_criteria_2>
+- <success_criteria_3>
+
+## Determinism and Reproducibility
+
+The milestone should demonstrate:
+- Deterministic or bounded-repeatable execution where required
+- Replayable traces and inspectable artifacts
+- Stable command entry points for demos
+
+Evidence locations:
+- <determinism_evidence_path_1>
+- <determinism_evidence_path_2>
+
+## Risks and Open Questions
+
+Known risks:
+- <risk_1>
+- <risk_2>
+
+Open questions:
+- <open_question_1>
+- <open_question_2>
+
+## Status
+
+Current status: <status>
+
+- Planning: <planning_status>
+- Execution: <execution_status>
+- Validation: <validation_status>
+- Release readiness: <release_status>
+
+## Exit Criteria
+
+- All canonical milestone documents are complete and internally consistent.
+- All WBS items are implemented or explicitly deferred.
+- Demo matrix is runnable and validated.
+- Quality gates (fmt, clippy, test, CI) are passing.
+- Milestone checklist is complete or exceptions are documented.
+- Release artifacts (notes, tag, docs) are ready.

--- a/docs/templates/planning/1.0.0/release_notes.md
+++ b/docs/templates/planning/1.0.0/release_notes.md
@@ -1,0 +1,57 @@
+# Release Notes Template
+
+## Metadata
+- Product: `<product_name>`
+- Version: `<version>`
+- Release date: `<release_date>`
+- Tag: `<tag_name>`
+
+## How To Use
+- Keep statements implementation-accurate and test-validated.
+- Prefer concise bullets over marketing language.
+- Explicitly separate shipped behavior from "What's Next."
+
+# `<product_name>` `<version>` Release Notes
+
+## Summary
+<summary_paragraph>
+
+## Highlights
+- <highlight_1>
+- <highlight_2>
+- <highlight_3>
+
+## What's New In Detail
+
+### <area_1>
+- <detail_1a>
+- <detail_1b>
+
+### <area_2>
+- <detail_2a>
+- <detail_2b>
+
+### <area_3>
+- <detail_3a>
+- <detail_3b>
+
+## Upgrade Notes
+- <upgrade_note_1>
+- <upgrade_note_2>
+
+## Known Limitations
+- <limitation_1>
+- <limitation_2>
+
+## Validation Notes
+- <validation_note_1>
+- <validation_note_2>
+
+## What's Next
+- <next_1>
+- <next_2>
+
+## Exit Criteria
+- Notes reflect only shipped behavior.
+- Known limitations and future work are explicitly separated.
+- Final text is ready to paste into GitHub Release UI without further editing.

--- a/docs/templates/planning/1.0.0/release_plan.md
+++ b/docs/templates/planning/1.0.0/release_plan.md
@@ -1,0 +1,71 @@
+# Release Process Template
+
+## Metadata
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Release date: `<release_date>`
+- Release manager: `<release_manager>`
+
+## How To Use
+- Execute sections in order and capture links for each completed step.
+- Keep this doc focused on shipping mechanics; use release notes for narrative.
+- Mark blockers immediately; do not publish until gates pass.
+- Ceremony is a confirmation and publication phase, not a hidden implementation
+  phase.
+
+## 0) Release-Tail Convergence
+- [ ] Live trackers refreshed and reflected honestly:
+  - coverage/test tracker
+  - Rust module watch / refactoring tracker
+  - any active milestone-specific gap/risk tracker
+- [ ] Gap analysis refreshed or explicitly confirmed still current
+- [ ] Closed-issue closeout pass refreshed so issue/card truth is not stale
+  - capture a merged-needs-closeout visibility report before apply mode when useful
+- [ ] Release-truth docs aligned:
+  - `README.md`
+  - `CHANGELOG.md`
+  - `Cargo.toml`
+  - `REVIEW.md`
+  - feature list
+  - milestone checklist
+  - release plan
+  - release notes
+- [ ] Review artifacts collected and review disposition reflected truthfully
+- [ ] End-of-milestone report written or refreshed (`<end_of_milestone_report_link>`)
+- [ ] Next-milestone handoff prepared before ceremony starts
+- [ ] Any remaining work is either landed, explicitly deferred, or routed
+
+## 1) Release Readiness
+- [ ] Milestone checklist complete (`<milestone_checklist_link>`)
+- [ ] Release notes approved (`<release_notes_link>`)
+- [ ] Go/no-go decision recorded (`<decision_link>`)
+
+## 2) Branch And Tag Preparation
+- [ ] Target branch confirmed (`<target_branch>`)
+- [ ] Working tree clean
+- [ ] Version string(s) validated (`<version_validation_link>`)
+- [ ] Tag created: `<tag_name>`
+- [ ] Tag pushed and verified
+
+## 3) GitHub Release Steps
+- [ ] GitHub Release draft created from `<tag_name>` (`<release_draft_link>`)
+- [ ] Release body populated from approved notes
+- [ ] Links to key PRs/issues included
+- [ ] Release visibility confirmed (draft/prerelease/final)
+- [ ] Release published
+
+## 4) Verification
+- [ ] Post-release CI status checked (`<ci_run_link>`)
+- [ ] Release links tested (docs, artifacts, notes)
+- [ ] Immediate regressions triaged and tracked (`<triage_link>`)
+
+## 5) Communication
+- [ ] Community announcement published (`<announcement_link>`)
+- [ ] Internal update posted (`<internal_update_link>`)
+- [ ] Roadmap/status updated (`<roadmap_update_link>`)
+
+## Exit Criteria
+- No hidden implementation or unresolved truth-maintenance work remains in the ceremony phase.
+- Tag and GitHub Release are published and accessible.
+- Verification completed with no unknown critical failures.
+- Communication links captured.

--- a/docs/templates/planning/1.0.0/sprint.md
+++ b/docs/templates/planning/1.0.0/sprint.md
@@ -1,0 +1,49 @@
+# Sprint Template
+
+## Metadata
+- Sprint: `<sprint_id>`
+- Milestone: `<milestone>`
+- Start date: `<start_date>`
+- End date: `<end_date>`
+- Owner: `<owner>`
+
+## How To Use
+- Keep scope small enough to finish with green CI and merged PRs.
+- List work items in planned execution order.
+- Track blockers here (not scattered chat notes).
+
+## Sprint Goal
+<sprint_goal>
+
+## Planned Scope
+- <scope_item_1>
+- <scope_item_2>
+- <scope_item_3>
+
+## Work Plan
+| Order | Item | Issue | Owner | Status |
+|---|---|---|---|---|
+| 1 | <work_item_1> | <issue_1> | <owner_1> | <status_1> |
+| 2 | <work_item_2> | <issue_2> | <owner_2> | <status_2> |
+| 3 | <work_item_3> | <issue_3> | <owner_3> | <status_3> |
+
+## Cadence Expectations
+- Use issue cards (`input`/`output`) for each item.
+- Keep changes scoped per issue; use draft PRs until checks pass.
+- Run required quality gates (fmt/clippy/test) for code changes.
+
+## Risks / Dependencies
+- Dependency: <dependency_1>
+  - Risk: <risk_1>
+  - Mitigation: <mitigation_1>
+
+## Demo / Review Plan
+- Demo artifact: <demo_artifact>
+- Review date: <review_date>
+- Sign-off owners: <signoff_owners>
+
+## Exit Criteria
+- All planned scope items completed or explicitly deferred with rationale.
+- Linked issues/PRs updated and traceable.
+- CI is green for merged work.
+- Sprint summary captured in milestone docs.

--- a/docs/templates/planning/1.0.0/vision.md
+++ b/docs/templates/planning/1.0.0/vision.md
@@ -1,0 +1,242 @@
+# Vision Template
+
+## Metadata
+- Project: `<project_name>`
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Date: `<date>`
+- Owner: `<owner>`
+- Related issues: <issues>
+
+## Purpose
+Define the milestone-level vision for the project: what changes at this stage, why it matters, and which strategic pillars it advances.
+
+## How To Use
+- Write this as a milestone vision, not a full design spec.
+- Focus on direction, priorities, and intended outcomes rather than implementation details.
+- Keep the structure stable across milestones so changes in emphasis are easy to compare over time.
+- Prefer concrete milestone framing over vague aspiration.
+- Keep section titles stable unless there is a strong reason to change them.
+- If a section is not relevant, state that briefly rather than deleting the section.
+
+## Overview
+
+Version `<version>` is the milestone where `<project_name>` evolves from `<previous_state>` into `<target_state>`.
+
+This release should establish or strengthen the foundation for:
+
+- <foundation_1>
+- <foundation_2>
+- <foundation_3>
+
+`<version>` focuses on **<primary_focus>**.
+
+The goal is to make the project more useful to:
+
+- <audience_1>
+- <audience_2>
+- <audience_3>
+
+This milestone should strengthen the architectural or strategic pillars of:
+
+- <pillar_1>
+- <pillar_2>
+- <pillar_3>
+- <pillar_4>
+
+<overview_close>
+
+---
+
+# Core Goals
+
+`<version>` advances `<project_name>` in five major areas:
+
+1. <goal_area_1>
+2. <goal_area_2>
+3. <goal_area_3>
+4. <goal_area_4>
+5. <goal_area_5>
+
+---
+
+# 1. <goal_area_1>
+
+`<version>` improves `<goal_area_1>` so the project can `<outcome_1>`.
+
+Key objectives:
+
+- <objective_1a>
+- <objective_1b>
+- <objective_1c>
+- <objective_1d>
+
+These capabilities move the project toward **<strategic_effect_1>**.
+
+The system or product should guarantee:
+
+- <guarantee_1a>
+- <guarantee_1b>
+- <guarantee_1c>
+
+---
+
+# 2. <goal_area_2>
+
+`<goal_area_2>` must improve without sacrificing `<constraint_2>`.
+
+`<version>` introduces or improves:
+
+- <improvement_2a>
+- <improvement_2b>
+- <improvement_2c>
+- <improvement_2d>
+
+The goal is to move from `<before_state_2>` toward **<after_state_2>**.
+
+These changes should help users:
+
+- <user_benefit_2a>
+- <user_benefit_2b>
+
+---
+
+# 3. <goal_area_3>
+
+A central principle of `<project_name>` is **<principle_3>**.
+
+The project must not merely `<anti_goal_3>`. It must `<desired_behavior_3>`.
+
+`<version>` strengthens this pillar with:
+
+- <capability_3a>
+- <capability_3b>
+- <capability_3c>
+- <capability_3d>
+
+This work supports the broader principle of **<broader_principle_3>**.
+
+The result should make the project more:
+
+- <quality_3a>
+- <quality_3b>
+- <quality_3c>
+
+---
+
+# 4. <goal_area_4>
+
+`<version>` continues development of `<goal_area_4>`.
+
+The focus remains on **<focus_4>**, not `<non_goal_4>`.
+
+Key capabilities:
+
+- <capability_4a>
+- <capability_4b>
+- <capability_4c>
+- <capability_4d>
+
+This milestone should help the project better represent or support:
+
+- <support_4a>
+- <support_4b>
+- <support_4c>
+
+These improvements should guide the system toward `<desired_state_4>`.
+
+---
+
+# 5. <goal_area_5>
+
+To support real-world use, `<version>` must improve `<goal_area_5>`.
+
+Important targets include:
+
+- <target_5a>
+- <target_5b>
+- <target_5c>
+- <target_5d>
+
+This work should strengthen the development and operating workflow by improving:
+
+- <workflow_benefit_5a>
+- <workflow_benefit_5b>
+- <workflow_benefit_5c>
+
+<close_5>
+
+---
+
+# Special Focus: `<special_focus_title>`
+
+`<special_focus_title>` becomes a central focus of `<version>`.
+
+Previous releases `<previous_special_focus_state>`.
+
+`<version>` advances this area with:
+
+- <special_focus_1>
+- <special_focus_2>
+- <special_focus_3>
+- <special_focus_4>
+
+This area is responsible for ensuring that `<special_focus_scope>` remain:
+
+- <special_quality_1>
+- <special_quality_2>
+- <special_quality_3>
+
+This keeps the project aligned with `<alignment_principle>`.
+
+---
+
+# Milestone Context
+
+`<previous_milestone>` represents `<previous_milestone_significance>`.
+
+From `<next_phase_start>` onward the project will likely shift toward:
+
+- <next_phase_item_1>
+- <next_phase_item_2>
+- <next_phase_item_3>
+
+The goal is to have `<future_goal>` by **<future_target_milestone>**.
+
+`<version>` therefore focuses on `<contextual_focus>` before that stage.
+
+---
+
+# Long-Term Direction
+
+`<project_name>` is being designed as `<long_term_identity>`.
+
+Its long-term goals include:
+
+- <long_term_goal_1>
+- <long_term_goal_2>
+- <long_term_goal_3>
+- <long_term_goal_4>
+
+These principles aim to move the project beyond `<old_mode>` toward `<new_mode>`.
+
+---
+
+# Summary
+
+`<version>` is the milestone where `<project_name>` becomes:
+
+- <summary_quality_1>
+- <summary_quality_2>
+- <summary_quality_3>
+- <summary_quality_4>
+
+It strengthens `<summary_strength_1>`, advances `<summary_strength_2>`, improves `<summary_strength_3>`, and stabilizes `<summary_strength_4>`.
+
+These improvements prepare the project for `<next_stage>`.
+
+## Exit Criteria
+- The milestone's strategic priorities are explicit and internally consistent.
+- The five core goal areas and special focus section are filled with milestone-specific content.
+- The vision can be read without requiring implementation details from the design document.
+- The long-term direction clearly connects this milestone to the next phase of the roadmap.

--- a/docs/templates/planning/1.0.0/wbs.md
+++ b/docs/templates/planning/1.0.0/wbs.md
@@ -1,0 +1,65 @@
+# Work Breakdown Structure (WBS) Template
+
+## Metadata
+- Milestone: `<milestone>`
+- Version: `<version>`
+- Date: `<date>`
+- Owner: `<owner>`
+
+## How To Use
+- Break work into independently-mergeable issues.
+- Keep each item measurable and testable.
+- Include deliverables + dependencies + issue links.
+- `WP-01` is **always** the milestone **design pass** (canonical docs + WBS + decisions + sprint plan + checklist).
+- Reserve the final WPs for the release tail in this order: `WP-13` demos, `WP-14` quality/coverage gate, `WP-15` docs/review convergence, `WP-16` release ceremony.
+
+## WBS Summary
+<wbs_summary>
+
+## Work Packages
+| ID | Work Package | Description | Deliverable | Dependencies | Issue |
+|---|---|---|---|---|---|
+| WP-01 | Design pass (milestone docs + planning) | <description_01> | <deliverable_01> | <deps_01> | <issue_01> |
+| WP-02 | <package_02> | <description_02> | <deliverable_02> | <deps_02> | <issue_02> |
+| WP-03 | <package_03> | <description_03> | <deliverable_03> | <deps_03> | <issue_03> |
+| WP-04 | <package_04> | <description_04> | <deliverable_04> | <deps_04> | <issue_04> |
+| WP-05 | <package_05> | <description_05> | <deliverable_05> | <deps_05> | <issue_05> |
+| WP-06 | <package_06> | <description_06> | <deliverable_06> | <deps_06> | <issue_06> |
+| WP-07 | <package_07> | <description_07> | <deliverable_07> | <deps_07> | <issue_07> |
+| WP-08 | <package_08> | <description_08> | <deliverable_08> | <deps_08> | <issue_08> |
+| WP-09 | <package_09> | <description_09> | <deliverable_09> | <deps_09> | <issue_09> |
+| WP-10 | <package_10> | <description_10> | <deliverable_10> | <deps_10> | <issue_10> |
+| WP-11 | <package_11> | <description_11> | <deliverable_11> | <deps_11> | <issue_11> |
+| WP-12 | <package_12> | <description_12> | <deliverable_12> | <deps_12> | <issue_12> |
+| WP-13 | Demo matrix + integration demos | <description_13> | <deliverable_13> | <deps_13> | <issue_13> |
+| WP-14 | Coverage / quality gate (ratchet + exclusions) | <description_14> | <deliverable_14> | <deps_14> | <issue_14> |
+| WP-15 | Docs + review pass (repo-wide alignment) | <description_15> | <deliverable_15> | <deps_15> | <issue_15> |
+| WP-16 | Release ceremony (final validation + tag + notes + cleanup) | <description_16> | <deliverable_16> | <deps_16> | <issue_16> |
+
+## Sequencing
+- Phase 1: <phase_1>
+- Phase 2: <phase_2>
+- Phase 3: <phase_3>
+
+## Acceptance Mapping
+- WP-01 (Design pass) -> <acceptance_criteria_01>
+- WP-02 -> <acceptance_criteria_02>
+- WP-03 -> <acceptance_criteria_03>
+- WP-04 -> <acceptance_criteria_04>
+- WP-05 -> <acceptance_criteria_05>
+- WP-06 -> <acceptance_criteria_06>
+- WP-07 -> <acceptance_criteria_07>
+- WP-08 -> <acceptance_criteria_08>
+- WP-09 -> <acceptance_criteria_09>
+- WP-10 -> <acceptance_criteria_10>
+- WP-11 -> <acceptance_criteria_11>
+- WP-12 -> <acceptance_criteria_12>
+- WP-13 (Demos) -> <acceptance_criteria_13>
+- WP-14 (Quality gate) -> <acceptance_criteria_14>
+- WP-15 (Docs/review) -> <acceptance_criteria_15>
+- WP-16 (Release ceremony) -> <acceptance_criteria_16>
+
+## Exit Criteria
+- Every in-scope requirement maps to at least one WBS item.
+- Every WBS item has an owner, issue reference, and concrete deliverable.
+- Dependency order is explicit enough to execute deterministically.

--- a/docs/templates/planning/README.md
+++ b/docs/templates/planning/README.md
@@ -1,0 +1,83 @@
+# Versioned Project Planning Templates
+
+This directory is the canonical tracked home for ADL project and milestone
+planning templates.
+
+The active template set is declared in [`current.json`](current.json). Each
+file under `1.0.0/` is a direct copy-and-fill document, not a fenced example
+embedded in prose.
+
+## Current Set
+
+- Template set: `1.0.0`
+- Template root: `docs/templates/planning/1.0.0/`
+- Registry: `docs/templates/planning/current.json`
+- Placeholder style: stable identifier-style angle-bracket placeholders such as
+  `<version>` and `<milestone_title>`
+
+## Template-Filled Does Not Mean Reviewed
+
+Planning-template validation is structural. It can prove that a draft has the
+right shape, required sections, and no unresolved placeholders.
+
+It does not prove that the plan is reviewed, approved, ready to execute, merged,
+released, or true. Those claims must come from issue cards, PR state, review
+records, release records, or explicit human decisions.
+
+## Versioning Policy
+
+- Template-set versions use SemVer.
+- `1.0.0/` is immutable after adoption except for obvious typo fixes.
+- Future semantic changes create a new SemVer directory, such as `1.1.0/` or
+  `2.0.0/`, then update `current.json`.
+- Tools should resolve active paths from `current.json` when practical.
+
+## Template Objects
+
+The first planning-template set includes:
+
+| Key | Role | Path |
+|---|---|---|
+| `readme` | Milestone README | `docs/templates/planning/1.0.0/readme.md` |
+| `wbs` | Work Breakdown Structure | `docs/templates/planning/1.0.0/wbs.md` |
+| `sprint` | Sprint Plan | `docs/templates/planning/1.0.0/sprint.md` |
+| `vision` | Milestone Vision | `docs/templates/planning/1.0.0/vision.md` |
+| `design` | Milestone Design | `docs/templates/planning/1.0.0/design.md` |
+| `decisions` | Decision Log | `docs/templates/planning/1.0.0/decisions.md` |
+| `demo_matrix` | Demo Matrix | `docs/templates/planning/1.0.0/demo_matrix.md` |
+| `feature_doc` | Feature Document | `docs/templates/planning/1.0.0/feature_doc.md` |
+| `milestone_checklist` | Milestone Checklist | `docs/templates/planning/1.0.0/milestone_checklist.md` |
+| `release_plan` | Release Plan | `docs/templates/planning/1.0.0/release_plan.md` |
+| `release_notes` | Release Notes | `docs/templates/planning/1.0.0/release_notes.md` |
+
+## Compatibility
+
+Legacy flat files under `docs/templates/*_TEMPLATE.md` remain compatibility
+surfaces until migration is complete. New planning work should prefer the
+versioned registry and active template paths in this directory.
+
+## Focused Validation
+
+Use the planning-template validator to check generated or filled planning docs:
+
+```bash
+python3 adl/tools/validate_planning_template.py \
+  --registry docs/templates/planning/current.json \
+  --template readme \
+  --input docs/templates/planning/fixtures/minimal/readme.md
+```
+
+The validator checks:
+
+- registry JSON parses
+- selected template registry entry exists, is active, and points to an existing
+  file under the active template root
+- required sections for the selected template are present
+- unresolved identifier-style angle-bracket or legacy curly placeholders are
+  absent from filled outputs
+
+## Migration Note
+
+This template set does not rewrite existing milestone packages. Future issues
+may migrate one planning wave at a time and should record which template version
+was used.

--- a/docs/templates/planning/current.json
+++ b/docs/templates/planning/current.json
@@ -1,0 +1,131 @@
+{
+  "schema": "adl.planning_template_registry.v1",
+  "planning_template_set": "1.0.0",
+  "semver": "1.0.0",
+  "status": "active",
+  "object_kind": "planning_template_set",
+  "template_root": "docs/templates/planning/1.0.0/",
+  "placeholder_style": "angle_bracket",
+  "draft_truth_model": {
+    "generated": "Template-filled planning docs are generated drafts.",
+    "validated": "Validation proves structure and placeholder resolution only.",
+    "reviewed": "Review status must be recorded from an actual review.",
+    "approved": "Approval must come from human or lifecycle evidence, not template filling."
+  },
+  "templates": {
+    "readme": {
+      "object_kind": "planning_template",
+      "semantic_role": "Milestone README",
+      "path": "docs/templates/planning/1.0.0/readme.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/README_TEMPLATE.md",
+      "required_sections": ["Metadata", "Purpose", "How To Use", "Overview", "Scope Summary", "Document Map", "Execution Model", "Demo and Validation Surface", "Status", "Exit Criteria"]
+    },
+    "wbs": {
+      "object_kind": "planning_template",
+      "semantic_role": "Work Breakdown Structure",
+      "path": "docs/templates/planning/1.0.0/wbs.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/WBS_TEMPLATE.md",
+      "required_sections": ["Metadata", "How To Use", "WBS Summary", "Work Packages", "Sequencing", "Acceptance Mapping", "Exit Criteria"]
+    },
+    "sprint": {
+      "object_kind": "planning_template",
+      "semantic_role": "Sprint Plan",
+      "path": "docs/templates/planning/1.0.0/sprint.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/SPRINT_TEMPLATE.md",
+      "required_sections": ["Metadata", "How To Use", "Sprint Goal", "Planned Scope", "Work Plan", "Risks / Dependencies", "Demo / Review Plan", "Exit Criteria"]
+    },
+    "vision": {
+      "object_kind": "planning_template",
+      "semantic_role": "Milestone Vision",
+      "path": "docs/templates/planning/1.0.0/vision.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/VISION_TEMPLATE.md",
+      "required_sections": ["Metadata", "Purpose", "How To Use", "Overview", "Core Goals", "Milestone Context", "Long-Term Direction", "Summary", "Exit Criteria"]
+    },
+    "design": {
+      "object_kind": "planning_template",
+      "semantic_role": "Milestone Design",
+      "path": "docs/templates/planning/1.0.0/design.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/DESIGN_TEMPLATE.md",
+      "required_sections": ["Metadata", "Purpose", "Problem Statement", "Goals", "Non-Goals", "Scope", "Requirements", "Proposed Design", "Validation Plan", "Exit Criteria"]
+    },
+    "decisions": {
+      "object_kind": "planning_template",
+      "semantic_role": "Decision Log",
+      "path": "docs/templates/planning/1.0.0/decisions.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/DECISIONS_TEMPLATE.md",
+      "required_sections": ["Metadata", "Purpose", "How To Use", "Decision Log", "Open Questions", "Exit Criteria"]
+    },
+    "demo_matrix": {
+      "object_kind": "planning_template",
+      "semantic_role": "Demo Matrix",
+      "path": "docs/templates/planning/1.0.0/demo_matrix.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/DEMO_MATRIX_TEMPLATE.md",
+      "required_sections": ["Metadata", "Purpose", "How To Use", "Scope", "Runtime Preconditions", "Demo Coverage Summary", "Coverage Rules", "Demo Details", "Cross-Demo Validation", "Determinism Evidence", "Reviewer Sign-Off Surface", "Exit Criteria"]
+    },
+    "feature_doc": {
+      "object_kind": "planning_template",
+      "semantic_role": "Feature Document",
+      "path": "docs/templates/planning/1.0.0/feature_doc.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/FEATURE_DOC_TEMPLATE.md",
+      "required_sections": ["Metadata", "Template Rules", "Purpose", "Context", "Coverage / Ownership", "Overview", "Design", "Execution Flow", "Determinism and Constraints", "Integration Points", "Validation", "Acceptance Criteria", "Risks", "Future Work", "Notes"]
+    },
+    "milestone_checklist": {
+      "object_kind": "planning_template",
+      "semantic_role": "Milestone Checklist",
+      "path": "docs/templates/planning/1.0.0/milestone_checklist.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/MILESTONE_CHECKLIST_TEMPLATE.md",
+      "required_sections": ["Metadata", "Purpose", "Planning", "Execution Discipline", "Quality Gates", "Release Packaging", "Post-Release", "Exit Criteria"]
+    },
+    "release_plan": {
+      "object_kind": "planning_template",
+      "semantic_role": "Release Plan",
+      "path": "docs/templates/planning/1.0.0/release_plan.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/RELEASE_PLAN_TEMPLATE.md",
+      "required_sections": ["Metadata", "How To Use", "0) Release-Tail Convergence", "1) Release Readiness", "2) Branch And Tag Preparation", "3) GitHub Release Steps", "4) Verification", "5) Communication", "Exit Criteria"]
+    },
+    "release_notes": {
+      "object_kind": "planning_template",
+      "semantic_role": "Release Notes",
+      "path": "docs/templates/planning/1.0.0/release_notes.md",
+      "version": "1.0.0",
+      "status": "active",
+      "legacy_path": "docs/templates/RELEASE_NOTES_TEMPLATE.md",
+      "required_sections": ["Metadata", "How To Use", "Summary", "Highlights", "What's New In Detail", "Upgrade Notes", "Known Limitations", "Validation Notes", "What's Next", "Exit Criteria"]
+    }
+  },
+  "compatibility_fallbacks": {
+    "flat_templates": [
+      "docs/templates/README_TEMPLATE.md",
+      "docs/templates/WBS_TEMPLATE.md",
+      "docs/templates/SPRINT_TEMPLATE.md",
+      "docs/templates/VISION_TEMPLATE.md",
+      "docs/templates/DESIGN_TEMPLATE.md",
+      "docs/templates/DECISIONS_TEMPLATE.md",
+      "docs/templates/DEMO_MATRIX_TEMPLATE.md",
+      "docs/templates/FEATURE_DOC_TEMPLATE.md",
+      "docs/templates/MILESTONE_CHECKLIST_TEMPLATE.md",
+      "docs/templates/RELEASE_PLAN_TEMPLATE.md",
+      "docs/templates/RELEASE_NOTES_TEMPLATE.md"
+    ]
+  }
+}

--- a/docs/templates/planning/fixtures/minimal/readme.md
+++ b/docs/templates/planning/fixtures/minimal/readme.md
@@ -1,0 +1,104 @@
+# Milestone README Template
+
+## Metadata
+- Milestone: `fixture-milestone`
+- Version: `v0.0.0-fixture`
+- Date: `2026-05-23`
+- Owner: `fixture-owner`
+
+## Purpose
+Provide a single entry point for a filled planning-template fixture.
+
+## How To Use
+- Use this fixture only to prove the planning README shape validates.
+
+## Overview
+
+`fixture-milestone` represents a minimal generated planning packet fixture.
+
+This milestone focuses on:
+- fixture scope
+- fixture validation
+- fixture portability
+
+Key outcomes:
+- placeholder-free output
+- required-section coverage
+- no approval claim
+
+## Scope Summary
+
+### In scope
+- fixture validation
+
+### Out of scope
+- release truth
+
+## Document Map
+
+Canonical milestone documents:
+
+- Vision: `VISION.md`
+- Design: `DESIGN.md`
+- Work Breakdown Structure (WBS): `WBS.md`
+- Sprint plan: `SPRINT.md`
+- Decisions log: `DECISIONS.md`
+- Demo matrix: `DEMO_MATRIX.md`
+- Milestone checklist: `MILESTONE_CHECKLIST.md`
+- Release plan / process: `RELEASE_PLAN.md`
+- Release notes: `RELEASE_NOTES.md`
+
+Supporting / domain-specific docs:
+- none
+
+## Execution Model
+
+This fixture is not executable milestone truth.
+
+Execution expectations:
+- none; this is a validation fixture
+
+## Demo and Validation Surface
+
+Primary validation is defined by the planning-template validator.
+
+Additional validation surfaces:
+- none
+
+Success criteria:
+- required sections are present
+- unresolved placeholders are absent
+- no review or approval status is claimed
+
+## Determinism and Reproducibility
+
+The fixture should validate consistently with the same registry and input file.
+
+Evidence locations:
+- `docs/templates/planning/fixtures/minimal/readme.md`
+
+## Risks and Open Questions
+
+Known risks:
+- this fixture proves only the README template contract
+
+Open questions:
+- none
+
+## Status
+
+Current status: generated fixture
+
+- Planning: generated fixture only
+- Execution: not applicable
+- Validation: structurally valid when validator passes
+- Release readiness: not applicable
+
+## Exit Criteria
+
+- All canonical milestone documents are complete and internally consistent.
+- All WBS items are implemented or explicitly deferred.
+- Demo matrix is runnable and validated.
+- Quality gates are passing or explicitly scoped out.
+- Milestone checklist is complete or exceptions are documented.
+- Release artifacts are ready or explicitly scoped out.


### PR DESCRIPTION
## Summary

Adds the first SemVer project-planning template substrate for ADL milestone/planning docs.

## What changed

- Adds `docs/templates/planning/1.0.0/` with direct copy-and-fill planning templates.
- Adds `docs/templates/planning/current.json` registry.
- Adds planning-template README/runbook and compatibility note for legacy flat templates.
- Adds a minimal filled README fixture.
- Adds `adl/tools/validate_planning_template.py` for structural validation.

## Claim boundary

Validation is structural only. It proves registry shape, required sections, and placeholder resolution for filled docs. It does not prove review, approval, release, PR, merge, or closeout truth.

## Validation

- `python3 -m json.tool docs/templates/planning/current.json`
- `python3 -m py_compile adl/tools/validate_planning_template.py`
- `python3 adl/tools/validate_planning_template.py --registry docs/templates/planning/current.json --template readme --input docs/templates/planning/fixtures/minimal/readme.md`
- Negative unresolved-placeholder fixture check
- `git diff --check`

## Review

Bounded pre-PR subagent review completed. Findings were fixed before publication.

Closes #3302
