### PR TITLE
[v0.91.3][tools] Make planning-template helpers path-portable

### DIFF
--- a/adl/tools/fill_planning_template.py
+++ b/adl/tools/fill_planning_template.py
@@ -18,6 +18,7 @@ PLACEHOLDER = re.compile(r"<([A-Za-z][A-Za-z0-9_]*)>")
 
 
 def load_json(path: Path) -> dict[str, Any]:
+    path = path.resolve()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
@@ -29,7 +30,35 @@ def load_json(path: Path) -> dict[str, Any]:
     return data
 
 
-def resolve_template(registry: dict[str, Any], template_key: str) -> Path:
+def registry_repo_root(registry_path: Path) -> Path:
+    resolved = registry_path.resolve()
+    parts = resolved.parts
+    suffix = ("docs", "templates", "planning", "current.json")
+    if len(parts) >= len(suffix) and tuple(parts[-len(suffix) :]) == suffix:
+        return Path(*parts[: -len(suffix)])
+    return resolved.parent
+
+
+def resolve_registered_path(registry_path: Path, path_value: str) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        raise SystemExit(f"registered template path must be relative: {path_value}")
+    return registry_repo_root(registry_path) / path
+
+
+def is_relative_to_path(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_template(
+    registry: dict[str, Any],
+    registry_path: Path,
+    template_key: str,
+) -> tuple[Path, str]:
     templates = registry.get("templates", {})
     template = templates.get(template_key)
     if not isinstance(template, dict):
@@ -40,12 +69,15 @@ def resolve_template(registry: dict[str, Any], template_key: str) -> Path:
     if not isinstance(template_path_value, str):
         raise SystemExit(f"template path is missing or invalid: {template_key}")
     template_root = str(registry.get("template_root", ""))
-    if template_root and not template_path_value.startswith(template_root):
+    template_path = resolve_registered_path(registry_path, template_path_value)
+    if template_root and not is_relative_to_path(
+        template_path,
+        resolve_registered_path(registry_path, template_root),
+    ):
         raise SystemExit(f"template path is outside active template root: {template_path_value}")
-    template_path = Path(template_path_value)
     if not template_path.exists():
         raise SystemExit(f"registered template file does not exist: {template_path}")
-    return template_path
+    return template_path, template_path_value
 
 
 def stringify(value: Any) -> str:
@@ -70,7 +102,7 @@ def fill_template(template_text: str, values: dict[str, Any]) -> tuple[str, list
     return filled, sorted(missing)
 
 
-def generated_header(registry: dict[str, Any], template_key: str, template_path: Path) -> str:
+def generated_header(registry: dict[str, Any], template_key: str, template_path: str) -> str:
     return "\n".join(
         [
             "<!--",
@@ -102,11 +134,12 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    registry = load_json(Path(args.registry))
+    registry_path = Path(args.registry)
+    registry = load_json(registry_path)
     if registry.get("schema") != "adl.planning_template_registry.v1":
         raise SystemExit(f"unsupported registry schema: {registry.get('schema')!r}")
     values = load_json(Path(args.values))
-    template_path = resolve_template(registry, args.template)
+    template_path, template_display_path = resolve_template(registry, registry_path, args.template)
     template_text = template_path.read_text(encoding="utf-8")
     filled, missing = fill_template(template_text, values)
 
@@ -117,7 +150,7 @@ def main() -> int:
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(
-        generated_header(registry, args.template, template_path) + filled,
+        generated_header(registry, args.template, template_display_path) + filled,
         encoding="utf-8",
     )
     print(
@@ -125,7 +158,7 @@ def main() -> int:
             {
                 "status": "PASS" if not missing else "PARTIAL",
                 "template": args.template,
-                "template_path": str(template_path),
+                "template_path": template_display_path,
                 "values": args.values,
                 "output": str(output_path),
                 "missing_values": missing,

--- a/adl/tools/validate_planning_template.py
+++ b/adl/tools/validate_planning_template.py
@@ -24,6 +24,7 @@ CURLY_PLACEHOLDER = re.compile(r"\{\{[A-Za-z][A-Za-z0-9_]*\}\}")
 
 
 def load_registry(path: Path) -> dict[str, Any]:
+    path = path.resolve()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
@@ -35,6 +36,30 @@ def load_registry(path: Path) -> dict[str, Any]:
     return data
 
 
+def registry_repo_root(registry_path: Path) -> Path:
+    resolved = registry_path.resolve()
+    parts = resolved.parts
+    suffix = ("docs", "templates", "planning", "current.json")
+    if len(parts) >= len(suffix) and tuple(parts[-len(suffix) :]) == suffix:
+        return Path(*parts[: -len(suffix)])
+    return resolved.parent
+
+
+def resolve_registered_path(registry_path: Path, path_value: str) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        raise SystemExit(f"registered template path must be relative: {path_value}")
+    return registry_repo_root(registry_path) / path
+
+
+def is_relative_to_path(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
 def validate_required_sections(text: str, required_sections: list[str]) -> list[str]:
     missing: list[str] = []
     for section in required_sections:
@@ -44,7 +69,12 @@ def validate_required_sections(text: str, required_sections: list[str]) -> list[
     return missing
 
 
-def validate_document(registry: dict[str, Any], template_key: str, input_path: Path) -> int:
+def validate_document(
+    registry: dict[str, Any],
+    registry_path: Path,
+    template_key: str,
+    input_path: Path,
+) -> int:
     templates = registry.get("templates", {})
     template = templates.get(template_key)
     if not isinstance(template, dict):
@@ -58,9 +88,12 @@ def validate_document(registry: dict[str, Any], template_key: str, input_path: P
     if not isinstance(template_path_value, str):
         print(f"template path is missing or invalid: {template_key}", file=sys.stderr)
         return 2
-    template_path = Path(template_path_value)
+    template_path = resolve_registered_path(registry_path, template_path_value)
     template_root = str(registry.get("template_root", ""))
-    if template_root and not template_path_value.startswith(template_root):
+    if template_root and not is_relative_to_path(
+        template_path,
+        resolve_registered_path(registry_path, template_root),
+    ):
         print(
             f"template path is outside active template root: {template_path_value}",
             file=sys.stderr,
@@ -124,8 +157,9 @@ def main() -> int:
     parser.add_argument("--input", required=True)
     args = parser.parse_args()
 
-    registry = load_registry(Path(args.registry))
-    return validate_document(registry, args.template, Path(args.input))
+    registry_path = Path(args.registry)
+    registry = load_registry(registry_path)
+    return validate_document(registry, registry_path, args.template, Path(args.input))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Makes the planning-template fill and validate helpers path-portable. Registered template paths now resolve from the registry/repo root instead of the shell cwd.

## What changed

- `validate_planning_template.py` resolves registered template paths relative to the registry location.
- `fill_planning_template.py` uses the same registry-relative resolution.
- Absolute registered template paths are rejected as non-portable.
- Template-root containment checks now use path-aware ancestry instead of string-prefix matching.
- Generated Markdown and JSON status preserve repo-relative template provenance instead of resolved host paths.

## Validation

- `python3 -m py_compile adl/tools/validate_planning_template.py adl/tools/fill_planning_template.py`
- Repo-root fill + validate commands pass.
- Non-repo-cwd fill + validate commands from `/private/tmp` pass with absolute registry/values/input paths.
- Negative absolute registered-template-path check fails clearly.
- `git diff --check`

## Review

Bounded pre-PR subagent review completed. Findings were fixed before publication.

Closes #3308
