### PR TITLE
[v0.91.3][docs] Refresh planning-template helper docs

### DIFF
--- a/adl/tools/skills/planning-doc-editor/SKILL.md
+++ b/adl/tools/skills/planning-doc-editor/SKILL.md
@@ -40,6 +40,7 @@ Examples:
 - a sprint plan says it is approved when only generation occurred
 - a demo matrix has stale milestone labels
 - a release plan includes absolute host paths or temp paths
+- a planning-template registry or generated draft records resolved host paths
 - a planning packet needs status wording normalized before review
 
 Do not use this skill for:
@@ -123,6 +124,8 @@ those sources.
 Classify defects before editing:
 - unresolved placeholders
 - missing required sections
+- absolute registered template paths
+- generated-draft provenance that records resolved host paths
 - stale milestone or sprint claims
 - generated/reviewed/approved status drift
 - unsupported release or PR claims
@@ -145,6 +148,7 @@ Allowed edits:
 - normalize status labels such as `generated`, `draft`, `reviewed`, or
   `approved`
 - repair repo-relative links and portable paths
+- preserve repo-relative template provenance in generated planning docs
 - clarify validation that was run, not run, or deferred
 - add a short residual-risk or follow-up section when needed
 
@@ -161,6 +165,7 @@ Use the smallest validation that proves the edit:
 - placeholder scan for generated docs
 - required-section check when a template contract exists
 - portable-path scan when docs may be published
+- helper invocation from a non-repo cwd when path portability is the defect
 - markdown link/path check when links are part of the defect
 
 If validation is not run, record why.

--- a/docs/planning/PROJECT_PLANNING_TEMPLATE_TRANSITION_PLAN.md
+++ b/docs/planning/PROJECT_PLANNING_TEMPLATE_TRANSITION_PLAN.md
@@ -1,10 +1,10 @@
 # Project Planning Template Transition Plan
 
-Status: draft transition plan for issue `#3303`
+Status: current planning-template transition contract
 
 Version target: `v0.91.3`
 
-Related substrate issue: `#3302`
+Related issues: `#3302`, `#3303`, `#3308`, `#3310`
 
 ## Purpose
 
@@ -80,19 +80,25 @@ The first generator should be intentionally boring.
 Required behavior:
 
 - read `docs/templates/planning/current.json`
+- resolve registry template paths relative to the registry/repo root, not cwd
+- reject absolute registered template paths as non-portable
 - select one named planning document type
 - fill declared placeholders from an explicit input map
 - write the generated document to an explicit output path
 - stamp template version and generation status
+- record repo-relative template provenance, not resolved host paths
 - avoid hidden defaults that create false milestone truth
 
 Suggested command shape:
 
 ```bash
+ADL_TMP="${TMPDIR:-/tmp}"
+
 python3 adl/tools/fill_planning_template.py \
+  --registry docs/templates/planning/current.json \
   --template readme \
   --values examples/planning/values/minimal.json \
-  --output /tmp/adl-planning-fixture/README.md
+  --output "$ADL_TMP/adl-planning-fixture.md"
 ```
 
 ### Phase 3: Validation Contract
@@ -103,6 +109,8 @@ Required behavior:
 
 - fail on unresolved placeholders
 - fail on missing required sections for the selected document type
+- fail on absolute registered template paths
+- use path-aware template-root containment checks rather than string prefixes
 - report the template version used
 - report generated, reviewed, and approved status truth separately
 - avoid treating validation as approval
@@ -110,9 +118,32 @@ Required behavior:
 Suggested command shape:
 
 ```bash
+ADL_TMP="${TMPDIR:-/tmp}"
+
 python3 adl/tools/validate_planning_template.py \
+  --registry docs/templates/planning/current.json \
   --template readme \
-  --input /tmp/adl-planning-fixture/README.md
+  --input "$ADL_TMP/adl-planning-fixture.md"
+```
+
+Non-repo-cwd invocation should use symbolic paths rather than machine-local
+paths:
+
+```bash
+REPO="$(pwd)"
+ADL_TMP="${TMPDIR:-/tmp}"
+cd "$ADL_TMP"
+
+python3 "$REPO/adl/tools/fill_planning_template.py" \
+  --registry "$REPO/docs/templates/planning/current.json" \
+  --template readme \
+  --values "$REPO/docs/templates/planning/fixtures/minimal/readme_values.json" \
+  --output "$ADL_TMP/adl-planning-fixture.md"
+
+python3 "$REPO/adl/tools/validate_planning_template.py" \
+  --registry "$REPO/docs/templates/planning/current.json" \
+  --template readme \
+  --input "$ADL_TMP/adl-planning-fixture.md"
 ```
 
 Minimum first-slice document types:
@@ -171,8 +202,10 @@ Migration rules:
 
 - `generate` command reads a versioned registry.
 - `generate` command writes explicit generation metadata.
+- generated Markdown records repo-relative template provenance.
 - `validate` command rejects unresolved placeholders.
 - `validate` command checks required sections.
+- `validate` command rejects absolute registered template paths.
 - `validate` command does not mark review or approval.
 - `planning-doc-editor` skill exists and has a clear stop boundary.
 - `workflow-conductor` routes planning-doc defects to `planning-doc-editor`.

--- a/docs/templates/planning/README.md
+++ b/docs/templates/planning/README.md
@@ -15,6 +15,22 @@ embedded in prose.
 - Placeholder style: stable identifier-style angle-bracket placeholders such as
   `<version>` and `<milestone_title>`
 
+## Path Portability Contract
+
+Registry template paths are repo-relative contract paths. They must stay
+relative, such as `docs/templates/planning/1.0.0/readme.md`; absolute host paths
+are rejected as non-portable.
+
+The helper scripts resolve registered template paths relative to the registry's
+repository root, not the caller's current shell directory. This means the same
+registry can be used from the repository root or from another working directory
+when explicit paths are supplied for the registry, values, input, and output
+files.
+
+Generated Markdown records repo-relative template provenance in its header. It
+must not record resolved host paths such as user home directories, temporary
+worktree paths, or machine-local checkout roots.
+
 ## Template-Filled Does Not Mean Reviewed
 
 Planning-template validation is structural. It can prove that a draft has the
@@ -30,7 +46,7 @@ records, release records, or explicit human decisions.
 - `1.0.0/` is immutable after adoption except for obvious typo fixes.
 - Future semantic changes create a new SemVer directory, such as `1.1.0/` or
   `2.0.0/`, then update `current.json`.
-- Tools should resolve active paths from `current.json` when practical.
+- Tools resolve active paths from `current.json`.
 
 ## Template Objects
 
@@ -77,11 +93,33 @@ python3 adl/tools/validate_planning_template.py \
   --input docs/templates/planning/fixtures/minimal/readme_generated.md
 ```
 
+The same commands can run from another working directory with symbolic absolute
+inputs:
+
+```bash
+REPO="$(pwd)"
+ADL_TMP="${TMPDIR:-/tmp}"
+cd "$ADL_TMP"
+
+python3 "$REPO/adl/tools/fill_planning_template.py" \
+  --registry "$REPO/docs/templates/planning/current.json" \
+  --template readme \
+  --values "$REPO/docs/templates/planning/fixtures/minimal/readme_values.json" \
+  --output "$ADL_TMP/adl-planning-readme.md"
+
+python3 "$REPO/adl/tools/validate_planning_template.py" \
+  --registry "$REPO/docs/templates/planning/current.json" \
+  --template readme \
+  --input "$ADL_TMP/adl-planning-readme.md"
+```
+
 The validator checks:
 
 - registry JSON parses
 - selected template registry entry exists, is active, and points to an existing
   file under the active template root
+- registered template paths are relative and contained within the active
+  template root
 - required sections for the selected template are present
 - unresolved identifier-style angle-bracket or legacy curly placeholders are
   absent from filled outputs


### PR DESCRIPTION
## Summary

Refreshes planning-template docs to match merged #3308 path-portable helper behavior.

## What changed

- Adds a path portability contract to `docs/templates/planning/README.md`.
- Documents that registry template paths must remain repo-relative and absolute registered paths are rejected.
- Adds repo-root and non-repo-cwd helper invocation examples using symbolic variables.
- Updates the transition plan with explicit `--registry` usage, symbolic temp paths, path-aware containment expectations, and generated-draft provenance rules.
- Updates `planning-doc-editor` guidance for absolute registry paths and generated-draft host-path leakage.

## Claim boundary

This is docs-only. It does not change helper code, registry schema, or live milestone docs.

## Validation

- `rg -n "fill_planning_template|validate_planning_template|current.json|template_path|planning-template" docs adl -g "*.md"`
- `git diff --check`
- bounded pre-PR docs review; findings fixed before publication

Closes #3310
